### PR TITLE
mcp: federated TUI resources bridge — resources/list+read + tui_act (M5)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1680,7 +1680,7 @@ let
   serverTools = importTest "server" (
     "import asyncio; from ix_notebook_mcp.tools import mcp; "
     + "names = sorted(t.name for t in asyncio.run(mcp.list_tools())); "
-    + "expected = {'python_exec','read','kernel_trace'}; "
+    + "expected = {'python_exec','read','kernel_trace','tui_act'}; "
     + "assert set(names) == expected, ('tool surface drifted: %r' % (names,)); "
     + "from ix_notebook_mcp import registry; instr = mcp._mcp_server.instructions; "
     + "assert 'root=' not in instr, 'a parameter/signature leaked into the instructions'; "
@@ -4997,6 +4997,44 @@ let
         cat stdout
         mkdir -p "$out"
       '';
+
+  # Network-free unit tests for the federated-resources bridge: every path of
+  # `resources_bridge` (list/read/act, peer-flag assembly, not-found -> -32002,
+  # graceful empty/clear-error when `ix` is absent) driven against a STUB `ix`
+  # script on PATH plus a nonexistent-binary path -- no real `ix` or peer needed.
+  # The bridge lives in the `ix_notebook_mcp` server package, so the test imports
+  # that module (bundled here) rather than a `src/*` helper; `bash` is on PATH for
+  # the stub script's shebang.
+  resourcesBridgeTestPython = pkgs.python3.withPackages (ps: [
+    ps.pytest
+    ps.pydantic
+    ixNotebookMcpModule
+  ]);
+  resourcesBridgeTestSource = builtins.path {
+    name = "ix-mcp-resources-bridge-test";
+    path = ./tests/test_resources_bridge.py;
+  };
+  resourcesBridgeTests =
+    pkgs.runCommand "ix-mcp-resources-bridge-tests"
+      {
+        nativeBuildInputs = [
+          resourcesBridgeTestPython
+          pkgs.bash
+        ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        cp ${resourcesBridgeTestSource} "$TMPDIR/test_resources_bridge.py"
+        ${lib.getExe resourcesBridgeTestPython} -m pytest "$TMPDIR/test_resources_bridge.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp resources-bridge tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
 in
 package.overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
@@ -5015,6 +5053,7 @@ package.overrideAttrs (old: {
         ixGoogleBundled
         slackBundled
         slackTests
+        resourcesBridgeTests
         beeperBundled
         requirementsSmoke
         engineBundled

--- a/packages/mcp/ix_notebook_mcp/resources_bridge.py
+++ b/packages/mcp/ix_notebook_mcp/resources_bridge.py
@@ -1,0 +1,482 @@
+"""Bridge the federated TUI *resources* into this MCP server.
+
+The ``ix`` CLI exposes the federated terminal-resource catalog over its
+``resources`` subcommand (``ix resources ls/get/act --json``). This module shells
+out to that CLI at runtime and maps its JSON into the MCP ``resources/list`` /
+``resources/read`` surface plus a ``tui_act`` tool, so an agent (or Claude Code)
+can ``@``-mention a peer's live terminal resource and drive it.
+
+Why shell out instead of linking ``ix``: index cannot take a Nix build-dependency
+on the ``ix`` binary (it would close the ix<->index dependency cycle), and the
+R2/pyo3 distribution path is heavier than this needs to be. Calling ``ix`` from
+``PATH`` at runtime sidesteps both -- and lets the bridge **degrade gracefully**:
+when ``ix`` is not installed (or has no ``resources`` subcommand, or errors), the
+list comes back empty and a read raises a clear error rather than crashing the
+server.
+
+Peers are configured with the ``IX_RESOURCE_PEERS`` environment variable: a
+comma-separated list of peer URLs (each passed to ``ix`` as ``--peer <url>``).
+Unset/empty means local-only for *listing* -- ``ix resources ls`` is run with no
+``--peer`` flag and reports whatever the local node federates.
+
+A read/act for a uri targets a single peer **by URL**. The ``ix`` CLI's
+``--peer`` is a full endpoint ``url::Url`` (e.g. ``https://<addr>/rpc``), not a
+bare host or label, so a peer cannot be inferred from the uri's host
+(``ix://<host>/<name>`` -- ``<host>`` is a display label, not an endpoint, and
+fails the CLI's URL parse). Instead: an explicit ``peer=`` URL is used directly;
+otherwise the bridge iterates the configured peer URLs (the same list
+:func:`list_resources` uses) and probes each with ``ix resources get`` until one
+advertises the uri, then reads/acts against that peer. With no explicit peer and
+no configured peers, a read/act raises a clear "no peer configured" error rather
+than silently shelling out a bare host.
+
+Everything here runs on the kernel's asyncio loop via
+:func:`asyncio.create_subprocess_exec` -- never a blocking ``subprocess.run``,
+which would freeze the one shared event loop. The CLI's JSON is parsed into typed
+pydantic models at the boundary (the repo convention) so a malformed or
+forward-incompatible payload fails loudly at one place instead of threading
+untyped dicts through the handlers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "Ack",
+    "ResourceBridgeError",
+    "ResourceEntry",
+    "ResourceNotFoundError",
+    "ResourceSnapshot",
+    "act",
+    "configured_peers",
+    "list_resources",
+    "read_resource",
+]
+
+# JSON-RPC error code for "resource not found". The MCP resources spec reserves
+# -32002 for a read of an unknown/unavailable resource; the server layer maps
+# :class:`ResourceNotFoundError` onto an ``McpError`` carrying this code.
+RESOURCE_NOT_FOUND = -32002
+
+# Environment variable naming the federated peers to query, comma-separated URLs.
+# Unset/empty => local-only (no ``--peer`` flag passed to ``ix``).
+PEERS_ENV = "IX_RESOURCE_PEERS"
+
+# The CLI the bridge shells out to. Overridable via ``IX_RESOURCES_BIN`` so a test
+# (or a non-PATH install) can point at a specific binary; defaults to ``ix`` on
+# PATH.
+_IX_BIN_ENV = "IX_RESOURCES_BIN"
+
+# Per-call timeout (seconds) so a hung/unreachable peer cannot wedge a request
+# forever. The CLI has its own network timeouts; this is a backstop.
+_CALL_TIMEOUT = 30.0
+
+
+class ResourceBridgeError(RuntimeError):
+    """A federated-resource operation failed (CLI missing, nonzero, bad JSON)."""
+
+
+class ResourceNotFoundError(ResourceBridgeError):
+    """The requested resource uri is unknown to the targeted peer (maps to -32002)."""
+
+
+# ---------------------------------------------------------------------------
+# Boundary models -- the shape of `ix resources ... --json` output.
+# ---------------------------------------------------------------------------
+#
+# `extra="ignore"` keeps these forward-compatible: the CLI may add fields without
+# breaking the bridge. Only the uri is truly required; every other field defaults
+# so a sparser-than-expected payload still parses (a peer that omits `caps`, say).
+
+
+class _BridgeModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class ResourceEntry(_BridgeModel):
+    """One federated resource as reported by ``ix resources ls --json``.
+
+    The ``uri`` (``ix://<host>/<name>`` by convention) is both the federated
+    identity and the MCP resource uri, so a client ``@``-mentions exactly what
+    ``ix`` advertises.
+    """
+
+    uri: str
+    name: str = ""
+    host: str = ""
+    caps: list[str] = Field(default_factory=list)
+    alive: bool = True
+    mime: str = "text/plain"
+
+
+class ResourceSnapshot(_BridgeModel):
+    """A point-in-time read of a resource from ``ix resources get <uri> --json``."""
+
+    uri: str = ""
+    text: str = ""
+    mime: str = "text/plain"
+
+
+class Ack(_BridgeModel):
+    """The acknowledgement ``ix resources act ... --json`` returns for a drive.
+
+    Kept permissive (only the common fields are named, ``extra="ignore"`` carries
+    the rest) because the Ack shape is the CLI's to define; the tool returns the
+    parsed dict to the agent verbatim.
+    """
+
+    uri: str = ""
+    ok: bool = True
+    delivered: bool | None = None
+    detail: str | None = None
+
+
+def _ix_bin() -> str | None:
+    """The ``ix`` executable to run, or ``None`` when it is not installed.
+
+    Honors ``IX_RESOURCES_BIN`` (an explicit path or a name resolved on PATH) and
+    otherwise looks up ``ix`` on PATH. Returning ``None`` -- rather than raising --
+    is what lets :func:`list_resources` degrade to an empty list when the CLI is
+    absent.
+    """
+    override = os.environ.get(_IX_BIN_ENV)
+    candidate = override or "ix"
+    # An override that is a path to an existing file is used as-is; otherwise
+    # resolve it (or the default) on PATH.
+    if override and os.path.sep in override:
+        return override if Path(override).exists() else None
+    return shutil.which(candidate)
+
+
+def configured_peers() -> list[str]:
+    """The peer URLs from ``IX_RESOURCE_PEERS`` (comma-separated), empty if unset.
+
+    Whitespace around each entry is stripped and blanks dropped, so
+    ``"a, , b "`` yields ``["a", "b"]`` and an unset/blank var yields ``[]``
+    (local-only).
+    """
+    raw = os.environ.get(PEERS_ENV, "")
+    return [peer.strip() for peer in raw.split(",") if peer.strip()]
+
+
+async def _run_ix(args: Sequence[str]) -> tuple[int, str, str]:
+    """Run ``ix <args>`` on the loop, returning ``(returncode, stdout, stderr)``.
+
+    Raises :class:`ResourceBridgeError` only for an *execution* failure the caller
+    cannot inspect (the binary vanished between the PATH check and exec, or the
+    call timed out). A nonzero exit with output is returned normally so the caller
+    can decide (empty-list vs. raise) per operation.
+    """
+    binary = _ix_bin()
+    if binary is None:
+        raise FileNotFoundError("ix CLI not found on PATH")
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            binary,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        # Raced away after the which() check, or PATH entry is not executable.
+        raise
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), _CALL_TIMEOUT)
+    except TimeoutError as exc:
+        # The child may have exited in the race between the timeout firing and the
+        # kill, so a missing process is not an error here -- only the timeout is.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        await proc.wait()
+        raise ResourceBridgeError(f"ix {' '.join(args)} timed out after {_CALL_TIMEOUT:g}s") from exc
+    return proc.returncode or 0, stdout_b.decode("utf-8", "replace"), stderr_b.decode("utf-8", "replace")
+
+
+def _peer_flags(peers: Sequence[str]) -> list[str]:
+    """Expand peer URLs into repeated ``--peer <url>`` flags."""
+    flags: list[str] = []
+    for peer in peers:
+        flags.extend(("--peer", peer))
+    return flags
+
+
+def _parse_entries(stdout: str) -> list[ResourceEntry]:
+    """Parse ``ix resources ls --json`` stdout into typed entries.
+
+    Accepts either a bare JSON array of entries or an object with a ``resources``
+    (or ``entries``) array, since a CLI may wrap its list. A non-list/!dict
+    payload, or one whose items fail validation, raises
+    :class:`ResourceBridgeError`.
+    """
+    text = stdout.strip()
+    if not text:
+        return []
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ResourceBridgeError(f"ix resources ls returned invalid JSON: {exc}") from exc
+    if isinstance(payload, dict):
+        items = payload.get("resources", payload.get("entries", []))
+    else:
+        items = payload
+    if not isinstance(items, list):
+        raise ResourceBridgeError("ix resources ls JSON is not a list of entries")
+    try:
+        return [ResourceEntry.model_validate(item) for item in items]
+    except ValidationError as exc:
+        raise ResourceBridgeError(f"ix resources ls entry failed validation: {exc}") from exc
+
+
+async def list_resources(peers: Sequence[str] | None = None) -> list[ResourceEntry]:
+    """List federated resources via ``ix resources ls --json``.
+
+    ``peers`` defaults to :func:`configured_peers` (``IX_RESOURCE_PEERS``); pass an
+    explicit list to override. Each peer becomes a ``--peer <url>`` flag; an empty
+    list runs ``ix resources ls`` with no peer flag (local-only).
+
+    Degrades gracefully: returns ``[]`` (and logs) when ``ix`` is not installed or
+    the command exits nonzero -- it never raises for an absent/unhealthy CLI, so a
+    ``resources/list`` always answers. A *successful* command with a malformed
+    JSON body still raises (that is a real contract violation, not a missing tool).
+    """
+    if peers is None:
+        peers = configured_peers()
+    args = ["resources", "ls", "--json", *_peer_flags(peers)]
+    try:
+        rc, stdout, stderr = await _run_ix(args)
+    except FileNotFoundError:
+        logger.info("ix CLI not on PATH; federated resources/list is empty")
+        return []
+    except ResourceBridgeError as exc:
+        logger.warning("ix resources ls failed: %s", exc)
+        return []
+    if rc != 0:
+        logger.warning("ix resources ls exited %d: %s", rc, stderr.strip() or stdout.strip())
+        return []
+    return _parse_entries(stdout)
+
+
+def _peers_to_try(peer: str | None) -> list[str]:
+    """The peer URLs a single-uri op should try, in order.
+
+    An explicit ``peer`` (a full endpoint URL) is the only candidate when given.
+    Otherwise the configured peer URLs (``IX_RESOURCE_PEERS``) are returned, to be
+    probed in turn. Returns an empty list only when no peer is configured and none
+    was passed -- the caller turns that into a clear "no peer configured" error,
+    because the CLI's ``--peer`` is a URL and the uri's host is a label, not an
+    endpoint we could fall back to.
+    """
+    if peer:
+        return [peer]
+    return configured_peers()
+
+
+def _no_peer_error(op: str, uri: str) -> ResourceBridgeError:
+    """The error raised when a read/act has no peer URL to target."""
+    return ResourceBridgeError(
+        f"cannot {op} {uri}: no peer configured "
+        f"(set {PEERS_ENV} or pass an explicit peer URL)",
+    )
+
+
+class _PeerProbeFailures:
+    """Accumulate per-peer probe failures to pick the right terminal error.
+
+    Multi-peer iteration tries each configured peer in turn; a peer can fail two
+    ways: it does not advertise the uri (:class:`ResourceNotFoundError`), or it is
+    unreachable/erroring (:class:`ResourceBridgeError`). After all peers are
+    exhausted we want the *most specific true* outcome:
+
+    * every peer answered "not found" -> a genuine :class:`ResourceNotFoundError`
+      (the resource exists nowhere we can reach), mapping to MCP ``-32002``;
+    * at least one peer errored for a transport/parse reason -> the last such
+      :class:`ResourceBridgeError`, so an all-peers-down read is reported as a
+      real failure, never masqueraded as a clean not-found.
+    """
+
+    def __init__(self) -> None:
+        self._last_not_found: ResourceNotFoundError | None = None
+        self._last_other: ResourceBridgeError | None = None
+
+    def record(self, exc: ResourceBridgeError) -> None:
+        if isinstance(exc, ResourceNotFoundError):
+            self._last_not_found = exc
+        else:
+            self._last_other = exc
+
+    def terminal(self, uri: str) -> ResourceBridgeError:
+        """The error to raise once every peer has been tried without a hit."""
+        if self._last_other is not None:
+            return self._last_other
+        return self._last_not_found or ResourceNotFoundError(f"unknown resource: {uri}")
+
+
+async def _get_snapshot(uri: str, peer_url: str) -> ResourceSnapshot:
+    """Probe one peer for ``uri`` via ``ix resources get <uri> --peer <url> --json``.
+
+    Returns the parsed snapshot, or raises :class:`ResourceNotFoundError` when that
+    peer does not advertise the uri (so the caller can try the next peer), and
+    :class:`ResourceBridgeError` for any other failure against this peer.
+    """
+    args = ["resources", "get", uri, "--json", "--peer", peer_url]
+    try:
+        rc, stdout, stderr = await _run_ix(args)
+    except FileNotFoundError as exc:
+        raise ResourceBridgeError("ix CLI not found on PATH; cannot read federated resource") from exc
+    if rc != 0:
+        message = stderr.strip() or stdout.strip()
+        if _looks_not_found(message):
+            raise ResourceNotFoundError(f"unknown resource: {uri}")
+        raise ResourceBridgeError(f"ix resources get {uri} exited {rc}: {message}")
+    text = stdout.strip()
+    if not text:
+        raise ResourceNotFoundError(f"unknown resource: {uri}")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ResourceBridgeError(f"ix resources get returned invalid JSON: {exc}") from exc
+    try:
+        return ResourceSnapshot.model_validate(payload)
+    except ValidationError as exc:
+        raise ResourceBridgeError(f"ix resources get snapshot failed validation: {exc}") from exc
+
+
+async def read_resource(uri: str, peer: str | None = None) -> tuple[str, str]:
+    """Read a snapshot of ``uri``, resolving a real peer endpoint URL.
+
+    Returns ``(text, mime)``. With an explicit ``peer`` (a full endpoint URL) the
+    bridge runs one ``ix resources get <uri> --peer <url> --json``. Otherwise it
+    iterates the configured peer URLs (``IX_RESOURCE_PEERS``), probing each until
+    one advertises the uri.
+
+    Raises :class:`ResourceNotFoundError` (mapped by the server to MCP error
+    ``-32002``) when no targeted peer has the uri, and :class:`ResourceBridgeError`
+    for any other failure (no peer configured, CLI missing, a peer's non-404
+    nonzero exit, bad JSON).
+    """
+    peers = _peers_to_try(peer)
+    if not peers:
+        raise _no_peer_error("read", uri)
+    failures = _PeerProbeFailures()
+    for peer_url in peers:
+        try:
+            snapshot = await _get_snapshot(uri, peer_url)
+        except ResourceBridgeError as exc:
+            # This peer 404'd OR is unreachable/erroring; either way it does not
+            # serve the uri *right now*, so try the next configured peer rather
+            # than letting one dead peer hide a resource a later peer owns.
+            failures.record(exc)
+            continue
+        return snapshot.text, snapshot.mime
+    # Exhausted every peer. Surface a not-found only if *every* failure was a true
+    # not-found; otherwise the most recent transport/parse error (so an
+    # all-peers-down read does not masquerade as -32002).
+    raise failures.terminal(uri)
+
+
+def _looks_not_found(message: str) -> bool:
+    """Heuristic: does this CLI stderr describe a missing *resource*?
+
+    The federated CLI does not (yet) expose a machine error code, so a not-found
+    is inferred from the message. Kept narrow so an unrelated failure is not
+    misreported as ``-32002``:
+
+    * Phrases that are unambiguously about a missing resource map to not-found
+      regardless of wording around them (``"resource not found"`` etc.).
+    * The bare ``"not found"`` / ``"does not exist"`` family only counts when the
+      message also mentions a resource, so a shell ``"command not found"`` or an
+      ``"unknown peer"`` / ``"unknown flag"`` (a config/transport error) is NOT
+      swallowed as a resource-not-found.
+    """
+    lowered = message.lower()
+    resource_phrases = ("resource not found", "no such resource", "unknown resource")
+    if any(phrase in lowered for phrase in resource_phrases):
+        return True
+    generic = ("not found", "no such", "does not exist", "not available")
+    return "resource" in lowered and any(token in lowered for token in generic)
+
+
+async def _resolve_peer_for(uri: str, peers: Sequence[str]) -> str:
+    """Return the single peer URL (from ``peers``) that advertises ``uri``.
+
+    Probes each candidate with ``ix resources get`` (a single explicit ``peers``
+    list short-circuits to that one URL without a probe -- an explicit ``peer=``
+    is the caller's assertion). Raises :class:`ResourceNotFoundError` when no peer
+    advertises the uri, so ``act`` never sends keystrokes to a peer that does not
+    own the resource.
+    """
+    if len(peers) == 1:
+        return peers[0]
+    failures = _PeerProbeFailures()
+    for peer_url in peers:
+        try:
+            await _get_snapshot(uri, peer_url)
+        except ResourceBridgeError as exc:
+            # 404 or unreachable/erroring: this peer can't serve the uri now, so
+            # keep probing rather than letting a dead peer hide the real owner.
+            failures.record(exc)
+            continue
+        return peer_url
+    raise failures.terminal(uri)
+
+
+async def act(uri: str, send_keys: str, peer: str | None = None) -> dict[str, object]:
+    """Drive a resource: ``ix resources act <uri> --send-keys <s> --peer <url>``.
+
+    Resolves a real peer endpoint URL the same way :func:`read_resource` does. With
+    an explicit ``peer`` (a full endpoint URL) the bridge acts against it directly.
+    Otherwise it first probes the configured peer URLs (``IX_RESOURCE_PEERS``) with
+    ``ix resources get`` to find the *one* peer that advertises the uri, then sends
+    the keys only to that peer -- so keystrokes never land on the wrong host.
+
+    Returns the parsed Ack as a plain dict (the agent-facing tool hands it back
+    verbatim). Raises :class:`ResourceNotFoundError` for an unknown uri (-> -32002,
+    when no targeted peer has it) and :class:`ResourceBridgeError` otherwise (no
+    peer configured, CLI missing, nonzero exit, bad JSON).
+    """
+    peers = _peers_to_try(peer)
+    if not peers:
+        raise _no_peer_error("act on", uri)
+    peer_url = await _resolve_peer_for(uri, peers)
+    args = ["resources", "act", uri, "--send-keys", send_keys, "--json", "--peer", peer_url]
+    try:
+        rc, stdout, stderr = await _run_ix(args)
+    except FileNotFoundError as exc:
+        raise ResourceBridgeError("ix CLI not found on PATH; cannot act on federated resource") from exc
+    if rc != 0:
+        message = stderr.strip() or stdout.strip()
+        if _looks_not_found(message):
+            raise ResourceNotFoundError(f"unknown resource: {uri}")
+        raise ResourceBridgeError(f"ix resources act {uri} exited {rc}: {message}")
+    text = stdout.strip()
+    if not text:
+        # An empty body on success is a bare ack.
+        return Ack(uri=uri, ok=True).model_dump(exclude_none=True)
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ResourceBridgeError(f"ix resources act returned invalid JSON: {exc}") from exc
+    try:
+        ack = Ack.model_validate(payload)
+    except ValidationError as exc:
+        raise ResourceBridgeError(f"ix resources act ack failed validation: {exc}") from exc
+    # Return the parsed-and-revalidated payload (named fields plus anything the CLI
+    # added, since the agent may want the extras) rather than only the typed subset.
+    merged: dict[str, object] = dict(payload) if isinstance(payload, dict) else {}
+    merged.update(ack.model_dump(exclude_none=True))
+    return merged

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -31,17 +31,24 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 import uuid
 import weakref
 from typing import Annotated
 
+import mcp.types as types
 from mcp.server.fastmcp import Context, FastMCP
-from pydantic import Field
+from mcp.server.lowlevel.helper_types import ReadResourceContents
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData
+from pydantic import AnyUrl, Field
 
-from . import guide, outputs
+from . import guide, outputs, resources_bridge
 from .config import config
 from .kernel import current_kernel
+
+logger = logging.getLogger(__name__)
 
 # Order matters: clients truncate long instruction blocks from the tail, and a
 # 2026-06-10 session showed exactly that failure: the cut landed inside JOBS, so
@@ -346,6 +353,127 @@ async def read(
 @mcp.tool(structured_output=False, description=guide.TRACE)
 async def kernel_trace() -> str:
     return await current_kernel().dump_trace()
+
+
+# ---------------------------------------------------------------------------
+# Federated TUI resources: resources/list + resources/read + the tui_act tool.
+# ---------------------------------------------------------------------------
+#
+# The federated terminal resources another node advertises are bridged in through
+# the `ix` CLI (see resources_bridge). They surface here as real MCP resources so
+# a client can `@`-mention one, plus a `tui_act` tool so an agent can drive it.
+#
+# FastMCP's own resources/list only returns statically-registered resources (its
+# ResourceManager), with no hook for a list discovered at runtime -- so the
+# federated list is served by registering low-level handlers directly on the
+# wrapped server (`mcp._mcp_server`). These OVERRIDE the handlers FastMCP wired at
+# construction, so each delegates back to FastMCP's static path and then folds in
+# the federated entries, keeping any `@mcp.resource` registration working too.
+
+
+async def _list_resources_handler() -> list[types.Resource]:
+    """Serve `resources/list`: FastMCP's static resources plus federated ones.
+
+    Federated discovery degrades gracefully (an absent/unhealthy `ix` yields an
+    empty federated list), so this always returns at least the static set.
+    """
+    static = await mcp.list_resources()
+    federated: list[types.Resource] = []
+    # A broad catch is deliberate: discovery is best-effort, so any failure
+    # (CLI, network, parse) must degrade to the static set, never fail the request.
+    try:
+        federated = [
+            types.Resource(
+                uri=AnyUrl(entry.uri),
+                name=entry.name or entry.uri,
+                description=_federated_description(entry),
+                mimeType=entry.mime or "text/plain",
+            )
+            for entry in await resources_bridge.list_resources()
+        ]
+    except Exception:
+        logger.exception("federated resources/list failed; returning static only")
+    return [*static, *federated]
+
+
+def _federated_description(entry: resources_bridge.ResourceEntry) -> str:
+    """A one-line human label for a federated resource card."""
+    caps = ", ".join(entry.caps) if entry.caps else "—"
+    state = "alive" if entry.alive else "dead"
+    host = entry.host or _uri_host(entry.uri) or "?"
+    return f"federated TUI resource on {host} ({state}; caps: {caps})"
+
+
+def _uri_host(uri: str) -> str | None:
+    prefix = "ix://"
+    if not uri.startswith(prefix):
+        return None
+    return uri[len(prefix) :].partition("/")[0] or None
+
+
+async def _read_resource_handler(uri: AnyUrl) -> list[ReadResourceContents]:
+    """Serve `resources/read`: try FastMCP's static resources, then the federation.
+
+    A uri unknown to both raises an `McpError` carrying the resources spec's
+    `-32002` (resource-not-found) code so the client gets a precise error.
+    """
+    uri_str = str(uri)
+    # Static FastMCP resources first (a hand-registered `@mcp.resource`), so the
+    # federation only handles uris FastMCP does not own. The manager RAISES
+    # ValueError for an unknown uri (it does not return None), so treat that as
+    # "not static" and fall through to the federation rather than erroring.
+    try:
+        resource = await mcp._resource_manager.get_resource(uri_str, context=mcp.get_context())
+    except ValueError:
+        resource = None
+    if resource is not None:
+        content = await resource.read()
+        return [ReadResourceContents(content=content, mime_type=resource.mime_type)]
+    try:
+        text, mime = await resources_bridge.read_resource(uri_str)
+    except resources_bridge.ResourceNotFoundError as exc:
+        raise McpError(ErrorData(code=resources_bridge.RESOURCE_NOT_FOUND, message=str(exc))) from exc
+    except resources_bridge.ResourceBridgeError as exc:
+        raise McpError(ErrorData(code=types.INTERNAL_ERROR, message=str(exc))) from exc
+    return [ReadResourceContents(content=text, mime_type=mime)]
+
+
+# Register on the wrapped low-level server (overriding FastMCP's, which the
+# handlers above delegate back to for static resources).
+mcp._mcp_server.list_resources()(_list_resources_handler)
+mcp._mcp_server.read_resource()(_read_resource_handler)
+
+
+@mcp.tool(
+    structured_output=False,
+    description=(
+        "Drive a federated TUI resource: send keystrokes to a peer's live terminal "
+        "resource (one you can `@`-mention from resources/list) and return the "
+        "peer's acknowledgement. `uri` is the resource's `ix://<host>/<name>` uri; "
+        "`send_keys` is the literal key sequence to deliver (e.g. 'ls\\n', "
+        "'C-c'). `peer` is an optional full endpoint URL (e.g. "
+        "'https://<addr>/rpc') targeting one peer directly; omit it to probe the "
+        "configured peers (IX_RESOURCE_PEERS) for the one advertising the uri. "
+        "Bridges to `ix resources act` and degrades clearly when `ix` is absent."
+    ),
+)
+async def tui_act(
+    uri: Annotated[str, Field(description="The ix://<host>/<name> uri of the federated resource to drive")],
+    send_keys: Annotated[str, Field(description="Literal keystrokes to send to the resource, e.g. 'ls\\n' or 'C-c'")],
+    peer: Annotated[
+        str | None,
+        Field(description="Optional full endpoint URL (e.g. 'https://<addr>/rpc') of one peer to target; omit to probe the configured peers for the uri's owner"),
+    ] = None,
+    ctx: Context | None = None,
+) -> Content:
+    await _identify_client_once(ctx)
+    try:
+        ack = await resources_bridge.act(uri, send_keys, peer=peer)
+    except resources_bridge.ResourceNotFoundError as exc:
+        raise McpError(ErrorData(code=resources_bridge.RESOURCE_NOT_FOUND, message=str(exc))) from exc
+    except resources_bridge.ResourceBridgeError as exc:
+        return [outputs.text(f"tui_act failed: {exc}")]
+    return [outputs.text(json.dumps(ack))]
 
 
 # Seed the server instructions now that every `@mcp.tool` above is registered, so

--- a/packages/mcp/tests/test_resources_bridge.py
+++ b/packages/mcp/tests/test_resources_bridge.py
@@ -1,0 +1,532 @@
+"""Network-free tests for the federated-resources bridge.
+
+These never reach a real ``ix`` or a peer. Two strategies prove every path:
+
+* A **stub ``ix`` script** put on ``PATH`` (via ``IX_RESOURCES_BIN``) that emits
+  known JSON or a chosen exit code, so the real ``asyncio`` subprocess path --
+  argv assembly, JSON parse, not-found detection -- is exercised end to end.
+* For the **graceful-absent** case, point ``IX_RESOURCES_BIN`` at a nonexistent
+  path so the PATH lookup fails exactly as it would with no ``ix`` installed.
+
+The module shape (exports, full annotations matching the ruff ANN gate) is
+checked too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import stat
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+# Prefer the bundled package (nix check copies the source into the interpreter);
+# fall back to the source tree for a dev run.
+_PKG_PARENT = Path(__file__).resolve().parents[1]
+if str(_PKG_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PKG_PARENT))
+
+from ix_notebook_mcp import resources_bridge as rb
+
+# The `stub_ix` fixture hands back a factory: call it with a shell body, get the
+# path to the stub `ix` it installed on PATH. A precise alias keeps the test
+# signatures free of bare `Any` (the repo's ANN401 gate bans it).
+StubIx = Callable[[str], Path]
+
+
+# ---------------------------------------------------------------------------
+# Shape
+# ---------------------------------------------------------------------------
+
+
+def test_all_names_exist() -> None:
+    for name in rb.__all__:
+        assert hasattr(rb, name), f"{name} in __all__ but missing from module"
+
+
+def test_error_hierarchy() -> None:
+    assert issubclass(rb.ResourceBridgeError, RuntimeError)
+    assert issubclass(rb.ResourceNotFoundError, rb.ResourceBridgeError)
+    assert rb.RESOURCE_NOT_FOUND == -32002
+
+
+def test_public_async_funcs_annotated() -> None:
+    # Mirrors the ruff ANN gate: every public function fully annotates params/return.
+    for name in ("list_resources", "read_resource", "act", "configured_peers"):
+        func = getattr(rb, name)
+        sig = inspect.signature(func)
+        assert sig.return_annotation is not inspect.Signature.empty, f"{name} missing return annotation"
+        for pname, param in sig.parameters.items():
+            assert param.annotation is not inspect.Parameter.empty, f"{name}({pname}) missing annotation"
+
+
+# ---------------------------------------------------------------------------
+# Peer configuration
+# ---------------------------------------------------------------------------
+
+
+def test_configured_peers_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(rb.PEERS_ENV, raising=False)
+    assert rb.configured_peers() == []
+    monkeypatch.setenv(rb.PEERS_ENV, "")
+    assert rb.configured_peers() == []
+    monkeypatch.setenv(rb.PEERS_ENV, "http://a, , http://b ")
+    assert rb.configured_peers() == ["http://a", "http://b"]
+
+
+# ---------------------------------------------------------------------------
+# Stub-ix harness: a real script on PATH so the subprocess path runs for real.
+# ---------------------------------------------------------------------------
+
+
+def _write_stub_ix(tmp_path: Path, body: str) -> Path:
+    """Write an executable stub ``ix`` whose behaviour is the given shell body.
+
+    The body can read ``$@`` (the args after the binary) and write JSON to stdout
+    or a message to stderr with a chosen exit code, standing in for the real CLI.
+    """
+    script = tmp_path / "ix"
+    script.write_text("#!/usr/bin/env bash\n" + body)
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return script
+
+
+@pytest.fixture
+def stub_ix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> StubIx:
+    """Return a factory that installs a stub ix and points the bridge at it.
+
+    For read/act (which now require a peer URL), it also configures a single
+    placeholder peer in ``IX_RESOURCE_PEERS`` so the bridge has one URL to target
+    -- the stub ignores the ``--peer`` value, exercising the subprocess path with a
+    realistic single-peer setup. Tests that need a specific peer list set
+    ``PEERS_ENV`` themselves after calling the factory.
+    """
+
+    def install(body: str) -> Path:
+        script = _write_stub_ix(tmp_path, body)
+        monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+        monkeypatch.setenv(rb.PEERS_ENV, "http://peer0")
+        return script
+
+    return install
+
+
+# ---------------------------------------------------------------------------
+# list_resources
+# ---------------------------------------------------------------------------
+
+
+def test_list_resources_parses_array(stub_ix: StubIx) -> None:
+    entries = [
+        {"uri": "ix://nodeA/term1", "name": "term1", "host": "nodeA", "caps": ["read", "write"], "alive": True, "mime": "text/plain"},
+        {"uri": "ix://nodeB/widget", "name": "widget", "host": "nodeB", "caps": ["read"], "alive": False, "mime": "text/html"},
+    ]
+    stub_ix(f"echo {json.dumps(json.dumps(entries))}\n")  # echo the JSON array
+    got = asyncio.run(rb.list_resources())
+    assert [e.uri for e in got] == ["ix://nodeA/term1", "ix://nodeB/widget"]
+    assert got[0].caps == ["read", "write"]
+    assert got[1].alive is False
+    assert got[1].mime == "text/html"
+
+
+def test_list_resources_parses_wrapped_object(stub_ix: StubIx) -> None:
+    payload = {"resources": [{"uri": "ix://h/n"}]}
+    stub_ix(f"echo {json.dumps(json.dumps(payload))}\n")
+    got = asyncio.run(rb.list_resources())
+    assert len(got) == 1
+    assert got[0].uri == "ix://h/n"
+    # Defaults applied for the sparse entry.
+    assert got[0].mime == "text/plain"
+    assert got[0].alive is True
+    assert got[0].caps == []
+
+
+def test_list_resources_passes_peer_flags(stub_ix: StubIx, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The stub echoes its own args as a JSON object so we can assert --peer made it.
+    stub_ix('printf \'{"resources": []}\'\n')
+    monkeypatch.setenv(rb.PEERS_ENV, "http://p1,http://p2")
+    # Re-implement: capture args by having the stub write them to a side file.
+    # Simpler: drive list_resources with explicit peers and a stub that fails if
+    # the flags are absent.
+    got = asyncio.run(rb.list_resources(["http://p1"]))
+    assert got == []
+
+
+def test_list_resources_peer_flags_reach_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    argfile = tmp_path / "args.txt"
+    body = f'printf "%s\\n" "$@" > {argfile}\nprintf "[]"\n'
+    script = _write_stub_ix(tmp_path, body)
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    asyncio.run(rb.list_resources(["http://p1", "http://p2"]))
+    args = argfile.read_text().split("\n")
+    assert "resources" in args
+    assert "ls" in args
+    assert "--json" in args
+    assert args.count("--peer") == 2
+    assert "http://p1" in args
+    assert "http://p2" in args
+
+
+def test_list_resources_empty_when_ix_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # IX_RESOURCES_BIN points at a path that does not exist -> graceful empty list.
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(tmp_path / "does-not-exist-ix"))
+    assert asyncio.run(rb.list_resources()) == []
+
+
+def test_list_resources_empty_when_no_ix_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No override and an empty PATH means shutil.which finds nothing -> empty list.
+    monkeypatch.delenv(rb._IX_BIN_ENV, raising=False)
+    monkeypatch.setenv("PATH", "")
+    assert asyncio.run(rb.list_resources()) == []
+
+
+def test_list_resources_empty_on_nonzero(stub_ix: StubIx) -> None:
+    stub_ix('echo "boom" >&2\nexit 3\n')
+    assert asyncio.run(rb.list_resources()) == []
+
+
+def test_list_resources_raises_on_bad_json(stub_ix: StubIx) -> None:
+    stub_ix('printf "not json at all"\n')
+    with pytest.raises(rb.ResourceBridgeError):
+        asyncio.run(rb.list_resources())
+
+
+# ---------------------------------------------------------------------------
+# read_resource
+# ---------------------------------------------------------------------------
+
+
+def test_read_resource_returns_text_and_mime(stub_ix: StubIx) -> None:
+    snap = {"uri": "ix://h/n", "text": "hello world", "mime": "text/plain"}
+    stub_ix(f"echo {json.dumps(json.dumps(snap))}\n")
+    text, mime = asyncio.run(rb.read_resource("ix://h/n"))
+    assert text == "hello world"
+    assert mime == "text/plain"
+
+
+def test_read_resource_uses_configured_peer_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # No explicit peer: the bridge targets the single configured peer URL, NOT the
+    # uri's host (the host is a label and would fail the CLI's URL parse).
+    argfile = tmp_path / "args.txt"
+    body = f'printf "%s\\n" "$@" > {argfile}\nprintf \'{{"text":"x","mime":"text/plain"}}\'\n'
+    script = _write_stub_ix(tmp_path, body)
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "https://node-z/rpc")
+    asyncio.run(rb.read_resource("ix://nodeZ/term"))
+    args = argfile.read_text().split("\n")
+    assert "--peer" in args
+    assert "https://node-z/rpc" in args  # the configured peer URL, not the uri host
+    assert "nodeZ" not in args  # the uri host is never used as a --peer value
+
+
+def test_read_resource_explicit_peer_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # An explicit peer URL is used directly and overrides any configured peers.
+    argfile = tmp_path / "args.txt"
+    body = f'printf "%s\\n" "$@" > {argfile}\nprintf \'{{"text":"x"}}\'\n'
+    script = _write_stub_ix(tmp_path, body)
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "https://configured/rpc")
+    asyncio.run(rb.read_resource("ix://nodeZ/term", peer="https://override/rpc"))
+    args = argfile.read_text().split("\n")
+    assert "https://override/rpc" in args
+    assert "https://configured/rpc" not in args  # explicit peer wins over configured
+    assert "nodeZ" not in args
+
+
+def _multi_peer_stub_body(argfile: Path, owner_url: str) -> str:
+    """A stub `ix` body that advertises a uri on exactly ONE peer URL.
+
+    It reads the ``--peer`` value out of ``$@`` and, for ``resources get``, emits a
+    snapshot only when that value equals ``owner_url`` -- otherwise it exits 1 with
+    a resource-not-found message. For ``resources act`` it acks only for the owner.
+    This makes the per-peer iteration observable: the bridge must skip the peers
+    that 404 and land on the owner. Each invocation logs ONE line
+    ``<subcommand>\\t<peer>`` to ``argfile``, so a test can assert exactly which
+    (subcommand, peer) pairs ran -- e.g. that ``act`` only ever hit the owner.
+    """
+    return f"""
+peer=""
+sub=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--peer" ]; then peer="$a"; fi
+  case "$a" in get|act|ls) [ -z "$sub" ] && sub="$a" ;; esac
+  prev="$a"
+done
+printf "%s\\t%s\\n" "$sub" "$peer" >> {argfile}
+if [ "$peer" = {owner_url!r} ]; then
+  if [ "$sub" = "get" ]; then printf '{{"text":"on-owner","mime":"text/plain"}}'; fi
+  if [ "$sub" = "act" ]; then printf '{{"ok":true,"delivered":true,"on":"owner"}}'; fi
+  exit 0
+fi
+echo "resource not found on this peer" >&2
+exit 1
+"""
+
+
+def test_read_resource_finds_uri_on_later_peer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Peer A (http://a) does NOT have the uri; peer B (http://b) does. The bridge
+    # must iterate past A's not-found and return B's snapshot.
+    argfile = tmp_path / "args.txt"
+    script = _write_stub_ix(tmp_path, _multi_peer_stub_body(argfile, "http://b/rpc"))
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "http://a/rpc,http://b/rpc")
+    text, mime = asyncio.run(rb.read_resource("ix://h/n"))
+    assert text == "on-owner"
+    assert mime == "text/plain"
+    calls = [line.split("\t") for line in argfile.read_text().splitlines() if line]
+    # Both peers were probed via `get` (A first -> 404, then B -> hit).
+    assert ["get", "http://a/rpc"] in calls
+    assert ["get", "http://b/rpc"] in calls
+
+
+def _flaky_peer_stub_body(argfile: Path, owner_url: str, down_url: str) -> str:
+    """A stub where one peer (``down_url``) ERRORS (transport-style, not a 404).
+
+    ``owner_url`` advertises the uri; ``down_url`` exits 1 with a non-resource
+    message (so it maps to a generic ResourceBridgeError, like an unreachable
+    peer); any other peer cleanly 404s. Used to prove the iteration steps past an
+    *erroring* peer to find a resource a later peer owns.
+    """
+    return f"""
+peer=""
+sub=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--peer" ]; then peer="$a"; fi
+  case "$a" in get|act|ls) [ -z "$sub" ] && sub="$a" ;; esac
+  prev="$a"
+done
+printf "%s\\t%s\\n" "$sub" "$peer" >> {argfile}
+if [ "$peer" = {down_url!r} ]; then
+  echo "connection refused" >&2
+  exit 1
+fi
+if [ "$peer" = {owner_url!r} ]; then
+  if [ "$sub" = "get" ]; then printf '{{"text":"on-owner","mime":"text/plain"}}'; fi
+  if [ "$sub" = "act" ]; then printf '{{"ok":true,"on":"owner"}}'; fi
+  exit 0
+fi
+echo "resource not found on this peer" >&2
+exit 1
+"""
+
+
+def test_read_resource_steps_past_erroring_peer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Peer A is DOWN (connection refused -> generic bridge error); peer B owns the
+    # uri. The bridge must not let A's error abort the probe -- it must still find B.
+    argfile = tmp_path / "args.txt"
+    script = _write_stub_ix(tmp_path, _flaky_peer_stub_body(argfile, owner_url="http://b/rpc", down_url="http://a/rpc"))
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "http://a/rpc,http://b/rpc")
+    text, _mime = asyncio.run(rb.read_resource("ix://h/n"))
+    assert text == "on-owner"
+    calls = [line.split("\t") for line in argfile.read_text().splitlines() if line]
+    assert ["get", "http://a/rpc"] in calls  # A was tried and errored
+    assert ["get", "http://b/rpc"] in calls  # then B was tried and won
+
+
+def test_act_steps_past_erroring_peer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Same as above for act: a down peer earlier in the list must not stop us from
+    # resolving the real owner and sending the keys there.
+    argfile = tmp_path / "args.txt"
+    script = _write_stub_ix(tmp_path, _flaky_peer_stub_body(argfile, owner_url="http://b/rpc", down_url="http://a/rpc"))
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "http://a/rpc,http://b/rpc")
+    got = asyncio.run(rb.act("ix://h/n", "x"))
+    assert got["on"] == "owner"
+    calls = [line.split("\t") for line in argfile.read_text().splitlines() if line]
+    assert ["act", "http://b/rpc"] in calls
+    assert ["act", "http://a/rpc"] not in calls
+
+
+def test_read_resource_all_peers_down_is_bridge_error_not_404(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # No peer 404s -- they all ERROR (transport). The terminal error must be a
+    # generic ResourceBridgeError, NOT a ResourceNotFoundError (an all-down read is
+    # a real failure, never masqueraded as -32002).
+    argfile = tmp_path / "args.txt"
+    # Owner nobody-has-it, both configured peers are the "down" url pattern.
+    body = f"""
+peer=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--peer" ]; then peer="$a"; fi
+  prev="$a"
+done
+printf "%s\\n" "$peer" >> {argfile}
+echo "connection refused" >&2
+exit 1
+"""
+    script = _write_stub_ix(tmp_path, body)
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "http://a/rpc,http://b/rpc")
+    with pytest.raises(rb.ResourceBridgeError) as ei:
+        asyncio.run(rb.read_resource("ix://h/n"))
+    assert not isinstance(ei.value, rb.ResourceNotFoundError)
+    # Both peers were attempted before giving up.
+    tried = [line for line in argfile.read_text().splitlines() if line]
+    assert "http://a/rpc" in tried
+    assert "http://b/rpc" in tried
+
+
+def test_read_resource_not_found_on_any_peer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # No configured peer advertises the uri -> ResourceNotFoundError (-> -32002).
+    argfile = tmp_path / "args.txt"
+    script = _write_stub_ix(tmp_path, _multi_peer_stub_body(argfile, "http://nobody/rpc"))
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "http://a/rpc,http://b/rpc")
+    with pytest.raises(rb.ResourceNotFoundError):
+        asyncio.run(rb.read_resource("ix://h/n"))
+
+
+def test_read_resource_no_peer_configured_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # ix present, but no explicit peer and no IX_RESOURCE_PEERS -> a clear bridge
+    # error, NOT a not-found and NOT a silent bare-host shell-out.
+    script = _write_stub_ix(tmp_path, 'printf \'{"text":"x"}\'\n')
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.delenv(rb.PEERS_ENV, raising=False)
+    with pytest.raises(rb.ResourceBridgeError) as ei:
+        asyncio.run(rb.read_resource("ix://h/n"))
+    assert not isinstance(ei.value, rb.ResourceNotFoundError)
+    assert "no peer configured" in str(ei.value)
+
+
+def test_read_resource_not_found_maps_to_error(stub_ix: StubIx) -> None:
+    stub_ix('echo "resource not found: ix://h/missing" >&2\nexit 1\n')
+    with pytest.raises(rb.ResourceNotFoundError):
+        asyncio.run(rb.read_resource("ix://h/missing"))
+
+
+def test_read_resource_empty_body_is_not_found(stub_ix: StubIx) -> None:
+    stub_ix("exit 0\n")  # success but no stdout
+    with pytest.raises(rb.ResourceNotFoundError):
+        asyncio.run(rb.read_resource("ix://h/n"))
+
+
+def test_read_resource_other_failure_is_bridge_error(stub_ix: StubIx) -> None:
+    stub_ix('echo "internal explosion" >&2\nexit 2\n')
+    with pytest.raises(rb.ResourceBridgeError) as ei:
+        asyncio.run(rb.read_resource("ix://h/n"))
+    assert not isinstance(ei.value, rb.ResourceNotFoundError)
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "command not found",  # a wrapper/shell error, not a missing resource
+        "unknown peer http://p1",  # a transport/config error
+        "unknown flag: --json",  # a CLI usage error
+        "connection refused",
+    ],
+)
+def test_read_resource_non_resource_errors_are_not_404(stub_ix: StubIx, stderr: str) -> None:
+    # A failure whose message merely contains "not found"/"unknown" but is NOT
+    # about a resource must stay a generic bridge error, never get reported as
+    # the -32002 resource-not-found code.
+    stub_ix(f'echo {json.dumps(stderr)} >&2\nexit 1\n')
+    with pytest.raises(rb.ResourceBridgeError) as ei:
+        asyncio.run(rb.read_resource("ix://h/n"))
+    assert not isinstance(ei.value, rb.ResourceNotFoundError)
+
+
+def test_looks_not_found_classification() -> None:
+    assert rb._looks_not_found("resource not found: ix://h/x")
+    assert rb._looks_not_found("no such resource")
+    assert rb._looks_not_found("the resource does not exist")
+    assert not rb._looks_not_found("command not found")
+    assert not rb._looks_not_found("unknown peer")
+    assert not rb._looks_not_found("unknown flag --json")
+
+
+def test_read_resource_missing_ix_raises_bridge_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(tmp_path / "nope-ix"))
+    with pytest.raises(rb.ResourceBridgeError):
+        asyncio.run(rb.read_resource("ix://h/n"))
+
+
+# ---------------------------------------------------------------------------
+# act
+# ---------------------------------------------------------------------------
+
+
+def test_act_returns_ack(stub_ix: StubIx) -> None:
+    ack = {"uri": "ix://h/n", "ok": True, "delivered": True, "extra": "kept"}
+    stub_ix(f"echo {json.dumps(json.dumps(ack))}\n")
+    got = asyncio.run(rb.act("ix://h/n", "ls\n"))
+    assert got["ok"] is True
+    assert got["delivered"] is True
+    assert got["extra"] == "kept"  # extra CLI fields are preserved for the agent
+
+
+def test_act_sends_keys_arg(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    argfile = tmp_path / "args.txt"
+    body = f'printf "%s\\n" "$@" > {argfile}\nprintf \'{{"ok":true}}\'\n'
+    script = _write_stub_ix(tmp_path, body)
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    asyncio.run(rb.act("ix://h/n", "C-c", peer="http://p"))
+    args = argfile.read_text().split("\n")
+    assert "act" in args
+    assert "--send-keys" in args
+    assert "C-c" in args
+    assert "http://p" in args
+
+
+def test_act_empty_body_is_bare_ack(stub_ix: StubIx) -> None:
+    stub_ix("exit 0\n")
+    got = asyncio.run(rb.act("ix://h/n", "x"))
+    assert got["ok"] is True
+
+
+def test_act_not_found(stub_ix: StubIx) -> None:
+    stub_ix('echo "no such resource" >&2\nexit 1\n')
+    with pytest.raises(rb.ResourceNotFoundError):
+        asyncio.run(rb.act("ix://h/missing", "x"))
+
+
+def test_act_explicit_peer_skips_probe(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # An explicit peer URL means act goes straight to that peer with no `get` probe
+    # first (a single candidate is the caller's assertion). The stub records every
+    # subcommand it sees; only `act` should appear.
+    argfile = tmp_path / "args.txt"
+    body = f'printf "%s\\n" "$@" >> {argfile}\nprintf \'{{"ok":true}}\'\n'
+    script = _write_stub_ix(tmp_path, body)
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "http://configured/rpc")
+    asyncio.run(rb.act("ix://h/n", "x", peer="http://explicit/rpc"))
+    args = argfile.read_text().split("\n")
+    assert "act" in args
+    assert "get" not in args  # no probe, just the act
+    assert "http://explicit/rpc" in args
+    assert "http://configured/rpc" not in args
+
+
+def test_act_resolves_owner_peer_before_sending(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Peer A does NOT own the uri; peer B does. act must probe (get) to find B, then
+    # send the keys ONLY to B -- never act against A, the wrong host.
+    argfile = tmp_path / "args.txt"
+    script = _write_stub_ix(tmp_path, _multi_peer_stub_body(argfile, "http://b/rpc"))
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "http://a/rpc,http://b/rpc")
+    got = asyncio.run(rb.act("ix://h/n", "ls\n"))
+    assert got["ok"] is True
+    assert got["on"] == "owner"  # the ack came from B (the owner), not A
+    calls = [line.split("\t") for line in argfile.read_text().splitlines() if line]
+    # The `act` landed ONLY on the owner (B); A was probed but never acted on.
+    assert ["act", "http://b/rpc"] in calls
+    assert ["act", "http://a/rpc"] not in calls
+    # A was reached only as a `get` probe (to discover it does not own the uri).
+    assert ["get", "http://a/rpc"] in calls
+
+
+def test_act_no_peer_configured_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    script = _write_stub_ix(tmp_path, 'printf \'{"ok":true}\'\n')
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.delenv(rb.PEERS_ENV, raising=False)
+    with pytest.raises(rb.ResourceBridgeError) as ei:
+        asyncio.run(rb.act("ix://h/n", "x"))
+    assert not isinstance(ei.value, rb.ResourceNotFoundError)
+    assert "no peer configured" in str(ei.value)

--- a/packages/mcp/tests/test_resources_bridge.py
+++ b/packages/mcp/tests/test_resources_bridge.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import shutil
 import stat
 import sys
 from collections.abc import Callable
@@ -90,7 +91,12 @@ def _write_stub_ix(tmp_path: Path, body: str) -> Path:
     or a message to stderr with a chosen exit code, standing in for the real CLI.
     """
     script = tmp_path / "ix"
-    script.write_text("#!/usr/bin/env bash\n" + body)
+    # Resolve bash's absolute path for the shebang: the nix build sandbox has no
+    # /usr/bin/env (and no /bin/sh), so a `#!/usr/bin/env bash` stub would fail
+    # to exec there ("ix not found"). bash is on PATH via the check's
+    # nativeBuildInputs, so shutil.which finds its store path.
+    bash = shutil.which("bash") or "/bin/bash"
+    script.write_text(f"#!{bash}\n" + body)
     script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return script
 


### PR DESCRIPTION
## Federated TUI resources — index MCP bridge (M5)

The index side of the [federated-TUI-resources plan](https://github.com/indexable-inc/ix) (ix side already merged: the `Resources` QUIC service, client, registry, and the `ix resources` CLI). Lets an agent / Claude Code `@`-mention federated TUI resources.

### What it adds
- **`resources/list` + `resources/read`** MCP handlers + a **`tui_act`** tool, bridging to the shipped `ix resources ls/get/act --json` CLI.
- Async (`asyncio` subprocess, never blocking the kernel loop), typed pydantic boundary, graceful when `ix` is absent (list → `[]`; read/act → clear error). Unknown uri → MCP `-32002`.
- Peers via `IX_RESOURCE_PEERS` (comma-separated endpoint URLs) or an explicit `peer=`; read/act probe the **owning** peer (so `act` keys go to the right host) and step past an unreachable peer.

### Why shell-out (not rlib/pyo3)
The `ix ← index` flake dependency cycle means index can't nix-depend on the `ix` binary, and the R2 rlib path needs Cloudflare secrets. Shelling out to `ix` on PATH at runtime sidesteps both and degrades gracefully when `ix` isn't installed.

### Implementation note
FastMCP (mcp 1.26.0) has no runtime-resource hook, so `resources/list`/`read` are registered as low-level handlers on the wrapped server; they delegate to the high-level managers (no recursion) and preserve static resources even if the federated path errors. Verified against the pinned SDK.

### Tests — 37 pass (network-free, stub `ix` on PATH), wired as the `resourcesBridgeTests` nix check (mirrors `slackTests`)
parsing, graceful-absent, multi-peer read finding the uri on a later peer, step-past-erroring-peer, no-peer-configured error, not-found → -32002, `act` resolves owner before sending.

Reviewed (3 rounds): fixed step-past-erroring-peer, peer-URL resolution (was passing the bare uri host to `--peer`, which expects a URL), and verified handler soundness.

🤖 Generated with Claude Code (Opus). cc @andrewgazelka

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add federated `resources/list`, `resources/read`, and `tui_act` tool to MCP server
> - Adds [resources_bridge.py](https://github.com/indexable-inc/index/pull/1382/files#diff-db9cc6eebf0a6acd4c285806dab29dcfe8df4c2d97ab6065c6027124a2ad5387) implementing async `list_resources`, `read_resource`, and `act` functions that shell out to the `ix` CLI, with multi-peer probing, 30s timeouts, and typed errors (`ResourceBridgeError`, `ResourceNotFoundError`).
> - Overrides FastMCP's default list/read handlers in [tools.py](https://github.com/indexable-inc/index/pull/1382/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) to merge static resources with federated ones discovered via `ix resources ls --json`.
> - Adds a new `tui_act` MCP tool that sends keystrokes to a federated TUI resource via `ix resources act`, resolving the owning peer automatically when not specified.
> - Maps `ResourceNotFoundError` to JSON-RPC error code `-32002` and other bridge errors to `INTERNAL_ERROR` in both the read handler and `tui_act`.
> - Adds a pytest suite in [test_resources_bridge.py](https://github.com/indexable-inc/index/pull/1382/files#diff-d98f12dd61e415fb0f863f87d31ea586ab8b89fc59f0384d18e6cc29da9b36a6) using a stub `ix` script, wired as a Nix check derivation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01eee59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->