### PR TITLE
Fix Ray cluster fleet startup ordering

### DIFF
--- a/examples/ray/cluster/README.md
+++ b/examples/ray/cluster/README.md
@@ -26,8 +26,9 @@ nix run .#ray-cluster-up
 - [`pyproject.toml`](pyproject.toml), [`uv.lock`](uv.lock), and [`src/`](src/)
   are the Ray driver (`ray-demo`).
 - [`ix.nix`](ix.nix) defines the fleet: one head and two worker
-  replicas, all in one east-west group, with `dependsOn` so the head comes up
-  first.
+  replicas, all in one east-west group. Workers retry their Ray startup until
+  the head is reachable, so the fleet can boot the whole cluster together while
+  the head's health check waits for every node to join.
 - [`cluster-node.nix`](cluster-node.nix) owns one Ray node: the package, the
   pinned ports, the `nix-ld` loader environment, and the hardened long-running
   service. Head and worker differ only by their `ray start` flags.

--- a/examples/ray/cluster/ix.nix
+++ b/examples/ray/cluster/ix.nix
@@ -12,7 +12,6 @@ index.lib.mkFleet {
 
     ray-worker = {
       replicas = 2;
-      dependsOn = [ "ray-head" ];
       groups = [ eastWestGroup ];
       modules = [ ./worker.nix ];
     };


### PR DESCRIPTION
## Summary
- remove the Ray worker fleet dependency on the head
- update the README to describe concurrent cluster boot
- keep the head health check responsible for waiting until all three Ray nodes join

## Why
The fleet DAG runs a node's health checks before dependent nodes. Keeping `ray-worker.dependsOn = [ "ray-head" ]` means the head's `ray-demo --min-nodes 3` health check can wait for workers that the DAG has not started yet.

## Validation
- `nix eval --impure --json --expr 'let spec = import ./examples/ray/cluster/ix.nix { index = { lib.mkFleet = x: x; }; }; in { workerDependsOn = spec.nodes.ray-worker.dependsOn or []; workerReplicas = spec.nodes.ray-worker.replicas; }'`
- `git diff --check`

## E2E status
A prod source-switch attempt still hung in `ix up ... --build-vm ray-cluster-build-vm`, which appears to be outside this Ray example change. The Better Stack published-image path is also blocked until the Ray health-check images exist in `registry.ix.dev/ix`.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `dependsOn` ordering constraint between Ray worker and head fleet roles
> Previously, `ray-worker` replicas declared a `dependsOn = [ "ray-head" ]` dependency, forcing sequential startup. This is removed so workers start immediately and retry Ray startup until the head is reachable. The head's health check now gates readiness on all nodes joining. [ix.nix](https://github.com/indexable-inc/index/pull/1653/files#diff-8b2f952c236e5ba7886bddead5cb27c81e7523a57ceb007bed79a9ad0425721d) and [README.md](https://github.com/indexable-inc/index/pull/1653/files#diff-19dee05832d5cce4349f6738f089653263f847f03ae8a8abb784cf88fcf68dd6) are updated to reflect this.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d332f9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->