### PR TITLE
nix(ix-sdk-python): bump x86_64-linux wheel pin

### DIFF
--- a/packages/ix-sdk-python/default.nix
+++ b/packages/ix-sdk-python/default.nix
@@ -23,8 +23,8 @@ let
   # workspace-sdks.nix. Other systems fall through to the loud placeholder below.
   catalog = {
     x86_64-linux = {
-      url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/37h7h93kyfzv69k707ynaibkchjnpnwr/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
-      hash = "sha256-KYteEHzhGqMcfwLWdyT1wnkzOZDGaux+PJJ6WFkELbo=";
+      url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/q7dc3hr07fb49k3bb6bpvdvrw06b70zi/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
+      hash = "sha256-G01zJOF2IniVv5ioFEQEzoOZdVKF8YBBvJmviQb4Qts=";
     };
     aarch64-darwin = {
       url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/jmj8q0gsq5lnvv8aap6j7zh874bpzqjh/ix_sdk-0.1.0-cp313-abi3-macosx_11_0_arm64.whl";


### PR DESCRIPTION
Re-published from ix and re-pinned to the new content-addressed R2 wheel. Verified: nix build .#ix-sdk-python fetches + hash-matches, and the import surface test passes (ix_sdk 0.1.0; group + lifecycle + secret surface present).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump ix-sdk-python x86_64-linux wheel pin in Nix
> Updates the wheel artifact URL and sha256 hash for the `x86_64-linux` platform in [default.nix](https://github.com/indexable-inc/index/pull/1621/files#diff-80f46c8d1744ebc070c811611b94e45d792b24cdeeae53fcaf78e4db15945032) to reference the new wheel version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c3788c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->