### PR TITLE
Fix cargo-unit build-script link arg leak

### DIFF
--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1331,13 +1331,14 @@ fn append_extra_rustc_args(script: &mut String, unit: &Unit) {
 }
 
 fn unit_links(unit: &Unit) -> bool {
-    unit.is_bin()
-        || unit.is_test()
-        || unit.is_benchmark()
-        || unit.is_proc_macro()
-        || unit.target.has_crate_type("cdylib")
-        || unit.target.has_crate_type("dylib")
-        || unit.target.has_crate_type("staticlib")
+    !unit.is_custom_build_compile()
+        && (unit.is_bin()
+            || unit.is_test()
+            || unit.is_benchmark()
+            || unit.is_proc_macro()
+            || unit.target.has_crate_type("cdylib")
+            || unit.target.has_crate_type("dylib")
+            || unit.target.has_crate_type("staticlib"))
 }
 
 fn append_build_script_flag_reader(script: &mut String, run_ref: &str, unit: &Unit) {
@@ -4939,9 +4940,22 @@ version = "4.6.1"
                   "dependencies": [
                     { "index": 0, "extern_crate_name": "host" }
                   ]
+                },
+                {
+                  "pkg_id": "path+file:///workspace#build-helper@0.1.0",
+                  "target": {
+                    "kind": ["custom-build"],
+                    "crate_types": ["bin"],
+                    "name": "build-script-build",
+                    "src_path": "/workspace/build.rs",
+                    "edition": "2024"
+                  },
+                  "profile": { "name": "release", "opt_level": "3" },
+                  "mode": "build",
+                  "dependencies": []
                 }
               ],
-              "roots": [1]
+              "roots": [1, 2]
             }"#,
         )
         .unwrap();
@@ -4965,6 +4979,7 @@ version = "4.6.1"
         assert!(rendered.contains("${renderExtraRustcArgs \"hello\" \"x86_64-apple-darwin\"}"));
         assert!(rendered.contains("${renderExtraLinkRustcArgs \"x86_64-apple-darwin\"}"));
         assert!(!rendered.contains("${renderExtraLinkRustcArgs null}"));
+        assert!(!rendered.contains("${renderExtraRustcArgs \"build-helper\" null}"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the remaining cargo-unit native linker arg leak found while validating indexable-inc/index#1609 against the downstream home-manager flake.

Build script compile units have `crate_types = ["bin"]`, so the final-link hook still treated them like normal binaries and injected Ghostty/libkrun/LLD args. This excludes custom-build compile units from final-link args and adds a regression assertion.

Validation:
- `nix fmt packages/nix/nix-cargo-unit/src/render.rs`
- `cargo test --manifest-path packages/nix/nix-cargo-unit/Cargo.toml render::tests::extra_rustc_args_are_requested_for_the_unit_platform`

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `unit_links` leaking link args into cargo build-script compile units
> The `unit_links` function in [render.rs](https://github.com/indexable-inc/index/pull/1611/files#diff-91be6a053ea25b59c072a514f469215dbbfeb6abbba3ddb8d77ad99ffa244e7f) previously treated custom-build compile units as linking units, causing link-related Nix configuration to be emitted for build scripts. A guard is added so `unit_links` returns `false` immediately for any unit where `is_custom_build_compile()` is true, skipping all downstream link-arg emission for those units.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5eb924b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->