### PR TITLE
feat(humanlayer): boot an ix VM running the HumanLayer remote daemon

### DIFF
--- a/images/dev/humanlayer-daemon/default.nix
+++ b/images/dev/humanlayer-daemon/default.nix
@@ -1,0 +1,30 @@
+# A bootable ix VM that runs the HumanLayer (riptide) remote daemon.
+#
+# Builds on the dev base image so the daemon has the agent CLIs and build
+# toolchain a remote HumanLayer host needs to drive coding sessions. The daemon
+# itself is the `services.humanlayer` module.
+#
+# Auth: drop a launch token at `/run/secrets/humanlayer/launch-token` before
+# boot (mint with `humanlayer api auth daemon launch-token create` on an
+# authenticated host, or copy the launch command from app.humanlayer.com). The
+# token is read at service start and never baked into the image.
+{
+  ix,
+  pkgs,
+  ...
+}:
+{
+  imports = [ (ix.paths.root + "/images/dev/development-base") ];
+
+  # development-base sets the name with mkOptionDefault, so this plain
+  # assignment overrides it. Named distinctly from the `humanlayer` CLI package
+  # so the two do not collide in the flake package set.
+  ix.image.name = "humanlayer-daemon";
+
+  environment.systemPackages = [ pkgs.humanlayer ];
+
+  services.humanlayer = {
+    enable = true;
+    launchTokenFile = "/run/secrets/humanlayer/launch-token";
+  };
+}

--- a/modules/services/humanlayer/default.nix
+++ b/modules/services/humanlayer/default.nix
@@ -91,7 +91,10 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
-      path = [ pkgs.coreutils ];
+      path = [
+        cfg.package
+        pkgs.coreutils
+      ] ++ config.environment.systemPackages;
       environment.HOME = cfg.stateDir;
 
       # The CLI only accepts the launch token as an argument, so read it from the

--- a/modules/services/humanlayer/default.nix
+++ b/modules/services/humanlayer/default.nix
@@ -1,0 +1,114 @@
+# HumanLayer (riptide) remote daemon.
+#
+# Runs `humanlayer daemon launch` as a long-lived systemd service so an ix VM
+# can act as a remote HumanLayer host: the daemon dials out to the HumanLayer
+# cloud and drives coding sessions on this guest. It binds no inbound socket
+# (outbound-only), so there is no port claim.
+#
+# Auth: the daemon needs a launch token. Mint one on an authenticated host with
+# `humanlayer api auth daemon launch-token create` (or copy the launch command
+# from app.humanlayer.com) and place the token at {option}`launchTokenFile`
+# through your secret mechanism. The token is read at service start and is never
+# baked into the image. The daemon then exchanges the launch token for its own
+# daemon credentials. Mirrors the runtime-secret idiom in
+# modules/services/ci-runner (a `tokenFile` runtime path string).
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+  cfg = config.services.humanlayer;
+
+  # Environment selector. The CLI defaults to prod when no flag is passed; the
+  # other environments are opt-in for beta/dev/local backends.
+  envArg =
+    if cfg.environment == null then
+      ""
+    else
+      {
+        beta = " --beta";
+        dev = " --dev";
+        local = " --local";
+      }
+      .${cfg.environment};
+in
+{
+  options.services.humanlayer = {
+    enable = mkEnableOption "the HumanLayer (riptide) remote daemon";
+
+    package = mkPackageOption pkgs "humanlayer" { };
+
+    launchTokenFile = mkOption {
+      # A runtime path string, not `types.path`: the file is provided at boot by
+      # a secret mechanism outside the image, not a build input.
+      type = types.str;
+      example = "/run/secrets/humanlayer/launch-token";
+      description = ''
+        Path to a file holding a HumanLayer launch token, read when the daemon
+        starts. Mint one on an authenticated host with
+        `humanlayer api auth daemon launch-token create` and place it here. The
+        token is never baked into the image.
+      '';
+    };
+
+    environment = mkOption {
+      type = types.nullOr (
+        types.enum [
+          "beta"
+          "dev"
+          "local"
+        ]
+      );
+      default = null;
+      description = ''
+        HumanLayer backend environment. `null` uses the CLI default (prod). Set
+        to `beta`, `dev`, or `local` to target a non-production backend.
+      '';
+    };
+
+    stateDir = mkOption {
+      type = types.str;
+      default = "/var/lib/humanlayer";
+      description = ''
+        HOME for the daemon. The riptide daemon keeps its host id, logs, plugins,
+        and artifacts under `$HOME/.humanlayer`.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.humanlayer-daemon = {
+      description = "HumanLayer (riptide) remote daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      path = [ pkgs.coreutils ];
+      environment.HOME = cfg.stateDir;
+
+      # The CLI only accepts the launch token as an argument, so read it from the
+      # secret file at start and exec the daemon. Argv exposure is not a boundary
+      # here: a root process inside the guest is fully capable anyway (see the
+      # image-conventions skill), and the secret never leaves the VM.
+      script = ''
+        token="$(cat ${lib.escapeShellArg cfg.launchTokenFile})"
+        exec ${lib.getExe cfg.package} daemon launch --launch-token "$token"${envArg}
+      '';
+
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = 5;
+        StateDirectory = "humanlayer";
+        StateDirectoryMode = "0700";
+      };
+    };
+  };
+}

