### PR TITLE
Rename nullable update-script writer to updateScriptWriter

### DIFF
--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -30,9 +30,11 @@ let
       ixForPackages
       ;
     ix = ixForPackages;
-    # Pre-applied to the caller's pkgs so flake-output packages can build a
-    # `passthru.updateScript` without re-threading `ix` through callPackage.
-    writeNushellApplication = ixForPackages.writeNushellApplication pkgs;
+    # Capability passed only on the flake-package path: a writer the package can
+    # use to build its `passthru.updateScript`, pre-applied to the caller's pkgs
+    # so flake-output packages need not re-thread `ix` through callPackage. The
+    # overlay path leaves it unset, which is the signal to omit the updater.
+    updateScriptWriter = ixForPackages.writeNushellApplication pkgs;
   };
   inherit (import ./util/deep-merge.nix { inherit lib; }) strictList;
   buildEntry =

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -30,10 +30,14 @@ let
       ixForPackages
       ;
     ix = ixForPackages;
-    # Capability passed only on the flake-package path: a writer the package can
-    # use to build its `passthru.updateScript`, pre-applied to the caller's pkgs
-    # so flake-output packages need not re-thread `ix` through callPackage. The
-    # overlay path leaves it unset, which is the signal to omit the updater.
+    # The Nushell writer pre-applied to the caller's pkgs, for packages that
+    # build a checked Nushell command directly (e.g. chrome-vm, astlog scan).
+    writeNushellApplication = ixForPackages.writeNushellApplication pkgs;
+    # Same writer, exposed under a capability-oriented name for the nullable
+    # updateScript path: a writer the package can use to build its
+    # `passthru.updateScript`, pre-applied to the caller's pkgs so flake-output
+    # packages need not re-thread `ix` through callPackage. The overlay path
+    # leaves it unset, which is the signal to omit the updater.
     updateScriptWriter = ixForPackages.writeNushellApplication pkgs;
   };
   inherit (import ./util/deep-merge.nix { inherit lib; }) strictList;

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -142,10 +142,11 @@
     (import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; })
     .systemPrompt,
 
-  # Only the flake package set injects the Nushell writer; the overlay eval
-  # context does not. The updater is a maintainer-facing flake output, so the
-  # overlay build of `pkgs.claude-code` simply omits `passthru.updateScript`.
-  writeNushellApplication ? null,
+  # Writer used to build `passthru.updateScript`. Only the flake package set
+  # supplies it (lib/packages.nix); the overlay eval context leaves it null. The
+  # updater is a maintainer-facing flake output, so the overlay build of
+  # `pkgs.claude-code` simply omits `passthru.updateScript`.
+  updateScriptWriter ? null,
 }:
 
 let
@@ -309,13 +310,17 @@ let
 
   # Maintainer-facing updater that refreshes manifest.json from Anthropic's
   # signed per-version manifest (fails closed on a bad GPG signature); see
-  # ./update.nix. Only the flake package set injects the Nushell writer, so the
-  # overlay build of `pkgs.claude-code` omits `passthru.updateScript`.
+  # ./update.nix. Built only when this eval context supplied a writer (the flake
+  # package set), so the overlay build of `pkgs.claude-code` omits
+  # `passthru.updateScript`.
   updateScript =
-    if writeNushellApplication == null then
+    if updateScriptWriter == null then
       null
     else
-      import ./update.nix { inherit writeNushellApplication nix gnupg; };
+      import ./update.nix {
+        writeNushellApplication = updateScriptWriter;
+        inherit nix gnupg;
+      };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "claude-code";

--- a/packages/dia/default.nix
+++ b/packages/dia/default.nix
@@ -4,10 +4,11 @@
   fetchurl,
   undmg,
   nix,
-  # Only the flake package set injects the Nushell writer; the overlay eval
-  # context does not. The updater is a maintainer-facing flake output, so the
-  # overlay build of `pkgs.dia` simply omits `passthru.updateScript`.
-  writeNushellApplication ? null,
+  # Writer used to build `passthru.updateScript`. Only the flake package set
+  # supplies it (lib/packages.nix); the overlay eval context leaves it null. The
+  # updater is a maintainer-facing flake output, so the overlay build of
+  # `pkgs.dia` simply omits `passthru.updateScript`.
+  updateScriptWriter ? null,
 }:
 
 let
@@ -30,10 +31,10 @@ let
   # pass a version to pin an exact one. `nix store prefetch-file` downloads the
   # .dmg once and emits the SRI hash the fetcher pins.
   updateScript =
-    if writeNushellApplication == null then
+    if updateScriptWriter == null then
       null
     else
