### PR TITLE
mcp: report elapsed_s per run; system prompt treats slow runs as bugs

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -58,6 +58,8 @@ let
 
   indexKernel = "Do your work through the index Python kernel (the `python_exec` MCP tool) and reuse its persistent namespace across turns. Search with the in-process `fff.grep`/`fff.find` (run `api()` to list them). Never shell out to `rg` or `fd` inside the kernel, where they run non-interactively and silently mislead (`rg` with no path argument searches empty stdin and returns nothing). The index kernel is your shell: the Bash tool is denied where the kernel is present (the house default). If the kernel wedges (the event loop is frozen and neither `kernel_trace` nor a fresh `python_exec` revives it), restart the kernel or report the blocker rather than falling back to Bash.";
 
+  kernelTiming = "The index kernel reports `elapsed_s`, each `python_exec` run's wall-clock seconds, in every reply. Treat a slow run as a problem to fix, not a number to ignore: a call that takes seconds when it should take milliseconds is almost always a synchronous wait (`subprocess.run`, `time.sleep`, `requests`, a long CPU-bound op) freezing the one shared event loop, which also stalls every other job queued behind it; make it non-blocking (wrap it in `await asyncio.to_thread(...)`, prefer an async API, or shell out via the bundled `sh()`) and the time drops. When the work is genuinely heavy, run it as a background job and poll `.done()` rather than holding the foreground channel. Investigate a surprising `elapsed_s` (profile it, look for a blocking call, narrow the work) instead of accepting it.";
+
   fleetHistory = "When fleet-history search is available, search it for prior work before a non-trivial task: in the kernel, `import search`, then `await search.semantic(\"<task phrasing>\", source=[\"claude_history\"], top_k=5)`. Route by question type: `shell` for what-is-the-command, `github` for why-is-it-this-way, and `claude_history` for how-did-someone-do-this. For broader prior research, spawn a cheap-model subagent so raw hits never flood your context. The corpus knows prior decisions, known pitfalls, and whether a thing was already built. The backend can be unavailable (for example a spend limit); if it errors, note that and proceed rather than blocking on it.";
 
   structuredPrimitives = "Prefer a structured primitive over text munging: `view.ls`/`view.tree`/`view.cat` for the filesystem (pre-imported polars frames), `fff.grep`/`fff.find` for search, and CLI JSON modes (`gh --json`, `cargo metadata`, `nix --json`) parsed with `.json()`/`.jsonl()`/`.df()` on the `sh` Output. Never use awk, sed, or string-splitting. Run one command per `sh()` call and combine the results in Python. Return a tabular answer as a polars DataFrame.";
@@ -132,6 +134,7 @@ let
     modelTiering
     harness
     indexKernel
+    kernelTiming
     fleetHistory
     structuredPrimitives
     probeByExitCode

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2192,6 +2192,8 @@ let
         # full sizes the server uses to detect a truncated reply
         s = runtime._job_summary(a)
         assert s["output_chars"] == len(a.output) and s["result_chars"] == len("A done"), s
+        # elapsed_s rides every summary so the per-call reply reports the run's cost
+        assert isinstance(s["elapsed_s"], float) and s["elapsed_s"] >= 0.0, s
         # history() indexes the runs and returns a Result naming both jobs
         h = ns["history"]()
         assert isinstance(h, runtime.Result) and a.id in h.llm_result and b.id in h.llm_result
@@ -2864,6 +2866,9 @@ let
             assert summary is not None and summary["status"] == "wedged", summary
             assert elapsed < 15, ("watchdog did not fire promptly", elapsed)
             assert "asyncio.to_thread" in summary["error"], summary
