### PR TITLE
ci: stop running blast radius on every PR

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,9 +1,17 @@
 name: Blast radius
 
 on:
-  pull_request:
-    branches:
-      - main
+  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
+  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
+  # serves the whole team, so every PR queued one more eval-only runner and
+  # slowed the queue. The report is informational (a sticky PR comment), never
+  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
+  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
+  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  workflow_dispatch: {}
+  # pull_request:
+  #   branches:
+  #     - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Disables the per-PR **Blast radius** auto-run.

**Why:** the `evaluate` job runs a full-catalog eval (~57s "Report blast radius" step) on a shared `ix-ci` dispatcher runner for every PR. With many PRs open it queues one eval-only runner each and slows the merge queue. The output is an informational sticky comment, never a merge gate, so dropping the trigger costs no safety.

**Change:** swap the `pull_request` trigger for `workflow_dispatch`. Fully reversible: uncomment the `pull_request` block to restore.

sent by an AI agent (Claude) via Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop running blast-radius workflow automatically on every PR
> Replaces the `pull_request` trigger in [blast-radius.yml](.github/workflows/blast-radius.yml) with a `workflow_dispatch` trigger so the workflow only runs when manually invoked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05bac2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->