### PR TITLE
fix(minecraft): make hot-reload-agent jar build reproducible

### DIFF
--- a/examples/minecraft/blocks/packages.nix
+++ b/examples/minecraft/blocks/packages.nix
@@ -68,7 +68,11 @@ let
         javac --release ${jvmVersion} -classpath "$classpath" -d classes \
           $(find "$src/src/main/java" -name '*.java')
         cp -r "$src/src/main/resources/." classes/
-        jar --create --file "$out" -C classes .
+        # Pin every entry's timestamp to the zip-epoch minimum. `jar` otherwise
+        # stamps entries with the wall-clock mtime, so the jar (and its NAR)
+        # differs per build and trips "hash mismatch importing path" when a
+        # cache holds a different variant.
+        jar --create --file "$out" --date "1980-01-01T00:00:02Z" -C classes .
       '';
 
   # Offline integration check: committed fixtures -> ClickHouse local -> query.

--- a/lib/build/strip-uv-cache-stamp.py
+++ b/lib/build/strip-uv-cache-stamp.py
@@ -1,0 +1,29 @@
+"""Strip uv's non-reproducible build-provenance stamp from an installed venv.
+
+`uv build` writes a `uv_cache.json` into the local project's dist-info carrying
+a wall-clock timestamp, so the venv (and its NAR) differs per build and the
+stamp's hash flips the dist-info RECORD line. The file is build-cache metadata
+with no runtime role; removing it and its RECORD entry makes the install
+bit-identical. Run as: python strip-uv-cache-stamp.py <venv-dir>.
+"""
+
+import pathlib
+import sys
+
+
+def main() -> None:
+    venv = pathlib.Path(sys.argv[1])
+    for stamp in venv.rglob("*.dist-info/uv_cache.json"):
+        record = stamp.parent / "RECORD"
+        if record.exists():
+            kept = [
+                line
+                for line in record.read_text().splitlines()
+                if "/uv_cache.json," not in line
+            ]
+            record.write_text("".join(f"{line}\n" for line in kept))
+        stamp.unlink()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/build/strip-uv-cache-stamp.py
+++ b/lib/build/strip-uv-cache-stamp.py
@@ -1,9 +1,9 @@
-"""Strip uv's non-reproducible build-provenance stamp from an installed venv.
+"""Strip uv's non-reproducible build-provenance stamps from an installed venv.
 
