### PR TITLE
perf(nix): pin nixpkgs registry — 21min → 1s for nix shell

### DIFF
--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -525,6 +525,21 @@ in
     # keeps recent results for repeat invocations and bounds disk growth.
     # Optimise hardlinks duplicate store paths so the savings compound.
     nix = {
+      # Pin the system flake registry so `nix shell nixpkgs#foo` resolves
+      # against the nixpkgs bundled in the image instead of fetching a
+      # fresh tarball from GitHub on every invocation. Without this pin,
+      # the global registry's `github:NixOS/nixpkgs/nixpkgs-unstable`
+      # entry wins: nix downloads ~40 MB, extracts 100k files into
+      # /nix/store, and evaluates the entire tree — 20+ minutes on VCFS
+      # vs ~1 second with the pin. Every production NixOS VM deployment
+      # (microvm.nix, Devbox, fleet images) pins this.
+      registry.nixpkgs.to = {
+        type = "path";
+        path = pkgs.path;
+      };
+      # Also set NIX_PATH so legacy nix-shell / <nixpkgs> imports resolve
+      # without a channel subscription or network fetch.
+      nixPath = [ "nixpkgs=${pkgs.path}" ];
       settings = {
         experimental-features = [
           "nix-command"


### PR DESCRIPTION
## Summary
- Pin `nix.registry.nixpkgs` to `pkgs.path` in the shared image platform module
- Set `nix.nixPath` so legacy `<nixpkgs>` imports resolve locally

## Problem
Every `nix shell nixpkgs#foo` in an ix VM resolves the global registry (`github:NixOS/nixpkgs/nixpkgs-unstable`), re-fetches ~40MB from GitHub, extracts 100k files to VCFS, and evaluates the full tree. On VCFS this takes 20+ minutes.

## Fix
One config block: pin the system flake registry to the nixpkgs source already bundled in the image. Standard practice across microvm.nix, Devbox, and every production NixOS deployment.

## Measured
On anthony-compute-1 (ix dev node):
- Before: `nix shell nixpkgs#cowsay` = **21 minutes**
- After pin: `nix shell nixpkgs#figlet` = **1.1 seconds**
- `nix shell nixpkgs#fastfetch` (30 deps) = **3.6 minutes** (download time, not eval)

## Test plan
- [x] Tested `nix registry pin nixpkgs` manually on running VM — confirmed 1140x speedup
- [ ] Build ix/base image with this change
- [ ] Boot VM, verify `nix shell nixpkgs#hello` completes in <10s

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin nixpkgs registry in Nix image config to reduce `nix shell` startup from 21min to 1s
> Sets `registry.nixpkgs.to` and `nixPath` in [platform.nix](https://github.com/indexable-inc/index/pull/1579/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7) to point at the image-bundled `pkgs.path`. This makes both the flake registry (`nix shell nixpkgs#...`) and legacy NIX_PATH (`nix-shell`, `<nixpkgs>` imports) resolve locally instead of fetching from the network.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7a5e17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->