### PR TITLE
feat(mcp): add notion kernel helper (async httpx over Notion REST)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -587,6 +587,26 @@ let
         cp -r ${linearPythonSource}/linear/. "$site/"
       ''
   );
+  # Notion REST client: `import notion`, then `await notion.search(query)` /
+  # `page(id)` / `blocks(id)` / `db_query(id)` / `page_create` / `blocks_append`
+  # / `page_update`. Pure Python over the already-bundled httpx + polars; reads
+  # NOTION_API_KEY from the environment at call time. Cross-platform.
+  notionPythonSource = builtins.path {
+    name = "ix-mcp-notion-python-source";
+    path = ./src/notion;
+  };
+  notionModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-notion-python-module"
+      {
+        strictDeps = true;
+        meta.description = "Notion REST client bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/notion"
+        mkdir -p "$site"
+        cp -r ${notionPythonSource}/notion/. "$site/"
+      ''
+  );
   # `nox_autotriage`: nox-aware adapter that converts a nox conformance report
   # into linear.triage Findings and files them to Linear.  Depends on
   # linearModule (for linear.triage).  Entry point: python -m nox_autotriage.
@@ -1137,6 +1157,7 @@ let
       beeperModule
       tasksModule
       linearModule
+      notionModule
       noxAutotriageModule
       mcpClientModule
       # pymobiledevice3 9.27.0 (defined above) + the `iphone` wrapper that drives
@@ -1254,6 +1275,7 @@ let
     "nix"
     "nox_autotriage"
     "linear"
+    "notion"
     "google_auth"
     "slack"
     "beeper"
@@ -1675,7 +1697,7 @@ let
           cat stdout stderr >&2
           exit 1
         fi
-        for needle in MXBAI_API_KEY EXA_API_KEY LINEAR_API_KEY 'mgrep login'; do
+        for needle in MXBAI_API_KEY EXA_API_KEY LINEAR_API_KEY NOTION_API_KEY 'mgrep login'; do
           if ! grep -qF "$needle" stdout; then
             echo "requirements report is missing $needle:" >&2
             cat stdout stderr >&2
@@ -4968,6 +4990,36 @@ let
   ghosttyBundled = importTest "ghostty" "import ghostty; print('ghostty-ok', all(callable(getattr(ghostty, n)) for n in ('surfaces', 'my_tty', 'my_surface', 'close', 'close_me', 'focus', 'activate', 'is_running')), ghostty.__version__)";
   xBundled = importTest "x" "import x; print('x-ok', callable(x.posts), x.__version__)";
   linearBundled = importTest "linear" "import linear; print('linear-ok', all(callable(getattr(linear, n)) for n in ('issue', 'issue_update', 'issue_create', 'issue_search', 'comment_create', 'project_create')), linear.__version__)";
