### PR TITLE
fix(cargo-unit): buildBinary honors caller meta

### DIFF
--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -708,13 +708,31 @@ let
 
   /**
     Select one binary target from a generated workspace graph.
+
+    `meta` is merged onto the selected binary derivation (the same way
+    `selectRootWithTests` applies its `meta`), so a caller can set
+    `meta.mainProgram` and other fields. Without this, `meta` passed to
+    `buildBinary` lands in the `buildWorkspace` arg set and is dropped, so
+    `lib.getExe` on the result warns and only guesses the binary name.
   */
   buildBinary =
-    { binary, ... }@args:
+    {
+      binary,
+      meta ? { },
+      ...
+    }@args:
     let
-      workspace = buildWorkspace (removeAttrs args [ "binary" ]);
+      workspace = buildWorkspace (
+        removeAttrs args [
+          "binary"
+          "meta"
+        ]
+      );
+      root = rootOrThrow "buildBinary" "binary" (workspace.binaries or { }) binary;
     in
-    rootOrThrow "buildBinary" "binary" (workspace.binaries or { }) binary;
+    root.overrideAttrs (old: {
+      meta = (old.meta or { }) // meta;
+    });
 
   /**
     Pick a binary out of a pre-built `buildWorkspace` plus its test


### PR DESCRIPTION
## Problem
`cargoUnit.buildBinary` selects the binary derivation straight out of the generated workspace graph (`removeAttrs args [ "binary" ]` → `buildWorkspace`, then returns `workspace.binaries.<name>` raw) and applies no `meta`. A caller that sets `meta` (e.g. `meta.mainProgram`) has it silently dropped, so `lib.getExe` on the result warns and only guesses the binary name.

Observed downstream in ix: `nix run .#desktop-app` printed
```
getExe: Package "ix-desktop-app-0.1.0" does not have the meta.mainProgram attribute...
```

## Fix
Accept `meta ? {}` in `buildBinary` and merge it onto the selected derivation via `overrideAttrs`, mirroring what `selectRootWithTests` already does (`meta = (rootDrv.meta or {}) // meta;`). This makes `buildBinary` consistent with its sibling selectors and removes the footgun for every caller.

## Verification
Validated end-to-end against ix with `--override-input index` pointing at this branch and ix's `desktop-app.nix` passing `meta` plainly (no `overrideAttrs` workaround):
- `desktop-app.meta.mainProgram` → `ix-desktop-app`
- `apps.desktop-app.program` → no getExe warning
- nixfmt clean, `nix-instantiate --parse` OK


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `buildBinary` in cargo-unit to apply caller-supplied `meta` to the output derivation
> Previously, any `meta` passed to `buildBinary` was ignored and not applied to the selected binary derivation. The fix stores the binary derivation in a `root` binding, then returns an `overrideAttrs` that merges the caller-supplied `meta` into the derivation's existing `meta`. This allows callers to set fields like `meta.mainProgram` on the result. See [cargo-unit.nix](https://github.com/indexable-inc/index/pull/1623/files#diff-82054df1a7d1648a5be88265641a7ae5d3b9e4ec4cdea72c518359ea4ae3f804).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07cb689.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->