### PR TITLE
site: fix flaky site-case-tests (pre-bundle @xyflow/svelte in vitest)

### DIFF
--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -18,6 +18,16 @@ export default defineConfig({
       $lib: fileURLToPath(new URL('./src/lib', import.meta.url))
     }
   },
+  // Pre-bundle @xyflow/svelte so Vitest's browser dep optimizer does not
+  // discover it mid-run, re-optimize, and reload the page. That reload is the
+  // "[vitest] Vite unexpectedly reloaded a test" flake: updates.test.ts (and
+  // others) transitively import the diagram components that use @xyflow/svelte,
+  // so the first test that touches one triggers a re-optimize+reload and the
+  // suite is reported as "0 passed", failing CI. Listing it here forces it into
+  // the initial optimize pass. See the Vite warning's own remediation.
+  optimizeDeps: {
+    include: ['@xyflow/svelte']
+  },
   plugins: [
     svelte({
       extensions: ['.svelte', '.svx'],


### PR DESCRIPTION
## What

`site-case-tests` flakes intermittently with `[vitest] Vite unexpectedly reloaded a test ... new dependencies optimized: @xyflow/svelte`, reporting the suite as `0 passed` and failing `flake-check` (hit twice today, e.g. PR #1342's first run).

**Cause:** several `src/lib/diagrams/*.svelte` components import `@xyflow/svelte`, and `updates.test.ts` (and others) transitively load them. In Vitest browser mode, Vite's dep optimizer discovers `@xyflow/svelte` *mid-run*, re-optimizes, and reloads the page, which corrupts the in-flight test run.

**Fix:** add `@xyflow/svelte` to `optimizeDeps.include` in `site/vitest.config.ts` so it's pre-bundled in the initial optimize pass and never triggers a mid-run reload. This is exactly the remediation the Vite warning itself prints.

## Validation

Config-only; can't reproduce the browser/playwright flake on darwin (no x86_64-linux builder), so CI's `site-case-tests` is the verification. The change is the documented Vite fix and low-risk.

🤖 Authored with Claude Code (Opus).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pre-bundle `@xyflow/svelte` in Vitest to fix flaky site case tests
> Adds `optimizeDeps.include: ['@xyflow/svelte']` to [vitest.config.ts](https://github.com/indexable-inc/index/pull/1343/files#diff-7e7ec3d9ddeb2ceb7e73d53df0243b8f987728973447ad54ef78453838726938) so Vitest pre-bundles the dependency upfront rather than discovering it mid-run, which caused page reloads and flaky test failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b421ba6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->