### PR TITLE
ci(blast-radius): stop the PR comment coming up empty (#1411, #1415, #1421)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,24 +1,37 @@
 name: Blast radius
 
 on:
-  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
-  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
-  # serves the whole team, so every PR queued one more eval-only runner and
-  # slowed the queue. The report is informational (a sticky PR comment), never
-  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
-  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
-  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  # Opt-in per PR, not on every push. Auto-running on every PR meant the per-PR
+  # full-catalog eval (~57s "Report blast radius" step) claimed a shared `ix-ci`
+  # runner from the one dispatcher pool that serves the whole team, queuing an
+  # eval-only runner each push and slowing the queue (#1384). But fully disabling
+  # it left the report unreachable, so the sticky comment "came up empty" on every
+  # PR. The middle ground: it runs only when a maintainer adds the `blast-radius`
+  # label. Once labeled, each later push (`synchronize`) and reopen refreshes the
+  # comment. The job `if:` below gates EVERY event on the label, so adding any
+  # other label (or pushing to an unlabeled PR) skips `evaluate` and claims no
+  # runner. `workflow_dispatch` is kept for manual reruns (no-ops without PR
+  # context).
   workflow_dispatch: {}
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - main
 
 permissions:
   contents: read
 
 concurrency:
   group: blast-radius-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel an in-flight run when the new event will itself run an eval: a
+  # push (`synchronize`)/`reopened`, a `workflow_dispatch`, or the `blast-radius`
+  # label being added. An unrelated `labeled` event skips `evaluate` (see the job
+  # `if:`), but concurrency cancellation is applied at the workflow level BEFORE
+  # any job `if:`, so an unconditional `cancel-in-progress` would let adding any
+  # label kill an opted-in PR's running eval and leave the sticky comment
+  # unrefreshed. Gating the cancel on the same condition keeps unrelated label
+  # events from interrupting a real run.
+  cancel-in-progress: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'blast-radius' }}
 
 env:
   # The self-hosted runner's Nix daemon owns substituters; the job only sets
@@ -41,10 +54,22 @@ jobs:
   # token-backed step. The report leaves this job only as an artifact (plain
   # data) for the comment job.
   evaluate:
-    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
+    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml),
+    # and only when the PR carries the `blast-radius` label (the opt-in gate;
+    # see `on:` above). `contains` covers the steady state for every event while
+    # the label remains. The final clause keeps a `labeled` event from running
+    # the expensive eval when the label being added is something *other* than
+    # `blast-radius`: without it, labelling an already opted-in PR with any
+    # unrelated label would re-claim the self-hosted runner and undercut the
+    # opt-in. `synchronize`/`reopened` (action != 'labeled') still refresh the
+    # comment via the `contains` check alone. The `comment` job has
+    # `needs: evaluate` so it is skipped too whenever this gate is false.
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'blast-radius') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'blast-radius')
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
     # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD
@@ -125,6 +150,13 @@ jobs:
   # PR cannot influence.
   comment:
     needs: evaluate
+    # Run even when `evaluate` failed (a base/head eval error, often base-side
+    # and unrelated to this PR), so the PR never silently ends up with no blast-
+    # radius comment. `!cancelled()` covers success and failure but not a
+    # concurrency cancel; `result != 'skipped'` keeps it off the unlabeled /
+    # fork / Dependabot case, where `evaluate` itself was skipped (nothing to
+    # report).
+    if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +166,12 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Only present when `evaluate` succeeded (the upload step is `if: success()`).
+      # continue-on-error so a missing artifact after a failed eval drops through
+      # to the fallback step below instead of failing the job.
       - name: Download report
+        if: ${{ needs.evaluate.result == 'success' }}
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: blast-radius-${{ github.run_id }}
@@ -146,14 +183,29 @@ jobs:
       # Fail closed: require the full schema before rendering. Every field is
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
+      #
+      # `&& success()` is load-bearing on every gated step in this job: an
+      # explicit `if` drops the implicit `success()` GitHub adds to an
+      # unconditional step, so without it a failure in an earlier step would
+      # not stop this one. That short-circuit is what makes the validate ->
+      # render fail-closed chain below actually hold, and the gate-wiring test
+      # in tools/blast-radius-test.sh asserts every gated step restates it.
       - name: Validate report schema
