### PR TITLE
fix(velocity): create plugins dir in preStart, not via StateDirectory leaf

### DIFF
--- a/modules/services/velocity/default.nix
+++ b/modules/services/velocity/default.nix
@@ -722,6 +722,14 @@ in
       preStart = ''
         set -eu
 
+        # Create the managed-plugins dir as the velocity user so the symlinks
+        # below succeed. `${dataDir}` is a velocity-owned StateDirectory, so this
+        # mkdir creates `plugins/` velocity-owned. A tmpfiles `d` rule cannot do
+        # this (it runs in the host context, leaving the dir root-owned), and a
+        # nested `StateDirectory = "velocity/plugins"` leaf is left root-owned
+        # under PrivateUsers; neither is writable by the sandboxed service.
+        mkdir -p ${lib.escapeShellArg "${dataDir}/plugins"}
+
         if [ -f ${lib.escapeShellArg managedPluginManifest} ]; then
           while IFS= read -r plugin; do
             target=${lib.escapeShellArg "${dataDir}/plugins"}/$plugin
@@ -743,18 +751,7 @@ in
         WorkingDirectory = dataDir;
         ExecStart = lib.escapeShellArgs javaArgs;
         Restart = "on-failure";
-        # `plugins` is a StateDirectory leaf, not a tmpfiles `d` rule: the
-        # service is sandboxed (`ix.systemdHardening`: PrivateUsers,
-        # ProtectSystem=strict), so its preStart symlinks managed plugin jars
-        # into `${dataDir}/plugins` as the velocity user. systemd creates and
-        # chowns each StateDirectory leaf to User=/Group= in the service's user
-        # namespace before preStart runs; a tmpfiles rule runs in the host
-        # context and leaves the dir root-owned and unwritable for the
-        # sandboxed user (`ln: ... Permission denied`, crash-looping the proxy).
-        StateDirectory = [
-          "velocity"
-          "velocity/plugins"
-        ];
+        StateDirectory = "velocity";
       };
     };
   };


### PR DESCRIPTION
The previous fix made `${dataDir}/plugins` a nested StateDirectory leaf (StateDirectory = [ "velocity" "velocity/plugins" ]), but systemd leaves a nested StateDirectory subdir root-owned under PrivateUsers (it only chowns the top-level component). Verified on a live status guest: /var/lib/velocity is velocity:velocity but /var/lib/velocity/plugins stayed root:root, so the sandboxed preStart `ln` still failed with "Permission denied" and velocity crash-looped (start-limit-hit), failing the New-VMs status heartbeat.

/var/lib/velocity is itself a velocity-owned StateDirectory, so create the plugins subdir with `mkdir -p` in the preStart, which runs as the velocity user: the subdir is then velocity-owned and the symlinks succeed. Revert StateDirectory to just "velocity".

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix plugins directory creation in Velocity service to run as service user in preStart
> - Moves creation of `${dataDir}/plugins` from `StateDirectory` into the `preStart` script using `mkdir -p`, so the directory is owned by the `velocity` user rather than root.
> - Removes `"velocity/plugins"` from `StateDirectory` in [default.nix](https://github.com/indexable-inc/index/pull/1647/files#diff-86377384a7f22ae856b5483b819db7ca53d8660066385c95fd4e4cbd488b3555), leaving only the top-level `"velocity"` entry managed by systemd.
> - Risk: any existing deployments where systemd previously managed the plugins subdirectory will now have that directory created by `preStart`; permissions may differ on first upgrade.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 846035e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->