### PR TITLE
dashboard: square the board window tiles

### DIFF
--- a/packages/dashboard/dashboard-core/site/src/components/Board.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/Board.svelte
@@ -196,7 +196,6 @@
     flex-direction: column;
     background: var(--panel);
     border: 1px solid var(--edge);
-    border-radius: 9px;
     overflow: hidden;
     transition: border-color 0.12s ease;
   }


### PR DESCRIPTION
## What

Square the dashboard board's window tiles -- drop the `border-radius: 9px` on `.tile` in `Board.svelte`.

## Why

`.tile` had `border-radius: 9px` together with `overflow: hidden`, so the tile head's bottom border and the body content clipped at the rounded corners, showing a visible cut-off at the window's top edges. The focus-pane and feed cards were already square, so this just makes the board windows consistent and removes the clipping.

_Authored by Claude (Sonnet) via Claude Code._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove border-radius from board window tiles in the dashboard
> Removes the `border-radius` CSS property from the board tile container in [Board.svelte](https://github.com/indexable-inc/index/pull/1338/files#diff-3182b34b69c7502c6284a028b75e16079afc9301caf7b7fd5f9cefd39a5b5047), making tiles render with square corners.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ede88f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->