### PR TITLE
feat(mcp): add NUON LLM output rendering

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -85,10 +85,23 @@ Result(user_html="<table>…</table>", llm_result="42 rows, mean 3.1")
 
 The dashboard renders `user_html` (a rich HTML view for the human) while your
 `python_exec` tool result receives only `llm_result` (concise text). It is a mime
-bundle under the hood (`text/html` for the dashboard, `text/plain` for you), so a
-large rendered view never costs you tokens. For an ordinary value the two
-audiences share one rendering: a bare trailing expression still shows its rich
-repr on the dashboard and its text to you.
+bundle under the hood (`text/html` for the dashboard, `application/x-ix-llm+json`
+for you), so a large rendered view never costs you tokens.
+
+Objects can opt in directly:
+
+```python
+class Summary:
+    def __ix_html__(self):
+        return "<strong>human table</strong>"
+
+    def __ix_llm__(self):
+        return {"rows": 42, "mean": 3.1}
+```
+
+Non-string `llm_result` / `__ix_llm__` values are serialized as Nushell NUON.
+Polars DataFrames default to compact NUON with shape, schema, columns, and rows,
+while the dashboard still gets the styled HTML table.
 
 ## Asking the human: interactive input
 

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2218,6 +2218,43 @@ let
         d = await run("import polars as pl\npl.DataFrame({'x': [1, 2]})", budget=2.0, name="auto-df")
         assert d.status == "done", (d.status, d.error)
         assert isinstance(d.result, runtime.Result), type(d.result)
+        assert d.result.llm_result.startswith("{\"shape\":[2,1]"), d.result.llm_result
+        assert "\"columns\":[\"x\"]" in d.result.llm_result, d.result.llm_result
+        assert "\"rows\":[[1],[2]]" in d.result.llm_result, d.result.llm_result
+        import json as _json
+        import subprocess as _subprocess
+        import tempfile as _tempfile
+        from pathlib import Path as _Path
+
+        _nuon_path = _Path(_tempfile.mkdtemp()) / "df.nuon"
+        _nuon_path.write_text(d.result.llm_result)
+        _parsed = _json.loads(_subprocess.check_output(
+            ["nu", "-c", f"open --raw {_nuon_path} | from nuon | to json -r"],
+            text=True,
+        ))
+        assert _parsed["shape"] == [2, 1] and _parsed["rows"] == [[1], [2]], _parsed
+
+        class Split:
+            def __ix_html__(self):
+                return "<strong>human</strong>"
+            def __ix_llm__(self):
+                return {"answer": 42, "tags": ["nuon", "llm"]}
+
+        split = runtime.Result.of(Split())
+        assert split.user_html == "<strong>human</strong>", split.user_html
+        _split_path = _Path(_tempfile.mkdtemp()) / "split.nuon"
+        _split_path.write_text(split.llm_result)
+        _split = _json.loads(_subprocess.check_output(
+            ["nu", "-c", f"open --raw {_split_path} | from nuon | to json -r"],
+            text=True,
+        ))
+        assert _split == {"answer": 42, "tags": ["nuon", "llm"]}, (split.llm_result, _split)
+        from ix_notebook_mcp import outputs as _outputs_for_llm
+
+        _bundle = split._repr_mimebundle_()
+        assert runtime.IX_LLM_MIME in _bundle and _bundle["text/html"] == "<strong>human</strong>", _bundle
+        _content = _outputs_for_llm.to_mcp([{"output_type": "display_data", "data": _bundle}])
+        assert len(_content) == 1 and _content[0].text == split.llm_result, _content
         # Jupyter semantics: the last expression IS the result, whatever its type.
         sc = await run("1 + 1", budget=2.0, name="scalar")
         assert sc.status == "done", (sc.status, sc.error)
@@ -2700,6 +2737,7 @@ let
         nativeBuildInputs = [
           mcpPython
           pkgs.git
+          pkgs.nushell
         ];
         strictDeps = true;
       }

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -397,6 +397,39 @@ class Job:
         return head + ("\n" + out if out else "")
 
 
