### PR TITLE
feat(github-avatar): parse remote URL into host/owner/repo

### DIFF
--- a/packages/github-avatar/src/lib.rs
+++ b/packages/github-avatar/src/lib.rs
@@ -106,24 +106,53 @@ pub struct RepoSlug {
     pub repo: String,
 }
 
+/// A git remote URL decomposed into its `host`, `owner`, and `repo`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteUrl {
+    /// The remote host (e.g. `github.com`).
+    pub host: String,
+    /// The repository owner (user or org).
+    pub owner: String,
+    /// The repository name.
+    pub repo: String,
+}
+
+/// Parse a git remote URL into its host, owner, and repo.
+///
+/// Handles the URL forms (`https://host/owner/repo`, `http://...`,
+/// `ssh://git@host/owner/repo`) and the scp-like ssh form
+/// (`git@host:owner/repo`), each with or without a trailing `.git`. Returns
+/// `None` if the URL is not a recognized `host`/`owner`/`repo` triple.
+#[must_use]
+pub fn parse_remote_url(url: &str) -> Option<RemoteUrl> {
+    let url = url.trim();
+    let url = url.strip_suffix(".git").unwrap_or(url);
+
+    // The `scheme://` forms put the host in the authority (after the optional
+    // `user@`) and separate the path with `/`; the scp-like `user@host:path`
+    // form has no scheme and separates host from path with the first `:`.
+    let (authority, path) = match url.split_once("://") {
+        Some((_scheme, after)) => after.split_once('/')?,
+        None => url.split_once(':')?,
+    };
+    let host = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+
+    let (owner, repo) = path.split_once('/')?;
+    (!host.is_empty() && !owner.is_empty() && !repo.is_empty()).then(|| RemoteUrl {
+        host: host.to_string(),
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    })
+}
+
 /// Parse the [`RepoSlug`] from a GitHub remote URL (https or ssh forms).
 ///
 /// Returns `None` for non-GitHub remotes, so callers can skip the commit-author
 /// lookup entirely off GitHub.
 #[must_use]
 pub fn parse_remote(url: &str) -> Option<RepoSlug> {
-    let url = url.trim();
-    let url = url.strip_suffix(".git").unwrap_or(url);
-    let rest = url
-        .strip_prefix("https://github.com/")
-        .or_else(|| url.strip_prefix("http://github.com/"))
-        .or_else(|| url.strip_prefix("ssh://git@github.com/"))
-        .or_else(|| url.strip_prefix("git@github.com:"))?;
-    let (owner, repo) = rest.split_once('/')?;
-    (!owner.is_empty() && !repo.is_empty()).then(|| RepoSlug {
-        owner: owner.to_string(),
-        repo: repo.to_string(),
-    })
+    let RemoteUrl { host, owner, repo } = parse_remote_url(url)?;
+    (host == "github.com").then_some(RepoSlug { owner, repo })
 }
 
 /// Authenticated response for `GET /repos/{owner}/{repo}/commits/{sha}`; only
@@ -249,7 +278,9 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use super::{RepoSlug, User, is_valid_login, parse_noreply, parse_remote};
+    use super::{
+        RemoteUrl, RepoSlug, User, is_valid_login, parse_noreply, parse_remote, parse_remote_url,
+    };
 
     #[test]
     fn noreply_with_and_without_id() {
@@ -307,5 +338,54 @@ mod tests {
             want
         );
         assert_eq!(parse_remote("https://gitlab.com/foo/bar.git"), None);
+    }
+
+    #[test]
+    fn remote_url_host_owner_repo() {
+        let want = |host: &str| {
+            Some(RemoteUrl {
+                host: host.to_string(),
+                owner: "indexable-inc".to_string(),
+                repo: "index".to_string(),
+            })
+        };
+        // https/http, with and without a trailing `.git`.
+        assert_eq!(
+            parse_remote_url("https://github.com/indexable-inc/index.git"),
+            want("github.com")
+        );
+        assert_eq!(
+            parse_remote_url("https://github.com/indexable-inc/index"),
+            want("github.com")
+        );
+        assert_eq!(
+            parse_remote_url("http://github.com/indexable-inc/index"),
+            want("github.com")
+        );
+        // ssh URL form and scp-like ssh form.
+        assert_eq!(
+            parse_remote_url("ssh://git@github.com/indexable-inc/index.git"),
+            want("github.com")
+        );
+        assert_eq!(
+            parse_remote_url("git@github.com:indexable-inc/index.git"),
+            want("github.com")
+        );
+        assert_eq!(
+            parse_remote_url("git@github.com:indexable-inc/index"),
+            want("github.com")
+        );
+        // The host is preserved for non-GitHub remotes.
+        assert_eq!(
+            parse_remote_url("git@gitlab.com:foo/bar.git"),
+            Some(RemoteUrl {
+                host: "gitlab.com".to_string(),
+                owner: "foo".to_string(),
+                repo: "bar".to_string(),
+            })
+        );
+        // Not a host/owner/repo triple.
+        assert_eq!(parse_remote_url("not-a-url"), None);
+        assert_eq!(parse_remote_url("https://github.com/owner-only"), None);
     }
 }

--- a/packages/github-avatar/src/lib.rs
+++ b/packages/github-avatar/src/lib.rs
@@ -117,16 +117,32 @@ pub struct RemoteUrl {
     pub repo: String,
 }
 
