### PR TITLE
ci(blast-radius): post a fallback comment when the report cannot be rendered

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -125,6 +125,15 @@ jobs:
   # PR cannot influence.
   comment:
     needs: evaluate
+    # Run even when `evaluate` failed, so a PR never silently ends up with no
+    # blast-radius comment (the "comes up empty" report, #1415). The eval bail
+    # is frequently base-side (a transiently un-evaluable `main`) or a runner
+    # flake, i.e. unrelated to this PR. `!cancelled()` covers success and
+    # failure but not a concurrency cancel (which cancels this job too, so its
+    # own `cancelled()` is true); `result != 'skipped'` keeps it off forks and
+    # Dependabot, where `evaluate` itself was skipped and there is nothing to
+    # report.
+    if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +143,13 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Present only when `evaluate` succeeded (its upload step is `if: success()`).
+      # `continue-on-error` so a transient download failure does not fail the job
+      # outright: the render step then no-ops (no report.json) and the fallback
+      # composer (gated on render not having succeeded) takes over.
       - name: Download report
+        if: ${{ needs.evaluate.result == 'success' }}
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: blast-radius-${{ github.run_id }}
@@ -147,6 +162,7 @@ jobs:
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
       - name: Validate report schema
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
@@ -185,6 +201,8 @@ jobs:
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
+        id: render
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           jq -r '
@@ -261,12 +279,41 @@ jobs:
             printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
           fi
 
+      # The report could not be rendered (evaluate failed, or its artifact was
+      # unavailable, or rendering itself errored): write an explicit "could not
+      # compute" note rather than leaving the PR with no comment. `render` not
+      # succeeding (skipped or failed) is the single trigger, so this also
+      # overwrites any partial body the render step may have left behind before
+      # erroring -- the post step below only publishes whichever of render or
+      # this step actually succeeded. Keyed by the same marker, so the next
+      # successful run overwrites it in place. RUN_URL comes via env (a GitHub
+      # `${{ }}` expression is not shell-expandable), which also lets the test
+      # drive this script with a stub URL.
+      - name: Compose fallback comment
+        id: fallback
+        if: ${{ !cancelled() && steps.render.conclusion != 'success' }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            printf '<!-- blast-radius -->\n'
+            printf '### Blast radius\n\n'
+            printf 'Could not compute the blast radius for this run: the check catalog failed to evaluate at the base or head commit. This is usually a transient base-branch or runner issue rather than a problem with this PR. See the [run logs](%s).\n' "$RUN_URL"
+          } > comment.md
+
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no
       # duplicate comments), and restrict the match to comments this token can
       # actually PATCH: a user comment that happens to start with the marker
       # would otherwise be selected and every PATCH would 403 forever.
+      # Gate on a producer having SUCCEEDED (not merely `!cancelled()`): a failed
+      # render leaves a truncated `comment.md` (jq `>` creates the file before it
+      # finishes), and publishing that half-body is itself a "comes up empty"
+      # regression. Posting only a fully rendered or fallback body keeps the
+      # fail-closed behavior. (#1415 review thread.)
       - name: Post sticky comment
+        if: ${{ !cancelled() && (steps.render.conclusion == 'success' || steps.fallback.conclusion == 'success') }}
         run: |
           set -euo pipefail
           # `gh api --slurp` rejects `--jq`, so slurp the paginated pages (an

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -19,6 +19,7 @@ note() { printf '  %s\n' "$*"; }
 # Extract the exact run-scripts the trusted comment job executes.
 yq '.jobs.comment.steps[] | select(.name == "Validate report schema").run' "$workflow" > "$tmp/validate.sh"
 yq '.jobs.comment.steps[] | select(.name == "Render comment").run' "$workflow" > "$tmp/render.sh"
+yq '.jobs.comment.steps[] | select(.name == "Compose fallback comment").run' "$workflow" > "$tmp/fallback.sh"
 
 validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 
@@ -92,6 +93,26 @@ if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
   note "render backstop: marker survived truncation ok"
 else
   note "render backstop: FAIL (marker lost; sticky-comment keying breaks)"; fail=1
