### PR TITLE
fix(blast-radius): stop the PR comment coming up empty (charset + opt-in + resilient)

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -22,7 +22,15 @@ permissions:
 
 concurrency:
   group: blast-radius-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel an in-flight run when the new event will itself run an eval: a
+  # push (`synchronize`)/`reopened`, a `workflow_dispatch`, or the `blast-radius`
+  # label being added. An unrelated `labeled` event skips `evaluate` (see the job
+  # `if:`), but concurrency cancellation is applied at the workflow level BEFORE
+  # any job `if:`, so an unconditional `cancel-in-progress` would let adding any
+  # label kill an opted-in PR's running eval and leave the sticky comment
+  # unrefreshed. Gating the cancel on the same condition keeps unrelated label
+  # events from interrupting a real run.
+  cancel-in-progress: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'blast-radius' }}
 
 env:
   # The self-hosted runner's Nix daemon owns substituters; the job only sets

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,17 +1,21 @@
 name: Blast radius
 
 on:
-  # Disabled on PRs: the per-PR full-catalog eval (~57s "Report blast radius"
-  # step) claims a shared `ix-ci` runner from the one dispatcher pool that
-  # serves the whole team, so every PR queued one more eval-only runner and
-  # slowed the queue. The report is informational (a sticky PR comment), never
-  # a merge gate, so dropping the auto-trigger costs no safety. Re-enable by
-  # uncommenting the `pull_request` block below. `workflow_dispatch` only keeps
-  # `on:` non-empty (the jobs are PR-context gated, so a manual run no-ops).
+  # Opt-in per PR, not on every push. Auto-running on every PR meant the per-PR
+  # full-catalog eval (~57s "Report blast radius" step) claimed a shared `ix-ci`
+  # runner from the one dispatcher pool that serves the whole team, queuing an
+  # eval-only runner each push and slowing the queue (#1384). But fully disabling
+  # it left the report unreachable, so the sticky comment "came up empty" on every
+  # PR. Middle ground: it runs only when a maintainer adds the `blast-radius`
+  # label. Once labeled, each later push (`synchronize`) and reopen refreshes the
+  # comment. The `evaluate` job `if:` below re-checks the label on every event, so
+  # pushing to an unlabeled PR (or adding a different label) claims no runner.
+  # `workflow_dispatch` is kept for manual reruns (no-ops without PR context).
   workflow_dispatch: {}
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -41,10 +45,22 @@ jobs:
   # token-backed step. The report leaves this job only as an artifact (plain
   # data) for the comment job.
   evaluate:
-    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml).
+    # Same-repository, non-Dependabot PRs only (mirroring ai-review-gate.yml),
+    # and only while the PR carries the `blast-radius` label (the opt-in gate;
+    # see `on:` above). `contains` re-checks the label on every event, so a push
+    # to a PR that no longer has the label claims no runner. The final clause
+    # keeps a `labeled` event from running the expensive eval unless the label
+    # being added is `blast-radius` itself: without it, adding any unrelated
+    # label to an already opted-in PR would re-claim the self-hosted runner and
+    # undercut the opt-in. `synchronize`/`reopened` (action != 'labeled') still
+    # refresh the comment via the `contains` check alone. The `comment` job has
+    # `needs: evaluate`, so it is skipped too whenever this gate is false.
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'blast-radius') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'blast-radius')
     # Same self-hosted dispatcher as check.yml: the `ix-ci-run-*` label is
     # claimed by the org dispatcher, which mints an ephemeral runner with a warm
     # /nix/store. Evaluating .#ciChecks.x86_64-linux forces an x86_64-linux IFD
@@ -125,6 +141,13 @@ jobs:
   # PR cannot influence.
   comment:
     needs: evaluate
