### PR TITLE
ci: patch nix-fast-build so --skip-cached skips local (warm) CA outputs

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -198,12 +198,14 @@ let
   # --eval-workers 16 with --eval-max-memory-size 6144 is a headroom guard rail
   # (above nix-eval-jobs' 4 GiB default per worker, below the old 8 GiB), not a
   # workaround: the per-crate check split (see the `checks` block below) keeps
-  # each worker's eval bounded by the largest single crate. Pinned by commit to
-  # nix-fast-build 1.5.0, but pointed at the repo-built patched nix-eval-jobs via
-  # --nix-eval-jobs (the eval-step binary, not nix-fast-build itself, is what
-  # decides cacheStatus): without the patch, --skip-cached treats every floating
-  # CA rust unit as uncached and rebuilds ~1434 of them on every warm run. See
-  # the $eval_jobs comment below.
+  # each worker's eval bounded by the largest single crate. Both binaries are
+  # repo-built patches of nixpkgs' 1.5.0 / v2.34.1 (same commits the flake refs
+  # used to pin): the patched nix-eval-jobs (--nix-eval-jobs) resolves floating-CA
+  # outputs so they report a real cacheStatus instead of always-uncached, and the
+  # patched nix-fast-build makes --skip-cached skip a `local` (warm-store) output,
+  # not just a remotely-`cached` one. Without both, --skip-cached re-realizes every
+  # floating-CA rust unit and image closure (~1450) on every warm run. See the
+  # $fast_build and $eval_jobs comments below.
   #
   # Step 2 (nix-eval-jobs) is the schema/eval gate over the package outputs,
   # broader than the `checks` set step 1 built. nix-eval-jobs is the same
@@ -229,7 +231,15 @@ let
     name = "check";
     meta.description = "Run the full CI gate: build .#ciChecks.x86_64-linux and eval-validate .#packages.x86_64-linux";
     text = ''
-      const fast_build = "github:Mic92/nix-fast-build/7f185e0ec37b65b4730f892e0de9a831b0610f3a"
+      # Patched nix-fast-build (packages/nix/nix-fast-build): stock --skip-cached
+      # only skips a job whose nix-eval-jobs cacheStatus is `cached` (in a remote
+      # substituter); a `local` output (already in this warm runner's store but
+      # never pushed) falls through and is re-realized every run. On this CI the
+      # rust units and image closures are floating-CA and resolve to `local`, so
+      # the patch makes --skip-cached skip `local` too. nixpkgs' 1.5.0 tag is the
+      # same commit (7f185e0) the flake ref used to pin, so this is a like-for-like
+      # source swap plus the patch. Invoked directly by store path, not `nix run`.
+      const fast_build = "${lib.getExe repoPackages.nix-fast-build}"
       # Patched nix-eval-jobs (packages/nix/nix-eval-jobs): the stock binary
       # reports `local`/`notBuilt` for floating content-addressed outputs even
       # when they are in cache.ix.dev, so --skip-cached rebuilt every CA rust
