### PR TITLE
Remove fleet image tag plumbing

### DIFF
--- a/doc/ix-fleet/overview.md
+++ b/doc/ix-fleet/overview.md
@@ -78,7 +78,7 @@ each node key matches its `name`; and that every `dependsOn` names a real node.
   `nixosConfigurations` (see `examples/nixos-switch-multi/flake.nix` for a
   direct `ix up` flake and `examples/dev-fleet/default.nix` for the mkDev
   wrapper).
-- **`ReplacementImage`** (`:34`): `imageName`, `imageTag`, `destination`,
+- **`ReplacementImage`** (`:34`): `imageName`, `destination`,
   `source`, `sourceDrv` (the OCI image derivation to realise and push).
 - **`HealthCheck`** (`:54`): `description`, `command` (argv), `timeoutSec`,
   `attempts`, `intervalSec`, `requiresIpv4`, and `from` (`guest`|`host`, stored
@@ -121,7 +121,7 @@ are what `switch` is for.
   builds a spec `{"nodes": {name: {command, depends_on}}}` where each command
   re-invokes `ix-fleet ... _<verb>-node <name>` with the forwarded flags; it also
   adds a serialization edge between nodes that share a
-  `replacementImage.destination` so the same image tag is not pushed twice
+  `replacementImage.destination` so the same replacement image is not pushed twice
   concurrently. `run_dag_runner` resolves the runner from `IX_FLEET_DAG_RUNNER`
   or `dag-runner` on `PATH`, writes a temp spec, execs it, and turns a nonzero
   exit into the process exit status. `--dry-run` runs the per-node workflows

--- a/examples/declared-groups/ix.nix
+++ b/examples/declared-groups/ix.nix
@@ -1,6 +1,5 @@
 { index }:
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "declared-groups"; } ];
 
   nodes = {
     # No fleet-level `groups`: the api image itself declares

--- a/examples/east-west-firewall/ix.nix
+++ b/examples/east-west-firewall/ix.nix
@@ -3,7 +3,6 @@ let
   eastWestGroup = "east-west-firewall";
 in
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "east-west-firewall"; } ];
 
   nodes = {
     service = {

--- a/examples/hermes-agent/ix.nix
+++ b/examples/hermes-agent/ix.nix
@@ -1,7 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "hermes-agent"; } ];
 
   nodes.hermes = {
     modules = [

--- a/examples/hermes-api-server/ix.nix
+++ b/examples/hermes-api-server/ix.nix
@@ -11,7 +11,6 @@ let
   eastWestGroup = "hermes-api";
 in
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "hermes-api-server"; } ];
 
   nodes.hermes = {
     groups = [ eastWestGroup ];

--- a/examples/hermes-minecraft-operator/ix.nix
+++ b/examples/hermes-minecraft-operator/ix.nix
@@ -15,7 +15,6 @@ let
   eastWestGroup = "hermes-minecraft";
 in
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "hermes-minecraft-operator"; } ];
 
   nodes = {
     minecraft = {

--- a/examples/hermes-telegram/ix.nix
+++ b/examples/hermes-telegram/ix.nix
@@ -5,7 +5,6 @@
 # at /run/secrets/hermes.env), plus the long-poll Telegram platform and
 # a chat-tuned persona. See README.md for the BotFather walkthrough.
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "hermes-telegram"; } ];
 
   nodes.hermes = {
     modules = [

--- a/examples/minecraft-blocks/ix.nix
+++ b/examples/minecraft-blocks/ix.nix
@@ -18,7 +18,6 @@ let
   eastWestGroup = "minecraft-blocks";
 in
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "minecraft-blocks"; } ];
 
   nodes = {
     # The single durable, replayable source of truth.

--- a/examples/minecraft/crazy-terrain/ix.nix
+++ b/examples/minecraft/crazy-terrain/ix.nix
@@ -1,7 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "crazy-terrain"; } ];
 
   nodes.crazy-terrain = {
     # The minecraft module declares `ix.healthChecks.minecraft`; `ix-fleet up`

--- a/examples/minecraft/factions/ix.nix
+++ b/examples/minecraft/factions/ix.nix
@@ -1,10 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  # The tag is shared by every replacement image this example builds, so
-  # registry destinations read `factions:factions` instead of `:latest`.
-  defaults = [ { ix.image.tag = "factions"; } ];
-
   nodes.factions = {
     deployment.ipv4 = true;
     modules = [ ./minecraft.nix ];

--- a/examples/minecraft/survival/ix.nix
+++ b/examples/minecraft/survival/ix.nix
@@ -1,7 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "survival"; } ];
 
   nodes.survival = {
     # The minecraft module declares `ix.healthChecks.minecraft`; `ix-fleet up`

--- a/examples/multi-client-file-sharing/ix.nix
+++ b/examples/multi-client-file-sharing/ix.nix
@@ -1,7 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "multi-client-file-sharing"; } ];
 
   nodes = {
     file-server.modules = [ ./server.nix ];

--- a/examples/nginx-lifecycle/ix.nix
+++ b/examples/nginx-lifecycle/ix.nix
@@ -1,7 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "nginx-lifecycle"; } ];
 
   nodes.nginx = {
     deployment.recreateOnUp = true;

--- a/examples/nixos-switch/README.md
+++ b/examples/nixos-switch/README.md
@@ -41,9 +41,7 @@ nothing is recreated.
 
 ## Fork it
 
-Copy this directory into your own repo, keep `flake.nix` as the entrypoint, and change `ix.image.tag` in
-`ix.nix` to your own registry namespace. The switch path needs no admin
-rights: it builds and activates your own system onto your own VM.
+Copy this directory into your own repo and keep `flake.nix` as the entrypoint. The switch path needs no admin rights: it builds and activates your own system onto your own VM.
 
 ## Scope
 

--- a/examples/nixos-switch/ix.nix
+++ b/examples/nixos-switch/ix.nix
@@ -5,7 +5,6 @@
 # running VM in place. Edit `configuration.nix`, run it again, and the VM
 # converges.
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "nixos-switch"; } ];
 
   nodes.devbox = {
     modules = [ ./configuration.nix ];

--- a/examples/observability-stack/ix.nix
+++ b/examples/observability-stack/ix.nix
@@ -3,7 +3,6 @@ let
   eastWestGroup = "observability-stack";
 in
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "observability-stack"; } ];
 
   nodes = {
     observability = {

--- a/examples/polyglot-dev/ix.nix
+++ b/examples/polyglot-dev/ix.nix
@@ -1,7 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "polyglot-dev"; } ];
 
   nodes.workbench = {
     modules = [ ./tools.nix ];

--- a/examples/python-daily-scraper/ix.nix
+++ b/examples/python-daily-scraper/ix.nix
@@ -1,7 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "daily-scraper"; } ];
 
   nodes.scraper = {
     modules = [

--- a/examples/ray-cluster/ix.nix
+++ b/examples/ray-cluster/ix.nix
@@ -3,7 +3,6 @@ let
   eastWestGroup = "ray-cluster";
 in
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "ray-cluster"; } ];
 
   nodes = {
     ray-head = {

--- a/examples/s3-storage/ix.nix
+++ b/examples/s3-storage/ix.nix
@@ -1,7 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "s3-storage"; } ];
 
   # No `recreateOnUp`: this node holds object data, so it persists across
   # `ix-fleet up` instead of being rebuilt each time like the nginx demo.

