### PR TITLE
blast-radius: drop the pie chart from PR comments

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -155,8 +155,6 @@ jobs:
               (.added   | type == "array") and
               (.removed | type == "array") and
               ((.changed + .added + .removed) | all(name_ok)) and
-              (.categories | type == "array") and
-              (.categories | all((.name | name_ok) and (.count | type == "number"))) and
               (.causes | type == "array") and
               (.causes | all((.name | name_ok) and (.checks | type == "array") and (.checks | all(name_ok)))) and
               # `timings` is optional (omitted when empty by the Rust crate via
@@ -206,13 +204,7 @@ jobs:
             (if ((.added | length) > 0) or ((.removed | length) > 0)
              then "", "\(.added | length) added, \(.removed | length) removed"
              else empty end),
-            # v1: proportions of what rebuilt, by check family.
-            (if (.categories | length) > 0
-             then "", "```mermaid", "pie showData title Rebuilt checks by category",
-                  (.categories[] | "  \"\(.name | safename)\" : \(.count)"),
-                  "```"
-             else empty end),
-            # v2: which changed inputs fan out to which checks (top causes). A
+            # Which changed inputs fan out to which checks (top causes). A
             # single-check cause is the same node twice (the cause drv is that
             # check own per-unit derivation), so render it as one node labeled
             # with the check name and skip the arrow; multi-check causes still

--- a/packages/blast-radius/src/causes.rs
+++ b/packages/blast-radius/src/causes.rs
@@ -140,15 +140,6 @@ pub fn root_causes(
     causes
 }
 