@@ -266,7 +276,7 @@ let
         # outer `mut` from inside the catch closure).
         let build_failed = (
           try {
-            ^nix run $fast_build -- ...[
+            ^$fast_build ...[
               "--flake" ".#ciChecks.x86_64-linux"
               # Drive nix-fast-build's evaluator with the patched nix-eval-jobs
               # (CA cacheStatus fix) so --skip-cached actually skips warm CA

--- a/packages/nix/nix-fast-build/default.nix
+++ b/packages/nix/nix-fast-build/default.nix
@@ -1,0 +1,63 @@
+{
+  pkgs,
+}:
+let
+  # nix-fast-build's --skip-cached drops a job only when nix-eval-jobs reports
+  # its `cacheStatus` as `cached` (present in a configured *remote* substituter).
+  # A `local` status (output already realized in *this* runner's store, but not
+  # pushed anywhere) falls through to the build queue and gets re-realized every
+  # run (__init__.py, the `elif cache_status == "local"` arm).
+  #
+  # On index's persistent warm CI runner that is almost everything: the rust
+  # workspace units default to `contentAddressed = true` (lib/rust/cargo-unit.nix)
+  # and the image checks are floating-CA system closures (lib/per-system.nix), and
+  # none of them are pushed to cache.ix.dev, so the patched nix-eval-jobs
+  # (packages/nix/nix-eval-jobs) correctly resolves them to `local` -- at which
+  # point stock nix-fast-build re-realizes all ~1450 of them. Each is a no-op
+  # realize (~0.05-0.4s measured warm) but the per-drv dispatch over ~1450 units
+  # is the ~85s build-step floor.
+  #
+  # The patch makes `local` skip the build like `cached` does (still queueing an
+  # upload first if a binary-cache target is set): a locally-present output never
+  # needs (re)building. nix-eval-jobs#403 / nix#12128 fixed the *status*; this
+  # fixes what --skip-cached does with it.
+  package = pkgs.nix-fast-build.overrideAttrs (old: {
+    patches = (old.patches or [ ]) ++ [ ./skip-local.patch ];
+  });
+
+  # The patch only touches Python control flow, so the real risk is that the
+  # surrounding source drifted out from under the diff on a nixpkgs bump (the
+  # patch would fail to apply at build time) -- a build of `package` already
+  # catches that. The smoke test additionally runs the binary so an import-time
+  # break surfaces here rather than mid-CI-run; `--help` exits 0 without touching
+  # a store or daemon (absent in the sandbox).
+  smoke =
+    pkgs.runCommand "nix-fast-build-smoke"
+      {
+        nativeBuildInputs = [ package ];
+        strictDeps = true;
+      }
+      ''
+        help=$(nix-fast-build --help 2>&1) || true
+        case "$help" in
+          *"--skip-cached"*) ;;
+          *)
+            echo "nix-fast-build --help did not print usage" >&2
+            printf '%s\n' "$help" >&2
+            exit 1
+            ;;
+        esac
+        mkdir -p "$out"
+      '';
+in
+package.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests = (old.passthru.tests or { }) // {
+      inherit smoke;
+    };
+  };
+  meta = (old.meta or { }) // {
+    description = "nix-fast-build patched so --skip-cached also skips locally-realized (floating-CA) outputs, not just remotely-cached ones";
+    mainProgram = "nix-fast-build";
+  };
+})

--- a/packages/nix/nix-fast-build/package.nix
+++ b/packages/nix/nix-fast-build/package.nix
@@ -1,0 +1,17 @@
+{
+  id = "nix-fast-build";
+  # Surfaced in the repo package set (`repoPackages.nix-fast-build`, which the
+  # `check` app invokes directly) and as the `nix-fast-build` flake output.
+  # Deliberately NOT in the nixpkgs overlay: the override reads
+  # `pkgs.nix-fast-build` as its base, so injecting this package under the same
+  # name would make it its own base (infinite recursion) -- same reasoning as
+  # packages/nix/nix-eval-jobs. x86_64-linux only: it is the CI build system and
+  # the only consumer is the x86_64-linux-only `check` app.
+  packageSet = {
+    systems = [ "x86_64-linux" ];
+  };
+  flake = {
+    systems = [ "x86_64-linux" ];
+  };
+  passthruTests = true;
+}

