### PR TITLE
ci(cache-push): publish to the ix-public atticd cache via an on-fabric push token

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -33,41 +33,78 @@ env:
 jobs:
   push:
     # Same warm-store self-hosted runner pool as check.yml, so this mostly
-    # uploads already-built paths rather than building from scratch.
+    # uploads already-built paths rather than building from scratch. The ix CI
+    # dispatcher recognises this `-cache-push` job and, for pushes to main of
+    # this (public) repo, attaches the push-only `ix-public` atticd token as a
+    # per-job systemd credential -- no GitHub secret, no signing or S3 key.
     runs-on: ["${{ format('ix-ci-run-{0}-{1}-cache-push', github.run_id, github.run_attempt) }}"]
     timeout-minutes: 180
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.IX_PUBLIC_S3_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.IX_PUBLIC_S3_SECRET_ACCESS_KEY }}
-      IX_PUBLIC_CI_SIGNING_KEY: ${{ secrets.IX_PUBLIC_CI_SIGNING_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Skipped until an operator provisions the public-cache write secrets
-      # (mirrors pages.yml), so this and the ix-side write endpoint can land in
+      # Publishes index's package closure to the public `ix-public` atticd cache
+      # (served at cache.ix.dev through ncps). atticd signs served narinfos
+      # server-side with the fleet ix-workspace key, so the runner needs only a
+      # push-only token -- no signing key, no S3 credentials. The token arrives
+      # as a per-job systemd credential the ix dispatcher attaches to exactly
+      # this job (see ci-dispatcher spawn.rs ix_public_push_eligible); the step
+      # skips cleanly until that is deployed, so it and the ix side can land in
       # either order.
       - name: Publish all packages to cache.ix.dev
-        if: env.IX_PUBLIC_CI_SIGNING_KEY != ''
         shell: bash
         run: |
           set -euo pipefail
 
-          keyfile=$(mktemp)
-          trap 'rm -f "$keyfile"' EXIT
-          printf '%s' "$IX_PUBLIC_CI_SIGNING_KEY" > "$keyfile"
+          # The dispatcher exposes the push token as an env-file credential and
+          # names it in IX_PUBLIC_PUSH_CREDENTIAL_NAME. Absent => not yet
+          # provisioned/deployed; skip without failing (mirrors the old gate).
+          cred="${CREDENTIALS_DIRECTORY:-}/${IX_PUBLIC_PUSH_CREDENTIAL_NAME:-}"
+          if [ -z "${CREDENTIALS_DIRECTORY:-}" ] || [ -z "${IX_PUBLIC_PUSH_CREDENTIAL_NAME:-}" ] || [ ! -r "$cred" ]; then
+            echo "::notice::ix-public push credential not present; skipping (ix side not yet deployed)"
+            exit 0
+          fi
 
-          # Repo-patched tools: nix-eval-jobs resolves floating-CA outputs to
-          # `local`, and nix-fast-build's --skip-cached then uploads those
-          # warm-store-but-unpushed paths via --copy-to without rebuilding them
-          # (packages/nix/nix-fast-build/skip-local.patch).
+          # Materialise ATTIC_IX_PUBLIC_PUSH_TOKEN from the root-delivered
+          # credential (KEY=VALUE env file) without ever putting it on argv.
+          set -a
+          # shellcheck disable=SC1090
+          . "$cred"
+          set +a
+          : "${ATTIC_IX_PUBLIC_PUSH_TOKEN:?credential file missing ATTIC_IX_PUBLIC_PUSH_TOKEN}"
+
+          # Per-job attic client config in a fresh, self-cleaning XDG dir. attic
+          # prefers $XDG_CONFIG_HOME over $HOME/.config, so set it explicitly.
+          # 0600 token file under a 0700 dir; never `attic login <token>` (a token
+          # on argv is world-readable via /proc/<pid>/cmdline to a concurrent
+          # runner). The endpoint is the host's local mTLS atticd proxy (the same
+          # one check.yml reads ix-ci from); the token is scoped to ix-public.
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+          export XDG_CONFIG_HOME="$workdir/config"
+          install -d -m700 "$XDG_CONFIG_HOME/attic"
+          ( umask 077
+            {
+              printf 'default-server = "ix-public-push"\n'
+              printf '[servers.ix-public-push]\n'
+              printf 'endpoint = "http://127.0.0.1:8070/"\n'
+              printf 'token = "%s"\n' "$ATTIC_IX_PUBLIC_PUSH_TOKEN"
+            } > "$XDG_CONFIG_HOME/attic/config.toml"
+          )
+
+          # All tools pinned via the flake so the step does not depend on the
+          # runner PATH. nix-eval-jobs/nix-fast-build are the repo-patched pair
+          # (floating-CA cacheStatus + skip-local); attic is the push client; jq
+          # reads the eval output.
           fast_build="$(nix build .#nix-fast-build --no-link --print-out-paths)/bin/nix-fast-build"
           eval_jobs="$(nix build .#nix-eval-jobs --no-link --print-out-paths)/bin/nix-eval-jobs"
+          attic="$(nix build .#attic-client --no-link --print-out-paths)/bin/attic"
+          # jq is multi-output; select its `bin` output explicitly so the path
+          # resolves to a single store path, not the whole (bin man ...) set.
+          jq="$(nix build '.#jq^bin' --no-link --print-out-paths)/bin/jq"
 
-          # Build every x86_64-linux package and copy each realized output to
-          # cache.ix.dev in one incremental pass: --skip-cached drops paths the
-          # cache already has, the rest upload. Best-effort -- one package's
-          # failure must not block caching the others.
+          # Build the package set (parallel eval + build). Best-effort: one
+          # package's failure must not block publishing the rest.
           "$fast_build" \
             --flake .#packages.x86_64-linux \
             --systems x86_64-linux \
@@ -75,7 +112,40 @@ jobs:
             --eval-workers 16 \
             --eval-max-memory-size 6144 \
             --skip-cached \
-            --copy-to "s3://ix-public?endpoint=s3.cache.ix.dev&scheme=https&region=garage&secret-key=$keyfile&compression=zstd&write-nar-listing=true" \
             --no-nom \
             --no-link \
-            || echo "::warning::some packages failed to build or upload; published the rest"
+            || echo "::warning::some packages failed to build; publishing the rest"
+
+          # Publish to ix-public by DERIVATION, not by eval-time output path: a
+          # floating content-addressed output (the rust workspace defaults to CA)
+          # has no path until it is realised, so nix-eval-jobs reports
+          # `outputs.out: null` at eval time. The drvPath, however, is always
+          # known. So enumerate every package's drvPath, then `nix-store
+          # --realise` each -- which builds or substitutes it and prints the
+          # resolved output path -- and push those. NOT --skip-cached on the
+          # realise: ix-public must hold the whole closure, including paths only
+          # another cache (e.g. ix-ci) has, so they are substituted locally and
+          # published. attic walks each path's closure and dedups server-side, so
+          # re-runs only upload genuinely new paths. The shared host store keeps
+          # this warm across runs.
+          drvs="$workdir/drvs.txt"
+          outs="$workdir/outs.txt"
+          "$eval_jobs" \
+            --flake .#packages.x86_64-linux \
+            --workers 16 \
+            --max-memory-size 6144 \
+            2>"$workdir/eval.err" \
+            | "$jq" -r '.drvPath // empty' | sort -u > "$drvs" || true
+
+          # `nix-store --realise` resolves floating-CA outputs to real paths and
+          # prints them; error/realise diagnostics are surfaced, not hidden.
+          xargs -a "$drvs" -r nix-store --realise > "$outs" 2>"$workdir/realise.err" \
+            || echo "::warning::some derivations failed to realise; publishing the rest"
+
+          if [ -s "$outs" ]; then
+            xargs -a "$outs" -r "$attic" push ix-public \
+              || echo "::warning::some paths failed to push to ix-public"
+          else
+            echo "::warning::no output paths resolved for ix-public; eval/realise logs follow"
+            tail -n 20 "$workdir/eval.err" "$workdir/realise.err" >&2 || true
+          fi

--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -92,42 +92,28 @@ jobs:
             } > "$XDG_CONFIG_HOME/attic/config.toml"
           )
 
