### PR TITLE
claude-code: bump to 2.1.183

### DIFF
--- a/packages/agent/claude-code/manifest.json
+++ b/packages/agent/claude-code/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "2.1.170",
+  "version": "2.1.183",
   "platforms": {
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-6QNkbYt6MYgqgOzSdWmifYrFezcIdF80lwljLIQRf98="
+      "hash": "sha256-YhjvzNBhlOoLw4ESG/AwQKAnoE2ZHq7YhtoCoARJrQ8="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-kU8jpwu+1dmuVn4+BLhiBu2ZcbNxvJuso/eciIW/3bQ="
+      "hash": "sha256-xwJI+WtYMf+GrBaatTyH7FSA+Rrjhng9oRAEh1wq0bc="
     },
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-hJ4AcnegRCqydXDT49bUN4dQeUZZDo3RlH5aObcIH54="
+      "hash": "sha256-3ztAnFslKZ31LF7oH2SBHb3LLhjBvu/n9zPDJvCozc4="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-G7nQMkQKdVMvfdTK+8aH8iCq8Wxj66F+GS377C8EvSU="
+      "hash": "sha256-JgpuQ/6cb9iAAxdYGYL/UOT0QB0C72Jfqk33I7uXELM="
     }
   }
 }

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -18,7 +18,7 @@
 #
 # Rules tagged STOCK-DERIVED are adapted from Claude Code's OWN stock system
 # prompt, read at the pinned binary version (./claude-code/manifest.json,
-# currently 2.1.170) by capturing what the binary actually sends to the API:
+# currently 2.1.183) by capturing what the binary actually sends to the API:
 # point the unwrapped `libexec/Claude Code` at a local `ANTHROPIC_BASE_URL`
 # server and read the `system` blocks. The wrapper REPLACES the stock prompt
 # instead of appending (see ./claude-code's `systemPrompt` arg), so these


### PR DESCRIPTION
## What
Bump vendored Claude Code from **2.1.170 → 2.1.183** via the signed `updateScript` (Anthropic GPG signature verified against the pinned release key).

## Why
Picks up upstream fixes and, notably, crosses **v2.1.172**: subagents can now spawn nested subagents (up to 5 levels deep). Also refreshes the pinned-version note in `packages/agent/system-prompt.nix`.

## Validation
- `nix run .#claude-code.updateScript` — signature verified, manifest hashes refreshed for all 4 platforms.
- `nix build .#claude-code` incl. `installCheckPhase` on aarch64-darwin — green.

Note: the STOCK-DERIVED rules in `system-prompt.nix` were not re-captured against 2.1.183; the wrapper fully replaces the stock prompt, so this is a non-blocking manual follow-up if upstream reworded anything load-bearing.

(authored by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump claude-code version to 2.1.183
> Updates [manifest.json](https://github.com/indexable-inc/index/pull/1379/files#diff-7bb63b882296583d83c0c739010565abc2319324c3548ef3125e7c88f680491a) to reference version 2.1.183 with updated sha256 hashes, and updates the version comment in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1379/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ccd122.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->