### PR TITLE
claude/agents: assert raw agent name matches filename; fail loudly on frontmatter-less drop-in

### DIFF
--- a/lib/agents.nix
+++ b/lib/agents.nix
@@ -44,6 +44,21 @@ let
 
       ${agent.body}'';
 
+  # The `name:` from a hand-authored agent file's YAML frontmatter (the first
+  # `name:` line inside the leading `---` block), or null if absent. Used to
+  # check a raw file's declared name against its filename, the same invariant
+  # `renderAgent` enforces for rendered agents. The file is known to open with
+  # `---` (per-system.nix's discovery filters on that before this runs).
+  rawFrontmatterName =
+    path:
+    let
+      lines = lib.splitString "\n" (builtins.readFile path);
+      # Frontmatter is the leading block, so the first `name:` line is the
+      # declared agent name (a body line starting `name:` can't precede it).
+      nameLine = lib.findFirst (l: lib.hasPrefix "name:" l) null lines;
+    in
+    if nameLine == null then null else lib.removePrefix "name: " nameLine;
+
   mkAgentsDir =
     {
       pkgs,
@@ -55,10 +70,20 @@ let
         name = "${name}.md";
         path = pkgs.writeText "${name}.md" (renderAgent name agent);
       }) agents;
-      rawEntries = map (f: {
-        name = "${f.name}.md";
-        inherit (f) path;
-      }) rawFiles;
+      rawEntries = map (
+        f:
+        let
+          fmName = rawFrontmatterName f.path;
+        in
+        assert lib.assertMsg (fmName == f.name)
+          "agents.mkAgentsDir: raw agent file \"${f.name}.md\" declares frontmatter name=${
+            if fmName == null then "(missing)" else "\"${fmName}\""
+          } (must match its filename)";
+        {
+          name = "${f.name}.md";
+          inherit (f) path;
+        }
+      ) rawFiles;
       entries = renderedEntries ++ rawEntries;
       names = map (e: e.name) entries;
       collisions = lib.filter (n: lib.count (x: x == n) names > 1) (lib.unique names);
@@ -95,8 +120,10 @@ in
     - `rawFiles`: list of `{ name; path; }` for agents that already ship as a
       complete, hand-authored `.md` (frontmatter + body). The file at `path` is
       copied verbatim to `<name>.md`. Use this for static agents so adding one is
