### PR TITLE
subagent-cache: own the daemon, client hooks, and service module (ENG-4665)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,6 +1861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "dag-runner"
 version = "0.1.0"
 dependencies = [
@@ -2015,6 +2030,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom 0.2.17",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,6 +2187,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2434,6 +2485,12 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -2883,7 +2940,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3433,6 +3490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3445,6 +3508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4744,6 +4816,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4854,7 +4936,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -5217,6 +5299,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5517,6 +5609,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-ui-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5606,7 +5707,7 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools 0.14.0",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.39.4",
@@ -5682,7 +5783,7 @@ dependencies = [
  "http-body",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign",
@@ -6061,6 +6162,39 @@ dependencies = [
  "embedded-io 0.6.1",
  "heapless 0.7.17",
  "serde",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+ "serde_core",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -6679,7 +6813,7 @@ dependencies = [
  "form_urlencoded",
  "getrandom 0.2.17",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "http",
  "log",
@@ -6851,7 +6985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.13.0",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -7872,6 +8006,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strip-ansi-escapes"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7905,6 +8050,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "subagent-cache"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "clap",
+ "deadpool-postgres",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -8490,6 +8654,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.1",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -9234,10 +9424,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -9406,6 +9617,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9421,6 +9641,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -9651,6 +9880,19 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8945,6 +8945,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8954,12 +8964,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,3 +300,4 @@ uuid = "1"
 webpki-roots = "1"
 wry = "0.55"
 x509-parser = "0.18"
+xxhash-rust = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "packages/build-version",
   "packages/agent/claude-hooks",
   "packages/agent/claude-stories",
+  "packages/agent/subagent-cache",
   "packages/code/ast-merge/ast",
   "packages/code/ast-merge/cli",
   "packages/code/ast-merge/diff",
@@ -165,6 +166,7 @@ kitty = { path = "packages/terminal/kitty" }
 lake-iceberg = { path = "packages/search/lake/iceberg" }
 color-eyre = "0.6"
 dashboard-core = { path = "packages/dashboard/dashboard-core" }
+deadpool-postgres = "0.14"
 devicons = "0.6"
 dirs = "6"
 edit-applier = { path = "packages/code/edit-applier" }
@@ -252,6 +254,7 @@ tempfile = "3"
 terminal-light = "1"
 terminal-theme = { path = "packages/terminal/terminal-theme" }
 tokio = "1"
+tokio-postgres = "0.7"
 tokio-stream = "0.1"
 tokio-util = "0.7"
 toml = { version = "1.1.2", default-features = false }

--- a/modules/services/subagent-cache/default.nix
+++ b/modules/services/subagent-cache/default.nix
@@ -45,26 +45,22 @@ in
       '';
     };
 
-    databaseUrlFile = mkOption {
-      # A runtime path string, not `types.path`: the file is provided at boot by
-      # a secret mechanism outside the image, not a build input.
-      type = types.str;
-      example = "/run/subagent-cache/database-url";
+    environmentFiles = mkOption {
+      # Runtime path strings, not `types.path`: these are provided at boot by a
+      # secret mechanism outside the image, not build inputs.
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "/run/subagent-cache/db.env" ];
       description = ''
-        Path to a file holding the full Postgres connection URL, read when the
-        daemon starts and exported as `DATABASE_URL` (never placed on argv). The
-        password must not be baked into the store, so this is a runtime path.
-        The daemon bootstraps its own schema idempotently on startup.
-      '';
-    };
-
-    apiKeyFile = mkOption {
-      type = types.str;
-      example = "/run/subagent-cache/anthropic-api-key";
-      description = ''
-        Path to a file holding the Anthropic API key for the Stage-2 Haiku
-        judge, read when the daemon starts and exported as `ANTHROPIC_API_KEY`.
-        Provided at boot by a secret mechanism; never baked into the image.
+        systemd `EnvironmentFile` paths layered onto the daemon, for the two
+        secrets it reads from the environment: `DATABASE_URL` (the Postgres
+        connection string, password and all) and `ANTHROPIC_API_KEY` (the
+        Stage-2 Haiku judge key). Kept out of the unit's `environment` (which
+        lands in the world-readable store) and off argv. The consumer delivers
+        these through its own secret mechanism (e.g. the ix fleet composes
+        `DATABASE_URL` from the node's credential and injects `ANTHROPIC_API_KEY`
+        via its secret store). The daemon fails fast at startup if either is
+        missing, and bootstraps its own schema idempotently.
       '';
     };
 
@@ -111,7 +107,6 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
-      path = [ pkgs.coreutils ];
       environment = {
         SUBAGENT_CACHE_BIND = cfg.bind;
         SUBAGENT_CACHE_TTL_DAYS = toString cfg.ttlDays;
@@ -123,16 +118,12 @@ in
         # judge's HTTPS call to Anthropic needs an explicit CA bundle.
         SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
       };
-      # Read both secrets from their runtime files and export them (never argv),
-      # then exec the daemon. clap reads DATABASE_URL and the daemon reads
-      # ANTHROPIC_API_KEY once at startup (fail-fast on a misconfigured deploy).
-      script = ''
-        DATABASE_URL="$(cat ${lib.escapeShellArg cfg.databaseUrlFile})"
-        ANTHROPIC_API_KEY="$(cat ${lib.escapeShellArg cfg.apiKeyFile})"
-        export DATABASE_URL ANTHROPIC_API_KEY
-        exec ${lib.getExe cfg.package}
-      '';
       serviceConfig = {
+        # DATABASE_URL and ANTHROPIC_API_KEY arrive here, kept out of argv and the
+        # store. The daemon reads both from the environment and fails fast if
+        # either is absent.
+        EnvironmentFile = cfg.environmentFiles;
+        ExecStart = lib.getExe cfg.package;
         Restart = "on-failure";
         RestartSec = 5;
       };

--- a/modules/services/subagent-cache/default.nix
+++ b/modules/services/subagent-cache/default.nix
@@ -1,0 +1,141 @@
+# Content-validated subagent investigation cache daemon (ENG-4665).
+#
+# A small axum + Postgres daemon that serves a repeated read-only subagent
+# investigation from a prior finding while every file that finding read is still
+# byte-for-byte unchanged. Recall is Postgres full-text search; the only
+# outbound call is a one-shot Haiku judge that gates precision. The Claude Code
+# lookup/populate hooks (packages/agent/claude-hooks) own freshness re-hashing
+# and capture, and POST to this daemon over the trusted tailnet.
+#
+# This module is deliberately generic: it owns the systemd service and the
+# daemon's non-secret configuration, and takes the Postgres URL and the Anthropic
+# key as runtime file paths. The consumer (e.g. the ix fleet) supplies those
+# files through its own secret mechanism and adds placement, firewalling, and
+# database-unit ordering by merging onto `systemd.services.subagent-cache`.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+  cfg = config.services.subagent-cache;
+in
+{
+  options.services.subagent-cache = {
+    enable = mkEnableOption "the content-validated subagent investigation cache daemon (ENG-4665)";
+
+    package = mkPackageOption pkgs "subagent-cache" { };
+
+    bind = mkOption {
+      type = types.str;
+      default = "127.0.0.1:8787";
+      example = "100.64.0.1:3013";
+      description = ''
+        `addr:port` the HTTP API binds on. The Claude Code lookup and populate
+        hooks POST to it; bind a tailnet address to keep the daemon reachable
+        only over the trusted tailnet (it carries no TLS).
+      '';
+    };
+
+    databaseUrlFile = mkOption {
+      # A runtime path string, not `types.path`: the file is provided at boot by
+      # a secret mechanism outside the image, not a build input.
+      type = types.str;
+      example = "/run/subagent-cache/database-url";
+      description = ''
+        Path to a file holding the full Postgres connection URL, read when the
+        daemon starts and exported as `DATABASE_URL` (never placed on argv). The
+        password must not be baked into the store, so this is a runtime path.
+        The daemon bootstraps its own schema idempotently on startup.
+      '';
+    };
+
+    apiKeyFile = mkOption {
+      type = types.str;
+      example = "/run/subagent-cache/anthropic-api-key";
+      description = ''
+        Path to a file holding the Anthropic API key for the Stage-2 Haiku
+        judge, read when the daemon starts and exported as `ANTHROPIC_API_KEY`.
+        Provided at boot by a secret mechanism; never baked into the image.
+      '';
+    };
+
+    ttlDays = mkOption {
+      type = types.ints.positive;
+      default = 7;
+      description = ''
+        TTL backstop in days: an entry expires this long after its last populate
+        even if none of its files ever change.
+      '';
+    };
+
+    recallTopK = mkOption {
+      type = types.ints.positive;
+      default = 3;
+      description = "Number of full-text recall candidates the judge may inspect per lookup.";
+    };
+
+    recallFloor = mkOption {
+      type = types.float;
+      default = 0.01;
+      description = ''
+        Minimum `ts_rank` a candidate must score to reach the judge. Below it the
+        lookup is a cheap miss and the judge never fires.
+      '';
+    };
+
+    judgeApiBase = mkOption {
+      type = types.str;
+      default = "https://api.anthropic.com";
+      description = "Anthropic Messages API base URL for the Stage-2 judge.";
+    };
+
+    judgeModel = mkOption {
+      type = types.str;
+      default = "claude-haiku-4-5";
+      description = "Judge model id (a Haiku-class model).";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.subagent-cache = {
+      description = "Content-validated subagent investigation cache (ENG-4665)";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      path = [ pkgs.coreutils ];
+      environment = {
+        SUBAGENT_CACHE_BIND = cfg.bind;
+        SUBAGENT_CACHE_TTL_DAYS = toString cfg.ttlDays;
+        SUBAGENT_CACHE_TOP_K = toString cfg.recallTopK;
+        SUBAGENT_CACHE_RECALL_FLOOR = toString cfg.recallFloor;
+        SUBAGENT_CACHE_JUDGE_API_BASE = cfg.judgeApiBase;
+        SUBAGENT_CACHE_JUDGE_MODEL = cfg.judgeModel;
+        # A hardened unit's ProtectSystem hides the host trust store, so the
+        # judge's HTTPS call to Anthropic needs an explicit CA bundle.
+        SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+      };
+      # Read both secrets from their runtime files and export them (never argv),
+      # then exec the daemon. clap reads DATABASE_URL and the daemon reads
+      # ANTHROPIC_API_KEY once at startup (fail-fast on a misconfigured deploy).
+      script = ''
+        DATABASE_URL="$(cat ${lib.escapeShellArg cfg.databaseUrlFile})"
+        ANTHROPIC_API_KEY="$(cat ${lib.escapeShellArg cfg.apiKeyFile})"
+        export DATABASE_URL ANTHROPIC_API_KEY
+        exec ${lib.getExe cfg.package}
+      '';
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+  };
+}

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -210,10 +210,15 @@ let
   #   hooks.SessionStart: the context-digest hook (claude-hooks `session-digest`);
   #     see `claudeHooks` below.
   #   hooks.PreToolUse: the worktree isolation guard for file-edit tools
-  #     (claude-hooks `worktree-guard`). Shipped from this layer (not a project
-  #     .claude/settings.json) on purpose: project hooks only load for
-  #     sessions started inside that project, which is exactly the bypass the
-  #     guard closes (ENG-2692).
+  #     (claude-hooks `worktree-guard`), plus the subagent-cache lookup on the
+  #     `Agent` tool (claude-hooks `subagent-cache-lookup`, ENG-4665). Shipped
+  #     from this layer (not a project .claude/settings.json) on purpose: project
+  #     hooks only load for sessions started inside that project, which is
+  #     exactly the bypass the guard closes (ENG-2692) and the reason the cache
+  #     must be non-optional fleet-wide.
+  #   hooks.SubagentStop: the subagent-cache populate (claude-hooks
+  #     `subagent-cache-populate`, ENG-4665). Both cache hooks fail open to a
+  #     cold run when SUBAGENT_CACHE_URL is unset or the daemon is unreachable.
   #   permissions.deny `gh pr merge --admin`/`--force` (ENG-2688, postmortem
   #     ENG-2391: agent force-landed a red PR): admin/force merge is forbidden
   #     outright, not gated. The old `ask` rule was theatre — it only intercepts
@@ -315,8 +320,9 @@ let
           ]
           ++ denyTools;
       };
-      # The full hook set (context injectors, guards, review pair, friction) for
-      # Claude, rendered from the shared declaration list in ../hooks.nix.
+      # The full hook set (context injectors, guards, review pair, friction,
+      # subagent-cache) for Claude, rendered from the shared declaration list in
+      # ../hooks.nix.
       hooks = sharedHooks.claude;
     }
     // lib.optionalAttrs dangerouslySkipPermissions {

--- a/packages/agent/claude-code/hooks.nix
+++ b/packages/agent/claude-code/hooks.nix
@@ -1,4 +1,4 @@
-# The three hooks are subcommands of one compiled binary (packages/claude-hooks)
+# The hooks are subcommands of one compiled binary (packages/agent/claude-hooks)
 # rather than hand-rolled shell scripts. Each fails OPEN and SILENT (any
 # missing input, parse error, or kill-switch exits with no stdout: a noisy or
 # broken hook is strictly worse than no hook). See that crate for the full
@@ -12,6 +12,12 @@
 #  - prompt-priors (UserPromptSubmit): triple-gated, score-gated ambient priors
 #    from the corpus store (ENG-2707), capped ~1200 tokens. Kill switch:
 #    CLAUDE_CODE_DISABLE_PROMPT_PRIORS=1.
+#  - subagent-cache-lookup (PreToolUse on Agent) / subagent-cache-populate
+#    (SubagentStop): serve a fresh prior read-only subagent investigation from
+#    the subagent-cache daemon (packages/agent/subagent-cache) instead of
+#    re-running it, and capture each finished one (ENG-4665). POST to
+#    SUBAGENT_CACHE_URL; inert when unset. Kill switch:
+#    CLAUDE_CODE_DISABLE_SUBAGENT_CACHE=1.
 # Tool paths and the baked primary-checkout default ride as env on a thin
 # makeBinaryWrapper so the hook is self-contained under any user PATH, while
 # user knobs keep their CLAUDE_CODE_* names. IX_SEARCH (and the prompt-priors

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -279,5 +279,36 @@
   # crashes (fails open) on a minimal HOME.
   HOME="$PWD/no-home" ${claudeHooks}/bin/claude-hooks session-banner </dev/null >/dev/null
 
+  # Fail-open net for the subagent-cache hooks (ENG-4665): every skip and
+  # error path must exit 0 with NO output (a lookup that emits would block the
+  # Agent launch; a noisy populate would surface on every SubagentStop).
+  # SUBAGENT_CACHE_URL points at a closed port so the one path that does reach
+  # the network (a cacheable lookup) gets a refused connection and falls open.
+  sac() {
+    local desc="$1" sub="$2" input="$3" got
+    got="$(printf '%s' "$input" \
+      | SUBAGENT_CACHE_URL=http://127.0.0.1:1 ${claudeHooks}/bin/claude-hooks "$sub")"
+    if [ -n "$got" ]; then
+      printf 'subagent-cache %s check failed (%s): expected silent, got:\n%s\n' \
+        "$sub" "$desc" "$got" >&2
+      exit 1
+    fi
+  }
+  sac "malformed payload" subagent-cache-lookup 'not json'
+  sac "missing fields" subagent-cache-lookup '{"tool_input":{}}'
+  sac "non-cacheable agent skipped" subagent-cache-lookup \
+    '{"tool_input":{"subagent_type":"general-purpose","prompt":"how does X work"}}'
+  sac "cacheable lookup, daemon unreachable" subagent-cache-lookup \
+    '{"tool_input":{"subagent_type":"explore","prompt":"how does X work"}}'
+  sac "populate malformed payload" subagent-cache-populate 'not json'
+  sac "populate missing transcript" subagent-cache-populate \
+    '{"agent_type":"explore","last_assistant_message":"x","agent_transcript_path":"/no/such/transcript"}'
+  if [ -n "$(printf '%s' '{"tool_input":{"subagent_type":"explore","prompt":"how does X work"}}' \
+    | CLAUDE_CODE_DISABLE_SUBAGENT_CACHE=1 \
+      SUBAGENT_CACHE_URL=http://127.0.0.1:1 ${claudeHooks}/bin/claude-hooks subagent-cache-lookup)" ]; then
+    printf 'subagent-cache lookup check failed: kill switch must be silent\n' >&2
+    exit 1
+  fi
+
   runHook postInstallCheck
 ''

--- a/packages/agent/claude-hooks/Cargo.toml
+++ b/packages/agent/claude-hooks/Cargo.toml
@@ -3,7 +3,7 @@ name = "claude-hooks"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
-description = "Claude Code/Codex hook commands (session-digest, worktree-guard, prompt-priors, review pair, bash/cargo/search guards, session-banner, friction-report) as one compiled binary"
+description = "Claude Code/Codex hook commands (session-digest, worktree-guard, prompt-priors, subagent-cache, review pair, bash/cargo/search guards, session-banner, friction-report) as one compiled binary"
 
 [lints]
 workspace = true
@@ -12,8 +12,9 @@ workspace = true
 # `clock` for chrono::Local (friction-report log timestamps).
 chrono = { workspace = true, features = ["alloc", "clock"] }
 glob.workspace = true
-# friction-report files to Linear over HTTPS; blocking client keeps the detached
-# --analyze worker a plain synchronous process (no async runtime in a hook).
+# friction-report files to Linear over HTTPS, and the subagent-cache hooks POST
+# to their daemon. A blocking client keeps these short-lived sync hooks a plain
+# synchronous process (no async runtime).
 reqwest = { workspace = true, features = ["blocking"] }
 # friction-report's single-flight flock, detached-session spawn (setsid), and
 # process-group SIGKILL on model timeout.
@@ -22,8 +23,11 @@ regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 # friction-report routes the model child's stdout to a real temp file (not a
-# pipe), the immortal-worker fix preserved from the Python.
+# pipe), and the subagent-cache tests use it too.
 tempfile.workspace = true
+# xxh64 (seed 0) for the subagent-cache freshness hash; matches mgrep and the
+# hashes other developers' hooks wrote into the shared cache.
+xxhash-rust = { workspace = true, features = ["xxh64"] }
 
 [[bin]]
 name = "claude-hooks"

--- a/packages/agent/claude-hooks/src/main.rs
+++ b/packages/agent/claude-hooks/src/main.rs
@@ -24,6 +24,8 @@ use chrono::{DateTime, SecondsFormat};
 use serde::Serialize;
 use serde_json::Value;
 
+mod subagent_cache;
+
 /// `SessionStart` digest cap (~1500 tokens), inside the 10,000-char
 /// `additionalContext` limit.
 const DIGEST_CAP: usize = 6000;
@@ -81,6 +83,8 @@ fn main() -> ExitCode {
         Some("bash-habits-guard") => guards::bash_habits_guard(),
         Some("search-guard") => guards::search_guard(),
         Some("friction-report") => friction::friction_report(),
+        Some("subagent-cache-lookup") => subagent_cache::lookup(),
+        Some("subagent-cache-populate") => subagent_cache::populate(),
         other => {
             eprintln!("claude-hooks: unknown subcommand {other:?}");
             return ExitCode::from(2);

--- a/packages/agent/claude-hooks/src/subagent_cache.rs
+++ b/packages/agent/claude-hooks/src/subagent_cache.rs
@@ -1,0 +1,487 @@
+//! Subagent investigation cache hooks (ENG-4665).
+//!
+//! `subagent-cache-lookup` (`PreToolUse` on `Agent`) serves a fresh prior
+//! investigation instead of re-running a read-only subagent cold;
+//! `subagent-cache-populate` (`SubagentStop`) captures each finished one. Both
+//! fail OPEN and SILENT and POST to the daemon at `SUBAGENT_CACHE_URL`; when
+//! that is unset or unreachable the hooks are a no-op (silent cold run), so they
+//! are inert off the tailnet where the daemon lives. Kill switch:
+//! `CLAUDE_CODE_DISABLE_SUBAGENT_CACHE`.
+//!
+//! The daemon owns Stage-1 FTS recall and the Stage-2 Haiku judge; this client
+//! owns Stage-3 freshness (re-hashing each candidate's `file_deps` against the
+//! working tree) and the persona hash, because only the client sees its tree.
+//! `xxh64` (seed 0) matches mgrep and the hashes other developers' hooks wrote,
+//! so the shared cache speaks one freshness language.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::{DenyOutput, emit, flag_set, read_stdin};
+
+/// Read-only investigators whose work is the expensive, reusable unit. Mutating
+/// or open-ended agents are deliberately excluded. Override with the
+/// `SUBAGENT_CACHE_AGENTS` env var (comma-separated).
+const DEFAULT_CACHEABLE_AGENTS: &[&str] = &[
+    "explore",
+    "codebase-locator",
+    "codebase-analyzer",
+    "codebase-pattern-finder",
+];
+/// Findings larger than this are not served via the deny reason (it would bloat
+/// the model's context); fall through to a cold run. Override with
+/// `SUBAGENT_CACHE_MAX_FINDINGS`.
+const DEFAULT_MAX_FINDINGS: usize = 60_000;
+/// Daemon base URL when `SUBAGENT_CACHE_URL` is unset: nothing listens, so the
+/// hook fails open to a cold run.
+const DEFAULT_DAEMON_URL: &str = "http://127.0.0.1:8787";
+/// Budget for the lookup/populate calls; generous next to fail-open.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(3);
+/// The outcome ping is pure telemetry, so it gets a tight budget.
+const OUTCOME_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Serialize, Deserialize)]
+struct FileDep {
+    path: String,
+    hash: String,
+}
+
+#[derive(Deserialize)]
+struct Candidate {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    findings: String,
+    #[serde(default)]
+    file_deps: Vec<FileDep>,
+}
+
+/// The Stage-3 resolution for one lookup: which outcome to report and (on a
+/// hit) the findings to serve. A named struct because the house clippy fork
+/// forbids anonymous multi-value tuple returns.
+struct Selection {
+    outcome: &'static str,
+    candidate_id: Option<String>,
+    findings: Option<String>,
+}
+
+/// `PreToolUse(Agent)` lookup: serve a fresh cached investigation by `deny`-ing
+/// the launch with the findings packed into the reason (the only way a
+/// `PreToolUse` hook hands data back to the model), or stay silent for a cold run.
+pub fn lookup() {
+    if flag_set("CLAUDE_CODE_DISABLE_SUBAGENT_CACHE") {
+        return;
+    }
+    let Some(input) = read_stdin() else { return };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    let tool_input = payload.get("tool_input");
+    let agent_type = tool_input
+        .and_then(|t| t.get("subagent_type"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let prompt = tool_input
+        .and_then(|t| t.get("prompt"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if agent_type.is_empty() || prompt.is_empty() || !cacheable_agents().contains(agent_type) {
+        return;
+    }
+
+    let root = project_dir();
+    let req = json!({
+        "agent_type": agent_type,
+        "prompt": prompt,
+        "agent_def_hash": agent_def_hash(agent_type, &root),
+    });
+    let Some(resp) = post("/lookup", &req, HTTP_TIMEOUT) else {
+        return; // daemon down or error => fail open to a cold run
+    };
+    let candidates: Vec<Candidate> = resp
+        .get("candidates")
+        .and_then(|c| serde_json::from_value(c.clone()).ok())
+        .unwrap_or_default();
+
+    let selection = select_candidate(&candidates, &root, max_findings());
+    report_outcome(agent_type, &selection);
+    if let Some(findings) = selection.findings {
+        serve(agent_type, &findings);
+    }
+}
+
+/// `SubagentStop` populate: capture a finished investigation for reuse. Reads
+/// the question and the exact set of files the subagent `Read` from the
+/// transcript, hashes each, and upserts one cache entry. Best-effort.
+pub fn populate() {
+    if flag_set("CLAUDE_CODE_DISABLE_SUBAGENT_CACHE") {
+        return;
+    }
+    let Some(input) = read_stdin() else { return };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    let agent_type = payload
+        .get("agent_type")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let findings = payload
+        .get("last_assistant_message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let transcript = payload
+        .get("agent_transcript_path")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if agent_type.is_empty()
+        || findings.is_empty()
+        || transcript.is_empty()
+        || !cacheable_agents().contains(agent_type)
+    {
+        return;
+    }
+
+    let root = project_dir();
+    let Some(prompt) = first_user_text(Path::new(transcript)) else {
+        return;
+    };
+    // Drop deps that vanished between read and populate (hash None): an entry
+    // must record only files whose content we actually captured.
+    let deps: Vec<FileDep> = read_paths(Path::new(transcript), &root)
+        .into_iter()
+        .filter_map(|rel| hash_file(&root.join(&rel)).map(|hash| FileDep { path: rel, hash }))
+        .collect();
+
+    let req = json!({
+        "agent_type": agent_type,
+        "prompt": prompt,
+        "findings": findings,
+        "agent_def_hash": agent_def_hash(agent_type, &root),
+        "model": payload.get("model").and_then(Value::as_str),
+        "file_deps": deps,
+    });
+    let _ = post("/populate", &req, HTTP_TIMEOUT);
+}
+
+/// Pick the first fresh candidate under the findings cap, else report why none
+/// served. Correctness asymmetry: a false miss is cheap, a false hit is not, so
+/// anything uncertain falls through to a cold run.
+fn select_candidate(candidates: &[Candidate], root: &Path, max_findings: usize) -> Selection {
+    let mut stale_id: Option<String> = None;
+    let mut oversize_id: Option<String> = None;
+    for candidate in candidates {
+        if !is_fresh(candidate, root) {
+            if stale_id.is_none() {
+                stale_id.clone_from(&candidate.id);
+            }
+            continue;
+        }
+        if candidate.findings.len() > max_findings {
+            oversize_id.clone_from(&candidate.id);
+            continue;
+        }
+        return Selection {
+            outcome: "served",
+            candidate_id: candidate.id.clone(),
+            findings: Some(candidate.findings.clone()),
+        };
+    }
+    if oversize_id.is_some() {
+        return Selection {
+            outcome: "oversize",
+            candidate_id: oversize_id,
+            findings: None,
+        };
+    }
+    if stale_id.is_some() {
+        return Selection {
+            outcome: "stale",
+            candidate_id: stale_id,
+            findings: None,
+        };
+    }
+    Selection {
+        outcome: "miss",
+        candidate_id: None,
+        findings: None,
+    }
+}
+
+/// A candidate is fresh when every recorded dependency still hashes to the
+/// stored value. A vanished file hashes to `None` and so counts as changed.
+fn is_fresh(candidate: &Candidate, root: &Path) -> bool {
+    candidate
+        .file_deps
+        .iter()
+        .all(|dep| hash_file(&root.join(&dep.path)).as_deref() == Some(dep.hash.as_str()))
+}
+
+fn serve(agent_type: &str, findings: &str) {
+    let reason = format!(
+        "SUBAGENT CACHE HIT (ENG-4665): a prior {agent_type} investigation answered an \
+         equivalent question and every file it read is unchanged, so it was served from cache \
+         instead of re-running. Use these findings directly as the subagent's result:\n\n\
+         {findings}"
+    );
+    emit(DenyOutput {
+        hook_event_name: "PreToolUse",
+        permission_decision: "deny",
+        permission_decision_reason: reason,
+    });
+}
+
+fn report_outcome(agent_type: &str, selection: &Selection) {
+    let mut body = json!({ "agent_type": agent_type, "outcome": selection.outcome });
+    if let Some(id) = &selection.candidate_id {
+        body["candidate_id"] = Value::String(id.clone());
+    }
+    let _ = post("/outcome", &body, OUTCOME_TIMEOUT);
+}
+
+/// POST JSON to the daemon, returning the decoded body or `None` on any error.
+/// Fail-open is load-bearing: a cache outage must never block a subagent launch
+/// or fail a finished one, so every failure mode collapses to `None`.
+fn post(path: &str, body: &Value, timeout: Duration) -> Option<Value> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .build()
+        .ok()?;
+    let resp = client
+        .post(format!("{}{path}", daemon_url()))
+        .json(body)
+        .send()
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    // A 204 has an empty body; the lookup caller only reads `candidates`.
+    Some(resp.json::<Value>().unwrap_or(Value::Null))
+}
+
+fn daemon_url() -> String {
+    std::env::var("SUBAGENT_CACHE_URL")
+        .unwrap_or_else(|_| DEFAULT_DAEMON_URL.to_owned())
+        .trim_end_matches('/')
+        .to_owned()
+}
+
+fn max_findings() -> usize {
+    std::env::var("SUBAGENT_CACHE_MAX_FINDINGS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_MAX_FINDINGS)
+}
+
+fn cacheable_agents() -> HashSet<String> {
+    match std::env::var("SUBAGENT_CACHE_AGENTS") {
+        Ok(raw) if !raw.trim().is_empty() => raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect(),
+        _ => DEFAULT_CACHEABLE_AGENTS
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect(),
+    }
+}
+
+/// The repo root the hooks resolve relative paths against.
+fn project_dir() -> PathBuf {
+    std::env::var_os("CLAUDE_PROJECT_DIR")
+        .map(PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Hash of the persona file, or the sentinel `none` for a built-in agent (no
+/// def file). Both hooks compute this identically so the key is stable.
+fn agent_def_hash(agent_type: &str, root: &Path) -> String {
+    hash_file(&root.join(".claude/agents").join(format!("{agent_type}.md")))
+        .unwrap_or_else(|| "none".to_owned())
+}
+
+fn hash_bytes(data: &[u8]) -> String {
+    format!("xxh64:{:016x}", xxhash_rust::xxh64::xxh64(data, 0))
+}
+
+/// Content hash of a file, or `None` if it is missing/unreadable (treated as
+/// changed, mirroring mgrep's vanished-file handling).
+fn hash_file(path: &Path) -> Option<String> {
+    std::fs::read(path).ok().map(|bytes| hash_bytes(&bytes))
+}
+
+/// Repo-relative form of an absolute read path, or `None` if it is outside the
+/// repo. Cross-developer sharing requires repo-relative paths: an absolute
+/// `/tmp` or `/home` path never matches another machine.
+fn to_repo_relative(path: &Path, root: &Path) -> Option<String> {
+    let abs = path.canonicalize().ok()?;
+    let root = root.canonicalize().ok()?;
+    abs.strip_prefix(&root)
+        .ok()
+        .map(|rel| rel.to_string_lossy().into_owned())
+}
+
+/// Repo-relative paths the subagent actually `Read`, deduped and order-stable.
+/// Only `Read` calls count as dependencies; grep/glob/search touch far more
+/// files than they reason about.
+fn read_paths(transcript: &Path, root: &Path) -> Vec<String> {
+    let Ok(content) = std::fs::read_to_string(transcript) else {
+        return Vec::new();
+    };
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(entry) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let message = entry.get("message").unwrap_or(&entry);
+        let Some(blocks) = message.get("content").and_then(Value::as_array) else {
+            continue;
+        };
+        for block in blocks {
+            if block.get("type").and_then(Value::as_str) != Some("tool_use")
+                || block.get("name").and_then(Value::as_str) != Some("Read")
+            {
+                continue;
+            }
+            let Some(fp) = block
+                .get("input")
+                .and_then(|i| i.get("file_path"))
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+            else {
+                continue;
+            };
+            if let Some(rel) = to_repo_relative(Path::new(fp), root)
+                && seen.insert(rel.clone())
+            {
+                out.push(rel);
+            }
+        }
+    }
+    out
+}
+
+/// The subagent's initial prompt: the first user message's text. The
+/// `SubagentStop` payload does not carry it, but the transcript's first user
+/// message does.
+fn first_user_text(transcript: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(transcript).ok()?;
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(entry) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let message = entry.get("message").unwrap_or(&entry);
+        if message.get("role").and_then(Value::as_str) != Some("user") {
+            continue;
+        }
+        match message.get("content") {
+            Some(Value::String(text)) => return Some(text.clone()),
+            Some(Value::Array(blocks)) => {
+                let text: String = blocks
+                    .iter()
+                    .filter(|b| b.get("type").and_then(Value::as_str) == Some("text"))
+                    .filter_map(|b| b.get("text").and_then(Value::as_str))
+                    .collect();
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_owned());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Candidate, Selection, hash_bytes, is_fresh, select_candidate};
+    use std::path::Path;
+
+    fn candidate(id: &str, findings: &str, deps: Vec<(&str, &str)>) -> Candidate {
+        Candidate {
+            id: Some(id.to_owned()),
+            findings: findings.to_owned(),
+            file_deps: deps
+                .into_iter()
+                .map(|(path, hash)| super::FileDep {
+                    path: path.to_owned(),
+                    hash: hash.to_owned(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn golden_xxh64_vectors() {
+        // Verified against `xxhsum -H64` and mgrep's Rust xxh64.
+        assert_eq!(hash_bytes(b""), "xxh64:ef46db3751d8e999");
+        assert_eq!(hash_bytes(b"abc"), "xxh64:44bc2cf5ad770999");
+        assert_eq!(
+            hash_bytes(b"The quick brown fox jumps over the lazy dog"),
+            "xxh64:0b242d361fda71bc"
+        );
+    }
+
+    #[test]
+    fn fresh_only_when_all_deps_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("f.rs"), b"contents").expect("write");
+        let fresh = candidate("c1", "use this", vec![("f.rs", &hash_bytes(b"contents"))]);
+        let stale = candidate("c2", "old", vec![("f.rs", &hash_bytes(b"old"))]);
+        let gone = candidate("c3", "x", vec![("gone.rs", "xxh64:0000000000000000")]);
+        assert!(is_fresh(&fresh, root));
+        assert!(!is_fresh(&stale, root));
+        assert!(!is_fresh(&gone, root));
+    }
+
+    #[test]
+    fn serves_fresh_candidate_under_limit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("f.rs"), b"contents").expect("write");
+        let cand = candidate("c1", "use this", vec![("f.rs", &hash_bytes(b"contents"))]);
+        let Selection {
+            outcome,
+            candidate_id,
+            findings,
+        } = select_candidate(std::slice::from_ref(&cand), root, 60_000);
+        assert_eq!(outcome, "served");
+        assert_eq!(candidate_id.as_deref(), Some("c1"));
+        assert_eq!(findings.as_deref(), Some("use this"));
+    }
+
+    #[test]
+    fn reports_oversize_then_stale_then_miss() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("f.rs"), b"contents").expect("write");
+        let big = candidate("big", "too large", vec![("f.rs", &hash_bytes(b"contents"))]);
+        assert_eq!(
+            select_candidate(std::slice::from_ref(&big), root, 3).outcome,
+            "oversize"
+        );
+        let stale = candidate("stale", "old", vec![("f.rs", &hash_bytes(b"old"))]);
+        assert_eq!(
+            select_candidate(std::slice::from_ref(&stale), root, 60_000).outcome,
+            "stale"
+        );
+        assert_eq!(select_candidate(&[], Path::new("/"), 60_000).outcome, "miss");
+    }
+}

--- a/packages/agent/claude-hooks/src/subagent_cache.rs
+++ b/packages/agent/claude-hooks/src/subagent_cache.rs
@@ -24,9 +24,13 @@ use serde_json::{Value, json};
 use crate::{DenyOutput, emit, flag_set, read_stdin};
 
 /// Read-only investigators whose work is the expensive, reusable unit. Mutating
-/// or open-ended agents are deliberately excluded. Override with the
-/// `SUBAGENT_CACHE_AGENTS` env var (comma-separated).
+/// or open-ended agents are deliberately excluded. Matched case-sensitively
+/// against `subagent_type`, so the built-in explorer is listed under both the
+/// capitalized name Claude Code ships (`Explore`) and the lowercase house
+/// orchestrator (`explore`). Override with the `SUBAGENT_CACHE_AGENTS` env var
+/// (comma-separated).
 const DEFAULT_CACHEABLE_AGENTS: &[&str] = &[
+    "Explore",
     "explore",
     "codebase-locator",
     "codebase-analyzer",

--- a/packages/agent/hooks.nix
+++ b/packages/agent/hooks.nix
@@ -116,6 +116,26 @@ let
       event = "Stop";
       sub = "friction-report";
     }
+
+    # Subagent investigation cache (ENG-4665): serve a fresh prior read-only
+    # investigation instead of re-running it cold (PreToolUse on the Agent tool),
+    # and capture each finished one (SubagentStop). Claude-only: these are Claude
+    # Code's subagent-launch events. Always on; the hooks fail open to a cold run
+    # when SUBAGENT_CACHE_URL is unset or the daemon is unreachable, so they are
+    # inert off the tailnet. See packages/agent/subagent-cache.
+    {
+      event = "PreToolUse";
+      matcher = "Agent";
+      sub = "subagent-cache-lookup";
+      timeout = 15;
+      agents = [ "claude" ];
+    }
+    {
+      event = "SubagentStop";
+      sub = "subagent-cache-populate";
+      timeout = 30;
+      agents = [ "claude" ];
+    }
   ];
 
   defaults = {

--- a/packages/agent/subagent-cache/Cargo.toml
+++ b/packages/agent/subagent-cache/Cargo.toml
@@ -37,5 +37,8 @@ tokio-postgres = { workspace = true, features = [
   "with-uuid-1",
 ] }
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = [
+  "env-filter",
+  "json",
+] }
 uuid = { workspace = true, features = ["v4", "serde"] }

--- a/packages/agent/subagent-cache/Cargo.toml
+++ b/packages/agent/subagent-cache/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "subagent-cache"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Content-validated cache for subagent investigations (ENG-4665)"
+
+[lib]
+name = "subagent_cache"
+path = "src/lib.rs"
+
+[[bin]]
+name = "subagent-cache"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+axum = { workspace = true, features = ["http1", "tokio", "json"] }
+chrono = { workspace = true, features = ["clock"] }
+clap = { workspace = true, features = ["derive", "env"] }
+deadpool-postgres.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = [
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "signal",
+] }
+tokio-postgres = { workspace = true, features = [
+  "with-chrono-0_4",
+  "with-serde_json-1",
+  "with-uuid-1",
+] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+uuid = { workspace = true, features = ["v4", "serde"] }

--- a/packages/agent/subagent-cache/default.nix
+++ b/packages/agent/subagent-cache/default.nix
@@ -1,0 +1,10 @@
+{ ix, lib, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "subagent-cache";
+  meta = {
+    description = "Content-validated cache daemon for read-only subagent investigations (FTS recall + Haiku judge over Postgres)";
+    license = lib.licenses.mit;
+    mainProgram = "subagent-cache";
+  };
+}

--- a/packages/agent/subagent-cache/package.nix
+++ b/packages/agent/subagent-cache/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "subagent-cache";
+  packageSet = true;
+  flake = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/agent/subagent-cache/package.nix
+++ b/packages/agent/subagent-cache/package.nix
@@ -2,6 +2,7 @@
   id = "subagent-cache";
   packageSet = true;
   flake = true;
+  overlay = true;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/agent/subagent-cache/schema.sql
+++ b/packages/agent/subagent-cache/schema.sql
@@ -1,0 +1,33 @@
+-- Subagent cache schema (ENG-4665).
+--
+-- Owned and applied by the subagent-cache daemon on startup against its
+-- dedicated internal Postgres. It is deliberately NOT part of the production
+-- ix migration runner (crates/ix/db): that runner is bound to the global and
+-- regional prod roles, and this cache lives in a separate database to keep its
+-- blast radius isolated. Every statement is idempotent so bootstrap can run on
+-- every start.
+
+CREATE TABLE IF NOT EXISTS subagent_cache (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_type      text        NOT NULL,          -- "explore" | "codebase-locator" | ...
+  question        text        NOT NULL,          -- the prompt the subagent answered
+  question_tsv    tsvector    GENERATED ALWAYS AS (to_tsvector('english', question)) STORED,
+  findings        text        NOT NULL,          -- last_assistant_message (the cached value)
+  agent_def_hash  text        NOT NULL,          -- xxh64 of .claude/agents/<type>.md
+  model           text,                          -- generating model id, recorded for triage
+  file_deps       jsonb       NOT NULL,          -- [{ "path": ..., "hash": "xxh64:<hex>" }]
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  expires_at      timestamptz NOT NULL           -- TTL backstop
+);
+
+-- Stage-1 recall key: full-text rank over the question.
+CREATE INDEX IF NOT EXISTS subagent_cache_question_tsv_idx
+  ON subagent_cache USING gin (question_tsv);
+
+-- Recall filter: same agent_type, matching persona, not expired.
+CREATE INDEX IF NOT EXISTS subagent_cache_recall_idx
+  ON subagent_cache (agent_type, agent_def_hash, expires_at);
+
+-- One live row per (agent_type, question, persona): populate upserts onto it.
+CREATE UNIQUE INDEX IF NOT EXISTS subagent_cache_upsert_key
+  ON subagent_cache (agent_type, question, agent_def_hash);

--- a/packages/agent/subagent-cache/src/config.rs
+++ b/packages/agent/subagent-cache/src/config.rs
@@ -1,0 +1,42 @@
+//! Daemon configuration, all overridable via CLI flags or environment.
+
+use std::net::SocketAddr;
+
+/// Runtime configuration for the subagent-cache daemon.
+///
+/// The recall floor and top-K are deliberately config: the design fixes their
+/// shape but not their values, which must be tuned against measured hit and
+/// false-hit rates rather than asserted.
+#[derive(Debug, Clone, clap::Parser)]
+#[command(name = "subagent-cache", about = "Content-validated subagent investigation cache")]
+pub struct Config {
+    /// Postgres connection URL for the dedicated cache database.
+    #[arg(long, env = "DATABASE_URL")]
+    pub database_url: String,
+
+    /// Address to bind the HTTP server on.
+    #[arg(long, env = "SUBAGENT_CACHE_BIND", default_value = "127.0.0.1:8787")]
+    pub bind: SocketAddr,
+
+    /// Number of FTS candidates the judge may inspect per lookup.
+    #[arg(long, env = "SUBAGENT_CACHE_TOP_K", default_value_t = 3)]
+    pub recall_top_k: i64,
+
+    /// Minimum `ts_rank` a candidate must score to reach the judge. Below it,
+    /// the lookup is a cheap miss (the judge never fires).
+    #[arg(long, env = "SUBAGENT_CACHE_RECALL_FLOOR", default_value_t = 0.01)]
+    pub recall_floor: f32,
+
+    /// TTL backstop in days. An entry expires this long after its last
+    /// populate even if none of its files ever change.
+    #[arg(long, env = "SUBAGENT_CACHE_TTL_DAYS", default_value_t = 7)]
+    pub ttl_days: i64,
+
+    /// Anthropic Messages API base URL (overridable for tests/proxies).
+    #[arg(long, env = "SUBAGENT_CACHE_JUDGE_API_BASE", default_value = "https://api.anthropic.com")]
+    pub judge_api_base: String,
+
+    /// Judge model id. A Haiku-class model; overridable as model ids roll.
+    #[arg(long, env = "SUBAGENT_CACHE_JUDGE_MODEL", default_value = "claude-haiku-4-5")]
+    pub judge_model: String,
+}

--- a/packages/agent/subagent-cache/src/error.rs
+++ b/packages/agent/subagent-cache/src/error.rs
@@ -1,0 +1,64 @@
+//! Typed errors for the daemon. snafu only; source errors are preserved and
+//! never interpolated into the display string.
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("the cache database URL is not a valid Postgres connection string"))]
+    DbConfig { source: tokio_postgres::Error },
+
+    #[snafu(display("failed to build the cache database connection pool"))]
+    PoolBuild { source: deadpool_postgres::BuildError },
+
+    #[snafu(display("failed to acquire a cache database connection from the pool"))]
+    Pool { source: deadpool_postgres::PoolError },
+
+    #[snafu(display("failed to apply the cache schema"))]
+    Schema { source: tokio_postgres::Error },
+
+    #[snafu(display("recall query failed for agent_type {agent_type}"))]
+    Recall {
+        agent_type: String,
+        source: tokio_postgres::Error,
+    },
+
+    #[snafu(display("populate upsert failed for agent_type {agent_type}"))]
+    Populate {
+        agent_type: String,
+        source: tokio_postgres::Error,
+    },
+
+    #[snafu(display("failed to encode file_deps as JSON"))]
+    JsonEncode { source: serde_json::Error },
+
+    #[snafu(display("a stored file_deps value could not be decoded"))]
+    JsonDecode { source: serde_json::Error },
+
+    #[snafu(display("the judge request to {model} failed to send"))]
+    JudgeSend {
+        model: String,
+        source: reqwest::Error,
+    },
+
+    #[snafu(display("the judge returned HTTP {status}: {body}"))]
+    JudgeStatus { status: u16, body: String },
+
+    #[snafu(display("the judge response could not be decoded"))]
+    JudgeDecode { source: reqwest::Error },
+
+    #[snafu(display("the ANTHROPIC_API_KEY environment variable is not set"))]
+    MissingApiKey,
+
+    #[snafu(display("failed to bind the HTTP listener on {bind}"))]
+    Bind {
+        bind: std::net::SocketAddr,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("the HTTP server exited with an error"))]
+    Serve { source: std::io::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/packages/agent/subagent-cache/src/http.rs
+++ b/packages/agent/subagent-cache/src/http.rs
@@ -1,0 +1,137 @@
+//! axum HTTP surface: `/lookup`, `/populate`, `/healthz`, plus the lookup
+//! instrumentation that lets v1 measure its own hit rate.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::Router;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use deadpool_postgres::Pool;
+
+use crate::config::Config;
+use crate::error::Error;
+use crate::types::{Candidate, LookupRequest, LookupResponse, OutcomeRequest, PopulateRequest};
+use crate::{judge, store};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub pool: Pool,
+    pub http: reqwest::Client,
+    pub api_key: Arc<str>,
+    pub config: Arc<Config>,
+}
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/healthz", get(|| async { "ok" }))
+        .route("/lookup", post(lookup))
+        .route("/outcome", post(outcome))
+        .route("/populate", post(populate))
+        .with_state(state)
+}
+
+async fn lookup(
+    State(state): State<AppState>,
+    Json(req): Json<LookupRequest>,
+) -> Result<Json<LookupResponse>, Error> {
+    let cfg = &state.config;
+    let recalled = store::recall(
+        &state.pool,
+        store::RecallParams {
+            prompt: &req.prompt,
+            agent_type: &req.agent_type,
+            agent_def_hash: &req.agent_def_hash,
+            floor: cfg.recall_floor,
+            top_k: cfg.recall_top_k,
+        },
+    )
+    .await?;
+
+    if recalled.is_empty() {
+        tracing::info!(
+            target: "subagent_cache.lookup",
+            agent_type = %req.agent_type,
+            recalled = 0,
+            judged = 0,
+            result = "miss",
+            "lookup miss: no candidate cleared the recall floor",
+        );
+        return Ok(Json(LookupResponse {
+            candidates: Vec::new(),
+        }));
+    }
+
+    let accepted = judge::judge(
+        &judge::JudgeApi {
+            http: &state.http,
+            api_base: &cfg.judge_api_base,
+            api_key: &state.api_key,
+            model: &cfg.judge_model,
+        },
+        &req.prompt,
+        &recalled,
+    )
+    .await?;
+
+    let candidates: Vec<Candidate> = accepted
+        .iter()
+        .filter_map(|&i| recalled.get(i))
+        .map(|row| Candidate {
+            id: row.id,
+            findings: row.findings.clone(),
+            file_deps: row.file_deps.clone(),
+        })
+        .collect();
+
+    tracing::info!(
+        target: "subagent_cache.lookup",
+        agent_type = %req.agent_type,
+        recalled = recalled.len(),
+        judged = candidates.len(),
+        result = if candidates.is_empty() { "miss" } else { "hit" },
+        "lookup complete (client validates freshness)",
+    );
+
+    Ok(Json(LookupResponse { candidates }))
+}
+
+async fn outcome(Json(req): Json<OutcomeRequest>) -> StatusCode {
+    let candidate_id = req
+        .candidate_id
+        .map(|id| id.to_string())
+        .unwrap_or_default();
+    tracing::info!(
+        target: "subagent_cache.outcome",
+        agent_type = %req.agent_type,
+        outcome = req.outcome.as_str(),
+        candidate_id = %candidate_id,
+        "lookup outcome resolved by client",
+    );
+    StatusCode::NO_CONTENT
+}
+
+async fn populate(
+    State(state): State<AppState>,
+    Json(req): Json<PopulateRequest>,
+) -> Result<StatusCode, Error> {
+    store::populate(&state.pool, &req, state.config.ttl_days).await?;
+    tracing::info!(
+        target: "subagent_cache.populate",
+        agent_type = %req.agent_type,
+        deps = req.file_deps.len(),
+        "populated cache entry",
+    );
+    Ok(StatusCode::NO_CONTENT)
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        // Every variant is an internal failure from the client's view; the
+        // hook fails open to a cold run, so the body is for operators only.
+        tracing::error!(error = %snafu::Report::from_error(self), "request failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
+    }
+}

--- a/packages/agent/subagent-cache/src/judge.rs
+++ b/packages/agent/subagent-cache/src/judge.rs
@@ -1,0 +1,165 @@
+//! Stage 2: the precision gate. A single Haiku-class Messages API call decides
+//! which recalled candidates genuinely answer the new question.
+//!
+//! This is a one-shot structured yes/no, so it is a thin `reqwest` call to the
+//! Anthropic Messages API rather than the `claude` agent CLI (which exists for
+//! multi-turn turns, not a stateless classification) or a vendored SDK (a large
+//! surface for one endpoint). The key is read from the process environment and
+//! never placed on argv.
+//!
+//! The gate is governed by the correctness asymmetry: a false miss only costs a
+//! redundant cold run, a false hit serves a wrong answer. So the prompt is
+//! biased to exclude under doubt, and any decode/parse failure is fail-closed
+//! (treated as "no candidate matched").
+
+use serde::Deserialize;
+
+use crate::error::{JudgeDecodeSnafu, JudgeSendSnafu, JudgeStatusSnafu, Result};
+use crate::store::RecallRow;
+
+const SYSTEM: &str = "You are a strict cache-hit judge. You are given a NEW question and \
+a numbered list of CACHED investigations (each: the question it answered and the files it \
+read). Decide which cached investigations genuinely answer the NEW question with the same \
+intent and scope. Be conservative: if a cached entry is merely on the same topic but a \
+different question, depth, or scope, EXCLUDE it. A wrong inclusion serves a stale or \
+off-target answer, which is far worse than excluding a usable one. Reply with ONLY a \
+comma-separated list of the matching numbers (e.g. `1,3`), or `NONE` if none match.";
+
+/// Path cap so a wide investigation does not blow up the judge prompt.
+const MAX_DEP_PATHS: usize = 25;
+
+#[derive(Debug, Deserialize)]
+struct MessagesResponse {
+    content: Vec<ContentBlock>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContentBlock {
+    #[serde(default)]
+    text: String,
+}
+
+/// `max_tokens` for the judge reply: it only ever emits a short index list.
+const JUDGE_MAX_TOKENS: u32 = 64;
+
+/// The Anthropic Messages endpoint the judge calls, bundled so the call site
+/// stays within the 3-argument limit.
+#[derive(Debug, Clone, Copy)]
+pub struct JudgeApi<'a> {
+    pub http: &'a reqwest::Client,
+    pub api_base: &'a str,
+    pub api_key: &'a str,
+    pub model: &'a str,
+}
+
+/// Returns the indices (into `candidates`) the judge accepts, preserving the
+/// best-first recall order. An empty result means run cold.
+///
+/// # Errors
+/// Errors if the judge request fails to send, returns a non-success HTTP
+/// status, or the response body cannot be decoded.
+pub async fn judge(
+    api: &JudgeApi<'_>,
+    new_prompt: &str,
+    candidates: &[RecallRow],
+) -> Result<Vec<usize>> {
+    use snafu::ResultExt;
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let user = render_prompt(new_prompt, candidates);
+    let body = serde_json::json!({
+        "model": api.model,
+        "max_tokens": JUDGE_MAX_TOKENS,
+        "system": SYSTEM,
+        "messages": [{ "role": "user", "content": user }],
+    });
+
+    let resp = api
+        .http
+        .post(format!("{}/v1/messages", api.api_base))
+        .header("x-api-key", api.api_key)
+        .header("anthropic-version", "2023-06-01")
+        .json(&body)
+        .send()
+        .await
+        .context(JudgeSendSnafu { model: api.model.to_owned() })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        return JudgeStatusSnafu { status, body }.fail();
+    }
+
+    let parsed: MessagesResponse = resp.json().await.context(JudgeDecodeSnafu)?;
+    let text: String = parsed.content.iter().map(|b| b.text.as_str()).collect();
+    Ok(parse_indices(&text, candidates.len()))
+}
+
+fn render_prompt(new_prompt: &str, candidates: &[RecallRow]) -> String {
+    let mut s = String::new();
+    s.push_str("NEW question:\n");
+    s.push_str(new_prompt);
+    s.push_str("\n\nCACHED investigations:\n");
+    for (i, c) in candidates.iter().enumerate() {
+        let paths: Vec<&str> = c
+            .file_deps
+            .iter()
+            .take(MAX_DEP_PATHS)
+            .map(|d| d.path.as_str())
+            .collect();
+        s.push_str(&(i + 1).to_string());
+        s.push_str(". question: ");
+        s.push_str(&c.question);
+        s.push_str("\n   files: ");
+        s.push_str(&paths.join(", "));
+        s.push('\n');
+    }
+    s
+}
+
+/// Extract 1-based numbers from the judge reply and map them to in-range 0-based
+/// indices, deduped and order-preserving. Fail-closed: junk yields no hits.
+fn parse_indices(text: &str, n: usize) -> Vec<usize> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for token in text.split(|c: char| !c.is_ascii_digit()) {
+        if token.is_empty() {
+            continue;
+        }
+        if let Ok(num) = token.parse::<usize>()
+            && num >= 1
+            && num <= n
+            && seen.insert(num)
+        {
+            out.push(num - 1);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_indices;
+
+    #[test]
+    fn parses_comma_list() {
+        assert_eq!(parse_indices("1,3", 3), vec![0, 2]);
+    }
+
+    #[test]
+    fn ignores_out_of_range_and_dupes() {
+        assert_eq!(parse_indices("2, 2, 9", 3), vec![1]);
+    }
+
+    #[test]
+    fn none_yields_empty() {
+        assert!(parse_indices("NONE", 3).is_empty());
+    }
+
+    #[test]
+    fn junk_is_fail_closed() {
+        assert!(parse_indices("maybe the first one?", 3).is_empty());
+    }
+}

--- a/packages/agent/subagent-cache/src/lib.rs
+++ b/packages/agent/subagent-cache/src/lib.rs
@@ -1,0 +1,13 @@
+//! Content-validated cache for subagent investigations (ENG-4665).
+//!
+//! The daemon owns Stage-1 FTS recall and the Stage-2 Haiku judge over a
+//! dedicated Postgres. Stage-3 freshness (re-hashing dependency files) and the
+//! persona check live in the client hook, because only the client can see its
+//! working tree. See `04-plan-subagent-cache.md` for the protocol contract.
+
+pub mod config;
+pub mod error;
+pub mod http;
+pub mod judge;
+pub mod store;
+pub mod types;

--- a/packages/agent/subagent-cache/src/main.rs
+++ b/packages/agent/subagent-cache/src/main.rs
@@ -19,7 +19,13 @@ const MAX_DB_CONNECTIONS: usize = 8;
 #[snafu::report]
 #[tokio::main]
 async fn main() -> Result<()> {
+    // JSON logs to stderr: structured `target` + `fields` per event. A log
+    // shipper that ingests the systemd journal (e.g. the ix fleet's Vector ->
+    // ClickHouse pipeline, which parses a JSON MESSAGE into typed columns) gets
+    // the `target`, `agent_type`, and `outcome` fields the cache-observability
+    // dashboards key on, instead of an opaque text line.
     tracing_subscriber::fmt()
+        .json()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/packages/agent/subagent-cache/src/main.rs
+++ b/packages/agent/subagent-cache/src/main.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use clap::Parser;
+use deadpool_postgres::{Manager, Pool};
+use snafu::{OptionExt, ResultExt};
+use tokio_postgres::NoTls;
+
+use subagent_cache::config::Config;
+use subagent_cache::error::{
+    BindSnafu, DbConfigSnafu, MissingApiKeySnafu, PoolBuildSnafu, Result, ServeSnafu,
+};
+use subagent_cache::http::{AppState, router};
+use subagent_cache::store;
+
+/// Connection pool ceiling. The daemon is low-traffic (one call per subagent
+/// launch), so a small pool is ample.
+const MAX_DB_CONNECTIONS: usize = 8;
+
+#[snafu::report]
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let config = Config::parse();
+
+    // Read once at startup so a misconfigured deploy fails fast rather than on
+    // the first lookup. Never placed on argv.
+    let api_key: Arc<str> = std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty())
+        .context(MissingApiKeySnafu)?
+        .into();
+
+    // NoTls: the daemon co-locates with its dedicated Postgres and reaches it
+    // over the trusted host/vrack address, never the public internet.
+    let pg_config: tokio_postgres::Config =
+        config.database_url.parse().context(DbConfigSnafu)?;
+    let manager = Manager::new(pg_config, NoTls);
+    let pool: Pool = Pool::builder(manager)
+        .max_size(MAX_DB_CONNECTIONS)
+        .build()
+        .context(PoolBuildSnafu)?;
+    store::bootstrap(&pool).await?;
+
+    let bind = config.bind;
+    let state = AppState {
+        pool,
+        http: reqwest::Client::new(),
+        api_key,
+        config: Arc::new(config),
+    };
+
+    let listener = tokio::net::TcpListener::bind(bind)
+        .await
+        .context(BindSnafu { bind })?;
+    tracing::info!(%bind, "subagent-cache listening");
+
+    // Drain in-flight requests on SIGINT (ctrl_c). systemd's SIGTERM stop is an
+    // abrupt kill here, which is fine: the cache is fail-open, so a hard stop
+    // only costs cold runs, never correctness.
+    axum::serve(listener, router(state))
+        .with_graceful_shutdown(async {
+            let _ = tokio::signal::ctrl_c().await;
+            tracing::info!("shutting down");
+        })
+        .await
+        .context(ServeSnafu)?;
+    Ok(())
+}

--- a/packages/agent/subagent-cache/src/store.rs
+++ b/packages/agent/subagent-cache/src/store.rs
@@ -1,0 +1,133 @@
+//! Postgres-backed storage: schema bootstrap, Stage-1 FTS recall, and populate.
+//!
+//! `tokio-postgres` over a `deadpool` pool (no sqlx: its sqlite driver links the
+//! `sqlite3` native lib and collides with `rusqlite` elsewhere in this
+//! workspace). Plain runtime queries, so the crate builds without a live
+//! database or an offline query cache.
+
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Pool;
+use snafu::ResultExt;
+
+use crate::error::{JsonDecodeSnafu, JsonEncodeSnafu, PoolSnafu, PopulateSnafu, RecallSnafu, Result, SchemaSnafu};
+use crate::types::{FileDep, PopulateRequest};
+
+const SCHEMA: &str = include_str!("../schema.sql");
+
+/// One FTS candidate before judging and freshness validation.
+#[derive(Debug, Clone)]
+pub struct RecallRow {
+    pub id: uuid::Uuid,
+    pub question: String,
+    pub findings: String,
+    pub file_deps: Vec<FileDep>,
+    pub score: f32,
+}
+
+/// Apply the schema. Idempotent: safe to run on every startup.
+///
+/// # Errors
+/// Errors if a pooled connection cannot be acquired or the schema statements
+/// fail to execute.
+pub async fn bootstrap(pool: &Pool) -> Result<()> {
+    let client = pool.get().await.context(PoolSnafu)?;
+    client.batch_execute(SCHEMA).await.context(SchemaSnafu)?;
+    Ok(())
+}
+
+/// Inputs to a Stage-1 recall query.
+#[derive(Debug, Clone, Copy)]
+pub struct RecallParams<'a> {
+    pub prompt: &'a str,
+    pub agent_type: &'a str,
+    /// Persona hash; folds the persona check into the recall filter.
+    pub agent_def_hash: &'a str,
+    /// Minimum `ts_rank` for a candidate to reach the judge.
+    pub floor: f32,
+    /// Max candidates the judge may inspect.
+    pub top_k: i64,
+}
+
+/// Stage 1: rank non-expired rows of the same `agent_type` and persona by
+/// full-text relevance, returning the top-K above the recall floor, best-first.
+///
+/// # Errors
+/// Errors if a pooled connection cannot be acquired, the recall query fails, or
+/// a stored `file_deps` value cannot be decoded.
+pub async fn recall(pool: &Pool, params: RecallParams<'_>) -> Result<Vec<RecallRow>> {
+    let client = pool.get().await.context(PoolSnafu)?;
+    let rows = client
+        .query(
+            "SELECT id, question, findings, file_deps, \
+                    ts_rank(question_tsv, plainto_tsquery('english', $1)) AS score \
+             FROM subagent_cache \
+             WHERE agent_type = $2 AND agent_def_hash = $3 AND expires_at > now() \
+               AND question_tsv @@ plainto_tsquery('english', $1) \
+             ORDER BY score DESC \
+             LIMIT $4",
+            &[
+                &params.prompt,
+                &params.agent_type,
+                &params.agent_def_hash,
+                &params.top_k,
+            ],
+        )
+        .await
+        .context(RecallSnafu { agent_type: params.agent_type.to_owned() })?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let score: f32 = row.get("score");
+        // The floor gates whether the judge fires at all; apply it after the
+        // ranked fetch so the SQL evaluates `ts_rank` only once.
+        if score < params.floor {
+            continue;
+        }
+        let file_deps_json: serde_json::Value = row.get("file_deps");
+        let file_deps: Vec<FileDep> = serde_json::from_value(file_deps_json).context(JsonDecodeSnafu)?;
+        out.push(RecallRow {
+            id: row.get("id"),
+            question: row.get("question"),
+            findings: row.get("findings"),
+            file_deps,
+            score,
+        });
+    }
+    Ok(out)
+}
+
+/// Upsert one finished investigation onto the (`agent_type`, question, persona)
+/// key. The TTL backstop is computed here and stored as an absolute instant.
+///
+/// # Errors
+/// Errors if `file_deps` cannot be encoded, a pooled connection cannot be
+/// acquired, or the upsert fails.
+pub async fn populate(pool: &Pool, req: &PopulateRequest, ttl_days: i64) -> Result<()> {
+    let expires_at: DateTime<Utc> = Utc::now() + chrono::Duration::days(ttl_days);
+    let file_deps = serde_json::to_value(&req.file_deps).context(JsonEncodeSnafu)?;
+    let client = pool.get().await.context(PoolSnafu)?;
+    client
+        .execute(
+            "INSERT INTO subagent_cache \
+                (agent_type, question, findings, agent_def_hash, model, file_deps, expires_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7) \
+             ON CONFLICT (agent_type, question, agent_def_hash) DO UPDATE SET \
+                findings = EXCLUDED.findings, \
+                model = EXCLUDED.model, \
+                file_deps = EXCLUDED.file_deps, \
+                created_at = now(), \
+                expires_at = EXCLUDED.expires_at",
+            &[
+                &req.agent_type,
+                &req.prompt,
+                &req.findings,
+                &req.agent_def_hash,
+                &req.model,
+                &file_deps,
+                &expires_at,
+            ],
+        )
+        .await
+        .context(PopulateSnafu { agent_type: req.agent_type.clone() })?;
+    Ok(())
+}

