### PR TITLE
nix: add self-version helper + clang-mold-musl/lakekeeper/wasm-bindgen-cli packages

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -56,6 +56,7 @@ let
   netCidr = import ./util/net-cidr.nix { inherit lib; };
   publicArtifactsFor = pkgs: import ./util/public-artifacts.nix { inherit lib pkgs; };
   secretRefs = import ./util/secret-refs.nix { inherit lib; };
+  selfVersionFor = self: import ./util/self-version.nix { inherit lib self; };
   checks = import ./checks.nix { inherit lib; };
 
   /**
@@ -456,6 +457,7 @@ let
       rustWorkspace
       rustWorkspaceFor
       secretRefs
+      selfVersionFor
       skills
       systemdHardening
       toml

--- a/lib/util/self-version.nix
+++ b/lib/util/self-version.nix
@@ -1,0 +1,66 @@
+/**
+  Resolve the building flake's own commit identity for embedding in build
+  artifacts (e.g. a CLI `--version` string). `dirtyRev`/`rev` come from the git
+  flake input; the date is reshaped from `lastModifiedDate`, which Nix sets to the
+  locked revision's committer timestamp (or, in a dirty tree, the newest
+  working-file mtime).
+
+  A flake `self` with no revision (a non-git `path`/tarball source, or an eval
+  that perturbs `self` such as `--override-input`) reports the whole identity as
+  "unknown" so consumers never embed an empty string. When a revision IS present
+  the flake always carries the committer timestamp too, so a `lastModifiedDate`
+  that is not the expected 14-digit `YYYYMMDDHHMMSS` shape is a broken invariant
+  and throws rather than emitting a bogus version.
+
+  Returns:
+    commit     — full revision sha (no `-dirty` suffix), or "unknown".
+    commitShort — first 10 chars of `commit`, or "unknown".
+    commitDate — committer timestamp as second-precision UTC ISO 8601
+                 (`YYYY-MM-DDTHH:MM:SSZ`), or "unknown" when no revision is present.
+    dirty      — whether the working tree was dirty at build time.
+    version    — display string, e.g. `2026-06-07T08:10:28Z (51a9c880d6)` or
+                 `2026-06-07T08:10:28Z (51a9c880d6-dirty)`, or "unknown".
+*/
+{
+  lib,
+  self,
+}:
+let
+  rawRev = self.dirtyRev or self.rev or null;
+in
+if rawRev == null then
+  {
+    commit = "unknown";
+    commitShort = "unknown";
+    commitDate = "unknown";
+    dirty = false;
+    version = "unknown";
+  }
+else
+  let
+    dirty = lib.hasSuffix "-dirty" rawRev;
+    commit = lib.removeSuffix "-dirty" rawRev;
+    commitShort = builtins.substring 0 10 commit;
+    # A revision is present, so the flake must also carry the committer
+    # timestamp, formatted UTC as `YYYYMMDDHHMMSS` (exactly 14 digits). Reshape
+    # it to second-precision ISO 8601 (still UTC); any other width means the
+    # format assumption broke, so fail loudly rather than slice wrong offsets.
+    rawDate = self.lastModifiedDate;
+    commitDate =
+      if builtins.stringLength rawDate == 14 then
+        "${builtins.substring 0 4 rawDate}-${builtins.substring 4 2 rawDate}-${builtins.substring 6 2 rawDate}T${builtins.substring 8 2 rawDate}:${
+          builtins.substring 10 2 rawDate
+        }:${builtins.substring 12 2 rawDate}Z"
+      else
+        throw "self-version.nix: expected self.lastModifiedDate to be 14 digits (YYYYMMDDHHMMSS) for revision ${commit}, got ${builtins.toJSON rawDate}";
+    version = "${commitDate} (${commitShort}${lib.optionalString dirty "-dirty"})";
+  in
+  {
+    inherit
+      commit
+      commitShort
+      commitDate
+      dirty
+      version
+      ;
+  }

