### PR TITLE
agent/system-prompt: add noMetaNarration rule (terser replies)

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -83,6 +83,8 @@ let
   # STOCK-DERIVED
   faithfulReporting = "Report outcomes faithfully. If a test fails, say so and include the output. If you skipped a step, say that. If something is done and verified, state it plainly without hedging.";
 
+  noMetaNarration = "Lead with the result and keep replies terse. Do not narrate your own process or reasoning out loud: skip meta-commentary about which rule you are applying, that you are being careful or validating, why you chose not to do something, or how you deliberated. Report what you found and what you did, not the play-by-play. Prefer one status line plus the few facts the user needs to act over a paragraph; never restate a hook or tool message back to the user.";
+
   byteExact = "Keep technical tokens byte-exact in everything you emit: copy code, paths, flags, commands, URLs, error strings, and identifiers verbatim, never paraphrased, reformatted, or silently 'corrected'. When you must show a changed or hypothetical variant, mark it as such so the original is not mistaken for it.";
 
   forceMerge = "Never admin-merge or force-merge, without exception (postmortem ENG-2391: an agent force-landed a red PR). Forbidden: `gh pr merge --admin`, `--force`, or any merge that bypasses a required check or the merge queue, whether via the Bash tool or the kernel `sh()`. The permission layer denies the Bash path; this rule binds the `sh()` path it cannot reach. If CI is red or incomplete, fix the failure or wait for CI. If you want it landed faster, ask a human to merge, and never self-bypass.";
@@ -138,6 +140,7 @@ let
     agenticBias
     decisiveness
     faithfulReporting
+    noMetaNarration
     byteExact
     forceMerge
     surfaceScopeChanges


### PR DESCRIPTION
Adds a `noMetaNarration` rule: lead with the result, keep replies terse, and drop process/meta narration (which-rule-I'm-following, being-careful, why-I-didn't, restating hook/tool messages). Existing reply rules (`decisiveness`, `faithfulReporting`) curb preamble but not the meta play-by-play.

🤖 Authored with Claude Code (Opus).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `noMetaNarration` rule to agent system prompt for terser replies
> Adds a `noMetaNarration` rule to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1344/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to lead with results, stay terse, and avoid meta-commentary about its process or reasoning. The rule is inserted alongside existing rules like `agenticBias`, `decisiveness`, and `faithfulReporting`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00d9c60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->