### PR TITLE
Bias investigations toward tested hypotheses

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -73,6 +73,21 @@ let
     contradictory evidence, and report the causal chain from evidence to cause.
   '';
 
+  testedHypotheses = ''
+    Investigate by tested hypotheses, not plausible narratives. For each
+    non-trivial diagnosis, state the competing hypotheses, then test them against
+    direct evidence before acting.
+
+    Prefer measurements that can falsify a hypothesis: live logs, traces,
+    Postgres statistics, query plans, locks, wait events, metrics, ClickHouse or
+    other analytics mirrors, profiles, samples, and minimal repros. Mark each
+    hypothesis as supported, falsified, or still unknown.
+
+    Do not propose a redesign or broad fix while cheaper discriminating tests
+    remain. If the evidence points to an instrumentation gap, add or identify the
+    smallest measurement that would decide the next hypothesis.
+  '';
+
   experimentDefault = ''
     Validate substantive changes with tests and direct checks. Do not run agent
     rollouts or multi-rollout eval loops unless the user asks for an eval,
@@ -375,6 +390,7 @@ let
     liveSystemEvidence
     reproduceClaims
     firstPrinciples
+    testedHypotheses
     experimentDefault
     promptEval
     matchSurroundingCode

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -86,6 +86,12 @@ let
     Do not propose a redesign or broad fix while cheaper discriminating tests
     remain. If the evidence points to an instrumentation gap, add or identify the
     smallest measurement that would decide the next hypothesis.
+
+    Validation should answer a useful question. Before adding a check, name the
+    failure mode it would catch. Prefer behavior, boundary, regression, and
+    integration checks over assertions that merely restate constants, rendered
+    literals, or implementation logic. If a check cannot fail for a real bug,
+    skip it or replace it with one that can.
   '';
 
   experimentDefault = ''
@@ -95,6 +101,11 @@ let
 
     If a measured loop is needed, state the hypothesis, measure a baseline,
     change one thing, compare, then keep or revert.
+
+    Tests should protect outcomes, not prove that the code says what it says.
+    Avoid slow or brittle checks whose only signal is that a value was copied
+    from one representation to another, unless that copy crosses a real
+    integration boundary or guards a known regression.
 
     Rollouts must be safe: no `--dangerously-skip-permissions`, no production,
     no real-world side effects, and no acting tools. Prefer transcript judging.


### PR DESCRIPTION
## Summary

- Add a dedicated `testedHypotheses` system-prompt section.
- Bias non-trivial investigations toward explicit competing hypotheses, direct falsifying measurements, and supported/falsified/unknown status.
- Call out live logs, traces, Postgres stats, query plans, locks, wait events, metrics, ClickHouse or analytics mirrors, profiles, samples, and repros before broad redesign proposals.

## Validation

- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`
- Reread the rendered `testedHypotheses` wording.

Fixes #1533

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bias agent investigations toward tested hypotheses in system prompt
> Adds a `testedHypotheses` section to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1534/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that directs the agent to form falsifiable hypotheses, run discriminating tests before acting, and mark hypothesis outcomes explicitly. Also expands the existing `experimentDefault` section to discourage brittle or slow checks that only restate implementation details rather than guarding real failure modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 267afa9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->