### PR TITLE
feat(system-prompt): omitRules to drop named rules from the house prompt

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -122,6 +122,13 @@
       (import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; })
       .defaultServers,
 
+  # Rule names dropped from the default house prompt (forwarded to
+  # ../system-prompt.nix's `omitRules`). Only affects the computed `systemPrompt`
+  # default below; ignored when `systemPrompt` is passed explicitly. Lets a
+  # consumer bake a variant minus a rule without restating the whole prompt, e.g.
+  # `claude-code.override { omitRules = [ "htmlDeliverable" ]; }`. `[ ]` keeps all.
+  omitRules ? [ ],
+
   # Text used AS Claude Code's system prompt, REPLACING the stock prompt. The
   # string is materialized to a store file and baked into the wrapper as
   # `--system-prompt-file=<path>`: passing by path (not inline text) keeps
@@ -139,7 +146,10 @@
   # backward-compatibility engineering rule, plus a preference for working in git
   # worktrees); set to `null` to bake no flag and ship the stock prompt alone.
   systemPrompt ?
-    (import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; })
+    (import (ix.paths.packagesRoot + "/agent/common.nix") {
+      inherit lib ix repoPackages;
+      promptOmitRules = omitRules;
+    })
     .systemPrompt,
 
   # Only the flake package set injects the Nushell writer; the overlay eval

--- a/packages/agent/common.nix
+++ b/packages/agent/common.nix
@@ -4,9 +4,14 @@
   lib,
   ix,
   repoPackages ? { },
+  # Rule names dropped from the baked house prompt; forwarded to ./prompt.nix.
+  promptOmitRules ? [ ],
 }:
 let
-  prompt = import ./prompt.nix { inherit lib; };
+  prompt = import ./prompt.nix {
+    inherit lib;
+    omitRules = promptOmitRules;
+  };
   mcp = import ./mcp.nix { inherit lib ix repoPackages; };
 in
 prompt // mcp

--- a/packages/agent/prompt.nix
+++ b/packages/agent/prompt.nix
@@ -1,5 +1,9 @@
 # House system prompt helpers shared by agent CLI wrappers.
