### PR TITLE
feat(system-prompt): deliver human-facing answers as an HTML file

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -12,9 +12,18 @@
 # strings are byte-exact, and safety-critical rules (the force-merge gate,
 # stacked rebase, guards) keep their steps and conditions unambiguous.
 #
-# NOTE: there is deliberately no "talk like X in every reply" output-voice rule.
-# Replies are plain, clear prose (per the user's global writing rules); do not
-# re-add a reply-voice rule.
+# NOTE on output-format rules: Claude Code's own `outputStyle` setting (the
+# `/output-style` / settings.json mechanism for changing how replies look) does
+# NOTHING on this build. Output styles are appended only while the CLI assembles
+# its STOCK system prompt; because the wrapper passes `--system-prompt-file` (a
+# full replacement, see ./claude-code's `systemPrompt` arg), the style has no
+# base to attach to and is silently dropped. Verified by capturing the actual
+# `system` blocks the binary sends: wrapped binary with `outputStyle` set is
+# byte-identical to wrapped without it, and adding a fake `--system-prompt-file`
+# to the stock binary likewise drops a set style. So any reply-format/output-voice
+# guidance MUST live here in the baked prompt (or ride `--append-system-prompt`);
+# a settings-based output style cannot deliver it. The `htmlDeliverable` rule
+# below is exactly such guidance, baked here for that reason.
 #
 # Rules tagged STOCK-DERIVED are adapted from Claude Code's OWN stock system
 # prompt, read at the pinned binary version (./claude-code/manifest.json,
@@ -117,6 +126,8 @@ let
 
   coordinateBranches = "Another developer is actively working in this codebase. Treat an unmerged branch as unfinished for a reason you may not see, and never work on someone else's feature or branch without coordinating.";
 
+  htmlDeliverable = "When the user asks a question or asks for an answer, analysis, summary, report, or other result meant for a human to read, deliver it as a single self-contained HTML file rather than in chat: write it with the Write tool (inline CSS, no external assets), open it (macOS `open <path>`), and keep your chat reply to a one-line pointer to that file. Do not also restate the answer in chat. Exceptions where text output stays inline, because something other than a human reading consumes it: (1) a subagent's or tool's return value, whose final text IS the data the caller parses, so return the content, never a file path; (2) any format-constrained or machine-readable output (JSON, a schema, a commit message, raw command output); (3) non-interactive or headless runs where no human is at a desktop to open a file. A single short clarifying question that blocks all work may stay in chat.";
+
   # Order is significant: the rules read top-to-bottom in the baked prompt.
   order = [
     shokunin
@@ -161,6 +172,7 @@ let
     discloseAi
     noEmDashes
     coordinateBranches
+    htmlDeliverable
   ];
 in
 lib.concatStringsSep "\n\n" order


### PR DESCRIPTION
## What

Adds a `htmlDeliverable` rule to the house system prompt: answers/analyses/reports meant for a human to read are written to a self-contained HTML file and opened, and the chat reply is just a one-line pointer.

## Blast radius (please review)

This changes reply behavior **fleet-wide** for every Claude Code session. To avoid breaking the agentic system, the rule has explicit carve-outs that keep text inline:
1. subagent/tool return values (the final text IS the data a caller parses),
2. machine-readable / format-constrained output (JSON, schemas, commit messages, raw command output),
3. non-interactive / headless runs.

It also reverses a previously-documented decision in the file header ("deliberately no output-voice rule"); that NOTE is rewritten to explain the new rationale.

## Why bake it in (not an `outputStyle`)

Claude Code's `outputStyle` setting does nothing on this build: output styles are appended only while the CLI assembles its **stock** prompt, but the wrapper passes `--system-prompt-file` (a full replacement), so the style has no base to attach to. Verified by capturing the actual `system` blocks the binary sends: wrapped binary with `outputStyle` set is byte-identical to wrapped without it. So reply-format guidance must live in the baked prompt.

## Validation

- `nix-instantiate --parse` OK; `nix eval` of the baked string shows the rule present and last (23,863 chars, 43 paragraphs).

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deliver human-readable agent answers as self-contained HTML files
> - Adds an `htmlDeliverable` rule to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1396/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to write human-readable responses (questions, analyses, summaries, reports) as a single self-contained HTML file with inline CSS, then post only a one-line pointer in chat.
> - The file is written via the `Write` tool and opened with `open <path>` on macOS; the chat reply is kept minimal.
> - Exceptions include machine-readable output (JSON, schemas, commit messages), tool/subagent return values, and non-interactive/headless runs.
> - Also adds a NOTE explaining that `outputStyle`/`settings.json` does not apply when using `--system-prompt-file`, so reply-format rules must be embedded in the prompt itself.
> - Behavioral Change: agent responses to conversational or analytical prompts will now produce an HTML file rather than inline text in the chat.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07a6cfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->