### PR TITLE
docs(ix): platform docs for the agent funnel (ENG-5165)

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -7,7 +7,32 @@ From-source documentation for the packages in the `index` repo (a shared, open-s
 - `doc/<package>/` mirrors `packages/<package>/`, one directory per package.
 - Each package dir has an `overview.md`; larger packages add concern pages.
 - Pages cite real `path:line` references into the package source.
+- Every page opens with its title and a one-line summary, so this index (and an
+  agent's `llms.txt` map) can be generated from the pages themselves.
+- `doc/ix/` is the platform guide for users of the hosted `ix` platform (the
+  CLI, fleets, networking, secrets, ...). Those pages defer CLI flags to
+  `ix <verb> --help` and cite only public source. Start at
+  [ix/overview.md](ix/overview.md).
 - The `doc/assets/demo-*` files are README assets, not documentation pages.
+
+## ix platform
+
+User-facing guides for the hosted `ix` platform. Start at
+[ix/overview.md](ix/overview.md); it routes to the rest.
+
+| page | summary |
+| --- | --- |
+| [ix/overview.md](ix/overview.md) | The platform map: open-source vs hosted boundary, a first VM, and where each "how do I" lives. |
+| [ix/cli.md](ix/cli.md) | The `ix` verb map and mental model; flags live in `ix <verb> --help`. |
+| [ix/lifecycle.md](ix/lifecycle.md) | "I want to X" -> command: create, run, converge, stop, snapshot, destroy (single VM and fleet). |
+| [ix/fleet.md](ix/fleet.md) | Declarative multi-VM fleets via the separate `ix-fleet` tool. |
+| [ix/images.md](ix/images.md) | Build an image, tag and push to `registry.ix.dev`, boot a VM from it. |
+| [ix/networking.md](ix/networking.md) | Expose ports, private VM-to-VM groups, `<host>.ix.internal`, and public ingress. |
+| [ix/secrets.md](ix/secrets.md) | Declare a secret, attach it to a VM, materialize it in the guest. |
+| [ix/health-checks.md](ix/health-checks.md) | Write checks; `from: guest` vs `from: host`; the `unit:` shortcut. |
+| [ix/services.md](ix/services.md) | The ready-made services in `modules/services/` and how to enable one. |
+| [ix/environment.md](ix/environment.md) | The user-facing `IX_*` and credential environment variables. |
+| [ix/glossary.md](ix/glossary.md) | Disambiguate overloaded names: search, run, mcp, fleet, dashboard, index. |
 
 ## Packages
 

--- a/doc/ix/cli.md
+++ b/doc/ix/cli.md
@@ -1,0 +1,81 @@
+# ix CLI
+
+`ix` is the platform CLI for running your own microVMs: you create them, attach to
+them, and tear them down by name. This page is the verb
+map and the mental model, not a flag reference. For flags on any verb, run
+`ix <verb> --help`.
+
+## Mental model
+
+- **You own VMs.** A VM is a boot image wrapped in an ix boundary: networking,
+  logs, shell, snapshots, lifecycle. Name them with
+  `--name`, list with `ix ls`, address every later command by that name.
+- **`ix up` is declarative.** It builds your repo's NixOS config and converges the
+  VM in place, the same contract as `nixos-rebuild switch`: re-running
+  reconverges, with no separate switch command. Default
+  target is `.`.
+- **`ix new` / `ix run` are imperative one-offs.** `new` boots an OCI image as a
+  long-running VM; `run` boots a fresh VM, runs one command,
+  streams its output, and leaves the VM up. Reach for `up`
+  for a config you own and re-converge; reach for `new`/`run` for a quick image.
+- **Fleets are a separate tool.** Multi-VM declarative fleets live in `ix-fleet`
+  (`nix run .#ix-fleet -- --plan plan.json <verb>`), not in `ix`. See
+  [fleet.md](fleet.md). There is no `ix down`, `ix health`, `ix diff`, or
+  `ix fleet`. Single-VM teardown is `ix rm` (or `ix stop` to keep it).
+
+## Verbs
+
+Hidden/debug verbs are omitted; nested
+actions show as `verb <action>`.
+
+| group | verb | what it does |
+| --- | --- | --- |
+| Provision | `new [image]` | Boot an OCI image (default `ix/base:latest`) as a long-running VM, or warm-restore a snapshot UUID. |
+| | `run -- <cmd>` | Boot a fresh VM, run `<cmd>`, stream output, leave the VM up; exits with the command's code. |
+| | `up [targets]` | Declaratively build + converge VMs from your NixOS config, like `nixos-rebuild switch`. |
+| | `init` | Write a minimal `flake.nix` + `ix.nix` in the current dir; existing files untouched. |
+| Inventory | `ls` | List your VMs: name, state, region, address, usage. Read-only inventory. |
+| | `start <vm>` | Resume stopped VMs; does not create or change the image. |
+| | `stop <vm>` | Stop runtime but keep the VM startable; not deletion. |
+| | `restart <vm>` | Power-cycle the VM, same identity. |
+| | `rm <vm>` | Delete VMs, disks, runtime state. Alias `delete`. Stop instead if you may restart. |
+| | `snapshot [vm] [create\|ls]` | List or create saved VM states as recovery points. |
+| | `vm <describe\|set\|revert>` | Inspect placement, toggle internet ingress/egress, or revert by booting a new VM from a snapshot. |
+| Access | `shell <vm>` | Interactive shell in the guest; create or `--attach` a session. |
+| | `console <vm>` | Attach to the workload console for live stdin (REPL, installer). |
+| | `serial <vm>` | Host-terminated serial console: the rescue line when `ix shell` / the agent is dead. |
+| | `port-forward <vm> <l:r>` | Private dev tunnel from your laptop to a VM port; not public ingress. |
+| | `logs <vm>` | Read captured streams: `workload` (default), `kernel`, `diagnostic`, `platform`. |
+| Images / source | `image <ls\|push\|rm>` | Manage registry images; bare push refs land under `registry.ix.dev/<you>/`. |
+| | `source <ls\|rm>` | List or remove CAS-backed uploaded source trees. |
+| Networking | `group <create\|rm\|ls\|add\|rm-member\|members>` | East-west groups: decide which VMs reach each other privately. |
+| | `net up <group>` | Bring up the Linux overlay for a group (TUN device, `<name>.ix.internal` DNS). Needs sudo / `CAP_NET_ADMIN`. |
+| | `share <vm> <port>` | Publish a guest port on a public or email-gated (`--to`) share hostname. |
+| Secrets | `secret <set\|check\|ls\|rm>` | Store write-only secrets; `set` reads the value from a prompt/stdin/file, never the command line. |
+| Account | `login` | Sign in through the ix website; also switches profiles. |
+| | `billing <status\|top-up\|usage>` | View balance, add funds, inspect usage. |
+| Federated | `resources <ls\|get\|act\|attach>` | Drive remote federated TUI resources (agent terminals) over QUIC. |
+
+Hidden verbs exist for debugging (`doctor`, `reload`, `sysrq`, `trace`, `config`,
+`system`); they take `--admin`/`IX_ADMIN` or are otherwise internal and are not
+part of the day-to-day surface.
+
+## Flags
+
+This page does not transcribe flags. Run `ix <verb> --help` for the authoritative,
+current flag list on any verb. Four global flags apply everywhere:
+
+| flag | env | effect |
+| --- | --- | --- |
+| `--profile` | `IX_PROFILE` | Select a config profile. |
+| `--debug` | `IX_DEBUG` | Enable CLI debug tracing. |
+| `--admin` | `IX_ADMIN` | Use admin privileges (bypasses ownership checks). |
+| `--message-format` | - | Output format: `human` (default), `short`, `json`. |
+
+## See also
+
+- [fleet.md](fleet.md): multi-VM declarative fleets via the separate `ix-fleet`.
+- [lifecycle.md](lifecycle.md): provision -> run -> stop -> snapshot -> rm.
+- [networking.md](networking.md): groups, the overlay, and shares.
+- [secrets.md](secrets.md): the write-only secret store and default attachment.
+- [overview.md](overview.md): where `ix` sits in the platform.

--- a/doc/ix/environment.md
+++ b/doc/ix/environment.md
@@ -1,0 +1,87 @@
+# Environment variables
+
+This is a **curated** reference to the environment variables you are most likely
+to set when driving `ix`, its SDKs, and the search and MCP tools - not an
+exhaustive dump. Many more internal, computed, and wrapper-only variables exist
+in the codebase. To see the full set, grep the repos (for example
+`rg "env::var|os\.environ|process\.env|env = \"IX_"`). Everything below was
+verified by opening the source that reads it; each row cites `path:line`.
+
+## CLI and auth
+
+These are the variables an `ix` user actually exports. The CLI flags shadow them
+(`--profile`, `--debug`, `--admin`); the env var is the no-flag default. The
+SDKs (TypeScript, Python, and the Rust core they wrap) resolve a token and base
+URL the same way. See [cli.md](cli.md).
+
+| var | meaning | default | source (path:line) |
+| --- | --- | --- | --- |
+| `IX_TOKEN` | API bearer token. Required to talk to the ix platform. | none | ix CLI |
+| `IX_API_KEY` | Token fallback in the TS SDK if `IX_TOKEN` is unset. | none | `sdk/typescript/src/index.ts:1421` |
+| `IX_API_BASE_URL` | API base URL (TS SDK). | `https://api.ix.dev` | `sdk/typescript/src/index.ts:1428` |
+| `IX_REGION` | Pin VMs to a region instead of letting the API pick. | `us-west-1` (Python); first region the API returns (TS) | `sdk/python/ix_sdk/__init__.py:810`, `sdk/typescript/src/index.ts:1437` |
+| `IX_PROFILE` | Config profile to use (`--profile`). | none | ix CLI |
+| `IX_DEBUG` | Enable CLI debug tracing (`--debug`). Truthy value. | off | ix CLI |
+| `IX_ADMIN` | Use admin privileges, bypassing ownership checks (`--admin`). Truthy value. | off | ix CLI |
+
+`IX_TOKEN` is the one most paths require: `ix run` and the SDKs error out
+without it.
+
+## Search credentials
+
+The `search` CLI (`nix run .#search`) and the `indexer` authenticate to
+Mixedbread. **`MXBAI_API_KEY` is required**: without it (and without a prior
+`mgrep login`) `.#search` fails at auth.
+
+| var | meaning | default | source (path:line) |
+| --- | --- | --- | --- |
+| `MXBAI_API_KEY` | Mixedbread API key. Required unless you ran `mgrep login`. | none | `packages/search/mixedbread/src/lib.rs:40` |
+| `MXBAI_STORE` | Store name to query/index (`--store`). | `index` | `packages/search/search/src/main.rs:318`, `packages/search/search-core/src/config.rs:8` |
+| `MXBAI_BASE_URL` | Mixedbread API base URL (`--base-url`). | `https://api.mixedbread.com` | `packages/search/search/src/main.rs:322`, `packages/search/mixedbread/src/lib.rs:30` |
+
+## Run recorder
+
+The `run` wrapper records a command's output to a session directory and prints a
+summary. These tune that behavior.
+
+| var | meaning | default | source (path:line) |
+| --- | --- | --- | --- |
+| `IX_RUN_DIR` | Session directory root. | `./.ix/run` | `packages/tui/run/run.py:334` |
+| `IX_RUN_PRINT` | Output mode: `summary`, `full`, or `none`. | `summary` | `packages/tui/run/run.py:326` |
+| `IX_RUN_HEAD_LINES` | First lines to print in the summary. | `2` | `packages/tui/run/run.py:721` |
+| `IX_RUN_TAIL_LINES` | Last lines to print in the summary. | `2` | `packages/tui/run/run.py:722` |
+
+## ix-mcp
+
+User-tunable variables for the notebook MCP server. (Internal and
+fleet-injected ones such as `IX_MCP_EXEC_TOKEN` and `IX_MCP_SHARED` are omitted.)
+
+| var | meaning | default | source (path:line) |
+| --- | --- | --- | --- |
+| `IX_MCP_MAX_RESULT_CHARS` | Max characters of a tool result before paging kicks in. Floor 500. | `50000` | `packages/mcp/ix_notebook_mcp/outputs.py:25` |
+| `IX_MCP_SESSION` | Checkpoint the session to a file; set by `serve --session FILE`. | unset (off) | `packages/mcp/ix_notebook_mcp/runtime.py:2484` |
+
+## Health-check context (read-only)
+
+These are **injected by the platform into host health checks, not set by you.**
+`ix-fleet` populates them per node before running a check on the operator's
+machine; the check script reads them to learn about the node under test. Setting
+them yourself has no effect on the fleet. See
+[health-checks.md](health-checks.md).
+
+| var | meaning | source (path:line) |
+| --- | --- | --- |
+| `IX_NODE` | Fleet node name. Always set. | `packages/ix-fleet/src/ix_fleet/__init__.py:564` |
+| `IX_NODE_NAME` | Branch name reported by the API. | `packages/ix-fleet/src/ix_fleet/__init__.py:566` |
+| `IX_NODE_IMAGE` | Image the node is running. | `packages/ix-fleet/src/ix_fleet/__init__.py:567` |
+| `IX_NODE_STATUS` | Node status string. | `packages/ix-fleet/src/ix_fleet/__init__.py:568` |
+| `IX_NODE_IPV6` | Node IPv6 address. | `packages/ix-fleet/src/ix_fleet/__init__.py:569` |
+| `IX_NODE_IPV4` | Node IPv4 address, when assigned. | `packages/ix-fleet/src/ix_fleet/__init__.py:571` |
+| `IX_NODE_SUBDOMAIN` | Node subdomain, when assigned. | `packages/ix-fleet/src/ix_fleet/__init__.py:573` |
+| `IX_NODE_REGION` | Node region slug, when known. | `packages/ix-fleet/src/ix_fleet/__init__.py:575` |
+
+## See also
+
+- [overview.md](overview.md): where `ix` and these variables sit in the platform.
+- [cli.md](cli.md): the `ix` verbs the CLI/auth variables shadow.
+- [health-checks.md](health-checks.md): the host checks that read the `IX_NODE_*` variables.

--- a/doc/ix/fleet.md
+++ b/doc/ix/fleet.md
@@ -1,0 +1,110 @@
+# Running a fleet
+
+A fleet is a set of remote ix VMs (nodes) managed as one unit from a single
+declarative plan. You author the fleet in Nix with `index.lib.mkFleet`
+(`lib/image/fleet.nix:19-24`), which renders a JSON plan and exposes a runnable
+command per lifecycle verb; `ix-fleet` (`packages/ix-fleet`, Python) reads that
+plan and converges the live fleet to it. This page is the short how-to; the
+exhaustive from-source reference is [../ix-fleet/overview.md](../ix-fleet/overview.md).
+
+> `ix-fleet` is a separate tool from the [`ix` CLI](cli.md). It drives the same
+> ix control plane (a node is an ix branch) through the Python SDK and `IX_TOKEN`
+> from the environment, but you do not call `ix` directly to run a fleet.
+
+## The flow: mkFleet -> plan -> up
+
+You rarely write a plan by hand. You write a `mkFleet` spec; it renders the plan
+and gives you the verbs. A minimal real example
+(`examples/nginx-lifecycle/default.nix`):
+
+```nix
+{ index }:
+
+index.lib.mkFleet {
+  defaults = [ { ix.image.tag = "nginx-lifecycle"; } ];
+
+  nodes.nginx = {
+    deployment.recreateOnUp = true;
+    modules = [ ./service.nix ];
+  };
+}
+```
+
+A multi-node fleet adds `groups`, `replicas`, and `dependsOn`
+(`examples/ray-cluster/default.nix`):
+
+```nix
+nodes = {
+  ray-head = { groups = [ "ray-cluster" ]; modules = [ ./head.nix ]; };
+  ray-worker = {
+    replicas = 2;
+    dependsOn = [ "ray-head" ];
+    groups = [ "ray-cluster" ];
+    modules = [ ./worker.nix ];
+  };
+};
+```
+
+`mkFleet` returns, per node spec, a rendered `plan` plus one wrapped command per
+verb (`up`, `switch`, `replace`, `bootstrap`, `health`, `diff`, `down`); each
+command bakes in `--plan` so you run `nix run .#up` rather than passing the plan
+yourself (`lib/image/fleet.nix:405-426`). It also exposes
+`nixosConfigurations.<node>` (the bare node name -> that node's system) so
+`ix up .#<node>` resolves it; merge it into your flake's top-level
+`nixosConfigurations` (`lib/image/fleet.nix:436-443`, see `templates/dev/flake.nix`).
+
+To run a verb against the raw tool instead of the wrapper:
+`nix run .#ix-fleet -- --plan plan.json up` (`package.nix:4`). For all flags, run
+`nix run .#ix-fleet -- --help`.
+
+## Subcommands
+
+`ix-fleet --plan <path> [--on NODE|@TAG ...] [--dry-run] <subcommand>`. `--plan`
+is required; `--on` is repeatable and selects nodes by name or `@tag` (empty =
+all, in plan order); `--dry-run` prints the steps without calling the API
+(`__init__.py:897-990`).
+
+| verb | what it does |
+| --- | --- |
+| `plan` | Print the resolved, dependency-ordered node set as JSON. No API calls. |
+| `diff` | Print each selected node's desired switch target / source installable. |
+| `bootstrap` | Create nodes from their `bootstrapImage`, wait for guest readiness, ensure groups. |
+| `up` | Push each node's image and create-or-replace the node on it, then groups + health. |
+| `replace` | Like `up`, but always delete-then-create the node on the pushed image. |
+| `switch` | In-place NixOS system switch of running nodes (snapshots first). |
+| `health` | Run each selected node's health checks. |
+| `down` | Remove selected nodes in reverse plan order. |
+
+For up vs switch vs replace vs down and when to use each, see
+[lifecycle.md](lifecycle.md).
+
+## Node and plan fields (brief)
+
+You write the **authoring** surface (mkFleet); `ix-fleet` consumes the rendered
+**plan** surface. Both are listed below; the full field reference with types and
+defaults is in [../ix-fleet/overview.md](../ix-fleet/overview.md).
+
+Authoring (per node spec): `modules`/`module`, `deployment`, `tags`, `groups`,
+`dependsOn`, `replicas` (`lib/image/fleet.nix:109-114`). `deployment` accepts
+`bootstrapImage`, `destination`, `env`, `ipv4`, `l7ProxyPorts`,
+`noDefaultSecrets`, `recreateOnUp`, `region`, `secrets`, `switch` - and only
+those; unknown keys error (`lib/image/fleet.nix:77-102`). Health checks are not a
+deployment key: declare them in a node module as `ix.healthChecks.<name>`
+(`lib/image/fleet.nix:72-76`).
+
+Rendered plan (pydantic, `__init__.py:34-146`): a `FleetPlan` is `order`, `nodes`
+(name -> `FleetNode`), `secrets`. A `FleetNode` carries `name`, `system`,
+`switch` (`SwitchSpec`: `target`, `buildOn` auto|local|remote, `buildVm`,
+`sourceInstallable`, `overrideInputs`), `bootstrapImage`, `replacementImage`,
+`region`, `ipv4`, `snapshot`, `recreateOnUp`, `tags`, `groups`, `env`,
+`l7ProxyPorts`, `dependsOn`, `healthChecks`, `secrets`, `noDefaultSecrets`.
+
+## See also
+
+- [lifecycle.md](lifecycle.md) - up vs switch vs replace vs down.
+- [health-checks.md](health-checks.md) - declaring and running checks.
+- [secrets.md](secrets.md) - the secret-ref model.
+- [networking.md](networking.md) - east-west groups and L7 proxy ports.
+- [images.md](images.md) - bootstrap vs replacement images, the delete-then-create swap.
+- [../ix-fleet/overview.md](../ix-fleet/overview.md) - the full from-source reference.
+- [cli.md](cli.md) - the `ix` CLI (distinct from `ix-fleet`).

--- a/doc/ix/glossary.md
+++ b/doc/ix/glossary.md
@@ -1,0 +1,106 @@
+# Glossary: disambiguating overloaded names
+
+Several names in this repo mean more than one thing. `search` is a CLI, a Rust
+lib, a Python import, and a wheel with a different name again; `index` is a repo,
+a store, a verb, and a package. This page lists every real meaning of each
+overloaded term with its source, so an agent never conflates them. When in
+doubt, match the meaning to the entry point you are about to invoke (`nix run
+.#<name>`, an `import`, or an `ix` subcommand) and check it here first. See also
+[cli.md](cli.md), [overview.md](overview.md), and [environment.md](environment.md).
+
+## search
+
+| Meaning | What it is | Source |
+| --- | --- | --- |
+| `.#search` | Read-only semantic + regex CLI over the shared corpus store. Never indexes locally. Needs `MXBAI_API_KEY` (or a stored token) or it fails at auth. | `packages/search/search/Cargo.toml:2`, `packages/search/search/src/main.rs:3` |
+| `search-core` | Rust library the CLI is a thin wrapper over. | `packages/search/search-core/Cargo.toml:2` |
+| `search-py` | PyO3 bindings. Imported in Python as `import search`; the wheel is named `ix-search`. | `packages/search/search-py/python/search/__init__.py`, `packages/search/search-py/pyproject.toml:9` |
+| `file-search` | Independent BM25 / Tantivy file-and-path indexer. Unrelated to the semantic store. `.#file-search`. | `packages/search/file-search/Cargo.toml:2,6` |
+| `polars-mixedbread` | Polars IO plugin; `import polars_mixedbread`. | `packages/search/polars-mixedbread/pyproject.toml:6` |
+| `mixedbread` | Rust client lib for the Mixedbread vector store. | `packages/search/mixedbread/Cargo.toml:2` |
+| `search-eval` | Search-quality evaluation harness. `.#search-eval`. | `packages/search/search-eval/pyproject.toml:2` |
+| `indexer` | The thing that actually ingests content into the store; `search` only queries what `indexer` populates. | `packages/search/indexer/Cargo.toml:2,6` |
+
+The default Mixedbread store is itself named `index`
+(`packages/search/search/src/main.rs:1569`).
+
+## index
+
+- The **repo**: `indexable-inc/index`.
+- The **default store name** that `search` queries and `indexer` fills
+  (`packages/search/search/src/main.rs:1569`).
+- The **verb** "to index" (ingest content) - owned by `indexer`, not by
+  `search` (`packages/search/search/src/main.rs:3`).
+- The **package** `indexer` that performs that verb
+  (`packages/search/indexer/Cargo.toml:2`).
+
+## run
+
+Three unrelated things:
+
+- **`nix run`** - the Nix command that launches any flake app (`.#search`,
+  `.#mcp`, ...).
+- **`.#run`** - terminal session recorder: records a command's terminal
+  session, timing, and queryable output events. `nix run .#run -- <cmd>`
+  (`packages/tui/run/default.nix:14,17`).
+- **`ix run`** - boots a fresh VM, runs one command, streams output, leaves the
+  VM up (`doc/ix/cli.md:18-19,35`).
+
+## mcp
+
+- The **protocol** (Model Context Protocol).
+- The **server** package: flake app `.#mcp`, but the binary is `ix-mcp` and the
+  Python module is `ix_notebook_mcp`. Start it with `nix run .#mcp -- serve`
+  (`packages/mcp/default.nix:289`, `packages/mcp/ix_notebook_mcp/`,
+  `packages/mcp/README.md:13`).
+- A **dashboard embedded in `ix-mcp`** (distinct from the standalone
+  `.#dashboard`; see below) (`packages/mcp/README.md:17`).
+
+## fleet
+
+- **`.#ix-fleet`** - the CLI/tool that renders and executes fleet plans
+  (`packages/ix-fleet/Cargo.toml:2,4`).
+- A **fleet** - the set of remote ix VMs a plan describes.
+- A node in that fleet is called a **branch** by the ix SDK (`ix_sdk.BranchStatus`)
+  (`packages/ix-fleet/src/ix_fleet/__init__.py:221`).
+
+## dashboard
+
+- **`.#dashboard`** - standalone web canvas that aggregates every ix resource
+  producer socket into one live board (`packages/dashboard/dashboard/Cargo.toml:2,6`).
+- **`dashboard-core`** - the shared library: wire types, pane publisher, canvas
+  server (`packages/dashboard/dashboard-core/Cargo.toml:2,6`).
+- The **dashboard embedded in `ix-mcp`** - one view of the MCP server's feed,
+  served over HTTP (`packages/mcp/README.md:17`).
+
+## Wheel / import / binary names
+
+These do not match each other - check this table before importing or invoking.
+
+| Package | Flake app | Binary | Python import | Wheel / dist name |
+| --- | --- | --- | --- | --- |
+| `search` | `.#search` | `search` | - | - |
+| `search-py` | - | - | `search` | `ix-search` |
+| `mcp` | `.#mcp` | `ix-mcp` | `ix_notebook_mcp` | - |
+| `polars-mixedbread` | - | - | `polars_mixedbread` | `polars-mixedbread` |
+| `file-search` | `.#file-search` | `file-search` | - | - |
+
+## Which entry point should I use?
+
+- **Semantic search** of indexed content -> `.#search` (CLI) or `import search`
+  (Python). Set `MXBAI_API_KEY` first.
+- **File / path search** (BM25, local) -> `.#file-search`.
+- **Record a terminal run** -> `.#run`.
+- **Ingest / index content** into the store -> `.#indexer`.
+
+## room-server
+
+`room-server`: a Rust backend in the private ix monorepo (`crates/room/server`)
+that runs agent turns for symphony. It is not built in this public repo;
+references in `doc/symphony` and `doc/codex` resolve to it.
+
+## See also
+
+- [overview.md](overview.md): what is open vs hosted, and the page map.
+- [cli.md](cli.md): the `ix` subcommands these names can collide with.
+- [environment.md](environment.md): the `IX_*` variables referenced throughout.

--- a/doc/ix/health-checks.md
+++ b/doc/ix/health-checks.md
@@ -1,0 +1,70 @@
+# health checks
+
+A health check is a command that proves one of your image's services is actually ready, not just that systemd launched it. You declare checks in a NixOS module under `ix.healthChecks.<name>`, and the fleet runs them after a deploy: `ix-fleet --plan plan.json health`, and automatically as the post-deploy wait inside `up`, `replace`, and `switch`. A check either runs inside the VM (`from = "guest"`, the default) to prove the service is live locally, or on your own machine (`from = "host"`) to prove the node is reachable from outside. A check passes when its command exits 0; it is retried up to `attempts` times until it does, or the deploy fails.
+
+## Declaring a check
+
+Each entry under `ix.healthChecks` is a submodule (defined in `lib/image/platform.nix:20`):
+
+```nix
+ix.healthChecks.api = {
+  command = [ "curl" "-fsS" "http://localhost:8080/health" ];
+};
+```
+
+### Fields
+
+| field | type | default | meaning |
+| --- | --- | --- | --- |
+| `description` | string | the attr name | label shown in fleet health output (`platform.nix:24`) |
+| `unit` | string or null | `null` | sugar: probe a systemd unit (see below) (`platform.nix:30`) |
+| `command` | non-empty list of strings | (none; required unless `unit` set) | the argv to run (`platform.nix:64`) |
+| `from` | `"guest"` or `"host"` | `"guest"` | where the command runs (`platform.nix:47`) |
+| `timeoutSec` | positive int | `30` | per-attempt timeout (`platform.nix:79`) |
+| `attempts` | positive int | `30` | max attempts before the check fails (`platform.nix:85`) |
+| `intervalSec` | unsigned int | `2` | seconds to wait between failed attempts (`platform.nix:91`) |
+| `requiresIpv4` | bool | `false` | gate the check until the node has a public IPv4 (`platform.nix:97`) |
+
+Set exactly one of `unit` or `command`. Setting both (where `command` is not the one `unit` derives) is rejected at evaluation time (`platform.nix:190`, `:384`).
+
+`requiresIpv4` is only valid on `from = "host"` checks, and the node must be created with `deployment.ipv4 = true`; a guest check that sets it is rejected at eval time (`platform.nix:183`, `:377`). Use it for public-reachability probes that connect to the node's assigned IPv4.
+
+## The `unit:` sugar
+
+The overwhelmingly common check is "is this systemd unit running?". Instead of writing the full `systemctl` argv, set `unit`:
+
+```nix
+ix.healthChecks.nginx.unit = "nginx";
+```
+
+This desugars to `command = [ "systemctl" "is-active" "--quiet" "nginx.service" ]` (`platform.nix:12`, `:114`). A bare name gets the `.service` suffix; pass an explicit `foo.socket` or `foo.timer` to probe another unit type (`platform.nix:12`). The derived command is an `mkDefault`, so a real `command` you set wins; but setting both is flagged as a conflict rather than silently honoring one (`platform.nix:114`, `:190`).
+
+## Guest vs host
+
+`from = "guest"` (default) runs the argv inside the VM through the SDK exec channel (`__init__.py:600`). Use it for anything observable from inside the node: a unit is active, a port is listening, a database accepts connections.
+
+```nix
+# Guest: the nginx unit is active inside the VM.
+ix.healthChecks.nginx.unit = "nginx";
+```
+
+`from = "host"` runs the command on your machine as a subprocess (`__init__.py:630`). Before running, the fleet injects the node's facts as environment variables and `$VAR`-substitutes them into your argv (`__init__.py:563`, `:579`, `:628`): `IX_NODE`, `IX_NODE_NAME`, `IX_NODE_IMAGE`, `IX_NODE_STATUS`, `IX_NODE_IPV6`, and, when the node has reported them, `IX_NODE_IPV4`, `IX_NODE_SUBDOMAIN`, `IX_NODE_REGION`. Use host checks for what only an outside observer can see: public reachability, DNS, the gateway path. The tool you call must be on your own `PATH`.
+
+```nix
+# Host: the node is reachable at its public subdomain over TLS.
+ix.healthChecks.public = {
+  from = "host";
+  command = [ "curl" "-fsS" "https://$IX_NODE_SUBDOMAIN/health" ];
+};
+```
+
+## How and when they run
+
+Each check is attempted up to `attempts` times, `intervalSec` apart, with each attempt bounded by `timeoutSec` (`__init__.py:599`). The first exit-0 attempt passes; if none do, the check fails and reports the last command output (`__init__.py:653`). Run all checks for a plan with `ix-fleet --plan plan.json health`, or let them run automatically as the readiness wait at the end of `up`, `replace`, and `switch` (`__init__.py:869`, `:879`, `:889`). `--plan` is required (`__init__.py:1054`).
+
+## See also
+
+- [fleet.md](fleet.md): plans, nodes, and the deploy commands that run checks.
+- [services.md](services.md): the service modules whose readiness you are proving.
+- [networking.md](networking.md): `ix.networking.expose` and the ports a check probes.
+- [environment.md](environment.md): the `IX_NODE_*` env vars host checks receive.

--- a/doc/ix/images.md
+++ b/doc/ix/images.md
@@ -1,0 +1,99 @@
+# Images
+
+An ix VM boots from one OCI image. You build that image from a NixOS
+configuration with the index library, push it to your private registry
+namespace, then point a VM at it. This page is the build -> tag -> push -> boot
+model and the `ix image` verbs; for flags on any verb run `ix image --help`.
+
+## The model
+
+1. **Build.** Evaluate a NixOS config through the index image library
+   (`index.lib.mkImage`, `lib/image/default.nix:99`). A baseline platform
+   module is applied to every image automatically (`./platform.nix`, layered in
+   at `lib/image/default.nix:68-90`). The evaluated config yields the OCI
+   archive at `config.ix.build.ociImage`
+   (`lib/image/oci-layer.nix:28-31`, `:64`); `mkImage` returns exactly that
+   derivation. Each image is self-contained: ix runs one image per VM, it does
+   not stack images at runtime (`lib/image/default.nix:92-99`).
+2. **Tag.** The image name and tag come from `ix.image.name` and
+   `ix.image.tag` (`lib/image/oci-layer.nix:18-26`; tag defaults to `latest`).
+   In a fleet the node name seeds `ix.image.name` by default
+   (`lib/image/fleet.nix:218`). See `examples/nginx-lifecycle/default.nix:4`
+   for a real `ix.image.tag = "nginx-lifecycle";`.
+3. **Push.** Send the archive to your registry namespace with
+   `ix image push <source> <destination>`. A bare destination is stored under
+   `registry.ix.dev/<your-username>/`.
+4. **Boot.** Create a VM from a registry ref with `ix new <ref>` (or
+   `ix run`). See [cli.md](cli.md).
+
+## Pushing, listing, removing
+
+`ix image` manages the registry layer before any VM exists:
+
+- `ix image push <source> <destination>` - push an archive or ref. A plain
+  path source is read as `oci-archive:<path>`; a plain ref as `docker://<ref>`.
+  `--public` lets other ix users pull it; `--region` selects the target
+  registry.
+- `ix image ls` - list system images and your private images in a region.
+- `ix image rm <reference>` - delete one tag you own (digest refs are
+  rejected).
+
+## Base images
+
+`ix new` and `ix up --base` default to `ix/base:latest`, a NixOS system image.
+Use it for a general Linux VM, or
+pass your own fully-qualified registry ref to boot an application image.
+`ix up` needs a NixOS base so it can activate closures in place.
+
+## Example
+
+```nix
+# image.nix - a NixOS module evaluated by index.lib.mkImage
+{
+  ix.image = {
+    name = "hello";
+    tag = "v1";
+  };
+  # ... your services, packages, etc.
+}
+```
+
+```sh
+# build the archive (your flake exposes the mkImage output), then:
+ix image push ./result registry.ix.dev/<you>/hello:v1
+ix new registry.ix.dev/<you>/hello:v1 --name hello
+```
+
+## Images in a fleet
+
+A fleet node carries two images (`lib/image/fleet.nix:291-300`):
+
+- **`bootstrapImage`** - the create-time image used to first materialize a
+  missing node. Defaults to the shared NixOS bootstrap image under
+  `registry.ix.dev/...` (`lib/image/fleet.nix:48-49`,
+  `lib/image/default.nix:104-107`).
+- **`replacementImage`** (`{ imageName, imageTag, destination, source,
+  sourceDrv }`) - the image `up`/`replace` build and push from your config
+  (`lib/image/fleet.nix:292-300`). `destination` defaults to
+  `<imageName>:<imageTag>` (`lib/image/fleet.nix:248`).
+
+See [fleet.md](fleet.md) for the authoring surface.
+
+## Swapping a VM's image recreates it
+
+Each VM boots one image, and image swap is delete-then-create, not in-place:
+`client.create` inserts against a `UNIQUE (owner, name)` constraint, so
+changing a node's image removes and recreates it
+(`doc/ix-fleet/overview.md:107-109`). In a fleet, `replace` always does this,
+and `deployment.recreateOnUp = true` makes `up` do it too (see
+`examples/nginx-lifecycle/default.nix:7`). For when this recreate happens across
+create/replace/switch, see [lifecycle.md](lifecycle.md); the full lifecycle
+reference is [../ix-fleet/overview.md](../ix-fleet/overview.md).
+
+## See also
+
+- [cli.md](cli.md) - `ix new`, `ix up`, and the VM verbs.
+- [lifecycle.md](lifecycle.md) - when an image swap recreates the VM.
+- [services.md](services.md) - the ready-made service modules you compose into an image.
+- [fleet.md](fleet.md) - multi-VM plans, bootstrap vs replacement images.
+- [secrets.md](secrets.md) - attaching secrets to a VM at boot.

--- a/doc/ix/lifecycle.md
+++ b/doc/ix/lifecycle.md
@@ -1,0 +1,72 @@
+# VM lifecycle: which command?
+
+This page is a decision guide for the VM lifecycle: creating, running, converging
+config, power state, snapshots, and teardown. The single split that explains most
+of it: swapping a VM's **image** means destroy-and-recreate, while changing
+**config** on a VM that already exists is an in-place switch. Single VMs use the
+`ix` CLI; many VMs at once use `ix-fleet` (see [fleet.md](fleet.md)). For full
+flags, run the command with `--help`.
+
+## I want to... -> command
+
+| I want to... | Single VM (`ix`) | Fleet (`ix-fleet`) |
+| --- | --- | --- |
+| Create a VM from an OCI image | `ix new <image>` (default `ix/base:latest`) | `ix-fleet --plan p.json bootstrap` (from each node's `bootstrapImage`) |
+| Boot a VM, run one command, keep it up | `ix run <image> -- <cmd>` | - |
+| Bring up / converge from my NixOS config | `ix up [target]` (default `.`) | `ix-fleet --plan p.json up` |
+| Change config on a running VM (no recreate) | re-run `ix up` | `ix-fleet --plan p.json switch` |
+| Swap the VM's image | `ix new <image>` again (recreates) | `ix-fleet --plan p.json replace` (or `up`) |
+| Stop a VM but keep it | `ix stop <vm>` (`--force` hard-stops) | - |
+| Start a stopped VM | `ix start <vm>` | - |
+| Reboot a VM, same identity | `ix restart <vm>` (`--force` hard-stops first) | - |
+| Save current state | `ix snapshot create <vm>` | `switch` snapshots each node first |
+| Restore from a snapshot | `ix vm revert <snapshot>` (boots a NEW VM) | - |
+| Tear down | `ix rm <vm>` (alias `ix delete`) | `ix-fleet --plan p.json down` |
+| See what would change | - | `ix-fleet --plan p.json diff` / `plan` |
+| Check health | `ix doctor <vm>` | `ix-fleet --plan p.json health` |
+
+## Imperative vs declarative
+
+`ix new` and `ix run` are **imperative**: you hand ix an OCI image and it boots a
+VM around it. The image command becomes PID 1; ix wraps it with networking, logs,
+shell, and snapshots. `ix new` boots the image as a
+long-running VM; `ix run` boots a fresh VM, runs your command with output streamed
+back, exits with the command's exit code, and leaves the VM running.
+
+`ix up` is **declarative**: it builds the target NixOS system from your repo,
+creates the VM from `--base` if it does not exist yet, then activates that system
+in place. Re-running converges the VM to the current config: the same contract as
+`nixos-rebuild switch`, with no separate switch command for an existing VM.
+Default target is `.`;
+several targets in one run (for example `.#web .#worker`) need `--build-vm`.
+
+## Recreate vs switch: the key distinction
+
+- **Swapping the image is destroy-then-create.** A VM's identity is bound to its
+  image at creation, so changing the image means deleting the VM and creating a
+  new one. Single VM: run `ix new <image>` again. Fleet: `replace` always does
+  delete-then-create, and `up` recreates when the image changed
+  (`packages/ix-fleet/src/ix_fleet/__init__.py:426-431,820-841`).
+- **Changing config on a running VM is an in-place switch.** No recreate, no new
+  identity. Single VM: re-run `ix up` (it switches in place). Fleet:
+  `switch`, which snapshots each node first before activating the new closure
+  (`__init__.py:956-975`; see [fleet.md](fleet.md)).
+
+## Gotcha: there is no `ix down`
+
+`ix` has no `down` verb. To tear down a single VM use `ix rm <vm>` (alias
+`ix delete`), which destroys the VM identity, disks, and runtime state. To tear
+down a fleet use `ix-fleet --plan p.json down`,
+which removes nodes in reverse plan order
+(`packages/ix-fleet/src/ix_fleet/__init__.py:1025-1027`). Note that `ix stop` is
+power state only, not deletion: a stopped VM still exists and can be started again.
+
+Restore is also not in-place: `ix vm revert <snapshot>` boots a **new** VM from
+the snapshot and leaves the original untouched.
+
+## See also
+
+- [cli.md](cli.md): the full `ix` command surface.
+- [fleet.md](fleet.md): managing many VMs with `ix-fleet`.
+- [images.md](images.md): OCI images and the registry that `ix new` boots from.
+- [overview.md](overview.md): how the pieces fit together.

--- a/doc/ix/networking.md
+++ b/doc/ix/networking.md
@@ -1,0 +1,59 @@
+# ix networking
+
+ix gives you two coarse networking primitives and nothing finer. East-west is private VM-to-VM reachability: VMs that share a group slug reach each other by name as `<host>.ix.internal`, and anything outside the group has no route in. North-south is public reachability: whether a VM can be reached from (or reach) the internet at all, toggled per VM. Per-port policy (allowlists, L7, WAF, rate limiting) is not an ix concern: it lives inside the image's own `networking.firewall.*`, in a sidecar, or behind a gateway VM you build (`lib/image/platform.nix:315-321`). This page covers exposing a port, making two VMs talk, and reaching a VM from your laptop. For the commands themselves see [cli.md](cli.md); for declaring this across many nodes see [fleet.md](fleet.md).
+
+## Expose a port from an image
+
+`ix.networking.expose.<name>` is the one declaration for "this image listens here". Each entry registers a port claim (so collisions fail at eval time), opens the in-guest firewall for the port by default, and makes the listener discoverable from sibling nodes (`lib/image/platform.nix:194-247`, `:292-313`).
+
+```nix
+ix.networking.expose.http = {
+  port = 8080;
+  description = "public HTTP API";
+};
+```
+
+Fields (`lib/image/platform.nix:198-247`): `port`; `protocol` (`tcp` or `udp`, default `tcp`); `address` (default `"*"`, meaning every address); `namespace` (default `"default"`); `description` (defaults to the attribute name, shown in collision errors); `firewall` (default `true`). Set `firewall = false` when another mechanism already opens the port (a service's own `openFirewall = true`) and you only want the registry entry and cross-node discovery. Exposing a port does not make it public: it opens the in-guest firewall only. Reaching it from outside the VM still needs a group (east-west) or a north-south publish (below). See [services.md](services.md) for wiring this to a service module.
+
+### The eval-time collision gotcha
+
+Port claims are validated at build (eval) time, not at runtime. The registry tracks each listener by `(namespace, protocol, port)`, and a build fails when two claims in the same namespace collide. Address `"*"` overlaps any address, so two services that both bind `"*"` on the same protocol and port conflict even if you intended different interfaces (`lib/image/platform.nix:161-183`, `:366-375`). The error names the colliding services by their `description`, for example:
+
+```
+ix.networking.portClaims has same-namespace port collisions:
+  default/tcp/8080: http (*, public HTTP API), metrics (*, prometheus)
+```
+
+To fix it, put the two services on separate fleet nodes/VMs, or choose an explicit alternate port when co-locating them in one image is intentional. The platform itself claims `tcp/5001` (ix-console) and `udp/8443` (ix-agent), so avoid those (`lib/image/platform.nix:350-364`).
+
+## Make two VMs talk (east-west groups)
+
+Two VMs reach each other privately when they share a group slug. Declare membership at the image level with `ix.networking.groups`, at the fleet level with `nodes.<name>.groups`, or both: the fleet plan unions them (`lib/image/platform.nix:327-345`). VMs in the same group resolve each other as `<host>.ix.internal`, where `<host>` defaults to the VM's `networking.hostName` (overridable via `ix.networking.eastWest.hostName`, `lib/image/platform.nix:322-325`). A VM outside the group has no route in.
+
+```nix
+ix.networking.groups = [ "shared-db" ];
+```
+
+Slugs are scoped per owner, limited to `[a-z0-9_-]`, and capped at 63 characters (the DNS label limit); the fleet eval rejects anything else before any RPC runs (`lib/image/platform.nix:341-343`). The platform sets `networking.search` to `ix.internal`, so unqualified names like `shared-db-primary` resolve within a group without the suffix.
+
+To create or manage groups and membership directly from the CLI, use `ix group` (`create`, `add`, `members`, ...) and join at VM creation with `ix new --group <slug>` (repeatable). Run `ix group --help` and `ix new --help` for the exact flags.
+
+## Make a VM public (north-south)
+
+Public reachability is per VM and is a plain on/off, set at creation or changed later:
+
+- `ix new --ipv4` allocates a public IPv4 address (default is IPv6/proxy-based ingress).
+- `ix new --l7-proxy-port <PORT>` publishes an application port through the HTTP/TLS proxy; repeat for several ports.
+- `ix share <vm> <port>` publishes a guest TCP port on a public share hostname. Use `--public` for an open hostname or `--to <email>` (repeatable) for an email-gated one. Bare `ix share` lists existing shares.
+- `ix vm set --internet-ingress on|off` and `--internet-egress on|off` toggle inbound and outbound internet for an existing VM. East-west group traffic and the control plane keep working regardless.
+
+There is deliberately no per-port grammar on these toggles: finer filtering belongs in the image's `networking.firewall.*`. Run `ix vm set --help`, `ix new --help`, and `ix share --help` for the full flag set. See [lifecycle.md](lifecycle.md) for when these take effect across create/replace/switch.
+
+## Reach a VM from your laptop
+
+Two ways, depending on whether you want the whole group or one port:
+
+- `ix net up <group>` joins a group's private overlay from your machine (Linux only). It creates a TUN device, routes the group's private address range through it, and serves `<host>.ix.internal` from a local DNS stub, so every member VM is reachable by name on any port with nothing public. It runs in the foreground (Ctrl-C disconnects) and requires `CAP_NET_ADMIN` (run under sudo) and systemd-resolved.
+- `ix port-forward <vm> <local:remote>` opens a private debug tunnel from a local port to a port inside the VM (for example `ix port-forward web 8080:80`). This is for private debugging only; it does not publish the service as public ingress.
+
+Run `ix net --help` and `ix port-forward --help` for flags.

--- a/doc/ix/overview.md
+++ b/doc/ix/overview.md
@@ -1,0 +1,76 @@
+# ix platform
+
+`ix` is a platform for running your own microVMs: boot an image and you get a VM
+you own, with networking, secrets, logs, snapshots, a shell, and declarative
+config converged by name. You drive it with the `ix` CLI (`ix new`, `ix up`,
+`ix ls`, ...) over a hosted control plane. This page is the map for agents and
+people: what is open vs hosted, how to get a first VM, and which page answers
+each "how do I do X".
+
+## Open source vs the hosted platform
+
+Two repos, one boundary:
+
+- **`index` (this repo, MIT).** The open tooling: the NixOS library that builds
+  VM images and fleet plans (`lib/`), the ready-made service modules
+  (`modules/services/`), the base images (`images/`), and a large set of
+  standalone tools (search, mcp, tui, dashboard, `ix-fleet`, ...) under
+  `packages/`. You can read, fork, and run all of it (`LICENSE`).
+- **The hosted platform (private, proprietary).** The `ix` CLI, the control plane
+  it talks to, and the image registry (`registry.ix.dev`) are the hosted product,
+  under the Indexable SDK License. The CLI builds your open `index`-based config
+  and provisions it on platform infrastructure.
+
+Rule of thumb: if it builds an image, defines a service, or is a tool you run
+locally, it is open and lives here. If it creates, runs, or bills a VM, that is
+the hosted platform behind the `ix` CLI. `ix-fleet` is open (it renders plans),
+but it reaches the VMs through the hosted control plane.
+
+## Get a first VM
+
+```
+curl -fsSL https://ix.dev/install.sh | sh   # install the ix CLI
+ix login                                     # sign in through the website
+ix run ix/base:latest -- echo hello          # boot a VM, run one command
+ix ls                                        # see it; address it by name
+```
+
+`ix run` boots a fresh VM, runs the command, and leaves the VM up. For a config
+you own and re-converge instead of a one-off, scaffold and bring it up
+declaratively:
+
+```
+ix init          # write a minimal flake.nix + ix.nix
+ix up            # build your NixOS config and converge the VM in place
+```
+
+`ix up` is the declarative path: re-running it reconverges, the same contract as
+`nixos-rebuild switch`. See [lifecycle.md](lifecycle.md) for when to use which.
+
+## The map
+
+Start here, then follow the page that matches the question:
+
+| Page | Answers |
+| --- | --- |
+| [cli.md](cli.md) | The `ix` verb map and mental model. For flags, run `ix <verb> --help`. |
+| [lifecycle.md](lifecycle.md) | "I want to X" -> command: create, run, converge, stop, snapshot, destroy. |
+| [fleet.md](fleet.md) | Declarative multi-VM fleets via the separate `ix-fleet` tool. |
+| [images.md](images.md) | Build an image, tag/push to `registry.ix.dev`, boot a VM from it. |
+| [networking.md](networking.md) | Expose ports, private VM-to-VM groups, `<host>.ix.internal`, public ingress. |
+| [secrets.md](secrets.md) | Declare a secret, attach it to a VM, materialize it in the guest. |
+| [health-checks.md](health-checks.md) | Write checks; `from: guest` vs `from: host`; the `unit:` shortcut. |
+| [services.md](services.md) | The ready-made services in `modules/services/` and how to enable one. |
+| [environment.md](environment.md) | The user-facing `IX_*` and credential environment variables. |
+| [glossary.md](glossary.md) | Disambiguate overloaded names (search, run, mcp, fleet, dashboard, index). |
+
+For the package-level "from source" reference behind these pages, see the
+per-package docs under [`doc/`](../index.md), for example the
+[ix-fleet overview](../ix-fleet/overview.md).
+
+## See also
+
+- [cli.md](cli.md): the `ix` verb map and mental model.
+- [lifecycle.md](lifecycle.md): which command for create, run, converge, snapshot, destroy.
+- [fleet.md](fleet.md): declarative multi-VM fleets via `ix-fleet`.
+- [glossary.md](glossary.md): disambiguating overloaded names.

--- a/doc/ix/secrets.md
+++ b/doc/ix/secrets.md
@@ -1,0 +1,91 @@
+# secrets
+
+Give a VM a secret in two steps: **declare** it once in your account store with
+`ix secret set NAME`, then **attach** it when you create a VM with `ix new
+--secret NAME` (or mark it a default). At boot ix **materializes** the attached
+secret inside the guest, as an environment variable by default or as a file, and
+your service consumes it from there. Values are write-only: they go in through
+`set` and are never shown back. For every flag, run `ix secret
+--help` and `ix new --help` rather than copying flags from here.
+
+## The model: declare, attach, materialize
+
+1. **Declare.** `ix secret set NAME` stores or rotates one secret in your account
+   store, encrypted. The value comes from a hidden prompt, stdin, or `--value-file
+   PATH`: never from the command line. The name doubles as the
+   env var name when delivered as an env var.
+2. **Attach.** A secret is only delivered to VMs you attach it to. Attach per VM
+   at create time with `ix new --secret NAME` (repeat for several), or `ix run
+   --secret NAME`. Or mark it a default with
+   `ix secret set NAME --default` so it attaches to every new VM automatically;
+   opt a VM out with `ix new --no-default-secrets`.
+3. **Materialize.** At boot, ix injects each attached secret into the guest, as an
+   env var by default, or as a file when you set `--file`.
+
+## Example: a secret as an env var
+
+```
+ix secret set GH_TOKEN            # paste the value at the hidden prompt
+ix new ix/base:latest --secret GH_TOKEN
+```
+
+Inside the guest the value is the environment variable `GH_TOKEN`, available to
+the image command (the env var name is the secret name).
+
+## Example: a secret as a file
+
+Use `--file GUEST_PATH` to land the value as a file instead of an env var; pair it
+with `--owner` (guest unix user, defaults to root) and `--mode` (octal bits,
+defaults to 0600):
+
+```
+ix secret set NPM_TOKEN --file .npmrc --owner app --mode 0440
+ix new ix/base:latest --secret NPM_TOKEN
+```
+
+The guest gets `.npmrc` owned by `app` with mode 0440. `--owner` and `--mode`
+require `--file`.
+
+## Manage and verify
+
+- `ix secret ls` lists names and metadata only, never values.
+- `ix secret check NAME ...` exits non-zero listing any missing names, so deploy
+  tooling can fail fast before doing work.
+- `ix secret rm NAME` deletes a stored secret. VMs that already attached it keep
+  their copy.
+
+## Rotation
+
+Re-run `ix secret set NAME` with the new value. The store is updated, but VMs that
+already attached the old value keep it: attached copies are materialized at boot
+and persist until the VM is recreated. To pick up a rotated
+value, recreate the VM (delete and `ix new` again, or use a fleet `up`/`replace`).
+
+## Fleet plans
+
+A [fleet plan](../ix-fleet/overview.md) references secrets by name, never by
+value: plaintext stays in your account store, only the names live in the plan
+(`packages/ix-fleet/src/ix_fleet/__init__.py:85-89`). Each node lists `secrets:
+[NAME, ...]` and may set `noDefaultSecrets: true`, the exact equivalents of `ix
+new --secret NAME` and `--no-default-secrets` (`__init__.py:89-92`). Before any
+work, the CLI verifies every referenced secret exists in the store, mirroring `ix
+secret check`, and tells you to `ix secret set NAME` if one is missing
+(`__init__.py:374-394`). The plan's optional `secrets.provider` defaults to type
+`runtime-directory` with `mountRoot` `/run/secrets`, so file-mounted secrets land
+under `/run/secrets/<name>` (`__init__.py:124-128`).
+
+## How platform services are wired (not your path)
+
+The platform's own host services do not use the account store above. Their
+secrets are encrypted per-machine with the host's TPM2 chip and stored at
+`/etc/credstore.encrypted/<name>`; systemd decrypts them at service start via
+systemd-creds into the service's `$CREDENTIALS_DIRECTORY`. The canonical names map
+to a Vaultwarden-backed store for provisioning. This is internal
+platform plumbing; your path is `ix secret` plus fleet `secrets` above.
+
+## See also
+
+- [cli.md](cli.md): the `ix` CLI surface.
+- [fleet.md](fleet.md) and [ix-fleet overview](../ix-fleet/overview.md): declarative fleet plans.
+- [services.md](services.md): running and wiring your service in the guest.
+- [networking.md](networking.md): VM connectivity and ingress.

--- a/doc/ix/services.md
+++ b/doc/ix/services.md
@@ -1,0 +1,69 @@
+# Services
+
+`modules/services/` ships ready-made NixOS service modules you can drop into an
+ix image. Each is a self-contained module under `modules/services/<name>/` that
+exposes a single `enable` option (plus per-service tuning options). Turning one
+on installs the systemd units, packages, and defaults for that workload, and
+most services also declare their own `ix.networking` port claims and
+`ix.healthChecks` so the fleet knows how to reach and probe them. This page is
+an index: pick a service, read its module for the full option set, and set its
+verified enable option to `true`. Option names are NOT uniform: some live under
+`services.<name>`, others under `services.ix-<name>`. Use the exact option in
+the table below.
+
+## Available services
+
+| Service | What it is | Enable option (verified `path:line`) |
+| --- | --- | --- |
+| ci-runner | Self-hosted GitHub Actions runners for this repo on a persistent NixOS host, reusing the host `/nix/store` and Cachix substituter for warm builds. | `services.ci-runner.enable` (`modules/services/ci-runner/default.nix:29`) |
+| floodgate | Floodgate auth bridge installed as a Velocity plugin beside Geyser (lets Bedrock players join without a Java account). | `services.floodgate.enable` (`modules/services/floodgate/default.nix:59`) |
+| geyser | Geyser Bedrock-to-Java protocol bridge, installed as a Velocity plugin. | `services.geyser.enable` (`modules/services/geyser/default.nix:78`) |
+| git-clone | Clones a git repository on first boot, idempotently (later boots see `.git` and do nothing). | `services.git-clone.enable` (`modules/services/git-clone/default.nix:21`) |
+| humanlayer | Runs the HumanLayer (riptide) remote daemon as a long-lived systemd service so an ix VM acts as a remote HumanLayer host. | `services.humanlayer.enable` (`modules/services/humanlayer/default.nix:46`) |
+| minecraft | Loader-agnostic Java Minecraft server runtime (systemd unit, mods, Java, port; `serverJar`/`dropinDir` filled by a loader module). | `services.minecraft.enable` (`modules/services/minecraft/default.nix:809`) |
+| minecraft-bedrock | Minecraft Bedrock Dedicated Server (native Linux, kept separate from the Java loader family). | `services.minecraft-bedrock.enable` (`modules/services/minecraft-bedrock/default.nix:63`) |
+| minestom | Minestom server runtime that runs a user-built fat jar (no loaders, mods, or EULA). | `services.minestom.enable` (`modules/services/minestom/default.nix:40`) |
+| observability | Self-hosted OpenTelemetry, ClickHouse, and Grafana stack. | `services.ix-observability.enable` (`modules/services/observability/default.nix:114`) |
+| postgresql | PostgreSQL 18 with performance-tuned defaults for AMD EPYC Gen 5 (Zen 5). | `services.ix-postgresql.enable` (`modules/services/postgresql/default.nix:21`) |
+| ray | Ray cluster node plus the ix-mcp engine that drives the `fleet` distributed API. | `services.ix-ray.enable` (`modules/services/ray/default.nix:195`) |
+| remote-desktop | Browser-accessible remote desktop backed by Xpra's built-in HTML5 client. | `services.remote-desktop.enable` (`modules/services/remote-desktop/default.nix:71`) |
+| resource-monitor | Browser-accessible VM resource monitor. | `services.resource-monitor.enable` (`modules/services/resource-monitor/default.nix:127`) |
+| seaweedfs | Single-node S3-compatible object storage via SeaweedFS (`weed server -s3`). | `services.ix-seaweedfs.enable` (`modules/services/seaweedfs/default.nix:55`) |
+| spark | Apache Spark standalone cluster shipping the Gluten + Velox native execution engine by default. | `services.ix-spark.enable` (`modules/services/spark/default.nix:193`) |
+| subagent-cache | Content-validated subagent investigation cache daemon (axum + Postgres) that serves prior findings while their read files are unchanged. | `services.subagent-cache.enable` (`modules/services/subagent-cache/default.nix:33`) |
+| symphony | Minimal opinionated systemd unit for the Symphony runtime, reading secrets from an EnvironmentFile you control. | `services.symphony.enable` (`modules/services/symphony/default.nix:27`) |
+| velocity | Velocity Minecraft proxy. | `services.velocity.enable` (`modules/services/velocity/default.nix:239`) |
+
+Each module exposes more than `enable`. Read the module's `options` block for
+the full set (ports, data dirs, tuning, secrets wiring) before relying on
+defaults.
+
+## How to enable one
+
+In your image's NixOS modules, import the service module and set its enable
+option to `true`. Services typically declare their own
+[`ix.healthChecks`](./health-checks.md) and
+[`ix.networking`](./networking.md) port claims, so you usually do not wire ports
+or probes by hand: enabling the service is enough.
+
+Concrete example, enabling PostgreSQL (option verified at
+`modules/services/postgresql/default.nix:21`):
+
+```nix
+{
+  imports = [ ../modules/services/postgresql ];
+
+  services.ix-postgresql.enable = true;
+}
+```
+
+Then build the image and roll it out as usual. See [images.md](./images.md) for
+how services are composed into an image and [fleet.md](./fleet.md) for deploying
+that image across the fleet.
+
+## See also
+
+- [networking.md](./networking.md): port claims services declare via `ix.networking`.
+- [health-checks.md](./health-checks.md): health probes services declare via `ix.healthChecks`.
+- [images.md](./images.md): composing services into an ix image.
+- [fleet.md](./fleet.md): deploying images across the fleet.


### PR DESCRIPTION
## What

Adds `docs/ix/`, the user-facing platform guide that the beta-user funnel (ENG-5165) routes agents to. This is the content half of the funnel; the hosting half (the `Copy for agents` button + `llms.txt`) is a separate PR on the `ix` website.

The funnel: a user clicks **Copy for agents** on ix.dev -> pastes a primer into their agent -> agent fetches `ix.dev/llms.txt` (the map) -> routes to these raw markdown docs -> answers "how do I do X" correctly, no hallucination.

## Pages (`docs/ix/`)

| page | covers |
| --- | --- |
| `overview.md` | Funnel hub: open-source (MIT `index`) vs hosted platform boundary, first VM, the map |
| `cli.md` | The `ix` verb map + mental model. Defers flags to `ix <verb> --help` |
| `lifecycle.md` | "I want to X" -> command: create / run / converge / stop / snapshot / destroy |
| `fleet.md` | Declarative multi-VM plans via the separate `ix-fleet` tool |
| `images.md` | Build, tag, push to `registry.ix.dev`, boot a VM |
| `networking.md` | Expose ports, private groups, `<host>.ix.internal`, public ingress, port-claim collisions |
| `secrets.md` | Declare -> attach -> materialize in the guest; rotation |
| `health-checks.md` | `from: guest` vs `from: host`, the `unit:` shortcut |
| `services.md` | The 18 ready-made `modules/services/` + how to enable one |
| `environment.md` | Curated user-facing `IX_*` and credential vars |
| `glossary.md` | Disambiguates overloaded names: search (6 things), run, mcp, fleet, dashboard, index |

`docs/index.md` gains an **ix platform** section and records the title + one-line summary convention (so a future generator can build `llms.txt` from the pages - Stack D/E).

## Principles

- **Short, human, task-first** (~2-minute reads). One good example over exhaustive enumeration.
- **Never duplicate `--help`.** CLI flag detail is deferred to `ix <verb> --help` so it cannot rot.
- **Zero hallucination.** Every claim was verified against real source; pages cite only *public* `path:line` (private `ix`-repo internals were sanitized out).

This already corrects confusions an unprimed agent hits - e.g. there is no `ix down` / `ix health` / `ix diff` / `ix fleet` (those are `ix-fleet` subcommands or `nix run .#health`); the wheel is `ix-search` but you `import search`; `.#mcp` builds the `ix-mcp` binary.

## Scope

- Stacks B (platform docs), C (anti-confusion: glossary, env, FOSS boundary), D (summary convention) of ENG-5165.
- Stack A (hosting: button + `llms.txt`) ships as a separate PR on the `ix` web repo.
- Stack E (generator + CI staleness gate) is marked `[v2]` and deferred.

Refs ENG-5165.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add platform documentation for the ix agent funnel
> Adds 12 new documentation pages under `doc/ix/` covering the hosted ix platform, intended to support agent navigation and index generation.
>
> - [overview.md](https://github.com/indexable-inc/index/pull/1583/files#diff-fd9441b9d8f808f51aa7f791e3c3e4c33eb096e0333d4f4e833895207f069a43) delineates open-source vs hosted platform scope and provides a quick-start for provisioning a first VM
> - [cli.md](https://github.com/indexable-inc/index/pull/1583/files#diff-17f8b8e99082227405e01c4df6a4a35ff8bb772bd1c38d5405bd167ceb437ec6) explains the CLI mental model, distinguishing declarative (`up`) from imperative (`new`, `run`) verbs, with a grouped verb reference table
> - [lifecycle.md](https://github.com/indexable-inc/index/pull/1583/files#diff-7d91ac3be29c148449c764d45176c7b3f5744c257093887f64b9bdb112ae374b) maps tasks to commands for single VMs and fleets, clarifying image swap (recreates VM) vs config change (in-place switch)
> - [fleet.md](https://github.com/indexable-inc/index/pull/1583/files#diff-b13fbad0e6f76e8e1a5c0b123f45d88c2f556af18ca9aee01d1cb1d931daf4d8), [networking.md](https://github.com/indexable-inc/index/pull/1583/files#diff-b4634926d93afb54f82dc307c7d54ae97a92d3d7878b2464362b70369d02ba14), [secrets.md](https://github.com/indexable-inc/index/pull/1583/files#diff-a0fe11be615977083eeeda4a91548d8eca24f91f9dc2cc86e0173ec82bc95619), [health-checks.md](https://github.com/indexable-inc/index/pull/1583/files#diff-c0c2deec9bb2ed8b57edc1535ec93693fe248988cec1378d16efe3a2225ed6fd), [images.md](https://github.com/indexable-inc/index/pull/1583/files#diff-e37b236fc5dbdd058d73a1ca2078840c83cff3c13abb69d0556fd99969695a1b), [services.md](https://github.com/indexable-inc/index/pull/1583/files#diff-23fddc8465794ebd6d32282b861feca7be13351344bcc85cf949abbaa1ad5dda), and [environment.md](https://github.com/indexable-inc/index/pull/1583/files#diff-9a12028ff90c3c2dc548dc8fc1894cb5b4885a4c4be3e1cf9a0beb1d55bde4ab) each cover their respective subsystem in detail
> - [glossary.md](https://github.com/indexable-inc/index/pull/1583/files#diff-a106f7b20be746a93c3f8922204bb40588091c2b3983abf80ea058b3c89bd735) disambiguates overloaded names (search, index, run, mcp, fleet, dashboard)
> - [doc/index.md](https://github.com/indexable-inc/index/pull/1583/files#diff-47c5f70f455a0039334dd042f30fbb585c977a73ad838ee4747e5cd304ffb412) is updated with an `ix platform` section and a routing table to all new pages
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7295da0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->