+    # Run even when `evaluate` failed (a base/head eval error, often base-side
+    # and unrelated to this PR), so a labeled PR never silently ends up with no
+    # blast-radius comment. `!cancelled()` covers success and failure but not a
+    # concurrency cancel; `result != 'skipped'` keeps it off the unlabeled /
+    # fork / Dependabot case, where `evaluate` itself was skipped (nothing to
+    # report).
+    if: ${{ !cancelled() && needs.evaluate.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +157,14 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # The report exists only when `evaluate` succeeded (its upload step is
+      # `if: success()`). `continue-on-error` so a transient `download-artifact`
+      # flake routes to the fallback comment below (issue #1429) instead of
+      # killing the job with no comment.
       - name: Download report
+        id: download
+        if: ${{ needs.evaluate.result == 'success' }}
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: blast-radius-${{ github.run_id }}
@@ -146,14 +176,31 @@ jobs:
       # Fail closed: require the full schema before rendering. Every field is
       # type-checked, SHAs must be hex, and the `and` chain short-circuits so a
       # non-array `.changed` never reaches the `+`/`test` that would error.
+      #
+      # `continue-on-error`: a rejected (malformed/hostile) report or a missing
+      # file (download flake) must NOT kill the job -- it routes to the fallback
+      # comment. Fail-closed is preserved structurally instead: Render is gated
+      # on `steps.validate.outcome == 'success'`, so a report that fails this
+      # step is never rendered or posted (issue #1429).
       - name: Validate report schema
+        id: validate
+        if: ${{ needs.evaluate.result == 'success' }}
+        continue-on-error: true
         run: |
           set -euo pipefail
           # Slurp (-s) so the artifact must be exactly one object: `jq -e`
           # otherwise exits on the last value, letting `{}` followed by a valid
           # report pass while the render then emits a null first section.
           jq -e -s '
-            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +():-]+$");
+            # Charset is the legal nix store-path-name set (A-Za-z0-9 + - . _ ? =)
+            # plus the extra glyphs attr-path normalization can introduce
+            # (/, space, parens, :). A cause name is a derivation name, and
+            # fixed-output patch/fetch drvs legally carry `?` and `=`
+            # (e.g. `<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`);
+            # omitting them fail-closed the WHOLE report and posted no comment at
+            # all -- the "sometimes empty" bug (#1421). It still rejects every
+            # markdown/mention/HTML glyph (@ < > [ ] ` & | ; * # {).
+            def name_ok: type == "string" and test("^[A-Za-z0-9_./ +()?=:-]+$");
             length == 1 and
             (.[0] |
               (.base    | type == "string" and test("^[0-9a-f]{7,40}$")) and
@@ -184,11 +231,21 @@ jobs:
       # through a conservative charset (Nix attr names do) so a malicious PR
       # cannot inject mentions, HTML, or spoofed markers into a comment posted
       # with the write token. The trusted job owns the marker.
+      # Only when the report validated. Gating on `steps.validate.outcome` (not
+      # just `success()`) is what keeps the pipeline fail-closed now that Validate
+      # is `continue-on-error`: a rejected report leaves outcome != 'success', so
+      # this step is skipped and the fallback runs instead. `continue-on-error`
+      # so a render hiccup also routes to the fallback rather than killing the job.
       - name: Render comment
+        id: render
+        if: ${{ needs.evaluate.result == 'success' && steps.validate.outcome == 'success' }}
+        continue-on-error: true
         run: |
           set -euo pipefail
           jq -r '
-            def safename: select(test("^[A-Za-z0-9_./ +():-]+$"));
+            # Lockstep with the validator name_ok above: same charset, so a
+            # report that validated never has a label silently dropped here.
+            def safename: select(test("^[A-Za-z0-9_./ +()?=:-]+$"));
             # Mirror packages/blast-radius/src/report.rs::format_seconds: bucket
             # by magnitude, round to integer. Empty string for a missing entry
             # so a bare label renders when an attr was a substituter hit or new
@@ -247,7 +304,7 @@ jobs:
                      else empty end),
                     "", "</details>"
                else empty end)
-          ' report.json > comment.md
+          ' report.json > comment.md.tmp
           # Final hard guard against GitHub's 65536-char comment-body limit. The
           # changed-checks cap covers the common case, but the mermaid sections
           # are bounded only by the PR-controlled report, so a pathological shape
@@ -255,17 +312,50 @@ jobs:
           # post job keys on is at the TOP, so a tail truncation leaves it
           # intact) and append a notice.
           max_bytes=65000
-          if [ "$(wc -c < comment.md)" -gt "${max_bytes}" ]; then
-            head -c "${max_bytes}" comment.md > comment.md.trunc
-            mv comment.md.trunc comment.md
-            printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md
+          if [ "$(wc -c < comment.md.tmp)" -gt "${max_bytes}" ]; then
+            head -c "${max_bytes}" comment.md.tmp > comment.md.head
+            mv comment.md.head comment.md.tmp
+            printf '\n\n_Comment truncated to fit the GitHub comment size limit._\n' >> comment.md.tmp
           fi