--- a/packages/humanlayer/default.nix
+++ b/packages/humanlayer/default.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  nix,
+  # Bound to a real builder only on the flake-package path (lib/packages.nix),
+  # which is where `nix run .#humanlayer.updateScript` resolves; the overlay path
+  # passes nothing, so `pkgs.humanlayer` carries no updateScript. Same pattern as
+  # packages/yc and packages/agent/claude-code.
+  writeNushellApplication ? null,
+}:
+let
+  # Version and per-platform hashes live in manifest.json as the single owner;
+  # this file only reads them back. Refresh with
+  # `nix run .#humanlayer.updateScript` (see the updateScript below). Mirrors the
+  # packages/yc layout.
+  manifest = lib.importJSON ./manifest.json;
+  inherit (manifest) version;
+
+  # The `@humanlayer/cli` npm launcher is a thin JS shim that execs a
+  # platform-specific, bun-compiled standalone binary shipped in a sibling
+  # package (`@humanlayer/cli-<slug>`). We fetch that platform binary directly:
+  # it is the real `humanlayer` executable, so the JS launcher is not needed.
+  baseUrl = "https://registry.npmjs.org/@humanlayer";
+
+  inherit (stdenv.hostPlatform) system;
+  target =
+    manifest.platforms.${system}
+      or (throw "humanlayer: no prebuilt binary for ${system}; supported: ${lib.concatStringsSep ", " (builtins.attrNames manifest.platforms)}");
+
+  src = fetchurl {
+    url = "${baseUrl}/cli-${target.slug}/-/cli-${target.slug}-${version}.tgz";
+    inherit (target) hash;
+  };
+
+  # Tracks the upstream npm `latest` dist-tag and refreshes manifest.json with
+  # the per-platform SRI hashes. HumanLayer publishes no signed manifest, so
+  # there is NO provenance check: the updater pins whatever bytes the npm
+  # registry serves. The `nix build .#humanlayer` step in the update workflow
+  # only proves the pinned bytes fetch and patch on x86_64-linux, not that they
+  # are authentic, so the real gate is human review of the hash changes in the
+  # auto-bump PR. Same posture as packages/yc.
+  updateScript =
+    if writeNushellApplication == null then
+      null
+    else
+      writeNushellApplication {
+        name = "humanlayer-update";
+        runtimeInputs = [ nix ];
+        meta.description = "Refresh packages/humanlayer/manifest.json to the latest HumanLayer CLI release";
+        text = ''
+          const base = "https://registry.npmjs.org/@humanlayer"
+          const slugs = {
+            "x86_64-linux": "linux-x64",
+            "aarch64-linux": "linux-arm64",
+            "aarch64-darwin": "darwin-arm64",
+            "x86_64-darwin": "darwin-x64"
+          }
+
+          # Run from the repo root: `nix run .#humanlayer.updateScript -- [version]`.
+          # Without a version argument it tracks the upstream npm `latest` tag.
+          def main [version?: string] {
+            let v = ($version | default (http get $"($base)/cli/latest" | get version))
+            let platforms = (
+              $slugs
+              | transpose system slug
+              | reduce --fold {} {|row acc|
+                  let url = $"($base)/cli-($row.slug)/-/cli-($row.slug)-($v).tgz"
+                  let sri = (^nix store prefetch-file --json $url | from json | get hash)
+                  $acc | insert $row.system { slug: $row.slug, hash: $sri }
+                }
+            )
+            let out = "packages/humanlayer/manifest.json"
+            { version: $v, platforms: $platforms } | to json --indent 2 | save --force $out
+            print $"updated ($out) to ($v)"
+          }
+        '';
+      };
+in
+stdenv.mkDerivation {
+  pname = "humanlayer";
+  inherit version src;
+
+  # The npm tarball unpacks to `package/` (bin/humanlayer + package.json).
+  sourceRoot = "package";
+
+  # The Linux binaries are dynamically linked against a generic libc; patch their
+  # interpreter and standard library NEEDEDs to the Nix store. Darwin binaries
+  # need no patching.
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin/humanlayer $out/bin/humanlayer
+    runHook postInstall
+  '';
+
+  passthru = lib.optionalAttrs (updateScript != null) {
+    inherit updateScript;
+  };
+
+  meta = {
+    description = "HumanLayer CLI: manage the riptide remote daemon, agents, and HumanLayer API";
+    homepage = "https://humanlayer.com";
+    # License omitted rather than `licenses.unfree` so the per-system flake
+    # package set (which evaluates nixpkgs without `allowUnfree`) can still
+    # `nix run .#humanlayer`. Same posture as packages/yc. Distribution terms are
+    # HumanLayer's; this flake only repackages the published binaries.
+    mainProgram = "humanlayer";
+    platforms = builtins.attrNames manifest.platforms;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/packages/humanlayer/manifest.json
+++ b/packages/humanlayer/manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.27.10",
+  "platforms": {
+    "x86_64-linux": {
+      "slug": "linux-x64",
+      "hash": "sha256-rVnZtNJIwOjrMGyktQWAOq69CQvX3M2UssrDaAvVOG0="
+    },
+    "aarch64-linux": {
+      "slug": "linux-arm64",
+      "hash": "sha256-HXp9fE1t32Bet+f7CZZn2I2k+quEYuQTomz/UsDLiQQ="
+    },
+    "aarch64-darwin": {
+      "slug": "darwin-arm64",
+      "hash": "sha256-dB0KbEPuip0UmglvsLQ/7HUoaH6VOby5BgJV6KXN2yI="
+    },
+    "x86_64-darwin": {
+      "slug": "darwin-x64",
+      "hash": "sha256-j9I84fJCvG4U9Epm3fx45VT9XcmS/YO7UQMo1q+luuc="
+    }
+  }
+}

--- a/packages/humanlayer/package.nix
+++ b/packages/humanlayer/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "humanlayer";
+  packageSet = true;
+  flake = true;
+  overlay = true;
+  updateScript = true;
+}