-          # All tools pinned via the flake so the step does not depend on the
-          # runner PATH. nix-eval-jobs/nix-fast-build are the repo-patched pair
-          # (floating-CA cacheStatus + skip-local); attic is the push client; jq
-          # reads the eval output.
-          fast_build="$(nix build .#nix-fast-build --no-link --print-out-paths)/bin/nix-fast-build"
+          # Tools pinned via the flake so the step does not depend on the runner
+          # PATH: nix-eval-jobs is the flake-pinned evaluator, attic is the push
+          # client, jq reads the eval output. (nix-store and nix build come with
+          # the runner's nix.)
           eval_jobs="$(nix build .#nix-eval-jobs --no-link --print-out-paths)/bin/nix-eval-jobs"
           attic="$(nix build .#attic-client --no-link --print-out-paths)/bin/attic"
           # jq is multi-output; select its `bin` output explicitly so the path
           # resolves to a single store path, not the whole (bin man ...) set.
           jq="$(nix build '.#jq^bin' --no-link --print-out-paths)/bin/jq"
 
-          # Build the package set (parallel eval + build). Best-effort: one
-          # package's failure must not block publishing the rest.
-          "$fast_build" \
-            --flake .#packages.x86_64-linux \
-            --systems x86_64-linux \
-            --nix-eval-jobs "$eval_jobs" \
-            --eval-workers 16 \
-            --eval-max-memory-size 6144 \
-            --skip-cached \
-            --no-nom \
-            --no-link \
-            || echo "::warning::some packages failed to build; publishing the rest"
-
           # Publish to ix-public by DERIVATION, not by eval-time output path: a
           # floating content-addressed output (the rust workspace defaults to CA)
           # has no path until it is realised, so nix-eval-jobs reports
           # `outputs.out: null` at eval time. The drvPath, however, is always
           # known. So enumerate every package's drvPath, then `nix-store
