### PR TITLE
agent: discourage turbofish collect syntax

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -80,6 +80,11 @@ let
     Match the code around you: comment density, naming, structure, and idioms.
   '';
 
+  rustCollectStyle = ''
+    In Rust, do not use turbofish syntax to type collection results. Prefer a
+    local type annotation over forms like `.collect::<HashSet<_>>()`.
+  '';
+
   inlineComments = ''
     Comment non-obvious context: external constraints, gotchas, postmortems,
     spec quirks, or why-this-way decisions.
@@ -328,6 +333,7 @@ let
     experimentDefault
     promptEval
     matchSurroundingCode
+    rustCollectStyle
     inlineComments
     tieToIssue
     preV1


### PR DESCRIPTION
## Summary
- add a system-prompt rule preferring local type annotations over turbofish collection syntax
- call out `.collect::<HashSet<_>>()` as the concrete form to avoid

## Verification
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }' | rg -n 'turbofish|collect::<HashSet'`
- commit hooks: astlog, astlog-elixir, astlog-rust, deadnix, nixfmt, ruff, statix


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discourage turbofish collect syntax in Rust code generation system prompt
> Adds a new `rustCollectStyle` guideline to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1489/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to prefer local type annotations over turbofish syntax (e.g. `.collect::<Vec<_>>()`) when typing collection results in Rust.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac26d04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->