+        if: ${{ needs.evaluate.result == 'success' && success() }}
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
-            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
+            # Charset is the legal nix store-path-name set (a-zA-Z0-9 + - . _ ? =)
+            # plus the extra glyphs attr-path normalization can introduce
+            # (/, space, (, ), :). A cause name is a derivation name, and fixed-
+            # output patch/fetch drvs carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+            # `webkitgtk-2.52.4+abi=4.1`); omitting them fail-closed the whole
+            # report and posted no comment at all (the "sometimes empty" bug, #1421).
+            # It still rejects every markdown/mention/HTML glyph (@ < > [ ] ` & | ; * # {).
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +()?=:-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -185,10 +237,16 @@ jobs:
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
       - name: Render comment
+        # `&& success()` keeps this skipped if Validate failed (see the note on
+        # the Validate step): a report that did not pass the schema is never
+        # rendered, let alone posted.
+        if: ${{ needs.evaluate.result == 'success' && success() }}
         run: |
           set -euo pipefail
           jq -r '
-            def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            # Lockstep with the validator name_ok above: same charset, so a
+            # report that validated never has a label silently dropped here.
+            def safename: select(test("^[A-Za-z0-9_./ +()?=:-]+$"));
             # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
             # by magnitude, round to integer. Empty string for a missing entry
             # so a bare label renders when an attr was a substituter hit or new
@@ -261,11 +319,41 @@ jobs:
             printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
           fi
 
+      # `evaluate` failed (no report.json): post an explicit "could not compute"
+      # note rather than letting the comment job skip and leave the PR with no
+      # blast-radius comment at all. The eval bail is frequently base-side (a
+      # transiently un-evaluable `main`) or a runner flake, so the copy says as
+      # much. Keyed by the same marker, so the next successful run overwrites it
+      # in place. RUN_URL is passed via env (a GitHub `${{ }}` expression cannot
+      # be evaluated by the shell), which also lets the test drive this script
+      # with a stub URL.
+      - name: Compose fallback comment (eval failed)
+        # `&& success()` so a failure in an earlier comment-job step cannot
+        # reach the fallback either: the only producers are Render (good eval)
+        # and this step (failed eval), and both stay fail-closed.
+        if: ${{ needs.evaluate.result != 'success' && success() }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            printf '<!-- blast-radius -->\n'
+            printf '### Blast radius\n\n'
+            printf 'Could not compute the blast radius for this run: the check catalog failed to evaluate at the base or head commit. This is usually a transient base-branch or runner issue rather than a problem with this PR. See the [run logs](%s).\n' "$RUN_URL"
+          } > comment.md
+
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no
       # duplicate comments), and restrict the match to comments this token can
       # actually PATCH: a user comment that happens to start with the marker
       # would otherwise be selected and every PATCH would 403 forever.
