### PR TITLE
feat(system-prompt-eval): rich HTML scorecard with full action timelines

### DIFF
--- a/packages/agent/system-prompt-eval/README.md
+++ b/packages/agent/system-prompt-eval/README.md
@@ -85,6 +85,16 @@ fraction that reverse-engineered.
 - `--effort {high,xhigh,max}`: reasoning effort. Evals NEVER run in fast/low
   mode; `high` is the floor.
 
+## Scorecard
+
+Every run writes a self-contained HTML scorecard (`--html-out`, or a temp file by
+default; the path is printed) with three drill-in layers: summary cards per eval;
+a behaviors panel (name + full rubric + pass-rate + a clickable pass/fail dot per
+rollout); and per rollout, the verdicts with the judge's evidence plus the **full
+action timeline** — every assistant message, thinking block, tool call with its
+input, tool result, and the final answer. The `--json-out` report carries the
+same `steps` as machine-readable raw data.
+
 ## Time series
 
 Commit each run's `--json-out` under `eval-results/results-<date>-<rev>.json`.

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/agent.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/agent.py
@@ -29,11 +29,15 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-# Compact a tool input/result to keep the transcript inside the judge's budget
+# Compact a tool input/result to keep the JUDGE transcript inside its budget
 # while still showing the load-bearing tokens (a `gh issue create`, a Task
-# subagent description, a slack send).
+# subagent description, a slack send). The full, untruncated detail is kept
+# separately in `steps` for the HTML scorecard to render.
 _BLOCK_CAP = 600
 _TRANSCRIPT_CAP = 18000
+# Generous per-step cap for the rich HTML timeline: effectively full, but a guard
+# against a pathological multi-MB tool result blowing up the page.
+_STEP_CAP = 40000
 
 
 class AgentError(RuntimeError):
@@ -62,10 +66,16 @@ class RunMetrics:
 
 @dataclass(frozen=True, slots=True)
 class RunOutput:
-    """One rollout's compacted transcript plus its cost metrics."""
+    """One rollout's compact judge transcript, full step timeline, and metrics.
+
+    ``transcript`` is the compacted text the LLM judge reads. ``steps`` is the
+    full, ordered action timeline (assistant prose, thinking, every tool call with
+    its input, every tool result, the final answer) for the HTML scorecard.
+    """
 
     transcript: str
     metrics: RunMetrics
