### PR TITLE
agent: add codex plugin parity renderers

### DIFF
--- a/lib/agents.nix
+++ b/lib/agents.nix
@@ -16,7 +16,7 @@ let
     "mcpServers"
   ];
 
-  knownFrontmatter = frontmatterOrder;
+  knownFrontmatter = frontmatterOrder ++ [ "codex" ];
 
   isStringList = value: builtins.isList value && lib.all builtins.isString value;
   isMcpServers =
@@ -35,6 +35,7 @@ let
     let
       frontmatter =
         agent.frontmatter or (throw "agents.mkAgentsDir: agent ${name} is missing frontmatter");
+      claudeFrontmatter = builtins.removeAttrs frontmatter [ "codex" ];
       content = agent.content or (throw "agents.mkAgentsDir: agent ${name} is missing content");
       unknown = lib.subtractLists knownFrontmatter (builtins.attrNames frontmatter);
     in
@@ -69,11 +70,14 @@ let
     assert lib.assertMsg (assertOptional name frontmatter "mcpServers" isMcpServers
       "a list of server names or inline server attrsets"
     ) "agents.mkAgentsDir: agent ${name} frontmatter.mcpServers failed validation";
+    assert lib.assertMsg (assertOptional name frontmatter "codex" builtins.isAttrs
+      "an attrset"
+    ) "agents.mkAgentsDir: agent ${name} frontmatter.codex failed validation";
     {
       frontmatter = {
         inherit name;
       }
-      // frontmatter;
+      // claudeFrontmatter;
       inherit content;
     };
 