--- a/packages/clang-mold-musl/default.nix
+++ b/packages/clang-mold-musl/default.nix
@@ -1,0 +1,35 @@
+# `clang-mold-musl`: the linker driver `.cargo/config.toml` invokes for the
+# `x86_64-unknown-linux-musl` target. Wraps the cross-musl clang (with the right
+# musl sysroot, crt files, and libc.a baked in by the nixpkgs cc-wrapper) and
+# forces mold as the underlying linker.
+#
+# rustc invokes the "linker" as a C compiler driver (set
+# `link-self-contained=-linker` so rustc does not bundle lld). The driver picks
+# up musl crt + libc from the cc-wrapper; `-fuse-ld=mold` swaps the slow default
+# linker for mold.
+#
+# Set IX_LINKER=wild to use the wild linker instead of mold (experimental).
+{
+  ix,
+  pkgsCross,
+  mold,
+  wild,
+}:
+let
+  writeBashApplication = ix.writeBashApplication ix.pkgs;
+in
+writeBashApplication {
+  name = "clang-mold-musl";
+  runtimeInputs = [
+    pkgsCross.musl64.buildPackages.clang
+    mold
+    wild
+  ];
+  # The linker invocation from rustc includes "-no-pie" which clang warns about
+  # as unused; leave -u/-e/-o defaults alone and don't fail on that.
+  text = ''
+    linker="''${IX_LINKER:-mold}"
+    exec x86_64-unknown-linux-musl-clang "-fuse-ld=$linker" "$@"
+  '';
+  meta.description = "clang driver for the x86_64-unknown-linux-musl Rust target, linking with mold";
+}