--- a/site/src/lib/updates/humanlayer-daemon.svx
+++ b/site/src/lib/updates/humanlayer-daemon.svx
@@ -1,0 +1,19 @@
+---
+id: humanlayer-daemon
+postedAt: 2026-06-18T09:00:00-07:00
+title: "HumanLayer remote daemon in an ix VM"
+tags: [interesting, images, agents]
+links:
+  - label: image source
+    href: https://github.com/indexable-inc/index/blob/main/images/dev/humanlayer-daemon/default.nix
+  - label: service module
+    href: https://github.com/indexable-inc/index/blob/main/modules/services/humanlayer/default.nix
+  - label: CLI package
+    href: https://github.com/indexable-inc/index/blob/main/packages/humanlayer/default.nix
+---
+
+The `humanlayer-daemon` image boots an ix VM that runs the HumanLayer (riptide) remote daemon, so a guest can act as a remote HumanLayer host driving coding sessions. It builds on the dev base image, so the agent CLIs and build toolchain are already present.
+
+The daemon is the `services.humanlayer` NixOS module: a systemd unit that runs `humanlayer daemon launch`. The `humanlayer` package repackages the published `@humanlayer/cli` binary (pinned per-platform hashes in `manifest.json`, refreshed by `nix run .#humanlayer.updateScript`).
+
+Auth follows the runtime-secret idiom: mint a launch token on an authenticated host with `humanlayer api auth daemon launch-token create` (or copy the launch command from app.humanlayer.com) and drop it at `/run/secrets/humanlayer/launch-token`. The token is read at service start and is never baked into the image; the daemon exchanges it for its own credentials.


