### PR TITLE
mcp: add ghostty module to drive the Ghostty terminal (macOS)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -547,7 +547,7 @@ let
   );
   # Drive the Ghostty terminal over its AppleScript dictionary (Ghostty 1.3.2+):
   # `import ghostty`, then `await ghostty.surfaces()` reads every open surface
-  # (id/tty/pid/cwd/title) into polars and `await ghostty.close_me()` closes the
+  # (id/tty/pid/cwd/name) into polars and `await ghostty.close_me()` closes the
   # window this session runs in. Pure Python shelling `osascript` on the loop; no
   # native binding, so a plain toPythonModule like `worktree`/`tasks`. macOS-only
   # at import; bundled only in `darwinExtraPackages`.

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3778,6 +3778,14 @@ let
     assert ghostty._selector(tty="/dev/ttys001", id=None) == (
         '(first terminal whose tty is "/dev/ttys001")'
     )
+    # Fails closed unless exactly one selector is given (both set or both unset).
+    for bad in ({}, {"tty": "/dev/ttys001", "id": "X"}):
+        try:
+            ghostty._selector(tty=bad.get("tty"), id=bad.get("id"))
+        except ghostty.GhosttyError:
+            pass
+        else:
+            raise SystemExit(f"_selector accepted ambiguous args: {bad}")
 
     # _parse_ps + _walk_to_tty resolve the controlling tty from a synthetic table.
     tree = ghostty._parse_ps("100 1 ??\n200 100 ttys003\n300 200 ??\n")

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3745,6 +3745,76 @@ let
         mkdir -p "$out"
       '';
 
+  # The ghostty module: pure-logic checks that need no Ghostty, osascript, or
+  # display (the nix sandbox has none). Exercises the AppleScript-escape guard
+  # (the injection fix), the ps-ancestry parse/walk, and the surfaces readout
+  # split, and confirms the public coroutine surface.
+  ghosttyTestPy = pkgs.writeText "ix-mcp-ghostty-test.py" ''
+    import inspect
+
+    import ghostty
+
+    # Public surface is callable and async.
+    for name in (
+        "surfaces", "my_tty", "my_surface", "close", "close_me",
+        "focus", "activate", "is_running",
+    ):
+        assert inspect.iscoroutinefunction(getattr(ghostty, name)), name
+
+    # _escape_applescript neutralises a quote-injection payload, rejects newlines.
+    assert ghostty._escape_applescript('a"b') == 'a\\"b'
+    assert ghostty._escape_applescript("c\\d") == "c\\\\d"
+    try:
+        ghostty._escape_applescript("a\nb")
+    except ghostty.GhosttyError:
+        pass
+    else:
+        raise SystemExit("escape did not reject a newline")
+
+    # _selector escapes the value: no raw quote reaches the whose-clause, so the
+    # `" or true or "` predicate-injection cannot match every surface.
+    sel = ghostty._selector(tty=None, id='" or true or "')
+    assert sel.count('\\"') == 2, sel
+    assert ghostty._selector(tty="/dev/ttys001", id=None) == (
+        '(first terminal whose tty is "/dev/ttys001")'
+    )
+
+    # _parse_ps + _walk_to_tty resolve the controlling tty from a synthetic table.
+    tree = ghostty._parse_ps("100 1 ??\n200 100 ttys003\n300 200 ??\n")
+    assert tree[200] == (100, "ttys003"), tree
+    assert ghostty._walk_to_tty(tree, 300) == "/dev/ttys003"
+    assert ghostty._walk_to_tty(tree, 100) is None
+
+    # _parse_surfaces splits the RS/FS readout and coerces pid to int.
+    raw = "ID1\x1f/dev/ttys001\x1f42\x1f/tmp\x1fTitle\x1e"
+    assert ghostty._parse_surfaces(raw) == [
+        {"id": "ID1", "tty": "/dev/ttys001", "pid": 42,
+         "working_directory": "/tmp", "name": "Title"}
+    ]
+    assert set(ghostty._surface_schema()) == set(ghostty._FIELDS)
+
+    print("ghostty-ok")
+  '';
+  ghosttySmoke =
+    pkgs.runCommand "ix-mcp-ghostty-smoke"
+      {
+        nativeBuildInputs = [ mcpPython ];
+        strictDeps = true;
+      }
+      ''
+        ${lib.getExe mcpPython} ${ghosttyTestPy} >stdout 2>stderr || {
+          echo "ix-mcp ghostty smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        grep -qx 'ghostty-ok' stdout || {
+          echo "ix-mcp ghostty smoke did not confirm the ghostty module:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        mkdir -p "$out"
+      '';
+
   # The view module: tabular helpers return plain polars DataFrames (so they stay
   # composable), the file helpers return a Code view whose repr is the raw text,
   # and df_html renders the styled table the kernel installs globally. Pure local
@@ -5088,6 +5158,7 @@ package.overrideAttrs (old: {
         imessageBundled
         imessageSmoke
         ghosttyBundled
+        ghosttySmoke
         ;
     };
   };

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -545,6 +545,28 @@ let
         cp -r ${tasksPythonSource}/tasks/. "$site/"
       ''
   );
