### PR TITLE
Prebuild Claude agent materialization

### DIFF
--- a/.claude/hooks/agent-instructions.sh
+++ b/.claude/hooks/agent-instructions.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Serve the live-rendered agent skills and subagents at session start.
+# Serve the prebuilt agent skills and subagents at session start.
 #
-# Skills and subagents are not committed (see .gitignore). The `skills` flake
-# package holds one directory per skill under skills/; the `agents` package
-# holds the rendered subagents. This hook builds those packages and copies them
+# Skills and subagents are not committed (see .gitignore). They are Nix-built by
+# the agent wrapper and exposed through IX_CLAUDE_SKILLS_DIR and
+# IX_CLAUDE_AGENTS_DIR. This hook only copies those already-built store paths
 # into .claude/skills + .claude/agents (Claude Code) / .agents/skills (Codex).
 #
 # Output is the SessionStart hook JSON envelope. Codex requires a JSON object
@@ -23,56 +23,44 @@ root=${CLAUDE_PROJECT_DIR:-}
 # destination layout below and whether to materialize subagents.
 target=${1:-claude-md}
 
-# jq builds the JSON envelope. Prefer one on PATH; fall back to nixpkgs so the
-# hook works before direnv loads the devshell.
-if command -v jq >/dev/null 2>&1; then
-  jq() { command jq "$@"; }
-else
-  jq() { nix run nixpkgs#jq -- "$@"; }
-fi
+copy_tree() {
+  local src=$1 dest=$2
+
+  if [ -z "$src" ] || [ ! -d "$src" ]; then
+    return 0
+  fi
+
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  cp -R "$src"/. "$dest"/
+  chmod -R u+w "$dest"
+}
 
 # Copy the skills package onto disk. The package is symlink-free by build-time
 # assertion (see lib/skills.nix), but the destination directory itself must also
 # be real rather than a symlink to the store: Claude Code's `/`-autocomplete
 # discovery filters symlinks (anthropics/claude-code#36659) even though the skill
-# *loader* follows them fine. chmod because cp preserves the store's read-only
-# mode and the next session's rm -rf must succeed. Best-effort: a skills-build
-# failure must not abort the session, so guard the build and skip the copy if it
-# produces no path.
-skills_store=$(nix build --no-link --print-out-paths "$root#skills" 2>/dev/null || true)
-if [ -n "$skills_store" ]; then
-  case "$target" in
-  codex-md) dest="$root/.agents/skills" ;;
-  *)        dest="$root/.claude/skills" ;;
-  esac
-  rm -rf "$dest"
-  mkdir -p "$dest"
-  cp -R "$skills_store"/. "$dest"/
-  chmod -R u+w "$dest"
-fi
+# *loader* follows them fine. The wrapper, not this startup hook, owns the Nix
+# build so a stuck evaluator cannot block the first prompt.
+case "$target" in
+codex-md) copy_tree "${IX_CLAUDE_SKILLS_DIR:-}" "$root/.agents/skills" ;;
+*)        copy_tree "${IX_CLAUDE_SKILLS_DIR:-}" "$root/.claude/skills" ;;
+esac
 
 # Claude Code also discovers subagents from .claude/agents/*.md. Codex's
 # subagent model is config-driven (features.multi_agent_v2), not markdown
-# files, so materialize the rendered agents only for Claude. Same best-effort
-# guard and symlink-free copy as the skills block above.
+# files, so materialize the rendered agents only for Claude.
 if [ "$target" != codex-md ]; then
-  agents_store=$(nix build --no-link --print-out-paths "$root#agents" 2>/dev/null || true)
-  if [ -n "$agents_store" ]; then
-    dest="$root/.claude/agents"
-    rm -rf "$dest"
-    mkdir -p "$dest"
-    cp -R "$agents_store"/. "$dest"/
-    chmod -R u+w "$dest"
-  fi
+  copy_tree "${IX_CLAUDE_AGENTS_DIR:-}" "$root/.claude/agents"
 fi
 
 # Codex: emit an empty additionalContext, no reloadSkills field its parser
 # might reject.
 if [ "$target" = codex-md ]; then
