### PR TITLE
chore(ix-sdk-python): bump x86_64-linux wheel to the create-boots build

### DIFF
--- a/packages/ix-sdk-python/default.nix
+++ b/packages/ix-sdk-python/default.nix
@@ -23,8 +23,8 @@ let
   # workspace-sdks.nix. Other systems fall through to the loud placeholder below.
   catalog = {
     x86_64-linux = {
-      url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/5azviwv34h5k6s63wj4pvx1y0bw5831v/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
-      hash = "sha256-jys0Rb8ZeZ7GWDIKTspuc5lt0TmkIQbBNayT0hObgQY=";
+      url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/37h7h93kyfzv69k707ynaibkchjnpnwr/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
+      hash = "sha256-KYteEHzhGqMcfwLWdyT1wnkzOZDGaux+PJJ6WFkELbo=";
     };
     aarch64-darwin = {
       url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/jmj8q0gsq5lnvv8aap6j7zh874bpzqjh/ix_sdk-0.1.0-cp313-abi3-macosx_11_0_arm64.whl";


### PR DESCRIPTION
Re-pin the x86_64-linux ix_sdk wheel to the rebuild that includes the `Client.create` boot fix (ix sdk-py: create now starts the VM after the build, not just `build_commit_from_oci`). Without this bump ix-fleet keeps running the old wheel, so `up` creates the status VMs stopped and the regional-status "New VMs" heartbeats stay red.

aarch64-darwin is unchanged (no new darwin wheel built).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump ix-sdk-python x86_64-linux wheel to the create-boots build
> Updates the wheel URL and sha256 hash for the x86_64-linux entry in [default.nix](https://github.com/indexable-inc/index/pull/1588/files#diff-80f46c8d1744ebc070c811611b94e45d792b24cdeeae53fcaf78e4db15945032) to point to the create-boots build artifact.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2121d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->