### PR TITLE
feat: add VCFS guest eval image

### DIFF
--- a/images/system/vcfs-guest-eval/default.nix
+++ b/images/system/vcfs-guest-eval/default.nix
@@ -1,0 +1,17 @@
+# Runtime image for ix's VCFS guest benchmark controller.
+{ pkgs, ... }:
+{
+  ix.image.name = "ix/vcfs-guest-eval";
+
+  environment.systemPackages = [
+    pkgs.binutils
+    pkgs.cargo
+    pkgs.gcc
+    pkgs.git
+    pkgs.nodejs
+    pkgs.pkg-config
+    pkgs.pnpm
+    pkgs.rustc
+    pkgs.sqlite
+  ];
+}

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -743,6 +743,10 @@ let
     modules = [ (paths.root + "/images/system/base") ];
   };
 
+  vcfsGuestEvalImage = ix.mkImage {
+    modules = [ (paths.root + "/images/system/vcfs-guest-eval") ];
+  };
+
   # Non-NixOS OCI example images (ubuntu, debian, ...). They live under
   # `examples/oci` with the same hierarchical shape as fleet examples, but
   # return images instead of fleet plans and are exposed as opt-in packages only.
@@ -1089,6 +1093,7 @@ in
   packages =
     lib.optionalAttrs (system == ix.system) {
       base = baseImage;
+      vcfs-guest-eval = vcfsGuestEvalImage;
     }
     // {
       health-checks = healthChecks.dag;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `vcfs-guest-eval` NixOS guest image with development toolchain
> Adds a new NixOS image module at [images/system/vcfs-guest-eval/default.nix](https://github.com/indexable-inc/index/pull/1624/files#diff-1e4c680e5612ba0062514988dd61112e9873ca7a8f3c36ed553e9af83ca69d42) that builds an image named `ix/vcfs-guest-eval` with binutils, cargo, gcc, git, nodejs, pkg-config, pnpm, rustc, and sqlite preinstalled. The image is wired up in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1624/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) as `vcfsGuestEvalImage` and exposed as the `vcfs-guest-eval` package attribute for the matching system.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01b2fff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->