-  jq -n '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: ""}}'
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":""}}'
   exit 0
 fi
 
 # Claude Code: reloadSkills so the freshly materialized .claude/skills is picked
 # up this session.
-jq -n '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: "", reloadSkills: true}}'
+printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"","reloadSkills":true}}'

--- a/.gitignore
+++ b/.gitignore
@@ -57,15 +57,16 @@ __pycache__/
 .claude/settings.local.json
 CLAUDE.local.md
 
-# Skills are built into the `skills` flake package (one dir per skills/<name>)
-# and copied here by the SessionStart hook (.claude/hooks/agent-instructions.sh)
-# for Claude Code and Codex. Preview with
+# Skills are built into the `skills` flake package (one dir per skills/<name>).
+# The Claude wrapper exports that prebuilt store path to the SessionStart hook,
+# which copies it here for Claude Code and Codex. Preview with
 # `nix build .#skills --print-out-paths | xargs ls`.
 /.claude/skills
 /.agents/
 
-# Subagents are rendered into the `agents` flake package and copied here by the
-# hook for Claude Code (Codex's subagents are config-driven, not files).
+# Subagents are rendered into the `agents` flake package. The wrapper exports
+# that prebuilt store path to the hook for Claude Code (Codex's subagents are
+# config-driven, not files).
 /.claude/agents
 
 # macOS

--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -46,7 +46,10 @@ Because the store output is read-only, the bundled self-updater could never
 write, so the wrapper turns it off hard (`default.nix:375-381`):
 `DISABLE_AUTOUPDATER=1`, `DISABLE_INSTALLATION_CHECKS=1`, and
 `USE_BUILTIN_RIPGREP=0` (search uses the Nix `ripgrep` on PATH so the wrapper
-owns the version pin).
+owns the version pin). The wrapper also exports `IX_CLAUDE_SKILLS_DIR` and,
+when the full flake package set is in scope, `IX_CLAUDE_AGENTS_DIR`: these are
+prebuilt store paths for the repo SessionStart materializer, so startup copies
+agent content from Nix outputs instead of invoking `nix build` interactively.
 
 ### Soft env defaults (set only when unset)
 

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs ? ix.pkgs,
   ix,
   stdenv,
   fetchurl,
@@ -169,6 +170,33 @@ let
   manifest = lib.importJSON ./manifest.json;
   inherit (manifest) version;
 
