### PR TITLE
fix(velocity): force plugins dir velocity-owned via root ExecStartPre

### DIFF
--- a/modules/services/velocity/default.nix
+++ b/modules/services/velocity/default.nix
@@ -223,6 +223,26 @@ let
         fi
       '';
 
+  # Runs as User=velocity (second ExecStartPre); the first ExecStartPre has
+  # already forced `${dataDir}/plugins` velocity-owned as root.
+  velocityPreStart = pkgs.writeShellScript "velocity-pre-start" ''
+    set -eu
+
+    if [ -f ${lib.escapeShellArg managedPluginManifest} ]; then
+      while IFS= read -r plugin; do
+        target=${lib.escapeShellArg "${dataDir}/plugins"}/$plugin
+        if [ -L "$target" ]; then
+          rm -f "$target"
+        fi
+      done < ${lib.escapeShellArg managedPluginManifest}
+    fi
+
+    : > ${lib.escapeShellArg managedPluginManifest}
+    ${installManagedPlugins}
+    ${installManagedConfigFiles}
+    ${installForwardingSecret}
+  '';
+
   javaArgs = [
     java
     "-XX:MaxRAMPercentage=${toString cfg.maxRAMPercentage}"
@@ -719,31 +739,6 @@ in
         managed.plugins
       ]
       ++ lib.optional (forwardingSecretFile != null) forwardingSecretFile;
-      preStart = ''
-        set -eu
-
-        # Create the managed-plugins dir as the velocity user so the symlinks
-        # below succeed. `${dataDir}` is a velocity-owned StateDirectory, so this
-        # mkdir creates `plugins/` velocity-owned. A tmpfiles `d` rule cannot do
-        # this (it runs in the host context, leaving the dir root-owned), and a
-        # nested `StateDirectory = "velocity/plugins"` leaf is left root-owned
-        # under PrivateUsers; neither is writable by the sandboxed service.
-        mkdir -p ${lib.escapeShellArg "${dataDir}/plugins"}
-
-        if [ -f ${lib.escapeShellArg managedPluginManifest} ]; then
-          while IFS= read -r plugin; do
-            target=${lib.escapeShellArg "${dataDir}/plugins"}/$plugin
-            if [ -L "$target" ]; then
-              rm -f "$target"
-            fi
-          done < ${lib.escapeShellArg managedPluginManifest}
-        fi
-
-        : > ${lib.escapeShellArg managedPluginManifest}
-        ${installManagedPlugins}
-        ${installManagedConfigFiles}
-        ${installForwardingSecret}
-      '';
       serviceConfig = ix.systemdHardening // {
         Type = "simple";
         User = "velocity";
@@ -752,6 +747,17 @@ in
         ExecStart = lib.escapeShellArgs javaArgs;
         Restart = "on-failure";
         StateDirectory = "velocity";
+        # `${dataDir}/plugins` is created root-owned before the service starts
+        # (it persists in the golden-snapshot rootfs and is not re-chowned by a
+        # tmpfiles `d` rule or a nested StateDirectory leaf under PrivateUsers),
+        # so the sandboxed User=velocity script cannot symlink the managed
+        # plugin jars into it (`ln: ... Permission denied`, crash-looping the
+        # proxy). Force the dir velocity-owned as root (`+`) first, then run the
+        # plugin/config install as the velocity user.
+        ExecStartPre = [
+          "+${pkgs.coreutils}/bin/install -d -o velocity -g velocity -m 0755 ${dataDir}/plugins"
+          velocityPreStart
+        ];
       };
     };
   };


### PR DESCRIPTION
The managed-plugins dir /var/lib/velocity/plugins keeps ending up root-owned before velocity starts (it persists in the golden-snapshot rootfs; neither a tmpfiles `d` rule, a nested StateDirectory leaf, nor an in-script mkdir re-chowns a pre-existing dir under PrivateUsers - verified on a live status guest: /var/lib/velocity is velocity:velocity but /var/lib/velocity/plugins stays root:root). The sandboxed User=velocity preStart then fails to symlink the managed plugin jars (ln: ... Permission denied), velocity crash-loops (start-limit-hit), and the New-VMs status heartbeat fails.

Force the dir velocity-owned as root via a `+`-prefixed ExecStartPre (install -d -o velocity) before the velocity-user install script runs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ownership of Velocity plugins directory by creating it as root in `ExecStartPre`
> - Previously, `${dataDir}/plugins` was created inside `preStart`, which ran as the `velocity` user, causing ownership issues when the directory didn't already exist.
> - Replaces `preStart` with two `ExecStartPre` entries in [default.nix](https://github.com/indexable-inc/index/pull/1648/files#diff-86377384a7f22ae856b5483b819db7ca53d8660066385c95fd4e4cbd488b3555): the first runs as root (using the `+` prefix) to create the plugins directory with `velocity` ownership and mode `0755`; the second runs the new `velocityPreStart` script as the `velocity` user to clean up old managed plugin symlinks and reinstall plugins, config files, and the forwarding secret.
> - Behavioral Change: the plugins directory is now always owned by `velocity` regardless of prior state, enforced on every service start.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2be869d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->