### PR TITLE
Clarify default MCP servers

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -107,7 +107,7 @@ wrapper injects its defaults file only `unless_present` a caller `--settings`
 Rendered from the shared `ix.mcp` registry (`lib/util/mcp.nix`) so `index` is
 declared once for both this wrapper and codex. CLI `--mcp-config` layers merge,
 so a user's `--mcp-config` and a project `.mcp.json` still load alongside.
-Defaults to the house pair, additions only:
+Defaults to the default pair, additions only:
 
 - `index`: the ix notebook kernel (`ix-mcp serve`, `packages/mcp`) over stdio, present
   only when the `mcp` sibling is in scope (the flake package set, not the

--- a/doc/codex/overview.md
+++ b/doc/codex/overview.md
@@ -50,7 +50,7 @@ Defaults bump multi-agent fan-out well above stock:
 
 ### Baked MCP servers (`default.nix:62-73`, `80`)
 
-The house MCP servers are added as soft `-c mcp_servers.*` defaults from the same
+The default MCP servers are added as soft `-c mcp_servers.*` defaults from the same
 `ix.mcp` registry the claude-code wrapper renders, so Codex gets only the
 `index` MCP server and the Exa MCP server. The `index` server is present only
 when the `mcp` sibling is in scope (the flake package set, not the overlay;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -241,7 +241,7 @@ let
   toml = import ./util/toml.nix { inherit lib; };
 
   /**
-    Single source of truth for the MCP servers baked into the house wrappers.
+    Single source of truth for the MCP servers baked into the agent wrappers.
     Define a server once in a neutral shape and render it to each tool's native
     config with `mcp.toClaudeJson` (Claude Code's `mcpServers` JSON) and
     `mcp.toCodexEntries` (dotted `mcp_servers.*` codex `-c` flags), so `index`

--- a/lib/util/mcp.nix
+++ b/lib/util/mcp.nix
@@ -1,4 +1,4 @@
-# Single source of truth for the MCP servers the house wrappers bake in. Define
+# Single source of truth for the MCP servers the agent wrappers bake in. Define
 # a server ONCE in the neutral shape below and render it to each tool's native
 # config with `toClaudeJson` / `toCodexEntries`, so `index` (and any future
 # shared server) is declared in one place instead of copied into the Claude Code
@@ -42,7 +42,7 @@ let
   # config-launch turns into `-c <key>=<value>` flags (so a user's own
   # `mcp_servers.<name>` in config.toml still wins per the per-leaf presence
   # check). Codex keys stdio servers by `command`/`args`/`env` and HTTP servers
-  # by `url`, mirroring `[mcp_servers.<name>]` tables in config.toml. House MCP
+  # by `url`, mirroring `[mcp_servers.<name>]` tables in config.toml. Default MCP
   # tools are trusted defaults, so approve server tools unless the user config
   # sets a stricter `default_tools_approval_mode` or per-tool override.
   codexEntriesOne =
@@ -84,7 +84,7 @@ let
 in
 {
   /**
-    The house MCP server set, defined once for every wrapper that bakes it.
+    The default MCP server set, defined once for every wrapper that bakes it.
     Returns the neutral definitions; each consumer renders them with
     `toClaudeJson` / `toCodexEntries`.
 
@@ -93,7 +93,7 @@ in
       sibling is out of scope (e.g. the overlay package set), in which case only
       the keyless `exa` server is returned.
   */
-  houseServers =
+  defaultServers =
     {
       indexCommand ? null,
     }:

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -105,7 +105,7 @@
   # layers MERGE: a user's own `--mcp-config` and a discovered project
   # `.mcp.json` still load alongside this set, so baking the flag here replaces
   # the old pattern of consumers symlinkJoin-wrapping this wrapper a second time
-  # just to add it. Defaults to the house pair, additions only (no stock tool is
+  # just to add it. Defaults to the default pair, additions only (no stock tool is
   # disabled or overridden):
   #  - `index`: the ix notebook kernel (`ix-mcp serve`, packages/mcp) over
   #    stdio. Present only when the `mcp` sibling is in scope, i.e. in the
@@ -119,7 +119,7 @@
   mcpServers ?
     ix.mcp.toClaudeJson
       (import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; })
-      .houseServers,
+      .defaultServers,
 
   # Text used AS Claude Code's system prompt, REPLACING the stock prompt. The
   # string is materialized to a store file and baked into the wrapper as

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -88,12 +88,12 @@ let
       value = ix.toml.scalar v;
     }) flat;
 
-  # The house MCP servers, baked as soft `-c mcp_servers.*` defaults from the
-  # shared house server set (../common.nix `houseServers`, the same source the
+  # The default MCP servers, baked as soft `-c mcp_servers.*` defaults from the
+  # shared default server set (../common.nix `defaultServers`, the same source the
   # claude-code wrapper renders), so Codex gets only the index MCP server and
   # the Exa MCP server. Soft, so a user's own `[mcp_servers.<name>]` in
   # config.toml wins per the per-leaf presence check.
