### PR TITLE
Bias HTML answers toward diagrams for causal reports

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -348,13 +348,22 @@ let
     new structure, evidence, or links instead of restating the same sentence in
     cards, callouts, and bullets.
 
-    Prefer diagrams for causal chains, architecture, timelines, workflows, and
-    comparisons. Build diagrams with normal HTML and CSS in document flow:
-    cards, grids, borders, arrows, labels, and tables. Avoid raw SVG diagrams by
-    default because they are easy to clip, overlap, or scale poorly in the
-    rendered HTML. Use SVG only when it is explicitly requested or when a shape
-    cannot be expressed clearly with HTML and CSS. If SVG is necessary, verify
-    that the rendered page does not clip or overlap at the opened viewport.
+    Before writing the page, classify whether the answer contains a causal
+    chain, architecture, timeline, workflow, or comparison. If it does, make the
+    first draft visual: include a diagram or table that carries the structure of
+    the answer, then add concise evidence and notes around it. Do not wait for
+    the user to ask for a diagram.
+
+    Build diagrams with normal HTML and CSS in document flow: cards, grids,
+    borders, arrows, labels, and tables. Avoid raw SVG diagrams by default
+    because they are easy to clip, overlap, or scale poorly in the rendered
+    HTML. Use SVG only when it is explicitly requested or when a shape cannot be
+    expressed clearly with HTML and CSS. If SVG is necessary, verify that the
+    rendered page does not clip or overlap at the opened viewport.
+
+    Skip diagrams only when the answer is a simple fact, a short blocking
+    question, machine-readable output, or a diagram would add noise instead of
+    structure.
 
     Use tables and real links when they are clearer than prose.
 


### PR DESCRIPTION
## Summary

- Strengthen the HTML deliverable instructions to classify causal, architectural, timeline, workflow, and comparison answers before writing.
- Bias those answers toward a visual first draft with a diagram or table by default.
- Keep escape hatches for simple facts, blocking questions, machine-readable output, or cases where a diagram adds noise.

## Validation

- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`
- Reread the rendered `htmlDeliverable` wording.

Fixes #1531

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bias agent HTML answers toward proactive diagrams for causal and structural reports
> Updates [system-prompt.nix](https://github.com/indexable-inc/index/pull/1532/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to replace a general preference for diagrams with a prescriptive workflow: the agent now classifies each answer (causal chain, architecture, timeline, workflow, comparison) and proactively produces a diagram or table before the user asks.
>
> - Diagrams are skipped only under defined conditions: simple facts, short blocking questions, machine-readable output, or when visuals would add noise.
> - SVG use remains discouraged by default; when used, viewport verification is now required.
> - Behavioral Change: the agent will now produce unsolicited visuals for answers that match structural categories, which may increase response length and HTML output frequency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26b3432.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->