+  notionBundled = importTest "notion" "import notion, asyncio; print('notion-ok', all(asyncio.iscoroutinefunction(getattr(notion, n)) for n in ('search', 'page', 'blocks', 'db_query', 'page_create', 'blocks_append', 'page_update')), notion.__version__)";
+  notionTestPython = pkgs.python3.withPackages (ps: [
+    ps.pytest
+    ps.httpx
+    ps.polars
+    ps.pydantic
+    notionModule
+  ]);
+  notionTestSource = builtins.path {
+    name = "ix-mcp-notion-test";
+    path = ./tests/test_notion.py;
+  };
+  notionTests =
+    pkgs.runCommand "ix-mcp-notion-tests"
+      {
+        nativeBuildInputs = [ notionTestPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        cp ${notionTestSource} "$TMPDIR/test_notion.py"
+        ${lib.getExe notionTestPython} -m pytest "$TMPDIR/test_notion.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp notion tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
   noxAutotriageBundled = importTest "nox-autotriage" "import nox_autotriage; print('nox-autotriage-ok', callable(nox_autotriage.findings_from_conformance))";
   linearTriageTestPython = pkgs.python3.withPackages (ps: [
     ps.pytest
@@ -5187,6 +5239,8 @@ package.overrideAttrs (old: {
         xBundled
         linearBundled
         linearTriageTests
+        notionBundled
+        notionTests
         noxAutotriageBundled
         noxAutotriageTests
         iphoneBundled

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -232,6 +232,18 @@ MODULES: tuple[Module, ...] = (
             url="https://linear.app/settings/account/security",
         ),
     ),
+    Module(
+        "notion",
+        "Notion pages, databases, and blocks over the REST API using NOTION_API_KEY: "
+        "`await notion.search(query)` / `page(page_id)` / `blocks(block_id)` / "
+        "`db_query(database_id, filter=, sorts=)` / `page_create(parent, properties)` / "
+        "`blocks_append(block_id, children)` / `page_update(page_id, properties)`",
+        credential=Credential(
+            service="Notion",
+            env=("NOTION_API_KEY",),
+            url="https://www.notion.so/my-integrations",
+        ),
+    ),
 )
 
 # Always-present namespace builtins (installed by runtime.install; no import).

--- a/packages/mcp/src/notion/notion/__init__.py
+++ b/packages/mcp/src/notion/notion/__init__.py
@@ -1,0 +1,502 @@
+"""Notion workspace over the REST API using NOTION_API_KEY.
+
+Bundled like ``linear``/``slack`` so every session can ``import notion`` and
+read or write Notion pages, databases, and blocks without hand-rolling an httpx
+client each time. When ``NOTION_API_KEY`` is present in the environment the
+operations agents actually need work immediately with no additional setup:
+
+    import notion
+
+    # Search pages and databases (returns a polars DataFrame)
+    df = await notion.search("roadmap")
+    df = await notion.search("", filter="database")     # databases only
+
+    # Read a page (returns a typed `Page` model -- attribute access)
+    page = await notion.page("<page_id>")
+    page.url                       # the page's Notion URL
+    page.properties["Name"]        # raw property value
+
+    # Read a page's / block's children (a polars DataFrame, paginated)
+    blocks = await notion.blocks("<block_id>")
+
+    # Query a database (a polars DataFrame, paginated)
+    rows = await notion.db_query("<database_id>")
+    rows = await notion.db_query("<database_id>", sorts=[
+        {"property": "Name", "direction": "ascending"},
+    ])
+
+    # Create a page under a parent database or page
+    new = await notion.page_create(
+        {"database_id": "<database_id>"},
+        {"Name": {"title": [{"text": {"content": "New row"}}]}},
+    )
+    new.id                         # the new page's id
+
+    # Append blocks to a page / block
+    await notion.blocks_append("<block_id>", [
+        {"object": "block", "type": "paragraph",
+         "paragraph": {"rich_text": [{"text": {"content": "hello"}}]}},
+    ])
+
+    # Update a page's properties
+    await notion.page_update("<page_id>", {"In stock": {"checkbox": True}})
+
+All are async (kernel-loop style: no blocking network calls on the shared event
+loop) and wrap the Notion REST API (https://developers.notion.com/reference/intro).
+
+``NOTION_API_KEY`` is read from ``os.environ`` at call time so a session that
+sets the key after import still works. A missing key raises ``RuntimeError``
+with a clear message. Notion error envelopes
+(``{"object": "error", "status": ..., "code": ..., "message": ...}``) surface as
+:class:`NotionError` rather than silently returning ``None`` data.
+
+The ``_client`` hook (see below) lets tests inject an ``httpx.MockTransport``
+so every code path is exercisable with no network.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    import httpx
+
+__all__ = [
+    "NotionError",
+    "Page",
+    "blocks",
+    "blocks_append",
+    "db_query",
+    "page",
+    "page_create",
+    "page_update",
+    "search",
+]
+
+__version__ = "0.1.0"
+
+# The Notion REST API base. Every endpoint below is appended to this.
+_BASE_URL = "https://api.notion.com/v1"
+
+# The required ``Notion-Version`` header. Notion versions are dated; 2022-06-28
+# is the long-standing stable default that keeps the flat ``/v1/databases/{id}/
+# query`` surface and the classic page-property shapes. Newer dated versions
+# (2025-09-03, 2026-03-11) introduce breaking renames (data_sources, in_trash)
+# that this thin wrapper deliberately does not track. The header is required on
+# every request -- Notion 400s without it.
+_NOTION_VERSION = "2022-06-28"
+
+# How many rows a paginated list endpoint pulls per request (Notion's max).
+_PAGE_SIZE = 100
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+#
+# Notion responses are parsed into these pydantic models at the boundary (in the
+# public functions below) rather than passed around as untyped dicts. ``extra=
+# "ignore"`` keeps the models forward-compatible if Notion adds fields, and lets
+# the same model absorb the differing selection a create/update returns.
+
+
+class _NotionModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class Page(_NotionModel):
+    """A Notion page object.
+
+    ``properties`` and ``parent`` are kept as raw dicts because their shape is
+    schema-dependent (each database defines its own property names and types);
+    callers index into them directly.
+    """
+
+    id: str
+    object: str | None = None
+    url: str | None = None
+    created_time: str | None = None
+    last_edited_time: str | None = None
+    archived: bool | None = None
+    parent: dict[str, Any] | None = None
+    properties: dict[str, Any] = {}
+
+
+# Fixed schemas so empty results stay typed (polars cannot infer a schema from
+# zero rows). ``search``/``db_query`` return whole objects too unwieldy for a
+# flat frame, so each row is the stable identifying columns plus the raw object.
+_SEARCH_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
+    "id": pl.Utf8,
+    "object": pl.Utf8,
+    "title": pl.Utf8,
+    "url": pl.Utf8,
+    "created_time": pl.Utf8,
+    "last_edited_time": pl.Utf8,
+}
+
+_BLOCKS_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
+    "id": pl.Utf8,
+    "type": pl.Utf8,
+    "has_children": pl.Boolean,
+    "created_time": pl.Utf8,
+    "last_edited_time": pl.Utf8,
+    "text": pl.Utf8,
+}
+
+_DB_QUERY_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
+    "id": pl.Utf8,
+    "object": pl.Utf8,
+    "title": pl.Utf8,
+    "url": pl.Utf8,
+    "created_time": pl.Utf8,
+    "last_edited_time": pl.Utf8,
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+class NotionError(RuntimeError):
+    """Raised when the Notion REST response is an error envelope.
+
+    Notion returns ``{"object": "error", "status": ..., "code": ...,
+    "message": ...}`` on failure. The ``status``, ``code``, and ``message`` are
+    exposed as attributes so callers can branch on the code (e.g.
+    ``"object_not_found"``, ``"unauthorized"``, ``"validation_error"``) without
+    parsing the exception message.
+    """
+
+    def __init__(self, envelope: dict[str, Any]) -> None:
+        self.status = envelope.get("status")
+        self.code = envelope.get("code")
+        self.message = envelope.get("message", "")
+        self.envelope = envelope
+        super().__init__(f"Notion API error ({self.code}): {self.message}")
+
+
+def _api_key() -> str:
+    """Return the Notion API key from the environment or raise clearly."""
+    key = os.environ.get("NOTION_API_KEY", "")
+    if not key:
+        raise RuntimeError(
+            "NOTION_API_KEY is not set in the environment. "
+            "Provision the key (https://www.notion.so/my-integrations) and retry."
+        )
+    return key
+
+
+# _client is module-level so tests can replace it with a factory that injects
+# httpx.MockTransport without patching internals:
+#
+#   import notion, httpx
+#   notion._client = lambda **kw: httpx.AsyncClient(
+#       transport=httpx.MockTransport(handler), **kw
+#   )
+#
+# Production code calls _client() each time so that a key set after import
+# (common in notebooks) is always picked up.
+def _client(**kwargs: Any) -> httpx.AsyncClient:  # noqa: ANN401 -- forwarded verbatim to httpx.AsyncClient
+    """Return a fresh ``httpx.AsyncClient`` wired for the Notion REST API.
+
+    Keyword arguments are forwarded to the constructor, letting callers (and
+    tests) override ``base_url``, ``transport``, etc.
+    """
+    import httpx
+
+    key = _api_key()
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Notion-Version": _NOTION_VERSION,
+        "Content-Type": "application/json",
+    }
+    return httpx.AsyncClient(base_url=_BASE_URL, headers=headers, **kwargs)
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute one Notion REST call and return the decoded JSON body.
+
+    ``params`` are URL query parameters (httpx encodes them, so an opaque
+    pagination cursor with reserved characters stays intact -- never build the
+    query string by hand). ``json`` is the request body.
+
+    Raises :class:`NotionError` when the body is a Notion error envelope
+    (``{"object": "error", ...}``), regardless of the HTTP status code, so the
+    actionable Notion ``code``/``message`` always wins over a bare
+    ``HTTPStatusError``. ``httpx.HTTPStatusError`` still surfaces for a non-2xx
+    response whose body is *not* a parseable error envelope (e.g. a proxy 502).
+    """
+    import httpx
+
+    async with _client() as client:
+        resp = await client.request(method, path, params=params, json=json)
+        try:
+            body: dict[str, Any] = resp.json()
+        except ValueError:
+            resp.raise_for_status()
+            raise
+    if isinstance(body, dict) and body.get("object") == "error":
+        raise NotionError(body)
+    if resp.status_code >= httpx.codes.BAD_REQUEST:
+        resp.raise_for_status()
+    return body
+
+
+def _plain_text(rich_text: list[dict[str, Any]] | None) -> str:
+    """Flatten a Notion ``rich_text`` array to its concatenated plain text."""
+    if not rich_text:
+        return ""
+    return "".join(rt.get("plain_text", "") for rt in rich_text)
+
+
+def _object_title(obj: dict[str, Any]) -> str:
+    """Best-effort plain-text title for a page or database object.
+
+    A database carries a top-level ``title`` rich-text array; a page carries its
+    title inside the ``title``-typed entry of ``properties`` (whose key is the
+    schema-defined name, so it is found by type, not by name).
+    """
+    if obj.get("object") == "database":
+        return _plain_text(obj.get("title"))
+    for prop in (obj.get("properties") or {}).values():
+        if isinstance(prop, dict) and prop.get("type") == "title":
+            return _plain_text(prop.get("title"))
+    return ""
+
+
+def _block_text(block: dict[str, Any]) -> str:
+    """Best-effort plain text for a block (its ``rich_text``, if it has one)."""
+    body = block.get(block.get("type", ""), {})
+    if isinstance(body, dict):
+        return _plain_text(body.get("rich_text"))
+    return ""
+
+
+def _object_row(obj: dict[str, Any]) -> dict[str, Any]:
+    """The fixed-schema row for a page/database object (search + db_query)."""
+    return {
+        "id": obj.get("id", ""),
+        "object": obj.get("object", ""),
+        "title": _object_title(obj),
+        "url": obj.get("url", ""),
+        "created_time": obj.get("created_time", ""),
+        "last_edited_time": obj.get("last_edited_time", ""),
+    }
+
+
+def _block_row(block: dict[str, Any]) -> dict[str, Any]:
+    """The fixed-schema row for a block (blocks + blocks_append)."""
+    return {
+        "id": block.get("id", ""),
+        "type": block.get("type", ""),
+        "has_children": bool(block.get("has_children")),
+        "created_time": block.get("created_time", ""),
+        "last_edited_time": block.get("last_edited_time", ""),
+        "text": _block_text(block),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def search(query: str = "", filter: str | None = None) -> pl.DataFrame:
+    """Search pages and databases the integration can see, as a polars DataFrame.
+
+    ``query`` is matched against page and database titles; an empty string
+    returns everything shared with the integration. Pass ``filter="page"`` or
+    ``filter="database"`` to restrict the object type (Notion's ``filter`` takes
+    ``{"property": "object", "value": ...}``).
+
+    Columns: ``id``, ``object`` (``"page"`` / ``"database"``), ``title``,
+    ``url``, ``created_time``, ``last_edited_time``. Results are paginated
+    automatically. Raises :class:`NotionError` on API errors and ``RuntimeError``
+    when ``NOTION_API_KEY`` is not set.
+    """
+    payload: dict[str, Any] = {"page_size": _PAGE_SIZE}
+    if query:
+        payload["query"] = query
+    if filter is not None:
+        payload["filter"] = {"property": "object", "value": filter}
+
+    rows: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while True:
+        if cursor:
+            payload["start_cursor"] = cursor
+        data = await _request("POST", "/search", json=payload)
+        rows.extend(_object_row(obj) for obj in data.get("results", []))
+        cursor = data.get("next_cursor")
+        if not data.get("has_more") or not cursor:
+            break
+
+    if not rows:
+        return pl.DataFrame(schema=_SEARCH_SCHEMA)
+    return pl.DataFrame(rows, schema_overrides=_SEARCH_SCHEMA).select(list(_SEARCH_SCHEMA))
+
+
+async def page(page_id: str) -> Page:
+    """Fetch a Notion page by id.
+
+    Returns a typed :class:`Page` with attribute access::
+
+        p = await notion.page("<page_id>")
+        p.url                    # str
+        p.properties["Name"]     # the raw property value
+
+    Raises :class:`NotionError` if no page has that id (Notion returns an
+    ``object_not_found`` envelope) or on other API errors, and ``RuntimeError``
+    when ``NOTION_API_KEY`` is not set.
+    """
+    data = await _request("GET", f"/pages/{page_id}")
+    return Page.model_validate(data)
+
+
+async def blocks(block_id: str) -> pl.DataFrame:
+    """A block's (or page's) child blocks, as a polars DataFrame.
+
+    ``block_id`` is a block id or a page id (a page is itself a block). Columns:
+    ``id``, ``type`` (e.g. ``"paragraph"``, ``"heading_1"``, ``"to_do"``),
+    ``has_children``, ``created_time``, ``last_edited_time``, ``text`` (the
+    block's flattened ``rich_text`` plain text, empty for non-text blocks).
+    Results are paginated automatically.
+
+    Raises :class:`NotionError` on API errors and ``RuntimeError`` when
+    ``NOTION_API_KEY`` is not set.
+    """
+    rows: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while True:
+        # The cursor is an opaque token, so it goes through httpx's `params`
+        # (URL-encoded) rather than into a hand-built query string.
+        params: dict[str, Any] = {"page_size": _PAGE_SIZE}
+        if cursor:
+            params["start_cursor"] = cursor
+        data = await _request("GET", f"/blocks/{block_id}/children", params=params)
+        rows.extend(_block_row(block) for block in data.get("results", []))
+        cursor = data.get("next_cursor")
+        if not data.get("has_more") or not cursor:
+            break
+
+    if not rows:
+        return pl.DataFrame(schema=_BLOCKS_SCHEMA)
+    return pl.DataFrame(rows, schema_overrides=_BLOCKS_SCHEMA).select(list(_BLOCKS_SCHEMA))
+
+
+async def db_query(
+    database_id: str,
+    filter: dict[str, Any] | None = None,
+    sorts: list[dict[str, Any]] | None = None,
+) -> pl.DataFrame:
+    """Query a Notion database and return matching pages as a polars DataFrame.
+
+    ``filter`` and ``sorts`` are passed through verbatim to Notion's database
+    query (see https://developers.notion.com/reference/post-database-query), e.g.
+    ``filter={"property": "Status", "select": {"equals": "Done"}}`` and
+    ``sorts=[{"property": "Name", "direction": "ascending"}]``.
+
+    Columns: ``id``, ``object``, ``title``, ``url``, ``created_time``,
+    ``last_edited_time`` (one row per page in the database). Results are paginated
+    automatically. Raises :class:`NotionError` on API errors and ``RuntimeError``
+    when ``NOTION_API_KEY`` is not set.
+    """
+    payload: dict[str, Any] = {"page_size": _PAGE_SIZE}
+    if filter is not None:
+        payload["filter"] = filter
+    if sorts is not None:
+        payload["sorts"] = sorts
+
+    rows: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while True:
+        if cursor:
+            payload["start_cursor"] = cursor
+        data = await _request("POST", f"/databases/{database_id}/query", json=payload)
+        rows.extend(_object_row(obj) for obj in data.get("results", []))
+        cursor = data.get("next_cursor")
+        if not data.get("has_more") or not cursor:
+            break
+
+    if not rows:
+        return pl.DataFrame(schema=_DB_QUERY_SCHEMA)
+    return pl.DataFrame(rows, schema_overrides=_DB_QUERY_SCHEMA).select(
+        list(_DB_QUERY_SCHEMA)
+    )
+
+
+async def page_create(
+    parent: dict[str, Any],
+    properties: dict[str, Any],
+    children: list[dict[str, Any]] | None = None,
+) -> Page:
+    """Create a new Notion page and return the created :class:`Page`.
+
+    ``parent`` names where the page goes, e.g.
+    ``{"database_id": "<id>"}`` or ``{"page_id": "<id>"}``.
+    ``properties`` is the Notion property map; a database page must include the
+    database's title property, e.g.
+    ``{"Name": {"title": [{"text": {"content": "New row"}}]}}``.
+    ``children`` is an optional list of block objects for the page body.
+
+    Raises :class:`NotionError` on API errors (e.g. ``validation_error`` for a
+    property that does not match the database schema) and ``RuntimeError`` when
+    ``NOTION_API_KEY`` is not set.
+    """
+    payload: dict[str, Any] = {"parent": parent, "properties": properties}
+    if children is not None:
+        payload["children"] = children
+    data = await _request("POST", "/pages", json=payload)
+    return Page.model_validate(data)
+
+
+async def blocks_append(
+    block_id: str,
+    children: list[dict[str, Any]],
+) -> pl.DataFrame:
+    """Append ``children`` blocks to a block (or page) and return the new blocks.
+
+    ``block_id`` is the parent block or page id. ``children`` is a list of Notion
+    block objects, e.g.::
+
+        await notion.blocks_append("<page_id>", [
+            {"object": "block", "type": "paragraph",
+             "paragraph": {"rich_text": [{"text": {"content": "hi"}}]}},
+        ])
+
+    Returns a polars DataFrame of the appended blocks (same columns as
+    :func:`blocks`). Raises :class:`NotionError` on API errors and
+    ``RuntimeError`` when ``NOTION_API_KEY`` is not set.
+    """
+    data = await _request(
+        "PATCH", f"/blocks/{block_id}/children", json={"children": children}
+    )
+    rows = [_block_row(block) for block in data.get("results", [])]
+    if not rows:
+        return pl.DataFrame(schema=_BLOCKS_SCHEMA)
+    return pl.DataFrame(rows, schema_overrides=_BLOCKS_SCHEMA).select(list(_BLOCKS_SCHEMA))
+
+
+async def page_update(page_id: str, properties: dict[str, Any]) -> Page:
+    """Update a Notion page's properties and return the updated :class:`Page`.
+
+    ``properties`` is the partial Notion property map to change, e.g.
+    ``{"In stock": {"checkbox": True}}`` or
+    ``{"Status": {"select": {"name": "Done"}}}``.
+
+    Raises :class:`NotionError` on API errors (e.g. ``validation_error``) and
+    ``RuntimeError`` when ``NOTION_API_KEY`` is not set.
+    """
+    data = await _request("PATCH", f"/pages/{page_id}", json={"properties": properties})
+    return Page.model_validate(data)

--- a/packages/mcp/tests/test_notion.py
+++ b/packages/mcp/tests/test_notion.py
@@ -1,0 +1,358 @@
+"""Network-free tests for the `notion` helper.
+
+These never reach Notion: every code path is exercised with an
+``httpx.MockTransport`` injected via the module's ``_client`` hook, so there is
+no network and no real token. They cover: the missing-key RuntimeError, a
+successful search, a paginated db_query, a page_create, and the error-envelope
+to NotionError mapping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+# Prefer the bundled module (nix check); fall back to the source tree (dev run).
+NOTION_SRC = Path(__file__).resolve().parents[1] / "src" / "notion"
+if NOTION_SRC.is_dir() and str(NOTION_SRC) not in sys.path:
+    sys.path.insert(0, str(NOTION_SRC))
+
+import notion
+
+# Public callables = everything exported except the error class and the model.
+_NON_CALLABLE = {"NotionError", "Page"}
+_PUBLIC_FUNCS = [getattr(notion, name) for name in notion.__all__ if name not in _NON_CALLABLE]
+
+
+def test_all_names_exist() -> None:
+    for name in notion.__all__:
+        assert hasattr(notion, name), f"{name} in __all__ but missing from module"
+
+
+def test_error_type() -> None:
+    assert issubclass(notion.NotionError, RuntimeError)
+
+
+def test_public_funcs_are_async() -> None:
+    for func in _PUBLIC_FUNCS:
+        assert asyncio.iscoroutinefunction(func), f"{func.__name__} is not async"
+
+
+def test_type_hints_explicit() -> None:
+    # Mirrors the ruff ANN gate: every public function fully annotates its params
+    # and return type.
+    for func in _PUBLIC_FUNCS:
+        sig = inspect.signature(func)
+        assert sig.return_annotation is not inspect.Signature.empty, (
+            f"{func.__name__} missing return annotation"
+        )
+        for pname, param in sig.parameters.items():
+            assert param.annotation is not inspect.Parameter.empty, (
+                f"{func.__name__}({pname}) missing annotation"
+            )
+
+
+def _install_handler(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    key: str = "secret_test",
+) -> list[httpx.Request]:
+    """Wire ``notion._client`` to a MockTransport running ``handler``.
+
+    Returns the list the handler appends each received request to, so a test can
+    assert on the method/path/body that the module actually sent. A token is set
+    so ``_client`` (which calls ``_api_key``) does not raise.
+    """
+    monkeypatch.setenv("NOTION_API_KEY", key)
+    seen: list[httpx.Request] = []
+
+    def wrapped(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return handler(request)
+
+    def make_client() -> httpx.AsyncClient:
+        # Mirror production _client wiring (base_url + the required headers) so
+        # the header assertions exercise the real shape, but swap the network
+        # transport for the MockTransport.
+        return httpx.AsyncClient(
+            base_url=notion._BASE_URL,
+            headers={
+                "Authorization": f"Bearer {key}",
+                "Notion-Version": notion._NOTION_VERSION,
+                "Content-Type": "application/json",
+            },
+            transport=httpx.MockTransport(wrapped),
+        )
+
+    monkeypatch.setattr(notion, "_client", make_client)
+    return seen
+
+
+def test_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NOTION_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="NOTION_API_KEY"):
+        asyncio.run(notion.search("anything"))
+
+
+def test_search_returns_typed_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "results": [
+                    {
+                        "object": "page",
+                        "id": "page-1",
+                        "url": "https://notion.so/page-1",
+                        "created_time": "2026-01-01T00:00:00.000Z",
+                        "last_edited_time": "2026-01-02T00:00:00.000Z",
+                        "properties": {
+                            "Name": {
+                                "type": "title",
+                                "title": [{"plain_text": "Roadmap"}],
+                            }
+                        },
+                    },
+                    {
+                        "object": "database",
+                        "id": "db-1",
+                        "url": "https://notion.so/db-1",
+                        "created_time": "2026-01-03T00:00:00.000Z",
+                        "last_edited_time": "2026-01-04T00:00:00.000Z",
+                        "title": [{"plain_text": "Tasks DB"}],
+                    },
+                ],
+                "has_more": False,
+                "next_cursor": None,
+            },
+        )
+
+    seen = _install_handler(monkeypatch, handler)
+    df = asyncio.run(notion.search("road", filter="page"))
+
+    # The request shape the module sent.
+    assert seen[-1].method == "POST"
+    assert seen[-1].url.path == "/v1/search"
+    assert seen[-1].headers["Notion-Version"] == notion._NOTION_VERSION
+    assert seen[-1].headers["Authorization"] == "Bearer secret_test"
+
+    # The frame: titles flattened from both a page (via properties) and a
+    # database (via top-level title), columns in the fixed schema order.
+    assert df.columns == list(notion._SEARCH_SCHEMA)
+    assert df["title"].to_list() == ["Roadmap", "Tasks DB"]
+    assert df["object"].to_list() == ["page", "database"]
+
+
+def test_db_query_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
+    pages = [
+        {
+            "object": "list",
+            "results": [
+                {
+                    "object": "page",
+                    "id": "row-1",
+                    "url": "u1",
+                    "created_time": "t1",
+                    "last_edited_time": "t1",
+                    "properties": {"Name": {"type": "title", "title": [{"plain_text": "A"}]}},
+                }
+            ],
+            "has_more": True,
+            "next_cursor": "cursor-2",
+        },
+        {
+            "object": "list",
+            "results": [
+                {
+                    "object": "page",
+                    "id": "row-2",
+                    "url": "u2",
+                    "created_time": "t2",
+                    "last_edited_time": "t2",
+                    "properties": {"Name": {"type": "title", "title": [{"plain_text": "B"}]}},
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        },
+    ]
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        bodies.append(_json.loads(request.content))
+        return httpx.Response(200, json=pages[len(bodies) - 1])
+
+    seen = _install_handler(monkeypatch, handler)
+    df = asyncio.run(notion.db_query("db-1", sorts=[{"property": "Name", "direction": "ascending"}]))
+
+    # Two requests: the second carries the start_cursor from the first response.
+    assert len(seen) == 2
+    assert seen[0].url.path == "/v1/databases/db-1/query"
+    assert "start_cursor" not in bodies[0]
+    assert bodies[0]["sorts"] == [{"property": "Name", "direction": "ascending"}]
+    assert bodies[1]["start_cursor"] == "cursor-2"
+
+    # Both pages' rows are concatenated, in order.
+    assert df["id"].to_list() == ["row-1", "row-2"]
+    assert df["title"].to_list() == ["A", "B"]
+
+
+def test_page_create_returns_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "object": "page",
+                "id": "new-page",
+                "url": "https://notion.so/new-page",
+                "parent": {"database_id": "db-1"},
+                "properties": {"Name": {"type": "title", "title": [{"plain_text": "Hi"}]}},
+            },
+        )
+
+    seen = _install_handler(monkeypatch, handler)
+    created = asyncio.run(
+        notion.page_create(
+            {"database_id": "db-1"},
+            {"Name": {"title": [{"text": {"content": "Hi"}}]}},
+        )
+    )
+
+    assert seen[-1].method == "POST"
+    assert seen[-1].url.path == "/v1/pages"
+    assert isinstance(created, notion.Page)
+    assert created.id == "new-page"
+    assert created.url == "https://notion.so/new-page"
+
+
+def test_blocks_paginates_with_encoded_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A cursor with reserved characters must survive intact: it goes through
+    # httpx params (URL-encoded), never a hand-built query string. If the module
+    # interpolated it raw, the `&`/`=` would split into bogus query params and
+    # this round-trip would fetch the wrong page (or loop).
+    tricky_cursor = "a&b=c d+e/f"
+    pages = [
+        {
+            "object": "list",
+            "results": [{"object": "block", "id": "b-1", "type": "paragraph"}],
+            "has_more": True,
+            "next_cursor": tricky_cursor,
+        },
+        {
+            "object": "list",
+            "results": [{"object": "block", "id": "b-2", "type": "paragraph"}],
+            "has_more": False,
+            "next_cursor": None,
+        },
+    ]
+    calls: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        return httpx.Response(200, json=pages[len(calls) - 1])
+
+    seen = _install_handler(monkeypatch, handler)
+    df = asyncio.run(notion.blocks("page-1"))
+
+    assert len(seen) == 2
+    assert seen[0].url.path == "/v1/blocks/page-1/children"
+    # The second request carries the cursor decoded back to its exact value --
+    # proving it was encoded on the way out, not split into junk params.
+    assert "start_cursor" not in seen[0].url.params
+    assert seen[1].url.params["start_cursor"] == tricky_cursor
+    assert df["id"].to_list() == ["b-1", "b-2"]
+
+
+def test_blocks_append_returns_new_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "results": [
+                    {
+                        "object": "block",
+                        "id": "new-block",
+                        "type": "paragraph",
+                        "paragraph": {"rich_text": [{"plain_text": "hello"}]},
+                    }
+                ],
+            },
+        )
+
+    seen = _install_handler(monkeypatch, handler)
+    df = asyncio.run(
+        notion.blocks_append(
+            "page-1",
+            [
+                {
+                    "object": "block",
+                    "type": "paragraph",
+                    "paragraph": {"rich_text": [{"text": {"content": "hello"}}]},
+                }
+            ],
+        )
+    )
+
+    assert seen[-1].method == "PATCH"
+    assert seen[-1].url.path == "/v1/blocks/page-1/children"
+    assert df["id"].to_list() == ["new-block"]
+    assert df["text"].to_list() == ["hello"]
+
+
+def test_page_update_returns_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        bodies.append(_json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={"object": "page", "id": "p-1", "url": "https://notion.so/p-1", "properties": {}},
+        )
+
+    seen = _install_handler(monkeypatch, handler)
+    updated = asyncio.run(notion.page_update("p-1", {"In stock": {"checkbox": True}}))
+
+    assert seen[-1].method == "PATCH"
+    assert seen[-1].url.path == "/v1/pages/p-1"
+    assert bodies[-1] == {"properties": {"In stock": {"checkbox": True}}}
+    assert isinstance(updated, notion.Page)
+    assert updated.id == "p-1"
+
+
+def test_error_envelope_raises_notion_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Notion returns the error envelope with a non-2xx status; the module
+        # must surface the envelope's code/message, not a bare HTTPStatusError.
+        return httpx.Response(
+            404,
+            json={
+                "object": "error",
+                "status": 404,
+                "code": "object_not_found",
+                "message": "Could not find page with ID: missing.",
+            },
+        )
+
+    _install_handler(monkeypatch, handler)
+    with pytest.raises(notion.NotionError) as excinfo:
+        asyncio.run(notion.page("missing"))
+
+    err = excinfo.value
+    assert err.code == "object_not_found"
+    assert err.status == 404
+    assert "Could not find page" in err.message
+    assert "object_not_found" in str(err)


### PR DESCRIPTION
## What

Adds a `notion` kernel helper to the ix-mcp interpreter, mirroring the existing `linear`/`slack` helpers in structure, packaging, registration, and tests. A session can now `import notion` and read/write a Notion workspace with no setup beyond the API key.

## Surface

Thin async httpx wrapper over the Notion REST API (https://developers.notion.com/reference/intro), NOT the notion-client SDK. Auth header `Authorization: Bearer $NOTION_API_KEY` plus the required `Notion-Version: 2022-06-28` (module constant `_NOTION_VERSION`, the long-standing stable default), base URL `https://api.notion.com/v1`.

Read + write, all async, key read from `os.environ` at call time (clear `RuntimeError` if missing):

- `search(query="", filter=None)` -> polars DataFrame (POST /v1/search, paginated)
- `page(page_id)` -> typed `Page` model (GET /v1/pages/{id})
- `blocks(block_id)` -> polars DataFrame of child blocks (GET /v1/blocks/{id}/children, paginated)
- `db_query(database_id, filter=None, sorts=None)` -> polars DataFrame (POST /v1/databases/{id}/query, paginated)
- `page_create(parent, properties, children=None)` -> `Page` (POST /v1/pages)
- `blocks_append(block_id, children)` -> polars DataFrame (PATCH /v1/blocks/{id}/children)
- `page_update(page_id, properties)` -> `Page` (PATCH /v1/pages/{id})

Notion error envelopes (`{"object":"error","status":...,"code":...,"message":...}`) surface as `NotionError` (with `.status`/`.code`/`.message`), mirroring how `linear` raises `LinearError`. Fixed polars schemas keep empty results typed. A `_client()` hook lets tests inject `httpx.MockTransport`.

## Credentials

Needs `NOTION_API_KEY` in the environment (provisioned separately, e.g. 1Password + launchd seed). Nothing is baked into the repo; the helper only reads the env var. Registered in the requirements registry with `env=("NOTION_API_KEY",)`.

## Tests

`packages/mcp/tests/test_notion.py` exercises every code path with `httpx.MockTransport` (no network, no real token): missing-key `RuntimeError`, a successful search, a paginated `db_query`, a paginated `blocks` (asserting the opaque cursor is URL-encoded, not hand-built into the query string), `blocks_append`, `page_update`, `page_create`, and the error-envelope to `NotionError` mapping.

## Validation

- `nix build .#mcp` green (the real gate; builds the bundled module + runs assertions/tests)
- `nix build .#mcp.tests.{notionBundled,notionTests,requirementsSmoke,strictTypecheck}` all green
- ruff (repo policy) + zuban --strict clean over the module

Note: clippy and the x86_64-linux-only checks were not run locally (darwin host); they run in CI.

Generated with assistance from Claude (Opus 4.8).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Notion REST client kernel helper using async httpx
> - Adds a new `notion` Python module under [packages/mcp/src/notion](https://github.com/indexable-inc/index/pull/1397/files#diff-df366928fbcfba525b57091c041d3689e12ab994d7bf123dfe2d33bda266aef3) with async functions covering the core Notion REST API: `search`, `page`, `blocks`, `db_query`, `page_create`, `blocks_append`, and `page_update`.
> - Results are returned as typed `polars` DataFrames or `pydantic` `Page` models; API error envelopes raise `NotionError` with `status`, `code`, and `message` attributes.
> - Bundles the module into the MCP Nix package via [packages/mcp/default.nix](https://github.com/indexable-inc/index/pull/1397/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) and registers it in the module catalog in [ix_notebook_mcp/registry.py](https://github.com/indexable-inc/index/pull/1397/files#diff-92f567578e1217b8207dbbd21af1cdee4978728a8ca9e774cd65ed17170d2ae5) with a `NOTION_API_KEY` credential entry.
> - The Nix build runs the pytest suite in [tests/test_notion.py](https://github.com/indexable-inc/index/pull/1397/files#diff-41fa24ff83e5e40c0e3735d73ad5b6a1ff4f5cc112f013a52ab8c6a90fb9c7b5) using `httpx.MockTransport` and fails the build on test errors.
> - Behavioral Change: the requirements report check now also asserts `NOTION_API_KEY` is present in stdout, causing the build to fail if missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4a6736.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->