### PR TITLE
feat(code-tokenizer): add to_snake_case helper

### DIFF
--- a/packages/search/code-tokenizer/src/lib.rs
+++ b/packages/search/code-tokenizer/src/lib.rs
@@ -30,6 +30,28 @@ pub fn register_tokenizers(index: &tantivy::Index) {
         .register(CODE_STEMMED_TOKENIZER, code_stemmed);
 }
 
+/// Convert `input` to `snake_case`.
+///
+/// Splits on the same boundaries [`CodeTokenizer`] uses — `camelCase`,
+/// `snake_case`, `kebab-case`, whitespace, and any other non-alphanumeric run —
+/// then joins the lowercased words with `_`. Reusing the tokenizer keeps a
+/// single definition of where one "word" ends and the next begins, so this and
+/// search agree on acronym handling (`HTTPServer` → `http_server`).
+///
+/// Input with no alphanumeric characters (including `""`) yields `""`.
+pub fn to_snake_case(input: &str) -> String {
+    let mut stream = CodeTokenStream::new(input.to_owned());
+    let mut out = String::with_capacity(input.len());
+    while stream.advance() {
+        if !out.is_empty() {
+            out.push('_');
+        }
+        // `advance` already lowercased the token text in place.
+        out.push_str(&stream.token().text);
+    }
+    out
+}
+
 #[derive(Clone)]
 pub struct CodeTokenizer;
 

--- a/packages/search/code-tokenizer/src/tests/mod.rs
+++ b/packages/search/code-tokenizer/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod ansi;
 mod basic;
 mod helpers;
+mod snake_case;
 mod stemming;

--- a/packages/search/code-tokenizer/src/tests/snake_case.rs
+++ b/packages/search/code-tokenizer/src/tests/snake_case.rs
@@ -1,0 +1,72 @@
+use crate::to_snake_case;
+
+#[test]
+fn camel_case() {
+    assert_eq!(to_snake_case("HelloWorld"), "hello_world");
+}
+
+#[test]
+fn lower_camel_case() {
+    assert_eq!(to_snake_case("helloWorld"), "hello_world");
+}
+
+#[test]
+fn kebab_case() {
+    assert_eq!(to_snake_case("get-user-by-id"), "get_user_by_id");
+}
+
+#[test]
+fn space_separated() {
+    assert_eq!(to_snake_case("Hello World Name"), "hello_world_name");
+}
+
+#[test]
+fn already_snake_case() {
+    assert_eq!(to_snake_case("hello_world"), "hello_world");
+}
+
+#[test]
+fn screaming_snake_case() {
+    assert_eq!(to_snake_case("HELLO_WORLD"), "hello_world");
+}
+
+#[test]
+fn acronym_run() {
+    // Matches the tokenizer's acronym split so search and conversion agree.
+    assert_eq!(to_snake_case("HTTPServer"), "http_server");
+}
+
+#[test]
+fn single_letter_word() {
+    assert_eq!(to_snake_case("getXValue"), "get_x_value");
+}
+
+#[test]
+fn numbers_stay_attached() {
+    assert_eq!(to_snake_case("user123Id"), "user123_id");
+}
+
+#[test]
+fn mixed_delimiters_and_punctuation() {
+    assert_eq!(to_snake_case("hello@world-fooBar"), "hello_world_foo_bar");
+}
+
+#[test]
+fn collapses_repeated_separators() {
+    assert_eq!(to_snake_case("  foo__bar  "), "foo_bar");
+}
+
+#[test]
+fn single_word() {
+    assert_eq!(to_snake_case("hello"), "hello");
+}
+
+#[test]
+fn empty_string() {
+    assert_eq!(to_snake_case(""), "");
+}
+
+#[test]
+fn only_separators() {
+    assert_eq!(to_snake_case("  -_-  "), "");
+}


### PR DESCRIPTION
## What

Adds `to_snake_case(input: &str) -> String` to the `code-tokenizer` crate, converting CamelCase, kebab-case, and space-separated names into `snake_case`.

## How

Reuses the crate's existing `CodeTokenStream` identifier splitter and joins the (already-lowercased) words with `_`. This keeps a single definition of word/acronym boundaries, so conversion and search agree (`HTTPServer` -> `http_server`, `getXValue` -> `get_x_value`).

Input with no alphanumeric characters (including `""`) yields `""`; repeated separators collapse.

## Tests

14 new cases in `src/tests/snake_case.rs` (camel, lower-camel, kebab, space-separated, SCREAMING_SNAKE, acronym runs, numbers, mixed punctuation, empties). `cargo test -p code-tokenizer`: 56 passed.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `to_snake_case` helper to the code-tokenizer crate
> Adds a public `to_snake_case(&str) -> String` function to [lib.rs](https://github.com/indexable-inc/index/pull/1462/files#diff-ebe8f40007814c3123e184f19c9304bc398487dba3eab7cd7e4d775f6510119d) that uses `CodeTokenStream` to split input on the same boundaries as the tokenizer and joins lowercased tokens with underscores. Returns an empty string for inputs with no alphanumeric tokens. 14 tests cover camelCase, PascalCase, kebab-case, screaming snake, acronyms, numbers, mixed delimiters, and edge cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d003c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->