--- a/packages/clang-mold-musl/package.nix
+++ b/packages/clang-mold-musl/package.nix
@@ -1,0 +1,21 @@
+{
+  id = "clang-mold-musl";
+  packageSet = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+  flake = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+  overlay = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/packages/lakekeeper/default.nix
+++ b/packages/lakekeeper/default.nix
@@ -1,0 +1,50 @@
+# Lakekeeper, the Apache Iceberg REST catalog (Rust), shipped as an upstream
+# prebuilt binary like vector-bin.
+{
+  autoPatchelfHook,
+  fetchzip,
+  lib,
+  stdenv,
+}:
+let
+  system = stdenv.hostPlatform.system;
+  # Add a target here, with its own release hash, before building on another arch.
+  targets = {
+    x86_64-linux = "x86_64-unknown-linux-gnu";
+  };
+  target = targets.${system} or (throw "lakekeeper: unsupported system ${system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lakekeeper";
+  version = "0.12.3";
+
+  # Upstream ships a single bare `lakekeeper` binary in the tarball (no wrapping
+  # directory), so stripRoot must stay off.
+  src = fetchzip {
+    url = "https://github.com/lakekeeper/lakekeeper/releases/download/v${finalAttrs.version}/lakekeeper-${target}.tar.gz";
+    hash = "sha256-vb+LPLtlpJeKC1HbT70Yrb24SdGTknd09C/MPv/yF1U=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [
+    stdenv.cc.cc.lib
+    stdenv.cc.libc
+  ];
+
+  installPhase = ''
+    # shell
+    runHook preInstall
+    install -Dm755 "$src/lakekeeper" "$out/bin/lakekeeper"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Apache Iceberg REST Catalog written in Rust";
+    homepage = "https://lakekeeper.io";
+    license = lib.licenses.asl20;
+    mainProgram = "lakekeeper";
+    platforms = builtins.attrNames targets;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/packages/lakekeeper/package.nix
+++ b/packages/lakekeeper/package.nix
@@ -1,0 +1,12 @@
+{
+  id = "lakekeeper";
+  packageSet = {
+    systems = [ "x86_64-linux" ];
+  };
+  flake = {
+    systems = [ "x86_64-linux" ];
+  };
+  overlay = {
+    systems = [ "x86_64-linux" ];
+  };
+}

--- a/packages/wasm-bindgen-cli/default.nix
+++ b/packages/wasm-bindgen-cli/default.nix
@@ -1,0 +1,31 @@
+# Pinned `wasm-bindgen-cli` matching the `wasm-bindgen` Cargo dep.
+#
+# Schemas are not stable across patch bumps, so the CLI and the Rust crate MUST
+# match exactly. Built via nixpkgs's `buildWasmBindgenCli` factory. Consumers
+# that build wasm artifacts pin their `wasm-bindgen` crate to this version.
+{
+  buildWasmBindgenCli,
+  fetchCrate,
+  rustPlatform,
+}:
+let
+  version = "0.2.123";
+  src = fetchCrate {
+    pname = "wasm-bindgen-cli";
+    inherit version;
+    url = "https://static.crates.io/crates/wasm-bindgen-cli/wasm-bindgen-cli-${version}.crate";
+    hash = "sha256-ymeAEYsr7OnupWYJWjSeVGvq3+s+zxSNkODbzY62rYs=";
+  };
+  # `rustPlatform.importCargoLock` materializes the complete cargoDeps shape
+  # (per-crate `<name>-<version>` symlinks, `.cargo/config.toml`, and
+  # `Cargo.lock`) and vendors registry crates through `static.crates.io`, so the
+  # older `crates.io/api/v1/crates/.../download` endpoint (which rejects
+  # cargo-vendor's curl User-Agent) is never used. See nixpkgs
+  # `pkgs/build-support/rust/import-cargo-lock.nix`.
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = src + "/Cargo.lock";
+  };
+in
+buildWasmBindgenCli {
+  inherit version src cargoDeps;
+}

--- a/packages/wasm-bindgen-cli/package.nix
+++ b/packages/wasm-bindgen-cli/package.nix
@@ -1,0 +1,27 @@
+{
+  id = "wasm-bindgen-cli";
+  packageSet = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+  flake = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+  overlay = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
## What

Move a first batch of generic, reusable Nix primitives from `ix` into the open-source `index` layer. `ix` already consumes this flake; these have no proprietary coupling, so they belong here.

- **`lib/util/self-version.nix`** → `index.lib.selfVersionFor self`: resolve the building flake's own commit identity (`rev`/`dirtyRev` + `lastModifiedDate`) into a display version string, with a hard invariant on the 14-digit date shape.
- **`packages/clang-mold-musl`**: the clang driver `.cargo/config.toml` invokes for the `x86_64-unknown-linux-musl` Rust target, linking with mold. Linux only.
- **`packages/lakekeeper`**: Apache Iceberg REST catalog, upstream prebuilt binary (same shape as `vector-bin`). `x86_64-linux`; overlay-exposed as `pkgs.lakekeeper` because module consumers reach it via `mkPackageOption`.
- **`packages/wasm-bindgen-cli`**: version-pinned `wasm-bindgen-cli` (0.2.123) that must match the workspace's `wasm-bindgen` crate exactly, so it stays repo-owned rather than tracking nixpkgs.

## Why these and not others

This is the low-risk tranche of a larger ix→index audit. Two candidates were intentionally **excluded** as not cleanly open-sourceable:
- `cached-url` routes URLs through ix's internal artifact cache (`artifact-cache.registry.ix.internal`).
- `inventory-node` couples to ix's inventory schema (`vrackIpv4`, `inventory.nodes`).

## Follow-up

Once this lands, a follow-up ix PR bumps the `index` input and rewrites ix to consume these from `index.lib`/`index.packages`/`pkgs`, deleting the local copies.

## Validation

- `nixfmt --check`: clean.
- `nix eval`: `index.lib.selfVersionFor` produces a correct version string; all three packages evaluate; `lakekeeper` is correctly system-gated off darwin.
- astlog + package builds: deferred to CI (the local `.#lint` wrapper needs `ca-derivations`, disabled on darwin). Package files mirror committed templates (`vector-bin`, `igzip-as-gzip`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `selfVersionFor` helper and `clang-mold-musl`, `lakekeeper`, `wasm-bindgen-cli` packages to Nix flake
> - Adds [`lib/util/self-version.nix`](https://github.com/indexable-inc/index/pull/1610/files#diff-e1636b5a3e2dd4c6d942834b47fd1d6d1cec0aa7d516fb976dbf9250a079f00b) which computes structured commit identity (`commit`, `commitShort`, `commitDate`, `dirty`, `version`) from flake self metadata; throws at eval time if `lastModifiedDate` is present but not exactly 14 digits.
> - Exposes the helper as `selfVersionFor` via [`lib/default.nix`](https://github.com/indexable-inc/index/pull/1610/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188).
> - Adds [`packages/clang-mold-musl`](https://github.com/indexable-inc/index/pull/1610/files#diff-93df92297e2a9cdadb75a1b3c08c7b68e82f650d4a477c2ba17b9bb73f757840): a Bash wrapper around `x86_64-unknown-linux-musl-clang` that defaults to the `mold` linker, overridable via `IX_LINKER`.
> - Adds [`packages/lakekeeper`](https://github.com/indexable-inc/index/pull/1610/files#diff-a71c1a9b132fe1caa050eb10697fab97c2d98071b85ce070f6676a9fa53af1c7): fetches and autopatchelfs the prebuilt `lakekeeper` v0.12.3 binary for x86_64-linux.
> - Adds [`packages/wasm-bindgen-cli`](https://github.com/indexable-inc/index/pull/1610/files#diff-4dd692832856f61124b8eee02dff8037207f60e7af47377c1cf7f72a80c34668): builds `wasm-bindgen-cli` v0.2.123 from a pinned crate source using `buildWasmBindgenCli`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c0bd1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->