### PR TITLE
ci(blast-radius): stop the PR comment coming up empty (opt-in label + resilient comment + nix-name charset)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -303,6 +303,8 @@ jobs:
       # post with the write token even when the report could not be validated.
       - name: Compose fallback comment
         if: ${{ !cancelled() && (needs.evaluate.result == 'failure' || failure()) }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           {
@@ -314,6 +316,8 @@ jobs:
             echo "usually a transient runner or base-branch issue, not a problem"
             echo "with your change. Re-run the **Blast radius** workflow, or push"
             echo "again, to refresh this comment."
+            echo ""
+            echo "See the [Blast radius run](${RUN_URL}) for details."
           } > comment.md
 
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,17 +1,22 @@
 name: Blast radius
 
 on:
-  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
-  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
-  # serves the whole team, so every PR queued one more eval-only runner and
-  # slowed the queue. The report is informational (a sticky PR comment), never
-  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
-  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
-  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  # Opt-in on PRs via the `blast-radius` label. The per-PR full-catalog eval
+  # (~57s "Report blast radius" step) claims a shared `ix-ci` runner from the
+  # one dispatcher pool that serves the whole team, so auto-running on every PR
+  # queued one more eval-only runner each and slowed the merge queue (#1384).
+  # Gating on a label keeps the report available where it is wanted while an
+  # unlabeled PR claims no runner. `labeled` fires when the label is added;
+  # `synchronize`/`reopened` re-run it on later pushes only while the label is
+  # still present (the job-level `contains(...labels...)` guard enforces that,
+  # since `labeled` fires for ANY label). `workflow_dispatch` keeps manual
+  # invocation available (the jobs are PR-context gated, so a bare manual run
+  # no-ops).
   workflow_dispatch: {}
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -41,10 +46,14 @@ jobs:
   # token-backed step. The report leaves this job only as an artifact (plain
   # data) for the comment job.
   evaluate:
-    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
+    # Same-repository, non-Dependabot PRs carrying the `blast-radius` label only
+    # (mirroring ai-review-gate.yml's same-repo/non-bot guard). The label check
+    # is what makes the workflow opt-in: `labeled` fires for any label, so an
+    # unrelated label must not start the eval.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'blast-radius')
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
     # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD
@@ -125,6 +134,12 @@ jobs:
   # PR cannot influence.
   comment:
     needs: evaluate
+    # Run even when `evaluate` failed, so a transient base/head eval bail posts
+    # a "could not compute" note instead of leaving the comment silently absent
+    # (#1415, #1429). Skip only when `evaluate` was itself skipped (unlabeled /
+    # wrong-repo PR — nothing to report) or the run was cancelled. The per-step
+    # gates below route the success path vs the fallback path.
+    if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +149,10 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Real-report path only: when `evaluate` failed there is no artifact, and
+      # the Compose fallback step below handles that case.
       - name: Download report
+        if: ${{ needs.evaluate.result == 'success' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: blast-radius-${{ github.run_id }}
@@ -146,14 +164,27 @@ jobs:
       # Fail closed: require the full schema before rendering. Every field is
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
+      # An explicit `if` drops the implicit `success()`, so re-assert it: a
+      # failed Download must short-circuit here rather than validate a missing
+      # file. Same for the Render step below.
       - name: Validate report schema
+        if: ${{ needs.evaluate.result == 'success' && success() }}
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
-            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
+            # Charset = the complete legal nix store-path-name set
+            # (0-9 a-z A-Z + - . _ ? =) plus the attr-path glyphs the renderer
+            # shows (/ space ( ) :). `?` and `=` are legal in fixed-output
+            # patch/fetch drv names (`<sha>.patch?full_index=1`,
+            # `webkitgtk-2.52.4+abi=4.1`); omitting them fail-closed the whole
+            # report and the comment came up empty (#1421). Still rejects every
+            # injection glyph (@ < > [ ] ` & | ; * # { ") so a hostile report
+            # cannot smuggle a mention or HTML through a check label. Keep this
+            # in lockstep with `safename` in the Render step.
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +()?=:-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -185,10 +216,14 @@ jobs:
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
+        if: ${{ needs.evaluate.result == 'success' && success() }}
         run: |
           set -euo pipefail
           jq -r '
-            def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            # Keep this charset in lockstep with `name_ok` in the Validate step
+            # (the complete legal nix name set plus attr-path glyphs; `?`/`=`
+            # included so fixed-output patch/fetch drv names render, #1421).
+            def safename: select(test("^[A-Za-z0-9_./ +()?=:-]+$"));
             # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
             # by magnitude, round to integer. Empty string for a missing entry
             # so a bare label renders when an attr was a substituter hit or new
@@ -261,12 +296,36 @@ jobs:
             printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
           fi
 
+      # Fallback path: `evaluate` failed (no artifact) OR a prior step in this
+      # job failed (download/validate/render flaked). Write a fallback body
+      # under the SAME marker so the next good run overwrites it in place.
+      # This body is static (derived from no report data), so it is safe to
+      # post with the write token even when the report could not be validated.
+      - name: Compose fallback comment
+        if: ${{ !cancelled() && (needs.evaluate.result == 'failure' || failure()) }}
+        run: |
+          set -euo pipefail
+          {
+            echo "<!-- blast-radius -->"
+            echo "### Blast radius"
+            echo ""
+            echo "Could not compute the blast radius for this PR (the base/head"
+            echo "catalog eval or the comment pipeline did not complete). This is"
+            echo "usually a transient runner or base-branch issue, not a problem"
+            echo "with your change. Re-run the **Blast radius** workflow, or push"
+            echo "again, to refresh this comment."
+          } > comment.md
+
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no
       # duplicate comments), and restrict the match to comments this token can
       # actually PATCH: a user comment that happens to start with the marker
       # would otherwise be selected and every PATCH would 403 forever.
+      # `!cancelled()` + the comment.md existence guard posts whichever body was
+      # produced (real render or fallback); `success()` is wrong here because the
+      # fallback path runs after an earlier-step failure.
       - name: Post sticky comment
+        if: ${{ !cancelled() && hashFiles('comment.md') != '' }}
         run: |
           set -euo pipefail
           # `gh api --slurp` rejects `--jq`, so slurp the paginated pages (an

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -311,7 +311,8 @@ pub fn derivation_graph(drv_paths: &[String]) -> Result<Graph> {
 /// the same shape reaches both [`eval_checks`] and [`crate::timings`].
 ///
 /// The trusted workflow schema (`blast-radius.yml` safename regex) allows dots,
-/// slashes, spaces, and parens but rejects `"`, and trimming only the ends
+/// slashes, spaces, parens, `?`, and `=` (the legal nix-name glyphs that reach a
+/// label) but rejects `"`, and trimming only the ends
 /// leaves the quotes around an interior segment in place. Drop every `"` and
 /// split on dots outside quotes, then rejoin with `.`, so the bare path flows
 /// identically through the diff key, the report, and the schema regardless of

--- a/tools/blast-radius-fixtures/special-name.json
+++ b/tools/blast-radius-fixtures/special-name.json
@@ -1,0 +1,7 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":42,
+ "changed":["source-1a2b3c.patch?full_index=1","webkitgtk-2.52.4+abi=4.1"],
+ "added":[],"removed":[],
+ "causes":[{"name":"nixpkgs-fetch=pinned","checks":["source-1a2b3c.patch?full_index=1"]},
+           {"name":"webkitgtk-2.52.4+abi=4.1","checks":["webkitgtk-2.52.4+abi=4.1"]}],
+ "timings":{},
+ "phaseTimings":{"catalog-probe":0.4,"eval-base":1.0,"eval-head":1.0,"derivation-show-base":0.1,"derivation-show-head":0.1,"root-causes":0.05,"total":2.65}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -28,6 +28,18 @@ validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 # typed value constraint that keep an attacker from smuggling shapes into
 # the artifact.
 if validate "$fixtures/good.json" >/dev/null 2>&1; then note "validate good: ok"; else note "validate good: FAIL"; fail=1; fi
+# Regression for #1421: fixed-output patch/fetch drv names legally carry `?`
+# and `=` (`<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`). The old
+# narrow charset rejected them and fail-closed the whole report, so the PR
+# comment came up empty. The widened name_ok must accept this report.
+if validate "$fixtures/special-name.json" >/dev/null 2>&1; then note "validate special-name: ok"; else note "validate special-name: FAIL (charset rejects legal ?/= nix names)"; fail=1; fi
+# Render must also pass these names through safename (lockstep with name_ok).
+( cd "$tmp" && cp "$fixtures/special-name.json" report.json && bash render.sh )
+if grep -q 'webkitgtk-2.52.4+abi=4.1' "$tmp/comment.md" && grep -q 'source-1a2b3c.patch?full_index=1' "$tmp/comment.md"; then
+  note "render special-name: ok"
+else
+  note "render special-name: FAIL (safename dropped legal ?/= names)"; fail=1
+fi
 for bad in bad-name bad-check missing bad-phase-key bad-phase-value; do
   if validate "$fixtures/$bad.json" >/dev/null 2>&1; then
     note "validate $bad: FAIL (accepted hostile/old report)"; fail=1


### PR DESCRIPTION
## What

The blast-radius PR comment was **coming up empty** (= absent) on index PRs. Root cause is three independent failure modes, all fixed here:

1. **Trigger disabled (#1384).** `on: pull_request` was commented out (the per-PR full-catalog eval claims a shared `ix-ci` runner). Re-enabled **opt-in via the `blast-radius` label** (`types: [labeled, synchronize, reopened]` + a job-level `contains(...labels...,'blast-radius')` guard), so an unlabeled PR still claims no runner.
2. **Comment silently skipped on eval/render failure (#1415).** `comment` was `needs: evaluate` with default `if: success()`, so a transient base/head eval bail (or a render/validate step failure) left no comment. Now the `comment` job runs unless `evaluate` was *skipped* or the run was cancelled, and a fallback step posts a "could not compute" sticky note (same `<!-- blast-radius -->` marker, overwritten by the next good run) on **either** an `evaluate` failure **or** any in-job step failure. `Post sticky comment` posts whatever body exists (`hashFiles('comment.md')`), so no failure path is silent.
3. **Validator charset rejected legal nix names (#1421).** The trusted jq validator + renderer matched `^[A-Za-z0-9_./ +():-]+$`, but fixed-output patch/fetch drv names legally carry `?`/`=` (`<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`); one such name in the rebuild frontier fail-closed the whole report. Widened `name_ok` + `safename` in lockstep to `^[A-Za-z0-9_./ +()?=:-]+$` (still rejects every injection glyph). Rust mirror doc in `packages/blast-radius/src/nix.rs` updated to match.

## Test

`tools/blast-radius-test.sh` (the `blast-radius-test` flake check) extracts the workflow jq verbatim and runs it against fixtures, including `special-name.json` (`?`/`=` names, both validate + render), the overflow cap, the byte backstop, and the fallback path. Passes locally.

## Consolidation

This is the canonical fix; supersedes the duplicate #1444 (its two genuine extras — the fallback run link and the `nix.rs` charset doc — are grafted in here). Closes #1415, #1421.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make blast-radius CI workflow opt-in via label and post fallback comment on failure
> - The [blast-radius.yml](https://github.com/indexable-inc/index/pull/1445/files#diff-f18ec732b17d456a8d2f9c00a4941f9433314b97b8a3df9cea22bdaf15337468) workflow now only runs for same-repo, non-Dependabot PRs that carry the `blast-radius` label, preventing unsolicited runs on every PR.
> - When evaluation or rendering fails, a fallback 'could not compute' comment is posted under the same sticky marker instead of leaving the PR silent.
> - Widens the `jq` validation regex and render safename regex to accept `?` and `=` in Nix names, fixing a silent failure for packages with those characters.
> - Adds a [test fixture](https://github.com/indexable-inc/index/pull/1445/files#diff-fd11772d46c6fe1a44e23e9db9179c9569dfcc29e4cd10108f2ea8db91281c1c) and regression tests in [blast-radius-test.sh](https://github.com/indexable-inc/index/pull/1445/files#diff-008b7e349202f69865582328028ef88fb2c6c22cdfd1f42fbbf5533600c2e27b) to catch charset/safename regressions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b338a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->