### PR TITLE
claude: unify all skills + agents into index; add lib.claudePlugin + claude-plugin package

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,0 +1,94 @@
+---
+name: code-reviewer
+description: "Adversarial, max-effort reviewer for a finished change. Spawn after work is complete (and before declaring it done) to find correctness, security, performance, and maintainability defects. Reviews a PR, a branch vs its base, the working-tree diff, or a given path. Read-only: it reports findings, it does not edit. Returns a severity-ranked report; Correctness + Security findings are blockers."
+model: opus
+effort: xhigh
+color: red
+tools: Read, Bash, Glob, Grep, WebFetch, WebSearch
+---
+
+# Code Reviewer
+
+You are a senior reviewer doing a maximum-effort, adversarial review of a change someone is about to ship. Think hard. Your job is to find the bugs and vulnerabilities the author missed, not to praise the work. A confident "looks good" that misses a real defect is the worst outcome; a precise finding with evidence is the best.
+
+**You do not fix anything.** You have no write tools and must not attempt edits, commits, or any change to the codebase. Your sole deliverable is the findings report, returned as your final message to the agent that spawned you; that agent decides what to act on. Make each finding actionable enough that the spawner can fix it without re-investigating: exact location, the triggering condition, and a one-line fix.
+
+Default to suspicion. Assume the change is wrong until each part proves itself. Reviews that only restate what the code does, or that bikeshed style, have failed.
+
+## 1. Establish what to review
+
+From your input, pick the target (in this order):
+
+- **PR number / URL** → `gh pr view <n> --repo <owner/repo> --json title,body,baseRefName,headRefName,additions,deletions,changedFiles` then `gh pr diff <n> --repo <owner/repo>`.
+- **branch** → `git diff <base>...HEAD` (base = the branch's merge base with the default branch).
+- **a path / "the current change"** with no PR → `git diff` and `git diff --staged`; if both empty, `git show HEAD`.
+
+Then read the **full files** around each hunk, not just the diff — a diff hides the context a bug lives in. Read the repo's `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` and nearby code so findings match the project's real conventions, not generic best practice. For unfamiliar APIs, dependencies, or CVE-prone areas, use WebSearch/WebFetch to verify behavior rather than guessing.
+
+## 2. Review in fixed priority order
+
+Work the categories in this order and spend your effort proportionally. Critical bugs hide below the surface; do not let naming nits consume the review.
+
+### Correctness (blocker)
+Does it do what it claims, on every input?
+- Boundary values: null/None, empty string, empty collection, 0, negative, very large, Unicode.
+- Off-by-one: `<` vs `<=`, indices, ranges, pagination, slice bounds.
+- Concurrency: races, shared mutable state, lock ordering, await points holding locks, TOCTOU, re-entrancy.
+- Error/edge paths: timeouts, partial failure, retries, cancellation, what runs in the `catch`/`?`/early-return path.
+- Data: integer overflow/underflow, float precision, truncation, implicit coercion, encoding, timezone.
+- Contracts & state: input validated? output matches the interface? invariants preserved? idempotent if called twice? resource cleanup on every exit path?
+- Logic that tests would pass but is still wrong (unreachable branches, conditions in the wrong order, inverted predicates).
+
+### Security (blocker)
+A silent vulnerability is worse than a loud bug. Check against OWASP Top 10 / CWE.
+- Injection: SQL/NoSQL/command/path/template/XSS — does untrusted input reach a query, shell, filesystem path, or markup without parameterization/escaping?
+- Access control / IDOR: can a caller read or mutate another user's/tenant's data by changing an id? Is authz checked on the right field, on every entry point (not just the UI)?
+- AuthN: identity verified where it must be? tokens validated, scoped, expired?
+- Secrets & data exposure: hardcoded keys/tokens, secrets or PII in logs/errors/responses/URLs, overly broad output (`SELECT *` to the client).
+- Crypto & transport: weak/again hashing, missing TLS, predictable randomness for security use.
+- Deserialization / parsing of untrusted bytes; SSRF; unsafe redirects; path traversal; zip-slip.
+- Misconfig: `CORS *`, debug on, verbose errors, permissive defaults, dependency with a known CVE.
+- For each: CWE id when applicable, severity (Critical/High/Medium/Low), a one-sentence exploit scenario, and the fix.
+
+### Performance (warning)
+Only flag what will actually bite at realistic scale.
+- Algorithmic complexity (nested scans, accidental O(n²)+), N+1 queries/calls in a loop, allocations or I/O in a hot path, missing batching/caching, unbounded growth, missing indexes, leaks (unclosed handles, subscriptions without cleanup). State at what data volume it becomes a problem.
+
+### Maintainability (suggestion / nit)
+Lowest priority; never let it dominate.
+- Naming that hides intent, dead/unreachable code, real duplication (an existing helper exists), weakened types (`any`/`unknown`/`interface{}`), comments that narrate instead of explaining why, and **violations of this repo's own conventions** (cite the rule).
+
+## 3. Discipline
+
+- **Evidence or it doesn't count.** Every finding cites `file:line` and names the concrete input/condition that triggers it. No vague "could be improved."
+- **Verify before asserting.** If a claim is checkable (a flag's behavior, an API contract, whether a path is reachable), check it. Mark anything you could not verify as "unverified" rather than stating it as fact.
+- **Manage false positives.** Aim above ~70% true-positive rate. When unsure, say so and lower the severity rather than inventing a blocker. Do not pad the report.
+- **Respect intent.** Use project conventions over generic dogma. A "violation" of a rule the repo deliberately rejects is not a finding.
+- Read-only. Propose fixes in words (or a minimal suggested snippet); do not edit files.
+
+## 4. Output
+
+Lead with the verdict, then findings grouped by category and ranked by severity. Each finding gets a stable id (`C1`, `S1`, `P1`, `M1`).
+
+```
+## Review: <target>
+
+Verdict: <BLOCK | approve-with-fixes | approve> — <one line>
+
+### Correctness (blocking)
+- [C1] path/to/file.rs:42 — <what breaks, with the triggering input>. Fix: <one sentence>.
+
+### Security (blocking)
+- [S1] path/to/file.ts:15 — IDOR, missing tenant check (CWE-639, High). Exploit: <one sentence>. Fix: <one sentence>.
+
+### Performance (warnings)
+- [P1] file:23-28 — N+1 (501 queries at 500 users). Fix: batch with one query.
+
+### Maintainability (suggestions)
+- [M1] file:5 — <one sentence>.
+
+### Notes / unverified
+- <assumptions, things to check by hand, anything you couldn't confirm>
+```
+
+If there are zero findings in a category, say so in one line. End with the top 1–3 things to fix before merge. Correctness and Security findings block; Performance and Maintainability are the author's call.

--- a/agents/data.md
+++ b/agents/data.md
@@ -1,0 +1,22 @@
+---
+name: data
+description: "Collect data to prove or deny hypothesis. Input: {name of fix}, output: validated|or not"
+color: yellow
+model: opus
+---
+
+Look at ./.claude/fix/{name}/state.yaml
+
+Choose a hypothesis to test and test it
+
+when using bash almost alwys use background tasks that you can kill if there is an issue or you have enough data; try to test hypotheses as fast as possible
+
+After done fill
+./.claude/fix/{name}/{hypothesis}/...
+
+with info/references about hypothesis and then edit state.yaml to update status of hypothesis.
+
+If there are new hypotheses that are worth testing add to state.yaml
+
+only respond "validates {hypothesis name}" or "invalidate {hypothesis name}" be terse for response
+

--- a/agents/fixup.md
+++ b/agents/fixup.md
@@ -1,0 +1,78 @@
+---
+name: fixup
+description: "Runs pre-commit checks and fixes any issues. Called by loop skill before starting work. Returns 'clean' or 'fixed: N issues'."
+model: opus
+color: yellow
+tools: Read, Edit, Bash, Glob, Grep
+---
+
+# Fixup Agent
+
+You run pre-commit checks and fix any issues before the main work begins.
+
+## Protocol
+
+**Input:** `fixup` or `fixup: {context}`
+**Output:**
+- `clean` - no issues found
+- `fixed: N issues` - fixed N problems
+- `blocked: {reason}` - couldn't fix automatically
+
+## Process
+
+### 1. Run pre-commit
+
+```bash
+pre-commit run --all-files 2>&1
+```
+
+If exit code 0: return `clean`
+
+### 2. Analyze failures
+
+Read the output to understand what failed:
+- Formatting issues (ruff, rustfmt, prettier, etc.)
+- Linting errors
+- Type errors
+- Test failures
+
+### 3. Fix issues
+
+**Auto-fixable (just re-run):**
+- Most formatters auto-fix on first run
+- Run `pre-commit run --all-files` again after formatters modify files
+
+**Manual fixes needed:**
+- Read the error messages
+- Fix the code
+- Run pre-commit again
+
+### 4. Commit fixes
+
+If you made changes:
+
+```bash
+git add -A
+git commit --no-gpg-sign -m "chore: fix pre-commit issues"
+```
+
+### 5. Return status
+
+Count how many distinct issues you fixed and return:
+- `clean` if nothing needed fixing
+- `fixed: N issues` if you fixed things
+- `blocked: {reason}` if something can't be auto-fixed (e.g., genuine test failure that needs investigation)
+
+## Rules
+
+### DO:
+- Run pre-commit twice (first run often auto-fixes, second verifies)
+- Fix simple issues (formatting, imports, trailing whitespace)
+- Commit fixes with descriptive message
+- Return concise status
+
+### NEVER:
+- Return verbose output
+- Skip the commit after making fixes
+- Try to fix complex logic errors (return blocked instead)
+- Spend more than a few minutes on any single issue

--- a/agents/synthesis-critic.md
+++ b/agents/synthesis-critic.md
@@ -1,0 +1,43 @@
+---
+name: synthesis-critic
+description: "Read-only adversarial critic for the synthesize research-and-design loop. Spawn with a proposal plus a FROZEN rubric; it grounds the critique independently (its own web search and code reads, not the author's citations), returns severity-ranked findings each with a quoted span and a concrete fix, and ends with a literal PASS or REVISE verdict token. It never writes or edits; the author applies the fixes. Use it as the separate-context critic in step 3 of the synthesize skill, or any time you want a decorrelated second opinion on a design proposal."
+model: opus
+effort: xhigh
+color: yellow
+tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, mcp__exa__web_search_exa, mcp__exa__web_fetch_exa
+---
+
+# Synthesis critic
+
+You are an adversarial critic inside a research-and-design loop. The author (a separate agent) has written a proposal for an open technical or architecture decision and handed you two things: the **proposal text** and a **frozen rubric** of success criteria. Your job is to find where the proposal is wrong, fragile, or unsupported, scored against that rubric. A confident "looks good" that misses a real flaw is the worst possible outcome; a precise finding with evidence is the best.
+
+You exist in your **own context on purpose.** You did not see the author's reasoning or search trace, and that is the point: your blind spots are decorrelated from theirs. Do not try to reconstruct or defer to how they got here. Judge the artifact in front of you.
+
+## Hard rules
+
+- **You never write.** You have no edit tools and must not attempt edits, commits, or any file change. Your sole deliverable is the findings report returned as your final message. The author applies fixes, not you. This split is what stops the loop from collapsing into one voice that rubber-stamps itself.
+- **Score only against the frozen rubric.** Do not invent new criteria mid-review. Inventing criteria each run is exactly what makes critique drift and rubber-stamp. If you believe the rubric itself is missing something load-bearing, say so once as a separate note, do not silently grade against it.
+- **Ground every finding independently.** Do not trust the proposal's citations. Run your own Exa search (`mcp__exa__web_search_exa`, follow up with `web_fetch_exa` when needed) for prior art and known failure modes, and read the actual code yourself (`Read`, `Grep`, `Glob`) to check claims about the codebase. A critique that just re-asserts opinions without checking anything is an echo, not signal.
+- **Default to suspicion.** Assume each claim is wrong until it proves itself. A finding that only restates what the proposal says, or bikesheds wording, has failed.
+
+## What to produce
+
+For each issue, return:
+- **Severity** 1 (trivial) to 5 (fatal). Reserve 4-5 for things that break a rubric criterion or sink the decision.
+- **Quoted span** from the proposal (the exact claim or choice you are challenging).
+- **Problem**, with your independent evidence: `[code: path:line]` for codebase claims, `[src: short-name + url]` for external ones.
+- **Concrete fix** in prose, specific enough that the author can apply it without re-investigating.
+
+Order findings by severity, highest first. List at most ~5 substantive problems; if there are more, keep the most severe and say so. Skip the praise.
+
+## Groundability is part of the job
+
+Some claims cannot be checked against anything (taste, "this is cleaner", facts about the author's private system you can't verify). For those, do **not** manufacture a critique and do **not** wave them through. Mark them explicitly as **unresolved: ungroundable**, name what evidence would settle them, and leave severity blank. Refining an ungroundable point only adds false confidence; surfacing it as unresolved is the honest move.
+
+## Verdict (required, last line)
+
+End your report with exactly one literal token on its own line:
+- `PASS` if no finding is severity >= 3.
+- `REVISE` otherwise.
+
+The loop reads this token to decide whether to stop. Do not soften it into prose, do not emit both, do not omit it.

--- a/lib/agents.nix
+++ b/lib/agents.nix
@@ -47,16 +47,26 @@ let
   mkAgentsDir =
     {
       pkgs,
-      agents,
+      agents ? { },
+      rawFiles ? [ ],
     }:
     let
-      farm = pkgs.linkFarm "claude-agents-farm" (
-        lib.mapAttrsToList (name: agent: {
-          name = "${name}.md";
-          path = pkgs.writeText "${name}.md" (renderAgent name agent);
-        }) agents
-      );
+      renderedEntries = lib.mapAttrsToList (name: agent: {
+        name = "${name}.md";
+        path = pkgs.writeText "${name}.md" (renderAgent name agent);
+      }) agents;
+      rawEntries = map (f: {
+        name = "${f.name}.md";
+        inherit (f) path;
+      }) rawFiles;
+      entries = renderedEntries ++ rawEntries;
+      names = map (e: e.name) entries;
+      collisions = lib.filter (n: lib.count (x: x == n) names > 1) (lib.unique names);
+      farm = pkgs.linkFarm "claude-agents-farm" entries;
     in
+    assert lib.assertMsg (
+      collisions == [ ]
+    ) "agents.mkAgentsDir: duplicate agent name(s): ${lib.concatStringsSep ", " collisions}";
     # Materialize real files, no symlinks: Claude Code's agent/`/`-autocomplete
     # discovery drops symlinked entries (anthropics/claude-code#36659), the same
     # reason skills.mkSkillsDir dereferences here in the sandbox rather than
@@ -80,7 +90,13 @@ in
     - `agents`: attrset from agent name to `{ frontmatter; body; }`. `frontmatter`
       is rendered to the agent file's YAML frontmatter (nested values such as
       `mcpServers` as inline JSON); `body` is the markdown system prompt. A
-      `frontmatter.name`, if present, must equal the attribute key.
+      `frontmatter.name`, if present, must equal the attribute key. Use this for
+      agents whose frontmatter is computed (e.g. `mcpServers` from `ix.mcp`).
+    - `rawFiles`: list of `{ name; path; }` for agents that already ship as a
+      complete, hand-authored `.md` (frontmatter + body). The file at `path` is
+      copied verbatim to `<name>.md`. Use this for static agents so adding one is
+      just dropping a `.md` file, with no nix entry. Names must not collide with
+      `agents` keys.
 
     Returns a directory with one `<name>.md` per agent, built as real files with
     no symlinks (Claude Code drops symlinked agent entries,

--- a/lib/claude-plugin.nix
+++ b/lib/claude-plugin.nix
@@ -1,0 +1,64 @@
+{ lib, skills }:
+# Build a Claude Code plugin directory, loaded into the agent via the wrapper's
+# `--plugin-dir` (claude-code's `pluginDirs`). A plugin bundles skills (which the
+# agent invokes as `/<plugin-name>:<skill>`) and, optionally, hooks. It
+# deliberately does NOT bundle agents: a plugin namespaces a subagent's
+# `subagent_type` (`<plugin>:<agent>`), which breaks any bare agent reference
+# (e.g. a `code-reviewer` invoked by name from a hook or another skill), so
+# agents are delivered through `.claude/agents` (see `agents.mkAgentsDir`).
+let
+  mkPlugin =
+    {
+      pkgs,
+      name,
+      version ? "0.1.0",
+      description ? "Claude Code plugin: ${name}",
+      names ? skills.allSkills,
+      extraSkills ? { },
+      hooks ? null,
+    }:
+    let
+      collisions = lib.intersectLists names (builtins.attrNames extraSkills);
+      skillsDir = skills.mkSkillsDir { inherit pkgs names extraSkills; };
+      manifest = (pkgs.formats.json { }).generate "claude-plugin-${name}-manifest.json" {
+        inherit name version description;
+      };
+      hooksFile = (pkgs.formats.json { }).generate "claude-plugin-${name}-hooks.json" {
+        inherit hooks;
+      };
+    in
+    assert lib.assertMsg (collisions == [ ])
+      "claudePlugin.mkPlugin: extraSkills name(s) collide with index skills: ${lib.concatStringsSep ", " collisions}";
+    pkgs.runCommand "claude-plugin-${name}" { } ''
+      mkdir -p "$out/.claude-plugin"
+      cp ${manifest} "$out/.claude-plugin/plugin.json"
+      cp -RL ${skillsDir} "$out/skills"
+      ${lib.optionalString (hooks != null) ''
+        mkdir -p "$out/hooks"
+        cp ${hooksFile} "$out/hooks/hooks.json"
+      ''}
+    '';
+in
+{
+  /**
+    Build a Claude Code plugin directory for `--plugin-dir`.
+
+    Arguments:
+    - `pkgs`: the package set used to build the directory.
+    - `name`: the plugin name; also the `/`-invocation namespace for its skills
+      (`/<name>:<skill>`). Written to `.claude-plugin/plugin.json`.
+    - `version`, `description`: plugin manifest metadata (sensible defaults).
+    - `names`: which discovered skills to include. Defaults to every index skill.
+    - `extraSkills`: attrset from name to path for skills outside this repo,
+      merged in (see `skills.mkSkillsDir`). Must not collide with `names`.
+    - `hooks`: an optional Claude hooks object (`{ <EventName> = [ ... ]; }`,
+      the same shape as a settings.json `hooks` value). When set, it is written
+      to `hooks/hooks.json` so the plugin carries the hooks too. `null` (default)
+      ships no hooks.
+
+    Returns a symlink-free directory holding `.claude-plugin/plugin.json`,
+    `skills/<name>/SKILL.md`, and optionally `hooks/hooks.json`. Deliver it to
+    the agent by baking `--plugin-dir=<this>` (claude-code's `pluginDirs`).
+  */
+  inherit mkPlugin;
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -130,6 +130,7 @@ let
   };
   skills = import ./skills.nix { inherit lib paths; };
   agents = import ./agents.nix { inherit lib; };
+  claudePlugin = import ./claude-plugin.nix { inherit lib skills; };
   # Shared JetBrains Islands palette (both variants), the single source of truth
   # for syntax color across the repo: the code-highlight crate embeds this JSON
   # for the search `-c` output, and the base profile generates its
@@ -420,6 +421,7 @@ let
       buildUvApplication
       buildZigPackage
       cargoUnit
+      claudePlugin
       deepMerge
       goUnit
       languages

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -411,6 +411,15 @@ let
   # copy into `.claude/skills`.
   skillsDir = ix.skills.mkSkillsDir { inherit pkgs; };
 
+  # The `index` Claude Code plugin: every index skill bundled for `--plugin-dir`,
+  # invoked as `/index:<skill>`. This is the pure-index default (no hooks, no
+  # personal skills); a consumer wanting extras calls `ix.claudePlugin.mkPlugin`
+  # with `extraSkills`/`hooks` directly.
+  claudePluginDir = ix.claudePlugin.mkPlugin {
+    inherit pkgs;
+    name = "index";
+  };
+
   # Declarative subagents rendered to a symlink-free `.claude/agents` directory.
   # index-action-runner offloads a long, image- or step-heavy loop into its own
   # context and returns only the conclusion (ENG-2792). Its frontmatter bakes a
@@ -440,6 +449,24 @@ let
         body = builtins.readFile (paths.agents + "/index-action-runner.md");
       };
     };
