### PR TITLE
Add NUON split output hooks to MCP

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2218,21 +2218,20 @@ let
         d = await run("import polars as pl\npl.DataFrame({'x': [1, 2]})", budget=2.0, name="auto-df")
         assert d.status == "done", (d.status, d.error)
         assert isinstance(d.result, runtime.Result), type(d.result)
-        assert d.result.llm_result.startswith("{\"shape\":[2,1]"), d.result.llm_result
-        assert "\"columns\":[\"x\"]" in d.result.llm_result, d.result.llm_result
-        assert "\"rows\":[[1],[2]]" in d.result.llm_result, d.result.llm_result
+        assert d.result.llm_result.startswith("shape: (2, 1) | x:Int64"), d.result.llm_result
+        assert "[[x]; [1], [2]]" in d.result.llm_result, d.result.llm_result
         import json as _json
         import subprocess as _subprocess
         import tempfile as _tempfile
         from pathlib import Path as _Path
 
         _nuon_path = _Path(_tempfile.mkdtemp()) / "df.nuon"
-        _nuon_path.write_text(d.result.llm_result)
+        _nuon_path.write_text(d.result.llm_result.split("\n", 1)[1])
         _parsed = _json.loads(_subprocess.check_output(
             ["nu", "-c", f"open --raw {_nuon_path} | from nuon | to json -r"],
             text=True,
         ))
-        assert _parsed["shape"] == [2, 1] and _parsed["rows"] == [[1], [2]], _parsed
+        assert _parsed == [{"x": 1}, {"x": 2}], _parsed
 
         class Split:
             def __ix_html__(self):
@@ -3010,9 +3009,10 @@ let
     assert runtime.IX_LLM_MIME in llm_bundle["data"], list(llm_bundle["data"])
     decoded = json.loads(llm_bundle["data"][runtime.IX_LLM_MIME])
     assert decoded["text"] == "a chart of x" and len(decoded["images"]) == 1, decoded
-    # A result with no model images carries no IX_LLM_MIME (text/plain is the text).
+    # A result with no model images still carries IX_LLM_MIME so to_mcp can prefer
+    # the explicit model view over any human HTML fallback.
     plain_bundle = runtime._result_bundle(runtime.Result(user_html="<b>hi</b>", llm_result="hi"))
-    assert runtime.IX_LLM_MIME not in plain_bundle["data"], list(plain_bundle["data"])
+    assert json.loads(plain_bundle["data"][runtime.IX_LLM_MIME]) == {"text": "hi", "images": []}
     # A huge llm_result is clipped to the same cap as any other text mime, so it
     # can never bypass the limit into the store / each dashboard poll.
     big = runtime._result_bundle(
@@ -3027,6 +3027,9 @@ let
     stacked = runtime.Result.of(("GrepResult: 0 matches", pl.DataFrame({"a": [1, 2]})))
     assert stacked.user_html.count("<table") == 1, stacked.user_html[:200]
     assert "GrepResult: 0 matches" in stacked.llm_result and "shape:" in stacked.llm_result, stacked.llm_result
+    direct_df = runtime.Result.of(pl.DataFrame({"a": [1, 2], "b": ["x", "y"]}))
+    assert '[[a, b]; [1, "x"], [2, "y"]]' in direct_df.llm_result, direct_df.llm_result
+    assert "┌" not in direct_df.llm_result, direct_df.llm_result
     # A plain list of scalars is still ONE table (not stacked), unchanged.
     scalars = runtime.Result.of([1, 2, 3])
     assert scalars.user_html.count("<table") == 1, scalars.user_html[:200]
@@ -3037,7 +3040,7 @@ let
     assert len(nested.llm_images) == 1, ("nested Result dropped its images", nested.llm_images)
 
     # The table protocol: a non-DataFrame value exposing _ix_to_frame_() renders
-    # as its polars frame -- a styled table for the human, compact CSV for the
+    # as its polars frame: a styled table for the human, compact NUON for the
     # model -- instead of its one-line summary repr, so a rich result type shows
     # the model the real rows, not just a count.
     class _Framed:
@@ -3051,6 +3054,20 @@ let
     assert "<table" in framed.user_html, framed.user_html[:200]
     assert framed.llm_result.startswith("shape: (1, 2)") and "a.py" in framed.llm_result, framed.llm_result
     assert "summary" not in framed.llm_result, "must render the frame, not the summary repr"
+
+    # Jupyter-style rich hooks can split a bare object's human HTML from its
+    # model-facing text without manually constructing Result(...).
+    class _Widget:
+        def _repr_html_(self):
+            return "<strong>human</strong>"
+
+        def _repr_llm_(self):
+            return "model-view"
+
+    split = runtime.Result.of(_Widget())
+    assert split.user_html == "<strong>human</strong>", split.user_html
+    assert split.llm_result == "model-view", split.llm_result
+    assert runtime._nuon([{"a": 1, "b": 2}, {"a": 5, "b": 7}]) == "[[a, b]; [1, 2], [5, 7]]"
 
     # A hook that raises or returns a non-frame is ignored: fall back to the
     # normal repr path rather than blowing up the result.
@@ -3151,8 +3168,8 @@ let
         assert multi_row["status"] == "done", multi_row["status"]
         multi_text = [out["data"].get("text/plain", "") for out in json.loads(multi_row["outputs"])][-1]
         # Both values are shown: the bool by its repr, the list as its one-column
-        # frame (CSV rows 1/2/3), not collapsed to just the first value.
-        assert "True" in multi_text and "1\n2\n3" in multi_text, ("multi-value dropped a value", multi_text)
+        # frame (NUON rows 1/2/3), not collapsed to just the first value.
+        assert "true" in multi_text and "[[value]; [1], [2], [3]]" in multi_text, ("multi-value dropped a value", multi_text)
 
 
     asyncio.run(main())

--- a/packages/mcp/ix_notebook_mcp/outputs.py
+++ b/packages/mcp/ix_notebook_mcp/outputs.py
@@ -9,6 +9,7 @@ text). The kernel-side runtime also emits a structured summary under the
 from __future__ import annotations
 
 import base64
