### PR TITLE
fix: parse daily scraper CLI through CliApp

### DIFF
--- a/examples/python-daily-scraper/src/daily_scraper/__init__.py
+++ b/examples/python-daily-scraper/src/daily_scraper/__init__.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import duckdb
 import httpx
 from pydantic import BaseModel
-from pydantic_settings import BaseSettings, CliSettingsSource, PydanticBaseSettingsSource, SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    CliApp,
+    CliSettingsSource,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 
 
 LOGGER = logging.getLogger("daily_scraper")
@@ -136,9 +142,13 @@ def write_parquet(metric: RepoMetric, output_dir: Path) -> Path:
     return output_path
 
 
+def parse_args() -> CliArgs:
+    return CliApp.run(CliArgs)
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
-    args = CliArgs()
+    args = parse_args()
 
     metric = fetch_repo_metric(
         repo=args.repo,


### PR DESCRIPTION
daily-scraper keeps output_dir required because the systemd service passes --output-dir explicitly. Calling CliArgs() made zuban treat output_dir as a missing constructor argument during image builds, even though pydantic-settings would populate it from the CLI at runtime.

Use CliApp.run(CliArgs) behind parse_args() so pydantic-settings owns argv parsing and returns a typed CliArgs instance. The existing settings_customise_sources hook still drops env, dotenv, and secrets sources, so the CLI contract remains explicit and the strict build check no longer sees a missing required constructor argument.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parse daily scraper CLI arguments through `CliApp` instead of direct instantiation
> Adds a `parse_args()` function in [`__init__.py`](https://github.com/indexable-inc/index/pull/1498/files#diff-3d7ecea4ccb31f30c8f5a7e0338a71c43ed77aa239d4ed3c988d8ce9ec924b9c) that delegates argument parsing to `CliApp.run(CliArgs)` from `pydantic_settings`. The `main` entrypoint now calls `parse_args()` instead of constructing `CliArgs()` directly, so CLI-provided argument values are respected at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8666740.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->