### PR TITLE
nix: move reusable primitives into index

### DIFF
--- a/doc/ix/overview.md
+++ b/doc/ix/overview.md
@@ -15,7 +15,10 @@ Two repos, one boundary:
   VM images and fleet plans (`lib/`), the ready-made service modules
   (`modules/services/`), the base images (`images/`), and a large set of
   standalone tools (search, mcp, tui, dashboard, `ix-fleet`, ...) under
-  `packages/`. You can read, fork, and run all of it (`LICENSE`).
+  `packages/`. Shared Nix primitives live here too: checked script writers,
+  generic check constructors, PostgreSQL packages such as `postgresql_18_ix`,
+  and reusable `bw://folder/item/field` reference grammar. You can read, fork,
+  and run all of it (`LICENSE`).
 - **The hosted platform (private, proprietary).** The `ix` CLI, the control plane
   it talks to, and the image registry (`registry.ix.dev`) are the hosted product,
   under the Indexable SDK License. The CLI builds your open `index`-based config

--- a/doc/ix/services.md
+++ b/doc/ix/services.md
@@ -54,6 +54,8 @@ Concrete example, enabling PostgreSQL (option verified at
   imports = [ ../modules/services/postgresql ];
 
   services.ix-postgresql.enable = true;
+  # Optional: override `package`; the default is pkgs.postgresql_18_ix with
+  # the trusted uint128 extension available for CREATE EXTENSION.
 }
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -248,6 +248,23 @@
         "url": "https://github.com/linux-rdma/perftest"
       }
     },