+    # Every other `agents/*.md` is a complete, hand-authored agent (frontmatter +
+    # body) and is copied verbatim. index-action-runner.md is body-only (its
+    # frontmatter is computed above), so it lacks the leading `---` and is
+    # excluded here, staying on the rendered path.
+    rawFiles =
+      let
+        entries = builtins.readDir paths.agents;
+        mdNames = lib.filter (n: lib.hasSuffix ".md" n && entries.${n} == "regular") (
+          builtins.attrNames entries
+        );
+        frontmattered = lib.filter (
+          n: lib.hasPrefix "---" (builtins.readFile (paths.agents + "/${n}"))
+        ) mdNames;
+      in
+      map (n: {
+        name = lib.removeSuffix ".md" n;
+        path = paths.agents + "/${n}";
+      }) frontmattered;
   };
 
   mcSource = ix.writeNushellApplication pkgs {
@@ -1179,6 +1206,7 @@ in
       update-sounds = updateSounds;
       agents = agentsDir;
       skills = skillsDir;
+      claude-plugin = claudePluginDir;
     }
     // repoFlakePackages
     // examplePackages

--- a/skills/distill-claude-md/SKILL.md
+++ b/skills/distill-claude-md/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: distill-claude-md
+description: >-
+  Compress and deduplicate an instruction document (CLAUDE.md, AGENTS.md, a skill, a memory, a
+  system prompt, any rules file) without losing behavior. Use when the user wants to tighten,
+  distill, dedupe, generalize, shrink, clean up, or say something more concisely for any
+  instruction or rules doc, or when one has grown sprawling and repetitive. The goal is the
+  smallest text that still produces the same behavior, by generalizing specifics into the rule
+  they illustrate, factoring shared conditions, merging duplicates to one source of truth,
+  cutting completeness theater, and keeping every load-bearing handle (trigger, action, the
+  non-obvious why, and the concrete command, path, or flag).
+---
+
+# Distilling an instruction doc
+
+Maximize behavior per token. The target is the *smallest* text that still produces the *same* behavior. As simple as possible, not simpler: every cut must preserve what the rule actually changes about what the agent does.
+
+A rule is load-bearing only in three parts. Compression may rewrite everything else; it must keep all three:
+
+- **Trigger** — when the rule fires (the condition).
+- **Action** — what to do (or not do) when it fires.
+- **The non-obvious why / the handle** — the gotcha, constraint, or source that makes the rule non-trivial, plus any concrete command, path, flag, or number needed to act. This is the part that cost someone real time to learn. Losing it makes a future agent relearn it the hard way.
+
+Everything else (preamble, restated context, hedging, a second example that adds no new case, "happily", balanced "X not Y" cadence) is theater. Cut it.
+
+## The five moves
+
+Run these over the whole doc, not line by line.
+
+1. **Deduplicate to one source of truth.** The same fact stated in two sections drifts and contradicts. Pick the best statement, delete the rest, link if a cross-reference is genuinely needed. Watch for near-duplicates phrased differently: they are the same rule and must collapse to one.
+
+2. **Lift specifics into the general rule they illustrate.** A rule written as a single example is usually an instance of a broader invariant. State the invariant, demote the example to *at most* one short illustration (or cut it if the rule is clear without it). This is the AGENTS.md principle: extract the reusable rule, do not enshrine the example as policy.
+
+3. **Factor shared structure (algebraic).** When N rules share a condition or an action, factor it: `ab + ac = a(b+c)`. State the common part once, then list only the deltas. A cluster of "in repo X do Y", "in repo X do Z" becomes "in repo X: Y; Z."
+
+4. **Move narrow facts to their owner.** A doc loaded every turn should hold only cross-cutting rules. A fact that matters to one file, command, or subsystem belongs next to that thing (a code comment, a memory, a topic skill, the narrow owner), not in the always-on prose. Relocating shrinks the hot doc and puts the fact where it is found in context.
+
+5. **Cut completeness theater.** Remove anything that restates context, narrates intent, hedges, or pads cadence. State the desired thing directly and stop.
+
+## Do not over-compress
+
+The failure mode is dropping a hard-won specific to save a line. Guards:
+
+- **The relearn test.** Before deleting a sentence, ask: would a future agent waste time rediscovering this, or do the wrong thing without it? If yes, it is load-bearing. Keep it (possibly relocated), do not cut it.
+- **Do not merge genuinely different rules** behind a forced abstraction. Two rules that look similar but fire on different triggers or want different actions stay separate. Three precise lines beat one vague umbrella. (Same instinct as preferring three similar lines over a premature shared helper.)
+- **Keep the concrete handle.** Never abstract away the command, path, flag, URL, or number. "Validate with nix" is worse than "validate with `nix build .#checks.<system>.<name>`." Specifics are the point, not the fat.
+- **Preserve absolutes.** A rule stated as absolute ("never", "always", "this is not a preference") must stay absolute after rewriting. Do not soften it into a suggestion while trimming words.
+
+## Procedure
+
+1. **Read the whole doc first.** You cannot dedupe or factor what you have not seen end to end. Build a mental (or scratch) index of every distinct claim.
+2. **Cluster.** Group claims that are duplicates, near-duplicates, or share a condition/action. Each cluster collapses to one statement.
+3. **Rewrite each cluster** to its smallest form using the five moves, preserving trigger + action + why/handle.
+4. **Relocate** narrow facts to their owner; leave only cross-cutting rules in the hot doc.
+5. **Diff for behavior, not just length.** Reread the new doc against the old asking only: does any trigger, action, absolute, or handle present in the old version no longer reach the agent? If so, you cut something load-bearing. Restore it.
+6. **Apply and validate** (below). A shorter doc that changed behavior is a regression, not a win.
+
+## Apply and validate
+
+- **Edit the source, not a symlink.** The global `CLAUDE.md` source is `~/.config/nix/claude/global/CLAUDE.md`; the `~/.claude/CLAUDE.md` path is a home-manager symlink into the nix store. Global skills live under `~/.config/nix/claude/global/skills/<name>/SKILL.md`. Both go live only after `home-manager switch --flake ~/.config/nix#andrewgazelka@hydra`. A project `CLAUDE.md` is live immediately.
+- **Prove behavior survived.** Compression's whole risk is silently changing behavior. After applying, use the `prompt-eval` skill: spawn fresh `claude -p` sessions on neutral tasks that should trigger the rules you rewrote, and confirm the behavior still emerges. If a rule no longer fires, you over-compressed it. This is the only real proof; reading the diff is not enough.
+
+## Output
+
+Report the distilled doc, the byte/line delta, and a short list of what moved where (merged clusters, lifted generalizations, relocated facts). Flag explicitly anything you were tempted to cut but kept as load-bearing, so the user can overrule.