+/// Whether `s` is a single, safe owner/repo path segment.
+///
+/// Restricting to GitHub's charset (ASCII alphanumerics plus `-` `_` `.`, and
+/// never the relative segments `.`/`..`) keeps an attacker-influenced remote URL
+/// from smuggling `/`, `..`, `?`, `#`, or `@` into the authenticated
+/// `https://api.github.com/repos/{owner}/{repo}/...` request, where the `url`
+/// crate would normalize `..` and retarget the call (CWE-918). This mirrors the
+/// `is_valid_login` guard already applied to commit-author logins.
+fn is_repo_segment(s: &str) -> bool {
+    !s.is_empty()
+        && s != "."
+        && s != ".."
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+}
+
 /// Parse a git remote URL into its host, owner, and repo.
 ///
 /// Handles the URL forms (`https://host/owner/repo`, `http://...`,
 /// `ssh://git@host/owner/repo`) and the scp-like ssh form
 /// (`git@host:owner/repo`), each with or without a trailing `.git`. Returns
-/// `None` if the URL is not a recognized `host`/`owner`/`repo` triple.
+/// `None` unless the URL is a `host`/`owner`/`repo` triple whose owner and repo
+/// are each a single safe path segment (see [`is_repo_segment`]).
 #[must_use]
 pub fn parse_remote_url(url: &str) -> Option<RemoteUrl> {
     let url = url.trim();
-    let url = url.strip_suffix(".git").unwrap_or(url);
 
     // The `scheme://` forms put the host in the authority (after the optional
     // `user@`) and separate the path with `/`; the scp-like `user@host:path`
@@ -137,8 +153,13 @@ pub fn parse_remote_url(url: &str) -> Option<RemoteUrl> {
     };
     let host = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
 
+    // Drop surrounding slashes and a single trailing `.git` before splitting, so
+    // a trailing slash does not leak into `repo`.
+    let path = path.trim_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+
     let (owner, repo) = path.split_once('/')?;
-    (!host.is_empty() && !owner.is_empty() && !repo.is_empty()).then(|| RemoteUrl {
+    (!host.is_empty() && is_repo_segment(owner) && is_repo_segment(repo)).then(|| RemoteUrl {
         host: host.to_string(),
         owner: owner.to_string(),
         repo: repo.to_string(),
@@ -384,8 +405,32 @@ mod tests {
                 repo: "bar".to_string(),
             })
         );
+        // A trailing slash (and a `.git` behind it) is normalized away.
+        assert_eq!(
+            parse_remote_url("https://github.com/indexable-inc/index/"),
+            want("github.com")
+        );
+        assert_eq!(
+            parse_remote_url("https://github.com/indexable-inc/index.git/"),
+            want("github.com")
+        );
         // Not a host/owner/repo triple.
         assert_eq!(parse_remote_url("not-a-url"), None);
         assert_eq!(parse_remote_url("https://github.com/owner-only"), None);
+    }
+
+    #[test]
+    fn remote_url_rejects_unsafe_owner_repo() {
+        // `..` segments would be normalized by the `url` crate and retarget the
+        // authenticated API request, so they must not parse.
+        assert_eq!(parse_remote_url("https://github.com/a/../../user/repos"), None);
+        assert_eq!(parse_remote(""), None);
+        assert_eq!(parse_remote("https://github.com/a/../../user/repos"), None);
+        // Query/fragment/userinfo chars and extra path segments are rejected.
+        assert_eq!(parse_remote_url("https://github.com/owner/repo?x=1"), None);
+        assert_eq!(parse_remote_url("https://github.com/owner/repo#frag"), None);
+        assert_eq!(parse_remote_url("https://github.com/owner/repo@evil"), None);
+        assert_eq!(parse_remote_url("https://github.com/owner/repo/extra"), None);
+        assert_eq!(parse_remote_url("git@github.com:owner/.."), None);
     }
 }


### PR DESCRIPTION
## What
Adds `parse_remote_url(&str) -> Option<RemoteUrl>` to the `github-avatar` crate (our git-remote utility), decomposing a remote URL into **host, owner, repo**. Handles:
- `https://host/owner/repo(.git)` / `http://...`
- `ssh://git@host/owner/repo(.git)`
- scp-like `git@host:owner/repo(.git)`

…each with or without a trailing `.git`.

The existing inline parser `parse_remote` (github.com-only `RepoSlug`) is rebuilt on top of the new helper, so remote-URL decomposition has one source of truth. Behavior is preserved (existing `remote_https_and_ssh` test unchanged and passing).

## Note on scope
The task asked to use the helper "in the PR-creation path that currently parses the remote inline." There is **no PR-creation path** anywhere in the Rust code (grepped `index`, `ix`, and all local repos for `gh pr create`, octocrab `pulls()`, `POST /pulls`, `pull/new` — only hits are in `openai/codex`). The closest real call site that parses the remote inline and then uses it is `parse_remote`, which feeds the GitHub commit-author lookup; that is what I refactored. Happy to retarget if a PR-creation path lives elsewhere.

## Test
`cargo test -p github-avatar` → 5 passed (incl. new `remote_url_host_owner_repo`).

Closes #1418

(opened by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parse git remote URLs into structured `RemoteUrl` host/owner/repo in `github-avatar`
> - Adds a `RemoteUrl` struct and `parse_remote_url` function in [lib.rs](https://github.com/indexable-inc/index/pull/1419/files#diff-34122f3758627dfe712b33531ba09d01a6fe524a3ed2c33aeab4a9ae2e8e9fef) that parses both scheme-based (http/https/ssh) and scp-like SSH remote URLs into a structured `host`/`owner`/`repo` triple.
> - Normalizes trailing slashes and `.git` suffixes; rejects paths that are not exactly two segments via a new `is_repo_segment` validator.
> - Refactors `parse_remote` to delegate to `parse_remote_url` instead of using hardcoded prefix matching, then filters by `host == "github.com"`.
> - Behavioral Change: `parse_remote` now rejects GitHub remotes with unsafe owner/repo values (e.g. `..`, `?`, `#`, `@`, extra path segments) and accepts URLs with trailing slashes or `.git/`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99ecc10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->