### PR TITLE
feat: expose cargo-unit test checks

### DIFF
--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -12,6 +12,8 @@ let
     genericClosure
     hasAttr
     head
+    isList
+    isString
     length
     removeAttrs
     replaceStrings
@@ -53,6 +55,45 @@ let
     # Lazy: the `&&` short-circuits, so `config` (hence `importTOML`) is only
     # forced when the file exists and carries rustflags.
     if builtins.pathExists configPath && chosen != null then normalize chosen else [ ];
+
+  emptyTestPolicy = {
+    skip = [ ];
+    testThreads = null;
+  };
+
+  testPolicyFields = attrNames emptyTestPolicy;
+
+  normalizeTestPolicy =
+    packageName: rawPolicy:
+    let
+      unknownFields = filter (field: !(elem field testPolicyFields)) (attrNames rawPolicy);
+      policy = emptyTestPolicy // rawPolicy;
+      nonStringSkips = filter (testName: !(isString testName)) policy.skip;
+    in
+    assert lib.assertMsg (unknownFields == [ ])
+      "cargoUnit.buildWorkspace testPolicyByPackage.${packageName} has unknown fields: ${lib.concatStringsSep ", " unknownFields}";
+    assert lib.assertMsg (
+      isList policy.skip && nonStringSkips == [ ]
+    ) "cargoUnit.buildWorkspace testPolicyByPackage.${packageName}.skip must be a list of strings";
+    assert lib.assertMsg (policy.testThreads == null || isString policy.testThreads)
+      "cargoUnit.buildWorkspace testPolicyByPackage.${packageName}.testThreads must be null or a string";
+    policy;
+
+  libtestArgsForTestPolicy =
+    policy:
+    lib.concatMap (testName: [
+      "--skip"
+      testName
+    ]) policy.skip
+    ++ lib.optionals (policy.testThreads != null) [
+      "--test-threads"
+      policy.testThreads
+    ];
+
+  nextestFilterForTestPolicy =
+    policy:
+    lib.optionalString (policy.skip != [ ])
+      "-E ${escapeShellArg "not (${lib.concatMapStringsSep " | " (testName: "test(~${testName})") policy.skip})"}";
 
   /**
     Build a Rust workspace as one Nix derivation per Cargo rustc unit.
@@ -110,6 +151,12 @@ let
     `policyChecks`, plus the intermediate `unitGraphJson`, `unitsNix`, and `vendorDir`
     derivations for inspection.
 
+    `testPolicyByPackage.<package>` accepts structured test-runner policy:
+    `{ skip = [ "case_name" ]; testThreads = "1"; }`. `buildWorkspace` renders
+    it to libtest args for cargo-unit's per-test runner and to cargo-nextest
+    filters for `testChecksByTarget`. Callers should pass policy data, not
+    runner-specific argv.
+
     `rust.resolveArgs` resolves the shared bundle (context, policy, linker,
     effects, checks) once; the two IFD stages and the unit import below read the
     once-resolved values (configScript, toolchainId, cargoLockPath, render flags,
@@ -157,6 +204,21 @@ let
 
       explicitExtraUnits = rawArgs.extraUnits or { };
       extraLibraries = rawArgs.extraLibraries or { };
+      testPolicyByPackage = lib.mapAttrs normalizeTestPolicy (rawArgs.testPolicyByPackage or { });
+      testArgsFromPolicyByPackage = lib.mapAttrs (
+        _packageName: policy: libtestArgsForTestPolicy policy
+      ) testPolicyByPackage;
+      explicitTestArgsByPackage = rawArgs.testArgsByPackage or { };
+      testArgPolicyOverlap = filter (packageName: hasAttr packageName explicitTestArgsByPackage) (
+        attrNames testArgsFromPolicyByPackage
+      );
+      testArgsByPackage =
+        assert lib.assertMsg (testArgPolicyOverlap == [ ])
+          "cargoUnit.buildWorkspace received both testPolicyByPackage and testArgsByPackage for: ${lib.concatStringsSep ", " testArgPolicyOverlap}";
+        testArgsFromPolicyByPackage // explicitTestArgsByPackage;
+      packageTestInputs = rawArgs.packageTestInputs or { };
+      packageTestEnv = rawArgs.packageTestEnv or { };
+      testRunPrelude = rawArgs.testRunPrelude or "";
 
       # Every injected unit plus everything reachable from one through
       # `passthru.depUnits` (recorded by `mkPrebuiltLibraryUnit`), deduplicated
@@ -366,10 +428,12 @@ let
             # `clippy-driver` links against.
             extraClippyNativeBuildInputs = lib.optional perUnitClippyEnabled args.policy.clippy.package;
             extraEnv = args.env;
-            testRunPrelude = rawArgs.testRunPrelude or "";
-            testArgsByPackage = rawArgs.testArgsByPackage or { };
-            packageTestInputs = rawArgs.packageTestInputs or { };
-            packageTestEnv = rawArgs.packageTestEnv or { };
+            inherit
+              testRunPrelude
+              testArgsByPackage
+              packageTestInputs
+              packageTestEnv
+              ;
             packageBuildEnv = rawArgs.packageBuildEnv or { };
             inherit extraRustcArgsForPlatform;
             # Manifest-derived flags come first so per-call `policy.clippy`
@@ -496,10 +560,121 @@ let
       namedTargetSets = lib.listToAttrs (
         lib.zipListsWith lib.nameValuePair targetSetNames units.targetSets
       );
+      packageTestEnvForPackage = packageName: packageTestEnv.${packageName} or { };
+      nextestTargetTriple = rawArgs.target or pkgs.stdenv.hostPlatform.config;
+      nextestRustLibDir = "${args.rustToolchain}/lib/rustlib/${nextestTargetTriple}/lib";
+      nextestConfigFile = pkgs.writeText "cargo-unit-nextest.toml" ''
+        [profile.default]
+        retries = 0
+        slow-timeout = { period = "${rawArgs.nextestPerTestTimeout or "120s"}", terminate-after = 1 }
+        [profile.default.junit]
+        path = "junit.xml"
+      '';
+      mkNextestForTarget =
+        targetName: entry:
+        let
+          packageName = entry.packageName;
+          packageEnv = packageTestEnvForPackage packageName;
+          packagePolicy = testPolicyByPackage.${packageName} or emptyTestPolicy;
+          testBinary = entry.binary;
+        in
+        pkgs.runCommand "cargo-unit-nextest-${targetName}"
+          (
+            packageEnv
+            // {
+              __structuredAttrs = true;
+              strictDeps = true;
+              nativeBuildInputs = [
+                pkgs.cargo-nextest
+                pkgs.coreutils
+                nixCargoUnit
+              ]
+              ++ (packageTestInputs.${packageName} or [ ]);
+            }
+          )
+          ''
+            ${testRunPrelude}
+
+            workspace_root="$TMPDIR/nextest-ws"
+            mkdir -p "$workspace_root/src" "$workspace_root/target"
+            cat > "$workspace_root/Cargo.toml" <<EOF
+            [package]
+            name = ${escapeShellArg packageName}
+            version = "0.0.0"
+            edition = ${escapeShellArg entry.edition}
+            [lib]
+            EOF
+            : > "$workspace_root/src/lib.rs"
+
+            test_binary="$(readlink -f ${escapeShellArg testBinary})"
+            if [ ! -x "$test_binary" ]; then
+              echo >&2 "error: cargo-unit test binary missing or not executable: $test_binary"
+              exit 1
+            fi
+
+            nix-cargo-unit nextest-metadata \
+              --workspace-root "$workspace_root" \
+              --target-name ${escapeShellArg targetName} \
+              --package-name ${escapeShellArg packageName} \
+              --edition ${escapeShellArg entry.edition} \
+              --test-binary "$test_binary" \
+              --target-triple ${escapeShellArg nextestTargetTriple} \
+              --rust-libdir ${escapeShellArg nextestRustLibDir} \
+              --cargo-metadata "$workspace_root/cargo-metadata.json" \
+              --binaries-metadata "$workspace_root/binaries-metadata.json"
+
+            ${lib.concatStringsSep "\n" (map (name: "export ${name}") (attrNames packageEnv))}
+
+            cargo-nextest nextest run \
+              --config-file ${nextestConfigFile} \
+              --cargo-metadata "$workspace_root/cargo-metadata.json" \
+              --binaries-metadata "$workspace_root/binaries-metadata.json" \
+              --workspace-remap "$workspace_root" \
+              --no-fail-fast \
+              --no-tests=pass \
+              --test-threads ${
+                if packagePolicy.testThreads != null then
+                  packagePolicy.testThreads
+                else
+                  ''"''${NIX_BUILD_CORES:-1}"''
+              } \
+              ${nextestFilterForTestPolicy packagePolicy}
+
+            mkdir -p "$out"
+            if [ -f "$workspace_root/target/nextest/default/junit.xml" ]; then
+              cp "$workspace_root/target/nextest/default/junit.xml" "$out/junit.xml"
+            fi
+            echo "ran ${targetName} test target" > "$out/result"
+          '';
+      nextestByTarget = lib.mapAttrs mkNextestForTarget (units.tests or { });
+      libtestByTarget = lib.mapAttrs (_targetName: target: target.all) (units.tests or { });
+      testChecksByTarget = if args.policy.tests.useNextest then nextestByTarget else libtestByTarget;
+      testChecksAll =
+        pkgs.runCommand "cargo-unit-test-targets"
+          {
+            __structuredAttrs = true;
+            strictDeps = true;
+            deps = builtins.attrValues testChecksByTarget;
+          }
+          ''
+            set -euo pipefail
+            target_names=(${lib.escapeShellArgs (attrNames testChecksByTarget)})
+            mkdir -p "$out"
+            printf '%s\n' "''${target_names[@]}" > "$out/test-targets"
+            echo "ran ''${#target_names[@]} cargo-unit test targets" > "$out/result"
+          '';
     in
     units
     // {
-      inherit unitGraphJson unitsNix vendorDir;
+      inherit
+        unitGraphJson
+        unitsNix
+        vendorDir
+        testPolicyByPackage
+        nextestByTarget
+        testChecksByTarget
+        testChecksAll
+        ;
       targetSets = namedTargetSets;
       inherit (args) policy;
     };

--- a/lib/rust/policy.nix
+++ b/lib/rust/policy.nix
@@ -365,7 +365,7 @@ let
             ++ lib.optional hasLintPolicy "--"
             ++ clippyLintArgs args.policy;
 
-          rustFlags = lib.escapeShellArgs (
+          rustFlags = lib.concatStringsSep " " (
             rustcArgsForPolicyForPlatform args.policy pkgs.stdenv.hostPlatform.config
           );
         in
@@ -384,25 +384,27 @@ let
             }
             // args.env
           )
-          ''
-            ${configScript}
+          (
+            ''
+              ${configScript}
 
-            export CARGO_TARGET_DIR="$TMPDIR/cargo-target"
+              export CARGO_TARGET_DIR="$TMPDIR/cargo-target"
 
-          ''
-        + (lib.optionalString (rustFlags != "") /* bash */ ''
-          export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }${rustFlags}"
-        '')
-        + /* bash */ ''
+            ''
+            + (lib.optionalString (rustFlags != "") /* bash */ ''
+              export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }"${lib.escapeShellArg rustFlags}
+            '')
+            + /* bash */ ''
 
