### PR TITLE
fix(velocity): run as DynamicUser so it can write plugins after golden restore

### DIFF
--- a/modules/services/velocity/default.nix
+++ b/modules/services/velocity/default.nix
@@ -701,14 +701,6 @@ in
       "velocity/managed-plugins".source = managed.plugins;
     };
 
-    users.groups.velocity = { };
-    users.users.velocity = {
-      description = "Velocity service user";
-      isSystemUser = true;
-      group = "velocity";
-      home = dataDir;
-    };
-
     systemd.services.velocity = {
       description = "Velocity Minecraft proxy";
       after = [ "network-online.target" ];
@@ -722,12 +714,6 @@ in
       preStart = ''
         set -eu
 
-        # Create the managed-plugins dir as the velocity user so the symlinks
-        # below succeed. `${dataDir}` is a velocity-owned StateDirectory, so this
-        # mkdir creates `plugins/` velocity-owned. A tmpfiles `d` rule cannot do
-        # this (it runs in the host context, leaving the dir root-owned), and a
-        # nested `StateDirectory = "velocity/plugins"` leaf is left root-owned
-        # under PrivateUsers; neither is writable by the sandboxed service.
         mkdir -p ${lib.escapeShellArg "${dataDir}/plugins"}
 
         if [ -f ${lib.escapeShellArg managedPluginManifest} ]; then
@@ -746,8 +732,14 @@ in
       '';
       serviceConfig = ix.systemdHardening // {
         Type = "simple";
-        User = "velocity";
-        Group = "velocity";
+        # DynamicUser (not a static velocity user): systemd allocates the uid
+        # per boot and re-chowns the StateDirectory to it, so the managed
+        # plugins dir under `${dataDir}` is owned by the service even after a
+        # golden-snapshot restore changes the uid. A static User= leaves the
+        # snapshot's plugins dir owned by the previous uid (real host-root,
+        # outside the idmapped state mount), unwritable by the new service
+        # (`ln: ... Permission denied`, crash-looping the proxy).
+        DynamicUser = true;
         WorkingDirectory = dataDir;
         ExecStart = lib.escapeShellArgs javaArgs;
         Restart = "on-failure";


### PR DESCRIPTION
velocity's managed-plugin symlinks land in /var/lib/velocity/plugins. With a static User=velocity under PrivateUsers + StateDirectory, the status-VM golden snapshot freezes that dir owned by the boot's uid; on restore it is real host-root outside the idmapped state mount and the static user can't write it, so `ln` fails and the proxy crash-loops (start-limit-hit), failing the New-VMs status heartbeat.

Use DynamicUser: systemd allocates the uid per boot and re-chowns the StateDirectory to it, so the plugins dir is service-owned after a restore. Drop the now-unused static velocity user/group.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run Velocity service as `DynamicUser` to allow plugin writes after golden restore
> Replaces the static `velocity` user/group with a systemd `DynamicUser` in [default.nix](https://github.com/indexable-inc/index/pull/1649/files#diff-86377384a7f22ae856b5483b819db7ca53d8660066385c95fd4e4cbd488b3555). The static user/group declarations are removed from the NixOS module, and `DynamicUser = true` is set in the service's `serviceConfig` instead. Risk: the UID/GID assigned to the service is no longer stable across restarts, which may affect file ownership if state directories are managed outside of systemd's `StateDirectory`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72d3c31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->