+    steps: list[dict[str, object]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,8 +140,9 @@ class Rollout:
 
 
 def parse_stream(stdout: str) -> RunOutput:
-    """Flatten stream-json into a transcript and pull the final result metrics."""
+    """Flatten stream-json into a judge transcript, a full step timeline, metrics."""
     parts: list[str] = []
+    steps: list[dict[str, object]] = []
     metrics = RunMetrics()
     for raw in stdout.splitlines():
         line = raw.strip()
@@ -143,14 +154,16 @@ def parse_stream(stdout: str) -> RunOutput:
             continue
         kind = event.get("type")
         if kind == "assistant":
-            parts.extend(_assistant_blocks(event))
+            _assistant(event, parts, steps)
         elif kind == "user":
-            parts.extend(_tool_results(event))
+            _tool_results(event, parts, steps)
         elif kind == "result":
-            parts.append("FINAL: " + str(event.get("result", "")).strip())
+            result = str(event.get("result", "")).strip()
+            parts.append("FINAL: " + result)
+            steps.append({"kind": "final", "text": result[:_STEP_CAP]})
             metrics = _metrics_from_result(event)
     text = "\n".join(p for p in parts if p)
-    return RunOutput(transcript=text[:_TRANSCRIPT_CAP], metrics=metrics)
+    return RunOutput(transcript=text[:_TRANSCRIPT_CAP], metrics=metrics, steps=steps)
 
 
 def _metrics_from_result(event: dict[str, object]) -> RunMetrics:
@@ -175,40 +188,57 @@ def _float(value: object) -> float:
 
 
 
-def _assistant_blocks(event: dict[str, object]) -> list[str]:
+def _assistant(
+    event: dict[str, object], parts: list[str], steps: list[dict[str, object]]
+) -> None:
     message = event.get("message")
     if not isinstance(message, dict):
-        return []
+        return
     content = message.get("content")
     if not isinstance(content, list):
-        return []
-    out: list[str] = []
+        return
     for block in content:
         if not isinstance(block, dict):
             continue
         btype = block.get("type")
         if btype == "text":
-            out.append("ASSISTANT: " + str(block.get("text", "")).strip())
+            text = str(block.get("text", "")).strip()
+            parts.append("ASSISTANT: " + text)
+            steps.append({"kind": "text", "text": text[:_STEP_CAP]})
+        elif btype == "thinking":
+            steps.append(
+                {"kind": "thinking", "text": str(block.get("thinking", "")).strip()[:_STEP_CAP]}
+            )
         elif btype == "tool_use":
             name = str(block.get("name", "?"))
-            payload = json.dumps(block.get("input", {}), default=str)[:_BLOCK_CAP]
-            out.append(f"TOOL_USE {name}: {payload}")
-    return out
+            raw_input = block.get("input", {})
+            payload = json.dumps(raw_input, default=str)
+            parts.append(f"TOOL_USE {name}: {payload[:_BLOCK_CAP]}")
+            steps.append(
+                {
+                    "kind": "tool_use",
+                    "name": name,
+                    "input": json.dumps(raw_input, indent=2, default=str)[:_STEP_CAP],
+                }
+            )
 
 
-def _tool_results(event: dict[str, object]) -> list[str]:
+def _tool_results(
+    event: dict[str, object], parts: list[str], steps: list[dict[str, object]]
+) -> None:
     message = event.get("message")
     if not isinstance(message, dict):
-        return []
+        return
     content = message.get("content")
     if not isinstance(content, list):
-        return []
-    out: list[str] = []
+        return
     for block in content:
         if not isinstance(block, dict) or block.get("type") != "tool_result":
             continue
-        out.append("TOOL_RESULT: " + _result_text(block.get("content"))[:_BLOCK_CAP])
-    return out
+        text = _result_text(block.get("content"))
+        is_error = bool(block.get("is_error"))
+        parts.append("TOOL_RESULT: " + text[:_BLOCK_CAP])
+        steps.append({"kind": "tool_result", "text": text[:_STEP_CAP], "is_error": is_error})
 
 
 def _result_text(content: object) -> str:

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/first_principles_eval.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/first_principles_eval.py
@@ -23,7 +23,7 @@ import stat
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from . import sandbox as sb
@@ -73,6 +73,7 @@ class FpResult:
     output_tokens: int = 0
     cost_usd: float = 0.0
     transcript: str = ""
+    steps: list[dict[str, object]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -88,6 +89,7 @@ class FpResult:
             "output_tokens": self.output_tokens,
             "cost_usd": self.cost_usd,
             "transcript": self.transcript,
+            "steps": self.steps,
         }
 
 
@@ -242,6 +244,7 @@ def run(ctx: EvalContext, *, cases_path: Path | None = None) -> EvalReport:
             output_tokens=out.metrics.output_tokens,
             cost_usd=out.metrics.cost_usd,
             transcript=out.transcript,
+            steps=out.steps,
         )
 
     with ThreadPoolExecutor(max_workers=ctx.max_workers) as pool:

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/html.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/html.py
@@ -1,9 +1,16 @@
-"""Render an eval run as a single self-contained HTML scorecard.
+"""Render an eval run as a single self-contained, navigable HTML scorecard.
 
