### PR TITLE
ci(blast-radius): accept nix names with ? and = so the PR comment stops coming up empty (#1421)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -153,7 +153,19 @@ jobs:
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
-            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
+            # Charset is the legal nix store-path name set (a cause name is a
+            # derivation name): letters, digits, space, and _ . / + ( ) ? = : -
+            # The ? and = are load-bearing: fixed-output patch/fetch derivations
+            # surface as frontier causes named like
+            # e67caa0....patch?full_index=1 or webkitgtk-2.52.4+abi=4.1, and
+            # without them one such cause fail-closed the WHOLE report so no
+            # comment posted (#1421). Still excludes every markdown/mention/HTML
+            # injection char (at-sign, angle/square brackets, backtick, ampersand,
+            # pipe, semicolon, star, hash, braces, quotes, backslash) since the
+            # body is posted with the write token. Lockstep with safename in the
+            # render step and tools/blast-radius-test.sh. (Keep this jq
+            # apostrophe-free: it is single-quoted in the shell.)
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +()?=:-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -180,15 +192,18 @@ jobs:
           ' report.json > /dev/null \
             || { echo "::error::malformed blast-radius report.json"; exit 1; }
 
-      # Rebuild the Markdown from the validated data. Check names still pass
-      # through a conservative charset (Nix attr names do) so a malicious PR
-      # cannot inject mentions, HTML, or spoofed markers into a comment posted
+      # Rebuild the Markdown from the validated data. Names still pass through a
+      # conservative charset (the legal nix store-path name set) so a malicious
+      # PR cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
         run: |
           set -euo pipefail
           jq -r '
-            def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            # Lockstep with name_ok in the validate step: same legal nix
+            # store-path charset, including ? and = for fixed-output patch/fetch
+            # derivation cause names (#1421).
+            def safename: select(test("^[A-Za-z0-9_./ +()?=:-]+$"));
             # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
             # by magnitude, round to integer. Empty string for a missing entry
             # so a bare label renders when an attr was a substituter hit or new

--- a/tools/blast-radius-fixtures/bad-injection.json
+++ b/tools/blast-radius-fixtures/bad-injection.json
@@ -1,0 +1,2 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":1,"changed":["webkitgtk-2.52.4+abi=4.1 <img src=x>"],"added":[],"removed":[],
+ "causes":[],"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-fixtures/nix-name.json
+++ b/tools/blast-radius-fixtures/nix-name.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":120,"changed":["rust-test-bar","rust-test-foo"],"added":[],"removed":[],
+ "causes":[{"name":"e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1","checks":["rust-test-foo","rust-test-bar"]},
+           {"name":"webkitgtk-2.52.4+abi=4.1","checks":["rust-test-foo","rust-test-bar"]}],
+ "timings":{},"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -28,13 +28,27 @@ validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 # typed value constraint that keep an attacker from smuggling shapes into
 # the artifact.
 if validate "$fixtures/good.json" >/dev/null 2>&1; then note "validate good: ok"; else note "validate good: FAIL"; fail=1; fi
-for bad in bad-name bad-check missing bad-phase-key bad-phase-value; do
+for bad in bad-name bad-check missing bad-phase-key bad-phase-value bad-injection; do
   if validate "$fixtures/$bad.json" >/dev/null 2>&1; then
     note "validate $bad: FAIL (accepted hostile/old report)"; fail=1
   else
     note "validate $bad: rejected ok"
   fi
 done
+
+# Legal nix derivation names (a cause name IS a derivation name) contain `?` and
+# `=`: fixed-output patch/fetch derivations surface as frontier causes named
+# like `e67caa0....patch?full_index=1` or `webkitgtk-2.52.4+abi=4.1`. The
+# validator charset must accept them, or one such cause fail-closes the whole
+# report and no comment posts (#1421). This passes BEFORE the charset is widened
+# only if the bug is fixed; it is the regression guard for the empty-comment bug.
+if validate "$fixtures/nix-name.json" >/dev/null 2>&1; then note "validate nix-name (?/=): ok"; else note "validate nix-name (?/=): FAIL (rejected legal nix name -> empty comment)"; fail=1; fi
+( cd "$tmp" && cp "$fixtures/nix-name.json" report.json && bash render.sh )
+if grep -qF 'patch?full_index=1' "$tmp/comment.md" && grep -qF 'webkitgtk-2.52.4+abi=4.1' "$tmp/comment.md"; then
+  note "render nix-name (?/=): names survive into body ok"
+else
+  note "render nix-name (?/=): FAIL (legal nix name dropped from body)"; fail=1
+fi
 
 # Render: the good report produces the golden comment (flowchart + list).
 # `phaseTimings` is observability-only and never renders, so the golden


### PR DESCRIPTION
## Symptom
The blast-radius sticky PR comment **sometimes comes up empty** (no comment posts at all) on index PRs. Reported by a teammate; tracked in #1421.

## Root cause (reproduced)
The trusted `comment` job in `.github/workflows/blast-radius.yml` validates every check/cause/timing name against `name_ok: ^[A-Za-z0-9_./ +():-]+$` and **fail-closes the entire report** (`::error::malformed`, `exit 1`) if *any* single name is outside that charset.

But **a cause name is a nix derivation name**, and the legal store-path name charset includes `?` and `=`. Fixed-output patch/fetch derivations surface as rebuild-frontier causes named like:

- `e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1`
- `webkitgtk-2.52.4+abi=4.1`

**30 distinct such names** exist in a local `/nix/store` sample. Whenever a PR's frontier includes one, the whole report is rejected and no comment posts. The Rust producer's local `to_markdown` has no such guard, so it only reproduces in CI and only "sometimes" (data-dependent on the rebuilt set) — matching the report.

### MRE (verified red on `origin/main`, green here)
```json
{"base":"aaaaaaa","head":"bbbbbbb","total":120,"changed":["rust-test-foo"],"added":[],"removed":[],
 "causes":[{"name":"e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1","checks":["rust-test-foo"]}],
 "timings":{},"phaseTimings":{"total":1.0}}
```
Old validator → `exit 1` (no comment). New validator → passes.

## Fix
Widen `name_ok` and its render-step twin `safename` (kept in lockstep) to the actual legal nix-name set by adding `?` and `=`:
```
^[A-Za-z0-9_./ +()?=:-]+$
```
The charset still rejects every markdown/mention/HTML injection char (`@ < > [ ] ` `` ` `` ` & | ; * # { } ` quotes, backslash), so the write-token comment stays injection-safe.

## Tests (`tools/blast-radius-test.sh`, wired as the `blast-radius-test` flake check)
- `nix-name.json`: a `?`/`=` cause name **validates** and the names **survive into the rendered body** (multi-check cause so the derivation name actually renders). This is the regression guard for the empty-comment bug — it fails on `origin/main`, passes here.
- `bad-injection.json`: an injection char (`<img src=x>`) adjacent to a now-legal `=` is **still rejected**, proving the widening didn't open an injection hole.

All existing assertions still pass.

Fixes #1421

_(sent by an AI agent via Claude Code)_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix blast-radius PR comment rendering by accepting `?` and `=` in Nix derivation names
> - Widens the allowed character set in the `name_ok` regex and `safename` filter in [blast-radius.yml](.github/workflows/blast-radius.yml) to include `?` and `=`, matching legal Nix store-path/derivation name characters.
> - Adds test fixtures for valid Nix names (e.g. `patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`) and an HTML injection attempt, with assertions in [blast-radius-test.sh](tools/blast-radius-test.sh) to verify acceptance and rejection respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e727241.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->