+  # Drive the Ghostty terminal over its AppleScript dictionary (Ghostty 1.3.2+):
+  # `import ghostty`, then `await ghostty.surfaces()` reads every open surface
+  # (id/tty/pid/cwd/title) into polars and `await ghostty.close_me()` closes the
+  # window this session runs in. Pure Python shelling `osascript` on the loop; no
+  # native binding, so a plain toPythonModule like `worktree`/`tasks`. macOS-only
+  # at import; bundled only in `darwinExtraPackages`.
+  ghosttyPythonSource = builtins.path {
+    name = "ix-mcp-ghostty-python-source";
+    path = ./src/ghostty;
+  };
+  ghosttyModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-ghostty-python-module"
+      {
+        strictDeps = true;
+        meta.description = "Ghostty AppleScript control bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/ghostty"
+        mkdir -p "$site"
+        cp -r ${ghosttyPythonSource}/ghostty/. "$site/"
+      ''
+  );
   # Linear issue-tracker GraphQL client: `import linear`, then
   # `await linear.issue("ENG-123")` / `issue_update` / `issue_create` /
   # `project_create`. Pure Python over the already-bundled httpx; reads
@@ -770,6 +792,7 @@ let
       screenModule
       vmkitModule
       imessageModule
+      ghosttyModule
     ];
 
   # htpy: build HTML in plain Python (`div(class_="x")[ ... ]`), auto-escaping
@@ -4864,6 +4887,7 @@ let
   mapsBundled = importTest "maps" "import maps, MapKit; print('maps-ok', all(callable(getattr(maps, n)) for n in ('nearby', 'geocode', 'reverse_geocode')), callable(MapKit.MKLocalSearch.alloc))";
   vmkitBundled = importTest "vmkit" "import vmkit; print('vmkit-ok', callable(vmkit.boot_linux), callable(vmkit.drive), callable(vmkit.screenshot))";
   imessageBundled = importTest "imessage" "import imessage; print('imessage-ok', all(callable(getattr(imessage, n)) for n in ('messages', 'chats', 'contacts', 'send')))";
+  ghosttyBundled = importTest "ghostty" "import ghostty; print('ghostty-ok', all(callable(getattr(ghostty, n)) for n in ('surfaces', 'my_tty', 'my_surface', 'close', 'close_me', 'focus', 'activate', 'is_running')), ghostty.__version__)";
   xBundled = importTest "x" "import x; print('x-ok', callable(x.posts), x.__version__)";
   linearBundled = importTest "linear" "import linear; print('linear-ok', all(callable(getattr(linear, n)) for n in ('issue', 'issue_update', 'issue_create', 'issue_search', 'comment_create', 'project_create')), linear.__version__)";
   noxAutotriageBundled = importTest "nox-autotriage" "import nox_autotriage; print('nox-autotriage-ok', callable(nox_autotriage.findings_from_conformance))";
