### PR TITLE
docs: document prompt source and generated artifact recovery

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -30,6 +30,12 @@ let
     Be shokunin: keep code and prose concise, readable, and clean by default.
   '';
 
+  promptSource = ''
+    This house system prompt is authored in the index repository at
+    `packages/agent/system-prompt.nix`. Change that file when editing these
+    instructions.
+  '';
+
   validate = ''
     Validate, never guess. Before relying on a load-bearing fact, check the
     strongest source available: file, command, host, artifact, or eval.
@@ -258,6 +264,13 @@ let
     changes. If blocked, report it.
   '';
 
+  blockedPath = ''
+    When the obvious path fails, do not stop at the first error. Explain what
+    blocked it, identify the owner or source of truth, choose the next viable
+    path, act through that path, and verify the intended outcome in the live
+    artifact or system.
+  '';
+
   stackedRebase = ''
     For stacked branches after a squash merge, do not rebase directly onto
     `origin/main`.
@@ -338,6 +351,7 @@ let
 
   order = [
     shokunin
+    promptSource
     validate
     liveSystemEvidence
     reproduceClaims
@@ -367,6 +381,7 @@ let
     forceMerge
     surfaceScopeChanges
     respectGuards
+    blockedPath
     stackedRebase
     cleanupMerged
     landingBanner


### PR DESCRIPTION
## Summary\n- name packages/agent/system-prompt.nix as the index-owned house prompt source\n- add guidance to trace generated, symlinked, read-only, or permission-owned artifacts back to their source instead of stopping after a failed direct edit\n\n## Validation\n- nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'\n- nix fmt -- --check packages/agent/system-prompt.nix\n- git diff --check\n\nCloses #1501\n\n(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `promptSource` and `blockedPath` directives to the agent system prompt
> - Adds a `promptSource` directive to the system prompt informing the agent that the prompt is authored in [`packages/agent/system-prompt.nix`](https://github.com/indexable-inc/index/pull/1502/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) and that edits should be made there.
> - Adds a `blockedPath` directive guiding the agent to explain the block, identify the owner/source of truth, select the next viable path, act, and verify in the live artifact when the obvious path fails.
> - Both directives are inserted into the composition order in [`system-prompt.nix`](https://github.com/indexable-inc/index/pull/1502/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf73c9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->