### PR TITLE
nix: add igzip gzip shim package

### DIFF
--- a/packages/compression/igzip-as-gzip/default.nix
+++ b/packages/compression/igzip-as-gzip/default.nix
@@ -1,0 +1,67 @@
+{
+  ix,
+  lib,
+  symlinkJoin,
+  isa-l,
+}:
+let
+  writeBashApplication = ix.writeBashApplication ix.pkgs;
+
+  clampLevels = ''
+    args=()
+    for arg in "$@"; do
+      case "$arg" in
+        -[4-9]) args+=("-3") ;;
+        *) args+=("$arg") ;;
+      esac
+    done
+  '';
+
+  mkWrapper =
+    {
+      name,
+      flags ? [ ],
+      description,
+    }:
+    writeBashApplication {
+      inherit name;
+      runtimeInputs = [ isa-l ];
+      text = ''
+        ${clampLevels}
+        exec igzip ${lib.escapeShellArgs flags} "''${args[@]}"
+      '';
+      meta.description = description;
+    };
+
+  gzip = mkWrapper {
+    name = "gzip";
+    description = "gzip-compatible wrapper backed by ISA-L igzip";
+  };
+
+  gunzip = mkWrapper {
+    name = "gunzip";
+    flags = [ "-d" ];
+    description = "gunzip-compatible wrapper backed by ISA-L igzip";
+  };
+
+  zcat = mkWrapper {
+    name = "zcat";
+    flags = [
+      "-d"
+      "-c"
+    ];
+    description = "zcat-compatible wrapper backed by ISA-L igzip";
+  };
+in
+symlinkJoin {
+  name = "igzip-as-gzip";
+  paths = [
+    gzip
+    gunzip
+    zcat
+  ];
+  meta = {
+    description = "Drop-in gzip/gunzip/zcat replacement backed by ISA-L igzip";
+    mainProgram = "gzip";
+  };
+}

--- a/packages/compression/igzip-as-gzip/package.nix
+++ b/packages/compression/igzip-as-gzip/package.nix
@@ -1,0 +1,9 @@
+{
+  id = "igzip-as-gzip";
+  packageSet = true;
+  flake.systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
+  overlay = true;
+}


### PR DESCRIPTION
## Summary
- Add `packages/compression/igzip-as-gzip` as an index-owned compression package.
- Expose it through index flake packages and the nixpkgs overlay as `igzip-as-gzip`.

## Test plan
- nix fmt -- packages/compression/igzip-as-gzip
- nix eval '.#packages.x86_64-linux."igzip-as-gzip".name'
- nix eval --impure --expr 'let flake = builtins.getFlake "path:/Users/andrewgazelka/Projects/indexable-inc/index"; pkgs = import flake.inputs.nixpkgs { system = "x86_64-linux"; overlays = [ flake.overlays.default ]; }; in pkgs."igzip-as-gzip".name'
- ReadLints on new package files
- git diff --cached --check


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `igzip-as-gzip` Nix package providing `gzip`, `gunzip`, and `zcat` via ISA-L igzip
> - Adds [default.nix](https://github.com/indexable-inc/index/pull/1590/files#diff-0b190b1ab5134b2acde90782ede76038877471cf499000d605c6daf65effa2db) defining a `symlinkJoin` derivation that exposes `gzip`, `gunzip`, and `zcat` wrappers backed by `igzip` from ISA-L.
> - Each wrapper is a bash script that clamps compression level flags `-4` through `-9` down to `-3` (the maximum igzip supports) before passing args to `igzip`.
> - `gunzip` passes `-d` and `zcat` passes `-d -c` as fixed flags; all three share the same level-clamping logic.
> - [package.nix](https://github.com/indexable-inc/index/pull/1590/files#diff-39b30c3fa10f71d8f4d2ee514d4b58d70c4e4a532f6718e5a26068730179315d) limits the package to `x86_64-linux` and `aarch64-linux` and enables overlay exposure.
> - Behavioral Change: callers invoking `gzip -6` (or any level above `-3`) will silently have that flag replaced with `-3`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d4630b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->