+def _nuon_key(value: Any) -> str:
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _nuon(value: Any, *, _depth: int = 0) -> str:
+    """A compact Nushell NUON subset for model-facing structured output."""
+    if _depth > 8:
+        return json.dumps(_safe_repr(value), ensure_ascii=False)
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float):
+        if value == value and value not in (float("inf"), float("-inf")):
+            return repr(value)
+        return json.dumps(str(value), ensure_ascii=False)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, bytes):
+        return json.dumps(base64.b64encode(value).decode("ascii"), ensure_ascii=False)
+    if isinstance(value, Mapping):
+        return "{" + ",".join(f"{_nuon_key(k)}:{_nuon(v, _depth=_depth + 1)}" for k, v in value.items()) + "}"
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_nuon(v, _depth=_depth + 1) for v in value) + "]"
+    iso = getattr(value, "isoformat", None)
+    if callable(iso):
+        with contextlib.suppress(Exception):
+            return json.dumps(iso(), ensure_ascii=False)
+    return json.dumps(_safe_repr(value), ensure_ascii=False)
+
+
 def _llm_text(value: Any) -> str | None:
     """Coerce a model-facing text field to ``str`` (or None to keep a default).
 
@@ -412,7 +445,29 @@ def _llm_text(value: Any) -> str | None:
     inner = getattr(value, "llm_result", None)
     if isinstance(inner, str):
         return inner
-    return _safe_repr(value)
+    return _nuon(value)
+
+
+def _call_value_hook(value: Any, *names: str) -> Any:
+    for name in names:
+        hook = getattr(value, name, None)
+        if hook is None:
+            continue
+        try:
+            return hook() if callable(hook) else hook
+        except Exception:
+            return None
+    return None
+
+
+def _html_output(value: Any) -> str | None:
+    html = _call_value_hook(value, "__ix_html__", "_ix_html_", "_repr_html_", "__html__")
+    return html if isinstance(html, str) else None
+
+
+def _llm_output(value: Any) -> str | None:
+    out = _call_value_hook(value, "__ix_llm__", "_ix_llm_")
+    return _llm_text(out) if out is not None else None
 
 
 def _result_from_text(cls: type, value: Any, *, html: str | None = None) -> Result:
@@ -538,9 +593,9 @@ class Result:
         """Wrap any value: render it richly for the human (a DataFrame as a
         table, a figure as an image, anything else as its display HTML or repr)
         and hand the model concise text. For a polars DataFrame the model text is
-        the frame as compact, untruncated CSV (the human still gets the styled
-        HTML table), so a wide or long-stringed frame is never clipped to the
-        agent the way the boxed text repr clips it. Override with ``llm_result``."""
+        compact NUON (the human still gets the styled HTML table), so a wide or
+        long-stringed frame is never clipped to the agent the way the boxed text
+        repr clips it. Override with ``llm_result`` or define ``__ix_llm__``."""
         if isinstance(value, Result):
             # An existing Result is already split into its two views: copy it
             # faithfully (keeping llm_images) instead of rebuilding it from its
@@ -551,6 +606,13 @@ class Result:
                 llm_result=value.llm_result if llm_result is None else llm_result,
                 llm_images=value.llm_images,
             )
+        if not _is_polars_df(value):
+            llm_hook = _llm_output(value)
+            html_hook = _html_output(value)
+            if html_hook is not None or llm_hook is not None:
+                text_view = llm_result if llm_result is not None else (llm_hook or _nuon(value))
+                user = html_hook if html_hook is not None else f'<pre class="ix-result">{_escape_html(text_view)}</pre>'
+                return cls(user_html=user, llm_result=text_view)
         image_mime = _image_bytes_mime(value)
         if image_mime is not None:
             # Raw PNG/JPEG bytes (e.g. `await page.screenshot()`): show the human
