### PR TITLE
ci(blast-radius): restore the PR comment (opt-in label, resilient fallback, accept ?/= in nix names)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,17 +1,21 @@
 name: Blast radius
 
 on:
-  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
-  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
-  # serves the whole team, so every PR queued one more eval-only runner and
-  # slowed the queue. The report is informational (a sticky PR comment), never
-  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
-  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
-  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  # Opt-in on PRs via a `blast-radius` label, not every PR. The per-PR
+  # full-catalog eval (~57s "Report blast radius" step) claims a shared `ix-ci`
+  # runner from the one dispatcher pool that serves the whole team, so running
+  # it on every PR slowed the queue -- why #1384 disabled the trigger entirely.
+  # Gating on the label (see the `evaluate` job `if:`) keeps that cost off
+  # unlabeled PRs while restoring the comment for PRs a maintainer opts in.
+  # `labeled` fires the first run when the label is added; `synchronize` /
+  # `reopened` refresh the sticky comment on later pushes (each re-checks the
+  # label, so removing it stops future runs). `workflow_dispatch` keeps `on:`
+  # non-empty for manual runs (PR-context gated, so a bare dispatch no-ops).
   workflow_dispatch: {}
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -41,8 +45,13 @@ jobs:
   # token-backed step. The report leaves this job only as an artifact (plain
   # data) for the comment job.
   evaluate:
-    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
+    # Opt-in, same-repository, non-Dependabot PRs only. The `blast-radius` label
+    # is the opt-in gate (see the `on: pull_request` note); the same-repo +
+    # non-Dependabot checks mirror ai-review-gate.yml. On `workflow_dispatch`
+    # the `pull_request` context is empty, so this is false and the manual run
+    # no-ops -- matching the prior behavior.
     if: >-
+      contains(github.event.pull_request.labels.*.name, 'blast-radius') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
@@ -125,6 +134,14 @@ jobs:
   # PR cannot influence.
   comment:
     needs: evaluate
+    # Run whenever `evaluate` actually ran -- success OR failure -- so a failed
+    # eval still leaves the PR an explicit note instead of silently nothing (the
+    # "comment comes up empty" report: #1415). The eval bail is frequently
+    # base-side (a transiently un-evaluable `master`) or a runner flake, i.e.
+    # unrelated to the PR. Skip only when `evaluate` was skipped (unlabeled PR /
+    # fork / Dependabot): those opted out, so no comment is correct.
+    # `!cancelled()` lets a cancel-in-progress run bow out without posting.
+    if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +151,11 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Download + validate + render run only when the eval succeeded; the
+      # fallback step below covers the failure path. The eval's `Upload report`
+      # is `if: success()`, so the artifact exists exactly on this path.
       - name: Download report
