### PR TITLE
Add Nix web monitor daemon hot paths

### DIFF
--- a/doc/nix-web-monitor/internals.md
+++ b/doc/nix-web-monitor/internals.md
@@ -100,9 +100,12 @@ prompts, so a user without privilege gets a "needs root" status instead of a
 hang, `:98`). The tracer's stdout lines are parsed by the parser's
 `parse_fs_usage_line`/`parse_strace_line`, folded into a `DaemonTrace`, and a
 `DaemonInfo` is published every `SAMPLE_INTERVAL` (exactly 1s, so the per-window
-syscall delta is the per-second rate with no division, `:30`). Every failure path
-(no daemon, missing tracer, denied attach) degrades to a status string the panel
-shows and the loop retries after `RETRY_INTERVAL` (5s); the probe never returns
-an error (`:41`). `OpClass::classify` (`parser/src/daemon.rs:37`) groups
-syscalls so the panel shows work kind (Link/Rename dominate store optimisation,
-Write/Fsync dominate writing a path).
+syscall delta is the per-second rate with no division, `:30`). Path-bearing
+syscalls also update a one-second hot-path window; the panel lists the busiest
+paths by current rate, then cumulative count, so a silent build has a concrete
+\"what is doing the most\" readout instead of only the latest touched path. Every
+failure path (no daemon, missing tracer, denied attach) degrades to a status
+string the panel shows and the loop retries after `RETRY_INTERVAL` (5s); the
+probe never returns an error (`:41`). `OpClass::classify`
+(`parser/src/daemon.rs:37`) groups syscalls so the panel shows work kind
+(Link/Rename dominate store optimisation, Write/Fsync dominate writing a path).

--- a/doc/nix-web-monitor/overview.md
+++ b/doc/nix-web-monitor/overview.md
@@ -9,8 +9,9 @@ workspace crates:
   model for Nix's `internal-json` event stream. No I/O. Also exports the
   per-tracer syscall line parsers in its `daemon` module.
 - **`server`** (`nix-web-monitor`): the `axum` binary that spawns `nix`, feeds
-  stderr through the parser, resolves dependency edges, traces the daemon, and
-  streams deltas to browsers over a WebSocket. Wrapped with a built Svelte site.
+  stderr through the parser, resolves dependency edges, samples daemon syscall
+  hot paths, and streams deltas to browsers over a WebSocket. Wrapped with a
+  built Svelte site.
 
 The state-machine, transport, dependency-resolution, and daemon-tracing mechanics
 are in [internals](internals.md).
@@ -70,7 +71,8 @@ rather than serving HTML for the wrong MIME type).
 - `MonitorSnapshot` (`:958`) and `Delta` (`:248`): the seed-once / stream-deltas
   wire model the browser consumes. `BuildNode`/`BuildStatus` (`:1025`),
   `ActivityNode` (`:991`), `LogEntry` (`:1058`), `DerivationEdge` (`:984`),
-  `OptimiseStats` (`:229`), `DaemonInfo` (`daemon::DaemonInfo`).
+  `OptimiseStats` (`:229`), `DaemonInfo` (`daemon::DaemonInfo`, including
+  daemon syscall rates and hot paths).
 - `daemon` module (`parser/src/daemon.rs`): `OpClass::classify`,
   `parse_fs_usage_line` (macOS), `parse_strace_line` (Linux), and the rolling
   `DaemonTrace` -> `DaemonInfo` aggregator.

--- a/packages/nix/nix-web-monitor/parser/src/daemon.rs
+++ b/packages/nix/nix-web-monitor/parser/src/daemon.rs
@@ -10,6 +10,8 @@
 //! the per-tracer line parsers and the rolling aggregator. Spawning the tracer
 //! (privileged, platform-specific, best-effort) lives in the server.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 /// A class of filesystem syscall.