--- a/packages/agent/subagent-cache/src/types.rs
+++ b/packages/agent/subagent-cache/src/types.rs
@@ -1,0 +1,84 @@
+//! Wire types shared by the `/lookup` and `/populate` endpoints.
+//!
+//! The daemon never touches the filesystem: clients compute every file hash
+//! (they alone can see the working tree), so `file_deps` hashes are opaque
+//! strings here. Stage-3 freshness (re-hashing those deps against disk) and the
+//! persona check are owned by the client hook; the daemon owns Stage-1 recall
+//! and Stage-2 judging only.
+
+use serde::{Deserialize, Serialize};
+
+/// One file the subagent read, with the content hash recorded at populate time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileDep {
+    pub path: String,
+    /// mgrep's `xxh64:<16 hex>` format, treated opaquely by the daemon.
+    pub hash: String,
+}
+
+/// `POST /lookup` request body.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LookupRequest {
+    pub agent_type: String,
+    pub prompt: String,
+    /// xxh64 of the client's local `.claude/agents/<agent_type>.md`. Folds the
+    /// persona check into the recall filter.
+    pub agent_def_hash: String,
+}
+
+/// One judge-positive candidate returned to the client for local freshness
+/// validation.
+#[derive(Debug, Clone, Serialize)]
+pub struct Candidate {
+    pub id: uuid::Uuid,
+    pub findings: String,
+    pub file_deps: Vec<FileDep>,
+}
+
+/// `POST /lookup` response: judge-positive candidates, best-first. An empty list
+/// means the client should run the subagent cold.
+#[derive(Debug, Clone, Serialize)]
+pub struct LookupResponse {
+    pub candidates: Vec<Candidate>,
+}
+
+/// `POST /populate` request body: one finished investigation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PopulateRequest {
+    pub agent_type: String,
+    pub prompt: String,
+    pub findings: String,
+    pub agent_def_hash: String,
+    pub model: Option<String>,
+    pub file_deps: Vec<FileDep>,
+}
+
+/// `POST /outcome` request body: the client-side Stage-3 resolution for one
+/// lookup attempt. This is log-only telemetry; the daemon does not persist it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OutcomeRequest {
+    pub agent_type: String,
+    pub outcome: Outcome,
+    pub candidate_id: Option<uuid::Uuid>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    Served,
+    Stale,
+    Oversize,
+    Miss,
+}
+
+impl Outcome {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Served => "served",
+            Self::Stale => "stale",
+            Self::Oversize => "oversize",
+            Self::Miss => "miss",
+        }
+    }
+}

