### PR TITLE
fix(blast-radius): accept nix names with ? and = so the PR comment stops coming up empty (#1421)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -153,7 +153,14 @@ jobs:
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
-            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
+            # Charset is the legal nix store-path-name set (a-zA-Z0-9 + - . _ ? =)
+            # plus the extra glyphs attr-path normalization can introduce
+            # (/, space, (, ), :). A cause name is a derivation name, and fixed-
+            # output patch/fetch drvs carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+            # `webkitgtk-2.52.4+abi=4.1`); omitting them fail-closed the whole
+            # report and posted no comment at all (the "sometimes empty" bug, #1421).
+            # It still rejects every markdown/mention/HTML glyph (@ < > [ ] ` & | ; * # {).
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +()?=:-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -188,7 +195,9 @@ jobs:
         run: |
           set -euo pipefail
           jq -r '
-            def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            # Lockstep with the validator name_ok above: same charset, so a
+            # report that validated never has a label silently dropped here.
+            def safename: select(test("^[A-Za-z0-9_./ +()?=:-]+$"));
             # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
             # by magnitude, round to integer. Empty string for a missing entry
             # so a bare label renders when an attr was a substituter hit or new

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -311,7 +311,8 @@ pub fn derivation_graph(drv_paths: &[String]) -> Result<Graph> {
 /// the same shape reaches both [`eval_checks`] and [`crate::timings`].
 ///
 /// The trusted workflow schema (`blast-radius.yml` safename regex) allows dots,
-/// slashes, spaces, and parens but rejects `"`, and trimming only the ends
+/// slashes, spaces, parens, `?`, and `=` (the legal nix-name glyphs that reach a
+/// label) but rejects `"`, and trimming only the ends
 /// leaves the quotes around an interior segment in place. Drop every `"` and
 /// split on dots outside quotes, then rejoin with `.`, so the bare path flows
 /// identically through the diff key, the report, and the schema regardless of

--- a/tools/blast-radius-fixtures/special-name.json
+++ b/tools/blast-radius-fixtures/special-name.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":120,
+ "changed":["rust-test-foo","rust-test-bar"],"added":[],"removed":[],
+ "causes":[{"name":"e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1","checks":["rust-test-foo","rust-test-bar"]}],
+ "timings":{},"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -43,6 +43,24 @@ done
 ( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
 if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
 
+# Regression (#1421): a cause name is a nix derivation name, and fixed-output
+# patch/fetch drvs legally carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+# `webkitgtk-2.52.4+abi=4.1`). The validator's name_ok used to omit those two
+# glyphs and fail-closed the WHOLE report, so the comment job exited 1 and posted
+# no comment at all -- the "sometimes empty" symptom. The report must now both
+# validate and render with the name intact (validate and safename stay lockstep).
+if validate "$fixtures/special-name.json" >/dev/null 2>&1; then
+  note "validate special-name: ok"
+else
+  note "validate special-name: FAIL (rejected a legal nix derivation name)"; fail=1
+fi
+( cd "$tmp" && cp "$fixtures/special-name.json" report.json && bash render.sh )
+if grep -qF 'e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1' "$tmp/comment.md"; then
+  note "render special-name: name preserved ok"
+else
+  note "render special-name: FAIL (legal name dropped from comment)"; fail=1
+fi
+
 # Overflow guard: a PR touching a shared input rebuilds thousands of checks, and
 # an uncapped changed-checks list overflows GitHub's 65536-char comment limit
 # (HTTP 422), so no comment posts. Synthesize a large report and assert the body


### PR DESCRIPTION
## What

The trusted `comment` job in `.github/workflows/blast-radius.yml` validates every check/cause/timing name against `name_ok = ^[A-Za-z0-9_./ +():-]+$` and **fail-closes the WHOLE report** (`exit 1`, no comment) if any one name falls outside it.

But cause names are nix derivation names, whose legal charset includes `?` and `=` (e.g. `<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`). Whenever a PR's rebuild frontier includes such a fixed-output patch/fetch derivation, the comment job aborted and posted **nothing** — the "sometimes empty" symptom (#1421). The Rust producer's local `to_markdown` has no such guard, so it only reproduced in CI and only on data-dependent PRs (dependency bumps, toolchain changes).

## Fix

Widen `name_ok` and the renderer's `safename` (kept lockstep) to `^[A-Za-z0-9_./ +()?=:-]+$` — the legal nix-name glyphs that reach a label. Still rejects every markdown/mention/HTML glyph (`@ < > [ ] \` & | ; * # {`). Adds a regression fixture + assertions to `tools/blast-radius-test.sh`.

## Validation

`bash tools/blast-radius-test.sh` passes locally (yq-go + jq):
- `validate special-name: ok` / `render special-name: name preserved ok` (the #1421 regression)
- `validate bad-name: rejected ok` (injection still fail-closed)
- all existing schema/overflow/backstop assertions green

Closes #1421.

> Note: blast-radius is currently disabled on PRs (#1384) so this has no visible effect until the workflow is re-enabled (see #1427's opt-in work). This lands the root-cause correctness fix so the comment can't come up empty once re-enabled.

_(sent by an AI agent via Claude Code)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix blast-radius PR comment rendering to accept `?` and `=` in nix derivation names
> - Updates the `name_ok` jq regex in [blast-radius.yml](.github/workflows/blast-radius.yml) to allow `?` and `=` characters, which are valid nix derivation name glyphs, so the schema validator no longer rejects entire reports containing them.
> - Updates the `safename` jq regex in the render step to match, preserving labels with `?` and `=` instead of dropping them and producing an empty PR comment.
> - Adds a [special-name.json](tools/blast-radius-fixtures/special-name.json) fixture and a regression test in [blast-radius-test.sh](tools/blast-radius-test.sh) to catch regressions for names containing these characters.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbd506d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->