### PR TITLE
andrewgazelka/darwin: drop orbstack cask

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -39,7 +39,6 @@
       "notion"
       "obs@beta"
       "obsidian"
-      "orbstack"
       "postico"
       "prismlauncher"
       "raycast"


### PR DESCRIPTION
Removing the `orbstack` Homebrew cask so the next `darwin-rebuild switch` won't reinstall it: I'm fully uninstalling OrbStack from hydra (the aarch64-linux remote builder has moved to the vfkit guest, so OrbStack is no longer needed).

🤖 Generated with Claude Code (Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove orbstack cask from andrewgazelka's darwin configuration
> Removes `orbstack` from the list of casks in [darwin.nix](https://github.com/indexable-inc/index/pull/1378/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc). OrbStack will no longer be provisioned on this machine.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5be2182.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->