### PR TITLE
ci(blast-radius): restore the PR comment end-to-end (opt-in trigger + resilient job + legal-name charset)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -22,16 +22,28 @@ permissions:
   contents: read
 
 concurrency:
-  group: blast-radius-${{ github.ref }}
-  # Only cancel an in-flight run when the new event will itself run an eval: a
-  # push (`synchronize`)/`reopened`, a `workflow_dispatch`, or the `blast-radius`
-  # label being added. An unrelated `labeled` event skips `evaluate` (see the job
-  # `if:`), but concurrency cancellation is applied at the workflow level BEFORE
-  # any job `if:`, so an unconditional `cancel-in-progress` would let adding any
-  # label kill an opted-in PR's running eval and leave the sticky comment
-  # unrefreshed. Gating the cancel on the same condition keeps unrelated label
-  # events from interrupting a real run.
-  cancel-in-progress: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'blast-radius' }}
+  # Real eval-running events (a push `synchronize`/`reopened`, a
+  # `workflow_dispatch`, or the `blast-radius` label being added) share one
+  # per-ref group so a newer push supersedes an older in-flight eval. An
+  # unrelated `labeled` event runs NO eval (every job `if:` is false), but GitHub
+  # applies concurrency BEFORE any job `if:` and cancels not only the in-progress
+  # run but ALSO any previously *pending* run in the group -- and that pending
+  # cancellation ignores `cancel-in-progress`. So a shared group lets an
+  # unrelated label evict a real eval that is still queued for a self-hosted
+  # runner, leaving the sticky comment stale or absent (the "sometimes empty"
+  # symptom). Route those no-op events to a unique throwaway group
+  # (`blast-radius-noop-<run_id>`) so they can never evict, cancel, or queue
+  # behind a real run.
+  group: >-
+    ${{
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name != 'blast-radius')
+      && format('blast-radius-noop-{0}', github.run_id)
+      || format('blast-radius-{0}', github.ref)
+    }}
+  # Real events share the per-ref group, so a newer push cancels an older
+  # in-flight eval (don't stack evals). No-op events sit alone in their unique
+  # group, where this has no one to cancel.
+  cancel-in-progress: true
 
 env:
   # The self-hosted runner's Nix daemon owns substituters; the job only sets

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -48,15 +48,20 @@ jobs:
   evaluate:
     # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml),
     # and only when the PR carries the `blast-radius` label (the opt-in gate;
-    # see `on:` above). `labeled` events already carry the new label in
-    # `pull_request.labels`, so `contains` covers both the initial label-add and
-    # every later `synchronize`/`reopened` while the label remains. The `comment`
-    # job has `needs: evaluate` so it is skipped too whenever this gate is false.
+    # see `on:` above). `contains` covers the steady state for every event while
+    # the label remains. The final clause keeps a `labeled` event from running
+    # the expensive eval when the label being added is something *other* than
+    # `blast-radius`: without it, labelling an already opted-in PR with any
+    # unrelated label would re-claim the self-hosted runner and undercut the
+    # opt-in. `synchronize`/`reopened` (action != 'labeled') still refresh the
+    # comment via the `contains` check alone. The `comment` job has
+    # `needs: evaluate` so it is skipped too whenever this gate is false.
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
-      contains(github.event.pull_request.labels.*.name, 'blast-radius')
+      contains(github.event.pull_request.labels.*.name, 'blast-radius') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'blast-radius')
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
     # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -183,7 +183,14 @@ jobs:
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
-            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
+            # Charset is the legal nix store-path-name set (a-zA-Z0-9 + - . _ ? =)
+            # plus the extra glyphs attr-path normalization can introduce
+            # (/, space, (, ), :). A cause name is a derivation name, and fixed-
+            # output patch/fetch drvs carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+            # `webkitgtk-2.52.4+abi=4.1`); omitting them fail-closed the whole
+            # report and posted no comment at all (the "sometimes empty" bug, #1421).
+            # It still rejects every markdown/mention/HTML glyph (@ < > [ ] ` & | ; * # {).
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +()?=:-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -219,7 +226,9 @@ jobs:
         run: |
           set -euo pipefail
           jq -r '
