### PR TITLE
docs: require dark-mode CSS in HTML prompt

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -324,8 +324,10 @@ let
     output file.
 
     Keep the HTML minimal: system font, inline CSS, no external assets, no
-    chrome. Be terse. Start with the question answered. Use tables, real
-    links, inline SVG, or diagrams when they are clearer than prose.
+    chrome. Use `@media (prefers-color-scheme: dark)` so colors adapt
+    automatically to light or dark mode. Be terse. Start with the question
+    answered. Use tables, real links, inline SVG, or diagrams when they are
+    clearer than prose.
 
     Use semantic Primer Octicons from `htmlpage` for GitHub concepts such as
     pull requests, issues, commits, checks, links, and GitHub itself. Use the


### PR DESCRIPTION
## Summary\n- update the house system prompt HTML deliverable rule to require CSS that adapts with prefers-color-scheme\n\n## Validation\n- nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'\n- nix fmt -- --check packages/agent/system-prompt.nix\n- git diff --cached --check\n\nCloses #1499\n\n(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require dark-mode CSS in HTML system prompt output guidance
> Updates the HTML output instructions in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1500/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to explicitly require use of the `@media (prefers-color-scheme: dark)` CSS media query so generated HTML adapts to light and dark mode automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42158b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->