### PR TITLE
Add ix.dev Rust profile

### DIFF
--- a/lib/dev/options.nix
+++ b/lib/dev/options.nix
@@ -10,7 +10,7 @@
   Declared in `lib/dev/` (not `modules/`) so it is only in scope where a dev
   image pulls it in - it must not add `claude-code` to every image in the repo.
 */
-{ lib, ... }:
+{ lib, pkgs, ... }:
 let
   inherit (lib)
     mkOption
@@ -41,6 +41,90 @@ in
         Image under `images/dev/` every node is built on. The default,
         `development-base`, carries the build toolchain and the agent CLIs.
       '';
+    };
+
+    profiles = {
+      rust = {
+        enable = mkEnableOption "the recommended Rust development toolchain";
+
+        channel = mkOption {
+          type = types.enum [
+            "stable"
+            "beta"
+            "nightly"
+          ];
+          default = "nightly";
+          description = "Rust release channel for the dev profile toolchain.";
+        };
+
+        version = mkOption {
+          type = types.str;
+          default = "latest";
+          description = ''
+            Rust toolchain version. Use `latest`, a stable semver, or a nightly
+            date accepted by `ix.rustToolchainFor`.
+          '';
+        };
+
+        components = mkOption {
+          type = types.listOf types.str;
+          default = [
+            "cargo"
+            "clippy"
+            "llvm-tools-preview"
+            "rust-analyzer"
+            "rust-src"
+            "rust-std"
+            "rustc"
+            "rustfmt"
+          ];
+          description = "rustup components included in the profile toolchain.";
+        };
+
+        targets = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          description = "Extra rustc targets installed with the profile toolchain.";
+        };
+
+        profile = mkOption {
+          type = types.enum [
+            "minimal"
+            "default"
+            "complete"
+          ];
+          default = "minimal";
+          description = "rust-overlay profile baseline for the profile toolchain.";
+        };
+
+        packages = mkOption {
+          type = types.listOf types.package;
+          default = with pkgs; [
+            bacon
+            cargo-audit
+            cargo-deny
+            cargo-edit
+            cargo-expand
+            cargo-flamegraph
+            cargo-nextest
+            cargo-watch
+            clang
+            lldb
+            taplo
+            watchexec
+          ];
+          description = ''
+            Extra Rust-adjacent tools installed by the profile. Extend or
+            override this like any NixOS list option.
+          '';
+        };
+
+        setEnvironment = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Set common Rust development environment variables.";
+        };
+      };
     };
 
     selfSource = mkOption {

--- a/lib/dev/profiles.nix
+++ b/lib/dev/profiles.nix
@@ -1,0 +1,42 @@
+/**
+  Composable `ix.dev.profiles.*` language/tool stacks.
+
+  Keep these as ordinary NixOS module fragments so profiles compose through the
+  normal `environment.systemPackages` merge path instead of making templates
+  hand-maintain long package lists.
+*/
+{
+  config,
+  ix,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ix.dev.profiles;
+
+  rust = cfg.rust;
+  rustToolchain = ix.rustToolchainFor pkgs {
+    inherit (rust)
+      channel
+      version
+      components
+      targets
+      profile
+      ;
+  };
+in
+{
+  imports = [ ./options.nix ];
+
+  config = lib.mkMerge [
+    (lib.mkIf rust.enable {
+      environment.systemPackages = [ rustToolchain ] ++ rust.packages;
+
+      environment.variables = lib.mkIf rust.setEnvironment {
+        RUST_BACKTRACE = lib.mkDefault "1";
+        RUST_SRC_PATH = lib.mkDefault "${rustToolchain}/lib/rustlib/src/rust/library";
+      };
+    })
+  ];
+}

--- a/lib/image/dev.nix
+++ b/lib/image/dev.nix
@@ -48,6 +48,7 @@ let
   # per-node `defaults`.
   optionsModule = paths.root + "/lib/dev/options.nix";
   agentsModule = paths.root + "/lib/dev/agents.nix";
+  profilesModule = paths.root + "/lib/dev/profiles.nix";
 
   # On-disk export path on the elected server, and the internal SMB share name.
   shareDir = "/var/lib/ix-dev-share";
@@ -103,6 +104,7 @@ let
       defaults = [
         (paths.images + "/dev/${dev.baseImage}")
         agentsModule
+        profilesModule
         (
           { name, ... }:
           {


### PR DESCRIPTION
Adds a composable `ix.dev.profiles.rust` profile so dev environments can opt into the recommended Rust stack without hand-listing toolchain packages in `environment.systemPackages`.

What changed:
- Adds `ix.dev.profiles.rust` options for channel/version/components/targets/profile/packages/env.
- Adds `lib/dev/profiles.nix`, merged into every `mkDevFor` default node alongside the agent layer.
- Keeps `ix.dev.agents.{claude,codex}` defaulting on, so dev images still ship agents by default.

Validation:
- `nixfmt lib/dev/options.nix lib/dev/profiles.nix lib/image/dev.nix`
- `nix eval ./example#nixosConfigurations.dev.config.ix.dev.profiles.rust.enable --override-input index path:/Users/andrewgazelka/Projects/indexable-inc/index-ixdev-rust-profile --json --no-write-lock-file` -> `true`
- `nix eval ./example#nixosConfigurations.dev.config.ix.dev.agents.claude --override-input index path:/Users/andrewgazelka/Projects/indexable-inc/index-ixdev-rust-profile --json --no-write-lock-file` -> `true`
- `nix eval ./example#nixosConfigurations.dev.config.ix.dev.agents.codex --override-input index path:/Users/andrewgazelka/Projects/indexable-inc/index-ixdev-rust-profile --json --no-write-lock-file` -> `true`

Refs #1494

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Rust development profile to ix.dev
> - Adds a new `ix.dev.profiles.rust` option group in [lib/dev/options.nix](https://github.com/indexable-inc/index/pull/1495/files#diff-21e791d9c2cbed984f194d1e2442ae1c9bba0ca4ceda806d7052a081a43fcbc3) with configurable channel, version, components, targets, profile baseline, extra packages, and an environment variable flag.
> - Adds [lib/dev/profiles.nix](https://github.com/indexable-inc/index/pull/1495/files#diff-9708d0b102bd8cf94fcfe5ceefbe4fe18c5c58d59fab4dfed0b460cb6dd0fb4e) which installs the configured Rust toolchain via `ix.rustToolchainFor` and sets `RUST_BACKTRACE` and `RUST_SRC_PATH` when `rust.setEnvironment` is true.
> - Includes the profiles module in dev images by default via [lib/image/dev.nix](https://github.com/indexable-inc/index/pull/1495/files#diff-b0574b018c9f176e0ee521344c331ba0e543e2a1ac42037fa67601faa428867b), exposing `ix.dev.profiles.*` options to all dev image configurations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17a095c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->