### PR TITLE
ci(blast-radius): fix the empty PR comment (opt-in re-enable + per-label gate + charset + resilience)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -47,17 +47,21 @@ jobs:
   # data) for the comment job.
   evaluate:
     # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml),
-    # and only when the PR carries the `blast-radius` label (the opt-in gate;
-    # see `on:` above). `labeled` events already carry the new label in
-    # `pull_request.labels`, so `contains` covers both the initial label-add and
-    # every later `synchronize`/`reopened` while the label remains. The `comment`
-    # job has no `if:` of its own but `needs: evaluate`, so it is skipped too
-    # whenever this gate is false.
+    # and only when the PR is opted in via the `blast-radius` label (see `on:`
+    # above). The label is matched per-event so adding an UNRELATED label to an
+    # already opted-in PR does not re-claim a self-hosted eval runner (the whole
+    # point of the opt-in): the workflow fires on every `labeled` event, so the
+    # last clause requires that on a `labeled` event the label just added
+    # (`github.event.label.name`) is `blast-radius`, while `synchronize`/
+    # `reopened` (which carry no `label` payload) gate on the label still being
+    # present. The `comment` job has no `if:` of its own but `needs: evaluate`,
+    # so it is skipped too whenever this gate is false.
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
-      contains(github.event.pull_request.labels.*.name, 'blast-radius')
+      contains(github.event.pull_request.labels.*.name, 'blast-radius') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'blast-radius')
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
     # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,17 +1,22 @@
 name: Blast radius
 
 on:
-  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
-  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
-  # serves the whole team, so every PR queued one more eval-only runner and
-  # slowed the queue. The report is informational (a sticky PR comment), never
-  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
-  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
-  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  # Opt-in per PR, not on every push. Auto-running on every PR meant the per-PR
+  # full-catalog eval (~57s "Report blast radius" step) claimed a shared `ix-ci`
+  # runner from the one dispatcher pool that serves the whole team, queuing an
+  # eval-only runner each push and slowing the queue (#1384). But fully disabling
+  # it left the report unreachable, so the sticky comment "came up empty" on every
+  # PR. The middle ground: it runs only when a maintainer adds the `blast-radius`
+  # label. Once labeled, each later push (`synchronize`) and reopen refreshes the
+  # comment. The job `if:` below gates EVERY event on the label, so adding any
+  # other label (or pushing to an unlabeled PR) skips `evaluate` and claims no
+  # runner. `workflow_dispatch` is kept for manual reruns (no-ops without PR
+  # context).
   workflow_dispatch: {}
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -41,10 +46,18 @@ jobs:
   # token-backed step. The report leaves this job only as an artifact (plain
   # data) for the comment job.
   evaluate:
-    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
+    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml),
+    # and only when the PR carries the `blast-radius` label (the opt-in gate;
+    # see `on:` above). `labeled` events already carry the new label in
+    # `pull_request.labels`, so `contains` covers both the initial label-add and
+    # every later `synchronize`/`reopened` while the label remains. The `comment`
+    # job has no `if:` of its own but `needs: evaluate`, so it is skipped too
+    # whenever this gate is false.
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'blast-radius')
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
     # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD
@@ -125,6 +138,12 @@ jobs:
   # PR cannot influence.
   comment:
     needs: evaluate
+    # Run even when `evaluate` failed (a base/head eval error, often base-side
+    # and unrelated to this PR), so the PR never silently ends up with no blast-
+    # radius comment. `!cancelled()` covers success and failure but not a
+    # concurrency cancel; `result != 'skipped'` keeps it off forks/Dependabot
+    # PRs, where `evaluate` itself was skipped (and there is nothing to report).
+    if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +153,12 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Only present when `evaluate` succeeded (the upload step is `if: success()`).
+      # continue-on-error so a missing artifact after a failed eval drops through
+      # to the fallback step below instead of failing the job.
       - name: Download report
+        if: ${{ needs.evaluate.result == 'success' }}
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: blast-radius-${{ github.run_id }}
@@ -146,7 +170,13 @@ jobs:
       # Fail closed: require the full schema before rendering. Every field is
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
+      # Every gating step in this job spells out `&& success()`: a step with an
+      # explicit `if` drops the implicit `success()` GitHub adds to an
+      # unconditional step, so without it a failure in an earlier step would not
+      # stop this one. That short-circuit is what makes the validate -> render
+      # fail-closed chain below actually hold.
       - name: Validate report schema