-Inline CSS, no external assets, dark-mode aware. Shows each eval's headline,
-per-behavior pass rates, the longest all-pass streak, cost (time/tokens/$), and a
-per-rollout table where each row expands to the judge's evidence and the raw
-transcript. The same JSON that feeds this is the machine-readable raw data.
+Inline CSS + a little inline JS, no external assets, dark-mode aware. The page
+has three layers you can drill into:
+
+1. a summary band: one card per eval with its headline score, streak, and cost;
+2. per eval, a behaviors panel (name + full rubric + pass-rate + per-rollout
+   chips) and a list of rollouts;
+3. per rollout, the verdicts with the judge's evidence AND the full action
+   timeline: every assistant message, thinking block, tool call with its input,
+   tool result, and the final answer.
+
+The same JSON that feeds this (``--json-out``) is the machine-readable raw data.
 """
 
 from __future__ import annotations
@@ -22,6 +29,10 @@ def _pct(value: float) -> str:
     return f"{value:.0%}"
 
 
+def _num(value: object) -> float:
+    return float(value) if isinstance(value, (int, float)) else 0.0
+
+
 def _chip(label: str, value: str) -> str:
     return f'<span class="chip"><b>{_esc(label)}</b> {_esc(value)}</span>'
 
@@ -30,112 +41,269 @@ def _cost_chips(summary: dict[str, object]) -> str:
     cost = summary.get("cost")
     if not isinstance(cost, dict):
         return ""
-    out = []
-    if isinstance(cost.get("mean_duration_s"), (int, float)):
-        out.append(_chip("mean", f"{float(cost['mean_duration_s']):.0f}s"))
-    if isinstance(cost.get("total_output_tokens"), (int, float)):
-        out.append(_chip("out tok", f"{int(float(cost['total_output_tokens']))}"))
-    if isinstance(cost.get("total_input_tokens"), (int, float)):
-        out.append(_chip("in tok", f"{int(float(cost['total_input_tokens']))}"))
-    if isinstance(cost.get("total_cost_usd"), (int, float)):
-        out.append(_chip("cost", f"${float(cost['total_cost_usd']):.2f}"))
+    out: list[str] = []
+    if "mean_duration_s" in cost:
+        out.append(_chip("mean", f"{_num(cost['mean_duration_s']):.0f}s"))
+    if "total_output_tokens" in cost:
+        out.append(_chip("out tok", f"{int(_num(cost['total_output_tokens'])):,}"))
+    if "total_input_tokens" in cost:
+        out.append(_chip("in tok", f"{int(_num(cost['total_input_tokens'])):,}"))
+    if "total_cost_usd" in cost:
+        out.append(_chip("cost", f"${_num(cost['total_cost_usd']):.2f}"))
     return "".join(out)
 
 
-def _behavior_table(summary: dict[str, object]) -> str:
-    per = summary.get("per_behavior")
-    if not isinstance(per, dict) or not per:
-        return ""
-    rows = "".join(
-        f"<tr><td>{_esc(bid)}</td><td class='num'>{_pct(float(rate))}</td>"
-        f"<td class='bar'><span style='width:{float(rate) * 100:.0f}%'></span></td></tr>"
-        for bid, rate in per.items()
-        if isinstance(rate, (int, float))
-    )
-    return f"<table class='beh'><tr><th>behavior</th><th>pass</th><th></th></tr>{rows}</table>"
+# ---- step timeline ---------------------------------------------------------
 
 
-def _case_row(case: dict[str, object]) -> str:
+def _step(step: dict[str, object]) -> str:
+    kind = str(step.get("kind", ""))
+    if kind == "text":
+        return f'<div class="step text"><div class="lbl">assistant</div><div class="prose">{_esc(step.get("text", ""))}</div></div>'
+    if kind == "thinking":
+        return (
+            '<details class="step thinking"><summary>thinking</summary>'
+            f'<pre>{_esc(step.get("text", ""))}</pre></details>'
+        )
+    if kind == "tool_use":
+        name = _esc(step.get("name", "?"))
+        return (
+            f'<details class="step tooluse" open><summary>🔧 <b>{name}</b></summary>'
+            f'<pre>{_esc(step.get("input", ""))}</pre></details>'
+        )
+    if kind == "tool_result":
+        err = " error" if step.get("is_error") else ""
+        label = "tool result (error)" if step.get("is_error") else "tool result"
+        return (
+            f'<details class="step toolresult{err}"><summary>{label}</summary>'
+            f'<pre>{_esc(step.get("text", ""))}</pre></details>'
+        )
+    if kind == "final":
+        return f'<div class="step final"><div class="lbl">final answer</div><div class="prose">{_esc(step.get("text", ""))}</div></div>'
+    return ""
+
+
+def _timeline(case: dict[str, object]) -> str:
+    steps = case.get("steps")
+    if not isinstance(steps, list) or not steps:
+        # No structured steps (e.g. a safe-mode run captured before this feature):
+        # fall back to the compact transcript so nothing is lost.
+        tr = case.get("transcript")
+        if isinstance(tr, str) and tr.strip():
+            return f'<pre class="fallback">{_esc(tr)}</pre>'
+        return '<p class="muted">no transcript captured</p>'
+    rows = "".join(_step(s) for s in steps if isinstance(s, dict))
+    n = len(steps)
+    return f'<div class="timeline"><div class="muted">{n} steps</div>{rows}</div>'
+
+
+# ---- verdicts --------------------------------------------------------------
+
+
+def _verdicts(case: dict[str, object]) -> str:
+    present = case.get("present")
+    evidence = case.get("evidence")
+    if isinstance(present, dict):  # behaviors eval
+        ev = evidence if isinstance(evidence, dict) else {}
+        rows = "".join(
+            f'<tr class="{"y" if v else "n"}"><td>{"✓" if v else "✗"}</td>'
+            f"<td>{_esc(b)}</td><td>{_esc(ev.get(b, ''))}</td></tr>"
+            for b, v in present.items()
+        )
+        return f'<table class="verdicts"><tr><th></th><th>behavior</th><th>evidence</th></tr>{rows}</table>'
+    # first-principles / reverse-engineering: a single judged dimension
+    if "verdict" in case:
+        v = _esc(case.get("verdict", "?"))
+        return (
+            f'<table class="verdicts"><tr><td><b>verdict</b></td><td>{v}</td></tr>'
+            f'<tr><td><b>answer</b></td><td>{_esc(case.get("answer", ""))}</td></tr>'
+            f'<tr><td><b>evidence</b></td><td>{_esc(case.get("evidence", ""))}</td></tr></table>'
+        )
+    if "reverse_engineered" in case:
+        re = bool(case.get("reverse_engineered"))
+        return (
+            f'<table class="verdicts"><tr><td><b>reverse-engineered</b></td>'
+            f'<td>{"yes" if re else "no"}</td></tr>'
+            f'<tr><td><b>answer</b></td><td>{_esc(case.get("answer", ""))}</td></tr>'
+            f'<tr><td><b>evidence</b></td><td>{_esc(case.get("evidence", ""))}</td></tr></table>'
+        )
+    return ""
+
+
+def _status(case: dict[str, object]) -> tuple[str, str]:
+    if case.get("error"):
+        return "bad", "ERROR"
+    present = case.get("present")
+    if isinstance(present, dict):
+        ok = sum(1 for v in present.values() if v is True)
+        cls = "good" if ok == len(present) else ("warn" if ok else "bad")
+        return cls, f"{ok}/{len(present)}"
+    if "verdict" in case:
+        v = str(case.get("verdict", "?"))
+        return {"validated": "good", "stale": "bad"}.get(v, "warn"), v
+    if "reverse_engineered" in case:
+        re = bool(case.get("reverse_engineered"))
+        return ("good" if re else "bad"), ("RE" if re else "guessed")
+    return "warn", "?"
+
+
+def _rollout(case: dict[str, object], anchor: str) -> str:
+    cls, badge = _status(case)
     cid = _esc(case.get("case_id", "?"))
     roll = _esc(case.get("rollout", ""))
-    err = case.get("error")
-    present = case.get("present")
-    if err:
-        status = "<span class='bad'>ERROR</span>"
-        detail = _esc(err)
-    elif isinstance(present, dict):
-        ok = sum(1 for v in present.values() if v is True)
-        status = f"<span class='{'good' if ok == len(present) else 'warn'}'>{ok}/{len(present)}</span>"
-        detail = ", ".join(
-            f"{_esc(b)}={'Y' if v else 'N'}" for b, v in present.items()
-        )
-    else:
-        verdict = str(case.get("verdict", "?"))
-        cls = {"validated": "good", "stale": "bad"}.get(verdict, "warn")
-        status = f"<span class='{cls}'>{_esc(verdict)}</span>"
-        detail = _esc(case.get("answer", ""))
-    transcript = _esc(case.get("transcript", ""))
-    evidence = case.get("evidence")
-    ev_html = ""
-    if isinstance(evidence, dict):
-        ev_html = "<ul>" + "".join(
-            f"<li><b>{_esc(b)}:</b> {_esc(t)}</li>" for b, t in evidence.items()
-        ) + "</ul>"
-    elif isinstance(evidence, str):
-        ev_html = f"<p>{_esc(evidence)}</p>"
     dur = case.get("duration_ms")
-    dur_s = f"{int(dur) / 1000:.0f}s" if isinstance(dur, (int, float)) else "-"
-    return (
-        f"<tr><td>{cid}</td><td class='num'>{roll}</td><td>{status}</td>"
-        f"<td class='num'>{dur_s}</td><td>{detail}</td></tr>"
-        f"<tr class='exp'><td colspan='5'><details><summary>evidence + transcript</summary>"
-        f"{ev_html}<pre>{transcript}</pre></details></td></tr>"
+    dur_s = f"{_num(dur) / 1000:.0f}s" if isinstance(dur, (int, float)) and dur else "-"
+    out_tok = int(_num(case.get("output_tokens")))
+    cost = _num(case.get("cost_usd"))
+    meta = f'<span class="rmeta">{dur_s} · {out_tok:,} tok · ${cost:.2f}</span>'
+    summary_line = (
+        f'<summary id="{anchor}"><span class="badge {cls}">{_esc(badge)}</span> '
+        f"<b>{cid}</b> #{roll} {meta}</summary>"
     )
+    body = _verdicts(case)
+    err = case.get("error")
+    if err:
+        body += f'<p class="bad">{_esc(err)}</p>'
+    body += '<div class="tl-h">action timeline</div>' + _timeline(case)
+    return f'<details class="rollout">{summary_line}{body}</details>'
 
 
-def _eval_section(rep: EvalReport) -> str:
+# ---- behaviors panel -------------------------------------------------------
+
+
+def _behaviors_panel(summary: dict[str, object], cases: Sequence[dict[str, object]], eid: str) -> str:
+    defs = summary.get("behavior_defs")
+    rates = summary.get("per_behavior")
+    if not isinstance(defs, list) or not defs:
+        return ""
+    rate_map = rates if isinstance(rates, dict) else {}
+    blocks: list[str] = []
+    for d in defs:
+        if not isinstance(d, dict):
+            continue
+        bid = str(d.get("id", ""))
+        rate = _num(rate_map.get(bid))
+        # per-rollout chips that jump to the rollout
+        chips: list[str] = []
+        for i, c in enumerate(cases):
+            present = c.get("present")
+            if not (isinstance(present, dict) and bid in present):
+                continue
+            ok = present[bid] is True
+            chips.append(
+                f'<a class="dot {"y" if ok else "n"}" href="#{eid}-{i}" '
+                f'title="{_esc(c.get("case_id", ""))} #{_esc(c.get("rollout", ""))}">'
+                f'{"✓" if ok else "✗"}</a>'
+            )
+        blocks.append(
+            f'<div class="beh"><div class="beh-head"><b>{_esc(d.get("name", bid))}</b>'
+            f'<span class="beh-rate">{_pct(rate)}</span></div>'
+            f'<div class="bar"><span style="width:{rate * 100:.0f}%"></span></div>'
+            f'<div class="rubric">{_esc(d.get("rubric", ""))}</div>'
+            f'<div class="dots">{"".join(chips)}</div></div>'
+        )
+    return f'<div class="panel">{"".join(blocks)}</div>'
+
+
+# ---- sections --------------------------------------------------------------
+
+
+def _eval_section(rep: EvalReport, idx: int) -> str:
+    eid = f"e{idx}"
     streak = "" if rep.longest_streak is None else _chip("streak", str(rep.longest_streak))
+    s = rep.summary
+    counts = ""
+    if "scored" in s or "rollouts" in s:
+        total = int(_num(s.get("total", s.get("rollouts", 0))))
+        errd = int(_num(s.get("errored", 0)))
+        counts = _chip("runs", f"{total}" + (f" ({errd} err)" if errd else ""))
     head = (
-        f"<h2>{_esc(rep.name)} <span class='headline'>{_pct(rep.headline)}</span></h2>"
-        f"<div class='chips'>{streak}{_cost_chips(rep.summary)}</div>"
+        f'<h2 id="{eid}">{_esc(rep.name)} <span class="headline {_grade(rep.headline)}">{_pct(rep.headline)}</span></h2>'
+        f'<div class="chips">{streak}{counts}{_cost_chips(s)}</div>'
     )
-    rows = "".join(_case_row(c) for c in rep.cases)
-    table = (
-        "<table class='cases'><tr><th>case</th><th>#</th><th>status</th>"
-        f"<th>time</th><th>detail</th></tr>{rows}</table>"
+    panel = _behaviors_panel(s, rep.cases, eid)
+    rollouts = "".join(_rollout(c, f"{eid}-{i}") for i, c in enumerate(rep.cases))
+    return f'<section>{head}{panel}<h3>rollouts</h3>{rollouts}</section>'
+
+
+def _grade(h: float) -> str:
+    return "good" if h >= 0.8 else ("warn" if h >= 0.5 else "bad")
+
+
+def _summary_card(rep: EvalReport, idx: int) -> str:
+    return (
+        f'<a class="scard" href="#e{idx}"><div class="scard-h">{_esc(rep.name)}</div>'
+        f'<div class="scard-n {_grade(rep.headline)}">{_pct(rep.headline)}</div></a>'
     )
-    return f"<section>{head}{_behavior_table(rep.summary)}{table}</section>"
 
 
 def render_html(metadata: dict[str, object], reports: Sequence[EvalReport]) -> str:
     meta_chips = "".join(_chip(k, str(v)) for k, v in metadata.items())
-    sections = "".join(_eval_section(r) for r in reports)
+    cards = "".join(_summary_card(r, i) for i, r in enumerate(reports))
+    sections = "".join(_eval_section(r, i) for i, r in enumerate(reports))
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>system-prompt eval scorecard</title>
 <style>
-:root {{ color-scheme: light dark; }}
-body {{ font: 14px/1.5 ui-monospace, "Berkeley Mono", Menlo, monospace; margin: 2rem auto; max-width: 60rem; padding: 0 1rem; }}
-h1 {{ font-size: 1.4rem; }}
-h2 {{ font-size: 1.1rem; margin-top: 2rem; border-top: 1px solid #8884; padding-top: 1rem; }}
-.headline {{ float: right; font-size: 1.6rem; font-weight: 700; }}
-.chips {{ margin: .5rem 0; }}
-.chip {{ display: inline-block; background: #8881; border-radius: 6px; padding: 2px 8px; margin: 2px; font-size: 12px; }}
-table {{ border-collapse: collapse; width: 100%; margin: .5rem 0; }}
-th, td {{ text-align: left; padding: 4px 8px; border-bottom: 1px solid #8883; vertical-align: top; }}
-.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
-.good {{ color: #2e9d4e; font-weight: 700; }}
-.warn {{ color: #c98a00; font-weight: 700; }}
-.bad {{ color: #d4493f; font-weight: 700; }}
-.beh .bar {{ width: 40%; }}
-.beh .bar span {{ display: inline-block; height: 10px; background: #2e9d4e; border-radius: 3px; }}
-.exp td {{ border-bottom: 1px solid #8883; }}
-details summary {{ cursor: pointer; color: #6a8; }}
-pre {{ white-space: pre-wrap; word-break: break-word; background: #8881; padding: 8px; border-radius: 6px; max-height: 28rem; overflow: auto; }}
+:root {{ color-scheme: light dark; --line:#8884; --soft:#8881; --good:#2e9d4e; --warn:#c98a00; --bad:#d4493f; }}
+* {{ box-sizing: border-box; }}
+body {{ font: 14px/1.55 ui-monospace,"Berkeley Mono",Menlo,monospace; margin: 0 auto; max-width: 68rem; padding: 1.5rem 1rem 6rem; }}
+h1 {{ font-size: 1.4rem; margin: 0 0 .3rem; }}
+h2 {{ font-size: 1.15rem; margin: 2rem 0 .2rem; }}
+h3 {{ font-size: .95rem; opacity: .7; margin: 1.2rem 0 .4rem; text-transform: uppercase; letter-spacing: .04em; }}
+.muted {{ opacity: .6; }}
+.good {{ color: var(--good); }} .warn {{ color: var(--warn); }} .bad {{ color: var(--bad); }}
+.headline {{ float: right; font-size: 1.5rem; font-weight: 800; }}
+.chips {{ margin: .3rem 0 .6rem; }}
+.chip {{ display:inline-block; background: var(--soft); border-radius: 6px; padding: 2px 8px; margin: 2px 3px 2px 0; font-size: 12px; }}
+.cards {{ display:flex; flex-wrap:wrap; gap:.6rem; margin:.8rem 0 1.2rem; }}
+.scard {{ flex:1 1 12rem; text-decoration:none; color:inherit; border:1px solid var(--line); border-radius:10px; padding:.7rem .9rem; }}
+.scard-h {{ font-size:.85rem; opacity:.8; }}
+.scard-n {{ font-size:1.7rem; font-weight:800; }}
+.panel {{ display:grid; grid-template-columns: repeat(auto-fit,minmax(18rem,1fr)); gap:.8rem; margin:.4rem 0 .8rem; }}
+.beh {{ border:1px solid var(--line); border-radius:10px; padding:.7rem .8rem; }}
+.beh-head {{ display:flex; justify-content:space-between; }}
+.beh-rate {{ font-weight:800; }}
+.bar {{ background: var(--soft); border-radius:4px; height:8px; margin:.4rem 0; overflow:hidden; }}
+.bar span {{ display:block; height:100%; background: var(--good); }}
+.rubric {{ font-size:12px; opacity:.7; margin:.2rem 0 .4rem; }}
+.dots {{ display:flex; flex-wrap:wrap; gap:3px; }}
+.dot {{ width:18px; height:18px; line-height:18px; text-align:center; border-radius:4px; font-size:11px; text-decoration:none; color:#fff; }}
+.dot.y {{ background: var(--good); }} .dot.n {{ background: var(--bad); }}
+.rollout {{ border:1px solid var(--line); border-radius:10px; margin:.4rem 0; padding:.1rem .6rem; }}
+.rollout > summary {{ cursor:pointer; padding:.5rem .2rem; font-size:13px; }}
+.rmeta {{ float:right; opacity:.6; font-size:12px; }}
+.badge {{ display:inline-block; min-width:3.2rem; text-align:center; border-radius:5px; padding:1px 6px; font-weight:700; font-size:12px; color:#fff; }}
+.badge.good {{ background: var(--good); }} .badge.warn {{ background: var(--warn); }} .badge.bad {{ background: var(--bad); }}
+.verdicts {{ border-collapse:collapse; width:100%; margin:.4rem 0; font-size:13px; }}
+.verdicts td, .verdicts th {{ border-bottom:1px solid var(--line); padding:3px 6px; vertical-align:top; text-align:left; }}
+.verdicts tr.y td:first-child {{ color: var(--good); }} .verdicts tr.n td:first-child {{ color: var(--bad); }}
+.tl-h {{ font-size:.8rem; opacity:.6; text-transform:uppercase; letter-spacing:.04em; margin:.8rem 0 .3rem; }}
+.timeline {{ border-left:2px solid var(--line); padding-left:.7rem; margin-left:.2rem; }}
+.step {{ margin:.45rem 0; }}
+.step .lbl {{ font-size:11px; opacity:.55; text-transform:uppercase; letter-spacing:.04em; }}
+.step.text .prose, .step.final .prose {{ white-space:pre-wrap; }}
+.step.final {{ border:1px solid var(--good); border-radius:8px; padding:.5rem .7rem; background:rgba(46,157,78,.08); }}
+.step details > summary {{ cursor:pointer; font-size:12px; }}
+.step.tooluse > summary {{ color:#3b82f6; }}
+.step.toolresult.error {{ }}
+.step.toolresult.error > summary {{ color: var(--bad); }}
+.step.thinking {{ opacity:.7; }}
+pre {{ white-space:pre-wrap; word-break:break-word; background:var(--soft); padding:8px; border-radius:6px; max-height:32rem; overflow:auto; margin:.25rem 0; font-size:12px; }}
+.fallback {{ max-height:none; }}
+.toolbar {{ position:sticky; top:0; background:Canvas; padding:.4rem 0; border-bottom:1px solid var(--line); margin-bottom:.6rem; z-index:5; }}
+.toolbar button {{ font:inherit; font-size:12px; padding:3px 9px; border:1px solid var(--line); border-radius:6px; background:var(--soft); cursor:pointer; }}
+a {{ color:#3b82f6; }}
 </style></head>
 <body>
 <h1>system-prompt eval scorecard</h1>
 <div class="chips">{meta_chips}</div>
+<div class="cards">{cards}</div>
+<div class="toolbar">
+  <button onclick="document.querySelectorAll('details.rollout,details.step').forEach(d=>d.open=true)">expand all</button>
+  <button onclick="document.querySelectorAll('details.rollout,details.step').forEach(d=>d.open=false)">collapse all</button>
+  <span class="muted"> — click any run to see its full action timeline; click a behavior dot to jump to that run</span>
+</div>
 {sections}
 </body></html>"""

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/judge.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/judge.py
@@ -108,11 +108,17 @@ class Judge:
         )
         raw = self._call(_SYSTEM, user)
         out = _JudgeOutput.model_validate(raw)
