### PR TITLE
feat: add minimal ix base image

### DIFF
--- a/images/system/base/default.nix
+++ b/images/system/base/default.nix
@@ -1,0 +1,8 @@
+# Minimal ix VM base image. `lib/image/oci-layer.nix` auto-enables the shared
+# base profile for every image, so this module only names the publish target.
+{
+  ix.image = {
+    name = "ix/base";
+    tag = "latest";
+  };
+}

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -763,6 +763,10 @@ let
         exampleNames = lib.attrNames exampleFleets;
       };
 
+  baseImage = ix.mkImage {
+    modules = [ (paths.root + "/images/system/base") ];
+  };
+
   # Non-NixOS OCI example images (ubuntu, debian, ...). They live under
   # `examples/_non-nix-oci` so fleet discovery skips the subtree (leading
   # underscore). Each is imported with the example `{ index }` contract and
@@ -1099,28 +1103,32 @@ let
     );
 in
 {
-  packages = {
-    health-checks = healthChecks.dag;
-    health-checks-zellij = healthChecks.zellij;
-    inherit check lint site;
-    site-dev = site.passthru.devServer;
-    bench-filesystem = benchFilesystem;
-    update-mods = updateMods;
-    update-loaders = updateLoaders;
-    inherit update;
-    ix-shell-sync-ignored = ixShellSyncIgnored;
-    mc-source = mcSource;
-    update-sounds = updateSounds;
-    agents = agentsDir;
-    skills = skillsDir;
-    claude-plugin = claudePluginDir;
-  }
-  // repoFlakePackages
-  // examplePackages
-  // nonNixExampleImages
-  // nonNixExampleDescriptions
-  // crossPackages
-  // healthChecks.lifecyclePackages;
+  packages =
+    lib.optionalAttrs (system == ix.system) {
+      base = baseImage;
+    }
+    // {
+      health-checks = healthChecks.dag;
+      health-checks-zellij = healthChecks.zellij;
+      inherit check lint site;
+      site-dev = site.passthru.devServer;
+      bench-filesystem = benchFilesystem;
+      update-mods = updateMods;
+      update-loaders = updateLoaders;
+      inherit update;
+      ix-shell-sync-ignored = ixShellSyncIgnored;
+      mc-source = mcSource;
+      update-sounds = updateSounds;
+      agents = agentsDir;
+      skills = skillsDir;
+      claude-plugin = claudePluginDir;
+    }
+    // repoFlakePackages
+    // examplePackages
+    // nonNixExampleImages
+    // nonNixExampleDescriptions
+    // crossPackages
+    // healthChecks.lifecyclePackages;
 
   # Flat keying: one derivation per `checks.<system>.<name>`, as the flake schema
   # and `nix flake check` require. The `.#check` gate and blast-radius consume

--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -37,6 +37,13 @@ in
   };
 
   config = lib.mkIf config.ix.profiles.base.enable {
+    # `cache.ix.dev` is the ix pull-through cache for guest Nix operations. Put
+    # it in the auto-enabled base profile so every image gets the same warm
+    # binary-cache path unless an image explicitly disables the profile.
+    nix.settings.substituters = lib.mkBefore [
+      "https://cache.ix.dev"
+    ];
+
     # Cubic halves cwnd on any loss, so a residential last-mile at
     # 30 ms and a couple percent loss caps a single TCP flow far
     # below the path's real capacity. BBR models bottleneck bandwidth

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2186,14 +2186,7 @@ let
   base =
     let
       config = evalConfig [ ];
-      imageConfig = evalConfig [
-        {
-          ix.image = {
-            name = "ix/base";
-            tag = "latest";
-          };
-        }
-      ];
+      imageConfig = evalConfig [ (paths.root + "/images/system/base") ];
     in
     {
       inherit config imageConfig;
@@ -2768,6 +2761,15 @@ let
           && claims.ix-agent.port == 8443
           && claims.ix-agent.address == "*";
         message = "base profile should reserve ix guest sidecar listener ports";
+      }
+      {
+        assertion =
+          base.imageConfig.ix.image.name == "ix/base" && base.imageConfig.ix.image.tag == "latest";
+        message = "base image should publish as ix/base:latest";
+      }
+      {
+        assertion = lib.elemAt base.config.nix.settings.substituters 0 == "https://cache.ix.dev";
+        message = "base profile should route Nix through cache.ix.dev before fallback substituters";
       }
     ];
 


### PR DESCRIPTION
## Summary
- add `images/system/base` as the minimal `ix/base:latest` NixOS image
- expose it as `packages.x86_64-linux.base`
- put `https://cache.ix.dev` in the auto-enabled base profile so all default images use the ix pull-through cache before `cache.nixos.org`

## Validation
- `nix fmt -- images/system/base/default.nix modules/profiles/base/default.nix lib/per-system.nix tests/default.nix`
- `git diff --cached --check`
- `nix eval --raw .#packages.x86_64-linux.base.name`
- `nix eval --json .#lib --apply 'lib: (lib.evalImageConfig { modules = [ (lib.paths.root + "/images/system/base") ]; }).ix.image'`
- `nix eval --json .#lib --apply 'lib: (lib.evalImageConfig { modules = [ ]; }).nix.settings.substituters'`
- `nix eval --json .#lib --apply 'lib: (lib.evalImageConfig { modules = [ (lib.paths.root + "/images/system/base") ]; }).nix.settings.substituters'`

## Notes
- `nix run .#lint` is currently blocked by existing unrelated repo-wide lint findings in `packages/mcp/*` plus existing astlog/statix findings outside this change.
- `nix eval .#checks.x86_64-linux.eval` is blocked on this aarch64-darwin machine by existing x86_64-linux builder/platform availability, before reaching the new base assertions.

Refs #1541

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add minimal `ix/base` OCI image to the flake
> - Adds [images/system/base/default.nix](https://github.com/indexable-inc/index/pull/1542/files#diff-c2971e6a657d758b024b1ae0154caf2394b1a9879d514bcb8b6602b388307f57) defining an OCI image published as `ix/base:latest`.
> - Exposes the image as a `base` package in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1542/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) for the `ix.system` target only.
> - Adds `https://cache.ix.dev` as a preferred Nix substituter via `lib.mkBefore` in the base profile.
> - Adds tests verifying the image publishes as `ix/base:latest` and that the substituter is correctly prefixed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a992038.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->