### PR TITLE
ci: drop redundant cache push step from pages.yml

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,14 +18,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Surfaced at job level so the push step's `if` can gate on the signing key
-    # being configured. That lets this repo's change land before the operator
-    # finishes the ix-side write endpoint + secrets without reddening Pages: the
-    # push is simply skipped until IX_PUBLIC_CI_SIGNING_KEY exists.
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.IX_PUBLIC_S3_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.IX_PUBLIC_S3_SECRET_ACCESS_KEY }}
-      IX_PUBLIC_CI_SIGNING_KEY: ${{ secrets.IX_PUBLIC_CI_SIGNING_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -45,24 +37,10 @@ jobs:
       - name: Build site
         run: nix build .#site -L
 
-      # Publish the built closure to the ix public cache so later CI runs and ix
-      # VMs substitute it instead of rebuilding. The public cache.ix.dev vhost is
-      # read-only, so writes go to the S3 API at s3.cache.ix.dev; `secret-key=`
-      # signs each NAR as it is copied (mirrors ix's on-fabric ix-public-cache-push).
-      # `push` (main) only -- PR runs lack secrets and untrusted builds must not
-      # reach the public cache -- and skipped until the signing key is configured,
-      # so this change and the ix write endpoint can land in either order.
-      - name: Push to cache.ix.dev
-        if: github.event_name == 'push' && env.IX_PUBLIC_CI_SIGNING_KEY != ''
-        run: |
-          set -euo pipefail
-          keyfile=$(mktemp)
-          trap 'rm -f "$keyfile"' EXIT
-          printf '%s' "$IX_PUBLIC_CI_SIGNING_KEY" > "$keyfile"
-          nix copy \
-            --to "s3://ix-public?endpoint=s3.cache.ix.dev&scheme=https&region=garage&secret-key=$keyfile&compression=zstd&write-nar-listing=true" \
-            ./result
-
+      # The site's closure is published to cache.ix.dev by the dedicated
+      # cache-push.yml workflow (which pushes the full `packages.x86_64-linux`
+      # build closure, a superset of this site's runtime closure), so Pages no
+      # longer pushes to the cache itself. See indexable-inc/index#1639.
       - name: Prepare Pages artifact
         run: |
           mkdir -p site-dist


### PR DESCRIPTION
## What

Removes the `Push to cache.ix.dev` step from `pages.yml`, plus the job-level `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `IX_PUBLIC_CI_SIGNING_KEY` env block that existed only to feed it.

## Why

#1640 adds `cache-push.yml`, which builds and pushes the **entire** `packages.x86_64-linux` set to `cache.ix.dev` on every push to main. `.#site` resolves to `packages.x86_64-linux.site`, and `cache-push.yml` uploads each package's **full build closure** — a strict superset of the **runtime closure of `./result`** that `pages.yml` was pushing.

So `pages.yml`'s cache push is now duplicate work. Dropping it leaves `pages.yml` with a single concern: building the docs site and deploying it to GitHub Pages. The `build` job still `nix build .#site` for the Pages artifact; it just no longer copies to the cache.

## Ordering

This should land **after** #1640 is merged and `cache-push.yml` is confirmed to upload the site closure. Until then, `pages.yml`'s push is the only thing populating the cache for the site (and is itself gated/skipped until the signing-key secret exists).

## Validation

`actionlint` clean.

Refs #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove cache push step from pages.yml workflow
> The `pages.yml` build job no longer publishes the site closure to `cache.ix.dev` and no longer sets AWS or signing key environment variables. Cache publishing is now handled by a dedicated `cache-push.yml` workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ada7ef4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->