+        # Keep only verdicts for behaviors we actually asked about: a judge that
+        # echoes an extra/hallucinated id would otherwise leak into `present` and
+        # skew the per-rollout badge (the scoring math is id-guarded, the badge is
+        # not).
+        requested = {b.id for b in behaviors}
         by_id = {
             v.behavior_id: BehaviorVerdict(
                 behavior_id=v.behavior_id, present=v.present, evidence=v.evidence
             )
             for v in out.verdicts
+            if v.behavior_id in requested
         }
         # Any behavior the judge dropped is scored absent, not silently missing.
         for b in behaviors:

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/model.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/model.py
@@ -59,6 +59,8 @@ class RolloutResult:
     input_tokens: int = 0
     output_tokens: int = 0
     cost_usd: float = 0.0
+    # Full action timeline for the HTML scorecard.
+    steps: list[dict[str, object]] = field(default_factory=list)
 
     def all_expected_present(self, expected: tuple[str, ...]) -> bool:
         """True iff every expected behavior was judged present (and no error)."""

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/report.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/report.py
@@ -100,6 +100,9 @@ def summarize(
         "errored": errored,
         "tasks": len(tasks),
         "behaviors": len(behaviors),
+        "behavior_defs": [
+            {"id": b.id, "name": b.name, "rubric": b.rubric} for b in behaviors
+        ],
         "cost": cost_summary(results),
     }
 
