### PR TITLE
agent: bake house prompt into codex wrapper

### DIFF
--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -60,8 +60,20 @@
     };
     agents.max_depth = 3;
   },
+
+  # The house model/base instructions Codex should run with. Kept outside the
+  # overridable `settings` default so callers that replace `settings` for their
+  # own soft defaults do not silently drop the prompt.
+  modelInstructionsFile ? null,
 }:
 let
+  common = import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; };
+  effectiveModelInstructionsFile =
+    if modelInstructionsFile != null then
+      modelInstructionsFile
+    else
+      builtins.toFile "codex-system-prompt.txt" common.systemPrompt;
+
   # The compiled Rust launcher (packages/config-launch): reads IX_LAUNCH_SPEC
   # (a baked JSON file describing the target binary, config path, forced flags,
   # and soft defaults), performs per-key TOML presence detection against the
@@ -82,17 +94,22 @@ let
   # streamable-HTTP MCP support is gated behind version-specific keys, so the
   # keyless `exa` server stays claude-only rather than baking an unverified HTTP
   # config into every codex session.
-  mcpStdioServers =
-    lib.filterAttrs (_: def: (def.transport or "stdio") == "stdio")
-      (import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; })
-      .houseServers;
+  mcpStdioServers = lib.filterAttrs (
+    _: def: (def.transport or "stdio") == "stdio"
+  ) common.houseServers;
   spec = (formats.json { }).generate "codex-launch-spec.json" {
     target = lib.getExe codex;
     config_dir_env = "CODEX_HOME";
     config_dir_default = "~/.codex";
     config_file = "config.toml";
     forced = entriesOf (ix.attrs.flattenToDotted forcedSettings);
-    soft = entriesOf (ix.attrs.flattenToDotted settings) ++ ix.mcp.toCodexEntries mcpStdioServers;
+    soft =
+      entriesOf (
+        ix.attrs.flattenToDotted (
+          { model_instructions_file = toString effectiveModelInstructionsFile; } // settings
+        )
+      )
+      ++ ix.mcp.toCodexEntries mcpStdioServers;
   };
 
   # Codex reads hooks from config, not from launch flags, so expose the rendered
@@ -153,6 +170,7 @@ symlinkJoin {
   # consumer to deliver to `~/.codex/hooks.json` (see the `hooksJson` comment).
   passthru = {
     inherit hooksJson;
+    modelInstructionsFile = effectiveModelInstructionsFile;
     permissions = sharedPermissions.codex;
   };
   meta = codex.meta // {


### PR DESCRIPTION
## Summary
- bake the shared house prompt into the Codex wrapper via model_instructions_file
- keep the prompt outside overridable soft settings so personal config overrides do not drop it
- expose the generated prompt path through passthru for inspection

## Verification
- nix build .#codex --no-link --print-out-paths
- commit hooks: astlog, astlog-elixir, astlog-rust, deadnix, nixfmt, ruff, statix

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bake house system prompt into codex wrapper as `model_instructions_file`
> - Adds a `modelInstructionsFile` parameter to [default.nix](https://github.com/indexable-inc/index/pull/1488/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5); when not provided, a temp file containing the house system prompt is generated automatically.
> - Injects `model_instructions_file` into the codex launch spec's soft defaults so the instructions are always present at launch.
> - Exposes the effective instructions file path via `passthru.modelInstructionsFile` for downstream consumers.
> - Behavioral Change: the generated `codex-launch-spec.json` now always includes a `model_instructions_file` key, which was absent before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1848169.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->