--- a/packages/agent/subagent-cache/tests/store_integration.rs
+++ b/packages/agent/subagent-cache/tests/store_integration.rs
@@ -1,0 +1,84 @@
+//! Integration test for the storage layer against a real Postgres.
+//!
+//! Skipped unless `SUBAGENT_CACHE_TEST_DATABASE_URL` points at a throwaway
+//! database (the only thing that can exercise the generated `tsvector` column
+//! and `ts_rank`). Run locally with e.g.
+//!   `SUBAGENT_CACHE_TEST_DATABASE_URL=postgres://localhost/sac_test` cargo test
+//! The bootstrap is idempotent, so the test applies the schema twice.
+
+use deadpool_postgres::{Manager, Pool};
+use subagent_cache::store;
+use subagent_cache::types::{FileDep, PopulateRequest};
+use tokio_postgres::NoTls;
+
+fn dep(path: &str, hash: &str) -> FileDep {
+    FileDep { path: path.to_owned(), hash: hash.to_owned() }
+}
+
+#[tokio::test]
+async fn populate_then_recall_roundtrip() {
+    let Ok(url) = std::env::var("SUBAGENT_CACHE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: SUBAGENT_CACHE_TEST_DATABASE_URL not set");
+        return;
+    };
+
+    let pg_config: tokio_postgres::Config = url.parse().expect("parse url");
+    let pool: Pool = Pool::builder(Manager::new(pg_config, NoTls))
+        .build()
+        .expect("pool");
+    pool.get()
+        .await
+        .expect("connect")
+        .batch_execute("DROP TABLE IF EXISTS subagent_cache")
+        .await
+        .expect("drop");
+
+    // Idempotent: bootstrap twice.
+    store::bootstrap(&pool).await.expect("bootstrap 1");
+    store::bootstrap(&pool).await.expect("bootstrap 2");
+
+    let req = PopulateRequest {
+        agent_type: "explore".into(),
+        prompt: "how does the room turn lifecycle work".into(),
+        findings: "the lifecycle is ...".into(),
+        agent_def_hash: "xxh64:1111111111111111".into(),
+        model: Some("claude-sonnet".into()),
+        file_deps: vec![dep("crates/room/server/src/lib.rs", "xxh64:abc")],
+    };
+    store::populate(&pool, &req, 7).await.expect("populate");
+
+    // Same key upserts in place (no duplicate row).
+    store::populate(&pool, &req, 7).await.expect("re-populate");
+
+    // Recall on overlapping keywords, matching agent_type + persona.
+    let rows = store::recall(
+        &pool,
+        store::RecallParams {
+            prompt: "room turn lifecycle",
+            agent_type: "explore",
+            agent_def_hash: "xxh64:1111111111111111",
+            floor: 0.0,
+            top_k: 3,
+        },
+    )
+    .await
+    .expect("recall");
+    assert_eq!(rows.len(), 1, "exactly one live entry");
+    assert_eq!(rows[0].findings, "the lifecycle is ...");
+    assert_eq!(rows[0].file_deps.len(), 1);
+
+    // Wrong persona => filtered out.
+    let none = store::recall(
+        &pool,
+        store::RecallParams {
+            prompt: "room turn lifecycle",
+            agent_type: "explore",
+            agent_def_hash: "xxh64:ffff",
+            floor: 0.0,
+            top_k: 3,
+        },
+    )
+    .await
+    .expect("recall persona");
+    assert!(none.is_empty(), "persona mismatch must not recall");
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3400,6 +3400,36 @@ let
       }
     ];
 
