### PR TITLE
ci: publish index's public closure (incl. crate FODs) to cache.ix.dev

### DIFF
--- a/.github/workflows/warm-public-cache.yml
+++ b/.github/workflows/warm-public-cache.yml
@@ -1,21 +1,11 @@
 name: Warm public cache
 
-# Publish index's public build closure to the ix-public flat cache
-# (cache.ix.dev) so fleet `ix up` builds and developer machines can substitute
-# index's own artifacts -- including build-time crate FODs (nix-cargo-unit /
-# ix-mcp vendor) that a build sandbox cannot fetch from crates.io. Companion to
-# the ix-repo change that fronts the ix-public bucket through ncps
-# (indexable-inc/ix#5802).
-#
-# Scope: PUBLIC outputs only -- `.#packages.<system>` for every system index
-# exposes. Never ciChecks/tests or any private path. The push goes through the
-# on-fabric `ix-public-cache-push` helper (nix copy -> Garage S3, signed with
-# the fleet `ix-workspace` key).
+# Publish index's public package closures (incl. build-time crate FODs) to the
+# ix-public bucket so fleet `ix up` and dev machines can substitute them.
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -27,35 +17,21 @@ concurrency:
 
 jobs:
   warm:
-    # One job per system index publishes packages for (flake.nix `devSystems`).
-    # x86_64-linux is for fleet `ix up` (Linux VMs); the aarch64-linux and the
-    # two Darwin entries warm the cache for ARM and Mac *developers* pulling
-    # index's dev tools. fail-fast: false so one arch's runner being
-    # unavailable does not drop the others.
     strategy:
       fail-fast: false
       matrix:
         include:
           - system: x86_64-linux
-            # The image base pins nixpkgs.hostPlatform.gcc.arch = znver5, so the
-            # x86_64-linux closure needs the builder to advertise it.
-            extraSystemFeatures: "gccarch-znver5"
+            extraSystemFeatures: gccarch-znver5
           - system: aarch64-linux
             extraSystemFeatures: ""
           - system: aarch64-darwin
             extraSystemFeatures: ""
           - system: x86_64-darwin
             extraSystemFeatures: ""
-    # Per-system self-hosted runner. The ix-ci dispatcher must mint a runner of
-    # the matching arch/OS for this label (today only x86_64-linux is wired for
-    # the check gate -- see review note in the PR); alternatively a single
-    # x86_64-linux runner with darwin/aarch64 remote builders can build all
-    # systems and publish from one host.
     runs-on: ["${{ format('ix-ci-run-{0}-{1}-warm-{2}', github.run_id, github.run_attempt, matrix.system) }}"]
     timeout-minutes: 60
     env:
-      # Same eval knobs as the check gate. extra-system-features is per-system
-      # (znver5 only applies to the x86_64-linux image closure).
       NIX_CONFIG: |-
         experimental-features = nix-command flakes ca-derivations
         accept-flake-config = true
@@ -71,10 +47,6 @@ jobs:
           set -euo pipefail
           system='${{ matrix.system }}'
 
-          # Collect the derivation path of every public package for this system.
-          # The recursive walk descends `recurseForDerivations` catalog groups
-          # and keeps only actual derivations, so the set is exactly
-          # `.#packages.<system>`.
           mapfile -t drvs < <(
             nix eval --raw ".#packages.$system" --apply '
               set:
@@ -87,20 +59,8 @@ jobs:
               in builtins.concatStringsSep "\n" (collect set)
             '
           )
-          printf '%s: %d public package derivations\n' "$system" "${#drvs[@]}"
-
-          # Realize them (warm store -> near no-op) so every output, including
-          # the fixed-output crate tarballs, exists before we enumerate the
-          # closure.
           nix build --no-link "${drvs[@]/%/^*}"
 
-          # Full BUILD closure with outputs: `--include-outputs` is what pulls
-          # the build-time crate FODs in, not just runtime deps. This is the
-          # piece every existing push omits.
+          # --include-outputs captures build-time crate FODs, not just runtime deps.
           mapfile -t paths < <(nix-store --query --requisites --include-outputs "${drvs[@]}")
-          printf '%s: %d store paths to publish\n' "$system" "${#paths[@]}"
-
-          # On-fabric publisher: nix copy -> Garage ix-public bucket, signed
-          # ix-workspace. Needs root to read the secret-store env file; the
-          # runner is granted sudo NOPASSWD for exactly this command (see PR).
           sudo ix-public-cache-push "${paths[@]}"

