### PR TITLE
Restore ix.mcp.houseServers compatibility

### DIFF
--- a/lib/util/mcp/servers.nix
+++ b/lib/util/mcp/servers.nix
@@ -9,17 +9,7 @@
 #   { transport = "http";  url = <str>; }
 # and `servers` throughout is an attrset from server name to such a definition.
 { lib }:
-{
-  /**
-    The default MCP server set, defined once for every wrapper that bakes it.
-    Returns the neutral definitions; each consumer renders them with
-    `toClaudeJson` / `toCodexEntries`.
-
-    Arguments:
-    - `indexCommand`: path to the `ix-mcp` entrypoint, or `null` when the `mcp`
-      sibling is out of scope (e.g. the overlay package set), in which case only
-      the keyless `exa` server is returned.
-  */
+let
   defaultServers =
     {
       indexCommand ? null,
@@ -37,4 +27,23 @@
         url = "https://mcp.exa.ai/mcp";
       };
     };
+in
+{
+  /**
+    The default MCP server set, defined once for every wrapper that bakes it.
+    Returns the neutral definitions; each consumer renders them with
+    `toClaudeJson` / `toCodexEntries`.
+
+    Arguments:
+    - `indexCommand`: path to the `ix-mcp` entrypoint, or `null` when the `mcp`
+      sibling is out of scope (e.g. the overlay package set), in which case only
+      the keyless `exa` server is returned.
+  */
+  inherit defaultServers;
+
+  /**
+    Compatibility name for consumers pinned to the original MCP registry API.
+    Use `defaultServers` in new code.
+  */
+  houseServers = defaultServers;
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2482,6 +2482,15 @@ let
         message = "Codex MCP entries should include the Exa MCP server even when index MCP is unavailable";
       }
       {
+        assertion =
+          ix.mcp.houseServers {
+            indexCommand = "/bin/ix-mcp";
+          } == ix.mcp.defaultServers {
+            indexCommand = "/bin/ix-mcp";
+          };
+        message = "MCP registry should keep houseServers as a compatibility alias for defaultServers";
+      }
+      {
         assertion = lib.all (
           entry: lib.hasPrefix "mcp_servers.index." entry.key || lib.hasPrefix "mcp_servers.exa." entry.key
         ) sampleCodexMcpEntries;


### PR DESCRIPTION
## Summary
- keep `ix.mcp.defaultServers` as the canonical registry helper
- restore `ix.mcp.houseServers` as a compatibility alias for existing flake consumers
- add an MCP regression assertion for the alias

Fixes #1554

## Validation
- `nix run nixpkgs#nixfmt-rfc-style -- lib/util/mcp/servers.nix tests/default.nix`
- `nix eval --raw --impure --expr 'let lib = (import <nixpkgs> {}).lib; mcp = import ./lib/util/mcp.nix { inherit lib; }; in (mcp.houseServers {}).exa.url'`
- `nix eval --json --impure --expr 'let lib = (import <nixpkgs> {}).lib; mcp = import ./lib/util/mcp.nix { inherit lib; }; in mcp.houseServers { indexCommand = "/bin/ix-mcp"; } == mcp.defaultServers { indexCommand = "/bin/ix-mcp"; }'`
- `nix eval --raw --impure --expr 'let flake = builtins.getFlake (toString ./.); tests = import ./tests { nixpkgs = flake.inputs.nixpkgs; ix = flake.lib; paths = flake.lib.paths; }; failures = builtins.filter (a: !a.assertion) tests.groups.mcp; in builtins.toJSON (map (a: a.message) failures)'`
- `nix build /Users/andrewgazelka/.config/nix#homeConfigurations.andrewgazelka.activationPackage --no-link --override-input index git+file:///Users/andrewgazelka/Projects/indexable-inc/index-wt-1554-houseServers`

(sent by Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `houseServers` as a compatibility alias for `defaultServers` in `ix.mcp`
> Adds `houseServers` to the [mcp/servers.nix](https://github.com/indexable-inc/index/pull/1555/files#diff-a74190c62a3086f0b0e05489808b80559c743c45cb2f5d09e9734aa712b7604b) module exports as an alias that returns the same value as `defaultServers`. A test in [tests/default.nix](https://github.com/indexable-inc/index/pull/1555/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) verifies the two produce identical output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c739f64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->