### PR TITLE
docs(images): map vcfs-guest-eval packages to benchmark ops

### DIFF
--- a/images/system/vcfs-guest-eval/default.nix
+++ b/images/system/vcfs-guest-eval/default.nix
@@ -1,4 +1,20 @@
-# Runtime image for ix's VCFS guest benchmark controller.
+# Boot image for ix's VCFS guest benchmark (`vcfs-guest-eval`).
+#
+# `ix new registry.ix.dev/ix/vcfs-guest-eval:latest` boots a VM from this
+# image; the controller uploads the `vcfs-bench` binary and runs the `real`
+# suite inside it. Each `real` op shells out to a host tool that must already
+# be on the guest PATH (crates/storage/fs/vcfs/guest-bench/src/workloads/mod.rs):
+#
+#   sqlite.{write_txn,read_query}  -> sqlite3   (pkgs.sqlite)
+#   pnpm.{install,build}           -> pnpm/node (pkgs.pnpm, pkgs.nodejs)
+#   cargo.build                    -> cargo + a C linker
+#                                     (pkgs.cargo, pkgs.rustc, pkgs.gcc,
+#                                      pkgs.binutils, pkgs.pkg-config)
+#   git.status (macro)             -> git       (pkgs.git)
+#
+# `nix` (nix.shell / macro ops) and `strace` (the controller wraps the bench
+# in strace) come from NixOS and the auto-enabled base profile, so they are
+# not repeated here.
 { pkgs, ... }:
 {
   ix.image.name = "ix/vcfs-guest-eval";


### PR DESCRIPTION
The `ix/vcfs-guest-eval` image (added in #1624) lists nine packages with no note on why each is there. This documents the mapping from each package to the VCFS `real` benchmark op that shells out to it, and records that `nix` and `strace` come from NixOS + the auto-enabled base profile rather than this list.

No behavior change: the package set is identical. Verified the image still builds and that the guest closure ships sqlite3, node, pnpm, git, nix, cargo, rustc, cc, and strace.

Context: the built image was rebuilt and pushed to `registry.ix.dev/ix/vcfs-guest-eval:latest` in region `internal-hari` so the benchmark suite stops failing on the missing `sqlite3`/`pnpm`/`node`/`git` binaries.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document host tool requirements for vcfs-guest-eval benchmark image
> Adds a multi-line comment block to [default.nix](https://github.com/indexable-inc/index/pull/1631/files#diff-1e4c680e5612ba0062514988dd61112e9873ca7a8f3c36ed553e9af83ca69d42) describing how the image is used and which host tools must be on PATH for each workload (sqlite3, pnpm/node, cargo and Rust toolchain components, git). Notes that `nix` and `strace` come from the base profile. No functional changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97f4039.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->