--- a/.github/workflows/warm-public-cache.yml
+++ b/.github/workflows/warm-public-cache.yml
@@ -1,0 +1,83 @@
+name: Warm public cache
+
+# Publish index's public build closure to the ix-public flat cache
+# (cache.ix.dev) so fleet `ix up` builds can substitute index's own artifacts
+# -- including build-time crate FODs (nix-cargo-unit / ix-mcp vendor) that the
+# build sandbox cannot fetch from crates.io. Companion to the ix-repo change
+# that fronts the ix-public bucket through ncps (indexable-inc/ix#5802).
+#
+# Scope: PUBLIC outputs only -- `.#packages.x86_64-linux`. Never ciChecks/tests
+# or any private path. The push goes through the on-fabric `ix-public-cache-push`
+# helper (nix copy -> Garage S3, signed with the fleet `ix-workspace` key).
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-public-cache
+  cancel-in-progress: false
+
+env:
+  # Same eval knobs as the check gate: CA derivations for the rust units,
+  # the znver5 system feature the image base pins, and accept-flake-config so
+  # the cache.ix.dev substituter from the flake nixConfig is honoured.
+  NIX_CONFIG: |-
+    experimental-features = nix-command flakes ca-derivations
+    accept-flake-config = true
+    extra-system-features = gccarch-znver5
+    max-jobs = auto
+    cores = 1
+
+jobs:
+  warm:
+    # Same self-hosted ix-ci-run-* dispatcher as check.yml: a warm, persistent
+    # /nix/store on a host that already carries the ix-public-cache-push helper
+    # and its secret-store credentials.
+    runs-on: ["${{ format('ix-ci-run-{0}-{1}-warm-public-cache', github.run_id, github.run_attempt) }}"]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Publish public closure to cache.ix.dev
+        run: |
+          set -euo pipefail
+
+          # Collect the derivation path of every public package. The recursive
+          # walk descends `recurseForDerivations` catalog groups and keeps only
+          # actual derivations, so the set is exactly `.#packages.x86_64-linux`.
+          mapfile -t drvs < <(
+            nix eval --raw .#packages.x86_64-linux --apply '
+              set:
+              let
+                collect = v:
+                  if builtins.isAttrs v then
+                    if (v.type or "") == "derivation" then [ v.drvPath ]
+                    else builtins.concatMap collect (builtins.attrValues v)
+                  else [ ];
+              in builtins.concatStringsSep "\n" (collect set)
+            '
+          )
+          printf 'public package derivations: %d\n' "${#drvs[@]}"
+
+          # Realize them (warm store -> near no-op) so every output, including
+          # the fixed-output crate tarballs, exists before we enumerate the
+          # closure.
+          nix build --no-link "${drvs[@]/%/^*}"
+
+          # Full BUILD closure with outputs: `--include-outputs` is what pulls
+          # the build-time crate FODs in, not just runtime deps. This is the
+          # piece every existing push omits.
+          mapfile -t paths < <(nix-store --query --requisites --include-outputs "${drvs[@]}")
+          printf 'store paths to publish: %d\n' "${#paths[@]}"
+
+          # On-fabric publisher: nix copy -> Garage ix-public bucket, signed
+          # ix-workspace. Needs root to read the secret-store env file; the
+          # runner is granted sudo NOPASSWD for exactly this command (see PR).
+          sudo ix-public-cache-push "${paths[@]}"

--- a/.github/workflows/warm-public-cache.yml
+++ b/.github/workflows/warm-public-cache.yml
@@ -1,14 +1,16 @@
 name: Warm public cache
 
 # Publish index's public build closure to the ix-public flat cache
-# (cache.ix.dev) so fleet `ix up` builds can substitute index's own artifacts
-# -- including build-time crate FODs (nix-cargo-unit / ix-mcp vendor) that the
-# build sandbox cannot fetch from crates.io. Companion to the ix-repo change
-# that fronts the ix-public bucket through ncps (indexable-inc/ix#5802).
+# (cache.ix.dev) so fleet `ix up` builds and developer machines can substitute
+# index's own artifacts -- including build-time crate FODs (nix-cargo-unit /
+# ix-mcp vendor) that a build sandbox cannot fetch from crates.io. Companion to
+# the ix-repo change that fronts the ix-public bucket through ncps
+# (indexable-inc/ix#5802).
 #