-{ lib }:
+{
+  lib,
+  # Rule names dropped from the baked prompt; forwarded to ./system-prompt.nix.
+  omitRules ? [ ],
+}:
 let
   providerNames = {
     claude = "Claude Code";
@@ -19,7 +23,7 @@ let
     provider:
     lib.concatStringsSep "\n\n" [
       (import ./system-prompt.nix {
-        inherit lib;
+        inherit lib omitRules;
         agentName = providerNames.${provider};
       })
       extraSystemPrompts.${provider}

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -1,6 +1,10 @@
 {
   lib,
   agentName ? "Claude Code",
+  # Rule names (the bindings in `order`) to drop from this build's prompt. Lets a
+  # consumer bake a variant without a given rule, e.g.
+  # `claude-code.override { omitRules = [ "htmlDeliverable" ]; }`. Default keeps every rule.
+  omitRules ? [ ],
 }:
 # The house system prompt the agent wrappers run with, REPLACING the stock prompt
 # where the upstream CLI supports replacement. Each rule is a
@@ -398,48 +402,55 @@ let
     requested, and keep navigation obvious.
   '';
 
+  # Each entry pairs a rule's name with its text so a consumer can drop one by name
+  # (via `omitRules`) without string surgery on the joined prompt.
   order = [
-    shokunin
-    promptSource
-    validate
-    liveSystemEvidence
-    reproduceClaims
-    firstPrinciples
-    experimentDefault
-    promptEval
-    matchSurroundingCode
-    rustCollectStyle
-    inlineComments
-    tieToIssue
-    preV1
-    oneImplementation
-    separateDefinitions
-    fixAtSource
-    worktree
-    shellCwd
-    backgroundSubagents
-    modelTiering
-    harness
-    indexKernel
-    structuredPrimitives
-    autonomy
-    agenticBias
-    decisiveness
-    faithfulReporting
-    noMetaNarration
-    byteExact
-    forceMerge
-    surfaceScopeChanges
-    respectGuards
-    blockedPath
-    stackedRebase
-    cleanupMerged
-    landingBanner
-    noEmDashes
-    coordinateBranches
-    discloseAi
-    reportToPlaybook
-    htmlDeliverable
+    { name = "shokunin"; text = shokunin; }
+    { name = "promptSource"; text = promptSource; }
+    { name = "validate"; text = validate; }
+    { name = "liveSystemEvidence"; text = liveSystemEvidence; }
+    { name = "reproduceClaims"; text = reproduceClaims; }
+    { name = "firstPrinciples"; text = firstPrinciples; }
+    { name = "experimentDefault"; text = experimentDefault; }
+    { name = "promptEval"; text = promptEval; }
+    { name = "matchSurroundingCode"; text = matchSurroundingCode; }
+    { name = "rustCollectStyle"; text = rustCollectStyle; }
+    { name = "inlineComments"; text = inlineComments; }
+    { name = "tieToIssue"; text = tieToIssue; }
+    { name = "preV1"; text = preV1; }
+    { name = "oneImplementation"; text = oneImplementation; }
+    { name = "separateDefinitions"; text = separateDefinitions; }
+    { name = "fixAtSource"; text = fixAtSource; }
+    { name = "worktree"; text = worktree; }
+    { name = "shellCwd"; text = shellCwd; }
+    { name = "backgroundSubagents"; text = backgroundSubagents; }
+    { name = "modelTiering"; text = modelTiering; }
+    { name = "harness"; text = harness; }
+    { name = "indexKernel"; text = indexKernel; }
+    { name = "structuredPrimitives"; text = structuredPrimitives; }
+    { name = "autonomy"; text = autonomy; }
+    { name = "agenticBias"; text = agenticBias; }
+    { name = "decisiveness"; text = decisiveness; }
+    { name = "faithfulReporting"; text = faithfulReporting; }
+    { name = "noMetaNarration"; text = noMetaNarration; }
+    { name = "byteExact"; text = byteExact; }
+    { name = "forceMerge"; text = forceMerge; }
+    { name = "surfaceScopeChanges"; text = surfaceScopeChanges; }
+    { name = "respectGuards"; text = respectGuards; }
+    { name = "blockedPath"; text = blockedPath; }
+    { name = "stackedRebase"; text = stackedRebase; }
+    { name = "cleanupMerged"; text = cleanupMerged; }
+    { name = "landingBanner"; text = landingBanner; }
+    { name = "noEmDashes"; text = noEmDashes; }
+    { name = "coordinateBranches"; text = coordinateBranches; }
+    { name = "discloseAi"; text = discloseAi; }
+    { name = "reportToPlaybook"; text = reportToPlaybook; }
+    { name = "htmlDeliverable"; text = htmlDeliverable; }
   ];
+
+  unknownOmits = builtins.filter (name: !(builtins.any (rule: rule.name == name) order)) omitRules;
+  kept = builtins.filter (rule: !(builtins.elem rule.name omitRules)) order;
 in
-lib.concatStringsSep "\n\n" order
+assert lib.assertMsg (unknownOmits == [ ])
+  "system-prompt.nix: omitRules names not found in order: ${lib.concatStringsSep ", " unknownOmits}";
+lib.concatStringsSep "\n\n" (map (rule: rule.text) kept)


### PR DESCRIPTION
## What

Add an `omitRules` parameter to the house system prompt so a consumer can bake a variant **without** a named rule, without restating the whole prompt or doing string surgery.

Threaded `system-prompt.nix` -> `prompt.nix` -> `common.nix` -> `claude-code/default.nix`. Default is `[ ]`, so every existing consumer (dev images, the eval, direct users) is byte-for-byte unchanged.

`order` now pairs each rule's name with its text; an `assert` rejects unknown `omitRules` names so a typo fails loudly instead of silently keeping the rule.

## Why

Downstream `ix` wants the `htmlDeliverable` rule (deliver every human answer as a self-contained HTML file) on Andrew's machines only, and stripped elsewhere. That needs a real build-time removal, not a counter-instruction. This is the upstream primitive: `claude-code.override { omitRules = [ "htmlDeliverable" ]; }`.

## Verification

- `nix eval` of `system-prompt.nix`: default contains the HTML rule; `omitRules = [ "htmlDeliverable" ]` drops it while keeping neighbors; an unknown name throws.
- Same through `common.nix` (`promptOmitRules`) and `claude-code.override { omitRules = ... }` evaluates (the override accepts the arg).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `omitRules` option to drop named rules from the default system prompt
> - Adds an `omitRules` parameter (default `[]`) to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1570/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df), propagated through [prompt.nix](https://github.com/indexable-inc/index/pull/1570/files#diff-5559a2a80a64417c055fd920fda60b94b9e4c5b6db3e14aaaf33c17cac3ba1eb), [common.nix](https://github.com/indexable-inc/index/pull/1570/files#diff-6e6ea9bcd37d43542775f46f4a2342510acf460cdaa9240e6d406c3cc3ec9419), and [default.nix](https://github.com/indexable-inc/index/pull/1570/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8).
> - Refactors the rule list in `system-prompt.nix` from plain text bindings to a list of `{ name, text }` attrsets, enabling filtering by name.
> - Rules named in `omitRules` are excluded from the generated prompt; an assertion fails at evaluation time if any name in `omitRules` does not match a known rule.
> - Only affects the computed default system prompt; passing an explicit `systemPrompt` bypasses this logic entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88d9c91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->