@@ -598,7 +660,7 @@ class Result:
         if frame is not None:
             # A rich result type (fff GrepResult/SearchResult) that exposes a
             # polars frame: render that frame the same as a bare DataFrame -- a
-            # styled table for the human, compact CSV for the model -- so the
+            # styled table for the human, compact NUON for the model -- so the
             # model reads the real rows, not a one-line summary repr.
             text_view = llm_result if llm_result is not None else _df_llm_text(frame)
             try:
@@ -614,11 +676,11 @@ class Result:
         elif _is_polars_df(value):
             text_view = _df_llm_text(value)
         else:
-            text_view = _safe_repr(value)
+            text_view = _nuon(value)
         if _is_polars_df(value):
             # A frame (incl. a dict/records value coerced above) renders as the
             # dashboard's styled table directly -- a table for the human, compact
-            # CSV for you -- and works even without the IPython display formatter.
+            # NUON for you -- and works even without the IPython display formatter.
             try:
                 import view as _view
 
@@ -644,8 +706,7 @@ class Result:
         # server unpacks and the dashboard ignores; text/plain is the fallback.
         bundle: dict = {"text/html": self.user_html, "text/plain": self.llm_result or ""}
         images = [img for img in (_coerce_image(i) for i in self.llm_images) if img]
-        if images:
-            bundle[IX_LLM_MIME] = {"text": self.llm_result or "", "images": images}
+        bundle[IX_LLM_MIME] = {"text": self.llm_result or "", "images": images}
         return bundle
 
     def __call__(self) -> Result:
@@ -664,7 +725,7 @@ class Result:
 def _as_frame_if_tabular(value: Any) -> Any:
     """A mapping (a config dict, counts) or a list of mappings (records) is
     tabular: render it as a polars frame -- a styled table for the human, compact
-    CSV for you -- rather than a raw dict/list repr. Anything else is returned
+    NUON for you -- rather than a raw dict/list repr. Anything else is returned
     unchanged. Keeps `Result({...})` from shoving a dict under text/html (invalid)
     and from collapsing to a bare repr."""
     try:
@@ -692,7 +753,7 @@ def _as_frame_if_tabular(value: Any) -> Any:
             return value
     if isinstance(value, (list, tuple)) and value:
         # A plain list/tuple of scalars is tabular too: one styled `value` column
-        # for the human, compact CSV for you. (Lists of mappings are records above.)
+        # for the human, compact NUON for you. (Lists of mappings are records above.)
         try:
             return pl.DataFrame({"value": list(value)})
         except Exception:
@@ -1796,17 +1857,22 @@ def _ansi_to_html(text: str) -> str:
 
 # How many rows of a DataFrame the model-facing text carries. The human's HTML
 # table is unaffected (it renders the whole frame, paged); this only bounds the
-# CSV handed back to the agent so a million-row frame cannot flood its context.
+# NUON handed back to the agent so a million-row frame cannot flood its context.
 _DF_LLM_ROWS = 200
 
 
 def _is_polars_df(value: Any) -> bool:
-    """True for a polars DataFrame, by duck typing. runtime.py stays import-light
-    (polars is the user's to bring), so it never imports polars to check."""
+    """True for a polars DataFrame, by duck typing.
+
+    runtime.py stays import-light (polars is the user's to bring), and Nix-built
+    wheels may expose extension-backed classes whose module is not simply
+    ``polars.*``.
+    """
     return (
-        type(value).__module__.split(".", 1)[0] == "polars"
-        and hasattr(value, "write_csv")
+        hasattr(value, "iter_rows")
         and hasattr(value, "columns")
+        and hasattr(value, "dtypes")
+        and hasattr(value, "shape")
         and hasattr(value, "height")
     )
 
