### PR TITLE
feat(mcp): interactive input for HTML resources (ask / Input)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -90,6 +90,44 @@ large rendered view never costs you tokens. For an ordinary value the two
 audiences share one rendering: a bare trailing expression still shows its rich
 repr on the dashboard and its text to you.
 
+## Asking the human: interactive input
+
+A `Resource` pushes a view *to* the human; an `Input` is the channel the human
+pushes back *on*, so the agent can pop a window up and await a reply:
+
+```python
+name   = await ask("What should I name the branch?")          # the typed string
+target = await ask("Deploy where?", choices=["staging", "prod"])  # the chosen string
+creds  = await ask("DB creds", fields=["user", "password"])   # {"user": ..., "password": ...}
+```
+
+`ask` renders a form as a live resource (a dashboard pane, and a floating window
+under `ix-windows`), blocks until the human submits, closes the window, and
+returns the answer. Because it waits on a human it exceeds your `python_exec`
+budget and backgrounds: read the answer in a later call with `await jobs['<id>']`.
+
+For anything past a simple form, use the `Input` primitive directly: drop its
+`.script` into any HTML you render and have your markup call `ixSubmit(payload)`.
+
+```python
+inp = Input(title="canvas")
+register_resource(
+    render=lambda: inp.script + "<button onclick='ixSubmit({clicked:1})'>go</button>",
+    id=inp.id, title="canvas",
+)
+payload = await inp                      # -> {"clicked": 1}; or `async for` a stream
+```
+
+How it flows: the resource HTML mounts in a sandboxed, opaque-origin iframe
+(`sandbox="allow-scripts"`), and `ixSubmit` makes a cross-origin `fetch` to the
+data API's `POST /api/input` (the one write path besides `/api/exec`). That
+appends the submission to the store's `inputs` queue; the kernel drains it on its
+flush tick and the awaiting call resolves. The channel id is an address, not a
+secret (it rides in the HTML the read endpoints serve), so `/api/input` is
+authorized by the network boundary like `/api/exec`: allowed on a loopback bind,
+and on a tailnet bind only when the operator trusts the tailnet
+(`IX_MCP_EXEC_TRUST_NETWORK`, which the fleet sets).
+
 ## How it works
 
 `ix-mcp serve` starts one IPython kernel (over `jupyter-client`), a read-only

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -4871,6 +4871,79 @@ let
         mkdir -p "$out"
       '';
 