+          # Publish atomically: only a fully-rendered body becomes comment.md, so
+          # the post step never picks up a half-written file if render is killed
+          # mid-way.
+          mv comment.md.tmp comment.md
+
+      # No usable report (eval bailed, the artifact download flaked, the report
+      # was rejected, or render failed): post an explicit "could not compute"
+      # note rather than leaving the PR with no blast-radius comment at all (the
+      # "comes up empty" bug, issues #1415 and #1429). The eval bail is
+      # frequently base-side (a transiently un-evaluable `main`) or a runner
+      # flake, so the copy says as much. Keyed by the same marker, so the next
+      # successful run overwrites it in place. RUN_URL is passed via env (a
+      # GitHub `${{ }}` expression cannot be evaluated by the shell), which also
+      # lets the test drive this script with a stub URL.
+      - name: Compose fallback comment (no usable report)
+        id: fallback
+        if: ${{ needs.evaluate.result != 'success' || steps.render.outcome != 'success' }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            printf '<!-- blast-radius -->\n'
+            printf '### Blast radius\n\n'
+            printf 'Could not compute the blast radius for this run: the check catalog failed to evaluate, or the report could not be downloaded or rendered. This is usually a transient base-branch or runner issue rather than a problem with this PR. See the [run logs](%s).\n' "$RUN_URL"
+          } > comment.md
 
       # One sticky comment per PR, keyed by the `<!-- blast-radius -->` marker.
       # Paginate the comment list so the marker is found on busy PRs (no
       # duplicate comments), and restrict the match to comments this token can
       # actually PATCH: a user comment that happens to start with the marker
       # would otherwise be selected and every PATCH would 403 forever.
+      #
+      # Exactly one producer leaves a complete comment.md: Render on a good
+      # report, else Compose fallback (which fires whenever Render did not
+      # succeed). Both Validate and Render are `continue-on-error`, so their
+      # failure does not trip `success()` here; the default `success()` gate
+      # still fail-closes against a genuinely broken job (e.g. the fallback
+      # `printf` itself erroring) so a half-written body is never posted.
       - name: Post sticky comment
         run: |
           set -euo pipefail

