### PR TITLE
Require explicit MCP session names before acting tools

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2925,9 +2925,21 @@ let
             from ix_notebook_mcp import tools
             from ix_notebook_mcp.config import set_config
             from ix_notebook_mcp.kernel import set_kernel
+            from mcp.shared.exceptions import McpError
 
             set_config(config)
             set_kernel(kernel)
+
+            try:
+                await tools.python_exec("Result.ok('blocked')", budget=1.0, intent="blocked first")
+            except McpError as exc:
+                assert "session_set_name" in str(exc), exc
+            else:
+                raise AssertionError("python_exec ran before the session was named")
+
+            named = await tools.session_set_name("wedge smoke")
+            assert "wedge smoke" in " ".join(getattr(c, "text", "") or "" for c in named), named
+
             started = loop.time()
             clamped = await tools.python_exec(
                 "await asyncio.sleep(30)\nResult.ok('done')", budget=600.0, intent="bigbudget"

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -121,13 +121,14 @@ INTRO = (
 )
 
 SESSION = (
-    "First, name this session: `session.name = '<what you are working on>'` (in a "
-    "`python_exec` cell). Every run you make is grouped under this session on the live "
-    "dashboard, and a human may be watching several agents at once — a clear name is how "
-    "they tell yours apart. It defaults to the connecting client and working directory "
-    "(e.g. `claude-code · index`), which is ambiguous once agents share a repo, so set it. "
-    "Also pass a one-line `intent` on every `python_exec` (it is required): the intent titles "
-    "the run's card, so the board reads as a list of intents, not raw code."
+    "First, call `session_set_name` with a short label for what you are working on. "
+    "Acting tools are blocked until this MCP session is explicitly named. Every run "
+    "you make is grouped under this session on the live dashboard, and a human may "
+    "be watching several agents at once; a clear name is how they tell yours apart. "
+    "It defaults to the connecting client and working directory (e.g. `claude-code · index`), "
+    "which is ambiguous once agents share a repo, so name it. Also pass a one-line "
+    "`intent` on every `python_exec` (it is required): the intent titles the run's "
+    "card, so the board reads as a list of intents, not raw code."
 )
 
 DISCOVER = (

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -226,6 +226,14 @@ class Kernel:
         with contextlib.suppress(Exception):  # session label is a convenience; must not break the tool call
             await self._execute(f"session._set_client({client!r})", timeout=10.0)
 
+    async def set_session_name(self, name: str) -> None:
+        """Set the dashboard session label without creating an execution card.
+
+        This is the MCP-side naming handshake, not user code, so it uses the raw
+        shell channel instead of ``__ix_exec``.
+        """
+        await self._execute(f"session.name = {name!r}\nsession._sync()", timeout=10.0)
+
     async def _interrupt(self) -> bool:
         """Break a synchronous call wedging the kernel's event loop. ipykernel's
         own ``interrupt_kernel`` cancels the asyncio task, which a synchronous call

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -124,6 +124,7 @@ def _session_id(ctx: Context | None) -> str | None:
 # session label defaults to it (see runtime.Session). A latch, not per-call work.
 _client_identified = False
 _dashboard_started = False
+_named_sessions: set[str] = set()
 
 
 async def _start_dashboard_once() -> None:
@@ -186,6 +187,38 @@ async def _identify_client_once(ctx: Context | None) -> None:
         await current_kernel().set_client(label)
 
 
+def _session_key(ctx: Context | None) -> str:
+    """Stable key for the MCP session that must explicitly name itself."""
+    return _session_id(ctx) or "__stdio__"
+
+
+def _session_name_required() -> bool:
+    """Whether acting tools must be preceded by ``session_set_name``."""
+    return os.environ.get("IX_MCP_REQUIRE_SESSION_NAME", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+async def _require_session_name(ctx: Context | None, *, intent: str | None = None) -> None:
+    """Fail fast until this MCP session has named its dashboard group."""
+    if not _session_name_required() or _session_key(ctx) in _named_sessions:
+        return
+    suggestion = f" Suggested name from this call: {intent!r}." if intent else ""
+    raise McpError(
+        ErrorData(
+            code=types.INVALID_REQUEST,
+            message=(
+                "Name this dashboard session first: call session_set_name with a "
+                "short human task label before using acting tools."
+                f"{suggestion}"
+            ),
+        )
+    )
+
+
 def _first_sentence(text: str) -> str:
     """The lead clause of a tool's description, for the one-line tool overview the
     server instructions build from the registry. Cuts at the earliest sentence
@@ -244,6 +277,41 @@ mcp._mcp_server.version = os.environ.get("IX_MCP_VERSION") or "dev"
 Content = list[outputs.Content]
 
 
+@mcp.tool(
+    structured_output=False,
+    description=(
+        "Name this MCP connection's dashboard session. Call this before acting "
+        "tools such as python_exec, read, kernel_trace, or tui_act; the name "
+        "should be a short human task label, not code or secrets."
+    ),
+)
+async def session_set_name(
+    name: Annotated[
+        str,
+        Field(
+            description=(
+                "Short human task label for this dashboard session, 3 to 80 "
+                "characters, with no code or secrets"
+            )
+        ),
+    ],
+    ctx: Context | None = None,
+) -> Content:
+    await _start_dashboard_once()
+    await _identify_client_once(ctx)
+    clean = " ".join((name or "").split())
+    if not 3 <= len(clean) <= 80:
+        raise McpError(
+            ErrorData(
+                code=types.INVALID_PARAMS,
+                message="Session name must be 3 to 80 non-whitespace characters.",
+            )
+        )
+    await current_kernel().set_session_name(clean)
+    _named_sessions.add(_session_key(ctx))
+    return [outputs.text(f"dashboard session named: {clean}")]
+
+
 # Every tool sets structured_output=False: FastMCP otherwise derives an output
 # schema from the return annotation and DUPLICATES the entire reply as
 # `structuredContent` JSON, so each image block went to the client twice (once
@@ -269,6 +337,7 @@ async def python_exec(
 ) -> Content:
     await _start_dashboard_once()
     await _identify_client_once(ctx)
+    await _require_session_name(ctx, intent=intent)
     # A foreground budget is how long the run holds the one shared shell channel
     # before it backgrounds, so cap it: a giant budget (a 15-minute `await
     # jobs[...]`) would block every other call behind it. The clamp is surfaced
@@ -359,6 +428,7 @@ async def read(
 ) -> Content:
     await _start_dashboard_once()
     await _identify_client_once(ctx)
+    await _require_session_name(ctx, intent=f"read {target}")
     sid = _session_id(ctx)
     code = f"await __ix_read({target!r}, {start!r}, {end!r}, session={sid!r})"
     # Title the run by what it reads (with the line span when given) so its card
@@ -374,8 +444,10 @@ async def read(
 
 
 @mcp.tool(structured_output=False, description=guide.TRACE)
-async def kernel_trace() -> str:
+async def kernel_trace(ctx: Context | None = None) -> str:
     await _start_dashboard_once()
+    await _identify_client_once(ctx)
+    await _require_session_name(ctx, intent="kernel trace")
     return await current_kernel().dump_trace()
 
 
@@ -492,6 +564,7 @@ async def tui_act(
 ) -> Content:
     await _start_dashboard_once()
     await _identify_client_once(ctx)
+    await _require_session_name(ctx, intent=f"drive {uri}")
     try:
         ack = await resources_bridge.act(uri, send_keys, peer=peer)
     except resources_bridge.ResourceNotFoundError as exc:


### PR DESCRIPTION
## Summary
- add `session_set_name` so MCP clients explicitly name their dashboard session
- block acting tools until the current MCP session is named
- update instructions and smoke coverage for the new handshake

Fixes #1614

## Validation
- `python3 -m py_compile packages/mcp/ix_notebook_mcp/tools.py packages/mcp/ix_notebook_mcp/kernel.py packages/mcp/ix_notebook_mcp/guide.py`
- direct fake-kernel guard probe: passed
- direct real-kernel session-name smoke from worktree source: passed
- `nix build .#mcp.passthru.tests.wedgeSmoke --print-build-logs`: did not reach the MCP test because dependency `potential_utf-0.1.5` failed while building the dependency graph

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require explicit session naming before MCP acting tools can execute
> - Adds a new `session_set_name` MCP tool that sets the dashboard session label via the kernel and marks the session as named in a module-level `_named_sessions` set.
> - Adds an `_require_session_name` guard in [tools.py](https://github.com/indexable-inc/index/pull/1615/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) that raises `McpError(INVALID_REQUEST)` on `python_exec`, `read`, `kernel_trace`, and `tui_act` until the session is explicitly named.
> - Session naming enforcement is controlled by the `IX_MCP_REQUIRE_SESSION_NAME` env var and defaults to enabled; sessions are keyed by MCP session id, falling back to `__stdio__`.
> - Updates the [guide.py](https://github.com/indexable-inc/index/pull/1615/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) instructions to direct clients to call `session_set_name` first.
> - Behavioral Change: all acting tools now fail with `INVALID_REQUEST` until `session_set_name` is called, unless the env var disables enforcement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95da149.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->