### PR TITLE
Agent: mark embedded script syntax

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -18,6 +18,7 @@
     "elixir-lsp.elixir-ls",
     "sumneko.lua",
     "fwcd.kotlin",
-    "redhat.vscode-xml"
+    "redhat.vscode-xml",
+    "rdfox.rdfox-rdf"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "java.configuration.updateBuildConfiguration": "automatic",
   "direnv.restart.automatic": true,
   "files.associations": {
+    "*.astlog": "datalog",
     "*.nu": "nushell",
     "common.json": "jsonc",
     "*-mods.json": "jsonc"
@@ -31,7 +32,10 @@
     "tests/fixtures/cargo-unit-hello/Cargo.toml"
   ],
   "rust-analyzer.check.command": "clippy",
-  "rust-analyzer.check.extraArgs": ["--all-targets", "--all-features"],
+  "rust-analyzer.check.extraArgs": [
+    "--all-targets",
+    "--all-features"
+  ],
   "rust-analyzer.cargo.features": "all",
   "rust-analyzer.imports.granularity.group": "module",
   "rust-analyzer.imports.prefix": "crate",
@@ -46,7 +50,17 @@
   "rust-analyzer.diagnostics.experimental.enable": true,
   "nix.serverSettings": {
     "nixd": {
-      "formatting": { "command": ["nixfmt"] }
+      "formatting": {
+        "command": [
+          "nixfmt"
+        ]
+      }
+    }
+  },
+  "nix-embedded-languages.include": {
+    "nu|nushell": {
+      "name": "Nushell",
+      "scopeName": "source.nushell"
     }
   },
   "search.exclude": {

--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -1239,6 +1239,74 @@
 (lint keep-phase-hooks error
   "a phase override that drops its `runHook pre<Phase>` / `runHook post<Phase>` calls strips downstream hooks; keep both hooks for that phase")
 
+;; phase-string-syntax-comment: multiline shell phases should opt into editor
+;; shell highlighting with a harmless first-line shell comment.
+(rule (phase-string-syntax-comment n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text-match p "(^|\\.)(prePatch|postPatch|patchPhase|preBuild|postBuild|buildPhase|preInstall|postInstall|installPhase|preCheck|postCheck|checkPhase|preConfigure|postConfigure|configurePhase|preFixup|postFixup|fixupPhase|unpackPhase|distPhase|installCheckPhase|shellHook)$")
+  (text-match v "^''[[:space:]]*# (shell|bash|sh|syntax: (shell|bash|sh))"))
+(rule (phase-string-without-syntax-comment n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text-match p "(^|\\.)(prePatch|postPatch|patchPhase|preBuild|postBuild|buildPhase|preInstall|postInstall|installPhase|preCheck|postCheck|checkPhase|preConfigure|postConfigure|configurePhase|preFixup|postFixup|fixupPhase|unpackPhase|distPhase|installCheckPhase|shellHook)$")
+  (not (phase-string-syntax-comment n)))
+(lint phase-string-without-syntax-comment error
+  "multiline shell phase strings need `# shell` as their first line so editors highlight the embedded shell")
+
+;; nushell-text-without-syntax-comment: embedded Nushell app bodies should opt
+;; into editor highlighting with a harmless first-line Nushell comment.
+(rule (nushell-text-syntax-comment n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text p "text")
+  (text-match v "^''[[:space:]]*# (nu|nushell|syntax: (nu|nushell))"))
+(rule (nushell-looking-text n)
+  (match nix "
+    (binding
+      attrpath: (attrpath) @p
+      expression: (indented_string_expression) @v) @n")
+  (text p "text")
+  (text-match v "^''[[:space:]]*(def |def --wrapped |const |let |use |source |export def |module )"))
+(rule (nushell-text-without-syntax-comment n)
+  (nushell-looking-text n)
+  (not (nushell-text-syntax-comment n)))
+(lint nushell-text-without-syntax-comment error
+  "multiline Nushell `text` strings need `# nu` as their first line so editors highlight the embedded Nushell")
+
+;; python-text-without-syntax-comment: embedded Python source files should opt
+;; into editor highlighting with a harmless first-line Python comment.
+(rule (python-text-syntax-comment n)
+  (match nix "
+    (apply_expression
+      function: (apply_expression
+        function: [(variable_expression) (select_expression)] @f
+        argument: (string_expression) @s)
+      argument: (indented_string_expression) @v) @n")
+  (text-match f "^(pkgs\\.)?writeText$")
+  (text-match s "\\.py\"$")
+  (text-match v "^''[[:space:]]*# (python|py|syntax: (python|py))"))
+(rule (python-text n)
+  (match nix "
+    (apply_expression
+      function: (apply_expression
+        function: [(variable_expression) (select_expression)] @f
+        argument: (string_expression) @s)
+      argument: (indented_string_expression)) @n")
+  (text-match f "^(pkgs\\.)?writeText$")
+  (text-match s "\\.py\"$"))
+(rule (python-text-without-syntax-comment n)
+  (python-text n)
+  (not (python-text-syntax-comment n)))
+(lint python-text-without-syntax-comment error
+  "multiline Python `writeText \"*.py\"` strings need `# python` as their first line so editors highlight the embedded Python")
+
 ;; prefer-substituteinplace: `sed -i` / `awk` in a phase fails silently when the
 ;; pattern stops matching; use `substituteInPlace ... --replace-fail`.
 (rule (prefer-substituteinplace n)

--- a/astlog-rules/tests/keep-phase-hooks/good.fixture
+++ b/astlog-rules/tests/keep-phase-hooks/good.fixture
@@ -1,4 +1,5 @@
 { buildPhase = ''
+  # shell
   runHook preBuild
   make something
   do something else

--- a/astlog-rules/tests/nushell-text-without-syntax-comment/bad.fixture
+++ b/astlog-rules/tests/nushell-text-without-syntax-comment/bad.fixture
@@ -1,0 +1,7 @@
+{
+  text = ''
+    def main [] {
+      print "ok"
+    }
+  '';
+}

--- a/astlog-rules/tests/nushell-text-without-syntax-comment/good.fixture
+++ b/astlog-rules/tests/nushell-text-without-syntax-comment/good.fixture
@@ -1,0 +1,8 @@
+{
+  text = ''
+    # nu
+    def main [] {
+      print "ok"
+    }
+  '';
+}

--- a/astlog-rules/tests/phase-string-without-syntax-comment/bad.fixture
+++ b/astlog-rules/tests/phase-string-without-syntax-comment/bad.fixture
@@ -1,0 +1,7 @@
+{
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 tool $out/bin/tool
+    runHook postInstall
+  '';
+}

--- a/astlog-rules/tests/phase-string-without-syntax-comment/good.fixture
+++ b/astlog-rules/tests/phase-string-without-syntax-comment/good.fixture
@@ -1,0 +1,8 @@
+{
+  installPhase = ''
+    # shell
+    runHook preInstall
+    install -Dm755 tool $out/bin/tool
+    runHook postInstall
+  '';
+}

--- a/astlog-rules/tests/python-text-without-syntax-comment/bad.fixture
+++ b/astlog-rules/tests/python-text-without-syntax-comment/bad.fixture
@@ -1,0 +1,5 @@
+{
+  src = pkgs.writeText "tool.py" ''
+    print("ok")
+  '';
+}

--- a/astlog-rules/tests/python-text-without-syntax-comment/good.fixture
+++ b/astlog-rules/tests/python-text-without-syntax-comment/good.fixture
@@ -1,0 +1,6 @@
+{
+  src = pkgs.writeText "tool.py" ''
+    # python
+    print("ok")
+  '';
+}

--- a/examples/minecraft-blocks/packages.nix
+++ b/examples/minecraft-blocks/packages.nix
@@ -232,6 +232,7 @@ let
       runtimeInputs = [ pkgs.clickhouse ];
       meta.description = "Query the minecraft block_events spatial view in ClickHouse";
       text = ''
+        # nu
         let ch = [
           "client" "--host" "${host}" "--port" "${toString port}"
           "--database" "${schema.database}" "--format" "PrettyCompact"

--- a/examples/minecraft-blocks/view.nix
+++ b/examples/minecraft-blocks/view.nix
@@ -60,6 +60,7 @@ let
     ix.writeNushellApplication pkgs {
       name = "mc-blocks-apply-init";
       text = ''
+        # nu
         let base = [ "client" "--host" "${clickhouseHost}" "--port" "${toString clickhousePort}" ]
         while (^${lib.getExe pkgs.clickhouse} ...$base --query "SELECT 1" | complete).exit_code != 0 { sleep 1sec }
         open --raw "${initSql}" | ^${lib.getExe pkgs.clickhouse} ...$base --multiquery

--- a/examples/observability-stack/app.nix
+++ b/examples/observability-stack/app.nix
@@ -37,6 +37,7 @@ let
     ix.writeNushellApplication pkgs {
       name = "ix-observability-demo-check";
       text = ''
+        # nu
         let base = [ "client" "--host" "${observability.host}" "--port" "${toString observability.clickhousePort}" "--database" "${observability.database}" ]
         let traces = (^${lib.getExe pkgs.clickhouse} ...$base --query "SELECT count() FROM otel_traces WHERE ServiceName = '${serviceName}' AND SpanName = '${spanName}' AND Timestamp >= now() - INTERVAL 1 DAY" | str trim | into int)
         let logs = (^${lib.getExe pkgs.clickhouse} ...$base --query "SELECT count() FROM otel_logs WHERE Body LIKE '%${marker}%' AND Timestamp >= now() - INTERVAL 1 DAY" | str trim | into int)

--- a/examples/ray-cluster/cluster-node.nix
+++ b/examples/ray-cluster/cluster-node.nix
@@ -80,6 +80,7 @@ let
       pkgs.coreutils
     ];
     text = ''
+      # nu
       let node_ip = (
         ip -4 -o addr show scope global
         | lines

--- a/lib/build/bun-lock.nix
+++ b/lib/build/bun-lock.nix
@@ -177,6 +177,7 @@ lib.fix (self: {
         strictDeps = true;
 
         buildPhase = ''
+          # shell
           runHook preBuild
 
           cp ${packageFile} package.json
@@ -195,6 +196,7 @@ lib.fix (self: {
         '';
 
         installPhase = ''
+          # shell
           runHook preInstall
 
           mkdir -p "$out"

--- a/lib/build/elixir-check.nix
+++ b/lib/build/elixir-check.nix
@@ -104,6 +104,7 @@ pkgs.stdenv.mkDerivation {
   '';
 
   buildPhase = ''
+    # shell
     runHook preBuild
     mix compile ${depsCheckFlag} --warnings-as-errors
     runHook postBuild
@@ -111,6 +112,7 @@ pkgs.stdenv.mkDerivation {
 
   doCheck = true;
   checkPhase = ''
+    # shell
     runHook preCheck
     mix format --check-formatted
     mix credo --strict
@@ -119,6 +121,7 @@ pkgs.stdenv.mkDerivation {
   '';
 
   installPhase = ''
+    # shell
     runHook preInstall
     mkdir -p "$out"
     runHook postInstall

--- a/lib/build/go-unit.nix
+++ b/lib/build/go-unit.nix
@@ -201,8 +201,11 @@ let
       doCheck = true;
       strictDeps = true;
       installPhase = ''
+        # shell
+        runHook preInstall
         mkdir -p "$out"
         touch "$out/done"
+        runHook postInstall
       '';
       passthru.goUnit = {
         inherit (args)

--- a/lib/build/gradle-fat-jar.nix
+++ b/lib/build/gradle-fat-jar.nix
@@ -223,6 +223,7 @@ pkgs.stdenvNoCC.mkDerivation (
     gradleInitScript = localMavenInitScript;
 
     preConfigure = ''
+      # shell
       ${preConfigure}
       rm -rf .gradle build
     '';

--- a/lib/build/js-site.nix
+++ b/lib/build/js-site.nix
@@ -80,6 +80,7 @@ let
         derivationAttrs = {
           inherit bunNodeModules;
           configurePhase = ''
+            # shell
             runHook preConfigure
 
             patchShebangs .
@@ -143,6 +144,7 @@ pkgs.stdenvNoCC.mkDerivation (
     nativeBuildInputs = manager.nativeBuildInputs ++ extraNativeBuildInputs;
 
     buildPhase = ''
+      # shell
       runHook preBuild
       ${preBuild}
       ${lib.escapeShellArgs buildCommand}
@@ -150,6 +152,7 @@ pkgs.stdenvNoCC.mkDerivation (
     '';
 
     installPhase = ''
+      # shell
       runHook preInstall
       mkdir -p "$out"/${lib.escapeShellArg installDir}
       cp -R ${lib.escapeShellArg (distDir + "/.")} "$out"/${lib.escapeShellArg installDir}/

--- a/lib/build/libghostty-vt.nix
+++ b/lib/build/libghostty-vt.nix
@@ -61,11 +61,17 @@ let
   # deps), so these go through the checked Nushell writer.
   xcrunShim = writeNushellApplication pkgs {
     name = "xcrun";
-    text = ''def --wrapped main [...args] { print "${appleSdkRoot}" }'';
+    text = ''
+      # nu
+      def --wrapped main [...args] { print "${appleSdkRoot}" }
+    '';
   };
   xcodeSelectShim = writeNushellApplication pkgs {
     name = "xcode-select";
-    text = ''def --wrapped main [...args] { print "${appleSdk}" }'';
+    text = ''
+      # nu
+      def --wrapped main [...args] { print "${appleSdk}" }
+    '';
   };
 
   darwinSdkInputs = lib.optionals isDarwin [
@@ -103,6 +109,7 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
+    # shell
     runHook preInstall
 
     export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-cache"

--- a/lib/build/npm-vitest.nix
+++ b/lib/build/npm-vitest.nix
@@ -61,14 +61,18 @@ let
       inherit version;
       dontUnpack = false;
       buildPhase = ''
+        # shell
         runHook preBuild
         ${preTest}
         ${vitestCli} run
         runHook postBuild
       '';
       installPhase = ''
+        # shell
+        runHook preInstall
         mkdir -p "$out"
         echo passed > "$out/result"
+        runHook postInstall
       '';
     }
   );
@@ -79,14 +83,18 @@ let
       pname = "${pname}-vitest-manifest";
       inherit version;
       buildPhase = ''
+        # shell
         runHook preBuild
         ${preTest}
         ${vitestCli} list --json --static-parse > tests.json
         runHook postBuild
       '';
       installPhase = ''
+        # shell
+        runHook preInstall
         mkdir -p "$out"
         cp tests.json "$out/tests.json"
+        runHook postInstall
       '';
     }
   );
@@ -166,14 +174,18 @@ let
             vitestArgs = caseArgs entry;
           };
           buildPhase = ''
+            # shell
             runHook preBuild
             ${preTest}
             ${vitestCli} run ${lib.escapeShellArgs (caseArgs entry)}
             runHook postBuild
           '';
           installPhase = ''
+            # shell
+            runHook preInstall
             mkdir -p "$out"
             echo passed > "$out/result"
+            runHook postInstall
           '';
         }
       )

--- a/lib/build/svelte-site.nix
+++ b/lib/build/svelte-site.nix
@@ -78,6 +78,7 @@ let
         derivationAttrs = {
           inherit bunNodeModules;
           configurePhase = ''
+            # shell
             runHook preConfigure
 
             patchShebangs .
@@ -166,6 +167,7 @@ let
       nativeBuildInputs = manager.nativeBuildInputs ++ extraNativeBuildInputs;
 
       buildPhase = ''
+        # shell
         runHook preBuild
         ${preBuild}
         ${lib.escapeShellArgs buildCommand}
@@ -173,6 +175,7 @@ let
       '';
 
       installPhase = ''
+        # shell
         runHook preInstall
         mkdir -p "$out"/${lib.escapeShellArg installDir}
         cp -R ${lib.escapeShellArg (distDir + "/.")} "$out"/${lib.escapeShellArg installDir}/
@@ -249,6 +252,7 @@ let
     inherit (manager) runtimeInputs;
     meta.description = "Run the ${pname} Svelte dev server from a mutable checkout";
     text = ''
+      # nu
       const checkout_subdir = ${builtins.toJSON devConfig.checkoutSubdir}
       const install_argv = ${builtins.toJSON manager.devInstallCommand}
       const run_prefix = ${builtins.toJSON devRunPrefix}

--- a/lib/build/uv-application.nix
+++ b/lib/build/uv-application.nix
@@ -227,6 +227,7 @@ pkgs.stdenvNoCC.mkDerivation (_: {
   doInstallCheck = check;
 
   installPhase = ''
+    # shell
     runHook preInstall
 
     export HOME="$TMPDIR/home"
@@ -255,6 +256,7 @@ pkgs.stdenvNoCC.mkDerivation (_: {
   '';
 
   installCheckPhase = ''
+    # shell
     runHook preInstallCheck
 
     ${selectedChecker.phase}

--- a/lib/build/zig-package.nix
+++ b/lib/build/zig-package.nix
@@ -140,6 +140,7 @@ pkgs.stdenv.mkDerivation (
     dontBuild = true;
 
     installPhase = ''
+      # shell
       runHook preInstall
 
       ${zigCacheScript}

--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -394,6 +394,7 @@ let
           name = if sub == null then "ix-fleet" else "ix-fleet-${sub}";
           runtimeInputs = [ ixFleet ];
           text = ''
+            # nu
             def --wrapped main [...args] {
               ${userLocalBinPath}
               exec ${lib.getExe ixFleet} --plan ${plan} ${lib.optionalString (sub != null) "${sub} "}...$args

--- a/lib/image/health-checks.nix
+++ b/lib/image/health-checks.nix
@@ -81,6 +81,7 @@ let
     writeNushellApplication pkgs {
       name = "health-check-${name}";
       text = ''
+        # nu
         def main [] {
           let home = ($env.HOME? | default "")
           if $home != "" {
@@ -143,6 +144,7 @@ let
     meta.description = "Boot every example fleet in parallel, run its health checks, and tear the VMs down";
     runtimeInputs = [ dagRunner ];
     text = ''
+      # nu
       def --wrapped main [...args] {
         exec ${lib.getExe dagRunner} ...$args ${specFile}
       }
@@ -175,6 +177,7 @@ let
     meta.description = "Boot every example fleet, run its health checks, and view each in a zellij pane";
     runtimeInputs = [ pkgs.zellij ];
     text = ''
+      # nu
       def main [] {
         ${ixTokenPrompt}
 

--- a/lib/minecraft/sync-managed.nix
+++ b/lib/minecraft/sync-managed.nix
@@ -52,6 +52,7 @@ in
 writeNushellApplication pkgs {
   name = "minecraft-sync-managed";
   text = ''
+    # nu
     def main [] {
       exec ${lib.getExe package} ${lib.escapeShellArgs args}
     }

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -46,6 +46,7 @@ let
       repoPackages.astlog
     ];
     text = ''
+      # nu
       def "main nixfmt" [] {
         let nix_files = (fd --extension nix | lines)
         nixfmt --check ...$nix_files
@@ -175,6 +176,7 @@ let
     meta.description = "Run all Nix formatting and lint checks in parallel via dag-runner";
     runtimeInputs = [ repoPackages.dag-runner ];
     text = ''
+      # nu
       def --wrapped main [...args] {
         exec dag-runner ...$args ${lintSpec}
       }
@@ -612,6 +614,7 @@ let
     meta.description = "Refresh every repo content source (Minecraft catalogs + pinned binaries) in parallel via dag-runner";
     runtimeInputs = [ repoPackages.dag-runner ];
     text = ''
+      # nu
       def --wrapped main [...args] {
         exec dag-runner ...$args ${updateSpec}
       }

--- a/lib/util/bench.nix
+++ b/lib/util/bench.nix
@@ -63,6 +63,7 @@ let
     # so a perf job can override the store or pin a baseline without a second
     # entry point.
     text = ''
+      # nu
       def --wrapped main [...args] {
         exec ${exe} run --suite ${lib.escapeShellArg name} --runs ${toString runs} ${cmdFlags} ...$args
       }

--- a/lib/util/secrets.nix
+++ b/lib/util/secrets.nix
@@ -80,6 +80,7 @@ let
       command = writeNushellApplication pkgs {
         name = "check-secret-refs";
         text = ''
+          # nu
           def check-secret [key: string, field: any, folder: any] {
             let folder_args = if ($folder | is-empty) { [] } else { [--folder $folder] }
             let value_args = if ($field | is-empty) { [--raw] } else { [--field $field] }
@@ -131,6 +132,7 @@ let
       command = writeNushellApplication pkgs {
         name = "materialize-secret-refs";
         text = ''
+          # nu
           def read-secret [key: string, field: any, folder: any] {
             let folder_args = if ($folder | is-empty) { [] } else { [--folder $folder] }
             if ($field | is-empty) {
@@ -264,6 +266,7 @@ let
           materializeSecrets
         ];
         text = ''
+          # nu
           def --wrapped main [...args] {
             check-secret-refs
             materialize-secret-refs

--- a/lib/util/writers.nix
+++ b/lib/util/writers.nix
@@ -214,6 +214,7 @@ let
       ''
       + text;
       checkPhase = ''
+        # shell
         runHook preCheck
         ${lib.getExe' pkgs.bash "bash"} -n "$target"
         ${lib.getExe pkgs.shellcheck} --shell=bash --severity=warning "$target"
@@ -283,6 +284,7 @@ let
           mainProgram = meta.mainProgram or name;
         };
         text = ''
+          # nu
           const process_compose_args = ${builtins.toJSON processComposeArgs}
 
           def main [...args: string] {

--- a/modules/services/minecraft-bedrock/server.nix
+++ b/modules/services/minecraft-bedrock/server.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
+    # shell
     runHook preInstall
 
     mkdir -p "$out/bin" "$out/share/minecraft-bedrock-server"

--- a/modules/services/minecraft/default.nix
+++ b/modules/services/minecraft/default.nix
@@ -709,6 +709,7 @@ let
       syncManaged
     ];
     text = ''
+      # nu
       const driver = ${builtins.toJSON autoReloadDriver}
       const socket = ${builtins.toJSON cfg.autoReload.socketPath}
       const plan = ${builtins.toJSON "${dataDir}/.ix-managed-${cfg.dropinDir}.reload-plan"}
@@ -757,6 +758,7 @@ let
     name = "minecraft-world-border";
     runtimeInputs = [ pkgs.minecraft-rcon ];
     text = ''
+      # nu
       def rcon [command: string] {
         minecraft-rcon --host 127.0.0.1 --port ${toString rconPort} --password-file ${builtins.toJSON rconPasswordFile} $command
       }

--- a/modules/services/observability/default.nix
+++ b/modules/services/observability/default.nix
@@ -56,6 +56,7 @@ let
     name = "ix-observe";
     runtimeInputs = [ cfg.clickhouse.package ];
     text = ''
+      # nu
       let clickhouse_args = [
         "client"
         "--host"

--- a/modules/services/ray/default.nix
+++ b/modules/services/ray/default.nix
@@ -120,6 +120,7 @@ let
       cfg.package
     ];
     text = ''
+      # nu
       def main [] {
         let ip = (do --ignore-errors {
           ^tailscale ip -4 | lines | where ($it | str trim | is-not-empty) | first
@@ -157,6 +158,7 @@ let
       cfg.notebookPackage
     ];
     text = ''
+      # nu
       def main [] {
         let ip = (do --ignore-errors {
           ^tailscale ip -4 | lines | where ($it | str trim | is-not-empty) | first

--- a/modules/services/remote-desktop/default.nix
+++ b/modules/services/remote-desktop/default.nix
@@ -24,6 +24,7 @@ let
       pkgs.xterm
     ];
     text = ''
+      # nu
       def main [] {
         job spawn { ^xterm }
         exec icewm-session
@@ -49,6 +50,7 @@ let
       cfg.package
     ];
     text = ''
+      # nu
       def main [] {
         let args = ${
           builtins.toJSON (

--- a/modules/services/spark/default.nix
+++ b/modules/services/spark/default.nix
@@ -140,6 +140,7 @@ let
       cfg.package
     ];
     text = ''
+      # nu
       def main [...args: string] {
         let ip = (do --ignore-errors {
           ^tailscale ip -4 | lines | where ($it | str trim | is-not-empty) | first

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -160,6 +160,9 @@ let
 
   # Set only when the caller has not already provided an env value.
   wrapperEnvDefaults = {
+    # Drops [1m] variants from /model without touching model selection.
+    # Re-enable 1M per machine: `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
+    CLAUDE_CODE_DISABLE_1M_CONTEXT = 1;
   };
 
   # Settings defaults are injected only when the caller passed no `--settings`;

--- a/packages/agent/claude-code/update.nix
+++ b/packages/agent/claude-code/update.nix
@@ -19,6 +19,7 @@ writeNushellApplication {
   ];
   meta.description = "Refresh packages/agent/claude-code/manifest.json to a signed Claude Code release";
   text = ''
+    # nu
     const base = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
     const signing_key = "${./release-signing-key.asc}"
     const slugs = {

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -143,6 +143,7 @@ symlinkJoin {
   # invocation while everything else stays pristine.
   nativeBuildInputs = [ makeBinaryWrapper ];
   postBuild = ''
+    # shell
     rm -f $out/bin/${binName}
     makeBinaryWrapper ${launcher}/bin/config-launch $out/bin/${binName} \
       --inherit-argv0 \

--- a/packages/agent/pi-harnesses/engine/README.md
+++ b/packages/agent/pi-harnesses/engine/README.md
@@ -3,9 +3,10 @@
 The Index-side Pi engine harness (ENG-2262). It runs [Pi](https://pi.dev) as a
 Room-facing engine with **the built-in tools absent**, exposing **only** the
 `ix-mcp` tool surface, selecting the model declaratively, and emitting a
-machine-readable JSON event stream. This is the Pi equivalent of the Claude
-"tools removed" posture in `packages/agent/claude-code` (`restrictToTools`), and it is
-the first task in the ENG-2261 "Pi Room integration" stack.
+machine-readable JSON event stream. This mirrors the Claude Code posture in
+`packages/agent/claude-code`: keep one shell/file/web surface by routing through
+the index MCP server. It is the first task in the ENG-2261 "Pi Room integration"
+stack.
 
 ## What it is
 

--- a/packages/agent/pi-harnesses/engine/default.nix
+++ b/packages/agent/pi-harnesses/engine/default.nix
@@ -55,11 +55,13 @@ let
     dontNpmBuild = true;
     doCheck = true;
     checkPhase = ''
+      # shell
       runHook preCheck
       npm test
       runHook postCheck
     '';
     installPhase = ''
+      # shell
       runHook preInstall
       mkdir -p $out
       cp ix-mcp-bridge.ts env.js package.json $out/
@@ -90,6 +92,7 @@ stdenv.mkDerivation {
   doCheck = true;
 
   buildPhase = ''
+        # shell
         runHook preBuild
 
     ${lib.optionalString isLinux ''
@@ -340,12 +343,14 @@ stdenv.mkDerivation {
   '';
 
   checkPhase = ''
+    # shell
     runHook preCheck
     PYTHONPATH=${./.} ${pythonCommand} ${./room_event_mapper_test.py}
     runHook postCheck
   '';
 
   installPhase = ''
+    # shell
     runHook preInstall
     mkdir -p "$out/bin" "$out/lib"
     cp pi-harness "$out/bin/pi-harness"

--- a/packages/agent/pi-harnesses/engine/extension/ix-mcp-bridge.ts
+++ b/packages/agent/pi-harnesses/engine/extension/ix-mcp-bridge.ts
@@ -9,9 +9,9 @@ import { buildMcpEnv } from "./env.js";
 // tools once at startup, and re-expose each through pi.registerTool. The harness
 // launches Pi with --no-builtin-tools, so these bridged tools are the ONLY tools
 // the model sees: shell, file IO and HTTP all happen inside the shared IPython
-// kernel via `python_exec`. This reproduces the Claude `restrictToTools` posture
-// (index/packages/agent/claude-code/default.nix) on Pi, except Pi makes the built-ins
-// genuinely absent rather than merely denied.
+// kernel via `python_exec`. This mirrors the Claude Code single-surface posture
+// (index/packages/agent/claude-code/default.nix), except Pi makes the built-ins
+// genuinely absent rather than relying on permission denies.
 //
 // Each Pi run spawns its own `ix-mcp serve`, so it gets its own kernel. Shared
 // hc2 kernels are a later ticket (ENG-2264).

--- a/packages/agent/pi-harnesses/shared/mk-pi-harness.nix
+++ b/packages/agent/pi-harnesses/shared/mk-pi-harness.nix
@@ -104,6 +104,7 @@ stdenv.mkDerivation {
   doCheck = checkFiles != [ ];
 
   buildPhase = ''
+    # shell
     runHook preBuild
     mkdir -p share/${name}/lib
     ${copyInto "share/${name}" extensions}
@@ -124,6 +125,7 @@ stdenv.mkDerivation {
   '';
 
   checkPhase = ''
+    # shell
     runHook preCheck
     cdir=$(mktemp -d)
     ${copyInto "$cdir" checkLib}
@@ -133,6 +135,7 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
+    # shell
     runHook preInstall
     mkdir -p "$out/bin"
     cp -r share "$out/share"

--- a/packages/agent/policy/hooks.nix
+++ b/packages/agent/policy/hooks.nix
@@ -19,6 +19,7 @@ let
     nixCargoGuard = hookRunnerSubcommand "cargo-guard";
     shellHabitGuard = hookRunnerSubcommand "bash-habits-guard";
     indexedSearchGuard = hookRunnerSubcommand "search-guard";
+    promptPriors = hookRunnerSubcommand "prompt-priors";
     subagentCacheLookup = hookRunnerSubcommand "subagent-cache-lookup";
     reviewEditLogger = hookRunnerSubcommand "review-log-edit";
     stopReviewGate = hookRunnerSubcommand "review-gate";
@@ -75,6 +76,13 @@ let
         matcher = "Agent";
         command = hookCommands.subagentCacheLookup;
         timeout = 15;
+        agents = [ "claude" ];
+      }
+    ];
+
+    UserPromptSubmit = [
+      {
+        command = hookCommands.promptPriors;
         agents = [ "claude" ];
       }
     ];

--- a/packages/agent/symphony/default.nix
+++ b/packages/agent/symphony/default.nix
@@ -120,6 +120,7 @@ in
     pkgs.openssh
   ];
   text = ''
+    # nu
     def --wrapped main [...args] {
       exec ${src}/bin/run-nix ...$args
     }

--- a/packages/agent/system-prompt-eval-viewer/default.nix
+++ b/packages/agent/system-prompt-eval-viewer/default.nix
@@ -27,6 +27,7 @@ let
     };
     npmDepsHash = "sha256-Y7hsx0h2lMVTSsNYMXfi6TCqc7qBQH6poKptG2HPHfA=";
     installPhase = ''
+      # shell
       runHook preInstall
       cp -r dist $out
       runHook postInstall
@@ -49,6 +50,7 @@ ix.writeNushellApplication ix.pkgs {
     coreutils
   ];
   text = ''
+    # nu
     def main [json?: string] {
       let d = (^mktemp -d | str trim)
       ^cp -r ${site}/. $d

--- a/packages/andrewgazelka/hive/default.nix
+++ b/packages/andrewgazelka/hive/default.nix
@@ -70,6 +70,7 @@ in
     erlang
   ];
   text = ''
+    # nu
     def --wrapped main [...args] {
       # mix compiles in place, so stage the read-only source into a writable
       # temp dir before running the demo.

--- a/packages/code/astlog/scan/default.nix
+++ b/packages/code/astlog/scan/default.nix
@@ -32,6 +32,7 @@ writeNushellApplication {
     mainProgram = "astlog-scan";
   };
   text = ''
+    # nu
     def main [] {
       let repo_root = (^git rev-parse --show-toplevel | str trim)
       cd $repo_root

--- a/packages/code/scipql/cli/default.nix
+++ b/packages/code/scipql/cli/default.nix
@@ -44,6 +44,7 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    # shell
     runHook preInstall
     mkdir -p "$out/bin"
     # Prefix, not suffix: scipql must use its own pinned rust-analyzer/cargo/

--- a/packages/dev/install-vscode-extensions/default.nix
+++ b/packages/dev/install-vscode-extensions/default.nix
@@ -1,0 +1,78 @@
+{
+  ix,
+  lib,
+  writeNushellApplication,
+}:
+let
+  extensions = (lib.importJSON (ix.paths.root + "/.vscode/extensions.json")).recommendations;
+  extensionsJson = builtins.toJSON extensions;
+in
+writeNushellApplication {
+  name = "install-vscode-extensions";
+  meta = {
+    description = "Install the VS Code/Cursor extensions recommended by this workspace";
+    mainProgram = "install-vscode-extensions";
+  };
+  text = ''
+    # nu
+    def editor_cmd [] {
+      if (which cursor | is-not-empty) {
+        "cursor"
+      } else if (which code | is-not-empty) {
+        "code"
+      } else {
+        error make {
+          msg: "Install Cursor or VS Code first"
+          label: {
+            text: "expected a `cursor` or `code` command on PATH"
+            span: (metadata $env.PATH).span
+          }
+        }
+      }
+    }
+
+    def installed_extensions [editor: string] {
+      try {
+        ^$editor --list-extensions | lines
+      } catch {
+        []
+      }
+    }
+
+    def main [] {
+      let editor = editor_cmd
+      let desired = '${extensionsJson}' | from json
+      let installed = installed_extensions $editor
+      let missing = $desired | where {|extension| $extension not-in $installed }
+
+      if ($missing | is-empty) {
+        print $"All ($desired | length) recommended extensions are already installed for ($editor)."
+        return
+      }
+
+      let failed = $missing | each {|extension|
+        print $"Installing ($extension)..."
+        let installed_extension = try {
+          ^$editor --install-extension $extension
+          true
+        } catch {|err|
+          print $"Failed to install ($extension): ($err.msg)"
+          false
+        }
+        if $installed_extension { null } else { $extension }
+      } | compact
+
+      if ($failed | is-not-empty) {
+        error make {
+          msg: $"Failed to install ($failed | length) recommended extensions"
+          label: {
+            text: ($failed | str join ", ")
+            span: (metadata $failed).span
+          }
+        }
+      }
+
+      print $"Installed ($missing | length) recommended extensions for ($editor)."
+    }
+  '';
+}

--- a/packages/dev/install-vscode-extensions/package.nix
+++ b/packages/dev/install-vscode-extensions/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "install-vscode-extensions";
+  packageSet = true;
+  flake = true;
+}

--- a/packages/dia/default.nix
+++ b/packages/dia/default.nix
@@ -38,6 +38,7 @@ let
         runtimeInputs = [ nix ];
         meta.description = "Refresh packages/dia/manifest.json to a Dia release";
         text = ''
+          # nu
           const base = "https://releases.diabrowser.com/release"
 
           # Run from the repo root: `nix run .#dia.updateScript -- [version]`.
@@ -78,6 +79,7 @@ stdenv.mkDerivation {
   dontFixup = true;
 
   installPhase = ''
+    # shell
     runHook preInstall
     mkdir -p "$out/Applications" "$out/bin"
     cp -R Dia.app "$out/Applications/Dia.app"

--- a/packages/fff/default.nix
+++ b/packages/fff/default.nix
@@ -63,6 +63,7 @@ rustPlatform.buildRustPackage {
   # picked up automatically. Copy the unhashed final artifact into lib/ (skip
   # the hashed copy under deps/) for both the Linux .so and the macOS .dylib.
   postInstall = ''
+    # shell
     mkdir -p "$out/lib"
     find target -type f \( -name 'libfff_c.so' -o -name 'libfff_c.dylib' \) \
       -not -path '*/deps/*' -exec install -Dm555 {} "$out/lib/" \;

--- a/packages/humanlayer/default.nix
+++ b/packages/humanlayer/default.nix
@@ -56,6 +56,7 @@ let
         runtimeInputs = [ nix ];
         meta.description = "Refresh packages/humanlayer/manifest.json to the latest HumanLayer CLI release";
         text = ''
+          # nu
           const base = "https://registry.npmjs.org/@humanlayer"
           const slugs = {
             "x86_64-linux": "linux-x64",
@@ -103,6 +104,7 @@ stdenvNoCC.mkDerivation {
   dontStrip = true;
 
   installPhase = ''
+    # shell
     runHook preInstall
 
     mkdir -p \

--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -113,6 +113,7 @@ let
 
   package = unwrapped.overrideAttrs (old: {
     postInstall = ''
+      # shell
       ${old.postInstall or ""}
       # Drop the prebuilt ix_sdk wheel into the venv site-packages so `import
       # ix_sdk` resolves both at runtime and for the ty install check, without a

--- a/packages/launchk/default.nix
+++ b/packages/launchk/default.nix
@@ -32,6 +32,7 @@ rustPlatform.buildRustPackage {
   # tarball has no `.git`, so resolve the about-box string to the crate version
   # instead. --replace-fail keeps this guard honest if upstream moves the call.
   postPatch = ''
+    # shell
     substituteInPlace launchk/src/main.rs \
       --replace-fail "git_version!()" 'env!("CARGO_PKG_VERSION")'
   '';

--- a/packages/llm-clippy/default.nix
+++ b/packages/llm-clippy/default.nix
@@ -54,6 +54,7 @@ ix.buildRustPackage pkgs {
   env.RUSTC_BOOTSTRAP = "1";
 
   postInstall = ''
+    # shell
     for bin in "$out/bin/cargo-clippy" "$out/bin/clippy-driver"; do
       wrapProgram "$bin" \
         --prefix ${rustcLibPathVar} : "${toolchain}/lib"

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1376,6 +1376,7 @@ let
   # darwin guard off macOS. Runs real rg/fd (on the check's PATH); pure local FS,
   # no network, so the build sandbox runs it.
   fsearchTestPy = pkgs.writeText "ix-mcp-fsearch-test.py" ''
+    # python
     import asyncio
     import os
     import subprocess
@@ -1660,6 +1661,7 @@ let
   # slack declaration against the slack module's own constants, so the declared
   # probe can never drift from the resolution order the module actually uses.
   requirementsTestPy = pkgs.writeText "ix-mcp-requirements-test.py" ''
+    # python
     import os
     from pathlib import Path
 
@@ -1783,6 +1785,7 @@ let
   # real tailscale state. The mock is shell, not a subprocess of an actual
   # tailscale, so this test runs in the Nix sandbox.
   bindDefaultTest = pkgs.writeText "ix-mcp-bind-default-test.py" ''
+    # python
     from unittest.mock import patch
     from ix_notebook_mcp import cli
 
@@ -1860,6 +1863,7 @@ let
   # return None on non-darwin platforms. Dependency-free pure Python, so the
   # build sandbox runs it.
   sshAuthSockTest = pkgs.writeText "ix-mcp-ssh-auth-sock-test.py" ''
+    # python
     import os
     import tempfile
     from pathlib import Path
@@ -1931,6 +1935,7 @@ let
   # dead-redirect fix, both pure Python (real loopback sockets, no `dashboard`
   # binary), so the sandbox runs it.
   dashboardLauncherTest = pkgs.writeText "ix-mcp-dashboard-launcher-test.py" ''
+    # python
     import asyncio
     import json
     import os
@@ -2143,6 +2148,7 @@ let
   # result. This is the core "multiple async" contract, provable without a kernel
   # or network, so the sandbox runs it.
   runtimeTestPy = pkgs.writeText "ix-mcp-runtime-test.py" ''
+    # python
     import asyncio
 
     from ix_notebook_mcp import runtime
@@ -2421,6 +2427,7 @@ let
   # streams output, and that `feed.job` fetches one run by the id a python_exec
   # tool result names (and None for a miss).
   feedTestPy = pkgs.writeText "ix-mcp-feed-test.py" ''
+    # python
     import tempfile
     import time
 
@@ -2487,6 +2494,7 @@ let
   # Covers the store singleton row, runtime.Session's label precedence + store
   # mirror, and the reserved `__session__` pane the bridge publishes.
   sessionIdentityTestPy = pkgs.writeText "ix-mcp-session-identity-test.py" ''
+    # python
     import tempfile
 
     from ix_notebook_mcp import pane_bridge, runtime, store
@@ -2566,6 +2574,7 @@ let
   # routes (incl. the by-id lookup an embedder keys off the job id in a tool
   # reply) return the run's nbformat output bundles, cells, and live resources.
   apiTest = pkgs.writeText "ix-mcp-api-test.py" ''
+    # python
     import asyncio, tempfile
     from pathlib import Path
 
@@ -2717,6 +2726,7 @@ let
   # 'running' by the dead server is marked interrupted, and a second reopen has
   # nothing to replay (the restore folds everything into a fresh checkpoint).
   sessionTestPy = pkgs.writeText "ix-mcp-session-test.py" ''
+    # python
     import asyncio
     import tempfile
 
@@ -2802,6 +2812,7 @@ let
   # (await __ix_exec), and ipykernel interrupts async cells by cancelling the
   # asyncio task, which a synchronous call never yields to.
   wedgeTestPy = pkgs.writeText "ix-mcp-wedge-test.py" ''
+    # python
     import asyncio
     import os
     import tempfile
@@ -2923,6 +2934,7 @@ let
   # image payload normalizes to a base64 string. Stands up an InteractiveShell
   # in-process so the formatter runs without booting a kernel; sandbox-safe.
   richTestPy = pkgs.writeText "ix-mcp-rich-test.py" ''
+    # python
     import asyncio
     import json
     import os
@@ -3115,6 +3127,7 @@ let
   # unchanged. In process (a shell, the store), no kernel boot or network, so
   # the sandbox runs it.
   yieldTestPy = pkgs.writeText "ix-mcp-yield-test.py" ''
+    # python
     import asyncio
     import json
     import os
@@ -3240,6 +3253,7 @@ let
   # bindings to the store, which is where the dashboard reads them. In-process, no
   # kernel or network, so the sandbox runs it.
   bindingsTestPy = pkgs.writeText "ix-mcp-bindings-test.py" ''
+    # python
     import asyncio
     import inspect
     import json
@@ -3371,6 +3385,7 @@ let
   # so no real VM (or Virtualization.framework entitlement) is needed; pure
   # in-process, sandbox-safe.
   vmkitResourceTestPy = pkgs.writeText "ix-mcp-vmkit-resource-test.py" ''
+    # python
     import asyncio
     import os
     import time
@@ -3481,6 +3496,7 @@ let
   # builds tiny fixture databases with the real schema subset and round-trips an
   # archived NSAttributedString through Foundation, so the sandbox runs it.
   imessageTestPy = pkgs.writeText "ix-mcp-imessage-test.py" ''
+    # python
 
     import os
     import sqlite3
@@ -3726,6 +3742,7 @@ let
   # math (incl. the latitude cosine correction) and the polars schema shapes, and
   # confirms the public coroutines and MapKit binding are present.
   mapsTestPy = pkgs.writeText "ix-mcp-maps-test.py" ''
+    # python
     import inspect
     import math
 
@@ -3785,6 +3802,7 @@ let
   # (the injection fix), the ps-ancestry parse/walk, and the surfaces readout
   # split, and confirms the public coroutine surface.
   ghosttyTestPy = pkgs.writeText "ix-mcp-ghostty-test.py" ''
+    # python
     import inspect
 
     import ghostty
@@ -3863,6 +3881,7 @@ let
   # and df_html renders the styled table the kernel installs globally. Pure local
   # FS over the bundled view/polars/pygments, so the sandbox runs it.
   viewTestPy = pkgs.writeText "ix-mcp-view-test.py" ''
+    # python
     import polars as pl
 
     import view
@@ -3966,6 +3985,7 @@ let
   # a Result, so a cell can end with it), exit-code capture, and check=True.
   # Pure local subprocess over the bundled ansi2html, so the sandbox runs it.
   shTestPy = pkgs.writeText "ix-mcp-sh-test.py" ''
+    # python
     import asyncio
 
     import sh
@@ -4134,6 +4154,7 @@ let
   # on_error="collect" survives a failing host (recording it in attrs). Pure
   # Python over the bundled asyncssh + polars, so the sandbox runs it.
   fleetTestPy = pkgs.writeText "ix-mcp-fleet-test.py" ''
+    # python
     import asyncio
     import sys
 
@@ -4281,6 +4302,7 @@ let
   # with a child fileTransfer carrying progress, a build with a log line and a set
   # phase, the matching stops, and a trailing error msg.
   nixTestPy = pkgs.writeText "ix-mcp-nix-test.py" ''
+    # python
     import polars as pl
 
     import nix
@@ -4416,6 +4438,7 @@ let
   # and `wt / "x"` joins onto it, commit() stages new files, and remove() drops
   # the tree. Pure git + the bundled sh, so the sandbox runs it.
   worktreeTestPy = pkgs.writeText "ix-mcp-worktree-test.py" ''
+    # python
     import asyncio
     import os
     import pathlib
@@ -4511,6 +4534,7 @@ let
   # never-headless launch argv, the clear error when nothing is on the port, and
   # that api() now lists both the module and the bundled playwright library.
   browserTestPy = pkgs.writeText "ix-mcp-browser-test.py" ''
+    # python
     import asyncio
     import sys
 
@@ -4732,6 +4756,7 @@ let
   # has geometry and a CSS selector that actually resolves, and that the
   # interactive_only / viewport_only lean modes behave.
   browserVdomTestPy = pkgs.writeText "ix-mcp-browser-vdom-test.py" ''
+    # python
     import asyncio
     import sys
 

--- a/packages/minecraft/bossbar-overlay/app/default.nix
+++ b/packages/minecraft/bossbar-overlay/app/default.nix
@@ -71,6 +71,7 @@ rustPlatform.buildRustPackage {
   buildInputs = runtimeLibs;
 
   preBuild = ''
+    # shell
     # Drop the extracted Minecraft art where each crate's `include_bytes!` expects
     # it: the shared font into overlay-core, the sprites into each app.
     mkdir -p crates/overlay-core/assets crates/bossbar/assets/boss_bar \

--- a/packages/minecraft/bossbar-overlay/cli.nix
+++ b/packages/minecraft/bossbar-overlay/cli.nix
@@ -20,6 +20,7 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    # shell
     runHook preInstall
     install -Dm755 $src $out/bin/bossbar
     patchShebangs $out/bin/bossbar

--- a/packages/minecraft/minecraft-assets/default.nix
+++ b/packages/minecraft/minecraft-assets/default.nix
@@ -47,6 +47,7 @@ stdenvNoCC.mkDerivation {
   # loudly (`unzip` exits non-zero) if a path stops existing in a future jar, so
   # a silently missing sprite cannot slip through as an empty asset dir.
   buildPhase = ''
+    # shell
     runHook preBuild
 
     mkdir -p "$out/boss_bar" "$out/gui" "$out/font" "$out/entity" "$out/particle"

--- a/packages/minecraft/minecraft/hot-reload-agent/default.nix
+++ b/packages/minecraft/minecraft/hot-reload-agent/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ jdk25 ];
 
   buildPhase = ''
+    # shell
     runHook preBuild
 
     mkdir -p classes
@@ -34,6 +35,7 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
+    # shell
     runHook preInstall
 
     install -Dm0644 minecraft-hot-reload-agent.jar \

--- a/packages/minecraft/minecraft/sound/default.nix
+++ b/packages/minecraft/minecraft/sound/default.nix
@@ -26,6 +26,7 @@ symlinkJoin {
   # no Minecraft install. `--set-default` keeps MCSOUND_ASSETS overridable at
   # runtime (e.g. to point at a real Minecraft / Prism install instead).
   postBuild = ''
+    # shell
     wrapProgram $out/bin/minecraft-sound \
       --set-default MCSOUND_ASSETS ${sounds}/sounds
   '';

--- a/packages/minecraft/minecraft/sound/sounds.nix
+++ b/packages/minecraft/minecraft/sound/sounds.nix
@@ -53,6 +53,7 @@ stdenvNoCC.mkDerivation {
   outputHash = lock.packHash;
 
   buildPhase = ''
+    # shell
     runHook preBuild
 
     list="$TMPDIR/sounds.tsv"

--- a/packages/polars-sftp/default.nix
+++ b/packages/polars-sftp/default.nix
@@ -78,6 +78,7 @@ let
     # for a cdylib-only crate. Replace it: find the cdylib the build hook produced
     # and package the wheel.
     installPhase = ''
+      # shell
       runHook preInstall
       # Match the cdylib in the target's release dir, not the identical copy under
       # release/deps/, so the result is deterministic.

--- a/packages/spark/spark-gluten/default.nix
+++ b/packages/spark/spark-gluten/default.nix
@@ -71,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontAutoPatchelf = true;
 
   buildPhase = ''
+    # shell
     runHook preBuild
     tar xzf "$src"
     mkdir exploded
@@ -94,6 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
+    # shell
     runHook preInstall
     mkdir -p "$out/share/java"
     ( cd exploded && zip -q -r -1 "$out/share/java/${jarName}" . )

--- a/packages/spark/spark-hive/default.nix
+++ b/packages/spark/spark-hive/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   installPhase = ''
+    # shell
     runHook preInstall
     mkdir -p "$out"
     mv * "$out/"

--- a/packages/terminal/tmux/default.nix
+++ b/packages/terminal/tmux/default.nix
@@ -19,6 +19,7 @@ symlinkJoin {
   ];
   nativeBuildInputs = [ makeWrapper ];
   postBuild = ''
+    # shell
     wrapProgram $out/bin/tmux --add-flags "-f ${./tmux.conf}"
   '';
   meta = tmux.meta // {

--- a/packages/tonbo-artifacts/default.nix
+++ b/packages/tonbo-artifacts/default.nix
@@ -20,6 +20,7 @@ stdenvNoCC.mkDerivation {
   strictDeps = true;
 
   installPhase = ''
+    # shell
     runHook preInstall
 
     install -Dm755 "$src" "$out/bin/artifacts"

--- a/packages/vineflower/default.nix
+++ b/packages/vineflower/default.nix
@@ -23,6 +23,7 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ jdk ];
 
   installPhase = ''
+    # shell
     runHook preInstall
     mkdir -p $out/share/java $out/bin
     cp ${jar} $out/share/java/vineflower.jar

--- a/packages/vm/chrome-vm/default.nix
+++ b/packages/vm/chrome-vm/default.nix
@@ -32,6 +32,7 @@ writeNushellApplication {
     gnugrep
   ];
   text = ''
+    # nu
     def main [out?: string] {
       let flake = ($env.IX_CHROME_VM_FLAKE? | default "github:indexable-inc/index")
       let outpath = ($out | default $"($env.PWD)/chrome-vm-shot.png")

--- a/packages/yc/default.nix
+++ b/packages/yc/default.nix
@@ -47,6 +47,7 @@ let
         runtimeInputs = [ nix ];
         meta.description = "Refresh packages/yc/manifest.json to the latest YC CLI release";
         text = ''
+          # nu
           const base = "${baseUrl}"
           const slugs = {
             "aarch64-darwin": "darwin-arm64",
@@ -85,6 +86,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
 
   installPhase = ''
+    # shell
     runHook preInstall
     install -Dm755 $src $out/bin/yc
     runHook postInstall

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -601,6 +601,7 @@ let
   pythonAppClosureProbe = ix.writePythonApplication pkgs {
     name = "python-app-closure-probe";
     src = pkgs.writeText "python-app-closure-probe.py" ''
+      # python
       print("python app source is in the runtime closure")
     '';
     # `check = false` already skips the checker, so the default flip cannot


### PR DESCRIPTION
## Summary
- add astlog rules and fixtures requiring syntax marker comments for embedded shell phases, Nushell text bodies, and inline Python writeText sources
- add `# shell`, `# nu`, and `# python` markers across Nix build phases, writers, package snippets, and MCP Python test fixtures
- add the VS Code extension installer package and workspace recommendations/settings for the highlighting flow

## Validation
- commit hook passed: deadnix, statix, astlog, astlog-elixir, nixfmt, astlog-rust, ruff
- local astlog fixture self-test passed
- targeted syntax-comment / python-text astlog scan was clean

## Note
- `nix run .#lint -- astlog` failed before reaching astlog with `dag-runner: unexpected argument ... lint-dag.json`; the commit hook lint path succeeded.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add syntax marker comments to embedded shell, Nushell, and Python scripts in Nix derivations
> - Adds a first-line `# shell`, `# nu`, or `# python` comment to every embedded script string in Nix derivations so editors can apply syntax highlighting to the correct language.
> - Introduces lint rules in [nix.astlog](https://github.com/indexable-inc/index/pull/1483/files#diff-de5bc8426aac324b41bb80bf1cfa277c527b5423c78e6e4767189c3b0330cc60) that error when phase strings or `writeText`/`text` bodies are missing these syntax comments, with test fixtures for each rule.
> - Adds an `install-vscode-extensions` Nushell tool that installs missing workspace-recommended extensions into VS Code or Cursor.
> - Several `installPhase`, `checkPhase`, and `buildPhase` blocks gain `runHook pre*/post*` calls that were previously missing, making those phases extensible via NixPkgs hook conventions.
> - Sets `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` as a default environment variable in the `claude-code` wrapper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed247fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->