### PR TITLE
docs(ix): add Nix install path, drop 'microVM' wording

### DIFF
--- a/doc/ix/cli.md
+++ b/doc/ix/cli.md
@@ -1,9 +1,37 @@
 # ix CLI
 
-`ix` is the platform CLI for running your own microVMs: you create them, attach to
+`ix` is the platform CLI for running your own VMs: you create them, attach to
 them, and tear them down by name. This page is the verb
 map and the mental model, not a flag reference. For flags on any verb, run
 `ix <verb> --help`.
+
+## Install
+
+The official installer drops the `ix` binary on your `PATH`:
+
+```sh
+curl -fsSL https://ix.dev/install.sh | sh
+```
+
+Or install it with Nix from the
+[`ix-cli`](https://github.com/indexable-inc/ix-cli) flake, which pins the same
+`ix.dev` binary by content hash:
+
+```sh
+nix run github:indexable-inc/ix-cli -- ls        # run without installing
+nix profile install github:indexable-inc/ix-cli  # install into your profile
+```
+
+As a flake input:
+
+```nix
+{
+  inputs.ix.url = "github:indexable-inc/ix-cli";
+  # then use ix.packages.${system}.default
+}
+```
+
+Supported platforms: `aarch64-darwin` and `x86_64-linux`.
 
 ## Mental model
 

--- a/doc/ix/overview.md
+++ b/doc/ix/overview.md
@@ -1,6 +1,6 @@
 # ix platform
 
-`ix` is a platform for running your own microVMs: boot an image and you get a VM
+`ix` is a platform for running your own VMs: boot an image and you get a VM
 you own, with networking, secrets, logs, snapshots, a shell, and declarative
 config converged by name. You drive it with the `ix` CLI (`ix new`, `ix up`,
 `ix ls`, ...) over a hosted control plane. This page is the map for agents and


### PR DESCRIPTION
- `doc/ix/cli.md`: new **Install** section covering the `curl https://ix.dev/install.sh | sh` installer and the Nix flake at [`indexable-inc/ix-cli`](https://github.com/indexable-inc/ix-cli) (`nix run` / `nix profile install` / flake input). The flake pins the same `ix.dev` binary by content hash.
- Replaced "microVMs" with "VMs" in `cli.md` and `overview.md` (the only two occurrences in `doc/`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Nix install instructions and replace 'microVM' with 'VM' in ix docs
> - Adds a new 'Install' section to [doc/ix/cli.md](https://github.com/indexable-inc/index/pull/1601/files#diff-17f8b8e99082227405e01c4df6a4a35ff8bb772bd1c38d5405bd167ceb437ec6) covering a curl-based installer, Nix flake run/install commands, flake input usage, and supported platforms (`aarch64-darwin`, `x86_64-linux`).
> - Replaces 'microVMs' with 'VMs' in both [doc/ix/cli.md](https://github.com/indexable-inc/index/pull/1601/files#diff-17f8b8e99082227405e01c4df6a4a35ff8bb772bd1c38d5405bd167ceb437ec6) and [doc/ix/overview.md](https://github.com/indexable-inc/index/pull/1601/files#diff-fd9441b9d8f808f51aa7f791e3c3e4c33eb096e0333d4f4e833895207f069a43).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fb46f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->