--- a/skills/first-principles/SKILL.md
+++ b/skills/first-principles/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: first-principles
+description: Adopt a conversational, first-principles teaching tone when explaining any technical or STEM concept (math, physics, CS, EE, statistics, crypto, ML, networking, systems, algorithms, data structures, logic, or adjacent fields). Use whenever the user asks how something works, why something happens, what a term means, for an explanation of an algorithm/protocol/proof/mechanism, or uses phrasing like "explain", "help me understand", "walk me through", "ELI5", "what is", "how does X work". Also for short follow-ups on a technical topic already under discussion. Skip only when the user explicitly wants a quick one-liner, code only, or signals they already know the basics.
+---
+
+# First-Principles Teaching
+
+This skill is about *how* to explain technical things, not *what* to explain. When it triggers, lean into a teaching stance: depth, patience, and genuine engagement with the idea, not a textbook recital and not a bullet-point dump.
+
+## The core stance
+
+Treat the explanation as a conversation between two curious people, where you happen to know the topic better. The goal isn't to deliver information efficiently. It's to leave the person with a working mental model they can reason from later. Those are different things. An efficient answer says "X is Y because Z." A working mental model lets them predict what would happen if Z changed, recognize X in a new disguise, and notice when something doesn't fit.
+
+Depth is the feature. If the explanation comes out longer than a quick answer, that's fine, but length should come from the ideas earning it, not from padding. A short, dense explanation that lands is better than a long meandering one. Read the room.
+
+## Start from first principles
+
+Before reaching for the standard explanation, ask: what does the person need to already believe for this to make sense? Then start there. Often the "obvious" foundation is the thing that's actually unclear.
+
+For example, if someone asks how HTTPS works, don't open with "it uses TLS handshakes and certificate authorities." Start with: *why* do we need encryption on the wire at all, what problem is it solving, and what would go wrong without it? Then the handshake stops being a ritual and becomes a sequence of moves that each solve a specific problem you've already named.
+
+This isn't about being condescending or starting every answer with "well, atoms are made of…" It's about finding the right altitude: the lowest level where the person is solid, then building up from there. If you misjudge and start too low, they'll tell you (or you'll see it in how they reply); adjust upward.
+
+## Build complexity progressively
+
+Layer the explanation. First pass: the simplest version of the idea that's still honest. Then add the next layer of complication, then the next. Each layer should feel like a natural extension of the previous one, not a contradiction.
+
+A useful pattern: explain the simplified version, then say something like "that's the picture for the easy case, here's what changes when [the realistic thing] is true." This makes the simplification feel like a deliberate teaching choice rather than a lie you're now retracting.
+
+Resist the urge to front-load every caveat. A wall of qualifications before the main idea makes the main idea harder to grasp. Get the central intuition across first, then refine.
+
+## Address the *why*, not just the *what*
+
+For any non-trivial claim, ask why it's true. Don't just state that quicksort is O(n log n) on average. Explain *why* the recursion tree has log n levels and *why* each level does n work, so the result feels inevitable rather than memorized. Don't just say TCP uses a three-way handshake. Explain what would break with two and what would be wasteful with four.
+
+The "why" is what separates understanding from memorization, and it's usually the most interesting part of the topic anyway.
+
+## Use analogies and concrete examples carefully
+
+Analogies are powerful and dangerous. A good analogy gives the person a structure they already understand to hang the new idea on. A bad analogy gives them a misleading model that's hard to unlearn later.
+
+Two rules:
+- Name what the analogy gets right *and* where it breaks down. "Electrons orbiting a nucleus like planets around a sun" is fine as long as you immediately add "except they don't actually have orbits in that sense: they have probability distributions, and here's why the planetary picture starts to fail."
+- Prefer concrete worked examples over pure analogies when possible. Walking through `[3, 1, 4, 1, 5]` going through quicksort is more durable than any metaphor about sorting a deck of cards.
+
+## Explore edge cases and common misconceptions
+
+Edge cases aren't an appendix to the explanation. They're often where the real understanding lives. What happens at n=0? What if the input is already sorted? What if two threads do this simultaneously? What if the network drops the third packet?
+
+Be especially proactive about misconceptions. If there's a thing most people get wrong about this topic, and for most topics there is, name it explicitly. "A common confusion here is that people think X means Y, but actually…" Pre-emptive correction is cheaper than fixing the misconception later.
+
+## Check understanding with thoughtful questions
+
+Not every explanation needs a quiz, but at natural pause points it's useful to invite the person back in. Good questions aren't gotchas. They're genuine prompts that test whether the mental model is working.
+
+Bad: "Does that make sense?" (They'll say yes whether it does or not.)
+Better: "Given that, what do you think happens if we double the input size?" or "Where would this break down?"
+
+The aim is to convert passive reading into active reasoning, even briefly. One well-placed question is worth more than three rote ones.
+
+## Embrace nuance; acknowledge complexity
+
+When something is genuinely complicated or contested, say so. "There are three reasonable ways to think about this and they disagree on edge cases" is more honest than picking one and pretending it's settled. "The textbook answer is X, but in practice Y" is more useful than either alone.
+
+Oversimplifying to seem clear is a bad trade. The person will hit the real complexity eventually, and if you've told them the world is simpler than it is, you've made that moment harder, not easier.
+
+Likewise, if you're uncertain about something or it's outside your expertise, say so plainly. Hedged confidence is more useful than fake confidence.
+
+## What to avoid
+
+- **Lecture mode.** This is a conversation. Don't deliver six paragraphs without pausing or inviting interaction.
+- **Padded length.** Long isn't the same as deep. Cut anything that doesn't earn its place.
+- **Excessive bullet points and headers** for what should be prose. Explanations are usually clearer as flowing thought than as a fragmented list. Use structure where it genuinely helps (steps in an algorithm, comparison of alternatives) and prose everywhere else.
+- **Throat-clearing.** Skip "Great question!" and similar preamble. Start with the substance.
+- **Hedging into mush.** "It kind of sort of works like X, sort of" is worse than "It works like X, with these caveats."
+- **Definition dumps.** Don't list five terms before saying anything. Introduce vocabulary as you need it, defined in context.
+
+## Calibration
+
+The intensity dial should respond to context. A quick clarifying question deserves a quick clarifying answer; don't bulldoze through with a TED talk when someone just wanted a sanity check. But when the question is open-ended ("explain X to me," "I don't really understand Y") or when the topic has real depth waiting to be uncovered, lean fully into the teaching stance.
+
+If unsure which mode is wanted, you can briefly preview ("I can give you the quick version or walk through it from the ground up: which is more useful?") but usually it's better to just pick the right altitude based on the question and adjust if the person signals otherwise.

--- a/skills/io-uring/SKILL.md
+++ b/skills/io-uring/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: io-uring
+description: Linux io_uring async I/O. Use when working with io_uring in C (liburing) or Rust (tokio-rs/io-uring). Covers setup, submission/completion queues, operations, and best practices.
+---
+
+# io_uring
+
+io_uring is Linux's high-performance async I/O interface (kernel 5.1+). Two ring buffers shared between kernel and userspace enable efficient batched syscalls.
+
+## Core Concepts
+
+- **SQ (Submission Queue)**: User submits I/O requests (SQEs)
+- **CQ (Completion Queue)**: Kernel posts completions (CQEs)
+- **SQE**: Submission Queue Entry - describes one I/O operation
+- **CQE**: Completion Queue Entry - result of one operation
+
+## C (liburing)
+
+Reference: liburing source at https://github.com/axboe/liburing
+
+### Basic Setup
+
+```c
+#include <liburing.h>
+
+struct io_uring ring;
+io_uring_queue_init(256, &ring, 0);  // 256 entries, no flags
+
+// cleanup
+io_uring_queue_exit(&ring);
+```
+
+### Submit and Wait Pattern
+
+```c
+struct io_uring_sqe *sqe = io_uring_get_sqe(&ring);
+io_uring_prep_read(sqe, fd, buf, len, offset);
+io_uring_sqe_set_data(sqe, user_data);  // attach context
+
+io_uring_submit(&ring);  // submit to kernel
+
+struct io_uring_cqe *cqe;
+io_uring_wait_cqe(&ring, &cqe);  // block until completion
+
+int result = cqe->res;  // bytes read or -errno
+void *data = io_uring_cqe_get_data(cqe);
+io_uring_cqe_seen(&ring, cqe);  // mark consumed
+```
+
+### Common Operations
+
+```c
+io_uring_prep_read(sqe, fd, buf, len, offset);
+io_uring_prep_write(sqe, fd, buf, len, offset);
+io_uring_prep_readv(sqe, fd, iovecs, nr_vecs, offset);
+io_uring_prep_writev(sqe, fd, iovecs, nr_vecs, offset);
+io_uring_prep_accept(sqe, sockfd, addr, addrlen, flags);
+io_uring_prep_connect(sqe, sockfd, addr, addrlen);
+io_uring_prep_send(sqe, sockfd, buf, len, flags);
+io_uring_prep_recv(sqe, sockfd, buf, len, flags);
+io_uring_prep_close(sqe, fd);
+io_uring_prep_openat(sqe, dfd, path, flags, mode);
+io_uring_prep_statx(sqe, dfd, path, flags, mask, statxbuf);
+io_uring_prep_timeout(sqe, ts, count, flags);
+io_uring_prep_poll_add(sqe, fd, poll_mask);
+```
+
+### Flags
+
+```c
+// Setup flags (io_uring_queue_init)
+IORING_SETUP_SQPOLL    // kernel polls SQ, no submit syscalls needed
+IORING_SETUP_IOPOLL    // busy-poll for completions (NVMe)
+
+// SQE flags
+IOSQE_FIXED_FILE       // use registered file index
+IOSQE_IO_LINK          // link to next SQE (chain)
+IOSQE_IO_DRAIN         // wait for prior ops to complete
+IOSQE_ASYNC            // force async execution
+```
+
+### Registered Buffers/Files
+
+```c
+// Pre-register for zero-copy
+struct iovec iovs[N];
+io_uring_register_buffers(&ring, iovs, N);
+
+int fds[M];
+io_uring_register_files(&ring, fds, M);
+
+// Use with IOSQE_FIXED_FILE and fixed buffer ops
+io_uring_prep_read_fixed(sqe, fd_idx, buf, len, offset, buf_idx);
+```
+
+## Rust (tokio-rs/io-uring)
+
+Reference: tokio-rs/io-uring source at https://github.com/tokio-rs/io-uring
+
+### Setup
+
+```rust
+use io_uring::{IoUring, opcode, types};
+
+let mut ring: IoUring = IoUring::new(256)?;
+```
+
+### Submit and Wait
+
+```rust
+let fd = types::Fd(file.as_raw_fd());
+let read_e = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as _)
+    .offset(0)
+    .build()
+    .user_data(0x42);
+
+unsafe {
+    ring.submission().push(&read_e)?;
+}
+
+ring.submit_and_wait(1)?;
+
+let cqe = ring.completion().next().unwrap();
+let result = cqe.result();  // bytes or -errno
+let user_data = cqe.user_data();
+```
+
+### Common Opcodes
+
+```rust
+opcode::Read::new(fd, buf, len).offset(off)
+opcode::Write::new(fd, buf, len).offset(off)
+opcode::Readv::new(fd, iovecs, nr_vecs)
+opcode::Writev::new(fd, iovecs, nr_vecs)
+opcode::Accept::new(fd, addr, addrlen)
+opcode::Connect::new(fd, addr, addrlen)
+opcode::Send::new(fd, buf, len)
+opcode::Recv::new(fd, buf, len)
+opcode::Close::new(fd)
+opcode::OpenAt::new(fd, path)
+opcode::Timeout::new(ts)
+opcode::PollAdd::new(fd, mask)
+```
+
+### Squeue/Cqueue Access
+
+```rust
+let mut sq = ring.submission();
+let mut cq = ring.completion();
+
+// Check available slots
+sq.is_full();
+sq.capacity();
+cq.is_empty();
+cq.len();
+
+// Sync with kernel
+sq.sync();
+cq.sync();
+```
+
+### Entry Builder Pattern
+
+```rust
+let entry = opcode::Read::new(fd, buf, len)
+    .offset(offset)
+    .build()
+    .user_data(42)
+    .flags(io_uring::squeue::Flags::ASYNC);
+```
+
+## Best Practices
+
+1. **Batch operations** - submit multiple SQEs before calling submit()
+2. **Use registered buffers/files** for hot paths (avoids per-op overhead)
+3. **SQPOLL mode** for ultra-low latency (kernel thread polls SQ)
+4. **Check kernel version** - features vary by kernel (5.1 base, 5.6+ for most ops)
+5. **Handle EAGAIN** - SQ can fill up, CQ can overflow
+6. **user_data for context** - associate requests with application state
+
+## Kernel Version Features
+
+- 5.1: Basic ops (read/write/fsync)
+- 5.4: timeout, poll
+- 5.5: accept, connect, send, recv
+- 5.6: splice, provide_buffers, many improvements
+- 5.7: link timeout, statx
+- 5.11: shutdown, renameat, mkdirat
+- 5.19: zero-copy send
+- 6.0: zero-copy recv, multishot accept

--- a/skills/merge-pr/SKILL.md
+++ b/skills/merge-pr/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: merge-pr
+description: Autonomously drive a pull request to merged by spawning a background subagent (the fork) that watches CI fail-fast, fixes each failure on the PR branch, re-pushes, and merges when green, all without blocking the main session. Use when the user wants to watch and merge a PR, babysit it, fix CI and merge, get a PR in, or otherwise hand off a PR's CI-to-merge loop so they can keep working. The skill never blocks the main thread; it launches the watcher and returns immediately.
+---
+
+# merge-pr
+
+Hand a PR's whole "watch CI → fix failures → merge" loop to a **background subagent** so the main session stays live. The skill's job is to identify the PR, launch the fork, and return control immediately. The fork does the grind and reports back via a completion notification.
+
+## What the skill does (main thread)
+
+1. **Resolve the target PR.**
+   - If the user named a PR number / URL, use it.
+   - Otherwise resolve the PR for the current branch: `gh pr view --json number,headRefName,headRepository,baseRefName,url,state`.
+   - If there is no PR for the branch and the branch has unpushed commits, that is a fork in the road: ask whether to open one first (or open it if the user already said "push and merge"). Do not invent a PR.
+
+2. **Spawn the fork** with the `Agent` tool, `run_in_background: true`, `model: opus`. Pass it the PR number, repo, and the charter below verbatim (filled in). Then **tell the user one line**: which PR is being watched and that the loop is running in the background. Do not foreground-wait.
+
+3. **On the completion notification**, relay the outcome: merged (with commit), or stopped-stuck (with the failure it could not fix and why), or blocked (needs a human decision).
+
+Keep all CI watching inside the fork, and even there make it event-driven (see below). A foreground `gh pr checks --watch` / `gh run watch` in the main thread holds a Bash slot up to the 600s timeout and freezes the session, so route it through `run_in_background` + `Monitor` instead.
+
+## The fork's charter (paste into the subagent prompt)
+
+> You own PR #<N> in <owner/repo> from now until it is merged or you are genuinely stuck. Loop:
+>
+> 1. **Watch CI fail-fast.** Run `gh pr checks <N> --watch --fail-fast --interval 20` so you wake the instant ANY check fails (not after all finish). Do NOT block a foreground Bash slot on it: launch it with `run_in_background: true` and wait on it with the `Monitor` tool / an `until` condition, so the watch returns the moment a check fails or all pass. `--fail-fast` needs gh ≥ 2.42; if it is rejected, drop the flag and parse `gh pr checks <N> --json name,state,bucket` on each wake instead.
+> 2. **If all checks pass → merge.** Use the repo's merge norm: for `indexable-inc/index` and `indexable-inc/ix`, admin force-merge immediately (`gh pr merge <N> --admin --squash`; merge queue is on, so do NOT pass `--delete-branch`). For other repos, enable auto-merge (`gh pr merge <N> --auto --squash`) unless the user said force-merge. Then report "merged" with the squash commit sha and stop.
+> 3. **If a check failed → diagnose and fix.**
+>    - Pull the failing logs: `gh pr checks <N>` to find the failed check, then `gh run view <run-id> --log-failed` (or `--log` for the failing job) to read the actual error. Read the real error, do not guess.
+>    - Work on the PR branch in an **isolated worktree** off the PR head, never the shared main checkout (in index/ix a PreToolUse hook blocks edits on main anyway). `git fetch origin` then `git worktree add ../<repo>-pr<N> <headRef>` and fix there. Validate the fix at the layer it touches via the repo's own commands (e.g. `nix build .#…`, `nix run .#lint`, the scoped `nix build .#checks.<system>.<name>`) before pushing, so you are not burning CI to test a guess.
+>    - Commit (match the repo's commit style) and `git push`. Remove the worktree when done.
+> 4. **Re-watch from step 1.**
+>
+> **Stuck detection (do not loop forever).** Keep a short signature of each failure (check name + the load-bearing error line). If the SAME failure recurs after your fix, or you see 3 consecutive failed CI rounds without net progress, STOP and report: the failing check, the error, what you tried, and why you could not fix it. A flaky/transient infra failure (timeout, runner died, cache outage) is not your bug: re-run it once (`gh run rerun <run-id> --failed`) and only escalate if it fails again the same way.
+>
+> **Escalate, do not guess, when:** the fix needs a product decision, the failure is in code you did not touch and the right fix is ambiguous, a required check needs human approval, or merging is blocked by a review the user must give. Report the specific blocker.
+>
+> **Watch the clock.** If a single CI round runs far longer than that repo's checks normally take, investigate the long-pole step rather than waiting it out (in index/ix, treat any check over ~1 min as a problem to look at, not wait on).
+>
+> Report concisely when done: final state (merged + sha / stopped-stuck / blocked), and for anything you fixed, one line per fix.
+
+## Notes
+
+- The fork is a real background `Agent`, so the user keeps working while it runs; its final message arrives as a task-completion notification. Relay what matters, do not make the user read the transcript.
+- If the user wants to watch several PRs, spawn one fork per PR in a single message so they run concurrently.
+- This composes with, rather than replaces, repo-local skills: inside `indexable-inc/index` the `ci-merge` skill already encodes that repo's watch-fix-merge specifics, so the fork should prefer it there.
+- Keep any commit/PR text the fork writes short and human, and add the one-line AI attribution on anything outward-facing, per global style.

--- a/skills/prompt-eval/SKILL.md
+++ b/skills/prompt-eval/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: prompt-eval
+description: Evaluate whether a prompt or instruction change actually works by spawning a fresh, clean-context Claude agent and checking if it produces the intended behavior. Use when the user edits a CLAUDE.md, a skill, an agent or subagent definition, a system prompt, a tool description, or a memory and wants to verify the change took effect, test that Claude now follows the new rule, A/B a prompt tweak, or confirm the output comes out in the form they wanted. Spawns separate sessions with neutral tasks and reports a pass rate.
+---
+
+# Prompt-change evaluation
+
+A prompt change is only "done" when a fresh agent, one that loaded the prompt the same way a real session will, actually behaves the way you intended. This skill is how to prove that. The core move is exactly what it sounds like: spawn a separate Claude in a clean context, hand it a normal task, and watch whether the new behavior emerges on its own.
+
+## The cardinal rules
+
+These are what make the eval valid instead of self-deluding:
+
+1. **Never evaluate in the current session.** Your own context already contains the change (you just made it, or it is loaded), so any in-session check trivially "passes" and proves nothing. The test must run in a *separate process* that re-reads the prompt from disk: `claude -p ...`, which is a real production session (full Claude Code system prompt, the same memory hierarchy, the session model). An Agent-tool subagent is **not** equivalent: per the Claude Code docs it does load `~/.claude/CLAUDE.md` (only the built-in Explore and Plan agents skip it), but it runs its own minimal system prompt rather than the full Claude Code one, and CLAUDE.md reaches it as a soft user message, so it under-applies stylistic/house-style rules and gives false negatives. Dogfooded 2026-06-04: a `general-purpose` subagent on both opus and sonnet ignored a global ✅/❌/🤔 convention that real `claude -p` sessions applied 5/5. So use the Agent tool only to test an agent/subagent *definition* (its own prompt is the thing under test); use `claude -p` for CLAUDE.md, skill, memory, or system-prompt changes.
+
+2. **Apply the change first if it needs a switch.** Global `CLAUDE.md` and global skills are store symlinks: they do not change until `home-manager switch`. If you skip it, the fresh agent reads the OLD prompt and your eval is meaningless. Project `CLAUDE.md` and out-of-store-symlinked files are live, no switch needed. Confirm the on-disk file the fresh agent will read actually contains the change before testing.
+
+3. **Do not lead the witness.** Give the test agent a *neutral, representative task* that a real user would say, one that should organically trigger the new behavior. Do NOT mention the rule, quote it, or ask "do you follow X". That tests recall, not behavior. (Exception: to check that an instruction merely *loaded*, a direct "what does your instruction say about X" is fine, but that is a weaker check than observing the behavior emerge.)
+
+4. **Sample more than once.** Model output is stochastic. One run is noise. Run N (3-5, more for subtle changes) and report the rate, e.g. `4/5`. A change that fires 2/5 of the time is 🤔, not ✅.
+
+5. **A/B to attribute the effect.** "It did X" is weak if it did X before too. Compare against the baseline: run the task against the pre-change prompt (run before applying, keep the old output), or toggle the change (`--append-system-prompt` with vs without, a clean profile vs the real one). The claim you want is "the change caused the difference," not "the output looks fine."
+
+## Procedure
+
+1. **Name the observable.** State the concrete success criterion before running anything: what must the output contain, what form must it take, what must it avoid. If the change produces no observable difference in output, it is not testable, say so.
+2. **Pick the trigger task.** A real-sounding prompt that should make the behavior surface naturally. Write it down.
+3. **Run the fresh agent N times** (see templates). Capture each raw output as evidence.
+4. **Judge each sample** against the criterion (optionally with a separate judge agent for objectivity, see below).
+5. **Report** the pass rate with ✅ / ❌ / 🤔 and paste a representative sample so the verdict is backed by an observation, not a vibe.
+
+## Command templates
+
+Default to **Opus 4.8** on every eval run (`--model opus` for `claude -p`, `model: opus` for the Agent tool) unless you are deliberately testing a different tier. Your real sessions run on Opus 4.8, so the eval must too, or you are measuring a different model.
+
+Fresh clean-context run (prompt-file changes, CLAUDE.md / skills / memory):
+```
+claude -p "<neutral representative task>" --model opus --allowedTools ""
+```
+- Run from the directory whose project `CLAUDE.md` you changed; global `CLAUDE.md` loads regardless of cwd.
+- `--model opus --allowedTools ""` forbids tools so the eval isolates prompt-driven reasoning/output. Drop it (or pass a tight allowlist) only when tool use is the behavior under test.
+- Loop it for a rate:
+```
+for i in $(seq 1 5); do echo "--- run $i ---"; claude -p "<task>" --model opus --allowedTools ""; done
+```
+
+A/B a system-prompt-style change:
+```
+claude -p "<task>" --model opus --allowedTools ""                                  # baseline
+claude -p "<task>" --append-system-prompt "<the new instruction>" --model opus --allowedTools ""   # with change
+```
+
+Separate judge (objective grading, batchable):
+```
+claude -p "Criterion: <criterion>. Candidate output below. Answer PASS or FAIL on line 1, one-line reason on line 2.\n\n<candidate>" --model opus --allowedTools ""
+```
+
+Agent/subagent-definition changes: spawn via the Agent tool with that `subagent_type`, give it the neutral task, inspect the returned output. (This is the one case where the Agent tool is right, because the definition is what you are testing.)
+
+## Reporting
+
+Use the status-emoji convention:
+- ✅ the change reliably produces the intended behavior (high pass rate, attributable to the change)
+- ❌ it does not (fails, or the behavior was already there so the change did nothing)
+- 🤔 flaky or partial (fires sometimes, or right behavior in the wrong form), with the rate stated
+
+Always include the pass rate and at least one real sampled output. If you could not A/B, say the effect is unattributed.
+
+## Gotchas
+
+- The fresh agent inherits the same global config (model, hooks, other CLAUDE.md sections). That is realistic, but a *different* instruction can mask or fight yours. If a change does not fire, check for a conflicting rule before concluding it failed.
+- `claude -p` is a full session and costs tokens/time; keep tasks small and N modest. Background long batches rather than blocking.
+- **Match the model, default to Opus 4.8.** Run the eval on the same model your real sessions use, which is Opus 4.8 by default (`--model opus` for `claude -p`, `model: opus` for the Agent tool). Keep baseline and candidate on the same model. A weaker model (or a model mismatch) drops soft conventions and confounds the result, you will blame the prompt for a model effect.
+- A change that only affects what a session *sees at startup* (loaded instructions) is validated by a single fresh session reading it back; a change meant to alter *behavior under load* needs the neutral-task + sampling approach.

--- a/skills/review-changes/SKILL.md
+++ b/skills/review-changes/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: review-changes
+description: "Run a multi-agent adversarial review over the current working-tree changes. Fans out one finder per dimension (correctness, security, performance, maintainability) over the git diff, adversarially verifies each finding to cut false positives, and returns ranked blockers vs warnings. Invoke after completing a substantive change, or when the Stop review gate asks for it. This reviews a finished local diff, not a remote PR (use /review for a PR)."
+---
+
+# review-changes
+
+Launch a multi-agent review of the **working-tree diff** through the Workflow
+tool, then act on the confirmed blockers. This is the worker behind the
+always-on Stop review gate (`review-gate.py`); it is also fine to invoke
+directly.
+
+## When to run
+
+- The Stop gate blocked with "run the review-changes skill", or
+- you just finished a substantive change and want the adversarial pass before
+  declaring it done.
+
+Skip for genuinely trivial changes (a typo, a one-line doc/comment, a config
+value with no logic). Say so in one line and stop.
+
+## How to run
+
+1. Find the change context: `cwd` = repo root via `git rev-parse --show-toplevel`
+   (fall back to the current directory if not in a git tree). The review targets
+   `git diff` plus `git diff --staged`; if both are empty because the change was
+   already committed, the finders fall back to `git show HEAD`.
+
+2. Call the **Workflow** tool with the committed review script (do not inline a
+   script of your own):
+
+   ```
+   Workflow({
+     scriptPath: "/Users/andrewgazelka/.config/nix/claude/global/skills/review-changes/review.workflow.js",
+     args: { cwd: "<repo root>" }
+   })
+   ```
+
+   The workflow runs in the background and notifies on completion. It fans out
+   one `code-reviewer` finder per dimension over the diff, pipelines each finding
+   through an independent skeptic that tries to refute it, and returns the
+   surviving findings ranked, with Correctness and Security marked as blockers.
+
+3. When it completes, report the verdict to the user, blockers first. Fix the
+   confirmed Correctness/Security findings in the same turn, or state plainly why
+   a finding is declined. Performance and Maintainability are the author's call.
+   If the workflow returns zero confirmed findings, say so in one line and move
+   on.
+
+## Notes
+
+- The review is read-only; it never edits. You apply the fixes.
+- The workflow reuses the global `code-reviewer` agent as its finder, so findings
+  follow the same severity and evidence discipline as a manual reviewer pass.

--- a/skills/review-changes/review.workflow.js
+++ b/skills/review-changes/review.workflow.js
@@ -1,0 +1,147 @@
+export const meta = {
+  name: 'review-changes',
+  description:
+    'Multi-agent adversarial review of the working-tree diff: one code-reviewer finder per dimension, then an independent skeptic that tries to refute each finding.',
+  phases: [
+    { title: 'Review', detail: 'one code-reviewer per dimension over the git diff' },
+    { title: 'Verify', detail: 'an independent skeptic tries to refute each finding' },
+  ],
+}
+
+// The skill passes the repo root; default to the session cwd if it does not.
+// Workaround: the Workflow tool delivers `args` as a JSON-encoded STRING even
+// when the caller passes a real object, so `args.cwd` reads undefined and the
+// review silently targets the wrong directory. Parse it back until
+// https://github.com/anthropics/claude-code/issues/67627 is fixed.
+const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args
+const cwd = parsedArgs && parsedArgs.cwd ? parsedArgs.cwd : '.'
+
+// Surfaced once so the finder and the verifier read the exact same change.
+// HEAD is shown ONLY when the working tree is clean (the change was already
+// committed); otherwise reviewing HEAD would pull the previous, unrelated commit
+// into every review. cwd is single-quoted to tolerate spaces/$/backticks.
+const diffCmd =
+  `cd '${cwd}' && ` +
+  `if git --no-pager diff --quiet && git --no-pager diff --staged --quiet; then ` +
+  `echo '(working tree clean; reviewing the last commit)' && git --no-pager show HEAD; ` +
+  `else git --no-pager diff && git --no-pager diff --staged; fi`
+
+const FINDING_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          category: {
+            type: 'string',
+            enum: ['correctness', 'security', 'performance', 'maintainability'],
+          },
+          severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low'] },
+          file: { type: 'string' },
+          line: { type: 'string' },
+          title: { type: 'string' },
+          triggering_condition: { type: 'string' },
+          fix: { type: 'string' },
+        },
+        required: ['category', 'severity', 'file', 'line', 'title', 'triggering_condition', 'fix'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    is_real: { type: 'boolean' },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    reason: { type: 'string' },
+  },
+  required: ['is_real', 'confidence', 'reason'],
+}
+
+const DIMENSIONS = [
+  {
+    key: 'correctness',
+    focus:
+      'Correctness only: boundary values, off-by-one, concurrency and races, error/cancellation/early-return paths, integer or float issues, broken contracts or invariants, and logic that tests would pass but is still wrong.',
+  },
+  {
+    key: 'security',
+    focus:
+      'Security only (OWASP/CWE): injection, broken access control / IDOR, authn/authz gaps, secret or PII exposure, weak crypto or predictable randomness, unsafe deserialization, SSRF, path traversal. Give a CWE id and a one-line exploit per finding.',
+  },
+  {
+    key: 'performance',
+    focus:
+      'Performance only: accidental O(n^2)+ work, N+1 queries or calls in a loop, allocation or I/O in a hot path, missing batching or caching, unbounded growth, and leaks. State the data volume at which it bites.',
+  },
+  {
+    key: 'maintainability',
+    focus:
+      'Maintainability only: intent-hiding names, dead or unreachable code, real duplication of an existing helper, weakened types, comments that narrate the code, and violations of the repo conventions (cite the rule).',
+  },
+]
+
+const findPrompt = (d) =>
+  `Review the current change in ${cwd}. Get the diff with:\n  ${diffCmd}\n` +
+  `Then read the full files around each hunk for context, and the repo's CLAUDE.md / AGENTS.md so findings match its real conventions.\n\n` +
+  `Restrict your review to ONE dimension: ${d.focus}\n\n` +
+  `Report only real, evidence-backed defects, each with an exact file:line, the concrete triggering input or condition, and a one-line fix. ` +
+  `Do not pad; do not bikeshed. If there are no defects in this dimension, return an empty findings array.`
+
+const verifyPrompt = (f) =>
+  `An independent reviewer flagged this finding on the change in ${cwd}:\n\n` +
+  `  [${f.category}/${f.severity}] ${f.file}:${f.line} - ${f.title}\n` +
+  `  Triggering condition: ${f.triggering_condition}\n` +
+  `  Proposed fix: ${f.fix}\n\n` +
+  `Your job is to REFUTE it. Get the diff with:\n  ${diffCmd}\n` +
+  `Read the actual code around ${f.file}:${f.line} and decide whether this defect can really occur on a reachable path. ` +
+  `Default to is_real=false unless you can concretely confirm the triggering path; be skeptical of false positives.`
+
+phase('Review')
+const reviews = await pipeline(
+  DIMENSIONS,
+  (d) =>
+    agent(findPrompt(d), {
+      label: `find:${d.key}`,
+      phase: 'Review',
+      agentType: 'code-reviewer',
+      schema: FINDING_SCHEMA,
+    }).then((r) => (r && Array.isArray(r.findings) ? r.findings : [])),
+  (findings) =>
+    parallel(
+      findings.map((f) => () =>
+        agent(verifyPrompt(f), {
+          label: `verify:${f.category}:${f.file}`,
+          phase: 'Verify',
+          schema: VERDICT_SCHEMA,
+        }).then((v) => ({ ...f, verdict: v }))
+      )
+    )
+)
+
+const confirmed = reviews
+  .flat()
+  .filter(Boolean)
+  .filter((f) => f.verdict && f.verdict.is_real)
+
+const rank = { critical: 0, high: 1, medium: 2, low: 3 }
+confirmed.sort((a, b) => rank[a.severity] - rank[b.severity])
+
+const isBlocker = (f) => f.category === 'correctness' || f.category === 'security'
+const blockers = confirmed.filter(isBlocker)
+const warnings = confirmed.filter((f) => !isBlocker(f))
+
+return {
+  cwd,
+  total_confirmed: confirmed.length,
+  verdict: blockers.length > 0 ? 'BLOCK' : warnings.length > 0 ? 'approve-with-fixes' : 'approve',
+  blockers,
+  warnings,
+}

