### PR TITLE
feat(mcp): default to writing output as an HTML file and opening it

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -188,6 +188,13 @@ HTML = (
     "light-only colors), so it follows the viewer's OS theme — the dashboard is dark by default."
 )
 
+OUTPUT_HTML = (
+    "By default, when you give the human an output, write it to an HTML file and then open it: build "
+    "the page with htpy, write it to a file (`Path('out.html').write_text(str(el))`), and open it for "
+    "the viewer with `await sh(['open', 'out.html'])` so it lands in their browser. Reach past a plain "
+    "text answer to this rendered page for anything worth seeing."
+)
+
 POLARS = (
     "Prefer polars for any tabular data: return a DataFrame (or `Result.of(df)`) and the human "
     "gets the styled HTML table for free while you get the frame as compact, untruncated CSV — so "

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -190,7 +190,7 @@ HTML = (
 
 OUTPUT_HTML = (
     "By default, when you give the human an output, write it to an HTML file and then open it: build "
-    "the page with htpy, write it to a file (`Path('out.html').write_text(str(el))`), and open it for "
+    "the page with htpy, write it to a file (`from pathlib import Path; Path('out.html').write_text(str(el))`), and open it for "
     "the viewer with `await sh(['open', 'out.html'])` so it lands in their browser. Reach past a plain "
     "text answer to this rendered page for anything worth seeing."
 )

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -64,6 +64,7 @@ _KERNEL_GUIDE = guide.compose(
     guide.modules_index(),
     guide.credentials_note(),
     guide.HTML,
+    guide.OUTPUT_HTML,
     guide.VERIFY,
     guide.RESULT_SPLIT,
     guide.RESULT_VARIANTS,


### PR DESCRIPTION
Adds an `OUTPUT_HTML` fragment to the MCP kernel guide so that, by default, when the agent gives the human an output it builds the page with htpy, writes it to an HTML file, and opens it in the viewer's browser (`open`). Wired into `_KERNEL_GUIDE` right after the existing `HTML` fragment.

Note: this nudges agents toward a standalone opened HTML page in addition to the dashboard `cells` pane. Flagging the placement/wording for a sanity check since it touches the fleet-wide system prompt.

Validated: `nix build .#mcp` green (ruff gate included); fragment confirmed present in the composed instructions.

_Drafted by Claude (Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default kernel guide to write output as an HTML file and open it
> Adds a new `OUTPUT_HTML` guidance constant in [guide.py](https://github.com/indexable-inc/index/pull/1358/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) that instructs the kernel to render results with htpy, write them to `out.html` via pathlib, and open the file via an async shell call. The constant is inserted into `_KERNEL_GUIDE` in [tools.py](https://github.com/indexable-inc/index/pull/1358/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) immediately after the existing `HTML` guidance section.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f4e0d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->