### PR TITLE
fix: deny codex exec_command with index mcp

### DIFF
--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -15,7 +15,10 @@ let
     ]
     ++ lib.optional (mcpServers ? index) "Bash";
 
-  supersededCodexTools = lib.optional (mcpServers ? index) "Bash";
+  supersededCodexTools = lib.optionals (mcpServers ? index) [
+    "Bash"
+    "exec_command"
+  ];
 in
 {
   claude = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3392,8 +3392,11 @@ let
               mcpServers.index = { };
             };
           in
-          policy.codex.deniedToolPatterns == [ "Bash" ];
-        message = "Codex should deny the Bash tool when the index MCP is available";
+          policy.codex.deniedToolPatterns == [
+            "Bash"
+            "exec_command"
+          ];
+        message = "Codex should deny shell tools when the index MCP is available";
       }
       {
         # Bypass-permissions is enforced through Claude's managed-settings layer


### PR DESCRIPTION
Closes #1508

## Summary
- deny Codex `exec_command` alongside `Bash` when the index MCP server is configured
- update the policy assertion to cover both shell tool surfaces

## Validation
- `nix eval --impure --json --expr 'let lib = (import <nixpkgs> {}).lib; policy = import ./packages/agent/policy/permissions.nix { inherit lib; mcpServers.index = {}; }; in policy.codex.deniedToolPatterns'`
- `nix fmt -- --check packages/agent/policy/permissions.nix tests/default.nix`
- `git diff --check`

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deny `exec_command` alongside `Bash` when the index MCP server is present
> In [permissions.nix](https://github.com/indexable-inc/index/pull/1510/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d), `exec_command` is added to `supersededCodexTools` alongside `Bash` when the `index` MCP server is present, so both shell tools are denied. The corresponding test in [tests/default.nix](https://github.com/indexable-inc/index/pull/1510/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) is updated to assert `deniedToolPatterns` contains both `"Bash"` and `"exec_command"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8eff44f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->