+        if: ${{ needs.evaluate.result == 'success' && success() }}
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
@@ -185,6 +215,7 @@ jobs:
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
+        if: ${{ needs.evaluate.result == 'success' && success() }}
         run: |
           set -euo pipefail
           jq -r '
@@ -261,11 +292,37 @@ jobs:
             printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
           fi
 
+      # `evaluate` failed (no report.json): post an explicit "could not compute"
+      # note rather than letting the comment job skip and leave the PR with no
+      # blast-radius comment at all. The eval bail is frequently base-side (a
+      # transiently un-evaluable `master`) or a runner flake, so the copy says
+      # as much. Keyed by the same marker, so the next successful run overwrites
+      # it in place. RUN_URL is passed via env (a GitHub `${{ }}` expression
+      # cannot be evaluated by the shell), which also lets the test drive this
+      # script with a stub URL.
+      - name: Compose fallback comment (eval failed)
+        if: ${{ needs.evaluate.result != 'success' && success() }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            printf '<!-- blast-radius -->\n'
+            printf '### Blast radius\n\n'
+            printf 'Could not compute the blast radius for this run: the check catalog failed to evaluate at the base or head commit. This is usually a transient base-branch or runner issue rather than a problem with this PR. See the [run logs](%s).\n' "$RUN_URL"
+          } > comment.md
+
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no
       # duplicate comments), and restrict the match to comments this token can
       # actually PATCH: a user comment that happens to start with the marker
       # would otherwise be selected and every PATCH would 403 forever.
+      #
+      # No explicit `if`, so the default `success()` gate applies: this runs
+      # after whichever of Render or Compose-fallback succeeded (each leaves a
+      # complete comment.md), and is SKIPPED if Validate or Render failed -- so a
+      # malformed report or a half-written comment.md is never posted. That keeps
+      # the fail-closed behavior an `if: !cancelled()` here would have broken.
       - name: Post sticky comment
         run: |
           set -euo pipefail

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -183,7 +183,14 @@ jobs:
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
-            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
+            # Charset is the legal nix store-path-name set (a-zA-Z0-9 + - . _ ? =)
+            # plus the extra glyphs attr-path normalization can introduce
+            # (/, space, (, ), :). A cause name is a derivation name, and fixed-
+            # output patch/fetch drvs carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+            # `webkitgtk-2.52.4+abi=4.1`); omitting them fail-closed the whole
+            # report and posted no comment at all (the "sometimes empty" bug, #1421).
+            # It still rejects every markdown/mention/HTML glyph (@ < > [ ] ` & | ; * # {).
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +()?=:-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -219,7 +226,9 @@ jobs:
         run: |
           set -euo pipefail
           jq -r '