@@ -63,6 +65,17 @@ pub struct DaemonOps {
     pub stat: u64,
     pub unlink: u64,
     pub other: u64,
+}
+
+/// One hot path sampled from daemon syscalls.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DaemonHotPath {
+    pub path: String,
+    /// Cumulative path-bearing syscalls since tracing started.
+    pub count: u64,
+    /// Path-bearing syscalls in the last one-second publish window.
+    pub ops_per_sec: u64,
 }
 
 impl DaemonOps {
@@ -128,6 +141,8 @@ pub struct DaemonInfo {
     /// The most recent path the daemon touched, for a "currently working on"
     /// readout. `None` until a path-bearing syscall is seen.
     pub current_path: Option<String>,
+    /// Highest-traffic paths sampled from daemon syscalls, hottest window first.
+    pub hot_paths: Vec<DaemonHotPath>,
 }
 
 /// Rolling aggregator that folds [`SyscallEvent`]s into a [`DaemonInfo`].
@@ -140,13 +155,28 @@ pub struct DaemonTrace {
     pub ops: DaemonOps,
     pub workers: Vec<u32>,
     pub current_path: Option<String>,
+    paths: BTreeMap<String, u64>,
+    window_paths: BTreeMap<String, u64>,
 }
 
 impl DaemonTrace {
+    /// Start a trace for the daemon worker pids the server attached to.
+    #[must_use]
+    pub fn with_workers(workers: Vec<u32>) -> Self {
+        Self {
+            workers,
+            ..Self::default()
+        }
+    }
+
     /// Fold one parsed syscall event into the running totals.
     pub fn record(&mut self, event: SyscallEvent) {
         self.ops.bump(event.op);
         if let Some(path) = event.path {
+            let total = self.paths.entry(path.clone()).or_insert(0);
+            *total = total.saturating_add(1);
+            let window = self.window_paths.entry(path.clone()).or_insert(0);
+            *window = window.saturating_add(1);
             self.current_path = Some(path);
         }
     }
@@ -154,7 +184,13 @@ impl DaemonTrace {
     /// Project the current totals into a wire [`DaemonInfo`]. `ops_per_sec` is
     /// supplied by the caller, which alone knows the wall-clock between samples.
     #[must_use]
-    pub fn info(&self, tracing: bool, status: String, ops_per_sec: u64) -> DaemonInfo {
+    pub fn info(
+        &self,
+        tracing: bool,
+        status: String,
+        ops_per_sec: u64,
+        hot_paths: Vec<DaemonHotPath>,
+    ) -> DaemonInfo {
         DaemonInfo {
             tracing,
             status,
@@ -162,7 +198,36 @@ impl DaemonTrace {
             ops: self.ops,
             ops_per_sec,
             current_path: self.current_path.clone(),
+            hot_paths,
         }
+    }
+
+    /// The highest-traffic paths for the current sampling window.
+    #[must_use]
+    pub fn hot_paths(&self, limit: usize) -> Vec<DaemonHotPath> {
+        let mut paths: Vec<_> = self
+            .paths
+            .iter()
+            .map(|(path, count)| DaemonHotPath {
+                path: path.clone(),
+                count: *count,
+                ops_per_sec: self.window_paths.get(path).copied().unwrap_or(0),
+            })
+            .collect();
+        paths.sort_by(|left, right| {
+            right
+                .ops_per_sec
+                .cmp(&left.ops_per_sec)
+                .then_with(|| right.count.cmp(&left.count))
+                .then_with(|| left.path.cmp(&right.path))
+        });
+        paths.truncate(limit);
+        paths
+    }
+
+    /// Start a new publish window after the server has emitted hot paths.
+    pub fn clear_window(&mut self) {
+        self.window_paths.clear();
     }
 }
 
@@ -307,10 +372,7 @@ mod tests {
 
     #[test]
     fn trace_records_and_projects() {
-        let mut trace = DaemonTrace {
-            workers: vec![10, 11],
-            ..DaemonTrace::default()
-        };
+        let mut trace = DaemonTrace::with_workers(vec![10, 11]);
         trace.record(SyscallEvent {
             op: OpClass::Write,
             path: Some("/nix/store/x".to_owned()),
@@ -319,7 +381,7 @@ mod tests {
             op: OpClass::Fsync,
             path: None,
         });
-        let info = trace.info(true, "tracing".to_owned(), 42);
+        let info = trace.info(true, "tracing".to_owned(), 42, trace.hot_paths(5));
         assert!(info.tracing);
         assert_eq!(info.ops.write, 1);
         assert_eq!(info.ops.fsync, 1);
@@ -327,5 +389,37 @@ mod tests {
         assert_eq!(info.current_path.as_deref(), Some("/nix/store/x"));
         assert_eq!(info.workers, vec![10, 11]);
         assert_eq!(info.ops_per_sec, 42);
+        assert_eq!(
+            info.hot_paths,
+            vec![DaemonHotPath {
+                path: "/nix/store/x".to_owned(),
+                count: 1,
+                ops_per_sec: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn hot_paths_sort_by_current_window_then_total() {
+        let mut trace = DaemonTrace::default();
+        trace.record(SyscallEvent {
+            op: OpClass::Open,
+            path: Some("/nix/store/cold".to_owned()),
+        });
+        trace.record(SyscallEvent {
+            op: OpClass::Open,
+            path: Some("/nix/store/cold".to_owned()),
+        });
+        trace.clear_window();
+        trace.record(SyscallEvent {
+            op: OpClass::Open,
+            path: Some("/nix/store/hot".to_owned()),
+        });
+
+        let hot_paths = trace.hot_paths(2);
+        assert_eq!(hot_paths[0].path, "/nix/store/hot");
+        assert_eq!(hot_paths[0].ops_per_sec, 1);
+        assert_eq!(hot_paths[1].path, "/nix/store/cold");
+        assert_eq!(hot_paths[1].count, 2);
     }
 }

--- a/packages/nix/nix-web-monitor/server/site/src/components/DaemonPanel.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/DaemonPanel.svelte
@@ -67,6 +67,18 @@
           {middleTruncate(daemon.currentPath, 56)}
         </div>
       {/if}
+      {#if daemon.hotPaths.length > 0}
+        <div class="daemon-hot">
+          <div class="daemon-hot-title">hot paths</div>
+          {#each daemon.hotPaths as hot (hot.path)}
+            <div class="daemon-hot-row" title={hot.path}>
+              <span class="daemon-hot-path">{middleTruncate(hot.path, 48)}</span>
+              <span class="daemon-hot-rate">{hot.opsPerSec}/s</span>
+              <span class="daemon-hot-count">{hot.count}</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
     {/if}
   </div>
 </section>

--- a/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
@@ -64,7 +64,8 @@ function createWorking(): Working {
       workers: [],
       ops: { link: 0, rename: 0, open: 0, write: 0, fsync: 0, stat: 0, unlink: 0, other: 0 },
       opsPerSec: 0,
-      currentPath: null
+      currentPath: null,
+      hotPaths: []
     },
     activation: { active: false, command: '', steps: [], status: '' },
     diff: null,

--- a/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
@@ -53,6 +53,13 @@ export const daemonOpsSchema = v.object({
   other: v.number()
 });
 
+/// One hot path sampled from daemon syscalls.
+export const daemonHotPathSchema = v.object({
+  path: v.string(),
+  count: v.number(),
+  opsPerSec: v.number()
+});
+
 /// Live nix-daemon syscall view. `tracing` is false when no tracer is attached
 /// (no daemon, or it needs root), in which case `status` explains why and the
 /// counters are zero. Mirrors the Rust `DaemonInfo`.
@@ -62,7 +69,8 @@ export const daemonInfoSchema = v.object({
   workers: v.array(v.number()),
   ops: daemonOpsSchema,
   opsPerSec: v.number(),
-  currentPath: v.nullable(v.string())
+  currentPath: v.nullable(v.string()),
+  hotPaths: v.array(daemonHotPathSchema)
 });
 
 /// One activation step (a `home`/`os` switch's `activate` run): a named unit of
@@ -190,6 +198,7 @@ export type ActivityType = v.InferOutput<typeof activityTypeSchema>;
 export type ActivityProgress = v.InferOutput<typeof activityProgressSchema>;
 export type OptimiseStats = v.InferOutput<typeof optimiseStatsSchema>;
 export type DaemonOps = v.InferOutput<typeof daemonOpsSchema>;
+export type DaemonHotPath = v.InferOutput<typeof daemonHotPathSchema>;
 export type DaemonInfo = v.InferOutput<typeof daemonInfoSchema>;
 export type ActivationStep = v.InferOutput<typeof activationStepSchema>;
 export type Activation = v.InferOutput<typeof activationSchema>;
@@ -226,10 +235,11 @@ export const EMPTY_SNAPSHOT: MonitorSnapshot = Object.freeze({
     tracing: false,
     status: '',
     workers: [],
-    ops: { link: 0, rename: 0, open: 0, write: 0, fsync: 0, stat: 0, unlink: 0, other: 0 },
-    opsPerSec: 0,
-    currentPath: null
-  },
+      ops: { link: 0, rename: 0, open: 0, write: 0, fsync: 0, stat: 0, unlink: 0, other: 0 },
+      opsPerSec: 0,
+      currentPath: null,
+      hotPaths: []
+    },
   activation: { active: false, command: '', steps: [], status: '' },
   diff: null,
   expected: {},

--- a/packages/nix/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix/nix-web-monitor/server/site/src/style.css
@@ -574,6 +574,51 @@ main.dragging-v .splitter-v::after {
   text-overflow: ellipsis;
 }
 
+.daemon-hot {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding-top: 0.2rem;
+  border-top: 1px solid var(--line-soft);
+}
+
+.daemon-hot-title {
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* path | current rate | cumulative count. */
+.daemon-hot-row {
+  display: grid;
+  grid-template-columns: 1fr 3rem 3.5rem;
+  gap: 0.35rem;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.daemon-hot-path {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.daemon-hot-rate,
+.daemon-hot-count {
+  text-align: right;
+}
+
+.daemon-hot-rate {
+  color: var(--accent);
+}
+
+.daemon-hot-count {
+  color: var(--faint);
+}
+
 /* ---------- activation + diff panels (switch only) ---------- */
 
 /* Both ride at the top of the side pane during a switch and cap their height so

--- a/packages/nix/nix-web-monitor/server/src/daemon.rs
+++ b/packages/nix/nix-web-monitor/server/src/daemon.rs
@@ -179,10 +179,7 @@ async fn trace_loop(
     let stderr = child.stderr.take();
     let mut lines = BufReader::new(stdout).lines();
 
-    let mut trace = DaemonTrace {
-        workers: pids,
-        ..DaemonTrace::default()
-    };
+    let mut trace = DaemonTrace::with_workers(pids);
     // Counts at the previous tick; the difference over the ~1s window is the
     // per-second rate the panel shows.
     let mut last_total: u64 = 0;
@@ -209,7 +206,8 @@ async fn trace_loop(
                 last_total = total;
                 let worker_count = trace.workers.len();
                 let status = format!("tracing nix-daemon ({worker_count} workers)");
-                let info = trace.info(true, status, ops_per_sec);
+                let info = trace.info(true, status, ops_per_sec, trace.hot_paths(5));
+                trace.clear_window();
                 monitor.write().await.set_daemon(info);
                 let _ = broadcast_deltas(monitor, deltas).await;
             }
@@ -256,7 +254,7 @@ async fn publish_status(
     deltas: &broadcast::Sender<Bytes>,
     status: &str,
 ) {
-    let info = DaemonTrace::default().info(false, status.to_owned(), 0);
+    let info = DaemonTrace::default().info(false, status.to_owned(), 0, Vec::new());
     monitor.write().await.set_daemon(info);
     let _ = broadcast_deltas(monitor, deltas).await;
 }


### PR DESCRIPTION
## Summary
- sample path-bearing nix-daemon syscalls into a one-second hot-path window
- expose `daemon.hotPaths` over the existing snapshot/delta wire shape
- render hot paths in the daemon panel with current rate and cumulative count
- document the daemon hot-path sampling path

## Validation
- `rustfmt --edition 2024 --check packages/nix/nix-web-monitor/parser/src/daemon.rs packages/nix/nix-web-monitor/server/src/daemon.rs`
- `cargo test -p nix-web-monitor-parser daemon`
- `cargo check -p nix-web-monitor`
- `cargo test -p nix-web-monitor`
- `npm run build` in `packages/nix/nix-web-monitor/server/site`

## Notes
- `cargo fmt --manifest-path packages/nix/nix-web-monitor/parser/Cargo.toml --check` still reports pre-existing formatting diffs in `parser/src/activation.rs` and `parser/src/lib.rs` outside this change.
- `cargo clippy -p nix-web-monitor-parser -p nix-web-monitor -- -D warnings` is blocked by existing workspace/toolchain lint configuration (`clippy::fallible_int_fallback`, `clippy::anonymous_tuple_return_type`, and cargo metadata lints in unrelated packages).

Fixes #1566

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hot path tracking to the Nix web monitor daemon panel
> - Adds `DaemonHotPath` to the parser's `DaemonInfo`, tracking per-path cumulative counts and per-window `ops_per_sec` by sampling path-bearing syscalls in `DaemonTrace`.
> - The server's `trace_loop` computes the top 5 hot paths each tick, passes them into `DaemonInfo`, then clears the window counters so rates reflect only the current one-second sample.
> - The `DaemonPanel` Svelte component renders a new "hot paths" grid showing truncated path, current rate, and cumulative count when `hotPaths` is non-empty.
> - Client-side types and the default empty snapshot are updated to include `hotPaths: []`, keeping schema validation consistent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ac254c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->