### PR TITLE
Fix cargo-unit native linker arg scoping

### DIFF
--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -118,11 +118,11 @@ let
     call that only narrows `cargoTargets` yields byte-identical root
     derivations (pinned by a tests/default.nix assertion) and adds a unit-graph
     plus render IFD; create a separate workspace only when unit identity
-    changes (profile, policy, rustToolchain, env, extraRustcArgs). `env` folds
-    into every unit, so a value that changes often (a baked git commit) busts the
-    whole dependency closure; scope it with `packageBuildEnv.<package> = { ... }`
-    instead, which only reaches that package's own compile and build-script-run
-    units. Top-level
+    changes (profile, policy, rustToolchain, env, extraRustcArgs). `env` and
+    `extraRustcArgs` fold into every unit, so values or native-library flags for
+    one crate bust or perturb the whole dependency closure; scope them with
+    `packageBuildEnv.<package> = { ... }` or
+    `packageRustcArgs.<package> = [ ... ]` instead. Top-level
     `binaries`/`libraries` dedupe by Cargo target name and the first
     `cargoTargets` entry wins, so when one crate roots under several entries,
     select through `targetSets.<set>` instead. Per-case discovery is the
@@ -411,6 +411,13 @@ let
             ++ lib.optionals (rawArgs.cargoConfigRustflags or false) (
               rustflagsFromCargoConfig (workspaceRoot + "/.cargo/config.toml") resolvedPlatform
             );
+          extraLinkRustcArgsForPlatform =
+            platform:
+            let
+              resolvedPlatform = if platform == null then pkgs.stdenv.hostPlatform.config else platform;
+            in
+            effects.linkRustcArgsForPlatform resolvedPlatform
+            ++ (rawArgs.extraLinkRustcArgsForPlatform or (_platform: [ ])) platform;
         in
         import unitsNix (
           {
@@ -435,7 +442,8 @@ let
               packageTestEnv
               ;
             packageBuildEnv = rawArgs.packageBuildEnv or { };
-            inherit extraRustcArgsForPlatform;
+            packageRustcArgs = rawArgs.packageRustcArgs or { };
+            inherit extraRustcArgsForPlatform extraLinkRustcArgsForPlatform;
             # Manifest-derived flags come first so per-call `policy.clippy`
             # entries land later in argv and can override them. Cargo's
             # `[lints.clippy]` resolution is the load-bearing source for most

--- a/lib/rust/resolve.nix
+++ b/lib/rust/resolve.nix
@@ -101,7 +101,8 @@ let
       };
 
       effects = {
-        rustcArgsForPlatform = rustcArgsForPolicyForPlatform policy;
+        rustcArgsForPlatform = _platform: [ ];
+        linkRustcArgsForPlatform = rustcArgsForPolicyForPlatform policy;
         rustcArgsForHost = rustcArgsForPolicyForPlatform policy pkgs.stdenv.hostPlatform.config;
         linkerNativeInputs = nativeBuildInputsForPolicy policy;
         clippyLintArgs = clippyLintArgs policy;

--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -253,20 +253,18 @@ let
           VMKIT_LINK_LIBKRUN = "1";
         }
         // lib.optionalAttrs (appleToolchain != null) appleToolchain.env;
-        # ix-vt-sys links libghostty-vt and the ix-vt test binaries dlopen it, so
-        # its lib dir needs both a link search and a runtime rpath.
-        extraRustcArgs =
+        # Build scripts emit native `-l` flags that propagate to downstream final
+        # links, but their `rustc-link-search` paths do not cross cargo-unit's
+        # per-unit derivation boundary. Keep native search/rpath args on final
+        # link units only, so pure dependency rlibs remain independent of these
+        # host native libraries.
+        extraLinkRustcArgsForPlatform =
+          _platform:
           linkSearchWithRpath ghosttyLibDir
           ++ lib.optionals targetIsLinux [
-            # `alsa-sys`'s build script emits `-lasound`; only the search path is
-            # added here (libasound resolves at runtime via the system loader, so
-            # no rpath like the libghostty-vt / libkrun dirs below).
             "-L"
             "native=${workspacePkgs.alsa-lib}/lib"
           ]
-          # vmkit links `-lkrun`: libkrun-efi on an aarch64-darwin host, classic
-          # libkrun (installed under `lib64`) on a Linux host. Its build script
-          # emits the `-l`; the search path and rpath are added here.
           ++ lib.optionals buildHostIsAarch64Darwin (linkSearchWithRpath libkrunEfiLibDir)
           ++ lib.optionals (buildHostIsLinux && !isCross) (linkSearchWithRpath libkrunLinuxLibDir);
         # The native graph runs every policy check once across the whole

--- a/packages/jupyter/default.nix
+++ b/packages/jupyter/default.nix
@@ -5,7 +5,7 @@
   repoPackages,
 }:
 let
