### PR TITLE
nix: enforce package overlay intent

### DIFF
--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -149,6 +149,41 @@
 (lint no-builtins-path-without-name error
   "`builtins.path` without `name` derives the store-path name from the working directory; set `name = \"<stable>\"` so the result is reproducible across clones")
 
+;; package-overlay-intent-explicit: Public package metadata must make the
+;; overlay decision explicit. `flake = true` publishes a CLI/build surface;
+;; `packageSet = true` publishes the repo-internal package-set surface. The
+;; nixpkgs overlay surface is intentionally separate, so write `overlay = false`
+;; for leaf packages that should stay out of `pkgs`, `overlay = true` for
+;; packages that should be available as `pkgs.<id>`, or `overlay.attrName = ...`
+;; when the nixpkgs name needs a repo-owned prefix.
+(rule (package-metadata-id attrs)
+  (match nix "
+    (attrset_expression
+      (binding_set
+        (binding attrpath: (attrpath) @id_path))) @attrs")
+  (text id_path "id"))
+(rule (package-metadata-package-set attrs)
+  (match nix "
+    (attrset_expression
+      (binding_set
+        (binding attrpath: (attrpath) @package_set_path
+          expression: (variable_expression) @package_set_value))) @attrs")
+  (text package_set_path "packageSet")
+  (text package_set_value "true"))
+(rule (package-metadata-flake attrs)
+  (match nix "
+    (attrset_expression
+      (binding_set
+        (binding attrpath: (attrpath) @flake_path))) @attrs")
+  (text-match flake_path "^flake(\\.|$)"))
+(rule (package-overlay-intent-explicit n)
+  (package-metadata-id n)
+  (package-metadata-package-set n)
+  (package-metadata-flake n)
+  (no-descendant n "identifier" "overlay"))
+(lint package-overlay-intent-explicit error
+  "flake-exposed package metadata with `packageSet = true` must make overlay intent explicit: `overlay = false`, `overlay = true`, or `overlay.attrName = ...`")
+
 ;; no-chained-attrset-update: `A // { ... } // { ... }` builds one attrset in
 ;; two steps. Merge the adjacent literals into a single `// { ... }`.
 ;; `//` is right-associative, so the chain parses as `A // ({...} // {...})`

--- a/astlog-rules/tests/package-overlay-intent-explicit/bad.fixture
+++ b/astlog-rules/tests/package-overlay-intent-explicit/bad.fixture
@@ -1,6 +1,5 @@
 {
-  id = "tonbo-artifacts";
+  id = "example";
   packageSet = true;
   flake.systems = [ "x86_64-linux" ];
-  overlay = false;
 }

--- a/astlog-rules/tests/package-overlay-intent-explicit/good.fixture
+++ b/astlog-rules/tests/package-overlay-intent-explicit/good.fixture
@@ -1,5 +1,5 @@
 {
-  id = "tmux";
+  id = "example";
   packageSet = true;
   flake = true;
   overlay = false;

--- a/lib/build/bun-lock.nix
+++ b/lib/build/bun-lock.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  # astlog-ignore: no-pkgs-in-callpackage
   pkgs,
 }:
 let

--- a/lib/build/go-unit.nix
+++ b/lib/build/go-unit.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  # astlog-ignore: no-pkgs-in-callpackage
   pkgs,
   go,
 }:

--- a/lib/build/zig-package.nix
+++ b/lib/build/zig-package.nix
@@ -24,6 +24,7 @@ _:
   - `meta`: standard derivation meta.
 */
 pkgs:
+# astlog-ignore: no-at-pattern-shortcut
 {
   pname,
   version ? "0.0.0",

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -69,7 +69,10 @@ let
       lib
       packageRegistry
       buildIxRustTool
+      cargoUnitFor
       clippy-fork
+      rustWorkspaceFor
+      writeNushellApplication
       writePythonApplication
       ;
     # Pure cross-cutting helpers (deepMerge, writers, ...) so overlay packages

--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -2,7 +2,10 @@
   lib,
   packageRegistry,
   buildIxRustTool,
+  cargoUnitFor,
   clippy-fork,
+  rustWorkspaceFor,
+  writeNushellApplication,
   writePythonApplication,
   # Curated cross-cutting helper surface (`lib`'s `sharedHelpers`), threaded in
   # as the `ix` arg so overlay-built packages can reach pure helpers like
@@ -33,6 +36,8 @@ let
     inherit
       entry
       final
+      prev
+      lib
       buildIxRustTool
       clippy-fork
       ;
@@ -41,9 +46,12 @@ let
     # `pkgs` callPackage formal. Same value as the `pkgs` arg below (`final`).
     ix = ix // {
       pkgs = final;
+      cargoUnit = cargoUnitFor final;
+      rustWorkspace = rustWorkspaceFor final;
     };
     pkgs = final;
     inherit (entry) path;
+    writeNushellApplication = writeNushellApplication final;
     writePythonApplication = writePythonApplication final;
   };
   buildOverlayPackage =

--- a/packages/agent/claude-stories/package.nix
+++ b/packages/agent/claude-stories/package.nix
@@ -2,6 +2,7 @@
   id = "claude-stories";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/agent/codex/package.nix
+++ b/packages/agent/codex/package.nix
@@ -11,4 +11,5 @@
   # (`nix run .#codex`, `index.packages.<sys>.codex`) that bakes our defaults on
   # top of that same base, without changing what the overlay hands other code.
   flake = true;
+  overlay = false;
 }

