### PR TITLE
mcp: document register_resource usage + overlay + self-contained HTML

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -790,13 +790,47 @@ class Resource:
 def register_resource(
     source: Any = None, *, title: str | None = None, render: Any = None, id: str | None = None, kind: str = "html", alive: Any = None
 ) -> Resource:
-    """Register a live HTML resource for the dashboard sidebar.
+    """Register a live HTML resource: a view the dashboard shows in its sidebar.
 
-    Pass a ``render`` callable returning the current HTML (sync or async), or a
-    ``source`` object the runtime renders by calling its ``resource_html()`` /
-    ``to_html()`` (whichever it has). ``alive`` is an optional predicate; when it
-    returns False the resource closes itself and leaves the sidebar. Returns the
-    :class:`Resource` handle (call ``.close()`` to remove it explicitly).
+    A resource is a *live* HTML pane (unlike ``cells``, which are static
+    snapshots): its ``render`` is re-invoked on refresh, so returning fresh HTML
+    updates the pane in place. Use it for a dashboard you want to keep glancing at
+    -- a status board, a queue, a metric -- rather than a one-shot result.
+
+    Arguments::
+
+        register_resource(render=lambda: html, title="queue", id="queue")  # callable
+        register_resource(obj)            # obj.resource_html() / obj.to_html()
+        register_resource(render=fn, alive=lambda: job.running)  # auto-closes
+
+    - ``render``: a callable (sync or async) returning the current HTML. Or pass a
+      ``source`` object with ``resource_html()`` / ``to_html()``.
+    - ``id``: give a STABLE id so re-registering REPLACES the same resource (a loop
+      updating one view), instead of spawning a new pane each call. Omitted -> a
+      random id, i.e. a new resource every time.
+    - ``alive``: optional predicate; when it returns False the resource closes
+      itself and leaves the sidebar. Else call ``.close()`` on the returned handle.
+
+    Viewing it as a native overlay window (macOS): besides the web dashboard, the
+    ``ix-windows`` consumer renders each live resource as its own floating, blurred,
+    auto-sizing overlay window. Run it alongside your session::
+
+        nix run .#ix-windows
+
+    Windows open/close/refresh automatically as resources appear, update, and
+    close. Move one by dragging its card chrome (the padding around the content);
+    it is not resizable (size follows the content).
+
+    Write SELF-CONTAINED HTML. The body is rendered inside a sandboxed,
+    opaque-origin ``<iframe>`` (``sandbox="allow-scripts"``, no
+    ``allow-same-origin``) with no page origin, in both the dashboard and the
+    overlay. So inline all CSS, JS, and data: external CDN scripts/styles,
+    same-origin ``fetch``, cookies, and storage are blocked. Pre-render anything
+    needing a library and embed the result -- e.g. render a mermaid diagram to SVG
+    server-side (``kroki.io``, the ``mermaid`` CLI, ...) and put the static
+    ``<svg>`` in the HTML; loading ``mermaid.js`` from a CDN silently fails.
+
+    Returns the :class:`Resource` handle (call ``.close()`` to remove it).
     """
     if render is None:
         if source is None:

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -821,14 +821,17 @@ def register_resource(
     close. Move one by dragging its card chrome (the padding around the content);
     it is not resizable (size follows the content).
 
-    Write SELF-CONTAINED HTML. The body is rendered inside a sandboxed,
+    Prefer SELF-CONTAINED HTML. The body is rendered inside a sandboxed,
     opaque-origin ``<iframe>`` (``sandbox="allow-scripts"``, no
-    ``allow-same-origin``) with no page origin, in both the dashboard and the
-    overlay. So inline all CSS, JS, and data: external CDN scripts/styles,
-    same-origin ``fetch``, cookies, and storage are blocked. Pre-render anything
-    needing a library and embed the result -- e.g. render a mermaid diagram to SVG
-    server-side (``kroki.io``, the ``mermaid`` CLI, ...) and put the static
-    ``<svg>`` in the HTML; loading ``mermaid.js`` from a CDN silently fails.
+    ``allow-same-origin``) in both the dashboard and the overlay, so same-origin
+    ``fetch``, cookies, and storage are unavailable. Absolute HTTPS scripts/styles
+    may still load (subject to the browser and the remote server / CORS), but they
+    are a live network dependency, not an isolated pane -- and an ES-module
+    ``import`` from a CDN was observed to fail under the opaque origin. For
+    reproducible, offline panes, pre-render anything needing a library and embed
+    the static output -- e.g. render a mermaid diagram to SVG server-side
+    (``kroki.io``, the ``mermaid`` CLI, ...) and put the static ``<svg>`` in the
+    HTML.
 
     Returns the :class:`Resource` handle (call ``.close()`` to remove it).
     """


### PR DESCRIPTION
## What

Expand the `register_resource` docstring (surfaced via `api()` / `help()`) to cover how to use it properly:

- **Stable `id`** replaces in place (a loop updating one view) vs. a random id spawning a new pane each call.
- **Live vs. static** — `render` is re-invoked on refresh (contrast with `cells`).
- **`alive` predicate** auto-closes the resource.
- **Viewing as a native overlay** — `nix run .#ix-windows` renders each live resource as a floating, blurred, auto-sizing window (drag by the chrome, not resizable).
- **Self-contained HTML rule** — the body runs in a sandboxed, opaque-origin iframe (`allow-scripts`, no `allow-same-origin`) in both the dashboard and the overlay, so inline all CSS/JS/data; pre-render anything needing a library (e.g. mermaid -> SVG via kroki/CLI), since CDN scripts silently fail.

Docstring-only; parses clean, lines ≤88.

🤖 Authored with Claude Code (Opus).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `register_resource` usage with overlay, iframe, and self-contained HTML guidance
> Expands the docstring for `register_resource` in [runtime.py](https://github.com/indexable-inc/index/pull/1335/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) with structured documentation covering argument behaviors, stable ID guidance, auto-closing semantics, overlay window rendering via ix-windows, iframe sandboxing and origin constraints, and a recommendation to prefer self-contained HTML for external asset compatibility. No executable code changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a4e94f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->