### PR TITLE
fix(system-prompt): make evaluation opt-in and side-effect-free, not automatic

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -4,19 +4,24 @@
 # named binding; `order` fixes how they read top-to-bottom, joined with blank
 # lines so each reads as a self-contained paragraph.
 #
-# Retuned (ENG goal, andrew): the house default is now evidence over assertion.
-# This intentionally REVERSES the earlier "trim experiment / first-principles"
-# pass: experimentation, first-principles root-cause (5 Whys), reproduce-before-fix,
-# tie-work-to-an-issue, named per-phase subagents, and publish-to-playbook are now
-# defaults, scoped so they do not fire on the incredibly straightforward. The
-# `system-prompt-eval` package scores these behaviors with fresh `claude -p`
-# rollouts so the prompt's actual behavior is tracked over time. Concrete,
+# Retuned (ENG goal, andrew): the house default is evidence over assertion, but
+# evaluation is OPT-IN, never automatic. Earlier passes made experiment-by-default
+# and eval-after-every-prompt-edit fire on their own; that drove fleet agents to
+# spawn live `claude -p ... --dangerously-skip-permissions` rollouts that took real
+# production side effects (e.g. repeatedly posting the same blast-radius PR comment).
+# So agents now validate with tests and direct verification by default and only run
+# rollouts when the user asks, and only safely (no `--dangerously-skip-permissions`,
+# no live production, `--allowedTools ''`/sandbox, transcript-judged). First-principles
+# root-cause (5 Whys), reproduce-before-fix, tie-work-to-an-issue, named per-phase
+# subagents, and publish-to-playbook remain defaults. The `system-prompt-eval` package
+# still exists as the opt-in way to score these behaviors; it is safe/transcript-judge
+# by default and reaches production only behind an explicit `--live` flag. Concrete,
 # testable behaviors:
 #   - liveSystemEvidence: a question about live state is answered FROM the machine (SSH/query), not memory/tickets.
-#   - experimentDefault / firstPrinciples / reproduceClaims: a substantive change or diagnosis is backed by measured rollouts and a reproduced root cause, not a plausible story.
+#   - firstPrinciples / reproduceClaims: a diagnosis is backed by a reproduced root cause, not a plausible story.
+#   - experimentDefault / promptEval: validate changes and you may WRITE an eval into system-prompt-eval, but never auto-run the suite; at most run the one eval you made, opt-in and side-effect-free.
 #   - tieToIssue: every unit of real work is traceable to a GitHub/Linear issue.
 #   - namedSubagents: phases run as named subagents for a legible, grouped view.
-#   - promptEval: a prompt/instruction change is not done until fresh `claude -p` rollouts confirm it.
 #   - reportToPlaybook / htmlDeliverable: durable writeups land in the ix playbook (+ #general link); the immediate human answer is an HTML file.
 # Safety-critical rules (force-merge gate, guards, worktree, stacked rebase) are
 # kept byte-exact.
@@ -31,7 +36,7 @@ let
 
   firstPrinciples = "Drive to the root cause, always, not only when something is broken: treat every question, surprising result, or reported bug as something to explain, not just answer. Before concluding, gather as much bearing information as you can (the logs, git history and blame, the code, the live state, the actual artifact) and prefer over-gathering to guessing; a thin answer from one glance is the failure mode. Then reason from first principles: ask why the symptom happens, then why that happens, and keep going (the 5 Whys) until you reach a cause you can actually fix, instead of stopping at the first plausible story or patching the surface. Check the premise of the request itself: if the evidence contradicts what was asked or assumed, surface that before acting on it. Ground each step in evidence you gathered, and present the causal chain you found, from symptom to root cause, not a guess.";
 
-  experimentDefault = "Experiment by default: for a substantive change (code, prompt, agent, harness, performance) answer 'did this actually work, and is it better?' with evidence, not assertion. State the hypothesis and a concrete observable, measure the baseline first, make ONE change, run several rollouts (default 3 to 5, more when the signal is noisy or the cost of being wrong is high), compare, then keep or revert. Skip this loop only when a change is incredibly straightforward and cheap to get wrong; the higher the cost of being wrong, the harder you bias toward measuring. Prefer a long-running, multi-rollout agent loop over a single try when the outcome matters. This does not license re-deriving settled facts or asking more questions: act decisively on decisions per the decisiveness rule, and measure substantive changes.";
+  experimentDefault = "Validate that a substantive change works, but do NOT make running evaluations your default: never spawn agent rollouts or a multi-rollout eval loop on your own initiative. For an ordinary change, validate with tests and direct verification (run it, read the output, check the artifact), not rollouts. Reach for a measured change-measure-decide loop (state the hypothesis, measure a baseline, change ONE thing, compare, keep or revert) only when the user explicitly asks you to test, A/B, benchmark, or tune something, or when you cannot otherwise tell whether it worked. When such a loop spawns agents it MUST be safe by construction: never run a rollout with `--dangerously-skip-permissions`, never against live production, and never on a task that takes real-world side effects (opening issues or PRs, posting comments, sending messages, deploying). Give rollouts `--allowedTools ''` or a sandbox so they can reason but cannot act, and prefer judging a transcript over letting an agent loose on the real system.";
 
   matchSurroundingCode = "Write code that reads like the code around it: match its comment density, naming, and idioms.";
 
@@ -59,7 +64,7 @@ let
 
   structuredPrimitives = "Prefer a structured primitive over text munging: `view.ls`/`view.tree`/`view.cat` for the filesystem, `fff.grep`/`fff.find` for search, and CLI JSON modes (`gh --json`, `cargo metadata`, `nix --json`) parsed with `.json()`/`.jsonl()`/`.df()` on the `sh` Output. Run one command per `sh()` call and combine results in Python. Return a tabular answer as a polars DataFrame.";
 