--- a/packages/agent/pi-harnesses/base/package.nix
+++ b/packages/agent/pi-harnesses/base/package.nix
@@ -2,4 +2,5 @@
   id = "pi-base";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/agent/pi-harnesses/beam/package.nix
+++ b/packages/agent/pi-harnesses/beam/package.nix
@@ -2,4 +2,5 @@
   id = "pi-beam";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/agent/pi-harnesses/prosecutor/package.nix
+++ b/packages/agent/pi-harnesses/prosecutor/package.nix
@@ -2,4 +2,5 @@
   id = "pi-prosecutor";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/agent/symphony/package.nix
+++ b/packages/agent/symphony/package.nix
@@ -7,4 +7,5 @@
   id = "symphony";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/agent/system-prompt-eval-viewer/package.nix
+++ b/packages/agent/system-prompt-eval-viewer/package.nix
@@ -2,4 +2,5 @@
   id = "system-prompt-eval-viewer";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/agent/system-prompt-eval/package.nix
+++ b/packages/agent/system-prompt-eval/package.nix
@@ -2,6 +2,7 @@
   id = "system-prompt-eval";
   packageSet = true;
   flake = true;
+  overlay = false;
   # Without this the offline scoring/printsHelp tests in default.nix never reach
   # the required flake-check job: ciChecks only collects passthru.tests for
   # packages that declare passthruTests here. The non-rust prefix keeps the check

--- a/packages/andrewgazelka/hive/package.nix
+++ b/packages/andrewgazelka/hive/package.nix
@@ -6,4 +6,5 @@
   id = "hive";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/blast-radius/package.nix
+++ b/packages/blast-radius/package.nix
@@ -2,6 +2,7 @@
   id = "blast-radius";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/code/ast-merge/cli/package.nix
+++ b/packages/code/ast-merge/cli/package.nix
@@ -2,6 +2,7 @@
   id = "ast-merge";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/code/clone-detect/cli/package.nix
+++ b/packages/code/clone-detect/cli/package.nix
@@ -2,6 +2,7 @@
   id = "clone";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/code/scipql/cli/package.nix
+++ b/packages/code/scipql/cli/package.nix
@@ -2,5 +2,6 @@
   id = "scipql";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
 }

--- a/packages/config-launch/package.nix
+++ b/packages/config-launch/package.nix
@@ -2,6 +2,7 @@
   id = "config-launch";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/dag-runner/package.nix
+++ b/packages/dag-runner/package.nix
@@ -2,6 +2,7 @@
   id = "dag-runner";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/dashboard/dashboard/package.nix
+++ b/packages/dashboard/dashboard/package.nix
@@ -2,6 +2,7 @@
   id = "dashboard";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/dev/htmlpage/package.nix
+++ b/packages/dev/htmlpage/package.nix
@@ -2,4 +2,5 @@
   id = "htmlpage";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/dev/install-vscode-extensions/package.nix
+++ b/packages/dev/install-vscode-extensions/package.nix
@@ -2,4 +2,5 @@
   id = "install-vscode-extensions";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/elevenlabs-say/package.nix
+++ b/packages/elevenlabs-say/package.nix
@@ -2,4 +2,5 @@
   id = "elevenlabs-say";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/flecs-query/mcp/package.nix
+++ b/packages/flecs-query/mcp/package.nix
@@ -2,6 +2,7 @@
   id = "ix-flecs-query-mcp";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/git-log-pretty/package.nix
+++ b/packages/git-log-pretty/package.nix
@@ -2,6 +2,7 @@
   id = "git-log-pretty";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/google/calendar/cli/package.nix
+++ b/packages/google/calendar/cli/package.nix
@@ -2,6 +2,7 @@
   id = "gcal";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/google/gmail/cli/package.nix
