### PR TITLE
feat(agent): unify Claude+Codex hooks into one compiled, shared declaration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,8 +1296,12 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "glob",
+ "libc",
+ "regex",
+ "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -6699,6 +6703,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -257,10 +257,11 @@ let
   #     gate fleet-wide anyway, since the default skip-flag already makes `ask`
   #     inert); the kernel `sh()` path carries no equivalent prompt.
 
-  # The three hooks (session-digest, worktree-guard, prompt-priors) are
-  # subcommands of one compiled binary, wrapped with their tool paths and the
-  # baked primary-checkout default; each fails open and silent. See ./hooks.nix
-  # for the full design, kill switches, and per-hook rationale.
+  # Every hook is a subcommand of one compiled binary, wrapped with its tool
+  # paths and the baked primary-checkout default; each fails open and silent.
+  # ./hooks.nix builds the binary (and its wrapper env); ../hooks.nix is the
+  # neutral declaration list (which subcommand on which event/matcher) shared
+  # with the codex wrapper.
   claudeHooks = import ./hooks.nix {
     inherit
       lib
@@ -272,7 +273,18 @@ let
       repoPackages
       ;
   };
-  hookCmd = sub: "${claudeHooks}/bin/claude-hooks ${sub}";
+  # The settings.json `hooks` block, rendered for Claude from the shared
+  # declaration list (the same list renders the codex wrapper's hooks). Located
+  # via ix.paths (the no-parent-path house rule forbids a `../` literal), same
+  # as the common.nix import above.
+  sharedHooks = import (ix.paths.packagesRoot + "/agent/hooks.nix") {
+    inherit
+      lib
+      claudeHooks
+      primaryCheckouts
+      repoPackages
+      ;
+  };
 
   # Tools denied via the flagSettings `permissions.deny` layer; see the
   # `permissions.deny` bullets in the doc block above for why each, and why deny
@@ -303,48 +315,9 @@ let
           ]
           ++ denyTools;
       };
-      hooks = {
-        SessionStart = [
-          {
-            hooks = [
-              {
-                type = "command";
-                command = hookCmd "session-digest";
-                # A local file read; generous next to the CLI's 60s default.
-                timeout = 5;
-              }
-            ];
-          }
-        ];
-        PreToolUse = lib.optional (primaryCheckouts != [ ]) {
-          matcher = "Edit|MultiEdit|Write|NotebookEdit";
-          hooks = [
-            {
-              type = "command";
-              command = hookCmd "worktree-guard";
-              # The hook runs a handful of local `git rev-parse` calls; well
-              # past that something is wedged and failing open beats stalling
-              # every edit.
-              timeout = 10;
-            }
-          ];
-        };
-      }
-      // lib.optionalAttrs (repoPackages ? search) {
-        UserPromptSubmit = [
-          {
-            hooks = [
-              {
-                type = "command";
-                command = hookCmd "prompt-priors";
-                # Generous ceiling over the script's own 2s search budget; the
-                # CLI default is 60s, far past fail-open.
-                timeout = 5;
-              }
-            ];
-          }
-        ];
-      };
+      # The full hook set (context injectors, guards, review pair, friction) for
+      # Claude, rendered from the shared declaration list in ../hooks.nix.
+      hooks = sharedHooks.claude;
     }
     // lib.optionalAttrs dangerouslySkipPermissions {
       skipDangerousModePermissionPrompt = true;

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -202,5 +202,82 @@
     exit 1
   fi
 
