### PR TITLE
astlog/nix: scope 3 Nixcademy lints flagged by review

### DIFF
--- a/astlog-rules/nix-lints.md
+++ b/astlog-rules/nix-lints.md
@@ -1940,9 +1940,9 @@ Setting `makeFlagsArray` directly re-splits values containing spaces, so `[ "CFL
 
 **🔴 error**
 
-`callPackage` fills named parameters from `pkgs` and adds an `override` attribute for re-evaluating with modified arguments. Taking `pkgs` itself routes dependencies through `pkgs.foo`, which `override` cannot reach. List the exact dependencies as parameters so each is overridable.
+`callPackage` fills named parameters from `pkgs` and adds an `override` attribute for re-evaluating with modified arguments. Taking `pkgs` itself routes dependencies through `pkgs.foo`, which `override` cannot reach. List the exact dependencies as parameters so each is overridable. Scoped to package functions: a `pkgs` formal on a function whose body builds a derivation (`mkDerivation` / `buildPythonPackage` / `buildGoModule` / ...), so a NixOS module or flake output that legitimately takes `pkgs` is not flagged.
 
-*Matches:* `formal` · *predicates:* `text` · *1 pattern variant*
+*Matches:* `formal` · *predicates:* `text`, `text-match`, `ancestor` · *1 pattern variant*
 
 <table><tr><th>flagged</th><th>ok</th></tr><tr><td>
 
@@ -2006,7 +2006,7 @@ package.overrideAttrs (old: { patches = old.patches or [ ] ++ [ ./my-bugfix.patc
 
 **🔴 error**
 
-When you replace a phase wholesale, keep the `runHook preX` / `runHook postX` calls. Without them, downstream consumers can no longer prepend or append actions via `preX` / `postX` overrides. The rule negates an `runHook`-presence helper so it fires only on phase strings missing the calls.
+When you replace a phase wholesale, keep **both** the `runHook pre<Phase>` and `runHook post<Phase>` calls for that exact phase. Without them, downstream consumers can no longer prepend or append actions via `preX` / `postX` overrides. The rule negates a per-phase helper that holds only when both the matching pre and post hook are present, so it fires on any phase string missing either hook (or carrying a different phase's hooks), not just one with no hook at all.
 
 *Matches:* `binding` · *predicates:* `text-match`, `not` · *1 pattern variant*
 
@@ -2014,8 +2014,9 @@ When you replace a phase wholesale, keep the `runHook preX` / `runHook postX` ca
 
 ```nix
 { buildPhase = ''
-  do something
-  make something else
+  runHook preBuild
+  make something
+  do something else
 ''; }
 ```
 
@@ -2150,9 +2151,9 @@ Overlay functions that preserve and re-expose what they extend.
 
 **🔴 error**
 
-An overlay that writes `a = { b = foo; };` replaces the whole `pkgs.a`, dropping everything else that lived inside it. Reference the existing set through `prev` and merge with `//`, guarding with `or {}`. Scoped to overlay (`final: prev:`) context via an ancestor join.
+An overlay that writes `a = { b = foo; };` at the top level of the returned set replaces the whole `pkgs.a`, dropping everything else that lived inside it. Reference the existing set through `prev` and merge with `//`, guarding with `or {}`. Scoped to **direct members** of the overlay body (via `parent`), so an attrset-valued binding nested deeper (a `meta`, an `overrideAttrs` lambda) is not flagged.
 
-*Matches:* `binding` · *predicates:* `text`, `ancestor` · *1 pattern variant*
+*Matches:* `binding` · *predicates:* `text`, `parent` · *1 pattern variant*
 
 <table><tr><th>flagged</th><th>ok</th></tr><tr><td>
 

--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -1116,14 +1116,25 @@
 (lint extend-makeflagsarray error
   "assigning `makeFlagsArray` directly mangles space-containing values; append to it in a `preBuild` shell snippet")
 
