### PR TITLE
feat(ix-fleet): wait on server-side system_ready instead of execing bash

### DIFF
--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -292,36 +292,46 @@ async def run_cli(
     return stdout
 
 
-BOOTSTRAP_PROBE_SCRIPT = (
-    "set -euo pipefail\n"
-    "export PATH=/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH\n"
-    "if command -v systemctl >/dev/null 2>&1; then\n"
-    "  systemctl start nix-daemon.socket >/dev/null 2>&1 || true\n"
-    "fi\n"
-    "nix --extra-experimental-features nix-command store info >/dev/null"
-)
+# How long to wait for a node to finish systemd activation before giving up.
+# A module constant so tests can shrink it without monkeypatching the clock.
+_BOOTSTRAP_DEADLINE_SECONDS = 180
 
 
 async def wait_node_ready(node: FleetNode, *, dry_run: bool) -> None:
+    """Block until the node finished guest systemd activation, the point where
+    `/run/current-system` is wired up and the workload's units have started, so
+    health checks can run.
+
+    Readiness is a server-side fact: `branch.system_ready()` is a unary RPC the
+    server forwards live to the VM's orchestrator, which probes the guest. We do
+    not exec a shell here. That is deliberate: bash and the workload's binaries
+    live under `/run/current-system/sw/bin`, which does not exist until
+    activation finishes, so an early `branch.bash(...)` raised "command not
+    found" and failed the deploy. Polling the typed readiness signal rides
+    activation's own edge instead.
+    """
     if dry_run:
-        step(f"+ wait until {node.name} bootstrap is ready (guest nix store probe)")
+        step(f"+ wait until {node.name} finishes systemd activation")
         return
 
     step(f"waiting for {node.name} bootstrap")
     c = client()
-    deadline = asyncio.get_running_loop().time() + 180
-    last_error = ""
+    deadline = asyncio.get_running_loop().time() + _BOOTSTRAP_DEADLINE_SECONDS
+    last_error = "no readiness probe completed"
     while asyncio.get_running_loop().time() < deadline:
-        branch = await c.find_by_name(node.name)
-        if branch is None:
-            last_error = f"{node.name} not found"
-        else:
-            # check=False: a not-yet-ready store info is expected while we poll,
-            # so inspect the exit code instead of raising CommandError.
-            result = await branch.bash(BOOTSTRAP_PROBE_SCRIPT, check=False, quiet=True)
-            if result.exit_code == 0:
-                return
-            last_error = (result.stderr or result.stdout).strip()
+        try:
+            branch = await c.find_by_name(node.name)
+            if branch is None:
+                last_error = f"{node.name} not found"
+            else:
+                status = await branch.system_ready()
+                if status.ready:
+                    return
+                last_error = status.reason or "system not activated"
+        except ix_sdk.IxError as probe_error:
+            # Transient RPC / not-ready errors are expected while the guest is
+            # still coming up; keep polling until the deadline rather than fail.
+            last_error = str(probe_error)
         await asyncio.sleep(2)
 
     raise RuntimeError(f"{node.name} bootstrap did not become ready: {last_error}")

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import types
 import typing
 import unittest
 from pathlib import Path
@@ -896,6 +897,77 @@ def async_recorder(
         return result
 
     return record
+
+
+class WaitNodeReadyTests(unittest.TestCase):
+    """`wait_node_ready` polls the server-side `system_ready` signal, treating
+    `NotActivated` and transient SDK errors as keep-polling, not failure."""
+
+    @staticmethod
+    def _node() -> ix_fleet.FleetNode:
+        return ix_fleet.FleetNode.model_validate(fleet_node("web"))
+
+    @staticmethod
+    def _fake_client(outcomes: list[object]) -> type:
+        remaining = list(outcomes)
+
+        class FakeBranch:
+            async def system_ready(self) -> object:
+                outcome = remaining.pop(0) if remaining else outcomes[-1]
+                if isinstance(outcome, BaseException):
+                    raise outcome
+                return outcome
+
+        class FakeClient:
+            async def find_by_name(self, name: str) -> FakeBranch:
+                del name
+                return FakeBranch()
+
+        return FakeClient
+
+    async def _no_sleep(self, _seconds: float) -> None:
+        return None
+
+    def _run(self, outcomes: list[object]) -> None:
+        with (
+            patch.object(ix_fleet, "client", self._fake_client(outcomes)),
+            patch.object(ix_fleet, "step", lambda _message: None),
+            patch.object(asyncio, "sleep", self._no_sleep),
+        ):
+            asyncio.run(ix_fleet.wait_node_ready(self._node(), dry_run=False))
+
+    def test_returns_once_system_ready(self) -> None:
+        ready = types.SimpleNamespace(ready=True, at="2026-01-01T00:00:00Z", reason=None)
+        self._run([ready])
+
+    def test_polls_through_not_activated(self) -> None:
+        not_yet = types.SimpleNamespace(ready=False, at=None, reason="not_activated")
+        ready = types.SimpleNamespace(ready=True, at=None, reason=None)
+        self._run([not_yet, not_yet, ready])
+
+    def test_transient_ixerror_keeps_polling(self) -> None:
+        err = ix_fleet.ix_sdk.IxError("upstream timeout")
+        ready = types.SimpleNamespace(ready=True, at=None, reason=None)
+        self._run([err, ready])
+
+    def test_times_out_when_never_activated(self) -> None:
+        not_yet = types.SimpleNamespace(ready=False, at=None, reason="not_activated")
+        with (
+            patch.object(ix_fleet, "_BOOTSTRAP_DEADLINE_SECONDS", 0.1),
+            patch.object(ix_fleet, "client", self._fake_client([not_yet])),
+            patch.object(ix_fleet, "step", lambda _message: None),
+            patch.object(asyncio, "sleep", self._no_sleep),
+            pytest.raises(RuntimeError) as caught,
+        ):
+            asyncio.run(ix_fleet.wait_node_ready(self._node(), dry_run=False))
+        assert "not_activated" in str(caught.value)
+
+    def test_dry_run_makes_no_live_call(self) -> None:
+        def fail_client() -> typing.NoReturn:
+            self.fail("dry-run readiness wait must not touch the live client")
+
+        with patch.object(ix_fleet, "client", fail_client):
+            asyncio.run(ix_fleet.wait_node_ready(self._node(), dry_run=True))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
wait_node_ready execs `bash -c 'nix store info'` in the guest to detect readiness. That fails until NixOS activation wires up /run/current-system/sw/bin: the guest cannot resolve `bash` and the SDK raises "command not found" before any ExecResult, escaping the poll loop and failing the deploy. It is the dominant "New VMs" status-heartbeat failure.

Poll the server-side `branch.system_ready()` signal instead: a unary RPC the server forwards live to the VM's orchestrator, which probes guest systemd activation. No shell exec, so no dependency on bash being resolvable before activation. Transient SDK errors during boot are treated as keep-polling, and the bash BOOTSTRAP_PROBE_SCRIPT is removed.

Requires the republished ix_sdk wheel exposing branch.system_ready().

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace shell-based bootstrap probe in `wait_node_ready` with server-side `branch.system_ready()` polling
> - `wait_node_ready` in [__init__.py](https://github.com/indexable-inc/index/pull/1622/files#diff-d83777ed2e90ee1f7371ffa0e55fe375c817b07e2cb2a15a5b58423ad93dae3e) no longer execs a guest bash script; it now polls `branch.system_ready()` via the ix SDK until `status.ready` is true.
> - Transient `ix_sdk.IxError` exceptions are caught and treated as non-fatal, keeping the poll loop alive.
> - A new `_BOOTSTRAP_DEADLINE_SECONDS = 180` constant controls the timeout; on expiry, the error message includes the last server-provided reason.
> - Five new tests in [test_ix_fleet.py](https://github.com/indexable-inc/index/pull/1622/files#diff-bff8ac90f8b3db8d3eb62a10bb3ad78b44fb0f639cd3b244afc5f77b23728b13) cover the happy path, partial activation polling, transient errors, timeout, and dry-run behavior.
> - Behavioral Change: dry-run mode now logs a different step message and skips all live calls; timeout error text has changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 391ba5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->