### PR TITLE
Redesign MCP dashboard jobs page

### DIFF
--- a/packages/dashboard/dashboard-core/site/src/components/FeedView.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/FeedView.svelte
@@ -92,13 +92,9 @@
     showResult[key] = !showResult[key];
   }
 
-  // The short run id from a pane key (`scope<0x1f>id`): the trailing id, shown as
-  // quiet meta so a human can still correlate a row to a `jobs['<id>']` without it
-  // being the headline (the title/intent is).
-  function shortId(key: string): string {
+  function paneId(key: string): string {
     const sep = key.indexOf(SCOPE_SEP);
-    const id = sep === -1 ? key : key.slice(sep + 1);
-    return id.includes('/') ? id.slice(id.lastIndexOf('/') + 1) : id;
+    return sep === -1 ? key : key.slice(sep + 1);
   }
 
   // A namespace pane (the kernel's live globals) is not a run — it has its own
@@ -197,8 +193,9 @@
       const p = it.pane;
       return (
         (p.title ?? '').toLowerCase().includes(q) ||
-        shortId(it.key).toLowerCase().includes(q) ||
-        tag(p).toLowerCase().includes(q)
+        paneId(it.key).toLowerCase().includes(q) ||
+        tag(p).toLowerCase().includes(q) ||
+        (p.subtitle ?? '').toLowerCase().includes(q)
       );
     });
   });
@@ -249,6 +246,25 @@
   function openSelected(): void {
     if (selectedKey) showResult[selectedKey] = !showResult[selectedKey];
   }
