### PR TITLE
mcp: document polars JSON/struct query idiom in kernel guide

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -213,7 +213,13 @@ POLARS = (
     "works. Nested data renders recursively: a dict of dicts (or a frame with struct/list columns) "
     "shows each value as a nushell-style nested sub-table, so prefer one frame with struct/list "
     "columns over a `{label: blob}` dict that collapses each value to a clipped repr — or add each "
-    "item as its own `cells.add`."
+    "item as its own `cells.add`. To QUERY JSON or nested data, decode a JSON-string column with "
+    "`str.json_decode()` into a Struct, then reach into it: `pl.col('s').struct.field('x')` for one "
+    "field, `.struct.unnest()` to expand every field into its own column. There is no single "
+    "'does any field match' op — reduce across fields with `pl.any_horizontal(...)` / "
+    "`pl.all_horizontal(...)` over the unnested struct (e.g. "
+    "`pl.any_horizontal(pl.col('s').struct.unnest().is_null())` is 'any field is null'); add "
+    "`.fill_null(False)` inside the reducer when a missing field should count as no-match."
 )
 
 RESULT_SPLIT = (


### PR DESCRIPTION
Adds the polars JSON/struct **query** idiom to the MCP kernel guide (`POLARS` fragment).

polars `pl` is already pre-imported by default (runtime.py) and the guide already covers *rendering* tabular data, but it said nothing about *querying* nested/JSON data. This documents:

- `str.json_decode()` to parse a JSON-string column into a Struct
- `pl.col('s').struct.field('x')` / `.struct.unnest()` to reach into fields
- `pl.any_horizontal(...)` / `pl.all_horizontal(...)` as the "does any/every field match" idiom (there is no single op), plus the `.fill_null(False)` caveat

Validated: `nix build .#mcp` ✅.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document Polars JSON/struct query idiom in the kernel guide
> Extends the guidance string in [guide.py](https://github.com/indexable-inc/index/pull/1381/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) to explain how to work with JSON or nested data in Polars. Covers decoding JSON-string columns with `str.json_decode()`, accessing struct fields via `struct.field()`, unnesting all fields with `struct.unnest()`, and reducing across fields using `pl.any_horizontal()` / `pl.all_horizontal()`, including a note to use `.fill_null(False)` when missing fields should count as no-match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c67227.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->