### PR TITLE
ix-windows: draggable, non-resizable, rounded overlay + docs

### DIFF
--- a/docs/ix-windows/overview.md
+++ b/docs/ix-windows/overview.md
@@ -54,8 +54,9 @@ subscriber is async, and the page's measuring script also feeds events back. The
 binary:
 
 1. Builds a `tao` `EventLoop` parameterized on [`UserEvent`] as its user-event
-   type, and a proxy. [`UserEvent`] wraps either a `ProducerEvent`
-   (`UserEvent::Producer`) or a content-size report (`UserEvent::Resize`).
+   type, and a proxy. [`UserEvent`] is one of a `ProducerEvent`
+   (`UserEvent::Producer`), a content-size report (`UserEvent::Resize`), or a
+   move request (`UserEvent::Drag`, posted when the user presses the card chrome).
 2. Spawns a side thread running a multi-thread tokio runtime that calls
    [`subscribe`](../dashboard-core/overview.md#consumer-side-subscribe-srcsubscribers)
    and forwards each event as `UserEvent::Producer` into the loop via a clone of
@@ -63,8 +64,8 @@ binary:
 3. Runs the event loop with `ControlFlow::Wait` (reactive viewer, not an
    animation loop) and dispatches to a [`WindowManager`]:
    `Producer(Snapshot)` -> `apply_snapshot`, `Producer(Gone)` -> `producer_gone`,
-   `Resize { window, .. }` -> `resize`, `WindowEvent::CloseRequested` ->
-   `window_closed`.
+   `Resize { window, .. }` -> `resize`, `Drag { window }` -> `begin_drag`,
+   `WindowEvent::CloseRequested` -> `window_closed`.
 
 ## The engine: `WindowManager` (`src/lib.rs`)
 
@@ -91,19 +92,25 @@ Public surface:
   resize/reflow loop.
 - [`producer_gone(producer)`]: drop every window of a disconnected producer and
   clear its dismissals.
+- [`begin_drag(window)`]: begin an interactive move of the window whose chrome the
+  user pressed (`OUTER_JS` posts `"drag"` on mousedown over the card), by calling
+  `drag_window`. A borderless, non-resizable window has no native title bar, so
+  this is how the overlay is moved.
 - [`window_closed(window_id)`]: the user closed a window; remove it and record
   the dismissal. Returns whether it was one of ours.
 - [`is_empty`]: whether any resource windows are open.
 
 ### Reconcile invariants
 
-- **In-place refresh.** `OpenWindow::refresh` swaps only the `#ix-root` inner
-  HTML via `evaluate_script` when the html changed, and resets the title when it
-  changed, so the document, scroll position, and focus survive an update (a full
-  reload would flicker and reset them). The new HTML is injected as a
-  `serde_json::to_string` JS string literal, so arbitrary resource HTML is
-  escaped safely. The page's `ResizeObserver` notices the resulting size change
-  and drives a `resize`.
+- **In-place refresh.** `OpenWindow::refresh` swaps the sandboxed iframe's
+  `srcdoc` (`#ix-frame`) via `evaluate_script` when the html changed, and resets
+  the title when it changed, so the trusted outer document, the window, and focus
+  survive an update (scroll position inside the iframe resets, the trade for never
+  running producer script in the trusted document). The new inner document is
+  injected as a `serde_json::to_string` JS string literal, so arbitrary resource
+  HTML is escaped safely; the iframe sandbox (not that escaping) is what contains
+  any script in the body. The iframe's own `ResizeObserver` notices the resulting
+  size change and reports it, driving a `resize`.
 - **Dismissal tracking.** `dismissed` records resources the user closed while
   still live. Without it, the next snapshot (any content change republishes one)
   would find the window gone and re-open it, fighting the user. It is cleared
@@ -123,17 +130,29 @@ Public surface:
   (`HUDWindow` material, `BehindWindow` blending) as the content view's first
   subview, beneath the transparent webview, with a rounded, shadowed layer. The
   rendered HTML paints on top of it.
-- **Transparent shell.** `shell(title, body)` wraps the resource HTML in a fully
-  transparent document whose `#ix-root` panel shrink-wraps its content with a
-  faint tint and rounded corners (the `STYLE` constant); the `<title>` is
-  escaped, the body injected verbatim (the same trust model as the web
-  dashboard's sandboxed html pane).
-- **Auto-size to content.** The shell embeds `MEASURE_JS`: a `ResizeObserver` on
-  `#ix-root` posts the panel's `offsetWidth`x`offsetHeight` over `wry`'s IPC
-  channel (coalesced to one report per frame, deduped). The IPC handler forwards
-  it as `UserEvent::Resize`, and `WindowManager::resize` fits the OS window. The
-  panel is `inline-block` / `max-width` so its intrinsic size does not depend on
-  the window width, which keeps the measurement stable (no resize loop).
+- **Sandboxed shell.** `shell(title, body)` builds a fully transparent trusted
+  outer document whose `#ix-root` panel (the `STYLE` constant) shrink-wraps a
+  single child: a `sandbox="allow-scripts"` (no `allow-same-origin`) `<iframe>`
+  (`#ix-frame`) whose `srcdoc` is the resource body wrapped by `inner_document`.
+  The producer HTML therefore runs in an opaque origin with no access to the
+  trusted document, `window.ipc`, cookies, or storage -- the same trust model as
+  the web dashboard's html pane. Because that origin is opaque and the document
+  has no page URL, the body must be self-contained: external CDN scripts/styles
+  and same-origin `fetch` are blocked, so anything needing a library is
+  pre-rendered (e.g. mermaid -> SVG) and embedded.
+- **Auto-size to content.** `INNER_JS` (inside the iframe) runs a `ResizeObserver`
+  on `#ix-content` and `postMessage`s the measured size out; `OUTER_JS` (the
+  trusted document) validates that message, sizes the iframe, then posts the
+  card's `offsetWidth`x`offsetHeight` over `wry`'s IPC channel (coalesced per
+  frame, deduped). The IPC handler forwards it as `UserEvent::Resize`, and
+  `WindowManager::resize` fits the OS window. `#ix-content` is `width: max-content`
+  so its intrinsic size does not depend on the window width, which keeps the
+  measurement stable (no resize loop).
+- **Move by chrome.** `OUTER_JS` also listens for a primary-button `mousedown` on
+  `#ix-root`; a press that reaches the trusted document landed on the card chrome
+  (the iframe captures its own events), so it posts `"drag"`, which the IPC
+  handler turns into `UserEvent::Drag` -> `begin_drag` -> `drag_window`. Producer
+  content inside the iframe stays interactive.
 - **120Hz.** `enable_high_refresh` disables WebKit's private
   `PreferPageRenderingUpdatesNear60FPSEnabled` experimental feature via the
   private `_setEnabled:forExperimentalFeature:` selector (gated by

--- a/packages/ix-windows/README.md
+++ b/packages/ix-windows/README.md
@@ -30,6 +30,21 @@ tiling, no layout manager.
   content grows.
 - **Floating across spaces.** The window is always-on-top and joins all spaces /
   floats over fullscreen apps (`NSWindowCollectionBehavior`).
+- **Move, don't resize.** The card is borderless, so there is no title bar: drag
+  it by its **chrome** (the padding/background around the content) to move it. The
+  window is not user-resizable -- its size is owned by the content (auto-fit), so a
+  manual resize would just fight the next content report.
+
+## Self-contained HTML only
+
+A resource's HTML is rendered inside a sandboxed, opaque-origin `<iframe>`
+(`sandbox="allow-scripts"`, no `allow-same-origin`) loaded with no page origin, so
+it must be **self-contained**: inline all CSS and JS and data. External CDN
+scripts/styles, same-origin `fetch`, cookies, and storage are blocked by the
+sandbox. Pre-render anything that needs a library and embed the result -- e.g.
+render a mermaid diagram to SVG server-side (`kroki.io`, the `mermaid` CLI, ...)
+and put the static `<svg>` in the HTML, rather than loading `mermaid.js` from a
+CDN (which silently fails).
 
 ## macOS
 

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -58,6 +58,10 @@ pub enum UserEvent {
         width: f64,
         height: f64,
     },
+    /// The user pressed on the card chrome; begin an interactive move of the
+    /// window. A borderless, non-resizable window has no native title bar to
+    /// drag, so `OUTER_JS` starts the drag and the loop calls `drag_window`.
+    Drag { window: WindowId },
 }
 
 /// A pane's global identity across producers: `(producer id, pane id)`. A pane id
@@ -268,6 +272,19 @@ impl WindowManager {
         }
     }
 
+    /// Begin an interactive move of the window whose chrome the user pressed.
+    /// `OUTER_JS` posts `"drag"` on mousedown over the card chrome; `drag_window`
+    /// hands the rest of the gesture to the OS so the overlay tracks the cursor.
+    /// A failure (e.g. no active press) is non-fatal -- the click is just ignored.
+    pub fn begin_drag(&self, window: WindowId) {
+        let Some(key) = self.by_window.get(&window) else {
+            return;
+        };
+        if let Some(open) = self.windows.get(key) {
+            let _ = open.window.drag_window();
+        }
+    }
+
     /// Whether any resource windows are currently open.
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -288,7 +305,10 @@ impl WindowManager {
         self.opened = self.opened.wrapping_add(1);
         // Borderless + transparent + always-on-top: a floating overlay card. Not
         // user-resizable -- the window size is owned by the content (auto-fit via
-        // `resize`), so a manual drag would just fight the next content report.
+        // `resize`), so a manual resize would just fight the next content report.
+        // It stays movable: `OUTER_JS` starts a window drag on mousedown over the
+        // card chrome (`UserEvent::Drag` -> `drag_window`), since a borderless,
+        // non-resizable window has no native title bar to grab.
         // `install_blur` rounds the corners (the macOS server only rounds *titled*
         // windows, so a borderless window is square until its layer is rounded).
         let builder = tao::window::WindowBuilder::new()
@@ -320,7 +340,10 @@ impl WindowManager {
         let webview = match WebViewBuilder::new()
             .with_transparent(true)
             .with_ipc_handler(move |request| {
-                if let Some((w, h)) = parse_size(request.body().as_str()) {
+                let body = request.body().as_str();
+                if body == "drag" {
+                    let _ = proxy.send_event(UserEvent::Drag { window: id });
+                } else if let Some((w, h)) = parse_size(body) {
                     let _ = proxy.send_event(UserEvent::Resize {
                         window: id,
                         width: w,
@@ -501,6 +524,14 @@ const OUTER_JS: &str = "\
   var frame = document.getElementById('ix-frame');
   var root = document.getElementById('ix-root');
   if (!frame || !root) return;
+  // Drag the borderless window by its chrome: a mousedown that reaches this
+  // (outer, trusted) document landed on the card padding/background, not inside
+  // the iframe (which captures its own events), so producer content stays
+  // interactive while the surrounding card is a move handle.
+  root.addEventListener('mousedown', function (event) {
+    if (event.button !== 0) return;
+    if (window.ipc && window.ipc.postMessage) window.ipc.postMessage('drag');
+  });
   window.addEventListener('message', function (event) {
     if (event.source !== frame.contentWindow) return;
     var data = event.data;

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -286,14 +286,17 @@ impl WindowManager {
         // Cascade each overlay so several do not perfectly overlap.
         let step = f64::from(self.opened % 8) * 32.0;
         self.opened = self.opened.wrapping_add(1);
-        // Borderless + transparent + always-on-top: a floating overlay card. The
-        // macOS window server only rounds *titled* windows, so dropping
-        // decorations leaves the corners to the blur view's own rounded layer.
+        // Borderless + transparent + always-on-top: a floating overlay card. Not
+        // user-resizable -- the window size is owned by the content (auto-fit via
+        // `resize`), so a manual drag would just fight the next content report.
+        // `install_blur` rounds the corners (the macOS server only rounds *titled*
+        // windows, so a borderless window is square until its layer is rounded).
         let builder = tao::window::WindowBuilder::new()
             .with_title(&pane.title)
             .with_decorations(false)
             .with_transparent(true)
             .with_always_on_top(true)
+            .with_resizable(false)
             .with_inner_size(LogicalSize::new(INITIAL_SIZE.0, INITIAL_SIZE.1))
             .with_position(LogicalPosition::new(64.0 + step, 64.0 + step));
         let window = match builder.build(target) {
@@ -602,6 +605,15 @@ fn install_blur(window: &Window) {
         // Place the blur beneath the webview (added as the content view's first
         // subview), so the rendered HTML paints on top of it.
         content.addSubview_positioned_relativeTo(&effect, NSWindowOrderingMode::Below, None);
+
+        // Round the *content view* itself (not just the blur), so the webview on
+        // top is clipped to the same radius -- otherwise its square layer paints
+        // over the blur's rounded corners and the overlay looks square.
+        content.setWantsLayer(true);
+        if let Some(layer) = content.layer() {
+            layer.setCornerRadius(14.0);
+            layer.setMasksToBounds(true);
+        }
 
         ns_window.setHasShadow(true);
         ns_window.invalidateShadow();

--- a/packages/ix-windows/src/main.rs
+++ b/packages/ix-windows/src/main.rs
@@ -82,6 +82,9 @@ fn main() {
             }) => {
                 manager.resize(window, width, height);
             }
+            Event::UserEvent(UserEvent::Drag { window }) => {
+                manager.begin_drag(window);
+            }
             Event::WindowEvent {
                 window_id,
                 event: WindowEvent::CloseRequested,


### PR DESCRIPTION
## What

Polish the `ix-windows` resource overlay so it behaves like a proper floating card.

- **Draggable** — borderless windows have no title bar, so `OUTER_JS` starts a window drag on a primary-button `mousedown` over the card chrome (`UserEvent::Drag` -> `begin_drag` -> `drag_window`). Content inside the sandboxed iframe stays interactive (only the chrome is a move handle).
- **Non-resizable** (`with_resizable(false)`) — the size is owned by the content (auto-fit), so a manual resize just fought the next content report.
- **Rounded corners** — the macOS server only rounds *titled* windows, so the borderless content-view layer is rounded explicitly.
- **Docs** — README gains *Move, don't resize* + a *Self-contained HTML only* section; the overview doc is updated to the current iframe/sandbox model (it still referenced a removed `MEASURE_JS` / `#ix-root` inner-HTML swap) and the new `Drag`/`begin_drag` surface.

## Test

- `nix build .#ix-windows` green.
- Ran the binary against a live resource: window auto-sized to content (e.g. 394×136), dragged by the card edge, button inside stayed clickable, corners rounded, no manual resize.

## Notes

Mermaid-in-overlay confirmed working only when the SVG is **pre-rendered** and embedded (CDN `mermaid.js` is blocked by the opaque-origin sandbox); documented in the README.

_Reviewed by the adversarial review-changes workflow: approve-with-fixes, 0 blockers; the confirmed doc-staleness findings are fixed here._

🤖 Authored with Claude Code (Opus).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add draggable, non-resizable, rounded overlay windows to ix-windows
> - Adds a `UserEvent::Drag` variant and `WindowManager::begin_drag` method to initiate a native OS window drag when the webview posts a `"drag"` IPC message from the card chrome.
> - Windows are now created with `with_resizable(false)`; users move them by dragging the chrome instead.
> - Fixes rounded corner clipping on macOS by enabling a CALayer with corner radius and `masksToBounds` on the content view after blur installation.
> - Updates documentation to describe the sandboxed iframe approach, drag-to-move behavior, and the IPC message flow from inner JS to outer JS to the event loop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2427e06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->