+  # Interactive input: the browser -> kernel write path behind interactive
+  # resources (packages/mcp/tests/test_inputs.py). Covers the store queue, the
+  # dashboard `/api/input` gate + CORS (over a real aiohttp TestServer), and the
+  # kernel-side drain into an awaiting `Input` / `ask`. Needs the full mcp
+  # interpreter (ix_notebook_mcp + aiohttp) plus pytest, which bare mcpPython omits.
+  inputsTestPython = mcpPythonInterp.withPackages (
+    ps:
+    mcpPythonPackages ps
+    ++ [
+      ps.pytest
+    ]
+  );
+  inputsTestSource = builtins.path {
+    name = "ix-mcp-inputs-test";
+    path = ./tests/test_inputs.py;
+  };
+  inputsTests =
+    pkgs.runCommand "ix-mcp-inputs-tests"
+      {
+        nativeBuildInputs = [ inputsTestPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        cp ${inputsTestSource} "$TMPDIR/test_inputs.py"
+        ${lib.getExe inputsTestPython} -m pytest "$TMPDIR/test_inputs.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp inputs tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
+
+  # End-to-end browser proof of the interactive-input path: a real headless
+  # Chromium mounts an `Input`'s HTML in a sandboxed, opaque-origin srcdoc iframe
+  # (as HtmlBody.svelte does), clicks the button, and the cross-origin `ixSubmit`
+  # fetch must reach the real aiohttp `/api/input` and drain into the awaiting
+  # channel (packages/mcp/tests/test_input_browser.py). Same interpreter + bundled
+  # browser as the vdom smoke, plus pytest.
+  inputBrowserTestPython = mcpPythonInterp.withPackages (
+    ps:
+    mcpPythonPackages ps
+    ++ [
+      ps.pytest
+    ]
+  );
+  inputBrowserTestSource = builtins.path {
+    name = "ix-mcp-input-browser-test";
+    path = ./tests/test_input_browser.py;
+  };
+  inputBrowserSmoke =
+    pkgs.runCommand "ix-mcp-input-browser-smoke"
+      {
+        nativeBuildInputs = [ inputBrowserTestPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        export PLAYWRIGHT_BROWSERS_PATH=${lib.escapeShellArg playwrightBrowsers}
+        export FONTCONFIG_FILE=${fontsConf}
+        cp ${inputBrowserTestSource} "$TMPDIR/test_input_browser.py"
+        ${lib.getExe inputBrowserTestPython} -m pytest "$TMPDIR/test_input_browser.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp input browser smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
+
   screenBundled = importTest "screen" "import screen; print('screen-ok', all(callable(getattr(screen, n)) for n in ('capture', 'click', 'write', 'press', 'key_down', 'key_up', 'apps', 'frontmost', 'launch', 'activate', 'terminate', 'accessibility_trusted')))";
   coreLocationBundled = importTest "corelocation" "import CoreLocation; print('corelocation-ok', callable(CoreLocation.CLLocationManager.alloc))";
   scriptingBridgeBundled = importTest "scriptingbridge" "import ScriptingBridge; print('scriptingbridge-ok', callable(ScriptingBridge.SBApplication.applicationWithBundleIdentifier_))";
@@ -5038,6 +5111,8 @@ package.overrideAttrs (old: {
         sessionIdentitySmoke
         feedSmoke
         apiSmoke
+        inputsTests
+        inputBrowserSmoke
         wedgeSmoke
         richSmoke
         yieldSmoke

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -447,6 +447,11 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
     # human-facing dashboard is the Loro hub when we auto-spawn one; otherwise
     # there is no per-server hub, so point at this server's own data API.
     os.environ["IX_MCP_DASHBOARD_URL"] = cfg.hub_url() if _auto_dashboard() else cfg.dashboard_url()
+    # The data API base, ALWAYS this server's own read/write API (never the hub):
+    # the runtime bakes it into an interactive resource's `ixSubmit` so the
+    # browser posts user input to `/api/input` here. Distinct from
+    # IX_MCP_DASHBOARD_URL above, which may point at the human-facing hub.
+    os.environ["IX_MCP_DATA_API_URL"] = cfg.dashboard_url()
     os.environ["IPYTHONDIR"] = str(_prepare_ipython_startup(dashboard_port))
 
     # On macOS the process env inherits the empty Apple launchd SSH agent

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -77,6 +77,9 @@ class Config:
     # (a tailnet/LAN bind, not 127.0.0.1). A set `exec_token` still wins (it is
     # then additionally required). With neither, the endpoint stays disabled.
     # Sourced from IX_MCP_EXEC_TRUST_NETWORK by the CLI; the fleet service sets it.
+    # It ALSO gates `/api/input` (the interactive-resource write path): on a
+    # non-loopback bind, input is accepted only when this is set (loopback always
+    # accepts it). See `dashboard.input_submit`.
     exec_trust_network: bool = False
 
     # Seconds past a cell's own ``budget`` that the server waits for the kernel to

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -2,9 +2,12 @@
 
 Auto-started by the CLI. It serves the live execution log as JSON
 (``/api/jobs``, ``/api/jobs/{id}``, ``/api/resources``, ``/api/cells``,
-``/api/snapshot``) plus the tailnet-gated ``/api/exec`` write path, which
-embedders poll (the room server reads ``/api/snapshot``; a peer's
-``fleet.in_kernel`` drives ``/api/exec``).
+``/api/snapshot``) plus two write paths: the tailnet-gated ``/api/exec`` an
+embedder polls (the room server reads ``/api/snapshot``; a peer's
+``fleet.in_kernel`` drives ``/api/exec``), and ``/api/input``, which an
+interactive resource's ``ixSubmit`` posts the human's reply to (authorized by the
+network boundary like ``/api/exec``: loopback, or a trusted tailnet; see
+:class:`runtime.Input`).
 
 The human-facing UI is no longer served here: the MCP publishes its runs,
 resources, and live namespace as Loro panes to the shared ``dashboard`` hub
@@ -17,12 +20,31 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import json
 import sqlite3
 
 from aiohttp import web
 
 from . import feed, store
 from .config import Config, live_hub, port_open
+
+# Cap on one input submission's body. A submission is a small form payload (a
+# name, a choice, a few fields), never a file upload, so a generous-but-bounded
+# limit keeps a hostile tailnet peer from growing the store with one giant POST.
+_MAX_INPUT_BYTES = 256 * 1024
+
+# CORS for the input write path. An interactive resource renders inside a
+# sandboxed, opaque-origin iframe (``sandbox="allow-scripts"``, no
+# allow-same-origin), so its `fetch` carries ``Origin: null`` and the browser
+# blocks reading the response unless we allow it. We allow any origin: the
+# endpoint authorizes by the unguessable channel-id capability in the body, not
+# by origin, and the data API only binds the trust boundary (loopback/tailnet).
+_CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Max-Age": "86400",
+}
 
 
 def landing_html() -> str:
@@ -163,6 +185,67 @@ def build_app(config: Config, conn: sqlite3.Connection) -> web.Application:
             }
         )
 
+    async def input_preflight(_request: web.Request) -> web.Response:
+        # The browser preflights any non-simple cross-origin POST. The injected
+        # `ixSubmit` sends `text/plain` to stay a simple request (no preflight),
+        # but answer OPTIONS too so a producer that posts `application/json`
+        # itself still works.
+        return web.Response(status=204, headers=_CORS_HEADERS)
+
+    async def input_submit(request: web.Request) -> web.Response:
+        # The browser -> kernel write path behind interactive resources: append a
+        # DATA payload (never code) to a channel the agent explicitly opened.
+        #
+        # Authorization is the NETWORK boundary, not a secret. The channel id is an
+        # address, not a capability: it is embedded in the resource HTML, which the
+        # read endpoints (`/api/resources`, `/api/snapshot`) and the dashboard hub
+        # serve to anyone who can reach the bind, so it cannot be treated as a
+        # secret. Instead, input is a write governed like `/api/exec`: allowed on a
+        # loopback bind (the local user is trusted, and input is low-risk), or on a
+        # non-loopback (tailnet) bind only when the operator trusts the tailnet
+        # (`IX_MCP_EXEC_TRUST_NETWORK`, which the fleet sets); otherwise refused.
+        # The channel-open check then prevents queueing input no awaiter reads.
+        if config.host not in _LOOPBACK_HOSTS and not config.exec_trust_network:
+            return web.json_response(
+                {
+                    "error": "input endpoint disabled on this non-loopback bind "
+                    "(set IX_MCP_EXEC_TRUST_NETWORK to accept input over the tailnet)"
+                },
+                status=403,
+                headers=_CORS_HEADERS,
+            )
+        raw = await request.read()
+        if len(raw) > _MAX_INPUT_BYTES:
+            return web.json_response(
+                {"error": f"payload exceeds {_MAX_INPUT_BYTES} bytes"},
+                status=413,
+                headers=_CORS_HEADERS,
+            )
+        try:
+            body = json.loads(raw)
+        except (ValueError, UnicodeDecodeError):
+            return web.json_response(
+                {"error": "body must be JSON"}, status=400, headers=_CORS_HEADERS
+            )
+        channel = body.get("channel") if isinstance(body, dict) else None
+        if not isinstance(channel, str) or not channel:
+            return web.json_response(
+                {"error": "missing 'channel'"}, status=400, headers=_CORS_HEADERS
+            )
+        if "payload" not in body:
+            return web.json_response(
+                {"error": "missing 'payload'"}, status=400, headers=_CORS_HEADERS
+            )
+        if not store.channel_open(conn, channel):
+            # Unknown or already-closed channel: refuse rather than queue input no
+            # awaiter will ever read (and so an attacker cannot grow the table by
+            # posting to random ids).
+            return web.json_response(
+                {"error": "no such open channel"}, status=404, headers=_CORS_HEADERS
+            )
+        store.add_input(conn, channel=channel, payload=json.dumps(body["payload"]))
+        return web.json_response({"ok": True}, headers=_CORS_HEADERS)
+
     app.router.add_get("/", index)
     app.router.add_get("/api/jobs", jobs)
     app.router.add_get("/api/jobs/{id}", job)
@@ -170,6 +253,8 @@ def build_app(config: Config, conn: sqlite3.Connection) -> web.Application:
     app.router.add_get("/api/cells", cells)
     app.router.add_get("/api/snapshot", snapshot)
     app.router.add_post("/api/exec", exec_run)
+    app.router.add_post("/api/input", input_submit)
+    app.router.add_route("OPTIONS", "/api/input", input_preflight)
     return app
 
 

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -243,6 +243,17 @@ BUILTINS: tuple[Builtin, ...] = (
     Builtin("resources", "the live, self-updating views (a terminal, a widget)"),
     Builtin("register_resource", "publish a live Resource to the dashboard"),
     Builtin(
+        "ask",
+        "pop a window asking the human and await the reply: `await ask(\"prompt\")` / "
+        "`ask(\"prompt\", choices=[...])` / `ask(\"prompt\", fields=[...])`. Blocks on the "
+        "human, so it exceeds your budget and backgrounds -- read it back with `await jobs['<id>']`",
+    ),
+    Builtin(
+        "Input",
+        "the general input primitive behind `ask`: drop its `.script` into any resource HTML, "
+        "have the markup call `ixSubmit(payload)`, then `await` the submission (or `async for`)",
+    ),
+    Builtin(
         "sh",
         "shell out on the loop; the Output IS a Result (ANSI as HTML for the human, "
         "`.text`/`.code`/`.ok` for you), and `.json()`/`.jsonl()`/`.df()` parse a JSON-mode "

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -40,6 +40,7 @@ import json
 import os
 import pathlib
 import re
+import secrets
 import signal
 import sys
 import time
@@ -821,6 +822,12 @@ def register_resource(
     close. Move one by dragging its card chrome (the padding around the content);
     it is not resizable (size follows the content).
 
+    Interactive (a form the human fills in): pair the resource with an
+    :class:`Input`, drop its ``.script`` into the HTML, and ``await`` the reply --
+    or just use :func:`ask` for a ready-made form. A cross-origin ``fetch`` to the
+    data API DOES work from the sandbox (that is how input flows back); only
+    *same-origin* access to the embedding page is blocked.
+
     Prefer SELF-CONTAINED HTML. The body is rendered inside a sandboxed,
     opaque-origin ``<iframe>`` (``sandbox="allow-scripts"``, no
     ``allow-same-origin``) in both the dashboard and the overlay, so same-origin
@@ -860,6 +867,253 @@ def register_resource(
 
 jobs: dict[str, Job] = {}
 resources: dict[str, Resource] = {}
+
+
+# --------------------------------------------------------------------------- #
+# Interactive input: the browser -> kernel path that lets a rendered resource
+# (or cell) carry a form the human fills in, so the agent can pop a window up and
+# await the reply. An `Input`'s id is an ADDRESS, not a secret: it rides in the
+# rendered HTML, which the read endpoints and the dashboard hub serve to anyone on
+# the bind, so `/api/input` authorizes by the network boundary (loopback or a
+# trusted tailnet), the same posture as `/api/exec`. The injected `ixSubmit(payload)`
+# posts to that endpoint; the server appends to the store's `inputs` queue; the kernel's flush
+# tick (`_drain_inputs`) delivers each payload here and the agent's `await`
+# resolves. No same-origin access, cookies, or hub plumbing involved: an
+# opaque-origin sandboxed iframe can still make a cross-origin `fetch`.
+# --------------------------------------------------------------------------- #
+
+input_channels: dict[str, Input] = {}
+
+
+def _escape_attr(text: str) -> str:
+    """Escape a string for an HTML double-quoted attribute value. ``_escape_html``
+    covers text nodes (``&<>``); an attribute also needs the quote escaped so a
+    value containing ``"`` cannot break out of the attribute."""
+    return _escape_html(str(text)).replace('"', "&quot;")
+
+
+class Input:
+    """A live input channel: render arbitrary HTML with a form and await the reply.
+
+    Where a :class:`Resource` is output the kernel pushes to the human, an
+    ``Input`` is the channel the human pushes back on. Create one, drop its
+    :attr:`script` into any HTML you render (a resource, a cell), and have your
+    markup call the injected ``ixSubmit(payload)`` -- each call delivers
+    ``payload`` here. Read submissions with ``await channel`` (the next one) or
+    ``async for payload in channel`` (a stream):
+
+        inp = Input(title="name")
+        register_resource(
+            render=lambda: inp.script + "<button onclick='ixSubmit({clicked:1})'>go</button>",
+            id=inp.id, title="name",
+        )
+        payload = await inp            # -> {"clicked": 1}
+
+    For the common "ask a question, get an answer" case use :func:`ask`, which
+    builds the form, pops the window, and returns the response for you.
+
+    ``await`` blocks until the human responds, which will exceed your
+    ``python_exec`` budget and background the run; read the answer later with
+    ``await jobs['<id>']``.
+    """
+
+    def __init__(self, title: str = "input", id: str | None = None) -> None:
+        # The id addresses this channel in submissions; it is not an auth secret
+        # (it rides in the served HTML). Mint a long random token anyway so ids do
+        # not collide and are not enumerable, but `/api/input` gates on the network
+        # boundary, not on knowing this id.
+        self.id = id or secrets.token_urlsafe(18)
+        self.title = title
+        self.status = "open"
+        self.created = time.time()
+        self._queue: asyncio.Queue = asyncio.Queue()
+        input_channels[self.id] = self
+        # Open the channel in the store immediately so a submission that races the
+        # first render (the human clicks fast) is still authorized, not 404'd.
+        if _store is not None and _store_conn is not None:
+            with contextlib.suppress(Exception):  # best-effort: a missing store just means no submissions arrive
+                _store.open_channel(_store_conn, id=self.id, title=self.title)
+
+    @property
+    def endpoint(self) -> str:
+        """The absolute ``/api/input`` URL the injected script posts to. Absolute
+        because the sandboxed iframe's origin is ``about:srcdoc`` -- a relative URL
+        would resolve against that, not the data API."""
+        base = os.environ.get("IX_MCP_DATA_API_URL", "").rstrip("/")
+        return f"{base}/api/input"
+
+    @property
+    def script(self) -> str:
+        """A ``<script>`` to embed in the resource HTML. It defines
+        ``window.ixSubmit(payload)`` (POST ``payload`` to this channel) and the
+        lower-level ``window.ix.submit(channelId, payload)`` for HTML driving more
+        than one channel. Posts ``text/plain`` so the cross-origin request stays
+        a CORS *simple* request (no preflight); the server parses the JSON body
+        regardless of content type."""
+        # endpoint/id are a URL and a urlsafe token: both safe inside a JS string.
+        return (
+            "<script>(function(){"
+            f'var E={json.dumps(self.endpoint)},C={json.dumps(self.id)};'
+            "var x=(window.ix=window.ix||{});"
+            "x.submit=function(c,p){return fetch(E,{method:'POST',"
+            "headers:{'Content-Type':'text/plain;charset=UTF-8'},"
+            "body:JSON.stringify({channel:c,payload:p})}).then(function(r){return r.json();});};"
+            "window.ixSubmit=function(p){return x.submit(C,p);};"
+            "})();</script>"
+        )
+
+    def _deliver(self, payload: Any) -> None:
+        """Hand a drained submission to the awaiting coroutine (kernel-internal)."""
+        self._queue.put_nowait(payload)
+
+    async def recv(self, timeout: float | None = None) -> Any:
+        """The next submission's payload. Waits forever by default; pass
+        ``timeout`` (seconds) to raise ``TimeoutError`` instead."""
+        if timeout is None:
+            return await self._queue.get()
+        return await asyncio.wait_for(self._queue.get(), timeout)
+
+    def __await__(self) -> Any:
+        return self.recv().__await__()
+
+    def __aiter__(self) -> Input:
+        return self
+
+    async def __anext__(self) -> Any:
+        return await self._queue.get()
+
+    def closed(self) -> bool:
+        return self.status == "closed"
+
+    def close(self) -> Input:
+        """Close the channel: `/api/input` stops accepting submissions for it and
+        its queued-but-undelivered inputs are dropped. Idempotent."""
+        self.status = "closed"
+        input_channels.pop(self.id, None)
+        if _store is not None and _store_conn is not None:
+            with contextlib.suppress(Exception):  # best-effort: closing is advisory once the awaiter is gone
+                _store.close_channel(_store_conn, id=self.id)
+        return self
+
+    def __repr__(self) -> str:
+        return f"<Input {self.id} ({self.title}) [{self.status}]>"
+
+
+def _ask_form_html(
+    channel: Input,
+    prompt: str,
+    *,
+    fields: list[str] | None,
+    choices: list[str] | None,
+    multiline: bool,
+    submit_label: str,
+) -> str:
+    """The self-contained form HTML :func:`ask` renders: a prompt, the inputs, and
+    a wiring script that gathers the values and calls ``ixSubmit``. Themed for the
+    dashboard's light/dark surface; every agent-supplied string is escaped."""
+    if choices is not None:
+        body = "".join(
+            f'<button type="button" class="ix-choice" data-ix-value="{_escape_attr(c)}">'
+            f"{_escape_html(str(c))}</button>"
+            for c in choices
+        )
+        controls = f'<div class="ix-choices">{body}</div>'
+    elif fields is not None:
+        controls = "".join(
+            f'<label class="ix-field"><span>{_escape_html(str(f))}</span>'
+            f'<input name="{_escape_attr(f)}" autocomplete="off"></label>'
+            for f in fields
+        ) + f'<button type="submit" class="ix-submit">{_escape_html(submit_label)}</button>'
+    else:
+        control = (
+            '<textarea name="value" rows="3" autofocus></textarea>'
+            if multiline
+            else '<input name="value" autocomplete="off" autofocus>'
+        )
+        controls = f'{control}<button type="submit" class="ix-submit">{_escape_html(submit_label)}</button>'
+    style = (
+        "<style>"
+        ".ix-ask{font:14px/1.5 ui-sans-serif,system-ui,sans-serif;padding:14px 16px;"
+        "max-width:34rem}"
+        ".ix-prompt{font-weight:600;margin-bottom:10px}"
+        ".ix-field{display:flex;flex-direction:column;gap:3px;margin-bottom:8px}"
+        ".ix-field span{font-size:12px;opacity:.7}"
+        ".ix-ask input,.ix-ask textarea{font:inherit;padding:6px 8px;border:1px solid "
+        "color-mix(in srgb,currentColor 25%,transparent);border-radius:6px;background:transparent;"
+        "color:inherit;width:100%;box-sizing:border-box}"
+        ".ix-choices{display:flex;flex-wrap:wrap;gap:8px}"
+        ".ix-ask button{font:inherit;cursor:pointer;padding:6px 12px;border-radius:6px;"
+        "border:1px solid color-mix(in srgb,currentColor 30%,transparent);background:"
+        "color-mix(in srgb,currentColor 8%,transparent);color:inherit}"
+        ".ix-ask button:hover{background:color-mix(in srgb,currentColor 16%,transparent)}"
+        ".ix-submit{margin-top:10px}"
+        ".ix-done{margin-top:10px;font-weight:600;color:#3fb950}"
+        ".ix-ask[data-done] form{opacity:.5;pointer-events:none}"
+        "</style>"
+    )
+    wiring = (
+        "<script>(function(){"
+        "var root=document.currentScript.closest('.ix-ask');"
+        "var form=root.querySelector('form');"
+        "function finish(p){window.ixSubmit(p);root.setAttribute('data-done','');"
+        "root.querySelector('.ix-done').hidden=false;}"
+        "root.querySelectorAll('button[data-ix-value]').forEach(function(b){"
+        "b.addEventListener('click',function(){finish({value:b.getAttribute('data-ix-value')});});});"
+        "form.addEventListener('submit',function(e){e.preventDefault();"
+        "var fd=new FormData(form),o={};fd.forEach(function(v,k){o[k]=v;});"
+        "finish(o);});"
+        "})();</script>"
+    )
+    return (
+        f'{style}<div class="ix-ask"><div class="ix-prompt">{_escape_html(str(prompt))}</div>'
+        f'<form>{controls}</form><div class="ix-done" hidden>✓ sent</div></div>'
+        f"{channel.script}{wiring}"
+    )
+
+
+async def ask(
+    prompt: str,
+    *,
+    fields: list[str] | None = None,
+    choices: list[str] | None = None,
+    title: str | None = None,
+    multiline: bool = False,
+    submit_label: str = "Submit",
+) -> Any:
+    """Pop an input window asking the human, wait for their reply, return it.
+
+    Renders a form as a live :class:`Resource` (a dashboard pane, and a floating
+    window under ``ix-windows``), blocks until the human submits, closes the
+    window, and returns the response shaped to what you asked for:
+
+        await ask("What should I name the branch?")          # -> the typed string
+        await ask("Deploy where?", choices=["staging", "prod"])  # -> the chosen string
+        await ask("DB creds", fields=["user", "password"])   # -> {"user": ..., "password": ...}
+
+    ``choices`` and ``fields`` are mutually exclusive; pass neither for a single
+    free-text answer (``multiline=True`` for a textarea). Because it waits on a
+    human it will exceed your ``python_exec`` budget and background the run --
+    retrieve the answer in a later call with ``await jobs['<id>']``.
+
+    For HTML beyond a simple form, use :class:`Input` directly.
+    """
+    if choices is not None and fields is not None:
+        raise ValueError("pass choices or fields, not both")
+    channel = Input(title=title or prompt)
+    html = _ask_form_html(
+        channel, prompt, fields=fields, choices=choices, multiline=multiline, submit_label=submit_label
+    )
+    resource = register_resource(render=lambda: html, id=channel.id, title=title or prompt, kind="input")
+    try:
+        payload = await channel.recv()
+    finally:
+        channel.close()
+        resource.close()
+    # Shape the reply: a single free-text or single-choice answer reads as the
+    # bare value; a multi-field form reads as the dict the caller named.
+    if fields is None and isinstance(payload, dict) and set(payload) == {"value"}:
+        return payload["value"]
+    return payload
 
 
 @dataclasses.dataclass
@@ -2149,6 +2403,40 @@ async def _sweep_resources() -> None:
             )
 
 
+def _drain_inputs() -> None:
+    """Deliver every queued user submission to its live channel. The browser-side
+    `/api/input` appended them (a separate process); this is the kernel end of
+    that path. A submission for a channel that is gone (closed, or the kernel
+    restarted) has no awaiter, so it is dropped -- either way the row is consumed
+    so the queue stays empty between ticks.
+
+    Dequeue (DELETE) BEFORE delivering, so a delivered submission can never be
+    re-read and delivered twice (which would duplicate into a streaming channel's
+    queue). If the delete fails the rows survive and retry next tick, but nothing
+    was delivered yet, so there is still no duplicate. A crash between the delete
+    and the put loses at most the in-flight batch, which a human just re-submits."""
+    if _store is None or _store_conn is None:
+        return
+    try:
+        pending = _store.pending_inputs(_store_conn)
+    except Exception:
+        return  # best-effort: a read error this tick just retries next tick
+    if not pending:
+        return
+    try:
+        _store.delete_inputs(_store_conn, [row["seq"] for row in pending])
+    except Exception:
+        return  # leave the rows queued; nothing delivered yet, so no duplicate
+    for row in pending:
+        channel = input_channels.get(row["channel"])
+        if channel is not None and not channel.closed():
+            try:
+                payload = json.loads(row["payload"])
+            except (ValueError, TypeError):
+                payload = row["payload"]
+            channel._deliver(payload)
+
+
 async def _flusher() -> None:
     """Throttled background loop: persist every running job's output tail and
     re-render every live resource to the store so the dashboard shows both live.
@@ -2165,6 +2453,7 @@ async def _flusher() -> None:
                         _store_conn, job.id, job.output, job._displays or None, line=job.line
                     )
         await _sweep_resources()
+        _drain_inputs()
         cells._sync()
         session._sync()
         if _SESSION and _snapshot_dirty and not _snapshot_busy and not _restoring:
@@ -2942,6 +3231,9 @@ def install(user_ns: dict | None = None) -> None:
     target["resources"] = resources
     target["Resource"] = Resource
     target["register_resource"] = register_resource
+    target["Input"] = Input
+    target["ask"] = ask
+    target["input_channels"] = input_channels
     target["__ix_run"] = __ix_run
     target["__ix_exec"] = __ix_exec
     target["__ix_read"] = __ix_read

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -85,6 +85,37 @@ CREATE TABLE IF NOT EXISTS session (
     client      TEXT NOT NULL DEFAULT '',
     updated_at  REAL NOT NULL
 );
+
+-- Input channels: the address registry behind interactive resources. The kernel
+-- opens a channel when the agent creates an `Input`/`ask` (the rendered HTML's
+-- `ixSubmit` posts to this id), and closes it when the input is done. The
+-- dashboard's `/api/input` write path is the only OTHER process that touches this
+-- table, and only to READ it: a POST is accepted only for an `open` channel, so a
+-- submission for a finished or never-created channel never enters the queue. The
+-- id is NOT a secret (it rides in the HTML the read endpoints serve); it is just
+-- an address. `/api/input` authorizes by the network boundary (see dashboard.py).
+CREATE TABLE IF NOT EXISTS channels (
+    id          TEXT PRIMARY KEY,
+    title       TEXT NOT NULL DEFAULT '',
+    status      TEXT NOT NULL DEFAULT 'open',
+    created_at  REAL NOT NULL,
+    updated_at  REAL NOT NULL
+);
+
+-- Inputs: the user's submissions, an append-only queue from the browser to the
+-- kernel. The dashboard's `/api/input` appends one row per submission; the
+-- kernel runtime drains them on its flush tick, delivers each to the awaiting
+-- `Channel`, and DELETEs it (the row is a transient message, not history), so the
+-- table stays empty between submissions. `seq` orders delivery; `channel` joins
+-- to `channels`. This is the one place the two processes have a writer each on
+-- the same table family (server inserts, kernel deletes); WAL keeps them honest.
+CREATE TABLE IF NOT EXISTS inputs (
+    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+    channel     TEXT NOT NULL,
+    payload     TEXT NOT NULL,
+    created_at  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS inputs_channel ON inputs (channel, seq);
 """
 
 
@@ -395,6 +426,74 @@ def close_resource(conn: sqlite3.Connection, *, id: str, updated_at: float) -> N
 
 
 # --------------------------------------------------------------------------- #
+# Channels + inputs: the browser -> kernel write path behind interactive
+# resources. The kernel owns the `channels` lifecycle (open on create, closed on
+# done); the dashboard's `/api/input` reads `channels` to authorize a submission
+# and appends to `inputs`; the kernel drains `inputs` on its flush tick. See the
+# schema comments for the trust model (the channel id is a bearer capability).
+# --------------------------------------------------------------------------- #
+
+
+def open_channel(conn: sqlite3.Connection, *, id: str, title: str) -> None:
+    """Open (or re-open) an input channel so `/api/input` accepts submissions for
+    it. Idempotent: re-opening a known id refreshes its title and `open` status."""
+    now = _now()
+    conn.execute(
+        "INSERT INTO channels (id, title, status, created_at, updated_at) "
+        "VALUES (?, ?, 'open', ?, ?) "
+        "ON CONFLICT(id) DO UPDATE SET title = excluded.title, status = 'open', "
+        "updated_at = excluded.updated_at",
+        (id, title, now, now),
+    )
+
+
+def close_channel(conn: sqlite3.Connection, *, id: str) -> None:
+    """Close a channel so `/api/input` rejects further submissions, and drop any
+    of its still-undelivered inputs (no awaiter remains to read them)."""
+    conn.execute(
+        "UPDATE channels SET status = 'closed', updated_at = ? WHERE id = ?", (_now(), id)
+    )
+    conn.execute("DELETE FROM inputs WHERE channel = ?", (id,))
+
+
+def channel_open(conn: sqlite3.Connection, id: str) -> bool:
+    """Whether ``id`` names a channel currently accepting input. The dashboard's
+    `/api/input` gate: an unknown or closed id is refused (so a submission for a
+    finished or never-created channel never enters the queue)."""
+    row = conn.execute("SELECT status FROM channels WHERE id = ?", (id,)).fetchone()
+    return row is not None and row[0] == "open"
+
+
+def add_input(conn: sqlite3.Connection, *, channel: str, payload: str) -> None:
+    """Append one user submission (a JSON ``payload`` string) for ``channel``. The
+    dashboard is the sole inserter; the kernel drains and deletes."""
+    conn.execute(
+        "INSERT INTO inputs (channel, payload, created_at) VALUES (?, ?, ?)",
+        (channel, payload, _now()),
+    )
+
+
+def pending_inputs(conn: sqlite3.Connection) -> list[dict]:
+    """Every queued submission, oldest first, as ``{seq, channel, payload}`` dicts.
+    The kernel reads these on its flush tick, delivers each to the matching live
+    channel, and calls :func:`delete_inputs` with the seqs it handled."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT seq, channel, payload FROM inputs ORDER BY seq ASC"
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def delete_inputs(conn: sqlite3.Connection, seqs: list[int]) -> None:
+    """Remove the input rows the kernel just delivered (by ``seq``), so each
+    submission is delivered exactly once and the queue stays empty between them."""
+    if not seqs:
+        return
+    placeholders = ",".join("?" for _ in seqs)
+    conn.execute(f"DELETE FROM inputs WHERE seq IN ({placeholders})", seqs)  # noqa: S608 -- placeholders are bound params, seqs are the values
+
+
+# --------------------------------------------------------------------------- #
 # Sessions: the pieces that make one store file a reopenable notebook.
 #
 # A session file carries three things: the execution log (the cells and their
@@ -460,6 +559,14 @@ def mark_interrupted(conn: sqlite3.Connection, *, ended_at: float) -> int:
         "UPDATE resources SET status = 'closed', updated_at = ? WHERE status != 'closed'",
         (ended_at,),
     )
+    # An open input channel awaits a submission in a coroutine that died with the
+    # kernel; close it so a stale capability cannot accept input nobody reads, and
+    # drop any queued-but-undelivered submissions for the same reason.
+    conn.execute(
+        "UPDATE channels SET status = 'closed', updated_at = ? WHERE status != 'closed'",
+        (ended_at,),
+    )
+    conn.execute("DELETE FROM inputs")
     return cur.rowcount
 
 

--- a/packages/mcp/tests/test_input_browser.py
+++ b/packages/mcp/tests/test_input_browser.py
@@ -1,0 +1,88 @@
+"""End-to-end proof of the interactive-input path through a REAL headless browser.
+
+The unit tests (``test_inputs.py``) cover the store queue, the ``/api/input``
+gate, and the kernel drain in isolation. This test closes the one assumption
+they cannot: that an interactive resource's injected ``ixSubmit`` -- running
+inside a sandboxed, opaque-origin ``srcdoc`` iframe exactly as the dashboard's
+``HtmlBody.svelte`` mounts it (``sandbox="allow-scripts"``, no
+allow-same-origin) -- can actually reach the data API with a cross-origin
+``fetch`` and land a submission. It stands up the real aiohttp data API, renders
+a real ``Input``'s HTML in a real Chromium-hosted sandboxed iframe, clicks the
+button, and asserts the payload arrives and drains into the awaiting channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+
+from ix_notebook_mcp import dashboard, runtime, store
+from ix_notebook_mcp.config import Config
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def test_sandboxed_iframe_fetch_delivers_input(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("playwright")
+    from playwright.async_api import async_playwright
+
+    async def run() -> None:
+        # The real data API over a real loopback socket.
+        db = tmp_path / "browser.db"
+        conn = store.connect(db)
+        port = _free_port()
+        base = f"http://127.0.0.1:{port}"
+        cfg = Config(workdir=tmp_path, store_path=db, host="127.0.0.1", dashboard_port=port)
+        runner = web.AppRunner(dashboard.build_app(cfg, conn))
+        await runner.setup()
+        await web.TCPSite(runner, "127.0.0.1", port).start()
+
+        # The kernel side shares the same store and learns the endpoint the way
+        # the CLI wires it (IX_MCP_DATA_API_URL -> Input.script).
+        monkeypatch.setenv("IX_MCP_DATA_API_URL", base)
+        monkeypatch.setattr(runtime, "_store", store)
+        monkeypatch.setattr(runtime, "_store_conn", conn)
+        runtime.input_channels.clear()
+        inp = runtime.Input(title="play")
+        body = (
+            inp.script
+            + "<button id='go' onclick='ixSubmit({clicked:true,who:&quot;ada&quot;})'>Go</button>"
+        )
+
+        try:
+            async with async_playwright() as p:
+                browser = await p.chromium.launch()
+                try:
+                    page = await browser.new_page()
+                    # Mount the body exactly like HtmlBody.svelte: a sandboxed,
+                    # opaque-origin srcdoc iframe. Assigning .srcdoc via JS avoids
+                    # hand-escaping the HTML into an attribute.
+                    await page.set_content('<iframe id="f" sandbox="allow-scripts"></iframe>')
+                    await page.eval_on_selector("#f", "(el, html) => { el.srcdoc = html; }", body)
+                    await page.frame_locator("#f").locator("#go").click()
+
+                    # The cross-origin fetch must land a row server-side.
+                    for _ in range(100):
+                        if store.pending_inputs(conn):
+                            break
+                        await asyncio.sleep(0.05)
+                    assert store.pending_inputs(conn), "submission never reached /api/input"
+                finally:
+                    await browser.close()
+
+            # And the kernel drain delivers it to the awaiting channel.
+            runtime._drain_inputs()
+            got = await asyncio.wait_for(inp.recv(), timeout=2.0)
+            assert got == {"clicked": True, "who": "ada"}
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(run())

--- a/packages/mcp/tests/test_inputs.py
+++ b/packages/mcp/tests/test_inputs.py
@@ -1,0 +1,278 @@
+"""Interactive input: the browser -> kernel write path behind interactive
+resources. Covers the store queue (`channels`/`inputs`), the dashboard
+`/api/input` gate + CORS, the kernel-side drain into a live `Input`, and the
+`ask` convenience end to end (a store submission resolves the awaiting call)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from ix_notebook_mcp import dashboard, runtime, store
+from ix_notebook_mcp.config import Config
+
+# --------------------------------------------------------------------------- #
+# store: the channel registry and the input queue
+# --------------------------------------------------------------------------- #
+
+
+def test_channel_gate_and_input_queue_roundtrip(tmp_path: Path) -> None:
+    conn = store.connect(tmp_path / "in.db")
+    # An unknown channel is not open: `/api/input` refuses it.
+    assert store.channel_open(conn, "nope") is False
+    store.open_channel(conn, id="cap1", title="name")
+    assert store.channel_open(conn, "cap1") is True
+
+    store.add_input(conn, channel="cap1", payload=json.dumps({"value": "ada"}))
+    store.add_input(conn, channel="cap1", payload=json.dumps({"value": "linus"}))
+    pending = store.pending_inputs(conn)
+    assert [json.loads(p["payload"])["value"] for p in pending] == ["ada", "linus"]
+    # seq orders delivery and is what the kernel deletes by.
+    assert pending[0]["seq"] < pending[1]["seq"]
+
+    store.delete_inputs(conn, [pending[0]["seq"]])
+    remaining = store.pending_inputs(conn)
+    assert [json.loads(p["payload"])["value"] for p in remaining] == ["linus"]
+
+
+def test_close_channel_refuses_and_drops_queued(tmp_path: Path) -> None:
+    conn = store.connect(tmp_path / "in.db")
+    store.open_channel(conn, id="cap", title="t")
+    store.add_input(conn, channel="cap", payload="null")
+    store.close_channel(conn, id="cap")
+    # A closed channel no longer accepts input, and its undelivered queue is gone.
+    assert store.channel_open(conn, "cap") is False
+    assert store.pending_inputs(conn) == []
+
+
+def test_mark_interrupted_closes_channels_and_clears_inputs(tmp_path: Path) -> None:
+    conn = store.connect(tmp_path / "in.db")
+    store.open_channel(conn, id="cap", title="t")
+    store.add_input(conn, channel="cap", payload="1")
+    store.mark_interrupted(conn, ended_at=123.0)
+    # A reopened session must not leave a stale capability accepting input no
+    # awaiter reads, nor carry forward a previous run's queued submissions.
+    assert store.channel_open(conn, "cap") is False
+    assert store.pending_inputs(conn) == []
+
+
+# --------------------------------------------------------------------------- #
+# dashboard: the /api/input write path + CORS, with no kernel involved
+# --------------------------------------------------------------------------- #
+
+
+def _app(tmp_path: Path) -> tuple[Config, sqlite3.Connection]:
+    db = tmp_path / "api.db"
+    conn = store.connect(db)
+    cfg = Config(workdir=tmp_path, store_path=db)
+    return cfg, conn
+
+
+async def _client(cfg: Config, conn: sqlite3.Connection) -> TestClient:
+    client = TestClient(TestServer(dashboard.build_app(cfg, conn)))
+    await client.start_server()
+    return client
+
+
+def test_api_input_network_gate(tmp_path: Path) -> None:
+    async def run() -> None:
+        db = tmp_path / "gate.db"
+        conn = store.connect(db)
+        store.open_channel(conn, id="cap", title="t")
+        body = json.dumps({"channel": "cap", "payload": 1})
+        # A non-loopback (tailnet) bind without trust refuses input: the channel id
+        # rides in HTML the read endpoints serve, so it is not a secret -- input is
+        # authorized by the network boundary, like /api/exec.
+        untrusted = Config(workdir=tmp_path, store_path=db, host="100.64.0.1")
+        client = await _client(untrusted, conn)
+        try:
+            resp = await client.post("/api/input", data=body)
+            assert resp.status == 403
+            assert store.pending_inputs(conn) == []
+        finally:
+            await client.close()
+        # Trusting the tailnet (what the fleet sets) accepts it.
+        trusted = Config(workdir=tmp_path, store_path=db, host="100.64.0.1", exec_trust_network=True)
+        client = await _client(trusted, conn)
+        try:
+            resp = await client.post("/api/input", data=body)
+            assert resp.status == 200
+            assert len(store.pending_inputs(conn)) == 1
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+def test_api_input_accepts_open_channel_and_queues(tmp_path: Path) -> None:
+    async def run() -> None:
+        cfg, conn = _app(tmp_path)
+        store.open_channel(conn, id="cap", title="t")
+        client = await _client(cfg, conn)
+        try:
+            resp = await client.post(
+                "/api/input", data=json.dumps({"channel": "cap", "payload": {"value": "hi"}})
+            )
+            assert resp.status == 200
+            assert (await resp.json())["ok"] is True
+            # The submission is queued for the kernel to drain.
+            pending = store.pending_inputs(conn)
+            assert len(pending) == 1
+            assert json.loads(pending[0]["payload"]) == {"value": "hi"}
+            # CORS so the opaque-origin iframe can read the response.
+            assert resp.headers["Access-Control-Allow-Origin"] == "*"
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+def test_api_input_rejects_unknown_and_closed_channel(tmp_path: Path) -> None:
+    async def run() -> None:
+        cfg, conn = _app(tmp_path)
+        client = await _client(cfg, conn)
+        try:
+            resp = await client.post(
+                "/api/input", data=json.dumps({"channel": "ghost", "payload": 1})
+            )
+            assert resp.status == 404
+            assert store.pending_inputs(conn) == []
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+def test_api_input_validation_and_size_cap(tmp_path: Path) -> None:
+    async def run() -> None:
+        cfg, conn = _app(tmp_path)
+        store.open_channel(conn, id="cap", title="t")
+        client = await _client(cfg, conn)
+        try:
+            # Missing payload key is a 400 (distinct from a closed channel's 404).
+            resp = await client.post("/api/input", data=json.dumps({"channel": "cap"}))
+            assert resp.status == 400
+            # Not JSON is a 400.
+            resp = await client.post("/api/input", data="not json")
+            assert resp.status == 400
+            # Oversized body is a 413, not an unbounded write.
+            big = json.dumps({"channel": "cap", "payload": "x" * (dashboard._MAX_INPUT_BYTES + 10)})
+            resp = await client.post("/api/input", data=big)
+            assert resp.status == 413
+            assert store.pending_inputs(conn) == []
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+def test_api_input_preflight_returns_cors(tmp_path: Path) -> None:
+    async def run() -> None:
+        cfg, conn = _app(tmp_path)
+        client = await _client(cfg, conn)
+        try:
+            resp = await client.options("/api/input")
+            assert resp.status == 204
+            assert resp.headers["Access-Control-Allow-Origin"] == "*"
+            assert "POST" in resp.headers["Access-Control-Allow-Methods"]
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+# --------------------------------------------------------------------------- #
+# runtime: the kernel end -- a queued submission drains into the awaiting Input
+# --------------------------------------------------------------------------- #
+
+
+def _wire_runtime(monkeypatch: pytest.MonkeyPatch, conn: sqlite3.Connection) -> None:
+    monkeypatch.setattr(runtime, "_store", store)
+    monkeypatch.setattr(runtime, "_store_conn", conn)
+    runtime.input_channels.clear()
+
+
+def test_input_script_targets_endpoint_and_channel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IX_MCP_DATA_API_URL", "http://node:9000/")
+    conn = store.connect(tmp_path / "r.db")
+    _wire_runtime(monkeypatch, conn)
+    inp = runtime.Input(title="name")
+    # Opening the channel makes a fast submission authorized before first render.
+    assert store.channel_open(conn, inp.id) is True
+    script = inp.script
+    assert "http://node:9000/api/input" in script
+    assert inp.id in script
+    assert "ixSubmit" in script
+
+
+def test_drain_delivers_payload_to_awaiting_input(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+        inp = runtime.Input(title="name")
+        # Simulate the browser POST landing via the dashboard.
+        store.add_input(conn, channel=inp.id, payload=json.dumps({"value": "ada"}))
+        # The flush tick drains the store into the live channel.
+        runtime._drain_inputs()
+        assert await asyncio.wait_for(inp.recv(), timeout=1.0) == {"value": "ada"}
+        # The row is consumed (delivered exactly once).
+        assert store.pending_inputs(conn) == []
+
+    asyncio.run(run())
+
+
+def test_drain_drops_input_for_closed_channel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = store.connect(tmp_path / "r.db")
+    _wire_runtime(monkeypatch, conn)
+    inp = runtime.Input(title="x")
+    inp.close()
+    store.add_input(conn, channel=inp.id, payload="1")
+    runtime._drain_inputs()
+    # No awaiter remains; the orphaned submission is dropped, not retained.
+    assert store.pending_inputs(conn) == []
+
+
+def test_ask_resolves_from_submission_and_shapes_reply(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        monkeypatch.setenv("IX_MCP_DATA_API_URL", "http://node:9000/")
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+
+        async def answer_after(channel_title_substr: str, payload: dict) -> None:
+            # Wait for ask() to open its channel, then deliver a submission as the
+            # browser would, and run the drain the flusher normally runs.
+            for _ in range(200):
+                live = [c for c in runtime.input_channels.values() if not c.closed()]
+                if live:
+                    store.add_input(conn, channel=live[0].id, payload=json.dumps(payload))
+                    runtime._drain_inputs()
+                    return
+                await asyncio.sleep(0.005)
+            raise AssertionError("ask never opened a channel")
+
+        # Single free-text answer reads as the bare value.
+        asker = asyncio.ensure_future(runtime.ask("name?"))
+        await answer_after("name?", {"value": "ada"})
+        assert await asyncio.wait_for(asker, timeout=1.0) == "ada"
+        # The window (resource) and channel are closed once answered.
+        assert all(c.closed() for c in runtime.input_channels.values())
+
+        # A multi-field form reads as the dict the caller named.
+        asker = asyncio.ensure_future(runtime.ask("creds", fields=["user", "password"]))
+        await answer_after("creds", {"user": "ada", "password": "pw"})
+        assert await asyncio.wait_for(asker, timeout=1.0) == {"user": "ada", "password": "pw"}
+
+    asyncio.run(run())
+
+
+def test_ask_rejects_choices_and_fields_together() -> None:
+    async def run() -> None:
+        with pytest.raises(ValueError, match="choices or fields"):
+            await runtime.ask("x", choices=["a"], fields=["b"])
+
+    asyncio.run(run())


### PR DESCRIPTION
## What

Interactive **input** for the MCP server's HTML resources. Before, a `Resource` could only push HTML *to* the human; now the human can push *back*. The agent can pop a window up and await a reply.

```python
name   = await ask("What should I name the branch?")             # the typed string
target = await ask("Deploy where?", choices=["staging", "prod"]) # the chosen string
creds  = await ask("DB creds", fields=["user", "password"])      # {"user": ..., "password": ...}
```

`ask` renders a form as a live resource (a dashboard pane, and a floating window under `ix-windows`), blocks until the human submits, closes the window, and returns the answer. It backgrounds past the budget like any long await; read it back with `await jobs['<id>']`. For arbitrary HTML, the `Input` primitive: drop its `.script` into any resource and have your markup call `ixSubmit(payload)`.

## How

- The resource HTML mounts in a sandboxed, opaque-origin iframe (`sandbox="allow-scripts"`, no `allow-same-origin`) in both the web dashboard and `ix-windows`. An opaque-origin sandbox can still make a **cross-origin `fetch`**, which is what `ixSubmit` does.
- New `POST /api/input` on the data API (server process) validates the channel is open and appends the submission to a store `inputs` queue. The kernel (separate process) drains it on its existing 0.5s flush tick and the awaiting `await` resolves. Same store-as-source-of-truth shape as jobs/cells/resources.
- **Pure Python, one package.** No `dashboard-core` (Rust) or `site` (Svelte) changes.

## Security

`/api/input` is authorized by the **network boundary** like `/api/exec`, NOT by a secret: the channel id rides in HTML the read endpoints + hub serve, so it is an address, not a capability. Allowed on a loopback bind; on a tailnet bind only when `IX_MCP_EXEC_TRUST_NETWORK` is set (the fleet sets it). Reviewed by the `code-reviewer` agent: an earlier "secret capability" design was a flagged blocker and was replaced by this gate.

## Tests (wired as nix checks)

- `inputsTests` (`test_inputs.py`): store queue, `/api/input` gate + CORS + size cap over a real aiohttp `TestServer`, kernel drain, `ask` shaping, network gate.
- `inputBrowserSmoke` (`test_input_browser.py`): a real headless Chromium mounts an `Input`'s HTML in a sandboxed opaque-origin iframe, clicks the button, and the cross-origin `ixSubmit` fetch must reach the real `/api/input` and drain into the awaiting channel.

Validated locally: both new checks green, plus `apiSmoke`/`serverTools`/`runtimeSmoke`/`sessionSmoke`/`feedSmoke`/`evalSmoke`/`requirementsSmoke` and `nix build .#mcp`. Also exercised end-to-end against a live `ix-mcp serve` over `mcp_client` (real `/api/input` POST -> `await inp.recv()` resolved).

🤖 Generated with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add interactive `ask()` and `Input` primitives for HTML resource input in MCP notebooks
> - Adds `ask()` and `Input` to the runtime namespace, allowing notebook code to render an HTML form as a live resource and await user submission via the browser.
> - Adds a `/api/input` endpoint to the dashboard with CORS preflight support, network-gated authorization (loopback always allowed; non-loopback requires `exec_trust_network`), and a 256 KiB body cap.
> - Persists channel and submission state in the SQLite store via new `channels` and `inputs` tables; the flusher drains pending submissions each tick and delivers them to awaiting `Input` queues with exactly-once semantics.
> - On kernel interruption, all open channels are closed and queued inputs are cleared to prevent stale channels from accepting submissions with no awaiter.
> - Adds pytest and Playwright browser smoke tests covering the full submission flow, network gating, and `ask()` reply shaping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de39cb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->