### PR TITLE
darwin: install opal app cask

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -39,6 +39,7 @@
       "notion"
       "obs@beta"
       "obsidian"
+      "opal-app"
       "postico"
       "prismlauncher"
       "raycast"


### PR DESCRIPTION
## Summary
- Add the `opal-app` Homebrew cask to Andrew's nix-darwin package set.

## Checks
- `brew info --cask opal-app`
- `nix run .#lint`
- `nix eval --impure --expr 'let f = builtins.getFlake (toString ./.); in builtins.elem "opal-app" (import f.darwinModules.andrewgazelka).homebrew.casks'`

Fixes #1651
Related: andrewgazelka/nix#29

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `opal-app` cask to darwin configuration
> Adds `opal-app` to the list of installed applications in [darwin.nix](https://github.com/indexable-inc/index/pull/1652/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b871ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->