### PR TITLE
feat(mcp): default to merging your own PRs once checks are green

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -179,6 +179,13 @@ VERIFY = (
     "'the tab switches on screen'."
 )
 
+AUTOMERGE = (
+    "By default, merge a pull request you open yourself rather than handing it back: once its "
+    "required checks are green, resolve your own review threads and merge it (through the merge "
+    "queue when the repo sets one). Leave a PR open only when the change genuinely needs human "
+    "sign-off or the user asked you to."
+)
+
 HTML = (
     "htpy (build HTML in Python with `div(class_='x')[...]`; it auto-escapes every text node and "
     "attribute, so use it instead of f-string HTML, which is where escaping gets forgotten; an "

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -66,6 +66,7 @@ _KERNEL_GUIDE = guide.compose(
     guide.HTML,
     guide.OUTPUT_HTML,
     guide.VERIFY,
+    guide.AUTOMERGE,
     guide.RESULT_SPLIT,
     guide.RESULT_VARIANTS,
     guide.READABLE,


### PR DESCRIPTION
Adds an `AUTOMERGE` fragment to the MCP kernel guide: by default the agent merges a PR it opened itself once required checks are green (resolving its own review threads, through the merge queue where the repo sets one), and leaves a PR open only when the change needs human sign-off or the user asked. Wired into `_KERNEL_GUIDE` after `VERIFY`.

Validated: `nix build .#mcp` green (ruff gate included); fragment confirmed in the composed instructions.

_Drafted by Claude (Opus 4.8)._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automerge guidance to MCP kernel instructions for self-merging PRs once checks pass
> Adds a new `AUTOMERGE` guidance block to [guide.py](https://github.com/indexable-inc/index/pull/1362/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) that instructs the agent to merge its own PRs once checks are green, resolve its own review threads, and use the merge queue when configured. The block is inserted into `_KERNEL_GUIDE` in [tools.py](https://github.com/indexable-inc/index/pull/1362/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6), so agents will now follow this default behavior unless human sign-off is explicitly needed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c02c111.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->