+    subagent-cache =
+      let
+        svc =
+          (evalConfig [
+            {
+              services.subagent-cache = {
+                enable = true;
+                bind = "100.64.0.1:3013";
+                databaseUrlFile = "/run/subagent-cache/database-url";
+                apiKeyFile = "/run/subagent-cache/anthropic-api-key";
+                ttlDays = 14;
+              };
+            }
+          ]).systemd.services.subagent-cache;
+      in
+      [
+        {
+          assertion =
+            svc.environment.SUBAGENT_CACHE_BIND == "100.64.0.1:3013"
+            && svc.environment.SUBAGENT_CACHE_TTL_DAYS == "14";
+          message = "subagent-cache module should pass bind and ttlDays through to the daemon env";
+        }
+        {
+          # Secrets are read from runtime files in the start script, never baked
+          # into the unit environment (which lands in the world-readable store).
+          assertion = !(svc.environment ? DATABASE_URL) && !(svc.environment ? ANTHROPIC_API_KEY);
+          message = "subagent-cache module must keep secrets out of the unit environment";
+        }
+      ];
+
     vitest = [
       {
         assertion = builtins.length vitestWorkspaceCases == 2;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3408,8 +3408,7 @@ let
               services.subagent-cache = {
                 enable = true;
                 bind = "100.64.0.1:3013";
-                databaseUrlFile = "/run/subagent-cache/database-url";
-                apiKeyFile = "/run/subagent-cache/anthropic-api-key";
+                environmentFiles = [ "/run/subagent-cache/db.env" ];
                 ttlDays = 14;
               };
             }
@@ -3423,10 +3422,13 @@ let
           message = "subagent-cache module should pass bind and ttlDays through to the daemon env";
         }
         {
-          # Secrets are read from runtime files in the start script, never baked
-          # into the unit environment (which lands in the world-readable store).
-          assertion = !(svc.environment ? DATABASE_URL) && !(svc.environment ? ANTHROPIC_API_KEY);
-          message = "subagent-cache module must keep secrets out of the unit environment";
+          # Secrets ride EnvironmentFile, never the unit environment (which lands
+          # in the world-readable store).
+          assertion =
+            svc.serviceConfig.EnvironmentFile == [ "/run/subagent-cache/db.env" ]
+            && !(svc.environment ? DATABASE_URL)
+            && !(svc.environment ? ANTHROPIC_API_KEY);
+          message = "subagent-cache module must deliver secrets via EnvironmentFile, not the unit environment";
         }
       ];
 


