### PR TITLE
Fix HumanLayer launcher shebang handling

### DIFF
--- a/packages/humanlayer/default.nix
+++ b/packages/humanlayer/default.nix
@@ -90,7 +90,16 @@ stdenvNoCC.mkDerivation {
   inherit version;
   dontUnpack = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs_22
+  ];
+
+  # Do not auto-patchelf the platform payload. The Linux package is a Bun
+  # standalone executable with embedded application metadata; patchelfing it
+  # makes it start as generic `bun`, so `humanlayer daemon ...` fails with
+  # "Script not found". The npm JS launcher below executes the payload as
+  # published, which is the form verified on NixOS.
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Summary
- add nodejs_22 to nativeBuildInputs so patchShebangs can resolve the HumanLayer npm launcher shebang
- document why the Bun standalone platform payload must not be auto-patchelfed

Follow-up to #1478; addresses the AI review findings there.

## Verification
- nix build .#humanlayer --print-out-paths
- ./result/bin/humanlayer daemon launch --help

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix shebang handling in HumanLayer launcher by adding Node.js 22 to build inputs
> Adds `nodejs_22` to `nativeBuildInputs` in [default.nix](https://github.com/indexable-inc/index/pull/1479/files#diff-33b58e177ce718308782df42303578214fe1610e2e1f6a2ecf4aabdcad99a558) alongside `makeWrapper`. Also adds comments clarifying that the platform payload should not be auto-patchelfed and that the npm JS launcher executes the payload as published.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f6955d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->