### PR TITLE
Recommend separating definitions from implementation

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -126,6 +126,16 @@ let
     stays in the package.
   '';
 
+  separateDefinitions = ''
+    Keep declarative definitions separate from the machinery that renders,
+    executes, or adapts them. Put registries, schemas, fixtures, and policy data
+    where they can be read as data.
+
+    Implementation modules should consume those definitions through narrow
+    helpers. Mix the two only when the split would add indirection without making
+    the source of truth easier to find or reuse.
+  '';
+
   fixAtSource = ''
     Fix problems at their source. If the cause is upstream, fix it upstream and
     open a PR. Use local workarounds only as a last resort, linked to the
@@ -403,6 +413,7 @@ let
     tieToIssue
     preV1
     oneImplementation
+    separateDefinitions
     fixAtSource
     worktree
     shellCwd


### PR DESCRIPTION
## Summary
- add general house-prompt guidance to keep declarative definitions separate from renderer, adapter, and executor machinery
- keep the rule general, with an escape hatch when the split would only add indirection

Fixes #1551

## Validation
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`
- reread the rendered wording around the new rule

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'separateDefinitions' principle to agent system prompt
> Adds a new `separateDefinitions` guideline to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1553/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that recommends keeping declarative definitions separate from implementation machinery and consuming them via narrow helpers. The entry is included in the existing aggregate-principles list alongside similar guidelines.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b6347c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->