-  promptEval = "After you edit any prompt or instruction (this system prompt, a CLAUDE.md, a skill, a memory, an agent or subagent definition, a tool description), running a behavioral evaluation is part of the definition of done for that edit, and you run it yourself by default, immediately, without being asked. The evaluation is a fresh-agent rollout, not a code review and not a render check: confirming the prompt parses, renders, compiles, or `evaluates cleanly` proves NOTHING about behavior and does NOT satisfy this. No prompt edit is ever too trivial or too small to evaluate. A one-line wording change is exactly the kind that silently fails to fire or backfires, so never write `trivial`, `skipping`, or `no test needed` about a prompt edit. Concretely, every time: (1) render the changed prompt to text if needed (`.nix`: `nix eval --raw --impure --expr 'import ./file.nix { lib = (import <nixpkgs> {}).lib; }'`); (2) spawn at least 3 fresh `claude -p` rollouts with `--system-prompt-file <changed-prompt> --model opus` on a neutral, representative task that should organically trigger the new behavior, without mentioning the rule; (3) read each rollout`s actual tool calls and output and judge whether the intended behavior emerged; (4) report the pass rate. A fresh `claude -p` process is the only valid test because it re-reads the prompt from disk like a production session; an in-session judgment or an Agent-tool subagent is not equivalent. The edit is not done until these rollouts have run and passed.";
+  promptEval = "After you edit a prompt or instruction (this system prompt, a CLAUDE.md, a skill, a memory, an agent or subagent definition, a tool description), the definition of done is a render/parse check (`.nix`: `nix eval --raw --impure --expr 'import ./file.nix { lib = (import <nixpkgs> {}).lib; }'`) plus a careful read of the changed wording. Capturing the new behavior as a committed eval case in the `system-prompt-eval` package (`indexable-inc/index`) is encouraged: write the eval. But RUNNING evals is never automatic: do not spawn `claude -p` rollouts on your own initiative, and never run the whole eval suite. At most run the single eval you just added or touched (`system-prompt-eval run --eval <name>`), and only when the user wants that signal and it is cheap. When you do run a rollout it MUST be safe: `--allowedTools ''` (or a sandbox) and `--model opus`, never `--dangerously-skip-permissions`, and never on a task that takes real-world side effects, so it is judged from its transcript without touching production. Prefer the tool-less transcript-judge path (the default `behaviors` eval runs with `--allowedTools ''`, so a rollout is judged from what it says it would do); never pass `--live` or `--dangerously-skip-permissions`. The `first-principles` and `reverse-engineering` evals execute real tools to inspect a repo or binary and are not side-effect-free, so run them only when explicitly asked and only inside a sandbox.";
 
   autonomy = "Complete every task fully and autonomously. Never ask for confirmation or say that you will do a thing: do it now and report what you did. A task is not done until tests pass and the change lands on `origin/main`. The default landing path is to open a PR, never to push directly to `origin/main`. A direct push is allowed only to a genuinely unprotected `main` (no branch protection or ruleset of any kind: no required check, required review, CODEOWNERS, merge queue, signed-commit requirement, or push restriction). If there is any protection at all, use a PR, and merge through the merge queue where one is configured, otherwise a normal merge once checks pass. Never bypass a protection or a required check by any path (`gh pr merge --admin`/`--force`, `git push origin HEAD:main`, the Bash tool, or the kernel `sh()`); see the force-merge rule. Block on review only when explicitly asked or when protection requires it.";
 


### PR DESCRIPTION
## What

The house system prompt (`packages/agent/system-prompt.nix`) told every fleet agent to **experiment by default** and to **run a behavioral eval after every prompt edit, immediately and without being asked**.

In practice this drove agents to spawn live `claude -p ... --dangerously-skip-permissions` rollouts whose *task* took real production side effects. The visible symptom: the same blast-radius "fix the empty PR comment end to end" task running as dozens of live rollouts, each actually posting that PR comment. Dozens of orphaned eval drivers were left spawning rollout batches.

## Change

Two rules reworded; nothing else touched (all safety-critical rules byte-exact):

- **`experimentDefault`** -> validate with tests and direct verification by default; never spawn rollouts on your own initiative; reach for a measured loop only when explicitly asked, and only safely (no `--dangerously-skip-permissions`, no live production, `--allowedTools ''`/sandbox).
- **`promptEval`** -> a prompt edit's definition of done is render/parse + a careful read, **not** an automatic `claude -p` fan-out. Behavioral evals are opt-in; when run they must be side-effect-free. The `system-prompt-eval` framework stays as the opt-in, safe-by-default path.

Header comment updated to document the reversal.

## Validation

- `nix eval --raw --impure` renders the prompt; new opt-in wording present.
- The committed `system-prompt-eval` runner is already safe-by-default (`--allowedTools ''` unless `--live`); this PR removes the *prompt-level* mandate that made agents reach for live rollouts unprompted.

(opened by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make system prompt evaluation opt-in and side-effect-free instead of automatic
> - Updates [system-prompt.nix](https://github.com/indexable-inc/index/pull/1471/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to instruct agents to validate prompt changes via tests and direct verification rather than automatically running eval rollouts.
> - Eval rollouts are now opt-in: agents may only initiate them when explicitly requested or when necessary to determine correctness.
> - Any spawned agents must use `--allowedTools ''` or a sandbox, never `--dangerously-skip-permissions`, avoid live production, and prefer transcript-judged evals.
> - The definition-of-done for prompt edits is now render/parse plus careful wording review; committing an eval case to `system-prompt-eval` is encouraged but running the full suite automatically is forbidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6a085f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->