### PR TITLE
ci: write check logs to runner path

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,7 +86,30 @@ jobs:
       # requires a status named `flake-check`; this job is it, and it fails iff a
       # check fails to build or the flake stops evaluating.
       - name: Build all flake checks
-        run: nix run .#check
+        run: |
+          set -euo pipefail
+
+          commit="$(git rev-parse HEAD 2>/dev/null || printf 'unknown')"
+          workflow="${GITHUB_WORKFLOW:-local}"
+          run_tag="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
+          log_root="${IX_CI_RUN_LOG_ROOT:-/var/log/ix-ci/runs}"
+          log_dir="${log_root}/${commit}/${workflow}"
+          if install -d -m 0755 "${log_dir}" 2>/tmp/index-ci-log-dir.err && [[ -w "${log_dir}" ]]; then
+            check_log="${log_dir}/${run_tag}.stdout"
+          else
+            fallback_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+            check_log="${fallback_dir%/}/index-check-${run_tag}.stdout"
+          fi
+
+          printf 'index check log: %s\n' "${check_log}"
+          if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+            {
+              printf "## index check\n\n"
+              printf "log: \`%s\`\n" "${check_log}"
+            } >>"${GITHUB_STEP_SUMMARY}"
+          fi
+
+          nix run .#check >"${check_log}" 2>&1
 
       # The `check` app writes nix-fast-build per-attr durations to
       # check-results.json in the workspace (see lib/per-system.nix). Upload it


### PR DESCRIPTION
## Summary
- write the `Check` workflow output to a durable runner log path under `/var/log/ix-ci/runs/<commit>/<workflow>/` when available
- print the selected log path to both the Actions log and step summary
- fall back to the runner temp directory when the server log tree is unavailable

## Validation
- `nix run nixpkgs#actionlint -- .github/workflows/check.yml`
- `git diff --check -- .github/workflows/check.yml`
- commit hook lint suite

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redirect nix check logs to a file on the runner in CI
> - Updates the `Build all flake checks` step in [check.yml](.github/workflows/check.yml) to redirect `nix run` stdout and stderr to a log file instead of streaming to the job log.
> - The script computes a log path under a configurable root directory, falling back to a temp directory if the preferred path is not writable, then prints the path and appends a summary entry.
> - Risk: strict bash flags (`set -euo pipefail`) are now active, so unset variables or command errors will fail the step earlier than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c130b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->