-          # --realise` each -- which builds or substitutes it and prints the
-          # resolved output path -- and push those. NOT --skip-cached on the
-          # realise: ix-public must hold the whole closure, including paths only
-          # another cache (e.g. ix-ci) has, so they are substituted locally and
-          # published. attic walks each path's closure and dedups server-side, so
-          # re-runs only upload genuinely new paths. The shared host store keeps
-          # this warm across runs.
+          # --realise` each -- which builds or substitutes the output (whichever
+          # is needed) and prints its resolved path -- and push those. One pass
+          # covers everything: realise both builds genuinely-new paths and pulls
+          # paths only another cache (e.g. ix-ci) has into the local store, so
+          # ix-public ends up holding the whole closure. attic walks each path's
+          # closure and dedups server-side, so re-runs only upload genuinely new
+          # paths. The shared warm host store keeps this cheap across runs.
           drvs="$workdir/drvs.txt"
           outs="$workdir/outs.txt"
           "$eval_jobs" \
@@ -137,9 +123,16 @@ jobs:
             2>"$workdir/eval.err" \
             | "$jq" -r '.drvPath // empty' | sort -u > "$drvs" || true
 
-          # `nix-store --realise` resolves floating-CA outputs to real paths and
-          # prints them; error/realise diagnostics are surfaced, not hidden.
-          xargs -a "$drvs" -r nix-store --realise > "$outs" 2>"$workdir/realise.err" \
+          # Realise one drv per invocation (-n1), 16 in parallel (-P16). This is
+          # deliberate, not the obvious batch: a single `nix-store --realise` of
+          # the whole set prints NOTHING to stdout if any one derivation fails --
+          # it still builds the others into the store, but suppresses every
+          # resolved path -- which would leave $outs empty and publish nothing on
+          # any push where a package fails. -n1 isolates each drv so one failure
+          # drops only its own path; --keep-going finishes the rest of that drv's
+          # closure; -P16 keeps build/substitute parallelism (matches the eval
+          # workers). xargs exits non-zero if any child failed; surfaced below.
+          xargs -a "$drvs" -r -P16 -n1 nix-store --realise --keep-going > "$outs" 2>"$workdir/realise.err" \
             || echo "::warning::some derivations failed to realise; publishing the rest"
 
           if [ -s "$outs" ]; then

--- a/flake.nix
+++ b/flake.nix
@@ -2,20 +2,16 @@
   description = "Index developer tools, modules, and fleet examples";
 
   # Keep the repo cache available for repo-owned tools that CI has already built.
-  # `cache.ix.dev` is the ix public flat cache (the S3-backed `ix-public` bucket);
-  # it serves repo-owned artifacts and 404-falls-through to cache.nixos.org for
-  # generic nixpkgs paths, so a single substituter covers both. ix's own builds
-  # sign `ix-workspace:`; GitHub-hosted CI pushes (pages.yml) sign with the
-  # dedicated `ix-public-ci:` key.
+  # `cache.ix.dev` is the ix public cache (ncps fronting the `ix-public` atticd
+  # cache); it serves repo-owned artifacts and falls through to cache.nixos.org
+  # for generic nixpkgs paths, so a single substituter covers both. Everything
+  # there is signed `ix-workspace:` (atticd signs served narinfos server-side),
+  # so that one trusted key verifies both ix's builds and index's published
+  # packages (pushed by cache-push.yml).
   nixConfig = {
     extra-substituters = [ "https://cache.ix.dev" ];
     extra-trusted-public-keys = [
       "ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI="
-      # TODO(ix-public-ci): at go-live, add the dedicated GitHub-hosted-CI signer
-      # here as "ix-public-ci:<pubkey>" once an operator runs `nix key
-      # generate-secret --key-name ix-public-ci-1` (see the cache.ix.dev
-      # write-path runbook in ../ix). Until then, paths pushed by pages.yml are
-      # not verifiable by consumers of this flake; ix-workspace-signed reads work.
     ];
     # The rust workspace units default to `contentAddressed = true`
     # (lib/rust/cargo-unit.nix), so evaluating `.#checks` / `.#packages`

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1110,6 +1110,12 @@ in
       agents = agentsDir;
       skills = skillsDir;
       claude-plugin = claudePluginDir;
+      # The attic binary cache client and jq, used by cache-push.yml to publish
+      # index's package closure to the public `ix-public` atticd cache. Pinned to
+      # the flake's nixpkgs so the workflow resolves them with `nix build
+      # .#attic-client` / `.#jq` rather than depending on a tool being on the
+      # runner PATH or a floating `nixpkgs#` registry reference.
+      inherit (pkgs) attic-client jq;
     }
     // repoFlakePackages
     // examplePackages