-# Scope: PUBLIC outputs only -- `.#packages.x86_64-linux`. Never ciChecks/tests
-# or any private path. The push goes through the on-fabric `ix-public-cache-push`
-# helper (nix copy -> Garage S3, signed with the fleet `ix-workspace` key).
+# Scope: PUBLIC outputs only -- `.#packages.<system>` for every system index
+# exposes. Never ciChecks/tests or any private path. The push goes through the
+# on-fabric `ix-public-cache-push` helper (nix copy -> Garage S3, signed with
+# the fleet `ix-workspace` key).
 
 on:
   push:
@@ -23,37 +25,58 @@ concurrency:
   group: warm-public-cache
   cancel-in-progress: false
 
-env:
-  # Same eval knobs as the check gate: CA derivations for the rust units,
-  # the znver5 system feature the image base pins, and accept-flake-config so
-  # the cache.ix.dev substituter from the flake nixConfig is honoured.
-  NIX_CONFIG: |-
-    experimental-features = nix-command flakes ca-derivations
-    accept-flake-config = true
-    extra-system-features = gccarch-znver5
-    max-jobs = auto
-    cores = 1
-
 jobs:
   warm:
-    # Same self-hosted ix-ci-run-* dispatcher as check.yml: a warm, persistent
-    # /nix/store on a host that already carries the ix-public-cache-push helper
-    # and its secret-store credentials.
-    runs-on: ["${{ format('ix-ci-run-{0}-{1}-warm-public-cache', github.run_id, github.run_attempt) }}"]
+    # One job per system index publishes packages for (flake.nix `devSystems`).
+    # x86_64-linux is for fleet `ix up` (Linux VMs); the aarch64-linux and the
+    # two Darwin entries warm the cache for ARM and Mac *developers* pulling
+    # index's dev tools. fail-fast: false so one arch's runner being
+    # unavailable does not drop the others.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            # The image base pins nixpkgs.hostPlatform.gcc.arch = znver5, so the
+            # x86_64-linux closure needs the builder to advertise it.
+            extraSystemFeatures: "gccarch-znver5"
+          - system: aarch64-linux
+            extraSystemFeatures: ""
+          - system: aarch64-darwin
+            extraSystemFeatures: ""
+          - system: x86_64-darwin
+            extraSystemFeatures: ""
+    # Per-system self-hosted runner. The ix-ci dispatcher must mint a runner of
+    # the matching arch/OS for this label (today only x86_64-linux is wired for
+    # the check gate -- see review note in the PR); alternatively a single
+    # x86_64-linux runner with darwin/aarch64 remote builders can build all
+    # systems and publish from one host.
+    runs-on: ["${{ format('ix-ci-run-{0}-{1}-warm-{2}', github.run_id, github.run_attempt, matrix.system) }}"]
     timeout-minutes: 60
+    env:
+      # Same eval knobs as the check gate. extra-system-features is per-system
+      # (znver5 only applies to the x86_64-linux image closure).
+      NIX_CONFIG: |-
+        experimental-features = nix-command flakes ca-derivations
+        accept-flake-config = true
+        extra-system-features = ${{ matrix.extraSystemFeatures }}
+        max-jobs = auto
+        cores = 1
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Publish public closure to cache.ix.dev
+      - name: Publish ${{ matrix.system }} public closure to cache.ix.dev
         run: |
           set -euo pipefail
+          system='${{ matrix.system }}'
 
-          # Collect the derivation path of every public package. The recursive
-          # walk descends `recurseForDerivations` catalog groups and keeps only
-          # actual derivations, so the set is exactly `.#packages.x86_64-linux`.
+          # Collect the derivation path of every public package for this system.
+          # The recursive walk descends `recurseForDerivations` catalog groups
+          # and keeps only actual derivations, so the set is exactly
+          # `.#packages.<system>`.
           mapfile -t drvs < <(
-            nix eval --raw .#packages.x86_64-linux --apply '
+            nix eval --raw ".#packages.$system" --apply '
               set:
               let
                 collect = v:
@@ -64,7 +87,7 @@ jobs:
               in builtins.concatStringsSep "\n" (collect set)
             '
           )
-          printf 'public package derivations: %d\n' "${#drvs[@]}"
+          printf '%s: %d public package derivations\n' "$system" "${#drvs[@]}"
 
           # Realize them (warm store -> near no-op) so every output, including
           # the fixed-output crate tarballs, exists before we enumerate the
@@ -75,7 +98,7 @@ jobs:
           # the build-time crate FODs in, not just runtime deps. This is the
           # piece every existing push omits.
           mapfile -t paths < <(nix-store --query --requisites --include-outputs "${drvs[@]}")
