### PR TITLE
Restrict Codex tools to index and Exa MCP

### DIFF
--- a/doc/codex/overview.md
+++ b/doc/codex/overview.md
@@ -28,10 +28,11 @@ kinds of `-c key=value` overrides.
 
 Applied on EVERY invocation (`-c` is codex's highest-precedence layer, above
 `~/.codex/config.toml`), so reserved for wrapper invariants the user must not
-silently lose. The only one baked: `check_for_update_on_startup = false`, since
-the store binary is read-only and the wrapper owns the version pin, so the check
-only ever costs a network round-trip it can never act on. Anything
-security-shaped (sandbox mode, approval policy) is left to the user's config.
+silently lose. The wrapper always disables the startup update check because the
+store binary is read-only and the wrapper owns the version pin. When the index
+MCP server is available, shared policy also disables Codex's built-in shell,
+browser, computer-use, image-generation, and standalone web-search tool features
+so the available tool surface stays with the index and Exa MCP servers.
 
 ### Soft defaults (`settings`, `default.nix:41-47`)
 
@@ -47,16 +48,13 @@ Defaults bump multi-agent fan-out well above stock:
 - `agents.max_depth = 3` (parent -> child -> grandchild -> great-grandchild),
   still read under v2.
 
-### Baked MCP server (`default.nix:62-73`, `80`)
+### Baked MCP servers (`default.nix:62-73`, `80`)
 
-The `index` MCP server is added as soft `-c mcp_servers.index.*` defaults from
-the same `ix.mcp` registry the claude-code wrapper renders, so the kernel is
-declared once for both tools. Only stdio servers are baked
-(`mcpStdioServers` filters `transport == "stdio"`): codex's streamable-HTTP MCP
-support is gated behind version-specific keys, so the keyless `exa` HTTP server
-stays claude-only. The `index` server is present only when the `mcp` sibling is
-in scope (the flake package set, not the overlay; `repoPackages`,
-`default.nix:10-15`, `71`).
+The house MCP servers are added as soft `-c mcp_servers.*` defaults from the same
+`ix.mcp` registry the claude-code wrapper renders, so Codex gets only the
+`index` MCP server and the Exa MCP server. The `index` server is present only
+when the `mcp` sibling is in scope (the flake package set, not the overlay;
+`repoPackages`, `default.nix:10-15`, `71`).
 
 ### Remote-SSH reach (`default.nix:83-92`)
 

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -88,20 +88,14 @@ let
       value = ix.toml.scalar v;
     }) flat;
 
-  # The `index` MCP server, baked as soft `-c mcp_servers.index.*` defaults from
-  # the shared house server set (../common.nix `houseServers`, the same source
-  # the claude-code wrapper renders), so the kernel is declared once for both
-  # tools. Soft, so a user's own `[mcp_servers.index]` in config.toml wins per
-  # the per-leaf presence check. Only stdio servers are baked: codex's
-  # streamable-HTTP MCP support is gated behind version-specific keys, so the
-  # keyless `exa` server stays claude-only rather than baking an unverified HTTP
-  # config into every codex session.
-  mcpStdioServers = lib.filterAttrs (
-    _: def: (def.transport or "stdio") == "stdio"
-  ) common.houseServers;
+  # The house MCP servers, baked as soft `-c mcp_servers.*` defaults from the
+  # shared house server set (../common.nix `houseServers`, the same source the
+  # claude-code wrapper renders), so Codex gets only the index MCP server and
+  # the Exa MCP server. Soft, so a user's own `[mcp_servers.<name>]` in
+  # config.toml wins per the per-leaf presence check.
+  mcpServers = common.houseServers;
   sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
-    inherit lib;
-    mcpServers = mcpStdioServers;
+    inherit lib mcpServers;
   };
   effectiveForcedSettings =
     forcedSettings
@@ -122,7 +116,7 @@ let
           { model_instructions_file = toString effectiveModelInstructionsFile; } // settings
         )
       )
-      ++ ix.mcp.toCodexEntries mcpStdioServers;
+      ++ ix.mcp.toCodexEntries mcpServers;
   };
   spec = (formats.json { }).generate "codex-launch-spec.json" specValue;
 

