### PR TITLE
fix: sort dashboard sessions by creation time

### DIFF
--- a/packages/dashboard/dashboard-core/site/package.json
+++ b/packages/dashboard/dashboard-core/site/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "dev": "vite dev"
+    "dev": "vite dev",
+    "test": "node --test tests/*.test.ts"
   },
   "dependencies": {
     "svelte": "^5.55.7"

--- a/packages/dashboard/dashboard-core/site/src/components/FeedView.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/FeedView.svelte
@@ -4,6 +4,8 @@
   import { store, timeline, SCOPE_SEP } from '$lib/stream.svelte';
   import { ui, focusPane, humanAge, humanDuration, setSession } from '$lib/ui.svelte';
   import { setListNav } from '$lib/keys.svelte';
+  import { feedSessions, shortScope } from '$lib/feed-sessions';
+  import { paneScope } from '$lib/scope';
   import { rendererFor } from '$lib/renderers';
   import CodeBlock from './CodeBlock.svelte';
   import ExecBody from './ExecBody.svelte';
@@ -109,39 +111,11 @@
     return (p.kind ?? 'data') === 'data' && p.renderer === 'session';
   }
 
-  // The scope a pane key belongs to (its producer = one MCP session). '' is the
-  // in-process scope; a real MCP producer is "<pid>-<uuid>".
-  function scopeOf(key: string): string {
-    const sep = key.indexOf(SCOPE_SEP);
-    return sep === -1 ? '' : key.slice(0, sep);
-  }
-  // A short, legible label for a scope with no session pane to name it.
-  function shortScope(scope: string): string {
-    return scope ? scope.slice(0, 8) : 'local';
-  }
-
-  // Every live session: one entry per producer scope, labelled by its session
-  // pane's title (the user-set name, else client · workdir), falling back to a
-  // short scope id. Drives the header's session selector.
-  const sessions = $derived.by(() => {
-    const labels = new Map<string, string>();
-    const scopes = new Set<string>();
-    for (const key of Object.keys(store.panes)) {
-      const scope = scopeOf(key);
-      scopes.add(scope);
-      const p = store.panes[key];
-      if ((p.kind ?? 'data') === 'data' && p.renderer === 'session') {
-        labels.set(scope, p.title || 'session');
-      }
-    }
-    return [...scopes]
-      // The in-process scope ('') carries no session pane and its option value
-      // would collide with the "All sessions" option, so it is never a selectable
-      // session; drop it.
-      .filter((scope) => scope !== '')
-      .map((scope) => ({ scope, label: labels.get(scope) || shortScope(scope) }))
-      .sort((a, b) => (a.label < b.label ? -1 : 1));
-  });
+  // Every live session: one entry per producer scope, ordered by when that scope
+  // first appeared. The selector drops the in-process scope because its option
+  // value would collide with "All sessions", but grouped feed rows still use it.
+  const allSessions = $derived(feedSessions(store.panes));
+  const sessions = $derived(allSessions.filter((s) => s.scope !== ''));
 
   // The active session scope, validated against what is live: a saved selection
   // for a session that has since gone falls back to all ('').