+
+
+  type FeedItem = { key: string; pane: Pane };
+  type SessionGroup = { scope: string; label: string; items: FeedItem[] };
+  function sessionLabel(scope: string): string {
+    return sessions.find((s) => s.scope === scope)?.label || shortScope(scope);
+  }
+  const grouped = $derived.by<SessionGroup[]>(() => {
+    const groups = new Map<string, FeedItem[]>();
+    for (const it of filtered) {
+      const scope = it.pane.scope || '';
+      const rows = groups.get(scope) ?? [];
+      rows.push(it);
+      groups.set(scope, rows);
+    }
+    return [...groups.entries()]
+      .map(([scope, rows]) => ({ scope, label: sessionLabel(scope), items: rows }))
+      .sort((a, b) => (a.label < b.label ? -1 : 1));
+  });
 
   // Register this view's motions with the global keymap while it is mounted.
   onMount(() => {
@@ -308,26 +324,34 @@
     <!-- Left: the timeline list. One quiet line per run; the rail threads the
          dots. Selecting a row drives the detail panel; it never expands inline. -->
     <ol class="feed-list">
-      {#each filtered as it (it.key)}
-        {@const p = it.pane}
-        {@const running = ledRun(p)}
-        {@const isErr = ledErr(p)}
-        <li class="entry" class:err={isErr} class:selected={selectedKey === it.key} data-key={it.key}>
-          <button class="entry-row" onclick={() => (selectedKey = it.key)} title={`${tag(p)}${p.subtitle ? ' · ' + p.subtitle : ''}`}>
-            <span class="entry-dot" class:live={ledLive(p)} class:run={running} class:err={isErr}></span>
-            <span class="entry-main">
-              <span class="entry-title" title={p.title}>{p.title || '(pane)'}</span>
-              <span class="entry-sub">{shortId(it.key)}<span class="entry-sub-tag"> · {tag(p)}</span></span>
-            </span>
-            {#if running}
-              <span class="entry-now">running</span>
-            {:else if p.duration_ms != null}
-              <span class="entry-age" title="execution time">{humanDuration(p.duration_ms)}</span>
-            {:else}
-              <span class="entry-age">{humanAge(p.created_at, refMs)}</span>
-            {/if}
-          </button>
+      {#each grouped as group (group.scope)}
+        <li class="session-group">
+          <div class="session-label">
+            <span>{group.label}</span>
+            <em>{group.items.length}</em>
+          </div>
         </li>
+        {#each group.items as it (it.key)}
+          {@const p = it.pane}
+          {@const running = ledRun(p)}
+          {@const isErr = ledErr(p)}
+          <li class="entry" class:err={isErr} class:selected={selectedKey === it.key} data-key={it.key}>
+            <button class="entry-row" onclick={() => (selectedKey = it.key)} title={p.subtitle || p.title || ''}>
+              <span class="entry-dot" class:live={ledLive(p)} class:run={running} class:err={isErr}></span>
+              <span class="entry-main">
+                <span class="entry-title" title={p.title}>{p.title || '(pane)'}</span>
+                {#if p.subtitle}<span class="entry-sub">{p.subtitle}</span>{/if}
+              </span>
+              {#if running}
+                <span class="entry-now">running</span>
+              {:else if p.duration_ms != null}
+                <span class="entry-age" title="execution time">{humanDuration(p.duration_ms)}</span>
+              {:else}
+                <span class="entry-age">{humanAge(p.created_at, refMs)}</span>
+              {/if}
+            </button>
+          </li>
+        {/each}
       {/each}
     </ol>
 
@@ -356,7 +380,7 @@
         </div>
         <div class="detail-meta">
           {#if ledRun(p)}running{:else if p.duration_ms != null}{humanDuration(p.duration_ms)}{:else}{humanAge(p.created_at, refMs)}{/if}
-          {#if tag(p)} · {tag(p)}{/if}{#if p.subtitle} · {p.subtitle}{/if}
+          {#if p.subtitle} · {p.subtitle}{/if}
         </div>
 
         <div class="detail-body">
@@ -389,24 +413,25 @@
                 </div>
               {/if}
             {:else}
-              <!-- Output (the point): human-facing stdout/stderr, plus the result
-                   only when it is the run's sole output. A rich table/plot/image
-                   attachment renders separately below, so the box keys on the
-                   captured streams (and a still-running run, to show "running…"). -->
+              {#if hasSource}
+                <div class="detail-section first">
+                  <div class="detail-label">code</div>
+                  <div class="entry-box entry-code"><CodeBlock code={p.source ?? ''} lang={p.lang ?? 'text'} /></div>
+                </div>
+              {/if}
               {#if hasStreamOut || resultIsPrimary || ledRun(p)}
-                <div class="entry-box cell cell-out"><ExecBody pane={p} chrome={false} expanded hideResult={!resultIsPrimary} /></div>
+                <div class="detail-section">
+                  <div class="detail-label">output</div>
+                  <div class="entry-box cell cell-out"><ExecBody pane={p} chrome={false} expanded hideResult={!resultIsPrimary} /></div>
+                </div>
               {/if}
               {#if selectedOut}
                 {@const OutBody = rendererFor(selectedOut.kind, selectedOut.renderer)}
-                <div class="entry-box pane entry-body detail-out">
-                  <div class="body html-body"><OutBody pane={selectedOut} /></div>
-                </div>
-              {/if}
-              <!-- Code, shown by default: the source beside its output. -->
-              {#if hasSource}
                 <div class="detail-section">
-                  <div class="detail-label">code</div>
-                  <div class="entry-box entry-code"><CodeBlock code={p.source ?? ''} lang={p.lang ?? 'text'} /></div>
+                  <div class="detail-label">rich output</div>
+                  <div class="entry-box pane entry-body detail-out">
+                    <div class="body html-body"><OutBody pane={selectedOut} /></div>
+                  </div>
                 </div>
               {/if}
             {/if}

--- a/packages/dashboard/dashboard-core/site/src/style.css
+++ b/packages/dashboard/dashboard-core/site/src/style.css
@@ -407,10 +407,14 @@ body {
 /* Left list: status dots threaded on one continuous rail, the intent beside each
    and its duration on the right. Selecting a row drives the detail panel. */
 .feed-list {
-  flex: 0 0 clamp(260px, 30%, 380px); min-width: 0; overflow: auto;
+  flex: 0 0 clamp(300px, 32%, 420px); min-width: 0; overflow: auto;
   border-right: 1px solid var(--edge);
-  list-style: none; margin: 0; padding: 8px 6px 40px;
+  list-style: none; margin: 0; padding: 10px 8px 40px;
 }
+.session-group { position: sticky; top: 0; z-index: 2; padding: 12px 8px 6px; background: color-mix(in srgb, var(--bg) 92%, transparent); -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px); }
+.session-label { display: flex; align-items: center; gap: 8px; color: var(--ink-dim); font-size: 12px; font-weight: 650; letter-spacing: -0.01em; }
+.session-label::before { content: ""; width: 7px; height: 7px; border-radius: 999px; background: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.session-label em { margin-left: auto; font-style: normal; font-family: var(--mono); font-size: 10px; color: var(--ink-faint); }
 
 /* Each row: a status dot, a two-line main column (the intent/title headline over a
    quiet `id · tag` sub-line), and the duration/age on the right. */
@@ -419,17 +423,17 @@ body {
   display: grid; grid-template-columns: 9px minmax(0, 1fr) auto;
   align-items: center; column-gap: 12px; width: 100%;
   font: inherit; text-align: left; color: var(--ink);
-  background: none; border: 0; cursor: pointer; padding: 9px 12px;
-  /* Hover and selection read as soft pills rather than full-bleed bands. */
-  border-radius: 9px;
-  transition: background 0.12s ease;
+  background: none; border: 0; cursor: pointer; padding: 10px 12px;
+  border-radius: 12px;
+  transition: background 0.12s ease, box-shadow 0.12s ease;
 }
 .entry-row:hover { background: var(--panel); }
 /* The selected row: a modern Raycast-style filled pill — a soft accent-tinted
    fill across the whole rounded row, no left bar. The fill alone reads as
    "selected" against the plain hover. */
 .entry.selected > .entry-row {
-  background: color-mix(in srgb, var(--accent) 14%, var(--panel));
+  background: color-mix(in srgb, var(--accent) 13%, var(--panel));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 28%, transparent);
 }
 .entry.selected > .entry-row:hover {
   background: color-mix(in srgb, var(--accent) 18%, var(--panel));
@@ -472,7 +476,7 @@ body {
 /* Right detail panel: header (dot + intent), a meta line, then the body. */
 .feed-detail {
   flex: 1 1 auto; min-width: 0; overflow: auto;
-  padding: 16px clamp(12px, 2vw, 24px) 48px;
+  padding: 22px clamp(16px, 3vw, 34px) 56px;
 }
 .detail-empty {
   color: var(--ink-faint); font-family: var(--mono); font-size: 13px; padding: 24px 4px;
@@ -492,7 +496,8 @@ body {
 /* A titled section in the detail panel (e.g. "code", "code · output"): a quiet
    uppercase label over its box, so the panel reads as labelled regions rather
    than a stack of anonymous slabs. */
-.detail-section { margin-top: 14px; }
+.detail-section { margin-top: 16px; }
+.detail-section.first { margin-top: 0; }
 .detail-label {
   margin: 0 0 5px 2px;
   font-family: var(--mono); font-size: 10px; letter-spacing: 0.07em;
@@ -528,7 +533,7 @@ body {
 
 /* The block: a flat bordered box. Split blocks lay the code and output columns
    side by side with a divider; the output column is the wider one. */
-.entry-box { border: 1px solid var(--edge); background: var(--bg); overflow: hidden; }
+.entry-box { border: 1px solid var(--edge); background: var(--panel); overflow: hidden; border-radius: 12px; }
 .entry-cols { display: grid; grid-template-columns: minmax(0, 2fr) minmax(0, 3fr); }
 .cell { min-width: 0; max-height: 460px; overflow: auto; }
 /* shiki output (code blocks and auto-detected JSON output) sits flush on the
@@ -543,7 +548,7 @@ body {
 
 /* Untraced exec (older producer / subprocess output): the code, syntax-highlighted
    and full width, with its output stacked directly below — no fake side gutter. */
-.entry-code { padding: 10px 12px; border-bottom: 1px solid var(--edge); user-select: text; overflow-x: auto; }
+.entry-code { padding: 12px 14px; user-select: text; overflow-x: auto; }
 .entry-code pre,
 .entry-code .shiki {
   margin: 0; padding: 0;

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -3146,8 +3146,22 @@ async def __ix_read(target: Any, start: int | None = None, end: int | None = Non
     else:
         body = full
         span = f"{total} lines"
-    note = f"read {label} \u00b7 {span}, {len(body)} chars"
-    user = f'<div class="ix-ok">{icon} {_escape_html(note)}</div>'
+    note = f"read {label} · {span}, {len(body)} chars"
+    user = (
+        '<section style="font:13px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;" '
+        'class="ix-read">'
+        '<style>.ix-read{display:flex;flex-direction:column;gap:10px;color:#e8e8ee}'
+        '.ix-read header{display:flex;align-items:center;gap:10px}'
+        '.ix-read strong{display:block;font-weight:650;color:#f2f2f6}'
+        '.ix-read span{display:block;color:#8a8a95;font-size:11px;margin-top:2px}'
+        '.ix-read pre{margin:0;max-height:420px;overflow:auto;padding:12px 14px;'
+        'border:1px solid #24242a;border-radius:12px;background:#0b0b0e;color:#ececef}'
+        '.ix-read code{white-space:pre;font:inherit}</style>'
+        f'<header>{icon}<div><strong>{_escape_html(label)}</strong>'
+        f'<span>{_escape_html(span)}, {len(body)} chars</span></div></header>'
+        f'<pre><code>{_escape_html(body)}</code></pre>'
+        '</section>'
+    )
     return Result(user_html=user, llm_result=body)
 
 


### PR DESCRIPTION
## Summary
- group the MCP dashboard jobs list by session label
- remove raw job ids and runtime labels from job rows/details
- show exec code above output in the job detail
- render `read` tool dashboard output as a scrollable contents preview instead of a one-line card

## Validation
- `npm run check`
- `npm run build`
- `python3 -m py_compile packages/mcp/ix_notebook_mcp/runtime.py`

Note: targeted pytest could not run because this shell and `nix develop --impure` both resolved to Python without pytest.

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign MCP dashboard jobs page with session grouping and structured detail panels
> - Feed items in [FeedView.svelte](https://github.com/indexable-inc/index/pull/1605/files#diff-299efa94d7c1e14167867dd904b46de36edccb3740e7b4c37f2de65a206c66e5) are now grouped by session scope, with sticky session headers showing a label and item count.
> - The detail panel is restructured into labeled sections (code, output, rich output) with adjusted ordering; the tag line is removed from the detail header meta.
> - Filter matching now includes pane subtitles and the full post-scope identifier; item rows show subtitles inline instead of the old id/tag subline.
> - [style.css](https://github.com/indexable-inc/index/pull/1605/files#diff-fb2c1239e1b0fc19cff65c15124557437fbd813ae5f982d538301120b0398bf3) adds sticky session header styles with blurred backgrounds, updated row padding/border-radius, and panel-colored rounded entry boxes.
> - `__ix_read` in [runtime.py](https://github.com/indexable-inc/index/pull/1605/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now returns structured HTML with a styled pre/code block showing actual read content, instead of a plain note.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9176631.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->