+import json
 import os
 import re
 
@@ -82,6 +83,11 @@ def to_mcp(outputs: list[dict]) -> list[Content]:
             if IX_LLM_MIME in data:
                 # A Result's explicit model view: its text, then its images.
                 spec = data[IX_LLM_MIME]
+                if isinstance(spec, str):
+                    try:
+                        spec = json.loads(spec)
+                    except json.JSONDecodeError:
+                        spec = None
                 if isinstance(spec, dict):
                     if spec.get("text"):
                         content.append(text(spec["text"]))

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -398,7 +398,19 @@ class Job:
 
 
 def _nuon_key(value: Any) -> str:
-    return json.dumps(str(value), ensure_ascii=False)
+    text = str(value)
+    return text if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", text) else json.dumps(text, ensure_ascii=False)
+
+
+def _nuon_table(columns: list[Any], rows: list[Mapping[Any, Any]], *, _depth: int = 0) -> str:
+    header = ", ".join(_nuon_key(c) for c in columns)
+    if not rows:
+        return f"[[{header}];]"
+    body = ", ".join(
+        "[" + ", ".join(_nuon(row.get(c), _depth=_depth + 1) for c in columns) + "]"
+        for row in rows
+    )
+    return f"[[{header}]; {body}]"
 
 
 def _nuon(value: Any, *, _depth: int = 0) -> str:
@@ -420,9 +432,19 @@ def _nuon(value: Any, *, _depth: int = 0) -> str:
     if isinstance(value, bytes):
         return json.dumps(base64.b64encode(value).decode("ascii"), ensure_ascii=False)
     if isinstance(value, Mapping):
-        return "{" + ",".join(f"{_nuon_key(k)}:{_nuon(v, _depth=_depth + 1)}" for k, v in value.items()) + "}"
+        return "{" + ", ".join(f"{_nuon_key(k)}: {_nuon(v, _depth=_depth + 1)}" for k, v in value.items()) + "}"
     if isinstance(value, (list, tuple)):
-        return "[" + ",".join(_nuon(v, _depth=_depth + 1) for v in value) + "]"
+        if value and all(isinstance(v, Mapping) for v in value):
+            columns: list[Any] = []
+            seen: set[str] = set()
+            for row in value:
+                for key in row:
+                    text = str(key)
+                    if text not in seen:
+                        seen.add(text)
+                        columns.append(key)
+            return _nuon_table(columns, value, _depth=_depth)
+        return "[" + ", ".join(_nuon(v, _depth=_depth + 1) for v in value) + "]"
     iso = getattr(value, "isoformat", None)
     if callable(iso):
         with contextlib.suppress(Exception):
@@ -466,7 +488,7 @@ def _html_output(value: Any) -> str | None:
 
 
 def _llm_output(value: Any) -> str | None:
-    out = _call_value_hook(value, "__ix_llm__", "_ix_llm_")
+    out = _call_value_hook(value, "__ix_llm__", "_ix_llm_", "_repr_llm_")
     return _llm_text(out) if out is not None else None
 
 
@@ -1896,22 +1918,18 @@ def _frame_view(value: Any) -> Any:
 def _df_llm_text(df: Any) -> str:
     """A polars DataFrame as compact NUON for the model.
 
-    Values are never width-truncated (only the row count is bounded by
-    ``_DF_LLM_ROWS``), so the agent reads the real data instead of a boxed repr.
+    The shape + dtype header orients the reader; the body is a Nushell table
+    literal with headers listed once. Values are never width-truncated (only the
+    row count is bounded by ``_DF_LLM_ROWS``), so the agent reads the real data
+    instead of a boxed repr.
     """
     try:
         rows, cols = df.shape
         head = df.head(_DF_LLM_ROWS)