--- a/skills/ssh-hosts/SKILL.md
+++ b/skills/ssh-hosts/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: ssh-hosts
+description: List the user's SSH host aliases (from ~/.ssh/config and its Includes) and recently used ssh targets. Use when connecting to a host, running a remote command over ssh, scp/rsync to a machine, or deciding which alias to use.
+---
+
+# SSH hosts
+
+Run `ssh-hosts` to get the live list. It reads the machine fresh each time, so
+the output is current rather than a snapshot baked into this skill:
+
+```bash
+ssh-hosts
+```
+
+It prints two sections:
+
+- **SSH host aliases** parsed from `~/.ssh/config` and any `Include` files, with
+  HostName / User / Port. Connect with the alias directly, e.g. `ssh hc1`.
+- **Recent ssh commands** from shell history, newest first, showing what the
+  user actually connects to.
+
+Prefer an existing alias over a raw `user@host`: the alias already carries the
+right HostName, User, and Port, so `ssh hc1` beats `ssh andrew@<ip> -p 9999`.

--- a/skills/stt/SKILL.md
+++ b/skills/stt/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: stt
+description: Transcribe speech to text locally with whisper.cpp (no API key, runs on hydra's Apple Silicon GPU). Use whenever the user wants to transcribe audio or video, get a transcript, run STT/speech-to-text, caption a file, or pull the words out of a recording (mp4, mov, wav, m4a, mp3, aiff, podcast, voice memo, Twitter/YouTube video). Encodes the validated best-accuracy recipe and the param tradeoffs.
+---
+
+# Local Speech-to-Text (whisper.cpp)
+
+Transcribe locally on hydra with no API key. The index repo has **no STT package**
+(only `elevenlabs-say` TTS); whisper.cpp from nixpkgs is the tool. See [[whisper-stt-local]].
+
+## The recipe (use this by default)
+
+```bash
+# 1. Extract 16 kHz mono WAV (whisper.cpp requires this).
+nix shell nixpkgs#ffmpeg -c ffmpeg -y -i INPUT -ar 16000 -ac 1 -c:a pcm_s16le /tmp/aud.wav
+
+# 2. Get the model once (cached in /tmp; ~3 GB).
+nix shell nixpkgs#whisper-cpp -c whisper-cpp-download-ggml-model large-v3 /tmp
+
+# 3. Transcribe. --carry-initial-prompt is the load-bearing flag.
+nix shell nixpkgs#whisper-cpp -c whisper-cli \
+  -m /tmp/ggml-large-v3.bin -f /tmp/aud.wav -nt -otxt -of OUTPUT \
+  --prompt "Claude, Claude Code, Anthropic, MCP, <domain names here>" \
+  --carry-initial-prompt
+```
+
+`-nt` = no timestamps (drop it for timestamped segments; add `-osrt`/`-ovtt` for subtitle files).
+Runs ~100 s for a 30 min file on an M-series GPU via Metal.
+
+## Why these choices (measured, not guessed)
+
+Benchmarked on a 30 min podcast. Metric = domain-term hit-rate: every "cloud/quad/clod"
+in the audio is really "Claude", so `claude / (claude + mishears)` is a real accuracy proxy.
+
+| config | model | hit-rate | mishears | secs |
+|---|---|---|---|---|
+| default (no prompt) | large-v3 | 0.16 | 38 | 97 |
+| `--prompt` only (no carry) | large-v3 | 0.29 | 32 | 111 |
+| **`--prompt` + `--carry-initial-prompt`** | **large-v3** | **0.89** | **5** | 101 |
+| + `--vad` | large-v3 | 0.66 | 15 | 110 |
+| + `--beam-size 8` | large-v3 | 0.61 | 18 | 115 |
+| `--prompt` + carry | large-v2 | 0.80 | 9 | 99 |
+| `--prompt` + carry | turbo | 0.36 | 27 | 38 |
+
+**Takeaways:**
+
+1. **`--carry-initial-prompt` is the dominant lever** (0.16 → 0.89, ~7.6x fewer errors).
+   A plain `--prompt` only conditions the first ~30 s window; `--carry-initial-prompt`
+   re-injects it into *every* window, so domain vocab sticks through a long file. Always
+   pass both together. Put the real proper nouns / jargon / names in the prompt.
+2. **large-v3 is the most accurate** model. large-v2 is close (0.80) and hallucinates
+   slightly less on silence; turbo is much worse on rare words (its decoder is distilled
+   to 4 layers) but ~2.6x faster (38 s) — use turbo only when speed beats accuracy and
+   the vocab is common.
+3. **Skip `--vad` on clean continuous speech** — it *hurt* here (0.89 → 0.66) because
+   segment splitting breaks the carried-prompt context. VAD is for noisy audio or long
+   silences/music where whisper otherwise hallucinates loops. Reach for it only then:
+   add `--vad --vad-model /tmp/ggml-silero-v5.1.2.bin` (download from
+   `https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v5.1.2.bin`).
+4. **Beam size 5 (default) is enough** — bumping to 8 didn't help. Defaults best-of 5,
+   beam 5, temperature fallback are already good; don't fiddle.
+5. **Disable previous-context conditioning** with `--max-context 0` only if you see
+   repetition/hallucination loops propagating (it stops error carry-over; costs some
+   coherence). Not needed on clean audio.
+
+## Cleanup pass
+
+Even at 0.89, a few mishears remain. Sweep them with a word-boundary regex (see
+[[whisper-stt-local]] for the pattern); `\bcloud\b`/`\bquad\b` → `Claude`, etc. Grep
+for likely homophones of your domain terms and confirm by context before replacing.
+
+## Hosted alternative
+
+ElevenLabs **Scribe** is the hosted STT counterpart to `elevenlabs-say`, but there is
+no `ELEVENLABS_API_KEY` in the secret stores yet, so local whisper.cpp is the path.

--- a/skills/synthesize/SKILL.md
+++ b/skills/synthesize/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: synthesize
+description: Iterative research-and-design loop that converges on the best answer to an open architecture or technical-decision question. Use when the user wants to think through a hard design choice, explore approaches, weigh tradeoffs, "find the best way to do X", produce an RFC/ADR/proposal, or asks to research a topic and iterate to a recommendation. Grounds in Exa web search plus the codebase, drafts a proposal, has a separate read-only critic (its own isolated context, independent research) tear it apart against a frozen rubric, refines, and loops a bounded number of times until it converges, then emits an ADR-shaped recommendation. Fires on phrasings like "what's the best architecture for", "research X and propose", "think through", "iterate until you find the best", or "synthesize".
+---
+
+# Synthesize: research → propose → critique → refine → converge
+
+For an open question with real tradeoffs, one pass underuses the model: it commits to the first plausible answer and never plays devil's advocate against itself. This skill is the structured loop that fixes that. Ground the question in evidence, draft a proposal, have a **separate** critic break it against a **frozen** rubric, refine only what the critic flagged, and stop the moment the loop runs out of signal. The output is a decision memo (ADR-shaped), not a chat recap.
+
+This is grounded in the published shape of self-refine / reflexion / generator-critic loops (Madaan 2023, Shinn 2023, Anthropic's effective-agents writing, the agent-patterns catalog). Two findings drive every rule below: **the gain curve is concave and short** (iteration 0→1 is the big lift, 2 is smaller, 3 is the cap, 4+ regresses through over-editing), and **same-model self-critique rubber-stamps** (a model that just wrote and defended text treats it as committed work and approves it). So we bound iterations hard and separate the critic from the author.
+
+## When to use it (and when not)
+
+Use it when the decision is **reversible-but-expensive, multi-dimensional, and groundable**: there's real code or literature to anchor on, and being wrong costs days. Examples: "should this be one binary or three crates", "what's the right cache invalidation strategy here", "pick a wire format for the SDK boundary".
+
+Skip it when the answer is obvious (best practice clearly applies, no debate needed), when it's a pure fact lookup (just search), or when evaluation needs knowledge the model lacks (novel domain facts, your private business logic). On ungroundable questions the loop polishes a confident wrong answer into a more confident wrong answer. If you can't ground the critique in something checkable (code, a benchmark, a cited source), say so and don't pretend the loop adds rigor.
+
+## The procedure
+
+### 0. Frame and freeze the rubric (before any looping)
+
+State the question in one sentence and write down the **success criteria as a fixed checklist** of 3 to 7 items. This rubric is frozen for the whole run. The critic scores against *these* and may not invent new criteria each round (free-form criteria is what makes critique drift and rubber-stamp). Criteria must be near-binary and checkable, e.g. "handles the 10x-scale case without a rewrite", "no new operational surface the team can't run", "every claim cites code or a source". Avoid "rate elegance 1-10": scores aren't actionable.
+
+### 1. Ground (this is what makes the loop honest)
+
+Gather evidence *before* proposing. In parallel:
+- **External**: `mcp__exa__web_search_exa` for prior art, best practices, and known failure modes. Describe the ideal page, not keywords. Follow up with `web_fetch_exa` on the best 1-3 URLs when highlights are thin. Scope to ~5 results, this is triage not a dump.
+- **Internal**: search the codebase (`mgrep search -a --agentic` for semantics, `rg` for exact strings) for how the relevant thing is done today, existing constraints, and prior decisions. Recall any relevant memory.
+
+Every claim in the proposal must later trace to one of these. Mark internal evidence `[code: path:line]` and external `[src: short-name]`.
+
+### 2. Propose (draft v0)
+
+Write the first proposal: the recommended approach, **2-3 genuine alternatives** (not strawmen), and for each the tradeoffs. Be concrete and cite grounding. This draft sets the ceiling, so spend real effort here, but do not polish, the critic is next.
+
+### 3. Critique with a SEPARATE, read-only critic (the load-bearing step)
+
+Never critique your own draft inline, and never let the critic edit anything. Spawn a fresh critic via the Agent tool in its **own isolated context**, so it does not inherit your reasoning or your search trace. Its blind spots are then decorrelated from yours and it can't rationalize a defect it would have committed.
+
+Use the dedicated **`synthesis-critic`** agent (`subagent_type: synthesis-critic`). It is purpose-built for this step: structurally read-only (no Edit/Write tools, so it *can't* write rather than being asked not to), it grounds independently (its own Exa search and code reads), scores against the frozen rubric only, and ends with a `PASS`/`REVISE` token. Hand it **only the proposal text and the frozen rubric**, nothing about how you got there. (If `synthesis-critic` is unavailable, fall back to `code-reviewer` for code-heavy decisions or `Explore` otherwise, both read-only; avoid `general-purpose` since it *can* write.)
+
+The critic returns severity-ranked findings (quoted span, problem with its own evidence, concrete fix, scored 1 to 5) and the verdict token. The critic researches and finds; **you, the author, apply the fixes** in step 4. That split is the whole point: it stops the roles from collapsing back into one voice that rubber-stamps itself.
+
+For high-stakes or genuinely two-sided calls, run it as a **debate**: one read-only critic argues the proposal is wrong (find the fragility), then a builder pass defends or adapts, both seeing the full exchange. Tension beats premature consensus.
+
+### 4. Refine (surgically)
+
+Address only findings at **severity >= 3**. Touch only the flagged spans. Do **not** "rewrite the whole thing in light of the review", that is exactly where over-correction comes from: the revision step wrecks parts that were already fine. Minor/trivial notes are logged, not acted on. If a fix needs more grounding, loop back to step 1 for that one point.
+
+### 5. Halt (stop early, on purpose)
+
+After each refine, stop if **any** of:
+- the critic returned `PASS` (no finding >= severity 3), or
+- **no progress**: the new draft is materially the same as the prior one, or
+- **oscillation**: the draft is reverting toward an earlier version, or
+- you hit **iteration 3** (hard cap).
+
+Default expectation: **converge in 1 to 2 critique rounds.** The 0→1 pass is the real lift; round 2 catches the rest; round 3 is the ceiling and usually a no-op. Do not run a third round "to be safe", that's hope, not signal. If you ever feel pulled to a 4th round, the loop has nothing left to find: stop and report what's genuinely unresolved instead.
+
+### 6. Emit the decision memo (ADR-shaped)
+
+Output, concisely:
+- **Decision**: the recommended approach, one or two sentences.
+- **Context**: the question and the binding constraints (cited).
+- **Alternatives considered**: each rejected option and the *specific* reason it lost.
+- **Tradeoffs / consequences**: what this buys and what it costs, including the risk that ages worst.
+- **Open questions**: what stayed unresolved and what evidence would settle it. Don't manufacture false confidence.
+
+Keep it tight. Lead with the decision. This memo is the deliverable; offer to drop it into an RFC/ADR file or a Linear issue if the user wants it persisted.
+
+## Failure modes to watch (from the literature)
+
+- **Rubber-stamp critic**: if critiques sound vaguely positive and each revision is cosmetic, the critic isn't separated enough or the rubric is too loose. Tighten to "list at most 5 problems, severity 4-5 first, quote the exact span."
+- **Over-correction**: if the refined draft is worse (a judge would prefer the prior), the revise step drifted into rewrite-everything. Re-scope it to the flagged spans only.
+- **Runaway loop**: never "iterate until the critic is happy", a stubborn critic rephrases the same complaint forever. The iteration cap and no-progress check are the safety belt, not a smarter critic.
+- **Polishing a wrong answer**: on ungroundable points the loop adds confidence, not correctness. If the critique can't cite anything checkable, flag the point as unresolved rather than refining it.


### PR DESCRIPTION
## What

Make the index repo the single source for Claude Code skills + agents, and let it own the plugin.

- **Move in** the 9 personal skills (distill-claude-md, first-principles, io-uring, merge-pr, prompt-eval, review-changes, ssh-hosts, stt, synthesize) and 4 personal agents (code-reviewer, data, fixup, synthesis-critic). They're now under `skills/` and `agents/`.
- **`lib/agents.nix`**: `mkAgentsDir` gains `rawFiles` — a complete hand-authored agent `.md` (frontmatter + body) drops into `agents/` and is auto-discovered (by leading `---`) in `per-system.nix`. `index-action-runner` stays on the rendered path because its `mcpServers` is computed from `ix.mcp`.
- **`lib/claude-plugin.nix`** (new): `lib.claudePlugin.mkPlugin { pkgs, name, names?, extraSkills?, hooks? }` builds a Claude Code plugin dir (`.claude-plugin/plugin.json` + `skills/` + optional `hooks/hooks.json`) for the wrapper's `--plugin-dir`. Plugin skills invoke as `/<name>:<skill>`. Agents are intentionally NOT bundled (a plugin namespaces `subagent_type`, which would break bare agent refs like `code-reviewer`).
- **`packages.<sys>.claude-plugin`**: the `index` plugin (all index skills).

## Why

So a consumer (my nix config) can bake one `--plugin-dir=${index-plugin}` and get every skill globally as `/index:<skill>`, with agents delivered bare via `.claude/agents`. Follows the existing `mkSkillsDir`/`mkAgentsDir` pattern.

## Validation

- `nix build .#claude-plugin .#agents .#skills` ✅ — plugin has `.claude-plugin/plugin.json` (name=index) + 45 skills; agents = index-action-runner (rendered, mcpServers intact) + 4 raw.
- `nix run .#skill-lint -- skills` ✅ 0 errors (4 pre-existing antithesis token-budget warnings).
- `nix run .#lint`: my files clean (the nixfmt/ruff failures are pre-existing on `packages/mcp/*` + `modules/services/humanlayer`, unrelated).

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify all skills and agents into a Claude Code plugin package via `claudePlugin.mkPlugin`
> - Introduces `lib/claude-plugin.nix` with a `mkPlugin` builder that produces a Claude Code `--plugin-dir`-compatible directory, bundling selected skills and optional hooks into a plugin manifest.
> - Exposes the builder via `lib/default.nix` as `claudePlugin` and wires up a default `index` plugin in `per-system.nix`, available as the `claude-plugin` package output.
> - Extends `agents.mkAgentsDir` in `lib/agents.nix` to accept `rawFiles`, allowing hand-authored frontmattered `.md` agent files to be included verbatim alongside rendered agents; asserts on name collisions.
> - Adds four new agent definitions (`code-reviewer`, `data`, `fixup`, `synthesis-critic`) and ten new skills (`distill-claude-md`, `first-principles`, `io-uring`, `merge-pr`, `prompt-eval`, `review-changes`, `ssh-hosts`, `stt`, `synthesize`) with a multi-agent adversarial review workflow script in `skills/review-changes/review.workflow.js`.
> - Risk: `mkAgentsDir` now asserts (hard failure) on duplicate agent names instead of silently overwriting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5274c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->