--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -17,7 +17,13 @@ let
 
   codexForcedSettings = lib.optionalAttrs (mcpServers ? index) {
     features = {
+      browser_use = false;
+      browser_use_external = false;
+      computer_use = false;
+      image_generation = false;
+      in_app_browser = false;
       shell_tool = false;
+      standalone_web_search = false;
       unified_exec = false;
     };
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -138,13 +138,11 @@ let
   # ix guest sidecars are opened by the shared platform base config.
   baseFirewallTcpPorts = [ 5001 ];
   baseFirewallUdpPorts = [ 8443 ];
-  sampleCodexMcpEntries = ix.mcp.toCodexEntries {
-    index = {
-      transport = "stdio";
-      command = "/bin/ix-mcp";
-      args = [ "serve" ];
-    };
-  };
+  sampleCodexMcpEntries = ix.mcp.toCodexEntries (
+    ix.mcp.houseServers {
+      indexCommand = "/bin/ix-mcp";
+    }
+  );
   sampleCodexMcpEntry = key: lib.findFirst (entry: entry.key == key) null sampleCodexMcpEntries;
 
   minecraft =
@@ -2454,6 +2452,20 @@ let
           };
         message = "Codex MCP entries should approve trusted house server tools by default";
       }
+      {
+        assertion =
+          sampleCodexMcpEntry "mcp_servers.exa.url" == {
+            key = "mcp_servers.exa.url";
+            value = "\"https://mcp.exa.ai/mcp\"";
+          };
+        message = "Codex MCP entries should include the Exa MCP server";
+      }
+      {
+        assertion = lib.all (
+          entry: lib.hasPrefix "mcp_servers.index." entry.key || lib.hasPrefix "mcp_servers.exa." entry.key
+        ) sampleCodexMcpEntries;
+        message = "Codex MCP entries should be limited to index and Exa when index MCP is available";
+      }
     ];
 
     ix-ray = [
@@ -3423,25 +3435,41 @@ let
             };
           in
           policy.codex.forcedSettings.features == {
+            browser_use = false;
+            browser_use_external = false;
+            computer_use = false;
+            image_generation = false;
+            in_app_browser = false;
             shell_tool = false;
+            standalone_web_search = false;
             unified_exec = false;
           };
-        message = "Codex policy should disable built-in shell tools when the index MCP is available";
+        message = "Codex policy should disable built-in tools when the index MCP is available";
       }
       {
         assertion =
           let
             forced = repoPackages.codex.passthru.specValue.forced;
           in
-          builtins.elem {
-            key = "features.shell_tool";
-            value = "false";
-          } forced
-          && builtins.elem {
-            key = "features.unified_exec";
-            value = "false";
-          } forced;
-        message = "Codex wrapper should render shell-tool disables into forced launch config";
+          lib.all
+            (
+              key:
+              builtins.elem {
+                key = "features.${key}";
+                value = "false";
+              } forced
+            )
+            [
+              "browser_use"
+              "browser_use_external"
+              "computer_use"
+              "image_generation"
+              "in_app_browser"
+              "shell_tool"
+              "standalone_web_search"
+              "unified_exec"
+            ];
+        message = "Codex wrapper should render built-in tool disables into forced launch config";
       }
       {
         # Bypass-permissions is enforced through Claude's managed-settings layer


### PR DESCRIPTION
## Summary
- include the Exa MCP server in the Codex wrapper MCP defaults alongside the index MCP server
- force-disable Codex built-in shell, browser, computer-use, image-generation, and standalone web-search tool features when index MCP is available
- add regression assertions that Codex MCP entries are limited to index and Exa

## Checks
- `nix fmt -- packages/agent/codex/default.nix packages/agent/policy/permissions.nix tests/default.nix docs/codex/overview.md`
- `nix-instantiate --parse packages/agent/codex/default.nix`
- `nix-instantiate --parse packages/agent/policy/permissions.nix`
- `nix-instantiate --parse tests/default.nix`
- targeted `nix eval --raw --impure --expr ...` assertions for MCP entries and disabled Codex tool features

Refs #1517

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict Codex to index and Exa MCP servers and disable built-in shell and browser tools
> - Replaces the stdio-only MCP server filter in [default.nix](https://github.com/indexable-inc/index/pull/1518/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5) with the full `houseServers` set, giving Codex access to both the index and Exa MCP servers.
> - Expands the forced-disable list in [permissions.nix](https://github.com/indexable-inc/index/pull/1518/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) to cover `browser_use`, `browser_use_external`, `computer_use`, `image_generation`, `in_app_browser`, and `standalone_web_search` in addition to `shell_tool` and `unified_exec` when the index MCP server is present.
> - Updates tests to assert Exa is present, MCP entries are scoped to only index and Exa, and all built-in tools are disabled.
> - Behavioral Change: Codex instances with the index MCP server available will have significantly more built-in capabilities forcibly disabled than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63e4589.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->