### PR TITLE
Add GitHub report style guidance

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -344,7 +344,9 @@ let
     Keep the HTML minimal: system font, inline CSS, no external assets, no
     chrome. Use `@media (prefers-color-scheme: dark)` so colors adapt
     automatically to light or dark mode. Be terse. Start with the question
-    answered.
+    answered. Keep reports DRY: one place states the result, later sections add
+    new structure, evidence, or links instead of restating the same sentence in
+    cards, callouts, and bullets.
 
     Prefer diagrams for causal chains, architecture, timelines, workflows, and
     comparisons. Build diagrams with normal HTML and CSS in document flow:
@@ -357,10 +359,13 @@ let
     Use tables and real links when they are clearer than prose.
 
     Use semantic Primer Octicons from `htmlpage` for GitHub concepts such as
-    pull requests, issues, commits, checks, links, and GitHub itself. Use the
-    matching icon and GitHub/Primer colors for the concept. Do not invent
-    decorative icons, do not use gradients unless explicitly requested, and
-    keep navigation obvious.
+    pull requests, issues, commits, checks, links, and GitHub itself. Use
+    faithful GitHub/Primer colors for meaning: purple for merged pull requests,
+    green for passing checks and completion, red for closed failures, yellow for
+    attention, blue for links and open navigation, and neutral gray for commits,
+    metadata, and cleanup. Pair each icon with the matching color and label. Do
+    not invent decorative icons, do not use gradients unless explicitly
+    requested, and keep navigation obvious.
   '';
 
   order = [


### PR DESCRIPTION
## Summary
- Add DRY report composition guidance to the HTML deliverable section.
- Require faithful GitHub/Primer semantic colors with Primer Octicons for PRs, checks, failures, attention, links, commits, metadata, and cleanup.

## Validation
- `nix eval --raw --impure --expr '''import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'''`
- Reread the rendered `htmlDeliverable` wording.

Refs #1528

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DRY report guidance and Octicon color conventions to agent system prompt
> Updates the system prompt in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1529/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) with two new guidance areas:
> - Instructs the agent to keep reports DRY by avoiding repeated statements across sections.
> - Expands Octicon usage rules to specify GitHub/Primer color associations (purple for merged PRs, green for passing checks, red for closed/failures, yellow for attention, blue for links/open navigation, gray for commits/metadata) and requires icons to be paired with a matching color and label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e31c66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->