### PR TITLE
Forward API env vars to index MCP

### DIFF
--- a/lib/util/mcp/renderers.nix
+++ b/lib/util/mcp/renderers.nix
@@ -9,13 +9,17 @@ let
   # is `{ type = "stdio"; command; args; env; }` / `{ type = "http"; url; }`).
   claudeOne =
     def:
+    let
+      forwardedEnv = lib.genAttrs (def.envVars or [ ]) (name: "\${${name}:-}");
+      env = forwardedEnv // (def.env or { });
+    in
     if isStdio def then
       {
         type = "stdio";
         inherit (def) command;
       }
       // lib.optionalAttrs (def ? args) { inherit (def) args; }
-      // lib.optionalAttrs (def ? env) { inherit (def) env; }
+      // lib.optionalAttrs (env != { }) { inherit env; }
     else
       {
         type = "http";
@@ -44,6 +48,10 @@ let
         key = "${prefix}.env.${k}";
         value = toml.scalar v;
       }) (def.env or { });
+      envVarEntries = lib.optional (def ? envVars && def.envVars != [ ]) {
+        key = "${prefix}.env_vars";
+        value = tomlArray def.envVars;
+      };
     in
     [
       {
@@ -63,6 +71,7 @@ let
           key = "${prefix}.args";
           value = tomlArray def.args;
         }
+        ++ envVarEntries
         ++ envEntries
       else
         [

--- a/lib/util/mcp/servers.nix
+++ b/lib/util/mcp/servers.nix
@@ -5,11 +5,21 @@
 # and Codex wrappers in two different schemas.
 #
 # A neutral server definition is one of:
-#   { transport = "stdio"; command = <str>; args ? [ <str> ]; env ? { <k> = <str>; }; }
+#   { transport = "stdio"; command = <str>; args ? [ <str> ]; env ? { <k> = <str>; }; envVars ? [ <str> ]; }
 #   { transport = "http";  url = <str>; }
 # and `servers` throughout is an attrset from server name to such a definition.
 { lib }:
 let
+  indexApiEnvVars = [
+    "GH_TOKEN"
+    "GITHUB_TOKEN"
+    "IX_TOKEN"
+    "LINEAR_API_KEY"
+    "NOTION_API_KEY"
+    "SLACK_TOKEN"
+    "SLACK_USER_TOKEN"
+  ];
+
   defaultServers =
     {
       indexCommand ? null,
@@ -19,6 +29,7 @@ let
         transport = "stdio";
         command = indexCommand;
         args = [ "serve" ];
+        envVars = indexApiEnvVars;
       };
     }
     // {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -157,6 +157,11 @@ let
       indexCommand = "/bin/ix-mcp";
     }
   );
+  sampleClaudeMcpServers = ix.mcp.toClaudeJson (
+    ix.mcp.defaultServers {
+      indexCommand = "/bin/ix-mcp";
+    }
+  );
   sampleCodexMcpEntriesWithoutIndex = ix.mcp.toCodexEntries (ix.mcp.defaultServers { });
   sampleCodexMcpEntry = key: lib.findFirst (entry: entry.key == key) null sampleCodexMcpEntries;
   sampleCodexMcpEntryWithoutIndex =
@@ -2464,6 +2469,18 @@ let
             value = "\"approve\"";
           };
         message = "Codex MCP entries should approve trusted default server tools by default";
+      }
+      {
+        assertion =
+          sampleCodexMcpEntry "mcp_servers.index.env_vars" == {
+            key = "mcp_servers.index.env_vars";
+            value = ''[ "GH_TOKEN", "GITHUB_TOKEN", "IX_TOKEN", "LINEAR_API_KEY", "NOTION_API_KEY", "SLACK_TOKEN", "SLACK_USER_TOKEN" ]'';
+          };
+        message = "Codex MCP entries should explicitly forward API environment variables to index MCP";
+      }
+      {
+        assertion = sampleClaudeMcpServers.index.env.LINEAR_API_KEY == "\${LINEAR_API_KEY:-}";
+        message = "Claude MCP config should forward API environment variables to index MCP";
       }
       {
         assertion =


### PR DESCRIPTION
## Summary
- add a shared `envVars` field to MCP server definitions
- forward `LINEAR_API_KEY`, `IX_TOKEN`, and related API/token variables to the `index` MCP server
- render Codex forwarding explicitly as `mcp_servers.index.env_vars`, while Claude gets `${VAR:-}` expansion entries

Fixes #1561

## Validation
- `nix-instantiate --parse lib/util/mcp/servers.nix lib/util/mcp/renderers.nix tests/default.nix`
- targeted `nix eval --raw --impure --expr ...` assertion for Claude env expansion and Codex `env_vars`

Note: `nix flake show --json` and Linux check enumeration were blocked by unavailable x86_64-linux builders on this host before reaching this change.

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward API env vars to the index MCP server for Claude and Codex renderers
> - Adds `indexApiEnvVars` (GH_TOKEN, GITHUB_TOKEN, IX_TOKEN, LINEAR_API_KEY, NOTION_API_KEY, SLACK_TOKEN, SLACK_USER_TOKEN) to the default `index` server definition in [servers.nix](https://github.com/indexable-inc/index/pull/1564/files#diff-a74190c62a3086f0b0e05489808b80559c743c45cb2f5d09e9734aa712b7604b).
> - Updates the Claude renderer in [renderers.nix](https://github.com/indexable-inc/index/pull/1564/files#diff-fb3cdbcae956fcfccc1df437d49a73e65277961a83fa0db272be6ca312b09183) to emit an `env` block for stdio servers that merges explicit `def.env` with passthrough entries (`${NAME:-}`) for each declared `envVar`.
> - Updates the Codex renderer to emit an `env_vars` TOML array when `def.envVars` is non-empty.
> - Adds test assertions verifying both the Codex `env_vars` list and the Claude passthrough pattern for `LINEAR_API_KEY`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58ca52a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->