### PR TITLE
fix(cache-push): pin xargs via the flake so realise can run

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -94,13 +94,18 @@ jobs:
 
           # Tools pinned via the flake so the step does not depend on the runner
           # PATH: nix-eval-jobs is the flake-pinned evaluator, attic is the push
-          # client, jq reads the eval output. (nix-store and nix build come with
+          # client, jq reads the eval output, findutils provides xargs. The
+          # runner PATH carries coreutils + nix but not findutils, so bare
+          # `xargs` is `command not found`. (nix-store and nix build come with
           # the runner's nix.)
           eval_jobs="$(nix build .#nix-eval-jobs --no-link --print-out-paths)/bin/nix-eval-jobs"
           attic="$(nix build .#attic-client --no-link --print-out-paths)/bin/attic"
           # jq is multi-output; select its `bin` output explicitly so the path
           # resolves to a single store path, not the whole (bin man ...) set.
           jq="$(nix build '.#jq^bin' --no-link --print-out-paths)/bin/jq"
+          # findutils is multi-output (out info locate); select `out` (where
+          # xargs lives) so the path resolves to a single store path.
+          xargs="$(nix build '.#findutils^out' --no-link --print-out-paths)/bin/xargs"
 
           # Publish to ix-public by DERIVATION, not by eval-time output path: a
           # floating content-addressed output (the rust workspace defaults to CA)
@@ -132,11 +137,11 @@ jobs:
           # drops only its own path; --keep-going finishes the rest of that drv's
           # closure; -P16 keeps build/substitute parallelism (matches the eval
           # workers). xargs exits non-zero if any child failed; surfaced below.
-          xargs -a "$drvs" -r -P16 -n1 nix-store --realise --keep-going > "$outs" 2>"$workdir/realise.err" \
+          "$xargs" -a "$drvs" -r -P16 -n1 nix-store --realise --keep-going > "$outs" 2>"$workdir/realise.err" \
             || echo "::warning::some derivations failed to realise; publishing the rest"
 
           if [ -s "$outs" ]; then
-            xargs -a "$outs" -r "$attic" push ix-public \
+            "$xargs" -a "$outs" -r "$attic" push ix-public \
               || echo "::warning::some paths failed to push to ix-public"
           else
             echo "::warning::no output paths resolved for ix-public; eval/realise logs follow"

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1110,12 +1110,14 @@ in
       agents = agentsDir;
       skills = skillsDir;
       claude-plugin = claudePluginDir;
-      # The attic binary cache client and jq, used by cache-push.yml to publish
-      # index's package closure to the public `ix-public` atticd cache. Pinned to
-      # the flake's nixpkgs so the workflow resolves them with `nix build
-      # .#attic-client` / `.#jq` rather than depending on a tool being on the
-      # runner PATH or a floating `nixpkgs#` registry reference.
-      inherit (pkgs) attic-client jq;
+      # The attic binary cache client, jq, and findutils (xargs), used by
+      # cache-push.yml to publish index's package closure to the public
+      # `ix-public` atticd cache. Pinned to the flake's nixpkgs so the workflow
+      # resolves them with `nix build .#attic-client` / `.#jq` / `.#findutils`
+      # rather than depending on a tool being on the runner PATH or a floating
+      # `nixpkgs#` registry reference. The runner PATH carries coreutils + nix
+      # but not findutils, so bare `xargs` is `command not found`.
+      inherit (pkgs) attic-client jq findutils;
     }
     // repoFlakePackages
     // examplePackages


### PR DESCRIPTION
The publish step pins nix-eval-jobs, attic, and jq via the flake "so the step does not depend on the runner PATH" but still called bare `xargs`, which lives in findutils -- absent from the runner PATH (coreutils + nix only). It failed with `xargs: command not found`, so $outs came up empty and the job published nothing while still exiting 0 ("no output paths resolved for ix-public").

Expose findutils as a flake package and resolve `.#findutils^out` for xargs (^out because findutils is multi-output: out info locate), matching the existing pin-via-flake pattern.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `xargs` to a flake-built `findutils` binary in the cache-push workflow
> The GitHub Actions runner PATH does not include `findutils`, causing `xargs` calls in the cache-push workflow to fail. Fixes this by building `findutils` from the flake and assigning its `xargs` path to a variable, then replacing bare `xargs` invocations in the realise and push steps with the pinned binary. The flake also exposes `findutils` as a top-level package attribute in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1650/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 681b2d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->