### PR TITLE
fix(minecraft): allow managed-datapack symlinks past world validation

### DIFF
--- a/modules/services/minecraft/default.nix
+++ b/modules/services/minecraft/default.nix
@@ -1207,6 +1207,12 @@ in
 
         minecraft-status = {
           from = "guest";
+          # A cold Paper boot resolves plugin libraries from remote Maven repos
+          # and generates the world before it binds the listener, which on an
+          # ephemeral status VM runs well past the default 30x2s=60s window.
+          # Give it 60x2s=120s so the probe waits for a real cold start instead
+          # of failing a still-initializing server.
+          attempts = 60;
           description =
             "Minecraft answers SLP"
             + lib.optionalString (
@@ -1282,6 +1288,17 @@ in
       preStart = ''
         mkdir -p ${dataDir}/${cfg.dropinDir}
         echo "eula=true" > ${dataDir}/eula.txt
+        # ix-managed datapacks are symlinked from the Nix store into each
+        # world's datapacks/ dir. Minecraft's world content-validation
+        # (>=1.20-pre7) refuses to load a world containing symlinks whose
+        # targets are not on this allow-list and exits before binding its
+        # port, so without it the server never answers SLP. Allow the store
+        # and the managed-datapacks tree the sync script links through.
+        printf '%s\n' \
+          '# ix-managed datapacks live in the read-only Nix store; allow them past world validation.' \
+          '[prefix]/nix/store' \
+          '[prefix]/etc/minecraft/managed-datapacks' \
+          > ${dataDir}/allowed_symlinks.txt
         ${lib.getExe syncManaged}
       '';
     };


### PR DESCRIPTION
Minecraft's world content-validation (>=1.20-pre7) refuses to load a world containing symlinks whose targets are not allowlisted, so the ix-managed `max-height` datapack (symlinked from the Nix store into each world's datapacks/ dir) made Paper exit before binding its port: the server never answered SLP and the `minecraft-status` health check failed every boot. This kept the regional "New VMs" status heartbeat red for the factions and survival workloads.

Write `allowed_symlinks.txt` in the level root allowing the Nix store and the managed-datapacks tree the sync script links through, and widen the `minecraft-status` window 30->60 attempts (60s->120s) so the probe waits out a cold Paper boot (remote Maven plugin resolution plus world generation) instead of failing a still-initializing server.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow managed-datapack symlinks to pass Minecraft world validation
> - Writes `allowed_symlinks.txt` to the data directory on start, permitting symlinks under `/nix/store` and `/etc/minecraft/managed-datapacks` so worlds using those paths pass validation and the server can bind its port.
> - Increases the `minecraft-status` probe `attempts` to 60 to accommodate longer cold-boot times.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fb5b5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->