### PR DESCRIPTION
## What

A HumanLayer integration so an ix VM can run the HumanLayer (riptide) remote daemon, acting as a remote host that drives coding sessions.

Three pieces, following existing repo conventions:

- **`packages/humanlayer`** - repackages the published `@humanlayer/cli` standalone binary (the bun-compiled exe shipped inside the per-platform `@humanlayer/cli-<slug>` npm tarball). Per-platform SRI hashes are pinned in `manifest.json` and refreshed by `nix run .#humanlayer.updateScript` (tracks the npm `latest` tag). HumanLayer publishes no signed manifest, so there is no provenance check - the auto-bump PR's hash diff is the review gate. Same prebuilt-binary shape as `packages/yc`.
- **`modules/services/humanlayer`** - a `services.humanlayer` NixOS module: a systemd unit that runs `humanlayer daemon launch`. Outbound-only (no inbound socket), so no port claim.
- **`images/dev/humanlayer-daemon`** - a bootable ix VM that enables the service on the dev base image (so the daemon has the agent CLIs + toolchain it needs). Named distinctly from the `humanlayer` CLI package to avoid a flake package-set name collision.

Plus a site updates entry.

## Auth (runtime secret, never baked)

The daemon needs a launch token. Mint one on an authenticated host:

```
humanlayer api auth daemon launch-token create
```

(or copy the launch command from app.humanlayer.com), then drop it at `/run/secrets/humanlayer/launch-token` via your secret mechanism. It is read at service start; the daemon exchanges it for its own credentials. This follows the `ci-runner` `tokenFile` runtime-path idiom.

## Verification

- `nix build .#humanlayer` builds and the patched binary runs on this host (aarch64-linux).
- Lint passes (`nix run .#lint`: deadnix, statix, astlog, nixfmt all green).
- The service module renders correctly in a standalone eval: `token="$(cat /run/secrets/humanlayer/launch-token)"` then `exec .../humanlayer daemon launch --launch-token "$token"[ --beta]`.
- The `humanlayer-daemon` image evaluates past the module (full x86_64-linux image build needs an x86_64 builder, unavailable on this aarch64 host).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Boot an ix VM running the HumanLayer remote daemon
> - Adds [`packages/humanlayer`](https://github.com/indexable-inc/index/pull/1367/files#diff-33b58e177ce718308782df42303578214fe1610e2e1f6a2ecf4aabdcad99a558), a Nix derivation that fetches the prebuilt `@humanlayer/cli` npm binary for Linux and Darwin, patching the ELF interpreter on Linux via `autoPatchelfHook`.
> - Adds [`modules/services/humanlayer`](https://github.com/indexable-inc/index/pull/1367/files#diff-8f685b1c54e9b19e4e2c97fd8bf566c888c1f55f02bf49e221110673afa8d606), a NixOS module that runs `humanlayer daemon launch` as a systemd service, reading a launch token from a configured file path and restarting on failure with a 5s delay.
> - Adds [`images/dev/humanlayer-daemon`](https://github.com/indexable-inc/index/pull/1367/files#diff-50a0af3d1ca150c5409820781d994b01b9d711c061b6b9b6d901d7362457ac28), an ix image that bundles the CLI and enables the daemon service with the token path set to `/run/secrets/humanlayer/launch-token`.
> - Adds a [site update post](https://github.com/indexable-inc/index/pull/1367/files#diff-2f2dcaa18c88c4207d69f5d7db82ab28b23967069b5f933c55869c35b843c78f) announcing the new image, module, and package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bb7a7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->