+fi
+
+# Fallback comment: when `evaluate` fails (or its artifact / render does) there
+# is no rendered report, so the comment job posts an explicit "could not
+# compute" note instead of leaving the PR with no blast-radius comment (the
+# "comes up empty" report, #1415). Exercise the workflow's own extracted script
+# and assert it produces a marker-prefixed body (so the sticky-comment keying
+# still finds and overwrites it on the next successful run) plus the explanation
+# and run link.
+( cd "$tmp" && rm -f report.json comment.md && RUN_URL="https://github.com/indexable-inc/index/actions/runs/123" bash fallback.sh )
+if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
+  note "fallback: marker present ok"
+else
+  note "fallback: FAIL (missing marker; sticky-comment keying breaks)"; fail=1
+fi
+if grep -q 'Could not compute the blast radius' "$tmp/comment.md" \
+   && grep -q 'actions/runs/123' "$tmp/comment.md"; then
+  note "fallback: note + run link ok"
+else
+  note "fallback: FAIL (missing explanation or run link)"; fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi


### PR DESCRIPTION
## Symptom

A teammate reported the **blast-radius PR comment "sometimes comes up empty"** on index PRs.

## Root cause (from live state, not memory)

- **The renderer never posts a blank body.** Reproduced the workflow's own validate+render jq against good / zero-change / overflow / pathological reports: it always emits at least the `### Blast radius` header. Confirmed in the wild too (prior scans found 368/368 blast-radius comments well-formed). So **"empty" means the comment is absent.**
- **The real bug: the `comment` job is `needs: evaluate` with the default `if: success()`.** When `evaluate` bails, `comment` is **silently skipped** and the PR is left with no comment. The eval bail is frequently **base-side** (a transiently un-evaluable `main`) or a runner flake, i.e. nothing to do with the PR. Across recent failed `Blast radius` runs, every failure was in `evaluate`'s "Report blast radius" step.
- (Separately, #1384 commented out the `pull_request` trigger entirely for shared-runner cost. Re-enabling it is a team call, tracked in #1411/#1413 and **left untouched here**.)

## Fix

Make the `comment` job resilient so a PR never silently ends up without a blast-radius comment:

- Run `comment` even when `evaluate` failed: `if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}` (still skipped on forks/Dependabot, where `evaluate` itself was skipped).
- Gate `Download report` / `Validate` / `Render` on `evaluate` success; `Download` is `continue-on-error` so a transient artifact miss falls through to the fallback.
- New **Compose fallback comment** step fires whenever `render` did not succeed (eval failure, missing artifact, *or* a render error), writing an explicit "could not compute" note under the same `<!-- blast-radius -->` marker so the next good run overwrites it in place.
- **Post only a producer that SUCCEEDED** (`steps.render.conclusion == 'success' || steps.fallback.conclusion == 'success'`), so a half-written `comment.md` from a failed render is never patched onto the PR.

This last point is the correctness fix the AI-review gate flagged on **#1416** (its `Post` step ran on bare `!cancelled()` and could publish a partial body). This PR **supersedes #1416** — same approach, with that gap closed — so #1416 and the duplicate investigations can be closed in favor of this one.

## Test

Extended `tools/blast-radius-test.sh` (which extracts the workflow's own step scripts, so it can't drift) with a fallback case: runs the extracted fallback script with no report and asserts a marker-prefixed body + the "could not compute" note + the run link.

Validated locally:
- `tools/blast-radius-test.sh` → all passed (incl. new fallback case)
- `actionlint .github/workflows/blast-radius.yml` → clean
- adversarial code-review of the diff (named subagent) → only the post-gating concern, fixed here

Fixes #1415

sent by an AI agent (Claude) via Claude Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Post a fallback comment in the blast-radius workflow when report rendering fails
> - The `comment` job in [blast-radius.yml](.github/workflows/blast-radius.yml) now runs when `evaluate` fails (but not when skipped), so failures are always surfaced on the PR.
> - Download and render steps run only when `evaluate` succeeded; download errors are tolerated via `continue-on-error`.
> - A new 'Compose fallback comment' step runs when rendering did not succeed and posts a minimal marker-prefixed comment with a link to the Actions run URL.
> - The 'Post sticky comment' step only fires when either the rendered or fallback body is available, preventing partial posts.
> - A new test block in [blast-radius-test.sh](https://github.com/indexable-inc/index/pull/1425/files#diff-008b7e349202f69865582328028ef88fb2c6c22cdfd1f42fbbf5533600c2e27b) validates the fallback comment output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f70b473.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->