### PR TITLE
fix(velocity): chown plugins/ via tmpfiles so the proxy can install plugins

### DIFF
--- a/modules/services/velocity/default.nix
+++ b/modules/services/velocity/default.nix
@@ -709,6 +709,15 @@ in
       home = dataDir;
     };
 
+    # The status-VM image bakes `${dataDir}/plugins` root-owned, and systemd's
+    # StateDirectory does not re-chown a pre-existing dir, so the velocity-user
+    # preStart cannot symlink managed plugin jars into it (`ln: ... Permission
+    # denied`, crash-looping the proxy). A tmpfiles `d` rule adjusts the existing
+    # dir to velocity ownership on each boot, before the service starts.
+    systemd.tmpfiles.rules = [
+      "d ${dataDir}/plugins 0755 velocity velocity - -"
+    ];
+
     systemd.services.velocity = {
       description = "Velocity Minecraft proxy";
       after = [ "network-online.target" ];
@@ -743,12 +752,7 @@ in
         WorkingDirectory = dataDir;
         ExecStart = lib.escapeShellArgs javaArgs;
         Restart = "on-failure";
-        # `plugins/` is listed explicitly so systemd creates and owns it as the
-        # velocity user (it also re-applies ownership to an existing dir). Without
-        # it the dir is left root-owned, and the velocity-user preStart cannot
-        # symlink managed plugin jars into it, crash-looping the proxy with
-        # `ln: ... Permission denied`.
-        StateDirectory = "velocity velocity/plugins";
+        StateDirectory = "velocity";
       };
     };
   };


### PR DESCRIPTION
Velocity runs as the dedicated `velocity` user, but the status-VM image bakes `/var/lib/velocity/plugins` root-owned, and systemd's StateDirectory does not re-chown a pre-existing directory. The velocity-user preStart then failed to symlink managed plugin jars into it (`ln: ... '/var/lib/velocity/plugins/ floodgate-velocity.jar': Permission denied`), crash-looping the unit into `start-limit-hit` and failing the `velocity` health check. Minecraft avoids this only because it runs as root.

Adjust the dir to velocity ownership on each boot with a tmpfiles `d` rule (which applies to an existing dir, unlike StateDirectory), and drop the now-redundant preStart `mkdir`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `plugins/` directory ownership for Velocity proxy by using tmpfiles.d
> The Velocity service couldn't install plugins because `StateDirectory` doesn't guarantee ownership of subdirectories on systems where the data dir pre-exists. This fix adds a `systemd.tmpfiles.rules` entry to create `${dataDir}/plugins` with mode 0755 and `velocity:velocity` ownership on each boot, and removes `velocity/plugins` from `StateDirectory` in [default.nix](https://github.com/indexable-inc/index/pull/1644/files#diff-86377384a7f22ae856b5483b819db7ca53d8660066385c95fd4e4cbd488b3555).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 238592e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->