### PR TITLE
base profile: install terminfo so clear works under TERM=xterm-ghostty

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -44,6 +44,14 @@ in
       "https://cache.ix.dev"
     ];
 
+    # Install terminfo for every common terminal emulator so ncurses tools
+    # (`clear`, `tmux`, `vim`, ...) work no matter what `$TERM` an operator's
+    # client propagates in. Without this, shelling in from Ghostty fails with
+    # `'xterm-ghostty': unknown terminal type.` because the guest only ships
+    # ncurses' built-in set. Pulls only the small `terminfo` outputs (ghostty,
+    # kitty, alacritty, wezterm, foot, ...), not the terminal binaries.
+    environment.enableAllTerminfo = true;
+
     # Cubic halves cwnd on any loss, so a residential last-mile at
     # 30 ms and a couple percent loss caps a single TCP flow far
     # below the path's real capacity. BBR models bottleneck bandwidth


### PR DESCRIPTION
## Problem

Shelling into an ix VM from Ghostty fails on the first ncurses command:

```
[root@(none):/]# clear
'xterm-ghostty': unknown terminal type.
```

`$TERM=xterm-ghostty` propagates from the host terminal into the guest, but the
VM images only ship ncurses' built-in terminfo set, which has no `xterm-ghostty`
entry. `clear`, `tmux`, `vim`, and anything else ncurses-based then breaks.

## Fix

Set `environment.enableAllTerminfo = true` in the auto-enabled base profile
(`modules/profiles/base/default.nix`), so every VM ships terminfo for the common
terminal emulators (ghostty, kitty, alacritty, wezterm, foot, ...). This is the
canonical NixOS remedy for "unknown terminal type" and only pulls the small
`terminfo` outputs, not the terminal binaries.

## Verification

- `nixfmt --check` passes on the changed file.
- `ghostty.terminfo` resolves in the pinned nixpkgs on both `x86_64-linux` and
  `aarch64-linux`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install terminfo entries in base profile so `clear` works under TERM=xterm-ghostty
> Sets `environment.enableAllTerminfo = true` in [modules/profiles/base/default.nix](https://github.com/indexable-inc/index/pull/1568/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) so terminfo entries for common terminal emulators are present on the system. This prevents ncurses-based tools from failing with "unknown terminal type" when connecting from terminals like Ghostty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39cb53a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->