### PR TITLE
docs(iphone): document cable-free Wi-Fi control

### DIFF
--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -134,11 +134,12 @@ MODULES: tuple[Module, ...] = (
     ),
     Module(
         "iphone",
-        "drive a USB-connected iPhone/iPad via pymobiledevice3: list devices/apps into polars "
-        "(`iphone.devices()` / `apps()`), `screenshot()` a developer-mounted device to a PIL "
+        "drive a physical iPhone/iPad (USB or Wi-Fi) via pymobiledevice3: list devices/apps into "
+        "polars (`iphone.devices()` / `apps()`), `screenshot()` a developer-mounted device to a PIL "
         "image, `tap`/`swipe`/`launch`, and mount the Developer Disk Image. Developer commands "
-        "need a root `tunneld` daemon — start it explicitly with `iphone.start_tunneld(sudo=True)` "
-        "— plus a USB device with Developer Mode on",
+        "need a root `tunneld` daemon (start it explicitly with `iphone.start_tunneld(sudo=True)`) "
+        "plus a device with Developer Mode on; works cable-free once the device is paired and "
+        "network-enabled (see the iphone-control skill)",
     ),
     Module(
         "tasks",

--- a/skills/iphone-control/SKILL.md
+++ b/skills/iphone-control/SKILL.md
@@ -84,14 +84,17 @@ resolve. Verify with `await iphone.devices()` (the row's `ConnectionType` reads
 
 What is solid vs fragile wirelessly:
 
-- **Solid**: inventory (`devices`/`info`/`apps`), and all WDA UI control
-  (`source`, `tap`, `type_text`, the WDA screenshot) — these ride lockdown and
-  the WDA HTTP forward.
-- **Fragile**: the DVT developer services (`launch`, the DVT `screenshot`,
-  `simulate_location`, DDI mount) need the RemoteXPC tunnel, and `tunneld` over
-  Wi-Fi is less reliable than over USB on iOS 17+. If a DVT call hangs or fails
-  wirelessly, re-tether for that step. WDA-based automation (the common case) is
-  unaffected.
+- **Solid**: inventory (`devices`/`info`/`apps`), plus WDA UI control (`source`,
+  `tap`, `type_text`, the WDA screenshot) **once WDA is already running** and the
+  usbmux forward is established. These ride lockdown and the WDA HTTP forward.
+- **Fragile**: any call that starts or uses DVT developer services needs the
+  RemoteXPC tunnel, and `tunneld` over Wi-Fi is less reliable than over USB on
+  iOS 17+. That includes `wda_start` itself: it launches the XCUITest runner via
+  `developer dvt xcuitest` before opening the forward, so the WDA *startup* rides
+  the fragile path even though the taps that follow do not. Also `launch`, the
+  DVT `screenshot`, `simulate_location`, and the DDI mount. If one of these hangs
+  or fails wirelessly, re-tether for that step (notably the one-time
+  `wda_build_install` and each `wda_start`), then run the taps over Wi-Fi.
 
 **iPhone Mirroring is not a substitute**: it is a consumer feature with no API
 or CLI, room-range only (Bluetooth + same Apple ID, phone locked). Automating it

--- a/skills/iphone-control/SKILL.md
+++ b/skills/iphone-control/SKILL.md
@@ -77,10 +77,12 @@ nothing):
 3. The usual one-time gates below (Developer Mode, Apple ID in Xcode,
    `wda_build_install()`).
 
-Then unplug. On the same LAN the device stays reachable; for off-LAN, put the
-Mac and the iPhone on the same Tailscale network so the usbmux/tunnel hops
-resolve. Verify with `await iphone.devices()` (the row's `ConnectionType` reads
-`Network`) and proceed exactly as over USB.
+Then unplug. On the same LAN the device stays reachable. Verify with
+`await iphone.devices()` (the row's `ConnectionType` reads `Network`) and proceed
+exactly as over USB. Off-LAN does **not** work as-is: macOS `usbmuxd` discovers
+network devices via Bonjour/mDNS on the local segment, which an L3 overlay like
+Tailscale does not satisfy, and the helper only targets a UDID that
+`usbmux list` already shows. Keep the Mac and device on the same LAN.
 
 What is solid vs fragile wirelessly:
 

--- a/skills/iphone-control/SKILL.md
+++ b/skills/iphone-control/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: iphone-control
-description: "Drive a USB-connected iPhone/iPad from the kernel iphone helper: screenshots, app launch, GPS, and real taps/typing via WebDriverAgent. Use when controlling a physical iOS device, automating an app, requesting a ride, or filling a form on a real iPhone. Covers the one-time human gates and the WDA gotchas."
+description: "Drive a physical iPhone/iPad (over USB cable or Wi-Fi) from the kernel iphone helper: screenshots, app launch, GPS, and real taps/typing via WebDriverAgent. Use when controlling a physical iOS device, automating an app, requesting a ride, or filling a form on a real iPhone, including cable-free over the network. Covers the one-time human gates, going wireless, and the WDA gotchas."
 ---
 
 ## iPhone control
 
-The kernel `iphone` helper (pymobiledevice3 9.27.0) drives a USB-connected
-device. Start every task with `await iphone.doctor()` — it names exactly which
-prerequisite is missing instead of a multi-step debug.
+The kernel `iphone` helper (pymobiledevice3 9.27.0) drives a physical device
+over USB **or** Wi-Fi. Start every task with `await iphone.doctor()` — it names
+exactly which prerequisite is missing instead of a multi-step debug.
 
 ### What works without WebDriverAgent
 
@@ -57,6 +57,46 @@ After both, `await iphone.wda_build_install()` builds+signs+installs WDA once
   uses W3C actions over a forwarded `:8100`.
 - **Coordinates are points**, not screenshot pixels (≈ pixels / device scale).
   `source()` rects are already in points; tap their centers.
+
+### Wireless (no cable)
+
+The helper is transport-agnostic: every call goes through `pymobiledevice3
+usbmux ...` and the `tunneld` daemon, both of which macOS serves over USB **and**
+Wi-Fi. `devices()` lists a network-connected device the same as a USB one (it
+even dedupes a device that shows up on both, see the `_one_device` comment). The
+WDA forward's local end is always `127.0.0.1:8100`; usbmux routes it to the
+device whether that hop is USB or Wi-Fi. So no code path is cable-specific.
+
+What you must do **once over the cable** to bootstrap (wireless cannot pair from
+nothing):
+
+1. Plug in and **Trust** the device (the pairing record persists on the Mac).
+2. Enable **Connect via network**: Xcode > Window > Devices & Simulators >
+   select the device > check "Connect via network". This is what makes macOS
+   `usbmuxd` advertise the device over the LAN.
+3. The usual one-time gates below (Developer Mode, Apple ID in Xcode,
+   `wda_build_install()`).
+
+Then unplug. On the same LAN the device stays reachable; for off-LAN, put the
+Mac and the iPhone on the same Tailscale network so the usbmux/tunnel hops
+resolve. Verify with `await iphone.devices()` (the row's `ConnectionType` reads
+`Network`) and proceed exactly as over USB.
+
+What is solid vs fragile wirelessly:
+
+- **Solid**: inventory (`devices`/`info`/`apps`), and all WDA UI control
+  (`source`, `tap`, `type_text`, the WDA screenshot) — these ride lockdown and
+  the WDA HTTP forward.
+- **Fragile**: the DVT developer services (`launch`, the DVT `screenshot`,
+  `simulate_location`, DDI mount) need the RemoteXPC tunnel, and `tunneld` over
+  Wi-Fi is less reliable than over USB on iOS 17+. If a DVT call hangs or fails
+  wirelessly, re-tether for that step. WDA-based automation (the common case) is
+  unaffected.
+
+**iPhone Mirroring is not a substitute**: it is a consumer feature with no API
+or CLI, room-range only (Bluetooth + same Apple ID, phone locked). Automating it
+would mean screen-scraping the Mac mirror window and posting synthetic events,
+which is far more brittle than the WDA path above. Use Wi-Fi WDA, not Mirroring.
 
 ### Safety
 


### PR DESCRIPTION
## What

Document that the kernel `iphone` helper already works **cable-free over Wi-Fi**, no code change needed.

The helper routes every call through `pymobiledevice3 usbmux ...` and the `tunneld` daemon, both of which macOS serves over USB *and* Wi-Fi. `devices()` already lists/dedupes a network-connected device, and the WDA forward's local end is always `127.0.0.1:8100` regardless of transport. So nothing in the code is USB-specific; the only gap was docs.

## Changes

- `skills/iphone-control/SKILL.md`: new **Wireless (no cable)** section (one-time USB bootstrap: Trust + "Connect via network"; solid vs fragile wirelessly; why iPhone Mirroring is not a scriptable substitute). Description + intro de-USB-only'd.
- `packages/mcp/ix_notebook_mcp/registry.py`: `iphone` one-liner now says "USB or Wi-Fi".

## Solid vs fragile wireless

- Solid: `devices`/`info`/`apps` + all WDA UI control (`source`/`tap`/`type_text`/WDA screenshot).
- Fragile: DVT services (`launch`, DVT `screenshot`, `simulate_location`, DDI mount) need the RemoteXPC tunnel; `tunneld`-over-Wi-Fi is shaky on iOS 17+.

Docs-only (plus one string literal). `registry.py` compiles; markdown validated.

🤖 Drafted by Claude (Opus 4.x) via Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document Wi-Fi (cable-free) control in the iphone-control skill
> - Updates [SKILL.md](https://github.com/indexable-inc/index/pull/1336/files#diff-a7efcbec8ea15bc3183d473ed302fb9c89c4819b3c8101007d3f77dd0a033553) with a new 'Wireless (no cable)' section covering pairing/bootstrap steps, network prerequisites, and notes on what works reliably vs. what is fragile over Wi-Fi.
> - Updates the `iphone` module description in [registry.py](https://github.com/indexable-inc/index/pull/1336/files#diff-92f567578e1217b8207dbbd21af1cdee4978728a8ca9e774cd65ed17170d2ae5) to reflect USB or Wi-Fi operation and mention cable-free use once paired/network-enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61d991d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->