### PR TITLE
feat(perftest): package linux-rdma perftest for RDMA/RoCE benchmarks

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,6 +255,23 @@
         "type": "github"
       }
     },
+    "perftest-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780225113,
+        "narHash": "sha256-oNvzQubmslZ4JUNww/wvWd54JDsDLamCDlorHWlNtaY=",
+        "ref": "refs/tags/26.04.17",
+        "rev": "720b61082454e189b1f21835ec175536a944afc3",
+        "revCount": 1432,
+        "type": "git",
+        "url": "https://github.com/linux-rdma/perftest"
+      },
+      "original": {
+        "ref": "refs/tags/26.04.17",
+        "type": "git",
+        "url": "https://github.com/linux-rdma/perftest"
+      }
+    },
     "pyproject-build-systems": {
       "inputs": {
         "nixpkgs": [
@@ -358,6 +375,7 @@
         "images": "images",
         "launchk-src": "launchk-src",
         "nixpkgs": "nixpkgs",
+        "perftest-src": "perftest-src",
         "rust-overlay": "rust-overlay",
         "site": "site",
         "skills": "skills",

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,11 @@
       flake = false;
     };
 
+    perftest-src = {
+      url = "git+https://github.com/linux-rdma/perftest?ref=refs/tags/26.04.17";
+      flake = false;
+    };
+
     fff-src = {
       url = "github:dmtrKovalenko/fff/v0.9.1";
       flake = false;
@@ -168,6 +173,7 @@
       hermes-agent,
       btop-src,
       drgn-src,
+      perftest-src,
       fff-src,
       launchk-src,
       snix-src,
@@ -252,6 +258,7 @@
           hermes-agent
           btop-src
           drgn-src
+          perftest-src
           fff-src
           launchk-src
           snix-src

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -8,6 +8,7 @@
   hermes-agent,
   btop-src,
   drgn-src,
+  perftest-src,
   fff-src,
   launchk-src,
   snix-src,
@@ -452,6 +453,7 @@ let
       ;
     btopSrc = btop-src;
     drgnSrc = drgn-src;
+    perftestSrc = perftest-src;
     fffSrc = fff-src;
     launchkSrc = launchk-src;
     snixSrc = snix-src;

--- a/packages/perftest/default.nix
+++ b/packages/perftest/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  ix,
+  stdenv,
+  autoreconfHook,
+  pkg-config,
+  rdma-core,
+  pciutils,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "perftest";
+  version = "26.04.17";
+
+  src = ix.perftestSrc;
+
+  # perftest ships autogen.sh (an `autoreconf -i` wrapper) rather than a
+  # committed ./configure, so autoreconfHook regenerates the build system.
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  # libibverbs + librdmacm (+ libibumad) come from rdma-core; libpci from
+  # pciutils feeds the optional PCI-relative-path reporting. CUDA/ROCm GPUDirect
+  # paths auto-detect and stay off without their toolkits, which is what we want
+  # for a plain RoCE latency/bandwidth benchmark.
+  buildInputs = [
+    rdma-core
+    pciutils
+  ];
+
+  meta = {
+    description = "RDMA (RoCE/InfiniBand) verbs and connection-manager latency/bandwidth benchmarks";
+    longDescription = ''
+      linux-rdma perftest: ib_send_bw / ib_write_bw / ib_read_bw and the matching
+      *_lat tools, plus raw_ethernet_*. Used to measure RoCEv2 one-way latency and
+      multi-QP aggregate bandwidth across the fleet vRack, e.g. a single process
+      driving N queue pairs over a LACP bond: `ib_send_bw -R -q 8 -D 10 <peer>`.
+      The suite installs many binaries under bin/; mainProgram points at
+      ib_send_bw so `nix run .#perftest -- ...` runs the multi-QP bandwidth tool,
+      while the rest are reachable via `nix shell .#perftest`.
+    '';
+    homepage = "https://github.com/linux-rdma/perftest";
+    # Dual-licensed GPLv2-or-BSD-2 (see COPYING); record both.
+    license = with lib.licenses; [
+      gpl2Only
+      bsd2
+    ];
+    mainProgram = "ib_send_bw";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})

--- a/packages/perftest/default.nix
+++ b/packages/perftest/default.nix
@@ -8,7 +8,7 @@
   pciutils,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "perftest";
   version = "26.04.17";
 
@@ -53,4 +53,4 @@ stdenv.mkDerivation (finalAttrs: {
       "aarch64-linux"
     ];
   };
-})
+}

