### PR TITLE
fix(postgresql): bind postgresql_18 explicitly so the package isn't downgraded to 17

### DIFF
--- a/packages/postgresql/uint128/default.nix
+++ b/packages/postgresql/uint128/default.nix
@@ -2,9 +2,14 @@
   ix,
   lib,
   pkgs,
-  postgresql ? pkgs.postgresql_18,
 }:
 let
+  # Bind PostgreSQL 18 explicitly instead of taking a `postgresql` argument. The
+  # package framework builds this with `lib.callPackageWith (pkgs // ...)` (see
+  # lib/packages.nix), so a `postgresql` formal would be auto-filled from
+  # `pkgs.postgresql`: the unversioned alias, currently PG 17.10. That shadows a
+  # `? pkgs.postgresql_18` default and builds the extension for the wrong major.
+  postgresql = pkgs.postgresql_18;
   postgresqlBuildExtension =
     pkgs.callPackage (pkgs.path + "/pkgs/servers/sql/postgresql/postgresqlBuildExtension.nix")
       {

--- a/packages/postgresql/with-uint128/default.nix
+++ b/packages/postgresql/with-uint128/default.nix
@@ -1,9 +1,17 @@
 {
   pkgs,
-  postgresql ? pkgs.postgresql_18,
   postgresql_18_uint128 ? pkgs.postgresql_18_uint128,
 }:
 
+# Bind PostgreSQL 18 explicitly instead of taking a `postgresql` argument. These
+# packages are built with `lib.callPackageWith (pkgs // ...)` (see
+# lib/packages.nix), so a `postgresql` formal would be auto-filled from
+# `pkgs.postgresql`: the unversioned alias, currently PG 17.10. That shadows a
+# `? pkgs.postgresql_18` default and silently ships a downgraded server.
+# Referencing `pkgs.postgresql_18` here cannot be shadowed.
+let
+  postgresql = pkgs.postgresql_18;
+in
 (postgresql.withPackages (_: [ postgresql_18_uint128 ])).overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
     uint128Extension = postgresql_18_uint128;


### PR DESCRIPTION
The `postgresql_18_ix` package set (`postgresql-uint128`, `postgresql-with-uint128`) took a `postgresql ? pkgs.postgresql_18` argument. But these packages are built via `lib.callPackageWith (pkgs // ...)` (lib/packages.nix), so the `postgresql` formal was auto-filled from `pkgs.postgresql`: the unversioned alias, currently PostgreSQL 17.10. That silently shadowed the `pkgs.postgresql_18` default, so `postgresql_18_ix` shipped `postgresql-and-plugins-17.10` and downgraded every consumer from PG 18 to PG 17, bricking PG-18 data directories on deploy ("database files are incompatible with server").

Bind `pkgs.postgresql_18` directly (a `let`, not a shadowable formal) in both packages. `postgresql-with-uint128` now evaluates and builds to `postgresql-and-plugins-18.4`, with the uint128 extension compiled against the 18.4 server headers.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `postgresql_18` binding to prevent downgrade to unversioned alias
> Replaces the default function parameter `postgresql ? pkgs.postgresql_18` with an explicit `let` binding in both [`packages/postgresql/uint128/default.nix`](https://github.com/indexable-inc/index/pull/1596/files#diff-bea36ee63712ee26e9e451d108e15b12ba97b6d1024e0425b5881385510b137b) and [`packages/postgresql/with-uint128/default.nix`](https://github.com/indexable-inc/index/pull/1596/files#diff-6990b5deeeb228f93a9125fdbe33da2fb7ee69467a052b1f232d2ec5d79e085b). This ensures the extension and the composed package are always built against `pkgs.postgresql_18`, rather than accepting an auto-filled unversioned `postgresql` alias that could resolve to PostgreSQL 17.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 309b7c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->