-          cd ${args.src}
+              cd ${args.src}
 
-          cargo clippy \
-            --frozen --offline \
-            ${lib.escapeShellArgs clippyArgs}
+              cargo clippy \
+                --frozen --offline \
+                ${lib.escapeShellArgs clippyArgs}
 
-          mkdir -p "$out"
-        '';
+              mkdir -p "$out"
+            ''
+          );
     in
     {
       inherit cargoAuditCheck cargoMacheteCheck cargoClippyCheck;

--- a/packages/nix/nix-cargo-unit/src/main.rs
+++ b/packages/nix/nix-cargo-unit/src/main.rs
@@ -27,6 +27,9 @@ enum Command {
     /// Merge several Cargo unit-graph JSON files.
     Merge(MergeArgs),
 
+    /// Emit cargo-nextest metadata for one cargo-unit-built test binary.
+    NextestMetadata(NextestMetadataArgs),
+
     /// Render generated Nix from Cargo unit-graph JSON on stdin.
     Render(RenderArgs),
 
@@ -54,6 +57,45 @@ struct MergeArgs {
     /// Cargo unit-graph JSON files to merge.
     #[arg(required = true, value_name = "PATH")]
     graphs: Vec<PathBuf>,
+}
+
+#[derive(Debug, clap::Args)]
+struct NextestMetadataArgs {
+    /// Synthetic workspace root nextest should report in diagnostics.
+    #[arg(long, value_name = "PATH")]
+    workspace_root: PathBuf,
+
+    /// Cargo-unit test target name.
+    #[arg(long, value_name = "NAME")]
+    target_name: String,
+
+    /// Cargo package name that owns the test target.
+    #[arg(long, value_name = "NAME")]
+    package_name: String,
+
+    /// Rust edition from the Cargo package target.
+    #[arg(long, value_name = "EDITION")]
+    edition: String,
+
+    /// Cargo-unit-built libtest binary to run through nextest.
+    #[arg(long, value_name = "PATH")]
+    test_binary: PathBuf,
+
+    /// Rust target triple used to build the test binary.
+    #[arg(long, value_name = "TRIPLE")]
+    target_triple: String,
+
+    /// Rust target libdir for nextest build metadata.
+    #[arg(long, value_name = "PATH")]
+    rust_libdir: PathBuf,
+
+    /// Output path for cargo metadata JSON.
+    #[arg(long, value_name = "PATH")]
+    cargo_metadata: PathBuf,
+
+    /// Output path for nextest binaries metadata JSON.
+    #[arg(long, value_name = "PATH")]
+    binaries_metadata: PathBuf,
 }
 
 #[derive(Debug, clap::Args)]
@@ -107,6 +149,142 @@ fn merge(args: MergeArgs) -> color_eyre::Result<()> {
     println!();
 
     Ok(())
+}
+
+fn nextest_metadata(args: &NextestMetadataArgs) -> color_eyre::Result<()> {
+    let target_directory = args.workspace_root.join("target").display().to_string();
+    let package_id = format!(
+        "path+file://{}#{}@0.0.0",
+        args.workspace_root.display(),
+        args.target_name
+    );
+
+    let cargo_metadata = nextest_cargo_metadata(args, &package_id, &target_directory);
+    let binaries_metadata = nextest_binaries_metadata(args, &package_id, &target_directory);
+
+    write_json(&args.cargo_metadata, &cargo_metadata)?;
+    write_json(&args.binaries_metadata, &binaries_metadata)?;
+
+    Ok(())
+}
+
+fn nextest_cargo_metadata(
+    args: &NextestMetadataArgs,
+    package_id: &str,
+    target_directory: &str,
+) -> serde_json::Value {
+    let manifest_path = args.workspace_root.join("Cargo.toml").display().to_string();
+    let src_path = args.workspace_root.join("src/lib.rs").display().to_string();
+
+    let cargo_target = serde_json::json!({
+        "kind": ["lib"],
+        "crate_types": ["lib"],
+        "name": &args.package_name,
+        "src_path": src_path,
+        "edition": &args.edition,
+        "doc": true,
+        "doctest": false,
+        "test": true
+    });
+    let cargo_package = serde_json::json!({
+        "name": &args.package_name,
+        "version": "0.0.0",
+        "id": package_id,
+        "source": null,
+        "dependencies": [],
+        "features": {},
+        "manifest_path": manifest_path,
+        "edition": &args.edition,
+        "metadata": null,
+        "publish": null,
+        "authors": [],
+        "categories": [],
+        "keywords": [],
+        "license": null,
+        "license_file": null,
+        "description": null,
+        "readme": null,
+        "repository": null,
+        "homepage": null,
+        "documentation": null,
+        "links": null,
+        "default_run": null,
+        "rust_version": null,
+        "targets": [cargo_target]
+    });
+
+    serde_json::json!({
+        "version": 1,
+        "workspace_root": args.workspace_root.display().to_string(),
+        "target_directory": target_directory,
+        "workspace_members": [package_id],
+        "workspace_default_members": [package_id],
+        "resolve": null,
+        "metadata": null,
+        "packages": [cargo_package]
+    })
+}
+
+fn nextest_binaries_metadata(
+    args: &NextestMetadataArgs,
+    package_id: &str,
+    target_directory: &str,
+) -> serde_json::Value {
+    let rust_libdir = args.rust_libdir.display().to_string();
+    let test_binary = args.test_binary.display().to_string();
+
+    let host_platform = serde_json::json!({
+        "platform": {
+            "triple": &args.target_triple,
+            "target-features": "unknown"
+        },
+        "libdir": {
+            "status": "available",
+            "path": rust_libdir
+        }
+    });
+    let build_meta = serde_json::json!({
+        "target-directory": target_directory,
+        "build-directory": target_directory,
+        "base-output-directories": ["debug"],
+        "non-test-binaries": {},
+        "build-script-out-dirs": {},
+        "build-script-info": {},
+        "linked-paths": [],
+        "platforms": {
+            "host": host_platform,
+            "targets": []
+        },
+        "target-platforms": [
+            {
+                "triple": &args.target_triple,
+                "target-features": "unknown"
+            }
+        ],
+        "target-platform": null
+    });
+    let binary = serde_json::json!({
+        "binary-id": &args.target_name,
+        "binary-name": &args.target_name,
+        "package-id": package_id,
+        "kind": "lib",
+        "binary-path": test_binary,
+        "build-platform": "target"
+    });
+
+    serde_json::json!({
+        "rust-build-meta": build_meta,
+        "rust-binaries": {
+            args.target_name.as_str(): binary
+        }
+    })
+}
+
+fn write_json(path: &std::path::Path, value: &serde_json::Value) -> color_eyre::Result<()> {
+    let file = std::fs::File::create(path)
+        .wrap_err_with(|| format!("creating JSON output {}", path.display()))?;
+    serde_json::to_writer_pretty(file, value)
+        .wrap_err_with(|| format!("writing JSON output {}", path.display()))
 }
 
 fn render(args: RenderArgs) -> color_eyre::Result<()> {
@@ -181,7 +359,60 @@ fn main() -> color_eyre::Result<()> {
 
     match Cli::parse().command {
         Command::Merge(args) => merge(args),
+        Command::NextestMetadata(args) => nextest_metadata(&args),
         Command::Render(args) => render(args),
         Command::ScanPanics(args) => scan_panics(args),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nextest_metadata_writes_package_and_binary_metadata() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let workspace_root = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        let cargo_metadata = tmp.path().join("cargo-metadata.json");
+        let binaries_metadata = tmp.path().join("binaries-metadata.json");
+
+        nextest_metadata(&NextestMetadataArgs {
+            workspace_root: workspace_root.clone(),
+            target_name: "crate_tests".to_owned(),
+            package_name: "crate-name".to_owned(),
+            edition: "2024".to_owned(),
+            test_binary: PathBuf::from("/nix/store/test-binary/bin/crate_tests"),
+            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+            rust_libdir: PathBuf::from("/nix/store/rust/lib/rustlib/x86_64-unknown-linux-gnu/lib"),
+            cargo_metadata: cargo_metadata.clone(),
+            binaries_metadata: binaries_metadata.clone(),
+        })
+        .expect("write nextest metadata");
+
+        let cargo: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(cargo_metadata).expect("read cargo metadata"),
+        )
+        .expect("parse cargo metadata");
+        let binaries: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(binaries_metadata).expect("read binaries metadata"),
+        )
+        .expect("parse binaries metadata");
+
+        assert_eq!(cargo["packages"][0]["name"], "crate-name");
+        assert_eq!(cargo["packages"][0]["edition"], "2024");
+        assert_eq!(cargo["packages"][0]["targets"][0]["edition"], "2024");
+        assert_eq!(
+            cargo["packages"][0]["manifest_path"],
+            workspace_root.join("Cargo.toml").display().to_string()
+        );
+        assert_eq!(
+            binaries["rust-binaries"]["crate_tests"]["binary-path"],
+            "/nix/store/test-binary/bin/crate_tests"
+        );
+        assert_eq!(
+            binaries["rust-build-meta"]["platforms"]["host"]["platform"]["triple"],
+            "x86_64-unknown-linux-gnu"
+        );
     }
 }

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -294,7 +294,9 @@ pub fn render_units_nix(graph: &UnitGraph, options: &RenderOptions) -> Result<St
         source_audit_entries: render_source_audit_entries(&prepared),
         unit_entries: render_unit_entries(graph, options, &prepared)?,
         clippy_unit_entries: render_clippy_unit_entries(graph, options, &prepared)?,
-        clippy_unit_names_by_package: render_clippy_unit_names_by_package(graph, options, &prepared),
+        clippy_unit_names_by_package: render_clippy_unit_names_by_package(
+            graph, options, &prepared,
+        ),
         panic_object_unit_entries: render_panic_object_unit_entries(graph, options, &prepared)?,
         policy_check_entries: render_policy_check_entries(graph, options, &prepared)?,
         unused_crate_dependencies_by_package: render_unused_crate_dependencies_by_package(
@@ -819,8 +821,7 @@ fn render_unit_derivation(
     // the failures seen on the shared CI store. Keep tests and benches
     // input-addressed; they still benefit from upstream CA on their inputs.
     let unit = &graph.units[index];
-    let content_addressed =
-        options.content_addressed && !unit.is_test() && !unit.is_benchmark();
+    let content_addressed = options.content_addressed && !unit.is_test() && !unit.is_benchmark();
     append_content_addressing(&mut attrs, content_addressed);
     attrs.multiline(
         "buildPhase",
@@ -2947,10 +2948,11 @@ fn render_test_entries_for(
         let binary = test_binary_expr(unit, prepared, *index);
         let _ = writeln!(
             entries,
-            "    {} = mkTestEntry {{ name = {}; binary = \"{binary}\"; packageName = {}; }};",
+            "    {} = mkTestEntry {{ name = {}; binary = \"{binary}\"; packageName = {}; edition = {}; }};",
             nix_attr(&key),
             nix_attr(&key),
             nix_attr(&unit.package_name()),
+            nix_attr(&unit.target.edition),
         );
     }
 
@@ -3575,6 +3577,8 @@ mod tests {
         assert!(rendered.contains("packageBuildEnv.${attrs.packageName or \"\"} or {}"));
         assert!(rendered.contains("builtins.removeAttrs attrs [ \"packageName\" ]"));
         assert!(rendered.contains("mkTestEntry ="));
+        assert!(rendered.contains("edition = \"2024\";"));
+        assert!(rendered.contains("inherit name binary packageName edition testArgs;"));
         assert!(rendered.contains("RUST_TEST_THREADS"));
         assert!(rendered.contains("mkTestCases ="));
         assert!(rendered.contains("testTargets = ["));

--- a/packages/nix/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix/nix-cargo-unit/templates/units.nix.askama
@@ -713,11 +713,12 @@ let
     );
 
   mkTestEntry =
-    { name, binary, packageName }:
+    { name, binary, packageName, edition }:
     let
       testArgs = testArgsByPackage.${packageName} or [];
     in
     {
+      inherit name binary packageName edition testArgs;
       # Runs the whole test binary in one derivation, mirroring `cargo test`.
       all = pkgs.runCommand "cargo-unit-test-${name}" (packageTestAttrs packageName) ''
         export RUST_TEST_THREADS="$NIX_BUILD_CORES"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4188,6 +4188,20 @@ let
         message = "cargo-unit workspaces should expose test targets as separate checks";
       }
       {
+        assertion = builtins.hasAttr "cargo_unit_hello" cargoUnitWorkspace.nextestByTarget;
+        message = "cargo-unit workspaces should expose cargo-nextest checks per test target";
+      }
+      {
+        assertion =
+          cargoUnitWorkspace.testChecksByTarget.cargo_unit_hello.drvPath
+          == cargoUnitWorkspace.nextestByTarget.cargo_unit_hello.drvPath;
+        message = "cargo-unit testChecksByTarget should use cargo-nextest when policy.tests.useNextest is enabled";
+      }
+      {
+        assertion = lib.isDerivation cargoUnitWorkspace.testChecksAll;
+        message = "cargo-unit workspaces should expose an aggregate test-check derivation";
+      }
+      {
         assertion = cargoUnitWorkspace.doctests != { };
         message = "cargo-unit workspaces should expose doctest targets as separate checks";
       }


### PR DESCRIPTION
## Summary
- expose per-target Rust test checks from cargo-unit workspaces
- add cargo-nextest metadata generation for already-built cargo-unit test binaries
- add structured per-package test policy for skips and test thread settings
- preserve the real Cargo target edition in nextest metadata

## Validation
- nix build --no-link .#nix-cargo-unit
- nextest metadata smoke test preserving edition 2024
- ix rust-workspace-package-index.drvPath eval with local index override

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose cargo-nextest test checks in `buildWorkspace` with per-package policy support
> - Adds `testPolicyByPackage` to `buildWorkspace` in [cargo-unit.nix](https://github.com/indexable-inc/index/pull/1490/files#diff-82054df1a7d1648a5be88265641a7ae5d3b9e4ec4cdea72c518359ea4ae3f804), allowing per-package configuration of skipped tests and thread counts for both libtest and cargo-nextest runners.
> - Introduces `mkNextestForTarget`, which builds a per-target derivation that synthesizes a cargo workspace, runs `cargo-nextest`, and captures JUnit XML output.
> - Adds a `nextest-metadata` subcommand to the `nix-cargo-unit` CLI ([main.rs](https://github.com/indexable-inc/index/pull/1490/files#diff-50450bb2844bd5aadba4f54593d42a14331704e3f8ebc3bfe70408fbac02781e)) that emits synthetic cargo and nextest binaries metadata JSON for a given test binary.
> - Propagates Rust edition into generated test entry Nix via updates to [render.rs](https://github.com/indexable-inc/index/pull/1490/files#diff-91be6a053ea25b59c072a514f469215dbbfeb6abbba3ddb8d77ad99ffa244e7f) and [units.nix.askama](https://github.com/indexable-inc/index/pull/1490/files#diff-cac33d78fca2d2ceb303a3b0eb79eeedf44ecaac1e57d9d3d8ae4b3888f2a20f).
> - Risk: conflicts between `testPolicyByPackage` and explicit `testArgsByPackage` now cause assertion failures at evaluation time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fe68f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->