-      writeNushellApplication {
+      updateScriptWriter {
         name = "dia-update";
         runtimeInputs = [ nix ];
         meta.description = "Refresh packages/dia/manifest.json to a Dia release";

--- a/packages/humanlayer/default.nix
+++ b/packages/humanlayer/default.nix
@@ -5,11 +5,12 @@
   makeWrapper,
   nodejs_22,
   nix,
-  # Bound to a real builder only on the flake-package path (lib/packages.nix),
-  # which is where `nix run .#humanlayer.updateScript` resolves; the overlay path
-  # passes nothing, so `pkgs.humanlayer` carries no updateScript. Same pattern as
+  # Writer used to build `passthru.updateScript`. Bound to a real builder only on
+  # the flake-package path (lib/packages.nix), which is where
+  # `nix run .#humanlayer.updateScript` resolves; the overlay path leaves it
+  # null, so `pkgs.humanlayer` carries no updateScript. Same pattern as
   # packages/yc and packages/agent/claude-code.
-  writeNushellApplication ? null,
+  updateScriptWriter ? null,
 }:
 let
   # Version and per-platform hashes live in manifest.json as the single owner;
@@ -48,10 +49,10 @@ let
   # are authentic, so the real gate is human review of the hash changes in the
   # auto-bump PR. Same posture as packages/yc.
   updateScript =
-    if writeNushellApplication == null then
+    if updateScriptWriter == null then
       null
     else
-      writeNushellApplication {
+      updateScriptWriter {
         name = "humanlayer-update";
         runtimeInputs = [ nix ];
         meta.description = "Refresh packages/humanlayer/manifest.json to the latest HumanLayer CLI release";

--- a/packages/yc/default.nix
+++ b/packages/yc/default.nix
@@ -4,10 +4,11 @@
   fetchurl,
   autoPatchelfHook,
   nix,
-  # Bound to a real builder only on the flake-package path (lib/packages.nix),
-  # which is where `nix run .#yc.updateScript` resolves; the overlay path passes
-  # nothing, so `pkgs.yc` carries no updateScript. Same pattern as claude-code.
-  writeNushellApplication ? null,
+  # Writer used to build `passthru.updateScript`. Bound to a real builder only on
+  # the flake-package path (lib/packages.nix), which is where
+  # `nix run .#yc.updateScript` resolves; the overlay path leaves it null, so
+  # `pkgs.yc` carries no updateScript. Same pattern as claude-code.
+  updateScriptWriter ? null,
 }:
 let
   # Slug map and pinned hashes live in manifest.json as the single owner; this
@@ -39,10 +40,10 @@ let
   # auto-bump PR. The S3 bucket denies ListBucket, hence the `latest` pointer
   # rather than enumerating versions.
   updateScript =
-    if writeNushellApplication == null then
+    if updateScriptWriter == null then
       null
     else
-      writeNushellApplication {
+      updateScriptWriter {
         name = "yc-update";
         runtimeInputs = [ nix ];
         meta.description = "Refresh packages/yc/manifest.json to the latest YC CLI release";


### PR DESCRIPTION
## Problem

Several package definitions accepted `writeNushellApplication ? null` solely so `passthru.updateScript` is present on the flake-package path and omitted on the overlay/plain package path. The name made the guard read oddly — a reader asks why `writeNushellApplication` would ever be null, when the real concept is "this eval context did not provide an updater builder."

## Change

Rename the nullable formal to the capability-oriented `updateScriptWriter` across:

- `packages/agent/claude-code/default.nix`
- `packages/yc/default.nix`
- `packages/humanlayer/default.nix`
- `packages/dia/default.nix`

and update `lib/packages.nix` to inject the writer under the new name. Call-site comments are updated to describe the capability.

`packages/agent/claude-code/update.nix` keeps its own `writeNushellApplication` parameter: that helper receives the builder directly and is never null, so the odd-reading guard the issue describes doesn't apply there.

## Behavior

Unchanged — flake packages still expose `passthru.updateScript`; overlay/plain builds still omit it. Verified:

- `nix eval .#yc.updateScript.name` → `yc-update`; `.#claude-code.updateScript.name` → `claude-code-update`
- Overlay path: `pkgs.claude-code.passthru ? updateScript` → `false`

Closes #1535

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `writeNushellApplication` argument to `updateScriptWriter` in package derivations
> Renames the nullable `writeNushellApplication` optional argument to `updateScriptWriter` across four package derivations ([claude-code](https://github.com/indexable-inc/index/pull/1573/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), [dia](https://github.com/indexable-inc/index/pull/1573/files#diff-8e3d8be48a9106ee0cc3b4331ec6e1acc4cb00397218ff9cda045b0e1c46ea06), [humanlayer](https://github.com/indexable-inc/index/pull/1573/files#diff-33b58e177ce718308782df42303578214fe1610e2e1f6a2ecf4aabdcad99a558), [yc](https://github.com/indexable-inc/index/pull/1573/files#diff-0df35cd256ac3e08097668bd35bc840354461acfc70a04ccf3a15f891af4b421)) to better reflect its role as a writer for `passthru.updateScript`. Also adds `updateScriptWriter` as a named alias in [lib/packages.nix](https://github.com/indexable-inc/index/pull/1573/files#diff-f353132c25d1c6d3f15551dba2d12c8c65c630f707c44f44e14229726bad009c). The internal forwarding to `update.nix` still uses the original `writeNushellApplication` name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa48410.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->