### PR TITLE
feat(ix-vt): OscTitleTracker for the OSC window title

### DIFF
--- a/packages/tui/vt/ix-vt/src/lib.rs
+++ b/packages/tui/vt/ix-vt/src/lib.rs
@@ -701,18 +701,17 @@ const ST_FINAL: u8 = b'\\';
 const CAN: u8 = 0x18;
 const SUB: u8 = 0x1a;
 
-/// Where the framing scanner is within an `ESC ] … (BEL | ESC \)` OSC sequence.
+/// Where the framing scanner is within an `ESC ] … (BEL | ESC | CAN | SUB)` OSC
+/// sequence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FrameState {
     /// Outside any escape sequence.
     Ground,
-    /// Saw `ESC`; a following `]` opens an OSC.
+    /// Saw `ESC`; a following `]` opens an OSC (and a following `\` after an OSC
+    /// is the tail of a String Terminator, which lands back in `Ground`).
     Escape,
     /// Inside an OSC payload, forwarding bytes to the parser.
     Osc,
-    /// Inside an OSC payload and just saw `ESC`; a following `\` is the ST
-    /// terminator, anything else aborts the sequence.
-    OscEscape,
 }
 
 /// Tracks the most recent OSC window title in a raw terminal byte stream.
@@ -798,24 +797,18 @@ impl OscTitleTracker {
                     unsafe { sys::ghostty_osc_reset(self.parser) };
                     FrameState::Ground
                 }
-                ESC => FrameState::OscEscape,
+                // ESC always ends the OSC string: a following `\` makes it a
+                // clean ST, but any other escape sequence still terminates and
+                // dispatches the OSC (ghostty does the same). So finish here and
+                // re-enter Escape; a following `\` then harmlessly falls back to
+                // Ground, and a `[`, `]`, … starts its own sequence.
+                ESC => {
+                    self.finish(ST_FINAL);
+                    FrameState::Escape
+                }
                 _ => {
                     unsafe { sys::ghostty_osc_next(self.parser, byte) };
                     FrameState::Osc
-                }
-            },
-            FrameState::OscEscape => match byte {
-                ST_FINAL => {
-                    self.finish(ST_FINAL);
-                    FrameState::Ground
-                }
-                ESC => FrameState::OscEscape,
-                // The ESC began a different sequence, not an ST: abandon the
-                // partial OSC and reinterpret this byte from Ground (so a fresh
-                // ESC still opens the next sequence).
-                _ => {
-                    unsafe { sys::ghostty_osc_reset(self.parser) };
-                    self.step(FrameState::Ground, byte)
                 }
             },
         }