@@ -166,7 +140,7 @@
   const items = $derived(
     Object.keys(store.panes)
       .filter((key) => !isOutputAttachment(key))
-      .map((key) => ({ key, pane: { ...store.panes[key], key, scope: scopeOf(key) } as Pane }))
+      .map((key) => ({ key, pane: { ...store.panes[key], key, scope: paneScope(key) } as Pane }))
       .filter((it) => !isNamespace(it.pane) && !isSession(it.pane))
       .sort(
         (a, b) =>
@@ -251,9 +225,10 @@
   type FeedItem = { key: string; pane: Pane };
   type SessionGroup = { scope: string; label: string; items: FeedItem[] };
   function sessionLabel(scope: string): string {
-    return sessions.find((s) => s.scope === scope)?.label || shortScope(scope);
+    return allSessions.find((s) => s.scope === scope)?.label || shortScope(scope);
   }
   const grouped = $derived.by<SessionGroup[]>(() => {
+    const sessionOrder = new Map(allSessions.map((session, index) => [session.scope, index]));
     const groups = new Map<string, FeedItem[]>();
     for (const it of filtered) {
       const scope = it.pane.scope || '';
@@ -263,7 +238,11 @@
     }
     return [...groups.entries()]
       .map(([scope, rows]) => ({ scope, label: sessionLabel(scope), items: rows }))
-      .sort((a, b) => (a.label < b.label ? -1 : 1));
+      .sort(
+        (a, b) =>
+          (sessionOrder.get(a.scope) ?? Number.MAX_SAFE_INTEGER) -
+            (sessionOrder.get(b.scope) ?? Number.MAX_SAFE_INTEGER) || a.scope.localeCompare(b.scope),
+      );
   });
 
   // Register this view's motions with the global keymap while it is mounted.

--- a/packages/dashboard/dashboard-core/site/src/components/NamespaceView.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/NamespaceView.svelte
@@ -3,24 +3,15 @@
   // surface instead of interleaved into the run feed. Collects every namespace
   // `data` pane (one per Python session) and renders each as an expandable tree.
   import { onMount } from 'svelte';
-  import { store, SCOPE_SEP } from '$lib/stream.svelte';
+  import { store } from '$lib/stream.svelte';
+  import { namespaceSessions } from '$lib/namespace-sessions';
   import { buildNsItems, parseRows, nsParent, type NsRow as Row } from '$lib/namespace';
   import { setListNav } from '$lib/keys.svelte';
-  import type { Pane } from '$lib/types';
   import NamespaceBody from './NamespaceBody.svelte';
 
-  // Every namespace pane, oldest scope first for a stable order. A namespace pane
+  // Every namespace pane, oldest session first for a stable order. A namespace pane
   // is a `data` pane with the `namespace` renderer (see introspect / pane_bridge).
-  const sessions = $derived(
-    Object.keys(store.panes)
-      .map((key) => {
-        const sep = key.indexOf(SCOPE_SEP);
-        const scope = sep === -1 ? '' : key.slice(0, sep);
-        return { key, pane: { ...store.panes[key], key, scope } as Pane };
-      })
-      .filter((it) => (it.pane.kind ?? 'data') === 'data' && it.pane.renderer === 'namespace')
-      .sort((a, b) => (a.key < b.key ? -1 : 1)),
-  );
+  const sessions = $derived(namespaceSessions(store.panes));
 
   // Selection + expansion are owned here so the keyboard can walk the whole tree
   // across sessions. Each session renders with the same `s<index>` path prefix the

--- a/packages/dashboard/dashboard-core/site/src/lib/feed-sessions.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/feed-sessions.ts
@@ -1,0 +1,48 @@
+import { compareCreatedAt, paneScope } from './scope.ts';
+import type { PaneRecord } from './types.ts';
+
+export interface FeedSession {
+  scope: string;
+  label: string;
+  createdAt?: number;
+}
+
+export function shortScope(scope: string): string {
+  return scope ? scope.slice(0, 8) : 'local';
+}
+
+function noteCreated(created: Map<string, number>, scope: string, pane: PaneRecord): void {
+  const value = pane.created_at;
+  if (value === undefined) return;
+  const previous = created.get(scope);
+  if (previous === undefined || value < previous) created.set(scope, value);
+}
+
+function compareFeedSessions(a: FeedSession, b: FeedSession): number {
+  const byCreated = compareCreatedAt(a.createdAt, b.createdAt);
+  if (byCreated !== 0) return byCreated;
+  return a.scope.localeCompare(b.scope);
+}
+
+export function feedSessions(panes: Record<string, PaneRecord>): FeedSession[] {
+  const labels = new Map<string, string>();
+  const created = new Map<string, number>();
+  const scopes = new Set<string>();
+
+  for (const [key, pane] of Object.entries(panes)) {
+    const scope = paneScope(key);
+    scopes.add(scope);
+    noteCreated(created, scope, pane);
+    if ((pane.kind ?? 'data') === 'data' && pane.renderer === 'session') {
+      labels.set(scope, pane.title || 'session');
+    }
+  }
+
+  return [...scopes]
+    .map((scope) => ({
+      scope,
+      label: labels.get(scope) || shortScope(scope),
+      createdAt: created.get(scope),
+    }))
+    .sort(compareFeedSessions);
+}

--- a/packages/dashboard/dashboard-core/site/src/lib/namespace-sessions.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/namespace-sessions.ts
@@ -1,0 +1,23 @@
+import { compareCreatedAt, paneScope } from './scope.ts';
+import type { Pane, PaneRecord } from './types.ts';
+
+export interface NamespaceSession {
+  key: string;
+  pane: Pane;
+}
+
+function compareNamespaceSessions(a: NamespaceSession, b: NamespaceSession): number {
+  const byCreated = compareCreatedAt(a.pane.created_at, b.pane.created_at);
+  if (byCreated !== 0) return byCreated;
+  return a.key.localeCompare(b.key);
+}
+
+export function namespaceSessions(panes: Record<string, PaneRecord>): NamespaceSession[] {
+  return Object.keys(panes)
+    .map((key) => ({
+      key,
+      pane: { ...panes[key], key, scope: paneScope(key) } as Pane,
+    }))
+    .filter((it) => (it.pane.kind ?? 'data') === 'data' && it.pane.renderer === 'namespace')
+    .sort(compareNamespaceSessions);
+}

--- a/packages/dashboard/dashboard-core/site/src/lib/scope.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/scope.ts
@@ -1,0 +1,13 @@
+export const SCOPE_SEP = String.fromCharCode(0x1f); // matches dashboard::hub::SCOPE_SEP
+
+export function paneScope(key: string): string {
+  const sep = key.indexOf(SCOPE_SEP);
+  return sep === -1 ? '' : key.slice(0, sep);
+}
+
+export function compareCreatedAt(a: number | undefined, b: number | undefined): number {
+  if (a !== undefined && b !== undefined && a !== b) return a - b;
+  if (a !== undefined && b === undefined) return -1;
+  if (a === undefined && b !== undefined) return 1;
+  return 0;
+}

--- a/packages/dashboard/dashboard-core/site/src/lib/stream.svelte.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/stream.svelte.ts
@@ -9,9 +9,10 @@
 // Switching to a saved recording swaps the document for one fetched over HTTP,
 // so live and replay share one rendering path.
 import { LoroDoc, type ChangeMeta, type OpId } from 'https://esm.sh/loro-crdt@1';
+import { paneScope, SCOPE_SEP } from './scope.ts';
 import type { PaneRecord } from './types';
 
-export const SCOPE_SEP = String.fromCharCode(0x1f); // matches dashboard::hub::SCOPE_SEP
+export { SCOPE_SEP };
 
 export const store = $state({
   panes: {} as Record<string, PaneRecord>,
@@ -109,8 +110,7 @@ function readPanes(): void {
   store.panes = panes;
   const scopes = new Set<string>();
   for (const key of Object.keys(panes)) {
-    const sep = key.indexOf(SCOPE_SEP);
-    scopes.add(sep === -1 ? '' : key.slice(0, sep));
+    scopes.add(paneScope(key));
   }
   store.producers = scopes.size;
   const n = Object.keys(panes).length;

--- a/packages/dashboard/dashboard-core/site/tests/feed-sessions.test.ts
+++ b/packages/dashboard/dashboard-core/site/tests/feed-sessions.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { feedSessions } from '../src/lib/feed-sessions.ts';
+import { SCOPE_SEP } from '../src/lib/scope.ts';
+import type { PaneRecord } from '../src/lib/types.ts';
+
+function sessionPane(title: string, created_at: number): PaneRecord {
+  return {
+    kind: 'data',
+    renderer: 'session',
+    title,
+    created_at,
+  };
+}
+
+describe('feedSessions', () => {
+  it('sorts sessions by creation time', () => {
+    const panes: Record<string, PaneRecord> = {
+      [`late${SCOPE_SEP}session`]: sessionPane('A label sorts first', 300),
+      [`early${SCOPE_SEP}session`]: sessionPane('Z label sorts last', 100),
+      [`middle${SCOPE_SEP}run`]: { kind: 'exec', title: 'run', created_at: 200 },
+    };
+
+    assert.deepEqual(
+      feedSessions(panes).map((s) => s.scope),
+      ['early', 'middle', 'late'],
+    );
+  });
+
+  it('uses scope as the stable tie-break', () => {
+    const panes: Record<string, PaneRecord> = {
+      [`bravo${SCOPE_SEP}session`]: sessionPane('Bravo', 100),
+      [`alpha${SCOPE_SEP}session`]: sessionPane('Alpha', 100),
+    };
+
+    assert.deepEqual(
+      feedSessions(panes).map((s) => s.scope),
+      ['alpha', 'bravo'],
+    );
+  });
+});

--- a/packages/dashboard/dashboard-core/site/tests/namespace-sessions.test.ts
+++ b/packages/dashboard/dashboard-core/site/tests/namespace-sessions.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { namespaceSessions } from '../src/lib/namespace-sessions.ts';
+import { SCOPE_SEP } from '../src/lib/scope.ts';
+import type { PaneRecord } from '../src/lib/types.ts';
+
+function namespacePane(created_at: number): PaneRecord {
+  return {
+    kind: 'data',
+    renderer: 'namespace',
+    created_at,
+    body: '[]',
+  };
+}
+
+describe('namespaceSessions', () => {
+  it('sorts namespace sessions by creation time', () => {
+    const panes: Record<string, PaneRecord> = {
+      [`z-oldest${SCOPE_SEP}namespace`]: namespacePane(100),
+      [`a-newest${SCOPE_SEP}namespace`]: namespacePane(300),
+      [`m-middle${SCOPE_SEP}namespace`]: namespacePane(200),
+      [`early-non-namespace${SCOPE_SEP}run`]: { kind: 'exec', created_at: 1 },
+    };
+
+    assert.deepEqual(
+      namespaceSessions(panes).map((s) => s.pane.scope),
+      ['z-oldest', 'm-middle', 'a-newest'],
+    );
+  });
+});

--- a/packages/dashboard/dashboard-core/site/tsconfig.json
+++ b/packages/dashboard/dashboard-core/site/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "allowJs": false,
     "baseUrl": ".",
     "checkJs": false,


### PR DESCRIPTION
## Summary
- Sort dashboard feed session selector entries by first pane `created_at` instead of label.
- Sort grouped feed sessions with the same creation-time order.
- Share scope parsing and timestamp comparison with namespace session ordering.

## Tests
- `npm test`
- `npm run check`
- `npm run build`

Fixes #1618

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort dashboard sessions by creation time instead of alphabetically
> - Extracts shared utilities (`paneScope`, `compareCreatedAt`, `shortScope`) into [scope.ts](https://github.com/indexable-inc/index/pull/1619/files#diff-ebb2e26b1a96592bbd5bcbbc8844fb4812b1a0dc0f6ea34e901343760fc44645) and new modules [feed-sessions.ts](https://github.com/indexable-inc/index/pull/1619/files#diff-cbf9bd49d8a778478efe2ed97c15dd8b6291c71c1b93ac4060ae119b02c2833e) and [namespace-sessions.ts](https://github.com/indexable-inc/index/pull/1619/files#diff-007d6d6416f7fe070effe34cc5a2b4c7937ec96ada408d0f1538debc4d938f6d).
> - `FeedView` and `NamespaceView` components now derive their session lists from these shared utilities, ordering sessions by earliest pane `created_at` with a scope-name tiebreak instead of lexicographic label/key order.
> - Adds node:test suites for the new session-ordering logic and enables `allowImportingTsExtensions` in tsconfig.
> - Behavioral Change: session selector options in `FeedView` and namespace entries in `NamespaceView` will appear in creation-time order rather than alphabetical order.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f82e1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->