--- a/packages/blast-radius/src/nix.rs
+++ b/packages/blast-radius/src/nix.rs
@@ -311,7 +311,8 @@ pub fn derivation_graph(drv_paths: &[String]) -> Result<Graph> {
 /// the same shape reaches both [`eval_checks`] and [`crate::timings`].
 ///
 /// The trusted workflow schema (`blast-radius.yml` safename regex) allows dots,
-/// slashes, spaces, and parens but rejects `"`, and trimming only the ends
+/// slashes, spaces, parens, `?`, and `=` (the legal nix-name glyphs that reach a
+/// label) but rejects `"`, and trimming only the ends
 /// leaves the quotes around an interior segment in place. Drop every `"` and
 /// split on dots outside quotes, then rejoin with `.`, so the bare path flows
 /// identically through the diff key, the report, and the schema regardless of

--- a/tools/blast-radius-fixtures/special-name.json
+++ b/tools/blast-radius-fixtures/special-name.json
@@ -1,0 +1,4 @@
+{"base":"aaaaaaa","head":"bbbbbbb","total":120,
+ "changed":["rust-test-foo","rust-test-bar"],"added":[],"removed":[],
+ "causes":[{"name":"e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1","checks":["rust-test-foo","rust-test-bar"]}],
+ "timings":{},"phaseTimings":{"total":1.0}}

--- a/tools/blast-radius-test.sh
+++ b/tools/blast-radius-test.sh
@@ -19,6 +19,7 @@ note() { printf '  %s\n' "$*"; }
 # Extract the exact run-scripts the trusted comment job executes.
 yq '.jobs.comment.steps[] | select(.name == "Validate report schema").run' "$workflow" > "$tmp/validate.sh"
 yq '.jobs.comment.steps[] | select(.name == "Render comment").run' "$workflow" > "$tmp/render.sh"
+yq '.jobs.comment.steps[] | select(.name == "Compose fallback comment (no usable report)").run' "$workflow" > "$tmp/fallback.sh"
 
 validate() { ( cd "$tmp" && cp "$1" report.json && bash validate.sh ); }
 
@@ -42,6 +43,24 @@ done
 # any drift here means the renderer leaked them.
 ( cd "$tmp" && cp "$fixtures/good.json" report.json && bash render.sh )
 if diff -u "$fixtures/good.expected.md" "$tmp/comment.md"; then note "render good: ok"; else note "render good: FAIL (output drift)"; fail=1; fi
+
+# Regression (#1421): a cause name is a nix derivation name, and fixed-output
+# patch/fetch drvs legally carry `?` and `=` (e.g. `<sha>.patch?full_index=1`,
+# `webkitgtk-2.52.4+abi=4.1`). The validator's name_ok used to omit those two
+# glyphs and fail-closed the WHOLE report, so the comment job exited 1 and posted
+# no comment at all -- the "sometimes empty" symptom. The report must now both
+# validate and render with the name intact (validate and safename stay lockstep).
+if validate "$fixtures/special-name.json" >/dev/null 2>&1; then
+  note "validate special-name: ok"
+else
+  note "validate special-name: FAIL (rejected a legal nix derivation name)"; fail=1
+fi
+( cd "$tmp" && cp "$fixtures/special-name.json" report.json && bash render.sh )
+if grep -qF 'e67caa006c75181b45b761cd50294cb3c8e18f1a.patch?full_index=1' "$tmp/comment.md"; then
+  note "render special-name: name preserved ok"
+else
+  note "render special-name: FAIL (legal name dropped from comment)"; fail=1
+fi
 
 # Overflow guard: a PR touching a shared input rebuilds thousands of checks, and
 # an uncapped changed-checks list overflows GitHub's 65536-char comment limit
@@ -92,6 +111,69 @@ if head -c 64 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
   note "render backstop: marker survived truncation ok"
 else
   note "render backstop: FAIL (marker lost; sticky-comment keying breaks)"; fail=1
+fi
+
+# Fallback comment: when there is no usable report (eval bailed, the artifact
+# download flaked, the report was rejected, or render failed) the comment job
+# posts an explicit "could not compute" note instead of skipping and leaving the
+# PR with no blast-radius comment (the "comes up empty" bug, #1415 / #1429).
+# Assert it produces a marker-prefixed body so the sticky-comment keying still
+# finds and overwrites it on the next successful run.
+( cd "$tmp" && rm -f report.json comment.md && RUN_URL="https://github.com/indexable-inc/index/actions/runs/123" bash fallback.sh )
+if head -c 21 "$tmp/comment.md" | grep -q '^<!-- blast-radius -->'; then
+  note "fallback: marker present ok"
+else
+  note "fallback: FAIL (missing marker; sticky-comment keying breaks)"; fail=1
+fi
+if grep -q 'Could not compute the blast radius' "$tmp/comment.md" \
+   && grep -q 'actions/runs/123' "$tmp/comment.md"; then
+  note "fallback: note + run link ok"
+else
+  note "fallback: FAIL (missing explanation or run link)"; fail=1
+fi
+
+# Orchestration invariants (#1429). The "always post a comment, but stay fail-
+# closed" guarantee lives in the comment job's step `if:`/`continue-on-error`
+# wiring, which jq cannot exercise. Assert it structurally with yq so it can't
+# silently regress:
+#   1. Validate + Render are `continue-on-error: true`, so a rejected report,
+#      a download flake, or a render hiccup routes to the fallback instead of
+#      killing the job with no comment.
+#   2. Render is gated on `steps.validate.outcome == 'success'` -- this (not the
+#      implicit success()) is what keeps an unvalidated/hostile report from ever
+#      being rendered now that Validate is continue-on-error.
+#   3. The fallback fires whenever Render did not succeed
+#      (`steps.render.outcome != 'success'`), covering eval failure AND a flaked
+#      comment pipeline.
+#   4. Post sticky comment keeps the default `success()` gate (no explicit `if:`)
+#      so a genuinely broken job never publishes a partial body.
+# `select(...) |` filters before the field access so only the matching step
+# emits (otherwise every non-matching step emits a blank line via `// ""`).
+# Bracket-quote the key so a hyphenated field (continue-on-error) is read as a
+# key, not parsed as subtraction by yq.
+field() { yq ".jobs.comment.steps[] | select(.name == \"$1\") | .[\"$2\"] // \"\"" "$workflow"; }
+for step in "Validate report schema" "Render comment"; do
+  if [ "$(field "$step" "continue-on-error")" = "true" ]; then
+    note "orchestration [$step]: continue-on-error ok"
+  else
+    note "orchestration [$step]: FAIL (not continue-on-error; a failure would kill the job, no fallback)"; fail=1
+  fi
+done
+if field "Render comment" "if" | grep -q "steps.validate.outcome == 'success'"; then
+  note "orchestration [Render]: gated on validate outcome (fail-closed) ok"
+else
+  note "orchestration [Render]: FAIL (renders without a successful validate; hostile report could be posted)"; fail=1
+fi
+if field "Compose fallback comment (no usable report)" "if" | grep -q "steps.render.outcome != 'success'"; then
+  note "orchestration [fallback]: fires on render failure (covers #1429) ok"
+else
+  note "orchestration [fallback]: FAIL (does not cover a flaked comment pipeline)"; fail=1
+fi
+post_if="$(field "Post sticky comment" "if")"
+if [ -z "$post_if" ]; then
+  note "orchestration [Post]: default success() gate (fail-closed) ok"
+else
+  note "orchestration [Post]: FAIL (explicit if '$post_if' can post a partial/unvalidated body)"; fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then echo "blast-radius-test: FAILED"; exit 1; fi


### PR DESCRIPTION
## Why

A teammate reported the blast-radius PR comment **"sometimes comes up empty."** The rendered body is never blank — **"empty" means the sticky comment is absent.** Validating from live run history surfaced multiple causes; this is the complete, tested end-to-end fix.

> Context: a burst of parallel agent sessions opened/closed ~10 overlapping fix PRs (#1428/#1430/#1431/#1446/#1447/#1448/#1449) for this same bug and then closed all of them, leaving `main` unfixed. This PR is the single consolidated, complete fix (it is also the only one that covers the #1429 residual). The duplicates are closed.

## Root causes (all validated)

1. **Validator charset rejected legal nix names (#1421) — the actual "sometimes".** The trusted `comment` job validates every cause/check name and *fail-closes the whole report* if any is outside `^[A-Za-z0-9_./ +():-]+$`. Cause names are nix derivation names; fixed-output patch/fetch drvs legally carry `?`/`=` (`<sha>.patch?full_index=1`, `webkitgtk-2.52.4+abi=4.1`). A PR whose rebuild frontier touched such a drv → validate exits 1 → no comment. **MRE:** the old regex rejects `...patch?full_index=1`; the widened `^[A-Za-z0-9_./ +()?=:-]+$` accepts it while still rejecting every markdown/mention/HTML glyph.
2. **Disabled on PRs (#1411 / #1384).** #1384 commented out the `pull_request` trigger, so the comment never appears.
3. **Comment job skipped / still empty on a flaked pipeline (#1415 / #1429).** It was `needs: evaluate` + default `if: success()` (skipped on eval bail); and even on a green eval, a download flake or rejected report left no comment *and* no fallback.

## Fix

- **Charset:** widen validator `name_ok` + renderer `safename` in **lockstep**; `nix.rs` doc updated; `special-name.json` fixture + regression test.
- **Opt-in trigger:** re-enable `pull_request` (`labeled`/`synchronize`/`reopened`) gated on the `blast-radius` label, ignoring `labeled` events for other labels, with a matching `concurrency.cancel-in-progress` guard — restores the comment without the per-PR runner cost #1384 removed.
- **Always-comment, fail-closed (#1415 + #1429):** comment job runs on eval failure too; `Download`/`Validate`/`Render` are `continue-on-error`, so eval bail, download flake, rejected report, or render hiccup all route to an explicit **"could not compute"** fallback (same marker, overwritten by the next good run). Fail-closed: `Render` is gated on `steps.validate.outcome == 'success'`, render write is atomic, `Post` keeps default `success()`.

## Tests

`tools/blast-radius-test.sh` (the `blast-radius-test` flake check) covers charset, fallback, overflow/backstop, and **yq orchestration invariants** for the continue-on-error / outcome-gating wiring. **All 21 assertions pass locally; `actionlint` clean.**

Follow-up: #1423 (move the write-token post into a base-branch `workflow_run` context) stays open as separate hardening.

Closes #1411
Closes #1415
Closes #1421
Closes #1429

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix blast-radius PR comment being empty by adding opt-in label gating, charset fixes, and a fallback comment
> - The workflow now triggers on `labeled`, `synchronize`, and `reopened` PR events, but the evaluate job only runs for same-repo, non-Dependabot PRs that carry a `blast-radius` label — unrelated label events are ignored.
> - Artifact download, schema validation, and rendering steps now use `continue-on-error: true` so failures route to a fallback path instead of killing the job.
> - A new fallback step writes a minimal marker-prefixed comment when evaluation, download, validation, or rendering fails, ensuring the PR comment is never empty.
> - The jq regex in validation and rendering now accepts `?` and `=` in derivation names, fixing silent drops for paths like `?full_index=1`.
> - Behavioral Change: the comment job now runs even when `evaluate` fails (but still skips when `evaluate` was skipped), and concurrency cancellation no longer preempts in-progress runs triggered by unrelated labels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd02e2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->