-            def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            # Lockstep with the validator name_ok above: same charset, so a
+            # report that validated never has a label silently dropped here.
+            def safename: select(test("^[A-Za-z0-9_./ +()?=:-]+$"));
             # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
             # by magnitude, round to integer. Empty string for a missing entry
             # so a bare label renders when an attr was a substituter hit or new

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -175,8 +175,15 @@ jobs:
       # Fail closed: require the full schema before rendering. Every field is
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
+      #
+      # `&& success()` is load-bearing on every gated step in this job: an
+      # explicit `if` drops the implicit `success()` GitHub adds to an
+      # unconditional step, so without it a failure in an earlier step would
+      # not stop this one. That short-circuit is what makes the validate ->
+      # render fail-closed chain below actually hold, and the gate-wiring test
+      # in tools/blast-radius-test.sh asserts every gated step restates it.
       - name: Validate report schema
-        if: ${{ needs.evaluate.result == 'success' }}
+        if: ${{ needs.evaluate.result == 'success' && success() }}
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
@@ -222,7 +229,10 @@ jobs:
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
-        if: ${{ needs.evaluate.result == 'success' }}
+        # `&& success()` keeps this skipped if Validate failed (see the note on
+        # the Validate step): a report that did not pass the schema is never
+        # rendered, let alone posted.
+        if: ${{ needs.evaluate.result == 'success' && success() }}
         run: |
           set -euo pipefail
           jq -r '
@@ -310,7 +320,10 @@ jobs:
       # be evaluated by the shell), which also lets the test drive this script
       # with a stub URL.
       - name: Compose fallback comment (eval failed)
-        if: ${{ needs.evaluate.result != 'success' }}
+        # `&& success()` so a failure in an earlier comment-job step cannot
+        # reach the fallback either: the only producers are Render (good eval)
+        # and this step (failed eval), and both stay fail-closed.
+        if: ${{ needs.evaluate.result != 'success' && success() }}
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -23,7 +23,15 @@ permissions:
 
 concurrency:
   group: blast-radius-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel an in-flight run when the new event will itself run an eval: a
+  # push (`synchronize`)/`reopened`, a `workflow_dispatch`, or the `blast-radius`
+  # label being added. An unrelated `labeled` event skips `evaluate` (see the job
+  # `if:`), but concurrency cancellation is applied at the workflow level BEFORE
+  # any job `if:`, so an unconditional `cancel-in-progress` would let adding any
+  # label kill an opted-in PR's running eval and leave the sticky comment
+  # unrefreshed. Gating the cancel on the same condition keeps unrelated label
+  # events from interrupting a real run.
+  cancel-in-progress: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'blast-radius' }}
 
 env:
   # The self-hosted runner's Nix daemon owns substituters; the job only sets

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,17 +1,22 @@
 name: Blast radius
 
 on:
-  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
-  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
-  # serves the whole team, so every PR queued one more eval-only runner and
-  # slowed the queue. The report is informational (a sticky PR comment), never
-  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
-  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
-  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  # Opt-in per PR, not on every push. Auto-running on every PR meant the per-PR
+  # full-catalog eval (~57s "Report blast radius" step) claimed a shared `ix-ci`
+  # runner from the one dispatcher pool that serves the whole team, queuing an
+  # eval-only runner each push and slowing the queue (#1384). But fully disabling
+  # it left the report unreachable, so the sticky comment "came up empty" on every
+  # PR. The middle ground: it runs only when a maintainer adds the `blast-radius`
+  # label. Once labeled, each later push (`synchronize`) and reopen refreshes the
+  # comment. The job `if:` below gates EVERY event on the label, so adding any
+  # other label (or pushing to an unlabeled PR) skips `evaluate` and claims no
+  # runner. `workflow_dispatch` is kept for manual reruns (no-ops without PR
+  # context).
   workflow_dispatch: {}
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -41,10 +46,17 @@ jobs:
   # token-backed step. The report leaves this job only as an artifact (plain
   # data) for the comment job.
   evaluate:
-    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
+    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml),
+    # and only when the PR carries the `blast-radius` label (the opt-in gate;
+    # see `on:` above). `labeled` events already carry the new label in
+    # `pull_request.labels`, so `contains` covers both the initial label-add and
+    # every later `synchronize`/`reopened` while the label remains. The `comment`
+    # job has `needs: evaluate` so it is skipped too whenever this gate is false.
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'blast-radius')
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
     # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD
@@ -125,6 +137,13 @@ jobs:
   # PR cannot influence.
   comment:
     needs: evaluate