-          printf 'store paths to publish: %d\n' "${#paths[@]}"
+          printf '%s: %d store paths to publish\n' "$system" "${#paths[@]}"
 
           # On-fabric publisher: nix copy -> Garage ix-public bucket, signed
           # ix-workspace. Needs root to read the secret-store env file; the

--- a/.github/workflows/warm-public-cache.yml
+++ b/.github/workflows/warm-public-cache.yml
@@ -1,11 +1,12 @@
 name: Warm public cache
 
-# Publish index's public package closures (incl. build-time crate FODs) to the
-# ix-public bucket so fleet `ix up` and dev machines can substitute them.
+# Publish index's public package closures (incl. crate FODs) to the ix-public
+# bucket. Runs after Check so the x86_64-linux workspace is already warm.
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: [Check]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -17,6 +18,11 @@ concurrency:
 
 jobs:
   warm:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.event == 'push')
     strategy:
       fail-fast: false
       matrix:
@@ -50,17 +56,20 @@ jobs:
           mapfile -t drvs < <(
             nix eval --raw ".#packages.$system" --apply '
               set:
-              let
-                collect = v:
-                  if builtins.isAttrs v then
-                    if (v.type or "") == "derivation" then [ v.drvPath ]
-                    else builtins.concatMap collect (builtins.attrValues v)
-                  else [ ];
+              let collect = v:
+                if builtins.isAttrs v then
+                  if (v.type or "") == "derivation" then [ v.drvPath ]
+                  else builtins.concatMap collect (builtins.attrValues v)
+                else [ ];
               in builtins.concatStringsSep "\n" (collect set)
             '
           )
+
+          # Warm store (post-Check): the rust workspace is already built, so this
+          # only realizes the package finals the gate skips; no rebuild.
           nix build --no-link "${drvs[@]/%/^*}"
 
-          # --include-outputs captures build-time crate FODs, not just runtime deps.
+          # nix copy uploads only paths the bucket lacks (diff push);
+          # --include-outputs captures build-time crate FODs.
           mapfile -t paths < <(nix-store --query --requisites --include-outputs "${drvs[@]}")
           sudo ix-public-cache-push "${paths[@]}"


### PR DESCRIPTION
## Problem
`ix up` fails for fleets built from the base profile (masked as `internal server error`). The real cause: index's own build artifacts — notably the `nix-cargo-unit` / `ix-mcp` vendor **crate FODs** — are never published to any cache the fleet substitutes from. The build sandbox has no `static.crates.io` egress, so any crate not already warm in ncps 404s and the build dies. Today only `.#site` is pushed to the public cache; everything else (including build-time FODs) is absent.

## Change
Add a `main`-gated workflow on the self-hosted `ix-ci-run-*` runner that publishes index's **public build closure** to the `ix-public` bucket (`cache.ix.dev`):
- enumerates `.#packages.x86_64-linux` (recursively, derivations only),
- realizes them (warm store → near no-op),
- computes `nix-store --query --requisites --include-outputs` — **the `--include-outputs` is what captures the crate FODs**, not just runtime deps,
- publishes via the on-fabric `ix-public-cache-push` (nix copy → Garage S3, signed `ix-workspace`).

## Scope guard
Publishes **only `.#packages.x86_64-linux`** — index's public packages. It never touches `ciChecks`/tests or any private/fabric path. (Example-fleet `nixosConfigurations` toplevels are an easy add if you want their system closures warmed too — flagged for your call.)

## Review notes / prerequisites
- **Runner privilege:** `ix-public-cache-push` reads the secret-store env file and needs root. This assumes the `ix-ci-run-*` runner is granted `sudo` NOPASSWD for exactly that command. If you'd rather, it can run via a dedicated push credential instead of sudo — your call on the wiring.
- **Pairs with indexable-inc/ix#5802 / its PR**: that change fronts the `ix-public` bucket through ncps so fleets can *read* what this publishes. Neither fixes `ix up` alone; both are needed.
- Draft for review — does not run until merged to `main`, and self-contained (separate from the required `flake-check` status).

Part B of indexable-inc/ix#5802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish index public closure including crate FODs to cache.ix.dev after CI checks
> Adds a new [warm-public-cache.yml](.github/workflows/warm-public-cache.yml) GitHub Actions workflow that runs after the 'Check' workflow succeeds on `main` (or on manual dispatch).
>
> - Evaluates and builds all package derivations for four target systems: `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`, and `x86_64-darwin`
> - Computes full closures including build-time crate FODs via `nix-store --query --requisites --include-outputs`
> - Uploads resulting store paths to the public cache via `ix-public-cache-push`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 053857e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->