### PR TITLE
Fix Pages site build

### DIFF
--- a/site/src/lib/components/ContribNews.svelte
+++ b/site/src/lib/components/ContribNews.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script module lang="ts">
   export interface NewsItem {
     headline: string;
     description: string;
@@ -7,7 +7,9 @@
     category: 'Lead' | 'Tooling' | 'Antithesis' | 'Storage' | 'CI' | 'Filesystem';
     timestamp: Date;
   }
+</script>
 
+<script lang="ts">
   export let item: NewsItem;
 
   const categoryColors: Record<NewsItem['category'], { bg: string; text: string }> = {
@@ -37,6 +39,7 @@
   </div>
   <h3 class="headline">{item.headline}</h3>
   <p class="description">{item.description}</p>
+  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
   <a href={item.prUrl} target="_blank" rel="noopener noreferrer" class="pr-link">
     #{item.prNumber}
   </a>

--- a/site/src/routes/last-24-hours/+page.svelte
+++ b/site/src/routes/last-24-hours/+page.svelte
@@ -71,7 +71,7 @@
   </header>
 
   <main class="news-feed">
-    {#each newsItems as item (item.prNumber)}
+    {#each newsItems as item, index (index)}
       <ContribNews {item} />
     {/each}
   </main>


### PR DESCRIPTION
Fixes the Pages build failure by moving the exported NewsItem type into a Svelte module script and satisfying the site lint rules for the last-24-hours page.\n\nValidation:\n- nix build .#packages.aarch64-linux.site -L

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Pages site build by correcting news feed keying and script structure
> - Splits `ContribNews.svelte` into a module context script and an instance script, moving the `NewsItem` interface export to the module script.
> - Adds an inline `eslint-disable` comment to bypass the `svelte/no-navigation-without-resolve` rule on an anchor element.
> - Changes the news feed each-block in `+page.svelte` to key by index instead of `prNumber`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b9661f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->