+    # Run even when `evaluate` failed (a base/head eval error, often base-side
+    # and unrelated to this PR), so the PR never silently ends up with no blast-
+    # radius comment. `!cancelled()` covers success and failure but not a
+    # concurrency cancel; `result != 'skipped'` keeps it off the unlabeled /
+    # fork / Dependabot case, where `evaluate` itself was skipped (nothing to
+    # report).
+    if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +153,12 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Only present when `evaluate` succeeded (the upload step is `if: success()`).
+      # continue-on-error so a missing artifact after a failed eval drops through
+      # to the fallback step below instead of failing the job.
       - name: Download report
+        if: ${{ needs.evaluate.result == 'success' }}
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: blast-radius-${{ github.run_id }}
@@ -147,6 +171,7 @@ jobs:
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
       - name: Validate report schema
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
@@ -185,6 +210,7 @@ jobs:
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           jq -r '
@@ -261,11 +287,38 @@ jobs:
             printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
           fi
 
+      # `evaluate` failed (no report.json): post an explicit "could not compute"
+      # note rather than letting the comment job skip and leave the PR with no
+      # blast-radius comment at all. The eval bail is frequently base-side (a
+      # transiently un-evaluable `main`) or a runner flake, so the copy says as
+      # much. Keyed by the same marker, so the next successful run overwrites it
+      # in place. RUN_URL is passed via env (a GitHub `${{ }}` expression cannot
+      # be evaluated by the shell), which also lets the test drive this script
+      # with a stub URL.
+      - name: Compose fallback comment (eval failed)
+        if: ${{ needs.evaluate.result != 'success' }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            printf '<!-- blast-radius -->\n'
+            printf '### Blast radius\n\n'
+            printf 'Could not compute the blast radius for this run: the check catalog failed to evaluate at the base or head commit. This is usually a transient base-branch or runner issue rather than a problem with this PR. See the [run logs](%s).\n' "$RUN_URL"
+          } > comment.md
+
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no
       # duplicate comments), and restrict the match to comments this token can
       # actually PATCH: a user comment that happens to start with the marker
       # would otherwise be selected and every PATCH would 403 forever.