--- a/lib/codex-agents.nix
+++ b/lib/codex-agents.nix
@@ -1,0 +1,231 @@
+{
+  lib,
+  toml,
+}:
+# Render the same declarative subagent definitions used by Claude Code into
+# Codex custom-agent TOML files. Codex identifies custom agents by the `name`
+# field and loads one standalone file per agent from `.codex/agents/`.
+let
+  assertOptional =
+    agentName: attrs: field: predicate: expected:
+    assert lib.assertMsg (
+      !(builtins.hasAttr field attrs) || predicate attrs.${field}
+    ) "codexAgents.mkAgentsDir: agent ${agentName} ${field} must be ${expected}";
+    true;
+
+  effortMap = {
+    xhigh = "high";
+    high = "high";
+    medium = "medium";
+    low = "low";
+  };
+
+  isStringList = value: builtins.isList value && lib.all builtins.isString value;
+
+  hasWriteTool =
+    tools:
+    lib.any (tool: builtins.elem tool [
+      "Edit"
+      "MultiEdit"
+      "NotebookEdit"
+      "Write"
+    ]) tools;
+
+  renderScalar =
+    key: value:
+    ''${key} = ${toml.scalar value}'';
+
+  renderList =
+    key: values:
+    ''${key} = [ ${lib.concatStringsSep ", " (map toml.scalar values)} ]'';
+
+  renderMcpServer =
+    name: value:
+    let
+      attrs = value.${name};
+      common = [
+        "[mcp_servers.${name}]"
+        ''default_tools_approval_mode = "approve"''
+      ];
+      stdio =
+        common
+        ++ [
+          (renderScalar "command" attrs.command)
+        ]
+        ++ lib.optional (attrs ? args) (renderList "args" attrs.args)
+        ++ lib.optional (attrs ? env && attrs.env != { }) (
+          lib.concatStringsSep "\n" (
+            [
+              "[mcp_servers.${name}.env]"
+            ]
+            ++ lib.mapAttrsToList renderScalar attrs.env
+          )
+        );
+      http =
+        common
+        ++ [
+          (renderScalar "url" attrs.url)
+        ];
+    in
+    lib.concatStringsSep "\n" (
+      if (attrs.type or "stdio") == "http" then http else stdio
+    );
+
+  renderAgentMcp =
+    servers:
+    lib.concatStringsSep "\n\n" (
+      map (
+        server:
+        let
+          names = builtins.attrNames server;
+          name = builtins.head names;
+        in
+        assert lib.assertMsg (builtins.length names == 1)
+          "codexAgents.mkAgentsDir: mcpServers entries must contain exactly one server";
+        renderMcpServer name server
+      ) servers
+    );
+
+  renderAgent =
+    name: agent:
+    let
+      frontmatter = agent.frontmatter or (throw "codexAgents.mkAgentsDir: agent ${name} is missing frontmatter");
+      content = agent.content or (throw "codexAgents.mkAgentsDir: agent ${name} is missing content");
+      tools = frontmatter.tools or [ ];
+      codex = frontmatter.codex or { };
+      mcpServers = frontmatter.mcpServers or [ ];
+      rendered =
+        [
+          (renderScalar "name" (frontmatter.name or name))
+          (renderScalar "description" frontmatter.description)
+          (renderScalar "developer_instructions" content)
+        ]
+        ++ lib.optional (frontmatter ? effort && !(codex ? model_reasoning_effort) && builtins.hasAttr frontmatter.effort effortMap)
+          (renderScalar "model_reasoning_effort" effortMap.${frontmatter.effort})
+        ++ lib.optional (tools != [ ] && !hasWriteTool tools)
+          (renderScalar "sandbox_mode" "read-only")
+        ++ lib.optional (codex ? model) (renderScalar "model" codex.model)
+        ++ lib.optional (codex ? model_reasoning_effort)
+          (renderScalar "model_reasoning_effort" codex.model_reasoning_effort)
+        ++ lib.optional (codex ? sandbox_mode) (renderScalar "sandbox_mode" codex.sandbox_mode)
+        ++ lib.optional (codex ? nickname_candidates)
+          (renderList "nickname_candidates" codex.nickname_candidates)
+        ++ lib.optional (mcpServers != [ ]) (renderAgentMcp mcpServers);
+    in
+    assert lib.assertMsg ((frontmatter.name or name) == name)
+      "codexAgents.mkAgentsDir: agent ${name} has frontmatter.name=${frontmatter.name or "?"} (must match its key)";
+    assert lib.assertMsg (builtins.isString content)
+      "codexAgents.mkAgentsDir: agent ${name} content must be a string";
+    assert lib.assertMsg (builtins.isString frontmatter.description)
+      "codexAgents.mkAgentsDir: agent ${name} frontmatter.description must be a string";
+    assert lib.assertMsg (assertOptional name frontmatter "tools" isStringList "a list of strings")
+      "codexAgents.mkAgentsDir: agent ${name} frontmatter.tools failed validation";
+    assert lib.assertMsg (assertOptional name codex "nickname_candidates" isStringList "a list of strings")
+      "codexAgents.mkAgentsDir: agent ${name} frontmatter.codex.nickname_candidates failed validation";
+    lib.concatStringsSep "\n" rendered + "\n";
+
+  stripYamlString =
+    value:
+    let
+      trimmed = lib.trim value;
+      length = builtins.stringLength trimmed;
+    in
+    if length >= 2 && lib.hasPrefix "\"" trimmed && lib.hasSuffix "\"" trimmed then
+      lib.substring 1 (length - 2) trimmed
+    else if length >= 2 && lib.hasPrefix "'" trimmed && lib.hasSuffix "'" trimmed then
+      lib.substring 1 (length - 2) trimmed
+    else
+      trimmed;
+
+  splitRawMarkdown =
+    path:
+    let
+      lines = map (lib.removeSuffix "\r") (lib.splitString "\n" (builtins.readFile path));
+      step =
+        state: line:
+        if state.inFrontmatter then
+          if line == "---" then
+            state // {
+              inFrontmatter = false;
+              closed = true;
+            }
+          else
+            state // { frontmatter = state.frontmatter ++ [ line ]; }
+        else
+          state // { body = state.body ++ [ line ]; };
+      parsed = builtins.foldl' step {
+        inFrontmatter = true;
+        closed = false;
+        frontmatter = [ ];
+        body = [ ];
+      } (lib.drop 1 lines);
+    in
+    assert lib.assertMsg (lines != [ ] && builtins.head lines == "---")
+      "codexAgents.mkAgentsDir: raw agent ${toString path} must start with YAML frontmatter";
+    assert lib.assertMsg parsed.closed
+      "codexAgents.mkAgentsDir: raw agent ${toString path} has unterminated YAML frontmatter";
+    parsed;
+
+  rawFrontmatterValue =
+    frontmatter: key:
+    let
+      prefix = "${key}:";
+      matches = lib.filter (line: lib.hasPrefix prefix line) frontmatter;
+      match = builtins.match "[^:]+:[[:space:]]*(.*)" (builtins.head matches);
+    in
+    if matches == [ ] then null else stripYamlString (builtins.head match);
+
+  rawMarkdownAgent =
+    file:
+    let
+      parsed = splitRawMarkdown file.path;
+      name = rawFrontmatterValue parsed.frontmatter "name";
+      description = rawFrontmatterValue parsed.frontmatter "description";
+      toolsText = rawFrontmatterValue parsed.frontmatter "tools";
+      tools =
+        if toolsText == null || toolsText == "" then
+          [ ]
+        else
+          map lib.trim (lib.splitString "," toolsText);
+    in
+    assert lib.assertMsg (name == file.name)
+      "codexAgents.mkAgentsDir: raw agent ${file.name} has frontmatter.name=${if name == null then "?" else name} (must match its file name)";
+    assert lib.assertMsg (description != null && description != "")
+      "codexAgents.mkAgentsDir: raw agent ${file.name} is missing description frontmatter";
+    {
+      frontmatter = {
+        inherit description tools;
+        name = file.name;
+      };
+      content = lib.concatStringsSep "\n" parsed.body;
+    };
+
+  mkAgentsDir =
+    {
+      pkgs,
+      agents ? { },
+      rawFiles ? [ ],
+    }:
+    let
+      renderedEntries =
+        lib.mapAttrsToList (name: agent: {
+          name = "${name}.toml";
+          path = pkgs.writeText "${name}.toml" (renderAgent name agent);
+        }) agents
+        ++ map (file: {
+          name = "${file.name}.toml";
+          path = pkgs.writeText "${file.name}.toml" (renderAgent file.name (rawMarkdownAgent file));
+        }) rawFiles;
+      entryNames = map (entry: entry.name) renderedEntries;
+      duplicateEntries =
+        lib.unique (
+          lib.filter (name: (builtins.length (lib.filter (candidate: candidate == name) entryNames)) > 1) entryNames
+        );
+    in
+    assert lib.assertMsg (duplicateEntries == [ ])
+      "codexAgents.mkAgentsDir: duplicate rendered Codex agent file(s): ${lib.concatStringsSep ", " duplicateEntries}";
+    pkgs.linkFarm "codex-agents" renderedEntries;
+in
+{
+  inherit mkAgentsDir renderAgent;
+}

