### PR TITLE
flake: shallow-fetch snix-src so cold direnv loads stop hanging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -416,12 +416,13 @@
         "narHash": "sha256-NKP/1lgKRne7+nW8MaTQbPtfVPa4mqZuvIBcai4neDM=",
         "ref": "canon",
         "rev": "3251a55da2c9ebdf7392e281d959eb70ed5b6054",
-        "revCount": 22462,
+        "shallow": true,
         "type": "git",
         "url": "https://git.snix.dev/snix/snix"
       },
       "original": {
         "ref": "canon",
+        "shallow": true,
         "type": "git",
         "url": "https://git.snix.dev/snix/snix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -112,8 +112,18 @@
     # instead of the upstream crate2nix `Cargo.nix`. The Cargo workspace lives in
     # the repo's `snix/` subdirectory. Pinned in flake.lock; `nix flake update
     # snix-src` to bump.
+    #
+    # `shallow=1` is load-bearing, not cosmetic: only the source tree at the
+    # pinned rev is ever used (`ix.snixSrc` -> `packages/nix/snix`), never git
+    # history or `revCount`. Without it the lock records `revCount`, which forces
+    # Nix to clone snix's entire ~22k-commit history (~500 MB) to materialize the
+    # input. nix-direnv's `use flake` then runs `nix flake archive` on every cold
+    # load (it gc-roots every input), so that full clone ran on each fresh
+    # `direnv` load and hung the shell for minutes. git.snix.dev serves an
+    # arbitrary SHA at depth 1, so the shallow fetch grabs just the pinned commit
+    # (~2 s) even after `canon` has moved ahead of the pin.
     snix-src = {
-      url = "git+https://git.snix.dev/snix/snix?ref=canon";
+      url = "git+https://git.snix.dev/snix/snix?ref=canon&shallow=1";
       flake = false;
     };
 


### PR DESCRIPTION
## What

Make the `snix-src` flake input a **shallow** git fetch:

```diff
-      url = "git+https://git.snix.dev/snix/snix?ref=canon";
+      url = "git+https://git.snix.dev/snix/snix?ref=canon&shallow=1";
```

and drop the now-unobtainable `revCount` from its lock node (same `rev`, same `narHash`).

## Why — `direnv` gets stuck

`.envrc` runs `use flake`, and nix-direnv 3.1.2's `use_flake` runs `nix flake archive` after `print-dev-env` to gc-root **every** flake input. The `snix-src` input pointed at `?ref=canon` with no `shallow`, so the lock recorded `revCount: 22462` and Nix had to clone snix's **entire ~22k-commit history (~500 MB)** to materialize it — even though the dev shell only needs `astlog` + `nixfmt`.

On a cold git cache (fresh clone, new machine, or after a GC) that full clone runs on the first `direnv` load, and direnv hangs for minutes with no output beyond the 5s "taking a while" warning.

```mermaid
flowchart TD
    cd["cd into repo / direnv reload"] --> uf["use flake (nix-direnv)"]
    uf --> pde["nix print-dev-env<br/>(astlog + nixfmt only)"]
    uf --> arch["nix flake archive<br/>gc-roots EVERY input"]
    arch --> snix{"snix-src in git cache?"}
    snix -->|"no (cold)"| full["full-history clone<br/>120306 deltas, ~500 MB<br/>⟶ direnv STUCK"]
    snix -->|yes| fast["instant"]
    full -.->|"shallow=1 fix"| depth1["depth-1 fetch of pinned SHA<br/>2194 objects, 3.3 MiB, ~2 s"]
```

`ix.snixSrc` is consumed **only** as a source tree (`ix.snixSrc + "/snix"`, `"${ix.snixSrc}"` in `packages/nix/snix`); nothing reads git history, `rev`, or `revCount`, so a shallow fetch is fully equivalent.

## Verification

- `nix flake metadata` accepts the edited lock with **no re-lock**: `rev` stays `3251a55d…`, `narHash` unchanged, `shallow: true` recorded. Byte-identical source ⟹ no snix rebuild.
- git.snix.dev serves an arbitrary SHA at `--depth 1` (`uploadpack.allowAnySHA1InWant`), so the pin still resolves even though `canon` has already advanced to `1f86b75d…`.
- Cold shallow fetch (fresh `XDG_CACHE_HOME`, `narHash` pinned so Nix verifies tree identity): **2194 objects, 3.3 MiB, ~2.2 s** vs. the old full clone of 120306 deltas.
- `nix flake archive` (the exact nix-direnv command) succeeds and resolves `snix-src` to the shallow path.
- `nix run .#lint` green (nixfmt, deadnix, statix, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Shallow-fetch `snix-src` input to prevent cold direnv loads from hanging
> Appends `&shallow=1` to the `snix-src` git URL in [flake.nix](https://github.com/indexable-inc/index/pull/1347/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0), so Nix fetches only the pinned revision instead of the full history. A comment block explains the rationale for shallow fetching.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd608da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->