### PR TITLE
Centralize agent hook runner packaging

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -125,12 +125,12 @@ independent work, do work through the index Python kernel and `search` priors,
 gate admin/force merges on a fresh local build, never use em dashes, and more
 (`system-prompt.nix:7-37`). Set to `null` to ship the stock prompt alone.
 
-### Hooks (`hooks.nix`, `default.nix:209-285`)
+### Hooks (`packages/agent/policy/hook-runner.nix`, `default.nix:209-285`)
 
-Three hooks, all subcommands of one compiled binary (`packages/claude-hooks`)
+Lifecycle hooks, all subcommands of one compiled binary (`packages/agent/claude-hooks`)
 wrapped with their tool paths and the baked primary-checkout default; each fails
 open and silent
-(`hooks.nix:1-20`):
+(`packages/agent/policy/hook-runner.nix:1-20`):
 
 - `SessionStart` -> `session-digest`: cats the pre-rendered fleet context digest
   (`~/.cache/ix/context-digest.md`), capped ~6000 chars. Kill switch

--- a/doc/claude-hooks/overview.md
+++ b/doc/claude-hooks/overview.md
@@ -1,6 +1,6 @@
 # claude-hooks
 
-`packages/claude-hooks` is one compiled binary with three Claude Code hook
+`packages/agent/claude-hooks` is one compiled binary with Claude Code hook
 subcommands, replacing the old hand-rolled `writeShellScript` hooks in
 `packages/agent/claude-code`. The governing rule: every hook fails OPEN and SILENT.
 Any missing input, parse error, or kill-switch returns with no stdout, because a
@@ -97,16 +97,16 @@ capped to `PRIORS_CAP = 4800` chars (~1200 tokens) (`render_priors`,
 [timestamp] score N` (`provenance`, `src/main.rs:376-396`), matching the old jq
 projection so the model can discount stale content. In claude-code this hook (and
 `IX_SEARCH`) is wired only when the `search` sibling package is in scope
-(`hooks.nix:17-20,35`).
+(`packages/agent/policy/hook-runner.nix:17-20,35`).
 
 ## How it is built and wired
 
 `default.nix` selects the `claude-hooks` binary with
 `ix.cargoUnit.selectBinaryWithTests` (flake output `claude-hooks`,
 `package.nix`). The claude-code layer re-wraps it in
-`packages/agent/claude-code/hooks.nix`: `makeBinaryWrapper` sets `IX_GIT`,
+`packages/agent/policy/hook-runner.nix`: `makeBinaryWrapper` sets `IX_GIT`,
 `IX_DEFAULT_PRIMARY_CHECKOUTS`, and (conditionally) `IX_SEARCH`, then registers
-the three subcommands as hook commands in the generated settings JSON
+the subcommands as hook commands in the generated settings JSON
 (`packages/agent/claude-code/default.nix:244-285`) with generous per-hook timeouts (5s,
 10s, 5s) that sit well past the fail-open budgets. `install-check.nix` asserts
 the fail-open behavior, the digest cap, and the guard deny/allow paths.

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -169,7 +169,7 @@ let
   # Claude treats repeated settings flags as first-wins.
 
   # Build the hook runner once; shared policy renders it for each wrapper.
-  hookRunner = import ./hooks.nix {
+  hookRunner = import (ix.paths.packagesRoot + "/agent/policy/hook-runner.nix") {
     inherit
       lib
       runCommand

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -122,7 +122,7 @@ let
 
   # Codex reads hooks from config, not from launch flags, so expose the rendered
   # shared hook policy for home-manager or managed requirements consumers.
-  hookRunner = import (ix.paths.packagesRoot + "/agent/claude-code/hooks.nix") {
+  hookRunner = import (ix.paths.packagesRoot + "/agent/policy/hook-runner.nix") {
     inherit
       lib
       runCommand

--- a/packages/agent/policy/hook-runner.nix
+++ b/packages/agent/policy/hook-runner.nix
@@ -1,5 +1,6 @@
-# The hooks are subcommands of one compiled binary (packages/agent/claude-hooks)
-# rather than hand-rolled shell scripts. Each fails OPEN and SILENT (any
+# Shared hook runner wrapper for Claude Code and Codex. The hooks are
+# subcommands of one compiled binary (packages/agent/claude-hooks) rather than
+# hand-rolled shell scripts. Each fails OPEN and SILENT (any
 # missing input, parse error, or kill-switch exits with no stdout: a noisy or
 # broken hook is strictly worse than no hook). See that crate for the full
 # design and its measured rationale:


### PR DESCRIPTION
## Summary
- moved the shared hook runner wrapper to `packages/agent/policy/hook-runner.nix`
- updated Claude Code and Codex wrappers to import hook runner packaging from the shared policy location
- updated hook docs to point at the new shared location

## Verification
- `nix fmt packages/agent/policy/hook-runner.nix packages/agent/claude-code/default.nix packages/agent/codex/default.nix`
- `nix-instantiate --parse packages/agent/policy/hook-runner.nix`
- `nix-instantiate --parse packages/agent/claude-code/default.nix`
- `nix-instantiate --parse packages/agent/codex/default.nix`
- `nix-instantiate --parse packages/agent/policy/hooks.nix`
- `nix build .#codex --no-link`
- `nix build .#claude-code --no-link`

Fixes #1556

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move hook runner to shared location at `packages/agent/policy/hook-runner.nix`
> Relocates the hook runner Nix package from `packages/agent/claude-code/hooks.nix` to `packages/agent/policy/hook-runner.nix` so it can be shared between the Claude Code and Codex agents. Both `packages/agent/claude-code/default.nix` and `packages/agent/codex/default.nix` are updated to import from the new path, and documentation is updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 182404a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->