### PR TITLE
ci(blast-radius): make the PR comment opt-in via a `blast-radius` label

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,17 +1,22 @@
 name: Blast radius
 
 on:
-  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
-  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
-  # serves the whole team, so every PR queued one more eval-only runner and
-  # slowed the queue. The report is informational (a sticky PR comment), never
-  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
-  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
-  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  # Opt-in per PR, not on every push. Auto-running on every PR meant the per-PR
+  # full-catalog eval (~57s "Report blast radius" step) claimed a shared `ix-ci`
+  # runner from the one dispatcher pool that serves the whole team, queuing an
+  # eval-only runner each push and slowing the queue (#1384). But fully disabling
+  # it left the report unreachable, so the sticky comment "came up empty" on every
+  # PR. The middle ground: it runs only when a maintainer adds the `blast-radius`
+  # label. Once labeled, each later push (`synchronize`) and reopen refreshes the
+  # comment. The job `if:` below gates EVERY event on the label, so adding any
+  # other label (or pushing to an unlabeled PR) skips `evaluate` and claims no
+  # runner. `workflow_dispatch` is kept for manual reruns (no-ops without PR
+  # context).
   workflow_dispatch: {}
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -41,10 +46,18 @@ jobs:
   # token-backed step. The report leaves this job only as an artifact (plain
   # data) for the comment job.
   evaluate:
-    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
+    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml),
+    # and only when the PR carries the `blast-radius` label (the opt-in gate;
+    # see `on:` above). `labeled` events already carry the new label in
+    # `pull_request.labels`, so `contains` covers both the initial label-add and
+    # every later `synchronize`/`reopened` while the label remains. The `comment`
+    # job has no `if:` of its own but `needs: evaluate`, so it is skipped too
+    # whenever this gate is false.
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'blast-radius')
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
     # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD


### PR DESCRIPTION
## What

Make the **Blast radius** PR comment **opt-in** via a `blast-radius` label instead of all-or-nothing.

## Why

A teammate reported the comment "sometimes comes up empty." I dug in (full writeup in #1411):

- The comment **body is never empty** — 368/368 blast-radius comments repo-wide have full content; 0 report `0 of N`, 0 miss the rebuild line.
- The **Mermaid never breaks** — all 49 distinct flowcharts render cleanly in mermaid-cli 11.12; causes are capped (`max_causes=6`) so the diagram is always tiny.
- "Empty" actually meant **absent**: of the last 200 runs ~30% posted nothing — 18 `cancelled` (cancel-in-progress on a new push) + 41 `action_required` (fork/approval-gated).
- #1384 then commented out the `pull_request` trigger entirely (shared `ix-ci` runner-slot cost), so new PRs now get **no** comment at all.

This is the middle ground between "every PR" (the queue cost #1384 fixed) and "never" (the current empty state), and matches the #general "should we make blast radius opt-in?" thread.

## How

- `on: pull_request` re-added but only for `types: [labeled, synchronize, reopened]`.
- The `evaluate` job `if:` now also requires `contains(github.event.pull_request.labels.*.name, 'blast-radius')`. `comment` has `needs: evaluate`, so it's skipped in lockstep.
- Net effect: a PR runs blast-radius **only after** a maintainer adds the `blast-radius` label; each later push refreshes the sticky comment; any other PR (or other label) skips `evaluate` and **claims no runner**.
- Created the `blast-radius` repo label.

## Test

- `actionlint` clean on the changed workflow.
- Logic verified against GitHub's event payloads: `labeled` events already carry the new label in `pull_request.labels`, so one `contains` check covers both the initial add and subsequent `synchronize`/`reopened`.

Closes #1411.

_(opened by an AI agent via Claude Code)_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make blast-radius PR comment opt-in via a `blast-radius` label
> The [blast-radius workflow](https://github.com/indexable-inc/index/pull/1413/files#diff-f18ec732b17d456a8d2f9c00a4941f9433314b97b8a3df9cea22bdaf15337468) previously had the `pull_request` trigger commented out. This change enables it for `labeled`, `synchronize`, and `reopened` events targeting `main`, but gates the `evaluate` job on the PR carrying a `blast-radius` label — so the job only runs when explicitly opted in.
>
> - `workflow_dispatch` trigger is retained, but the `evaluate` job will not run on manual dispatches due to the explicit `pull_request` event check in the `if:` condition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97e0530.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->