--- a/lib/codex-plugin.nix
+++ b/lib/codex-plugin.nix
@@ -1,0 +1,96 @@
+{ lib, skills }:
+# Build a Codex plugin directory and local marketplace from the same skill source
+# set that backs Claude Code plugins. Codex plugins use `.codex-plugin/plugin.json`
+# and are discovered through a marketplace file under `.agents/plugins/`.
+let
+  marketplaceEntry =
+    {
+      name,
+      path,
+      category ? "Productivity",
+      installation ? "AVAILABLE",
+      authentication ? "ON_INSTALL",
+      displayName ? name,
+      shortDescription ? null,
+    }:
+    {
+      inherit name category;
+      source = {
+        source = "local";
+        inherit path;
+      };
+      policy = {
+        inherit installation authentication;
+      };
+      interface = {
+        inherit displayName;
+      }
+      // lib.optionalAttrs (shortDescription != null) {
+        inherit shortDescription;
+      };
+    };
+
+  mkPlugin =
+    {
+      pkgs,
+      name,
+      version ? "0.1.0",
+      description ? "Codex plugin: ${name}",
+      names ? skills.allSkills,
+      extraSkills ? { },
+      skillsDir ? skills.mkSkillsDir { inherit pkgs names extraSkills; },
+      hooks ? null,
+    }:
+    let
+      collisions = lib.intersectLists names (builtins.attrNames extraSkills);
+      manifest =
+        (pkgs.formats.json { }).generate "codex-plugin-${name}-manifest.json" (
+          {
+            inherit name version description;
+            skills = "./skills/";
+          }
+          // lib.optionalAttrs (hooks != null) {
+            hooks = "./hooks/hooks.json";
+          }
+        );
+      hooksFile = (pkgs.formats.json { }).generate "codex-plugin-${name}-hooks.json" {
+        inherit hooks;
+      };
+    in
+    assert lib.assertMsg (collisions == [ ])
+      "codexPlugin.mkPlugin: extraSkills name(s) collide with index skills: ${lib.concatStringsSep ", " collisions}";
+    pkgs.runCommand "codex-plugin-${name}" { } ''
+      mkdir -p "$out/.codex-plugin"
+      cp ${manifest} "$out/.codex-plugin/plugin.json"
+      cp -RL ${skillsDir} "$out/skills"
+      ${lib.optionalString (hooks != null) ''
+        mkdir -p "$out/hooks"
+        cp ${hooksFile} "$out/hooks/hooks.json"
+      ''}
+      links=$(find "$out" -type l)
+      if [ -n "$links" ]; then
+        echo "codex-plugin: symlinks survived materialization:" >&2
+        echo "$links" >&2
+        exit 1
+      fi
+    '';
+
+  mkMarketplace =
+    {
+      pkgs,
+      name,
+      plugins,
+    }:
+    let
+      marketplace = (pkgs.formats.json { }).generate "codex-plugin-marketplace-${name}.json" {
+        inherit name plugins;
+      };
+    in
+    pkgs.runCommand "codex-plugin-marketplace-${name}" { } ''
+      mkdir -p "$out"
+      cp ${marketplace} "$out/marketplace.json"
+    '';
+in
+{
+  inherit mkPlugin mkMarketplace marketplaceEntry;
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -143,8 +143,10 @@ let
   markdown = import ./util/markdown.nix { inherit lib; };
   skills = import ./skills.nix { inherit lib paths; };
   agents = import ./agents.nix { inherit lib markdown; };
+  codexAgents = import ./codex-agents.nix { inherit lib toml; };
   hermes = import ./hermes { };
   claudePlugin = import ./claude-plugin.nix { inherit lib skills; };
+  codexPlugin = import ./codex-plugin.nix { inherit lib skills; };
   # Shared JetBrains Islands palette (both variants), the single source of truth
   # for syntax color across the repo: the code-highlight crate embeds this JSON
   # for the search `-c` output, and the base profile generates its
@@ -437,6 +439,8 @@ let
       cargoUnit
       checks
       claudePlugin
+      codexAgents
+      codexPlugin
       deepMerge
       goUnit
       hermes

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -422,6 +422,22 @@ let
     inherit pkgs;
     name = "index";
   };
