### PR TITLE
perf(rust): link native macOS builds with lld

### DIFF
--- a/lib/rust/policy.nix
+++ b/lib/rust/policy.nix
@@ -138,6 +138,11 @@ let
           default = pkgs.stdenv.hostPlatform.isLinux;
           description = "Link with mold on Linux.";
         };
+        useLld = lib.mkOption {
+          type = lib.types.bool;
+          default = pkgs.stdenv.hostPlatform.isDarwin;
+          description = "Link with lld on macOS (the default cctools ld64 is single-threaded and slow).";
+        };
       };
     };
   };
@@ -184,18 +189,36 @@ let
       };
     };
 
-  # `platform` is a rust target triple (e.g. `x86_64-unknown-linux-gnu`); mold is
-  # Linux-only, so the flags are gated on a `-linux-` triple. Host builds pass
-  # `pkgs.stdenv.hostPlatform.config` rather than a sentinel, so there is one
-  # Linux test and a non-triple argument fails loudly instead of defaulting.
+  # `platform` is a rust target triple (e.g. `x86_64-unknown-linux-gnu`); the fast
+  # linker is per-OS, so each branch is gated on the triple: mold for a `-linux-`
+  # triple, lld for an `-apple-darwin` triple. Host builds pass
+  # `pkgs.stdenv.hostPlatform.config` rather than a sentinel, so the tests run on a
+  # real triple and a non-triple argument fails loudly instead of defaulting.
+  #
+  # The lld branch borrows the `-B${pkgs.lld}/bin -fuse-ld=lld` incantation from the
+  # Linux->darwin cross toolchain in `lib/darwin/apple-sdk-toolchain.nix` (the `-B`
+  # makes the clang driver resolve `ld64.lld`), but applies only to a *native* darwin
+  # link: it is additionally gated on a darwin build host. The cross toolchain already
+  # injects `-fuse-ld=lld` via `CARGO_TARGET_<T>_LINKER`, so without this host gate a
+  # future darwin-host darwin-cross would stack the flag on that wrapper.
   rustcArgsForPolicyForPlatform =
     policy: platform:
     lib.optionals (policy.linker.useMold && lib.hasInfix "-linux-" platform) [
       "-C"
       "link-arg=-fuse-ld=mold"
-    ];
+    ]
+    ++
+      lib.optionals
+        (policy.linker.useLld && pkgs.stdenv.hostPlatform.isDarwin && lib.hasInfix "-apple-darwin" platform)
+        [
+          "-C"
+          "link-arg=-fuse-ld=lld"
+          "-C"
+          "link-arg=-B${pkgs.lld}/bin"
+        ];
 
-  nativeBuildInputsForPolicy = policy: lib.optional policy.linker.useMold pkgs.mold;
+  nativeBuildInputsForPolicy =
+    policy: lib.optional policy.linker.useMold pkgs.mold ++ lib.optional policy.linker.useLld pkgs.lld;
 
   clippyLintArgs =
     policy:


### PR DESCRIPTION
## What

Make the native macOS Rust link use **lld** instead of cctools `ld64-956.6` (single-threaded). Today `lib/rust/policy.nix` gives Linux the fast path via `linker.useMold` but Darwin falls through `cc` with no `-fuse-ld`, so every native-mac rustc link uses the slow default ld64.

## Change

- New `linker.useLld` policy option (default = darwin build host), parallel to `useMold`.
- `rustcArgsForPolicyForPlatform` emits `-C link-arg=-fuse-ld=lld -C link-arg=-B${pkgs.lld}/bin` for `-apple-darwin` triples; `pkgs.lld` added to native inputs.
- The `-B` mirrors the known-good incantation already shipping in `lib/darwin/apple-sdk-toolchain.nix` for the Linux→darwin cross toolchain.
- lld branch is additionally gated on a **darwin build host** so a future darwin-host darwin-cross can't stack `-fuse-ld=lld` on that toolchain's own `CARGO_TARGET_*_LINKER`.
- **Linux is byte-unchanged** (still mold).

## Validation (on aarch64-darwin)

- Eval: darwin → `fuse-ld=lld` + `-B…/lld/bin`; linux → `fuse-ld=mold` (unchanged).
- Built `nix-cargo-unit`: `RUSTFLAGS` carries the lld flags, `lld` in `nativeBuildInputs`, runs as valid arm64 Mach-O. (`-fuse-ld=lld` is fail-loud, so a clean link proves lld was used.)
- Built the full **ix** workspace against this branch end-to-end: links, runs, and keeps a valid **ad-hoc Mach-O signature** (clears the ENG-2143 signing concern). `ix-sdk` cdylibs included.

## Follow-up

ix picks this up via a `flake.lock` `index` bump (separate PR).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Link native macOS Rust builds with lld
> Adds `policy.linker.useLld` to [policy.nix](https://github.com/indexable-inc/index/pull/1569/files#diff-1e9fc9e82126fab41f36b73b16145d577144b54f6de555bd23656741a3100cbf), defaulting to `true` on Darwin. When enabled, rustc is invoked with `-C link-arg=-fuse-ld=lld` and `-C link-arg=-B${pkgs.lld}/bin`, and `pkgs.lld` is added to `nativeBuildInputs`. Mirrors the existing mold setup for Linux.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c8322f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->