-  mcpServers = common.houseServers;
+  mcpServers = common.defaultServers;
   sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
     inherit lib mcpServers;
   };

--- a/packages/agent/mcp.nix
+++ b/packages/agent/mcp.nix
@@ -1,4 +1,4 @@
-# House MCP server set shared by agent CLI wrappers.
+# Default MCP server set shared by agent CLI wrappers.
 {
   lib,
   ix,
@@ -8,7 +8,7 @@
   # Rendered from the shared `ix.mcp` registry with the kernel pointed at the
   # `mcp` sibling when it is in scope. Each wrapper adapts this to its own
   # config shape (`ix.mcp.toClaudeJson` / `ix.mcp.toCodexEntries`).
-  houseServers = ix.mcp.houseServers {
+  defaultServers = ix.mcp.defaultServers {
     indexCommand = if repoPackages ? mcp then lib.getExe repoPackages.mcp else null;
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -153,11 +153,14 @@ let
   baseFirewallTcpPorts = [ 5001 ];
   baseFirewallUdpPorts = [ 8443 ];
   sampleCodexMcpEntries = ix.mcp.toCodexEntries (
-    ix.mcp.houseServers {
+    ix.mcp.defaultServers {
       indexCommand = "/bin/ix-mcp";
     }
   );
+  sampleCodexMcpEntriesWithoutIndex = ix.mcp.toCodexEntries (ix.mcp.defaultServers { });
   sampleCodexMcpEntry = key: lib.findFirst (entry: entry.key == key) null sampleCodexMcpEntries;
+  sampleCodexMcpEntryWithoutIndex =
+    key: lib.findFirst (entry: entry.key == key) null sampleCodexMcpEntriesWithoutIndex;
   agentCommon = import (paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; };
   sampleClaudeSystemPrompt = agentCommon.systemPromptFor "claude";
   sampleCodexSystemPrompt = agentCommon.systemPromptFor "codex";
@@ -2460,7 +2463,7 @@ let
             key = "mcp_servers.index.default_tools_approval_mode";
             value = "\"approve\"";
           };
-        message = "Codex MCP entries should approve trusted house server tools by default";
+        message = "Codex MCP entries should approve trusted default server tools by default";
       }
       {
         assertion =
@@ -2469,6 +2472,14 @@ let
             value = "\"https://mcp.exa.ai/mcp\"";
           };
         message = "Codex MCP entries should include the Exa MCP server";
+      }
+      {
+        assertion =
+          sampleCodexMcpEntryWithoutIndex "mcp_servers.exa.url" == {
+            key = "mcp_servers.exa.url";
+            value = "\"https://mcp.exa.ai/mcp\"";
+          };
+        message = "Codex MCP entries should include the Exa MCP server even when index MCP is unavailable";
       }
       {
         assertion = lib.all (


### PR DESCRIPTION
## Summary
- Renamed MCP wrapper defaults from `houseServers` to `defaultServers`.
- Kept the Exa HTTPS MCP endpoint in the default set even when the local `index` MCP server is unavailable.
- Added an eval assertion for the no-index case.

## Validation
- `nix run nixpkgs#nixfmt-rfc-style -- lib/util/mcp.nix packages/agent/mcp.nix packages/agent/codex/default.nix packages/agent/claude-code/default.nix tests/default.nix lib/default.nix`
- `nix eval --raw --impure --expr 'let lib = (import <nixpkgs> {}).lib; mcp = import ./lib/util/mcp.nix { inherit lib; }; in (mcp.defaultServers {}).exa.url'`
- `nix eval --json --impure --expr 'let lib = (import <nixpkgs> {}).lib; mcp = import ./lib/util/mcp.nix { inherit lib; }; in mcp.toCodexEntries (mcp.defaultServers {})'`
- `nix eval --raw --impure --expr 'let flake = builtins.getFlake (toString ./.); tests = import ./tests { nixpkgs = flake.inputs.nixpkgs; ix = flake.lib; paths = flake.lib.paths; }; failures = builtins.filter (a: !a.assertion) tests.groups.mcp; in builtins.toJSON (map (a: a.message) failures)'`

Fixes #1545

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `houseServers` to `defaultServers` in MCP server configuration
> Renames the `houseServers` attribute and function to `defaultServers` across the MCP configuration layer, including [mcp.nix](https://github.com/indexable-inc/index/pull/1546/files#diff-f70a76d7dd82c8fd07876567087fe2e2412453d6b2d8db0d3ba66c77ed1530b8), [lib/util/mcp.nix](https://github.com/indexable-inc/index/pull/1546/files#diff-30f208a31e39d4388eb8b510d8a6962b9cd1a5d7b074429d38190a855a620744), and the claude-code and codex agent packages. Also adds a test asserting that the Exa MCP server is included even when the index MCP server is unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00a92f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->