+            # a wedged reply still carries elapsed_s (the slowest case the field
+            # exists to surface), reporting the seconds the call blocked
+            assert isinstance(summary["elapsed_s"], float) and summary["elapsed_s"] >= 0.5, summary
 
             _, after = await kernel.python_exec("Result.text('alive')", budget=10.0, name="after")
             assert after is not None and after["status"] == "done", after

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -63,6 +63,10 @@ def _wedged_summary(budget: float, grace: float, deadline: float, *, interrupted
         "result": None,
         "result_chars": 0,
         "error": message,
+        # The wall-clock seconds this call blocked before the server gave up, so a
+        # wedged reply still carries elapsed_s (and reports the slowest case the
+        # field exists to surface) rather than a misleading null.
+        "elapsed_s": round(deadline, 2),
     }
 
 

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2864,6 +2864,11 @@ def _job_summary(job: Job) -> dict:
         "result": None if job._result is None else _safe_repr(job._result),
         "result_chars": len(_result_text(job)),
         "error": job.error,
+        # Wall-clock seconds the run has taken (final once it ends, elapsed-so-far
+        # while it is still backgrounded). Surfaced in every reply so the caller
+        # notices a slow run and treats it as a problem to fix -- usually a sync
+        # call freezing the loop (make it async/background), not just an FYI.
+        "elapsed_s": round((job.ended or time.time()) - job.started, 2),
         # Where a still-running job is right now (cell line), so a budget-expired
         # reply can say not just "running" but "running, on line N".
         "line": _current_line(job) if job.running() else None,

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -255,7 +255,17 @@ async def python_exec(
     if summary is None:
         return rendered
     header = outputs.text(
-        json.dumps({"job": summary.get("id"), "status": summary.get("status"), "running": summary.get("running")})
+        json.dumps(
+            {
+                "job": summary.get("id"),
+                "status": summary.get("status"),
+                "running": summary.get("running"),
+                # Wall-clock cost of this run, reported by default so the caller
+                # notices a slow run (the house system prompt's kernel-timing rule
+                # says to treat one as a problem to fix, not an FYI).
+                "elapsed_s": summary.get("elapsed_s"),
+            }
+        )
     )
     parts: Content = [header]
     # The kernel folds a cell's stdout into its result (Jupyter semantics; see


### PR DESCRIPTION
## What

The index kernel now reports each `python_exec` run's wall-clock seconds as **`elapsed_s`** in both the per-call reply header and the job summary, and the house system prompt gains a rule telling the agent to treat a slow run as a problem to fix.

Clean separation of concerns:
- **MCP = mechanism.** `runtime._job_summary` carries `elapsed_s` (final once a job ends, elapsed-so-far while it is still backgrounded), and `tools.python_exec` surfaces it in the JSON reply header the model already reads. No behavioral prose added to the MCP guide.
- **System prompt = behavior.** A new `kernelTiming` rule (right after `indexKernel`) frames a slow run as almost always a synchronous call freezing the one shared event loop, with the fix (`await asyncio.to_thread`, an async API, or `sh()` / background-and-poll).

## Why

Surfacing the cost on every reply biases the agent to *notice* slow runs; the system-prompt rule tells it what to do about them (usually: stop blocking the shared loop).

## Validation

- `nix build .#mcp.tests.runtimeSmoke` ✅ (locks the new summary field with an assertion)
- `nix build .#mcp.tests.serverTools` ✅ (guide/tools still compose)
- `nix eval` of `packages/agent/system-prompt.nix` ✅ (rule present, ordered after `indexKernel`)

(authored by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report elapsed_s per kernel run and treat slow runs as bugs in system prompt
> - Adds an `elapsed_s` field to job summaries in [`runtime.py`](https://github.com/indexable-inc/index/pull/1376/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) and [`kernel.py`](https://github.com/indexable-inc/index/pull/1376/files#diff-ced4fbbdf05b4f126e987804d73fdc2d811511b346e4985a9996ae7903683d1c), reporting wall-clock seconds for both completed and wedged runs.
> - Surfaces `elapsed_s` in the `python_exec` tool's JSON header block so run cost is visible by default.
> - Updates [`system-prompt.nix`](https://github.com/indexable-inc/index/pull/1376/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to include a timing rule instructing the agent to treat slow runs as bugs and prefer async/background patterns.
> - Adds test assertions in [`default.nix`](https://github.com/indexable-inc/index/pull/1376/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) to verify `elapsed_s` is present and valid in both normal and wedged summaries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de40070.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->