### PR TITLE
Make worktree-first prompt explicit

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -30,8 +30,8 @@
 #   - tieToIssue: every unit of real work is traceable to a GitHub/Linear issue.
 #   - namedSubagents: phases run as named subagents for a legible, grouped view.
 #   - reportToPlaybook / htmlDeliverable: durable writeups land in the ix playbook (+ #general link); the immediate human answer is an HTML file.
-# Safety-critical rules (force-merge gate, guards, worktree, stacked rebase) are
-# kept byte-exact.
+# Safety-critical rules (force-merge gate, guards, worktree, stacked rebase)
+# stay explicit and hard to miss.
 let
   shokunin = ''
     Be shokunin: keep code and prose concise, readable, and clean by default.
@@ -147,8 +147,10 @@ let
   '';
 
   worktree = ''
-    Always work in a dedicated git worktree on its own branch. Never edit the
-    primary checkout. If an edit would touch it, stop and create a worktree.
+    Before changing files in a repository, your first step is to create or enter
+    a dedicated git worktree on its own branch. Use `git worktree` rather than
+    editing the primary checkout. If you discover you are in the primary
+    checkout, stop before editing and create a worktree.
   '';
 
   shellCwd = ''
@@ -407,6 +409,7 @@ let
   order = [
     { name = "shokunin"; text = shokunin; }
     { name = "promptSource"; text = promptSource; }
+    { name = "worktree"; text = worktree; }
     { name = "validate"; text = validate; }
     { name = "liveSystemEvidence"; text = liveSystemEvidence; }
     { name = "reproduceClaims"; text = reproduceClaims; }
@@ -421,7 +424,6 @@ let
     { name = "oneImplementation"; text = oneImplementation; }
     { name = "separateDefinitions"; text = separateDefinitions; }
     { name = "fixAtSource"; text = fixAtSource; }
-    { name = "worktree"; text = worktree; }
     { name = "shellCwd"; text = shellCwd; }
     { name = "backgroundSubagents"; text = backgroundSubagents; }
     { name = "modelTiering"; text = modelTiering; }


### PR DESCRIPTION
## Summary
- move the worktree rule near the top of the rendered system prompt
- make it say the first step before changing repository files is to create or enter a dedicated `git worktree`
- update the nearby comment so safety-critical rules are explicit rather than claiming byte-exact wording

## Validation
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`

Refs #1581

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make worktree-first guidance explicit in agent system prompt
> - Rewrites the `worktree` section in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1582/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to explicitly require creating or entering a dedicated git worktree on its own branch before editing any files.
> - Adds a direct instruction to stop and create a worktree if the agent finds itself in the primary checkout.
> - Moves the `worktree` entry earlier in the assembled prompt sequence, immediately after `promptSource`, so the rule appears before other guidance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18aec91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->