+  codexPluginDir = ix.codexPlugin.mkPlugin {
+    inherit pkgs;
+    name = "index";
+  };
+  codexPluginMarketplace = ix.codexPlugin.mkMarketplace {
+    inherit pkgs;
+    name = "index-local";
+    plugins = [
+      (ix.codexPlugin.marketplaceEntry {
+        name = "index";
+        path = "./plugins/index";
+        displayName = "index";
+        shortDescription = "Index shared agent skills.";
+      })
+    ];
+  };
 
   # Declarative subagents rendered to a symlink-free `.claude/agents` directory.
   # Keep this outside the Claude plugin: plugins namespace subagent names, but
@@ -438,6 +454,27 @@ let
     inherit pkgs;
     agents = agentDefinitions.renderedAgents;
     inherit (agentDefinitions) rawFiles;
+  };
+  codexAgentsDir = ix.codexAgents.mkAgentsDir {
+    inherit pkgs;
+    agents = agentDefinitions.renderedAgents;
+    inherit (agentDefinitions) rawFiles;
+  };
+  codexRawAgentsFixtureDir = ix.codexAgents.mkAgentsDir {
+    inherit pkgs;
+    rawFiles = [
+      {
+        name = "raw-reviewer";
+        path = pkgs.writeText "raw-reviewer.md" ''
+          ---
+          name: raw-reviewer
+          description: "Review from raw Markdown."
+          tools: Read, Glob, Grep
+          ---
+          Review code from raw Markdown.
+        '';
+      }
+    ];
   };
 
   mcSource = ix.writeNushellApplication pkgs {
@@ -807,6 +844,12 @@ let
           agent-skills = pkgs.runCommand "agent-skills-check" { } ''
             test -d ${skillsDir}
             test -d ${agentsDir}
+            test -d ${codexAgentsDir}
+            test -f ${codexRawAgentsFixtureDir}/raw-reviewer.toml
+            grep -q 'name = "raw-reviewer"' ${codexRawAgentsFixtureDir}/raw-reviewer.toml
+            grep -q 'sandbox_mode = "read-only"' ${codexRawAgentsFixtureDir}/raw-reviewer.toml
+            test -f ${codexPluginDir}/.codex-plugin/plugin.json
+            test -f ${codexPluginMarketplace}/marketplace.json
             mkdir -p "$out"
           '';
           # Pins the last-applied 3-way merge behind homeModules.mutable-json:
@@ -1103,6 +1146,9 @@ in
       mc-source = mcSource;
       update-sounds = updateSounds;
       agents = agentsDir;
+      codex-agents = codexAgentsDir;
+      codex-plugin = codexPluginDir;
+      codex-plugin-marketplace = codexPluginMarketplace;
       skills = skillsDir;
       claude-plugin = claudePluginDir;
     }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -167,6 +167,35 @@ let
   agentCommon = import (paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; };
   sampleClaudeSystemPrompt = agentCommon.systemPromptFor "claude";
   sampleCodexSystemPrompt = agentCommon.systemPromptFor "codex";