+    "pg-uint128-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1762189440,
+        "narHash": "sha256-D2eTxzVZCQk9Cz4bhSmKu9hfL8r1RwkjS8ajadKb5sY=",
+        "owner": "pg-uint",
+        "repo": "pg-uint128",
+        "rev": "db7a79a0f5ccd3d59404d6b9510e01f0876699ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pg-uint",
+        "ref": "1.2.0",
+        "repo": "pg-uint128",
+        "type": "github"
+      }
+    },
     "pyproject-build-systems": {
       "inputs": {
         "nixpkgs": [
@@ -350,6 +367,7 @@
         "launchk-src": "launchk-src",
         "nixpkgs": "nixpkgs",
         "perftest-src": "perftest-src",
+        "pg-uint128-src": "pg-uint128-src",
         "rust-overlay": "rust-overlay",
         "site": "site",
         "skills": "skills",

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,13 @@
       flake = false;
     };
 
+    # PostgreSQL uint128 extension source. The package marks the extension trusted
+    # so non-superuser database owners can run `CREATE EXTENSION uint128`.
+    pg-uint128-src = {
+      url = "github:pg-uint/pg-uint128/1.2.0";
+      flake = false;
+    };
+
     fff-src = {
       url = "github:dmtrKovalenko/fff/v0.9.1";
       flake = false;
@@ -174,6 +181,7 @@
       btop-src,
       drgn-src,
       perftest-src,
+      pg-uint128-src,
       fff-src,
       launchk-src,
       snix-src,
@@ -220,6 +228,7 @@
         tests = tests.outPath;
         bench.filesystem = bench-filesystem.outPath;
         site = site.outPath;
+        pgUint128Src = pg-uint128-src;
         packagesRoot = ./packages;
         minecraftCatalogs = ./packages/minecraft/catalogs;
         minecraftMods = ./packages/minecraft/catalogs/mods;

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+}:
+{
+  mkNixUnitSuites =
+    {
+      pkgs,
+      nixUnit,
+      src,
+      suiteTiers,
+      entryFor ? (
+        tier: name:
+        pkgs.writeText "nix-unit-entry-${tier}-${name}.nix" ''
+          import ${src}/checks/${tier}/${name}.nix {
+            lib = import ${pkgs.path + "/lib"};
+          }
+        ''
+      ),
+      resultPrefix ? "eval",
+    }:
+    let
+      mkCheck =
+        tier: name:
+        pkgs.runCommand "${resultPrefix}-${tier}-${name}" { nativeBuildInputs = [ nixUnit ]; } ''
+          export HOME="$(mktemp -d)"
+          export NIX_STORE_DIR=${builtins.storeDir}
+          export NIX_REMOTE="$HOME/store"
+          nix-unit --eval-store "$HOME/store" --gc-roots-dir "$HOME/gc" ${entryFor tier name}
+          mkdir -p "$out"
+          printf 'nix-unit ok: %s/%s\n' ${lib.escapeShellArg tier} ${lib.escapeShellArg name} > "$out/result"
+        '';
+
+      byTier = lib.mapAttrs (tier: names: lib.genAttrs names (mkCheck tier)) suiteTiers;
+    in
+    {
+      flat = lib.concatMapAttrs (
+        tier: byName:
+        lib.mapAttrs' (name: drv: lib.nameValuePair "${resultPrefix}-${tier}-${name}" drv) byName
+      ) byTier;
+    };
+
+  mkBooleanCheck =
+    {
+      pkgs,
+      prefix,
+    }:
+    name:
+    {
+      ok,
+      successMessage ? "${prefix} ok: ${name}",
+      failureMessage,
+    }:
+    pkgs.runCommand "${prefix}-${name}" { __structuredAttrs = true; } (
+      if ok then
+        ''
+          mkdir -p "$out"
+          printf '%s\n' ${lib.escapeShellArg successMessage} > "$out/result"
+        ''
+      else
+        ''
+          printf '%s\n' ${lib.escapeShellArg failureMessage} >&2
+          exit 1
+        ''
+    );
+
+  mkScriptCheck =
+    {
+      pkgs,
+      prefix,
+      nativeBuildInputs ? [ ],
+    }:
+    name: script:
+    pkgs.runCommand "${prefix}-${name}"
+      {
+        __structuredAttrs = true;
+        inherit nativeBuildInputs;
+      }
+      ''
+        ${script}
+        mkdir -p "$out"
+        printf '${prefix} ok: %s\n' ${lib.escapeShellArg name} > "$out/result"
+      '';
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -49,8 +49,13 @@ let
     writePythonApplication
     writeNushellApplication
     writeBashApplication
+    writeRustApplication
     writeProcessComposeApplication
     ;
+  netCidr = import ./util/net-cidr.nix { inherit lib; };
+  publicArtifactsFor = pkgs: import ./util/public-artifacts.nix { inherit lib pkgs; };
+  secretRefs = import ./util/secret-refs.nix { inherit lib; };
+  checks = import ./checks.nix { inherit lib; };
 
   /**
     Repo-local nixpkgs overlay.
@@ -425,6 +430,7 @@ let
       buildUvApplication
       buildZigPackage
       cargoUnit
+      checks
       claudePlugin
       deepMerge
       goUnit
@@ -438,11 +444,14 @@ let
       mkMinecraftNbtFormat
       mkMinecraftSyncManaged
       mutableJson
+      netCidr
       paths
+      publicArtifactsFor
       relativePath
       ruffAnnArgs
       rustWorkspace
       rustWorkspaceFor
+      secretRefs
       skills
       systemdHardening
       toml
@@ -450,6 +459,7 @@ let
       writeNushellApplication
       writeProcessComposeApplication
       writePythonApplication
+      writeRustApplication
       ;
     btopSrc = btop-src;
     drgnSrc = drgn-src;

--- a/lib/util/lists.nix
+++ b/lib/util/lists.nix
@@ -17,7 +17,13 @@ let
     (they key a grouping). Returned sorted and de-duplicated.
   */
   findDuplicates = findDuplicatesBy lib.id;
+
+  /**
+    Build an attrset from a list by mapping each element to a
+    `lib.nameValuePair`-shaped `{ name; value; }` result.
+  */
+  genAttrs' = xs: f: lib.listToAttrs (map f xs);
 in
 {
-  inherit findDuplicatesBy findDuplicates;
+  inherit findDuplicatesBy findDuplicates genAttrs';
 }

--- a/lib/util/net-cidr.nix
+++ b/lib/util/net-cidr.nix
@@ -1,0 +1,57 @@
+{ lib }:
+let
+  uintInRange =
+    upper: value:
+    value != ""
+    && builtins.match "[0-9]+" value != null
+    && (
+      let
+        n = lib.toInt value;
+      in
+      n >= 0 && n <= upper
+    );
+
+  isValidIpv4Cidr =
+    s:
+    let
+      parts = lib.splitString "/" s;
+      addrPart = if builtins.length parts == 2 then builtins.elemAt parts 0 else "";
+      prefixPart = if builtins.length parts == 2 then builtins.elemAt parts 1 else "";
+      octets = lib.splitString "." addrPart;
+      octetIsByte = o: o != "" && builtins.match "[0-9]+" o != null && uintInRange 255 o;
+    in
+    builtins.isString s
+    && builtins.length parts == 2
+    && builtins.length octets == 4
+    && builtins.all octetIsByte octets
+    && uintInRange 32 prefixPart;
+
+  isValidIpv6Cidr =
+    s:
+    let
+      parts = lib.splitString "/" s;
+      addrPart = if builtins.length parts == 2 then builtins.elemAt parts 0 else "";
+      prefixPart = if builtins.length parts == 2 then builtins.elemAt parts 1 else "";
+      hextets = lib.splitString ":" addrPart;
+      nonEmptyHextets = builtins.filter (h: h != "") hextets;
+      compressionParts = lib.splitString "::" addrPart;
+      hasCompression = builtins.length compressionParts == 2;
+      tooManyCompressionMarkers = builtins.length compressionParts > 2;
+      hextetIsValid = h: builtins.match "[0-9A-Fa-f]{1,4}" h != null;
+      hextetCount = builtins.length nonEmptyHextets;
+    in
+    builtins.isString s
+    && builtins.length parts == 2
+    && addrPart != ""
+    && builtins.match ".*\\..*" addrPart == null
+    && !(lib.hasInfix ":::" addrPart)
+    && !tooManyCompressionMarkers
+    && builtins.all hextetIsValid nonEmptyHextets
+    && (if hasCompression then hextetCount < 8 else builtins.length hextets == 8 && hextetCount == 8)
+    && uintInRange 128 prefixPart;
+
+  isValidIpCidr = c: builtins.isString c && (isValidIpv4Cidr c || isValidIpv6Cidr c);
+in
+{
+  inherit isValidIpv4Cidr isValidIpv6Cidr isValidIpCidr;
+}

--- a/lib/util/public-artifacts.nix
+++ b/lib/util/public-artifacts.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  pkgs,
+}:
+let
+  noNixStoreReferencesInputs = [
+    pkgs.binutils
+    pkgs.coreutils
+    pkgs.file
+    pkgs.findutils
+    pkgs.gnugrep
+    pkgs.gnutar
+    pkgs.gzip
+    pkgs.jq
+    pkgs.llvmPackages.llvm
+    pkgs.patchelf
+    pkgs.removeReferencesTo
+    pkgs.ripgrep
+    pkgs.unzip
+  ];
+
+  scanNoNixStoreReferences =
+    {
+      requireStaticExecutables ? false,
+    }:
+    ''
+      scan_root=$(mktemp -d)
+      store_path_regex='/nix/store/[0-9a-df-np-sv-z]{32}-'
+      printf '%s' "$artifacts" | jq -r '.[] | [.name, .path] | @tsv' |
+        while IFS=$'\t' read -r name path; do
+          artifact_root="$scan_root/$name"
+          mkdir -p "$artifact_root"
+
+          if [ -d "$path" ]; then
+            cp -R "$path/." "$artifact_root/"
+          else
+            case "$path" in
+              *.tgz|*.tar.gz)
+                tar -xzf "$path" -C "$artifact_root"
+                ;;
+              *.whl|*.zip)
+                unzip -q "$path" -d "$artifact_root"
+                ;;
+              *)
+                cp "$path" "$artifact_root/$(basename "$path")"
+                ;;
+            esac
+          fi
+
+          while IFS= read -r -d $'\0' archive; do
+            unpacked="$archive.unpacked"
+            mkdir -p "$unpacked"
+            case "$archive" in
+              *.tgz|*.tar.gz)
+                tar -xzf "$archive" -C "$unpacked"
+                ;;
+              *.whl|*.zip)
+                unzip -q "$archive" -d "$unpacked"
+                ;;
+            esac
+          done < <(find "$artifact_root" -type f \( -name "*.tgz" -o -name "*.tar.gz" -o -name "*.whl" -o -name "*.zip" \) -print0)
+
+          while IFS= read -r -d $'\0' candidate; do
+            file_type=$(file -b "$candidate")
+            if strings -a "$candidate" | rg "$store_path_regex"; then
+              echo "$name contains a Nix store reference in $candidate" >&2
+              exit 1
+            fi
+
+            case "$file_type" in
+              *ELF*)
+                if [ "${lib.boolToString requireStaticExecutables}" = "true" ]; then
+                  if patchelf --print-interpreter "$candidate" >/dev/null 2>&1; then
+                    echo "$name must be static for public distribution, but $candidate has a dynamic interpreter" >&2
+                    exit 1
+                  fi
+                  if ! echo "$file_type" | grep -Eq "static|statically"; then
+                    echo "$name must be statically linked for public distribution, but $candidate is $file_type" >&2
+                    exit 1
+                  fi
+                fi
+                ;;
+              *Mach-O*)
+                load_commands=$(llvm-objdump --macho --dylibs-used --rpaths "$candidate")
+                if echo "$load_commands" | rg "$store_path_regex"; then
+                  echo "$name must not load or search Nix store paths for public distribution" >&2
+                  exit 1
+                fi
+                ;;
+            esac
+          done < <(find "$artifact_root" -type f -print0)
+        done
+    '';
+
+  mkNoNixStoreReferencesCheck =
+    {
+      artifacts,
+      name,
+      requireStaticExecutables ? false,
+    }:
+    let
+      artifactsJson = (pkgs.formats.json { }).generate "${name}-artifacts.json" artifacts;
+    in
+    pkgs.runCommand name
+      {
+        __structuredAttrs = true;
+        strictDeps = true;
+        nativeBuildInputs = noNixStoreReferencesInputs;
+      }
+      ''
+        set -euo pipefail
+
+        artifacts=$(cat ${artifactsJson})
+
+        ${scanNoNixStoreReferences { inherit requireStaticExecutables; }}
+
+        touch "$out"
+      '';
+in
+{
+  inherit mkNoNixStoreReferencesCheck noNixStoreReferencesInputs scanNoNixStoreReferences;
+}