### PR DESCRIPTION
Moves the entire ENG-4665 subagent investigation cache into index so it ships as the single owner: the daemon, the client hooks, and the NixOS service module. ix will consume this via the flake input and keep the DB + daemon hosted on hil-compute-2 (companion ix PR).

## What's here

- **Daemon crate** `packages/agent/subagent-cache` (axum + Postgres + one-shot Haiku judge). Ported from `ix/crates/tools/subagent-cache` with two forced redos:
  - `sqlx` → `tokio-postgres` + `deadpool-postgres`. `sqlx`'s sqlite driver links the `sqlite3` native lib and collides with `rusqlite` (the `indexer` crate) on cargo's `links` rule, so `sqlx` cannot enter this workspace at all. The Postgres wire protocol, SQL, and `schema.sql` are byte-identical, so the cache is drop-in compatible with any existing data.
  - dropped the ix-internal `service-init` dep for index's daemon idiom (`tracing_subscriber::fmt().init()` + `tokio::signal::ctrl_c` graceful shutdown). `/healthz` already covers liveness.
- **Client hooks** as two subcommands of `packages/agent/claude-hooks` (`subagent-cache-lookup` on PreToolUse/`Agent`, `subagent-cache-populate` on SubagentStop), wired into `claude-code`'s `settingsDefaults.hooks` so the cache is **non-optional fleet-wide**. Both fail open and silent: they POST to `SUBAGENT_CACHE_URL` and no-op when it is unset or the daemon is unreachable, so they are inert off the tailnet. xxh64 (seed 0) matches mgrep; `reqwest::blocking` for the one-shot POSTs; kill switch `CLAUDE_CODE_DISABLE_SUBAGENT_CACHE`.
- **NixOS module** `nixosModules.subagent-cache` (`services.subagent-cache`): generic, owns the systemd unit + non-secret config, takes the Postgres URL and Anthropic key as runtime file paths. The consumer supplies secrets + placement + firewalling by merging onto the service.

