### PR TITLE
ci(blast-radius): restore the PR comment end to end (opt-in label, eval-failure fallback, nix-name charset)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,17 +1,21 @@
 name: Blast radius
 
 on:
-  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
-  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
-  # serves the whole team, so every PR queued one more eval-only runner and
-  # slowed the queue. The report is informational (a sticky PR comment), never
-  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
-  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
-  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  # Opt-in on PRs via a `blast-radius` label, not every PR. The per-PR
+  # full-catalog eval (~57s "Report blast radius" step) claims a shared `ix-ci`
+  # runner from the one dispatcher pool that serves the whole team, so running
+  # it on every PR slowed the queue -- why #1384 disabled the trigger entirely.
+  # Gating on the label (see the `evaluate` job `if:`) keeps that cost off
+  # unlabeled PRs while restoring the comment for PRs a maintainer opts in.
+  # `labeled` fires the first run when the label is added; `synchronize` /
+  # `reopened` refresh the sticky comment on later pushes (each re-checks the
+  # label, so removing it stops future runs). `workflow_dispatch` keeps `on:`
+  # non-empty for manual runs (PR-context gated, so a bare dispatch no-ops).
   workflow_dispatch: {}
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -41,8 +45,13 @@ jobs:
   # token-backed step. The report leaves this job only as an artifact (plain
   # data) for the comment job.
   evaluate:
-    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
+    # Opt-in, same-repository, non-Dependabot PRs only. The `blast-radius` label
+    # is the opt-in gate (see the `on: pull_request` note); the same-repo +
+    # non-Dependabot checks mirror ai-review-gate.yml. On `workflow_dispatch`
+    # the `pull_request` context is empty, so this is false and the manual run
+    # no-ops -- matching the prior behavior.
     if: >-
+      contains(github.event.pull_request.labels.*.name, 'blast-radius') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
@@ -125,6 +134,14 @@ jobs:
   # PR cannot influence.
   comment:
     needs: evaluate
+    # Run whenever `evaluate` actually ran -- success OR failure -- so a failed
+    # eval still leaves the PR an explicit note instead of silently nothing (the
+    # "comment comes up empty" report: #1415). The eval bail is frequently
+    # base-side (a transiently un-evaluable `master`) or a runner flake, i.e.
+    # unrelated to the PR. Skip only when `evaluate` was skipped (unlabeled PR /
+    # fork / Dependabot): those opted out, so no comment is correct.
+    # `!cancelled()` lets a cancel-in-progress run bow out without posting.
+    if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +151,11 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Download + validate + render run only when the eval succeeded; the
+      # fallback step below covers the failure path. The eval's `Upload report`
+      # is `if: success()`, so the artifact exists exactly on this path.
       - name: Download report