+  # PreToolUse guards (cargo-guard, bash-habits-guard, search-guard): a shared
+  # deny/allow asserter on the JSON permissionDecision channel.
+  pre_guard() {
+    local sub="$1" desc="$2" expect="$3" input="$4" got verdict
+    got="$(printf '%s' "$input" | ${claudeHooks}/bin/claude-hooks "$sub")"
+    case "$got" in
+    ''') verdict=allow ;;
+    *'"permissionDecision":"deny"'*) verdict=deny ;;
+    *) verdict="unparsed: $got" ;;
+    esac
+    if [ "$verdict" != "$expect" ]; then
+      printf '%s check failed (%s): expected %s, got %s\n' "$sub" "$desc" "$expect" "$verdict" >&2
+      exit 1
+    fi
+  }
+
+  pre_guard cargo-guard "bare cargo in monorepo denied" deny \
+    '{"tool_name":"Bash","cwd":"/x/indexable-inc/ix","tool_input":{"command":"cargo test"}}'
+  pre_guard cargo-guard "nix-wrapped cargo allowed" allow \
+    '{"tool_name":"Bash","cwd":"/x/indexable-inc/ix","tool_input":{"command":"nix run .#run -- cargo test"}}'
+  pre_guard cargo-guard "cargo outside monorepo allowed" allow \
+    '{"tool_name":"Bash","cwd":"/tmp/other","tool_input":{"command":"cargo test"}}'
+  pre_guard cargo-guard "non-Bash tool fails open" allow '{"tool_name":"Edit"}'
+  pre_guard cargo-guard "malformed payload fails open" allow 'not json'
+
+  pre_guard bash-habits-guard "stderr to /dev/null denied" deny \
+    '{"tool_name":"Bash","tool_input":{"command":"make 2>/dev/null"}}'
+  pre_guard bash-habits-guard "plain stdout /dev/null allowed" allow \
+    '{"tool_name":"Bash","tool_input":{"command":"make >/dev/null"}}'
+  pre_guard bash-habits-guard "recursive grep denied" deny \
+    '{"tool_name":"Bash","tool_input":{"command":"grep -r foo ."}}'
+  pre_guard bash-habits-guard "no-verify denied" deny \
+    '{"tool_name":"Bash","tool_input":{"command":"git commit --no-verify"}}'
+  pre_guard bash-habits-guard "quoted mention not a false positive" allow \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo '2>/dev/null'\"}}"
+
+  pre_guard search-guard "Search tool denied" deny '{"tool_name":"Search"}'
+  pre_guard search-guard "WebSearch not denied" allow '{"tool_name":"WebSearch"}'
+
+  # Review pair: log-edit records an edited path, the Stop gate then blocks once
+  # (JSON decision:block) and consumes the marker; a stop_hook_active re-entry
+  # allows silently (the loop guard).
+  rstate="$PWD/review-state"
+  printf '%s' '{"session_id":"s1","tool_input":{"file_path":"/a/b.rs"}}' \
+    | CLAUDE_REVIEW_STATE_DIR="$rstate" ${claudeHooks}/bin/claude-hooks review-log-edit
+  gate="$(printf '%s' '{"session_id":"s1"}' \
+    | CLAUDE_REVIEW_STATE_DIR="$rstate" ${claudeHooks}/bin/claude-hooks review-gate)"
+  case "$gate" in
+  *'"decision":"block"'*) : ;;
+  *) printf 'review-gate check failed: expected decision:block, got:\n%s\n' "$gate" >&2; exit 1 ;;
+  esac
+  again="$(printf '%s' '{"session_id":"s1"}' \
+    | CLAUDE_REVIEW_STATE_DIR="$rstate" ${claudeHooks}/bin/claude-hooks review-gate)"
+  if [ -n "$again" ]; then
+    printf 'review-gate check failed: consumed marker should allow silently, got:\n%s\n' "$again" >&2
+    exit 1
+  fi
+  loop="$(printf '%s' '{"session_id":"s1","stop_hook_active":true}' \
+    | CLAUDE_REVIEW_STATE_DIR="$rstate" ${claudeHooks}/bin/claude-hooks review-gate)"
+  if [ -n "$loop" ]; then
+    printf 'review-gate check failed: stop_hook_active must allow silently, got:\n%s\n' "$loop" >&2
+    exit 1
+  fi
+
+  # friction-report self-gates on an ix-contributor git author; the sandbox has
+  # no git identity, so it must exit 0 silently (never block Stop, never file).
+  if [ -n "$(printf '%s' '{"session_id":"s1","transcript_path":"/dev/null"}' \
+    | HOME="$PWD/no-home" GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+      ${claudeHooks}/bin/claude-hooks friction-report)" ]; then
+    printf 'friction-report check failed: non-contributor must exit silently\n' >&2
+    exit 1
+  fi
+
+  # session-banner is best-effort host introspection; assert only that it never
+  # crashes (fails open) on a minimal HOME.
+  HOME="$PWD/no-home" ${claudeHooks}/bin/claude-hooks session-banner </dev/null >/dev/null
+
   runHook postInstallCheck
 ''

--- a/packages/agent/claude-hooks/Cargo.toml
+++ b/packages/agent/claude-hooks/Cargo.toml
@@ -3,16 +3,27 @@ name = "claude-hooks"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
-description = "Claude Code hook commands (session-digest, worktree-guard, prompt-priors) as one compiled binary"
+description = "Claude Code/Codex hook commands (session-digest, worktree-guard, prompt-priors, review pair, bash/cargo/search guards, session-banner, friction-report) as one compiled binary"
 
 [lints]
 workspace = true
 
 [dependencies]
-chrono = { workspace = true, features = ["alloc"] }
+# `clock` for chrono::Local (friction-report log timestamps).
+chrono = { workspace = true, features = ["alloc", "clock"] }
 glob.workspace = true
+# friction-report files to Linear over HTTPS; blocking client keeps the detached
+# --analyze worker a plain synchronous process (no async runtime in a hook).
+reqwest = { workspace = true, features = ["blocking"] }
+# friction-report's single-flight flock, detached-session spawn (setsid), and
+# process-group SIGKILL on model timeout.
+libc.workspace = true
+regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+# friction-report routes the model child's stdout to a real temp file (not a
+# pipe), the immortal-worker fix preserved from the Python.
+tempfile.workspace = true
 
 [[bin]]
 name = "claude-hooks"

--- a/packages/agent/claude-hooks/src/friction.rs
+++ b/packages/agent/claude-hooks/src/friction.rs
@@ -1,0 +1,925 @@
+//! Compiled port of the personal `friction-report.py` Stop hook.
+//!
+//! It mines a finished session transcript for "friction" — every moment the
+//! session fell short of fully agentic work (user had to intervene, ambient
+//! context was missing, a tool was too weak, the agent got confused, work was
+//! slow) — and files each confirmed item to the Linear "Shitty" project. It
+//! reads both transcript dialects: Claude session JSONL and the codex fork's
+//! rollout JSONL.
+//!
+//! Like every hook in this crate it fails OPEN and SILENT: any missing input,
+//! parse error, network failure, or kill-switch returns quietly with nothing on
+//! stdout/stderr. A noisy or broken Stop hook is strictly worse than no hook,
+//! and Stop must never be blocked.
+//!
+//! Flow. The foreground half only validates stdin, re-spawns THIS SAME binary
+//! detached as `claude-hooks friction-report --analyze` (payload in env), and
+//! returns 0 immediately, so stopping is never blocked and a hook timeout can
+//! never bite. The detached `--analyze` half does the slow work (transcript
+//! delta, model call, Linear round-trips).
+//!
+//! Immortal-worker / process-group rationale (preserved verbatim from the
+//! Python): the model is `claude`, whose wrapper spawns a node grandchild. If
+//! its stdout is a PIPE, that grandchild inherits and holds the pipe open, so a
+//! `communicate()`-style read blocks past the timeout forever — workers went
+//! immortal and piled up (50+, load 80). So the model child gets stdout to a
+//! TEMP FILE (no pipe to block on) and runs in its OWN session/process group, so
+//! a timeout can `killpg` the whole tree, not just the direct child. The same
+//! `setsid` detach is used for the background `--analyze` worker.
+
+use std::ffi::OsString;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+use std::os::fd::AsRawFd as _;
+use std::os::unix::process::CommandExt as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+// Linear "Shitty" project (slug b30ae521fda7) and its team (ENG). UUIDs pinned
+// so hook time needs no lookup round-trip.
+const LINEAR_TEAM_ID: &str = "a8845362-21c7-4283-ba80-cea987a3ee74"; // ENG / Engineering
+const LINEAR_PROJECT_ID: &str = "acfc01e7-7246-4ebb-91f5-6d5bb8d1c476"; // Shitty
+
+const DEFAULT_LINEAR_URL: &str = "https://api.linear.app/graphql";
+const DEFAULT_MODEL: &str = "claude-haiku-4-5-20251001";
+const DEFAULT_CLAUDE_CMD: &str = "claude";
+const DEFAULT_MIN_DELTA_CHARS: usize = 600;
+
+const MAX_DELTA_CHARS: usize = 60_000;
+const MAX_ITEMS_PER_RUN: usize = 3;
+const MAX_ISSUES_PER_SESSION: usize = 12;
+const MODEL_TIMEOUT: Duration = Duration::from_mins(4);
+
+const SKIP_PREFIXES: &[&str] = &["<system-reminder>", "<command-", "<local-command"];
+
+const SYSTEM_PROMPT: &str = "You review a slice of an AI coding-agent session transcript and extract FRICTION: concrete moments where the session fell short of the ideal of fully agentic work that never needed the user. File an item only for:
+
+- user-intervention: the user had to step in mid-task: correct course, re-explain, answer something the agent should have known, or do part of the work manually.
+- missing-context: the agent lacked context that should have been ambient/global (project docs, CLAUDE.md/AGENTS.md, memory) and burned time rediscovering or guessing it.
+- weak-tool: a tool was not powerful enough, missing, confusing, or misleading, forcing workarounds or retries.
+- confusion: the agent misunderstood the codebase, task, or environment in a way better upfront info would have prevented.
+- slowdown: anything else that made the work clearly slower than it should have been.
+
+Output ONLY a JSON array, no prose, no code fences. [] when nothing clears the bar (the common case). Each item:
+{\"kind\":\"<one of the five>\",\"title\":\"<specific, <=80 chars>\",\"description\":\"<2-5 sentences: what happened, what the agent expected, and the smallest concrete change (new global context, tool improvement, doc) that would have prevented it. Briefly quote the decisive moment.>\"}
+
+High bar, at most 3 items. Normal iteration, the user stating a NEW requirement, routine tool output, and stylistic preferences are NOT friction. Every item must name the specific tool, file, or missing fact; generic complaints are worthless.";
+
+const MUTATION: &str = "mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { identifier url } } }";
+
+// --- env-backed config ---
+
+fn env_or(name: &str, default: &str) -> String {
+    std::env::var(name)
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_owned())
+}
+
+fn state_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("FRICTION_STATE_DIR").filter(|v| !v.is_empty()) {
+        return PathBuf::from(dir);
+    }
+    let home = std::env::var_os("HOME").map_or_else(|| PathBuf::from("/var/empty"), PathBuf::from);
+    home.join(".claude/.friction-state")
+}
+
+fn model() -> String {
+    env_or("FRICTION_MODEL", DEFAULT_MODEL)
+}
+
+fn min_delta_chars() -> usize {
+    std::env::var("FRICTION_MIN_DELTA")
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(DEFAULT_MIN_DELTA_CHARS)
+}
+
+// --- logging ---
+
+/// Timestamped line appended to `<state>/friction.log`; best-effort, never
+/// raises. This is the only output channel: nothing ever touches stdout/stderr.
+fn log(msg: &str) {
+    let dir = state_dir();
+    if fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let Ok(mut f) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("friction.log"))
+    else {
+        return;
+    };
+    let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S");
+    let _ = writeln!(f, "{ts} {msg}");
+}
+
+// --- per-session state ---
+
+struct State {
+    offset: u64,
+    filed: Vec<String>,
+}
+
+fn read_state(path: &Path) -> State {
+    if let Ok(text) = fs::read_to_string(path)
+        && let Ok(Value::Object(map)) = serde_json::from_str::<Value>(&text)
+    {
+        let offset = map.get("offset").and_then(Value::as_u64).unwrap_or(0);
+        let filed = map
+            .get("filed")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default();
+        return State { offset, filed };
+    }
+    State {
+        offset: 0,
+        filed: Vec::new(),
+    }
+}
+
+/// Atomic write via temp file + rename, mirroring the Python `os.replace`.
+fn write_state(path: &Path, state: &State) {
+    let body = json!({ "offset": state.offset, "filed": state.filed });
+    let Ok(serialized) = serde_json::to_vec(&body) else {
+        return;
+    };
+    let tmp = path.with_extension("json.tmp");
+    let Ok(mut f) = File::create(&tmp) else {
+        return;
+    };
+    if f.write_all(&serialized).is_err() {
+        return;
+    }
+    let _ = fs::rename(&tmp, path);
+}
+
+// --- transcript condensing ---
+//
+// Claude session JSONL wraps messages as {"type":"user"|"assistant",
+// "message":{"role","content":[...]}}; the codex rollout JSONL wraps them as
+// {"payload":{...}} with output_text/input_text content items and user_message
+// event payloads. Tool results ride user-role messages, so only their is_error
+// entries are kept, labeled distinctly.
+
+enum Labeled {
+    Text(String),
+    Error(String),
+}
+
+fn skip_text(s: &str) -> bool {
+    let lstripped = s.trim_start();
+    SKIP_PREFIXES.iter().any(|p| lstripped.starts_with(p))
+}
+
+fn labeled_texts(content: Option<&Value>) -> Vec<Labeled> {
+    let mut out = Vec::new();
+    match content {
+        Some(Value::String(s)) => out.push(Labeled::Text(s.clone())),
+        Some(Value::Array(items)) => {
+            for c in items {
+                let Some(obj) = c.as_object() else { continue };
+                let t = obj.get("type").and_then(Value::as_str);
+                match t {
+                    Some("text" | "output_text" | "input_text") => {
+                        if let Some(text) = obj.get("text").and_then(Value::as_str)
+                            && !text.is_empty()
+                        {
+                            out.push(Labeled::Text(text.to_owned()));
+                        }
+                    }
+                    Some("tool_result")
+                        if obj.get("is_error").and_then(Value::as_bool) == Some(true) =>
+                    {
+                        // json.dumps(content)[:400] — serialize even null.
+                        let dumped = serde_json::to_string(obj.get("content").unwrap_or(&Value::Null))
+                            .unwrap_or_else(|_| "null".to_owned());
+                        out.push(Labeled::Error(dumped.chars().take(400).collect()));
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+    out.retain(|l| {
+        let s = match l {
+            Labeled::Text(s) | Labeled::Error(s) => s,
+        };
+        !skip_text(s)
+    });
+    out
+}
+
+fn take_chars(s: &str, n: usize) -> String {
+    s.chars().take(n).collect()
+}
+
+fn condense(raw: &str) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for line in raw.lines() {
+        let Ok(mut obj) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if !obj.is_object() {
+            continue;
+        }
+        if obj.get("isMeta").and_then(Value::as_bool) == Some(true)
+            || obj.get("isCompactSummary").and_then(Value::as_bool) == Some(true)
+        {
+            continue;
+        }
+        // codex dialect: unwrap payload, with a special-case for user_message.
+        if let Some(payload) = obj.get("payload").filter(|p| p.is_object()).cloned() {
+            if payload.get("type").and_then(Value::as_str) == Some("user_message")
+                && let Some(message) = payload.get("message").filter(|m| !m.is_null())
+            {
+                let text = value_to_str(message);
+                parts.push(format!("USER: {}", take_chars(&text, 2000)));
+                continue;
+            }
+            obj = payload;
+        }
+        // message is the inner dict if present and a dict, else obj itself.
+        let msg = match obj.get("message") {
+            Some(m) if m.is_object() => m,
+            _ => &obj,
+        };
+        let role = msg.get("role").and_then(Value::as_str);
+        if role != Some("user") && role != Some("assistant") {
+            continue;
+        }
+        let role = role.unwrap_or_default();
+        for labeled in labeled_texts(msg.get("content")) {
+            match labeled {
+                Labeled::Error(text) => {
+                    parts.push(format!("TOOL ERROR: {}", take_chars(&text, 2000)));
+                }
+                Labeled::Text(text) => {
+                    parts.push(format!("{}: {}", role.to_uppercase(), take_chars(&text, 2000)));
+                }
+            }
+        }
+    }
+    parts.join("\n\n")
+}
+
+/// `str(x)` analogue for codex `payload.message`: a bare string is unquoted,
+/// anything else is its JSON repr (matching Python's `str(...)` closely enough
+/// for the labeled USER line).
+fn value_to_str(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Keep only the last `n` chars (the tail), like Python `delta[-n:]`.
+fn tail_chars(s: &str, n: usize) -> String {
+    let total = s.chars().count();
+    if total <= n {
+        return s.to_owned();
+    }
+    s.chars().skip(total - n).collect()
+}
+
+// --- model invocation ---
+
+#[derive(Clone)]
+struct Item {
+    kind: String,
+    title: String,
+    description: String,
+}
+
+/// Spawn `claude` headless and parse a JSON array of friction items. See the
+/// module doc for the temp-file-not-pipe + own-process-group rationale.
+fn ask_model(delta: &str, cwd: Option<&str>) -> Vec<Item> {
+    let claude_cmd = env_or("FRICTION_CLAUDE_CMD", DEFAULT_CLAUDE_CMD);
+    let model = model();
+    let user_prompt = format!(
+        "Extract friction items from this transcript slice (cwd: {}). Output only the JSON array.",
+        cwd.filter(|c| !c.is_empty()).unwrap_or("unknown")
+    );
+    let home = std::env::var_os("HOME").map_or_else(|| PathBuf::from("/"), PathBuf::from);
+
+    // stdout to a temp file, not a pipe.
+    let Ok(mut outf) = tempfile::tempfile() else {
+        log("model invocation failed: could not create temp file");
+        return Vec::new();
+    };
+    let Ok(out_for_child) = outf.try_clone() else {
+        log("model invocation failed: could not clone temp file");
+        return Vec::new();
+    };
+
+    let mut cmd = Command::new(&claude_cmd);
+    cmd.args([
+        "-p",
+        "--model",
+        &model,
+        "--allowedTools",
+        "",
+        "--setting-sources",
+        "",
+        "--strict-mcp-config",
+        "--mcp-config",
+        "{\"mcpServers\":{}}",
+        // --append-system-prompt, not --system-prompt: the index claude-code
+        // wrapper bakes --append-system-prompt-file; the CLI rejects mixing that
+        // with --system-prompt. Append is last-wins, so this replaces the house
+        // append with the extractor instructions.
+        "--append-system-prompt",
+        SYSTEM_PROMPT,
+        &user_prompt,
+    ])
+    .current_dir(&home)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::from(out_for_child))
+    .stderr(Stdio::null());
+    // start_new_session: new session AND process group (pgid == pid), so a
+    // timeout can killpg the whole node tree, not just the direct child.
+    set_new_session(&mut cmd);
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            log(&format!("model invocation failed: {e}"));
+            return Vec::new();
+        }
+    };
+    let pgid = child.id().cast_signed();
+
+    // Feed the delta on stdin and close it, so claude sees EOF and proceeds.
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(delta.as_bytes());
+        // dropped here -> closed.
+    }
+
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if started.elapsed() >= MODEL_TIMEOUT {
+                    // SIGKILL the whole process group, then reap.
+                    unsafe {
+                        libc::killpg(pgid, libc::SIGKILL);
+                    }
+                    let _ = child.wait();
+                    log("model invocation timed out; killed process group");
+                    return Vec::new();
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                log(&format!("model invocation failed: {e}"));
+                return Vec::new();
+            }
+        }
+    };
+
+    let mut raw = String::new();
+    if outf.seek(SeekFrom::Start(0)).is_err() || outf.read_to_string(&mut raw).is_err() {
+        log("model invocation failed: could not read temp output");
+        return Vec::new();
+    }
+    let s = raw.trim();
+
+    if !status.success() {
+        match status.code() {
+            Some(code) => log(&format!("model exited {code}")),
+            None => log("model exited (signal)"),
+        }
+        return Vec::new();
+    }
+    parse_items(s)
+}
+
+/// Slice from the first `[` to the last `]`, JSON-parse, keep dicts with a
+/// non-empty title AND description.
+fn parse_items(s: &str) -> Vec<Item> {
+    let Some(a) = s.find('[') else {
+        log(&format!(
+            "no JSON array in model output: {:?}",
+            take_chars(s, 200)
+        ));
+        return Vec::new();
+    };
+    let Some(b) = s.rfind(']') else {
+        log(&format!(
+            "no JSON array in model output: {:?}",
+            take_chars(s, 200)
+        ));
+        return Vec::new();
+    };
+    if b <= a {
+        log(&format!(
+            "no JSON array in model output: {:?}",
+            take_chars(s, 200)
+        ));
+        return Vec::new();
+    }
+    let Ok(Value::Array(items)) = serde_json::from_str::<Value>(&s[a..=b]) else {
+        log(&format!("unparseable model output: {}", take_chars(s, 200)));
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|it| {
+            let obj = it.as_object()?;
+            let title = obj.get("title").and_then(Value::as_str).filter(|s| !s.is_empty())?;
+            let description = obj
+                .get("description")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())?;
+            Some(Item {
+                kind: obj
+                    .get("kind")
+                    .and_then(Value::as_str)
+                    .unwrap_or("friction")
+                    .to_owned(),
+                title: title.to_owned(),
+                description: description.to_owned(),
+            })
+        })
+        .collect()
+}
+
+// --- Linear ---
+
+fn linear_key() -> Option<String> {
+    if let Some(key) = std::env::var("FRICTION_LINEAR_KEY")
+        .ok()
+        .filter(|v| !v.is_empty())
+    {
+        return Some(key);
+    }
+    if let Some(key) = std::env::var("LINEAR_API_KEY").ok().filter(|v| !v.is_empty()) {
+        return Some(key);
+    }
+    // Login Keychain entry (same one ci-triage uses).
+    let out = Command::new("security")
+        .args(["find-generic-password", "-s", "pr-watch-linear", "-w"])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    let key = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    if key.is_empty() { None } else { Some(key) }
+}
+
+/// POST issueCreate. Auth header is the RAW key (NOT `Bearer`). Any error logs
+/// and returns false.
+fn file_issue(key: &str, item: &Item, session: &str, cwd: &str) -> bool {
+    let model = model();
+    let host = hostname();
+    let description = format!(
+        "{}\n\n---\n- kind: `{}`\n- session: `{}`\n- cwd: `{}`\n- host: `{}`\n\n_Filed automatically by the friction-report Stop hook (model: {}; sent by an AI agent via Claude Code)._",
+        item.description.trim(),
+        item.kind,
+        session,
+        cwd,
+        host,
+        model,
+    );
+    let title = take_chars(&item.title, 255);
+    let body = json!({
+        "query": MUTATION,
+        "variables": {
+            "input": {
+                "teamId": LINEAR_TEAM_ID,
+                "projectId": LINEAR_PROJECT_ID,
+                "title": title,
+                "description": description,
+            }
+        },
+    });
+
+    let url = env_or("FRICTION_LINEAR_URL", DEFAULT_LINEAR_URL);
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log(&format!("linear POST failed: {e}"));
+            return false;
+        }
+    };
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Authorization", key)
+        .json(&body)
+        .send();
+    let res: Value = match resp.and_then(reqwest::blocking::Response::json) {
+        Ok(v) => v,
+        Err(e) => {
+            log(&format!("linear POST failed: {e}"));
+            return false;
+        }
+    };
+    let issue = res
+        .get("data")
+        .and_then(|d| d.get("issueCreate"))
+        .and_then(|c| c.get("issue"));
+    if let Some(identifier) = issue
+        .and_then(|i| i.get("identifier"))
+        .and_then(Value::as_str)
+    {
+        let issue_url = issue
+            .and_then(|i| i.get("url"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        log(&format!("filed {identifier} {issue_url} :: {}", item.title));
+        return true;
+    }
+    let dumped = serde_json::to_string(&res).unwrap_or_default();
+    log(&format!("issueCreate failed: {}", take_chars(&dumped, 500)));
+    false
+}
+
+fn hostname() -> String {
+    Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+fn normalize_title(title: &str) -> String {
+    title.to_lowercase().split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+// --- single-flight slot ---
+
+/// Holds the analyze.lock fd for the process lifetime once acquired; dropping it
+/// (closing the fd) would release the flock.
+struct Slot {
+    _file: File,
+}
+
+/// Non-blocking exclusive flock: at most one background analysis runs at a time.
+/// Extra Stops skip cheaply (`None`); nothing is lost because the per-session
+/// offset only advances inside a run that proceeds.
+fn acquire_slot() -> Option<Slot> {
+    let dir = state_dir();
+    fs::create_dir_all(&dir).ok()?;
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(dir.join("analyze.lock"))
+        .ok()?;
+    // SAFETY: a plain flock syscall on a valid owned fd; no aliasing.
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc != 0 {
+        return None;
+    }
+    Some(Slot { _file: file })
+}
+
+// --- analysis ---
+
+fn analyze(payload: &Value) {
+    let Some(_slot) = acquire_slot() else {
+        return;
+    };
+    let Some(session) = payload.get("session_id").and_then(Value::as_str) else {
+        return;
+    };
+    let Some(transcript) = payload.get("transcript_path").and_then(Value::as_str) else {
+        return;
+    };
+    let cwd = payload.get("cwd").and_then(Value::as_str).unwrap_or("?");
+
+    let dir = state_dir();
+    let state_path = dir.join(format!("{session}.json"));
+    let mut state = read_state(&state_path);
+
+    let Ok(meta) = fs::metadata(transcript) else {
+        return;
+    };
+    let size = meta.len();
+    let Ok(mut f) = File::open(transcript) else {
+        return;
+    };
+    // A rewritten/truncated transcript resets the window to the start; title
+    // dedupe below keeps that from double-filing.
+    let seek_to = if state.offset <= size { state.offset } else { 0 };
+    if f.seek(SeekFrom::Start(seek_to)).is_err() {
+        return;
+    }
+    let mut raw_bytes = Vec::new();
+    if f.read_to_end(&mut raw_bytes).is_err() {
+        return;
+    }
+    // errors="replace": lossy decode.
+    let raw = String::from_utf8_lossy(&raw_bytes);
+
+    // Advance + persist the offset BEFORE analysis on purpose: losing a delta to
+    // a crash beats double-filing it.
+    state.offset = size;
+    write_state(&state_path, &state);
+
+    if state.filed.len() >= MAX_ISSUES_PER_SESSION {
+        log(&format!("{session}: per-session cap reached, skipping"));
+        return;
+    }
+
+    let condensed = condense(&raw);
+    let delta = tail_chars(&condensed, MAX_DELTA_CHARS);
+    if delta.chars().count() < min_delta_chars() {
+        return;
+    }
+
+    let items = ask_model(&delta, payload.get("cwd").and_then(Value::as_str));
+    if items.is_empty() {
+        return;
+    }
+    let Some(key) = linear_key() else {
+        log("no Linear key (LINEAR_API_KEY / Keychain pr-watch-linear); skipping filing");
+        return;
+    };
+    for item in items.iter().take(MAX_ITEMS_PER_RUN) {
+        let normalized = normalize_title(&item.title);
+        if state.filed.contains(&normalized) {
+            continue;
+        }
+        if file_issue(&key, item, session, cwd) {
+            state.filed.push(normalized);
+            write_state(&state_path, &state);
+        }
+    }
+}
+
+// --- foreground entry / detach ---
+
+/// Human ix-contributor author emails (as of 2026-06-11), the compiled-in
+/// replacement for the old `conditions/ix-contributor` wrapper. Friction files
+/// to indexable's Linear, so it self-gates: only run when the git author has
+/// commits in indexable-inc/ix|index. Bot/CI identities are deliberately
+/// excluded. Regenerate with `git -C <repo> log --format='%ae' --all | sort -u`.
+const IX_CONTRIBUTORS: &[&str] = &[
+    "andrew.gazelka@gmail.com",
+    "andrew@ix.dev",
+    "7644264+andrewgazelka@users.noreply.github.com",
+    "44930139+TestingPlant@users.noreply.github.com",
+    "73809867+harivansh-afk@users.noreply.github.com",
+    "rathiharivansh@gmail.com",
+    "hari@ix.dev",
+    "burnersiscool@gmail.com",
+    "rangel.dominick03@gmail.com",
+    "donovan@ix.dev",
+    "hyfloac@users.noreply.github.com",
+    "16706311+hyfloac@users.noreply.github.com",
+    "mail@hyfloac.com",
+    "101477459+wyattgill9@users.noreply.github.com",
+    "wyattgill9@users.noreply.github.com",
+    "wyattgill01@outlook.com",
+    "wyatt@ix.dev",
+    "nathan@ix.dev",
+    "anthony@ix.dev",
+    "git@techcable.net",
+    "techcable@techcable.net",
+    "tgr@tgrcode.com",
+    "anna328p@gmail.com",
+    "mudkip@mudkip.dev",
+    "156468454+Paramount50@users.noreply.github.com",
+    "93566418+DCR-03@users.noreply.github.com",
+];
+
+/// True when the effective git author email is a known ix contributor. Fails
+/// CLOSED (false) on any error: a machine with no/foreign git identity does not
+/// file to indexable's Linear.
+fn is_ix_contributor() -> bool {
+    let git = std::env::var("IX_GIT").unwrap_or_else(|_| "git".to_owned());
+    let Ok(out) = Command::new(git)
+        .args(["config", "--get", "user.email"])
+        .output()
+    else {
+        return false;
+    };
+    if !out.status.success() {
+        return false;
+    }
+    let Ok(email) = String::from_utf8(out.stdout) else {
+        return false;
+    };
+    IX_CONTRIBUTORS.contains(&email.trim())
+}
+
+/// Public entry point. Reads its own argv to detect `--analyze`; the integrator
+/// calls `friction::friction_report()` from the `friction-report` match arm.
+///
+/// Foreground path (no `--analyze`): validate stdin, then either run analyze
+/// inline (if `FRICTION_FOREGROUND` is set — the test hook) or re-spawn this
+/// binary detached as `--analyze` and return immediately so Stop is never
+/// blocked. Everything is wrapped to fail open and silent.
+pub fn friction_report() {
+    // Self-gate (replaces conditions/ix-contributor): only ix contributors file
+    // to indexable's Linear. Checked on BOTH the foreground and the detached
+    // `--analyze` path so a non-contributor never reaches the model or Linear.
+    if !is_ix_contributor() {
+        return;
+    }
+    if std::env::args().skip(1).any(|a| a == "--analyze") {
+        // Detached worker: payload rides in the env. Any crash logs only.
+        let Some(raw) = std::env::var_os("FRICTION_PAYLOAD") else {
+            return;
+        };
+        let Some(raw) = raw.to_str() else { return };
+        let Ok(payload) = serde_json::from_str::<Value>(raw) else {
+            log("analyze: unparseable FRICTION_PAYLOAD");
+            return;
+        };
+        analyze(&payload);
+        return;
+    }
+
+    let Some(input) = read_stdin() else {
+        return;
+    };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    if !payload.is_object() {
+        return;
+    }
+    let Some(session) = payload.get("session_id").and_then(Value::as_str) else {
+        return;
+    };
+    // session_id becomes a state filename; reject anything not a plain component.
+    if session.is_empty() || session == "." || session == ".." || !is_plain_component(session) {
+        return;
+    }
+    let Some(transcript) = payload.get("transcript_path").and_then(Value::as_str) else {
+        return;
+    };
+    if transcript.is_empty() || !Path::new(transcript).is_file() {
+        return;
+    }
+    let _ = fs::create_dir_all(state_dir());
+
+    if std::env::var_os("FRICTION_FOREGROUND").is_some_and(|v| !v.is_empty()) {
+        analyze(&payload);
+        return;
+    }
+
+    detach_analyze(&payload);
+}
+
+fn read_stdin() -> Option<String> {
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf).ok()?;
+    Some(buf)
+}
+
+/// True when `basename(s) == s` and s is not `.`/`..` — i.e. a plain filename
+/// component with no path separators, matching `os.path.basename(s) == s`.
+fn is_plain_component(s: &str) -> bool {
+    Path::new(s).file_name().map(OsString::from) == Some(OsString::from(s))
+}
+
+/// Re-spawn THIS binary as `friction-report --analyze`, detached (new session,
+/// stdin=/dev/null, stdout+stderr appended to friction.log), so Stop returns
+/// immediately. Best-effort: any failure is silent.
+fn detach_analyze(payload: &Value) {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let Ok(payload_json) = serde_json::to_string(payload) else {
+        return;
+    };
+    let dir = state_dir();
+    if fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let Ok(logf) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("friction.log"))
+    else {
+        return;
+    };
+    let Ok(logf2) = logf.try_clone() else {
+        return;
+    };
+
+    let mut detach = Command::new(exe);
+    detach
+        .args(["friction-report", "--analyze"])
+        .env("FRICTION_PAYLOAD", payload_json)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(logf))
+        .stderr(Stdio::from(logf2));
+    // start_new_session: own session so it outlives the hook's process tree.
+    set_new_session(&mut detach);
+    let _ = detach.spawn();
+    // We deliberately do NOT wait: the child owns the slow work.
+}
+
+/// `start_new_session=True` equivalent: call `setsid()` in the child between
+/// fork and exec, putting it in a brand-new session and process group (pgid ==
+/// pid), detached from the controlling terminal.
+fn set_new_session(cmd: &mut Command) {
+    // SAFETY: setsid is async-signal-safe and the only thing we do in the
+    // child before exec; no allocation, no shared-state mutation.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{condense, normalize_title, parse_items};
+
+    #[test]
+    fn condense_claude_dialect() {
+        let jsonl = [
+            r#"{"type":"user","message":{"role":"user","content":"please fix the build"}}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"on it"}]}}"#,
+            // tool_result error rides a user-role message
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","is_error":true,"content":"boom"}]}}"#,
+            // skipped: system-reminder prefix
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"<system-reminder>ignore me</system-reminder>"}]}}"#,
+            // skipped: isMeta
+            r#"{"type":"user","isMeta":true,"message":{"role":"user","content":"meta noise"}}"#,
+        ]
+        .join("\n");
+        let out = condense(&jsonl);
+        assert!(out.contains("USER: please fix the build"), "{out}");
+        assert!(out.contains("ASSISTANT: on it"), "{out}");
+        assert!(out.contains("TOOL ERROR: \"boom\""), "{out}");
+        assert!(!out.contains("ignore me"), "{out}");
+        assert!(!out.contains("meta noise"), "{out}");
+    }
+
+    #[test]
+    fn condense_codex_dialect() {
+        let jsonl = [
+            // codex user_message event
+            r#"{"payload":{"type":"user_message","message":"deploy the fleet"}}"#,
+            // codex wraps a normal message under payload
+            r#"{"payload":{"type":"agent","message":{"role":"assistant","content":[{"type":"output_text","text":"deploying"}]}}}"#,
+            // skipped: command prefix
+            r#"{"payload":{"message":{"role":"user","content":[{"type":"input_text","text":"<command-name>x</command-name>"}]}}}"#,
+        ]
+        .join("\n");
+        let out = condense(&jsonl);
+        assert!(out.contains("USER: deploy the fleet"), "{out}");
+        assert!(out.contains("ASSISTANT: deploying"), "{out}");
+        assert!(!out.contains("command-name"), "{out}");
+    }
+
+    #[test]
+    fn normalized_title_dedupe() {
+        assert_eq!(
+            normalize_title("  Missing   CLAUDE.md  Context "),
+            "missing claude.md context"
+        );
+        // dedupe is exact-match on the normalized form
+        let filed = vec![normalize_title("Weak grep tool")];
+        assert!(filed.contains(&normalize_title("weak   GREP   tool")));
+        assert!(!filed.contains(&normalize_title("weak grep tooling")));
+    }
+
+    #[test]
+    fn parse_items_slices_array_from_prose() {
+        let raw = "Here are the items you asked for:\n\
+                   [{\"kind\":\"weak-tool\",\"title\":\"t1\",\"description\":\"d1\"}, \
+                   {\"title\":\"\",\"description\":\"empty title dropped\"}, \
+                   {\"title\":\"t2\",\"description\":\"\"}, \
+                   {\"title\":\"t3\",\"description\":\"d3\"}]\nThanks!";
+        let items = parse_items(raw);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].title, "t1");
+        assert_eq!(items[0].kind, "weak-tool");
+        assert_eq!(items[1].title, "t3");
+        // kind defaults to "friction" when absent
+        assert_eq!(items[1].kind, "friction");
+    }
+
+    #[test]
+    fn parse_items_no_array() {
+        assert!(parse_items("no brackets here").is_empty());
+        assert!(parse_items("]backwards[").is_empty());
+    }
+}

--- a/packages/agent/claude-hooks/src/friction.rs
+++ b/packages/agent/claude-hooks/src/friction.rs
@@ -896,7 +896,7 @@ mod tests {
             "missing claude.md context"
         );
         // dedupe is exact-match on the normalized form
-        let filed = vec![normalize_title("Weak grep tool")];
+        let filed = [normalize_title("Weak grep tool")];
         assert!(filed.contains(&normalize_title("weak   GREP   tool")));
         assert!(!filed.contains(&normalize_title("weak grep tooling")));
     }

--- a/packages/agent/claude-hooks/src/guards.rs
+++ b/packages/agent/claude-hooks/src/guards.rs
@@ -1,0 +1,223 @@
+//! `PreToolUse` guards, compiled ports of the personal `cargo-guard.py`,
+//! `bash-habits-guard.py`, and `search-guard.py`.
+//!
+//! Each blocks a known-bad call and tells the agent the better path. Unlike the
+//! Python originals (which exit 2 with a stderr message), these emit the index
+//! house JSON deny (`permissionDecision: "deny"`, same channel as
+//! `worktree-guard`), which both Claude Code and the Codex fork honor. Every
+//! guard fails OPEN: a parse error, the wrong tool, or an unmatched command
+//! returns with no output and the call proceeds.
+
+use serde_json::Value;
+
+use crate::DenyOutput;
+
+fn deny(reason: String) {
+    crate::emit(DenyOutput {
+        hook_event_name: "PreToolUse",
+        permission_decision: "deny",
+        permission_decision_reason: reason,
+    });
+}
+
+fn payload() -> Option<Value> {
+    serde_json::from_str(&crate::read_stdin()?).ok()
+}
+
+fn command_of(payload: &Value) -> String {
+    payload
+        .get("tool_input")
+        .and_then(|t| t.get("command"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned()
+}
+
+/// True when `word` is a shell env-assignment prefix like `FOO=bar`.
+fn is_env_assignment(word: &str) -> bool {
+    regex::Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*=")
+        .is_ok_and(|re| re.is_match(word))
+}
+
+/// `PreToolUse(Bash)`: block bare `cargo <sub>` inside indexable-inc/index|ix
+/// (and their worktrees), steering work to nix. Nix-wrapped cargo
+/// (`nix run .#run -- cargo ...`) is allowed: cargo is not the first word there.
+pub fn cargo_guard() {
+    let Some(payload) = payload() else { return };
+    if payload.get("tool_name").and_then(Value::as_str) != Some("Bash") {
+        return;
+    }
+    let cwd = payload.get("cwd").and_then(Value::as_str).unwrap_or_default();
+    // The `(/|$)` keeps `ix` from also matching `index`.
+    let in_monorepo = regex::Regex::new(r"/indexable-inc/(index|ix)(/|$)")
+        .is_ok_and(|re| re.is_match(cwd));
+    if !in_monorepo {
+        return;
+    }
+    let cmd = command_of(&payload);
+    let first_word_is_cargo = |segment: &str| {
+        segment
+            .split_whitespace()
+            .find(|w| !is_env_assignment(w))
+            .is_some_and(|w| w == "cargo")
+    };
+    let any_cargo = regex::Regex::new(r"&&|\|\||;|\n|\|")
+        .is_ok_and(|re| re.split(&cmd).any(first_word_is_cargo));
+    if any_cargo {
+        deny(
+            "cargo is disabled in indexable-inc/index and /ix. Use nix: \
+             `nix build .#<pkg>`, `nix run .#<name>`, `nix run .#lint`. \
+             For a real passthrough use `nix run .#run -- cargo <args>`; \
+             hand-edit Cargo.lock for path crates. (cargo-guard hook)"
+                .to_owned(),
+        );
+    }
+}
+
+const GREP_PREFIXES: &[&str] = &[
+    "env", "sudo", "command", "nice", "time", "xargs", "stdbuf", "nohup",
+];
+
+fn is_recursive_flag(tok: &str) -> bool {
+    if tok == "--recursive" || tok.starts_with("--dereference-recursive") {
+        return true;
+    }
+    // bundled short flags, e.g. -r, -R, -rn, -rin
+    regex::Regex::new(r"^-[A-Za-z]*$").is_ok_and(|re| re.is_match(tok))
+        && tok[1..].contains(['r', 'R'])
+}
+
+/// True when `stage` (a statement's first pipe stage) runs `grep` recursively so
+/// it walks a tree (a `... | grep -r` reading a pipe does not traverse).
+fn grep_walks_tree(stage: &str) -> bool {
+    let toks: Vec<&str> = stage.split_whitespace().collect();
+    let mut i = 0;
+    while i < toks.len() && (is_env_assignment(toks[i]) || GREP_PREFIXES.contains(&toks[i])) {
+        i += 1;
+    }
+    if toks.get(i) != Some(&"grep") {
+        return false;
+    }
+    for t in &toks[i + 1..] {
+        if *t == "--" {
+            break; // everything after -- is operands, not flags
+        }
+        if is_recursive_flag(t) {
+            return true;
+        }
+    }
+    false
+}
+
+/// `PreToolUse(Bash)`: block recurring bad command shapes (output-to-/dev/null,
+/// recursive `grep -r`, `--no-verify`). Quote/escape-aware so a literal mention
+/// inside a commit message or `echo` is not a false positive.
+pub fn bash_habits_guard() {
+    let Some(payload) = payload() else { return };
+    if payload.get("tool_name").and_then(Value::as_str) != Some("Bash") {
+        return;
+    }
+    let raw = command_of(&payload);
+
+    // Match operators, not literal text inside a quoted string. Neutralize
+    // escaped chars, then drop quoted substrings (a real `2>/dev/null` /
+    // `grep -r` is never quoted). Accepted miss: a redirection genuinely wrapped
+    // in quotes or a heredoc body.
+    let strip = |re: &str, s: String| {
+        regex::Regex::new(re).map_or_else(|_| s.clone(), |r| r.replace_all(&s, " ").into_owned())
+    };
+    let cmd = strip(r#""[^"]*""#, strip(r"'[^']*'", strip(r"\\.", raw)));
+
+    // 1. stderr-to-null / all-to-null / the `>/dev/null 2>&1` idiom.
+    let to_null = [
+        r"2\s*>>?\s*/dev/null",
+        r"&\s*>>?\s*/dev/null",
+        r">\s*/dev/null\s+2\s*>\s*&\s*1",
+    ]
+    .iter()
+    .any(|re| regex::Regex::new(re).is_ok_and(|r| r.is_match(&cmd)));
+    if to_null {
+        deny(
+            "Don't discard stderr/output to /dev/null - you won't see why a command \
+             failed, and 223 such calls in your history silently ate the error. \
+             Filter specific noise instead: `cmd 2>&1 | grep -vE '<pattern>'`, or send \
+             stderr to a file you read (`cmd 2>/tmp/err`). Plain `>/dev/null` \
+             (stdout only, stderr kept) is fine. (bash-habits-guard hook)"
+                .to_owned(),
+        );
+        return;
+    }
+
+    // 2. Recursive grep that walks a tree: grep as the command of a statement's
+    //    first pipe stage.
+    let walks = regex::Regex::new(r"&&|\|\||;|\n").is_ok_and(|re| {
+        re.split(&cmd)
+            .any(|statement| grep_walks_tree(statement.split('|').next().unwrap_or("")))
+    });
+    if walks {
+        deny(
+            "Never recursive-`grep` a tree: it walks .git, result symlinks into \
+             /nix/store, and node_modules, and can hit the 600s timeout. Use `rg` \
+             (gitignore-aware drop-in: `rg <pat> [dir]`) or semantic search; scope \
+             any plain grep to a specific subdirectory. (bash-habits-guard hook)"
+                .to_owned(),
+        );
+        return;
+    }
+
+    // 3. --no-verify (bypassing git hooks).
+    if regex::Regex::new(r"(^|\s)--no-verify(\s|$)").is_ok_and(|re| re.is_match(&cmd)) {
+        deny(
+            "Don't bypass git hooks with --no-verify. If a hook is too slow or wrong, \
+             fix the hook, not the commit. If you truly must bypass it, run the command \
+             yourself outside the agent. (bash-habits-guard hook)"
+                .to_owned(),
+        );
+    }
+}
+
+/// `PreToolUse(Search)`: deny the built-in Search tool, redirect to mgrep. The
+/// settings matcher is `^Search$`, but the exact-name check here is a second
+/// guard so a loose matcher can never block `WebSearch`/`ToolSearch`/`mcp__*`.
+pub fn search_guard() {
+    let Some(payload) = payload() else { return };
+    if payload.get("tool_name").and_then(Value::as_str) != Some("Search") {
+        return;
+    }
+    deny(
+        "The Search tool is disabled. Use mgrep instead: \
+         `mgrep search --agentic \"<query>\" <path>` for semantic code/file search \
+         (locations-only first, then Read the hits), or `rg` for exact-string \
+         matches. (search-guard hook)"
+            .to_owned(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{grep_walks_tree, is_recursive_flag};
+
+    #[test]
+    fn recursive_flag_detection() {
+        assert!(is_recursive_flag("-r"));
+        assert!(is_recursive_flag("-rn"));
+        assert!(is_recursive_flag("-R"));
+        assert!(is_recursive_flag("--recursive"));
+        assert!(!is_recursive_flag("-n"));
+        assert!(!is_recursive_flag("--include=*.rs"));
+    }
+
+    #[test]
+    fn grep_tree_walk_vs_pipe() {
+        assert!(grep_walks_tree("grep -r foo ."));
+        assert!(grep_walks_tree("sudo grep -rn foo src"));
+        assert!(grep_walks_tree("FOO=bar grep -R x"));
+        // not recursive
+        assert!(!grep_walks_tree("grep -n foo file"));
+        // grep reading a pipe (the caller passes only the first stage, but a bare
+        // non-recursive grep is fine)
+        assert!(!grep_walks_tree("grep foo"));
+        // -- ends flags
+        assert!(!grep_walks_tree("grep -- -r"));
+    }
+}

--- a/packages/agent/claude-hooks/src/main.rs
+++ b/packages/agent/claude-hooks/src/main.rs
@@ -1,13 +1,19 @@
-//! Claude Code hook commands, one compiled binary with three subcommands that
-//! replace the old hand-rolled `writeShellScript` hooks in
-//! `packages/agent/claude-code`. Every hook fails OPEN and SILENT: any missing input,
-//! parse error, or kill-switch returns with no stdout, because a noisy or broken
-//! hook is strictly worse than no hook.
+//! Claude Code / Codex hook commands, one compiled binary whose subcommands
+//! replace the old hand-rolled shell/Python hooks in `packages/agent/claude-code`
+//! and the personal `~/.config/nix` dotfiles. Every hook fails OPEN and SILENT:
+//! any missing input, parse error, or kill-switch returns with no stdout/stderr,
+//! because a noisy or broken hook is strictly worse than no hook.
 //!
-//! Tool paths and the baked primary-checkout default are passed by the
-//! claude-code wrapper via env (`IX_GIT`, `IX_SEARCH`,
-//! `IX_DEFAULT_PRIMARY_CHECKOUTS`); user-facing knobs keep their
-//! `CLAUDE_CODE_*` names.
+//! The neutral declaration list that maps each subcommand to its event/matcher
+//! for both agents lives in `packages/agent/hooks.nix`; the claude-code wrapper
+//! bakes the binary's tool paths and primary-checkout default via env
+//! (`IX_GIT`, `IX_SEARCH`, `IX_DEFAULT_PRIMARY_CHECKOUTS`), while user-facing
+//! knobs keep their `CLAUDE_CODE_*` names.
+
+mod friction;
+mod guards;
+mod review;
+mod session_banner;
 
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
@@ -68,6 +74,13 @@ fn main() -> ExitCode {
         Some("session-digest") => session_digest(),
         Some("worktree-guard") => worktree_guard(),
         Some("prompt-priors") => prompt_priors(),
+        Some("session-banner") => session_banner::session_banner(),
+        Some("review-log-edit") => review::review_log_edit(),
+        Some("review-gate") => review::review_gate(),
+        Some("cargo-guard") => guards::cargo_guard(),
+        Some("bash-habits-guard") => guards::bash_habits_guard(),
+        Some("search-guard") => guards::search_guard(),
+        Some("friction-report") => friction::friction_report(),
         other => {
             eprintln!("claude-hooks: unknown subcommand {other:?}");
             return ExitCode::from(2);
@@ -79,15 +92,15 @@ fn main() -> ExitCode {
 // --- shared helpers ---
 
 /// True when an env var is present and non-empty (the kill-switch convention).
-fn flag_set(name: &str) -> bool {
+pub(crate) fn flag_set(name: &str) -> bool {
     std::env::var_os(name).is_some_and(|v| !v.is_empty())
 }
 
-fn home() -> PathBuf {
+pub(crate) fn home() -> PathBuf {
     std::env::var_os("HOME").map_or_else(|| PathBuf::from("/var/empty"), PathBuf::from)
 }
 
-fn read_stdin() -> Option<String> {
+pub(crate) fn read_stdin() -> Option<String> {
     let mut buf = String::new();
     std::io::stdin().read_to_string(&mut buf).ok()?;
     Some(buf)
@@ -99,17 +112,17 @@ fn cap_chars(s: &str, max: usize) -> String {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ContextOutput {
-    hook_event_name: &'static str,
-    additional_context: String,
+pub(crate) struct ContextOutput {
+    pub(crate) hook_event_name: &'static str,
+    pub(crate) additional_context: String,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct DenyOutput {
-    hook_event_name: &'static str,
-    permission_decision: &'static str,
-    permission_decision_reason: String,
+pub(crate) struct DenyOutput {
+    pub(crate) hook_event_name: &'static str,
+    pub(crate) permission_decision: &'static str,
+    pub(crate) permission_decision_reason: String,
 }
 
 #[derive(Serialize)]
@@ -118,7 +131,7 @@ struct Wrap<T> {
     hook_specific_output: T,
 }
 
-fn emit<T: Serialize>(inner: T) {
+pub(crate) fn emit<T: Serialize>(inner: T) {
     if let Ok(s) = serde_json::to_string(&Wrap {
         hook_specific_output: inner,
     }) {

--- a/packages/agent/claude-hooks/src/review.rs
+++ b/packages/agent/claude-hooks/src/review.rs
@@ -1,0 +1,168 @@
+//! Always-on review trigger, the compiled port of the personal `review-log-edit.py`
+//! (`PostToolUse` logger) and `review-gate.py` (Stop gate) pair.
+//!
+//! `review-log-edit` appends each edited path to a per-session marker; `review-gate`
+//! reads that marker on Stop and blocks the session once per change-set with a nudge
+//! to run the multi-agent `review-changes` skill, then consumes the marker so a
+//! review is required at most once per change-set. Both fail OPEN: any parse error,
+//! missing field, or bad session id exits silently and lets the session proceed.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// Per-session marker dir; overridable so the hooks can be tested against a temp
+/// dir (the personal `review-hooks.test.py` contract).
+fn state_dir() -> PathBuf {
+    std::env::var_os("CLAUDE_REVIEW_STATE_DIR")
+        .filter(|v| !v.is_empty())
+        .map_or_else(|| crate::home().join(".claude/.review-state"), PathBuf::from)
+}
+
+/// `session_id` is interpolated into a file path; accept only a plain filename
+/// component so a crafted value cannot escape the state dir.
+fn safe_session(payload: &Value) -> Option<String> {
+    let session = payload.get("session_id").and_then(Value::as_str)?;
+    if session.is_empty() || session == "." || session == ".." || session.contains('/') {
+        return None;
+    }
+    Some(session.to_owned())
+}
+
+fn marker_path(session: &str) -> PathBuf {
+    state_dir().join(format!("{session}.changed"))
+}
+
+/// `PostToolUse(Write|Edit|MultiEdit|NotebookEdit)`: record the edited path.
+/// Side effect only, never blocks.
+pub fn review_log_edit() {
+    let Some(input) = crate::read_stdin() else {
+        return;
+    };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    let Some(session) = safe_session(&payload) else {
+        return;
+    };
+    // Write/Edit/MultiEdit use file_path; NotebookEdit uses notebook_path.
+    let Some(path) = payload
+        .get("tool_input")
+        .and_then(|t| t.get("file_path").or_else(|| t.get("notebook_path")))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+    else {
+        return;
+    };
+    let dir = state_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join(format!("{session}.changed")))
+    {
+        use std::io::Write as _;
+        let _ = writeln!(f, "{path}");
+    }
+}
+
+#[derive(Serialize)]
+struct StopBlock {
+    decision: &'static str,
+    reason: String,
+}
+
+/// Stop: block once per change-set if there are unreviewed edits.
+pub fn review_gate() {
+    let Some(input) = crate::read_stdin() else {
+        return;
+    };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    let Some(session) = safe_session(&payload) else {
+        return;
+    };
+    let marker = marker_path(&session);
+
+    // Loop guard: this Stop is already a forced continuation from a prior block.
+    // Clear the marker and allow, so the next genuine change-set can trigger again.
+    if payload
+        .get("stop_hook_active")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let _ = std::fs::remove_file(&marker);
+        return;
+    }
+
+    let Ok(contents) = std::fs::read_to_string(&marker) else {
+        return;
+    };
+    let mut files: Vec<String> = contents
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect();
+    files.sort_unstable();
+    files.dedup();
+    if files.is_empty() {
+        return;
+    }
+
+    // Consume the marker so the review is required at most once per change-set.
+    let _ = std::fs::remove_file(&marker);
+
+    let preview = files
+        .iter()
+        .take(10)
+        .map(|p| format!("  - {p}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let more = if files.len() > 10 {
+        format!("\n  ... and {} more", files.len() - 10)
+    } else {
+        String::new()
+    };
+    let reason = format!(
+        "Unreviewed edits to {} file(s) this session:\n{preview}{more}\n\n\
+         Before finishing, run the `review-changes` skill: it launches a multi-agent \
+         review workflow over the working-tree diff (one finder per dimension, then an \
+         adversarial verifier per finding). Fix any Correctness or Security blockers it \
+         confirms, or say plainly why a finding is declined; Performance and \
+         Maintainability are judgment calls.\n\n\
+         Skip ONLY if the change is genuinely trivial (a typo, a one-line doc/comment, a \
+         config value with no logic): say so in one line and stop. If this turn was a \
+         question to the user rather than finished work, restate that question after you \
+         dispatch the review.",
+        files.len()
+    );
+    // Stop hook contract: a top-level {"decision":"block","reason":...}, NOT the
+    // hookSpecificOutput wrapper the PreToolUse/SessionStart hooks use.
+    if let Ok(s) = serde_json::to_string(&StopBlock {
+        decision: "block",
+        reason,
+    }) {
+        println!("{s}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::safe_session;
+    use serde_json::json;
+
+    #[test]
+    fn session_rejects_path_escapes() {
+        assert_eq!(safe_session(&json!({"session_id": "abc-123"})).as_deref(), Some("abc-123"));
+        assert!(safe_session(&json!({"session_id": "../escape"})).is_none());
+        assert!(safe_session(&json!({"session_id": "a/b"})).is_none());
+        assert!(safe_session(&json!({"session_id": "."})).is_none());
+        assert!(safe_session(&json!({"session_id": ""})).is_none());
+        assert!(safe_session(&json!({})).is_none());
+    }
+}

--- a/packages/agent/claude-hooks/src/session_banner.rs
+++ b/packages/agent/claude-hooks/src/session_banner.rs
@@ -1,0 +1,136 @@
+//! `SessionStart` banner, the compiled port of the personal `session-start-hook`
+//! bash script: report the host's live timezone/OS/kernel/hardware and an
+//! auto-discovered inventory of local git repos under `~/Projects`, grouped by
+//! org. Emitted as `SessionStart` `additionalContext`. Best-effort: any probe
+//! that fails is simply omitted, and the hook never errors.
+
+use std::fmt::Write as _;
+use std::path::Path;
+use std::process::Command;
+
+use crate::ContextOutput;
+
+/// Run `prog args...` and return trimmed stdout, or None on failure / empty.
+fn run(prog: &str, args: &[&str]) -> Option<String> {
+    let out = Command::new(prog).args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    let t = s.trim();
+    (!t.is_empty()).then(|| t.to_owned())
+}
+
+/// Same with an extra env var (used for the `TZ=...` date line).
+fn run_env(prog: &str, args: &[&str], key: &str, val: &str) -> Option<String> {
+    let out = Command::new(prog).args(args).env(key, val).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    let t = s.trim();
+    (!t.is_empty()).then(|| t.to_owned())
+}
+
+/// IANA timezone name from the `/etc/localtime` symlink target, falling back to
+/// the current abbreviation.
+fn host_timezone() -> Option<String> {
+    if let Ok(target) = std::fs::read_link("/etc/localtime") {
+        let s = target.to_string_lossy();
+        if let Some(idx) = s.find("/zoneinfo/") {
+            let name = &s[idx + "/zoneinfo/".len()..];
+            if !name.is_empty() {
+                return Some(name.to_owned());
+            }
+        }
+    }
+    run("date", &["+%Z"])
+}
+
+/// Inventory of repos under `~/Projects`, grouped by org. A directory counts as
+/// a repo when it has a `.git` entry (file or dir, so worktrees count), which
+/// also stops the scan from descending into a repo's own subdirs.
+fn repo_inventory(out: &mut String) {
+    let projects = crate::home().join("Projects");
+    let Ok(entries) = std::fs::read_dir(&projects) else {
+        return;
+    };
+    let _ = writeln!(out, "repos (~/Projects/<org>/<repo>):");
+    let mut orgs: Vec<std::path::PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    orgs.sort();
+    let mut loose: Vec<String> = Vec::new();
+    for org in &orgs {
+        // A top-level repo (org dir is itself a checkout): list it under (top-level).
+        if org.join(".git").exists() {
+            if let Some(name) = org.file_name() {
+                loose.push(name.to_string_lossy().into_owned());
+            }
+            continue;
+        }
+        let Ok(children) = std::fs::read_dir(org) else {
+            continue;
+        };
+        let mut names: Vec<String> = children
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.is_dir() && p.join(".git").exists())
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        names.sort();
+        if !names.is_empty() {
+            let org_name = org.file_name().map_or_else(String::new, |n| n.to_string_lossy().into_owned());
+            let _ = writeln!(out, "  {org_name}: {}", names.join(" "));
+        }
+    }
+    if !loose.is_empty() {
+        let _ = writeln!(out, "  (top-level): {}", loose.join(" "));
+    }
+}
+
+pub fn session_banner() {
+    let mut out = String::new();
+
+    if let Some(tz) = host_timezone() {
+        let now = run("date", &["+%Z %z"]).unwrap_or_default();
+        let _ = writeln!(out, "host timezone: {tz} ({now})");
+    }
+    if let Some(d) = run_env("date", &[], "TZ", "America/Los_Angeles") {
+        let _ = writeln!(out, "date (TZ=America/Los_Angeles date): {d}");
+    }
+
+    // OS: prefer macOS `sw_vers`, else `uname -sr`.
+    if Path::new("/usr/bin/sw_vers").exists() || run("sw_vers", &["-productName"]).is_some() {
+        let name = run("sw_vers", &["-productName"]).unwrap_or_default();
+        let ver = run("sw_vers", &["-productVersion"]).unwrap_or_default();
+        let build = run("sw_vers", &["-buildVersion"]).unwrap_or_default();
+        let _ = writeln!(out, "os (sw_vers): {name} {ver} ({build})");
+    } else if let Some(u) = run("uname", &["-sr"]) {
+        let _ = writeln!(out, "os (uname -sr): {u}");
+    }
+
+    if let Some(k) = run("uname", &["-srm"]) {
+        let _ = writeln!(out, "kernel (uname -srm): {k}");
+    }
+
+    if let Some(model) = run("sysctl", &["-n", "hw.model"]) {
+        let _ = writeln!(out, "hardware model (sysctl -n hw.model): {model}");
+    }
+    if let Some(chip) = run("sysctl", &["-n", "machdep.cpu.brand_string"]) {
+        let _ = writeln!(out, "hardware chip (sysctl -n machdep.cpu.brand_string): {chip}");
+    }
+
+    repo_inventory(&mut out);
+
+    let context = out.trim_end().to_owned();
+    if context.is_empty() {
+        return;
+    }
+    crate::emit(ContextOutput {
+        hook_event_name: "SessionStart",
+        additional_context: context,
+    });
+}

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -3,9 +3,19 @@
   ix,
   codex,
   makeBinaryWrapper,
+  runCommand,
+  git,
   symlinkJoin,
   formats,
   binName ? "codex",
+
+  # Shell globs the (claude-only) worktree-guard protects, threaded into the
+  # shared hook module so both wrappers feed it the same inputs. Unused in the
+  # codex render (worktree-guard is claude-only), kept only for parity.
+  primaryCheckouts ? [
+    "/home/*/index"
+    "/home/*/ix"
+  ],
 
   # Sibling repo packages from the flake package set (threaded by
   # lib/packages.nix), used to locate the `ix-mcp` entrypoint for the baked
@@ -79,6 +89,40 @@ let
     forced = entriesOf (ix.attrs.flattenToDotted forcedSettings);
     soft = entriesOf (ix.attrs.flattenToDotted settings) ++ ix.mcp.toCodexEntries mcpStdioServers;
   };
+
+  # Codex hooks come from the SAME declaration list as Claude's
+  # (../hooks.nix), rendered to codex's field-aligned hook schema. Codex does
+  # NOT discover hooks via a `-c` pointer; it reads `~/.codex/hooks.json` /
+  # inline `[hooks]` / plugin manifests, and a non-managed command hook is
+  # skipped until reviewed/trusted (its hash is recorded). So this wrapper does
+  # not bake the hooks into the launch spec — it EXPOSES the rendered file as
+  # `passthru.hooksJson`, which a consumer delivers to `~/.codex/hooks.json`
+  # (home-manager) and trusts once via `/hooks` (or installs as a managed
+  # `requirements.toml` layer). The hook commands are absolute store paths into
+  # the compiled `claude-hooks` binary, the same binary the claude-code wrapper
+  # builds (cached, one derivation).
+  claudeHooks = import (ix.paths.packagesRoot + "/agent/claude-code/hooks.nix") {
+    inherit
+      lib
+      runCommand
+      makeBinaryWrapper
+      ix
+      git
+      primaryCheckouts
+      repoPackages
+      ;
+  };
+  hooksJson = (formats.json { }).generate "codex-hooks.json" {
+    hooks =
+      (import (ix.paths.packagesRoot + "/agent/hooks.nix") {
+        inherit
+          lib
+          claudeHooks
+          primaryCheckouts
+          repoPackages
+          ;
+      }).codex;
+  };
 in
 # These baked defaults also reach the Codex GUI app's remote-SSH sessions, not
 # just terminal use. The desktop app does NOT ship its own binary to the remote
@@ -103,6 +147,9 @@ symlinkJoin {
       --inherit-argv0 \
       --set IX_LAUNCH_SPEC ${spec}
   '';
+  # The codex hooks.json rendered from the shared declaration list, for a
+  # consumer to deliver to `~/.codex/hooks.json` (see the `hooksJson` comment).
+  passthru = { inherit hooksJson; };
   meta = codex.meta // {
     description = "${codex.meta.description or "OpenAI Codex CLI"} (index wrapper with baked defaults)";
     mainProgram = binName;

--- a/packages/agent/hooks.nix
+++ b/packages/agent/hooks.nix
@@ -1,0 +1,167 @@
+# Single source of truth for agent lifecycle hooks, consumed by BOTH agent
+# wrappers under ./ (claude-code, codex) — the hook analogue of common.nix
+# (which shares systemPrompt + houseServers). Each hook is one subcommand of the
+# compiled `claude-hooks` binary (packages/agent/claude-hooks); this module only
+# DECLARES which subcommand runs on which event/matcher for which agent, then
+# renders that one list into each agent's native hook-config shape.
+#
+# Imported from a wrapper's default.nix as
+#   (import ../hooks.nix { inherit lib claudeHooks primaryCheckouts repoPackages; }).claude
+# (or `.codex`). `claudeHooks` is the built binary package from
+# ./claude-code/hooks.nix; the wrapper already builds it, so it threads it in
+# rather than this module rebuilding it.
+#
+# Claude Code and the Codex fork share the hook event model and the
+# `{matcher?, hooks:[{type="command",command,timeout?}]}` shape field-for-field,
+# so one declaration list renders to both; the only per-agent difference is which
+# declarations apply (the `agents` field) — codex has no `Search` tool and edits
+# via apply_patch, so the Search/Edit-matched and review hooks are claude-only.
+{
+  lib,
+  # The built claude-hooks binary (./claude-code/hooks.nix output).
+  claudeHooks,
+  # Shell globs of primary checkouts the worktree-guard protects; [] disables it.
+  primaryCheckouts ? [ ],
+  # Flake package set; `prompt-priors` is wired only when the `search` sibling is
+  # in scope (it shells out to IX_SEARCH), matching the claude-code package.
+  repoPackages ? { },
+}:
+let
+  hookCmd = sub: "${claudeHooks}/bin/claude-hooks ${sub}";
+
+  # One declaration per hook. Fields:
+  #   event     hook event name (SessionStart, PreToolUse, PostToolUse, Stop, ...)
+  #   sub       claude-hooks subcommand; the command is `<bin> <sub>`
+  #   matcher   optional tool-name matcher (omit for always-run events)
+  #   timeout   optional per-hook timeout (s); omit for the CLI default
+  #   agents    which agents get it; defaults to both
+  #   enable    optional bool gate (drops the declaration when false)
+  declarations = [
+    # SessionStart context: the pre-rendered fleet digest, plus the live host
+    # banner + ~/Projects repo inventory. Both just add context; harmless on codex.
+    {
+      event = "SessionStart";
+      sub = "session-digest";
+      timeout = 5;
+    }
+    {
+      event = "SessionStart";
+      sub = "session-banner";
+      timeout = 5;
+    }
+
+    # Score-gated ambient priors from the corpus store. Claude-only and gated on
+    # the search sibling (it execs IX_SEARCH).
+    {
+      event = "UserPromptSubmit";
+      sub = "prompt-priors";
+      timeout = 5;
+      agents = [ "claude" ];
+      enable = repoPackages ? search;
+    }
+
+    # Deny edits whose target resolves into a protected primary checkout. The
+    # Edit/Write matcher is claude-shaped (codex edits via apply_patch).
+    {
+      event = "PreToolUse";
+      matcher = "Edit|MultiEdit|Write|NotebookEdit";
+      sub = "worktree-guard";
+      timeout = 10;
+      agents = [ "claude" ];
+      enable = primaryCheckouts != [ ];
+    }
+
+    # Bash guards: steer cargo to nix in the monorepos, and catch shell
+    # anti-patterns. Codex's shell tool is matcher-aliased to "Bash", so both.
+    {
+      event = "PreToolUse";
+      matcher = "Bash";
+      sub = "cargo-guard";
+    }
+    {
+      event = "PreToolUse";
+      matcher = "Bash";
+      sub = "bash-habits-guard";
+    }
+
+    # Deny the built-in Search tool (claude-only: codex has no Search tool).
+    {
+      event = "PreToolUse";
+      matcher = "^Search$";
+      sub = "search-guard";
+      agents = [ "claude" ];
+    }
+
+    # Review gate pair: log edits, then require a review once per change-set on
+    # Stop. Claude-only — codex edits via apply_patch, which the matcher never
+    # sees, so the gate could never arm there.
+    {
+      event = "PostToolUse";
+      matcher = "Write|Edit|MultiEdit|NotebookEdit";
+      sub = "review-log-edit";
+      agents = [ "claude" ];
+    }
+    {
+      event = "Stop";
+      sub = "review-gate";
+      agents = [ "claude" ];
+    }
+
+    # Friction mining on every stop: analyze the transcript delta in the
+    # background and file genuine friction to Linear. Reads both transcript
+    # dialects, so both agents. Self-gates on the git author being an ix
+    # contributor (compiled-in), replacing the old conditions/ix-contributor
+    # wrapper.
+    {
+      event = "Stop";
+      sub = "friction-report";
+    }
+  ];
+
+  defaults = {
+    matcher = null;
+    timeout = null;
+    agents = [
+      "claude"
+      "codex"
+    ];
+    enable = true;
+  };
+
+  withDefaults = map (d: defaults // d) declarations;
+
+  unique = lib.foldl' (acc: x: if lib.elem x acc then acc else acc ++ [ x ]) [ ];
+
+  # Render the declaration list into the settings.json/codex `hooks` attrset for
+  # one agent: { <Event> = [ { matcher?; hooks = [ { type; command; timeout?; } ]; } ]; }.
+  forAgent =
+    agent:
+    let
+      mine = builtins.filter (d: d.enable && lib.elem agent d.agents) withDefaults;
+      events = unique (map (d: d.event) mine);
+      groupsFor =
+        event:
+        let
+          ofEvent = builtins.filter (d: d.event == event) mine;
+          group =
+            matcher:
+            {
+              hooks = map (
+                d:
+                {
+                  type = "command";
+                  command = hookCmd d.sub;
+                }
+                // lib.optionalAttrs (d.timeout != null) { inherit (d) timeout; }
+              ) (builtins.filter (d: d.matcher == matcher) ofEvent);
+            }
+            // lib.optionalAttrs (matcher != null) { inherit matcher; };
+        in
+        map group (unique (map (d: d.matcher) ofEvent));
+    in
+    lib.genAttrs events groupsFor;
+in
+{
+  claude = forAgent "claude";
+  codex = forAgent "codex";
+}


### PR DESCRIPTION
## What

Unify Claude Code and Codex lifecycle hooks into **one compiled binary** and **one shared declaration** living in this repo, replacing the split where 3 hooks were compiled+wired inline in the claude-code package and 7 more were hand-maintained as scripts in a personal `~/.config/nix` list rendered separately per agent.

## Changes

- **`claude-hooks` crate** grows from 3 to 10 subcommands: ports the 7 personal scripts to Rust (`review-log-edit`, `review-gate`, `cargo-guard`, `bash-habits-guard`, `search-guard`, `session-banner`, `friction-report`), each fail-open/silent like the existing three.
  - `friction-report` self-gates on the git author being an ix contributor (compiled-in list, replacing `conditions/ix-contributor`) and preserves the Python's immortal-worker fix: model child's stdout to a temp file (not a pipe), own process group, `killpg` on timeout.
- **`packages/agent/hooks.nix` (new)**: a neutral declaration list (`event`/`matcher`/`sub`/`agents`/`timeout`/`enable`), the hook analogue of `common.nix`, rendering `{ claude; codex; }` in the field-aligned schema both agents share. One list, two renders.
- **`claude-code/default.nix`**: imports `.claude` instead of the inline `hooks = {...}` block. No behavior change for the existing 3 hooks.
- **`codex/default.nix`**: exposes `.codex` as `passthru.hooksJson`. Codex discovers hooks from `~/.codex/hooks.json` / `[hooks]` / plugin manifests (no `-c` file pointer), and its hash-pinned trust gate means a `hooks.json` + one-time `/hooks` trust — the same delivery the personal config already uses. A consumer points `~/.codex/hooks.json` at this.
- **Tests**: `install-check.nix` gains behavioral checks for every new subcommand (deny/allow, review round-trip + loop guard, friction non-contributor silence); each hook also has Rust unit tests.

## Agent targeting

Both agents: session-digest, session-banner, cargo-guard, bash-habits-guard, friction-report. Claude-only (codex has no Search tool and edits via apply_patch): worktree-guard, prompt-priors, search-guard, review pair.

## Verified locally (aarch64-darwin)

- `cargo test -p claude-hooks`: 16/16 pass; clippy clean (repo pedantic/nursery).
- `nix build .#claude-code`: builds incl. `installCheckPhase` (all new hook checks pass).
- `nix build .#codex.hooksJson`: builds; rendered set verified.
- `nix run .#lint`: clean.

## Follow-up (separate PR)

Personal `~/.config/nix` cleanup: drop the local hook list, point `~/.codex/hooks.json` at `codex.hooksJson`, remove the migrated scripts + `conditions/ix-contributor`, and set the Mac's `primaryCheckouts`. Lands after this merges and `inputs.index` is bumped.

## Note for reviewers

This makes these hooks **fleet-wide defaults** for every index/ix agent (review gate, friction-report → indexable Linear (email-gated), the bash/cargo guards). Flagging since it changes default behavior for everyone, not just me.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify Claude and Codex hooks into a single shared declaration in hooks.nix
> - Introduces [hooks.nix](https://github.com/indexable-inc/index/pull/1476/files#diff-7e1da95735b9f3ab1af7abaa5341f4a219b19df80df74b37c11a2f6e8b61a04b) as the single source of truth for all agent hooks, replacing inline hook definitions in both [claude-code/default.nix](https://github.com/indexable-inc/index/pull/1476/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) and [codex/default.nix](https://github.com/indexable-inc/index/pull/1476/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5).
> - Adds several new hooks implemented in the `claude-hooks` Rust binary: `cargo-guard`, `bash-habits-guard`, and `search-guard` (PreToolUse denials), `review-log-edit` and `review-gate` (PostToolUse/Stop review workflow), `session-banner` (SessionStart context), and `friction-report` (Stop hook that detaches a background worker to mine transcripts and file Linear issues).
> - The `codex` derivation now exposes a `passthru.hooksJson` artifact for consumers to deliver hooks to `~/.codex/hooks.json`.
> - Risk: `friction-report` spawns background processes and can file Linear issues automatically; gating relies on a compiled contributor email list and git author identity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdd9bd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->