+      #
+      # Default `success()` gate (no explicit `if:`): exactly one producer runs
+      # (Render on a good eval, Compose fallback otherwise) and the other is
+      # skipped; a skipped step does not trip `success()`, so this posts after
+      # whichever producer ran. Critically it stays FAIL-CLOSED: if Render (or
+      # Validate) errors, `success()` is false and no half-written comment.md is
+      # published.
       - name: Post sticky comment
         run: |
           set -euo pipefail

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -311,7 +311,8 @@ pub fn derivation_graph(drv_paths: &[String]) -> Result<Graph> {
 /// the same shape reaches both [`eval_checks`] and [`crate::timings`].
 ///
 /// The trusted workflow schema (`blast-radius.yml` safename regex) allows dots,
-/// slashes, spaces, and parens but rejects `"`, and trimming only the ends
+/// slashes, spaces, parens, `?`, and `=` (the legal nix-name glyphs that reach a
+/// label) but rejects `"`, and trimming only the ends
 /// leaves the quotes around an interior segment in place. Drop every `"` and
 /// split on dots outside quotes, then rejoin with `.`, so the bare path flows
 /// identically through the diff key, the report, and the schema regardless of

--- a/tools/blast-radius-fixtures/special-name.json
+++ b/tools/blast-radius-fixtures/special-name.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":120,
+ "changed":["rust-test-foo","rust-test-bar"],"added":[],"removed":[],
+ "causes":[{"name":"e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1","checks":["rust-test-foo","rust-test-bar"]}],
+ "timings":{},"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -19,6 +19,7 @@ note() { printf '  %s\n' "$*"; }
 # Extract the exact run-scripts the trusted comment job executes.
 yq '.jobs.comment.steps[] | select(.name == "Validate report schema").run' "$workflow" > "$tmp/validate.sh"
 yq '.jobs.comment.steps[] | select(.name == "Render comment").run' "$workflow" > "$tmp/render.sh"
+yq '.jobs.comment.steps[] | select(.name == "Compose fallback comment (eval failed)").run' "$workflow" > "$tmp/fallback.sh"
 
 validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 
@@ -42,6 +43,24 @@ done
 # any drift here means the renderer leaked them.
 ( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
 if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
+
+# Regression (#1421): a cause name is a nix derivation name, and fixed-output
+# patch/fetch drvs legally carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+# `webkitgtk-2.52.4+abi=4.1`). The validator's name_ok used to omit those two
+# glyphs and fail-closed the WHOLE report, so the comment job exited 1 and posted
+# no comment at all -- the "sometimes empty" symptom. The report must now both
+# validate and render with the name intact (validate and safename stay lockstep).
+if validate "$fixtures/special-name.json" >/dev/null 2>&1; then
+  note "validate special-name: ok"
+else
+  note "validate special-name: FAIL (rejected a legal nix derivation name)"; fail=1
+fi
+( cd "$tmp" && cp "$fixtures/special-name.json" report.json && bash render.sh )
+if grep -qF 'e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1' "$tmp/comment.md"; then
+  note "render special-name: name preserved ok"
+else
+  note "render special-name: FAIL (legal name dropped from comment)"; fail=1
+fi
 
 # Overflow guard: a PR touching a shared input rebuilds thousands of checks, and
 # an uncapped changed-checks list overflows GitHub's 65536-char comment limit
@@ -92,6 +111,46 @@ if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
   note "render backstop: marker survived truncation ok"
 else
   note "render backstop: FAIL (marker lost; sticky-comment keying breaks)"; fail=1
+fi
+
+# Fallback comment: when `evaluate` fails there is no report.json, so the
+# comment job posts an explicit "could not compute" note instead of skipping
+# and leaving the PR with no blast-radius comment (the "comes up empty" bug,
+# issue #1415). Assert it produces a marker-prefixed body so the sticky-comment
+# keying still finds and overwrites it on the next successful run.
+( cd "$tmp" && rm -f report.json comment.md && RUN_URL="https://github.com/indexable-inc/index/actions/runs/123" bash fallback.sh )
+if head -c 21 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
+  note "fallback: marker present ok"
+else
+  note "fallback: FAIL (missing marker; sticky-comment keying breaks)"; fail=1
+fi
+if grep -q 'Could not compute the blast radius' "$tmp/comment.md" \
+   && grep -q 'actions/runs/123' "$tmp/comment.md"; then
+  note "fallback: note + run link ok"
+else
+  note "fallback: FAIL (missing explanation or run link)"; fail=1
+fi
+
+# Fail-closed gating wiring. An explicit `if` on a step drops the implicit
+# `success()` GitHub adds to an unconditional step, so the produce-then-post
+# chain only stays fail-closed if every gated step re-states `success()` and the
+# post step keeps its default `success()` gate. A bare `if: !cancelled()` on the
+# post step (or a missing `success()` on render) would publish a half-written or
+# unvalidated comment.md -- exactly the regression caught in review on #1416.
+# These are workflow-level conditions jq cannot exercise, so assert them here.
+gate_if() { yq ".jobs.comment.steps[] | select(.name == \"$1\").if // \"\"" "$workflow"; }
+for step in "Validate report schema" "Render comment" "Compose fallback comment (eval failed)"; do
+  if gate_if "$step" | grep -q 'success()'; then
+    note "gate [$step]: success() present ok"
+  else
+    note "gate [$step]: FAIL (missing success(); explicit if dropped the implicit gate)"; fail=1
+  fi
+done
+post_if="$(gate_if "Post sticky comment")"
+if [ -z "$post_if" ] || printf '%s' "$post_if" | grep -q 'success()'; then
+  note "gate [Post sticky comment]: fail-closed (default/explicit success()) ok"
+else
+  note "gate [Post sticky comment]: FAIL (gate '$post_if' can post an unvalidated/partial body)"; fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi


### PR DESCRIPTION
## Problem

The sticky **Blast radius** comment is "sometimes coming up empty" on index PRs. "Empty" = **absent**: no comment posts at all. Three independent root causes, all live on `main`:

| # | Root cause | Effect |
|---|---|---|
| [#1421](https://github.com/indexable-inc/index/issues/1421) | Comment-job schema validator `name_ok` regex `^[A-Za-z0-9_./ +():-]+$` **rejects `?` and `=`** — legal nix derivation-name glyphs (fixed-output patch/fetch drvs: `<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`) | one such check name fail-closes the whole report → job exits 1 → **no comment** |
| [#1415](https://github.com/indexable-inc/index/issues/1415) | `comment` job has `needs: evaluate` and no `if:`, so any base/head eval hiccup (often base-side, unrelated to the PR) **skips the comment job** | **no comment** |
| [#1411](https://github.com/indexable-inc/index/issues/1411) | #1384 commented out the `pull_request` trigger entirely | doesn't run on PRs at all |

## Fix

- **Charset**: widen `name_ok` (validator) and `safename` (render) to include `?=`, kept lockstep so a report that validates never has a label silently dropped; mirror the note in `nix.rs`.
- **Resilient comment**: run `comment` on eval failure and post an explicit "could not compute" fallback (same `<!-- blast-radius -->` marker, overwritten by the next good run), with fail-closed `success()` gating on every producer step.
- **Opt-in trigger**: re-enable `pull_request` as opt-in via the `blast-radius` label (`labeled`/`synchronize`/`reopened`), gating both the eval and the concurrency-cancel on the label so unrelated label events never claim a shared `ix-ci` runner.

## Validation

`tools/blast-radius-test.sh` (wired into `flake-check` via `lib/per-system.nix`) extended with a `special-name` fixture, fallback-comment, and gate-wiring assertions. Verified red→green locally:

- **RED** (this test vs old `main` workflow): `validate special-name: FAIL (rejected a legal nix derivation name)` + fallback/gate failures.
- **GREEN** (this PR): all 20 assertions pass.

Closes #1411, closes #1415, closes #1421.

---
> Note: this overlaps several in-flight PRs (#1431, #1441, #1449, #1453, #1454) opened by parallel rollouts of an A/B prompt experiment running this same task. Only one consolidated fix should land; this branch is a clean, locally-validated copy off current `main`.

*(opened by an AI agent via Claude Code)*


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix empty PR comments in blast-radius workflow by adding label gating and fallback comment
> - The `blast-radius` workflow now only runs when a PR carries the `blast-radius` label, preventing spurious triggers from unrelated label events.
> - Adds a fallback comment step that posts a minimal explanation with a link to the run when evaluation fails, so the PR comment is never empty.
> - Unrelated label additions no longer cancel in-flight runs; cancellation is now scoped to `workflow_dispatch`, `synchronize`/`reopened`, and `blast-radius` label events.
> - Expands the cause-name character allowlist in the jq validator and renderer to accept `?` and `=`, with a new fixture and regression tests in [blast-radius-test.sh](https://github.com/indexable-inc/index/pull/1464/files#diff-008b7e349202f69865582328028ef88fb2c6c22cdfd1f42fbbf5533600c2e27b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81aba32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->