@@ -824,22 +817,28 @@ impl OscTitleTracker {
     /// Terminate the current OSC and, if it set the window title, capture it.
     fn finish(&mut self, terminator: u8) {
         let command = unsafe { sys::ghostty_osc_end(self.parser, terminator) };
-        if unsafe { sys::ghostty_osc_command_type(command) }
-            == sys::GhosttyOscCommandType::GHOSTTY_OSC_COMMAND_CHANGE_WINDOW_TITLE
+        // Ask only for the title string rather than reading the command *type*:
+        // `ghostty_osc_command_data` returns false for any command that is not a
+        // window-title change, which both classifies the command and avoids
+        // materializing the `GhosttyOscCommandType` enum from the FFI return
+        // (ghostty could in principle return a tag outside the checked-in enum,
+        // which would be UB to form as a Rust enum).
+        let mut text: *const c_char = ptr::null();
+        let ok = unsafe {
+            sys::ghostty_osc_command_data(
+                command,
+                sys::GhosttyOscCommandData::GHOSTTY_OSC_DATA_CHANGE_WINDOW_TITLE_STR,
+                (&raw mut text).cast::<c_void>(),
+            )
+        };
+        // The string is owned by the parser and only valid until the next
+        // `ghostty_osc_*` call (including the reset below), so copy it now. Skip
+        // a title that is not valid UTF-8 (ghostty's stream path ignores those
+        // too) rather than substituting replacement characters.
+        if ok && !text.is_null()
+            && let Ok(title) = unsafe { CStr::from_ptr(text) }.to_str()
         {
-            let mut text: *const c_char = ptr::null();
-            let ok = unsafe {
-                sys::ghostty_osc_command_data(
-                    command,
-                    sys::GhosttyOscCommandData::GHOSTTY_OSC_DATA_CHANGE_WINDOW_TITLE_STR,
-                    (&raw mut text).cast::<c_void>(),
-                )
-            };
-            // The string is owned by the parser and only valid until the next
-            // `ghostty_osc_*` call (including the reset below), so copy it now.
-            if ok && !text.is_null() {
-                self.title = Some(unsafe { CStr::from_ptr(text) }.to_string_lossy().into_owned());
-            }
+            self.title = Some(title.to_owned());
         }
         unsafe { sys::ghostty_osc_reset(self.parser) };
     }

--- a/packages/tui/vt/ix-vt/src/lib.rs
+++ b/packages/tui/vt/ix-vt/src/lib.rs
@@ -14,8 +14,9 @@
 //! [`uzaaft/libghostty-rs`]: https://github.com/uzaaft/libghostty-rs
 //! [`resize`]: Terminal::resize
 
-use std::ffi::c_void;
+use std::ffi::{CStr, c_void};
 use std::fmt;
+use std::os::raw::c_char;
 use std::ptr;
 
 use ix_vt_sys as sys;
@@ -684,5 +685,152 @@ fn read_resolved_color(
         sys::GhosttyResult::GHOSTTY_SUCCESS => Ok(Some(unsafe { out.assume_init() }.into())),
         sys::GhosttyResult::GHOSTTY_INVALID_VALUE => Ok(None),
         other => Err(check(other).unwrap_err()),
+    }
+}
+
+/// `ESC` (0x1b), the introducer of every escape sequence.
+const ESC: u8 = 0x1b;
+/// `BEL` (0x07), one of the two OSC terminators.
+const BEL: u8 = 0x07;
+/// `]` (0x5d): the byte after `ESC` that opens an OSC sequence.
+const OSC_INTRODUCER: u8 = b']';
+/// `\` (0x5c): the byte after `ESC` that forms a String Terminator (ST).
+const ST_FINAL: u8 = b'\\';
+
+/// Where the framing scanner is within an `ESC ] … (BEL | ESC \)` OSC sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FrameState {
+    /// Outside any escape sequence.
+    Ground,
+    /// Saw `ESC`; a following `]` opens an OSC.
+    Escape,
+    /// Inside an OSC payload, forwarding bytes to the parser.
+    Osc,
+    /// Inside an OSC payload and just saw `ESC`; a following `\` is the ST
+    /// terminator, anything else aborts the sequence.
+    OscEscape,
+}
+
+/// Tracks the most recent OSC window title in a raw terminal byte stream.
+///
+/// libghostty-vt's [`Terminal`] does not expose the window title an application
+/// sets via OSC 0/2 (there is no such `ghostty_terminal_get` key), so a consumer
+/// that needs it (e.g. a multiplexer labeling a session by its live title) feeds
+/// the same byte stream here. This wraps ghostty's streaming OSC parser behind a
+/// small `ESC ]` … `BEL`/`ST` framing scanner, so a title sequence split across
+/// reads is still captured. Using ghostty's parser (not a hand-rolled scan) is
+/// what makes the OSC 0 vs 1 vs 2 title/icon classification correct.
+///
+/// The captured [`title`](Self::title) is owned, so it stays valid after the
+/// next [`feed`](Self::feed). Like [`Terminal`], the underlying parser has
+/// thread affinity (the raw pointer keeps it `!Send`); keep the tracker on one
+/// thread and do not add an `unsafe impl Send`.
+pub struct OscTitleTracker {
+    parser: sys::GhosttyOscParser_ptr,
+    frame: FrameState,
+    title: Option<String>,
+}
+
+impl OscTitleTracker {
+    /// Create an empty tracker.
+    ///
+    /// # Errors
+    /// Returns [`Error::OutOfMemory`] if ghostty cannot allocate the parser.
+    pub fn new() -> Result<Self> {
+        let mut parser: sys::GhosttyOscParser_ptr = ptr::null_mut();
+        check(unsafe { sys::ghostty_osc_new(ptr::null(), &raw mut parser) })?;
+        Ok(Self {
+            parser,
+            frame: FrameState::Ground,
+            title: None,
+        })
+    }
+
+    /// The most recent window title seen, if any.
+    #[must_use]
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Feed a chunk of raw terminal output, updating [`title`](Self::title) when
+    /// a complete OSC title sequence is seen. Byte boundaries are arbitrary: the
+    /// framing state persists across calls, so a sequence split mid-stream is
+    /// still parsed.
+    pub fn feed(&mut self, data: &[u8]) {
+        for &byte in data {
+            self.frame = self.step(self.frame, byte);
+        }
+    }
+
+    /// Advance the framing scanner one byte from `state`, returning the next
+    /// state and driving the OSC parser for payload bytes / terminators.
+    fn step(&mut self, state: FrameState, byte: u8) -> FrameState {
+        match state {
+            FrameState::Ground if byte == ESC => FrameState::Escape,
+            FrameState::Ground => FrameState::Ground,
+            FrameState::Escape => match byte {
+                OSC_INTRODUCER => {
+                    unsafe { sys::ghostty_osc_reset(self.parser) };
+                    FrameState::Osc
+                }
+                // Consecutive ESC: still waiting on the introducer.
+                ESC => FrameState::Escape,
+                _ => FrameState::Ground,
+            },
+            FrameState::Osc => match byte {
+                BEL => {
+                    self.finish(BEL);
+                    FrameState::Ground
+                }
+                ESC => FrameState::OscEscape,
+                _ => {
+                    unsafe { sys::ghostty_osc_next(self.parser, byte) };
+                    FrameState::Osc
+                }
+            },
+            FrameState::OscEscape => match byte {
+                ST_FINAL => {
+                    self.finish(ST_FINAL);
+                    FrameState::Ground
+                }
+                ESC => FrameState::OscEscape,
+                // The ESC began a different sequence, not an ST: abandon the
+                // partial OSC and reinterpret this byte from Ground (so a fresh
+                // ESC still opens the next sequence).
+                _ => {
+                    unsafe { sys::ghostty_osc_reset(self.parser) };
+                    self.step(FrameState::Ground, byte)
+                }
+            },
+        }
+    }
+
+    /// Terminate the current OSC and, if it set the window title, capture it.
+    fn finish(&mut self, terminator: u8) {
+        let command = unsafe { sys::ghostty_osc_end(self.parser, terminator) };
+        if unsafe { sys::ghostty_osc_command_type(command) }
+            == sys::GhosttyOscCommandType::GHOSTTY_OSC_COMMAND_CHANGE_WINDOW_TITLE
+        {
+            let mut text: *const c_char = ptr::null();
+            let ok = unsafe {
+                sys::ghostty_osc_command_data(
+                    command,
+                    sys::GhosttyOscCommandData::GHOSTTY_OSC_DATA_CHANGE_WINDOW_TITLE_STR,
+                    (&raw mut text).cast::<c_void>(),
+                )
+            };
+            // The string is owned by the parser and only valid until the next
+            // `ghostty_osc_*` call (including the reset below), so copy it now.
+            if ok && !text.is_null() {
+                self.title = Some(unsafe { CStr::from_ptr(text) }.to_string_lossy().into_owned());
+            }
+        }
+        unsafe { sys::ghostty_osc_reset(self.parser) };
+    }
+}
+
+impl Drop for OscTitleTracker {
+    fn drop(&mut self) {
+        unsafe { sys::ghostty_osc_free(self.parser) };
     }
 }

