### PR TITLE
fix(velocity): own plugins/ via StateDirectory so the proxy can install plugins

### DIFF
--- a/modules/services/velocity/default.nix
+++ b/modules/services/velocity/default.nix
@@ -722,8 +722,6 @@ in
       preStart = ''
         set -eu
 
-        mkdir -p ${lib.escapeShellArg "${dataDir}/plugins"}
-
         if [ -f ${lib.escapeShellArg managedPluginManifest} ]; then
           while IFS= read -r plugin; do
             target=${lib.escapeShellArg "${dataDir}/plugins"}/$plugin
@@ -745,7 +743,12 @@ in
         WorkingDirectory = dataDir;
         ExecStart = lib.escapeShellArgs javaArgs;
         Restart = "on-failure";
-        StateDirectory = "velocity";
+        # `plugins/` is listed explicitly so systemd creates and owns it as the
+        # velocity user (it also re-applies ownership to an existing dir). Without
+        # it the dir is left root-owned, and the velocity-user preStart cannot
+        # symlink managed plugin jars into it, crash-looping the proxy with
+        # `ln: ... Permission denied`.
+        StateDirectory = "velocity velocity/plugins";
       };
     };
   };


### PR DESCRIPTION
Velocity runs as the dedicated `velocity` user, but `/var/lib/velocity/plugins` was left root-owned (the image bakes it, and the velocity-user preStart's `mkdir -p` no-ops on the existing dir). The preStart then failed to symlink managed plugin jars into it (`ln: ... '/var/lib/velocity/plugins/ floodgate-velocity.jar': Permission denied`), crash-looping the unit into `start-limit-hit` and failing the `velocity` health check. Minecraft avoids this only because it runs as root.

List `velocity/plugins` in StateDirectory so systemd creates it and re-applies velocity ownership on each start, and drop the now-redundant preStart `mkdir`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Velocity plugin directory ownership by declaring it in `StateDirectory`
> Adds `velocity/plugins` to `StateDirectory` in [default.nix](https://github.com/indexable-inc/index/pull/1643/files#diff-86377384a7f22ae856b5483b819db7ca53d8660066385c95fd4e4cbd488b3555) so systemd creates and owns both the state directory and the plugins subdirectory before the service starts. Removes the now-redundant `mkdir -p` call for the plugins directory from the `preStart` script.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d04d220.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->