### PR TITLE
nix: preserve genAttrs helper argument order

### DIFF
--- a/lib/util/lists.nix
+++ b/lib/util/lists.nix
@@ -22,7 +22,7 @@ let
     Build an attrset from a list by mapping each element to a
     `lib.nameValuePair`-shaped `{ name; value; }` result.
   */
-  genAttrs' = lib.flip lib.genAttrs';
+  genAttrs' = xs: f: lib.genAttrs' xs f;
 in
 {
   inherit findDuplicatesBy findDuplicates genAttrs';


### PR DESCRIPTION
## Summary
- Restore `lib.lists.genAttrs'` to the public `xs: f:` argument order used by ix.
- Keep the implementation backed by nixpkgs `lib.genAttrs'`.

## Test plan
- nix eval --impure helper smoke test
- nix run .#lint
- git diff --check


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `genAttrs'` argument order to expect `(xs, f)` instead of `(f, xs)`
> Changes the implementation of `genAttrs'` in [lists.nix](https://github.com/indexable-inc/index/pull/1594/files#diff-ce86db6e7fd6c6084c4b72ba5ac9e396937999905f3c3033a6b08105e9c0e6ba) from `lib.flip lib.genAttrs'` to an explicit `xs: f: lib.genAttrs' xs f`, correcting the argument order to match the helper's intended `(xs, f)` signature. Risk: any existing call sites that rely on partial application with `f` as the first argument will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0a1920.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->