@@ -118,6 +121,7 @@ def cases_json(results: Sequence[RolloutResult]) -> list[dict[str, object]]:
             "output_tokens": r.output_tokens,
             "cost_usd": r.cost_usd,
             "transcript": r.transcript,
+            "steps": r.steps,
         }
         for r in results
     ]

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/reverse_engineering_eval.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/reverse_engineering_eval.py
@@ -20,7 +20,7 @@ import shutil
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from . import sandbox as sb
@@ -76,6 +76,7 @@ class ReResult:
     output_tokens: int = 0
     cost_usd: float = 0.0
     transcript: str = ""
+    steps: list[dict[str, object]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -90,6 +91,7 @@ class ReResult:
             "output_tokens": self.output_tokens,
             "cost_usd": self.cost_usd,
             "transcript": self.transcript,
+            "steps": self.steps,
         }
 
 
@@ -164,6 +166,7 @@ def _run_case(ctx: EvalContext, case: ReCase, binary: Path) -> tuple[str, ReResu
         output_tokens=out.metrics.output_tokens,
         cost_usd=out.metrics.cost_usd,
         transcript=out.transcript,
+        steps=out.steps,
         answer=_final_answer(out.transcript),
     )
     return out.transcript, res

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/runner.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/runner.py
@@ -54,6 +54,7 @@ def run_eval(
             input_tokens=out.metrics.input_tokens,
             output_tokens=out.metrics.output_tokens,
             cost_usd=out.metrics.cost_usd,
+            steps=out.steps,
         )
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:


### PR DESCRIPTION
Completely redesigns the eval HTML scorecard so you can drill into every run.

**Captures full structured steps** per rollout (new `steps`): assistant prose, thinking, every tool call **with its full input**, every tool result (flagged on error), and the final answer. Stored untruncated in the `--json-out` raw data too.

**Redesigned HTML** (`html.py`): summary cards per eval; a behaviors panel showing each behavior's name + full rubric + pass-rate bar + a clickable pass/fail dot per rollout (jumps to that run); and per rollout a collapsible card that expands to the verdicts (with judge evidence) and the full action timeline. Expand-all/collapse-all, dark-mode, self-contained.

Builds clean (zuban + ruff), offline tests pass. Follow-up to #1401.

_Opened by an AI agent via Claude Code._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add rich HTML scorecard with per-rollout action timelines to system-prompt-eval
> - Adds a structured `steps` timeline to `RunOutput` in [agent.py](https://github.com/indexable-inc/index/pull/1406/files#diff-e31593cacb2019985d326178ed8dc1380826e91a79a914208f5cfa62eeb89508), capturing assistant text, thinking blocks, tool-use inputs (pretty-printed JSON), tool results, and a final answer per rollout.
> - Redesigns [html.py](https://github.com/indexable-inc/index/pull/1406/files#diff-4188b0c659c5447efe48d252fa6a8df5140b6e06a3a6a8cd12d54a27543aed64) to generate a self-contained scorecard with three drill-in layers: a summary card band, expandable eval sections with a behaviors panel (pass rates, rubric, per-rollout dots), and expandable rollout blocks with full action timelines.
> - Propagates `steps` through `RolloutResult`, `FpResult`, `ReResult`, and the JSON report so the HTML and machine-readable outputs share the same data.
> - Adds a `behavior_defs` array (id, name, rubric) to the JSON summary for display use.
> - Fixes `Judge.grade` to filter verdicts to only requested behavior ids and explicitly mark missing ones as absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe374ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->