+++ b/packages/google/gmail/cli/package.nix
@@ -2,6 +2,7 @@
   id = "gmail";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/google/mcp/package.nix
+++ b/packages/google/mcp/package.nix
@@ -2,6 +2,7 @@
   id = "ix-google-mcp";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/indexbench/package.nix
+++ b/packages/indexbench/package.nix
@@ -2,6 +2,7 @@
   id = "indexbench";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/ix-dev-diagnose/package.nix
+++ b/packages/ix-dev-diagnose/package.nix
@@ -2,6 +2,7 @@
   id = "ix-dev-diagnose";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/ix-fleet/package.nix
+++ b/packages/ix-fleet/package.nix
@@ -2,6 +2,7 @@
   id = "ix-fleet";
   packageSet = true;
   flake = true;
+  overlay = false;
   passthruTests = {
     prefix = "ix-fleet";
   };

--- a/packages/ix-sdk-python/package.nix
+++ b/packages/ix-sdk-python/package.nix
@@ -2,6 +2,7 @@
   id = "ix-sdk-python";
   packageSet = true;
   flake = true;
+  overlay = false;
   passthruTests = {
     prefix = "ix-sdk-python";
   };

--- a/packages/llm-clippy/package.nix
+++ b/packages/llm-clippy/package.nix
@@ -2,4 +2,5 @@
   id = "llm-clippy";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/minecraft/bossbar-overlay/book-overlay/package.nix
+++ b/packages/minecraft/bossbar-overlay/book-overlay/package.nix
@@ -1,6 +1,7 @@
 {
   id = "book-overlay";
   flake = true;
+  overlay = false;
   packageSet = true;
   path = ./book.nix;
 }

--- a/packages/minecraft/bossbar-overlay/package.nix
+++ b/packages/minecraft/bossbar-overlay/package.nix
@@ -1,6 +1,7 @@
 {
   id = "bossbar";
   flake = true;
+  overlay = false;
   packageSet = true;
   # The flake output builds the CLI wrapper, not the Tauri overlay app; the
   # desktop app stays a `bun run tauri dev`/`build` target.

--- a/packages/minecraft/bossbar-overlay/xp-orb-overlay/package.nix
+++ b/packages/minecraft/bossbar-overlay/xp-orb-overlay/package.nix
@@ -1,6 +1,7 @@
 {
   id = "xp-orb-overlay";
   flake = true;
+  overlay = false;
   packageSet = true;
   path = ./orb.nix;
 }

--- a/packages/minecraft/minecraft/nbt/package.nix
+++ b/packages/minecraft/minecraft/nbt/package.nix
@@ -2,6 +2,7 @@
   id = "minecraft-nbt";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/minecraft/minecraft/probe/package.nix
+++ b/packages/minecraft/minecraft/probe/package.nix
@@ -2,4 +2,5 @@
   id = "mc-probe";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/minecraft/minecraft/sync-managed/package.nix
+++ b/packages/minecraft/minecraft/sync-managed/package.nix
@@ -2,6 +2,7 @@
   id = "minecraft-sync-managed";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/mynoise/package.nix
+++ b/packages/mynoise/package.nix
@@ -2,6 +2,7 @@
   id = "mynoise";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/nix/nix-cargo-unit/package.nix
+++ b/packages/nix/nix-cargo-unit/package.nix
@@ -2,6 +2,7 @@
   id = "nix-cargo-unit";
   packageSet = true;
   flake = true;
+  overlay = false;
   # Not inRustWorkspace: this crate is a standalone Cargo workspace (own
   # Cargo.toml + Cargo.lock), so it is built as a plain package and kept out of
   # the root workspace unit graph. passthruTests still gate on packageSet.

--- a/packages/nix/nix-output-monitor/package.nix
+++ b/packages/nix/nix-output-monitor/package.nix
@@ -2,6 +2,17 @@
   id = "nix-output-monitor";
   packageSet = true;
   flake = true;
-  overlay = true;
+  overlay = {
+    build =
+      {
+        lib,
+        path,
+        prev,
+        ...
+      }:
+      lib.callPackageWith prev path {
+        pkgs = prev;
+      };
+  };
   passthruTests = true;
 }

--- a/packages/nix/snix/package.nix
+++ b/packages/nix/snix/package.nix
@@ -5,5 +5,6 @@
   # external fetched Cargo workspace, not a member of this repo's workspace.
   id = "snix";
   flake = true;
+  overlay = false;
   packageSet = true;
 }