-`uv build` writes a `uv_cache.json` into the local project's dist-info carrying
-a wall-clock timestamp, so the venv (and its NAR) differs per build and the
-stamp's hash flips the dist-info RECORD line. The file is build-cache metadata
-with no runtime role; removing it and its RECORD entry makes the install
+uv writes a `uv_cache.json` into every installed package's dist-info carrying a
+wall-clock timestamp, so the venv (and its NAR) differs per build and each
+stamp's hash flips its dist-info RECORD line. The files are build-cache metadata
+with no runtime role; removing them and their RECORD entries makes the install
 bit-identical. Run as: python strip-uv-cache-stamp.py <venv-dir>.
 """
 
@@ -12,16 +12,26 @@ import sys
 
 
 def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: strip-uv-cache-stamp.py <venv-dir>")
     venv = pathlib.Path(sys.argv[1])
     for stamp in venv.rglob("*.dist-info/uv_cache.json"):
         record = stamp.parent / "RECORD"
         if record.exists():
+            # RECORD lines are `path,sha256=...,size`, path relative to
+            # site-packages. Drop the line whose path field is exactly this
+            # stamp (not a substring match) so a same-named data file elsewhere
+            # stays listed. A stamp with no RECORD entry is left for the
+            # unlink below; removing the orphan file is still reproducible.
+            target = f"{stamp.parent.name}/uv_cache.json"
             kept = [
                 line
-                for line in record.read_text().splitlines()
-                if "/uv_cache.json," not in line
+                for line in record.read_text(encoding="utf-8").splitlines()
+                if line.split(",", 1)[0] != target
             ]
-            record.write_text("".join(f"{line}\n" for line in kept))
+            record.write_text(
+                "".join(f"{line}\n" for line in kept), encoding="utf-8"
+            )
         stamp.unlink()
 
 

--- a/lib/build/uv-application.nix
+++ b/lib/build/uv-application.nix
@@ -245,6 +245,17 @@ pkgs.stdenvNoCC.mkDerivation (_: {
       --python "$out/venv/bin/python" \
       dist/*.whl
 
+    # uv's build backend writes a `uv_cache.json` build-provenance stamp into
+    # the installed project's dist-info, carrying a wall-clock timestamp. That
+    # makes the venv non-reproducible (the stamp differs per build, and its
+    # hash flips the dist-info RECORD line), which trips "hash mismatch
+    # importing path" on a cache that holds a different variant. It is
+    # build-cache metadata with no runtime role, so drop it and its RECORD
+    # entry for a bit-identical install. Done in Python (RECORD line removal
+    # keys on a hash we cannot know ahead of time, so substituteInPlace cannot
+    # express it) and the helper fails loudly on a malformed RECORD.
+    ${pythonExecutable} ${./strip-uv-cache-stamp.py} "$out/venv"
+
     test -x "$out/venv/bin/${mainProgram}"
     makeWrapper "$out/venv/bin/${mainProgram}" "$out/bin/${mainProgram}" ${
       lib.optionalString (

--- a/lib/build/uv-application.nix
+++ b/lib/build/uv-application.nix
@@ -245,15 +245,15 @@ pkgs.stdenvNoCC.mkDerivation (_: {
       --python "$out/venv/bin/python" \
       dist/*.whl
 
-    # uv's build backend writes a `uv_cache.json` build-provenance stamp into
-    # the installed project's dist-info, carrying a wall-clock timestamp. That
-    # makes the venv non-reproducible (the stamp differs per build, and its
-    # hash flips the dist-info RECORD line), which trips "hash mismatch
-    # importing path" on a cache that holds a different variant. It is
-    # build-cache metadata with no runtime role, so drop it and its RECORD
-    # entry for a bit-identical install. Done in Python (RECORD line removal
-    # keys on a hash we cannot know ahead of time, so substituteInPlace cannot
-    # express it) and the helper fails loudly on a malformed RECORD.
+    # uv writes a `uv_cache.json` build-provenance stamp into every installed
+    # package's dist-info, carrying a wall-clock timestamp. That makes the venv
+    # non-reproducible (each stamp differs per build, and its hash flips its
+    # dist-info RECORD line), which trips "hash mismatch importing path" on a
+    # cache that holds a different variant. They are build-cache metadata with
+    # no runtime role, so drop them and their RECORD entries for a bit-identical
+    # install. Done in Python (removing a RECORD line keys on the exact stamp
+    # path, not a hash we can know ahead of time, so substituteInPlace cannot
+    # express it).
     ${pythonExecutable} ${./strip-uv-cache-stamp.py} "$out/venv"
 
     test -x "$out/venv/bin/${mainProgram}"

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs ? ix.pkgs,
   ix,
   stdenv,
   fetchurl,
@@ -160,6 +159,12 @@
 }:
 
 let
+  # Read the package set from `ix`, not a `pkgs` callPackage formal: a `pkgs`
+  # arg in the formal set breaks `.override` (astlog no-pkgs-in-callpackage),
+  # and the rebound `ix.pkgs` is the set the rest of this file already uses
+  # (see `inherit (ix) pkgs` below).
+  inherit (ix) pkgs;
+
   # Version and per-platform SRI hashes are generated, never hand-edited. Bump
   # with `nix run .#claude-code.updateScript -- <version>`, which refetches
   # Anthropic's per-version manifest and rewrites manifest.json. We pin by raw

--- a/packages/minecraft/minecraft/hot-reload-agent/default.nix
+++ b/packages/minecraft/minecraft/hot-reload-agent/default.nix
@@ -29,7 +29,13 @@ stdenv.mkDerivation {
 
     mkdir -p classes
     javac --release 21 -d classes $(find src -name '*.java' -print)
-    jar cfm minecraft-hot-reload-agent.jar MANIFEST.MF -C classes .
+    # `jar` stamps every entry with the current wall-clock mtime, so this
+    # input-addressed derivation's NAR content varies per build. That trips
+    # "hash mismatch importing path" whenever two machines cache different
+    # variants of the same store path. Pin every entry to the zip-epoch
+    # minimum (DOS time is 2s-resolution from 1980) for a bit-identical jar.
+    jar --create --file minecraft-hot-reload-agent.jar --manifest MANIFEST.MF \
+      --date "1980-01-01T00:00:02Z" -C classes .
 
     runHook postBuild
   '';


### PR DESCRIPTION
`jar` stamps every zip entry with the current wall-clock mtime, so this input-addressed derivation's NAR content differs on every build even though its store path is fixed. When two machines cache different variants of the same path, substitution aborts with:

  error: hash mismatch importing path
    '/nix/store/...-minecraft-hot-reload-agent-0.1.0';
    specified: sha256:0czl9...
    got:       sha256:0042...

That broke `ix`'s `push-images` (the regional-status minecraft images bundle this agent) under `require-sigs = true`, `fallback = false`.

The build is otherwise deterministic: javac output and jar entry order are stable, and two builds differ only in the per-entry timestamp field. Pin every entry to the zip-epoch minimum (`1980-01-01T00:00:02Z`, the 2s-resolution DOS-time floor) via `jar --date` (OpenJDK 19+; this package already uses jdk25) for a bit-identical archive.

Verified: `nix build --rebuild` on the agent now matches (was "output differs" before); the patched `jar` command produces a byte-identical jar across time-separated builds.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make hot-reload-agent and UV application JAR builds reproducible by pinning timestamps
> - Pins ZIP entry timestamps to `1980-01-01T00:00:02Z` in the [hot-reload-agent](https://github.com/indexable-inc/index/pull/1630/files#diff-5353c53c5512719468a6f51c8e70d548b48ad8e71c4c4dcbac84d7af921a1103) and [blocks packages](https://github.com/indexable-inc/index/pull/1630/files#diff-b28061fdba8b520e3544480661edb4fa9e937d8c523e19f339de703578ab0727) JAR build steps, producing bit-identical archives across builds.
> - Adds [strip-uv-cache-stamp.py](https://github.com/indexable-inc/index/pull/1630/files#diff-3d8902606aa706938d67606bff5dbcd9147d6473597a58c8d212bae3e1eb2cc7), a script that removes non-reproducible `uv_cache.json` stamp files from dist-info directories and strips the corresponding RECORD entries.
> - Invokes the new script in [uv-application.nix](https://github.com/indexable-inc/index/pull/1630/files#diff-09a8d5eb2b4f7112629f9b9003c69b22610e8610d4caa27e4f3c6bf9e382db37) after wheel installation so the venv output no longer contains uv cache stamps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab2bee7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->