--- a/lib/util/secret-refs.nix
+++ b/lib/util/secret-refs.nix
@@ -1,0 +1,24 @@
+{ lib }:
+let
+  segment =
+    name: value:
+    assert lib.assertMsg (
+      !lib.hasInfix "/" value
+    ) "Vaultwarden ${name} segment must not contain '/': ${value}";
+    value;
+
+  pattern = "^bw://[^/]+/[^/]+/[^/]+$";
+
+  mkRef =
+    {
+      folder,
+      item,
+      field,
+    }:
+    "bw://${segment "folder" folder}/${segment "item" item}/${segment "field" field}";
+in
+{
+  inherit pattern mkRef;
+  isRef = ref: builtins.match pattern ref != null;
+  type = lib.types.strMatching pattern;
+}

--- a/lib/util/writers.nix
+++ b/lib/util/writers.nix
@@ -226,6 +226,48 @@ let
     };
 
   /**
+    Package a single-file Rust command as a standalone executable.
+
+    This is for small std-only operational helpers. Use a normal workspace crate
+    when the command needs crates.io dependencies or tests.
+  */
+  writeRustApplication =
+    pkgs:
+    {
+      name,
+      text,
+      edition ? "2024",
+      runtimeInputs ? [ ],
+      rustToolchain ? pkgs.rustc,
+      meta ? { },
+    }:
+    pkgs.runCommand name
+      {
+        inherit text;
+        nativeBuildInputs = [
+          rustToolchain
+          pkgs.stdenv.cc
+        ]
+        ++ lib.optional (runtimeInputs != [ ]) pkgs.makeWrapper;
+        passAsFile = [ "text" ];
+        meta = meta // {
+          mainProgram = meta.mainProgram or name;
+        };
+      }
+      (
+        ''
+          mkdir -p "$out/bin"
+          rustc --edition ${edition} -O --crate-name ${
+            lib.replaceStrings [ "-" ] [ "_" ] name
+          } -o "$out/bin/${name}" "$textPath"
+        ''
+        + lib.optionalString (runtimeInputs != [ ]) ''
+          wrapProgram "$out/bin/${name}" \
+            --prefix PATH : ${lib.makeBinPath runtimeInputs}
+        ''
+      );
+
+  /**
     Package a process-compose specification as a `nix run` application.
 
     Generates a checked YAML config from Nix values and wraps

--- a/modules/services/postgresql/default.nix
+++ b/modules/services/postgresql/default.nix
@@ -10,6 +10,7 @@ let
     mkDefault
     mkEnableOption
     mkIf
+    mkPackageOption
     mkOption
     types
     ;
@@ -34,6 +35,13 @@ in
     dataDir = mkOption {
       type = types.str;
       default = "/var/lib/postgresql/18";
+    };
+
+    package = mkPackageOption pkgs "postgresql_18_ix" {
+      extraDescription = ''
+        PostgreSQL package to run. The default includes the trusted `uint128`
+        extension so non-superuser database owners can create it in migrations.
+      '';
     };
 
     sharedBuffersMiB = mkOption {
@@ -101,7 +109,7 @@ in
 
     services.postgresql = {
       enable = true;
-      package = pkgs.postgresql_18;
+      inherit (cfg) package;
       inherit (cfg) dataDir port;
       enableJIT = true;
       # Tuned defaults for a dedicated VM. Override any of these by setting

--- a/packages/postgresql/uint128/default.nix
+++ b/packages/postgresql/uint128/default.nix
@@ -1,0 +1,56 @@
+{
+  ix,
+  lib,
+  pkgs,
+  postgresql ? pkgs.postgresql_18,
+}:
+let
+  postgresqlBuildExtension =
+    pkgs.callPackage (pkgs.path + "/pkgs/servers/sql/postgresql/postgresqlBuildExtension.nix")
+      {
+        inherit postgresql;
+      };
+  postgresqlTestExtension =
+    pkgs.callPackage (pkgs.path + "/pkgs/servers/sql/postgresql/postgresqlTestExtension.nix")
+      {
+        inherit postgresql;
+      };
+in
+postgresqlBuildExtension (finalAttrs: {
+  pname = "uint128";
+  version = "1.2.0";
+
+  nativeBuildInputs = [ postgresql.stdenv.cc ];
+
+  src = ix.paths.pgUint128Src;
+
+  # Mark the extension `trusted` so non-superuser DB owners can run
+  # `CREATE EXTENSION uint128` during migrations. Safe because pg-uint128 only
+  # defines data types and operators, with no filesystem or shell access.
+  postInstall = ''
+    # shell
+    control="$out/share/postgresql/extension/uint128.control"
+    if [ ! -f "$control" ]; then
+      echo "postgresql-uint128: expected control file at $control" >&2
+      exit 1
+    fi
+    if ! grep -q '^trusted' "$control"; then
+      echo "trusted = true" >> "$control"
+    fi
+  '';
+
+  passthru.tests = {
+    extension = postgresqlTestExtension {
+      inherit (finalAttrs) finalPackage;
+      sql = "CREATE EXTENSION uint128;";
+    };
+  };
+
+  meta = {
+    description = "Unsigned integer types for PostgreSQL";
+    homepage = "https://github.com/pg-uint/pg-uint128";
+    license = lib.licenses.postgresql;
+    maintainers = [ ];
+    inherit (postgresql.meta) platforms;
+  };
+})

--- a/packages/postgresql/uint128/package.nix
+++ b/packages/postgresql/uint128/package.nix
@@ -1,0 +1,9 @@
+{
+  id = "postgresql-uint128";
+  packageSet = true;
+  flake.systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
+  overlay.attrName = "postgresql_18_uint128";
+}

--- a/packages/postgresql/with-uint128/default.nix
+++ b/packages/postgresql/with-uint128/default.nix
@@ -1,0 +1,11 @@
+{
+  pkgs,
+  postgresql ? pkgs.postgresql_18,
+  postgresql_18_uint128 ? pkgs.postgresql_18_uint128,
+}:
+
+(postgresql.withPackages (_: [ postgresql_18_uint128 ])).overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    uint128Extension = postgresql_18_uint128;
+  };
+})

--- a/packages/postgresql/with-uint128/package.nix
+++ b/packages/postgresql/with-uint128/package.nix
@@ -1,0 +1,9 @@
+{
+  id = "postgresql-with-uint128";
+  packageSet = true;
+  flake.systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
+  overlay.attrName = "postgresql_18_ix";
+}


### PR DESCRIPTION
## Summary
- Move reusable Nix primitives into index: PostgreSQL uint128 packages, checked writers, generic check constructors, public artifact helpers, CIDR helpers, and bw:// secret-ref grammar.
- Extend the index PostgreSQL module to default to the uint128-enabled PostgreSQL package.
- Document the index/ix boundary for reusable primitives.

## Test plan
- nix fmt -- flake.nix lib modules/services/postgresql packages/postgresql doc/ix
- nix eval .#packages.aarch64-linux.postgresql-with-uint128.pname
- nix eval .#packages.aarch64-linux.postgresql-uint128.pname
- nix eval .#lib.secretRefs.pattern
- nix eval .#lib.checks --apply builtins.attrNames
- ReadLints on changed Nix surfaces
- git diff --check


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move reusable Nix primitives into the ix library and add PostgreSQL uint128 extension
> - Adds `pkgs.postgresql_18_ix`, a PostgreSQL 18 build bundled with the `uint128` extension marked trusted, so `CREATE EXTENSION uint128` works without superuser privileges.
> - The PostgreSQL service module now defaults to `pkgs.postgresql_18_ix` and accepts a `package` option to override it.
> - New utilities are exported from [lib/default.nix](https://github.com/indexable-inc/index/pull/1589/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188): `writeRustApplication` (single-file Rust binaries), `netCidr` (IPv4/IPv6 CIDR validation), `secretRefs` (validated `bw://folder/item/field` references), `publicArtifacts` (scan for Nix store references in release artifacts), and `checks` (composable check derivation builders).
> - Adds `pg-uint128-src` (v1.2.0) as a flake input and exposes `pgUint128Src` in flake outputs for downstream consumers.
> - Behavioral Change: the PostgreSQL service now defaults to `postgresql_18_ix` instead of `postgresql_18`; deployments not overriding `package` will switch to the uint128-bundled build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e06fc17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->