--- a/packages/tui/vt/ix-vt/src/lib.rs
+++ b/packages/tui/vt/ix-vt/src/lib.rs
@@ -696,6 +696,10 @@ const BEL: u8 = 0x07;
 const OSC_INTRODUCER: u8 = b']';
 /// `\` (0x5c): the byte after `ESC` that forms a String Terminator (ST).
 const ST_FINAL: u8 = b'\\';
+/// `CAN` (0x18) and `SUB` (0x1a): per ECMA-48 either one aborts an in-progress
+/// control string, so they cancel a partial OSC rather than landing in its text.
+const CAN: u8 = 0x18;
+const SUB: u8 = 0x1a;
 
 /// Where the framing scanner is within an `ESC ] … (BEL | ESC \)` OSC sequence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -725,6 +729,10 @@ enum FrameState {
 /// next [`feed`](Self::feed). Like [`Terminal`], the underlying parser has
 /// thread affinity (the raw pointer keeps it `!Send`); keep the tracker on one
 /// thread and do not add an `unsafe impl Send`.
+///
+/// Framing covers the 7-bit OSC forms terminal programs actually emit (`ESC ]`
+/// opener, `BEL` or `ESC \` terminator, `CAN`/`SUB` abort); the 8-bit C1 forms
+/// (`0x9d` opener, `0x9c` ST) are not recognized.
 pub struct OscTitleTracker {
     parser: sys::GhosttyOscParser_ptr,
     frame: FrameState,
@@ -770,6 +778,9 @@ impl OscTitleTracker {
             FrameState::Ground => FrameState::Ground,
             FrameState::Escape => match byte {
                 OSC_INTRODUCER => {
+                    // Reset on open so a previous OSC abandoned without a
+                    // terminator (e.g. an `ESC [` arrived mid-payload) cannot
+                    // bleed into this one.
                     unsafe { sys::ghostty_osc_reset(self.parser) };
                     FrameState::Osc
                 }
@@ -780,6 +791,11 @@ impl OscTitleTracker {
             FrameState::Osc => match byte {
                 BEL => {
                     self.finish(BEL);
+                    FrameState::Ground
+                }
+                // CAN/SUB abort the control string: drop the partial OSC.
+                CAN | SUB => {
+                    unsafe { sys::ghostty_osc_reset(self.parser) };
                     FrameState::Ground
                 }
                 ESC => FrameState::OscEscape,

--- a/packages/tui/vt/ix-vt/tests/osc_title.rs
+++ b/packages/tui/vt/ix-vt/tests/osc_title.rs
@@ -1,0 +1,55 @@
+//! `OscTitleTracker` over ghostty's streaming OSC parser: it captures the
+//! window title from OSC 0/2, ignores the icon-only OSC 1, and tolerates a
+//! sequence split across feed boundaries.
+
+use ix_vt::OscTitleTracker;
+
+#[test]
+fn captures_bel_terminated_title() {
+    let mut t = OscTitleTracker::new().expect("create tracker");
+    assert_eq!(t.title(), None, "no title before any input");
+
+    // OSC 2 (set window title), BEL-terminated: ESC ] 2 ; hello BEL.
+    t.feed(b"\x1b]2;hello\x07");
+    assert_eq!(t.title(), Some("hello"));
+}
+
+#[test]
+fn captures_st_terminated_title_and_osc0() {
+    let mut t = OscTitleTracker::new().expect("create tracker");
+    // OSC 0 sets icon *and* window title; ST-terminated: ESC ] 0 ; world ESC \.
+    t.feed(b"\x1b]0;world\x1b\\");
+    assert_eq!(t.title(), Some("world"));
+}
+
+#[test]
+fn title_persists_and_updates_across_feeds() {
+    let mut t = OscTitleTracker::new().expect("create tracker");
+    // A title split across three feeds, including a mid-payload boundary and a
+    // split ST terminator (ESC in one chunk, '\\' in the next).
+    t.feed(b"\x1b]2;split-");
+    t.feed(b"title\x1b");
+    t.feed(b"\\");
+    assert_eq!(t.title(), Some("split-title"));
+
+    // Ordinary output between sequences leaves the title untouched.
+    t.feed(b"some normal output\r\n");
+    assert_eq!(t.title(), Some("split-title"));
+
+    // A later title replaces the earlier one.
+    t.feed(b"\x1b]2;second\x07");
+    assert_eq!(t.title(), Some("second"));
+}
+
+#[test]
+fn icon_only_osc1_does_not_change_title() {
+    let mut t = OscTitleTracker::new().expect("create tracker");
+    t.feed(b"\x1b]2;real-title\x07");
+    // OSC 1 sets the icon name, not the window title.
+    t.feed(b"\x1b]1;icon-name\x07");
+    assert_eq!(
+        t.title(),
+        Some("real-title"),
+        "icon-only OSC 1 must not overwrite the window title"
+    );
+}

--- a/packages/tui/vt/ix-vt/tests/osc_title.rs
+++ b/packages/tui/vt/ix-vt/tests/osc_title.rs
@@ -42,6 +42,16 @@ fn title_persists_and_updates_across_feeds() {
 }
 
 #[test]
+fn can_aborts_an_in_progress_title() {
+    let mut t = OscTitleTracker::new().expect("create tracker");
+    t.feed(b"\x1b]2;keep\x07");
+    // A CAN (0x18) mid-payload aborts the control string, so this title is
+    // dropped, not captured, and the previous one stands.
+    t.feed(b"\x1b]2;abor\x18ted\x07");
+    assert_eq!(t.title(), Some("keep"));
+}
+
+#[test]
 fn icon_only_osc1_does_not_change_title() {
     let mut t = OscTitleTracker::new().expect("create tracker");
     t.feed(b"\x1b]2;real-title\x07");

--- a/packages/tui/vt/ix-vt/tests/osc_title.rs
+++ b/packages/tui/vt/ix-vt/tests/osc_title.rs
@@ -42,6 +42,25 @@ fn title_persists_and_updates_across_feeds() {
 }
 
 #[test]
+fn esc_terminates_an_unterminated_title() {
+    let mut t = OscTitleTracker::new().expect("create tracker");
+    // OSC 2 with no BEL/ST, directly followed by a CSI: ghostty dispatches the
+    // title on the ESC, so it must be captured (not dropped).
+    t.feed(b"\x1b]2;vim\x1b[2J");
+    assert_eq!(t.title(), Some("vim"));
+}
+
+#[test]
+fn invalid_utf8_title_is_ignored() {
+    let mut t = OscTitleTracker::new().expect("create tracker");
+    t.feed(b"\x1b]2;good\x07");
+    // A title with an invalid UTF-8 byte is skipped, not lossily replaced, so
+    // the previous title stands.
+    t.feed(b"\x1b]2;\xff\x07");
+    assert_eq!(t.title(), Some("good"));
+}
+
+#[test]
 fn can_aborts_an_in_progress_title() {
     let mut t = OscTitleTracker::new().expect("create tracker");
     t.feed(b"\x1b]2;keep\x07");


### PR DESCRIPTION
## What

Add `OscTitleTracker` to `ix-vt`: a safe wrapper over ghostty's streaming OSC
parser that captures the live OSC window title (OSC 0/2) from a raw terminal
byte stream.

## Why

`ix_vt::Terminal` exposes no window-title getter (`GhosttyTerminalData` has no
title key), so a consumer that labels a session by its live title cannot read it
from a render `Snapshot`. The downstream need is the `ix` multiplexer
([ixmux](https://github.com/andrewgazelka/ixmux)) swapping its `vt100` emulator
for `ix-vt`; `tui` could use it too (it also has no title source today).

## How

A small `ESC ] … (BEL | ESC \)` framing scanner extracts OSC payloads and feeds
them to ghostty's `ghostty_osc_*` parser, so:

- sequences split across reads are still parsed (the framing state persists
  across `feed` calls, including a split `ST` terminator);
- OSC 0/2 (title) vs OSC 1 (icon) classification is done by ghostty's parser,
  not a hand-rolled scan.

The captured title is copied out of the parser-owned (transient) string into an
owned `String`.

## Tests

`tests/osc_title.rs`: BEL- and ST-terminated titles, OSC 0, a title split across
three feeds, persistence across non-title output, OSC 1 ignored, and
replacement. Validated locally (`cargo test -p ix-vt`: osc_title 4 + round_trip
3 pass) and `nix build .#ix-vt`.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `OscTitleTracker` to parse OSC window title sequences from terminal output
> - Introduces `OscTitleTracker` in [lib.rs](https://github.com/indexable-inc/index/pull/1374/files#diff-380b2028e1ad0ef1c65bcc54363cac0bcf356148601c2fcfe909e43b391958a0), a state machine that scans raw terminal byte streams for OSC sequences and extracts the window title.
> - Implements a `FrameState` enum to track framing across chunked feeds, handling BEL-terminated, ST-terminated (`ESC \`), and ESC-terminated sequences, with correct abort on `CAN`/`SUB`.
> - Delegates OSC payload parsing to the ghostty OSC parser via FFI (`ghostty_osc_new`, `ghostty_osc_next`, `ghostty_osc_end`, `ghostty_osc_free`).
> - Captures the title only for OSC 0/2 commands with valid UTF-8 content; leaves the previous title intact on invalid input or non-title commands.
> - Test coverage in [osc_title.rs](https://github.com/indexable-inc/index/pull/1374/files#diff-2eb4f71823e84e1e1a50a0b1bc1877727864c72c0c9b7ed5b644145c82e28133) covers BEL/ST termination, OSC 0, mid-sequence splits, invalid UTF-8, `CAN` abort, and OSC 1 exclusion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 275c0e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->