### PR TITLE
claude-code: bake --add-dir/--plugin-dir for declarative global skills

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -42,6 +42,30 @@
   # runtime. `{ }` (default) ships only the computed defaults.
   extraSettings ? { },
 
+  # Directories baked into the wrapper as `--add-dir=<dir>` flags, one per entry.
+  # `--add-dir` grants tool file-access to a directory, AND (the reason this arg
+  # exists) Claude Code loads any `<dir>/.claude/skills/` and `<dir>/CLAUDE.md`
+  # found under it — the documented exception that makes `.claude/skills` under an
+  # added dir discoverable as BARE `/<skill-name>` commands, regardless of the
+  # session's cwd. This is the declarative, cwd-independent way to ship a fixed
+  # set of skills globally (parallel to how `mcpServers` bakes `--mcp-config`):
+  # point an entry at a store dir whose `.claude/skills/<name>/SKILL.md` tree is a
+  # materialized `skills.mkSkillsDir` output. The skills the CLI's own
+  # `.claude/skills` discovery (project + `~/.claude/skills`) finds still load
+  # alongside; this only adds. `[ ]` (default) bakes no flag. See the `=`-form
+  # note in `wrapperFlags`: `--add-dir` is variadic, so the space form would
+  # swallow the next argv token.
+  addDirs ? [ ],
+
+  # Directories baked into the wrapper as `--plugin-dir=<dir>` flags, one per
+  # entry: load a Claude Code plugin (a dir with `.claude-plugin/plugin.json`,
+  # bundling its own `skills/`, `agents/`, `hooks/`, `.mcp.json`, ...) for every
+  # session. Plugin skills/agents are NAMESPACED (`/<plugin>:<skill>`), unlike the
+  # bare names `addDirs` yields, so reach for this when you want a self-contained,
+  # provenance-tagged bundle rather than loose global skills. `[ ]` (default)
+  # bakes no flag.
+  pluginDirs ? [ ],
+
   # Shell glob patterns for the durable primary checkouts the PreToolUse
   # worktree guard protects (the claude-hooks `worktree-guard` subcommand): a file-edit tool call
   # whose target resolves into a PRIMARY checkout (git-dir == git-common-dir,
@@ -389,6 +413,13 @@ let
   #    explicit later `--thinking-display=omitted` on the CLI still wins
   #    (single-value options are last-wins).
   #  - `--dangerously-skip-permissions` (see its arg comment).
+  #  - `--add-dir=<dir>` (per `addDirs` entry): allow tool access to <dir> and
+  #    load any `<dir>/.claude/skills` + `<dir>/CLAUDE.md` under it. The `=` form
+  #    is MANDATORY here, not just preferred: `--add-dir <directories...>` is
+  #    variadic and would swallow the following argv token (the same class of bug
+  #    as `--mcp-config` above). See the `addDirs` arg comment.
+  #  - `--plugin-dir=<dir>` (per `pluginDirs` entry): load a plugin directory for
+  #    every session (namespaced skills/agents/hooks). See the `pluginDirs` arg.
   wrapperFlags = [
     "--debug"
     "--thinking-display=summarized"
@@ -397,7 +428,9 @@ let
   ++ lib.optional (
     systemPrompt != null
   ) "--system-prompt-file=${builtins.toFile "claude-code-system-prompt.txt" systemPrompt}"
-  ++ lib.optional (mcpServers != { }) "--mcp-config=${mcpConfigFile}";
+  ++ lib.optional (mcpServers != { }) "--mcp-config=${mcpConfigFile}"
+  ++ map (d: "--add-dir=${d}") addDirs
+  ++ map (d: "--plugin-dir=${d}") pluginDirs;
 
   envEntries = attrs: lib.mapAttrsToList (key: value: { inherit key value; }) attrs;
 

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -70,6 +70,36 @@
     } \
     --settings=/dev/null -p hi
 
+  # addDirs/pluginDirs render as single, prepended `=` tokens. `--add-dir` is
+  # variadic in the CLI, so a space-form token would swallow the next positional
+  # (proven against the real binary); this guards that the launcher keeps each as
+  # one argv entry, ahead of the subcommand. Synthesize a spec with the two flags
+  # appended to `flags` (mirrors what `map (d: "--add-dir=${"\${d}"}") addDirs`
+  # produces in the wrapper) and assert they land between the baked flags and the
+  # injected `--settings`.
+  ${lib.getExe jq} '.flags += ["--add-dir=/nix/store/sample-skills", "--plugin-dir=/nix/store/sample-plugin"]' \
+    "$PWD/test-spec.json" > "$PWD/dirs-spec.json"
+  dirs_got="$(IX_LAUNCH_SPEC="$PWD/dirs-spec.json" "$launcher" mcp list)"
+  dirs_want=${
+    lib.escapeShellArg (
+      lib.concatStringsSep "\n" (
+        wrapperFlags
+        ++ [
+          "--add-dir=/nix/store/sample-skills"
+          "--plugin-dir=/nix/store/sample-plugin"
+          "--settings=${settingsDefaultsFile}"
+          "mcp"
+          "list"
+        ]
+      )
+    )
+  }
+  if [ "$dirs_got" != "$dirs_want" ]; then
+    printf 'claude launcher argv check failed: add-dir/plugin-dir tokens\nexpected:\n%s\ngot:\n%s\n' \
+      "$dirs_want" "$dirs_got" >&2
+    exit 1
+  fi
+
   # Session-digest hook net: absent/empty digests stay silent (exit 0, no
   # output, so a host without the ix-context-digest timer loses nothing), a
   # present digest rides additionalContext verbatim, and an oversized digest


### PR DESCRIPTION
## What

Add two opt-in args to the `claude-code` wrapper (default `[ ]`, zero behavior change for existing consumers):

- `addDirs` → baked as `--add-dir=<dir>` per entry
- `pluginDirs` → baked as `--plugin-dir=<dir>` per entry

rendered in `wrapperFlags`, parallel to how `mcpServers` bakes `--mcp-config` and `systemPrompt` bakes `--system-prompt-file`.

## Why

`--add-dir=<dir>` makes Claude Code load `<dir>/.claude/skills/<name>/` as **bare** `/<skill>` commands regardless of the session cwd (documented exception: skills + CLAUDE.md load from an added dir). This is the declarative, fleet-wide way to ship a fixed skill set globally instead of relying on per-project `.claude/skills` or a hand-maintained `~/.claude/skills`. Consumed by my nix config to make all index skills global.

## Notes

- `--add-dir` is **variadic** in the CLI, so the `=` form (one argv token) is mandatory — the space form swallows the next positional. Verified against the real binary; `install-check.nix` guards the single-token prepend via a synthesized spec.

## Validation

- `nix build .#claude-code` ✅ (runs `installCheckPhase`, incl. the new add-dir/plugin-dir assertion)
- Built `claude-code.override { addDirs = [ <tmp .claude/skills root> ]; }`, ran headless from `/tmp` (unrelated cwd) with **no** manual flag → the probe skill loaded and returned its marker. ✅

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--add-dir` and `--plugin-dir` flag support to the claude-code wrapper
> - Adds `addDirs` and `pluginDirs` parameters to [default.nix](https://github.com/indexable-inc/index/pull/1385/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), which map to `--add-dir=<dir>` and `--plugin-dir=<dir>` flags in the generated wrapper.
> - Uses `=`-form single-token arguments to avoid variadic CLI parsing issues.
> - Extends [install-check.nix](https://github.com/indexable-inc/index/pull/1385/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) with a test that verifies argv ordering and token format for both new flags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4033cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->