### PR TITLE
Improve index MCP ergonomics and subagent guidance

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -147,7 +147,8 @@ let
   '';
 
   backgroundSubagents = ''
-    Delegate by default with named subagents. Split real work into clear phases
+    Delegate by default with named subagents. Use them frequently whenever
+    independent work can run in parallel, and split real work into clear phases
     such as issue lookup, repro, fix, and verification.
 
     Spawn one subagent per self-contained task, in the background and in its own

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3987,6 +3987,7 @@ let
   shTestPy = pkgs.writeText "ix-mcp-sh-test.py" ''
     # python
     import asyncio
+    import inspect
 
     import sh
     from ix_notebook_mcp.runtime import Result
@@ -4047,8 +4048,19 @@ let
         # The module object itself is callable: the documented
         # `import sh; await sh(cmd)` works without reaching for `sh.sh`.
         assert callable(sh), "sh module is not callable"
+        assert inspect.signature(sh) == inspect.signature(sh.sh)
+        assert "cmd" in inspect.signature(sh).parameters
         direct = await sh("printf hi", cwd=".")
         assert direct.ok and direct.text == "hi", repr(direct.text)
+        try:
+            sh("git", "status")
+        except TypeError as exc:
+            assert "argv as a single list" in str(exc), exc
+        else:
+            raise SystemExit("expected sh('git', 'status') to explain argv-list form")
+
+        zsh_out = await sh.zsh("print -r -- ''${ZSH_VERSION:+zsh}", cwd=".")
+        assert zsh_out.ok and zsh_out.text.strip() == "zsh", repr(zsh_out.text)
 
         # cwd defaults to the current directory: no required-kwarg TypeError.
         import os