@@ -5063,6 +5087,7 @@ package.overrideAttrs (old: {
         vmkitResourceSmoke
         imessageBundled
         imessageSmoke
+        ghosttyBundled
         ;
     };
   };

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -129,7 +129,7 @@ MODULES: tuple[Module, ...] = (
     Module(
         "ghostty",
         "drive the Ghostty terminal via its AppleScript dictionary: read every open "
-        "surface into polars (`await ghostty.surfaces()` -> id/tty/pid/cwd/title), and "
+        "surface into polars (`await ghostty.surfaces()` -> id/tty/pid/cwd/name), and "
         "close/focus/activate one by tty or id. `await ghostty.close_me()` shuts the "
         "window this very session runs in -- the end-of-task move once fully done "
         "(macOS only)",

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -127,6 +127,14 @@ MODULES: tuple[Module, ...] = (
         "stack (macOS only)",
     ),
     Module(
+        "ghostty",
+        "drive the Ghostty terminal via its AppleScript dictionary: read every open "
+        "surface into polars (`await ghostty.surfaces()` -> id/tty/pid/cwd/title), and "
+        "close/focus/activate one by tty or id. `await ghostty.close_me()` shuts the "
+        "window this very session runs in -- the end-of-task move once fully done "
+        "(macOS only)",
+    ),
+    Module(
         "iphone",
         "drive a physical iPhone/iPad (USB or Wi-Fi) via pymobiledevice3: list devices/apps into "
         "polars (`iphone.devices()` / `apps()`), `screenshot()` a developer-mounted device to a PIL "

--- a/packages/mcp/src/ghostty/ghostty/__init__.py
+++ b/packages/mcp/src/ghostty/ghostty/__init__.py
@@ -1,0 +1,267 @@
+"""Drive the Ghostty terminal from the ix-mcp interpreter (macOS only).
+
+Bundled like ``screen``/``maps``/``imessage`` so every session can ``import
+ghostty`` on Darwin with no install step. Ghostty 1.3.2+ exposes an AppleScript
+dictionary whose ``terminal`` surfaces carry ``id``/``tty``/``pid``/``working
+directory``/``name``; this module reads those into a polars frame and lets you
+close, focus, or activate a surface.
+
+    import ghostty
+    await ghostty.surfaces()          # every open surface as a polars frame
+    await ghostty.my_tty()            # the tty this very session runs on
+    await ghostty.close_me()          # close the window this session lives in
+
+The marquee use is ``close_me``: an agent that has *fully* finished its work can
+shut its own window. It resolves the session's controlling tty by walking the
+kernel process up to its claude/login ancestor (the kernel is a child of the CLI
+that launched it), matches the Ghostty surface whose ``tty`` equals it, and
+closes that surface. The match is exact (``/dev/ttysNNN``), so it never touches a
+sibling session sharing the app.
+
+Why AppleScript over a subprocess of ``ghostty`` the binary: Ghostty has no CLI
+to enumerate or close surfaces; the scripting dictionary is the only supported
+control surface. Each call shells ``osascript`` on the event loop via
+``asyncio.create_subprocess_exec`` (never the blocking ``subprocess.run``), so a
+co-running coroutine on the shared kernel is never frozen.
+
+macOS-only: importing on a non-Darwin platform raises ``RuntimeError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
+
+__all__ = [
+    "GhosttyError",
+    "activate",
+    "close",
+    "close_me",
+    "focus",
+    "is_running",
+    "my_surface",
+    "my_tty",
+    "surfaces",
+]
+
+__version__ = "0.1.0"
+
+if sys.platform != "darwin":
+    raise RuntimeError(
+        "ghostty: the Ghostty AppleScript control surface is macOS-only "
+        f"(running on {sys.platform!r})."
+    )
+
+# AppleScript control-character separators. Surface titles and working
+# directories can contain spaces, tabs, even pipes, but never the ASCII unit/
+# record separators (US=31, RS=30), so they delimit the readout unambiguously.
+_FS = "\x1f"
+_RS = "\x1e"
+
+# The five terminal properties surfaces() reads, in column order. `tty` is the
+# Ghostty 1.3.2+ addition this whole module hinges on.
+_FIELDS = ("id", "tty", "pid", "working_directory", "name")
+
+
+class GhosttyError(RuntimeError):
+    """A Ghostty AppleScript call failed, or no surface matched the request."""
+
+
+async def _osascript(script: str) -> str:
+    """Run one AppleScript and return its stdout, raising GhosttyError on failure."""
+    proc = await asyncio.create_subprocess_exec(
+        "osascript",
+        "-e",
+        script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    if proc.returncode != 0:
+        raise GhosttyError(
+            f"osascript failed (exit {proc.returncode}): "
+            f"{err.decode(errors='replace').strip()}"
+        )
+    return out.decode(errors="replace")
+
+
+async def is_running() -> bool:
+    """True when Ghostty is already running.
+
+    Checked first by every call that would otherwise ``tell application
+    "Ghostty"`` and silently launch the app. ``is running`` does not launch it.
+    """
+    out = await _osascript('tell application "System Events" to (name of processes) contains "Ghostty"')
+    return out.strip() == "true"
+
+
+async def _ps_tree() -> dict[int, tuple[int, str]]:
+    """Snapshot the process table as ``pid -> (ppid, tty)`` in one ``ps`` call.
+
+    One subprocess, parsed in Python, beats a ``ps`` per ancestor: the walk in
+    :func:`my_tty` then never touches the loop again.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "ps", "-Ao", "pid=,ppid=,tty=", stdout=asyncio.subprocess.PIPE
+    )
+    out, _ = await proc.communicate()
+    tree: dict[int, tuple[int, str]] = {}
+    for line in out.decode(errors="replace").splitlines():
+        parts = line.split(None, 2)
+        if len(parts) < 2:
+            continue
+        pid_s, ppid_s = parts[0], parts[1]
+        tty = parts[2].strip() if len(parts) == 3 else ""
+        try:
+            tree[int(pid_s)] = (int(ppid_s), tty)
+        except ValueError:
+            continue
+    return tree
+
+
+async def my_tty() -> str | None:
+    """The controlling tty of this session, e.g. ``"/dev/ttys000"``, or None.
+
+    The kernel runs as a child of the claude/codex process that launched the MCP
+    server, which is itself attached to the Ghostty surface's pty. So walk the
+    parent chain from this process and return the first ancestor bound to a real
+    ``ttysNNN`` device. ``ps`` prints the tty as ``ttys000``; Ghostty's
+    AppleScript ``tty`` reports ``/dev/ttys000``, so normalise to the latter.
+    """
+    tree = await _ps_tree()
+    pid: int | None = os.getpid()
+    seen: set[int] = set()
+    while pid is not None and pid not in seen:
+        seen.add(pid)
+        ppid, tty = tree.get(pid, (0, ""))
+        if tty.startswith("ttys"):
+            return f"/dev/{tty}"
+        pid = ppid or None
+    return None
+
+
+def _surface_schema() -> dict[str, type[str] | type[int]]:
+    """Column dtypes for the surfaces() frame (pid is the only integer)."""
+    return {f: (int if f == "pid" else str) for f in _FIELDS}
+
+
+async def surfaces() -> pl.DataFrame:
+    """Every open Ghostty surface as a polars frame.
+
+    Columns: ``id``, ``tty``, ``pid``, ``working_directory``, ``name``. Empty
+    frame (correct schema) when Ghostty is not running, so callers can filter
+    without a special case.
+    """
+    import polars as pl
+
+    schema = _surface_schema()
+    if not await is_running():
+        return pl.DataFrame(schema=schema)
+    script = (
+        'tell application "Ghostty"\n'
+        f"  set fs to (ASCII character 31)\n"
+        f"  set rs to (ASCII character 30)\n"
+        '  set out to ""\n'
+        "  repeat with s in terminals\n"
+        "    set out to out & (id of s) & fs & (tty of s) & fs & (pid of s) & fs"
+        " & (working directory of s) & fs & (name of s) & rs\n"
+        "  end repeat\n"
+        "  return out\n"
+        "end tell"
+    )
+    raw = await _osascript(script)
+    rows: list[dict[str, object]] = []
+    for record in raw.split(_RS):
+        if not record.strip():
+            continue
+        cells = record.split(_FS)
+        if len(cells) != len(_FIELDS):
+            continue
+        row: dict[str, object] = dict(zip(_FIELDS, (c.strip() for c in cells)))
+        try:
+            row["pid"] = int(str(row["pid"]))
+        except ValueError:
+            row["pid"] = None
+        rows.append(row)
+    return pl.DataFrame(rows, schema=schema) if rows else pl.DataFrame(schema=schema)
+
+
+async def my_surface() -> pl.DataFrame:
+    """The single-row frame for this session's own surface (empty if unmatched)."""
+    tty = await my_tty()
+    frame = await surfaces()
+    if tty is None:
+        return frame.clear()
+    return frame.filter(frame["tty"] == tty)
+
+
+def _selector(*, tty: str | None, id: str | None) -> str:
+    """The AppleScript ``whose`` clause selecting one terminal by tty or id."""
+    if tty is not None:
+        return f'(first terminal whose tty is "{tty}")'
+    if id is not None:
+        return f'(first terminal whose id is "{id}")'
+    raise GhosttyError("pass exactly one of tty= or id=")
+
+
+async def _command(verb: str, *, tty: str | None, id: str | None) -> str:
+    """Run a single-terminal command (``close`` / ``focus`` / ``activate window``)."""
+    if not await is_running():
+        raise GhosttyError("Ghostty is not running")
+    sel = _selector(tty=tty, id=id)
+    script = (
+        'tell application "Ghostty"\n'
+        f"  set s to {sel}\n"
+        f"  {verb} s\n"
+        "end tell"
+    )
+    await _osascript(script)
+    return f"{verb}: {tty or id}"
+
+
+async def close(*, tty: str | None = None, id: str | None = None) -> str:
+    """Close one terminal surface, selected by ``tty`` or by ``id``.
+
+    Closing the last surface in a window closes the window. Pass exactly one of
+    ``tty`` / ``id``.
+    """
+    return await _command("close", tty=tty, id=id)
+
+
+async def focus(*, tty: str | None = None, id: str | None = None) -> str:
+    """Focus one terminal surface (and bring its window forward)."""
+    return await _command("focus", tty=tty, id=id)
+
+
+async def activate(*, tty: str | None = None, id: str | None = None) -> str:
+    """Bring the window owning a terminal surface to the front."""
+    if not await is_running():
+        raise GhosttyError("Ghostty is not running")
+    sel = _selector(tty=tty, id=id)
+    script = (
+        'tell application "Ghostty"\n'
+        f"  activate window of {sel}\n"
+        "end tell"
+    )
+    await _osascript(script)
+    return f"activate: {tty or id}"
+
+
+async def close_me() -> str:
+    """Close the Ghostty surface this session is running in.
+
+    Resolves :func:`my_tty` and closes the matching surface, ending the session.
+    The deliberate end-of-task move for an agent that is fully done.
+    """
+    tty = await my_tty()
+    if tty is None:
+        raise GhosttyError(
+            "could not resolve this session's tty (no ttys* ancestor); "
+            "not running under a Ghostty pty?"
+        )
+    return await close(tty=tty)

--- a/packages/mcp/src/ghostty/ghostty/__init__.py
+++ b/packages/mcp/src/ghostty/ghostty/__init__.py
@@ -142,8 +142,8 @@ def _walk_to_tty(tree: dict[int, tuple[int, str]], start: int) -> str | None:
 
     Pure counterpart of :func:`my_tty`. ``ps`` prints the tty as ``ttys000``;
     Ghostty's AppleScript ``tty`` reports ``/dev/ttys000``, so normalise to the
-    latter. The loop is bounded by a ``seen`` set so a cyclic/elf table cannot
-    spin.
+    latter. The loop is bounded by a ``seen`` set so a cyclic/self-referential
+    ps table (a pid that is its own ancestor) cannot spin.
     """
     pid: int | None = start
     seen: set[int] = set()

--- a/packages/mcp/src/ghostty/ghostty/__init__.py
+++ b/packages/mcp/src/ghostty/ghostty/__init__.py
@@ -240,12 +240,17 @@ async def my_surface() -> pl.DataFrame:
 
 
 def _selector(*, tty: str | None, id: str | None) -> str:  # noqa: A002 - mirrors the public close(id=) kwarg
-    """The AppleScript ``whose`` clause selecting one terminal by tty or id."""
+    """The AppleScript ``whose`` clause selecting one terminal by tty or id.
+
+    Fails closed unless *exactly* one selector is given: with both present,
+    silently preferring one could close/focus the wrong surface, and this is a
+    destructive control API.
+    """
+    if (tty is None) == (id is None):
+        raise GhosttyError("pass exactly one of tty= or id=")
     if tty is not None:
         return f'(first terminal whose tty is "{_escape_applescript(tty)}")'
-    if id is not None:
-        return f'(first terminal whose id is "{_escape_applescript(id)}")'
-    raise GhosttyError("pass exactly one of tty= or id=")
+    return f'(first terminal whose id is "{_escape_applescript(id)}")'
 
 
 async def _command(verb: str, *, tty: str | None, id: str | None) -> str:  # noqa: A002 - mirrors public kwarg

--- a/packages/mcp/src/ghostty/ghostty/__init__.py
+++ b/packages/mcp/src/ghostty/ghostty/__init__.py
@@ -3,8 +3,9 @@
 Bundled like ``screen``/``maps``/``imessage`` so every session can ``import
 ghostty`` on Darwin with no install step. Ghostty 1.3.2+ exposes an AppleScript
 dictionary whose ``terminal`` surfaces carry ``id``/``tty``/``pid``/``working
-directory``/``name``; this module reads those into a polars frame and lets you
-close, focus, or activate a surface.
+directory``/``name``; this module reads those into a polars frame (columns
+``id``/``tty``/``pid``/``working_directory``/``name``) and lets you close, focus,
+or activate a surface.
 
     import ghostty
     await ghostty.surfaces()          # every open surface as a polars frame
@@ -14,9 +15,11 @@ close, focus, or activate a surface.
 The marquee use is ``close_me``: an agent that has *fully* finished its work can
 shut its own window. It resolves the session's controlling tty by walking the
 kernel process up to its claude/login ancestor (the kernel is a child of the CLI
-that launched it), matches the Ghostty surface whose ``tty`` equals it, and
-closes that surface. The match is exact (``/dev/ttysNNN``), so it never touches a
-sibling session sharing the app.
+that launched it), confirms that tty matches exactly one open Ghostty surface,
+and closes it. The match is exact (``/dev/ttysNNN``), so it never touches a
+sibling session sharing the app; if the session is not directly on a Ghostty pty
+(e.g. nested under tmux or ssh) the resolved tty matches no surface and it
+refuses rather than guessing.
 
 Why AppleScript over a subprocess of ``ghostty`` the binary: Ghostty has no CLI
 to enumerate or close surfaces; the scripting dictionary is the only supported
@@ -72,6 +75,21 @@ class GhosttyError(RuntimeError):
     """A Ghostty AppleScript call failed, or no surface matched the request."""
 
 
+def _escape_applescript(value: str) -> str:
+    """Escape a string for safe interpolation into an AppleScript ``"..."`` literal.
+
+    Selector values (``tty``/``id``) reach AppleScript inside a quoted string. An
+    unescaped ``"`` would let a value like ``" or true or "`` turn the ``whose``
+    predicate into one that matches any surface, or inject further statements. So
+    backslash-escape ``\\`` and ``"``, and reject newlines outright (AppleScript
+    string literals cannot span lines, and a newline could only be an attempt to
+    break out of the statement).
+    """
+    if "\n" in value or "\r" in value:
+        raise GhosttyError("selector value must not contain a newline")
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 async def _osascript(script: str) -> str:
     """Run one AppleScript and return its stdout, raising GhosttyError on failure."""
     proc = await asyncio.create_subprocess_exec(
@@ -100,18 +118,13 @@ async def is_running() -> bool:
     return out.strip() == "true"
 
 
-async def _ps_tree() -> dict[int, tuple[int, str]]:
-    """Snapshot the process table as ``pid -> (ppid, tty)`` in one ``ps`` call.
+def _parse_ps(text: str) -> dict[int, tuple[int, str]]:
+    """Parse ``ps -Ao pid=,ppid=,tty=`` output into ``pid -> (ppid, tty)``.
 
-    One subprocess, parsed in Python, beats a ``ps`` per ancestor: the walk in
-    :func:`my_tty` then never touches the loop again.
+    Pure (no subprocess) so the ancestry walk is unit-testable offline.
     """
-    proc = await asyncio.create_subprocess_exec(
-        "ps", "-Ao", "pid=,ppid=,tty=", stdout=asyncio.subprocess.PIPE
-    )
-    out, _ = await proc.communicate()
     tree: dict[int, tuple[int, str]] = {}
-    for line in out.decode(errors="replace").splitlines():
+    for line in text.splitlines():
         parts = line.split(None, 2)
         if len(parts) < 2:
             continue
@@ -124,17 +137,15 @@ async def _ps_tree() -> dict[int, tuple[int, str]]:
     return tree
 
 
-async def my_tty() -> str | None:
-    """The controlling tty of this session, e.g. ``"/dev/ttys000"``, or None.
+def _walk_to_tty(tree: dict[int, tuple[int, str]], start: int) -> str | None:
+    """Walk parents from ``start`` and return the first ``/dev/ttysNNN``, else None.
 
-    The kernel runs as a child of the claude/codex process that launched the MCP
-    server, which is itself attached to the Ghostty surface's pty. So walk the
-    parent chain from this process and return the first ancestor bound to a real
-    ``ttysNNN`` device. ``ps`` prints the tty as ``ttys000``; Ghostty's
-    AppleScript ``tty`` reports ``/dev/ttys000``, so normalise to the latter.
+    Pure counterpart of :func:`my_tty`. ``ps`` prints the tty as ``ttys000``;
+    Ghostty's AppleScript ``tty`` reports ``/dev/ttys000``, so normalise to the
+    latter. The loop is bounded by a ``seen`` set so a cyclic/elf table cannot
+    spin.
     """
-    tree = await _ps_tree()
-    pid: int | None = os.getpid()
+    pid: int | None = start
     seen: set[int] = set()
     while pid is not None and pid not in seen:
         seen.add(pid)
@@ -145,9 +156,50 @@ async def my_tty() -> str | None:
     return None
 
 
+async def _ps_tree() -> dict[int, tuple[int, str]]:
+    """Snapshot the process table as ``pid -> (ppid, tty)`` in one ``ps`` call."""
+    proc = await asyncio.create_subprocess_exec(
+        "ps", "-Ao", "pid=,ppid=,tty=", stdout=asyncio.subprocess.PIPE
+    )
+    out, _ = await proc.communicate()
+    return _parse_ps(out.decode(errors="replace"))
+
+
+async def my_tty() -> str | None:
+    """The controlling tty of this session, e.g. ``"/dev/ttys000"``, or None.
+
+    The kernel runs as a child of the claude/codex process that launched the MCP
+    server, which is itself attached to the Ghostty surface's pty. So walk the
+    parent chain from this process and return the first ancestor bound to a real
+    ``ttysNNN`` device.
+    """
+    return _walk_to_tty(await _ps_tree(), os.getpid())
+
+
 def _surface_schema() -> dict[str, type[str] | type[int]]:
     """Column dtypes for the surfaces() frame (pid is the only integer)."""
     return {f: (int if f == "pid" else str) for f in _FIELDS}
+
+
+def _parse_surfaces(raw: str) -> list[dict[str, object]]:
+    """Parse the ``_RS``/``_FS``-delimited surfaces readout into row dicts.
+
+    Pure (no AppleScript) so the record/field split is unit-testable offline.
+    """
+    rows: list[dict[str, object]] = []
+    for record in raw.split(_RS):
+        if not record.strip():
+            continue
+        cells = record.split(_FS)
+        if len(cells) != len(_FIELDS):
+            continue
+        row: dict[str, object] = dict(zip(_FIELDS, (c.strip() for c in cells)))
+        try:
+            row["pid"] = int(str(row["pid"]))
+        except ValueError:
+            row["pid"] = None
+        rows.append(row)
+    return rows
 
 
 async def surfaces() -> pl.DataFrame:
@@ -164,8 +216,8 @@ async def surfaces() -> pl.DataFrame:
         return pl.DataFrame(schema=schema)
     script = (
         'tell application "Ghostty"\n'
-        f"  set fs to (ASCII character 31)\n"
-        f"  set rs to (ASCII character 30)\n"
+        "  set fs to (ASCII character 31)\n"
+        "  set rs to (ASCII character 30)\n"
         '  set out to ""\n'
         "  repeat with s in terminals\n"
         "    set out to out & (id of s) & fs & (tty of s) & fs & (pid of s) & fs"
@@ -174,20 +226,7 @@ async def surfaces() -> pl.DataFrame:
         "  return out\n"
         "end tell"
     )
-    raw = await _osascript(script)
-    rows: list[dict[str, object]] = []
-    for record in raw.split(_RS):
-        if not record.strip():
-            continue
-        cells = record.split(_FS)
-        if len(cells) != len(_FIELDS):
-            continue
-        row: dict[str, object] = dict(zip(_FIELDS, (c.strip() for c in cells)))
-        try:
-            row["pid"] = int(str(row["pid"]))
-        except ValueError:
-            row["pid"] = None
-        rows.append(row)
+    rows = _parse_surfaces(await _osascript(script))
     return pl.DataFrame(rows, schema=schema) if rows else pl.DataFrame(schema=schema)
 
 
@@ -200,31 +239,26 @@ async def my_surface() -> pl.DataFrame:
     return frame.filter(frame["tty"] == tty)
 
 
-def _selector(*, tty: str | None, id: str | None) -> str:
+def _selector(*, tty: str | None, id: str | None) -> str:  # noqa: A002 - mirrors the public close(id=) kwarg
     """The AppleScript ``whose`` clause selecting one terminal by tty or id."""
     if tty is not None:
-        return f'(first terminal whose tty is "{tty}")'
+        return f'(first terminal whose tty is "{_escape_applescript(tty)}")'
     if id is not None:
-        return f'(first terminal whose id is "{id}")'
+        return f'(first terminal whose id is "{_escape_applescript(id)}")'
     raise GhosttyError("pass exactly one of tty= or id=")
 
 
-async def _command(verb: str, *, tty: str | None, id: str | None) -> str:
-    """Run a single-terminal command (``close`` / ``focus`` / ``activate window``)."""
+async def _command(verb: str, *, tty: str | None, id: str | None) -> str:  # noqa: A002 - mirrors public kwarg
+    """Run a single-terminal command (``close`` / ``focus``)."""
     if not await is_running():
         raise GhosttyError("Ghostty is not running")
     sel = _selector(tty=tty, id=id)
-    script = (
-        'tell application "Ghostty"\n'
-        f"  set s to {sel}\n"
-        f"  {verb} s\n"
-        "end tell"
-    )
+    script = 'tell application "Ghostty"\n' f"  set s to {sel}\n" f"  {verb} s\n" "end tell"
     await _osascript(script)
     return f"{verb}: {tty or id}"
 
 
-async def close(*, tty: str | None = None, id: str | None = None) -> str:
+async def close(*, tty: str | None = None, id: str | None = None) -> str:  # noqa: A002 - by-id selector
     """Close one terminal surface, selected by ``tty`` or by ``id``.
 
     Closing the last surface in a window closes the window. Pass exactly one of
@@ -233,21 +267,17 @@ async def close(*, tty: str | None = None, id: str | None = None) -> str:
     return await _command("close", tty=tty, id=id)
 
 
-async def focus(*, tty: str | None = None, id: str | None = None) -> str:
+async def focus(*, tty: str | None = None, id: str | None = None) -> str:  # noqa: A002 - by-id selector
     """Focus one terminal surface (and bring its window forward)."""
     return await _command("focus", tty=tty, id=id)
 
 
-async def activate(*, tty: str | None = None, id: str | None = None) -> str:
+async def activate(*, tty: str | None = None, id: str | None = None) -> str:  # noqa: A002 - by-id selector
     """Bring the window owning a terminal surface to the front."""
     if not await is_running():
         raise GhosttyError("Ghostty is not running")
     sel = _selector(tty=tty, id=id)
-    script = (
-        'tell application "Ghostty"\n'
-        f"  activate window of {sel}\n"
-        "end tell"
-    )
+    script = 'tell application "Ghostty"\n' f"  activate window of {sel}\n" "end tell"
     await _osascript(script)
     return f"activate: {tty or id}"
 
@@ -255,13 +285,22 @@ async def activate(*, tty: str | None = None, id: str | None = None) -> str:
 async def close_me() -> str:
     """Close the Ghostty surface this session is running in.
 
-    Resolves :func:`my_tty` and closes the matching surface, ending the session.
-    The deliberate end-of-task move for an agent that is fully done.
+    Resolves :func:`my_tty`, confirms it matches exactly one open surface, then
+    closes that surface, ending the session. The deliberate end-of-task move for
+    an agent that is fully done. Refuses (raises :class:`GhosttyError`) when the
+    tty cannot be resolved or matches no surface, rather than risk closing the
+    wrong window.
     """
     tty = await my_tty()
     if tty is None:
         raise GhosttyError(
             "could not resolve this session's tty (no ttys* ancestor); "
             "not running under a Ghostty pty?"
+        )
+    frame = await surfaces()
+    if tty not in frame["tty"].to_list():
+        raise GhosttyError(
+            f"this session's tty {tty} matches no open Ghostty surface "
+            "(nested under tmux/ssh or a detached pty?); refusing to guess which to close"
         )
     return await close(tty=tty)


### PR DESCRIPTION
## What

Adds a bundled `ghostty` module to the ix-mcp interpreter (macOS only) that drives the Ghostty terminal over its AppleScript dictionary (Ghostty 1.3.2+ exposes `id`/`tty`/`pid`/`working directory`/`name` on each `terminal` surface).

```python
import ghostty
await ghostty.surfaces()    # every open surface -> polars (id/tty/pid/cwd/name)
await ghostty.my_tty()      # the tty this session runs on
await ghostty.close_me()    # close the window this session lives in
# plus close()/focus()/activate() by tty= or id=
```

The headline is `close_me()`: it resolves the session's controlling tty by walking the kernel process up to its claude/login ancestor (the kernel is a child of the CLI that launched it) and closes the Ghostty surface whose `tty` matches exactly, so it never touches a sibling session sharing the app. The end-of-task move for an agent that is fully done.

## How

- Pure Python shelling `osascript` on the event loop via `asyncio.create_subprocess_exec` (never the blocking `subprocess.run`), so a co-running coroutine on the shared kernel is never frozen. No native binding, so a plain `toPythonModule` like `worktree`/`tasks`, bundled only in `darwinExtraPackages`.
- Registry entry (so it shows in `api()` and the instructions), `default.nix` wiring, and a `ghosttyBundled` import-test check.

## Validation

- ✅ `nix build .#mcp.tests.ghosttyBundled` (aarch64-darwin) green: bundled module imports, all 8 functions callable.
- ✅ Exercised live on hydra against a real Ghostty 1.3.2: `surfaces()` lists open surfaces, `my_tty()`/`my_surface()` correctly resolve this session, and `close()` by tty closed the targeted window.

🤖 Generated with Claude Code (Opus)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ghostty` MCP module to control the Ghostty terminal via AppleScript on macOS
> - Adds a new `ghostty` Python package under [packages/mcp/src/ghostty/](https://github.com/indexable-inc/index/pull/1380/files#diff-f722bfb70ee0b1fc38645db650de45678e6411f64aa66bbf5a1374e9a6769779) exposing async coroutines: `surfaces`, `my_tty`, `my_surface`, `close`, `focus`, `activate`, and `close_me`.
> - `surfaces` returns a polars DataFrame of open Ghostty terminal surfaces (id, tty, pid, working_directory, name) via AppleScript; other commands select a surface by exactly one of `tty` or `id`.
> - `close_me` walks the ps parent tree to resolve the current session's controlling tty, then closes the matching Ghostty surface with safety checks.
> - Bundles the module into the MCP Python interpreter on Darwin via [packages/mcp/default.nix](https://github.com/indexable-inc/index/pull/1380/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) and registers it in the module catalog in [registry.py](https://github.com/indexable-inc/index/pull/1380/files#diff-92f567578e1217b8207dbbd21af1cdee4978728a8ca9e774cd65ed17170d2ae5).
> - Smoke tests validate selector ambiguity rejection, AppleScript escaping, ps parsing, and surface schema at build time.
> - Risk: module raises `GhosttyError` at import on non-macOS platforms, so any cross-platform usage will fail immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 394606a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->