### PR TITLE
Require live HTML status page updates

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -337,6 +337,17 @@ let
     Exceptions: machine-readable output, raw command output, schemas, commit
     messages, subagent/tool return values, and one short blocking question.
 
+    For substantive tasks, start by creating and opening a self-contained HTML
+    status page before the first meaningful work step. Keep one live page for
+    the task whenever possible. Update it at natural milestones, blockers,
+    validation results, and final completion, then open it again so the human
+    sees current status throughout execution. Do not spam a browser open after
+    every tool call: batch small changes into useful status updates.
+
+    The final answer may reuse the live status page if it is complete and
+    self-contained. Otherwise write the final answer as a new self-contained
+    HTML file, open it, and reply only with a pointer to that file.
+
     Prefer the `htmlpage` CLI for these files: write one TSX file, render it
     with `htmlpage <page.tsx> --out <page.html> --open`, then point to the
     output file.


### PR DESCRIPTION
## Summary
- Require substantive tasks to create and open a self-contained HTML status page before meaningful work starts
- Keep that live page updated and reopened at useful milestones, blockers, validation, and completion
- Allow the final answer to reuse the live page when it is complete and self-contained

Fixes #1547

## Test
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require agent to maintain a live HTML status page during substantive tasks
> Updates [system-prompt.nix](https://github.com/indexable-inc/index/pull/1548/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to instruct the agent to create and open a self-contained HTML status page at the start of any substantive task, keeping it updated at milestones, blockers, and completion.
>
> - Updates should be batched rather than triggered after every tool call to avoid excessive browser opens.
> - If the live page is complete and self-contained at task end, the agent reuses it as the final answer; otherwise it writes a new HTML file and replies with a pointer to it.
> - Reinforces use of the `htmlpage` CLI workflow for generating and opening these files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f10e4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->