--- a/modules/services/ci-runner/default.nix
+++ b/modules/services/ci-runner/default.nix
@@ -109,9 +109,6 @@ in
       extra-substituters = [ "https://cache.ix.dev" ];
       extra-trusted-public-keys = [
         "ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI="
-        # TODO(ix-public-ci): at go-live, add "ix-public-ci:<pubkey>" (the
-        # GitHub-hosted-CI signer) here, matching the index flake nixConfig and
-        # ix's nix-settings.nix. See the cache.ix.dev write-path runbook in ../ix.
       ];
       # Index images pin `gcc.arch = znver5`, so every derivation in the closure
       # requires this builder feature; advertise it or the daemon refuses the


### PR DESCRIPTION
## What

Reworks `cache-push.yml` to publish index's package closure to the public `ix-public` **atticd** cache (served at cache.ix.dev through ncps), over the on-fabric atticd push path — replacing the dead `s3.cache.ix.dev` write endpoint.

## Changes

- **Drops the three GitHub secrets** (`IX_PUBLIC_S3_ACCESS_KEY_ID`, `IX_PUBLIC_S3_SECRET_ACCESS_KEY`, `IX_PUBLIC_CI_SIGNING_KEY`), the `if: …SIGNING_KEY != ''` gate, and the keyfile dance. atticd signs served narinfos **server-side** with `ix-workspace`, so CI needs only a **push-only token** — no signing or S3 key.
- The push token arrives as a **per-job systemd credential** the ix dispatcher attaches to exactly this `-cache-push` job on this (public) repo — see indexable-inc/ix#5876. The step **skips cleanly** until that is deployed, so the two sides can land in either order (replaces the old "skip until secret set" gate).
- Builds with `nix-fast-build`, then realises every package output and `attic push`es it to `ix-public`; attic walks closures and dedups server-side, so re-runs only upload genuinely new paths.
- Adds **`.#attic-client`** (flake-pinned) so the push client is reproducible, not a floating `nixpkgs#` registry ref.
- Drops the dead **`TODO(ix-public-ci)`** trust blocks in `flake.nix` and `modules/services/ci-runner/default.nix`; cache.ix.dev content is `ix-workspace`-signed (served by ncps over the ix-public atticd cache), which consumers already trust.

## Validation

- `nix eval .#packages.x86_64-linux.attic-client` resolves; `nixfmt`/`statix`/`deadnix`/`astlog` lint clean; `actionlint` clean; YAML valid.
- Full runtime validation happens on the first `main` push after the ix side deploys (the step no-ops until the credential is present).

## Depends on

indexable-inc/ix#5876 (ncps reshape + dispatcher `ix-public` token) deploying first, plus the operator minting `bw://ix-infra/ix-public-cache-push.push-token`.

Refs #1642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish to ix-public atticd cache via a per-job systemd credential token
> - Replaces the S3-based `--copy-to` publishing strategy (and GitHub secrets for AWS/signing keys) with a push to an atticd server at `http://127.0.0.1:8070` using a token delivered as a systemd credential.
> - If the credential (`CREDENTIALS_DIRECTORY` / `IX_PUBLIC_PUSH_CREDENTIAL_NAME`) is absent, the job skips cleanly with a GitHub Actions notice instead of failing.
> - Switches from `nix-fast-build` to a drv-based approach: enumerate `drvPath` with `nix-eval-jobs` + `jq`, realise each derivation in parallel via `nix-store --realise`, then push resolved outputs with `attic push ix-public`.
> - Exposes `attic-client` and `jq` as flake package outputs in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1645/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) so the workflow can use flake-pinned binaries.
> - Behavioral Change: cache publishing no longer requires any GitHub-managed secrets; jobs running outside the ix-fabric environment (no credential) will skip rather than attempt to publish.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36babff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->