### PR TITLE
fix(mcp): autostart dashboard on first tool use

### DIFF
--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -735,14 +735,7 @@ def _dashboard(*, open_browser: bool = True) -> int:
     """Open the one shared dashboard, starting it if needed. Idempotent: a hub
     already running is reused (no second board), which is the whole point of the
     machine-wide singleton -- repeated runs never pile up dashboards."""
-    # Serialize concurrent launches: without this, two `ix-mcp dashboard` runs can
-    # both see no hub and both spawn one (TOCTOU between the check and the bind).
-    # Holding an exclusive lock around check-or-spawn means the loser blocks, then
-    # finds the winner's hub.json and reuses it.
-    lock_path = runtime_dir() / "hub.lock"
-    with lock_path.open("w") as lock:
-        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
-        state = live_hub() or _spawn_shared_hub()
+    state = ensure_shared_dashboard()
     if state is None:
         return 1
     url = state["url"]
@@ -753,6 +746,30 @@ def _dashboard(*, open_browser: bool = True) -> int:
     if open_browser and sys.stdout.isatty():
         webbrowser.open(url)
     return 0
+
+
+def ensure_shared_dashboard(*, open_browser: bool = False) -> dict | None:
+    """Start or reuse the shared dashboard hub.
+
+    Tool calls use this directly for first-use autostart, where stdout is the MCP
+    protocol stream and must stay untouched. ``ix-mcp dashboard`` remains the
+    user-facing CLI wrapper that prints the URL and applies the TTY browser-open
+    policy.
+    """
+    # Serialize concurrent launches: without this, two `ix-mcp dashboard` runs can
+    # both see no hub and both spawn one (TOCTOU between the check and the bind).
+    # Holding an exclusive lock around check-or-spawn means the loser blocks, then
+    # finds the winner's hub.json and reuses it.
+    lock_path = runtime_dir() / "hub.lock"
+    with lock_path.open("w") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        state = live_hub() or _spawn_shared_hub()
+    if state is None:
+        return None
+    url = state["url"]
+    if open_browser:
+        webbrowser.open(url)
+    return state
 
 
 def _one_shot(code: str) -> int:

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -29,6 +29,7 @@ restates a tool by hand.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -122,6 +123,26 @@ def _session_id(ctx: Context | None) -> str | None:
 # Set once the connecting client has been identified to the kernel, so the
 # session label defaults to it (see runtime.Session). A latch, not per-call work.
 _client_identified = False
+_dashboard_started = False
+
+
+async def _start_dashboard_once() -> None:
+    """Best-effort first-tool dashboard startup.
+
+    `serve` no longer owns a per-server hub, but a first real tool call is the
+    moment a human expects the website to exist. Reuse the shared singleton so
+    abnormal MCP exits do not leave one orphan hub per server.
+    """
+    global _dashboard_started
+    if _dashboard_started:
+        return
+    _dashboard_started = True
+    try:
+        from .cli import ensure_shared_dashboard
+
+        await asyncio.to_thread(ensure_shared_dashboard, open_browser=True)
+    except Exception:
+        logger.exception("dashboard autostart failed")
 
 
 def _client_label(ctx: Context | None) -> str:
@@ -246,6 +267,7 @@ async def python_exec(
     budget: Annotated[float, Field(description="Seconds to wait before backgrounding the run (server-side cap: 120s; larger values are clamped and a notice is appended to the reply)")] = 15.0,
     ctx: Context | None = None,
 ) -> Content:
+    await _start_dashboard_once()
     await _identify_client_once(ctx)
     # A foreground budget is how long the run holds the one shared shell channel
     # before it backgrounds, so cap it: a giant budget (a 15-minute `await
@@ -335,6 +357,7 @@ async def read(
     end: Annotated[int | None, Field(description="Last line to include (inclusive)")] = None,
     ctx: Context | None = None,
 ) -> Content:
+    await _start_dashboard_once()
     await _identify_client_once(ctx)
     sid = _session_id(ctx)
     code = f"await __ix_read({target!r}, {start!r}, {end!r}, session={sid!r})"
@@ -352,6 +375,7 @@ async def read(
 
 @mcp.tool(structured_output=False, description=guide.TRACE)
 async def kernel_trace() -> str:
+    await _start_dashboard_once()
     return await current_kernel().dump_trace()
 
 
@@ -466,6 +490,7 @@ async def tui_act(
     ] = None,
     ctx: Context | None = None,
 ) -> Content:
+    await _start_dashboard_once()
     await _identify_client_once(ctx)
     try:
         ack = await resources_bridge.act(uri, send_keys, peer=peer)

--- a/packages/mcp/tests/test_dashboard_autostart.py
+++ b/packages/mcp/tests/test_dashboard_autostart.py
@@ -1,0 +1,25 @@
+"""First MCP tool use starts the shared dashboard hub once."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+def test_start_dashboard_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    from ix_notebook_mcp import tools
+
+    calls: list[bool] = []
+
+    def fake_ensure_shared_dashboard(*, open_browser: bool = False) -> dict[str, object]:
+        calls.append(open_browser)
+        return {"url": "http://127.0.0.1:8080/"}
+
+    monkeypatch.setattr("ix_notebook_mcp.cli.ensure_shared_dashboard", fake_ensure_shared_dashboard)
+    monkeypatch.setattr(tools, "_dashboard_started", False)
+
+    asyncio.run(tools._start_dashboard_once())
+    asyncio.run(tools._start_dashboard_once())
+
+    assert calls == [True]


### PR DESCRIPTION
## Summary
- restore first-tool MCP dashboard autostart using the shared singleton hub
- keep `ix-mcp dashboard` as the URL-printing CLI wrapper
- add a regression test for one-shot autostart

Fixes #1602

## Validation
- `nix run .#mcp -- eval "1+1"`
- `nix shell nixpkgs#ruff -c ruff check packages/mcp/ix_notebook_mcp/cli.py packages/mcp/ix_notebook_mcp/tools.py packages/mcp/tests/test_dashboard_autostart.py`
- attempted `nix shell nixpkgs#python3Packages.pytest -c pytest packages/mcp/tests/test_dashboard_autostart.py -q -p no:cacheprovider`, blocked because the bare pytest shell lacks the MCP package dependency

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Autostart the dashboard hub on first MCP tool use
> - Adds `_start_dashboard_once()` in [tools.py](https://github.com/indexable-inc/index/pull/1603/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6), a one-shot async latch that calls `cli.ensure_shared_dashboard` in a thread with `open_browser=True` on the first tool invocation per server lifetime.
> - Adds `ensure_shared_dashboard()` in [cli.py](https://github.com/indexable-inc/index/pull/1603/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5), which serializes hub start via an exclusive flock, reuses a live hub or spawns one, and returns the hub state dict (including URL) or `None`.
> - Inserts `await _start_dashboard_once()` at the top of `python_exec`, `read`, `kernel_trace`, and `tui_act` tools so the dashboard is available before any tool executes.
> - Behavioral Change: any first tool call in a process will now spawn a browser window pointing at the dashboard hub.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d720fbb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->