### PR TITLE
feat(text-utils): add to_snake_case helper crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8337,6 +8337,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "text-utils"
+version = "0.1.0"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
   "packages/nix/oci-image-builder",
   "packages/search/polars-mixedbread",
   "packages/progress-style",
+  "packages/text-utils",
   "packages/tui/reel",
   "packages/repo-walker",
   "packages/screencast/screencast",

--- a/packages/text-utils/Cargo.toml
+++ b/packages/text-utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "text-utils"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Small string-case helpers (snake_case, ...)"
+
+[lints]
+workspace = true

--- a/packages/text-utils/package.nix
+++ b/packages/text-utils/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "text-utils";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/text-utils/src/lib.rs
+++ b/packages/text-utils/src/lib.rs
@@ -1,0 +1,130 @@
+//! Small string-case helpers.
+
+/// Convert a `CamelCase`, `kebab-case`, or space-separated name into `snake_case`.
+///
+/// Word boundaries are detected at:
+/// - any run of non-alphanumeric characters (spaces, `-`, `_`, punctuation);
+/// - a lowercase letter or digit followed by an uppercase letter
+///   (`fooBar` -> `foo_bar`);
+/// - the end of an acronym, i.e. an uppercase letter that is both preceded by an
+///   uppercase letter and followed by a lowercase one (`HTTPServer` ->
+///   `http_server`).
+///
+/// Separator runs collapse and leading/trailing separators are dropped, so the
+/// result never contains a doubled or edge underscore. Non-ASCII letters are
+/// lowercased per Unicode rules.
+///
+/// # Examples
+/// ```
+/// use text_utils::to_snake_case;
+///
+/// assert_eq!(to_snake_case("CamelCase"), "camel_case");
+/// assert_eq!(to_snake_case("kebab-case"), "kebab_case");
+/// assert_eq!(to_snake_case("space separated"), "space_separated");
+/// assert_eq!(to_snake_case("HTTPServer"), "http_server");
+/// assert_eq!(to_snake_case("getHTTPResponseCode"), "get_http_response_code");
+/// ```
+#[must_use]
+pub fn to_snake_case(input: &str) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    // Headroom for the underscores we insert at word boundaries.
+    let mut out = String::with_capacity(input.len() + input.len() / 2);
+
+    for (i, &c) in chars.iter().enumerate() {
+        if !c.is_alphanumeric() {
+            // A run of separators becomes a single boundary, never a leading or
+            // doubled underscore.
+            if !out.is_empty() && !out.ends_with('_') {
+                out.push('_');
+            }
+            continue;
+        }
+
+        if c.is_uppercase() {
+            let prev = i.checked_sub(1).map(|p| chars[p]);
+            // `fooBar` / `v2X`: a lowercase letter or digit precedes this upper.
+            let after_lower_or_digit =
+                prev.is_some_and(|p| p.is_lowercase() || p.is_ascii_digit());
+            // `HTTPServer`: an acronym ends where Upper is followed by lower.
+            let acronym_end = prev.is_some_and(char::is_uppercase)
+                && chars.get(i + 1).is_some_and(|n| n.is_lowercase());
+
+            if (after_lower_or_digit || acronym_end) && !out.is_empty() && !out.ends_with('_')
+            {
+                out.push('_');
+            }
+        }
+
+        out.extend(c.to_lowercase());
+    }
+
+    // A trailing separator run leaves one underscore; drop it.
+    if out.ends_with('_') {
+        out.pop();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_snake_case;
+
+    #[test]
+    fn camel_case() {
+        assert_eq!(to_snake_case("CamelCase"), "camel_case");
+        assert_eq!(to_snake_case("camelCase"), "camel_case");
+        assert_eq!(to_snake_case("Camel"), "camel");
+    }
+
+    #[test]
+    fn kebab_case() {
+        assert_eq!(to_snake_case("kebab-case"), "kebab_case");
+        assert_eq!(to_snake_case("a-b-c"), "a_b_c");
+    }
+
+    #[test]
+    fn space_separated() {
+        assert_eq!(to_snake_case("space separated"), "space_separated");
+        assert_eq!(to_snake_case("Title Case Name"), "title_case_name");
+    }
+
+    #[test]
+    fn acronyms() {
+        assert_eq!(to_snake_case("HTTPServer"), "http_server");
+        assert_eq!(to_snake_case("getHTTPResponseCode"), "get_http_response_code");
+        assert_eq!(to_snake_case("XMLHttpRequest"), "xml_http_request");
+        assert_eq!(to_snake_case("ABC"), "abc");
+    }
+
+    #[test]
+    fn digits() {
+        assert_eq!(to_snake_case("version2Point0"), "version2_point0");
+        assert_eq!(to_snake_case("v2X"), "v2_x");
+    }
+
+    #[test]
+    fn mixed_separators() {
+        assert_eq!(to_snake_case("Some-Mixed Case_String"), "some_mixed_case_string");
+    }
+
+    #[test]
+    fn collapses_and_trims_separators() {
+        assert_eq!(to_snake_case("  Multiple   Spaces  "), "multiple_spaces");
+        assert_eq!(to_snake_case("--leading-and-trailing--"), "leading_and_trailing");
+        assert_eq!(to_snake_case("already_snake"), "already_snake");
+    }
+
+    #[test]
+    fn edge_cases() {
+        assert_eq!(to_snake_case(""), "");
+        assert_eq!(to_snake_case("---"), "");
+        assert_eq!(to_snake_case("a"), "a");
+        assert_eq!(to_snake_case("A"), "a");
+    }
+
+    #[test]
+    fn unicode_lowercasing() {
+        assert_eq!(to_snake_case("Été"), "été");
+        assert_eq!(to_snake_case("naïveCase"), "naïve_case");
+    }
+}


### PR DESCRIPTION
Adds a small `text-utils` crate. There was no shared text-utilities module, so this gives string-case helpers a real home.

`to_snake_case(input: &str) -> String` converts CamelCase, kebab-case, and space-separated names into snake_case:
- boundaries at separator runs, lower/digit -> Upper, and acronym ends (`HTTPServer` -> `http_server`)
- separator runs collapse; leading/trailing separators trimmed
- Unicode-aware lowercasing

Validated locally: `cargo test -p text-utils` = 9 unit + 1 doctest passing. The fork clippy (`anonymous_tuple_return_type`/`fallible_int_fallback`) only runs in CI on x86_64-linux; the code uses neither pattern.

Closes #1455

(opened by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `to_snake_case` helper function in new `text-utils` crate
> Introduces a new `text-utils` workspace crate with a single public function `to_snake_case` in [lib.rs](https://github.com/indexable-inc/index/pull/1460/files#diff-07b1358d4c51de4966e7ab807ec8eb9fb5672a4abd90e95ba314afdbccd7f47e). The function converts CamelCase, kebab-case, space-separated, and mixed-format strings to snake_case with Unicode-aware lowercasing. Word boundaries are detected at non-alphanumeric runs, lowercase-to-uppercase transitions, and acronym boundaries (uppercase followed by lowercase after preceding uppercase).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f0ac91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->