--- a/examples/synced-github-auth/ix.nix
+++ b/examples/synced-github-auth/ix.nix
@@ -1,7 +1,6 @@
 { index }:
 
 index.lib.mkFleet {
-  defaults = [ { ix.image.tag = "synced-github-auth"; } ];
 
   # One GitHub token, declared once for the whole fleet. `ix.secrets`
   # normalizes this into a runtime path every node sees at the same place

--- a/images/system/base/default.nix
+++ b/images/system/base/default.nix
@@ -1,8 +1,5 @@
 # Minimal ix VM base image. `lib/image/oci-layer.nix` auto-enables the shared
 # base profile for every image, so this module only names the publish target.
 {
-  ix.image = {
-    name = "ix/base";
-    tag = "latest";
-  };
+  ix.image.name = "ix/base";
 }

--- a/lib/image/dev.nix
+++ b/lib/image/dev.nix
@@ -110,7 +110,6 @@ let
           { name, ... }:
           {
             ix.image.name = lib.mkDefault name;
-            ix.image.tag = lib.mkDefault "ix-dev";
           }
         )
         module

--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -243,9 +243,8 @@ let
     let
       config = nodeConfigs.${name};
       imageName = config.ix.image.name;
-      imageTag = config.ix.image.tag;
       deploy = spec.deployment;
