### PR TITLE
ci(blast-radius): opt-in via label + fallback comment on eval failure

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,17 +1,22 @@
 name: Blast radius
 
 on:
-  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
-  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
-  # serves the whole team, so every PR queued one more eval-only runner and
-  # slowed the queue. The report is informational (a sticky PR comment), never
-  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
-  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
-  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  # Opt-in per PR, not on every push. Auto-running on every PR meant the per-PR
+  # full-catalog eval (~57s "Report blast radius" step) claimed a shared `ix-ci`
+  # runner from the one dispatcher pool that serves the whole team, queuing an
+  # eval-only runner each push and slowing the queue (#1384). But fully disabling
+  # it left the report unreachable, so the sticky comment "came up empty" on every
+  # PR. The middle ground: it runs only when a maintainer adds the `blast-radius`
+  # label. Once labeled, each later push (`synchronize`) and reopen refreshes the
+  # comment. The job `if:` below gates EVERY event on the label, so adding any
+  # other label (or pushing to an unlabeled PR) skips `evaluate` and claims no
+  # runner. `workflow_dispatch` is kept for manual reruns (no-ops without PR
+  # context).
   workflow_dispatch: {}
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -41,10 +46,17 @@ jobs:
   # token-backed step. The report leaves this job only as an artifact (plain
   # data) for the comment job.
   evaluate:
-    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
+    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml),
+    # and only when the PR carries the `blast-radius` label (the opt-in gate;
+    # see `on:` above). `labeled` events already carry the new label in
+    # `pull_request.labels`, so `contains` covers both the initial label-add and
+    # every later `synchronize`/`reopened` while the label remains. The `comment`
+    # job has `needs: evaluate` so it is skipped too whenever this gate is false.
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'blast-radius')
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
     # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD
@@ -125,6 +137,13 @@ jobs:
   # PR cannot influence.
   comment:
     needs: evaluate
+    # Run even when `evaluate` failed (a base/head eval error, often base-side
+    # and unrelated to this PR), so the PR never silently ends up with no blast-
+    # radius comment. `!cancelled()` covers success and failure but not a
+    # concurrency cancel; `result != 'skipped'` keeps it off the unlabeled /
+    # fork / Dependabot case, where `evaluate` itself was skipped (nothing to
+    # report).
+    if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +153,12 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Only present when `evaluate` succeeded (the upload step is `if: success()`).
+      # continue-on-error so a missing artifact after a failed eval drops through
+      # to the fallback step below instead of failing the job.
       - name: Download report
+        if: ${{ needs.evaluate.result == 'success' }}
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: blast-radius-${{ github.run_id }}
@@ -147,6 +171,7 @@ jobs:
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
       - name: Validate report schema
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
@@ -185,6 +210,7 @@ jobs:
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           jq -r '
@@ -261,11 +287,38 @@ jobs:
             printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
           fi
 
+      # `evaluate` failed (no report.json): post an explicit "could not compute"
+      # note rather than letting the comment job skip and leave the PR with no
+      # blast-radius comment at all. The eval bail is frequently base-side (a
+      # transiently un-evaluable `main`) or a runner flake, so the copy says as
+      # much. Keyed by the same marker, so the next successful run overwrites it
+      # in place. RUN_URL is passed via env (a GitHub `${{ }}` expression cannot
+      # be evaluated by the shell), which also lets the test drive this script
+      # with a stub URL.
+      - name: Compose fallback comment (eval failed)
+        if: ${{ needs.evaluate.result != 'success' }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            printf '<!-- blast-radius -->\n'
+            printf '### Blast radius\n\n'
+            printf 'Could not compute the blast radius for this run: the check catalog failed to evaluate at the base or head commit. This is usually a transient base-branch or runner issue rather than a problem with this PR. See the [run logs](%s).\n' "$RUN_URL"
+          } > comment.md
+
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no
       # duplicate comments), and restrict the match to comments this token can
       # actually PATCH: a user comment that happens to start with the marker
       # would otherwise be selected and every PATCH would 403 forever.
+      #
+      # Default `success()` gate (no explicit `if:`): exactly one producer runs
+      # (Render on a good eval, Compose fallback otherwise) and the other is
+      # skipped; a skipped step does not trip `success()`, so this posts after
+      # whichever producer ran. Critically it stays FAIL-CLOSED: if Render (or
+      # Validate) errors, `success()` is false and no half-written comment.md is
+      # published.
       - name: Post sticky comment
         run: |
           set -euo pipefail

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -19,6 +19,7 @@ note() { printf '  %s\n' "$*"; }
 # Extract the exact run-scripts the trusted comment job executes.
 yq '.jobs.comment.steps[] | select(.name == "Validate report schema").run' "$workflow" > "$tmp/validate.sh"
 yq '.jobs.comment.steps[] | select(.name == "Render comment").run' "$workflow" > "$tmp/render.sh"