+  sampleCodexAgent = ix.codexAgents.renderAgent "reviewer" {
+    frontmatter = {
+      description = "Review a finished change.";
+      effort = "xhigh";
+      tools = [
+        "Read"
+        "Glob"
+        "Grep"
+      ];
+      mcpServers = ix.mcp.toAgentMcpServers {
+        docs = {
+          transport = "http";
+          url = "https://developers.openai.com/mcp";
+        };
+      };
+      codex.nickname_candidates = [
+        "Atlas"
+        "Delta"
+      ];
+    };
+    content = ''
+      Review code like an owner.
+    '';
+  };
+  sampleCodexMarketplaceEntry = ix.codexPlugin.marketplaceEntry {
+    name = "index";
+    path = "./plugins/index";
+    displayName = "index";
+  };
 
   minecraft =
     let
@@ -2517,6 +2546,28 @@ let
           lib.hasInfix "via Claude Code" sampleClaudeSystemPrompt
           && !(lib.hasInfix "via Codex" sampleClaudeSystemPrompt);
         message = "Claude prompt should disclose outward messages as Claude Code, not Codex";
+      }
+      {
+        assertion =
+          lib.hasInfix ''name = "reviewer"'' sampleCodexAgent
+          && lib.hasInfix ''description = "Review a finished change."'' sampleCodexAgent
+          && lib.hasInfix ''developer_instructions = '' sampleCodexAgent
+          && lib.hasInfix ''model_reasoning_effort = "high"'' sampleCodexAgent
+          && lib.hasInfix ''sandbox_mode = "read-only"'' sampleCodexAgent
+          && lib.hasInfix ''[mcp_servers.docs]'' sampleCodexAgent
+          && lib.hasInfix ''url = "https://developers.openai.com/mcp"'' sampleCodexAgent
+          && lib.hasInfix ''nickname_candidates = [ "Atlas", "Delta" ]'' sampleCodexAgent;
+        message = "Codex agent renderer should emit standalone custom-agent TOML from shared subagent definitions";
+      }
+      {
+        assertion =
+          sampleCodexMarketplaceEntry.source == {
+            source = "local";
+            path = "./plugins/index";
+          }
+          && sampleCodexMarketplaceEntry.policy.installation == "AVAILABLE"
+          && sampleCodexMarketplaceEntry.policy.authentication == "ON_INSTALL";
+        message = "Codex plugin marketplace entries should use the documented local source shape";
       }
     ];
 


### PR DESCRIPTION
## Why

Codex needs the same repo-owned agent surfaces that Claude already gets from the index Nix helpers: skills, subagent definitions, plugin packaging, and local marketplace metadata. This adds the index-side renderers so downstream repos can consume Codex-compatible artifacts without duplicating the shape.

## What changed

- Added `ix.codexAgents`:
  - renders Nix-defined agents into `.codex/agents/*.toml`
  - can also ingest checked-in Claude-style Markdown agent files with YAML frontmatter
  - maps read-only tool lists to Codex `sandbox_mode = "read-only"`
  - supports Codex-only frontmatter overrides under `frontmatter.codex`
  - carries MCP server declarations into Codex agent TOML

- Added `ix.codexPlugin`:
  - builds a Codex plugin directory with `.codex-plugin/plugin.json`
  - materializes skills into the plugin without store symlinks
  - emits a local marketplace `marketplace.json`
  - accepts a prebuilt `skillsDir` so consumers like ix can package their own combined skill set

- Exported package outputs:
  - `.#codex-agents`
  - `.#codex-plugin`
  - `.#codex-plugin-marketplace`

- Extended checks to force the new agent/plugin outputs, including raw Markdown agent conversion.

## Stack

This is the provider-side PR. ix consumption is in indexable-inc/ix#5757.

## Validation

CI should run the build/check matrix.