### PR TITLE
nix-web-monitor: add home/os switch with live activation + diff views

### DIFF
--- a/packages/nix/nix-web-monitor/parser/src/activation.rs
+++ b/packages/nix/nix-web-monitor/parser/src/activation.rs
@@ -1,0 +1,239 @@
+//! Live activation view for `nwm home switch` / `nwm os switch`.
+//!
+//! A "switch" is two phases Nix's internal-json stream does not cover: the
+//! `nix build` of the toplevel (which the build tree already renders) and then
+//! running the generation's `activate` script. The activate script is where the
+//! work the operator actually waits on happens (linking files, installing
+//! packages, restarting launch agents), and it reports its own progress as plain
+//! stdout lines, not internal-json. This module folds those lines into a small,
+//! wire-friendly [`Activation`] subtree the UI renders beside the build tree.
+//!
+//! home-manager emits a fixed, named step sequence via `_iNote "Activating %s"`,
+//! so each `Activating <step>` line opens a step and closes the previous one,
+//! giving a real step tree. nix-darwin's `activate` is unstructured, so the
+//! server seeds a single step up front and every line lands under it.
+//!
+//! Kept pure and `now_ms`-injected (like [`crate::daemon::DaemonTrace`]) so the
+//! classifier is unit-testable without a clock; the server stamps the time and
+//! drives it through [`crate::MonitorState`].
+
+use serde::{Deserialize, Serialize};
+
+/// Prefix home-manager prints (via `_iNote "Activating %s"`) before each
+/// activation step. The remainder of the line is the step name.
+const ACTIVATING_PREFIX: &str = "Activating ";
+
+/// home-manager's banner line at the top of activation. Recognised so a stray
+/// leading line does not become an unnamed step; carries no step itself.
+const HM_BANNER: &str = "Starting Home Manager activation";
+
+/// Status of one activation step.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivationStatus {
+    Running,
+    Done,
+    Failed,
+}
+
+/// One activation step: a named unit of the activate script's work plus the
+/// lines it printed while running.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivationStep {
+    pub name: String,
+    pub status: ActivationStatus,
+    /// Output lines captured while this step was the open one.
+    pub lines: Vec<String>,
+    pub started_at_ms: u64,
+    pub stopped_at_ms: Option<u64>,
+}
+
+/// Wire-friendly snapshot of the activation phase.
+///
+/// `active` mirrors `DaemonInfo::tracing` (the panel greys out until a switch
+/// starts); `status` mirrors `DaemonInfo::status` (a human line explaining the
+/// current phase, e.g. "running", "skipped (build failed)", "failed").
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Activation {
+    /// Whether an activation phase has begun. False on a plain `nix build`, so
+    /// the UI hides the panel entirely.
+    pub active: bool,
+    /// The activation command being run (e.g. `<out>/activate`).
+    pub command: String,
+    pub steps: Vec<ActivationStep>,
+    /// Human-readable phase status, always populated once `active`.
+    pub status: String,
+}
+
+impl Activation {
+    /// Begin an activation phase. `initial_step` seeds a first open step for the
+    /// unstructured (darwin) case so every line has somewhere to land; pass
+    /// `None` for home-manager, whose own `Activating` lines open the steps.
+    pub fn begin(&mut self, command: String, initial_step: Option<String>, now_ms: u64) {
+        self.active = true;
+        self.command = command;
+        "running".clone_into(&mut self.status);
+        self.steps.clear();
+        if let Some(name) = initial_step {
+            self.open_step(name, now_ms);
+        }
+    }
+
+    /// Fold one activation output line into the step tree.
+    ///
+    /// `Activating <name>` closes the open step and opens `<name>`; the banner is
+    /// swallowed; any other line is appended to the open step (or dropped if none
+    /// is open yet, which only happens for home-manager preamble before the first
+    /// step).
+    pub fn ingest_line(&mut self, line: &str, now_ms: u64) {
+        let trimmed = line.trim_end();
+        if trimmed == HM_BANNER {
+            return;
+        }
+        // home-manager step names are single identifiers (`_iNote "Activating
+        // %s" "<step>"`). Require a single whitespace-free token so a step's own
+        // output line that merely starts with "Activating " (e.g. a user script
+        // echoing "Activating my service") is treated as content, not a new step
+        // that would close the real one early.
+        if let Some(name) = trimmed.strip_prefix(ACTIVATING_PREFIX)
+            && !name.is_empty()
+            && !name.contains(char::is_whitespace)
+        {
+            self.close_open_step(ActivationStatus::Done, now_ms);
+            self.open_step(name.to_owned(), now_ms);
+            return;
+        }
+        if let Some(step) = self.open_step_mut() {
+            step.lines.push(line.to_owned());
+        }
+    }
+
+    /// Settle the activation phase: close the open step as done or failed and set
+    /// the terminal status. A failed activation marks the open step (the one that
+    /// was running when it died) `Failed`; a clean finish closes it `Done`.
+    pub fn finish(&mut self, success: bool, now_ms: u64) {
+        let end_status = if success {
+            ActivationStatus::Done
+        } else {
+            ActivationStatus::Failed
+        };
+        self.close_open_step(end_status, now_ms);
+        if success { "done" } else { "failed" }.clone_into(&mut self.status);
+    }
+
+    /// Set the phase status without changing steps. Used when a switch skips
+    /// activation entirely (e.g. the build failed), so the panel explains why it
+    /// stayed empty rather than sitting blank.
+    pub fn set_status(&mut self, status: String) {
+        self.active = true;
+        self.status = status;
+    }
+
+    fn open_step(&mut self, name: String, now_ms: u64) {
+        self.steps.push(ActivationStep {
+            name,
+            status: ActivationStatus::Running,
+            lines: Vec::new(),
+            started_at_ms: now_ms,
+            stopped_at_ms: None,
+        });
+    }
+
+    /// The currently-open (last, still-running) step, if any.
+    fn open_step_mut(&mut self) -> Option<&mut ActivationStep> {
+        self.steps
+            .last_mut()
+            .filter(|step| step.status == ActivationStatus::Running)
+    }
+
+    fn close_open_step(&mut self, status: ActivationStatus, now_ms: u64) {
+        if let Some(step) = self.open_step_mut() {
+            step.status = status;
+            step.stopped_at_ms = Some(now_ms);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn home_manager_sequence_builds_named_steps() {
+        let mut activation = Activation::default();
+        activation.begin("/nix/store/x-home/activate".to_owned(), None, 10);
+        // Banner carries no step.
+        activation.ingest_line("Starting Home Manager activation", 11);
+        assert!(activation.steps.is_empty(), "banner is not a step");
+
+        activation.ingest_line("Activating checkLinkTargets", 20);
+        activation.ingest_line("Activating writeBoundary", 30);
+        activation.ingest_line("some writeBoundary detail", 31);
+        activation.ingest_line("Activating linkGeneration", 40);
+
+        let names: Vec<&str> = activation.steps.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, ["checkLinkTargets", "writeBoundary", "linkGeneration"]);
+
+        // The first step closed Done when the next opened.
+        assert_eq!(activation.steps[0].status, ActivationStatus::Done);
+        assert_eq!(activation.steps[0].stopped_at_ms, Some(30));
+        // A non-Activating line appends to the then-open step.
+        assert_eq!(activation.steps[1].lines, ["some writeBoundary detail"]);
+        // The last step is still running until finish().
+        assert_eq!(activation.steps[2].status, ActivationStatus::Running);
+
+        activation.finish(true, 50);
+        assert_eq!(activation.steps[2].status, ActivationStatus::Done);
+        assert_eq!(activation.steps[2].stopped_at_ms, Some(50));
+        assert_eq!(activation.status, "done");
+    }
+
+    #[test]
+    fn failed_activation_marks_open_step_failed() {
+        let mut activation = Activation::default();
+        activation.begin("act".to_owned(), None, 0);
+        activation.ingest_line("Activating installPackages", 1);
+        activation.finish(false, 5);
+        assert_eq!(activation.steps[0].status, ActivationStatus::Failed);
+        assert_eq!(activation.status, "failed");
+    }
+
+    #[test]
+    fn unstructured_darwin_stream_lands_under_seeded_step() {
+        let mut activation = Activation::default();
+        // Darwin: server seeds a single step; lines have no `Activating` markers.
+        activation.begin("sudo darwin-rebuild activate".to_owned(), Some("activate".to_owned()), 0);
+        activation.ingest_line("setting up /etc...", 1);
+        activation.ingest_line("setting up launchd services...", 2);
+        assert_eq!(activation.steps.len(), 1);
+        assert_eq!(activation.steps[0].name, "activate");
+        assert_eq!(
+            activation.steps[0].lines,
+            ["setting up /etc...", "setting up launchd services..."]
+        );
+    }
+
+    #[test]
+    fn activating_line_with_spaces_is_content_not_a_step_boundary() {
+        let mut activation = Activation::default();
+        activation.begin("act".to_owned(), None, 0);
+        activation.ingest_line("Activating linkGeneration", 1);
+        // A step's own output that starts with "Activating " but is a sentence
+        // (has whitespace) must not open a new step.
+        activation.ingest_line("Activating my custom service now", 2);
+        assert_eq!(activation.steps.len(), 1, "no spurious second step");
+        assert_eq!(activation.steps[0].name, "linkGeneration");
+        assert_eq!(activation.steps[0].lines, ["Activating my custom service now"]);
+    }
+
+    #[test]
+    fn preamble_before_first_step_is_dropped_for_home() {
+        let mut activation = Activation::default();
+        activation.begin("act".to_owned(), None, 0);
+        // No open step yet: a stray line is dropped rather than inventing a step.
+        activation.ingest_line("some preamble", 1);
+        assert!(activation.steps.is_empty());
+    }
+}

--- a/packages/nix/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix/nix-web-monitor/parser/src/lib.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use snafu::Snafu;
 
+pub mod activation;
 pub mod daemon;
+pub use activation::{Activation, ActivationStatus, ActivationStep};
 pub use daemon::{DaemonInfo, DaemonOps, OpClass};
 
 const NIX_JSON_PREFIX: &str = "@nix ";
@@ -246,8 +248,11 @@ pub struct OptimiseStats {
     rename_all_fields = "camelCase"
 )]
 pub enum Delta {
-    /// Full state, used only to seed a new subscriber. Never broadcast.
-    Reset { snapshot: MonitorSnapshot },
+    /// Full state, used only to seed a new subscriber. Never broadcast. Boxed
+    /// because the snapshot dwarfs every other variant; without it `Delta` (which
+    /// is moved per incremental delta on the hot path) would carry the seed's
+    /// footprint everywhere. Serializes identically to an unboxed snapshot.
+    Reset { snapshot: Box<MonitorSnapshot> },
     /// A build was created or changed (status, phase, host, failure).
     BuildUpsert { build: BuildNode },
     /// An activity was created or changed (status, phase, progress).
@@ -261,6 +266,13 @@ pub enum Delta {
     OptimiseSet { optimise: OptimiseStats },
     /// The live nix-daemon syscall view changed (new counts, path, or status).
     DaemonSet { daemon: DaemonInfo },
+    /// The activation phase (a `switch`'s `activate` run) changed: a step opened
+    /// or closed, a line landed, or the phase status moved. Carries the whole
+    /// subtree, like [`DaemonSet`](Delta::DaemonSet): the step list is small.
+    ActivationSet { activation: Activation },
+    /// The generation diff (`nvd diff <old> <new>`) became available at the end
+    /// of a switch. A whole-string replace; produced once.
+    DiffSet { diff: String },
     /// The expected count for one activity type was (re)declared.
     ExpectedSet { name: String, value: i64 },
     /// One operator/error message was appended to the errors list.
@@ -291,6 +303,12 @@ pub struct MonitorState {
     pub optimise: OptimiseStats,
     /// Live nix-daemon syscall view, fed out-of-band by the server's tracer.
     pub daemon: DaemonInfo,
+    /// Live activation view, fed out-of-band by the server's switch orchestrator.
+    /// Empty (`active: false`) on a plain `nix build`.
+    pub activation: Activation,
+    /// Generation diff (`nvd diff`) text, set once at the end of a switch. `None`
+    /// outside a switch or before the diff lands.
+    pub diff: Option<String>,
     pub expected: BTreeMap<String, i64>,
     pub exit_code: Option<i32>,
     pub finished: bool,
@@ -367,6 +385,8 @@ impl MonitorState {
             progress: self.progress,
             optimise: self.optimise,
             daemon: self.daemon.clone(),
+            activation: self.activation.clone(),
+            diff: self.diff.clone(),
             expected: self.expected.clone(),
             dependencies: dependency_edges(&self.closure_deps, &observed),
             root_causes: root_cause_derivations(&self.closure_deps, &observed),
@@ -461,6 +481,47 @@ impl MonitorState {
         });
     }
 
+    /// Begin the activation phase of a switch and broadcast it. `initial_step`
+    /// seeds a single open step for the unstructured (darwin) activate; pass
+    /// `None` for home-manager, whose `Activating` lines open their own steps.
+    pub fn begin_activation(&mut self, command: String, initial_step: Option<String>) {
+        self.activation
+            .begin(command, initial_step, current_unix_ms());
+        self.emit_activation();
+    }
+
+    /// Fold one activation output line into the step tree and broadcast it.
+    pub fn push_activation_line(&mut self, line: &str) {
+        self.activation.ingest_line(line, current_unix_ms());
+        self.emit_activation();
+    }
+
+    /// Set a human activation phase status (e.g. "skipped (build failed)") and
+    /// broadcast it, so the panel explains a phase that produced no steps.
+    pub fn set_activation_status(&mut self, status: String) {
+        self.activation.set_status(status);
+        self.emit_activation();
+    }
+
+    /// Settle the activation phase: close the open step (done or failed) and set
+    /// the terminal status, then broadcast.
+    pub fn finish_activation(&mut self, success: bool) {
+        self.activation.finish(success, current_unix_ms());
+        self.emit_activation();
+    }
+
+    fn emit_activation(&mut self) {
+        self.emit(Delta::ActivationSet {
+            activation: self.activation.clone(),
+        });
+    }
+
+    /// Record the generation diff text (`nvd diff` output) and broadcast it.
+    pub fn set_diff(&mut self, diff: String) {
+        self.diff = Some(diff.clone());
+        self.emit(Delta::DiffSet { diff });
+    }
+
     /// Record the transitive input `.drv` closure of one derivation, learned
     /// from `nix-store --query --requisites`. The caller filters source paths
     /// and the derivation itself out before calling. Stored unfiltered by build
@@ -536,22 +597,34 @@ impl MonitorState {
         self.exit_code = exit_code;
         self.finished = true;
         if exit_code == Some(0) {
-            let promoted: Vec<String> = self
-                .builds
-                .iter_mut()
-                .filter(|(_, build)| {
-                    matches!(build.status, BuildStatus::Stopped | BuildStatus::Planned)
-                })
-                .map(|(derivation, build)| {
-                    build.status = BuildStatus::Succeeded;
-                    derivation.clone()
-                })
-                .collect();
-            for derivation in promoted {
-                self.emit_build(&derivation);
-            }
+            self.promote_unfinished_builds();
         }
         self.emit(Delta::Finished { exit_code });
+    }
+
+    /// Promote `Stopped`/`Planned` build rows to `Succeeded` and broadcast them,
+    /// without settling the run. A switch calls this after its build phase
+    /// succeeds so the rows read as done while activation proceeds, rather than
+    /// lingering as `Stopped` (and sorted with unfinished work) if a later
+    /// activation phase fails. [`finish`](Self::finish) reuses the same promotion
+    /// on a clean exit.
+    pub fn mark_builds_succeeded(&mut self) {
+        self.promote_unfinished_builds();
+    }
+
+    fn promote_unfinished_builds(&mut self) {
+        let promoted: Vec<String> = self
+            .builds
+            .iter_mut()
+            .filter(|(_, build)| matches!(build.status, BuildStatus::Stopped | BuildStatus::Planned))
+            .map(|(derivation, build)| {
+                build.status = BuildStatus::Succeeded;
+                derivation.clone()
+            })
+            .collect();
+        for derivation in promoted {
+            self.emit_build(&derivation);
+        }
     }
 
     fn apply_event(&mut self, event: &NixEvent) {
@@ -1054,6 +1127,10 @@ pub struct MonitorSnapshot {
     pub optimise: OptimiseStats,
     /// Live nix-daemon syscall view, fed out-of-band by the server's tracer.
     pub daemon: DaemonInfo,
+    /// Live activation view, fed out-of-band by the server's switch orchestrator.
+    pub activation: Activation,
+    /// Generation diff text (`nvd diff`), set once at the end of a switch.
+    pub diff: Option<String>,
     pub expected: BTreeMap<String, i64>,
     /// Minimal dependency DAG over derivations Nix actually built: each edge's
     /// `from` directly requires `to`. Derived from `direct_deps` at snapshot

--- a/packages/nix/nix-web-monitor/server/default.nix
+++ b/packages/nix/nix-web-monitor/server/default.nix
@@ -50,7 +50,13 @@ let
         # `nix-web-monitor build .#x` uses the same Nix as a bare
         # `nix build .#x` would. Pinning a specific Nix here drags an
         # extra copy into every closure and silently shadows custom
-        # builds.
+        # builds. The same reasoning keeps `home-manager`, `darwin-rebuild`,
+        # and `sudo` (used by the `home`/`os` switch subcommands) on the
+        # operator's PATH rather than bundled.
+        #
+        # `nvd` is the one exception: the post-switch generation diff should work
+        # out of the box, so it is appended with `--suffix` (an operator's own
+        # `nvd` earlier on PATH still wins).
         # Stamp the build revision and commit time for `--version`. These ride
         # the wrapper env (not `env!`) and the `build-version` crate renders
         # them at runtime, so a new commit re-stamps this tiny wrapper without
@@ -58,6 +64,7 @@ let
         # ix tool reads; see `build-version` and `ix.rev` / `ix.revEpoch`.
         makeWrapper ${lib.getExe unwrapped} "$out/bin/nix-web-monitor" \
           --set NIX_WEB_MONITOR_SITE_DIR "$out/share/nix-web-monitor" \
+          --suffix PATH : ${lib.makeBinPath [ pkgs.nvd ]} \
           --set IX_BUILD_REV ${lib.escapeShellArg ix.rev} \
           --set IX_BUILD_EPOCH ${lib.escapeShellArg (toString ix.revEpoch)}
       '';

--- a/packages/nix/nix-web-monitor/server/site/src/App.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/App.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
+  import ActivationPanel from '$components/ActivationPanel.svelte';
   import ActivityGraph from '$components/ActivityGraph.svelte';
   import BuildTable from '$components/BuildTable.svelte';
   import DaemonPanel from '$components/DaemonPanel.svelte';
+  import DiffPanel from '$components/DiffPanel.svelte';
   import ErrorPanel from '$components/ErrorPanel.svelte';
   import LogPanel from '$components/LogPanel.svelte';
   import SummaryBar from '$components/SummaryBar.svelte';
@@ -219,6 +221,10 @@
         onkeydown={sidebarKeydown}
       />
       <aside class="side-pane">
+        {#if snapshot.activation.active}
+          <ActivationPanel activation={snapshot.activation} />
+        {/if}
+        <DiffPanel diff={snapshot.diff} />
         <DaemonPanel daemon={snapshot.daemon} />
         <ActivityGraph activities={snapshot.activities} builds={snapshot.builds} />
       </aside>

--- a/packages/nix/nix-web-monitor/server/site/src/components/ActivationPanel.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/ActivationPanel.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { SvelteSet } from 'svelte/reactivity';
+  import PanelHeader from '$lib/PanelHeader.svelte';
+  import { formatDuration } from '$lib/format';
+  import { useNow } from '$lib/now.svelte';
+  import type { Activation, ActivationStep } from '$lib/types';
+
+  type Props = {
+    activation: Activation;
+  };
+
+  const { activation }: Props = $props();
+
+  /// Live clock so the open step's duration ticks while it runs.
+  const now = useNow();
+
+  /// Steps the user expanded to read their captured output lines. Keyed by step
+  /// name, which is unique within one activation run. `SvelteSet` is reactive, so
+  /// in-place mutation re-renders.
+  const expanded = new SvelteSet<string>();
+
+  function toggle(name: string): void {
+    if (expanded.has(name)) expanded.delete(name);
+    else expanded.add(name);
+  }
+
+  const doneCount = $derived(activation.steps.filter((step) => step.status === 'done').length);
+
+  function duration(step: ActivationStep): string {
+    const end = step.stoppedAtMs ?? now.value;
+    return formatDuration(Math.max(0, end - step.startedAtMs));
+  }
+</script>
+
+<section class="panel activation-panel">
+  <PanelHeader title="activation">
+    {#if activation.steps.length > 0}
+      <span class="panel-meta">{doneCount}/{activation.steps.length}</span>
+    {/if}
+  </PanelHeader>
+
+  <div class="activation-body">
+    {#if activation.steps.length === 0}
+      <!-- A phase that produced no steps (still starting, or skipped because an
+           earlier phase failed). The status explains why, so it never sits blank. -->
+      <div class="activation-status">{activation.status || 'waiting for activation…'}</div>
+    {:else}
+      {#each activation.steps as step (step.name)}
+        <div class="activation-step">
+          <button
+            class="activation-row"
+            type="button"
+            disabled={step.lines.length === 0}
+            aria-expanded={expanded.has(step.name)}
+            onclick={() => {
+              toggle(step.name);
+            }}
+          >
+            <span class="state" data-state={step.status} aria-hidden="true"></span>
+            <span class="activation-name">{step.name}</span>
+            {#if step.lines.length > 0}
+              <span class="activation-lines-count">{step.lines.length}</span>
+            {/if}
+            <span class="activation-duration">{duration(step)}</span>
+          </button>
+          {#if expanded.has(step.name) && step.lines.length > 0}
+            <pre class="activation-lines">{step.lines.join('\n')}</pre>
+          {/if}
+        </div>
+      {/each}
+    {/if}
+  </div>
+</section>

--- a/packages/nix/nix-web-monitor/server/site/src/components/DiffPanel.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/DiffPanel.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import PanelHeader from '$lib/PanelHeader.svelte';
+
+  type Props = {
+    diff: string | null;
+  };
+
+  const { diff }: Props = $props();
+</script>
+
+<!-- Self-hides until the post-switch `nvd diff` lands, so a plain build never
+     shows an empty panel. nvd output is short and pre-formatted, so a monospace
+     block is enough; no parsing. -->
+{#if diff !== null}
+  <section class="panel diff-panel">
+    <PanelHeader title="changes" />
+    <div class="diff-body">
+      <pre class="diff-text">{diff}</pre>
+    </div>
+  </section>
+{/if}

--- a/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
@@ -39,6 +39,8 @@ type Working = {
   progress: MonitorSnapshot['progress'];
   optimise: MonitorSnapshot['optimise'];
   daemon: MonitorSnapshot['daemon'];
+  activation: MonitorSnapshot['activation'];
+  diff: MonitorSnapshot['diff'];
   expected: Record<string, number>;
   dependencies: DerivationEdge[];
   rootCauses: string[];
@@ -64,6 +66,8 @@ function createWorking(): Working {
       opsPerSec: 0,
       currentPath: null
     },
+    activation: { active: false, command: '', steps: [], status: '' },
+    diff: null,
     expected: {},
     dependencies: [],
     rootCauses: [],
@@ -102,6 +106,12 @@ export function applyDelta(working: Working, delta: Delta): Working {
     case 'daemonSet':
       working.daemon = delta.daemon;
       return working;
+    case 'activationSet':
+      working.activation = delta.activation;
+      return working;
+    case 'diffSet':
+      working.diff = delta.diff;
+      return working;
     case 'expectedSet':
       working.expected = { ...working.expected, [delta.name]: delta.value };
       return working;
@@ -135,6 +145,8 @@ function fromSnapshot(snapshot: MonitorSnapshot): Working {
     progress: snapshot.progress,
     optimise: snapshot.optimise,
     daemon: snapshot.daemon,
+    activation: snapshot.activation,
+    diff: snapshot.diff,
     expected: { ...snapshot.expected },
     dependencies: snapshot.dependencies,
     rootCauses: snapshot.rootCauses,
@@ -174,6 +186,8 @@ export function projectSnapshot(working: Working): MonitorSnapshot {
     progress: working.progress,
     optimise: working.optimise,
     daemon: working.daemon,
+    activation: working.activation,
+    diff: working.diff,
     expected: { ...working.expected },
     dependencies: working.dependencies,
     rootCauses: working.rootCauses,

--- a/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
@@ -65,6 +65,27 @@ export const daemonInfoSchema = v.object({
   currentPath: v.nullable(v.string())
 });
 
+/// One activation step (a `home`/`os` switch's `activate` run): a named unit of
+/// work plus the output lines it printed. Mirrors the Rust `ActivationStep`.
+export const activationStepSchema = v.object({
+  name: v.string(),
+  status: v.picklist(['running', 'done', 'failed']),
+  lines: v.array(v.string()),
+  startedAtMs: v.number(),
+  stoppedAtMs: v.nullable(v.number())
+});
+
+/// Live activation view, populated only during a switch. `active` is false on a
+/// plain `nix build` (the panel hides); `status` mirrors `daemonInfo.status` as a
+/// human line ("running", "skipped (build failed)", "done", "failed"). Mirrors
+/// the Rust `Activation`.
+export const activationSchema = v.object({
+  active: v.boolean(),
+  command: v.string(),
+  steps: v.array(activationStepSchema),
+  status: v.string()
+});
+
 export const activityNodeSchema = v.object({
   id: v.number(),
   parent: v.nullable(v.number()),
@@ -122,6 +143,10 @@ export const snapshotSchema = v.object({
   progress: v.nullable(activityProgressSchema),
   optimise: optimiseStatsSchema,
   daemon: daemonInfoSchema,
+  /// Live activation view during a `home`/`os` switch; `active: false` otherwise.
+  activation: activationSchema,
+  /// Generation diff text (`nvd diff`), set once at the end of a switch.
+  diff: v.nullable(v.string()),
   expected: v.record(v.string(), v.number()),
   dependencies: v.array(derivationEdgeSchema),
   /// Built derivations that are root *causes*: their whole input closure is
@@ -149,6 +174,8 @@ export const deltaSchema = v.variant('type', [
   v.object({ type: v.literal('progressSet'), progress: activityProgressSchema }),
   v.object({ type: v.literal('optimiseSet'), optimise: optimiseStatsSchema }),
   v.object({ type: v.literal('daemonSet'), daemon: daemonInfoSchema }),
+  v.object({ type: v.literal('activationSet'), activation: activationSchema }),
+  v.object({ type: v.literal('diffSet'), diff: v.string() }),
   v.object({ type: v.literal('expectedSet'), name: v.string(), value: v.number() }),
   v.object({ type: v.literal('errorAppend'), message: v.string() }),
   v.object({ type: v.literal('dependenciesSet'), edges: v.array(derivationEdgeSchema) }),
@@ -164,6 +191,8 @@ export type ActivityProgress = v.InferOutput<typeof activityProgressSchema>;
 export type OptimiseStats = v.InferOutput<typeof optimiseStatsSchema>;
 export type DaemonOps = v.InferOutput<typeof daemonOpsSchema>;
 export type DaemonInfo = v.InferOutput<typeof daemonInfoSchema>;
+export type ActivationStep = v.InferOutput<typeof activationStepSchema>;
+export type Activation = v.InferOutput<typeof activationSchema>;
 export type ActivityNode = v.InferOutput<typeof activityNodeSchema>;
 export type BuildNode = v.InferOutput<typeof buildNodeSchema>;
 export type LogEntry = v.InferOutput<typeof logEntrySchema>;
@@ -201,6 +230,8 @@ export const EMPTY_SNAPSHOT: MonitorSnapshot = Object.freeze({
     opsPerSec: 0,
     currentPath: null
   },
+  activation: { active: false, command: '', steps: [], status: '' },
+  diff: null,
   expected: {},
   dependencies: [],
   rootCauses: [],

--- a/packages/nix/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix/nix-web-monitor/server/site/src/style.css
@@ -574,6 +574,102 @@ main.dragging-v .splitter-v::after {
   text-overflow: ellipsis;
 }
 
+/* ---------- activation + diff panels (switch only) ---------- */
+
+/* Both ride at the top of the side pane during a switch and cap their height so
+ * the daemon panel and activity graph below stay visible; they self-hide on a
+ * plain build (no activation, no diff). */
+.side-pane > .activation-panel,
+.side-pane > .diff-panel {
+  flex: 0 0 auto;
+  max-height: 40%;
+  border-bottom: 1px solid var(--line);
+}
+
+.activation-body {
+  min-height: 0;
+  overflow: auto;
+  padding: 0.3rem 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.activation-status {
+  color: var(--muted);
+  white-space: normal;
+  line-height: 1.4;
+  padding: 0.1rem 0.2rem;
+}
+
+/* step dot | name | line-count badge | duration */
+.activation-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.15rem 0.2rem;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+.activation-row:disabled {
+  cursor: default;
+}
+
+.activation-row:not(:disabled):hover {
+  background: var(--panel-soft);
+}
+
+.activation-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activation-lines-count {
+  color: var(--faint);
+  font-size: 0.85em;
+}
+
+.activation-duration {
+  color: var(--muted);
+}
+
+/* Activation steps finish "done"; reuse the succeeded colour for the dot. */
+.state[data-state='done'] {
+  background: var(--green);
+}
+
+.activation-lines {
+  margin: 0 0 0.2rem 1rem;
+  padding: 0.3rem 0.4rem;
+  background: var(--panel-soft);
+  border-radius: 3px;
+  color: var(--muted);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.diff-body {
+  min-height: 0;
+  overflow: auto;
+  padding: 0.3rem 0.4rem;
+}
+
+.diff-text {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: 1.4;
+}
+
 /* ---------- activity graph ---------- */
 
 .graph,

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -42,37 +42,86 @@ const SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Parser)]
 #[command(about = "Run a Nix command with quiet terminal output and a live browser monitor.")]
-#[allow(clippy::struct_field_names)] // `nix_args` is the wire-level name passed to `nix`; renaming would hurt the CLI help text.
 struct Args {
     /// Interface used by the web monitor. Defaults to all interfaces so the UI
     /// is reachable over LAN/Tailscale without a flag. The live feed is a plain
     /// WebSocket, so off-host access needs no certificate.
-    #[arg(long, default_value = "0.0.0.0")]
+    //
+    // `global = true` so the flag is accepted after a named subcommand too
+    // (`nwm home switch --port 8080`), not just before it.
+    #[arg(long, default_value = "0.0.0.0", global = true)]
     host: String,
 
     /// TCP port for the UI, the JSON snapshot, and the WebSocket delta feed.
-    #[arg(long, default_value_t = 7532)]
+    #[arg(long, default_value_t = 7532, global = true)]
     port: u16,
 
-    /// Static UI directory. The Nix package wrapper fills this in.
+    /// Static UI directory. The Nix package wrapper fills this in. Always comes
+    /// from the env the wrapper sets, so it is never passed after a subcommand
+    /// and need not be `global` (which clap forbids on a required argument).
     #[arg(long, env = "NIX_WEB_MONITOR_SITE_DIR")]
     site_dir: PathBuf,
 
     /// Exit when the Nix command finishes instead of keeping the web UI alive.
-    #[arg(long)]
+    #[arg(long, global = true)]
     exit_when_done: bool,
 
     /// Terminal output policy. The browser always receives the parsed stream.
-    #[arg(long, value_enum, default_value_t = TerminalOutput::Summary)]
+    #[arg(long, value_enum, default_value_t = TerminalOutput::Summary, global = true)]
     terminal_output: TerminalOutput,
 
     /// Pass `-v` to Nix for richer internal-json activity events.
-    #[arg(long)]
+    #[arg(long, global = true)]
     nix_verbose: bool,
 
-    /// Arguments passed to `nix`. Example: `build .#hello --keep-going`.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
-    nix_args: Vec<String>,
+    #[command(subcommand)]
+    command: NwmCommand,
+}
+
+/// What `nwm` runs under the monitor. The named subcommands wrap the
+/// build-then-activate dance of a system switch; the external fallback keeps the
+/// original behaviour of passing any other arguments straight to `nix`, so
+/// `nwm build .#x` and `nwm run .#ix -- new` are unchanged.
+#[derive(clap::Subcommand)]
+enum NwmCommand {
+    /// Build (and by default activate) a home-manager configuration, mirroring
+    /// `home-manager switch` with the build and activation shown live.
+    Home(SwitchSpec),
+
+    /// Build (and by default activate) a nix-darwin system configuration,
+    /// mirroring `darwin-rebuild switch`. Activation runs under `sudo`.
+    Os(SwitchSpec),
+
+    /// Any other arguments are passed straight to `nix` (e.g. `build .#hello`,
+    /// `run .#ix -- new`, or `flake update index --flake .`).
+    #[command(external_subcommand)]
+    Nix(Vec<String>),
+}
+
+#[derive(clap::Args)]
+struct SwitchSpec {
+    #[command(subcommand)]
+    action: SwitchAction,
+}
+
+#[derive(clap::Subcommand)]
+enum SwitchAction {
+    /// Build the configuration and activate it.
+    Switch(SwitchArgs),
+    /// Build the configuration only, without activating.
+    Build(SwitchArgs),
+}
+
+#[derive(clap::Args)]
+struct SwitchArgs {
+    /// Flake to build, defaulting to the current directory. Accepts a directory
+    /// (`~/.config/nix`) or `dir#name` to override the configuration name (which
+    /// otherwise defaults to `<user>@<host>` for home and `<host>` for os).
+    flake: Option<String>,
+
+    /// Update flake inputs before building.
+    #[arg(short = 'u', long)]
+    update: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -117,8 +166,8 @@ async fn main() -> Result<()> {
     let index_html =
         Bytes::from(std::fs::read(args.site_dir.join("index.html")).context("reading index.html")?);
 
-    let command = format!("nix {}", args.nix_args.join(" "));
-    let monitor = Arc::new(RwLock::new(MonitorState::new(command)));
+    let job = build_job(args.command).await.context("planning job")?;
+    let monitor = Arc::new(RwLock::new(MonitorState::new(job.command_label.clone())));
     let (deltas, _) = broadcast::channel::<Bytes>(DELTA_CHANNEL_CAPACITY);
 
     let http_addr: SocketAddr = format!("{}:{}", args.host, args.port)
@@ -139,15 +188,15 @@ async fn main() -> Result<()> {
     // life of the UI. Best-effort, so its handle is just aborted at shutdown.
     let daemon_probe = tokio::spawn(run_daemon_probe(Arc::clone(&monitor), deltas.clone()));
 
-    let build = tokio::spawn(run_nix_command(
-        args.nix_args,
+    let build = tokio::spawn(run_job(
+        job,
         args.terminal_output,
         args.nix_verbose,
         monitor,
         deltas,
     ));
 
-    let exit_code = build.await.context("joining Nix command task")??;
+    let exit_code = build.await.context("joining job task")??;
 
     if !args.exit_when_done {
         eprintln!(
@@ -250,7 +299,7 @@ async fn serve_socket(
         let state = monitor.read().await;
         let receiver = deltas.subscribe();
         let seed = match encode(&Delta::Reset {
-            snapshot: state.snapshot(),
+            snapshot: Box::new(state.snapshot()),
         }) {
             Ok(seed) => seed,
             Err(error) => {
@@ -288,7 +337,7 @@ async fn serve_socket(
                         let state = monitor.read().await;
                         receiver = deltas.subscribe();
                         match encode(&Delta::Reset {
-                            snapshot: state.snapshot(),
+                            snapshot: Box::new(state.snapshot()),
                         }) {
                             Ok(resync) => resync,
                             Err(error) => {
@@ -327,13 +376,27 @@ fn encode(delta: &Delta) -> Result<Bytes> {
     Ok(Bytes::from(payload))
 }
 
-async fn run_nix_command(
+/// Result of one monitored `nix` invocation.
+struct NixBuildOutcome {
+    exit_code: Option<i32>,
+    /// Captured stdout, empty unless the call requested capture.
+    stdout: String,
+}
+
+/// Run one monitored `nix` invocation: spawn it with `--log-format internal-json`,
+/// parse its stderr into the build tree, and either forward or capture its
+/// stdout. Returns the exit code and the captured stdout (empty unless
+/// `capture_stdout`). Does **not** call [`MonitorState::finish`]: a switch runs
+/// several phases under one monitor, so the caller settles the run when the whole
+/// job is done.
+async fn run_nix_build(
     nix_args: Vec<String>,
     terminal_output: TerminalOutput,
     nix_verbose: bool,
-    monitor: Arc<RwLock<MonitorState>>,
-    deltas: broadcast::Sender<Bytes>,
-) -> Result<Option<i32>> {
+    capture_stdout: bool,
+    monitor: &Arc<RwLock<MonitorState>>,
+    deltas: &broadcast::Sender<Bytes>,
+) -> Result<NixBuildOutcome> {
     let mut command = Command::new("nix");
     if nix_verbose {
         command.arg("-v");
@@ -355,42 +418,56 @@ async fn run_nix_command(
     let (deps_tx, deps_rx) = mpsc::unbounded_channel();
     let resolver_task = tokio::spawn(resolve_dependencies(
         deps_rx,
-        Arc::clone(&monitor),
+        Arc::clone(monitor),
         deltas.clone(),
     ));
 
-    let stdout_task = tokio::spawn(forward_stdout(stdout, terminal_output));
+    let stdout_task = tokio::spawn(forward_stdout(stdout, terminal_output, capture_stdout));
     let stderr_task = tokio::spawn(parse_stderr(
         stderr,
-        Arc::clone(&monitor),
+        Arc::clone(monitor),
         deltas.clone(),
         terminal_output,
         deps_tx,
     ));
 
     let status = child.wait().await.context("waiting for nix")?;
-    stdout_task.await.context("joining stdout reader")??;
+    let captured = stdout_task.await.context("joining stdout reader")??;
     stderr_task.await.context("joining stderr reader")??;
     resolver_task
         .await
         .context("joining dependency resolver")??;
 
-    let exit_code = status.code();
-    monitor.write().await.finish(exit_code);
-    broadcast_deltas(&monitor, &deltas).await?;
-
-    Ok(exit_code)
+    Ok(NixBuildOutcome {
+        exit_code: status.code(),
+        stdout: captured,
+    })
 }
 
 /// Forward Nix's stdout byte-for-byte so commands like `nix eval --raw`
 /// preserve exact output (no spurious trailing newline, no UTF-8 round-trip).
 /// With `--log-format internal-json`, log activity lands on stderr; stdout is
 /// reserved for the command's actual output, which never needs parsing.
-async fn forward_stdout<R>(stream: R, terminal_output: TerminalOutput) -> Result<()>
+///
+/// When `capture` is set the stdout is collected and returned instead of
+/// forwarded: a switch builds with `--print-out-paths` and needs the resulting
+/// store path to activate, not to print.
+async fn forward_stdout<R>(
+    stream: R,
+    terminal_output: TerminalOutput,
+    capture: bool,
+) -> Result<String>
 where
     R: AsyncRead + Unpin,
 {
     let mut reader = stream;
+    if capture {
+        let mut buf = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut buf)
+            .await
+            .context("capturing nix stdout")?;
+        return Ok(String::from_utf8_lossy(&buf).into_owned());
+    }
     match terminal_output {
         // Still drain so the child does not block on a full pipe.
         TerminalOutput::Quiet => {
@@ -404,7 +481,481 @@ where
                 .context("forwarding nix stdout")?;
         }
     }
+    Ok(String::new())
+}
+
+/// A planned unit of work and the label shown as the build-tree root.
+struct Job {
+    command_label: String,
+    kind: JobKind,
+}
+
+enum JobKind {
+    /// A single monitored `nix` invocation (passthrough or `flake update`).
+    Nix { args: Vec<String> },
+    /// A build-then-activate switch.
+    Switch(SwitchJob),
+}
+
+#[derive(Clone, Copy)]
+enum SwitchKind {
+    Home,
+    Os,
+}
+
+struct SwitchJob {
+    kind: SwitchKind,
+    /// Flake directory (or ref) the lock-update operates on.
+    flake_dir: String,
+    /// `<flake>#<attr>` passed to `nix build`.
+    build_target: String,
+    /// Activate after building (switch), or stop after the build.
+    do_switch: bool,
+    /// Update flake inputs before building.
+    update: bool,
+}
+
+/// Resolve a parsed subcommand into a [`Job`]: the build-tree root label plus the
+/// work to run. Async because switch attr resolution needs the short hostname.
+async fn build_job(command: NwmCommand) -> Result<Job> {
+    match command {
+        // `external_subcommand` collects the nix subcommand and its args verbatim.
+        NwmCommand::Nix(args) => Ok(Job {
+            command_label: format!("nix {}", args.join(" ")),
+            kind: JobKind::Nix { args },
+        }),
+        NwmCommand::Home(spec) => build_switch_job(SwitchKind::Home, spec).await,
+        NwmCommand::Os(spec) => build_switch_job(SwitchKind::Os, spec).await,
+    }
+}
+
+async fn build_switch_job(kind: SwitchKind, spec: SwitchSpec) -> Result<Job> {
+    let (args, do_switch) = match spec.action {
+        SwitchAction::Switch(args) => (args, true),
+        SwitchAction::Build(args) => (args, false),
+    };
+    // `dir#name` overrides the configuration name; a bare value is the flake dir.
+    let (flake_dir, name_override) = args.flake.map_or_else(
+        || (".".to_owned(), None),
+        |value| match value.split_once('#') {
+            Some((dir, name)) => (dir.to_owned(), Some(name.to_owned())),
+            None => (value, None),
+        },
+    );
+    let config_name = match name_override {
+        Some(name) => name,
+        None => match kind {
+            SwitchKind::Home => format!("{}@{}", current_user()?, short_hostname().await?),
+            // Mirror `darwin-rebuild`, which defaults the flake attribute to
+            // `scutil --get LocalHostName` (not `hostname -s`, which can differ).
+            SwitchKind::Os => local_host_name().await?,
+        },
+    };
+    // The attr part of the flakeref carries quotes around the config name (it
+    // contains `@` / `.`); Nix's flakeref parser accepts them in a single argv.
+    let attr = match kind {
+        SwitchKind::Home => format!(r#"homeConfigurations."{config_name}".activationPackage"#),
+        SwitchKind::Os => format!(r#"darwinConfigurations."{config_name}".system"#),
+    };
+    let build_target = format!("{flake_dir}#{attr}");
+    Ok(Job {
+        command_label: format!("nix build {build_target}"),
+        kind: JobKind::Switch(SwitchJob {
+            kind,
+            flake_dir,
+            build_target,
+            do_switch,
+            update: args.update,
+        }),
+    })
+}
+
+/// Run a planned job to completion and return its exit code.
+async fn run_job(
+    job: Job,
+    terminal_output: TerminalOutput,
+    nix_verbose: bool,
+    monitor: Arc<RwLock<MonitorState>>,
+    deltas: broadcast::Sender<Bytes>,
+) -> Result<Option<i32>> {
+    match job.kind {
+        JobKind::Nix { args } => {
+            let outcome =
+                run_nix_build(args, terminal_output, nix_verbose, false, &monitor, &deltas).await?;
+            settle(&monitor, &deltas, outcome.exit_code).await?;
+            Ok(outcome.exit_code)
+        }
+        JobKind::Switch(switch) => {
+            run_switch(switch, terminal_output, nix_verbose, &monitor, &deltas).await
+        }
+    }
+}
+
+/// Settle the monitor (`finish`) and flush the resulting deltas.
+async fn settle(
+    monitor: &Arc<RwLock<MonitorState>>,
+    deltas: &broadcast::Sender<Bytes>,
+    exit_code: Option<i32>,
+) -> Result<()> {
+    monitor.write().await.finish(exit_code);
+    broadcast_deltas(monitor, deltas).await
+}
+
+/// Orchestrate a switch: optional flake update, the monitored build, then (for
+/// `switch`) activation and an `nvd` generation diff. Each phase that bails sets
+/// a human activation status so the browser shows why a later phase did not run.
+async fn run_switch(
+    switch: SwitchJob,
+    terminal_output: TerminalOutput,
+    nix_verbose: bool,
+    monitor: &Arc<RwLock<MonitorState>>,
+    deltas: &broadcast::Sender<Bytes>,
+) -> Result<Option<i32>> {
+    // Phase 1: update flake inputs. A switch on a half-updated lock is wrong, so
+    // a failure aborts before building.
+    if switch.update {
+        eprintln!(
+            "nix-web-monitor: updating flake inputs in {}",
+            switch.flake_dir
+        );
+        // Run the update through the monitor so its fetches appear in the tree
+        // and any failure is parsed into the error panel, not lost to the
+        // terminal.
+        let update_args = vec![
+            "flake".to_owned(),
+            "update".to_owned(),
+            "--flake".to_owned(),
+            switch.flake_dir.clone(),
+        ];
+        let update_code = run_nix_build(update_args, terminal_output, nix_verbose, false, monitor, deltas)
+            .await?
+            .exit_code;
+        if update_code != Some(0) {
+            monitor
+                .write()
+                .await
+                .set_activation_status("skipped (flake update failed)".to_owned());
+            broadcast_deltas(monitor, deltas).await?;
+            settle(monitor, deltas, update_code).await?;
+            return Ok(update_code.or(Some(1)));
+        }
+    }
+
+    // Phase 2: build the toplevel, capturing its out path.
+    let build_args = vec![
+        "build".to_owned(),
+        switch.build_target.clone(),
+        "--no-link".to_owned(),
+        "--print-out-paths".to_owned(),
+    ];
+    let NixBuildOutcome {
+        exit_code: build_code,
+        stdout,
+    } = run_nix_build(build_args, terminal_output, nix_verbose, true, monitor, deltas).await?;
+    if build_code != Some(0) {
+        monitor
+            .write()
+            .await
+            .set_activation_status("skipped (build failed)".to_owned());
+        broadcast_deltas(monitor, deltas).await?;
+        settle(monitor, deltas, build_code).await?;
+        return Ok(build_code.or(Some(1)));
+    }
+    // The build succeeded, so it printed the activation/system store path. Both
+    // targets are single-output single-installable, so there is exactly one
+    // path; take the last non-empty line. A clean build that somehow printed no
+    // path is a distinct failure from a failed build, and must still exit
+    // non-zero rather than masquerade as success.
+    let Some(out_path) = stdout
+        .lines()
+        .map(str::trim)
+        .rfind(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+    else {
+        monitor
+            .write()
+            .await
+            .set_activation_status("failed (build produced no output path)".to_owned());
+        broadcast_deltas(monitor, deltas).await?;
+        settle(monitor, deltas, Some(1)).await?;
+        return Ok(Some(1));
+    };
+
+    // The build succeeded: promote its rows to `succeeded` now, so they read as
+    // done while activation runs rather than lingering as `stopped` (and sorted
+    // with unfinished work) if a later activation phase fails.
+    monitor.write().await.mark_builds_succeeded();
+    broadcast_deltas(monitor, deltas).await?;
+
+    if !switch.do_switch {
+        // Build-only: the operator wants the store path, which the build phase
+        // captured instead of forwarding (and `--no-link` left no `result`).
+        println!("{out_path}");
+        settle(monitor, deltas, Some(0)).await?;
+        return Ok(Some(0));
+    }
+
+    // Phase 3: activate. Capture the current generation first, before the
+    // activate script flips the profile symlink, so the diff compares old to new.
+    let old_generation = read_old_generation(switch.kind).await;
+    let activation_code =
+        run_activation(&switch, &out_path, terminal_output, monitor, deltas).await?;
+    if activation_code != Some(0) {
+        settle(monitor, deltas, activation_code).await?;
+        return Ok(activation_code.or(Some(1)));
+    }
+
+    // Phase 4: best-effort generation diff.
+    if let Some(old) = old_generation {
+        run_diff(&old, &out_path, monitor, deltas).await;
+    }
+    settle(monitor, deltas, Some(0)).await?;
+    Ok(Some(0))
+}
+
+/// Run the activation script for a built configuration, streaming its output into
+/// the activation subtree. home runs `<out>/activate` directly; os activation
+/// needs root, so it pre-authenticates `sudo` interactively (a clean password
+/// prompt on the terminal) and then runs the canonical
+/// `sudo <out>/sw/bin/darwin-rebuild activate` with its output piped.
+async fn run_activation(
+    switch: &SwitchJob,
+    out_path: &str,
+    terminal_output: TerminalOutput,
+    monitor: &Arc<RwLock<MonitorState>>,
+    deltas: &broadcast::Sender<Bytes>,
+) -> Result<Option<i32>> {
+    let mut command;
+    let display;
+    let initial_step;
+    match switch.kind {
+        SwitchKind::Home => {
+            let activate = format!("{out_path}/activate");
+            command = Command::new(&activate);
+            display = activate;
+            // home-manager's own `Activating <step>` lines open the steps.
+            initial_step = None;
+        }
+        SwitchKind::Os => {
+            eprintln!(
+                "nix-web-monitor: system activation needs sudo -- enter your password in this terminal"
+            );
+            let pre_auth = Command::new("sudo")
+                .arg("-v")
+                .status()
+                .await
+                .context("pre-authenticating sudo")?;
+            if pre_auth.code() != Some(0) {
+                monitor
+                    .write()
+                    .await
+                    .set_activation_status("failed (sudo authentication)".to_owned());
+                broadcast_deltas(monitor, deltas).await?;
+                return Ok(pre_auth.code().or(Some(1)));
+            }
+            // Record the new generation in the system profile before activating.
+            // `darwin-rebuild activate` (unlike `switch`) does NOT advance the
+            // profile, so without this a switch activates without registering the
+            // generation and rollbacks/diffs/reboots still see the old one. This
+            // mirrors `darwin-rebuild switch` (`nix-env -p <profile> --set`).
+            let set_profile = Command::new("sudo")
+                .args([
+                    "nix-env",
+                    "-p",
+                    "/nix/var/nix/profiles/system",
+                    "--set",
+                    out_path,
+                ])
+                .status()
+                .await
+                .context("recording system generation")?;
+            if set_profile.code() != Some(0) {
+                monitor
+                    .write()
+                    .await
+                    .set_activation_status("failed (recording system generation)".to_owned());
+                broadcast_deltas(monitor, deltas).await?;
+                return Ok(set_profile.code().or(Some(1)));
+            }
+            let activate = format!("{out_path}/sw/bin/darwin-rebuild");
+            command = Command::new("sudo");
+            command.arg(&activate).arg("activate");
+            display = format!("sudo {activate} activate");
+            // nix-darwin's activate is unstructured: one step holds every line.
+            initial_step = Some("activate".to_owned());
+        }
+    }
+
+    monitor
+        .write()
+        .await
+        .begin_activation(display, initial_step);
+    broadcast_deltas(monitor, deltas).await?;
+
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn().context("spawning activation")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("activation stdout was not captured")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("activation stderr was not captured")?;
+
+    let stdout_task = tokio::spawn(stream_activation(
+        stdout,
+        terminal_output,
+        Arc::clone(monitor),
+        deltas.clone(),
+    ));
+    let stderr_task = tokio::spawn(stream_activation(
+        stderr,
+        terminal_output,
+        Arc::clone(monitor),
+        deltas.clone(),
+    ));
+
+    let status = child.wait().await.context("waiting for activation")?;
+    stdout_task.await.context("joining activation stdout")??;
+    stderr_task.await.context("joining activation stderr")??;
+
+    let exit_code = status.code();
+    monitor.write().await.finish_activation(exit_code == Some(0));
+    broadcast_deltas(monitor, deltas).await?;
+    Ok(exit_code)
+}
+
+/// Read one activation stream line-by-line, folding each line into the activation
+/// subtree and (unless terminal output is `Quiet`) echoing it to the terminal so
+/// progress shows in both places. Lossy UTF-8 decode keeps the stream flowing
+/// past non-UTF-8 bytes, matching [`parse_stderr`].
+async fn stream_activation<R>(
+    stream: R,
+    terminal_output: TerminalOutput,
+    monitor: Arc<RwLock<MonitorState>>,
+    deltas: broadcast::Sender<Bytes>,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut reader = BufReader::new(stream);
+    let mut buf: Vec<u8> = Vec::new();
+    loop {
+        buf.clear();
+        let read = reader
+            .read_until(b'\n', &mut buf)
+            .await
+            .context("reading activation output")?;
+        if read == 0 {
+            break;
+        }
+        if buf.last() == Some(&b'\n') {
+            buf.pop();
+        }
+        if buf.last() == Some(&b'\r') {
+            buf.pop();
+        }
+        let line = String::from_utf8_lossy(&buf);
+        monitor.write().await.push_activation_line(&line);
+        broadcast_deltas(&monitor, &deltas).await?;
+        // `Quiet` prints only wrapper status lines, so suppress the per-line
+        // activation echo; the browser still receives every line.
+        if !matches!(terminal_output, TerminalOutput::Quiet) {
+            eprintln!("{line}");
+        }
+    }
     Ok(())
+}
+
+/// Run `nvd diff <old> <new>` and publish its output to the diff panel.
+/// Best-effort: a missing `nvd` or a diff failure leaves the panel empty with a
+/// terminal note rather than failing the switch, which has already succeeded.
+async fn run_diff(
+    old_generation: &str,
+    new_generation: &str,
+    monitor: &Arc<RwLock<MonitorState>>,
+    deltas: &broadcast::Sender<Bytes>,
+) {
+    let output = Command::new("nvd")
+        .arg("diff")
+        .arg(old_generation)
+        .arg(new_generation)
+        .output()
+        .await;
+    match output {
+        Ok(output) => {
+            let text = String::from_utf8_lossy(&output.stdout).into_owned();
+            if !text.trim().is_empty() {
+                monitor.write().await.set_diff(text);
+                if let Err(error) = broadcast_deltas(monitor, deltas).await {
+                    eprintln!("nix-web-monitor: broadcasting diff failed: {error:#}");
+                }
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("nix-web-monitor: nvd not found; skipping generation diff");
+        }
+        Err(error) => {
+            eprintln!("nix-web-monitor: running nvd diff failed: {error:#}");
+        }
+    }
+}
+
+/// Resolve the current generation profile path so the post-switch diff has a
+/// baseline. Returns `None` (diff skipped) if no candidate resolves.
+async fn read_old_generation(kind: SwitchKind) -> Option<String> {
+    let candidates = match kind {
+        SwitchKind::Home => {
+            let home = std::env::var("HOME").unwrap_or_default();
+            let user = std::env::var("USER").unwrap_or_default();
+            vec![
+                format!("{home}/.local/state/nix/profiles/home-manager"),
+                format!("/nix/var/nix/profiles/per-user/{user}/home-manager"),
+            ]
+        }
+        SwitchKind::Os => vec!["/nix/var/nix/profiles/system".to_owned()],
+    };
+    for candidate in candidates {
+        if let Ok(resolved) = tokio::fs::canonicalize(&candidate).await {
+            return Some(resolved.to_string_lossy().into_owned());
+        }
+    }
+    None
+}
+
+fn current_user() -> Result<String> {
+    std::env::var("USER").context("USER environment variable is not set")
+}
+
+/// The short (no-domain) hostname, used to default the configuration name.
+async fn short_hostname() -> Result<String> {
+    let output = Command::new("hostname")
+        .arg("-s")
+        .output()
+        .await
+        .context("running hostname -s")?;
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if name.is_empty() {
+        bail!("hostname -s returned an empty name");
+    }
+    Ok(name)
+}
+
+/// The macOS `LocalHostName`, which `darwin-rebuild` uses to default the flake
+/// attribute. Can differ from `hostname -s`, so the os switch must use the same
+/// source or it would build a different `darwinConfigurations.<name>`.
+async fn local_host_name() -> Result<String> {
+    let output = Command::new("scutil")
+        .args(["--get", "LocalHostName"])
+        .output()
+        .await
+        .context("running scutil --get LocalHostName")?;
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if name.is_empty() {
+        bail!("scutil --get LocalHostName returned an empty name");
+    }
+    Ok(name)
 }
 
 async fn parse_stderr<R>(
@@ -772,5 +1323,26 @@ mod tests {
 
         let decoded: Delta = rmp_serde::from_slice(&encoded).expect("payload decodes");
         assert_eq!(decoded, delta);
+    }
+
+    /// The activation and diff deltas ride the same wire as every other delta, so
+    /// a nested `Activation` subtree must round-trip through msgpack intact: this
+    /// is the contract the browser decodes per WebSocket frame during a switch.
+    #[test]
+    fn activation_and_diff_deltas_round_trip_through_msgpack() {
+        let mut activation = nix_web_monitor_parser::Activation::default();
+        activation.begin("/nix/store/x/activate".to_owned(), None, 1);
+        activation.ingest_line("Activating linkGeneration", 2);
+        let activation_delta = Delta::ActivationSet { activation };
+        let decoded: Delta = rmp_serde::from_slice(&encode(&activation_delta).expect("encodes"))
+            .expect("payload decodes");
+        assert_eq!(decoded, activation_delta);
+
+        let diff_delta = Delta::DiffSet {
+            diff: "<<< old\n>>> new".to_owned(),
+        };
+        let decoded: Delta =
+            rmp_serde::from_slice(&encode(&diff_delta).expect("encodes")).expect("payload decodes");
+        assert_eq!(decoded, diff_delta);
     }
 }


### PR DESCRIPTION
## What

Adds `nh`-style subcommands to `nix-web-monitor` (`nwm`) so a `home-manager switch` / `darwin-rebuild switch` is observable in the live browser UI, with the **activation phase** (the part you actually wait on) rendered as a live step tree:

- `nwm home switch [FLAKE] [-u]` — build `homeConfigurations."<user>@<host>".activationPackage`, then run `<out>/activate`.
- `nwm os switch [FLAKE] [-u]` — build `darwinConfigurations."<host>".system`, then activate via the canonical `sudo <out>/sw/bin/darwin-rebuild activate` (interactive `sudo -v` pre-auth first).
- `nwm flake update [INPUT...] [--flake DIR]` — update inputs under the monitor. `-u` on a switch runs the update first.
- `nwm home/os build` — build only, no activation.

Everything else still passes straight to `nix` (clap `external_subcommand`), so `nwm build .#x` and `nwm run .#ix -- new` are unchanged.

## How

A switch runs as a phase sequence under one monitor: optional flake update → monitored `nix build` (existing build tree) → activation → `nvd diff`. Activation and the diff are new **out-of-band subtrees**, mirroring the existing daemon-panel pattern (pure wire type in `parser/`, a `Delta` variant, a setter, a Svelte panel) — the build tree is reused unchanged.

- `parser/src/activation.rs` (new): pure, tested line classifier. home-manager's `Activating <step>` lines become named steps (anchored to a single-token name so a step's own output can't split it); `Starting Home Manager activation` is the banner; nix-darwin's unstructured activate streams under one seeded `activate` step.
- New `Delta::ActivationSet` / `DiffSet`, `MonitorState`/`MonitorSnapshot` `activation`/`diff` fields + setters.
- `server/src/main.rs`: subcommand restructure (`global = true` flags so they parse after a subcommand), `build_job`/`run_switch`/`run_activation`/`run_diff`, and `run_nix_build` (the old `run_nix_command` minus `finish`, with stdout capture for `--print-out-paths`).
- Svelte: `ActivationPanel.svelte` (step tree, live durations, expand-to-output) + `DiffPanel.svelte` (self-hides off a switch), wired through `types.ts`/`monitor-transport.ts`/`App.svelte`.
- `server/default.nix`: bundles `pkgs.nvd` via `--suffix PATH` (operator's own `nvd` still wins); `nix`/`home-manager`/`darwin-rebuild`/`sudo` stay on the operator's PATH as before.

Failure contract: flake-update fail → abort before build; build fail (or zero out-paths) → skip activation+diff with a distinct status and a non-zero exit; activation fail → skip diff, mark the open step failed, propagate the exit code.

## Testing

- `cargo test` for both crates green (parser classifier incl. anchored-match + darwin fallback + failed-step; `Delta::ActivationSet`/`DiffSet` msgpack round-trip).
- `svelte-check` + `eslint` + `vite build` clean.
- `nix build .#nix-web-monitor` builds.
- CLI parsing verified for every form incl. backward-compat passthrough and globals-after-subcommand.
- Reviewed by the `code-reviewer` agent (no blockers; its Low findings on the flake-update phase, the build-no-output-path edge, and the activation step-boundary match are applied in this PR).

Note: `os switch` mutates the system and needs an interactive terminal for the sudo prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `home`/`os` switch subcommands with live activation and diff views to nix-web-monitor
> - Adds `nwm home switch` and `nwm os switch` CLI subcommands that orchestrate: optional `nix flake update`, a monitored build phase, live activation streaming, and a post-switch generation diff via `nvd`.
> - Introduces an activation model ([activation.rs](https://github.com/indexable-inc/index/pull/1375/files#diff-cf1946bcbc2504134710825012a483875144980d02aeef883e18724cbe4ae287)) that parses activation output into named steps with status, timestamps, and captured lines, broadcast as `ActivationSet` WebSocket deltas.
> - Adds `ActivationPanel` and `DiffPanel` Svelte components to the UI, showing live step progress and the post-switch diff when available.
> - Wraps the server binary with `nvd` on PATH so generation diffs work by default ([default.nix](https://github.com/indexable-inc/index/pull/1375/files#diff-b66bbd31984b70403c9f30b1a7e014fab90ee09c73a1f53dad8da7ae90823b6e)).
> - Risk: `os switch` requires `sudo` for profile registration and activation; missing `sudo` auth will stall the process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a915399.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->