+        if: ${{ needs.evaluate.result == 'success' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: blast-radius-${{ github.run_id }}
@@ -147,13 +168,14 @@ jobs:
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
       - name: Validate report schema
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
-            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +()?=:-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -185,10 +207,11 @@ jobs:
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
+        if: ${{ needs.evaluate.result == 'success' }}
         run: |
           set -euo pipefail
           jq -r '
-            def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            def safename: select(test("^[A-Za-z0-9_./ +()?=:-]+$"));
             # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
             # by magnitude, round to integer. Empty string for a missing entry
             # so a bare label renders when an attr was a substituter hit or new
@@ -260,6 +283,27 @@ jobs:
             mv comment.md.trunc comment.md
             printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
           fi
+
+      # When evaluate did not succeed, compose an explicit "could not compute"
+      # note instead of leaving the PR with no comment. No PR-controlled data reaches
+      # this step (the report.json is not read), so it needs no schema gate. The
+      # same `<!-- blast-radius -->` marker means the next good run overwrites it
+      # in place. Authored here, on the trusted runner, so the marker stays
+      # under the write-token job's control.
+      - name: Fallback comment (eval failed)
+        if: ${{ needs.evaluate.result != 'success' }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            echo '<!-- blast-radius -->'
+            echo '### Blast radius'
+            echo ''
+            echo 'Could not compute the blast radius for this change: the evaluation step did not finish. This is often a transient base-branch eval or runner issue rather than a problem with this PR.'
+            echo ''
+            echo "See the [Blast radius run](${RUN_URL}) for details; pushing a new commit re-runs it."
+          } > comment.md
 
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -311,7 +311,8 @@ pub fn derivation_graph(drv_paths: &[String]) -> Result<Graph> {
 /// the same shape reaches both [`eval_checks`] and [`crate::timings`].
 ///
 /// The trusted workflow schema (`blast-radius.yml` safename regex) allows dots,
-/// slashes, spaces, and parens but rejects `"`, and trimming only the ends
+/// slashes, spaces, parens, `?`, and `=` (the legal nix-name glyphs that reach a
+/// label) but rejects `"`, and trimming only the ends
 /// leaves the quotes around an interior segment in place. Drop every `"` and
 /// split on dots outside quotes, then rejoin with `.`, so the bare path flows
 /// identically through the diff key, the report, and the schema regardless of

--- a/tools/blast-radius-fixtures/special-name.json
+++ b/tools/blast-radius-fixtures/special-name.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":120,
+ "changed":["rust-test-foo","rust-test-bar"],"added":[],"removed":[],
+ "causes":[{"name":"e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1","checks":["rust-test-foo","rust-test-bar"]}],
+ "timings":{},"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -43,6 +43,24 @@ done
 ( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
 if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
 
+# Regression (#1421): a cause name is a nix derivation name, and fixed-output
+# patch/fetch drvs legally carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+# `webkitgtk-2.52.4+abi=4.1`). The validator's name_ok used to omit those two
+# glyphs and fail-closed the WHOLE report, so the comment job exited 1 and posted
+# no comment at all -- the "sometimes empty" symptom. The report must now both
+# validate and render with the name intact (validate and safename stay lockstep).
+if validate "$fixtures/special-name.json" >/dev/null 2>&1; then
+  note "validate special-name: ok"
+else
+  note "validate special-name: FAIL (rejected a legal nix derivation name)"; fail=1
+fi
+( cd "$tmp" && cp "$fixtures/special-name.json" report.json && bash render.sh )
+if grep -qF 'e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1' "$tmp/comment.md"; then
+  note "render special-name: name preserved ok"
+else
+  note "render special-name: FAIL (legal name dropped from comment)"; fail=1
+fi
+
 # Overflow guard: a PR touching a shared input rebuilds thousands of checks, and
 # an uncapped changed-checks list overflows GitHub's 65536-char comment limit
 # (HTTP 422), so no comment posts. Synthesize a large report and assert the body
@@ -92,6 +110,30 @@ if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
   note "render backstop: marker survived truncation ok"
 else
   note "render backstop: FAIL (marker lost; sticky-comment keying breaks)"; fail=1
+fi
+
+# Fallback path: when the `evaluate` job fails, the `comment` job composes a
+# "could not compute" note (same `<!-- blast-radius -->` marker) instead of
+# leaving the PR with no comment at all (#1415). Extract that step's verbatim
+# script and assert the marker survives (sticky keying) and the run link and
+# explanation are present. RUN_URL stands in for the workflow expression the
+# step reads from its env.
+yq '.jobs.comment.steps[] | select(.name == "Fallback comment (eval failed)").run' "$workflow" > "$tmp/fallback.sh"
+( cd "$tmp" && rm -f comment.md && RUN_URL="https://github.com/indexable-inc/index/actions/runs/123" bash fallback.sh )
+if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
+  note "fallback: marker present ok"
+else
+  note "fallback: FAIL (marker missing; sticky-comment keying breaks)"; fail=1
+fi
+if grep -q 'Could not compute the blast radius' "$tmp/comment.md"; then
+  note "fallback: explanation present ok"
+else
+  note "fallback: FAIL (explanation missing)"; fail=1
+fi
+if grep -q 'actions/runs/123' "$tmp/comment.md"; then
+  note "fallback: run link present ok"
+else
+  note "fallback: FAIL (run link missing)"; fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi


### PR DESCRIPTION
## What

Restore the **blast-radius PR comment** end to end. A teammate reported it "sometimes comes up empty." Reproduced and root-caused before touching anything; the rendered body is never blank, so **"empty" means the comment is absent.** Three independent causes each drop it:

1. **Trigger disabled (#1384).** `pull_request` was commented out for runner cost, so PRs get **no comment at all** (dominant cause today).
2. **Eval bail silently skips the comment.** `comment` was `needs: evaluate` + default `if: success()`; a (frequently base-side, transient) eval failure dropped the comment entirely.
3. **Validator charset rejects legal nix names ("sometimes").** Both the schema validator and renderer matched `^[A-Za-z0-9_./ +():-]+$`, but cause names are **nix derivation names** whose legal charset includes `?` and `=` (e.g. `<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`). One such name in the rebuild frontier `::error::malformed`-ed the whole report → exit 1 → no comment. Only fires when the frontier hits such a drv, hence "sometimes", and only in CI (the Rust producer has no such guard).

## Fix

- **Re-enable on PRs, opt-in via a `blast-radius` label** (respects #1384's runner-cost reason). `types: [labeled, synchronize, reopened]`; `evaluate` gated on the label, so unlabeled / fork / Dependabot PRs claim no runner.
- **Resilient `comment` job.** Runs on eval success **or** failure (`!cancelled() && needs.evaluate.result != 'skipped'`); download/validate/render stay gated on success; on failure a new step posts an explicit "could not compute" sticky note (same `<!-- blast-radius -->` marker, overwritten by the next good run). Post stays fail-closed (default `success()`), so a half-written body is never published.
- **Widen `name_ok` + `safename` in lockstep** to `^[A-Za-z0-9_./ +()?=:-]+$`. Still rejects every markdown / mention / HTML glyph (`@ < > [ ] \` & | ; * # {`, newline). `nix.rs` doc comment updated to match.

## Tests

`tools/blast-radius-test.sh` (the `blast-radius-test` flake check) extracts the workflow's jq/steps verbatim so it can't drift from CI. Adds a **special-name** fixture (cause name with `?`/`=`) and a **fallback-path** case. Verified locally: **17/17 pass on this branch**; main's validator emits `::error::malformed` (exit 1) on the same legal name (red→green).

### Security
Re-enabling `on: pull_request` runs the write-token `comment` job from PR YAML, bounded to same-repo PRs; forks get a read-only token and are excluded by the job `if:`. Hardening the post phase into a `workflow_run` context is a tracked follow-up.

Supersedes the closed churn #1413/#1416/#1422/#1424/#1425/#1426/#1427/#1428/#1430/#1431/#1432/#1433 (a prior agent loop) and collapses them into this one verified change.

_sent by an AI agent (Claude) via Claude Code_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore blast-radius PR comment with opt-in label, eval-failure fallback, and Nix name charset fix
> - The [blast-radius.yml](.github/workflows/blast-radius.yml) workflow now triggers on `labeled`, `synchronize`, and `reopened` PR events, gated by the `blast-radius` label.
> - Adds a fallback sticky comment step that posts an explanation with a link to the run URL when the `evaluate` job fails, instead of silently doing nothing.
> - Expands the safename regex in the validator and renderer to accept `?` and `=` characters, which are legal in Nix derivation names; adds a [test fixture](tools/blast-radius-fixtures/special-name.json) and assertions in [blast-radius-test.sh](tools/blast-radius-test.sh) to cover this.
> - The comment job now runs on both `evaluate` success and failure, but skips when the job is cancelled or skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bf6f1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->