@@ -1815,7 +1881,7 @@ def _frame_view(value: Any) -> Any:
     """A non-DataFrame value that opts into the table protocol by exposing
     ``_ix_to_frame_()`` returning a polars DataFrame (e.g. an fff ``GrepResult``
     or ``SearchResult``). Returns that frame, else None. Lets a rich result type
-    render as the styled table for the human and compact CSV for the model,
+    render as the styled table for the human and compact NUON for the model,
     instead of falling back to its one-line summary repr."""
     hook = getattr(value, "_ix_to_frame_", None)
     if hook is None:
@@ -1828,19 +1894,27 @@ def _frame_view(value: Any) -> Any:
 
 
 def _df_llm_text(df: Any) -> str:
-    """A polars DataFrame as compact text for the model: a shape + dtype header
-    then CSV, with cell values never truncated (only the row count is bounded by
-    ``_DF_LLM_ROWS``). CSV is denser than the boxed repr and drops no value, so
-    the agent reads the real data instead of a width-clipped table."""
+    """A polars DataFrame as compact NUON for the model.
+
+    Values are never width-truncated (only the row count is bounded by
+    ``_DF_LLM_ROWS``), so the agent reads the real data instead of a boxed repr.
+    """
     try:
-        schema = ", ".join(f"{name}:{dtype}" for name, dtype in zip(df.columns, df.dtypes, strict=False))
         rows, cols = df.shape
-        body = df.head(_DF_LLM_ROWS).write_csv().rstrip("\n")
-        more = f"\n... ({rows - _DF_LLM_ROWS} more rows)" if rows > _DF_LLM_ROWS else ""
-        return f"shape: ({rows}, {cols}) | {schema}\n{body}{more}"
+        head = df.head(_DF_LLM_ROWS)
+        payload = {
+            "shape": [rows, cols],
+            "schema": {name: str(dtype) for name, dtype in zip(df.columns, df.dtypes, strict=False)},
+            "columns": list(df.columns),
+            "rows": [list(row) for row in head.iter_rows()],
+        }
+        if rows > _DF_LLM_ROWS:
+            payload["truncated"] = True
+            payload["shown_rows"] = _DF_LLM_ROWS
+        return _nuon(payload)
     except Exception:
-        # An exotic frame that resists write_csv falls back to its plain repr.
-        return _safe_repr(df)
+        # An exotic frame that resists row iteration falls back to safe NUON text.
+        return _nuon(_safe_repr(df))
 
 
 def _png_bytes(img: Any) -> bytes:


### PR DESCRIPTION
## Summary
- Add `__ix_html__` / `__ix_llm__` hooks for Python values rendered through `Result.of`.
- Serialize non-string LLM outputs as compact Nushell NUON.
- Switch Polars DataFrame model output to compact NUON while preserving styled HTML for humans.
- Keep the LLM MIME bundle explicit and covered by runtime smoke tests.

## Tests
- `python3 -m py_compile packages/mcp/ix_notebook_mcp/runtime.py`
- `nix build .#mcp.tests.runtimeSmoke --print-build-logs`

Refs #1585

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add NUON serialization for LLM-facing output in the MCP notebook runtime
> - Adds a `_nuon` serializer in [`runtime.py`](https://github.com/indexable-inc/index/pull/1586/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) that converts Python values (dicts, lists, scalars, bytes, etc.) to [Nushell NUON](https://www.nushell.sh/book/loading_data.html#nuon) format for model-facing output, replacing plain `repr` strings.
> - `_df_llm_text` now emits structured NUON for Polars DataFrames, including shape, schema, column names, and row data (truncated at the existing row limit).
> - Adds `_html_output` and `_llm_output` helpers that resolve `__ix_html__` / `__ix_llm__` hooks on values, letting user objects supply custom HTML and LLM representations.
> - `Result._repr_mimebundle_` now always includes the `IX_LLM_MIME` key (previously only emitted when images were present).
> - Behavioral Change: non-string `llm_result` values and DataFrame outputs now produce NUON instead of CSV or repr strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e6f366.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->