### PR TITLE
ix-windows: correct sandbox docs (opaque origin, not a network block)

### DIFF
--- a/docs/ix-windows/overview.md
+++ b/docs/ix-windows/overview.md
@@ -136,10 +136,11 @@ Public surface:
   (`#ix-frame`) whose `srcdoc` is the resource body wrapped by `inner_document`.
   The producer HTML therefore runs in an opaque origin with no access to the
   trusted document, `window.ipc`, cookies, or storage -- the same trust model as
-  the web dashboard's html pane. Because that origin is opaque and the document
-  has no page URL, the body must be self-contained: external CDN scripts/styles
-  and same-origin `fetch` are blocked, so anything needing a library is
-  pre-rendered (e.g. mermaid -> SVG) and embedded.
+  the web dashboard's html pane. The opaque origin removes same-origin `fetch`,
+  cookies, and storage (it is not a network block: absolute HTTPS subresources may
+  still load subject to CORS, though an ES-module `import` from a CDN was observed
+  to fail). For a reproducible offline pane the body should be self-contained, so
+  anything needing a library is pre-rendered (e.g. mermaid -> SVG) and embedded.
 - **Auto-size to content.** `INNER_JS` (inside the iframe) runs a `ResizeObserver`
   on `#ix-content` and `postMessage`s the measured size out; `OUTER_JS` (the
   trusted document) validates that message, sizes the iframe, then posts the

--- a/packages/ix-windows/README.md
+++ b/packages/ix-windows/README.md
@@ -35,16 +35,18 @@ tiling, no layout manager.
   window is not user-resizable -- its size is owned by the content (auto-fit), so a
   manual resize would just fight the next content report.
 
-## Self-contained HTML only
+## Prefer self-contained HTML
 
 A resource's HTML is rendered inside a sandboxed, opaque-origin `<iframe>`
 (`sandbox="allow-scripts"`, no `allow-same-origin`) loaded with no page origin, so
-it must be **self-contained**: inline all CSS and JS and data. External CDN
-scripts/styles, same-origin `fetch`, cookies, and storage are blocked by the
-sandbox. Pre-render anything that needs a library and embed the result -- e.g.
-render a mermaid diagram to SVG server-side (`kroki.io`, the `mermaid` CLI, ...)
-and put the static `<svg>` in the HTML, rather than loading `mermaid.js` from a
-CDN (which silently fails).
+same-origin `fetch`, cookies, and storage are unavailable. Absolute HTTPS
+scripts/styles may still load (subject to the browser and the remote server /
+CORS), but they are a live network dependency, not an isolated pane -- and an
+ES-module `import` from a CDN was observed to fail under the opaque origin. For a
+reproducible, offline overlay, **inline** your CSS/JS/data and pre-render anything
+that needs a library: e.g. render a mermaid diagram to SVG server-side
+(`kroki.io`, the `mermaid` CLI, ...) and embed the static `<svg>`, rather than
+loading `mermaid.js` from a CDN.
 
 ## macOS
 


### PR DESCRIPTION
## What

Follow-up to #1334: correct the `ix-windows` sandbox docs. The merged wording overstated the sandbox as a network block ("external CDN scripts/styles ... are blocked", mermaid "silently fails").

`sandbox="allow-scripts"` (no `allow-same-origin`) creates an **opaque origin** — that removes same-origin `fetch`, cookies, and storage, but it is *not* a CSP/network block: absolute HTTPS subresources can still load subject to CORS. What I actually observed failing was an **ES-module `import` from a CDN** under the opaque origin. Docs now say exactly that, and keep the real guidance: for a reproducible offline pane, inline assets and pre-render libraries (mermaid → SVG).

Matches the same correction made to the `register_resource` docstring in #1335 (flagged by the AI reviewer there).

🤖 Authored with Claude Code (Opus).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct sandbox docs to clarify opaque-origin behavior in ix-windows
> Updates [overview.md](https://github.com/indexable-inc/index/pull/1337/files#diff-6a6c7e7ce882c6a54912fdeba62a9754628175fe1f742bf3b2dbdb53fe43c074) and [README.md](https://github.com/indexable-inc/index/pull/1337/files#diff-680f682a35151c7a9c748c060d78bc64c2e0efdb94530083a835de730a0fac08) to fix a mis-description of the sandboxed shell: the restriction is opaque-origin (not a network block), meaning same-origin fetch, cookies, and storage are unavailable, but absolute HTTPS subresources may still load subject to CORS. ES-module imports from a CDN may fail. The recommendation is updated from "self-contained HTML only" to "prefer self-contained HTML" with pre-rendered assets (e.g., mermaid rendered to SVG) for reliable offline panes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85c69a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->