### PR TITLE
cargo-unit: force noninteractive nextest reporter

### DIFF
--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -570,6 +570,14 @@ let
         [profile.default.junit]
         path = "junit.xml"
       '';
+      nextestNonInteractiveEnv = {
+        # #1597: Nix builders can attach cargo-nextest to a pseudo-terminal
+        # without carrying the usual CI environment. Force the plain reporter
+        # path so progress redraws cannot stall dispatcher handoffs.
+        NEXTEST_HIDE_PROGRESS_BAR = "true";
+        NEXTEST_NO_INPUT_HANDLER = "true";
+        NEXTEST_SHOW_PROGRESS = "none";
+      };
       mkNextestForTarget =
         targetName: entry:
         let
@@ -581,6 +589,7 @@ let
         pkgs.runCommand "cargo-unit-nextest-${targetName}"
           (
             packageEnv
+            // nextestNonInteractiveEnv
             // {
               __structuredAttrs = true;
               strictDeps = true;
@@ -624,6 +633,7 @@ let
               --binaries-metadata "$workspace_root/binaries-metadata.json"
 
             ${lib.concatStringsSep "\n" (map (name: "export ${name}") (attrNames packageEnv))}
+            ${lib.concatStringsSep "\n" (map (name: "export ${name}") (attrNames nextestNonInteractiveEnv))}
 
             cargo-nextest nextest run \
               --config-file ${nextestConfigFile} \

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4259,6 +4259,13 @@ let
         message = "cargo-unit testChecksByTarget should use cargo-nextest when policy.tests.useNextest is enabled";
       }
       {
+        assertion =
+          cargoUnitWorkspace.nextestByTarget.cargo_unit_hello.NEXTEST_HIDE_PROGRESS_BAR == "true"
+          && cargoUnitWorkspace.nextestByTarget.cargo_unit_hello.NEXTEST_NO_INPUT_HANDLER == "true"
+          && cargoUnitWorkspace.nextestByTarget.cargo_unit_hello.NEXTEST_SHOW_PROGRESS == "none";
+        message = "cargo-unit cargo-nextest checks should force non-interactive reporter environment";
+      }
+      {
         assertion = lib.isDerivation cargoUnitWorkspace.testChecksAll;
         message = "cargo-unit workspaces should expose an aggregate test-check derivation";
       }


### PR DESCRIPTION
Fixes #1597.

This moves the nextest reporter guard to cargo-unit itself, where the `cargo-unit-nextest-*` derivations are generated. Nix builders can present stderr as a pseudo-terminal without normal CI environment markers, so cargo-nextest may otherwise pick the interactive progress path.

Validation:
- `nix-instantiate --parse lib/rust/cargo-unit.nix >/dev/null`
- `nix-instantiate --parse tests/default.nix >/dev/null`
- `nix run nixpkgs#nixfmt-rfc-style -- --check lib/rust/cargo-unit.nix tests/default.nix`

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force noninteractive reporter in `cargo-unit` nextest derivations
> Sets three environment variables (`NEXTEST_HIDE_PROGRESS_BAR=true`, `NEXTEST_NO_INPUT_HANDLER=true`, `NEXTEST_SHOW_PROGRESS=none`) on `cargo-unit` nextest derivations in [cargo-unit.nix](https://github.com/indexable-inc/index/pull/1599/files#diff-82054df1a7d1648a5be88265641a7ae5d3b9e4ec4cdea72c518359ea4ae3f804) to prevent interactive output in CI/Nix sandbox builds. A test assertion in [tests/default.nix](https://github.com/indexable-inc/index/pull/1599/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) validates that these variables are present on the derivation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ccbaa7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->