+  # Prebuilt agent content consumed by the repo SessionStart materializer. Claude
+  # Code can load store-backed skills through `--plugin-dir` / `--add-dir`, but
+  # bare subagents still have to exist under `.claude/agents`; exporting store
+  # paths lets that hook do a plain copy instead of running `nix build` during
+  # interactive startup. The overlay package has no sibling `mcp` package in
+  # scope, so it skips rendered agents whose MCP frontmatter depends on it.
+  agentSkillsDir = ix.skills.mkSkillsDir { inherit pkgs; };
+  agentAgentsDir =
+    if repoPackages ? mcp then
+      let
+        definitions = import (ix.paths.packagesRoot + "/agent/subagents.nix") {
+          inherit
+            ix
+            lib
+            pkgs
+            repoPackages
+            ;
+        };
+      in
+      ix.agents.mkAgentsDir {
+        inherit pkgs;
+        agents = definitions.renderedAgents;
+        inherit (definitions) rawFiles;
+      }
+    else
+      null;
+
   # Set only when the caller has not already provided an env value.
   wrapperEnvDefaults = {
     # Drops [1m] variants from /model without touching model selection.
@@ -284,11 +312,17 @@ let
   # tests below.
   launchSpec = (formats.json { }).generate "claude-code-launch-spec.json" {
     target = "@helper@";
-    env = envEntries {
-      DISABLE_AUTOUPDATER = "1";
-      DISABLE_INSTALLATION_CHECKS = "1";
-      USE_BUILTIN_RIPGREP = "0";
-    };
+    env = envEntries (
+      {
+        DISABLE_AUTOUPDATER = "1";
+        DISABLE_INSTALLATION_CHECKS = "1";
+        USE_BUILTIN_RIPGREP = "0";
+        IX_CLAUDE_SKILLS_DIR = "${agentSkillsDir}";
+      }
+      // lib.optionalAttrs (agentAgentsDir != null) {
+        IX_CLAUDE_AGENTS_DIR = "${agentAgentsDir}";
+      }
+    );
     env_defaults = envEntries (lib.mapAttrs (_: toString) wrapperEnvDefaults);
     path_prepend = pathPrepend;
     flags = wrapperFlags;

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -30,6 +30,26 @@
     chmod +x "$stub"
     sed "s|@helper@|$stub|" ${launchSpec} > "$PWD/test-spec.json"
 
+    spec_env() {
+      ${lib.getExe jq} -r --arg key "$1" '.env[] | select(.key == $key) | .value' \
+        "$PWD/test-spec.json"
+    }
+
+    skills_dir="$(spec_env IX_CLAUDE_SKILLS_DIR)"
+    if [ ! -d "$skills_dir" ]; then
+      printf 'claude launcher env check failed: IX_CLAUDE_SKILLS_DIR is not a directory: %s\n' \
+        "$skills_dir" >&2
+      exit 1
+    fi
+    ${lib.optionalString (repoPackages ? mcp) ''
+      agents_dir="$(spec_env IX_CLAUDE_AGENTS_DIR)"
+      if [ ! -d "$agents_dir" ] || [ -z "$(find "$agents_dir" -maxdepth 1 -name '*.md' -print -quit)" ]; then
+        printf 'claude launcher env check failed: IX_CLAUDE_AGENTS_DIR has no agent markdown files: %s\n' \
+          "$agents_dir" >&2
+        exit 1
+      fi
+    ''}
+
     check() {
       local desc="$1" expected="$2"
       shift 2


### PR DESCRIPTION
## Summary
- Moves skills and subagent materialization out of the SessionStart hook and into the Claude wrapper build.
- Exposes `IX_CLAUDE_SKILLS_DIR` and `IX_CLAUDE_AGENTS_DIR` as prebuilt store paths, then has the hook only copy them into the project layout.
- Adds install-check coverage that the wrapper spec points at real prebuilt skill and agent directories.

## Why
The hook used to run `nix build .#skills` and `nix build .#agents` on interactive startup. If evaluation or Rust package closure work was cold, Claude could sit on the first prompt before even answering `hi`.

## Validation
- `nixfmt packages/agent/claude-code/default.nix packages/agent/claude-code/install-check.nix`
- `git diff --check`
- `nix eval --raw --option accept-flake-config true .#claude-code.drvPath`
- `nix build --no-link --print-out-paths --option accept-flake-config true .#claude-code`
- Manual hook smoke: `claude-md`, `codex-md`, and missing env paths all return valid SessionStart JSON; Claude copies skills and agents, Codex copies skills only.

Closes #1627

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prebuild Claude agent and skills materialization via Nix store paths
> - The Claude Code wrapper now builds skills and agents directories at derivation time and exports them as `IX_CLAUDE_SKILLS_DIR` and `IX_CLAUDE_AGENTS_DIR` environment variables.
> - The [SessionStart hook](https://github.com/indexable-inc/index/pull/1629/files#diff-6858799d11b7350b7cfa67d7e2eb3803531b1452e81a3f91360b10859d7f1280) no longer invokes `nix build` at startup; instead it copies prebuilt content from the store paths using a new `copy_tree` helper.
> - Agents directory (`IX_CLAUDE_AGENTS_DIR`) is only built and exported when `repoPackages` includes `mcp`, and contains rendered subagent markdown files.
> - [install-check.nix](https://github.com/indexable-inc/index/pull/1629/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) now validates that `IX_CLAUDE_SKILLS_DIR` is a directory and, when applicable, that `IX_CLAUDE_AGENTS_DIR` contains at least one `.md` file.
> - Behavioral Change: agent and skills content is now materialized at build time rather than interactively at session start, eliminating runtime `nix build` invocations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd93685.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->