### PR TITLE
agent: add deep-debugging rule to house system prompt

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -32,6 +32,8 @@ let
 
   sourceOfRecord = "Rank evidence by reliability: specific beats general, local beats documentation, primary beats secondary, and directly observed beats recalled. Treat memory, training knowledge, and prior assumptions as leads to check, not as facts; when a lead contradicts what you observe, name the contradiction before resolving it. Any absence claim ('there is no X', 'nothing calls Y', 'it is not configured') requires a fresh search, never a recollection. Verify every checkable claim at the most local authoritative layer before you rely on it.";
 
+  deepDebugging = "When you diagnose a failure (a hang, crash, slowdown, leak, wrong output, or any 'why is it doing that'), never settle for a plausible story from the symptom, the error text, the on-screen status line, or your intuition about what is probably happening: go get direct evidence from the running system and let that, not a hypothesis, name the cause. Reach for the strongest probe the situation allows, and escalate until the cause is observed rather than inferred. Attach a debugger to a live or wedged process and read the actual backtrace (`lldb -p <pid> --batch -o bt -o detach -o quit`, or `gdb -p <pid> -batch -ex bt`; `bt all` for every thread); take repeated stack samples to find where time is truly spent instead of guessing the hot path (`sample <pid> 2` on macOS; `py-spy`, `perf`, `eu-stack`, or `cat /proc/<pid>/stack` on Linux); trace what a process is actually blocked on at the syscall and I/O layer (`dtruss`/`dtrace`/`fs_usage` on macOS; `strace`/`ltrace`/`bpftrace` on Linux); inspect live state directly (open files and sockets via `lsof`, connections via `ss`, the store/db/wire bytes, a core dump, the real log). Distinguish stuck from merely slow by measurement, not appearance: a flat CPU-time delta or a stack parked in a wait syscall is blocked, a stack that moves across samples is progressing, and a status line printed minutes ago proves nothing about now. Prefer a non-intrusive probe (sampling) before one that pauses the target (a debugger attach), and always detach cleanly so you never leave the process stopped. Read the actual artifact over its description: the stack over the spinner text, the bytes over the schema, the value over the variable name. Then report the specific observation and the confidence it earns; an intuition you did not check is not a finding.";
+
   # STOCK-DERIVED
   matchSurroundingCode = "Write code that reads like the code around it: match its comment density, naming, and idioms.";
 
@@ -118,6 +120,7 @@ let
     shokunin
     validateAlways
     sourceOfRecord
+    deepDebugging
     matchSurroundingCode
     inlineComments
     preV1


### PR DESCRIPTION
## What

Adds a `deepDebugging` rule to the house Claude system prompt (`packages/agent/system-prompt.nix`), placed right after `sourceOfRecord` in the evidence cluster.

## Why

When diagnosing failures (hangs, crashes, slowdowns), the agent too readily reasons from the symptom, the error text, or a stale on-screen status line instead of going to get direct evidence. This rule pushes it to escalate to the strongest available probe and let the observation, not a hypothesis, name the cause.

Motivated by a live session: a `nix run .#ix -- new` looked "stuck on copying to the store", but attaching `lldb` and sampling the process showed it was actually CPU-bound in flake evaluation. The on-screen line was stale. Intuition would have been wrong; the backtrace was right.

## The rule

Concretely it tells the agent to:
- attach a debugger and read the real backtrace (`lldb -p <pid> --batch -o bt -o detach -o quit`, `gdb -p`)
- sample for the hot path (`sample` / `py-spy` / `perf`) instead of guessing
- trace syscalls/IO (`dtruss`/`dtrace`, `strace`/`bpftrace`) to see what it's blocked on
- inspect live state (`lsof`, `ss`, core dumps, real logs, wire bytes)
- distinguish stuck from slow by measurement (flat CPU delta / wait-syscall = blocked; moving stack = progressing)
- prefer non-intrusive sampling before a pausing attach, and detach cleanly
- read the artifact over its description; an unchecked intuition is not a finding

## Validation

✅ `nix eval` of `system-prompt.nix` parses, rule present, prompt grows from 40 to 41 rules.

(opened by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deep-debugging guidance to agent house system prompt
> Adds a new `deepDebugging` prompt constant to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1369/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) with guidance on diagnosing failures using direct evidence and strong probes (debuggers, stack sampling, syscall tracing, etc.). The constant is included in the combined prompt set alongside existing entries like `shokunin` and `validateAlways`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b810e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->