--- a/packages/polars-sftp/package.nix
+++ b/packages/polars-sftp/package.nix
@@ -1,6 +1,7 @@
 {
   id = "polars-sftp";
   flake = true;
+  overlay = false;
   packageSet = true;
   # Gate the strict Python type/annotation check (default.nix passthru.tests.pyStrict)
   # in CI as `checks.<system>.polars-sftp-pyStrict`.

--- a/packages/screencast/screencast-ingest/package.nix
+++ b/packages/screencast/screencast-ingest/package.nix
@@ -2,6 +2,7 @@
   id = "screencast-ingest";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/search/file-search/package.nix
+++ b/packages/search/file-search/package.nix
@@ -2,6 +2,7 @@
   id = "file-search";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/search/polars-mixedbread/package.nix
+++ b/packages/search/polars-mixedbread/package.nix
@@ -8,6 +8,7 @@
   # no install-name fixups, and the cdylib links on macOS via build.rs. That lets
   # `nix build .#polars-mixedbread` work on darwin for local validation.
   flake = true;
+  overlay = false;
   packageSet = true;
   # Gate the pure-Python predicate-pushdown test (default.nix passthru.tests) in
   # CI as `checks.<system>.polars-mixedbread-pushdown`.

--- a/packages/search/search-eval/package.nix
+++ b/packages/search/search-eval/package.nix
@@ -2,4 +2,5 @@
   id = "search-eval";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/search/search/package.nix
+++ b/packages/search/search/package.nix
@@ -2,6 +2,7 @@
   id = "search";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/site/package.nix
+++ b/packages/site/package.nix
@@ -2,4 +2,5 @@
   id = "site";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/skill-lint/package.nix
+++ b/packages/skill-lint/package.nix
@@ -2,6 +2,7 @@
   id = "skill-lint";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/terminal/btop/package.nix
+++ b/packages/terminal/btop/package.nix
@@ -2,4 +2,5 @@
   id = "btop";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/tui/reel/package.nix
+++ b/packages/tui/reel/package.nix
@@ -2,6 +2,7 @@
   id = "reel";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/tui/run/package.nix
+++ b/packages/tui/run/package.nix
@@ -2,4 +2,5 @@
   id = "run";
   packageSet = true;
   flake = true;
+  overlay = false;
 }

--- a/packages/tui/vt/ix-vt/package.nix
+++ b/packages/tui/vt/ix-vt/package.nix
@@ -2,6 +2,7 @@
   id = "ix-vt";
   packageSet = true;
   flake = true;
+  overlay = false;
   inRustWorkspace = true;
   passthruTests = true;
 }

--- a/packages/tui/vt/libghostty-vt/package.nix
+++ b/packages/tui/vt/libghostty-vt/package.nix
@@ -2,4 +2,5 @@
   id = "libghostty-vt";
   packageSet = true;
   flake = true;
+  overlay = false;
 }


### PR DESCRIPTION
## Summary
- add `package-overlay-intent-explicit` to require flake-exposed package metadata in `packageSet` to declare overlay intent
- mark current package metadata with `overlay = false`, `overlay = true`, or explicit `overlay.attrName`
- make overlay context complete enough for newly overlay-exposed packages and switch `astlog-scan` to consume `astlog` directly

Refs #1592

## Validation
- `git diff --check`
- fixture self-check logic for `astlog-rules/{nix,rust,cargo,elixir}.astlog`
- `nix build .#astlog-scan --print-build-logs`
- package metadata `astlog scan astlog-rules/nix.astlog packages/**/package.nix --json`
- overlay drvPath eval for `astlog`, `astlog-scan`, `claude-hooks`, `ix-distiller`, `ix-indexer`, `ix-mcp`, `nix-output-monitor`, `nix-web-monitor`

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce explicit overlay intent in flake-exposed Nix package metadata
> - Adds a new `package-overlay-intent-explicit` astlog lint rule that errors when a package with `packageSet=true` and flake metadata omits an explicit `overlay` field.
> - Adds `overlay = false` to ~50 existing `package.nix` files to satisfy the new lint requirement.
> - Updates [lib/overlay.nix](https://github.com/indexable-inc/index/pull/1593/files#diff-65204771292c901d3da5be0a98b4162f557dc034fc1f1b58400a6d136b0525cd) to expose `cargoUnitFor`, `rustWorkspaceFor`, and `writeNushellApplication` in the overlay context, and adds `ix.cargoUnit` and `ix.rustWorkspace` computed values for overlay-built packages.
> - Converts `packages/nix/nix-output-monitor/package.nix` from `overlay = true` to a custom overlay attribute set that builds the package using `prev` as the callPackage scope.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c459c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->