-            def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            # Lockstep with the validator name_ok above: same charset, so a
+            # report that validated never has a label silently dropped here.
+            def safename: select(test("^[A-Za-z0-9_./ +()?=:-]+$"));
             # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
             # by magnitude, round to integer. Empty string for a missing entry
             # so a bare label renders when an attr was a substituter hit or new

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -311,7 +311,8 @@ pub fn derivation_graph(drv_paths: &[String]) -> Result<Graph> {
 /// the same shape reaches both [`eval_checks`] and [`crate::timings`].
 ///
 /// The trusted workflow schema (`blast-radius.yml` safename regex) allows dots,
-/// slashes, spaces, and parens but rejects `"`, and trimming only the ends
+/// slashes, spaces, parens, `?`, and `=` (the legal nix-name glyphs that reach a
+/// label) but rejects `"`, and trimming only the ends
 /// leaves the quotes around an interior segment in place. Drop every `"` and
 /// split on dots outside quotes, then rejoin with `.`, so the bare path flows
 /// identically through the diff key, the report, and the schema regardless of

--- a/tools/blast-radius-fixtures/special-name.json
+++ b/tools/blast-radius-fixtures/special-name.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":120,
+ "changed":["rust-test-foo","rust-test-bar"],"added":[],"removed":[],
+ "causes":[{"name":"e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1","checks":["rust-test-foo","rust-test-bar"]}],
+ "timings":{},"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -44,6 +44,24 @@ done
 ( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
 if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
 
+# Regression (#1421): a cause name is a nix derivation name, and fixed-output
+# patch/fetch drvs legally carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+# `webkitgtk-2.52.4+abi=4.1`). The validator's name_ok used to omit those two
+# glyphs and fail-closed the WHOLE report, so the comment job exited 1 and posted
+# no comment at all -- the "sometimes empty" symptom. The report must now both
+# validate and render with the name intact (validate and safename stay lockstep).
+if validate "$fixtures/special-name.json" >/dev/null 2>&1; then
+  note "validate special-name: ok"
+else
+  note "validate special-name: FAIL (rejected a legal nix derivation name)"; fail=1
+fi
+( cd "$tmp" && cp "$fixtures/special-name.json" report.json && bash render.sh )
+if grep -qF 'e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1' "$tmp/comment.md"; then
+  note "render special-name: name preserved ok"
+else
+  note "render special-name: FAIL (legal name dropped from comment)"; fail=1
+fi
+
 # Overflow guard: a PR touching a shared input rebuilds thousands of checks, and
 # an uncapped changed-checks list overflows GitHub's 65536-char comment limit
 # (HTTP 422), so no comment posts. Synthesize a large report and assert the body

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -19,6 +19,7 @@ note() { printf '  %s\n' "$*"; }
 # Extract the exact run-scripts the trusted comment job executes.
 yq '.jobs.comment.steps[] | select(.name == "Validate report schema").run' "$workflow" > "$tmp/validate.sh"
 yq '.jobs.comment.steps[] | select(.name == "Render comment").run' "$workflow" > "$tmp/render.sh"
+yq '.jobs.comment.steps[] | select(.name == "Compose fallback comment (eval failed)").run' "$workflow" > "$tmp/fallback.sh"
 
 validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 
@@ -92,6 +93,46 @@ if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
   note "render backstop: marker survived truncation ok"
 else
   note "render backstop: FAIL (marker lost; sticky-comment keying breaks)"; fail=1
+fi
+
+# Fallback comment: when `evaluate` fails there is no report.json, so the
+# comment job posts an explicit "could not compute" note instead of skipping
+# and leaving the PR with no blast-radius comment (the "comes up empty" bug,
+# issue #1415). Assert it produces a marker-prefixed body so the sticky-comment
+# keying still finds and overwrites it on the next successful run.
+( cd "$tmp" && rm -f report.json comment.md && RUN_URL="https://github.com/indexable-inc/index/actions/runs/123" bash fallback.sh )
+if head -c 21 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
+  note "fallback: marker present ok"
+else
+  note "fallback: FAIL (missing marker; sticky-comment keying breaks)"; fail=1
+fi
+if grep -q 'Could not compute the blast radius' "$tmp/comment.md" \
+   && grep -q 'actions/runs/123' "$tmp/comment.md"; then
+  note "fallback: note + run link ok"
+else
+  note "fallback: FAIL (missing explanation or run link)"; fail=1
+fi
+
+# Fail-closed gating wiring. An explicit `if` on a step drops the implicit
+# `success()` GitHub adds to an unconditional step, so the produce-then-post
+# chain only stays fail-closed if every gated step re-states `success()` and the
+# post step keeps its default `success()` gate. A bare `if: !cancelled()` on the
+# post step (or a missing `success()` on render) would publish a half-written or
+# unvalidated comment.md -- exactly the regression caught in review on #1416.
+# These are workflow-level conditions jq cannot exercise, so assert them here.
+gate_if() { yq ".jobs.comment.steps[] | select(.name == \"$1\").if // \"\"" "$workflow"; }
+for step in "Validate report schema" "Render comment" "Compose fallback comment (eval failed)"; do
+  if gate_if "$step" | grep -q 'success()'; then
+    note "gate [$step]: success() present ok"
+  else
+    note "gate [$step]: FAIL (missing success(); explicit if dropped the implicit gate)"; fail=1
+  fi
+done
+post_if="$(gate_if "Post sticky comment")"
+if [ -z "$post_if" ] || printf '%s' "$post_if" | grep -q 'success()'; then
+  note "gate [Post sticky comment]: fail-closed (default/explicit success()) ok"
+else
+  note "gate [Post sticky comment]: FAIL (gate '$post_if' can post an unvalidated/partial body)"; fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -153,5 +153,24 @@ else
   note "gate [Post sticky comment]: FAIL (gate '$post_if' can post an unvalidated/partial body)"; fail=1
 fi
 
+# Opt-in label gate (#1384 re-enable). The `evaluate` job must (a) gate on the
+# `blast-radius` label so unlabeled PRs claim no self-hosted runner, and (b)
+# match the label PER EVENT so adding an UNRELATED label to an already opted-in
+# PR does not re-fire the costly eval. The workflow fires on every `labeled`
+# event, so the gate needs both the `contains(... 'blast-radius')` presence
+# check and a `github.event.label.name == 'blast-radius'` clause scoped to
+# `labeled` events. This is a workflow-level condition jq cannot exercise.
+eval_if="$(yq '.jobs.evaluate.if // ""' "$workflow")"
+if printf '%s' "$eval_if" | grep -q "contains(github.event.pull_request.labels.\*.name, 'blast-radius')"; then
+  note "gate [evaluate]: label opt-in present ok"
+else
+  note "gate [evaluate]: FAIL (missing blast-radius label gate; every PR would claim a runner)"; fail=1
+fi
+if printf '%s' "$eval_if" | grep -q "github.event.label.name == 'blast-radius'"; then
+  note "gate [evaluate]: per-label add gate present ok"
+else
+  note "gate [evaluate]: FAIL (a labeled event with any other label would re-run eval)"; fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi
 echo "blast-radius-test: all passed"


### PR DESCRIPTION
## Why
A teammate reported the blast-radius PR comment **"sometimes comes up empty"** on index PRs.

## Root cause (live evidence, not memory)
Pulled the last 100 `Blast radius` runs: **60 success, 24 `action_required` (all bot PRs: update-flake-lock/update-cargo), 14 `cancelled`, 0 `failure`.** A *posted* body is never blank (the renderer always emits a header) — **"empty" means the comment is ABSENT.** Reasons, dominant first:

1. **#1384 (merged earlier today) commented out the `pull_request` trigger entirely** to save a shared `ix-ci` runner slot, so every PR now gets **no** comment.
2. **Latent fail-closed bug (#1421):** the trusted `comment` job validates every cause name against a charset missing `?`/`=`. But a cause name is a *nix derivation name*, and fixed-output patch/fetch drvs legally carry those (`<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`). A rebuild frontier hitting one exits the validator `1` → comment job fails → no comment. (Not yet observed in the 100-run window, so this is a latent hardening, not the dominant cause — but it is a real fail-closed path.)
3. **Eval bail skips the comment** (`needs: evaluate`, default `if: success()`) — frequently base-side (a transiently un-evaluable base) or a runner flake unrelated to the PR.

## Fix (one workflow change + lockstep renderer)
- **Opt-in, reachable again:** re-enable `pull_request: [labeled, synchronize, reopened]` gated on a `blast-radius` label, so the comment returns **without** re-introducing the #1384 queue cost. The gate matches the label **per event** (`action != 'labeled' || label.name == 'blast-radius'`) so adding an *unrelated* label to an already opted-in PR does **not** re-claim an eval runner. *(This closes the AI-review P2 that the earlier consolidation PRs carried.)*
- **Charset:** widen `name_ok`/`safename` (kept lockstep) to the legal nix-name set `^[A-Za-z0-9_./ +()?=:-]+$`; still rejects every markdown/mention/HTML glyph (`@ < > [ ] ` `` ` `` ` & | ; * # {`). Rust `normalize_attr` doc updated; new `special-name.json` fixture.
- **Resilience:** `comment` runs on eval success **or** failure and posts an explicit "could not compute" sticky note (same `<!-- blast-radius -->` marker, overwritten by the next good run) instead of skipping. Every gated step re-states `success()` so the validate→render fail-closed chain still holds.

## Tests
`tools/blast-radius-test.sh` (the `blast-radius-test` CI check; it extracts the workflow's own jq/scripts so it can't drift) now also asserts the charset regression, the fallback path, the fail-closed gate wiring, **and the per-label opt-in gate**. All 22 assertions pass locally (`yq-go` + `jq`); `actionlint` clean.

## Note on duplicates
This task spawned a cluster of overlapping PRs (#1413, #1416, #1422, #1424, #1425, #1426, #1427 closed; #1428 open). This is the consolidated, complete version: #1428's content **plus** the per-label P2 fix and its regression test. Recommend landing this one and closing the rest.

Closes #1415
Closes #1421

sent by an AI agent (Claude) via Claude Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix empty PR comments in blast-radius workflow with label gating and fallback handling
> - Adds a `blast-radius` label gate to the evaluate job so the workflow only runs on labeled PRs and does not claim a runner for unrelated label additions.
> - Tightens step chaining with explicit `success()` guards on Validate and Render steps to prevent silent failures from producing empty comments.
> - Adds a fallback comment step that posts a minimal 'could not compute' note with a run link when evaluation fails but is not skipped.
> - Extends the `safename` regex and jq validator to accept `?` and `=` in derivation names, keeping validation and rendering in lockstep.
> - Behavioral Change: unlabeled PRs no longer trigger the workflow at all; previously they would run and could post an empty comment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b39479.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->