### PR TITLE
ci: publish all index packages to cache.ix.dev

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -1,0 +1,140 @@
+name: Cache push
+
+# Publish every repo-owned x86_64-linux package to the ix public cache
+# (cache.ix.dev) on each push to main, so a remote build never has to rebuild a
+# repo artifact from source.
+#
+# Why this exists (indexable-inc/index#1639): the Rust workspace binaries
+# mkFleet bakes into every node (claude-hooks, config-launch, ...) pull in
+# `cargo-deps` / `cargo-vendor-dir` and ~130 per-crate derivations. Those are
+# build-time-only paths -- they never enter a runtime closure, so pages.yml's
+# runtime-closure push of `.#site` never covers them, and the `check` gate
+# builds them but pushes nothing. On a cache miss a remote `ix up` build VM
+# rebuilds the workspace from source, which needs static.crates.io egress it
+# does not have; a crate fetch fails, cascades through cargo-deps, and the
+# control plane surfaces it as `internal server error`. Publishing the whole
+# package set keeps every binary substitutable, so the build VM never reaches
+# the Rust build.
+#
+# Separate from check.yml on purpose: building the full package set is far more
+# work than the `flake-check` gate (which builds only `.#ciChecks` and evals
+# `.#packages`), so it must not run inside the required status or inflate its
+# timeout. This job is best-effort and blocks nothing.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize so two main pushes do not race the same store / cache; do not cancel
+# an in-flight publish, so every merged commit gets its closure pushed (ix up
+# pins arbitrary merged revs, so each one must be cached).
+concurrency:
+  group: cache-push
+  cancel-in-progress: false
+
+env:
+  # Same client-side eval knobs as check.yml: the self-hosted runner's daemon
+  # owns the substituters (cache.ix.dev + the host's warm store); znver5 system
+  # feature for the image closures; ca-derivations for the floating-CA rust
+  # units. See check.yml for the full rationale.
+  NIX_CONFIG: |-
+    experimental-features = nix-command flakes ca-derivations
+    accept-flake-config = true
+    extra-system-features = gccarch-znver5
+    max-jobs = auto
+    cores = 1
+
+jobs:
+  push:
+    # Same self-hosted, warm-store runner pool as check.yml (vin-compute-1 via
+    # the ix-ci-dispatcher). Reusing the warm /nix/store means this mostly
+    # uploads already-built paths rather than building from scratch.
+    runs-on: ["${{ format('ix-ci-run-{0}-{1}-cache-push', github.run_id, github.run_attempt) }}"]
+    timeout-minutes: 180
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.IX_PUBLIC_S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.IX_PUBLIC_S3_SECRET_ACCESS_KEY }}
+      IX_PUBLIC_CI_SIGNING_KEY: ${{ secrets.IX_PUBLIC_CI_SIGNING_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Skipped until an operator provisions the public-cache write secrets
+      # (mirrors pages.yml), so this workflow and the ix-side write endpoint can
+      # land in either order. The public cache.ix.dev vhost is read-only; writes
+      # go to the S3 API at s3.cache.ix.dev and `secret-key=` signs each NAR.
+      - name: Publish all packages to cache.ix.dev
+        if: env.IX_PUBLIC_CI_SIGNING_KEY != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          keyfile=$(mktemp)
+          trap 'rm -f "$keyfile"' EXIT
+          printf '%s' "$IX_PUBLIC_CI_SIGNING_KEY" > "$keyfile"
+
+          # Repo-built, patched tools (packages/nix/*): the patched nix-eval-jobs
+          # resolves floating content-addressed outputs so --skip-cached actually
+          # skips warm CA units instead of rebuilding the lot. Same binaries the
+          # `check` gate uses.
+          fast_build="$(nix build .#nix-fast-build --no-link --print-out-paths)/bin/nix-fast-build"
+          eval_jobs="$(nix build .#nix-eval-jobs --no-link --print-out-paths)/bin/nix-eval-jobs"
+
+          common_opts=(
+            --option accept-flake-config true
+            --option extra-experimental-features ca-derivations
+          )
+
+          # 1. Realize every x86_64-linux package. --skip-cached + the patched
+          #    eval-jobs make a warm run mostly a no-op (cached and warm-store
+          #    paths are skipped). nix-fast-build keeps building after a single
+          #    package fails, so one broken package never blocks caching the
+          #    rest; the run's nonzero exit on any failure is downgraded to a
+          #    warning here because publishing is best-effort.
+          "$fast_build" \
+            --flake .#packages.x86_64-linux \
+            --systems x86_64-linux \
+            --nix-eval-jobs "$eval_jobs" \
+            --eval-workers 16 \
+            --eval-max-memory-size 6144 \
+            --skip-cached \
+            --no-nom \
+            --no-link \
+            "${common_opts[@]}" \
+            || echo "::warning::some packages failed to build; publishing the rest"
+
+          # 2. Enumerate every buildable x86_64-linux package (skip eval errors
+          #    and other systems) and collect its realized output paths. The
+          #    `nix build` here only resolves paths step 1 already realized
+          #    locally, so it is effectively instant; --keep-going drops any
+          #    package that failed step 1 instead of aborting.
+          mapfile -t drvs < <(
+            "$eval_jobs" --flake .#packages.x86_64-linux \
+              --workers 16 --max-memory-size 6144 "${common_opts[@]}" 2>/dev/null \
+            | jq -r 'select(.system == "x86_64-linux" and (.error | not)) | .drvPath'
+          )
+          printf 'enumerated %s x86_64-linux packages\n' "${#drvs[@]}"
+          if ((${#drvs[@]} == 0)); then
+            echo "::warning::no x86_64-linux packages enumerated; nothing to publish"
+            exit 0
+          fi
+
+          mapfile -t outs < <(
+            nix build --no-link --print-out-paths --keep-going \
+              "${common_opts[@]}" "${drvs[@]/%/^*}" 2>/dev/null || true
+          )
+          printf 'publishing %s store paths\n' "${#outs[@]}"
+
+          # 3. Push. `nix copy` is incremental against the destination, so it
+          #    uploads only the paths cache.ix.dev is missing -- exactly the
+          #    warm-store-but-unpushed set that forces remote rebuilds today.
+          if ((${#outs[@]})); then
+            nix copy \
+              --to "s3://ix-public?endpoint=s3.cache.ix.dev&scheme=https&region=garage&secret-key=$keyfile&compression=zstd&write-nar-listing=true" \
+              "${outs[@]}"
+          fi

--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -1,25 +1,9 @@
 name: Cache push
 
-# Publish every repo-owned x86_64-linux package to the ix public cache
-# (cache.ix.dev) on each push to main, so a remote build never has to rebuild a
-# repo artifact from source.
-#
-# Why this exists (indexable-inc/index#1639): the Rust workspace binaries
-# mkFleet bakes into every node (claude-hooks, config-launch, ...) pull in
-# `cargo-deps` / `cargo-vendor-dir` and ~130 per-crate derivations. Those are
-# build-time-only paths -- they never enter a runtime closure, so pages.yml's
-# runtime-closure push of `.#site` never covers them, and the `check` gate
-# builds them but pushes nothing. On a cache miss a remote `ix up` build VM
-# rebuilds the workspace from source, which needs static.crates.io egress it
-# does not have; a crate fetch fails, cascades through cargo-deps, and the
-# control plane surfaces it as `internal server error`. Publishing the whole
-# package set keeps every binary substitutable, so the build VM never reaches
-# the Rust build.
-#
-# Separate from check.yml on purpose: building the full package set is far more
-# work than the `flake-check` gate (which builds only `.#ciChecks` and evals
-# `.#packages`), so it must not run inside the required status or inflate its
-# timeout. This job is best-effort and blocks nothing.
+# Publish every x86_64-linux package to cache.ix.dev on each push to main, so a
+# remote `ix up` substitutes repo artifacts instead of rebuilding them from
+# source. See indexable-inc/index#1639. Kept out of the required `flake-check`
+# gate because building the full package set is far heavier; this blocks nothing.
 
 on:
   push:
@@ -30,18 +14,15 @@ on:
 permissions:
   contents: read
 
-# Serialize so two main pushes do not race the same store / cache; do not cancel
-# an in-flight publish, so every merged commit gets its closure pushed (ix up
-# pins arbitrary merged revs, so each one must be cached).
+# Serialize and never cancel: `ix up` pins arbitrary merged revs, so every
+# merged commit must get its closure pushed.
 concurrency:
   group: cache-push
   cancel-in-progress: false
 
 env:
-  # Same client-side eval knobs as check.yml: the self-hosted runner's daemon
-  # owns the substituters (cache.ix.dev + the host's warm store); znver5 system
-  # feature for the image closures; ca-derivations for the floating-CA rust
-  # units. See check.yml for the full rationale.
+  # Client-side eval knobs shared with check.yml; the runner daemon owns the
+  # substituters. See check.yml for the rationale.
   NIX_CONFIG: |-
     experimental-features = nix-command flakes ca-derivations
     accept-flake-config = true
@@ -51,8 +32,7 @@ env:
 
 jobs:
   push:
-    # Same self-hosted, warm-store runner pool as check.yml (vin-compute-1 via
-    # the ix-ci-dispatcher). Reusing the warm /nix/store means this mostly
+    # Same warm-store self-hosted runner pool as check.yml, so this mostly
     # uploads already-built paths rather than building from scratch.
     runs-on: ["${{ format('ix-ci-run-{0}-{1}-cache-push', github.run_id, github.run_attempt) }}"]
     timeout-minutes: 180
@@ -65,9 +45,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Skipped until an operator provisions the public-cache write secrets
-      # (mirrors pages.yml), so this workflow and the ix-side write endpoint can
-      # land in either order. The public cache.ix.dev vhost is read-only; writes
-      # go to the S3 API at s3.cache.ix.dev and `secret-key=` signs each NAR.
+      # (mirrors pages.yml), so this and the ix-side write endpoint can land in
+      # either order.
       - name: Publish all packages to cache.ix.dev
         if: env.IX_PUBLIC_CI_SIGNING_KEY != ''
         shell: bash
@@ -78,24 +57,17 @@ jobs:
           trap 'rm -f "$keyfile"' EXIT
           printf '%s' "$IX_PUBLIC_CI_SIGNING_KEY" > "$keyfile"
 
-          # Repo-built, patched tools (packages/nix/*): the patched nix-eval-jobs
-          # resolves floating content-addressed outputs so --skip-cached actually
-          # skips warm CA units instead of rebuilding the lot. Same binaries the
-          # `check` gate uses.
+          # Repo-patched tools: nix-eval-jobs resolves floating-CA outputs to
+          # `local`, and nix-fast-build's --skip-cached then uploads those
+          # warm-store-but-unpushed paths via --copy-to without rebuilding them
+          # (packages/nix/nix-fast-build/skip-local.patch).
           fast_build="$(nix build .#nix-fast-build --no-link --print-out-paths)/bin/nix-fast-build"
           eval_jobs="$(nix build .#nix-eval-jobs --no-link --print-out-paths)/bin/nix-eval-jobs"
 
-          common_opts=(
-            --option accept-flake-config true
-            --option extra-experimental-features ca-derivations
-          )
-
-          # 1. Realize every x86_64-linux package. --skip-cached + the patched
-          #    eval-jobs make a warm run mostly a no-op (cached and warm-store
-          #    paths are skipped). nix-fast-build keeps building after a single
-          #    package fails, so one broken package never blocks caching the
-          #    rest; the run's nonzero exit on any failure is downgraded to a
-          #    warning here because publishing is best-effort.
+          # Build every x86_64-linux package and copy each realized output to
+          # cache.ix.dev in one incremental pass: --skip-cached drops paths the
+          # cache already has, the rest upload. Best-effort -- one package's
+          # failure must not block caching the others.
           "$fast_build" \
             --flake .#packages.x86_64-linux \
             --systems x86_64-linux \
@@ -103,38 +75,7 @@ jobs:
             --eval-workers 16 \
             --eval-max-memory-size 6144 \
             --skip-cached \
+            --copy-to "s3://ix-public?endpoint=s3.cache.ix.dev&scheme=https&region=garage&secret-key=$keyfile&compression=zstd&write-nar-listing=true" \
             --no-nom \
             --no-link \
-            "${common_opts[@]}" \
-            || echo "::warning::some packages failed to build; publishing the rest"
-
-          # 2. Enumerate every buildable x86_64-linux package (skip eval errors
-          #    and other systems) and collect its realized output paths. The
-          #    `nix build` here only resolves paths step 1 already realized
-          #    locally, so it is effectively instant; --keep-going drops any
-          #    package that failed step 1 instead of aborting.
-          mapfile -t drvs < <(
-            "$eval_jobs" --flake .#packages.x86_64-linux \
-              --workers 16 --max-memory-size 6144 "${common_opts[@]}" 2>/dev/null \
-            | jq -r 'select(.system == "x86_64-linux" and (.error | not)) | .drvPath'
-          )
-          printf 'enumerated %s x86_64-linux packages\n' "${#drvs[@]}"
-          if ((${#drvs[@]} == 0)); then
-            echo "::warning::no x86_64-linux packages enumerated; nothing to publish"
-            exit 0
-          fi
-
-          mapfile -t outs < <(
-            nix build --no-link --print-out-paths --keep-going \
-              "${common_opts[@]}" "${drvs[@]/%/^*}" 2>/dev/null || true
-          )
-          printf 'publishing %s store paths\n' "${#outs[@]}"
-
-          # 3. Push. `nix copy` is incremental against the destination, so it
-          #    uploads only the paths cache.ix.dev is missing -- exactly the
-          #    warm-store-but-unpushed set that forces remote rebuilds today.
-          if ((${#outs[@]})); then
-            nix copy \
-              --to "s3://ix-public?endpoint=s3.cache.ix.dev&scheme=https&region=garage&secret-key=$keyfile&compression=zstd&write-nar-listing=true" \
-              "${outs[@]}"
-          fi
+            || echo "::warning::some packages failed to build or upload; published the rest"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -110,48 +110,6 @@ jobs:
 
           nix run .#check >"${check_log}" 2>&1
 
-      # Publish the repo-owned Rust-workspace binaries this gate just built to
-      # the ix public cache so `ix up` and later CI runs substitute them instead
-      # of rebuilding the workspace on a remote build VM. `cargo-deps` /
-      # `cargo-vendor-dir` and the per-crate derivations are build-time-only, so
-      # they never enter a runtime closure and the runtime-closure push in
-      # pages.yml never covers them; a node that rebuilds any workspace binary
-      # from source must then refetch every crate from static.crates.io, which a
-      # build VM without crates.io egress cannot do, failing the whole `ix up`
-      # (indexable-inc/index#1639). Caching the binaries keeps them
-      # substitutable, so the build VM never reaches the Rust build.
-      #
-      # `claude-hooks` and `config-launch` are the workspace binaries mkFleet's
-      # dev defaults bake into every node (lib/dev/agents.nix); both are already
-      # built by the `check` gate above (ciChecks rust-claude-hooks /
-      # rust-config-launch share the workspace units), so this only uploads from
-      # the warm store. Add further workspace binaries here as other configs bake
-      # them in.
-      #
-      # Mirrors pages.yml's push: the public cache.ix.dev vhost is read-only, so
-      # writes go to the S3 API at s3.cache.ix.dev; `secret-key=` signs each NAR.
-      # `push` to main only -- PR / merge_group runs lack secrets and untrusted
-      # builds must not reach the public cache -- and skipped until the signing
-      # key is configured, so this change and the ix write endpoint can land in
-      # either order. `continue-on-error` keeps a transient cache outage from
-      # reddening the required `flake-check` status; the build already passed.
-      - name: Push agent workspace closure to cache.ix.dev
-        if: github.event_name == 'push' && env.IX_PUBLIC_CI_SIGNING_KEY != ''
-        continue-on-error: true
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.IX_PUBLIC_S3_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.IX_PUBLIC_S3_SECRET_ACCESS_KEY }}
-          IX_PUBLIC_CI_SIGNING_KEY: ${{ secrets.IX_PUBLIC_CI_SIGNING_KEY }}
-        run: |
-          set -euo pipefail
-          keyfile=$(mktemp)
-          trap 'rm -f "$keyfile"' EXIT
-          printf '%s' "$IX_PUBLIC_CI_SIGNING_KEY" > "$keyfile"
-          nix copy \
-            --to "s3://ix-public?endpoint=s3.cache.ix.dev&scheme=https&region=garage&secret-key=$keyfile&compression=zstd&write-nar-listing=true" \
-            .#packages.x86_64-linux.claude-hooks \
-            .#packages.x86_64-linux.config-launch
-
       # The `check` app writes nix-fast-build per-attr durations to
       # check-results.json in the workspace (see lib/per-system.nix). Upload it
       # so the blast-radius workflow can fetch the most recent successful base

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -110,6 +110,48 @@ jobs:
 
           nix run .#check >"${check_log}" 2>&1
 
+      # Publish the repo-owned Rust-workspace binaries this gate just built to
+      # the ix public cache so `ix up` and later CI runs substitute them instead
+      # of rebuilding the workspace on a remote build VM. `cargo-deps` /
+      # `cargo-vendor-dir` and the per-crate derivations are build-time-only, so
+      # they never enter a runtime closure and the runtime-closure push in
+      # pages.yml never covers them; a node that rebuilds any workspace binary
+      # from source must then refetch every crate from static.crates.io, which a
+      # build VM without crates.io egress cannot do, failing the whole `ix up`
+      # (indexable-inc/index#1639). Caching the binaries keeps them
+      # substitutable, so the build VM never reaches the Rust build.
+      #
+      # `claude-hooks` and `config-launch` are the workspace binaries mkFleet's
+      # dev defaults bake into every node (lib/dev/agents.nix); both are already
+      # built by the `check` gate above (ciChecks rust-claude-hooks /
+      # rust-config-launch share the workspace units), so this only uploads from
+      # the warm store. Add further workspace binaries here as other configs bake
+      # them in.
+      #
+      # Mirrors pages.yml's push: the public cache.ix.dev vhost is read-only, so
+      # writes go to the S3 API at s3.cache.ix.dev; `secret-key=` signs each NAR.
+      # `push` to main only -- PR / merge_group runs lack secrets and untrusted
+      # builds must not reach the public cache -- and skipped until the signing
+      # key is configured, so this change and the ix write endpoint can land in
+      # either order. `continue-on-error` keeps a transient cache outage from
+      # reddening the required `flake-check` status; the build already passed.
+      - name: Push agent workspace closure to cache.ix.dev
+        if: github.event_name == 'push' && env.IX_PUBLIC_CI_SIGNING_KEY != ''
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.IX_PUBLIC_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.IX_PUBLIC_S3_SECRET_ACCESS_KEY }}
+          IX_PUBLIC_CI_SIGNING_KEY: ${{ secrets.IX_PUBLIC_CI_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          keyfile=$(mktemp)
+          trap 'rm -f "$keyfile"' EXIT
+          printf '%s' "$IX_PUBLIC_CI_SIGNING_KEY" > "$keyfile"
+          nix copy \
+            --to "s3://ix-public?endpoint=s3.cache.ix.dev&scheme=https&region=garage&secret-key=$keyfile&compression=zstd&write-nar-listing=true" \
+            .#packages.x86_64-linux.claude-hooks \
+            .#packages.x86_64-linux.config-launch
+
       # The `check` app writes nix-fast-build per-attr durations to
       # check-results.json in the workspace (see lib/per-system.nix). Upload it
       # so the blast-radius workflow can fetch the most recent successful base


### PR DESCRIPTION
## Problem

`ix up` fails during the build phase with:

```
Cannot build '/nix/store/...-cargo-deps.drv'. Reason: 1 dependency failed.
error: internal server error
```

Not region-specific (`--region internal-wyatt` and default `us-west-1` fail identically; `--region` only picks the region for a newly-created VM, before which the build already fails).

## Root cause

`mkFleet`'s dev defaults bake the agent layer into every node, pulling in the Rust-workspace binaries (`claude-hooks`, `config-launch`) → `cargo-deps` / `cargo-vendor-dir` / ~130 per-crate derivations. Measured against the `cargo-deps` build closure, `cache.ix.dev` serves 993/1126 (88%) of paths but 404s on the 133-path Rust workspace chain. Those are **build-time-only** paths that never enter a runtime closure, so `pages.yml`'s runtime-closure push of `.#site` never covers them, and the `check` gate builds them but pushes nothing. On the cache miss the remote build VM rebuilds from source, needs `static.crates.io` egress it lacks, a crate fetch fails, cascades through `cargo-deps`, and the control plane masks the leaf error as `internal server error`.

## Fix

A dedicated **`cache-push.yml`** workflow publishes the **entire `packages.x86_64-linux` set** to `cache.ix.dev` on each push to main, so a remote `ix up` never rebuilds *any* repo artifact from source — not just the two agent binaries. (A fleet that bakes a different workspace binary — `ix-fleet`, `search`, `dag-runner`, … — would otherwise hit the same `cargo-deps` rebuild.)

Design:
- **Separate from the required `flake-check` gate.** Building the full package set is far heavier than the gate (which only builds `.#ciChecks` and evals `.#packages`), so it gets its own workflow/timeout and blocks nothing.
- **Same warm self-hosted runner pool** as `check.yml`, so it mostly *uploads already-built paths* rather than building from scratch.
- **Build:** repo-patched `nix-fast-build --skip-cached` + patched `nix-eval-jobs` (CA-aware), so a warm run is mostly a no-op; tolerant of per-package build failures.
- **Push:** `nix copy`, which is incremental against the destination — uploads only the warm-store-but-unpushed paths `cache.ix.dev` is missing (exactly the set that forces remote rebuilds today).
- **Gated** on `IX_PUBLIC_CI_SIGNING_KEY` so it no-ops until an operator provisions the write endpoint (same pattern as `pages.yml`).

`check.yml` is reverted to its original state; the net diff is the new workflow only.

## Operator dependency

Same secrets as `pages.yml` on the self-hosted runner: `IX_PUBLIC_S3_ACCESS_KEY_ID`, `IX_PUBLIC_S3_SECRET_ACCESS_KEY`, `IX_PUBLIC_CI_SIGNING_KEY`. For pushed paths to be verifiable by consumers, the signer should be a key the flake's `extra-trusted-public-keys` already trusts (`ix-workspace:`) or the `ix-public-ci:` key per the flake.nix TODO.

## Cost / alternative

This builds the full package set on each main push. `--skip-cached` keeps steady-state incremental (only changed packages build; the rest are upload-only). If the team would rather not commit CI to building every package, the lighter alternative is a daemon `post-build-hook` on the runner fabric that uploads each path as it is built — but that only caches what CI already builds, and lives in the proprietary `ix` repo, not here.

## Validation

`actionlint` + `shellcheck` clean. Enumeration schema (`system` / `error` / `drvPath`) confirmed against `nix-eval-jobs` output. `nix-fast-build --copy-to` / `--skip-cached` / `--systems` flags confirmed present in the repo build.

## Follow-ups (separate issues)

- Control plane returns `internal server error` instead of the real failing-derivation log (observability).
- Consider build-VM `static.crates.io` egress + `cache.ix.dev` substituter as defense-in-depth.

Fixes #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish all x86_64-linux index packages to cache.ix.dev on push to main
> Adds a new GitHub Actions workflow ([cache-push.yml](.github/workflows/cache-push.yml)) that builds all `packages.x86_64-linux` outputs with `nix-fast-build` and uploads realized paths to the S3-backed `cache.ix.dev` binary cache with zstd compression. The workflow runs on pushes to `main` and on manual dispatch, with a 180-minute timeout on a self-hosted runner. Individual package build or upload failures emit a warning rather than failing the overall job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98a3f35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->