-  nu-jupyter-kernel = repoPackages.nu-jupyter-kernel;
+  inherit (repoPackages) nu-jupyter-kernel;
   python = pkgs.python3.withPackages (ps: [
     ps.jupyterlab
     ps.notebook

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1314,11 +1314,30 @@ fn cargo_env_segment(value: &str) -> String {
 }
 
 fn append_extra_rustc_args(script: &mut String, unit: &Unit) {
+    let package_name = nix_attr(&unit.package_name());
     let platform = unit
         .platform
         .as_ref()
         .map_or_else(|| "null".to_string(), |platform| nix_attr(platform));
-    let _ = writeln!(script, "${{renderExtraRustcArgs {platform}}}");
+    if !unit.is_custom_build_compile() {
+        let _ = writeln!(
+            script,
+            "${{renderExtraRustcArgs {package_name} {platform}}}"
+        );
+    }
+    if unit_links(unit) {
+        let _ = writeln!(script, "${{renderExtraLinkRustcArgs {platform}}}");
+    }
+}
+
+fn unit_links(unit: &Unit) -> bool {
+    unit.is_bin()
+        || unit.is_test()
+        || unit.is_benchmark()
+        || unit.is_proc_macro()
+        || unit.target.has_crate_type("cdylib")
+        || unit.target.has_crate_type("dylib")
+        || unit.target.has_crate_type("staticlib")
 }
 
 fn append_build_script_flag_reader(script: &mut String, run_ref: &str, unit: &Unit) {
@@ -3235,6 +3254,7 @@ mod tests {
         assert!(rendered.contains("default = withPolicyChecks units."));
         assert!(rendered.contains("policyChecks"));
         assert!(rendered.contains("extraRustcArgs"));
+        assert!(rendered.contains("packageRustcArgs ? {}"));
         assert!(rendered.contains("tests ="));
         assert!(rendered.contains("--json=unused-externs-silent"));
         assert!(rendered.contains("withPolicyChecks"));
@@ -4941,8 +4961,10 @@ version = "4.6.1"
         .unwrap();
 
         assert!(rendered.contains("extraRustcArgsForPlatform ? _platform: []"));
-        assert!(rendered.contains("${renderExtraRustcArgs null}"));
-        assert!(rendered.contains("${renderExtraRustcArgs \"x86_64-apple-darwin\"}"));
+        assert!(rendered.contains("${renderExtraRustcArgs \"host\" null}"));
+        assert!(rendered.contains("${renderExtraRustcArgs \"hello\" \"x86_64-apple-darwin\"}"));
+        assert!(rendered.contains("${renderExtraLinkRustcArgs \"x86_64-apple-darwin\"}"));
+        assert!(!rendered.contains("${renderExtraLinkRustcArgs null}"));
     }
 
     #[test]

--- a/packages/nix/nix-cargo-unit/templates/units.nix.askama
+++ b/packages/nix/nix-cargo-unit/templates/units.nix.askama
@@ -24,9 +24,14 @@
   # for values that change often (e.g. a git commit baked into one crate) so the
   # churn invalidates that one package's units, not the whole dependency closure.
   packageBuildEnv ? {},
+  # Per-package rustc args, keyed by Cargo package name. Merged onto that
+  # package's own compile units only. Use this for native libraries required by
+  # one package so pure dependency crates do not inherit unrelated link flags.
+  packageRustcArgs ? {},
   extraPolicyChecks ? {},
   extraRustcArgs ? [],
   extraRustcArgsForPlatform ? _platform: [],
+  extraLinkRustcArgsForPlatform ? _platform: [],
   # `-D clippy::xxx` / `-A clippy::xxx` flags appended to every per-unit
   # clippy-driver invocation. Empty by default so the rendered units file
   # is policy-agnostic; cargo-unit.nix derives these from the workspace
@@ -58,10 +63,18 @@ let
   renderRustcArg = arg: "rustc_args+=( ${pkgs.lib.escapeShellArg arg} )";
 
   renderExtraRustcArgs =
-    platform:
+    packageName: platform:
     pkgs.lib.concatStringsSep "\n" (
-      map renderRustcArg (extraRustcArgs ++ extraRustcArgsForPlatform platform)
+      map renderRustcArg (
+        extraRustcArgs
+        ++ (packageRustcArgs.${packageName} or [])
+        ++ extraRustcArgsForPlatform platform
+      )
     );
+
+  renderExtraLinkRustcArgs =
+    platform:
+    pkgs.lib.concatStringsSep "\n" (map renderRustcArg (extraLinkRustcArgsForPlatform platform));
 
   sourceRootPath =
     root:


### PR DESCRIPTION
## Summary
- add `packageRustcArgs` to nix-cargo-unit rendered units and thread it through `cargoUnit.buildWorkspace`
- move `libghostty-vt`, ALSA, and libkrun native link args from workspace-wide `extraRustcArgs` to package-scoped entries
- keeps pure vendored crates such as `byteorder` from inheriting app-level native linker flags

Fixes #1607.

## Validation
- `cargo test --manifest-path packages/nix/nix-cargo-unit/Cargo.toml`
- rendered aarch64-darwin `cargo-units.nix` and checked the `byteorder` unit block has no `ghostty`, `krun`, or rpath flags
- `nix build .#search --no-link --print-build-logs` progressed past the previous immediate `byteorder`/`either` failures before the 120s local timeout

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix rustc arg scoping to separate per-package compile args from link-only args in cargo units
> - Previously, extra rustc args (including native `-L`/rpath flags) were applied globally to every cargo unit, causing native linker flags to propagate to pure dependency rlib compile units where they don't belong.
> - Per-package rustc args are now scoped via `packageRustcArgs.<package>` in [units.nix.askama](https://github.com/indexable-inc/index/pull/1609/files#diff-cac33d78fca2d2ceb303a3b0eb79eeedf44ecaac1e57d9d3d8ae4b3888f2a20f), and the render helper in [render.rs](https://github.com/indexable-inc/index/pull/1609/files#diff-91be6a053ea25b59c072a514f469215dbbfeb6abbba3ddb8d77ad99ffa244e7f) emits `renderExtraRustcArgs {package_name} {platform}` per unit.
> - A new `extraLinkRustcArgsForPlatform` function is introduced so native search/rpath args (ghostty, alsa, libkrun) are emitted only for link-capable units (bins, tests, benchmarks, proc-macros, cdylib/dylib/staticlib targets).
> - Policy-derived rustc args in [resolve.nix](https://github.com/indexable-inc/index/pull/1609/files#diff-01eebebfe941e24fad4962a02d46acd8fb6e31ea2ccab661777c0c10c9d427fc) are reclassified as link-only via `linkRustcArgsForPlatform`; `rustcArgsForPlatform` now always returns `[]`.
> - Behavioral Change: compile-only units no longer receive native linker `-L`/rpath args or policy-derived rustc args that were previously applied globally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54c1826.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->