### PR TITLE
ix-windows: kill sub-pixel scrollbars (measure via getBoundingClientRect+ceil)

### DIFF
--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -642,8 +642,16 @@ const OUTER_JS: &str = "\
     frame.style.width = Math.max(w, 1) + 'px';
     frame.style.height = Math.max(h, 1) + 'px';
     requestAnimationFrame(function () {
-      var rw = Math.ceil(root.offsetWidth);
-      var rh = Math.ceil(root.offsetHeight);
+      // Measure with getBoundingClientRect (sub-pixel) and round UP, not
+      // offsetWidth/Height (which round to the nearest integer, usually down): a
+      // rounded-down report makes the OS window a fraction smaller than the card,
+      // so the content overflows by < 1px and a scrollbar appears (and that
+      // scrollbar then nudges the other axis into overflowing too). Ceiling the
+      // true fractional size guarantees the window is >= the content, so neither
+      // axis scrolls.
+      var rect = root.getBoundingClientRect();
+      var rw = Math.ceil(rect.width);
+      var rh = Math.ceil(rect.height);
       ipc(rw + 'x' + rh);
     });
   });
@@ -685,8 +693,13 @@ const INNER_JS: &str = "\
   var lastW = -1, lastH = -1, pending = false;
   function report() {
     pending = false;
-    var w = Math.ceil(root.offsetWidth);
-    var h = Math.ceil(root.offsetHeight);
+    // getBoundingClientRect + ceil (not offsetWidth/Height, which round to the
+    // nearest integer and can land a pixel under the true fractional content
+    // width): rounding up guarantees the iframe the outer doc sizes to this is
+    // >= the content, so the producer pane never shows a sub-pixel scrollbar.
+    var rect = root.getBoundingClientRect();
+    var w = Math.ceil(rect.width);
+    var h = Math.ceil(rect.height);
     if (w === lastW && h === lastH) return;
     lastW = w; lastH = h;
     parent.postMessage({ t: 'ixsize', w: w, h: h }, '*');


### PR DESCRIPTION
## What

Overlay windows showed a tiny ("epsilon") horizontal *and* vertical scrollbar on many resources.

**Cause:** the auto-size measured the card/content with `offsetWidth`/`offsetHeight`, which round to the **nearest integer** (often down). A rounded-down report makes the OS window a fraction smaller than the content, so it overflows by <1px and a scrollbar appears, and that scrollbar then nudges the perpendicular axis into overflowing too.

**Fix:** measure with `getBoundingClientRect()` (sub-pixel) and `Math.ceil`, at both measure points (the inner `#ix-content` report and the outer card report). Rounding the true fractional size *up* guarantees the window is >= the content, so neither axis scrolls.

`nix build .#ix-windows` green.

🤖 Authored with Claude Code (Opus).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sub-pixel scrollbars in ix-windows by measuring size with `getBoundingClientRect` and `Math.ceil`
> Replaces `offsetWidth`/`offsetHeight` measurements with `getBoundingClientRect().width/height` followed by `Math.ceil` in both the outer document script and the sandboxed iframe's `report()` function in [lib.rs](https://github.com/indexable-inc/index/pull/1342/files#diff-1e1abdcf7151daee9cdb984d29eca28bda3ded2eaa1b78937674b8156ef55a43). Rounding up ensures reported dimensions are never smaller than the actual content, preventing sub-pixel overflow from producing unwanted scrollbars.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 137fd72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->