### PR TITLE
docs(mcp): add control-surface fallback guidance (CDP/iPhone/screen)

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -263,6 +263,23 @@ VERIFY = (
     "'the tab switches on screen'."
 )
 
+CONTROL = (
+    "When a system has no programmatic integration (no bundled module, API, or CLI for it, or the "
+    "one you have is too scope-limited to do the job), you can usually still drive it through a "
+    "control surface rather than giving up. Three are bundled: a Chromium browser over CDP "
+    "(`import browser`, then `await browser.goto(url)` / `await browser.vdom()` / "
+    "`await browser.read()` / `await browser.shot()`), the iPhone over WebDriverAgent "
+    "(`import iphone`: `iphone.tap`, `iphone.swipe`, `iphone.screenshot` — async, so await "
+    "them too), and the Mac itself by screen capture plus synthetic "
+    "input (`import screen`: `screen.capture`, `screen.click`, `screen.write`, `screen.press`). "
+    "Prefer CDP first: it reads the structured DOM (`browser.vdom`/`browser.read`) and clicks "
+    "elements by selector instead of guessing pixel coordinates, so it is by far the most "
+    "reliable. Reach for `screen` or `iphone` only when the target is a native app with no usable "
+    "web surface. Driving `screen` means mapping Retina capture pixels to screen points and "
+    "racing the lock screen, so treat it as the last resort. See the module index for each "
+    "surface's full API."
+)
+
 AUTOMERGE = (
     "By default, merge a pull request you open yourself rather than handing it back: once its "
     "required checks are green, resolve your own review threads and merge it (through the merge "

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -79,6 +79,7 @@ _KERNEL_GUIDE = guide.compose(
     guide.HTML,
     guide.OUTPUT_HTML,
     guide.VERIFY,
+    guide.CONTROL,
     guide.AUTOMERGE,
     guide.RESULT_SPLIT,
     guide.RESULT_VARIANTS,


### PR DESCRIPTION
Adds a `CONTROL` section to the kernel guide: when a system has no programmatic integration (or a scope-limited one), the kernel can still drive it through a bundled control surface. Documents the three surfaces (`browser` over CDP, `iphone` over WDA, `screen` for the Mac) and recommends CDP first (structured DOM + selector clicks) over pixel-based `screen`/`iphone` control.

Motivated by a real session where a scope-limited Slack token blocked the API path and the fallback to a control surface was not signposted in the guide.

_(sent by an AI agent via Claude Code)_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add control-surface fallback guidance for CDP, iPhone, and screen capture to `_KERNEL_GUIDE`
> Adds a new `CONTROL` constant in [guide.py](https://github.com/indexable-inc/index/pull/1352/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) with instructions for using Chromium via CDP, iPhone via WebDriverAgent, and Mac screen capture as control surface fallbacks, including example function calls and prioritization advice. The constant is inserted into `_KERNEL_GUIDE` in [tools.py](https://github.com/indexable-inc/index/pull/1352/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) between the `VERIFY` and `AUTOMERGE` sections, changing the guidance content presented to consumers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14be8a6. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->