### PR TITLE
fix(velocity): own plugins dir via StateDirectory, not tmpfiles

### DIFF
--- a/modules/services/velocity/default.nix
+++ b/modules/services/velocity/default.nix
@@ -709,15 +709,6 @@ in
       home = dataDir;
     };
 
-    # The status-VM image bakes `${dataDir}/plugins` root-owned, and systemd's
-    # StateDirectory does not re-chown a pre-existing dir, so the velocity-user
-    # preStart cannot symlink managed plugin jars into it (`ln: ... Permission
-    # denied`, crash-looping the proxy). A tmpfiles `d` rule adjusts the existing
-    # dir to velocity ownership on each boot, before the service starts.
-    systemd.tmpfiles.rules = [
-      "d ${dataDir}/plugins 0755 velocity velocity - -"
-    ];
-
     systemd.services.velocity = {
       description = "Velocity Minecraft proxy";
       after = [ "network-online.target" ];
@@ -752,7 +743,18 @@ in
         WorkingDirectory = dataDir;
         ExecStart = lib.escapeShellArgs javaArgs;
         Restart = "on-failure";
-        StateDirectory = "velocity";
+        # `plugins` is a StateDirectory leaf, not a tmpfiles `d` rule: the
+        # service is sandboxed (`ix.systemdHardening`: PrivateUsers,
+        # ProtectSystem=strict), so its preStart symlinks managed plugin jars
+        # into `${dataDir}/plugins` as the velocity user. systemd creates and
+        # chowns each StateDirectory leaf to User=/Group= in the service's user
+        # namespace before preStart runs; a tmpfiles rule runs in the host
+        # context and leaves the dir root-owned and unwritable for the
+        # sandboxed user (`ln: ... Permission denied`, crash-looping the proxy).
+        StateDirectory = [
+          "velocity"
+          "velocity/plugins"
+        ];
       };
     };
   };


### PR DESCRIPTION
The velocity service runs sandboxed (PrivateUsers + ProtectSystem=strict via ix.systemdHardening); its preStart symlinks managed plugin jars into /var/lib/velocity/plugins as the velocity user. The prior tmpfiles `d` rule could not make that dir writable for the sandboxed user: tmpfiles runs in the host context and left /var/lib/velocity/plugins root-owned, so the preStart `ln` failed with "Permission denied" and the proxy crash-looped (start-limit-hit), failing the New-VMs status heartbeat.

Make `plugins` a StateDirectory leaf instead: systemd creates and chowns each StateDirectory to User=/Group= in the service's user namespace before preStart runs, so the managed-plugin symlinks succeed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix velocity plugin directory ownership by using `StateDirectory` instead of tmpfiles
> The `plugins` subdirectory under the velocity state directory was previously created via a tmpfiles rule, which ran at boot outside the service sandbox. This caused permission errors when `preStart` tried to symlink managed plugin jars into it.
>
> - Removes the `d ${dataDir}/plugins` tmpfiles rule from [default.nix](https://github.com/indexable-inc/index/pull/1646/files#diff-86377384a7f22ae856b5483b819db7ca53d8660066385c95fd4e4cbd488b3555)
> - Adds `"velocity/plugins"` to `StateDirectory` so systemd creates and chowns the subdirectory inside the service namespace before `preStart` runs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39a3d8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->