-        payload = {
-            "shape": [rows, cols],
-            "schema": {name: str(dtype) for name, dtype in zip(df.columns, df.dtypes, strict=False)},
-            "columns": list(df.columns),
-            "rows": [list(row) for row in head.iter_rows()],
-        }
-        if rows > _DF_LLM_ROWS:
-            payload["truncated"] = True
-            payload["shown_rows"] = _DF_LLM_ROWS
-        return _nuon(payload)
+        schema = ", ".join(f"{name}:{dtype}" for name, dtype in zip(df.columns, df.dtypes, strict=False))
+        body = _nuon_table(list(head.columns), head.to_dicts())
+        more = f"\n... ({rows - _DF_LLM_ROWS} more rows)" if rows > _DF_LLM_ROWS else ""
+        return f"shape: ({rows}, {cols}) | {schema}\n{body}{more}"
     except Exception:
         # An exotic frame that resists row iteration falls back to safe NUON text.
         return _nuon(_safe_repr(df))

--- a/packages/mcp/tests/test_outputs.py
+++ b/packages/mcp/tests/test_outputs.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from ix_notebook_mcp import outputs
+
+
+def test_mcp_output_prefers_llm_mime_over_human_html() -> None:
+    content = outputs.to_mcp(
+        [
+            {
+                "output_type": "execute_result",
+                "data": {
+                    "text/html": "<strong>human-only</strong>",
+                    "text/plain": "fallback",
+                    outputs.IX_LLM_MIME: {"text": "model-only", "images": []},
+                },
+            }
+        ]
+    )
+
+    assert [getattr(item, "text", None) for item in content] == ["model-only"]

--- a/packages/mcp/tests/test_session_namespaces.py
+++ b/packages/mcp/tests/test_session_namespaces.py
@@ -13,6 +13,8 @@ stdout or a quiet ok.
 from __future__ import annotations
 
 import asyncio
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -208,3 +210,46 @@ def test_an_explicit_result_is_unchanged(monkeypatch: pytest.MonkeyPatch) -> Non
     job = run_cell("print('noise')\nResult.text('explicit')")
     assert job.status == "done"
     assert job.result.llm_result == "explicit"
+
+
+def test_repr_html_and_repr_llm_split_bare_object_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+    job = run_cell(
+        "class Widget:\n"
+        "    def _repr_html_(self):\n"
+        "        return '<strong>human</strong>'\n"
+        "    def _repr_llm_(self):\n"
+        "        return 'model-view'\n"
+        "Widget()"
+    )
+    assert job.status == "done", (job.status, job.error)
+    assert job.result.user_html == "<strong>human</strong>"
+    assert job.result.llm_result == "model-view"
+
+
+def test_polars_dataframe_defaults_to_compact_nuon_for_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    pl = pytest.importorskip("polars")
+    _wire(monkeypatch, {"pl": pl})
+    job = run_cell("pl.DataFrame({'name': ['ada', 'grace'], 'score': [10, 11]})")
+    assert job.status == "done", (job.status, job.error)
+    assert "shape: (2, 2)" in job.result.llm_result
+    assert "[[name, score]; [\"ada\", 10], [\"grace\", 11]]" in job.result.llm_result
+    assert "┌" not in job.result.llm_result
+
+    nu = shutil.which("nu")
+    if nu is None:
+        pytest.skip("nushell is required to parse the NUON e2e")
+    body = job.result.llm_result.split("\n", 1)[1]
+    parsed = subprocess.run(
+        [nu, "-c", "open --raw /dev/stdin | from nuon | get 1.name"],
+        input=body,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    assert parsed.stdout.strip() == "grace"
+
+
+def test_list_of_records_uses_nushell_table_nuon() -> None:
+    assert runtime._nuon([{"a": 1, "b": 2}, {"a": 5, "b": 7}]) == "[[a, b]; [1, 2], [5, 7]]"


### PR DESCRIPTION
## Summary

- add Jupyter-style HTML hooks and model-facing LLM hooks to `Result.of`
- switch default tabular/DataFrame model text to compact NUON table literals
- cover Polars, list-of-record NUON, and MCP LLM MIME routing in tests/smokes

Fixes #1584.

## Validation

- `nix build .#mcp.tests.richSmoke .#mcp.tests.sessionSmoke .#mcp.tests.yieldSmoke .#mcp.tests.runtimeSmoke .#mcp --print-build-logs`

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add NUON table output and `_repr_llm_` split hooks to MCP notebook runtime
> - DataFrame LLM text is now a readable `shape: (rows, cols) | schema` header followed by a NUON table of head rows, replacing the previous JSON/CSV-shaped payload; box-drawing characters are absent.
> - Lists of `Mapping`-typed records are rendered as NUON tables (single header + row entries) instead of JSON-like arrays in [`runtime.py`](https://github.com/indexable-inc/index/pull/1587/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95).
> - `_llm_output` now checks for `_repr_llm_` in addition to `__ix_llm__`/`_ix_llm_`, allowing objects to provide a model-facing text separate from their HTML repr.
> - [`outputs.py`](https://github.com/indexable-inc/index/pull/1587/files#diff-c0531af2f36a91cd56ac9ae4f0be9a0cbb88094a80355387d1b13e95e1568eb9) now accepts `IX_LLM_MIME` as either a dict or a JSON-encoded string; malformed strings are ignored.
> - Behavioral Change: MCP consumers previously received JSON-keyed DataFrame output (`shape`/`columns`/`rows`); they now receive plain NUON table text, and boolean values are lowercase (`true`/`false`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11e0cdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->