-      just dropping a `.md` file, with no nix entry. Names must not collide with
-      `agents` keys.
+      just dropping a `.md` file, with no nix entry. The file's frontmatter
+      `name:` must equal `name` (Claude registers the agent under the frontmatter
+      name, so a mismatch would silently install it under the wrong handle), and
+      names must not collide with `agents` keys.
 
     Returns a directory with one `<name>.md` per agent, built as real files with
     no symlinks (Claude Code drops symlinked agent entries,

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -426,48 +426,60 @@ let
   # FRESH inline `index` server from the shared `ix.mcp` registry, so each
   # spawned subagent gets its own kernel and browser rather than sharing the
   # parent's; the server is declared from the same source the wrappers render.
-  agentsDir = ix.agents.mkAgentsDir {
-    inherit pkgs;
-    agents = {
-      index-action-runner = {
-        frontmatter = {
-          name = "index-action-runner";
-          description =
-            "Offload a long, image-heavy or many-step loop (browser automation, "
-            + "scanning many images or PDFs, multi-step web flows) into an isolated "
-            + "context. Give it an outcome plus the exact fields to return; it drives "
-            + "the whole loop in its own index kernel and returns only the distilled "
-            + "result, keeping screenshots and DOM dumps out of the main thread.";
-          mcpServers = ix.mcp.toAgentMcpServers {
-            index = {
-              transport = "stdio";
-              command = lib.getExe repoPackages.mcp;
-              args = [ "serve" ];
+  agentsDir =
+    let
+      # Agents whose frontmatter is computed in nix rather than written in the
+      # file, so they are rendered (not copied verbatim) and their source `.md`
+      # is body-only. index-action-runner offloads a long, image- or step-heavy
+      # loop into its own context and returns only the conclusion (ENG-2792); its
+      # frontmatter bakes a FRESH inline `index` server from the shared `ix.mcp`
+      # registry, so each spawned subagent gets its own kernel and browser rather
+      # than sharing the parent's, declared from the source the wrappers render.
+      renderedAgents = {
+        index-action-runner = {
+          frontmatter = {
+            name = "index-action-runner";
+            description =
+              "Offload a long, image-heavy or many-step loop (browser automation, "
+              + "scanning many images or PDFs, multi-step web flows) into an isolated "
+              + "context. Give it an outcome plus the exact fields to return; it drives "
+              + "the whole loop in its own index kernel and returns only the distilled "
+              + "result, keeping screenshots and DOM dumps out of the main thread.";
+            mcpServers = ix.mcp.toAgentMcpServers {
+              index = {
+                transport = "stdio";
+                command = lib.getExe repoPackages.mcp;
+                args = [ "serve" ];
+              };
             };
           };
+          body = builtins.readFile (paths.agents + "/index-action-runner.md");
         };
-        body = builtins.readFile (paths.agents + "/index-action-runner.md");
       };
-    };
-    # Every other `agents/*.md` is a complete, hand-authored agent (frontmatter +
-    # body) and is copied verbatim. index-action-runner.md is body-only (its
-    # frontmatter is computed above), so it lacks the leading `---` and is
-    # excluded here, staying on the rendered path.
-    rawFiles =
-      let
-        entries = builtins.readDir paths.agents;
-        mdNames = lib.filter (n: lib.hasSuffix ".md" n && entries.${n} == "regular") (
-          builtins.attrNames entries
-        );
-        frontmattered = lib.filter (
-          n: lib.hasPrefix "---" (builtins.readFile (paths.agents + "/${n}"))
-        ) mdNames;
-      in
-      map (n: {
+      # A rendered agent's source `.md` is body-only and excluded here by name;
+      # every OTHER `agents/*.md` is a complete, hand-authored agent (frontmatter
+      # + body) copied verbatim. A non-rendered file without leading `---` is a
+      # mistake (a missing frontmatter block), so fail loudly with the offenders
+      # rather than silently dropping it from the agent set.
+      renderedFiles = map (n: "${n}.md") (builtins.attrNames renderedAgents);
+      entries = builtins.readDir paths.agents;
+      rawMdNames = lib.filter (
+        n: lib.hasSuffix ".md" n && entries.${n} == "regular" && !(lib.elem n renderedFiles)
+      ) (builtins.attrNames entries);
+      missingFrontmatter = lib.filter (
+        n: !(lib.hasPrefix "---" (builtins.readFile (paths.agents + "/${n}")))
+      ) rawMdNames;
+    in
+    assert lib.assertMsg (missingFrontmatter == [ ])
+      "agentsDir: agents/*.md without YAML frontmatter (add frontmatter, or render it in renderedAgents): ${lib.concatStringsSep ", " missingFrontmatter}";
+    ix.agents.mkAgentsDir {
+      inherit pkgs;
+      agents = renderedAgents;
+      rawFiles = map (n: {
         name = lib.removeSuffix ".md" n;
         path = paths.agents + "/${n}";
-      }) frontmattered;
-  };
+      }) rawMdNames;
+    };
 
   mcSource = ix.writeNushellApplication pkgs {
     name = "mc-source";


### PR DESCRIPTION
Two follow-up hardenings from the #1387 review of the unified Claude config.

## 1. Assert raw agent frontmatter `name:` matches its filename
`agents.mkAgentsDir` already enforces `frontmatter.name == key` for *rendered* agents (`renderAgent`), but `rawFiles` (the hand-authored `.md` drop-ins: code-reviewer, data, fixup, synthesis-critic) were copied verbatim with no check. Claude registers a subagent under its frontmatter `name`, so a file `code-reviewer.md` whose frontmatter said `name: foo` would silently install under the wrong handle. Now each `rawFiles` entry's frontmatter `name:` is checked against its filename.

## 2. Fail loudly on a frontmatter-less `agents/*.md`
`per-system.nix`'s `agents/*.md` discovery filtered to files starting with `---` and **silently dropped** the rest. The one legitimately body-only file (`index-action-runner.md`, frontmatter computed in nix) is now excluded *by name*, and every remaining file is asserted to have YAML frontmatter — so a malformed drop-in errors at eval instead of vanishing from the agent set.

## Validation
- `nix build .#agents .#claude-plugin` — green; all 5 agents materialize.
- Negative eval: raw name mismatch → `raw agent file "wrongname.md" declares frontmatter name="code-reviewer" (must match its filename)`.
- Negative eval: frontmatter-less file → `agentsDir: agents/*.md without YAML frontmatter: bad.md`.

🤖 Generated with Claude Code (Opus 4.x)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Assert raw agent frontmatter `name:` matches filename in `mkAgentsDir`
> - Adds `rawFrontmatterName` in [lib/agents.nix](https://github.com/indexable-inc/index/pull/1388/files#diff-f49dccddfbdebb7296c97ef89dc514bd0610fbceae7453f6ad2cfa3c6aca75c2) to extract the `name:` field from a raw agent file's YAML frontmatter, returning `null` if absent.
> - `mkAgentsDir` now asserts that each raw file's frontmatter `name:` matches its filename-derived name, failing loudly with the offending value or `(missing)` if the frontmatter is absent.
> - [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1388/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) adds a pre-build assertion that any non-rendered `agents/*.md` file starts with `---`, failing with a list of offenders instead of silently excluding them.
> - Behavioral Change: builds that previously succeeded with frontmatter-less drop-in agent files will now fail with an explicit assertion error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30ee157.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->