### PR TITLE
Preserve HumanLayer Bun payload

### DIFF
--- a/packages/humanlayer/default.nix
+++ b/packages/humanlayer/default.nix
@@ -100,6 +100,7 @@ stdenvNoCC.mkDerivation {
   # makes it start as generic `bun`, so `humanlayer daemon ...` fails with
   # "Script not found". The npm JS launcher below executes the payload as
   # published, which is the form verified on NixOS.
+  dontStrip = true;
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Summary
- add dontStrip=true to keep the HumanLayer Bun standalone payload intact

Follow-up to #1478 and #1479; addresses the remaining AI review finding about default strip rewriting the Bun payload.

## Verification
- nix build .#humanlayer --print-out-paths
- ./result/bin/humanlayer daemon launch --help

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable stripping of the HumanLayer Bun payload during build
> Sets `dontStrip = true` in [default.nix](https://github.com/indexable-inc/index/pull/1481/files#diff-33b58e177ce718308782df42303578214fe1610e2e1f6a2ecf4aabdcad99a558) to prevent Nix from stripping the HumanLayer Bun binary during the install phase, which would corrupt the payload bundled inside it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5d70fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->