### PR TITLE
fix: deny codex bash when index mcp is available

### DIFF
--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -140,6 +140,7 @@ let
   # Codex does not use Claude's `permissions.deny` JSON shape.
   sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
     inherit lib;
+    mcpServers = mcpStdioServers;
   };
 in
 # These baked defaults also reach the Codex GUI app's remote-SSH sessions, not

--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -14,6 +14,8 @@ let
       "WebFetch"
     ]
     ++ lib.optional (mcpServers ? index) "Bash";
+
+  supersededCodexTools = lib.optional (mcpServers ? index) "Bash";
 in
 {
   claude = {
@@ -21,6 +23,7 @@ in
   };
 
   codex = {
+    deniedToolPatterns = supersededCodexTools;
     protectedMergeCommandPatterns = [
       "gh pr merge*--admin*"
       "gh pr merge*--force*"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3385,6 +3385,17 @@ let
         message = "development-base should keep unrelated unfree CLIs out of the image";
       }
       {
+        assertion =
+          let
+            policy = import (paths.packagesRoot + "/agent/policy/permissions.nix") {
+              inherit lib;
+              mcpServers.index = { };
+            };
+          in
+          policy.codex.deniedToolPatterns == [ "Bash" ];
+        message = "Codex should deny the Bash tool when the index MCP is available";
+      }
+      {
         # Bypass-permissions is enforced through Claude's managed-settings layer
         # (/etc/claude-code/managed-settings.json): read-only, highest precedence,
         # leaving ~/.claude/settings.json app-owned. Pin both keys so a refactor


### PR DESCRIPTION
Closes #1505\n\n## Summary\n- add Codex deniedToolPatterns for Bash when the index MCP is configured\n- keep Claude's existing MCP-superseded Bash denial behavior\n- add an eval assertion covering the Codex policy output\n\n## Validation\n- nix eval --impure --json --expr 'let lib = (import <nixpkgs> {}).lib; policy = import ./packages/agent/policy/permissions.nix { inherit lib; mcpServers.index = {}; }; in policy'\n- nix fmt -- --check packages/agent/policy/permissions.nix tests/default.nix\n- git diff --check\n\n(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deny Codex `Bash` tool when the `index` MCP server is available
> - [permissions.nix](https://github.com/indexable-inc/index/pull/1506/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) gains a `deniedToolPatterns` field on the codex policy, populated with `["Bash"]` when `mcpServers.index` is present.
> - [default.nix](https://github.com/indexable-inc/index/pull/1506/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5) passes `mcpStdioServers` as `mcpServers` to `permissions.nix` so the conditional logic has access to the configured servers.
> - A test in [tests/default.nix](https://github.com/indexable-inc/index/pull/1506/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) asserts that `policy.codex.deniedToolPatterns` equals `["Bash"]` when `mcpServers.index` is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 363be5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->