### PR TITLE
Bias HTML report diagrams toward CSS

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -343,8 +343,17 @@ let
     Keep the HTML minimal: system font, inline CSS, no external assets, no
     chrome. Use `@media (prefers-color-scheme: dark)` so colors adapt
     automatically to light or dark mode. Be terse. Start with the question
-    answered. Use tables, real links, inline SVG, or diagrams when they are
-    clearer than prose.
+    answered.
+
+    Prefer diagrams for causal chains, architecture, timelines, workflows, and
+    comparisons. Build diagrams with normal HTML and CSS in document flow:
+    cards, grids, borders, arrows, labels, and tables. Avoid raw SVG diagrams by
+    default because they are easy to clip, overlap, or scale poorly in the
+    rendered HTML. Use SVG only when it is explicitly requested or when a shape
+    cannot be expressed clearly with HTML and CSS. If SVG is necessary, verify
+    that the rendered page does not clip or overlap at the opened viewport.
+
+    Use tables and real links when they are clearer than prose.
 
     Use semantic Primer Octicons from `htmlpage` for GitHub concepts such as
     pull requests, issues, commits, checks, links, and GitHub itself. Use the


### PR DESCRIPTION
## Summary
- Update the HTML deliverable guidance to prefer diagrams for causal chains, architecture, timelines, workflows, and comparisons.
- Bias diagram construction toward normal HTML/CSS document flow: cards, grids, borders, arrows, labels, and tables.
- Avoid raw SVG diagrams by default because they can clip, overlap, or scale poorly in rendered HTML.

## Validation
- `nix eval --raw --impure --expr '''import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'''`
- Reread the rendered wording around the changed `htmlDeliverable` section.

Refs #1525

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bias agent HTML report diagrams toward CSS/HTML over raw SVG
> Updates the agent system prompt in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1526/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to prefer CSS/HTML-based diagrams (cards, grids, borders, arrows, tables) over raw SVG when rendering visual content in HTML responses.
>
> - SVG is now discouraged by default; it should only be used when explicitly requested or when shapes cannot be expressed with HTML/CSS
> - When SVG is used, the agent must verify the rendered page does not clip or overlap at the opened viewport
> - Tables and real links remain encouraged when clearer than prose
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b50489e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->