### PR TITLE
Retire Cachix, route the CI cache through cache.ix.dev

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -23,7 +23,7 @@ concurrency:
 env:
   # The self-hosted runner's Nix daemon owns substituters; the job only sets
   # client-side eval knobs (matching check.yml). `accept-flake-config` consumes
-  # the flake's nixConfig (the indexable-inc Cachix substituter) without a
+  # the flake's nixConfig (the cache.ix.dev substituter) without a
   # prompt, which the inner nix-eval-jobs run needs to fetch the IFD closure.
   # `ca-derivations`: the rust units default to contentAddressed = true, so the
   # `.#checks` eval this job forces resolves content-addressed drvs. Without it

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,13 +23,12 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  # The self-hosted runner's Nix daemon owns substituters (the indexable-inc
-  # Cachix plus the host's local cache), so the job only sets client-side eval
-  # knobs here rather than installing Nix or managing a GitHub Actions store
-  # cache.
+  # The self-hosted runner's Nix daemon owns substituters (cache.ix.dev plus the
+  # host's local cache), so the job only sets client-side eval knobs here rather
+  # than installing Nix or managing a GitHub Actions store cache.
   #
-  # `accept-flake-config`: consume the flake's nixConfig (the indexable-inc
-  # Cachix substituter) without an interactive prompt.
+  # `accept-flake-config`: consume the flake's nixConfig (the cache.ix.dev
+  # substituter) without an interactive prompt.
   #
   # `extra-system-features = gccarch-znver5`: every image pins
   # `nixpkgs.hostPlatform.gcc.arch = "znver5"`, marking each derivation in the

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Surfaced at job level so the push step's `if` can gate on the signing key
+    # being configured. That lets this repo's change land before the operator
+    # finishes the ix-side write endpoint + secrets without reddening Pages: the
+    # push is simply skipped until IX_PUBLIC_CI_SIGNING_KEY exists.
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.IX_PUBLIC_S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.IX_PUBLIC_S3_SECRET_ACCESS_KEY }}
+      IX_PUBLIC_CI_SIGNING_KEY: ${{ secrets.IX_PUBLIC_CI_SIGNING_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -25,17 +33,35 @@ jobs:
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
         with:
+          # Read repo-owned artifacts from the ix public cache (the ix-public
+          # flat cache, with cache.nixos.org fallthrough). accept-flake-config
+          # would pull the same substituter from the flake nixConfig; pinning it
+          # here keeps the step self-describing.
           extra-conf: |
             accept-flake-config = true
-
-      - name: Set up Cachix
-        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        with:
-          name: indexable-inc
-          authToken: ${{ github.event_name == 'push' && secrets.CACHIX_AUTH_TOKEN || '' }}
+            extra-substituters = https://cache.ix.dev
+            extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
 
       - name: Build site
         run: nix build .#site -L
+
+      # Publish the built closure to the ix public cache so later CI runs and ix
+      # VMs substitute it instead of rebuilding. The public cache.ix.dev vhost is
+      # read-only, so writes go to the S3 API at s3.cache.ix.dev; `secret-key=`
+      # signs each NAR as it is copied (mirrors ix's on-fabric ix-public-cache-push).
+      # `push` (main) only -- PR runs lack secrets and untrusted builds must not
+      # reach the public cache -- and skipped until the signing key is configured,
+      # so this change and the ix write endpoint can land in either order.
+      - name: Push to cache.ix.dev
+        if: github.event_name == 'push' && env.IX_PUBLIC_CI_SIGNING_KEY != ''
+        run: |
+          set -euo pipefail
+          keyfile=$(mktemp)
+          trap 'rm -f "$keyfile"' EXIT
+          printf '%s' "$IX_PUBLIC_CI_SIGNING_KEY" > "$keyfile"
+          nix copy \
+            --to "s3://ix-public?endpoint=s3.cache.ix.dev&scheme=https&region=garage&secret-key=$keyfile&compression=zstd&write-nar-listing=true" \
+            ./result
 
       - name: Prepare Pages artifact
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,7 +9,7 @@ on:
     # discovered from the registry, so adding a package with an updateScript
     # needs no change here. claude-code promotes builds several times a week, so
     # check hourly to advance the open PR within the hour. A no-op run is a
-    # Cachix hit and the updater reuses one branch, so this stays cheap and
+    # cache hit and the updater reuses one branch, so this stays cheap and
     # never stacks PRs. flake.lock is updated by its own reusable workflow
     # (update-flake-lock.yml), not here.
     - cron: "37 * * * *"
@@ -31,18 +31,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # `accept-flake-config` lets the job consume the flake's indexable-inc
-      # Cachix substituter without a prompt.
+      # `accept-flake-config` lets the job consume the flake's cache.ix.dev
+      # substituter without a prompt.
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
         with:
+          # Read-only: the updater only needs warm substitutes to verify a freshly
+          # pinned hash builds. Publishing happens when the resulting PR merges and
+          # flake-check rebuilds on the self-hosted runners (which push to ix-ci).
           extra-conf: |
             accept-flake-config = true
-
-      - name: Set up Cachix
-        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        with:
-          name: indexable-inc
+            extra-substituters = https://cache.ix.dev
+            extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
 
       # Runs every content updater in parallel via dag-runner (see
       # lib/per-system.nix). Each regenerates its own source files relative to

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,21 @@
 {
   description = "Index developer tools, modules, and fleet examples";
 
-  # Keep the repo cache available for repo-owned tools that CI has already built. Generic nixpkgs paths still substitute from
-  # cache.nixos.org.
+  # Keep the repo cache available for repo-owned tools that CI has already built.
+  # `cache.ix.dev` is the ix public flat cache (the S3-backed `ix-public` bucket);
+  # it serves repo-owned artifacts and 404-falls-through to cache.nixos.org for
+  # generic nixpkgs paths, so a single substituter covers both. ix's own builds
+  # sign `ix-workspace:`; GitHub-hosted CI pushes (pages.yml) sign with the
+  # dedicated `ix-public-ci:` key.
   nixConfig = {
-    extra-substituters = [ "https://indexable-inc.cachix.org" ];
+    extra-substituters = [ "https://cache.ix.dev" ];
     extra-trusted-public-keys = [
-      "indexable-inc.cachix.org-1:HQ5mjdOyhgNjLVhjv0qgVMJ5YiO1zEEVMAtF9mTcpiI="
+      "ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI="
+      # TODO(ix-public-ci): at go-live, add the dedicated GitHub-hosted-CI signer
+      # here as "ix-public-ci:<pubkey>" once an operator runs `nix key
+      # generate-secret --key-name ix-public-ci-1` (see the cache.ix.dev
+      # write-path runbook in ../ix). Until then, paths pushed by pages.yml are
+      # not verifiable by consumers of this flake; ix-workspace-signed reads work.
     ];
     # The rust workspace units default to `contentAddressed = true`
     # (lib/rust/cargo-unit.nix), so evaluating `.#checks` / `.#packages`

--- a/modules/services/ci-runner/README.md
+++ b/modules/services/ci-runner/README.md
@@ -2,7 +2,7 @@
 
 Self-hosted GitHub Actions runners for this repository, registered as a small
 static pool on a persistent NixOS host. The point is cache locality: jobs share
-the host's `/nix/store` and the indexable-inc Cachix substituter, so a
+the host's `/nix/store` and the cache.ix.dev public substituter, so a
 `nix build .#...` step substitutes warm artifacts instead of rebuilding from a
 cold store on a throwaway cloud VM.
 
@@ -32,8 +32,8 @@ repository's self-hosted runners. A one-hour registration token does not work
 because ephemeral runners mint a new registration on every restart.
 
 The module wraps NixOS [`services.github-runners`][upstream] and adds the
-indexable-inc Cachix substituter and trusted key to `nix.settings`, plus `git`,
-`gh`, `cachix`, and the host's Nix on each job's PATH.
+cache.ix.dev substituter and its trusted keys to `nix.settings`, plus `git`,
+`gh`, and the host's Nix on each job's PATH.
 
 ## Opt a workflow in
 

--- a/modules/services/ci-runner/default.nix
+++ b/modules/services/ci-runner/default.nix
@@ -1,7 +1,7 @@
 # Self-hosted GitHub Actions runners for this repository, meant to run on a
 # persistent NixOS host instead of an ephemeral cloud VM. The win is cache
-# locality: jobs reuse the host's global /nix/store and the indexable-inc
-# Cachix substituter, so `nix build .#...` pulls warm artifacts instead of
+# locality: jobs reuse the host's global /nix/store and the cache.ix.dev
+# public substituter, so `nix build .#...` pulls warm artifacts instead of
 # rebuilding from a cold store every run. The per-job work directory is still
 # wiped (see `ephemeral`); only the shared store survives, which is exactly the
 # state that is safe to keep between jobs.
@@ -87,8 +87,8 @@ in
       default = [ ];
       example = lib.literalExpression "[ pkgs.gh pkgs.jq ]";
       description = ''
-        Extra packages on each job's PATH, on top of the git, Nix, and Cachix
-        tooling the module always provides.
+        Extra packages on each job's PATH, on top of the git and Nix tooling
+        the module always provides.
       '';
     };
   };
@@ -106,9 +106,12 @@ in
       # Consume the repo flake's nixConfig substituters without the interactive
       # prompt; `nix flake check` otherwise stalls waiting for confirmation.
       accept-flake-config = true;
-      extra-substituters = [ "https://indexable-inc.cachix.org" ];
+      extra-substituters = [ "https://cache.ix.dev" ];
       extra-trusted-public-keys = [
-        "indexable-inc.cachix.org-1:HQ5mjdOyhgNjLVhjv0qgVMJ5YiO1zEEVMAtF9mTcpiI="
+        "ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI="
+        # TODO(ix-public-ci): at go-live, add "ix-public-ci:<pubkey>" (the
+        # GitHub-hosted-CI signer) here, matching the index flake nixConfig and
+        # ix's nix-settings.nix. See the cache.ix.dev write-path runbook in ../ix.
       ];
       # Index images pin `gcc.arch = znver5`, so every derivation in the closure
       # requires this builder feature; advertise it or the daemon refuses the
@@ -124,7 +127,6 @@ in
       # failing on a name clash with the already-registered runner.
       replace = true;
       extraPackages = [
-        pkgs.cachix
         pkgs.gh
         pkgs.git
         config.nix.package

--- a/packages/minecraft/minecraft/sound/sounds.nix
+++ b/packages/minecraft/minecraft/sound/sounds.nix
@@ -6,7 +6,7 @@
 # that DOWNLOADS them from Mojang's official CDN at build time on the building
 # machine; it does not vendor them in this repo. The resulting store path
 # therefore contains Mojang content and MUST NOT be pushed to any shared or
-# public binary cache (e.g. `indexable-inc.cachix.org`), nor included in any
+# public binary cache (e.g. `cache.ix.dev`), nor included in any
 # image closure that gets cached or distributed. Each machine that wants
 # sounds builds this path locally from Mojang. Keep it out of CI cache pushes.
 {


### PR DESCRIPTION
## What

Retires `indexable-inc.cachix.org` and moves the repo's binary cache to the ix public flat cache **`https://cache.ix.dev`** (the S3-backed `ix-public` bucket, with a `cache.nixos.org` 404-fallthrough). Pairs with the write-endpoint PR indexable-inc/ix#5570.

## Changes

- **Reads (everywhere):** `flake.nix` nixConfig and `modules/services/ci-runner/` swap the substituter/key to `cache.ix.dev` + `ix-workspace:…`; dropped `pkgs.cachix`.
- **`pages.yml`:** replaces `cachix-action` with a read-config plus a **`main`-only push** to the S3 write endpoint (`s3.cache.ix.dev`), signed with the dedicated `ix-public-ci` key. The push is **gated on the signing-key secret existing** (`env.IX_PUBLIC_CI_SIGNING_KEY != ''`), so this can land before the ix-side endpoint is stood up without reddening Pages.
- **`update.yml`:** read-only swap (it runs on `schedule`/`workflow_dispatch`, never `push`, and didn't push before — kept that way).
- Comment-only fixups in `check.yml`, `blast-radius.yml`, `sounds.nix`.

## Why this is safe to merge now

Reads from `cache.ix.dev` (ix-workspace-signed artifacts + nixos.org fallthrough) work immediately. The push step self-skips until an operator adds the `IX_PUBLIC_CI_SIGNING_KEY` secret, so the two PRs can land in either order.

## Follow-up (go-live, gated)

The real `ix-public-ci:<pubkey>` trusted key (a `TODO` here) plus the GitHub secrets land per the operator runbook in indexable-inc/ix#5570 (`docs/ci/build-cache/public-write-path.md`).

## Verification

`actionlint` clean on `pages.yml`/`update.yml`; all edited Nix parses. Repo `nix run .#lint` couldn't realize `astlog` locally (untrusted-substituter, environmental) — changes are comment/string/list-element only and introduce no new Nix constructs, so CI lint should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace Cachix with cache.ix.dev as the CI binary cache
> - Updates all CI workflows, the Nix flake, and the self-hosted runner module to use `https://cache.ix.dev` as the substituter with the `ix-workspace` trusted public key, replacing the previous Cachix endpoint.
> - The [pages workflow](.github/workflows/pages.yml) now pushes built closures to the S3 write endpoint at `s3.cache.ix.dev` on push events when `IX_PUBLIC_CI_SIGNING_KEY` is set.
> - Removes the Cachix CLI setup step from all workflows and drops `pkgs.cachix` from the self-hosted runner's preinstalled packages.
> - Updates `nixConfig` in [flake.nix](https://github.com/indexable-inc/index/pull/1578/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) so flake consumers also resolve substitutes from `cache.ix.dev`.
> - Behavioral Change: jobs running on self-hosted runners will no longer have the Cachix CLI available on PATH.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b616aa8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->