+      #
+      # Default `success()` gate (no explicit `if:`): exactly one producer runs
+      # (Render on a good eval, Compose fallback otherwise) and the other is
+      # skipped; a skipped step does not trip `success()`, so this posts after
+      # whichever producer ran. Critically it stays FAIL-CLOSED: if Render (or
+      # Validate) errors, `success()` is false and no half-written comment.md is
+      # published.
       - name: Post sticky comment
         run: |
           set -euo pipefail

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -311,7 +311,8 @@ pub fn derivation_graph(drv_paths: &[String]) -> Result<Graph> {
 /// the same shape reaches both [`eval_checks`] and [`crate::timings`].
 ///
 /// The trusted workflow schema (`blast-radius.yml` safename regex) allows dots,
-/// slashes, spaces, and parens but rejects `"`, and trimming only the ends
+/// slashes, spaces, parens, `?`, and `=` (the legal nix-name glyphs that reach a
+/// label) but rejects `"`, and trimming only the ends
 /// leaves the quotes around an interior segment in place. Drop every `"` and
 /// split on dots outside quotes, then rejoin with `.`, so the bare path flows
 /// identically through the diff key, the report, and the schema regardless of

--- a/tools/blast-radius-fixtures/special-name.json
+++ b/tools/blast-radius-fixtures/special-name.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":120,
+ "changed":["rust-test-foo","rust-test-bar"],"added":[],"removed":[],
+ "causes":[{"name":"e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1","checks":["rust-test-foo","rust-test-bar"]}],
+ "timings":{},"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -44,6 +44,24 @@ done
 ( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
 if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
 
+# Regression (#1421): a cause name is a nix derivation name, and fixed-output
+# patch/fetch drvs legally carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+# `webkitgtk-2.52.4+abi=4.1`). The validator's name_ok used to omit those two
+# glyphs and fail-closed the WHOLE report, so the comment job exited 1 and posted
+# no comment at all -- the "sometimes empty" symptom. The report must now both
+# validate and render with the name intact (validate and safename stay lockstep).
+if validate "$fixtures/special-name.json" >/dev/null 2>&1; then
+  note "validate special-name: ok"
+else
+  note "validate special-name: FAIL (rejected a legal nix derivation name)"; fail=1
+fi
+( cd "$tmp" && cp "$fixtures/special-name.json" report.json && bash render.sh )
+if grep -qF 'e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1' "$tmp/comment.md"; then
+  note "render special-name: name preserved ok"
+else
+  note "render special-name: FAIL (legal name dropped from comment)"; fail=1
+fi
+
 # Overflow guard: a PR touching a shared input rebuilds thousands of checks, and
 # an uncapped changed-checks list overflows GitHub's 65536-char comment limit
 # (HTTP 422), so no comment posts. Synthesize a large report and assert the body

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -19,6 +19,7 @@ note() { printf '  %s\n' "$*"; }
 # Extract the exact run-scripts the trusted comment job executes.
 yq '.jobs.comment.steps[] | select(.name == "Validate report schema").run' "$workflow" > "$tmp/validate.sh"
 yq '.jobs.comment.steps[] | select(.name == "Render comment").run' "$workflow" > "$tmp/render.sh"
+yq '.jobs.comment.steps[] | select(.name == "Compose fallback comment (eval failed)").run' "$workflow" > "$tmp/fallback.sh"
 
 validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 
@@ -92,6 +93,24 @@ if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
   note "render backstop: marker survived truncation ok"
 else
   note "render backstop: FAIL (marker lost; sticky-comment keying breaks)"; fail=1
+fi
+
+# Fallback comment: when `evaluate` fails there is no report.json, so the
+# comment job posts an explicit "could not compute" note instead of skipping
+# and leaving the PR with no blast-radius comment (the "comes up empty" bug,
+# issue #1415). Assert it produces a marker-prefixed body so the sticky-comment
+# keying still finds and overwrites it on the next successful run.
+( cd "$tmp" && rm -f report.json comment.md && RUN_URL="https://github.com/indexable-inc/index/actions/runs/123" bash fallback.sh )
+if head -c 21 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
+  note "fallback: marker present ok"
+else
+  note "fallback: FAIL (missing marker; sticky-comment keying breaks)"; fail=1
+fi
+if grep -q 'Could not compute the blast radius' "$tmp/comment.md" \
+   && grep -q 'actions/runs/123' "$tmp/comment.md"; then
+  note "fallback: note + run link ok"
+else
+  note "fallback: FAIL (missing explanation or run link)"; fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -153,5 +153,22 @@ else
   note "gate [Post sticky comment]: FAIL (gate '$post_if' can post an unvalidated/partial body)"; fail=1
 fi
 
+# Concurrency routing. GitHub applies the workflow-level concurrency group
+# BEFORE any job `if:`, and cancels any previously *pending* run in a group
+# regardless of `cancel-in-progress`. If a no-op `labeled` event (jobs all skip)
+# shared the real per-ref group, it could evict a real eval still queued for a
+# self-hosted runner -- leaving the sticky comment stale (the "sometimes empty"
+# symptom). The group expression must route no-op label events to a unique
+# throwaway group keyed by run_id, while real events share the per-ref group.
+# This is a workflow-level expression jq cannot exercise, so pin its shape here.
+conc_group="$(yq '.concurrency.group' "$workflow")"
+if printf '%s' "$conc_group" | grep -q 'github.run_id' \
+   && printf '%s' "$conc_group" | grep -q 'github.ref' \
+   && printf '%s' "$conc_group" | grep -q "github.event.label.name != 'blast-radius'"; then
+  note "concurrency: no-op events routed to a unique group ok"
+else
+  note "concurrency: FAIL (no-op label events can evict a pending real eval)"; fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi
 echo "blast-radius-test: all passed"

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -131,5 +131,27 @@ else
   note "fallback: FAIL (missing explanation or run link)"; fail=1
 fi
 
+# Fail-closed gating wiring. An explicit `if` on a step drops the implicit
+# `success()` GitHub adds to an unconditional step, so the produce-then-post
+# chain only stays fail-closed if every gated step re-states `success()` and the
+# post step keeps its default `success()` gate. A bare `if: !cancelled()` on the
+# post step (or a missing `success()` on render) would publish a half-written or
+# unvalidated comment.md -- exactly the regression caught in review on #1416.
+# These are workflow-level conditions jq cannot exercise, so assert them here.
+gate_if() { yq ".jobs.comment.steps[] | select(.name == \"$1\").if // \"\"" "$workflow"; }
+for step in "Validate report schema" "Render comment" "Compose fallback comment (eval failed)"; do
+  if gate_if "$step" | grep -q 'success()'; then
+    note "gate [$step]: success() present ok"
+  else
+    note "gate [$step]: FAIL (missing success(); explicit if dropped the implicit gate)"; fail=1
+  fi
+done
+post_if="$(gate_if "Post sticky comment")"
+if [ -z "$post_if" ] || printf '%s' "$post_if" | grep -q 'success()'; then
+  note "gate [Post sticky comment]: fail-closed (default/explicit success()) ok"
+else
+  note "gate [Post sticky comment]: FAIL (gate '$post_if' can post an unvalidated/partial body)"; fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi
 echo "blast-radius-test: all passed"


### PR DESCRIPTION
## Why

A teammate reported the blast-radius PR comment "sometimes comes up empty." The rendered comment body is **never blank** (even a 0-rebuild report renders the `### Blast radius` header and summary, verified by running the trusted render jq on a degenerate report). "Empty" means the sticky comment is **absent / not updated**. There are three distinct root causes, each with its own tracking issue, plus a swarm of overlapping partial-fix PRs. This consolidates the fixes into one change.

## Root causes (all confirmed)

1. **Trigger fully disabled (#1411).** #1384 commented out `on: pull_request` to stop per-PR evals from claiming a shared `ix-ci` runner. Side effect: the workflow never runs on PRs, so the comment is never created. Confirmed: `origin/main`'s workflow still has the `pull_request` block commented out.
2. **Comment job skipped on eval bail (#1415).** `comment` was `needs: evaluate` with the default `if: success()`, so a transient base-side `main` eval failure (unrelated to the PR) silently skipped the comment entirely.
3. **Validator rejected legal Nix names (#1421).** Cause names are derivation names, and fixed-output patch/fetch drvs legally carry `?`/`=` (e.g. `<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`). The schema `name_ok` charset omitted those two glyphs, so `jq -e` fail-closed the **whole** report and no comment posted.

## Fix

- **Opt-in label trigger:** re-enable `on: pull_request` (`labeled`/`synchronize`/`reopened`), gated on the `blast-radius` label so it claims a runner only when a maintainer opts in. (#1411)
- **Resilient comment job:** run on eval failure too and post an explicit "could not compute" note keyed by the same `<!-- blast-radius -->` marker, so the next good run overwrites it. The Post step keeps the default `success()` gate, so a half-written `comment.md` is never published. (#1415)
- **Widen validator/safename charset** to the legal nix-name set (`?` and `=` added), in lockstep across the validator and renderer, with a `special-name.json` fixture and regression test. Still rejects every markdown/mention/HTML glyph. (#1421)

## Test

`tools/blast-radius-test.sh` (wired as the `blast-radius-test` flake check) — 17/17 pass locally, including the new `special-name` (charset) and `fallback` (eval-failed) cases. `actionlint` clean.

## Supersedes / consolidates

Folds in #1426 (charset) and the opt-in+resilient work from #1422/#1424/#1427 (and the closed #1425/#1416/#1413). Recommend closing the still-open duplicates (#1424, #1426, #1427) in favor of this one.

Closes #1411
Closes #1415
Closes #1421

---
sent by an AI agent (Claude) via Claude Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore blast-radius PR comment with opt-in label trigger, resilient fallback, and extended name charset
> - Adds `pull_request` triggers (`labeled`, `synchronize`, `reopened`) to [blast-radius.yml](.github/workflows/blast-radius.yml), gated so evaluation only runs for same-repo, non-Dependabot PRs carrying the `blast-radius` label.
> - Routes no-op label events (other labels added) to a throwaway concurrency group keyed by `run_id` so they don't cancel real in-flight runs.
> - Posts a fallback comment with a link to the run logs when evaluation fails, instead of leaving the PR with no blast-radius comment.
> - Extends the `name_ok` regex and renderer safename filter to accept `?` and `=` characters, matching legal Nix derivation name glyphs; adds a fixture and regression test in `tools/blast-radius-test.sh`.
> - Behavioral Change: the workflow no longer requires manual dispatch — labeling a PR with `blast-radius` triggers evaluation automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b589e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->