### PR TITLE
fix(ci): report cacheStatus=cached for floating-CA outputs so warm rust units skip rebuild

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -199,7 +199,11 @@ let
   # (above nix-eval-jobs' 4 GiB default per worker, below the old 8 GiB), not a
   # workaround: the per-crate check split (see the `checks` block below) keeps
   # each worker's eval bounded by the largest single crate. Pinned by commit to
-  # nix-fast-build 1.5.0.
+  # nix-fast-build 1.5.0, but pointed at the repo-built patched nix-eval-jobs via
+  # --nix-eval-jobs (the eval-step binary, not nix-fast-build itself, is what
+  # decides cacheStatus): without the patch, --skip-cached treats every floating
+  # CA rust unit as uncached and rebuilds ~1434 of them on every warm run. See
+  # the $eval_jobs comment below.
   #
   # Step 2 (nix-eval-jobs) is the schema/eval gate over the package outputs,
   # broader than the `checks` set step 1 built. nix-eval-jobs is the same
@@ -217,14 +221,23 @@ let
   # reports a per-attribute eval failure as a JSON `error` line and still exits 0,
   # so the gate is the error-line check; a startup or lock failure exits nonzero
   # and aborts the run (Nushell propagates external failures like bash
-  # `set -o pipefail`). Pinned by commit to nix-eval-jobs v2.34.1, matching the
-  # host Nix 2.34.x.
+  # `set -o pipefail`). Uses the repo-built patched nix-eval-jobs
+  # (packages/nix/nix-eval-jobs, nixpkgs' v2.34.1 + the CA cacheStatus patch),
+  # matching the host Nix 2.34.x; invoked directly by store path rather than
+  # `nix run`.
   check = ix.writeNushellApplication pkgs {
     name = "check";
     meta.description = "Run the full CI gate: build .#ciChecks.x86_64-linux and eval-validate .#packages.x86_64-linux";
     text = ''
       const fast_build = "github:Mic92/nix-fast-build/7f185e0ec37b65b4730f892e0de9a831b0610f3a"
-      const eval_jobs = "github:nix-community/nix-eval-jobs/65ebf5b7cd453a27af09cf02b1fc57b3568cc4b7"
+      # Patched nix-eval-jobs (packages/nix/nix-eval-jobs): the stock binary
+      # reports `local`/`notBuilt` for floating content-addressed outputs even
+      # when they are in cache.ix.dev, so --skip-cached rebuilt every CA rust
+      # unit (~1434) on every run. The patch resolves the CA output realisation
+      # against the substituters so a warm unit reports `cached` and is skipped.
+      # See nix#12128 / nix-eval-jobs#403. Built for x86_64-linux (the CI gate
+      # system); `check` itself is x86_64-linux-only.
+      const eval_jobs = "${lib.getExe repoPackages.nix-eval-jobs}"
 
       def main [] {
         # ca-derivations: the rust workspace units default to
@@ -255,6 +268,10 @@ let
           try {
             ^nix run $fast_build -- ...[
               "--flake" ".#ciChecks.x86_64-linux"
+              # Drive nix-fast-build's evaluator with the patched nix-eval-jobs
+              # (CA cacheStatus fix) so --skip-cached actually skips warm CA
+              # units rather than rebuilding the lot.
+              "--nix-eval-jobs" $eval_jobs
               "--eval-max-memory-size" "6144"
               "--eval-workers" "16"
               "--skip-cached"
@@ -325,7 +342,7 @@ let
         let tmp = (mktemp --directory --tmpdir "ix-check.XXXXXX")
         let report = ($tmp | path join "flake-schema-eval.jsonl")
         do --capture-errors {
-          ^nix run $eval_jobs -- ...[
+          ^$eval_jobs ...[
             "--flake" ".#packages.x86_64-linux"
             "--workers" "16"
             "--gc-roots-dir" ($tmp | path join "flake-schema-eval-gc")

--- a/packages/nix/nix-eval-jobs/ca-output-cache-status.patch
+++ b/packages/nix/nix-eval-jobs/ca-output-cache-status.patch
@@ -1,0 +1,132 @@
+diff --git a/src/drv.cc b/src/drv.cc
+index 32e9467..ee66d34 100644
+--- a/src/drv.cc
++++ b/src/drv.cc
+@@ -1,3 +1,6 @@
++#include <nix/store/path-info.hh>
++#include <nix/store/realisation.hh>
++#include <nix/store/store-open.hh>
+ #include <nix/store/path-with-outputs.hh>
+ #include <nix/store/store-api.hh>
+ #include <nix/store/local-fs-store.hh>
+@@ -105,6 +108,104 @@ auto queryInputDrvs(const nix::Derivation &drv)
+     return drvs;
+ }
+ 
++// Resolve a content-addressed derivation's output paths and tell whether they
++// are already obtainable, mirroring what `nix build` itself does in
++// nix::Store::queryMissing (libstore/misc.cc).
++//
++// A floating CA derivation has no statically known output path: queryOutputs
++// returns std::nullopt for each output until the build is realised, so the
++// surrounding queryCacheStatus skips the (null) outputs and only feeds the
++// input drvs to queryMissing. That walk never consults the top-level CA
++// output's realisation, so an output that is already cached at a substituter
++// is still reported as `local`/`notBuilt` and re-dispatched every eval (the
++// CA half of the cache-blindness in nix#12128 / nix-eval-jobs#403).
++//
++// Here, for every output with no known path, we ask each substituter for the
++// realisation of DrvOutput{outputHash, outputName} (the resolved-derivation
++// key, exactly as queryMissing does via staticOutputHashes +
++// getDefaultSubstituters). When a realisation is found we fill in the resolved
++// output path so the emitted JSON carries a real `outputs.<name>` instead of
++// null, and record whether the resolved path still needs substituting.
++//
++// Returns:
++//   - std::nullopt : not a CA case to special-case (every output already had a
++//                    known path), or at least one output has no realisation
++//                    anywhere (so the caller must fall through to queryMissing,
++//                    which will classify it as a build).
++//   - Cached       : every output resolved and at least one still needs a
++//                    substitute (i.e. it is in a cache but not local).
++//   - Local        : every output resolved and all are already valid locally.
++auto resolveCaOutputs(
++    nix::Store &store,
++    std::map<std::string, std::optional<nix::StorePath>> &outputs,
++    std::vector<nix::StorePath> &neededSubstitutes, const nix::Derivation &drv)
++    -> std::optional<Drv::CacheStatus> {
++    if (!nix::experimentalFeatureSettings.isEnabled(nix::Xp::CaDerivations)) {
++        return std::nullopt;
++    }
++
++    bool anyUnresolved = false;
++    for (auto const &[outputName, outputPath] : outputs) {
++        if (!outputPath) {
++            anyUnresolved = true;
++            break;
++        }
++    }
++    if (!anyUnresolved) {
++        return std::nullopt;
++    }
++
++    // staticOutputHashes keys each output by the hash of its resolved-input
++    // derivation, which is the DrvOutput a CA realisation is registered under
++    // in the store/substituter (libstore/misc.cc does the same to answer the
++    // floating-CA case in queryMissing).
++    auto outputHashes = nix::staticOutputHashes(store, drv);
++    auto substituters = nix::getDefaultSubstituters();
++
++    bool anyNeedsSubstitute = false;
++    for (auto &[outputName, outputPath] : outputs) {
++        if (outputPath) {
++            continue;
++        }
++        auto hashIt = outputHashes.find(outputName);
++        if (hashIt == outputHashes.end()) {
++            return std::nullopt;
++        }
++        nix::DrvOutput const id{hashIt->second, outputName};
++
++        std::shared_ptr<const nix::UnkeyedRealisation> realisation =
++            store.queryRealisation(id);
++        if (!realisation) {
++            for (auto &sub : substituters) {
++                realisation = sub->queryRealisation(id);
++                if (realisation) {
++                    break;
++                }
++            }
++        }
++        if (!realisation) {
++            // No realisation anywhere: this output must be built. Let the
++            // caller's queryMissing populate the per-input neededBuilds.
++            return std::nullopt;
++        }
++
++        outputPath = realisation->outPath;
++        if (!store.isValidPath(realisation->outPath)) {
++            neededSubstitutes.push_back(realisation->outPath);
++            anyNeedsSubstitute = true;
++        }
++    }
++
++    std::ranges::sort(
++        neededSubstitutes,
++        [](const nix::StorePath &lhs, const nix::StorePath &rhs) -> bool {
++            return lhs.name() != rhs.name() ? lhs.name() < rhs.name()
++                                            : lhs.to_string() < rhs.to_string();
++        });
++    return anyNeedsSubstitute ? Drv::CacheStatus::Cached
++                              : Drv::CacheStatus::Local;
++}
++
+ auto queryCacheStatus(
+     nix::Store &store,
+     std::map<std::string, std::optional<nix::StorePath>> &outputs,
+@@ -113,6 +214,15 @@ auto queryCacheStatus(
+     std::vector<nix::StorePath> &unknownPaths, const nix::Derivation &drv)
+     -> Drv::CacheStatus {
+ 
++    // Floating CA outputs have no static path; resolve them against the
++    // substituters first so a cached output is not misreported as notBuilt.
++    // Falls through to queryMissing when an output cannot be resolved (it must
++    // be built) so the per-input neededBuilds breakdown still populates.
++    if (auto caStatus =
++            resolveCaOutputs(store, outputs, neededSubstitutes, drv)) {
++        return *caStatus;
++    }
++
+     std::vector<nix::StorePathWithOutputs> paths;
+     // Add output paths
+     for (auto const &[key, val] : outputs) {

--- a/packages/nix/nix-eval-jobs/default.nix
+++ b/packages/nix/nix-eval-jobs/default.nix
@@ -1,0 +1,64 @@
+{
+  pkgs,
+}:
+let
+  # nix-eval-jobs reports `cacheStatus` per attribute; nix-fast-build's
+  # --skip-cached keys off it. For a floating content-addressed derivation
+  # (the rust workspace units default to `contentAddressed = true`, see
+  # lib/rust/cargo-unit.nix) the output path is not statically known at eval
+  # time, so the stock queryCacheStatus skips the (null) output and only walks
+  # the input drvs through queryMissing. That walk never consults the top-level
+  # CA output's realisation, so an output already present in cache.ix.dev is
+  # still reported `local`/`notBuilt` and nix-fast-build rebuilds every CA unit
+  # on every CI run (~1434 of them), even on a fully warm cache.
+  #
+  # The patch resolves each unknown CA output's realisation against the
+  # configured substituters (DrvOutput{staticOutputHash, outputName}) before
+  # falling back to queryMissing, exactly as nix::Store::queryMissing itself
+  # does for the floating-CA case (libstore/misc.cc). A resolved-and-cached
+  # output then reports `cached` (with a real `outputs.<name>`), so --skip-cached
+  # skips it. When an output has no realisation anywhere the helper bails to the
+  # original queryMissing path, preserving the per-input neededBuilds breakdown
+  # for genuinely-unbuilt drvs.
+  #
+  # Upstream: https://github.com/NixOS/nix/issues/12128
+  #           https://github.com/nix-community/nix-eval-jobs/issues/403
+  package = pkgs.nix-eval-jobs.overrideAttrs (old: {
+    patches = (old.patches or [ ]) ++ [ ./ca-output-cache-status.patch ];
+  });
+
+  # The override's real risk is the C++ rebuild against nix's libstore linking
+  # and the new symbols (staticOutputHashes, getDefaultSubstituters,
+  # Store::queryRealisation) resolving at all, so the smoke test runs the
+  # binary. `--help` exits 0 and prints usage without touching a store or
+  # daemon (absent in the sandbox).
+  smoke =
+    pkgs.runCommand "nix-eval-jobs-smoke"
+      {
+        nativeBuildInputs = [ package ];
+        strictDeps = true;
+      }
+      ''
+        help=$(nix-eval-jobs --help 2>&1) || true
+        case "$help" in
+          *"--check-cache-status"*) ;;
+          *)
+            echo "nix-eval-jobs --help did not print usage" >&2
+            printf '%s\n' "$help" >&2
+            exit 1
+            ;;
+        esac
+        mkdir -p "$out"
+      '';
+in
+package.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests = (old.passthru.tests or { }) // {
+      inherit smoke;
+    };
+  };
+  meta = (old.meta or { }) // {
+    description = "nix-eval-jobs patched to report cacheStatus for floating content-addressed outputs (nix#12128 / nix-eval-jobs#403)";
+    mainProgram = "nix-eval-jobs";
+  };
+})

--- a/packages/nix/nix-eval-jobs/package.nix
+++ b/packages/nix/nix-eval-jobs/package.nix
@@ -1,17 +1,16 @@
 {
   id = "nix-eval-jobs";
-  # Surfaced as `pkgs.nix-eval-jobs` (overlay) and the `nix-eval-jobs` flake
-  # output so the `check` app can hand its store path to nix-fast-build via
-  # --nix-eval-jobs. x86_64-linux only: it is the CI build/eval system, and the
-  # override is a heavy nix-against-libstore C++ rebuild not worth doing on
-  # systems that never run the gate.
+  # Surfaced in the repo package set (`repoPackages.nix-eval-jobs`, which the
+  # `check` app hands to nix-fast-build via --nix-eval-jobs) and as the
+  # `nix-eval-jobs` flake output. Deliberately NOT in the nixpkgs overlay: the
+  # override reads `pkgs.nix-eval-jobs` as its base, so injecting this package
+  # under the same name would make it its own base (infinite recursion).
+  # x86_64-linux only: it is the CI build/eval system, and the override is a
+  # heavy nix-against-libstore C++ rebuild not worth doing elsewhere.
   packageSet = {
     systems = [ "x86_64-linux" ];
   };
   flake = {
-    systems = [ "x86_64-linux" ];
-  };
-  overlay = {
     systems = [ "x86_64-linux" ];
   };
   passthruTests = true;

--- a/packages/nix/nix-eval-jobs/package.nix
+++ b/packages/nix/nix-eval-jobs/package.nix
@@ -1,0 +1,18 @@
+{
+  id = "nix-eval-jobs";
+  # Surfaced as `pkgs.nix-eval-jobs` (overlay) and the `nix-eval-jobs` flake
+  # output so the `check` app can hand its store path to nix-fast-build via
+  # --nix-eval-jobs. x86_64-linux only: it is the CI build/eval system, and the
+  # override is a heavy nix-against-libstore C++ rebuild not worth doing on
+  # systems that never run the gate.
+  packageSet = {
+    systems = [ "x86_64-linux" ];
+  };
+  flake = {
+    systems = [ "x86_64-linux" ];
+  };
+  overlay = {
+    systems = [ "x86_64-linux" ];
+  };
+  passthruTests = true;
+}


### PR DESCRIPTION
## Problem

The rust workspace units default to `contentAddressed = true` (`lib/rust/cargo-unit.nix`), so `.#ciChecks.x86_64-linux` resolves floating content-addressed (CA) derivations. CI step 1 is `nix run .#check`, which runs `nix-fast-build --skip-cached`. nix-fast-build only skips a job when nix-eval-jobs reports `cacheStatus == "cached"`.

For a floating-CA derivation, nix-eval-jobs cannot resolve the output path at eval time, so it returns `outputs.out: null` and `cacheStatus: "local"` (never `"cached"`). nix-fast-build builds `local` and `notBuilt` jobs and only skips `cached` ones, so every CA rust unit (~1434) is dispatched on every run even when its output is already in `cache.ix.dev`.

Upstream: NixOS/nix#12128, nix-community/nix-eval-jobs#403. The merged upstream fix (nix-eval-jobs#414) only addresses the FOD-with-uncached-input case; it explicitly bails (`return std::nullopt`) when an output path is null, which is exactly the floating-CA case, so it does not fix this.

## Fix

Patch nix-eval-jobs' `queryCacheStatus` (`packages/nix/nix-eval-jobs/ca-output-cache-status.patch`): before the existing `queryMissing` walk, resolve each unknown CA output's realisation against the configured substituters via `DrvOutput{staticOutputHash, outputName}` + `getDefaultSubstituters()->queryRealisation`, mirroring `nix::Store::queryMissing`'s own floating-CA path (`libstore/misc.cc`). A resolved-and-cached output then reports `cached` with a real `outputs.<name>`, so `--skip-cached` skips it. When an output has no realisation anywhere the helper bails to the original `queryMissing` path, preserving the per-input `neededBuilds` breakdown for genuinely-unbuilt drvs.

The patched binary is a repo package (`packages/nix/nix-eval-jobs/`, nixpkgs' v2.34.1 base — matching the host Nix 2.34.7 — plus the patch and a smoke test). The `check` app (`lib/per-system.nix`) now drives nix-fast-build with `--nix-eval-jobs <patched>` for step 1 and invokes the patched binary directly for step 2. `contentAddressed = true` is kept (the point is to fix cache visibility, not abandon CA).

## Validation (x86_64-linux, vin-compute-1, the CI runner)

- Patched nix-eval-jobs builds and links against libstore 2.34.7; smoke check (`rust-nix-eval-jobs-smoke`) passes; `nix build .#check` builds with the patched store path baked into the script.
- **Decisive cache-only test** (a floating-CA output present only in a `file://` substituter, not local), same inputs to both binaries:

  | | cacheStatus | outputs.out | nix-fast-build |
  |---|---|---|---|
  | stock v2.34.1 | `local` | `null` | rebuilds |
  | patched | `cached` | `/nix/store/…` (resolved) | **skips + substitutes** |

- On a fully warm store the patched binary also fills `outputs.out` for every CA leaf (stock left them `null`), and `nix-fast-build --nix-eval-jobs <patched> --skip-cached` runs end-to-end with no regression.

The before/after skip win lands on a fresh/GC'd runner where units are cached remotely but absent locally: stock dispatched all of them, patched skips every cached one.

---
AI-authored with Claude Opus 4.8.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `queryCacheStatus` in `nix-eval-jobs` to report `cached` for floating content-addressed outputs
> - Adds a patched `nix-eval-jobs` build in [packages/nix/nix-eval-jobs/](https://github.com/indexable-inc/index/pull/1346/files#diff-b97d7b3e7adadc53f5662b20b897f4e202e8dcae73bd13e6ea942ad8578ceb25) that introduces a `resolveCaOutputs` helper in `drv.cc`: when CA derivations are enabled and output paths are unknown, it queries the local store and substituters for each `DrvOutput` realisation and returns `Cached` or `Local` accordingly, rather than falling through to `queryMissing` which reported them as `notBuilt`.
> - Rewires the CI pipeline in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1346/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) to use this patched binary (via `lib.getExe repoPackages.nix-eval-jobs`) for both `nix-fast-build` (via `--nix-eval-jobs`) and the schema/eval step, replacing the upstream flake reference.
> - The practical effect is that warm Rust derivation units with floating CA outputs are correctly identified as already cached, skipping unnecessary rebuilds in CI.
> - Behavioral Change: `nix-fast-build` and the schema-eval step now use the repo-local patched binary; any divergence from upstream `nix-eval-jobs` behavior applies to all eval steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b271315.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->