### PR TITLE
Preapprove house MCP tools for Codex

### DIFF
--- a/lib/util/mcp.nix
+++ b/lib/util/mcp.nix
@@ -42,7 +42,9 @@ let
   # config-launch turns into `-c <key>=<value>` flags (so a user's own
   # `mcp_servers.<name>` in config.toml still wins per the per-leaf presence
   # check). Codex keys stdio servers by `command`/`args`/`env` and HTTP servers
-  # by `url`, mirroring `[mcp_servers.<name>]` tables in config.toml.
+  # by `url`, mirroring `[mcp_servers.<name>]` tables in config.toml. House MCP
+  # tools are trusted defaults, so approve server tools unless the user config
+  # sets a stricter `default_tools_approval_mode` or per-tool override.
   codexEntriesOne =
     name: def:
     let
@@ -52,25 +54,33 @@ let
         value = toml.scalar v;
       }) (def.env or { });
     in
-    if isStdio def then
-      [
-        {
-          key = "${prefix}.command";
-          value = toml.scalar def.command;
-        }
-      ]
-      ++ lib.optional (def ? args) {
-        key = "${prefix}.args";
-        value = tomlArray def.args;
+    [
+      {
+        key = "${prefix}.default_tools_approval_mode";
+        value = toml.scalar "approve";
       }
-      ++ envEntries
-    else
-      [
-        {
-          key = "${prefix}.url";
-          value = toml.scalar def.url;
+    ]
+    ++ (
+      if isStdio def then
+        [
+          {
+            key = "${prefix}.command";
+            value = toml.scalar def.command;
+          }
+        ]
+        ++ lib.optional (def ? args) {
+          key = "${prefix}.args";
+          value = tomlArray def.args;
         }
-      ];
+        ++ envEntries
+      else
+        [
+          {
+            key = "${prefix}.url";
+            value = toml.scalar def.url;
+          }
+        ]
+    );
 in
 {
   /**

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -138,6 +138,16 @@ let
   # ix guest sidecars are opened by the shared platform base config.
   baseFirewallTcpPorts = [ 5001 ];
   baseFirewallUdpPorts = [ 8443 ];
+  sampleCodexMcpEntries = ix.mcp.toCodexEntries {
+    index = {
+      transport = "stdio";
+      command = "/bin/ix-mcp";
+      args = [ "serve" ];
+    };
+  };
+  sampleCodexMcpEntry =
+    key:
+    lib.findFirst (entry: entry.key == key) null sampleCodexMcpEntries;
 
   minecraft =
     let
@@ -2437,6 +2447,18 @@ let
   ];
 
   groups = {
+    mcp = [
+      {
+        assertion =
+          sampleCodexMcpEntry "mcp_servers.index.default_tools_approval_mode"
+          == {
+            key = "mcp_servers.index.default_tools_approval_mode";
+            value = "\"approve\"";
+          };
+        message = "Codex MCP entries should approve trusted house server tools by default";
+      }
+    ];
+
     ix-ray = [
       {
         # The head runs both daemons (Ray GCS + the ix-mcp engine that drives it).


### PR DESCRIPTION
Fixes #1511.

## What changed
- Add `mcp_servers.<name>.default_tools_approval_mode = "approve"` to generated Codex MCP soft defaults.
- Keep it soft, so user config can still override the server default or a single tool.
- Add an eval assertion covering the generated entry.

## Validation
- `nix-instantiate --parse lib/util/mcp.nix`
- `nix-instantiate --parse tests/default.nix`
- `nix eval --raw --impure --expr 'let flake = builtins.getFlake (toString ./.); in builtins.toJSON (flake.lib.mcp.toCodexEntries { index = { transport = "stdio"; command = "/bin/ix-mcp"; args = [ "serve" ]; }; })'`
- `nix eval --raw --impure --expr 'let flake = builtins.getFlake (toString ./.); tests = import ./tests { nixpkgs = flake.inputs.nixpkgs; ix = flake.lib; paths = flake.lib.paths; }; in builtins.toJSON tests.groups.mcp'`
- `nix build .#codex -L --no-link --print-out-paths`, then read the generated launch spec and confirmed `mcp_servers.index.default_tools_approval_mode` is present with value `"approve"`.

Skipped full `nix build .#check`: it fails before reaching this change because `repoPackages.nix-fast-build` is missing at `lib/per-system.nix:245`.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preapprove house MCP tools for Codex by setting `default_tools_approval_mode` to `approve`
> - Updates `codexEntriesOne` in [mcp.nix](https://github.com/indexable-inc/index/pull/1512/files#diff-30f208a31e39d4388eb8b510d8a6962b9cd1a5d7b074429d38190a855a620744) to prepend a `mcp_servers.<name>.default_tools_approval_mode = "approve"` entry for every MCP server (both stdio and http), so house tools are trusted by default without requiring user confirmation.
> - Adds a test group in [tests/default.nix](https://github.com/indexable-inc/index/pull/1512/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that asserts the generated Codex entries include this approval mode entry for a sample stdio server.
> - Behavioral Change: Codex will now auto-approve tool calls from house MCP servers unless user config explicitly overrides `default_tools_approval_mode`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a030f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->