-/// A check's category for the v1 breakdown: the segment before the first dash
-/// (`image-foo` -> `image`, `rust-test-bar` -> `rust`, `lint` -> `lint`).
-pub fn category(name: &str) -> &str {
-    match name.split('-').next() {
-        Some(head) if !head.is_empty() => head,
-        _ => name,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,12 +308,5 @@ mod tests {
         assert_eq!(causes.len(), 1);
         assert_eq!(causes[0].name, "wide");
         assert_eq!(causes[0].checks, vec!["rust-1", "rust-2"]);
-    }
-
-    #[test]
-    fn category_splits_on_first_dash() {
-        assert_eq!(category("image-foo"), "image");
-        assert_eq!(category("rust-test-bar"), "rust");
-        assert_eq!(category("lint"), "lint");
     }
 }

--- a/packages/blast-radius/src/main.rs
+++ b/packages/blast-radius/src/main.rs
@@ -20,7 +20,7 @@ use clap::Parser;
 use color_eyre::eyre::{Result, bail};
 
 use causes::{Caps, root_causes};
-use report::{Report, categories};
+use report::Report;
 
 /// Phase labels are kebab-case and stable: they appear in CI logs and in
 /// `report.json.phaseTimings`, so renaming them breaks downstream readers.
@@ -269,7 +269,6 @@ fn main() -> Result<()> {
         base: short(&revs.base),
         head: short(&revs.head),
         total,
-        categories: categories(&changed, &added),
         causes: causes.into_iter().map(Into::into).collect(),
         changed,
         added,

--- a/packages/blast-radius/src/report.rs
+++ b/packages/blast-radius/src/report.rs
@@ -11,7 +11,7 @@ use std::fmt::Write as _;
 
 use serde::Serialize;
 
-use crate::causes::{Cause, category};
+use crate::causes::Cause;
 
 /// Maximum number of changed-check bullets to render in the `<details>` list.
 /// A PR touching a shared input rebuilds thousands of checks (on ix, 3817 of
@@ -21,12 +21,6 @@ use crate::causes::{Cause, category};
 /// caps identically; the `<summary>` carries the true total and the full list
 /// lives in the run artifact and logs.
 pub const CHANGED_LIST_CAP: usize = 200;
-
-#[derive(Debug, Serialize)]
-pub struct Category {
-    pub name: String,
-    pub count: usize,
-}
 
 #[derive(Debug, Serialize)]
 pub struct CauseJson {
@@ -52,7 +46,6 @@ pub struct Report {
     pub changed: Vec<String>,
     pub added: Vec<String>,
     pub removed: Vec<String>,
-    pub categories: Vec<Category>,
     pub causes: Vec<CauseJson>,
     /// Per-attribute wall-clock seconds from the prior successful Check run on
     /// the base branch (see [`crate::timings`]). Empty when no prior run was
@@ -83,28 +76,6 @@ pub fn format_seconds(seconds: f64) -> String {
     } else {
         format!("{:.0}h", (seconds / 3600.0).round())
     }
-}
-
-/// Count `changed + added` checks by category, most-rebuilt family first.
-pub fn categories(changed: &[String], added: &[String]) -> Vec<Category> {
-    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
-    for name in changed.iter().chain(added) {
-        *counts.entry(category(name)).or_insert(0) += 1;
-    }
-    let mut categories: Vec<Category> = counts
-        .into_iter()
-        .map(|(name, count)| Category {
-            name: name.to_owned(),
-            count,
-        })
-        .collect();
-    categories.sort_by(|left, right| {
-        right
-            .count
-            .cmp(&left.count)
-            .then_with(|| left.name.cmp(&right.name))
-    });
-    categories
 }
 
 impl Report {
@@ -140,14 +111,6 @@ impl Report {
                 self.added.len(),
                 self.removed.len()
             );
-        }
-
-        if !self.categories.is_empty() {
-            out.push_str("\n```mermaid\npie showData title Rebuilt checks by category\n");
-            for category in &self.categories {
-                let _ = writeln!(out, "  \"{}\" : {}", category.name, category.count);
-            }
-            out.push_str("```\n");
         }
 
         if !self.causes.is_empty() {
@@ -228,24 +191,6 @@ mod tests {
             ],
             added: vec!["mcp-evalSmoke".into()],
             removed: vec![],
-            categories: vec![
-                Category {
-                    name: "rust".into(),
-                    count: 2,
-                },
-                Category {
-                    name: "mcp".into(),
-                    count: 2,
-                },
-                Category {
-                    name: "image".into(),
-                    count: 1,
-                },
-                Category {
-                    name: "lint".into(),
-                    count: 1,
-                },
-            ],
             causes: vec![
                 CauseJson {
                     name: "ix-rust-workspace".into(),

--- a/tools/blast-radius-fixtures/bad-check.json
+++ b/tools/blast-radius-fixtures/bad-check.json
@@ -1,2 +1,2 @@
 {"base":"aaaaaaa","head":"bbbbbbb","total":1,"changed":[],"added":[],"removed":[],
- "categories":[],"causes":[{"name":"x","checks":["ok","`rm -rf`"]}]}
+ "causes":[{"name":"x","checks":["ok","`rm -rf`"]}],"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-fixtures/bad-name.json
+++ b/tools/blast-radius-fixtures/bad-name.json
@@ -1,2 +1,2 @@
-{"base":"aaaaaaa","head":"bbbbbbb","total":1,"changed":[],"added":[],"removed":[],
- "categories":[{"name":"rust\n@room ping","count":1}],"causes":[]}
+{"base":"aaaaaaa","head":"bbbbbbb","total":1,"changed":["rust\n@room ping"],"added":[],"removed":[],
+ "causes":[],"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-fixtures/bad-phase-key.json
+++ b/tools/blast-radius-fixtures/bad-phase-key.json
@@ -1,4 +1,4 @@
 {"base":"aaaaaaa","head":"bbbbbbb","total":1,
  "changed":[],"added":[],"removed":[],
- "categories":[],"causes":[],
+ "causes":[],
  "phaseTimings":{"Eval-Base":1.0}}

--- a/tools/blast-radius-fixtures/bad-phase-value.json
+++ b/tools/blast-radius-fixtures/bad-phase-value.json
@@ -1,4 +1,4 @@
 {"base":"aaaaaaa","head":"bbbbbbb","total":1,
  "changed":[],"added":[],"removed":[],
- "categories":[],"causes":[],
+ "causes":[],
  "phaseTimings":{"eval-base":"23s"}}

--- a/tools/blast-radius-fixtures/good.expected.md
+++ b/tools/blast-radius-fixtures/good.expected.md
@@ -6,14 +6,6 @@
 1 added, 0 removed
 
 ```mermaid
-pie showData title Rebuilt checks by category
-  "rust" : 2
-  "mcp" : 2
-  "image" : 1
-  "lint" : 1
-```
-
-```mermaid
 flowchart LR
   c0["ix-rust-workspace"]
   c1["image-base (<1s)"]

--- a/tools/blast-radius-fixtures/good.json
+++ b/tools/blast-radius-fixtures/good.json
@@ -1,7 +1,6 @@
 {"base":"aaaaaaa","head":"bbbbbbb","total":120,
  "changed":["mcp-serverTools","rust-test-search_core","image-base","lint"],
  "added":["mcp-evalSmoke"],"removed":[],
- "categories":[{"name":"rust","count":2},{"name":"mcp","count":2},{"name":"image","count":1},{"name":"lint","count":1}],
  "causes":[{"name":"ix-rust-workspace","checks":["mcp-serverTools","rust-test-search_core"]},
            {"name":"image-base-layer","checks":["image-base"]},
            {"name":"ix-images-lint","checks":["lint"]}],

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -23,7 +23,7 @@ yq '.jobs.comment.steps[] | select(.name == "Render comment").run' "$workflow" >
 validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 
 # Schema validation: the good report passes; hostile and old (missing
-# categories/causes/phaseTimings) reports are rejected fail-closed. The two
+# causes/phaseTimings) reports are rejected fail-closed. The two
 # `bad-phase-*` fixtures pin the kebab-case key constraint and the number-
 # typed value constraint that keep an attacker from smuggling shapes into
 # the artifact.
@@ -36,7 +36,7 @@ for bad in bad-name bad-check missing bad-phase-key bad-phase-value; do
   fi
 done
 
-# Render: the good report produces the golden comment (pie + flowchart + list).
+# Render: the good report produces the golden comment (flowchart + list).
 # `phaseTimings` is observability-only and never renders, so the golden
 # comment from a report carrying phaseTimings has no trace of those keys;
 # any drift here means the renderer leaked them.


### PR DESCRIPTION
Removes the mermaid **pie chart** ("Rebuilt checks by category") from the blast-radius PR comment, the circular v1 graphic. The flowchart (which changed inputs fan out to which checks) plus the changed-checks list already carry the signal; the pie added a disc without extra information.

Removed end to end so nothing dead is left behind:
- trusted jq renderer **and** schema validator in `.github/workflows/blast-radius.yml` (the job that actually posts the comment)
- the Rust `to_markdown` mirror in `packages/blast-radius/src/report.rs`
- the now-unused `categories` / `Category` / `category()` plumbing (`report.rs`, `causes.rs`, `main.rs`)

`tools/blast-radius-fixtures/bad-name.json` previously hid its injection-test payload (`rust\n@room ping`) inside `categories`; moved it into `changed` so the name-charset rejection stays covered, and added a valid `phaseTimings` to `bad-name.json`/`bad-check.json` so the charset gate is the only failing clause (it was previously masked by the missing-`phaseTimings` clause).

Validated locally:
- `nix build .#blast-radius` compiles
- `cargo test -p blast-radius` -> 13 passed
- `tools/blast-radius-test.sh` (extracts and runs the real workflow jq against fixtures) -> all passed
- adversarial code-review of the diff: no correctness or security findings

AI-attribution: drafted by Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove the categories pie chart from blast-radius PR comments
> - Removes the `Category` struct, `categories()` function, and the `categories` field from `Report` in [report.rs](https://github.com/indexable-inc/index/pull/1359/files#diff-2c62d3a5b277d0658a5553d55b62ab38ba2fe8e7e459d2d4910f85a98782dd93); the serialized JSON no longer includes a `categories` field.
> - Removes the Mermaid pie chart block from `Report::to_markdown`, so PR comments now render only the flowchart and changed-checks list.
> - Updates the [blast-radius.yml](https://github.com/indexable-inc/index/pull/1359/files#diff-f18ec732b17d456a8d2f9c00a4941f9433314b97b8a3df9cea22bdaf15337468) workflow to drop schema validation for `categories`, so reports without that field now validate successfully.
> - Updates test fixtures and golden output in [blast-radius-fixtures/](https://github.com/indexable-inc/index/pull/1359/files#diff-1a0ef09dd24d75644ab47df38475e3a4296832e91ade3fecec93e9ad664f3ed3) to reflect the removed field and chart.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8adcb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->