--- a/packages/nix/nix-fast-build/skip-local.patch
+++ b/packages/nix/nix-fast-build/skip-local.patch
@@ -1,0 +1,25 @@
+--- a/nix_fast_build/__init__.py
++++ b/nix_fast_build/__init__.py
+@@ -1153,9 +1153,19 @@
+         # them for pushing if they are cached locally
+         elif cache_status == "cached":
+             continue
+-        elif cache_status == "local" and upload_queue is not None:
+-            outputs = {k: v for k, v in job.get("outputs", {}).items() if v is not None}
+-            upload_queue.put_nowait(Build(attr, job["drvPath"], outputs))
++        elif cache_status == "local":
++            # The output is already realized in the local store, so it never
++            # needs (re)building -- skip it like a remotely-cached job. Still
++            # queue it for upload first if a binary-cache target is configured.
++            # Without this, --skip-cached re-realizes every locally-present
++            # floating-CA derivation on a persistent warm runner (index CI:
++            # ~1450 rust units + image closures), because upstream only
++            # continues on "cached" and falls through to the build queue for
++            # "local". See packages/nix/nix-fast-build/default.nix.
++            if upload_queue is not None:
++                outputs = {k: v for k, v in job.get("outputs", {}).items() if v is not None}
++                upload_queue.put_nowait(Build(attr, job["drvPath"], outputs))
++            continue
+         system = job.get("system")
+         if system and system not in opts.systems:
+             continue


### PR DESCRIPTION
## Problem

On our persistent warm CI runner the `build` step has a ~85s floor that isn't building anything: it re-realizes ~1450 already-present derivations every run.

## Root cause (measured on vin-compute-1, current `main`)

- #1346's patched **nix-eval-jobs** correctly resolves floating-CA outputs and now reports their real `cacheStatus`. For our rust units (`contentAddressed = true`) and image system-closures, that status is **`local`** (in this runner's store, never pushed to `cache.ix.dev`).
- **nix-fast-build's** `--skip-cached` only `continue`s on `cacheStatus == "cached"` (a *remote* substituter). `local` falls through to the build queue (`__init__.py`, the `elif cache_status == "local"` arm). `isCached: true` is ignored whenever `cacheStatus` is present.
- So `--skip-cached` skips **none** of them. Each realize is a warm no-op (~0.05-0.4s measured), but per-drv dispatch over ~1450 units is the floor.

End-to-end, stock nix-fast-build over 180 warm `local` units dispatched **all 180** (`builds: 18 → 170`); patched dispatched **0**.

```mermaid
flowchart LR
  E[nix-eval-jobs cacheStatus] -->|cached / remote| S[skip]
  E -->|local / warm store| B[stock: BUILD ~1450x]
  E -->|local / warm store| S2[patched: skip]
```

## Fix

`packages/nix/nix-fast-build`: override nixpkgs' nix-fast-build (1.5.0 == the `7f185e0` the flake ref pinned, byte-identical source) with a patch that makes `local` skip the build like `cached` does, still queueing an upload first if a binary-cache target is set. Mirrors the existing patched-nix-eval-jobs packaging (smoke test + registry marker). The `check` app now invokes it by store path instead of the `github:` flake ref.

#1346 fixed the *status*; this fixes what `--skip-cached` does with it.

## Validation (x86_64-linux, vin-compute-1)

- ✅ `nix build .#nix-fast-build` + smoke test pass
- ✅ `nix build .#check` builds; built script references the patched binary, no `nix run` for it
- ✅ functional: patched binary over 180 warm `local` units → `builds: 0`, 0 build attempts, exit 0 (stock: all 180 dispatched)

Only affects `--skip-cached` runs (the `cacheStatus` arm runs only when `--check-cache-status` is set). A single persistent runner has no upload target, so skipping `local` loses nothing.

_Written by an AI agent (Claude) on Andrew's machine._


## Caveat (behavior change)

Today, with nothing pushed to a remote cache, stock nix-fast-build *re-ran* every `local` check each cycle (it fell through to the build queue). After this patch a previously-passing `local` output is skipped until its inputs change. For deterministic checks that's an invisible no-op; for a check with hidden non-determinism (e.g. a VM/network test) it means it won't be re-exercised on the warm runner until inputs change. This is the standard `--skip-cached` / Nix trust-on-presence model (already true for `cached` and for input-addressed outputs ecosystem-wide), now also applied to local outputs. Flag if any of `minecraft-blocks-vm` / `scipql-e2e` / `site-test` / `cross-darwin-smoke` are known-flaky.
