### PR TITLE
site: add last-24-hours newspaper page (WIP)

### DIFF
--- a/site/src/lib/components/ContribNews.svelte
+++ b/site/src/lib/components/ContribNews.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  export interface NewsItem {
+    headline: string;
+    description: string;
+    prUrl: string;
+    prNumber: string;
+    category: 'Lead' | 'Tooling' | 'Antithesis' | 'Storage' | 'CI' | 'Filesystem';
+    timestamp: Date;
+  }
+
+  export let item: NewsItem;
+
+  const categoryColors: Record<NewsItem['category'], { bg: string; text: string }> = {
+    'Lead': { bg: '#dbeafe', text: '#111827' },
+    'Tooling': { bg: '#f3e8ff', text: '#581c87' },
+    'Antithesis': { bg: '#fee2e2', text: '#7f1d1d' },
+    'Storage': { bg: '#fed7aa', text: '#92400e' },
+    'CI': { bg: '#dcfce7', text: '#14532d' },
+    'Filesystem': { bg: '#f3f4f6', text: '#1f2937' }
+  };
+
+  const formattedTime = item.timestamp.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true
+  });
+</script>
+
+<article class="news-item">
+  <div class="header">
+    <span class="category" style="background-color: {categoryColors[item.category].bg}; color: {categoryColors[item.category].text}">
+      {item.category}
+    </span>
+    <time class="timestamp" dateTime={item.timestamp.toISOString()}>
+      {formattedTime}
+    </time>
+  </div>
+  <h3 class="headline">{item.headline}</h3>
+  <p class="description">{item.description}</p>
+  <a href={item.prUrl} target="_blank" rel="noopener noreferrer" class="pr-link">
+    #{item.prNumber}
+  </a>
+</article>
+
+<style>
+  .news-item {
+    padding: 1rem;
+    border-left: 4px solid #ccc;
+    margin-bottom: 1.5rem;
+    background: #fafafa;
+  }
+
+  .header {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+
+  .category {
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  .timestamp {
+    font-size: 0.75rem;
+    color: #666;
+  }
+
+  .headline {
+    margin: 0.5rem 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+
+  .description {
+    margin: 0.5rem 0;
+    color: #444;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  .pr-link {
+    display: inline-block;
+    margin-top: 0.5rem;
+    color: #0066cc;
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .pr-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/site/src/routes/last-24-hours/+page.svelte
+++ b/site/src/routes/last-24-hours/+page.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import ContribNews from '$lib/components/ContribNews.svelte';
+  import type { NewsItem } from '$lib/components/ContribNews.svelte';
+
+  // Sample data: the last 24h of merges across ix + index.
+  // TODO: Automate data collection from GitHub API and generate copy via Claude.
+  const newsItems: NewsItem[] = [
+    {
+      headline: 'ix now has a federated Resources layer',
+      description: 'Resources are addressable across machines and can be listed, read, and driven over QUIC. Enables cross-host resource discovery and manipulation.',
+      prUrl: 'https://github.com/indexable-inc/ix/pull/5200',
+      prNumber: '5200',
+      category: 'Lead',
+      timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000) // 2h ago
+    },
+    {
+      headline: 'The MCP kernel search runs on rg, fd and Spotlight',
+      description: 'Search primitives now use ripgrep and fd internally with no fff in the loop. Faster, more reliable searching across codebases.',
+      prUrl: 'https://github.com/indexable-inc/index/pull/1380',
+      prNumber: '1380',
+      category: 'Tooling',
+      timestamp: new Date(Date.now() - 4 * 60 * 60 * 1000) // 4h ago
+    },
+    {
+      headline: 'Antithesis is a continuous signal',
+      description: 'Health and CI gates now read Antithesis results as pass or fail. Test runs integrate directly into the merge pipeline.',
+      prUrl: 'https://github.com/indexable-inc/ix/pull/5195',
+      prNumber: '5195',
+      category: 'Antithesis',
+      timestamp: new Date(Date.now() - 6 * 60 * 60 * 1000) // 6h ago
+    },
+    {
+      headline: 'CAS keeps oversized manifests on disk',
+      description: 'The content-addressable store now handles large manifests efficiently. VM runtime remains async end to end.',
+      prUrl: 'https://github.com/indexable-inc/ix/pull/5190',
+      prNumber: '5190',
+      category: 'Storage',
+      timestamp: new Date(Date.now() - 8 * 60 * 60 * 1000) // 8h ago
+    },
+    {
+      headline: 'The build gate is a lint stage feeding rust and nix in parallel',
+      description: 'CI now runs clippy and nixfmt checks in parallel before proceeding to builds. Faster feedback on style violations.',
+      prUrl: 'https://github.com/indexable-inc/index/pull/1378',
+      prNumber: '1378',
+      category: 'CI',
+      timestamp: new Date(Date.now() - 10 * 60 * 60 * 1000) // 10h ago
+    },
+    {
+      headline: 'VCFS is free of the unlink race',
+      description: 'Large-file unlink no longer fails with EFBIG. Virtual filesystem now handles cleanup safely under concurrent access.',
+      prUrl: 'https://github.com/indexable-inc/ix/pull/5185',
+      prNumber: '5185',
+      category: 'Filesystem',
+      timestamp: new Date(Date.now() - 12 * 60 * 60 * 1000) // 12h ago
+    }
+  ];
+</script>
+
+<svelte:head>
+  <title>The Indexable Times | Last 24 Hours</title>
+  <meta name="description" content="The last 24 hours of merges across ix and index, presented as news stories." />
+</svelte:head>
+
+<section class="newspaper">
+  <header class="masthead">
+    <h1>The Indexable Times</h1>
+    <p class="subtitle">Last 24 hours of development across ix and index</p>
+    <p class="note">
+      <em>WIP: Data is currently hand-collected. Copy is generated via Claude. Automation coming soon.</em>
+    </p>
+  </header>
+
+  <main class="news-feed">
+    {#each newsItems as item (item.prNumber)}
+      <ContribNews {item} />
+    {/each}
+  </main>
+</section>
+
+<style>
+  .newspaper {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    font-family: Georgia, serif;
+  }
+
+  .masthead {
+    text-align: center;
+    margin-bottom: 2rem;
+    border-bottom: 3px solid #333;
+    padding-bottom: 1.5rem;
+  }
+
+  .masthead h1 {
+    margin: 0;
+    font-size: 3rem;
+    font-weight: 700;
+    letter-spacing: -1px;
+  }
+
+  .subtitle {
+    margin: 0.5rem 0 0 0;
+    font-size: 1.1rem;
+    color: #666;
+    font-style: italic;
+  }
+
+  .note {
+    margin: 1rem 0 0 0;
+    font-size: 0.9rem;
+    color: #999;
+  }
+
+  .news-feed {
+    margin-top: 2rem;
+  }
+</style>


### PR DESCRIPTION
# The Indexable Times

Adds a newspaper-style page showing the last 24 hours of merges across ix and index.

## Changes

- **ContribNews component**: Renders individual news items with category badges, timestamps, and PR links
- **last-24-hours page**: Displays a newspaper masthead with a feed of recent contributions
- **Sample data**: Currently uses hand-written example stories

## Status

**WIP**: This is a work in progress. The following still need automation:

- [ ] Real merge data collection from GitHub API
- [ ] Better prompting for Claude to generate news copy automatically  
- [ ] Auto-refresh mechanism to pull fresh data
- [ ] Styling refinements for better presentation

## Testing

The page renders at `/last-24-hours` with sample data. Next steps will focus on wiring it to real GitHub data and improving the prompting for copy generation.

---

_Draft for feedback on structure and approach. Better prompting and automation to follow._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add /last-24-hours newspaper-style page with static news items
> - Adds a new SvelteKit route at `/last-24-hours` ([+page.svelte](https://github.com/indexable-inc/index/pull/1390/files#diff-3363e0bed665b52c952ce8a1b078417bf2368e9b15e04b011d619da30e9f60eb)) that renders a newspaper-style list of recent PR merges with a masthead and head metadata.
> - Adds a `ContribNews` component ([ContribNews.svelte](https://github.com/indexable-inc/index/pull/1390/files#diff-650ae11a204c8e3da4a36ddc4088999709a3f1a20e661d1f5c617f483faf23db)) that renders a single news card with a category badge, localized 12-hour timestamp, headline, description, and PR link.
> - News items are currently a static array hardcoded in the page component (WIP).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4430b7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->