### PR TITLE
Fix provider-specific agent system prompt identity

### DIFF
--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -74,7 +74,7 @@ let
     if modelInstructionsFile != null then
       modelInstructionsFile
     else
-      builtins.toFile "codex-system-prompt.txt" common.systemPrompt;
+      builtins.toFile "codex-system-prompt.txt" (common.systemPromptFor "codex");
 
   # The compiled Rust launcher (packages/config-launch): reads IX_LAUNCH_SPEC
   # (a baked JSON file describing the target binary, config path, forced flags,

--- a/packages/agent/common.nix
+++ b/packages/agent/common.nix
@@ -12,11 +12,38 @@
   ix,
   repoPackages ? { },
 }:
+let
+  providerNames = {
+    claude = "Claude Code";
+    codex = "Codex";
+  };
+  extraSystemPrompts = {
+    claude = ''
+      You are Claude Code. When naming the coding-agent runtime or disclosing AI
+      authorship in outward-facing messages, say Claude Code.
+    '';
+    codex = ''
+      You are Codex. When naming the coding-agent runtime or disclosing AI
+      authorship in outward-facing messages, say Codex.
+    '';
+  };
+  systemPromptFor =
+    provider:
+    lib.concatStringsSep "\n\n" [
+      (import ./system-prompt.nix {
+        inherit lib;
+        agentName = providerNames.${provider};
+      })
+      extraSystemPrompts.${provider}
+    ];
+in
 {
+  inherit extraSystemPrompts systemPromptFor;
+
   # The house system prompt a wrapper bakes for its agent. One paragraph per
   # list element; see ./system-prompt.nix for the authored text and how
   # claude-code bakes it (`systemPrompt`, which REPLACES the stock prompt).
-  systemPrompt = import ./system-prompt.nix { inherit lib; };
+  systemPrompt = systemPromptFor "claude";
 
   # The house MCP servers (the `index` kernel plus `exa` web search), rendered
   # from the shared `ix.mcp` registry with the kernel pointed at the `mcp`

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -1,6 +1,9 @@
-{ lib }:
-# The house system prompt Claude Code runs with, REPLACING the stock prompt
-# (see the `systemPrompt` argument in ./claude-code/default.nix). Each rule is a
+{
+  lib,
+  agentName ? "Claude Code",
+}:
+# The house system prompt the agent wrappers run with, REPLACING the stock prompt
+# where the upstream CLI supports replacement. Each rule is a
 # named binding; `order` fixes how they read top-to-bottom, joined with blank
 # lines so each reads as a self-contained paragraph.
 #
@@ -159,7 +162,7 @@ let
   '';
 
   harness = ''
-    Know the Claude Code runtime. Text outside tools renders as GitHub-flavored
+    Know the ${agentName} runtime. Text outside tools renders as GitHub-flavored
     Markdown. Cite code as `file_path:line_number`.
 
     Batch independent native tool calls; `python_exec` calls serialize. Treat
@@ -312,7 +315,7 @@ let
   discloseAi = ''
     In messages another person will read, disclose AI authorship. Append the
     model and version when known, otherwise:
-    `(sent by an AI agent via Claude Code)`
+    `(sent by an AI agent via ${agentName})`
 
     This does not apply to replies to the user you are working with.
   '';

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -144,6 +144,9 @@ let
     }
   );
   sampleCodexMcpEntry = key: lib.findFirst (entry: entry.key == key) null sampleCodexMcpEntries;
+  agentCommon = import (paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; };
+  sampleClaudeSystemPrompt = agentCommon.systemPromptFor "claude";
+  sampleCodexSystemPrompt = agentCommon.systemPromptFor "codex";
 
   minecraft =
     let
@@ -2465,6 +2468,29 @@ let
           entry: lib.hasPrefix "mcp_servers.index." entry.key || lib.hasPrefix "mcp_servers.exa." entry.key
         ) sampleCodexMcpEntries;
         message = "Codex MCP entries should be limited to index and Exa when index MCP is available";
+      }
+    ];
+
+    provider-prompts = [
+      {
+        assertion = lib.hasInfix "You are Claude Code." sampleClaudeSystemPrompt;
+        message = "Claude wrapper prompt should identify Claude Code";
+      }
+      {
+        assertion = lib.hasInfix "You are Codex." sampleCodexSystemPrompt;
+        message = "Codex wrapper prompt should identify Codex";
+      }
+      {
+        assertion =
+          lib.hasInfix "via Codex" sampleCodexSystemPrompt
+          && !(lib.hasInfix "via Claude Code" sampleCodexSystemPrompt);
+        message = "Codex prompt should disclose outward messages as Codex, not Claude Code";
+      }
+      {
+        assertion =
+          lib.hasInfix "via Claude Code" sampleClaudeSystemPrompt
+          && !(lib.hasInfix "via Codex" sampleClaudeSystemPrompt);
+        message = "Claude prompt should disclose outward messages as Claude Code, not Codex";
       }
     ];
 


### PR DESCRIPTION
## Summary
- Add provider-specific system prompt rendering in `packages/agent/common.nix`.
- Keep Claude Code on the Claude identity prompt and point Codex at a Codex identity prompt.
- Parameterize the shared system prompt so runtime naming and AI-attribution text match the provider.
- Add eval assertions for Claude and Codex prompt identity text.

## Validation
- `nix fmt -- packages/agent/system-prompt.nix packages/agent/common.nix packages/agent/codex/default.nix tests/default.nix`
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`
- `nix eval --json --impure --expr '<targeted common.nix provider prompt assertions>'`
- `nix eval --json .#codex.specValue.soft --apply 'entries: builtins.elem "model_instructions_file" (map (entry: entry.key) entries)'`
- `nix eval --raw .#codex.modelInstructionsFile` and verified the rendered file contains `You are Codex.` and `via Codex`, not `via Claude Code`.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix provider-specific agent identity in system prompts for Codex and Claude
> - Introduces `systemPromptFor` in [common.nix](https://github.com/indexable-inc/index/pull/1524/files#diff-6e6ea9bcd37d43542775f46f4a2342510acf460cdaa9240e6d406c3cc3ec9419) that accepts a provider key and composes a system prompt with the correct agent name and a provider-specific identification paragraph.
> - Parameterizes [system-prompt.nix](https://github.com/indexable-inc/index/pull/1524/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) with an `agentName` argument (defaulting to `"Claude Code"`), replacing hardcoded occurrences in the harness and disclosure paragraphs.
> - Updates [codex/default.nix](https://github.com/indexable-inc/index/pull/1524/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5) to call `systemPromptFor "codex"` so the baked prompt identifies as Codex rather than Claude Code.
> - Adds provider-prompt tests in [tests/default.nix](https://github.com/indexable-inc/index/pull/1524/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) asserting each prompt contains the correct identity wording and excludes the other provider's wording.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84bd041.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->