### PR TITLE
fix(blast-radius): accept nix names with ? and = so the PR comment stops coming up empty (#1421)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -153,7 +153,15 @@ jobs:
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
-            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
+            # Charset is the legal nix store-path-name set (a-zA-Z0-9 + - . _ ? =)
+            # plus the extra glyphs attr-path normalization can introduce
+            # (/, space, (, ), :). A cause name is a derivation name, and fixed-
+            # output patch/fetch drvs carry `?` and `=` (e.g.
+            # `<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`); omitting
+            # them fail-closed the whole report and posted no comment at all (the
+            # "sometimes empty" bug, #1421). Still rejects every markdown/mention/
+            # HTML glyph (@ < > [ ] ` & | ; * # {).
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +()?=:-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -188,7 +196,9 @@ jobs:
         run: |
           set -euo pipefail
           jq -r '
-            def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            # Lockstep with the validator name_ok above: same charset, so a
+            # report that validated never has a label silently dropped here.
+            def safename: select(test("^[A-Za-z0-9_./ +()?=:-]+$"));
             # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
             # by magnitude, round to integer. Empty string for a missing entry
             # so a bare label renders when an attr was a substituter hit or new

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -311,7 +311,8 @@ pub fn derivation_graph(drv_paths: &[String]) -> Result<Graph> {
 /// the same shape reaches both [`eval_checks`] and [`crate::timings`].
 ///
 /// The trusted workflow schema (`blast-radius.yml` safename regex) allows dots,
-/// slashes, spaces, and parens but rejects `"`, and trimming only the ends
+/// slashes, spaces, parens, `?`, and `=` (the legal nix-name glyphs that reach a
+/// label) but rejects `"`, and trimming only the ends
 /// leaves the quotes around an interior segment in place. Drop every `"` and
 /// split on dots outside quotes, then rejoin with `.`, so the bare path flows
 /// identically through the diff key, the report, and the schema regardless of

--- a/tools/blast-radius-fixtures/special-name.json
+++ b/tools/blast-radius-fixtures/special-name.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":120,
+ "changed":["rust-test-foo","rust-test-bar"],"added":[],"removed":[],
+ "causes":[{"name":"e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1","checks":["rust-test-foo","rust-test-bar"]}],
+ "timings":{},"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -43,6 +43,24 @@ done
 ( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
 if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
 
+# Regression (#1421): a cause name is a nix derivation name, and fixed-output
+# patch/fetch drvs legally carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+# `webkitgtk-2.52.4+abi=4.1`). The validator's name_ok used to omit those two
+# glyphs and fail-closed the WHOLE report, so the comment job exited 1 and posted
+# no comment at all -- the "sometimes empty" symptom. The report must now both
+# validate and render with the name intact (validate and safename stay lockstep).
+if validate "$fixtures/special-name.json" >/dev/null 2>&1; then
+  note "validate special-name: ok"
+else
+  note "validate special-name: FAIL (rejected a legal nix derivation name)"; fail=1
+fi
+( cd "$tmp" && cp "$fixtures/special-name.json" report.json && bash render.sh )
+if grep -qF 'e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1' "$tmp/comment.md"; then
+  note "render special-name: name preserved ok"
+else
+  note "render special-name: FAIL (legal name dropped from comment)"; fail=1
+fi
+
 # Overflow guard: a PR touching a shared input rebuilds thousands of checks, and
 # an uncapped changed-checks list overflows GitHub's 65536-char comment limit
 # (HTTP 422), so no comment posts. Synthesize a large report and assert the body


### PR DESCRIPTION
## Symptom
The blast-radius sticky PR comment **sometimes comes up empty** (no comment posts at all) on index PRs.

## Root cause (reproduced)
The trusted `comment` job in `.github/workflows/blast-radius.yml` validates every cause/check/timing name against `name_ok: ^[A-Za-z0-9_./ +():-]+$` and **fail-closes the whole report** (`::error::malformed`, `exit 1`) if any name is outside that charset. But a **cause name is a nix derivation name**, and fixed-output patch/fetch drvs legally carry `?` and `=`:

- `e67caa0...patch?full_index=1`
- `webkitgtk-2.52.4+abi=4.1`

Empirically, **86 names in a local `/nix/store` sample** contain `?`/`=`, all rejected by the old regex. Whenever a PR's rebuild frontier includes one, the validator exits 1 and **no comment posts**. The Rust producer's local renderer has no such guard, so it only reproduces in CI and only "sometimes" (data-dependent on the rebuilt set).

## Fix
Widen `name_ok` (validate) and `safename` (render) in lockstep to add `?` and `=`:

```
^[A-Za-z0-9_./ +()?=:-]+$
```

Verified to still reject every markdown/mention/HTML injection glyph (`@ < > [ ] \` & | ; * # {`). Adds a patch-drv fixture (`special-name.json`) and a regression test asserting the report both validates and renders with the name intact. Scope is the empty-comment bug only -- this does **not** re-enable the PR trigger that #1384 deliberately disabled for runner cost.

## Verification
`tools/blast-radius-test.sh` (the `blast-radius-test` CI check) passes locally including the two new assertions:

```
validate special-name: ok
render special-name: name preserved ok
blast-radius-test: all passed
```

Note: a swarm of duplicate PRs (#1413, #1416, #1422, #1424–#1428, #1430–#1432) attacked this same issue and all closed without landing; this is the single consolidated fix.

Fixes #1421


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix blast-radius workflow to accept `?` and `=` in nix derivation names
> The `jq` regex in the [blast-radius.yml](https://github.com/indexable-inc/index/pull/1435/files#diff-f18ec732b17d456a8d2f9c00a4941f9433314b97b8a3df9cea22bdaf15337468) validation and rendering steps previously excluded `?` and `=`, causing reports with legal nix derivation names (e.g., fixed-output fetch/patch derivations) to fail validation or appear empty in PR comments.
>
> - Updates the `name_ok` and `safename` regex patterns from `^[A-Za-z0-9_./ +():-]+$` to `^[A-Za-z0-9_./ +()?=:-]+$` in both the validation and render steps.
> - Adds a [special-name.json](https://github.com/indexable-inc/index/pull/1435/files#diff-fd11772d46c6fe1a44e23e9db9179c9569dfcc29e4cd10108f2ea8db91281c1c) fixture with a cause name containing `?` and `=` to cover this case.
> - Adds a regression test in [blast-radius-test.sh](https://github.com/indexable-inc/index/pull/1435/files#diff-008b7e349202f69865582328028ef88fb2c6c22cdfd1f42fbbf5533600c2e27b) asserting validation succeeds and the name is preserved in rendered output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cbd2d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->