### PR TITLE
Fix HumanLayer CLI package

### DIFF
--- a/packages/humanlayer/default.nix
+++ b/packages/humanlayer/default.nix
@@ -1,8 +1,9 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchurl,
-  autoPatchelfHook,
+  makeWrapper,
+  nodejs_22,
   nix,
   # Bound to a real builder only on the flake-package path (lib/packages.nix),
   # which is where `nix run .#humanlayer.updateScript` resolves; the overlay path
@@ -16,20 +17,25 @@ let
   # `nix run .#humanlayer.updateScript` (see the updateScript below). Mirrors the
   # packages/yc layout.
   manifest = lib.importJSON ./manifest.json;
-  inherit (manifest) version;
+  inherit (manifest) version cliHash;
 
   # The `@humanlayer/cli` npm launcher is a thin JS shim that execs a
   # platform-specific, bun-compiled standalone binary shipped in a sibling
-  # package (`@humanlayer/cli-<slug>`). We fetch that platform binary directly:
-  # it is the real `humanlayer` executable, so the JS launcher is not needed.
+  # package (`@humanlayer/cli-<slug>`). Install both packages side by side,
+  # matching npm's node_modules layout, because the standalone binary starts as
+  # raw Bun when invoked outside the launcher.
   baseUrl = "https://registry.npmjs.org/@humanlayer";
 
-  inherit (stdenv.hostPlatform) system;
+  inherit (stdenvNoCC.hostPlatform) system;
   target =
     manifest.platforms.${system}
       or (throw "humanlayer: no prebuilt binary for ${system}; supported: ${lib.concatStringsSep ", " (builtins.attrNames manifest.platforms)}");
 
-  src = fetchurl {
+  cliSrc = fetchurl {
+    url = "${baseUrl}/cli/-/cli-${version}.tgz";
+    hash = cliHash;
+  };
+  platformSrc = fetchurl {
     url = "${baseUrl}/cli-${target.slug}/-/cli-${target.slug}-${version}.tgz";
     inherit (target) hash;
   };
@@ -62,6 +68,7 @@ let
           # Without a version argument it tracks the upstream npm `latest` tag.
           def main [version?: string] {
             let v = ($version | default (http get $"($base)/cli/latest" | get version))
+            let cli_hash = (^nix store prefetch-file --json $"($base)/cli/-/cli-($v).tgz" | from json | get hash)
             let platforms = (
               $slugs
               | transpose system slug
@@ -72,27 +79,35 @@ let
                 }
             )
             let out = "packages/humanlayer/manifest.json"
-            { version: $v, platforms: $platforms } | to json --indent 2 | save --force $out
+            { version: $v, cliHash: $cli_hash, platforms: $platforms } | to json --indent 2 | save --force $out
             print $"updated ($out) to ($v)"
           }
         '';
       };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "humanlayer";
-  inherit version src;
+  inherit version;
+  dontUnpack = true;
 
-  # The npm tarball unpacks to `package/` (bin/humanlayer + package.json).
-  sourceRoot = "package";
-
-  # The Linux binaries are dynamically linked against a generic libc; patch their
-  # interpreter and standard library NEEDEDs to the Nix store. Darwin binaries
-  # need no patching.
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     runHook preInstall
-    install -Dm755 bin/humanlayer $out/bin/humanlayer
+
+    mkdir -p \
+      "$out/lib/node_modules/@humanlayer/cli" \
+      "$out/lib/node_modules/@humanlayer/cli-${target.slug}" \
+      "$out/bin"
+
+    tar -xzf ${cliSrc} -C "$out/lib/node_modules/@humanlayer/cli" --strip-components=1
+    tar -xzf ${platformSrc} -C "$out/lib/node_modules/@humanlayer/cli-${target.slug}" --strip-components=1
+
+    patchShebangs "$out/lib/node_modules/@humanlayer/cli/bin/humanlayer"
+    wrapProgram "$out/lib/node_modules/@humanlayer/cli/bin/humanlayer" \
+      --prefix PATH : "${lib.makeBinPath [ nodejs_22 ]}"
+    ln -s "$out/lib/node_modules/@humanlayer/cli/bin/humanlayer" "$out/bin/humanlayer"
+
     runHook postInstall
   '';
 

--- a/packages/humanlayer/manifest.json
+++ b/packages/humanlayer/manifest.json
@@ -1,21 +1,22 @@
 {
-  "version": "0.27.10",
+  "version": "0.27.12",
+  "cliHash": "sha512-qIz/s+KWRf/fPDFBB+Ue/UvDPd/7bfLGYWDob4UiR94y13aWnaFPmFSXa7xCos3sKv4CO1yIyIUvjkk2BDa7oQ==",
   "platforms": {
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-rVnZtNJIwOjrMGyktQWAOq69CQvX3M2UssrDaAvVOG0="
+      "hash": "sha256-wpVG0mZoFpeJ2c6lZdd8T76JQKXiq2E5qzZcAap7AJw="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-HXp9fE1t32Bet+f7CZZn2I2k+quEYuQTomz/UsDLiQQ="
+      "hash": "sha256-ueOBzlqLUTf3lW3PUEc1q21UqXAo/M93NKC8T7SirKQ="
     },
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-dB0KbEPuip0UmglvsLQ/7HUoaH6VOby5BgJV6KXN2yI="
+      "hash": "sha256-8IdCBM3SZkOLk43IMhiKetzSLQ877XFpydD7wLtr7ek="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-j9I84fJCvG4U9Epm3fx45VT9XcmS/YO7UQMo1q+luuc="
+      "hash": "sha256-A+bmTLxFpP09qClS35MbOqIgUqA2IwEd+OLtsIfQ08s="
     }
   }
 }


### PR DESCRIPTION
## Summary
- package the @humanlayer/cli JS launcher alongside the platform binary package
- bump HumanLayer CLI to 0.27.12 with pinned launcher and platform hashes
- keep the update script writing the launcher hash into the manifest

## Verification
- nix build .#humanlayer --print-out-paths
- ./result/bin/humanlayer daemon launch --help

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix HumanLayer CLI package to install the npm launcher alongside the platform binary
> - Splits the single source fetch into two: one for the npm CLI tarball (`cliSrc`) and one for the platform-specific binary tarball (`platformSrc`), with hashes for both stored in [manifest.json](https://github.com/indexable-inc/index/pull/1478/files#diff-b9a360cab0e18f22a174c0388e0e2e177dc95552b8851a958992aedae6d57e70).
> - Switches [default.nix](https://github.com/indexable-inc/index/pull/1478/files#diff-33b58e177ce718308782df42303578214fe1610e2e1f6a2ecf4aabdcad99a558) from `stdenv.mkDerivation` + `autoPatchelfHook` to `stdenvNoCC.mkDerivation` + `makeWrapper`; both packages are installed under `$out/lib/node_modules`.
> - The installed `$out/bin/humanlayer` is now the npm CLI launcher script (with `nodejs_22` on PATH via `makeWrapper`) rather than the raw platform binary.
> - Updates the update script to prefetch the CLI tarball hash and write `cliHash` into `manifest.json` alongside version and platform hashes.
> - Behavioral Change: `$out/bin/humanlayer` now invokes the npm launcher script, which dispatches to the platform binary, rather than invoking the platform binary directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0697ee0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->