### PR TITLE
feat(system-prompt-eval): add --quiet to `run` to suppress progress output

### DIFF
--- a/packages/agent/system-prompt-eval/README.md
+++ b/packages/agent/system-prompt-eval/README.md
@@ -23,7 +23,14 @@ nix run .#system-prompt-eval -- run --eval first-principles --sandbox
 # test a candidate prompt edit before committing it
 nix run .#system-prompt-eval -- run --eval behaviors \
   --system-prompt-nix packages/agent/system-prompt.nix
+
+# quiet: no progress ticker or wrote/view-it notes, just the result tables
+nix run .#system-prompt-eval -- run --eval behaviors --quiet
 ```
+
+`--quiet` silences the stderr progress ticker and the `wrote`/`view it` notes;
+the result tables (stdout) and any `FAIL` diagnostics still print. Pair it with
+`--json-out` when scripting so you control the report path.
 
 ## Evals
 

--- a/packages/agent/system-prompt-eval/default.nix
+++ b/packages/agent/system-prompt-eval/default.nix
@@ -70,6 +70,13 @@ let
     mkdir -p "$out"
   '';
 
+  # Offline, deterministic: the CLI surface (the --quiet progress wiring),
+  # unit-tested against the installed package with no network or key.
+  cli = pkgs.runCommand "system-prompt-eval-cli" { strictDeps = true; } ''
+    ${unwrapped}/venv/bin/python ${./tests/test_cli.py}
+    mkdir -p "$out"
+  '';
+
   # No network and no API key: `list` and `--help` must work and name the program.
   printsHelp =
     pkgs.runCommand "system-prompt-eval-prints-help"
@@ -89,13 +96,14 @@ let
         esac
         system-prompt-eval list | grep -q behaviors
         system-prompt-eval list | grep -q first-principles
+        system-prompt-eval run --help | grep -q -- --quiet
         mkdir -p "$out"
       '';
 in
 package.overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
     tests = {
-      inherit scoring printsHelp;
+      inherit scoring cli printsHelp;
     };
   };
 })

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/cli.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/cli.py
@@ -25,7 +25,7 @@ import tempfile
 from pathlib import Path
 
 from . import behaviors_eval, first_principles_eval, reverse_engineering_eval
-from .core import EvalContext, EvalReport
+from .core import EvalContext, EvalReport, Progress, noop
 from .judge import DEFAULT_JUDGE_MODEL, Judge
 from .render import resolve_prompt
 
@@ -42,6 +42,11 @@ def _progress(message: str) -> None:
     print(f"  … {message}", file=sys.stderr, flush=True)
 
 
+def _make_progress(*, quiet: bool) -> Progress:
+    """The progress sink for a run: silent under ``--quiet``, else the stderr ticker."""
+    return noop if quiet else _progress
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="system-prompt-eval", description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -54,6 +59,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default="all",
         choices=("all", *EVALS.keys()),
         help="which eval to run (default: all)",
+    )
+    run.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress progress output (the stderr ticker and the wrote/view-it notes); "
+        "the result tables and FAIL diagnostics are still printed",
     )
     run.add_argument("--rollouts", type=int, default=5, help="rollouts per task/case")
     run.add_argument("--max-workers", type=int, default=4, help="concurrent agents")
@@ -146,6 +157,7 @@ def _run(args: argparse.Namespace) -> int:
         )
         return 2
     prompt_file, prompt_sha = resolve_prompt(args.system_prompt_file, args.system_prompt_nix)
+    progress = _make_progress(quiet=args.quiet)
     ctx = EvalContext(
         prompt_file=prompt_file,
         judge=Judge(model=args.judge_model),
@@ -159,12 +171,12 @@ def _run(args: argparse.Namespace) -> int:
         sandbox=args.sandbox,
         timeout=args.timeout,
         limit=args.limit,
-        progress=_progress,
+        progress=progress,
     )
 
     reports: list[EvalReport] = []
     for name in _selected(args.eval):
-        _progress(f"== eval: {name} ==")
+        progress(f"== eval: {name} ==")
         reports.append(_run_one(name, ctx))
 
     for rep in reports:
@@ -192,8 +204,9 @@ def _run(args: argparse.Namespace) -> int:
     json_out = args.json_out or (Path(tempfile.mkdtemp(prefix="sp-eval-")) / "result.json")
     json_out.parent.mkdir(parents=True, exist_ok=True)
     json_out.write_text(json.dumps(full, indent=2), encoding="utf-8")
-    print(f"\nwrote {json_out}", file=sys.stderr)
-    print(f"view it: nix run .#system-prompt-eval-viewer -- {json_out}", file=sys.stderr)
+    if not args.quiet:
+        print(f"\nwrote {json_out}", file=sys.stderr)
+        print(f"view it: nix run .#system-prompt-eval-viewer -- {json_out}", file=sys.stderr)
 
     rc = 0
     if args.fail_under is not None:

--- a/packages/agent/system-prompt-eval/tests/test_cli.py
+++ b/packages/agent/system-prompt-eval/tests/test_cli.py
@@ -1,0 +1,56 @@
+"""Offline, deterministic checks for the CLI surface.
+
+Runnable as a plain script (``python tests/test_cli.py``) so the Nix build can
+exercise it against the installed package with no test runner, no network, and no
+API key. These guard the ``--quiet`` wiring: the flag parses, and it routes
+progress to a silent sink instead of the stderr ticker.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr
+
+from system_prompt_eval.cli import _build_parser, _make_progress, _progress
+from system_prompt_eval.core import noop
+
+
+def test_quiet_defaults_off() -> None:
+    args = _build_parser().parse_args(["run"])
+    assert args.quiet is False
+
+
+def test_quiet_flag_parses() -> None:
+    args = _build_parser().parse_args(["run", "--quiet"])
+    assert args.quiet is True
+
+
+def test_make_progress_quiet_is_noop() -> None:
+    # Quiet must reuse the shared silent sink, not a fresh stub.
+    assert _make_progress(quiet=True) is noop
+    assert _make_progress(quiet=False) is _progress
+
+
+def test_quiet_sink_emits_nothing() -> None:
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        _make_progress(quiet=True)("hello")
+    assert buf.getvalue() == "", "quiet progress must print nothing to stderr"
+
+
+def test_loud_sink_emits_to_stderr() -> None:
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        _make_progress(quiet=False)("hello")
+    assert "hello" in buf.getvalue(), "default progress must print to stderr"
+
+
+def _main() -> None:
+    tests = [v for name, v in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+    print(f"ok: {len(tests)} cli tests passed")
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
## What

Adds `--quiet` to `system-prompt-eval run`, wired end to end.

- New `--quiet` flag on the `run` subparser.
- `_make_progress(quiet=...)` selects the progress sink: the existing `core.noop` under `--quiet`, else the stderr ticker `_progress`.
- The `wrote`/`view it` stderr notes are gated behind `not args.quiet`.
- Result tables (stdout) and `FAIL` diagnostics (stderr) still print, so scripted runs stay parseable.

## Tests

- New `tests/test_cli.py` (offline, no network/key, plain-script style): flag parsing, `_make_progress` routing, and that the quiet sink emits nothing while the default sink writes to stderr.
- Wired as a `cli` package check in `default.nix`; `printsHelp` now also asserts `--quiet` appears in `run --help`.
- `nix build .#system-prompt-eval.tests.{cli,scoring,printsHelp}` all green locally (zuban + ruff pass).

Closes #1461

(opened by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--quiet` flag to `system-prompt-eval run` to suppress stderr progress output
> - Adds a `--quiet` flag to the `run` subcommand in [cli.py](https://github.com/indexable-inc/index/pull/1466/files#diff-a9cd2e0013f52d47574d2700c23cbc689d43ade65ebf73b5f81ed7ca5960a889) that suppresses the stderr progress ticker and the final "wrote"/"view it" messages.
> - Result tables on stdout and FAIL diagnostics on stderr are still printed when `--quiet` is active; the flag is intended for use with `--json-out` for machine-readable output.
> - A `_make_progress` helper selects between a noop sink (quiet) and the existing `_progress` ticker (default).
> - Adds a standalone CLI test in [test_cli.py](https://github.com/indexable-inc/index/pull/1466/files#diff-e9af01394029d5011909ee6d9df92e2b4480e259f4447444c8e6eb4f8392d6a8) and updates the Nix derivation in [default.nix](https://github.com/indexable-inc/index/pull/1466/files#diff-f2bd2217bf16a8bf81141611a9a0f8132492cf1e0058bbf4b5966d53dff559d2) to run these checks and verify `--quiet` appears in `--help` output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58df17e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->