### PR TITLE
claude/agents: harden raw-agent name parse (frontmatter scope, CRLF, whitespace)

### DIFF
--- a/lib/agents.nix
+++ b/lib/agents.nix
@@ -44,20 +44,34 @@ let
 
       ${agent.body}'';
 
-  # The `name:` from a hand-authored agent file's YAML frontmatter (the first
-  # `name:` line inside the leading `---` block), or null if absent. Used to
-  # check a raw file's declared name against its filename, the same invariant
-  # `renderAgent` enforces for rendered agents. The file is known to open with
-  # `---` (per-system.nix's discovery filters on that before this runs).
+  # The `name:` value from a hand-authored agent file's YAML frontmatter, or
+  # null if absent. Used to check a raw file's declared name against its
+  # filename, the same invariant `renderAgent` enforces for rendered agents.
+  # The file is known to open with `---` (per-system.nix's discovery filters on
+  # that first). The scan is restricted to the frontmatter block (between the
+  # first two `---` fences) so a `name:` line in the markdown body can't be
+  # mistaken for the declared name; `\r` is stripped so CRLF files parse; and
+  # the value is taken via a regex tolerant of any whitespace after the colon
+  # (`name:foo`, `name:  foo`), not a fixed `"name: "` prefix.
   rawFrontmatterName =
     path:
     let
-      lines = lib.splitString "\n" (builtins.readFile path);
-      # Frontmatter is the leading block, so the first `name:` line is the
-      # declared agent name (a body line starting `name:` can't precede it).
-      nameLine = lib.findFirst (l: lib.hasPrefix "name:" l) null lines;
+      lines = map (lib.removeSuffix "\r") (lib.splitString "\n" (builtins.readFile path));
+      # Lines after the opening `---`, up to (not including) the closing `---`.
+      # foldl' rather than lib.takeWhile, which this nixpkgs pin lacks.
+      collect =
+        acc: l:
+        if acc.done || l == "---" then acc // { done = true; } else acc // { out = acc.out ++ [ l ]; };
+      fmLines =
+        (lib.foldl' collect {
+          out = [ ];
+          done = false;
+        } (lib.drop 1 lines)).out;
+      nameLine = lib.findFirst (lib.hasPrefix "name:") null fmLines;
+      m = if nameLine == null then null else builtins.match "name:[[:space:]]*(.*)" nameLine;
+      value = if m == null then null else builtins.head m;
     in
-    if nameLine == null then null else lib.removePrefix "name: " nameLine;
+    if value == "" then null else value;
 
   mkAgentsDir =
     {


### PR DESCRIPTION
Follow-up to the #1388 review (findings C1, C2, M1). `rawFrontmatterName` parsed a raw agent file's frontmatter `name:` with a fixed `removePrefix "name: "` over an unscoped, non-`\r`-stripped line scan. Latent traps for the next author (all 4 current files are LF + `name: ` single-space, so #1388 was green):

- **C2 (CRLF):** `lib.splitString "\n"` leaves `\r`, so a CRLF file yields `name: fixup\r` → parsed `"fixup\r" != "fixup"` → build-breaking false-positive assert. Now every line is `\r`-stripped.
- **C1 (whitespace):** `removePrefix "name: "` returns the *whole line unchanged* on any spacing mismatch (`name:foo`, `name:  foo`), tripping the assert with an opaque message. Now the value comes from `builtins.match "name:[[:space:]]*(.*)"`.
- **M1 (scope):** the scan ran over the whole file, so a `name:` line in the markdown body could be read as the declared name. Now scoped to the frontmatter block (between the first two `---` fences) via a `foldl'` (this nixpkgs pin lacks `lib.takeWhile`).

## Validation
- `nix build .#agents .#claude-plugin` green.
- Eval matrix: `name: alpha` (LF) → alpha; CRLF → beta; `name:gamma` → gamma; `name:   delta` → delta; a body `name:` with no frontmatter name → null.
- Negative eval: name/filename mismatch still fires with the correctly-extracted name.

🤖 Generated with Claude Code (Opus 4.x)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `rawFrontmatterName` to handle CRLF, whitespace, and frontmatter scope
> Updates `rawFrontmatterName` in [agents.nix](https://github.com/indexable-inc/index/pull/1389/files#diff-f49dccddfbdebb7296c97ef89dc514bd0610fbceae7453f6ad2cfa3c6aca75c2) to fix several edge cases in agent name parsing:
>
> - Restricts the `name:` search to lines within the leading `---` frontmatter block, ignoring any `name:` lines in the document body
> - Strips trailing `\r` from each line to handle CRLF line endings
> - Uses a regex to tolerate any amount of whitespace after the colon (e.g. `name:foo` or `name:  foo`)
> - Returns `null` instead of an empty string when the captured value is empty
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4aee60f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->