-      replacementDestination = deploy.destination or "${imageName}:${imageTag}";
+      replacementDestination = deploy.destination or "${imageName}:latest";
       switchBuildOn = deploy.switch.buildOn or "remote";
       ipv4HealthChecks = lib.filterAttrs (_: check: check.requiresIpv4) config.ix.healthChecks;
       # ix up expects a system out-path for local copy and a .drv for remote
@@ -290,10 +289,7 @@ let
       };
       inherit (deploy) bootstrapImage;
       replacementImage = {
-        inherit
-          imageName
-          imageTag
-          ;
+        inherit imageName;
         destination = replacementDestination;
         source = unsafeDiscardStringContext "${config.ix.build.ociImage}";
         sourceDrv = unsafeDiscardStringContext config.ix.build.ociImage.drvPath;

--- a/lib/image/oci-layer.nix
+++ b/lib/image/oci-layer.nix
@@ -19,11 +19,6 @@
         type = lib.types.str;
         description = "Image name (the OCI repository).";
       };
-      tag = lib.mkOption {
-        type = lib.types.str;
-        default = "latest";
-        description = "Image tag.";
-      };
     };
     build.ociImage = lib.mkOption {
       type = lib.types.package;
@@ -82,7 +77,8 @@
         '';
 
         stream = pkgs.dockerTools.streamLayeredImage {
-          inherit (config.ix.image) name tag;
+          inherit (config.ix.image) name;
+          tag = "latest";
           # Below the 127-layer registry limit with headroom for systemRoot
           # plus a few user layers.
           maxLayers = 67;

--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -31,7 +31,6 @@ let
       bootstrapImage = "registry.ix.dev/ix/base:latest";
       replacementImage = {
         imageName = "api";
-        imageTag = "latest";
         destination = "registry.ix.dev/example/api:latest";
         source = "/nix/store/api-image.tar";
         sourceDrv = "/nix/store/api-image.drv";
@@ -84,7 +83,6 @@ let
       bootstrapImage = "registry.ix.dev/ix/base:latest";
       replacementImage = {
         imageName = name;
-        imageTag = "latest";
         destination = "registry.ix.dev/example/${name}:latest";
         source = "/nix/store/${name}-image.tar";
         sourceDrv = "/nix/store/${name}-image.drv";

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -35,7 +35,6 @@ class ReplacementImage(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     imageName: str = Field(min_length=1)
-    imageTag: str = Field(min_length=1)
     destination: str = Field(min_length=1)
     source: str = Field(min_length=1)
     sourceDrv: str = Field(min_length=1)

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -25,7 +25,6 @@ def fleet_node(name: str, *, depends_on: list[str] | None = None) -> dict[str, t
         "bootstrapImage": "registry.ix.dev/ix/base:latest",
         "replacementImage": {
             "imageName": name,
-            "imageTag": "latest",
             "destination": f"registry.ix.dev/example/{name}:latest",
             "source": f"/nix/store/{name}-image.tar",
             "sourceDrv": f"/nix/store/{name}-image.drv",
@@ -179,7 +178,6 @@ class PushReplacementImageTests(unittest.TestCase):
                     "bootstrapImage": "registry.ix.dev/ix/base:latest",
                     "replacementImage": {
                         "imageName": "health-check-nginx",
-                        "imageTag": "nginx-lifecycle",
                         "destination": "health-check-nginx:nginx-lifecycle",
                         "source": str(source),
                         "sourceDrv": "/nix/store/example-image.drv",

--- a/packages/minecraft/catalogs/versions.nix
+++ b/packages/minecraft/catalogs/versions.nix
@@ -63,14 +63,13 @@ let
   };
 
   mkVariant =
-    tag:
+    _tag:
     {
       loader,
       version,
       mods,
     }:
     {
-      ix.image.tag = tag;
       services.minecraft = {
         inherit version;
         mods = lib.genAttrs mods (_: { });

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -78,10 +78,7 @@ let
   minecraftBedrockModule =
     { config, ... }:
     {
-      ix.image = {
-        name = "minecraft-bedrock";
-        tag = config.services.minecraft-bedrock.package.version;
-      };
+      ix.image.name = "minecraft-bedrock";
 
       services.minecraft-bedrock = {
         enable = true;
@@ -637,10 +634,7 @@ let
     let
       config = evalConfig [
         {
-          ix.image = {
-            name = "test/symphony-module";
-            tag = "test";
-          };
+          ix.image.name = "test/symphony-module";
           services.symphony = {
             enable = true;
             package = pkgs.hello;
@@ -2800,9 +2794,8 @@ let
         message = "base profile should reserve ix guest sidecar listener ports";
       }
       {
-        assertion =
-          base.imageConfig.ix.image.name == "ix/base" && base.imageConfig.ix.image.tag == "latest";
-        message = "base image should publish as ix/base:latest";
+        assertion = base.imageConfig.ix.image.name == "ix/base";
+        message = "base image should publish from the ix/base repository";
       }
       {
         assertion = lib.elemAt base.config.nix.settings.substituters 0 == "https://cache.ix.dev";
@@ -3052,10 +3045,7 @@ let
         message = "python-daily-scraper fleet plan should include a guest-side timer health check";
       }
       {
-        assertion =
-          !dailyScraperExample.plan.ipv4
-          && dailyScraperExample.plan.snapshot
-          && dailyScraperExample.plan.replacementImage.imageTag == "daily-scraper";
+        assertion = !dailyScraperExample.plan.ipv4 && dailyScraperExample.plan.snapshot;
         message = "python-daily-scraper fleet plan should keep the worker private with snapshots on";
       }
       {
@@ -3659,8 +3649,8 @@ let
 
     minecraft = [
       {
-        assertion = minecraft.config.ix.image.tag == defaultMinecraftVersion;
-        message = "default Minecraft module tag should follow versions.nix default";
+        assertion = minecraft.cfg.version == "26.1.2";
+        message = "default Minecraft module should follow versions.nix default runtime version";
       }
       {
         assertion = minecraft.cfg.properties."max-players" == 100000;


### PR DESCRIPTION
## Summary

- remove `ix.image.tag` from the image module surface
- make mkFleet default replacement destinations use `<imageName>:latest` without reading or emitting `imageTag`
- remove example fleet `defaults = [ { ix.image.tag = ...; } ];` blocks and update tests/docs

## Validation

- `git diff --check`
- `nix-instantiate --parse` on changed Nix files
- `nix eval --impure --json --expr <sample fleet replacementImage attrNames>` confirms replacement images now expose `destination`, `imageName`, `source`, and `sourceDrv`
- `nix eval --impure --json --expr <tryEval image tag option>` returns `false`, confirming `ix.image.tag` is no longer accepted

Known local blockers, reproduced on `origin/main` where applicable:

- `nix build .#ix-fleet --no-link` fails on main and this branch with ix-sdk type stubs missing `list_secrets`, `secrets`, and `no_default_secrets`
- `nix build .#check --no-link` fails on aarch64-darwin because `repoPackages.nix-fast-build` is missing
- `nix build .#packages.x86_64-linux.check --no-link` cannot build x86_64-linux `nix-fast-build` on this aarch64-darwin host

Refs #1574

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `ix.image.tag` from fleet image configuration
> - Removes `ix.image.tag` as a configurable option across the fleet image pipeline: [oci-layer.nix](https://github.com/indexable-inc/index/pull/1575/files#diff-2f593cc5e1a07acba76a950c1132a06b5d7646750989d806816be811310a32f4), [fleet.nix](https://github.com/indexable-inc/index/pull/1575/files#diff-9836ea3ef1875452d04d6213563ea9b0df81e37a277277836b0cb9df0ced1fa0), and the `ReplacementImage` Pydantic model in [__init__.py](https://github.com/indexable-inc/index/pull/1575/files#diff-d83777ed2e90ee1f7371ffa0e55fe375c817b07e2cb2a15a5b58423ad93dae3e).
> - OCI images are now always streamed with the `latest` tag; all example fleet configs and the Minecraft catalog drop their per-variant tag overrides accordingly.
> - `replacementImage.destination` defaults to `<imageName>:latest` and the `imageTag` field is removed from the `ReplacementImage` payload entirely.
> - Behavioral Change: any caller constructing a `ReplacementImage` that passes `imageTag` will now fail Pydantic validation; concurrency serialization uses the destination string rather than a separate tag field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bbbdcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->