### PR TITLE
fix(minecraft): copy managed configs writable instead of symlinking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,6 +4911,7 @@ dependencies = [
  "anyhow",
  "clap",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/packages/minecraft/minecraft/sync-managed/Cargo.toml
+++ b/packages/minecraft/minecraft/sync-managed/Cargo.toml
@@ -11,3 +11,6 @@ workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/packages/minecraft/minecraft/sync-managed/src/main.rs
+++ b/packages/minecraft/minecraft/sync-managed/src/main.rs
@@ -154,11 +154,25 @@ fn remove_if_present(path: &Path) -> Result<()> {
     }
 }
 
+/// How a managed file is placed into the mutable data dir.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Materialize {
+    /// Read-only symlink into the Nix store. Correct for content the server only
+    /// ever reads: plugin/mod jars and datapacks.
+    Symlink,
+    /// Writable copy of the store file. Required for config the server or its
+    /// plugins rewrite in place. Paper saves config atomically by writing a temp
+    /// beside the file's real path; for a store symlink that temp lands in the
+    /// read-only `/nix/store` and aborts startup (paper-global.yml, spigot.yml).
+    Copy,
+}
+
 fn sync_tree(
     source_dir: &Path,
     target_dir: &Path,
     manifest: &Path,
     preserve_removed: &BTreeSet<String>,
+    materialize: Materialize,
 ) -> Result<()> {
     fs::create_dir_all(target_dir).with_context(|| format!("creating {}", target_dir.display()))?;
     if let Some(parent) = manifest.parent() {
@@ -205,13 +219,29 @@ fn sync_tree(
             fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
         }
         remove_if_present(&target_path)?;
-        symlink(&source_path, &target_path).with_context(|| {
-            format!(
-                "linking {} to {}",
-                target_path.display(),
-                source_path.display()
-            )
-        })?;
+        match materialize {
+            Materialize::Symlink => {
+                symlink(&source_path, &target_path).with_context(|| {
+                    format!(
+                        "linking {} to {}",
+                        target_path.display(),
+                        source_path.display()
+                    )
+                })?;
+            }
+            Materialize::Copy => {
+                fs::copy(&source_path, &target_path).with_context(|| {
+                    format!(
+                        "copying {} to {}",
+                        source_path.display(),
+                        target_path.display()
+                    )
+                })?;
+                // Store sources are read-only (0444) and `fs::copy` carries that
+                // mode over, so make the copy owner-writable for in-place rewrites.
+                set_owner_read_write(&target_path)?;
+            }
+        }
         writeln!(
             &mut manifest_lines,
             "{} {}",
@@ -713,6 +743,7 @@ fn main() -> Result<()> {
         plan_plugman_reload(&config)?;
     }
 
+    // Jars are read-only at runtime, so they stay symlinked into the store.
     sync_tree(
         &config.managed_root.join("managed-dropins"),
         &config.data_dir.join(&config.dropin_dir),
@@ -720,19 +751,26 @@ fn main() -> Result<()> {
             .data_dir
             .join(format!(".ix-managed-{}", config.dropin_dir)),
         &BTreeSet::new(),
+        Materialize::Symlink,
     )?;
+    // Paper and its plugins rewrite their config in place on boot, so these are
+    // copied as writable files rather than read-only store symlinks.
     sync_tree(
         &config.managed_root.join("managed-config"),
         &config.data_dir.join("config"),
         &config.data_dir.join(".ix-managed-config"),
         &BTreeSet::new(),
+        Materialize::Copy,
     )?;
     sync_tree(
         &config.managed_root.join("managed-server-files"),
         &config.data_dir,
         &config.data_dir.join(".ix-managed-server-files"),
         &BTreeSet::from(["ops.json".to_owned(), "whitelist.json".to_owned()]),
+        Materialize::Copy,
     )?;
+    // Datapacks are read-only and allowlisted past world validation, so they
+    // stay symlinked.
     for world in &config.datapack_worlds {
         validate_rel_path_shape(world).context("checking datapack world name safety")?;
         sync_tree(
@@ -740,6 +778,7 @@ fn main() -> Result<()> {
             &config.data_dir.join(world).join("datapacks"),
             &config.data_dir.join(world).join(".ix-managed-datapacks"),
             &BTreeSet::new(),
+            Materialize::Symlink,
         )?;
     }
     reconcile_access(&config)?;
@@ -849,5 +888,67 @@ mod tests {
                 entry("managed-added", "Added"),
             ]
         );
+    }
+
+    #[test]
+    fn copy_materializes_a_writable_regular_file() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir()?;
+        let source = tmp.path().join("managed-config");
+        fs::create_dir_all(&source)?;
+        let src = source.join("paper-global.yml");
+        fs::write(&src, "verbose: false\n")?;
+        // Mimic the read-only Nix store source.
+        fs::set_permissions(&src, fs::Permissions::from_mode(0o444))?;
+
+        let target = tmp.path().join("config");
+        let manifest = tmp.path().join(".ix-managed-config");
+        sync_tree(
+            &source,
+            &target,
+            &manifest,
+            &BTreeSet::new(),
+            Materialize::Copy,
+        )?;
+
+        let dst = target.join("paper-global.yml");
+        let meta = fs::symlink_metadata(&dst)?;
+        assert!(
+            meta.file_type().is_file(),
+            "config must be a regular file Paper can rewrite, not a store symlink"
+        );
+        assert_eq!(fs::read_to_string(&dst)?, "verbose: false\n");
+        assert!(
+            meta.permissions().mode() & 0o200 != 0,
+            "copied config must be owner-writable"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn symlink_keeps_the_store_link() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let source = tmp.path().join("managed-dropins");
+        fs::create_dir_all(&source)?;
+        fs::write(source.join("Plugin.jar"), "jar")?;
+
+        let target = tmp.path().join("plugins");
+        let manifest = tmp.path().join(".ix-managed-plugins");
+        sync_tree(
+            &source,
+            &target,
+            &manifest,
+            &BTreeSet::new(),
+            Materialize::Symlink,
+        )?;
+
+        assert!(
+            fs::symlink_metadata(target.join("Plugin.jar"))?
+                .file_type()
+                .is_symlink(),
+            "jars must stay symlinked to the store"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
Paper and its plugins rewrite their config in place on boot (paper-global.yml, spigot.yml, bukkit.yml, per-plugin configs). The sync tool symlinked every managed file from the read-only Nix store into the data dir, so Paper's atomic save -- which writes a temp beside the file's resolved real path -- tried to create `/nix/store/.<pid>-paper-global.yml.tmp` and aborted startup with `FileSystemException: Read-only file system`, before the server bound its port. This kept the regional "New VMs" status heartbeat red even after the datapack symlink fix, because the server now booted past world validation only to crash on the first config save.

Give `sync_tree` a materialization mode: copy the config categories (managed-config, managed-server-files) as owner-writable regular files, and keep symlinking content the server only ever reads (managed-dropins jars, managed-datapacks -- the latter allowlisted past world validation). The manifest still records each source path, so plugman reload detection is unchanged. This generalizes the existing one-off de-symlink of server.properties in configure_rcon.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Copy managed configs as writable files instead of symlinking in minecraft sync
> - Introduces a `Materialize` enum (`Symlink`/`Copy`) in [main.rs](https://github.com/indexable-inc/index/pull/1636/files#diff-1a23f2b55b199befed97797a98412cee6d271257c6b394e13e9c25313266b198) and passes it to `sync_tree` to control how files are placed into the mutable data directory.
> - Files under `managed-config` and `managed-server-files` are now copied as writable regular files; `managed-dropins` jars and per-world datapacks remain symlinked.
> - In `Copy` mode, `sync_tree` copies the source file and calls `set_owner_read_write` to ensure the destination is owner-writable.
> - Behavioral Change: `managed-config` and `managed-server-files` destinations are now regular files instead of symlinks, so in-place edits no longer propagate back to the Nix store path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8163ed0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->