### PR TITLE
Test claude doctor diagnostics

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -15,6 +15,7 @@
   socat,
   nix,
   gnupg,
+  python3,
   formats,
   jq,
   binName ? "claude",
@@ -378,6 +379,8 @@ stdenv.mkDerivation (finalAttrs: {
       launchSpec
       settingsDefaultsFile
       wrapperFlags
+      python3
+      binName
       ;
   };
 

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -18,6 +18,8 @@
   launchSpec,
   settingsDefaultsFile,
   wrapperFlags,
+  python3,
+  binName,
 }:
 ''
   runHook preInstallCheck
@@ -99,6 +101,93 @@
       "$dirs_want" "$dirs_got" >&2
     exit 1
   fi
+
+  # Real-binary smoke net for the diagnostic command: `doctor` is an interactive
+  # terminal UI, so stdin redirected from /dev/null hangs and the command is not
+  # a good exit-status contract. Drive it through a local PTY, assert the wrapper
+  # reaches the diagnostic screen, then close the persistent UI process.
+  mkdir -p doctor-home doctor-home/config doctor-home/cache doctor-home/state
+  CLAUDE_DOCTOR_BIN="$out/bin/${binName}" \
+    HOME="$PWD/doctor-home" \
+    XDG_CONFIG_HOME="$PWD/doctor-home/config" \
+    XDG_CACHE_HOME="$PWD/doctor-home/cache" \
+    XDG_STATE_HOME="$PWD/doctor-home/state" \
+    TERM=xterm-256color \
+    ${lib.getExe python3} <<'PY'
+import os
+import pty
+import re
+import select
+import subprocess
+import sys
+import time
+
+master, slave = pty.openpty()
+env = os.environ.copy()
+proc = subprocess.Popen(
+    [env["CLAUDE_DOCTOR_BIN"], "doctor"],
+    cwd=os.getcwd(),
+    env=env,
+    stdin=slave,
+    stdout=slave,
+    stderr=slave,
+    close_fds=True,
+)
+os.close(slave)
+
+chunks = []
+sent_enter = False
+start = time.time()
+deadline = time.time() + 60
+while time.time() < deadline:
+    ready, _, _ = select.select([master], [], [], 0.2)
+    if ready:
+        try:
+            data = os.read(master, 4096)
+        except OSError:
+            break
+        if not data:
+            break
+        chunks.append(data)
+    output = b"".join(chunks)
+    if not sent_enter and (
+        (b"Enter" in output and b"close" in output) or time.time() - start > 25
+    ):
+        os.write(master, b"\r\n")
+        sent_enter = True
+    plain_loop = re.sub(
+        r"\x1b\[[0-?]*[ -/]*[@-~]", "", output.decode("utf-8", "replace")
+    )
+    compact_loop = re.sub(r"\s+", "", plain_loop)
+    if "Diagnostics" in compact_loop and "Search:OK" in compact_loop:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        break
+    if proc.poll() is not None:
+        break
+
+if proc.poll() is None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+os.close(master)
+raw = b"".join(chunks).decode("utf-8", "replace")
+plain = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", raw)
+compact = re.sub(r"\s+", "", plain)
+for needle in ("Diagnostics", "Search:OK"):
+    if needle not in compact:
+        sys.stderr.write(f"claude doctor check failed: missing {needle!r}\n")
+        sys.stderr.write(plain[-4000:])
+        sys.exit(1)
+PY
 
   # Session-digest hook net: absent/empty digests stay silent (exit 0, no
   # output, so a host without the ix-context-digest timer loses nothing), a


### PR DESCRIPTION
## Summary
- add a real-binary `claude doctor` smoke check to `packages/agent/claude-code` install checks
- run the interactive diagnostics under a PTY and assert it reaches `Diagnostics` with `Search: OK`
- avoid treating doctor warnings or the persistent UI as a non-zero exit-status contract

Closes #1563

## Test
- `nix build .#claude-code --print-out-paths`

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PTY-based smoke test for `claude doctor` diagnostics to install-check
> - Adds a Python PTY-driven test in [install-check.nix](https://github.com/indexable-inc/index/pull/1565/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) that launches the built binary with the `doctor` subcommand and verifies `Diagnostics` and `Search:OK` appear in the output.
> - The test sets `HOME`/`XDG_*` to a temp directory and `TERM` to `xterm-256color`, reads interactive output over a PTY, sends Enter once prompted or after a timeout, then strips ANSI sequences before checking markers.
> - Passes `python3` and `binName` through [default.nix](https://github.com/indexable-inc/index/pull/1565/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) into the install-check phase so the script can reference them.
> - Risk: build fails if `Search:OK` is not observed, meaning any regression in the `doctor` command will break the Nix package build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ba1b78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->