### PR TITLE
Add agents-render check validating rendered subagent output

### DIFF
--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -30,9 +30,11 @@ let
       ixForPackages
       ;
     ix = ixForPackages;
-    # Pre-applied to the caller's pkgs so flake-output packages can build a
-    # `passthru.updateScript` without re-threading `ix` through callPackage.
-    writeNushellApplication = ixForPackages.writeNushellApplication pkgs;
+    # Capability passed only on the flake-package path: a writer the package can
+    # use to build its `passthru.updateScript`, pre-applied to the caller's pkgs
+    # so flake-output packages need not re-thread `ix` through callPackage. The
+    # overlay path leaves it unset, which is the signal to omit the updater.
+    updateScriptWriter = ixForPackages.writeNushellApplication pkgs;
   };
   inherit (import ./util/deep-merge.nix { inherit lib; }) strictList;
   buildEntry =

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -802,6 +802,61 @@ let
             test -d ${agentsDir}
             mkdir -p "$out"
           '';
+          # Validates the rendered subagent output, making #1562's by-hand
+          # checks (frontmatter parses as YAML, `name` matches the filename,
+          # `tools` renders as a list) a permanent gate so the Nix-data source
+          # in packages/agent/subagents.nix can't drift from valid output.
+          agents-render =
+            pkgs.runCommand "agents-render-check"
+              {
+                nativeBuildInputs = [
+                  pkgs.yq-go
+                  pkgs.gawk
+                  pkgs.coreutils
+                ];
+              }
+              ''
+                shopt -s nullglob
+                count=0
+                for f in ${agentsDir}/*.md; do
+                  base=$(basename "$f" .md)
+                  # Frontmatter is the block between the first two `---` fences.
+                  fm=$(awk 'NR==1 && $0=="---"{open=1; next} open && $0=="---"{exit} open{print}' "$f")
+                  if [ -z "$fm" ]; then
+                    echo "agents-render: $base.md has no frontmatter block" >&2
+                    exit 1
+                  fi
+                  # Fails the build on malformed YAML.
+                  echo "$fm" | yq -e '.' >/dev/null
+                  name=$(echo "$fm" | yq -r '.name')
+                  if [ "$name" != "$base" ]; then
+                    echo "agents-render: $base.md frontmatter name=$name must match filename" >&2
+                    exit 1
+                  fi
+                  desc=$(echo "$fm" | yq -r '.description // ""')
+                  if [ -z "$desc" ]; then
+                    echo "agents-render: $base.md frontmatter description is required" >&2
+                    exit 1
+                  fi
+                  # tools, when present, must render as a YAML list (not a
+                  # comma-separated string); absent is the `!!null` tag.
+                  toolsTag=$(echo "$fm" | yq -r '.tools | tag')
+                  case "$toolsTag" in
+                    '!!seq' | '!!null') ;;
+                    *)
+                      echo "agents-render: $base.md frontmatter tools must be a list, got $toolsTag" >&2
+                      exit 1
+                      ;;
+                  esac
+                  count=$((count + 1))
+                done
+                if [ "$count" -eq 0 ]; then
+                  echo "agents-render: no rendered agent files found" >&2
+                  exit 1
+                fi
+                echo "agents-render: validated $count agent file(s)"
+                mkdir -p "$out"
+              '';
           # Pins the last-applied 3-way merge behind homeModules.mutable-json:
           # first-install, preserve an app-written key, enforce a key the app
           # changed, prune a key Nix stopped declaring, and keep a sibling key

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -142,10 +142,11 @@
     (import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; })
     .systemPrompt,
 
-  # Only the flake package set injects the Nushell writer; the overlay eval
-  # context does not. The updater is a maintainer-facing flake output, so the
-  # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.
-  writeNushellApplication ? null,
+  # Writer used to build `passthru.updateScript`. Only the flake package set
+  # supplies it (lib/packages.nix); the overlay eval context leaves it null. The
+  # updater is a maintainer-facing flake output, so the overlay build of
+  # `pkgs.claude-code` simply omits `passthru.updateScript`.
+  updateScriptWriter ? null,
 }:
 
 let
@@ -309,13 +310,17 @@ let
 
   # Maintainer-facing updater that refreshes manifest.json from Anthropic's
   # signed per-version manifest (fails closed on a bad GPG signature); see
-  # ./update.nix. Only the flake package set injects the Nushell writer, so the
-  # overlay build of `pkgs.claude-code` omits `passthru.updateScript`.
+  # ./update.nix. Built only when this eval context supplied a writer (the flake
+  # package set), so the overlay build of `pkgs.claude-code` omits
+  # `passthru.updateScript`.
   updateScript =
-    if writeNushellApplication == null then
+    if updateScriptWriter == null then
       null
     else
-      import ./update.nix { inherit writeNushellApplication nix gnupg; };
+      import ./update.nix {
+        writeNushellApplication = updateScriptWriter;
+        inherit nix gnupg;
+      };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "claude-code";

--- a/packages/dia/default.nix
+++ b/packages/dia/default.nix
@@ -4,10 +4,11 @@
   fetchurl,
   undmg,
   nix,
-  # Only the flake package set injects the Nushell writer; the overlay eval
-  # context does not. The updater is a maintainer-facing flake output, so the
-  # overlay build of `pkgs.dia` simply omits `passthru.updateScript`.
-  writeNushellApplication ? null,
+  # Writer used to build `passthru.updateScript`. Only the flake package set
+  # supplies it (lib/packages.nix); the overlay eval context leaves it null. The
+  # updater is a maintainer-facing flake output, so the overlay build of
+  # `pkgs.dia` simply omits `passthru.updateScript`.
+  updateScriptWriter ? null,
 }:
 
 let
@@ -30,10 +31,10 @@ let
   # pass a version to pin an exact one. `nix store prefetch-file` downloads the
   # .dmg once and emits the SRI hash the fetcher pins.
   updateScript =
-    if writeNushellApplication == null then
+    if updateScriptWriter == null then
       null
     else
-      writeNushellApplication {
+      updateScriptWriter {
         name = "dia-update";
         runtimeInputs = [ nix ];
         meta.description = "Refresh packages/dia/manifest.json to a Dia release";

--- a/packages/humanlayer/default.nix
+++ b/packages/humanlayer/default.nix
@@ -5,11 +5,12 @@
   makeWrapper,
   nodejs_22,
   nix,
-  # Bound to a real builder only on the flake-package path (lib/packages.nix),
-  # which is where `nix run .#humanlayer.updateScript` resolves; the overlay path
-  # passes nothing, so `pkgs.humanlayer` carries no updateScript. Same pattern as
+  # Writer used to build `passthru.updateScript`. Bound to a real builder only on
+  # the flake-package path (lib/packages.nix), which is where
+  # `nix run .#humanlayer.updateScript` resolves; the overlay path leaves it
+  # null, so `pkgs.humanlayer` carries no updateScript. Same pattern as
   # packages/yc and packages/agent/claude-code.
-  writeNushellApplication ? null,
+  updateScriptWriter ? null,
 }:
 let
   # Version and per-platform hashes live in manifest.json as the single owner;
@@ -48,10 +49,10 @@ let
   # are authentic, so the real gate is human review of the hash changes in the
   # auto-bump PR. Same posture as packages/yc.
   updateScript =
-    if writeNushellApplication == null then
+    if updateScriptWriter == null then
       null
     else
-      writeNushellApplication {
+      updateScriptWriter {
         name = "humanlayer-update";
         runtimeInputs = [ nix ];
         meta.description = "Refresh packages/humanlayer/manifest.json to the latest HumanLayer CLI release";

--- a/packages/yc/default.nix
+++ b/packages/yc/default.nix
@@ -4,10 +4,11 @@
   fetchurl,
   autoPatchelfHook,
   nix,
-  # Bound to a real builder only on the flake-package path (lib/packages.nix),
-  # which is where `nix run .#yc.updateScript` resolves; the overlay path passes
-  # nothing, so `pkgs.yc` carries no updateScript. Same pattern as claude-code.
-  writeNushellApplication ? null,
+  # Writer used to build `passthru.updateScript`. Bound to a real builder only on
+  # the flake-package path (lib/packages.nix), which is where
+  # `nix run .#yc.updateScript` resolves; the overlay path leaves it null, so
+  # `pkgs.yc` carries no updateScript. Same pattern as claude-code.
+  updateScriptWriter ? null,
 }:
 let
   # Slug map and pinned hashes live in manifest.json as the single owner; this
@@ -39,10 +40,10 @@ let
   # auto-bump PR. The S3 bucket denies ListBucket, hence the `latest` pointer
   # rather than enumerating versions.
   updateScript =
-    if writeNushellApplication == null then
+    if updateScriptWriter == null then
       null
     else
-      writeNushellApplication {
+      updateScriptWriter {
         name = "yc-update";
         runtimeInputs = [ nix ];
         meta.description = "Refresh packages/yc/manifest.json to the latest YC CLI release";


### PR DESCRIPTION
## Summary
Closes the last open item of #1560. The data refactor and rendering helpers landed in #1562 (which referenced but didn't close the issue); that PR validated the output **by hand** (PyYAML, manual `tools`-is-a-list check). This makes that validation a permanent flake check.

Adds an `agents-render` check that, for every rendered `.claude/agents/<name>.md`:
- extracts the frontmatter block (between the first two `---` fences)
- fails the build on malformed YAML (`yq -e`)
- asserts `name` matches the filename
- asserts `description` is non-empty
- asserts `tools`, when present, renders as a YAML list (`!!seq`), not a comma-separated string

This guards against the Nix-data source in `packages/agent/subagents.nix` drifting from valid rendered output.

## Why a structural check, not a golden snapshot
`mcpServers` renders a live store path (`lib.getExe repoPackages.mcp`), so a byte-for-byte snapshot would churn on every rebuild. Structural validation is stable and still catches the failure modes #1562 cared about.

## Validation
- Built the check's logic against a fixture agents dir: passes on valid input, fails with a clear message on a name/filename mismatch.
- `nix fmt` leaves the diff unchanged.

(Local full `nix flake check` / `.#agents` build is blocked by an unrelated broken `gcal`/`astlog` derivation in my local store; CI will exercise it.)

Refs #1560

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `agents-render-check` derivation to validate rendered agent Markdown frontmatter
> - Adds a `pkgs.runCommand` derivation in [per-system.nix](https://github.com/indexable-inc/index/pull/1571/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) that iterates `*.md` files in the agents directory and validates each file's YAML frontmatter: presence, parsability, `name` matching the filename stem, non-empty `description`, and `tools` being a list or null.
> - Renames the `writeNushellApplication` argument to `updateScriptWriter` across [lib/packages.nix](https://github.com/indexable-inc/index/pull/1571/files#diff-f353132c25d1c6d3f15551dba2d12c8c65c630f707c44f44e14229726bad009c) and all package `default.nix` files for clarity about its scope.
> - Behavioral Change: builds now fail if any rendered agent file is missing, has no frontmatter, contains malformed YAML, has a mismatched name, missing description, or non-list tools value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab7caab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->