### PR TITLE
Disable built-in web search in agent wrappers

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -97,8 +97,8 @@ wrapper injects its defaults file only `unless_present` a caller `--settings`
   so the local-build gate in the system prompt is applied (postmortem
   ENG-2391); ask rules are not enforced under the baked skip-permissions, so
   this is the practical gate for consumers who turn the flag off.
-- `permissions.deny` `WebSearch` / `WebFetch` (only while the `exa` MCP server
-  is baked): one web surface, not two; deny rules are enforced in every
+- `permissions.deny` `WebSearch` / `WebFetch`: one web surface, not two; use
+  Exa MCP for live web research. Deny rules are enforced in every
   permission mode.
 - `hooks` (below).
 

--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -8,14 +8,13 @@ let
     "Bash(gh pr merge*--force*)"
   ];
 
-  supersededBuiltinTools =
-    lib.optionals (mcpServers ? exa) [
-      "WebSearch"
-      "WebFetch"
-    ]
-    ++ lib.optional (mcpServers ? index) "Bash";
+  supersededBuiltinTools = [
+    "WebSearch"
+    "WebFetch"
+  ]
+  ++ lib.optional (mcpServers ? index) "Bash";
 
-  codexForcedSettings = lib.optionalAttrs (mcpServers ? index) {
+  codexForcedSettings = {
     features = {
       browser_use = false;
       browser_use_external = false;

--- a/packages/agent/subagents.nix
+++ b/packages/agent/subagents.nix
@@ -98,7 +98,7 @@ in
       model: opus
       effort: xhigh
       color: red
-      tools: Read, Bash, Glob, Grep, WebFetch, WebSearch
+      tools: Read, Bash, Glob, Grep, mcp__exa__web_search_exa, mcp__exa__web_fetch_exa
       ---
 
       # Code Reviewer
@@ -117,7 +117,7 @@ in
       - **branch** → `git diff <base>...HEAD` (base = the branch's merge base with the default branch).
       - **a path / "the current change"** with no PR → `git diff` and `git diff --staged`; if both empty, `git show HEAD`.
 
-      Then read the **full files** around each hunk, not just the diff — a diff hides the context a bug lives in. Read the repo's `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` and nearby code so findings match the project's real conventions, not generic best practice. For unfamiliar APIs, dependencies, or CVE-prone areas, use WebSearch/WebFetch to verify behavior rather than guessing.
+      Then read the **full files** around each hunk, not just the diff — a diff hides the context a bug lives in. Read the repo's `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` and nearby code so findings match the project's real conventions, not generic best practice. For unfamiliar APIs, dependencies, or CVE-prone areas, use Exa (`mcp__exa__web_search_exa`, then `mcp__exa__web_fetch_exa` when needed) to verify behavior rather than guessing.
 
       ## 2. Review in fixed priority order
 
@@ -298,7 +298,7 @@ in
       model: opus
       effort: xhigh
       color: yellow
-      tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, mcp__exa__web_search_exa, mcp__exa__web_fetch_exa
+      tools: Read, Bash, Glob, Grep, mcp__exa__web_search_exa, mcp__exa__web_fetch_exa
       ---
 
       # Synthesis critic

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3493,20 +3493,27 @@ let
           let
             policy = import (paths.packagesRoot + "/agent/policy/permissions.nix") {
               inherit lib;
-              mcpServers.index = { };
+              mcpServers = { };
             };
           in
-          policy.codex.forcedSettings.features == {
-            browser_use = false;
-            browser_use_external = false;
-            computer_use = false;
-            image_generation = false;
-            in_app_browser = false;
-            shell_tool = false;
-            standalone_web_search = false;
-            unified_exec = false;
-          };
-        message = "Codex policy should disable built-in tools when the index MCP is available";
+          policy.claude.deniedToolPatterns == [
+            "Bash(gh pr merge*--admin*)"
+            "Bash(gh pr merge*--force*)"
+            "WebSearch"
+            "WebFetch"
+          ]
+          &&
+            policy.codex.forcedSettings.features == {
+              browser_use = false;
+              browser_use_external = false;
+              computer_use = false;
+              image_generation = false;
+              in_app_browser = false;
+              shell_tool = false;
+              standalone_web_search = false;
+              unified_exec = false;
+            };
+        message = "agent policy should always disable built-in web search tools";
       }
       {
         assertion =


### PR DESCRIPTION
## Summary
- always deny Claude built-in `WebSearch` / `WebFetch` in the shared agent policy
- always force Codex built-in web/tool features off, including `features.standalone_web_search = false`
- update bundled subagents to use Exa MCP tools instead of built-in web tools

## Validation
- `nix fmt -- packages/agent/policy/permissions.nix packages/agent/subagents.nix tests/default.nix`
- `nix eval --json --impure --expr <focused permissions policy expression>`
- `nix eval --json .#packages.aarch64-darwin.codex.passthru.specValue.forced`
- `nix build --no-link .#codex .#claude-code`

## Notes
- `nix run .#check` is blocked locally before running checks because `repoPackages.nix-fast-build` is missing in this eval context.

Closes #1558

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable built-in WebSearch and WebFetch in agent wrappers in favor of Exa MCP tools
> - `supersededBuiltinTools` in [permissions.nix](https://github.com/indexable-inc/index/pull/1559/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) now always includes `WebSearch` and `WebFetch`, previously only when the Exa MCP server was configured.
> - `codexForcedSettings` is now unconditional, always disabling built-in web-related and exec features (`standalone_web_search`, `browser_use`, `shell_tool`, etc.).
> - Subagent configs in [subagents.nix](https://github.com/indexable-inc/index/pull/1559/files#diff-45a91ccd89dc7a844cea2a6fca8aef743ce1cb606f0f101ed57304b99528d898) are updated to reference `mcp__exa__web_search_exa` and `mcp__exa__web_fetch_exa` instead of the built-in tools.
> - Tests in [default.nix](https://github.com/indexable-inc/index/pull/1559/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) are updated to assert `WebSearch`/`WebFetch` are always denied, even with an empty `mcpServers` config.
> - Behavioral Change: agents that previously fell back to built-in web search when Exa MCP was absent will now have web search fully disabled in that case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 031281a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->