+        if: ${{ needs.evaluate.result == 'success' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: blast-radius-${{ github.run_id }}
@@ -147,6 +168,7 @@ jobs:
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
       - name: Validate report schema
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
@@ -185,6 +207,7 @@ jobs:
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           jq -r '
@@ -260,6 +283,27 @@ jobs:
             mv comment.md.trunc comment.md
             printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
           fi
+
+      # When evaluate did not succeed, compose an explicit "could not compute"
+      # note instead of leaving the PR with no comment. No PR-controlled data reaches
+      # this step (the report.json is not read), so it needs no schema gate. The
+      # same `<!-- blast-radius -->` marker means the next good run overwrites it
+      # in place. Authored here, on the trusted runner, so the marker stays
+      # under the write-token job's control.
+      - name: Fallback comment (eval failed)
+        if: ${{ needs.evaluate.result != 'success' }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            echo '<!-- blast-radius -->'
+            echo '### Blast radius'
+            echo ''
+            echo 'Could not compute the blast radius for this change: the evaluation step did not finish. This is often a transient base-branch eval or runner issue rather than a problem with this PR.'
+            echo ''
+            echo "See the [Blast radius run](${RUN_URL}) for details; pushing a new commit re-runs it."
+          } > comment.md
 
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -94,5 +94,29 @@ else
   note "render backstop: FAIL (marker lost; sticky-comment keying breaks)"; fail=1
 fi
 
+# Fallback path: when the `evaluate` job fails, the `comment` job composes a
+# "could not compute" note (same `<!-- blast-radius -->` marker) instead of
+# leaving the PR with no comment at all (#1415). Extract that step's verbatim
+# script and assert the marker survives (sticky keying) and the run link and
+# explanation are present. RUN_URL stands in for the workflow expression the
+# step reads from its env.
+yq '.jobs.comment.steps[] | select(.name == "Fallback comment (eval failed)").run' "$workflow" > "$tmp/fallback.sh"
+( cd "$tmp" && rm -f comment.md && RUN_URL="https://github.com/indexable-inc/index/actions/runs/123" bash fallback.sh )
+if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
+  note "fallback: marker present ok"
+else
+  note "fallback: FAIL (marker missing; sticky-comment keying breaks)"; fail=1
+fi
+if grep -q 'Could not compute the blast radius' "$tmp/comment.md"; then
+  note "fallback: explanation present ok"
+else
+  note "fallback: FAIL (explanation missing)"; fail=1
+fi
+if grep -q 'actions/runs/123' "$tmp/comment.md"; then
+  note "fallback: run link present ok"
+else
+  note "fallback: FAIL (run link missing)"; fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi
 echo "blast-radius-test: all passed"


### PR DESCRIPTION
## Problem

A teammate reported the blast-radius PR comment "sometimes comes up empty." I investigated end to end (evidence, not memory):

- **The comment body is never blank.** A repo-wide scan of every `github-actions[bot]` comment starting with `<!-- blast-radius -->` found **359/359 with full content** — 0 blank, 0 header-only, 0 `0 of N`; the lowest ever was `2 of 976`. A forced **zero-rebuild** render still produces a clear 118-byte `0 of N checks would rebuild` body. The renderer always emits marker + header + rebuild line.
- **"Empty" means the comment was *absent*.** And as of #1384 the `pull_request` trigger is commented out entirely, so **new PRs get no comment at all** — the dominant cause today.

### Root causes of a *missing* comment (both fixed here)
1. **Trigger disabled (#1384).** Commented out for shared `ix-ci` runner-slot cost.
2. **Eval bail silently skips the comment.** `comment` is `needs: evaluate` / `if: success()`; when `evaluate`'s "Report blast radius" step exits non-zero — **frequently base-side** (a transiently un-evaluable `master`) or a runner flake, i.e. unrelated to the PR — `comment` is skipped, leaving no comment.

## Fix (consolidates the two in-flight partials)

This supersedes #1413 (opt-in trigger) and #1416 (resilient fallback), which each fix only one cause and both edit this same file (so they conflict). One complete change:

- **Re-enable on PRs, opt-in via a `blast-radius` label.** Respects #1384's cost reason: unlabeled PRs claim no runner. Triggers on `labeled` / `synchronize` / `reopened`; `evaluate` is gated on `contains(...labels..., 'blast-radius')`.
- **Make `comment` resilient.** It now runs on eval success **or** failure (`if: !cancelled() && needs.evaluate.result != 'skipped'`); skipped only when `evaluate` itself was skipped (unlabeled / fork / Dependabot, which opted out). Download + validate + render stay gated on eval success; on failure a new step posts an explicit **"could not compute"** sticky note (same `<!-- blast-radius -->` marker, overwritten in place by the next good run) instead of nothing.

Eval **fail-closed** semantics (`guard_eval_failures`) are untouched — relaxing them (the deeper root of base-side flakes) is a separate design call.

## Test

`tools/blast-radius-test.sh` already extracts the workflow's jq verbatim so the test can't drift from what runs. Extended with a fallback-path case (extracts the new step, runs it, asserts the marker survives + the explanation and run link are present). Verified red→green (fails on the pre-change workflow, passes after). Full suite green; `actionlint` clean. Wired as the `blast-radius-test` flake check.

Supersedes #1413, #1416. Closes #1411, closes #1415.

_sent by an AI agent (Claude) via Claude Code_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore blast-radius PR comment with opt-in label gate and fallback on eval failure
> - The [blast-radius workflow](https://github.com/indexable-inc/index/pull/1427/files#diff-f18ec732b17d456a8d2f9c00a4941f9433314b97b8a3df9cea22bdaf15337468) now auto-triggers on `labeled`, `synchronize`, and `reopened` PR events targeting `main`, replacing the previously commented-out trigger.
> - The `evaluate` job is gated by a `blast-radius` label on the PR, in addition to same-repo and non-Dependabot checks.
> - The `comment` job now runs when `evaluate` completes (success or failure, but not skipped); on failure it posts a sticky fallback comment with an explanation and a link to the run instead of leaving no comment.
> - A new fallback-path test in [blast-radius-test.sh](https://github.com/indexable-inc/index/pull/1427/files#diff-008b7e349202f69865582328028ef88fb2c6c22cdfd1f42fbbf5533600c2e27b) validates the fallback comment contents (marker, explanation text, and run link).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e6464e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

---

## Update: consolidated #1426 (charset fail-close)

After independently verifying the root cause (368/368 historical bot comments had full bodies, min 183 chars — so "empty" means **absent**, not blank), this PR now also folds in the charset fix from #1426. That bug is real and complementary: a cause name is a nix derivation name, and fixed-output patch/fetch drvs legally carry `?`/`=` (86 such names in a local `/nix/store` sample, e.g. `<sha>.patch?full_index=1`). The trusted `comment` job's `name_ok` validator rejected those → fail-closed the whole report → **absent comment**. That validate step lives in the `comment` job, **not** `evaluate`, so this PR's eval-failure fallback would *not* have caught it — both fixes are required and neither alone is complete.

Widened `name_ok` + renderer `safename` in lockstep to `^[A-Za-z0-9_./ +()?=:-]+$` (still rejects every markdown/mention/HTML glyph), plus a regression fixture + assertions. Full `tools/blast-radius-test.sh` suite green (18/18, incl. special-name and fallback cases); `actionlint` clean.

Supersedes #1426.

_sent by an AI agent (Claude) via Claude Code_