+yq '.jobs.comment.steps[] | select(.name == "Compose fallback comment (eval failed)").run' "$workflow" > "$tmp/fallback.sh"
 
 validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 
@@ -92,6 +93,24 @@ if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
   note "render backstop: marker survived truncation ok"
 else
   note "render backstop: FAIL (marker lost; sticky-comment keying breaks)"; fail=1
+fi
+
+# Fallback comment: when `evaluate` fails there is no report.json, so the
+# comment job posts an explicit "could not compute" note instead of skipping
+# and leaving the PR with no blast-radius comment (the "comes up empty" bug,
+# issue #1415). Assert it produces a marker-prefixed body so the sticky-comment
+# keying still finds and overwrites it on the next successful run.
+( cd "$tmp" && rm -f report.json comment.md && RUN_URL="https://github.com/indexable-inc/index/actions/runs/123" bash fallback.sh )
+if head -c 21 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
+  note "fallback: marker present ok"
+else
+  note "fallback: FAIL (missing marker; sticky-comment keying breaks)"; fail=1
+fi
+if grep -q 'Could not compute the blast radius' "$tmp/comment.md" \
+   && grep -q 'actions/runs/123' "$tmp/comment.md"; then
+  note "fallback: note + run link ok"
+else
+  note "fallback: FAIL (missing explanation or run link)"; fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi


### PR DESCRIPTION
## Problem

A teammate reported the **blast-radius PR comment "sometimes comes up empty."** Investigated from live run history (issues #1411, #1415): the rendered body is never blank — **"empty" means the comment is absent**. Two causes:

1. **#1384 commented out the `pull_request` trigger entirely** (the per-PR full-catalog eval claimed a shared `ix-ci` runner slot), so PRs now get **no** comment at all.
2. The `comment` job is `needs: evaluate` with the default `if: success()`, so any eval bail — frequently a transient **base-side** `main` eval failure unrelated to the PR — **silently skipped** the comment.

## Fix (both, in one workflow change)

- **Opt-in via label** — re-enable `on: pull_request` for `[labeled, synchronize, reopened]`, and gate `evaluate` on the PR carrying the `blast-radius` label. It runs only after a maintainer opts in; each later push refreshes the sticky comment; unlabeled / fork / Dependabot PRs skip `evaluate` and claim no runner. Keeps #1384's queue-cost win.
- **Fallback on eval failure** — the `comment` job now runs even when `evaluate` failed (`!cancelled() && needs.evaluate.result != 'skipped'`) and posts an explicit **"could not compute"** note (same `<!-- blast-radius -->` marker, so the next good run overwrites it in place). Download / validate / render stay gated on a successful eval; exactly one producer (render **or** fallback) runs.
- **Stays fail-closed** — the `Post sticky comment` step keeps the **default `success()` gate** (no `!cancelled()`), so a half-written `comment.md` from a failed render is never published (a skipped sibling step does not trip `success()`).

## Test

`tools/blast-radius-test.sh` (wired as the `blast-radius-test` flake check) extracts the workflow's jq/run-scripts verbatim so it can't drift. Adds a fallback-path case asserting the marker + explanation + run link. Full suite passes locally (`jq` + `yq-go`); `actionlint` clean.

## Relationship to other PRs

Supersedes **#1413** (opt-in label) and **#1416** (fallback comment), combining both into one coherent workflow change and fixing the two review findings each carried:
- #1416 **P2**: `Post` step `if: !cancelled()` regressed fail-closed → reverted to default `success()`.
- #1413 **P1**: write-token `comment` job runs from PR-controlled YAML. Bounded here to same-repo (collaborator) PRs — forks are excluded by the job `if:` and get a read-only token on `pull_request` regardless. Hardening the post phase into a base-branch `workflow_run` context is tracked as a follow-up issue.

Closes #1411. Closes #1415.

sent by an AI agent (Claude) via Claude Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in label gate and fallback comment to blast-radius CI workflow
> - The blast-radius workflow now only runs for PRs labeled `blast-radius`, triggered on label-add, synchronize, and reopen events; unlabeled PRs, forks, and Dependabot PRs are skipped entirely.
> - When the `evaluate` job fails, a fallback comment is posted with the blast-radius marker and a link to the failed run, instead of silently dropping the comment.
> - Artifact download, schema validation, and render steps are guarded by `evaluate` success; the fallback comment step runs only on `evaluate` failure.
> - Adds a test in [blast-radius-test.sh](https://github.com/indexable-inc/index/pull/1422/files#diff-008b7e349202f69865582328028ef88fb2c6c22cdfd1f42fbbf5533600c2e27b) that extracts and runs the fallback producer script, asserting the marker and run link are present in the output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c30ef3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->