### PR TITLE
fix(ix-fleet): wait for guest readiness before health checks in `up`

### DIFF
--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -884,6 +884,14 @@ async def run_up_node_workflow(node: FleetNode, args: argparse.Namespace) -> Non
     if not args.skip_push:
         image = await push_replacement_image(node, dry_run=args.dry_run)
     await up_node(node, image, dry_run=args.dry_run)
+    # `up_node` recreates the VM on a fresh image and returns once `client.create`
+    # has issued the boot, not once the guest is reachable. Wait for the guest to
+    # answer an exec before health-checking, the same gate `ensure_node` gives the
+    # switch path: a `from: guest` check against a still-booting guest raises an
+    # exec RPC error (not a TimeoutError or non-zero exit), which escapes the
+    # retry loop in `run_health_check` and fails the whole `up` on the first
+    # attempt instead of waiting the boot out.
+    await wait_node_ready(node, dry_run=args.dry_run)
     await ensure_node_groups(node, dry_run=args.dry_run)
     if not args.skip_health:
         await run_node_health_checks(node, dry_run=args.dry_run)


### PR DESCRIPTION
`run_up_node_workflow` created the VM via `up_node` (which returns once `client.create` issues the boot, not once the guest is reachable) and then ran `from: guest` health checks immediately. A check against a still-booting guest makes `branch.exec` raise an exec RPC error ("internal server error", vsock guest.sock not up yet) that is neither a TimeoutError nor a non-zero exit, so it escapes `run_health_check`'s retry loop and fails the whole `up` on the first attempt before the VM ever finishes booting.

Add the `wait_node_ready` gate the switch path already gets via `ensure_node`, so the guest answers an exec before health checks run.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wait for guest readiness before health checks in `run_up_node_workflow`
> Previously, `run_up_node_workflow` would proceed to `ensure_node_groups` and `run_node_health_checks` immediately after `up_node`, which only signals boot initiation. An exec RPC error could escape retries if the guest was not yet reachable.
>
> Adds an awaited call to `wait_node_ready` after `up_node` in [__init__.py](https://github.com/indexable-inc/index/pull/1572/files#diff-d83777ed2e90ee1f7371ffa0e55fe375c817b07e2cb2a15a5b58423ad93dae3e) to block until the guest answers an exec before health checks begin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 669a904.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->