--- a/packages/perftest/default.nix
+++ b/packages/perftest/default.nix
@@ -43,9 +43,9 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/linux-rdma/perftest";
     # Dual-licensed GPLv2-or-BSD-2 (see COPYING); record both.
-    license = with lib.licenses; [
-      gpl2Only
-      bsd2
+    license = [
+      lib.licenses.gpl2Only
+      lib.licenses.bsd2
     ];
     mainProgram = "ib_send_bw";
     platforms = [

--- a/packages/perftest/package.nix
+++ b/packages/perftest/package.nix
@@ -1,0 +1,17 @@
+{
+  id = "perftest";
+  # perftest builds the RDMA verbs/CM benchmarks (ib_send_bw, ib_write_lat, ...)
+  # against libibverbs/librdmacm, so it is Linux-only. Gate the flake output and
+  # the package-set attr to Linux for the same reason drgn does: advertising them
+  # off-platform makes `nix flake check` force a build nixpkgs refuses to evaluate.
+  # The overlay stays unconditional (lazy; only a Linux closure ever forces it).
+  packageSet.systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
+  flake.systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
+  overlay = true;
+}


### PR DESCRIPTION
## What

Packages the [linux-rdma/perftest](https://github.com/linux-rdma/perftest) suite (`ib_send_bw`, `ib_write_bw`, `ib_read_bw`, the matching `*_lat` tools, and `raw_ethernet_*`) as a Linux-only flake package, pinned via a new `perftest-src` flake input. Mirrors the `drgn` packaging exactly (packageSet + flake + overlay gated to `x86_64/aarch64-linux`).

`mainProgram = ib_send_bw`, so:
- `nix run .#perftest -- -R -q 8 -D 10 <peer>` drives the multi-QP bandwidth tool
- `nix shell .#perftest` reaches the rest of the suite

## Why

Measuring RoCEv2 one-way latency and **multi-QP aggregate** bandwidth across the fleet vRack needs `ib_send_bw -q N` (N queue pairs in one process). `qperf` can't do this — its `rdma_cm` path doesn't parallelize, so single-QP RDMA caps at one 25G link and the real aggregate across the 2x25G LACP bond is unmeasurable. This gives every node a reusable `nix run index#perftest`.

## Validation

- `nix eval .#packages.x86_64-linux.perftest.drvPath` ✅
- `nix build .#packages.x86_64-linux.perftest` on vin-compute-1 ✅ (builds all binaries; autoreconfHook + rdma-core + pciutils)
- `nix fmt` clean; dropped a `with` to satisfy astlog no-with

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `perftest` package for RDMA/RoCE benchmarks on Linux
> - Adds a new [packages/perftest/default.nix](https://github.com/indexable-inc/index/pull/1480/files#diff-653b7eebaf2c071440a2b247874f65185a57cffdf3d8261f75847c8bb99eb8dd) derivation that builds the `linux-rdma/perftest` suite (tag `26.04.17`) with `rdma-core` and `pciutils`, providing binaries like `ib_send_bw`, `ib_write_bw`, and `raw_ethernet_*`.
> - Wires `perftest-src` as a flake input in [flake.nix](https://github.com/indexable-inc/index/pull/1480/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) and exposes it via `ix.perftestSrc` in [lib/default.nix](https://github.com/indexable-inc/index/pull/1480/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188).
> - Package is restricted to `x86_64-linux` and `aarch64-linux` with the overlay enabled via [packages/perftest/package.nix](https://github.com/indexable-inc/index/pull/1480/files#diff-1f9d9985d22e74bbc077888dabad8b9e4f3f0398da27d863a12f2911d781eb27).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfc1abe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->