-;; no-pkgs-in-callpackage: taking `pkgs` in a `callPackage` argument set routes
-;; dependencies through `pkgs.foo`, which `override` cannot reach; list the
-;; exact dependencies as parameters so each is overridable.
+;; no-pkgs-in-callpackage: taking `pkgs` in a `callPackage`-style package
+;; argument set routes dependencies through `pkgs.foo`, which `override` cannot
+;; reach; list the exact dependencies as parameters so each is overridable.
+;; Scoped to package functions -- a `pkgs` formal on a function whose body
+;; builds a derivation (mkDerivation / buildPythonPackage / buildGoModule / ...)
+;; -- so a NixOS module or flake output that legitimately takes `pkgs` is not
+;; flagged.
+(rule (mkderivation-call m)
+  (match nix "
+    (apply_expression
+      function: [(variable_expression) (select_expression)] @f) @m")
+  (text-match f "(^|\\.)(mkDerivation|mkDerivationNoCC|buildPythonPackage|buildPythonApplication|buildGoModule|buildGoApplication|buildRustPackage|buildPerlPackage|buildNpmPackage)$"))
 (rule (no-pkgs-in-callpackage n)
-  (match nix "(formal name: (identifier) @id) @n")
-  (text id "pkgs"))
+  (match nix "(function_expression (formals (formal name: (identifier) @id) @n)) @fn")
+  (text id "pkgs")
+  (mkderivation-call m)
+  (ancestor fn m))
 (lint no-pkgs-in-callpackage error
-  "taking `pkgs` in a `callPackage` argument set breaks `override`; list the exact dependencies you need")
+  "taking `pkgs` in a `callPackage` package argument set breaks `override`; list the exact dependencies you need")
 
 ;; keep-python-composable: pulling deps out of `python3Packages` blocks
 ;; per-dependency overrides; take the package names directly (each interpreter's
@@ -1146,15 +1157,76 @@
 (lint future-proof-overrideattrs error
   "`overrideAttrs` with an attrset drops pre-existing values; use the `(old: {{ ... }})` function form with `old.x or [ ]`")
 
-;; keep-phase-hooks: a wholesale phase override without `runHook pre*`/`post*`
-;; strips downstream pre/post hooks. `phase-has-runhook` is the absence check
-;; negated by the lint.
-(rule (phase-has-runhook n)
+;; keep-phase-hooks: a wholesale phase override must keep BOTH its
+;; `runHook pre<Phase>` and `runHook post<Phase>` calls, or downstream consumers
+;; lose the ability to prepend/append via pre/post overrides.
+;; `phase-correctly-hooked` holds only when the matching pre AND post hook for
+;; that exact phase are both present; the lint fires on any phase string missing
+;; either, or carrying a different phase's hooks.
+(rule (phase-correctly-hooked n)
   (match nix "
     (binding
       attrpath: (attrpath) @p
       expression: (indented_string_expression) @v) @n")
-  (text-match v "runHook"))
+  (text p "buildPhase")
+  (text-match v "runHook\\s+preBuild")
+  (text-match v "runHook\\s+postBuild"))
+(rule (phase-correctly-hooked n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text p "installPhase")
+  (text-match v "runHook\\s+preInstall")
+  (text-match v "runHook\\s+postInstall"))
+(rule (phase-correctly-hooked n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text p "checkPhase")
+  (text-match v "runHook\\s+preCheck")
+  (text-match v "runHook\\s+postCheck"))
+(rule (phase-correctly-hooked n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text p "configurePhase")
+  (text-match v "runHook\\s+preConfigure")
+  (text-match v "runHook\\s+postConfigure"))
+(rule (phase-correctly-hooked n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text p "unpackPhase")
+  (text-match v "runHook\\s+preUnpack")
+  (text-match v "runHook\\s+postUnpack"))
+(rule (phase-correctly-hooked n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text p "patchPhase")
+  (text-match v "runHook\\s+prePatch")
+  (text-match v "runHook\\s+postPatch"))
+(rule (phase-correctly-hooked n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text p "distPhase")
+  (text-match v "runHook\\s+preDist")
+  (text-match v "runHook\\s+postDist"))
+(rule (phase-correctly-hooked n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text p "installCheckPhase")
+  (text-match v "runHook\\s+preInstallCheck")
+  (text-match v "runHook\\s+postInstallCheck"))
 (rule (phase-binding-str n)
   (match nix "
     (binding
@@ -1163,9 +1235,9 @@
   (text-match p "^(buildPhase|installPhase|checkPhase|configurePhase|unpackPhase|patchPhase|distPhase|installCheckPhase)$"))
 (rule (keep-phase-hooks n)
   (phase-binding-str n)
-  (not (phase-has-runhook n)))
+  (not (phase-correctly-hooked n)))
 (lint keep-phase-hooks error
-  "a phase override without `runHook pre*`/`runHook post*` strips downstream hooks; bracket the body with the hook calls")
+  "a phase override that drops its `runHook pre<Phase>` / `runHook post<Phase>` calls strips downstream hooks; keep both hooks for that phase")
 
 ;; prefer-substituteinplace: `sed -i` / `awk` in a phase fails silently when the
 ;; pattern stops matching; use `substituteInPlace ... --replace-fail`.
@@ -1185,12 +1257,21 @@
   (match nix "(function_expression (identifier) @id) @f")
   (text id "prev"))
 
-;; overlay-preserve-nested: an overlay `a = { b = foo; };` replaces all of
-;; `prev.a`; merge with `prev.a or { } // { ... }`.
+;; overlay-preserve-nested: an overlay `a = { b = foo; };` at the TOP LEVEL of
+;; the returned set replaces all of `prev.a`; merge with
+;; `prev.a or { } // { ... }`. Scoped to direct members of the overlay body
+;; (`parent`), so an attrset-valued binding nested deeper (a `meta`, an
+;; `overrideAttrs` lambda) is not flagged.
+(rule (overlay-body-bset bset)
+  (match nix "
+    (function_expression
+      (identifier) @id
+      body: (attrset_expression (binding_set) @bset)) @f")
+  (text id "prev"))
 (rule (overlay-preserve-nested n)
-  (overlay-prev-fn f)
+  (overlay-body-bset bset)
   (match nix "(binding expression: (attrset_expression)) @n")
-  (ancestor f n))
+  (parent bset n))
 (lint overlay-preserve-nested error
   "overlay `a = {{ b; }}` drops the rest of `prev.a`; merge with `prev.a or {{ }} // {{ ... }}`")
 

--- a/astlog-rules/tests/keep-phase-hooks/bad.fixture
+++ b/astlog-rules/tests/keep-phase-hooks/bad.fixture
@@ -1,4 +1,5 @@
 { buildPhase = ''
-  do something
-  make something else
+  runHook preBuild
+  make something
+  do something else
 ''; }


### PR DESCRIPTION
Follow-up to #1391, addressing the AI review's three findings (all valid). Each was an over-broad/under-enforcing matcher; this scopes them precisely.

## P1 — `no-pkgs-in-callpackage` was not scoped to packages
Matched **any** `pkgs` formal, so it fired on every `{ pkgs, ... }:` — NixOS modules, flake outputs, lib helpers — not just callPackage'd package files.

**Fix:** ancestor join — a `pkgs` formal *on a function whose body builds a derivation* (`mkDerivation` / `buildPythonPackage` / `buildGoModule` / `buildRustPackage` / ...). A module or flake output that legitimately takes `pkgs` is no longer flagged.

## P2 — `overlay-preserve-nested` matched unrelated attrsets
Matched **any** attrset-valued binding anywhere under an overlay, so `meta = { ... }`, `overrideAttrs (o: { ... })`, nested config, etc. all tripped it.

**Fix:** `parent` join — only **direct members** of the overlay's top-level returned set, the only place a bare `a = { ... }` shadows `prev.a`.

## P3 — `keep-phase-hooks` accepted one or the wrong hook
A single `runHook` anywhere satisfied the presence check, so a phase with only `runHook preBuild` (missing `postBuild`), or with a *different* phase's hooks, passed.

**Fix:** a per-phase helper requires **both** `runHook pre<Phase>` **and** `runHook post<Phase>` for that exact phase (buildPhase→preBuild/postBuild, installPhase→preInstall/postInstall, ...). The lint fires on any phase override missing either, or carrying the wrong phase's hooks. `bad.fixture` updated to the missing-`postBuild` case.

## Validation
Ran the `astlog-rules` self-test logic against the **real `astlog` 0.1.0 binary**: all 22 nix fixtures pass (bad fires, good clean). Plus spot checks confirming the previously over-broad inputs now behave:
- `{ pkgs, lib, ... }: { environment.systemPackages = [ pkgs.hello ]; }` → no longer flagged
- `final: prev: { p = prev.p.overrideAttrs (o: { meta = { x = 1; }; }); }` → no longer flagged
- buildPhase with only `runHook preBuild`, or with `runHook preInstall` → now flagged

`nix-lints.md` updated for the three rules.

(authored by Claude Opus 4.8 via Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope 3 Nixcademy lints for `no-pkgs-in-callpackage`, `keep-phase-hooks`, and `overlay-preserve-nested`
> - `no-pkgs-in-callpackage` now fires only when a function building a derivation (matched via a new `mkderivation-call` helper) takes a `pkgs` formal; NixOS modules and flake outputs are no longer flagged.
> - `keep-phase-hooks` now requires both the matching `pre<Phase>` and `post<Phase>` runHook calls to be present; phases with only one hook are flagged. Eight per-phase helper rules replace the previous single `phase-has-runhook` rule.
> - `overlay-preserve-nested` now scopes to direct children of the overlay's top-level binding set via a new `overlay-body-bset` helper, avoiding false positives on nested attrsets inside `meta` or override lambdas.
> - The bad fixture for `keep-phase-hooks` is updated to include `runHook preBuild` but omit `runHook postBuild`, matching the new two-hook requirement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c61b41f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->