### PR TITLE
fix(base): disable fish man-page completion generation (fish 4.8.0 broke it)

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -119,6 +119,16 @@ in
         bash.enable = true;
         zsh.enable = true;
         fish.enable = true;
+        # fish 4.8.0 (current nixpkgs nixos-unstable) removed
+        # share/fish/tools/create_manpage_completions.py, which Home Manager's
+        # default `generateCompletions = true` invokes to derive completions
+        # from man pages. Every `<pkg>-fish-completions` derivation then fails
+        # ("python: can't open file …create_manpage_completions.py"), failing
+        # the whole system closure and breaking `ix up` for every fleet. The
+        # shell rc/integration wiring above is what we want from fish here;
+        # man-page completions are an orthogonal nicety.
+        # https://github.com/indexable-inc/index/issues/1632
+        fish.generateCompletions = false;
         # btop resource monitor, configured natively through the Home
         # Manager module (no opaque btop.conf to hand-maintain) so every
         # VM opens btop with the same tuned layout: 500 ms refresh, just


### PR DESCRIPTION
## Problem
`ix up` fails for **every** fleet built from the base profile, surfaced as a generic `internal server error`. The real cause is a build failure of the `nixos-system-<node>` closure.

## Root cause
`modules/profiles/base/default.nix` enables Home Manager `programs.fish` for root. Its `generateCompletions` defaults to `true`, generating a `<pkg>-fish-completions` derivation per package by running:

```
$fish/share/fish/tools/create_manpage_completions.py
```

nixpkgs `nixos-unstable` now ships **fish 4.8.0**, which removed that script (no `share/fish/tools/` dir at all):

```
python: can't open file '/nix/store/…-fish-4.8.0/share/fish/tools/create_manpage_completions.py': [Errno 2] No such file or directory
```

Every completion derivation fails → cascades up through `home-manager-generation → system-units → etc → activate → nixos-system-<node>` → `nix build` exits 100.

## Fix
Set `programs.fish.generateCompletions = false` in the base profile. Fish is enabled here for its rc/integration wiring (starship, atuin, zoxide, direnv, fzf); man-page→fish completions are an orthogonal nicety.

## Verification
Built `.#nixosConfigurations.test.config.system.build.toplevel` for a trivial `pkgs.hello` fleet:
- **before:** fails on `bash-interactive-…-fish-completions.drv` (reproduced on a fully-cached host — deterministic, not environmental)
- **after:** builds clean, exit 0 → `/nix/store/…-nixos-system-test-26.11.20260626.e73de5b`

## Follow-up (separate, `ix` repo)
`ix` launders this build failure into `internal server error` and discards the nix stderr (`orch/node-agent switch_ops.rs`). That masking is what turned a 30-second "fish completions don't build" into a long goose chase; tracked separately.

Fixes #1632

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable fish man-page completion generation broken by fish 4.8.0
> Sets `fish.generateCompletions = false` in [modules/profiles/base/default.nix](https://github.com/indexable-inc/index/pull/1633/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) to stop Home Manager from attempting to generate fish completions from man pages. This is a workaround for upstream tooling removed in fish 4.8.0 that broke the generation step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d458ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->