@@ -4128,7 +4140,10 @@ let
   shSmoke =
     pkgs.runCommand "ix-mcp-sh-smoke"
       {
-        nativeBuildInputs = [ mcpPython ];
+        nativeBuildInputs = [
+          mcpPython
+          pkgs.zsh
+        ];
         strictDeps = true;
       }
       ''

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -55,8 +55,10 @@ def credentials_note() -> str:
 
 NAMESPACE = (
     "The namespace persists across calls, so variables, functions, classes, and imports you "
-    "define stay defined and are reusable by every later call — define a helper once and call it "
-    "again next turn."
+    "define stay defined and are reusable by every later call: define a helper once and call it "
+    "again next turn. Bind expensive or large outputs to names (`out = await sh(...)`, "
+    "`df = ...`) instead of only printing or returning them, so later calls can inspect, filter, "
+    "or pass that same object to `read` without recomputing."
 )
 
 JOBS = (
@@ -75,10 +77,12 @@ JOBS = (
 PAGING = (
     "Every run is kept in `jobs`, so a truncated reply is never lost: page the run with "
     "jobs['<id>'].tail(n) / .head(n) / .slice(a, b) / .grep('pat') / .lines(a, b), or read "
-    "jobs['<id>'].output (stdout) and, once it has finished, jobs['<id>'].result (the value — "
+    "jobs['<id>'].output (stdout) and, once it has finished, jobs['<id>'].result (the value: "
     "it raises while the job is still running rather than return a misleading None, so `await "
     "jobs['<id>']` to wait for it; `.result` and `.result()` both work, and a finished Result's "
-    "`.text` is its rendered text); history() lists recent runs."
+    "`.text` is its rendered text). Prefer assigning the result to a variable before producing a "
+    "small final expression, e.g. `log = await sh(...); log[-4000:]`, so both the named object and "
+    "the pageable job survive for follow-up calls; history() lists recent runs."
 )
 
 BLOCKING = (
@@ -152,7 +156,10 @@ NO_SHELL = (
     "`view.edit(path, old, new)`, never blind. For meaning-based "
     "recall across a corpus, `import search`. When you genuinely must shell out, use the async "
     "`sh` (it runs off the loop, streams into the job's pageable output, and preserves clean "
-    "color); to run elsewhere pass `cwd=`, never a `cd X && ...` prefix. And shell out for "
+    "color); to run elsewhere pass `cwd=`, never a `cd X && ...` prefix. `sh` accepts either a "
+    "shell string (`await sh('git status --short')`) or an argv list (`await sh(['git', 'commit', "
+    "'-m', msg])`) that bypasses shell parsing. Use `await sh.zsh('setopt ...; ...')` only when "
+    "you intentionally need zsh syntax. And shell out for "
     "DATA, not text: when the CLI has a JSON mode (`gh --json`, `cargo metadata`, `nix "
     "--json`) use it and parse with `.json()` / `.jsonl()` / `.df()` on the Output (`.df()` "
     "is a polars frame ready to filter and render), one command per `sh()` call -- never "

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -269,9 +269,14 @@ BUILTINS: tuple[Builtin, ...] = (
     ),
     Builtin(
         "sh",
-        "shell out on the loop; the Output IS a Result (ANSI as HTML for the human, "
-        "`.text`/`.code`/`.ok` for you), and `.json()`/`.jsonl()`/`.df()` parse a JSON-mode "
-        "CLI straight to data / a polars frame: ask the tool for --json, never scrape TSV",
+        "shell out on the loop; use sh([...]) for argv-list/no shell parsing and sh('...') "
+        "only when shell parsing is intended; the Output IS a Result (ANSI as HTML for the "
+        "human, `.text`/`.code`/`.ok` for you), and `.json()`/`.jsonl()`/`.df()` parse a "
+        "JSON-mode CLI straight to data / a polars frame: ask the tool for --json, never scrape TSV",
+    ),
+    Builtin(
+        "zsh",
+        "explicit zsh -lc escape hatch for zsh-only shell syntax; prefer sh([...]) for normal commands",
     ),
     Builtin("api", "the live catalog of every helper, as a polars frame (`api('grep')` to filter)"),
     Builtin(

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2339,6 +2339,12 @@ def _type_error_hint(exc: TypeError) -> str:
     try:
         msg = str(exc)
         m = _TYPEERROR_CALL_RE.match(msg)
+        if m is None and msg.startswith("sh() takes 1 positional argument"):
+            return (
+                "\nHint: sh takes one command argument. Use sh(['git', 'status']) for "
+                "argv-list execution with no shell parsing, or sh('git status') when "
+                "shell parsing is intended; pass cwd= instead of cd."
+            )
         if not m:
             return ""
         func_name = m.group(1)
@@ -3252,6 +3258,7 @@ def install(user_ns: dict | None = None) -> None:
         import sh as _sh_module
 
         target["sh"] = _sh_module
+        target["zsh"] = _sh_module.zsh
     # Bind the filesystem-search helpers as top-level callables (`await grep(...)`
     # / `find(...)` / `spotlight(...)`) the way `sh` is bound, so the most common
     # search/listing actions need no import. They live in the bundled `fsearch`

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -80,14 +80,16 @@ import asyncio
 import codecs
 import contextlib
 import html as _html
+import inspect as _inspect
 import json as _json
 import os
 import re
 import shlex
 import signal
 import sys
+from typing import Any
 
-__all__ = ["Output", "ShellError", "sh"]
+__all__ = ["Output", "ShellError", "sh", "zsh"]
 
 __version__ = "0.1.0"
 
@@ -591,6 +593,26 @@ async def sh(
     return out
 
 
+async def zsh(cmd: str, **kwargs: Any) -> Output:
+    """Run ``cmd`` through ``zsh -lc`` while keeping :func:`sh`'s safety wrapper.
+
+    Use this only when the command intentionally depends on zsh syntax. For
+    prose-bearing arguments, keep using ``sh(['prog', arg])`` so the shell never
+    parses the argument. Pass ``cwd=`` instead of a leading ``cd``.
+    """
+    if re.match(r"\s*cd\b", cmd):
+        raise ValueError(
+            "zsh() takes no `cd ...` prefix: pass the working directory as cwd= and keep "
+            "the command itself clean."
+        )
+    if "`" in cmd:
+        raise ValueError(
+            "zsh(): backticks are shell command substitution. Use $(...) when you "
+            "intentionally want substitution, or sh([...]) when the text is prose."
+        )
+    return await sh(["zsh", "-lc", cmd], **kwargs)
+
+
 # Make the module itself callable, so the documented `import sh; await sh(cmd)`
 # works without reaching for `sh.sh`. The module object's class is swapped for a
 # ModuleType subclass that forwards a call to the sh() coroutine function. The
@@ -606,7 +628,17 @@ import functools as _functools
 class _CallableModule(_types.ModuleType):
     @_functools.wraps(sh)
     def __call__(self, *args: object, **kwargs: object) -> object:
+        if len(args) > 1:
+            raise TypeError(
+                "sh() takes one command argument. Pass argv as a single list, e.g. "
+                "await sh(['git', 'status'], cwd=repo), not sh('git', 'status')."
+            )
         return sh(*args, **kwargs)
 
 
-sys.modules[__name__].__class__ = _CallableModule
+_module = sys.modules[__name__]
+_module.__class__ = _CallableModule
+# `inspect.signature(callable_module)` inspects the bound __call__ method and
+# would otherwise drop `cmd`. Publish the real callable signature so api() shows
+# the load-bearing positional argument and the argv-list type.
+_module.__signature__ = _inspect.signature(sh)  # type: ignore[attr-defined]

--- a/packages/mcp/src/sh/test_guards.py
+++ b/packages/mcp/src/sh/test_guards.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
+import shutil
 import sys
 from pathlib import Path
 
@@ -25,6 +27,7 @@ import sh as _sh_module
 # sh() is the coroutine function inside the module; when the module is
 # imported standalone _sh_module.sh is the async function.
 sh = _sh_module.sh
+zsh = _sh_module.zsh
 
 
 def run(coro: object) -> object:
@@ -62,6 +65,13 @@ def test_backtick_in_argv_list_not_rejected() -> None:
         raise AssertionError("argv-list form with backticks in an argument should not be rejected") from None
     except Exception:  # noqa: S110 -- non-ValueError errors (git not found, no repo) are acceptable in this test
         pass
+
+
+def test_callable_module_signature_includes_cmd() -> None:
+    """api() sees inspect.signature(sh), so the callable module must expose cmd."""
+    sig = inspect.signature(_sh_module)
+    assert "cmd" in sig.parameters
+    assert str(sig).startswith("(cmd:")
 
 
 # ---------------------------------------------------------------------------
@@ -112,16 +122,41 @@ def test_benign_command_runs() -> None:
     assert "hello" in out.text  # type: ignore[union-attr]
 
 
+def test_zsh_helper_runs_zsh_syntax() -> None:
+    """zsh() is an explicit shell-syntax escape hatch with the same Output type."""
+    if shutil.which("zsh") is None:
+        pytest.skip("zsh is not installed")
+    out = run(zsh("print -r -- ${ZSH_VERSION:+zsh}", cwd="/tmp"))  # noqa: S108 -- test-only
+    assert out.ok, f"Expected exit 0, got {out.code}"  # type: ignore[union-attr]
+    assert "zsh" in out.text  # type: ignore[union-attr]
+
+
+def test_zsh_rejects_cd_prefix() -> None:
+    """zsh() keeps the cwd= guard from string sh() calls."""
+    with pytest.raises(ValueError, match="cwd="):
+        run(zsh("cd /tmp && print ok", cwd="."))
+
+
+def test_zsh_rejects_backticks() -> None:
+    """zsh() keeps the backtick guard; use $(...) for intentional substitution."""
+    with pytest.raises(ValueError, match=r"(?i)backtick|command substitution"):
+        run(zsh("print `pwd`", cwd="."))
+
+
 def _run_tests() -> None:
     tests = [
         test_backtick_in_string_command_raises,
         test_backtick_in_repr_string_raises,
         test_backtick_in_argv_list_not_rejected,
+        test_callable_module_signature_includes_cmd,
         test_commit_message_with_escaped_newline_raises,
         test_commit_message_with_real_newline_raises,
         test_simple_commit_message_not_rejected,
         test_cd_prefix_still_rejected,
         test_benign_command_runs,
+        test_zsh_helper_runs_zsh_syntax,
+        test_zsh_rejects_cd_prefix,
+        test_zsh_rejects_backticks,
     ]
     failed = []
     for t in tests:

--- a/packages/mcp/tests/test_sh_module.py
+++ b/packages/mcp/tests/test_sh_module.py
@@ -1,0 +1,40 @@
+import asyncio
+import inspect
+import pathlib
+import sys
+
+import pytest
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src" / "sh"))
+
+import sh  # noqa: E402
+
+
+def test_callable_module_signature_keeps_cmd_argument() -> None:
+    assert "cmd" in inspect.signature(sh).parameters
+    assert inspect.signature(sh) == inspect.signature(sh.sh)
+
+
+def test_extra_positional_arg_gets_argv_hint() -> None:
+    with pytest.raises(TypeError, match="argv as a single list"):
+        sh("git", "status")
+
+
+def test_zsh_helper_uses_zsh_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = {}
+
+    async def fake_sh(cmd: list[str], **kwargs: object) -> sh.Output:
+        seen["cmd"] = cmd
+        seen["kwargs"] = kwargs
+        return sh.Output(cmd="zsh -lc print", code=0, raw="ok\n", duration=0)
+
+    monkeypatch.setitem(sh.zsh.__globals__, "sh", fake_sh)
+
+    out = asyncio.run(sh.zsh("print $ZSH_VERSION", cwd="/tmp", timeout=1))
+
+    assert out.ok
+    assert seen == {
+        "cmd": ["zsh", "-lc", "print $ZSH_VERSION"],
+        "kwargs": {"cwd": "/tmp", "timeout": 1},
+    }

--- a/packages/mcp/tests/test_type_error_hint.py
+++ b/packages/mcp/tests/test_type_error_hint.py
@@ -101,6 +101,12 @@ class TestTypeErrorHint:
         finally:
             rt._user_ns = old_ns
 
+    def test_sh_extra_positional_arg_gets_argv_hint(self) -> None:
+        """The common sh('git', 'status') mistake should point at sh([...])."""
+        h = self.hint(TypeError("sh() takes 1 positional argument but 2 were given"))
+        assert "sh(['git', 'status'])" in h
+        assert "cwd=" in h
+
     def test_never_raises(self) -> None:
         """_type_error_hint must never raise regardless of input."""
         for exc in [


### PR DESCRIPTION
## Summary
- make the `sh` callable module advertise the real `cmd: str | list[str]` signature and give a clearer argv-list hint for extra positional args
- add `sh.zsh(...)` as the explicit zsh-syntax escape hatch, with smoke/unit coverage
- tighten index MCP guidance around binding reusable outputs and paging jobs
- update the house system prompt to say named subagents should be used frequently whenever independent work can run in parallel

## Validation
- `nix run nixpkgs#nixfmt-rfc-style -- packages/mcp/default.nix packages/agent/system-prompt.nix`
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`
- `nix build .#packages.aarch64-darwin.mcp.passthru.tests.shSmoke --no-link`
- `python3 -m pytest packages/mcp/tests/test_sh_module.py packages/mcp/tests/test_type_error_hint.py` failed locally: `/Users/andrewgazelka/.nix-profile/bin/python3: No module named pytest`

Refs #1521

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `zsh` builtin and improve `sh` ergonomics in the MCP notebook runtime
> - Adds a `zsh(cmd, **kwargs)` helper that runs commands via `zsh -lc`, exposed as a top-level builtin in the notebook runtime alongside `sh`.
> - Calling `sh` with multiple positional args (e.g. `sh('git', 'status')`) now raises a `TypeError` with a hint to use `sh(['git', 'status'])` instead.
> - `inspect.signature(sh)` on the callable module now correctly exposes the `cmd` parameter.
> - Updates system prompt and guide text to recommend named subagents for parallel work and clarifies `sh` argv-list vs. shell-string usage.
> - Behavioral Change: `sh` module rejects multiple positional arguments at call time; callers must pass argv as a single list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1ad3ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->