```mermaid
flowchart LR
  hooks["claude-hooks: lookup + populate"] --> cc["claude-code settingsDefaults.hooks"]
  hooks -->|"POST SUBAGENT_CACHE_URL"| daemon["subagent-cache daemon"]
  mod["nixosModules.subagent-cache"] --> daemon
  daemon --> pg[("Postgres")]
```

## Verification

`nix build` passes for `.#subagent-cache`, `.#claude-code`, and these checks: `rust-subagent-cache-{clippy,unusedCrateDependencies,subagent_cache-all,package}`, `rust-claude-hooks-{clippy,unusedCrateDependencies,claude-hooks-all,package}`, and `eval` (the new `subagent-cache` module assertions). Lock churn is minimal (only the new Postgres + xxhash subtrees; zero unrelated bumps).

The repo `lint` check is red, but it is **red on `origin/main` already** (38 pre-existing astlog findings + unformatted `modules/services/humanlayer` and `packages/mcp`); this branch adds no new astlog/nixfmt findings (verified `nixfmt --check` clean on every file it touches).

Refs ENG-4665.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add subagent-cache daemon, client hooks, and NixOS service module
> - Introduces a new `subagent-cache` HTTP daemon ([Cargo.toml](https://github.com/indexable-inc/index/pull/1475/files#diff-7b87e40e11291c33b6bb548a1e690a351307271af960a30da10522a007bc6bec)) backed by Postgres that stores and recalls subagent investigation results using full-text search and TTL management.
> - Adds `subagent-cache-lookup` (PreToolUse) and `subagent-cache-populate` (SubagentStop) subcommands to the `claude-hooks` binary; lookup short-circuits agent launches by denying with cached findings, populate persists results after a run.
> - The daemon calls the Anthropic Messages API via a judge step ([judge.rs](https://github.com/indexable-inc/index/pull/1475/files#diff-5916d785e7947a3c6087258484c15d3f039a6916526519c0ad858023974a96e9)) to filter recalled candidates before returning them to clients.
> - A new NixOS module ([modules/services/subagent-cache/default.nix](https://github.com/indexable-inc/index/pull/1475/files#diff-a4937ad4e74608240f025bede6b8b3557a21faf88ab35b09b44ce60aeb4834e9)) wires the daemon into systemd with configurable bind address, TTL, recall parameters, and secret injection via `EnvironmentFile`.
> - Behavioral Change: Claude sessions now invoke the cache hooks on every Agent tool use; hooks fail open and are silent when `SUBAGENT_CACHE_URL` is unset or `CLAUDE_CODE_DISABLE_SUBAGENT_CACHE` is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b30795f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->