### PR TITLE
update: fix content updaters

### DIFF
--- a/lib/util/writers.nix
+++ b/lib/util/writers.nix
@@ -116,6 +116,10 @@ let
         runtime_path = ${builtins.toJSON runtimePath}
         ambient_path = os.environ.get("PATH", "")
         os.environ["PATH"] = runtime_path + ((":" + ambient_path) if ambient_path else "")
+        # Nix Python does not consistently inherit a platform CA bundle; urllib needs this for HTTPS updaters.
+        ca_bundle = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+        os.environ.setdefault("SSL_CERT_FILE", ca_bundle)
+        os.environ.setdefault("REQUESTS_CA_BUNDLE", os.environ["SSL_CERT_FILE"])
         sys.argv = ${argv} + sys.argv[1:]
         runpy.run_path("${srcPath}", run_name="__main__")
       '';

--- a/packages/agent/claude-code/manifest.json
+++ b/packages/agent/claude-code/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "2.1.183",
+  "version": "2.1.197",
   "platforms": {
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-YhjvzNBhlOoLw4ESG/AwQKAnoE2ZHq7YhtoCoARJrQ8="
+      "hash": "sha256-jMDE0eTrHco7DMkqsC7jUF3nZOAj+MkBdhwWe3IEH7g="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-xwJI+WtYMf+GrBaatTyH7FSA+Rrjhng9oRAEh1wq0bc="
+      "hash": "sha256-XopXzHqSN38HRPpMeRkc+T1LJsecuRmwekB1Ef7RviY="
     },
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-3ztAnFslKZ31LF7oH2SBHb3LLhjBvu/n9zPDJvCozc4="
+      "hash": "sha256-9U5py8ibLaYaQVcAr3/1KhR+hiUX1PGw7s92hEjPf4M="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-JgpuQ/6cb9iAAxdYGYL/UOT0QB0C72Jfqk33I7uXELM="
+      "hash": "sha256-+0hHPEZ8J2Fax5mnVPTvC2jDY+RZbO+7WcOBXVGgzIo="
     }
   }
 }

--- a/packages/dia/manifest.json
+++ b/packages/dia/manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.34.1-81705",
-  "hash": "sha256-FHDJWxvYtu6rxyHJoj0h9vbIrD1NkN/XLUa1DPNw38U="
+  "version": "1.37.1-82782",
+  "hash": "sha256-27fv0PHiCf1NJkr2EFzHBtuo7ajbhFgXDTaws1fF8K0="
 }

--- a/packages/humanlayer/manifest.json
+++ b/packages/humanlayer/manifest.json
@@ -1,22 +1,22 @@
 {
-  "version": "0.27.12",
-  "cliHash": "sha512-qIz/s+KWRf/fPDFBB+Ue/UvDPd/7bfLGYWDob4UiR94y13aWnaFPmFSXa7xCos3sKv4CO1yIyIUvjkk2BDa7oQ==",
+  "version": "0.27.23",
+  "cliHash": "sha256-IH6PQkW6ONPqKljJe6AsCkSuPhfSDaalq4pPMOxfA0g=",
   "platforms": {
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-wpVG0mZoFpeJ2c6lZdd8T76JQKXiq2E5qzZcAap7AJw="
+      "hash": "sha256-GZDHuhnh0eeuDX7FvujcrKtxccpTmTohhXzv3JEQHZ8="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-ueOBzlqLUTf3lW3PUEc1q21UqXAo/M93NKC8T7SirKQ="
+      "hash": "sha256-k9KbyUzNW4nuiFGcVGIe1plMaE7/OLqHDWqIRNSJG5I="
     },
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-8IdCBM3SZkOLk43IMhiKetzSLQ877XFpydD7wLtr7ek="
+      "hash": "sha256-v9F49XjDJHyuRwHEIj+IYBVIMTbzc0FFE2PzaateaBY="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-A+bmTLxFpP09qClS35MbOqIgUqA2IwEd+OLtsIfQ08s="
+      "hash": "sha256-pTV6CqzWBQC2GsZ+nNCE4YNMTS80PRYFTHoRijukgiQ="
     }
   }
 }

--- a/packages/minecraft/catalogs/loaders/paper/1.21.11.json
+++ b/packages/minecraft/catalogs/loaders/paper/1.21.11.json
@@ -1,5 +1,5 @@
 {
-  "build": 69,
-  "hash": "sha256-zzdPKvnXHfzHU0Pze3IqerywkcV0ExuV47E8b8LLj64=",
-  "url": "https://api.papermc.io/v2/projects/paper/versions/1.21.11/builds/69/downloads/paper-1.21.11-69.jar"
+  "build": 132,
+  "hash": "sha256-X/70Ze7rXyo8I6JEGdl8Ua/X27SSP/Qt+aP1i7ocz7o=",
+  "url": "https://fill-data.papermc.io/v1/objects/5ffef465eeeb5f2a3c23a24419d97c51afd7dbb4923ff42df9a3f58bba1ccfba/paper-1.21.11-132.jar"
 }

--- a/packages/minecraft/catalogs/loaders/paper/26.1.2.json
+++ b/packages/minecraft/catalogs/loaders/paper/26.1.2.json
@@ -1,5 +1,5 @@
 {
-  "build": 64,
-  "hash": "sha256-gw1OtcFcvYAqnsny9U6qrrlRGVgzmuyYP9DIi60h2UA=",
-  "url": "https://fill-data.papermc.io/v1/objects/830d4eb5c15cbd802a9ec9f2f54eaaaeb9511958339aec983fd0c88bad21d940/paper-26.1.2-64.jar"
+  "build": 72,
+  "hash": "sha256-BVWgsEaKUZjY+xoW4fnpXIGpF6Lcjy4JhntARHQvZAE=",
+  "url": "https://fill-data.papermc.io/v1/objects/0555a0b0468a5198d8fb1a16e1f9e95c81a917a2dc8f2e09867b4044742f6401/paper-26.1.2-72.jar"
 }

--- a/packages/minecraft/catalogs/loaders/velocity/3.4.0-SNAPSHOT.json
+++ b/packages/minecraft/catalogs/loaders/velocity/3.4.0-SNAPSHOT.json
@@ -1,5 +1,5 @@
 {
-  "build": 559,
-  "hash": "sha256-zMSfcXUeziZWjTR2OS1hMMi0Py5fOogxMyW5J4pSur0=",
-  "url": "https://api.papermc.io/v2/projects/velocity/versions/3.4.0-SNAPSHOT/builds/559/downloads/velocity-3.4.0-SNAPSHOT-559.jar"
+  "build": 563,
+  "hash": "sha256-/lMCHzFoMiy2y2j3hpmGb9CY3zwwbkNZhHoQsNAmie8=",
+  "url": "https://fill-data.papermc.io/v1/objects/fe53021f3168322cb6cb68f78699866fd098df3c306e4359847a10b0d02689ef/velocity-3.4.0-SNAPSHOT-563.jar"
 }

--- a/packages/minecraft/catalogs/mods/1.21.11.json
+++ b/packages/minecraft/catalogs/mods/1.21.11.json
@@ -1,7 +1,7 @@
 {
   "distanthorizons": {
-    "hash": "sha512-CyOsAkwjz/3GkS6FLFeYV9nBwgCkt2kGTymIL97Pg0QqQ90bnNZXL1NY+iCMFhoII9z249MuU15X7upCw4/Cpw==",
-    "url": "https://cdn.modrinth.com/data/uCdwusMi/versions/B1HnfKO7/DistantHorizons-3.0.3-b-1.21.11-fabric-neoforge.jar"
+    "hash": "sha512-xvYesFuDg3ftWm8iMo67wsr/Ba5jZP+E+pfAA4qei7+rkRsRW217/31JAu6IMmgbGvO2leD6hZceHWO4iSmE0Q==",
+    "url": "https://cdn.modrinth.com/data/uCdwusMi/versions/WKoReI8f/DistantHorizons-3.1.2-b-1.21.11-fabric-neoforge.jar"
   },
   "fabric-api": {
     "hash": "sha512-wJLUjGRTvsMmT4D2o1uzNKujEStc1sDgsmds5NgecCyx5SIzfzpzI0jnV8wiJto8YBoxSuh2YzTxavcaE7zJjQ==",
@@ -16,15 +16,15 @@
     "url": "https://github.com/xandergos/terrain-diffusion-mc/releases/download/v2.1.0/terrain-diffusion-mc-2.1.0-cpu%2B1.21.11.jar"
   },
   "viabackwards": {
-    "hash": "sha512-PdqWj0OKGlqmDChW8Pp2fbZQGiexqOvR3HK6CYBEVu5gjL2CumahxymKCMnw450a464nzBa9+ssuMz6Tr/fsdQ==",
-    "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/W890fNPl/ViaBackwards-5.9.1.jar"
+    "hash": "sha512-owERMoP/jay18qxMRWMrN63nlWNonuNCyedLzhalyAXXLsZBsF+G/XclWDEoYPkvX9Uq4kbMKHYlNKS+15S+qg==",
+    "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/YjpKsm6j/ViaBackwards-5.10.0.jar"
   },
   "viarewind": {
-    "hash": "sha512-HB9Nt3XZ374oh3a9vS4LL0kQZDuQNGB9gT7lCdol/EXoTPsBg838MFYLJjLyTHXcxRpKm7Dej/KayeJL2J78lA==",
-    "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/cOg14EE7/ViaRewind-4.1.1.jar"
+    "hash": "sha512-6IsW3k5c3/wG7+GAdDj4nAf25L/5qNr3WW+Tcg5rpKTOuw3yf1ZzEtjZ8do2qQi8+67IA9WL+OHlxL3v8lvlzQ==",
+    "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/wzgBAvKl/ViaRewind-4.1.2.jar"
   },
   "viaversion": {
-    "hash": "sha512-e4nyd5xIc0L4p32ydYOpiGi7IBF6T6aKLgfaC7Ytpa70Rru8AXIKCpg6HqLpGmvSb8lHvv7hQP8eTiUev2As+A==",
-    "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/OGj9YIQN/ViaVersion-5.9.1.jar"
+    "hash": "sha512-O53082YOAnMRru4vae7om2wAEQu2pxmx63hWffXwA/j+nkV0V7QXdBAX7Wialgp5VuoysOpxL0gfK5o73pNVAQ==",
+    "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/ruzmiBqe/ViaVersion-5.10.0.jar"
   }
 }

--- a/packages/minecraft/catalogs/mods/26.1.2.json
+++ b/packages/minecraft/catalogs/mods/26.1.2.json
@@ -1,11 +1,11 @@
 {
   "bluemap": {
-    "hash": "sha512-sUA5DFBWVUkRMPdGU/wOnNlQHzXwAcF0llwTvM9Fu5GQDE7UOezbjYJHI/tXaIogzjdYK3s6SgRiOvCYVPb7LQ==",
-    "url": "https://cdn.modrinth.com/data/swbUV1cr/versions/D9j76thC/bluemap-5.20-fabric.jar"
+    "hash": "sha512-7Fl99+l08fKLqhUyU3NEKWjJZDoVem0mJ81cNviEHDAj8sCAI9IDvPp+DlG85p1GI7pxK6u4Tac71A8ODH9NvQ==",
+    "url": "https://cdn.modrinth.com/data/swbUV1cr/versions/VTvifNPN/bluemap-5.22-fabric.jar"
   },
   "c2me-fabric": {
-    "hash": "sha512-MuWiGRTs0WtFYNLVmkwalr6ShB1kLLJ4rNdkYcD+cOOHWUSRfLnlHaxxlCHXWr/9V7y6/m4pfnR36vNFFIV87Q==",
-    "url": "https://cdn.modrinth.com/data/VSNURh3q/versions/iFyIEVsG/c2me-fabric-mc26.1.2-0.3.7%2Balpha.0.69.jar"
+    "hash": "sha512-5aDaho4oqAg5i/1iwwrB+iid3OWarqwIv8PviGIPeNISaaIWNE23HXh/2ZWq0sWN9VPpwWzPYI+z6EO9Q4EK/g==",
+    "url": "https://cdn.modrinth.com/data/VSNURh3q/versions/1qBYfTmr/c2me-fabric-mc26.1.2-0.4.0-alpha.0.28.jar"
   },
   "chunky": {
     "hash": "sha512-uDv+eyGNCqYjKvl3rnQdwfgrEOUM0Su3WfZc9Ba4tivsy1Q+WH7wuWcKvgOBVmD44JG8aCNiTWXPBzAFcVc1Fg==",
@@ -16,68 +16,68 @@
     "url": "https://cdn.modrinth.com/data/Wnxd13zP/versions/RXNrUIjA/Clumps-fabric-26.1.2-26.1.2.1.jar"
   },
   "distanthorizons": {
-    "hash": "sha512-EbJS3jMI1ymdNGJazmUiPZxdQuUqNAu5yF+gJQwMNUrVlLcvCoJ9nXwEa5XdF6XlAPk5VPFNA9qf2sdZbEG1FA==",
-    "url": "https://cdn.modrinth.com/data/uCdwusMi/versions/FJrLlu3p/DistantHorizons-3.0.3-b-26.1.2-fabric-neoforge.jar"
+    "hash": "sha512-w1Y9e6MQGuV31Go7QYvKb4qMIzEwFT3+K6WNYtcsS5m7UTfya6gP4KrzmkYU4J7TLeQOKHIIq4c98PD5hDNTQg==",
+    "url": "https://cdn.modrinth.com/data/uCdwusMi/versions/SLJu35DT/DistantHorizons-3.1.2-b-26.1.2-fabric-neoforge.jar"
   },
   "fabric-api": {
-    "hash": "sha512-R/+hg2kmDIjqhH9mlMy0MaWqkFHGTo02EYanZ7t2Ldn8+/R0KsZVBetghikAoaPxSQmU50NTdmB96BHquL5EYQ==",
-    "url": "https://cdn.modrinth.com/data/P7dR8mSH/versions/BLz7ETCw/fabric-api-0.149.1%2B26.1.2.jar"
+    "hash": "sha512-TjHaPHlnFNJcoHnlJ3mAxUObsJ3K0z0SJMzN/sYAC3drpdFjI6nDEmgudzvd7a51qml6fA9K0rd7WxG6Z5tICg==",
+    "url": "https://cdn.modrinth.com/data/P7dR8mSH/versions/WC1KT7Yg/fabric-api-0.153.0%2B26.1.2.jar"
   },
   "ferrite-core": {
     "hash": "sha512-2B+pfhF4TBnUL4nC9DODHQB2A91xk87kX6F35KapxSs4SxmFhuBKD39jzZlv7XEzIleL3pqNtX4RiIVK5cvlhA==",
     "url": "https://cdn.modrinth.com/data/uXXizFIs/versions/d5ddUdiB/ferritecore-9.0.0-fabric.jar"
   },
   "grimac": {
-    "hash": "sha512-qn63YwP84TaNSOqmmQCluyc3oTrdPXGMeUd7OidOWpOH1FlKRqiEIS3yLQZ1qaMjuOIVv3kwNyxXGVl1y8coTw==",
-    "url": "https://cdn.modrinth.com/data/LJNGWSvH/versions/Vy5RMuNR/grimac-fabric-2.3.74-635708a.jar"
+    "hash": "sha512-yn2U5/r6vJ3zVNCe0mIDvNjnuf+fnS2lgZGSGSoRyHgBxcpM3rDlofpYhfW/xFXhpsAuRlP1fq/cXGlxDVURkQ==",
+    "url": "https://cdn.modrinth.com/data/LJNGWSvH/versions/VDYKAEly/grimac-fabric-2.3.74-e454008.jar"
   },
   "krypton": {
     "hash": "sha512-FCMyECg6dvPPQ1o7jdvL1lqFjSsaELiP9kPAoBSG39K/GEO9NFbNT7hsuzsG8t6gxOZjsZdqSOlt4W07WnB+yQ==",
     "url": "https://cdn.modrinth.com/data/fQEb0iXm/versions/kYAGItyj/krypton-0.3.0.jar"
   },
   "lithium": {
-    "hash": "sha512-kjGtBWZ9Tu8DSMcAv1Fgkp4Lcj2eFF/ZfH/O+Th6wubVJPsV2Z9H+Pg48dI1Mk/XUM3LZgO2OqtghdefvqqzGw==",
-    "url": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/R7MxYvuW/lithium-fabric-0.24.2%2Bmc26.1.2.jar"
+    "hash": "sha512-+sNR9bYVCIm5NVoBiJw1tXmBR9S+2ykVlKWQotQZCeuNxJTvAFExe/VYhvL8f+E0q74udVCY3zhHPtsr9DNX6Q==",
+    "url": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/fQBdPR1m/lithium-fabric-0.24.6%2Bmc26.1.2.jar"
   },
   "lithostitched": {
-    "hash": "sha512-2TgRMh1+GxFSXrzDJrq53sBjO4XvOw1CU9vima8JGzXTacXjrOX4pYrJenA9k1E4myLAepF8sATmXCaOWC0GbQ==",
-    "url": "https://cdn.modrinth.com/data/XaDC71GB/versions/dUL7i4Qf/lithostitched-1.7.7-fabric-26.1.jar"
+    "hash": "sha512-bGd0IP8BYCoAAPkPpT/oFRjJ61by78vZ6hL+zkEjNMYqUb4IK2lM6GuouXfoVVm/nPXlmYTdwWy8z3+8DwDN3g==",
+    "url": "https://cdn.modrinth.com/data/XaDC71GB/versions/7gxI2iZP/lithostitched-1.7.12-fabric-26.1.jar"
   },
   "luckperms": {
-    "hash": "sha512-v+nw4OLZ3+PBxFYpjb13ivAjENq6tdf7SlT8xKTowmU7rgvoQVHXxSmSBl2YhM2rl+we6mYH5/fPARJqE76GMA==",
-    "url": "https://cdn.modrinth.com/data/Vebnzrzj/versions/fTIdfb46/LuckPerms-Fabric-5.5.42.jar"
+    "hash": "sha512-b+3zH/TRdxA5RGO3v8l/K+upDqoDJ9bnGKqzGV7HSL+6KDWpr4BFk/wXiOJW26eVNNp/JJQRyNrsR7bh5w5vQg==",
+    "url": "https://cdn.modrinth.com/data/Vebnzrzj/versions/UHUghDkV/LuckPerms-Fabric-5.5.57.jar"
   },
   "servercore": {
-    "hash": "sha512-uZTxSFZYkwJL2edH1HOWsw8lYdVTy66YSdIgMGbbrlpFGUsIOVX2yY0hfQrWs7cCfR2a7dgj+3imF2jTwij1JQ==",
-    "url": "https://cdn.modrinth.com/data/4WWQxlQP/versions/2siue87F/servercore-fabric-1.5.17%2B26.1.2.jar"
+    "hash": "sha512-BW1W10UIvzTyXe2TI6chvpFbknN5YQDugcSoZ3FzZFOShbSul0njYNZpnUheP7oFYVAqjJSXloSwz3nOjoCvzQ==",
+    "url": "https://cdn.modrinth.com/data/4WWQxlQP/versions/H6TboTA2/servercore-fabric-1.5.19%2B26.1.2.jar"
   },
   "simple-voice-chat": {
-    "hash": "sha512-HraHpSEOfhWIfoSpMZXdjrz0XYWitlfSfHEa0B7Y6QlvSZ/LhNZWSFSYntLBO2qABmX7s4IimXfREl4NPrWoNg==",
-    "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/gVPjsMto/voicechat-fabric-2.6.17%2B26.1.2.jar"
+    "hash": "sha512-l6MtA9jgOrXMS1+omRjEn1ANkJlGsP5u0RRTSjK9nhO+NukLR9haXR5gwvuMCLzM9mqj3ffb2Azq8h/rFuypZA==",
+    "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/lT9C1Daj/voicechat-fabric-2.6.20%2B26.1.2.jar"
   },
   "spark": {
-    "hash": "sha512-4Gl2Y2icVFm37ZLyHYawGRu+f2MnrH6Jcq2fYxjveoypPaOoSVRZ7m8UQ8rf92VrFQ6g78gfjPEwDJMBSDovsw==",
-    "url": "https://cdn.modrinth.com/data/l6YH9Als/versions/J1GUYyGQ/spark-1.10.172-fabric.jar"
+    "hash": "sha512-Hcvyt2zqzwdSOvrq9j02JbAxgHfMbOWIu3Aa6kpJS8KlF5/SylrtqVE8aiJIwuxZA4forsasn9jj0Bdgu8Pb+w==",
+    "url": "https://cdn.modrinth.com/data/l6YH9Als/versions/iYFOl6lQ/spark-1.10.173-fabric.jar"
   },
   "tectonic": {
-    "hash": "sha512-GHez55Vq9FJe64dYOScZ/qjGJLC4XDb9Pjd4CvSqWCOjvWmBzv/yc2TJmatJKrz+oCRIonpAS8QeO52SThvJcQ==",
-    "url": "https://cdn.modrinth.com/data/lWDHr9jE/versions/jL2ZsTzx/tectonic-3.0.22-fabric-26.1.jar"
+    "hash": "sha512-W/fn0y/BPCh8UowzKP7uKfP8loZFOMYF0Yb4bbe9yN1xszZpzDaXYplIdnR+cfQqSvl72QTRai04FpzfNelUnw==",
+    "url": "https://cdn.modrinth.com/data/lWDHr9jE/versions/SlA5rCvn/tectonic-3.0.25-fabric-26.1.jar"
   },
   "terralith": {
     "hash": "sha512-WjvimGpiREbIKoh5405Mewn2+YoZN/1Nm89TVrgyHwuc67XlZ+jQCugWHSYbEI+3yagOvtYfLtuM2whSszy6zA==",
     "url": "https://cdn.modrinth.com/data/8oi3bsk5/versions/FCzSjHeG/Terralith_26.1_v2.6.2_Fabric.jar"
   },
   "viabackwards": {
-    "hash": "sha512-PdqWj0OKGlqmDChW8Pp2fbZQGiexqOvR3HK6CYBEVu5gjL2CumahxymKCMnw450a464nzBa9+ssuMz6Tr/fsdQ==",
-    "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/W890fNPl/ViaBackwards-5.9.1.jar"
+    "hash": "sha512-owERMoP/jay18qxMRWMrN63nlWNonuNCyedLzhalyAXXLsZBsF+G/XclWDEoYPkvX9Uq4kbMKHYlNKS+15S+qg==",
+    "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/YjpKsm6j/ViaBackwards-5.10.0.jar"
   },
   "viarewind": {
-    "hash": "sha512-HB9Nt3XZ374oh3a9vS4LL0kQZDuQNGB9gT7lCdol/EXoTPsBg838MFYLJjLyTHXcxRpKm7Dej/KayeJL2J78lA==",
-    "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/cOg14EE7/ViaRewind-4.1.1.jar"
+    "hash": "sha512-6IsW3k5c3/wG7+GAdDj4nAf25L/5qNr3WW+Tcg5rpKTOuw3yf1ZzEtjZ8do2qQi8+67IA9WL+OHlxL3v8lvlzQ==",
+    "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/wzgBAvKl/ViaRewind-4.1.2.jar"
   },
   "viaversion": {
-    "hash": "sha512-e4nyd5xIc0L4p32ydYOpiGi7IBF6T6aKLgfaC7Ytpa70Rru8AXIKCpg6HqLpGmvSb8lHvv7hQP8eTiUev2As+A==",
-    "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/OGj9YIQN/ViaVersion-5.9.1.jar"
+    "hash": "sha512-O53082YOAnMRru4vae7om2wAEQu2pxmx63hWffXwA/j+nkV0V7QXdBAX7Wialgp5VuoysOpxL0gfK5o73pNVAQ==",
+    "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/ruzmiBqe/ViaVersion-5.10.0.jar"
   },
   "vmp-fabric": {
     "hash": "sha512-JKDfJAeJOxz7VeJ9wcH+8AjfU1GNEYqjJFkk03tkKifXtq/elQ+/XQfEERxErCZNmuVrjYxqm1Ws37kboKFfFg==",

--- a/packages/minecraft/catalogs/mods/common.json
+++ b/packages/minecraft/catalogs/mods/common.json
@@ -3,10 +3,6 @@
     "hash": "sha512-ccUBMwIxZC28BfhIate3B1bDzU52s2pqDpElRB2VgGp98PcIjPyA+74CT1xRU8MZiDq884vMYeYWdIrvHn5GFQ==",
     "url": "https://cdn.modrinth.com/data/Gi02250Z/versions/7IRzJzBP/almanac-1.26.x-fabric-1.6.2.1.jar"
   },
-  "ksyxis": {
-    "hash": "sha512-VbHslAkQpsNvpAWVsNe4YX46gXxV7LLVwe5UwCaTbW8aS75jIoxg6/dRlbsU88kSjJE7qUnfLFh3ubmdIbq5pA==",
-    "url": "https://cdn.modrinth.com/data/2ecVyZ49/versions/kL32PN9Q/Ksyxis-1.4.3.jar"
-  },
   "lmd": {
     "hash": "sha512-2ovLUiqfx070ANS2vP0RMNHb1kWOuxUsF3Lra32zngmtRE5F0iII6AQvxwSNpPZYTi9RDouDlsnq6B90EPteBQ==",
     "url": "https://cdn.modrinth.com/data/vE2FN5qn/versions/eW5P1rHo/letmedespawn-1.26.x-fabric-1.6.2.1.jar"

--- a/packages/minecraft/catalogs/mods/metadata/catalog.json
+++ b/packages/minecraft/catalogs/mods/metadata/catalog.json
@@ -8,7 +8,7 @@
       "client_side": "unsupported",
       "color": 10246826,
       "date_created": "2023-01-19T22:41:03.307291Z",
-      "date_modified": "2026-05-13T01:43:37.466017Z",
+      "date_modified": "2026-05-27T21:30:47.211914Z",
       "description": "Advanced Portals is a portal plugin for bukkit designed to have a wide range of features which are easy to use.",
       "discord_url": "https://discord.sekwah.com/",
       "donation_urls": [
@@ -18,8 +18,8 @@
           "url": "https://ko-fi.com/sekwah"
         }
       ],
-      "downloads": 93101,
-      "followers": 184,
+      "downloads": 98881,
+      "followers": 189,
       "gallery": [
         {
           "created": "2023-01-20T02:31:34.379030Z",
@@ -124,10 +124,11 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/axTqSWQA/9610dd591c7d367556f80db5725ff0b9839f3b12_96.webp",
-      "issues_url": "https://github.com/sekwah41/Advanced-Portals/issues",
+      "issues_url": "https://codeberg.org/Sekwah/advanced-portals/issues",
       "license": {
         "id": "LGPL-3.0-only",
         "name": "GNU Lesser General Public License v3.0 only",
@@ -148,17 +149,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-13T01:43:33.340236Z",
-          "downloads": 1085,
+          "date_published": "2026-05-27T21:30:37.739216Z",
+          "downloads": 3793,
           "file": {
-            "filename": "Advanced-Portals-Spigot-2.7.1.jar",
+            "filename": "advanced-portals-2.8.0-spigot.jar",
             "hashes": {
-              "sha1": "6f69944d031329ff51728c226df5704b8454e4b8",
-              "sha512": "0245d487808c6fe945f343d534a551a8f6267e71a18a5c093fa27fbac36bad7de6d0ea6079b1f41a25d3dee3c4b1353083814aee3a413e1f6aa774d7f72d1fed"
+              "sha512": "51766fbdc70d057edb687997fe087e106332abee1bce36c8feec109902cec16ee6480bb9df2d5bbc9d39fbc936a79024ba489286b89e81656725f4df0dccaa08"
             },
             "primary": true,
-            "size": 3221108,
-            "url": "https://cdn.modrinth.com/data/axTqSWQA/versions/AXKMcS6i/Advanced-Portals-Spigot-2.7.1.jar"
+            "size": 3221235,
+            "url": "https://cdn.modrinth.com/data/axTqSWQA/versions/OiYxu4ab/advanced-portals-2.8.0-spigot.jar"
           },
           "game_versions": [
             "1.13",
@@ -209,9 +209,10 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "AXKMcS6i",
+          "id": "OiYxu4ab",
           "loaders": [
             "bukkit",
             "bungeecord",
@@ -221,170 +222,18 @@
             "velocity",
             "waterfall"
           ],
-          "name": "Spigot [MC 1.13+] 2.7.1",
+          "name": "Spigot [MC 1.13+] 2.8.0",
           "project_id": "axTqSWQA",
-          "version_number": "2.7.1-Spigot",
+          "version_number": "2.8.0-spigot",
           "version_type": "release"
         }
       },
       "server_side": "required",
       "slug": "advanced-portals",
       "source": "modrinth",
-      "source_url": "https://github.com/sekwah41/Advanced-Portals",
+      "source_url": "https://codeberg.org/Sekwah/advanced-portals",
       "title": "Advanced Portals",
       "wiki_url": "https://advancedportals.sekwah.com/"
-    },
-    "advancedserverlist": {
-      "categories": [
-        "utility"
-      ],
-      "client_side": "unsupported",
-      "color": 3969010,
-      "date_created": "2022-08-14T20:07:01.925909Z",
-      "date_modified": "2026-05-03T19:52:31.101733Z",
-      "description": "A plugin to display a custom MOTD, Player count text, player count hover and Favicon using conditions and priorities.",
-      "discord_url": "https://discord.gg/MyPTjpsgGH",
-      "donation_urls": [
-        {
-          "id": "ko-fi",
-          "platform": "Ko-fi",
-          "url": "https://ko-fi.com/andre_601"
-        },
-        {
-          "id": "patreon",
-          "platform": "Patreon",
-          "url": "https://patreon.com/andre_601"
-        }
-      ],
-      "downloads": 85124,
-      "followers": 191,
-      "gallery": [
-        {
-          "created": "2022-08-28T14:41:23.180400Z",
-          "description": "Example showing the different favicon options available.",
-          "featured": false,
-          "ordering": 0,
-          "title": "Favicons",
-          "url": "https://cdn.modrinth.com/data/xss83sOY/images/2a18570ea103d2e3a66139aea381e26a4c96a66d_350.webp"
-        },
-        {
-          "created": "2022-08-14T20:06:59.228688Z",
-          "description": "Simple showcase of the plugin's features",
-          "featured": true,
-          "ordering": 0,
-          "title": "Showcase",
-          "url": "https://cdn.modrinth.com/data/xss83sOY/images/5c541d3888a15a4bef810d8418a543f1e79bcb31_350.webp"
-        }
-      ],
-      "game_versions": [
-        "1.19",
-        "1.19.1",
-        "1.19.2",
-        "1.19.3",
-        "1.19.4",
-        "1.20",
-        "1.20.1",
-        "1.20.2",
-        "1.20.3",
-        "1.20.4",
-        "1.20.5",
-        "1.20.6",
-        "1.21",
-        "1.21.1",
-        "1.21.2",
-        "1.21.3",
-        "1.21.4",
-        "1.21.5",
-        "1.21.6",
-        "1.21.7",
-        "1.21.8",
-        "1.21.9",
-        "1.21.10",
-        "1.21.11"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/xss83sOY/icon.png",
-      "issues_url": "https://codeberg.org/Andre601/AdvancedServerList/issues",
-      "license": {
-        "id": "MIT",
-        "name": "MIT License",
-        "url": "https://codeberg.org/Andre601/AdvancedServerList/src/branch/master/LICENSE"
-      },
-      "loaders": [
-        "bungeecord",
-        "folia",
-        "paper",
-        "spigot",
-        "velocity",
-        "waterfall"
-      ],
-      "page_url": "https://modrinth.com/mod/advancedserverlist",
-      "project_id": "xss83sOY",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+paper": {
-          "date_published": "2026-05-03T19:52:31.064733Z",
-          "dependencies": [
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "VCAqN1ln",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "P1OZGk5p",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "HQyibRsN",
-              "version_id": null
-            }
-          ],
-          "downloads": 1464,
-          "file": {
-            "filename": "AdvancedServerList-Paper-5.8.0.jar",
-            "hashes": {
-              "sha1": "683604b4d69e6210a334238971d8a51dbb4a2095",
-              "sha512": "78974a16f39ecb24c5c143907998b9fe4fc9ab41b5e49737c421b51950b225cf26ffbf36dd276ec0cd71a9ef224ca24fed4d811a1027b85a31b84836796d497f"
-            },
-            "primary": true,
-            "size": 4955103,
-            "url": "https://cdn.modrinth.com/data/xss83sOY/versions/FhyeS2t7/AdvancedServerList-Paper-5.8.0.jar"
-          },
-          "game_versions": [
-            "1.20.6",
-            "1.21",
-            "1.21.1",
-            "1.21.2",
-            "1.21.3",
-            "1.21.4",
-            "1.21.5",
-            "1.21.6",
-            "1.21.7",
-            "1.21.9",
-            "1.21.10",
-            "1.21.11"
-          ],
-          "id": "FhyeS2t7",
-          "loaders": [
-            "folia",
-            "paper"
-          ],
-          "name": "v5.8.0 (paper, folia)",
-          "project_id": "xss83sOY",
-          "version_number": "5.8.0",
-          "version_type": "release"
-        }
-      },
-      "server_side": "required",
-      "slug": "advancedserverlist",
-      "source": "modrinth",
-      "source_url": "https://codeberg.org/Andre601/AdvancedServerList",
-      "title": "AdvancedServerList",
-      "wiki_url": "https://asl.andre601.ch"
     },
     "ajleaderboards": {
       "categories": [
@@ -394,7 +243,7 @@
       "client_side": "unsupported",
       "color": 14449700,
       "date_created": "2022-08-17T20:03:34.292390Z",
-      "date_modified": "2026-05-16T21:48:52.068415Z",
+      "date_modified": "2026-06-10T19:28:37.691566Z",
       "description": " Create leaderboards for almost anything! ",
       "discord_url": "https://discord.gg/GXv2F5sXCx",
       "donation_urls": [
@@ -404,8 +253,8 @@
           "url": "https://paypal.me/ajgeiss0702"
         }
       ],
-      "downloads": 87144,
-      "followers": 181,
+      "downloads": 100162,
+      "followers": 194,
       "gallery": [
         {
           "created": "2023-01-10T03:52:49.777495Z",
@@ -526,16 +375,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "lKEzGugV",
-              "version_id": null
+              "project_id": "lKEzGugV"
             }
           ],
-          "downloads": 4750,
+          "downloads": 11279,
           "file": {
             "filename": "ajLeaderboards-2.11.0.jar",
             "hashes": {
-              "sha1": "b4f8521364d3e55939fd3a89b5ae39837402193b",
               "sha512": "5742b2d974874db0f61b65f97fc14a4b1701146f7fd977699366bc0c26b0ed11c2a38bb8f4c9bad9383012aeb6e85e6c969388c6f98f8b78edb126b036dfab12"
             },
             "primary": true,
@@ -639,8 +485,8 @@
       "date_created": "2024-10-06T07:52:53.443841Z",
       "date_modified": "2026-04-19T09:46:51.200387Z",
       "description": "Almanac is a library used by my mods with mostly loader independent shared code between multiple mods to avoid duplication of code.",
-      "downloads": 13796316,
-      "followers": 387,
+      "downloads": 15622232,
+      "followers": 417,
       "game_versions": [
         "1.20.1",
         "1.20.2",
@@ -710,7 +556,18 @@
         "26.2-snapshot-4",
         "26.2-snapshot-5",
         "26.2-snapshot-6",
-        "26.2-snapshot-7"
+        "26.2-snapshot-7",
+        "26.2-snapshot-8",
+        "26.2-pre-1",
+        "26.2-pre-2",
+        "26.2-pre-3",
+        "26.2-pre-4",
+        "26.2-pre-5",
+        "26.2-pre-6",
+        "26.2-rc-1",
+        "26.2-rc-2",
+        "26.2",
+        "26.3-snapshot-1"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Gi02250Z/f0bb3148fcb735bb989ef5723d199114e1f24542.png",
       "license": {
@@ -733,16 +590,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 177263,
+          "downloads": 292881,
           "file": {
             "filename": "Almanac-1.21.11-x-fabric-1.6.2.jar",
             "hashes": {
-              "sha1": "a502baf3cf4ecf8312e7986a88dce69836df729a",
               "sha512": "2341101d7c051ebeb31d0e05ebcaf7b6930da99f2a03d9cf9c782af9b1905be327a7248c5ad4a0e5c05928081bcff4c81729cff3505a6cfa4023b87f686fd735"
             },
             "primary": true,
@@ -767,16 +621,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 31592,
+          "downloads": 101708,
           "file": {
             "filename": "almanac-1.26.x-fabric-1.6.2.1.jar",
             "hashes": {
-              "sha1": "00b8056d0ff85988abfb298667858b824c9e28e9",
               "sha512": "71c501330231642dbc05f8486ad7b70756c3cd4e76b36a6a0e9125441d95806a7df0f7088cfc80fbbe024f5c5153c319883abcf38bcc61e616748aef1e7e4615"
             },
             "primary": true,
@@ -792,7 +643,18 @@
             "26.2-snapshot-4",
             "26.2-snapshot-5",
             "26.2-snapshot-6",
-            "26.2-snapshot-7"
+            "26.2-snapshot-7",
+            "26.2-snapshot-8",
+            "26.2-pre-1",
+            "26.2-pre-2",
+            "26.2-pre-3",
+            "26.2-pre-4",
+            "26.2-pre-5",
+            "26.2-pre-6",
+            "26.2-rc-1",
+            "26.2-rc-2",
+            "26.2",
+            "26.3-snapshot-1"
           ],
           "id": "7IRzJzBP",
           "loaders": [
@@ -818,7 +680,7 @@
       "client_side": "optional",
       "color": 9244696,
       "date_created": "2021-11-20T23:37:39.568172Z",
-      "date_modified": "2026-04-01T04:53:14.572012Z",
+      "date_modified": "2026-06-18T10:22:52.828506Z",
       "description": "Food/hunger-related HUD improvements",
       "donation_urls": [
         {
@@ -827,8 +689,8 @@
           "url": "https://github.com/sponsors/squeek502"
         }
       ],
-      "downloads": 65975081,
-      "followers": 15540,
+      "downloads": 72663537,
+      "followers": 16401,
       "game_versions": [
         "1.10.2",
         "1.11.2",
@@ -869,7 +731,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/EsAfCjCV/icon.png",
       "issues_url": "https://github.com/squeek502/AppleSkin/issues",
@@ -893,16 +756,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 2992568,
+          "downloads": 3903782,
           "file": {
             "filename": "appleskin-fabric-mc1.21.11-3.0.8.jar",
             "hashes": {
-              "sha1": "441fdbf4e9c34fb61517ceb8e15618950dc4d314",
               "sha512": "d32206cb8d6fac7f0b579f7269203135777283e1639ccb68f8605e9f5469b5b54305fd36ba82c64b48b89ae4f1a38501bfb5827284520c3ec622d95edcfa34de"
             },
             "primary": true,
@@ -935,7 +795,7 @@
       "client_side": "required",
       "color": 1315603,
       "date_created": "2020-11-16T10:40:17.116288Z",
-      "date_modified": "2025-12-16T04:24:43.844528Z",
+      "date_modified": "2026-06-17T19:51:15.059581Z",
       "description": "An intermediary api aimed to ease developing multiplatform mods.",
       "donation_urls": [
         {
@@ -949,8 +809,8 @@
           "url": "https://patreon.com/shedaniel"
         }
       ],
-      "downloads": 76394767,
-      "followers": 7234,
+      "downloads": 82635826,
+      "followers": 7429,
       "game_versions": [
         "1.16.5",
         "1.17.1",
@@ -1009,7 +869,11 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/lhGA9TYQ/05fe3a61c28faaccaec3533b92e1b321edde7bf6_96.webp",
       "issues_url": "https://github.com/architectury/architectury/issues",
@@ -1033,16 +897,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 3469811,
+          "downloads": 4238225,
           "file": {
             "filename": "architectury-19.0.1-fabric.jar",
             "hashes": {
-              "sha1": "2d40563f7e36f7a03f094031aeaacb175117928e",
               "sha512": "7ca532844a0ed3d35e8515e13d1e84f8eadfceaae93281b79ad6b4dac253f4634e3dfcc7592f9543871dec117e1a3092c196ba5eae33735162de223be19dc4ad"
             },
             "primary": true,
@@ -1079,8 +940,8 @@
       "date_modified": "2026-04-26T13:21:02.224772Z",
       "description": "Adds various treasure items that can be found through exploration",
       "discord_url": "https://discord.gg/87pXJadaRr",
-      "downloads": 10118355,
-      "followers": 1788,
+      "downloads": 11012759,
+      "followers": 1909,
       "gallery": [
         {
           "created": "2022-06-14T16:56:46.582836Z",
@@ -1472,22 +1333,17 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "XaT8sLP6",
-              "version_id": null
+              "project_id": "9s6osm5g"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
+              "project_id": "XaT8sLP6"
             }
           ],
-          "downloads": 9239,
+          "downloads": 24650,
           "file": {
             "filename": "artifacts-fabric-14.0.3.jar",
             "hashes": {
-              "sha1": "2ae80c87ba0d6d559e3e13b3c7a78fc6813d7c97",
               "sha512": "d95c3ae4eb2a5039484352a74bf75126217a2f5ce5aa5905545473ef025ea914abebb57319342583439d0f2d5191470289d15ff7395d300f0efd7a72ee6ed3a0"
             },
             "primary": true,
@@ -1521,10 +1377,10 @@
       "client_side": "required",
       "color": 263172,
       "date_created": "2023-06-07T06:12:44.154539Z",
-      "date_modified": "2026-04-12T22:07:36.674115Z",
+      "date_modified": "2026-06-18T01:56:23.632447Z",
       "description": "Removes arbitrary limits on Minecraft's attribute system. Fixes MANY mods!",
-      "downloads": 17528878,
-      "followers": 739,
+      "downloads": 18677183,
+      "followers": 772,
       "game_versions": [
         "1.12.2",
         "1.13.2",
@@ -1565,7 +1421,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/lOOpEntO/68a2de475417c87817e11f49beaa903e4774ca20_96.webp",
       "issues_url": "https://github.com/Darkhax-Minecraft/AttributeFix/issues",
@@ -1589,22 +1446,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "aaRl8GiW"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "aaRl8GiW",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 38661,
+          "downloads": 53653,
           "file": {
             "filename": "attributefix-fabric-1.21.11-21.11.1.jar",
             "hashes": {
-              "sha1": "95995c0abe13cab9f310bb44d925988525f2f382",
               "sha512": "8e4171672e2631d7e11bdfb543079f3a9c4a7afe6c53478e25ad22f035e64031119543a65a06343c981323a1b7ee5847d6cf41ef1fa3eff10036a8cf180bde82"
             },
             "primary": true,
@@ -1647,18 +1499,18 @@
       "discord_url": "https://discord.gg/Bh2EZfB",
       "donation_urls": [
         {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/Archy-X"
-        },
-        {
           "id": "paypal",
           "platform": "Paypal",
           "url": "https://paypal.me/archydev"
+        },
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/Archy-X"
         }
       ],
-      "downloads": 171928,
-      "followers": 346,
+      "downloads": 184568,
+      "followers": 368,
       "game_versions": [
         "1.14.4",
         "1.15",
@@ -1701,7 +1553,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/uDdZAVls/aadaedbbb7f8c142a625a11081aa0d9bdfafecc2.jpeg",
       "issues_url": "https://github.com/Archy-X/AuraSkills/issues",
@@ -1721,11 +1574,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-04-06T21:15:12.492402Z",
-          "downloads": 11454,
+          "downloads": 22971,
           "file": {
             "filename": "AuraSkills-2.3.12.jar",
             "hashes": {
-              "sha1": "3809ac492d9eea1aa9cc08678d215e1ed10766a5",
               "sha512": "baceed31fca3817fbeee58e9de86bc7d2eff273ae4208aba7d7e5a95941fa5bbf0439eb3ece4a261135d669fc6575433ef8c40ac0830ff3138eba4cd64aeba27"
             },
             "primary": true,
@@ -1754,7 +1606,8 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
           "id": "QOb8ZzmE",
           "loaders": [
@@ -1790,8 +1643,8 @@
       "date_created": "2023-12-22T13:36:04.796703Z",
       "date_modified": "2024-08-22T10:51:21.965135Z",
       "description": "A reliable, stable fork of AuthMe with various bug fixes, new exciting features and Folia support",
-      "downloads": 201190,
-      "followers": 149,
+      "downloads": 227337,
+      "followers": 158,
       "gallery": [
         {
           "created": "2024-03-26T09:48:21.315408Z",
@@ -1896,11 +1749,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2024-08-22T10:51:21.965135Z",
-          "downloads": 183713,
+          "downloads": 209362,
           "file": {
             "filename": "AuthMe-5.7.0-FORK-Universal.jar",
             "hashes": {
-              "sha1": "c78691be2e09982baa7e61abe340515eb81af14a",
               "sha512": "3af6f1018e93d97d928c5141819dd2d17390280d76430303a14f01257eecc651a2b21243f86fdb13453d32c4f287345333b015001e918827df576589b6d4e390"
             },
             "primary": true,
@@ -2014,7 +1866,7 @@
       "client_side": "unsupported",
       "color": 3575310,
       "date_created": "2023-12-08T23:36:21.949709Z",
-      "date_modified": "2026-04-12T01:28:52.932903Z",
+      "date_modified": "2026-06-25T04:03:04.428373Z",
       "description": "A lightweight, customizable automatic tree chopping plugin for Paper/Folia servers.",
       "donation_urls": [
         {
@@ -2028,8 +1880,8 @@
           "url": "https://paypal.me/Maoyue914"
         }
       ],
-      "downloads": 85123,
-      "followers": 122,
+      "downloads": 96353,
+      "followers": 132,
       "game_versions": [
         "1.17",
         "1.17.1",
@@ -2062,7 +1914,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/pwCm0TtE/6584af951959d35f4e35b7fe918ff0da6726e398.png",
       "issues_url": "https://github.com/milkteamc/AutoTreeChop/issues",
@@ -2086,16 +1939,13 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "lKEzGugV",
-              "version_id": null
+              "project_id": "lKEzGugV"
             }
           ],
-          "downloads": 10673,
+          "downloads": 18320,
           "file": {
             "filename": "AutoTreeChop-1.7.4.jar",
             "hashes": {
-              "sha1": "3ed8075f60d412309bd265415a4b1615181d7520",
               "sha512": "22f98579b9f38da914995421d9213992f670b3caf57ae01721e6027f03aa22e020281ed7818b25a574ac374c854ad3169655a7c1852310bc14025b5a09d073a4"
             },
             "primary": true,
@@ -2164,11 +2014,11 @@
       "client_side": "unsupported",
       "color": 16450811,
       "date_created": "2023-11-21T17:37:30.910468Z",
-      "date_modified": "2026-04-05T19:57:02.425774Z",
+      "date_modified": "2026-06-20T09:40:53.033348Z",
       "description": "A lightweight grave (death chest) plugin focused on performance & compatibility.",
       "discord_url": "https://dc.artillex-studios.com/",
-      "downloads": 146522,
-      "followers": 312,
+      "downloads": 162594,
+      "followers": 327,
       "gallery": [
         {
           "created": "2023-11-21T17:43:51.187108Z",
@@ -2208,7 +2058,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Cz6msz34/81af253da3341515c8d798daf7b7797501472382_96.webp",
       "issues_url": "https://github.com/Artillex-Studios/AxGraves/issues",
@@ -2229,17 +2080,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-05T19:57:02.425774Z",
-          "downloads": 14375,
+          "date_published": "2026-06-20T09:40:53.033348Z",
+          "downloads": 3993,
           "file": {
-            "filename": "AxGraves-1.28.0.jar",
+            "filename": "AxGraves-1.29.0.jar",
             "hashes": {
-              "sha1": "325e0f67c55379e8e25eb0a8c729146d6aebb96f",
-              "sha512": "50d46e138efa3808f66d9df365b4aebfef8d9d0a6dedb957d62ca7821b76fa17f1ec455ebecf5b15f366106a3abfdc826cc21c70e0f254ecc5fdc211c0b32a00"
+              "sha512": "d95a55d4660d15a95e5f1bd578be619f9ca1ef3bc0995ccb59c612d4648b8fc1b4b507796dfcbf64dca81b7a8c8096392d77f77ede97221cde9bfb63b2ace80b"
             },
             "primary": true,
-            "size": 3997377,
-            "url": "https://cdn.modrinth.com/data/Cz6msz34/versions/rSHiNcdQ/AxGraves-1.28.0.jar"
+            "size": 4020473,
+            "url": "https://cdn.modrinth.com/data/Cz6msz34/versions/WDYTwhVj/AxGraves-1.29.0.jar"
           },
           "game_versions": [
             "1.20.2",
@@ -2261,9 +2111,10 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "rSHiNcdQ",
+          "id": "WDYTwhVj",
           "loaders": [
             "bukkit",
             "folia",
@@ -2271,9 +2122,9 @@
             "purpur",
             "spigot"
           ],
-          "name": "AxGraves 1.28.0",
+          "name": "AxGraves 1.29.0",
           "project_id": "Cz6msz34",
-          "version_number": "1.28.0",
+          "version_number": "1.29.0",
           "version_type": "release"
         }
       },
@@ -2283,6 +2134,141 @@
       "source_url": "https://github.com/Artillex-Studios/AxGraves",
       "title": "AxGraves",
       "wiki_url": "https://docs.artillex-studios.com/axgraves.html"
+    },
+    "axiom": {
+      "categories": [
+        "management",
+        "utility"
+      ],
+      "client_side": "optional",
+      "color": 14935011,
+      "date_created": "2023-09-07T19:59:25.129478Z",
+      "date_modified": "2026-06-22T17:35:23.386708Z",
+      "description": "The all-in-one tool for editing Minecraft Worlds.",
+      "discord_url": "https://discord.gg/axiomtool",
+      "donation_urls": [
+        {
+          "id": "paypal",
+          "platform": "Paypal",
+          "url": "https://www.paypal.com/paypalme/moulberry"
+        },
+        {
+          "id": "patreon",
+          "platform": "Patreon",
+          "url": "https://www.patreon.com/moulberry"
+        }
+      ],
+      "downloads": 9765460,
+      "followers": 5124,
+      "gallery": [
+        {
+          "created": "2023-09-08T13:48:44.312396Z",
+          "description": "The Context Menu lets you toggle useful building capabilities, swap your hotbar, adjust your flightspeed and swap your gamemodes.",
+          "featured": false,
+          "ordering": 0,
+          "title": "Builder Mode Context Menu",
+          "url": "https://cdn.modrinth.com/data/N6n5dqoA/images/6c3ebd37ea64eb4afa260903f01fd5811aace3b1_350.webp"
+        },
+        {
+          "created": "2023-09-08T13:35:24.854892Z",
+          "description": "The Editor Mode integrates familiar camera controls from 3D software with tailored tools for Minecraft building. ",
+          "featured": true,
+          "ordering": 0,
+          "title": "Editor Mode",
+          "url": "https://cdn.modrinth.com/data/N6n5dqoA/images/8812fa52b0f5659db0537ba0648ff41a31dc21c3_350.webp"
+        },
+        {
+          "created": "2023-09-08T13:45:42.757387Z",
+          "description": "The 'Move' Builder Tool shown in the Builder Mode of Axiom.",
+          "featured": false,
+          "ordering": 0,
+          "title": "Builder Mode Move",
+          "url": "https://cdn.modrinth.com/data/N6n5dqoA/images/a649488b5b9cb7a046b970ae0b20fb109dfbbcf6_350.webp"
+        },
+        {
+          "created": "2023-09-08T13:46:41.746638Z",
+          "description": "Replace Mode lets you easily replace any blocks in the world without having to break them first, it even remembers BlockStates!",
+          "featured": false,
+          "ordering": 0,
+          "title": "Replace Mode Showcase",
+          "url": "https://cdn.modrinth.com/data/N6n5dqoA/images/bd29b174d7f4ca2a4fdf411d74628d908cb67913_350.webp"
+        }
+      ],
+      "game_versions": [
+        "1.20",
+        "1.20.1",
+        "1.20.2",
+        "1.20.3",
+        "1.20.4",
+        "1.20.5",
+        "1.20.6",
+        "1.21",
+        "1.21.1",
+        "1.21.2",
+        "1.21.3",
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8",
+        "1.21.9",
+        "1.21.10",
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/N6n5dqoA/dd175669d5ac228dc00453d13528ad26c1f056ac.png",
+      "issues_url": "https://discord.gg/axiomtool",
+      "license": {
+        "id": "LicenseRef-All-Rights-Reserved",
+        "name": "",
+        "url": null
+      },
+      "loaders": [
+        "fabric"
+      ],
+      "page_url": "https://modrinth.com/mod/axiom",
+      "project_id": "N6n5dqoA",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+fabric": {
+          "date_published": "2026-05-04T03:22:44.141861Z",
+          "dependencies": [
+            {
+              "dependency_type": "required",
+              "project_id": "P7dR8mSH"
+            }
+          ],
+          "downloads": 194511,
+          "file": {
+            "filename": "Axiom-5.4.2-for-MC1.21.11.jar",
+            "hashes": {
+              "sha512": "a74e0714a6a222d9f2c297a38792be88e39d9949698d3e49efd16d6828eb2a0bef4495a29020bd0b0fa341d6eed7e2287eab1186d9143d1594467ab51da4f539"
+            },
+            "primary": true,
+            "size": 47085476,
+            "url": "https://cdn.modrinth.com/data/N6n5dqoA/versions/DLVQrqv2/Axiom-5.4.2-for-MC1.21.11.jar"
+          },
+          "game_versions": [
+            "1.21.11"
+          ],
+          "id": "DLVQrqv2",
+          "loaders": [
+            "fabric"
+          ],
+          "name": "Axiom 5.4.2",
+          "project_id": "N6n5dqoA",
+          "version_number": "5.4.2",
+          "version_type": "release"
+        }
+      },
+      "server_side": "optional",
+      "slug": "axiom",
+      "source": "modrinth",
+      "title": "Axiom",
+      "wiki_url": "https://axiomdocs.moulberry.com/"
     },
     "axiom-paper-plugin": {
       "categories": [
@@ -2308,8 +2294,8 @@
           "url": "https://www.paypal.com/paypalme/moulberry"
         }
       ],
-      "downloads": 187768,
-      "followers": 280,
+      "downloads": 204709,
+      "followers": 287,
       "gallery": [
         {
           "created": "2023-09-08T14:55:21.825755Z",
@@ -2360,11 +2346,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-04-10T05:24:37.359577Z",
-          "downloads": 9064,
+          "downloads": 18248,
           "file": {
             "filename": "AxiomPaperPlugin-5.0.4-for-MC1.21.11.jar",
             "hashes": {
-              "sha1": "007da7f1ce44fc6653029f66c3df8383bc25304b",
               "sha512": "8e91ed581e637cb506095c339b889feb2b69f40d4336a680027c65c0d5c60a19d69c41473fbe71e9d5e24e4221a359fb1b96927ed31b9c1614fe77a4ce59ba6a"
             },
             "primary": true,
@@ -2397,23 +2382,23 @@
       "client_side": "optional",
       "color": 4481462,
       "date_created": "2022-06-14T18:11:16.556742Z",
-      "date_modified": "2026-05-08T06:29:56.355688Z",
+      "date_modified": "2026-06-16T16:29:45.505426Z",
       "description": "Abstraction Layer for Multi-Loader Mods",
       "discord_url": "https://discord.gg/36qHFMNgAh",
       "donation_urls": [
         {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/BlayTheNinth"
-        },
-        {
           "id": "patreon",
           "platform": "Patreon",
           "url": "https://www.patreon.com/BlayTheNinth"
+        },
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/BlayTheNinth"
         }
       ],
-      "downloads": 44168519,
-      "followers": 2800,
+      "downloads": 48348780,
+      "followers": 2963,
       "game_versions": [
         "1.18",
         "1.18.1",
@@ -2442,7 +2427,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/MBAkmtvl/285b7bcfd6e525c043e640b08f3efc0cde90f7dd_96.webp",
       "issues_url": "https://github.com/TwelveIterations/Balm/issues",
@@ -2461,36 +2447,33 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-04-10T08:57:46.294419Z",
+          "date_published": "2026-06-15T14:07:29.461725Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 162255,
+          "downloads": 69807,
           "file": {
-            "filename": "balm-fabric-1.21.11-21.11.9.jar",
+            "filename": "balm-fabric-1.21.11-21.11.9.1.jar",
             "hashes": {
-              "sha1": "c86419f7e2460a1ab5da972a7a6f729e6794c92f",
-              "sha512": "42c894cf4d8d5f89d1806aa397f939d8ce75e079ce0c21f5a4720023eb64c861585e2b3d1ab50e4487b3e88612b03e31e09f70915093ba291d80349fcd0d56d5"
+              "sha512": "8c1d759a5abb065da25b395c166c82435417ad456995930cff7bba6c12067206efa57c8ca2c9accd3beb2e40c35982238519fc2a3697794998929c37a20377e2"
             },
             "primary": true,
-            "size": 873056,
-            "url": "https://cdn.modrinth.com/data/MBAkmtvl/versions/wk8IL07y/balm-fabric-1.21.11-21.11.9.jar"
+            "size": 873058,
+            "url": "https://cdn.modrinth.com/data/MBAkmtvl/versions/5POKgjJn/balm-fabric-1.21.11-21.11.9.1.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "wk8IL07y",
+          "id": "5POKgjJn",
           "loaders": [
             "fabric"
           ],
-          "name": "21.11.9+fabric-1.21.11",
+          "name": "21.11.9.1+fabric-1.21.11",
           "project_id": "MBAkmtvl",
-          "version_number": "21.11.9+fabric-1.21.11",
+          "version_number": "21.11.9.1+fabric-1.21.11",
           "version_type": "release"
         }
       },
@@ -2509,7 +2492,7 @@
       "client_side": "unknown",
       "color": 15329769,
       "date_created": "2022-08-21T23:10:23.073677Z",
-      "date_modified": "2025-12-22T17:50:23.613056Z",
+      "date_modified": "2026-06-23T11:47:24.747871Z",
       "description": "Experience the universe of Avatar: The Last Airbender in minecraft.",
       "discord_url": "https://discord.gg/sjwncgE",
       "donation_urls": [
@@ -2519,8 +2502,8 @@
           "url": "https://github.com/sponsors/PrimordialMoros"
         }
       ],
-      "downloads": 118327,
-      "followers": 386,
+      "downloads": 122465,
+      "followers": 394,
       "gallery": [
         {
           "created": "2024-04-14T16:41:10.907427Z",
@@ -2643,7 +2626,8 @@
         "1.21.7",
         "1.21.8",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/DzD7S3mv/05a6af0fe0fdec0fca9e963458cae3bb25fd8b6d_96.webp",
       "issues_url": "https://github.com/PrimordialMoros/Bending/issues",
@@ -2666,46 +2650,33 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "Vs77PB2W",
-              "version_id": null
+              "project_id": "Vs77PB2W"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "DKY9btbd",
-              "version_id": null
+              "project_id": "Vebnzrzj"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YqbUofZE",
-              "version_id": null
+              "project_id": "DKY9btbd"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "HQyibRsN",
-              "version_id": null
+              "project_id": "O4o4mKaq"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "O4o4mKaq",
-              "version_id": null
+              "project_id": "YqbUofZE"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "Vebnzrzj",
-              "version_id": null
+              "project_id": "HQyibRsN"
             }
           ],
-          "downloads": 5201,
+          "downloads": 6226,
           "file": {
             "filename": "bending-paper-3.15.0.jar",
             "hashes": {
-              "sha1": "abd26ce312427f6ad65577090db3b3c9c7c69e7c",
               "sha512": "b5377315dd7f5bab9d1ff9db00eb8765f019eb16ff1c44ae29222123cb5aee3e961cf94bf55389e0abb6318827c2e0764e85e5f44bc3580ac43e8f35d6d9bb3c"
             },
             "primary": true,
@@ -2747,8 +2718,8 @@
       "date_modified": "2026-03-07T00:46:29.830828Z",
       "description": "\u2694\ufe0f Easy, spectacular and fun melee combat system from Minecraft Dungeons.",
       "discord_url": "https://discord.gg/KN9b3pjFTM",
-      "downloads": 13441513,
-      "followers": 4218,
+      "downloads": 14301696,
+      "followers": 4357,
       "gallery": [
         {
           "created": "2022-07-04T19:06:54.784203Z",
@@ -2821,28 +2792,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "ha1mEyJS"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "ha1mEyJS",
-              "version_id": null
+              "project_id": "9s6osm5g"
             }
           ],
-          "downloads": 101782,
+          "downloads": 157413,
           "file": {
             "filename": "bettercombat-fabric-3.0.1+1.21.11.jar",
             "hashes": {
-              "sha1": "a4df0cd01bc60ae8b6ebb7a6c4119a2768f58264",
               "sha512": "7e3c726c5d6af641dd64687eb1b2da4142bee9295b3099466cce6eda77c1d1ddb41d07fb0c5d6be866cdda6c28b8c4f766af37ca0c7ba02c5f4ba2c76d45cd5c"
             },
             "primary": true,
@@ -2876,7 +2840,7 @@
       "client_side": "required",
       "color": 5379209,
       "date_created": "2022-09-02T19:38:08.030776Z",
-      "date_modified": "2026-04-03T17:28:29.841065Z",
+      "date_modified": "2026-06-24T11:54:37.509373Z",
       "description": "A Minecraft mod that improves the statistics screen and makes it more useful.",
       "donation_urls": [
         {
@@ -2885,8 +2849,8 @@
           "url": "https://thecsdev.com/fwd/support-me/"
         }
       ],
-      "downloads": 15283547,
-      "followers": 3639,
+      "downloads": 16354583,
+      "followers": 3732,
       "gallery": [
         {
           "created": "2026-02-08T12:14:41.674911Z",
@@ -3020,7 +2984,8 @@
         "26.1",
         "26.1.1",
         "26w14a",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/n6PXGAoM/c5a85914f01be35575abe61c2d19d48e08581034_96.webp",
       "issues_url": "https://github.com/TheCSDev/betterstats/issues",
@@ -3044,22 +3009,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "Eldc1g37",
-              "version_id": "X850L9UC"
+              "project_id": "Eldc1g37"
             }
           ],
-          "downloads": 152271,
+          "downloads": 240100,
           "file": {
             "filename": "betterstats-5.1.0+fabric-1.21.11.jar",
             "hashes": {
-              "sha1": "fd86b5ee833a53ecdbdef19783761b552d29616c",
               "sha512": "54bcb9336ba8088ad4611ffc37d29f7cc4ed3c89465d6cedfe065ea641f5c252aa1ac4b2306a9c033ee6db9f29a916ed6101cb85e1867de09073894b9bcafe34"
             },
             "primary": true,
@@ -3095,7 +3055,7 @@
       "client_side": "required",
       "color": 5468828,
       "date_created": "2023-11-19T06:25:48.199721Z",
-      "date_modified": "2026-05-19T14:53:44.838686Z",
+      "date_modified": "2026-06-20T17:57:24.998674Z",
       "description": "Adds 50+ unique biomes to enhance your world, with new trees, flowers, and more!",
       "discord_url": "https://discord.gg/GyyzU6T",
       "donation_urls": [
@@ -3105,8 +3065,8 @@
           "url": "https://ko-fi.com/forstride"
         }
       ],
-      "downloads": 22937614,
-      "followers": 4333,
+      "downloads": 27030257,
+      "followers": 4653,
       "gallery": [
         {
           "created": "2024-02-16T05:00:18.848684Z",
@@ -3249,11 +3209,11 @@
           "url": "https://cdn.modrinth.com/data/HXF82T3G/images/6326af8c20ab020ddf8338ebd2811b689891b410_350.webp"
         },
         {
-          "created": "2023-11-19T06:24:44.057364Z",
+          "created": "2026-06-06T01:23:18.382705Z",
           "featured": false,
           "ordering": 21,
           "title": "Glowing Grotto",
-          "url": "https://cdn.modrinth.com/data/HXF82T3G/images/0019fa368d42356ae394e6b2b980937191200313_350.webp"
+          "url": "https://cdn.modrinth.com/data/HXF82T3G/images/6afecdb590e36b29e19c0cfd54253e7daf135c83_350.webp"
         },
         {
           "created": "2023-11-22T04:51:48.291076Z",
@@ -3368,28 +3328,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "kkmrDlKT",
-              "version_id": null
+              "project_id": "s3dmwKy5"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "s3dmwKy5",
-              "version_id": null
+              "project_id": "kkmrDlKT"
             }
           ],
-          "downloads": 47628,
+          "downloads": 55675,
           "file": {
             "filename": "BiomesOPlenty-fabric-1.21.11-21.11.0.31.jar",
             "hashes": {
-              "sha1": "5da3900166ab30ae141e5c85f24d9e690a7968b6",
               "sha512": "d7cb092eaf51a8c3e96d1a03c4e5a6c33a1e577d7e046259a8f8995d7d54133b0042a87a9aa475150792177136e7267854706329fdcfe21995ad6c14ce23f100"
             },
             "primary": true,
@@ -3426,7 +3379,7 @@
       "client_side": "unsupported",
       "color": 274275,
       "date_created": "2022-05-10T20:59:10.483390Z",
-      "date_modified": "2026-04-12T17:16:06.199667Z",
+      "date_modified": "2026-06-17T07:15:14.370808Z",
       "description": "A Minecraft mapping tool that creates 3D models of your Minecraft worlds and displays them in a web viewer.",
       "discord_url": "https://discord.gg/zmkyJa3",
       "donation_urls": [
@@ -3441,8 +3394,8 @@
           "url": "https://www.patreon.com/bluecolored"
         }
       ],
-      "downloads": 355309,
-      "followers": 1330,
+      "downloads": 394420,
+      "followers": 1383,
       "gallery": [
         {
           "created": "2023-02-07T10:59:42.915364Z",
@@ -3518,7 +3471,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/swbUV1cr/b9a17ab8c850046101a47e62037225c9b007a2ca_96.webp",
       "issues_url": "https://github.com/BlueMap-Minecraft/BlueMap/issues",
@@ -3543,11 +3497,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-02-13T13:59:43.420539Z",
-          "downloads": 15589,
+          "downloads": 19429,
           "file": {
             "filename": "bluemap-5.16-paper.jar",
             "hashes": {
-              "sha1": "0be663c91ab5227fd729fb289844ea4f1b228957",
               "sha512": "4336174ede66d4c2f14d1830c068b7a8229afd0dd5e736526246486c1e3ff28eeed6c8044e74ddc81b5067a055a153189006389f5d3e70f434138fe7753628f2"
             },
             "primary": true,
@@ -3575,38 +3528,36 @@
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-04-12T17:15:27.532086Z",
+          "date_published": "2026-06-17T07:14:35.640358Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 4083,
+          "downloads": 2365,
           "file": {
-            "filename": "bluemap-5.20-fabric.jar",
+            "filename": "bluemap-5.22-fabric.jar",
             "hashes": {
-              "sha1": "eadc917975f07df107df5c3d2d50e83777172346",
-              "sha512": "b140390c505655491130f74653fc0e9cd9501f35f001c174965c13bccf45bb91900c4ed439ecdb8d824723fb57688a20ce37582b7b3a4a04623af09854f6fb2d"
+              "sha512": "ec597df7e974f1f28baa15325373442968c9643a157a6d2627cd5c36f8841c3023f2c08023d203bcfa7e0e51bce69d4623ba712babb84da73bd40f0e0c7f4dbd"
             },
             "primary": true,
-            "size": 6434198,
-            "url": "https://cdn.modrinth.com/data/swbUV1cr/versions/D9j76thC/bluemap-5.20-fabric.jar"
+            "size": 6494225,
+            "url": "https://cdn.modrinth.com/data/swbUV1cr/versions/VTvifNPN/bluemap-5.22-fabric.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "D9j76thC",
+          "id": "VTvifNPN",
           "loaders": [
             "fabric"
           ],
-          "name": "5.20-fabric",
+          "name": "5.22-fabric",
           "project_id": "swbUV1cr",
-          "version_number": "5.20-fabric",
+          "version_number": "5.22-fabric",
           "version_type": "release"
         }
       },
@@ -3626,11 +3577,11 @@
       "client_side": "required",
       "color": 8937541,
       "date_created": "2023-07-15T20:14:15.983206Z",
-      "date_modified": "2026-02-05T13:27:28.161535Z",
+      "date_modified": "2026-06-01T16:07:35.359914Z",
       "description": "Build your dream world in seconds with 10,000+ instant structures",
       "discord_url": "https://discord.gg/jf7TUVybrm",
-      "downloads": 212099,
-      "followers": 368,
+      "downloads": 243877,
+      "followers": 393,
       "gallery": [
         {
           "created": "2023-09-10T12:22:18.689479Z",
@@ -3718,7 +3669,8 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/9kNC5Mrh/952c86b4ac1879dc92fe951c8e4feec2316bd4b5_96.webp",
       "license": {
@@ -3740,11 +3692,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2025-12-17T16:44:37.274380Z",
-          "downloads": 17208,
+          "downloads": 22037,
           "file": {
             "filename": "BuildPastePlugin-1.16-1.21.10v2.02.jar",
             "hashes": {
-              "sha1": "4b11a9fd7dcf894cef4ea62c40d26fb7704f41e7",
               "sha512": "d80f1468c51d43f8e1dc7fd51c3f223db4adb71e73d250dd0ce4838189401f25a19757be9e84b7873575905063c298dbfb923c52faead1df99627039a53f28a9"
             },
             "primary": true,
@@ -3810,11 +3761,11 @@
       "client_side": "optional",
       "color": 5727033,
       "date_created": "2021-10-02T10:14:46.020070Z",
-      "date_modified": "2026-05-22T10:00:16.130116Z",
+      "date_modified": "2026-06-30T17:54:28.382932Z",
       "description": "A Fabric mod designed to improve the chunk performance of Minecraft.",
       "discord_url": "https://discord.relativitymc.org/",
-      "downloads": 25846158,
-      "followers": 6993,
+      "downloads": 28949886,
+      "followers": 7273,
       "gallery": [
         {
           "created": "2025-12-07T15:48:46.290558Z",
@@ -4080,7 +4031,18 @@
         "26.2-snapshot-5",
         "26.2-snapshot-6",
         "26.2-snapshot-7",
-        "26.2-snapshot-8"
+        "26.2-snapshot-8",
+        "26.2-pre-1",
+        "26.2-pre-2",
+        "26.2-pre-3",
+        "26.2-pre-4",
+        "26.2-pre-5",
+        "26.2-pre-6",
+        "26.2-rc-1",
+        "26.2-rc-2",
+        "26.2",
+        "26.3-snapshot-1",
+        "26.3-snapshot-2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/VSNURh3q/3c2ce471054466712a44c8758a03e03bb868f93b_96.webp",
       "issues_url": "https://github.com/RelativityMC/C2ME-fabric/issues",
@@ -4098,11 +4060,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2025-12-31T12:42:28.221773Z",
-          "downloads": 885473,
+          "downloads": 1019678,
           "file": {
             "filename": "c2me-fabric-mc1.21.11-0.3.6.0.0.jar",
             "hashes": {
-              "sha1": "587f9a3d9e4591e8e1a1c3eda61ed2f7bfa5dc46",
               "sha512": "c9b11100572fb71c3080ff11b011467624e8013b9942aade09a5c77eb62b3289667bad70501ddea8f35deb0a5d26884b79f76d4ed112d32342471ca7384b788a"
             },
             "primary": true,
@@ -4122,37 +4083,35 @@
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-22T09:44:59.560585Z",
-          "downloads": 8992,
+          "date_published": "2026-06-24T16:26:48.409829Z",
+          "downloads": 30880,
           "file": {
-            "filename": "c2me-fabric-mc26.1.2-0.3.7+alpha.0.69.jar",
+            "filename": "c2me-fabric-mc26.1.2-0.4.0-alpha.0.28.jar",
             "hashes": {
-              "sha1": "30597d4cb419eba4d0e6576b4523455e36f96c2e",
-              "sha512": "32e5a21914ecd16b4560d2d59a4c1a96be92841d642cb278acd76461c0fe70e3875944917cb9e51dac719421d75abffd57bcbafe6e297e7477eaf34514857ced"
+              "sha512": "e5a0da868e28a808398bfd62c30ac1fa289ddce59aaeac08bfc3ef88620f78d21269a216344db71d787fd995aad2c58df553e9c16ccf608fb3e843bd43810afe"
             },
             "primary": true,
-            "size": 4728722,
-            "url": "https://cdn.modrinth.com/data/VSNURh3q/versions/iFyIEVsG/c2me-fabric-mc26.1.2-0.3.7%2Balpha.0.69.jar"
+            "size": 3781111,
+            "url": "https://cdn.modrinth.com/data/VSNURh3q/versions/1qBYfTmr/c2me-fabric-mc26.1.2-0.4.0-alpha.0.28.jar"
           },
           "game_versions": [
             "26.1.2"
           ],
-          "id": "iFyIEVsG",
+          "id": "1qBYfTmr",
           "loaders": [
             "fabric"
           ],
-          "name": "0.3.7+alpha.0.69 devbuild for 26.1.2",
+          "name": "0.4.0-alpha.0.28 devbuild for 26.1.2",
           "project_id": "VSNURh3q",
-          "version_number": "0.3.7+alpha.0.69+26.1.2",
+          "version_number": "0.4.0-alpha.0.28+26.1.2",
           "version_type": "alpha"
         },
         "26.2-snapshot-5+fabric": {
           "date_published": "2026-04-28T15:16:27.896765Z",
-          "downloads": 1277,
+          "downloads": 1366,
           "file": {
             "filename": "c2me-fabric-mc26.2-snapshot-5-0.3.7+alpha.0.68.jar",
             "hashes": {
-              "sha1": "6557f53d0025ff78c9eb335bb7a0891a35351e3d",
               "sha512": "bb87235b31a76ad4cf54cc303b4b948341e30112173ba21379cd7a05e7d128b336ceb0d0c110d24b530bf2559fff4481c4752959a410cb1aecb1311a2f6214ac"
             },
             "primary": true,
@@ -4185,7 +4144,7 @@
       "client_side": "optional",
       "color": 5238351,
       "date_created": "2022-08-04T21:21:58.593977Z",
-      "date_modified": "2026-05-17T20:46:58.537084Z",
+      "date_modified": "2026-06-17T00:42:08.234099Z",
       "description": "A calculator in your chat with shortcuts designed for Minecraft",
       "donation_urls": [
         {
@@ -4199,13 +4158,13 @@
           "url": "https://github.com/sponsors/js802025"
         }
       ],
-      "downloads": 2451946,
-      "followers": 700,
+      "downloads": 2674734,
+      "followers": 729,
       "gallery": [
         {
           "created": "2024-01-25T03:18:47.356317Z",
           "description": "Straightforward syntax for speedy calculations",
-          "featured": false,
+          "featured": true,
           "ordering": 1,
           "title": "Simple Syntax",
           "url": "https://cdn.modrinth.com/data/XoHTb2Ap/images/1f723094c825bb8adf9310e9bf7798636bd2de40_350.webp"
@@ -4317,7 +4276,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/XoHTb2Ap/fe87f9fb4d48afbe539314b17e1be68ba242e58a.gif",
       "issues_url": "https://github.com/js802025/calcmod/issues",
@@ -4339,11 +4299,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-03-10T17:44:55.264755Z",
-          "downloads": 5437,
+          "downloads": 6584,
           "file": {
             "filename": "calcmod-1.5.0+paper.1.21.10.jar",
             "hashes": {
-              "sha1": "e434ca2d0ca88e49ebdca4b436da027dc488f0ed",
               "sha512": "1dd4c7686b7de5d125ed5dc58ab5f69af5f77aee980b0f9ada4230821ad90b6b4cd0c838aecae2c8a75376561b74d63bbe442d0bf1117cf173f1a52f9457a31c"
             },
             "primary": true,
@@ -4388,8 +4347,8 @@
           "url": "https://ko-fi.com/upcraftlp"
         }
       ],
-      "downloads": 12389607,
-      "followers": 1152,
+      "downloads": 13186521,
+      "followers": 1181,
       "game_versions": [
         "1.18",
         "1.18.1",
@@ -4463,11 +4422,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-03-11T23:47:35.539319Z",
-          "downloads": 105181,
+          "downloads": 134924,
           "file": {
             "filename": "cardinal-components-api-7.3.1.jar",
             "hashes": {
-              "sha1": "4ce70bf88e3bc4a0b1a072019d0964122f3180a3",
               "sha512": "987497d5c598813544cd89df2651155abddcc881c0b73fc3fed4514d5a9666e608701a37ec9be565f9fd70514ac3e22b1d162d5b82200f620da0cc5742cca4ff"
             },
             "primary": true,
@@ -4521,8 +4479,8 @@
           "url": "https://ko-fi.com/tschipp"
         }
       ],
-      "downloads": 19288667,
-      "followers": 4314,
+      "downloads": 21022601,
+      "followers": 4502,
       "gallery": [
         {
           "created": "2022-12-05T22:06:14.867832Z",
@@ -4588,11 +4546,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2025-12-27T22:34:51.235154Z",
-          "downloads": 401016,
+          "downloads": 487634,
           "file": {
             "filename": "carryon-fabric-1.21.11-2.9.0.jar",
             "hashes": {
-              "sha1": "8ae93967a302ab5a036655f8bba469bbfcf817a5",
               "sha512": "2a73c5a12898ba2c613afe1a9dec559011946b4b7b1338328d4c279a7cb921be6c8c9789c1b35037a0aa826eb27efa1a45090d28fd27bf7dffd3bacebab4c676"
             },
             "primary": true,
@@ -4632,18 +4589,18 @@
       "discord_url": "https://discord.gg/ZwVJukcNQG",
       "donation_urls": [
         {
-          "id": "paypal",
-          "platform": "Paypal",
-          "url": "https://www.paypal.com/paypalme/pop4959"
-        },
-        {
           "id": "github",
           "platform": "Github",
           "url": "https://github.com/sponsors/pop4959"
+        },
+        {
+          "id": "paypal",
+          "platform": "Paypal",
+          "url": "https://www.paypal.com/paypalme/pop4959"
         }
       ],
-      "downloads": 12740815,
-      "followers": 5509,
+      "downloads": 14215042,
+      "followers": 5816,
       "game_versions": [
         "1.13.2",
         "1.14",
@@ -4691,7 +4648,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/fALzjamp/e1954413665e57b7bae1feef44eda530270c7d47_96.webp",
       "issues_url": "https://github.com/pop4959/Chunky/issues",
@@ -4719,16 +4677,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 952559,
+          "downloads": 1163073,
           "file": {
             "filename": "Chunky-Fabric-1.4.55.jar",
             "hashes": {
-              "sha1": "19c34a23a5c1b2f6c73117b8eb4524b521e1926b",
               "sha512": "3be0e049e3dea6256b395ccb1f7dccc9c6b23cb7b1f6a717a7cd1ca55f9dbda489679df32868c72664ebb28ca05f2c366590d1e1a11f0dc5f69f947903bad833"
             },
             "primary": true,
@@ -4749,11 +4704,10 @@
         },
         "1.21.11+paper": {
           "date_published": "2025-06-21T08:01:39.060370Z",
-          "downloads": 361042,
+          "downloads": 398877,
           "file": {
             "filename": "Chunky-Bukkit-1.4.40.jar",
             "hashes": {
-              "sha1": "7c196c5bebd6017880f3c2a38fc297b3b99f5f93",
               "sha512": "b017fd180141b5c14c38dfb10128d5f5a1072a68ff93ee486d4465953331f5851f09a09b4a159364837a95d192198d8e9885ce39c46eed32dacbf1fd65c6f30f"
             },
             "primary": true,
@@ -4796,16 +4750,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 76020,
+          "downloads": 269353,
           "file": {
             "filename": "Chunky-Fabric-1.5.3.jar",
             "hashes": {
-              "sha1": "fc1f2f374c5c82117599071ed18b6ef9bba2c7fb",
               "sha512": "b83bfe7b218d0aa6232af977ae741dc1f82b10e50cd12bb759f65cf416b8b62beccb543e587ef0b9670abe03815660f8e091bc6823624d65cf07300571573516"
             },
             "primary": true,
@@ -4815,7 +4766,8 @@
           "game_versions": [
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
           "id": "4Eotm6ov",
           "loaders": [
@@ -4849,8 +4801,8 @@
       "date_modified": "2024-12-08T18:30:12.332165Z",
       "description": "An add-on for Chunky which lets you create and manage world borders",
       "discord_url": "https://discord.gg/ZwVJukcNQG",
-      "downloads": 300601,
-      "followers": 483,
+      "downloads": 321338,
+      "followers": 494,
       "gallery": [
         {
           "created": "2022-08-22T03:09:11.603977Z",
@@ -4947,16 +4899,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "fALzjamp",
-              "version_id": null
+              "project_id": "fALzjamp"
             }
           ],
-          "downloads": 35653,
+          "downloads": 40759,
           "file": {
             "filename": "ChunkyBorder-Bukkit-1.2.23.jar",
             "hashes": {
-              "sha1": "b0df0349eec56ad6a8ce1227c7d543036abec9b2",
               "sha512": "47997111bbf8454d26c7d03c9243e98b5f59bb020f89561202e742ff1af4f6ad96ae0a94e14fdda0711b54851c85fd5b5d754b1f0eb55236fa3f1df1c9622573"
             },
             "primary": true,
@@ -5006,7 +4955,7 @@
       "client_side": "optional",
       "color": 7882291,
       "date_created": "2024-03-19T19:54:06.233784Z",
-      "date_modified": "2026-04-11T17:25:58.609172Z",
+      "date_modified": "2026-06-18T12:27:08.251012Z",
       "description": "Confusing, Interesting and Considerably Agnostic Development Aid",
       "discord_url": "https://discord.gg/WcYsDDQtyR",
       "donation_urls": [
@@ -5016,8 +4965,8 @@
           "url": "https://ko-fi.com/enjarai"
         }
       ],
-      "downloads": 12335735,
-      "followers": 1161,
+      "downloads": 13289707,
+      "followers": 1198,
       "game_versions": [
         "1.16",
         "1.16.1",
@@ -5056,7 +5005,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/IwCkru1D/53eee5642c7c426729b8313628b83f8513322484.png",
       "issues_url": "https://codeberg.org/enjarai/cicada-lib/issues",
@@ -5077,16 +5027,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 1613821,
+          "downloads": 1818064,
           "file": {
             "filename": "cicada-lib-0.14.3+1.21.9-1.21.10.jar",
             "hashes": {
-              "sha1": "5df55ab2733c3bb729a9ea87fef8a4d26c2a57d1",
               "sha512": "7f78e8aa5dacea7bbc06850aa1068c9f84e800c1f9d8c040899445098dfb7504d1a57339b6174c3d334d64f4a4ae96b613f29d31c44ee0daf1aa7b8c96474455"
             },
             "primary": true,
@@ -5127,18 +5074,11 @@
       "client_side": "unsupported",
       "color": 16777215,
       "date_created": "2025-05-27T18:13:24.177041Z",
-      "date_modified": "2026-05-14T14:12:27.058803Z",
-      "description": "\ud83c\udf86Trusted on 2200+ Servers\ud83c\udf86\u2b50Controlls Mob Spawning \u2b50Limits Armor Stand\u2b50Item Frames\u2b50Laggy Chunkfinder and Unloader\u2b50And many more features\u2b50Check it out Yourself\u2b501.18-26.1.1\u2b50Bukkit/Spigot/Paper/PurPur\u2b50",
+      "date_modified": "2026-06-29T13:09:07.274252Z",
+      "description": "\ud83c\udf86Trusted on 2500+ Servers\ud83c\udf86\u2b50Controlls Mob Spawning \u2b50Limits Armor Stand\u2b50Item Frames\u2b50Laggy Chunkfinder and Unloader\u2b50And many more features\u2b50Check it out Yourself\u2b501.18-26.1.2\u2b50Bukkit/Spigot/Paper/PurPur\u2b50",
       "discord_url": "https://discord.com/invite/zkduHszK2e",
-      "donation_urls": [
-        {
-          "id": "other",
-          "platform": "Other",
-          "url": "https://mc-host24.de/donate/FS_HEFT"
-        }
-      ],
-      "downloads": 108152,
-      "followers": 63,
+      "downloads": 132647,
+      "followers": 73,
       "gallery": [
         {
           "created": "2025-07-30T13:44:26.068945Z",
@@ -5200,7 +5140,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/7bhTp28M/adfc7cd2b54f2c6e653e85189c7c86564b2068b1.gif",
       "issues_url": "https://discord.com/invite/zkduHszK2e",
@@ -5220,17 +5161,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-14T14:12:27.058803Z",
-          "downloads": 4847,
+          "date_published": "2026-06-29T13:09:07.274252Z",
+          "downloads": 615,
           "file": {
-            "filename": "ClearLag 1.7.7.1 VER 1.18-1.21.jar",
+            "filename": "ClearLag 1.11.1 VER 1.18-26.2.jar",
             "hashes": {
-              "sha1": "b61b3030f9588f684b59c433864763e7da18c797",
-              "sha512": "a449522629c619d798b331741d37eb1e1d33668118db35543b6692ef74ba7aa7e41566a526c5422c9c4a51409f9665c4b4648afa4af45a1565a411f12d3504db"
+              "sha512": "e27fb49e56b6afefa6652c417709e52daffd6408c26ffad63a118279fdb03b11ac0bff959f48c95034d368791f64f7813ec1416be458a1a4187172b9a2de7d54"
             },
             "primary": true,
-            "size": 181998,
-            "url": "https://cdn.modrinth.com/data/7bhTp28M/versions/2LmTmEgF/ClearLag%201.7.7.1%20VER%201.18-1.21.jar"
+            "size": 198562,
+            "url": "https://cdn.modrinth.com/data/7bhTp28M/versions/LaNOJYUT/ClearLag%201.11.1%20VER%201.18-26.2.jar"
           },
           "game_versions": [
             "1.18",
@@ -5262,18 +5202,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "2LmTmEgF",
+          "id": "LaNOJYUT",
           "loaders": [
             "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "ClearLag++ 1.7.7.1",
+          "name": "ClearLag++ 1.11.1",
           "project_id": "7bhTp28M",
-          "version_number": "1.7.7.1",
+          "version_number": "1.11.1",
           "version_type": "beta"
         }
       },
@@ -5295,11 +5236,11 @@
       "client_side": "optional",
       "color": 16504807,
       "date_created": "2025-01-14T16:15:28.113833Z",
-      "date_modified": "2026-04-20T08:27:33.350405Z",
+      "date_modified": "2026-06-21T13:53:07.714012Z",
       "description": "Click to pick up any mob into your inventory and carry\nthem around!",
       "discord_url": "https://discord.gg/zUetzp3Gzk",
-      "downloads": 133905,
-      "followers": 221,
+      "downloads": 163400,
+      "followers": 248,
       "gallery": [
         {
           "created": "2025-01-14T16:39:05.543653Z",
@@ -5352,7 +5293,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/tRdRT5jS/08afd66f210feeac992d88b9170540695e1a0864.png",
       "issues_url": "https://github.com/Clickism/ClickMobs/issues",
@@ -5375,11 +5317,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-03-26T18:54:56.423368Z",
-          "downloads": 9296,
+          "downloads": 16878,
           "file": {
             "filename": "ClickMobs-paper-1.3.1.jar",
             "hashes": {
-              "sha1": "dd74e5f4344b22f44dc65327a1fa9fd7f7a72cb6",
               "sha512": "423a85b69390160846713ce39e6d22a1a4b510af493bd2e460322fde02c8cb79c2154fee2bedcdbfc0885cf8696c6d69e847cd2d830d95f26bc5ded79213a578"
             },
             "primary": true,
@@ -5401,7 +5342,8 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
           "id": "tte1UNeO",
           "loaders": [
@@ -5437,11 +5379,11 @@
       "client_side": "unknown",
       "color": 13336164,
       "date_created": "2023-07-22T14:19:01.815330Z",
-      "date_modified": "2026-04-19T12:47:32.050850Z",
+      "date_modified": "2026-06-25T10:52:41.646703Z",
       "description": "Click to pick up villagers, reset their trades, change their biomes, claim them and much more!",
       "discord_url": "https://discord.gg/zUetzp3Gzk",
-      "downloads": 350422,
-      "followers": 450,
+      "downloads": 428877,
+      "followers": 500,
       "gallery": [
         {
           "created": "2025-03-11T21:31:06.283972Z",
@@ -5508,7 +5450,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/BITzwT7B/6be9d25207fe2406711546020b48b409803c40f6_96.webp",
       "issues_url": "https://github.com/Clickism/ClickVillagers/issues",
@@ -5531,17 +5474,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-02-15T11:31:24.327723Z",
-          "downloads": 57770,
+          "date_published": "2026-06-12T21:08:29.239298Z",
+          "downloads": 14345,
           "file": {
-            "filename": "ClickVillagers-paper-1.6.2.jar",
+            "filename": "ClickVillagers-paper-1.6.3.jar",
             "hashes": {
-              "sha1": "837b52d3a0aa3b9d1e060d612e6f756e86b76d4d",
-              "sha512": "1891c84c800147abd0a9c461f5c4329988f7f48df7f1bcab9769e1ee0fd1b462acae0fd419bb4c3ef0296aa15477a9857cb834e0ed8cf375fc2fceac40a38bcc"
+              "sha512": "e28a57e76b5731c82775d888252b77dd7f579b6926a2778b5ed5f9f19094991d4492398bd4d47c04ce3ed247aa20e87a6332bd9240160886e46293b93146e681"
             },
             "primary": true,
-            "size": 261223,
-            "url": "https://cdn.modrinth.com/data/BITzwT7B/versions/TA8iVq8Y/ClickVillagers-paper-1.6.2.jar"
+            "size": 262632,
+            "url": "https://cdn.modrinth.com/data/BITzwT7B/versions/iMS3EoIW/ClickVillagers-paper-1.6.3.jar"
           },
           "game_versions": [
             "1.21",
@@ -5558,17 +5500,18 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "TA8iVq8Y",
+          "id": "iMS3EoIW",
           "loaders": [
             "folia",
             "paper",
             "purpur"
           ],
-          "name": "ClickVillagers 1.6.2 for Paper",
+          "name": "ClickVillagers 1.6.3 for Paper",
           "project_id": "BITzwT7B",
-          "version_number": "paper-1.6.2",
+          "version_number": "paper-1.6.3",
           "version_type": "release"
         }
       },
@@ -5585,7 +5528,7 @@
       "client_side": "optional",
       "color": 11654752,
       "date_created": "2022-04-21T10:29:41.555173Z",
-      "date_modified": "2026-03-26T16:04:39.594678Z",
+      "date_modified": "2026-06-18T00:27:29.988672Z",
       "description": "Configuration Library for Minecraft Mods",
       "discord_url": "https://discord.gg/Vs9AVkxjYY",
       "donation_urls": [
@@ -5595,8 +5538,8 @@
           "url": "https://www.patreon.com/shedaniel"
         }
       ],
-      "downloads": 121843902,
-      "followers": 15058,
+      "downloads": 134686668,
+      "followers": 15715,
       "gallery": [
         {
           "created": "2022-04-21T10:31:01.159433Z",
@@ -5662,7 +5605,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/9s6osm5g/ed8a2316cbb6f4fc5f510e8e13a59a85cbbbff4d_96.webp",
       "issues_url": "https://github.com/shedaniel/ClothConfig/issues",
@@ -5682,11 +5626,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2025-12-21T13:12:08.556619Z",
-          "downloads": 9067888,
+          "downloads": 11207125,
           "file": {
             "filename": "cloth-config-21.11.153-fabric.jar",
             "hashes": {
-              "sha1": "4c224606a963bce223db5b27edb4959ecf40d4ee",
               "sha512": "8f455489d4b71069e998568cf4e1450116f4360a4eb481cd89117f629c6883164886cf63ca08ac4fc929dd13d1112152755a6216d4a1498ee6406ef102093e51"
             },
             "primary": true,
@@ -5721,7 +5664,7 @@
       "client_side": "optional",
       "color": 12368900,
       "date_created": "2023-06-04T08:54:48.176874Z",
-      "date_modified": "2026-04-11T19:05:08.691867Z",
+      "date_modified": "2026-06-17T00:44:51.019216Z",
       "description": "Clumps XP orbs together to reduce lag",
       "donation_urls": [
         {
@@ -5730,8 +5673,8 @@
           "url": "https://www.patreon.com/jaredlll08"
         }
       ],
-      "downloads": 27597534,
-      "followers": 4859,
+      "downloads": 30548158,
+      "followers": 5141,
       "game_versions": [
         "1.10.2",
         "1.11.2",
@@ -5780,7 +5723,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Wnxd13zP/6a965bb7974c3e759a53a1c89c35de4acd4cf86a_96.webp",
       "issues_url": "https://github.com/jaredlll08/Clumps/issues",
@@ -5803,16 +5747,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 1105986,
+          "downloads": 1406294,
           "file": {
             "filename": "Clumps-fabric-1.21.11-29.0.0.1.jar",
             "hashes": {
-              "sha1": "626fde9e970030cfc8cb64cd0a1abfc03d37ecc2",
               "sha512": "3cff3cd2d600a6d84030b38ce6244143d13774d5287627bb7312adae5edc7ae2d9151a2c9c39a00681c354d549b0a62ac48c0077ba586cc10c00d32f39e87f18"
             },
             "primary": true,
@@ -5836,16 +5777,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 169192,
+          "downloads": 424011,
           "file": {
             "filename": "Clumps-fabric-26.1.2-26.1.2.1.jar",
             "hashes": {
-              "sha1": "c1e9539fdadb3cba1c4b665a141e39a65e6ef674",
               "sha512": "369c20d8887c36c9fd4569a7c8dac1ffc51be036bb58763605535034a5aebd9fbb35de43cc0cc8c774d8dd02b2ab1776f90be1657f3796b38107f779edb4a77a"
             },
             "primary": true,
@@ -5878,7 +5816,7 @@
       "client_side": "optional",
       "color": 4597000,
       "date_created": "2022-08-30T10:44:01.264939Z",
-      "date_modified": "2026-05-01T14:13:13.558963Z",
+      "date_modified": "2026-06-29T16:27:51.706688Z",
       "description": "\ud83c\udf93 Collective is a shared library with common code for all of Serilum's mods.",
       "donation_urls": [
         {
@@ -5887,8 +5825,8 @@
           "url": "https://patreon.com/serilum"
         }
       ],
-      "downloads": 49444396,
-      "followers": 4769,
+      "downloads": 54059635,
+      "followers": 4974,
       "game_versions": [
         "1.16.5",
         "1.18.2",
@@ -5916,7 +5854,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/e0M1UDsY/f5e4fe9ac298e2c14591920d6bda937c566accd0_96.webp",
       "issues_url": "https://github.com/Serilum/.issue-tracker/labels/Library: Collective",
@@ -5936,31 +5875,30 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-01T14:12:45.130261Z",
-          "downloads": 186904,
+          "date_published": "2026-06-25T11:38:26.437875Z",
+          "downloads": 66057,
           "file": {
-            "filename": "collective-1.21.11-8.22.jar",
+            "filename": "collective-1.21.11-8.32.jar",
             "hashes": {
-              "sha1": "c2415063e15271a1c4208a107bb712c0710457b7",
-              "sha512": "53ffcc1ae26713254c11a975f4d5182e709b637f4706e563cf1d3e8b90bab510ed6552609a1e757e298f505ae9aabe1cdb952afbdc2879c8039226783733a3b4"
+              "sha512": "25fceab7df75a0ff8ce8c3f998a9d86e279b0da8d971ac539d135052bfb7d651ad159af23892c250ebdd3064489aea47db677d3c2be6e4df20ac5e25551f5909"
             },
             "primary": true,
-            "size": 959351,
-            "url": "https://cdn.modrinth.com/data/e0M1UDsY/versions/6EPDFSpU/collective-1.21.11-8.22.jar"
+            "size": 1046147,
+            "url": "https://cdn.modrinth.com/data/e0M1UDsY/versions/e4SDY5SX/collective-1.21.11-8.32.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "6EPDFSpU",
+          "id": "e4SDY5SX",
           "loaders": [
             "fabric",
             "forge",
             "neoforge",
             "quilt"
           ],
-          "name": "[Fabric/Forge/Neo] 1.21.11-8.22",
+          "name": "[Fabric/Forge/Neo] 1.21.11-8.32",
           "project_id": "e0M1UDsY",
-          "version_number": "1.21.11-8.22-fabric+forge+neo",
+          "version_number": "1.21.11-8.32-fabric+forge+neo",
           "version_type": "release"
         }
       },
@@ -5978,7 +5916,7 @@
       "client_side": "required",
       "color": 10758180,
       "date_created": "2023-02-03T00:12:22.007446Z",
-      "date_modified": "2026-03-07T01:54:02.396174Z",
+      "date_modified": "2026-06-22T23:54:54.557560Z",
       "description": "Adds sleeping bags and hammocks for, respectively, portability and turning day to night, without setting new spawns. Comes in 16 different colors!",
       "discord_url": "https://discord.gg/JWgrdwt",
       "donation_urls": [
@@ -5988,8 +5926,8 @@
           "url": "https://ko-fi.com/theillusivec4"
         }
       ],
-      "downloads": 16866526,
-      "followers": 2304,
+      "downloads": 18408074,
+      "followers": 2396,
       "gallery": [
         {
           "created": "2023-02-03T00:37:50.653024Z",
@@ -6054,7 +5992,9 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/SaCpeal4/ed4840f0c9a30e04ad88413bd82cd762dd6ec95d.png",
       "issues_url": "https://github.com/illusivesoulworks/comforts/issues",
@@ -6078,16 +6018,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 50241,
+          "downloads": 79180,
           "file": {
             "filename": "comforts-fabric-14.0.2+1.21.11.jar",
             "hashes": {
-              "sha1": "41365e7d2e06f4397a4e16a30184b9a79e20d32e",
               "sha512": "b80100877031245a00d834954319d614837ad46d248c073001c00dd0d6d453a327ff9ae8ab71c46ac45e5280427e351e594f3b2ce24a8c0714df2b10f479f9ef"
             },
             "primary": true,
@@ -6121,7 +6058,7 @@
       "client_side": "required",
       "color": 3815994,
       "date_created": "2023-02-05T13:04:45.141986Z",
-      "date_modified": "2026-05-14T15:11:19.223060Z",
+      "date_modified": "2026-06-16T18:35:50.502034Z",
       "description": "Adds the best controller support to Minecraft Java edition!",
       "discord_url": "https://discord.gg/bDhwyk9Apc",
       "donation_urls": [
@@ -6131,8 +6068,8 @@
           "url": "https://patreon.com/isxander"
         }
       ],
-      "downloads": 16009319,
-      "followers": 1670,
+      "downloads": 18155866,
+      "followers": 1764,
       "gallery": [
         {
           "created": "2025-08-16T16:32:07.751983Z",
@@ -6285,7 +6222,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/DOUdJVEm/5a6c126c4c761ba3e8e9d3ef09a68e16ff60ff22_96.webp",
       "issues_url": "https://github.com/isXander/Controlify/issues",
@@ -6307,28 +6245,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "1eAoo2KR"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "1eAoo2KR",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             }
           ],
-          "downloads": 13385,
+          "downloads": 241510,
           "file": {
             "filename": "controlify-3.0.0+lts+1.21.11-fabric.jar",
             "hashes": {
-              "sha1": "a254efc3e09f1fc05c7f5763904dec88fa04b7d6",
               "sha512": "5850e03856c0880cd3d3ee021ad35ac8ddd5da21d20360ed3a89f8dff2c23643f43715d1f28f6b37a6a89cdb9da829c81ed60ba9f479265107b1c28df924fbc5"
             },
             "primary": true,
@@ -6378,8 +6309,8 @@
           "url": "https://www.patreon.com/coreprotect"
         }
       ],
-      "downloads": 375326,
-      "followers": 1030,
+      "downloads": 414657,
+      "followers": 1069,
       "gallery": [
         {
           "created": "2022-12-09T22:23:11.401534Z",
@@ -6453,11 +6384,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-05-15T17:37:11.867368Z",
-          "downloads": 7123,
+          "downloads": 45274,
           "file": {
             "filename": "CoreProtect-CE-23.2.jar",
             "hashes": {
-              "sha1": "0be3e65f74bcd890305ed4144e51161ca9d4337c",
               "sha512": "2014aa7b3540ffd32c401b4bfe065944ea26fc56de5b118213a52f29db9eff19cc67bb0c80e3d7abd31a88af0404d4f6d65e5229d95fca3b25c1a5370fbb3857"
             },
             "primary": true,
@@ -6531,8 +6461,8 @@
       "date_created": "2022-10-24T01:31:20.164328Z",
       "date_modified": "2026-03-17T21:19:34.921195Z",
       "description": "A library mod containing code used across Corgi Taco's mods.",
-      "downloads": 11782209,
-      "followers": 274,
+      "downloads": 12617224,
+      "followers": 284,
       "game_versions": [
         "1.19.2",
         "1.19.3",
@@ -6565,16 +6495,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 80829,
+          "downloads": 99308,
           "file": {
             "filename": "Corgilib-Fabric-1.21.11-9.0.0.0.jar",
             "hashes": {
-              "sha1": "687e58061bed7d5e37776fe414076debb5292625",
               "sha512": "bf124b2b15009335091f3b88d32bc7b01f3866ff604a518eb86d5e6f5d78da938d12d1ef12c8b2c33b98b2463d9c35b25b63d0fb88b8a4040f2876b9367d35aa"
             },
             "primary": true,
@@ -6624,8 +6551,8 @@
           "url": "https://ko-fi.com/ryderbelserion"
         }
       ],
-      "downloads": 113901,
-      "followers": 103,
+      "downloads": 121190,
+      "followers": 106,
       "game_versions": [
         "1.8.8",
         "1.12.2",
@@ -6669,11 +6596,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2025-01-07T17:15:29.427809Z",
-          "downloads": 48359,
+          "downloads": 54128,
           "file": {
             "filename": "CrazyAuctions-1.7.0.jar",
             "hashes": {
-              "sha1": "28a07c51f2791336c73f0601b820f49117d13edf",
               "sha512": "ee3bcf797dac254f403763e7cc57f39a7338b7676300986ffb421c0901abada965bd7958c6d040972457d74a0b3dbeb65c29cb78ed2e022429e3c32cbe9aa549"
             },
             "primary": true,
@@ -6725,7 +6651,7 @@
       "client_side": "unsupported",
       "color": 2894893,
       "date_created": "2022-08-14T19:51:12.341947Z",
-      "date_modified": "2026-01-14T21:59:11.889651Z",
+      "date_modified": "2026-06-23T03:01:22.267058Z",
       "description": "Add unlimited crates to your server with 11 different crate types to choose from!",
       "discord_url": "https://discord.gg/badbones-s-live-chat-182615261403283459",
       "donation_urls": [
@@ -6735,8 +6661,8 @@
           "url": "https://ko-fi.com/ryderbelserion"
         }
       ],
-      "downloads": 278074,
-      "followers": 246,
+      "downloads": 290282,
+      "followers": 253,
       "gallery": [
         {
           "created": "2022-12-13T05:03:08.386296Z",
@@ -6840,28 +6766,21 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "w02MKsTg",
-              "version_id": null
+              "project_id": "w02MKsTg"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "lKEzGugV",
-              "version_id": null
+              "project_id": "5QNgOj66"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "5QNgOj66",
-              "version_id": null
+              "project_id": "lKEzGugV"
             }
           ],
-          "downloads": 17187,
+          "downloads": 23809,
           "file": {
             "filename": "CrazyCrates-5.0.0.jar",
             "hashes": {
-              "sha1": "8c9f7dfeb408c06e0d9abeefdeac88a5540f6c48",
               "sha512": "12a82d14413330f9982553c0a5094a4350e089b1affad3c7cefacb326e08c54fcd0f839a2e1b41c066876bf71dc6dcc6b7e87e31133a5a94bc9c8a27290b374f"
             },
             "primary": true,
@@ -6904,7 +6823,7 @@
       "client_side": "unsupported",
       "color": 2697513,
       "date_created": "2022-12-20T01:34:37.467974Z",
-      "date_modified": "2026-03-30T02:00:19.377901Z",
+      "date_modified": "2026-06-20T17:42:10.571833Z",
       "description": "Adds over 80 unique enchantments to your server and more! ",
       "discord_url": "https://discord.gg/badbones-s-live-chat-182615261403283459",
       "donation_urls": [
@@ -6914,8 +6833,8 @@
           "url": "https://ko-fi.com/ryderbelserion"
         }
       ],
-      "downloads": 175666,
-      "followers": 254,
+      "downloads": 183590,
+      "followers": 259,
       "gallery": [
         {
           "created": "2023-02-12T02:04:45.819830Z",
@@ -6953,7 +6872,8 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/krxPuhWb/af2ac4ec0d3f3183bde58911a75b54b04499eeb0_96.webp",
       "issues_url": "https://github.com/Crazy-Crew/CrazyEnchantments/issues",
@@ -6977,34 +6897,25 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "1u6JkXh5",
-              "version_id": null
+              "project_id": "Vs77PB2W"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "DKY9btbd",
-              "version_id": null
+              "project_id": "O4o4mKaq"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "Vs77PB2W",
-              "version_id": null
+              "project_id": "1u6JkXh5"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "O4o4mKaq",
-              "version_id": null
+              "project_id": "DKY9btbd"
             }
           ],
-          "downloads": 7081,
+          "downloads": 11280,
           "file": {
             "filename": "CrazyEnchantments-2.7.2.jar",
             "hashes": {
-              "sha1": "236d37f7109af9a78ac9a1ce66f5b30aeeab4048",
               "sha512": "7a34460f833b16c3c68a78121eebf670f137c6d7d68b1ae570c0d0311549ff0bed4787878a6985914a8236b0ce7cbf6df438e0aea90c3ffa58bf5d173ceb213d"
             },
             "primary": true,
@@ -7040,7 +6951,7 @@
       "client_side": "required",
       "color": 526344,
       "date_created": "2021-08-17T09:10:08.972681Z",
-      "date_modified": "2026-05-22T11:50:47.446990Z",
+      "date_modified": "2026-06-23T06:59:25.197785Z",
       "description": "A core mod",
       "discord_url": "https://discord.gg/W9QM3fS",
       "donation_urls": [
@@ -7050,8 +6961,8 @@
           "url": "https://www.patreon.com/creativemd"
         }
       ],
-      "downloads": 37419129,
-      "followers": 3287,
+      "downloads": 41388945,
+      "followers": 3418,
       "game_versions": [
         "1.12.2",
         "1.16.5",
@@ -7078,7 +6989,8 @@
         "1.21.10",
         "1.21.11",
         "26.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/OsZiaDHq/4953ecd3c0c8b185b2a56d64cdb104b03f3e5038_96.webp",
       "issues_url": "https://github.com/CreativeMD/CreativeCore/issues",
@@ -7101,16 +7013,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 708327,
+          "downloads": 1054048,
           "file": {
             "filename": "CreativeCore_FABRIC_v2.14.11_mc1.21.11.jar",
             "hashes": {
-              "sha1": "45720c9f59c67bcceddf062d21aec743a94856c4",
               "sha512": "f30d3ca11a53a74043010c9c8c2a470de708030c12d325a00b317d72357dc2c250eb0de6ca78bf7f5ba0257a13b61f4a79580b3b92a13ae1b6a8441c5adb76a5"
             },
             "primary": true,
@@ -7147,10 +7056,10 @@
       "client_side": "optional",
       "color": 4870466,
       "date_created": "2023-05-01T17:37:55.454619Z",
-      "date_modified": "2026-05-22T22:11:49.533609Z",
+      "date_modified": "2026-06-24T06:14:13.387102Z",
       "description": "A Library mod for easy structure config and runtime datapacks.",
-      "downloads": 13571691,
-      "followers": 1032,
+      "downloads": 14750159,
+      "followers": 1082,
       "gallery": [
         {
           "created": "2023-05-01T18:29:24.396580Z",
@@ -7196,7 +7105,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/cl223EMc/22b1072af55724911840b93a30cf8d3b3fc514bf_96.webp",
       "issues_url": "https://github.com/Cristelknight999/Cristel-Lib/issues",
@@ -7216,43 +7126,38 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-03-30T13:07:14.527558Z",
+          "date_published": "2026-06-13T14:12:03.349564Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "9s6osm5g"
             }
           ],
-          "downloads": 76661,
+          "downloads": 18615,
           "file": {
-            "filename": "cristellib-fabric-1.21.11-3.1.2.jar",
+            "filename": "cristellib-fabric-1.21.11-3.1.7.jar",
             "hashes": {
-              "sha1": "f45d16776277a09c34bf49bcc6c4b9582aa1350a",
-              "sha512": "39b55242591208c3c1bbd0eb0c4fe719cdf1bd9356146bd1712af9a35f0765415b5aa01165c9133b1eb2d14c4ac181dbe1756669683df0aa911dab2bbd356a2b"
+              "sha512": "0ef8f505f8acd70b67d72933fe41aff0831b8d6dee40d1e2058b7ac1d5b8fb9324b5ad978e072799fda2e1bba72725ea4323aa3c6243c5a284bec47b0f613c0c"
             },
             "primary": true,
-            "size": 585050,
-            "url": "https://cdn.modrinth.com/data/cl223EMc/versions/yWdD26Oh/cristellib-fabric-1.21.11-3.1.2.jar"
+            "size": 585390,
+            "url": "https://cdn.modrinth.com/data/cl223EMc/versions/1NM741mO/cristellib-fabric-1.21.11-3.1.7.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "yWdD26Oh",
+          "id": "1NM741mO",
           "loaders": [
             "fabric",
             "quilt"
           ],
-          "name": "Cristel Lib 3.1.2",
+          "name": "Cristel Lib 3.1.7",
           "project_id": "cl223EMc",
-          "version_number": "fabric-1.21.11-3.1.2",
+          "version_number": "fabric-1.21.11-3.1.7",
           "version_type": "release"
         }
       },
@@ -7270,14 +7175,14 @@
       "client_side": "optional",
       "color": 4668228,
       "date_created": "2022-03-19T16:17:46.891784Z",
-      "date_modified": "2026-05-22T16:43:33.453494Z",
+      "date_modified": "2026-06-17T17:48:50.829469Z",
       "description": "Customize your minecraft avatar!",
       "discord_url": "https://discord.gg/mKyXdEsMZD",
       "donation_urls": [
         {
-          "id": "patreon",
-          "platform": "Patreon",
-          "url": "https://www.patreon.com/tom5454"
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/tom5454"
         },
         {
           "id": "ko-fi",
@@ -7285,13 +7190,13 @@
           "url": "https://ko-fi.com/tom5454"
         },
         {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/tom5454"
+          "id": "patreon",
+          "platform": "Patreon",
+          "url": "https://www.patreon.com/tom5454"
         }
       ],
-      "downloads": 2301447,
-      "followers": 1532,
+      "downloads": 2512111,
+      "followers": 1592,
       "game_versions": [
         "b1.7.3",
         "1.2.5",
@@ -7397,7 +7302,8 @@
         "26.1.1",
         "26.2-snapshot-1",
         "26.1.2",
-        "26.2-snapshot-8"
+        "26.2-snapshot-8",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/h1E7sQNL/e9535e89447a025e014f9a319d752861982f97fa_96.webp",
       "issues_url": "https://github.com/tom5454/CustomPlayerModels/issues",
@@ -7426,11 +7332,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-05-22T16:43:33.453494Z",
-          "downloads": 83,
+          "downloads": 5715,
           "file": {
             "filename": "CustomPlayerModels-Paper-0.6.26a.jar",
             "hashes": {
-              "sha1": "6dd41d057fd7832f59ac791df5fa71f58d0d43e6",
               "sha512": "f943099dc2f5518bb069f2a27d9d0eb46c58427e84722ad0cf2166f8642bc91ae25439aa2228c730c913ce782b9b72b4555f51fc0c61449b0e7682476516678b"
             },
             "primary": true,
@@ -7481,7 +7386,7 @@
       "client_side": "optional",
       "color": 12886909,
       "date_created": "2022-03-17T20:44:31.607662Z",
-      "date_modified": "2026-04-10T20:43:37.699241Z",
+      "date_modified": "2026-06-22T15:52:17.877231Z",
       "description": "Fixes Minecraft bugs found on the bug tracker",
       "discord_url": "https://short.isxander.dev/discord",
       "donation_urls": [
@@ -7491,8 +7396,8 @@
           "url": "https://patreon.com/isxander"
         }
       ],
-      "downloads": 26429032,
-      "followers": 3280,
+      "downloads": 28880468,
+      "followers": 3369,
       "game_versions": [
         "1.18.2",
         "1.19",
@@ -7517,7 +7422,8 @@
         "1.21.8",
         "1.21.10",
         "1.21.11",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/QwxR6Gcd/d16ec025a7f2d9908248bb4d1477e3e624a2f17f_96.webp",
       "issues_url": "https://github.com/isXander/Debugify/issues",
@@ -7540,28 +7446,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "1eAoo2KR",
-              "version_id": null
+              "project_id": "1eAoo2KR"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             }
           ],
-          "downloads": 338997,
+          "downloads": 760291,
           "file": {
             "filename": "debugify-1.21.11+1.1.jar",
             "hashes": {
-              "sha1": "a8852a320c6d1a448cfc0f7cb0369e0a3c858146",
               "sha512": "156732558bf7c6280c8cb59160fa3842a22da196c8dd3f6fba3ef8b07367c1c793a42e928ac9d53917e1d00e7cff7f72ae13f6e5f233bd32d0db31acd8b43cbd"
             },
             "primary": true,
@@ -7595,7 +7494,7 @@
       "client_side": "unsupported",
       "color": 3359981,
       "date_created": "2024-05-18T19:49:03.658085Z",
-      "date_modified": "2026-05-10T09:36:40.208463Z",
+      "date_modified": "2026-06-28T07:10:03.530965Z",
       "description": "A lightweight yet very powerful hologram plugin with many features and configuration options.",
       "discord_url": "https://discord.com/invite/dACsCAEZSd",
       "donation_urls": [
@@ -7605,8 +7504,8 @@
           "url": "https://ko-fi.com/d0by1"
         }
       ],
-      "downloads": 164242,
-      "followers": 212,
+      "downloads": 195276,
+      "followers": 228,
       "gallery": [
         {
           "created": "2024-05-18T20:58:44.694106Z",
@@ -7724,7 +7623,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/w02MKsTg/da26ff80e9bcd5646284c57dd06a57b2e4361027.png",
       "issues_url": "https://github.com/DecentSoftware-eu/DecentHolograms/issues",
@@ -7742,17 +7642,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-01T13:45:08.629864Z",
-          "downloads": 10538,
+          "date_published": "2026-06-28T07:10:03.530965Z",
+          "downloads": 1830,
           "file": {
-            "filename": "DecentHolograms-2.9.10.jar",
+            "filename": "DecentHolograms-2.10.1.jar",
             "hashes": {
-              "sha1": "0fc69abbb9f28b472bf8a4e679700a7fbc6dc794",
-              "sha512": "451ebac334583d58269cc276459dc499d15f9bf584eb7da97af229ea0be0bbbcd903cbe0c7fe4afe72e6744aa49180c944379279ac98a4963eb551d8a8dbc519"
+              "sha512": "4be371d0b2258eb6d255b14155a730f8bc5998eee826e5fed54d402a1b3e315e7c03941f3b654ef648d800f74911ef25355a0d370a85e3c062eba74aad1ed678"
             },
             "primary": true,
-            "size": 2427715,
-            "url": "https://cdn.modrinth.com/data/w02MKsTg/versions/t9gURTWO/DecentHolograms-2.9.10.jar"
+            "size": 3938139,
+            "url": "https://cdn.modrinth.com/data/w02MKsTg/versions/Fva1FgWm/DecentHolograms-2.10.1.jar"
           },
           "game_versions": [
             "1.8",
@@ -7827,16 +7726,17 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "t9gURTWO",
+          "id": "Fva1FgWm",
           "loaders": [
             "paper",
             "spigot"
           ],
-          "name": "DecentHolograms 2.9.10",
+          "name": "DecentHolograms 2.10.1",
           "project_id": "w02MKsTg",
-          "version_number": "2.9.10",
+          "version_number": "2.10.1",
           "version_type": "release"
         }
       },
@@ -7855,7 +7755,7 @@
       "client_side": "unsupported",
       "color": 11291833,
       "date_created": "2025-05-07T22:21:45.963916Z",
-      "date_modified": "2026-05-17T15:46:25.735857Z",
+      "date_modified": "2026-06-04T02:55:08.936584Z",
       "description": "The all-in-one hub management solution",
       "donation_urls": [
         {
@@ -7864,8 +7764,8 @@
           "url": "https://ko-fi.com/itzsave"
         }
       ],
-      "downloads": 94033,
-      "followers": 43,
+      "downloads": 103314,
+      "followers": 48,
       "game_versions": [
         "1.2.1",
         "1.2.2",
@@ -7917,27 +7817,18 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-17T15:46:25.735857Z",
-          "downloads": 833,
+          "date_published": "2026-06-04T02:55:08.936584Z",
+          "downloads": 5387,
           "file": {
-            "filename": "DeluxeHub-3.7.5.jar",
+            "filename": "DeluxeHub-3.8.0.jar",
             "hashes": {
-              "sha1": "32b5464a216541955e1d4d547687be2f5a50cba7",
-              "sha512": "6e7c52ea72cfe463be4e9611d80b3420bca9579bccdc5c4251b7f1e262764019c1613f4f4b366af93942836df96e84ac2994103d6572f8c3b744e1b3ddb17b34"
+              "sha512": "1625902d19aa00f2dc7852edeeefb4a6077e2b3f80f51deeb001877142ac5bb045eab5c79eb0a3f6031b5a74851150192b1120e5e5dac7873a8b4a7fa0cb8cb0"
             },
             "primary": true,
-            "size": 5409475,
-            "url": "https://cdn.modrinth.com/data/FiktZRzq/versions/rmzbBoYy/DeluxeHub-3.7.5.jar"
+            "size": 2162108,
+            "url": "https://cdn.modrinth.com/data/FiktZRzq/versions/E1BZjbCF/DeluxeHub-3.8.0.jar"
           },
           "game_versions": [
-            "1.19",
-            "1.19.1",
-            "1.19.2",
-            "1.19.3",
-            "1.19.4",
-            "1.20",
-            "1.20.1",
-            "1.20.2",
             "1.20.3",
             "1.20.4",
             "1.20.5",
@@ -7958,15 +7849,15 @@
             "26.1.1",
             "26.1.2"
           ],
-          "id": "rmzbBoYy",
+          "id": "E1BZjbCF",
           "loaders": [
             "folia",
             "paper",
             "spigot"
           ],
-          "name": "DeluxeHub 3.7.5",
+          "name": "DeluxeHub 3.8.0",
           "project_id": "FiktZRzq",
-          "version_number": "3.7.5",
+          "version_number": "3.8.0",
           "version_type": "release"
         }
       },
@@ -8003,8 +7894,8 @@
           "url": "https://scarsz.me/donate"
         }
       ],
-      "downloads": 430004,
-      "followers": 799,
+      "downloads": 455922,
+      "followers": 825,
       "game_versions": [
         "1.7.10",
         "1.8",
@@ -8079,7 +7970,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/UmLGoGij/icon.png",
       "issues_url": "https://github.com/DiscordSRV/DiscordSRV/issues",
@@ -8101,11 +7993,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-04-24T12:01:20.640408Z",
-          "downloads": 17904,
+          "downloads": 42233,
           "file": {
             "filename": "DiscordSRV-Build-1.30.5.jar",
             "hashes": {
-              "sha1": "cbe8f9803af8dba9728c5fa44f23ac993862211c",
               "sha512": "ef31c7dd8962c7f907bc37b6d762c0ebd1b52f20ff72bb2dd35edb0e354010c03d3eb4cafa8f7acec42aa5e91988814bd0c338a5bced06095c07a6b9b366505c"
             },
             "primary": true,
@@ -8186,7 +8077,8 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
           "id": "ATlquwiT",
           "loaders": [
@@ -8217,7 +8109,7 @@
       "client_side": "optional",
       "color": 3976252,
       "date_created": "2022-01-23T05:46:55.026356Z",
-      "date_modified": "2026-05-04T12:37:25.350035Z",
+      "date_modified": "2026-06-20T15:41:29.247639Z",
       "description": "See farther without turning your game into a slide show",
       "discord_url": "https://discord.gg/xAB8G4cENx",
       "donation_urls": [
@@ -8227,8 +8119,8 @@
           "url": "https://ko-fi.com/distanthorizons"
         }
       ],
-      "downloads": 24903264,
-      "followers": 12984,
+      "downloads": 28067869,
+      "followers": 13394,
       "gallery": [
         {
           "created": "2022-06-07T02:51:26.416185Z",
@@ -8359,6 +8251,7 @@
         }
       ],
       "game_versions": [
+        "1.12.2",
         "1.16.3",
         "1.16.4",
         "1.16.5",
@@ -8390,7 +8283,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/uCdwusMi/e716cda9bb568b5373ff76e363fb4c6d7278fba6_96.webp",
       "issues_url": "https://gitlab.com/distant-horizons-team/distant-horizons/-/issues",
@@ -8409,57 +8303,55 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-04T12:37:19.908971Z",
-          "downloads": 186006,
+          "date_published": "2026-06-20T15:41:15.738354Z",
+          "downloads": 103623,
           "file": {
-            "filename": "DistantHorizons-3.0.3-b-1.21.11-fabric-neoforge.jar",
+            "filename": "DistantHorizons-3.1.2-b-1.21.11-fabric-neoforge.jar",
             "hashes": {
-              "sha1": "e6c12f7b81711427038d8d9cc48e2acaa125bade",
-              "sha512": "0b23ac024c23cffdc6912e852c579857d9c1c200a4b769064f29882fdecf83442a43dd1b9cd6572f5358fa208c161a0823dcf6e3d32e535e57eeea42c38fc2a7"
+              "sha512": "c6f61eb05b838377ed5a6f22328ebbc2caff05ae6364ff84fa97c0038a9e8bbfab911b115b6d7bff7d4902ee8832681b1af3b695e0fa85971e1d63b8892984d1"
             },
             "primary": true,
-            "size": 30102067,
-            "url": "https://cdn.modrinth.com/data/uCdwusMi/versions/B1HnfKO7/DistantHorizons-3.0.3-b-1.21.11-fabric-neoforge.jar"
+            "size": 30129522,
+            "url": "https://cdn.modrinth.com/data/uCdwusMi/versions/WKoReI8f/DistantHorizons-3.1.2-b-1.21.11-fabric-neoforge.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "B1HnfKO7",
+          "id": "WKoReI8f",
           "loaders": [
             "fabric",
             "neoforge"
           ],
-          "name": "3.0.3-b - 1.21.11 neo/fabric",
+          "name": "3.1.2-b - 1.21.11 neo/fabric",
           "project_id": "uCdwusMi",
-          "version_number": "3.0.3-b-1.21.11",
+          "version_number": "3.1.2-b-1.21.11",
           "version_type": "beta"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-04T12:37:25.350035Z",
-          "downloads": 162827,
+          "date_published": "2026-06-20T15:41:23.331530Z",
+          "downloads": 65788,
           "file": {
-            "filename": "DistantHorizons-3.0.3-b-26.1.2-fabric-neoforge.jar",
+            "filename": "DistantHorizons-3.1.2-b-26.1.2-fabric-neoforge.jar",
             "hashes": {
-              "sha1": "1259087c28a2f8c91e99cc000fead0ecb944ab73",
-              "sha512": "11b252de3308d7299d34625ace65223d9c5d42e52a340bb9c85fa0250c0c354ad594b72f0a827d9d7c046b95dd17a5e500f93954f14d03da9fdac7596c41b514"
+              "sha512": "c3563d7ba3101ae577d46a3b418bca6f8a8c233130153dfe2ba58d62d72c4b99bb5137f26ba80fe0aaf39a4614e09ed32de40e287208ab873df0f0f984335342"
             },
             "primary": true,
-            "size": 29981704,
-            "url": "https://cdn.modrinth.com/data/uCdwusMi/versions/FJrLlu3p/DistantHorizons-3.0.3-b-26.1.2-fabric-neoforge.jar"
+            "size": 30169200,
+            "url": "https://cdn.modrinth.com/data/uCdwusMi/versions/SLJu35DT/DistantHorizons-3.1.2-b-26.1.2-fabric-neoforge.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
             "26.1.2"
           ],
-          "id": "FJrLlu3p",
+          "id": "SLJu35DT",
           "loaders": [
             "fabric",
             "neoforge"
           ],
-          "name": "3.0.3-b - 26.1.2 neo/fabric",
+          "name": "3.1.2-b - 26.1.2 neo/fabric",
           "project_id": "uCdwusMi",
-          "version_number": "3.0.3-b-26.1.2",
+          "version_number": "3.1.2-b-26.1.2",
           "version_type": "beta"
         }
       },
@@ -8470,149 +8362,23 @@
       "title": "Distant Horizons",
       "wiki_url": "https://gitlab.com/distant-horizons-team/distant-horizons/-/wikis/home"
     },
-    "do-a-barrel-roll": {
-      "categories": [
-        "equipment",
-        "transportation"
-      ],
-      "client_side": "required",
-      "color": 394501,
-      "date_created": "2022-08-22T16:00:39.121484Z",
-      "date_modified": "2026-04-10T21:04:20.087905Z",
-      "description": "Microsoft flight simulator for Minecraft elytras.",
-      "discord_url": "https://discord.gg/WcYsDDQtyR",
-      "downloads": 8713957,
-      "followers": 3765,
-      "gallery": [
-        {
-          "created": "2023-01-08T09:57:05.777262Z",
-          "featured": true,
-          "ordering": 0,
-          "title": "Modrinth banner",
-          "url": "https://cdn.modrinth.com/data/6FtRfnLg/images/1418c90eda78c13f39b7705feb806b1e64d81b2c_350.webp"
-        }
-      ],
-      "game_versions": [
-        "1.17.1",
-        "1.18.2",
-        "1.19",
-        "1.19.1",
-        "1.19.2",
-        "1.19.3",
-        "1.19.4",
-        "1.20",
-        "1.20.1",
-        "1.20.2",
-        "1.20.3",
-        "1.20.4",
-        "1.20.5",
-        "1.20.6",
-        "1.21",
-        "1.21.1",
-        "1.21.2",
-        "1.21.3",
-        "1.21.4",
-        "1.21.5",
-        "1.21.6",
-        "1.21.7",
-        "1.21.8",
-        "1.21.9",
-        "1.21.10",
-        "1.21.11",
-        "26.1",
-        "26.1.1",
-        "26.1.2"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/6FtRfnLg/adc87c81f55b75a07d29349452c1c8da0ad925a4_96.webp",
-      "issues_url": "https://codeberg.org/enjarai/do-a-barrel-roll/issues",
-      "license": {
-        "id": "GPL-3.0-only",
-        "name": "GNU General Public License v3.0 only",
-        "url": null
-      },
-      "loaders": [
-        "fabric",
-        "forge",
-        "neoforge"
-      ],
-      "page_url": "https://modrinth.com/mod/do-a-barrel-roll",
-      "project_id": "6FtRfnLg",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+fabric": {
-          "date_published": "2025-12-16T19:53:43.505584Z",
-          "dependencies": [
-            {
-              "dependency_type": "embedded",
-              "file_name": null,
-              "project_id": "K01OU20C",
-              "version_id": null
-            },
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
-            },
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "IwCkru1D",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "1eAoo2KR",
-              "version_id": null
-            }
-          ],
-          "downloads": 354159,
-          "file": {
-            "filename": "do_a_barrel_roll-fabric-3.8.3+1.21.11.jar",
-            "hashes": {
-              "sha1": "ab0719761474257b10a505f11cf68fe6ebd28440",
-              "sha512": "46a877167b0e5726e621b569b0ef7e9ded9787861419579b61e01e6d74cd148f09e41783ab0b2f3cc0de3f0eb9feacca1e4a02c84151afbeb1cd632945a3fdeb"
-            },
-            "primary": true,
-            "size": 485426,
-            "url": "https://cdn.modrinth.com/data/6FtRfnLg/versions/QyuEXDMC/do_a_barrel_roll-fabric-3.8.3%2B1.21.11.jar"
-          },
-          "game_versions": [
-            "1.21.11"
-          ],
-          "id": "QyuEXDMC",
-          "loaders": [
-            "fabric"
-          ],
-          "name": "3.8.3 for Fabric 1.21.11",
-          "project_id": "6FtRfnLg",
-          "version_number": "3.8.3+1.21.11-fabric",
-          "version_type": "release"
-        }
-      },
-      "server_side": "optional",
-      "slug": "do-a-barrel-roll",
-      "source": "modrinth",
-      "source_url": "https://codeberg.org/enjarai/do-a-barrel-roll",
-      "title": "Do a Barrel Roll"
-    },
     "drop-head": {
       "additional_categories": [
         "equipment"
       ],
       "categories": [
+        "decoration",
         "game-mechanics",
         "utility"
       ],
       "client_side": "optional",
       "color": 8739916,
       "date_created": "2024-07-09T02:53:32.278119Z",
-      "date_modified": "2026-03-24T20:41:59.209970Z",
+      "date_modified": "2026-06-16T22:20:07.367402Z",
       "description": "Drop a player's head when they die",
       "discord_url": "https://discord.gg/FVq3j5heAc",
-      "downloads": 101791,
-      "followers": 200,
+      "downloads": 113956,
+      "followers": 211,
       "gallery": [
         {
           "created": "2025-10-28T18:00:20.001990Z",
@@ -8672,7 +8438,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/glYcmYBi/98cba83002e55a594eb45fd09d587b49ec670871_96.webp",
       "license": {
@@ -8700,16 +8467,13 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "o2nO79dr",
-              "version_id": null
+              "project_id": "o2nO79dr"
             }
           ],
-          "downloads": 44067,
+          "downloads": 50682,
           "file": {
             "filename": "Drop Head 2.0.0 (1.14-1.21.1).jar",
             "hashes": {
-              "sha1": "1d641a6eabe192953ce2c45c31851de88f314d95",
               "sha512": "05994eb8614fd983670abff81c8a3866af389cfd97de0e15b8e93ac586506037605dee2c4d83665dc4689a9b1f07ce01bee07540ad06dca83e04a7c70138b2a0"
             },
             "primary": true,
@@ -8787,23 +8551,23 @@
       "client_side": "required",
       "color": 263172,
       "date_created": "2023-04-09T06:32:15.494329Z",
-      "date_modified": "2026-03-30T01:12:22.387407Z",
+      "date_modified": "2026-06-19T16:54:08.177437Z",
       "description": "Open a LAN server to anyone, anywhere, anytime.",
       "discord_url": "https://discord.gg/VuyEUz6Ews",
       "donation_urls": [
         {
-          "id": "patreon",
-          "platform": "Patreon",
-          "url": "https://patreon.com/skyevg"
-        },
-        {
           "id": "ko-fi",
           "platform": "Ko-fi",
           "url": "https://ko-fi.com/skyevg"
+        },
+        {
+          "id": "patreon",
+          "platform": "Patreon",
+          "url": "https://patreon.com/skyevg"
         }
       ],
-      "downloads": 16393939,
-      "followers": 3494,
+      "downloads": 18507467,
+      "followers": 3657,
       "game_versions": [
         "1.17",
         "1.17.1",
@@ -8837,9 +8601,10 @@
         "26.1-snapshot-9",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
-      "icon_url": "https://cdn.modrinth.com/data/qANg5Jrr/10d983cad2496eaa6fd7fe9af2b7454763bc97c9_96.webp",
+      "icon_url": "https://cdn.modrinth.com/data/qANg5Jrr/b2a7b56dadf51d104bfb315e5e8241515e346fae_96.webp",
       "issues_url": "https://github.com/vgskye/e4mc-minecraft-architectury/issues",
       "license": {
         "id": "MIT",
@@ -8857,31 +8622,26 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-03-30T01:12:22.387407Z",
+          "date_published": "2026-06-19T16:54:07.107707Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "tNmWwdI2",
-              "version_id": null
+              "project_id": "tNmWwdI2"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 354763,
+          "downloads": 54603,
           "file": {
-            "filename": "e4mc-fabric-6.1.0.jar",
+            "filename": "e4mc-fabric-6.2.0.jar",
             "hashes": {
-              "sha1": "005880b9620a609422ba5ec6d5048a4e5fead820",
-              "sha512": "70acb611cb523fb6bff231e214775b7882cb3c30cabdec29623799b04b3b10c08d9c451323d858b5bf18cbe09b7e6069ae922edb9165ac166766849969bdc3dc"
+              "sha512": "d1568fc9086706552edc5b292f776d6ec6267817c66027599d765fa34c84250f71765ff1a713c53c3a30ec40f3836ccf428e93319006798dadba455f39c881ed"
             },
             "primary": true,
-            "size": 646623,
-            "url": "https://cdn.modrinth.com/data/qANg5Jrr/versions/9QMfnrh4/e4mc-fabric-6.1.0.jar"
+            "size": 661711,
+            "url": "https://cdn.modrinth.com/data/qANg5Jrr/versions/pS69vPZg/e4mc-fabric-6.2.0.jar"
           },
           "game_versions": [
             "1.18",
@@ -8912,14 +8672,14 @@
             "1.21.10",
             "1.21.11"
           ],
-          "id": "9QMfnrh4",
+          "id": "pS69vPZg",
           "loaders": [
             "fabric",
             "quilt"
           ],
-          "name": "[Fabric] 6.1.0",
+          "name": "[Fabric] 6.2.0",
           "project_id": "qANg5Jrr",
-          "version_number": "6.1.0-fabric",
+          "version_number": "6.2.0-fabric",
           "version_type": "release"
         }
       },
@@ -8935,13 +8695,13 @@
         "game-mechanics"
       ],
       "client_side": "required",
-      "color": 3946299,
+      "color": 2893868,
       "date_created": "2022-09-29T10:28:24.834603Z",
-      "date_modified": "2026-05-01T22:06:25.151226Z",
-      "description": "Be ready for overhauled anvils! Items stay, better name tags, many tweaks!",
+      "date_modified": "2026-06-18T12:05:28.423604Z",
+      "description": "Overhauled anvils with stored items, fairer costs, and no more frustrating repair penalties.",
       "discord_url": "https://lunapixel.studio/discord",
-      "downloads": 12448989,
-      "followers": 2332,
+      "downloads": 13543843,
+      "followers": 2430,
       "gallery": [
         {
           "created": "2025-07-29T07:35:01.743413Z",
@@ -8971,9 +8731,10 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
-      "icon_url": "https://cdn.modrinth.com/data/OZBR5JT5/c317debbe36e008daa3a0af715adf615b365aa5c_96.webp",
+      "icon_url": "https://cdn.modrinth.com/data/OZBR5JT5/6d18be3377180e9afe80da0551934b29bdd2bacb_96.webp",
       "issues_url": "https://github.com/Fuzss/easyanvils/issues",
       "license": {
         "id": "MPL-2.0",
@@ -8994,28 +8755,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "ohNO6lps",
-              "version_id": null
+              "project_id": "QAGBst4M"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "QAGBst4M",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "ohNO6lps"
             }
           ],
-          "downloads": 175661,
+          "downloads": 222854,
           "file": {
             "filename": "EasyAnvils-v21.11.0-mc1.21.11-Fabric.jar",
             "hashes": {
-              "sha1": "497c960ead200122d54f5cdb710c393f16839aab",
               "sha512": "530217082476d85d0e307dd2a977eda85dcad044eea33700883ebbd7b399b04f39222cad2415d2585c039fa9bbb533730565de4b7ac0087c25fc3291f0cf0866"
             },
             "primary": true,
@@ -9048,11 +8802,11 @@
       "client_side": "required",
       "color": 13353132,
       "date_created": "2022-07-17T19:26:49.063522Z",
-      "date_modified": "2026-04-28T12:31:03.103561Z",
+      "date_modified": "2026-06-18T12:11:44.459032Z",
       "description": "Enchanting tables as they always should have been! Items stay after closing, and easy re-rolls.",
       "discord_url": "https://lunapixel.studio/discord",
-      "downloads": 10638919,
-      "followers": 2248,
+      "downloads": 11452061,
+      "followers": 2327,
       "gallery": [
         {
           "created": "2025-07-29T07:35:10.942832Z",
@@ -9083,7 +8837,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/9hx3AbJM/5387d7206ba13438d088d127845d255c1a79b9c2_96.webp",
       "issues_url": "https://github.com/Fuzss/easymagic/issues",
@@ -9106,28 +8861,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "QAGBst4M",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "ohNO6lps"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "ohNO6lps",
-              "version_id": null
+              "project_id": "QAGBst4M"
             }
           ],
-          "downloads": 196878,
+          "downloads": 231779,
           "file": {
             "filename": "EasyMagic-v21.11.0-mc1.21.11-Fabric.jar",
             "hashes": {
-              "sha1": "f6d4707a8e63b98eab1cca14b7f38e8d284d3dde",
               "sha512": "7b633dedece11c327e8964dfa03e82d17de3b648796ca3d72a45e5936e045758a1536bee7374a63a00e148e91af7f99ab4fef95218343a24d52e128e9d7846f8"
             },
             "primary": true,
@@ -9165,7 +8913,7 @@
       "client_side": "required",
       "color": 4102288,
       "date_created": "2021-02-08T16:49:41.567984Z",
-      "date_modified": "2026-04-26T02:45:28.574763Z",
+      "date_modified": "2026-06-27T17:01:14.226357Z",
       "description": "Create your own emotes in Minecraft.",
       "discord_url": "https://discord.com/invite/6NfdRuE",
       "donation_urls": [
@@ -9180,8 +8928,8 @@
           "url": "https://ko-fi.com/dima_dencep"
         }
       ],
-      "downloads": 5792694,
-      "followers": 2164,
+      "downloads": 6278609,
+      "followers": 2272,
       "game_versions": [
         "1.16.5",
         "1.17-rc2",
@@ -9211,7 +8959,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/pZ2wrerK/eed7e2c9851392e5879c7d7cb763f142f124e6d2_96.webp",
       "issues_url": "https://github.com/KosmX/emotes/issues",
@@ -9235,29 +8984,28 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-26T02:43:04.204865Z",
-          "downloads": 3502,
+          "date_published": "2026-06-27T14:41:35.415697Z",
+          "downloads": 429,
           "file": {
-            "filename": "emotecraft-paper-for-MC1.21.11-3.2.0-b.build.149.jar",
+            "filename": "emotecraft-paper-for-MC1.21.11-3.2.0-b.build.151.jar",
             "hashes": {
-              "sha1": "7c9216cd8f752b7f7b72032562a85f4d3c71eeb1",
-              "sha512": "ec17117e71de436519b24cf54f895adfc6ac6e305a9c01317cbf3aabc9512c05ce26dffee6c1e3a3c43325f3f8cf2cf057501529dbde522c6a252a740951408b"
+              "sha512": "fc943d3f9a74cde7168108ebba31827d34c5f8a1253f5ec401ca374b4261941761a33e6b2847bbbf55b4054d54db17c40c0f5ab42e7290f0b5a3100911cc81b6"
             },
             "primary": true,
-            "size": 1905676,
-            "url": "https://cdn.modrinth.com/data/pZ2wrerK/versions/UQFjrKP6/emotecraft-paper-for-MC1.21.11-3.2.0-b.build.149.jar"
+            "size": 1905925,
+            "url": "https://cdn.modrinth.com/data/pZ2wrerK/versions/bVXhMtrE/emotecraft-paper-for-MC1.21.11-3.2.0-b.build.151.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "UQFjrKP6",
+          "id": "bVXhMtrE",
           "loaders": [
             "folia",
             "paper"
           ],
-          "name": "3.2.0-b.build.149",
+          "name": "3.2.0-b.build.151",
           "project_id": "pZ2wrerK",
-          "version_number": "3.2.0-b.build.149+1.21.11-paper",
+          "version_number": "3.2.0-b.build.151+1.21.11-paper",
           "version_type": "beta"
         }
       },
@@ -9268,6 +9016,165 @@
       "title": "Emotecraft",
       "wiki_url": "https://docs.zigythebird.com/emotecraft"
     },
+    "enchantment-descriptions": {
+      "categories": [
+        "magic",
+        "utility"
+      ],
+      "client_side": "required",
+      "color": 987412,
+      "date_created": "2023-06-07T08:19:18.472915Z",
+      "date_modified": "2026-06-18T02:49:40.835242Z",
+      "description": "Provides a way to get enchantment descriptions from enchanted books.",
+      "downloads": 31256368,
+      "followers": 3200,
+      "gallery": [
+        {
+          "created": "2023-06-07T08:19:03.529946Z",
+          "description": "When you have JEI installed you will also be able to read tooltips in the information category of JEI.",
+          "featured": false,
+          "ordering": 0,
+          "title": "JEI Compatability: Descriptions",
+          "url": "https://cdn.modrinth.com/data/UVtY3ZAC/images/3b02bcdbb17979e1f8b7319b6c9bdd47c6dd75f7.png"
+        },
+        {
+          "created": "2023-06-07T08:19:03.529946Z",
+          "description": "When JEI is installed you can see additional enchantment information such as a list of all items that can be enchanted by a given enchantment. Hovering over the items will also tell you how to apply the enchantment to that item.",
+          "featured": false,
+          "ordering": 1,
+          "title": "JEI Compatability: Compatible Items",
+          "url": "https://cdn.modrinth.com/data/UVtY3ZAC/images/50947d58838df709ca9a644de8a7b50e2629c02d.png"
+        },
+        {
+          "created": "2023-06-07T08:19:03.529946Z",
+          "description": "A screenshot of what an enchantment description tooltip looks like.",
+          "featured": false,
+          "ordering": 2,
+          "title": "Tooltip",
+          "url": "https://cdn.modrinth.com/data/UVtY3ZAC/images/db91fc869a83a648ba2db9c5138ca3c2f5d9d800.png"
+        },
+        {
+          "created": "2023-06-07T08:19:03.529946Z",
+          "description": "This is what the tooltip looks like in game. ",
+          "featured": false,
+          "ordering": 3,
+          "title": "Tooltip Screenshot",
+          "url": "https://cdn.modrinth.com/data/UVtY3ZAC/images/299554495de03058faaea236cb07aa418c5086aa.png"
+        }
+      ],
+      "game_versions": [
+        "1.9.4",
+        "1.10.2",
+        "1.11.2",
+        "1.12",
+        "1.12.2",
+        "1.13.2",
+        "1.14.3",
+        "1.14.4",
+        "1.15",
+        "1.15.1",
+        "1.15.2",
+        "1.16.1",
+        "1.16.2",
+        "1.16.3",
+        "1.16.4",
+        "1.16.5",
+        "21w13a",
+        "21w14a",
+        "21w15a",
+        "1.17-rc2",
+        "1.17",
+        "1.17.1-pre2",
+        "1.17.1",
+        "1.18",
+        "1.18.1",
+        "1.18.2",
+        "22w14a",
+        "1.19",
+        "1.19.1",
+        "1.19.2",
+        "1.19.3",
+        "1.19.4",
+        "1.20",
+        "1.20.1",
+        "1.20.2",
+        "1.20.3",
+        "1.20.4",
+        "1.21.1",
+        "1.21.2",
+        "1.21.3",
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8",
+        "1.21.9",
+        "1.21.10",
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/UVtY3ZAC/1f857baf3d1f78e40343925176c084838c91a891_96.webp",
+      "issues_url": "https://github.com/Darkhax-Minecraft/Enchantment-Descriptions/issues",
+      "license": {
+        "id": "LGPL-2.1-only",
+        "name": "GNU Lesser General Public License v2.1 only",
+        "url": null
+      },
+      "loaders": [
+        "fabric",
+        "forge",
+        "neoforge",
+        "quilt"
+      ],
+      "page_url": "https://modrinth.com/mod/enchantment-descriptions",
+      "project_id": "UVtY3ZAC",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+fabric": {
+          "date_published": "2026-02-01T09:13:02.909841Z",
+          "dependencies": [
+            {
+              "dependency_type": "required",
+              "project_id": "P7dR8mSH"
+            },
+            {
+              "dependency_type": "required",
+              "project_id": "aaRl8GiW"
+            }
+          ],
+          "downloads": 284567,
+          "file": {
+            "filename": "enchdesc-fabric-1.21.11-21.11.1.jar",
+            "hashes": {
+              "sha512": "00586e94c17263ced18ca6b7c2f439f62e67c4f70f010374bde97924e8bf7a864e0634c09d1635cb24639b0e91f07eb02bf4cd36d3731249d6ff3d4831e7bcac"
+            },
+            "primary": true,
+            "size": 82178,
+            "url": "https://cdn.modrinth.com/data/UVtY3ZAC/versions/IiO55grZ/enchdesc-fabric-1.21.11-21.11.1.jar"
+          },
+          "game_versions": [
+            "1.21.11"
+          ],
+          "id": "IiO55grZ",
+          "loaders": [
+            "fabric",
+            "quilt"
+          ],
+          "name": "EnchantmentDescriptions-fabric-1.21.11-21.11.1",
+          "project_id": "UVtY3ZAC",
+          "version_number": "21.11.1",
+          "version_type": "release"
+        }
+      },
+      "server_side": "optional",
+      "slug": "enchantment-descriptions",
+      "source": "modrinth",
+      "source_url": "https://github.com/Darkhax-Minecraft/Enchantment-Descriptions",
+      "title": "Enchantment Descriptions"
+    },
     "enhancedvisuals": {
       "categories": [
         "adventure",
@@ -9276,7 +9183,7 @@
       "client_side": "required",
       "color": 1380653,
       "date_created": "2022-11-14T10:24:05.495352Z",
-      "date_modified": "2026-05-05T12:08:43.716104Z",
+      "date_modified": "2026-06-22T13:54:50.784334Z",
       "description": "Feel the pain!",
       "discord_url": "https://discord.gg/W9QM3fS",
       "donation_urls": [
@@ -9286,8 +9193,8 @@
           "url": "https://www.patreon.com/creativemd"
         }
       ],
-      "downloads": 12550192,
-      "followers": 804,
+      "downloads": 14354869,
+      "followers": 834,
       "gallery": [
         {
           "created": "2022-11-14T11:21:06.760426Z",
@@ -9323,7 +9230,8 @@
         "1.21.10",
         "1.21.11",
         "26.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/KjL0jE2w/94613d78601f0b6b0c6e95f8eddd7d58738ac449_96.webp",
       "issues_url": "https://github.com/CreativeMD/EnhancedVisuals/issues",
@@ -9346,22 +9254,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "OsZiaDHq"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "OsZiaDHq",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 27489,
+          "downloads": 49301,
           "file": {
             "filename": "EnhancedVisuals_FABRIC_v1.8.27_mc1.21.11.jar",
             "hashes": {
-              "sha1": "ea405151c02efc6c30b2b0b198ca89a33619337e",
               "sha512": "f421b8d7510c83a97c14fb05f87c6db246d65044eae57fb5acde4717816c8f116c173fde69258004af35e30f0fb9248463717821984cede309a5431e5aa01900"
             },
             "primary": true,
@@ -9387,6 +9290,419 @@
       "source_url": "https://github.com/CreativeMD/EnhancedVisuals",
       "title": "EnhancedVisuals"
     },
+    "essentialsx": {
+      "additional_categories": [
+        "game-mechanics",
+        "management",
+        "transportation"
+      ],
+      "categories": [
+        "economy",
+        "social",
+        "utility"
+      ],
+      "client_side": "unsupported",
+      "color": 15486809,
+      "date_created": "2022-08-14T20:25:21.385783Z",
+      "date_modified": "2026-05-31T15:05:35.376401Z",
+      "description": "The essential plugin suite for Paper and Spigot servers.",
+      "discord_url": "https://essentialsx.net/community.html",
+      "donation_urls": [
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/EssentialsX"
+        },
+        {
+          "id": "patreon",
+          "platform": "Patreon",
+          "url": "https://patreon.com/essentialsx"
+        }
+      ],
+      "downloads": 599626,
+      "followers": 731,
+      "gallery": [
+        {
+          "created": "2023-01-11T00:31:38.380380Z",
+          "description": "The `/editsign` command lets you edit each line of a sign, including adding RGB colours to your signs. It even lets you tab-complete the existing content for quick editing!",
+          "featured": false,
+          "ordering": 0,
+          "title": "/editsign command",
+          "url": "https://cdn.modrinth.com/data/hXiIvTyT/images/13f67ee7b9087ec9744de203383b6c3779a16e4a.png"
+        },
+        {
+          "created": "2023-01-11T00:39:06.929715Z",
+          "description": "EssentialsX's warp system lets servers create warp points for anyone to teleport to. One of many utility commands, /warpinfo lets you see where warps lead to!",
+          "featured": false,
+          "ordering": 11,
+          "title": "/warpinfo command",
+          "url": "https://cdn.modrinth.com/data/hXiIvTyT/images/bc1f5bd4844c4206bf1a3b3116e6630e1e32080b.png"
+        },
+        {
+          "created": "2023-01-11T00:32:46.538784Z",
+          "description": "EssentialsX's Discord addon lets you bridge between in-game chat and chat channels on your Discord server!",
+          "featured": false,
+          "ordering": 20,
+          "title": "Discord: chat bridge",
+          "url": "https://cdn.modrinth.com/data/hXiIvTyT/images/1dbf1010e091cc1510e7266f54a466e0f86c5052.gif"
+        },
+        {
+          "created": "2023-01-11T00:34:37.053729Z",
+          "description": "With EssentialsX Discord, you can also allow your players to send private messages to players from Discord, without needing to log into the server.",
+          "featured": false,
+          "ordering": 21,
+          "title": "Discord: private messages",
+          "url": "https://cdn.modrinth.com/data/hXiIvTyT/images/6ef3001810156286c4d7ba2b97cc91106639b649.gif"
+        },
+        {
+          "created": "2023-01-11T00:37:21.145737Z",
+          "description": "EssentialsX Discord even allows admins to run console commands straight from Discord! Not only that, but command responses are wrapped up neatly in a private command response, so you can run server commands without interrupting an ongoing conversation.",
+          "featured": false,
+          "ordering": 26,
+          "title": "Discord: running console commands",
+          "url": "https://cdn.modrinth.com/data/hXiIvTyT/images/305efb27d9275ed125a4e9cd4d2e64f179768e6f.gif"
+        }
+      ],
+      "game_versions": [
+        "1.8.8",
+        "1.8.9",
+        "1.9.4",
+        "1.10.2",
+        "1.11.2",
+        "1.12.2",
+        "1.13.2",
+        "1.14.4",
+        "1.15.2",
+        "1.16.5",
+        "1.17.1",
+        "1.18.2",
+        "1.19.2",
+        "1.19.4",
+        "1.20.1",
+        "1.20.6",
+        "1.21.4",
+        "1.21.5",
+        "1.21.8",
+        "1.21.11",
+        "26.1.2"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/hXiIvTyT/e621675be1d0421b43b65ab8082507532d937009_96.webp",
+      "issues_url": "https://github.com/EssentialsX/Essentials/issues",
+      "license": {
+        "id": "GPL-3.0-only",
+        "name": "GNU General Public License v3.0 only",
+        "url": null
+      },
+      "loaders": [
+        "bukkit",
+        "paper",
+        "spigot"
+      ],
+      "page_url": "https://modrinth.com/mod/essentialsx",
+      "project_id": "hXiIvTyT",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+paper": {
+          "date_published": "2026-05-31T15:05:35.376401Z",
+          "dependencies": [
+            {
+              "dependency_type": "optional",
+              "project_id": "Vebnzrzj"
+            }
+          ],
+          "downloads": 60342,
+          "file": {
+            "filename": "EssentialsX-2.22.0.jar",
+            "hashes": {
+              "sha512": "472ecf71924801723643ca6e1f9931297de5aa0874a544f8a719e2e2f7c81af81ef7bcbd38b6e43f0260a9dae6abe42c97907e70e2430e326ff8cff12ebd61cf"
+            },
+            "primary": true,
+            "size": 4861125,
+            "url": "https://cdn.modrinth.com/data/hXiIvTyT/versions/nY6VN1XH/EssentialsX-2.22.0.jar"
+          },
+          "game_versions": [
+            "1.8.8",
+            "1.8.9",
+            "1.9.4",
+            "1.10.2",
+            "1.11.2",
+            "1.12.2",
+            "1.13.2",
+            "1.14.4",
+            "1.15.2",
+            "1.16.5",
+            "1.17.1",
+            "1.18.2",
+            "1.19.4",
+            "1.20.6",
+            "1.21.11",
+            "26.1.2"
+          ],
+          "id": "nY6VN1XH",
+          "loaders": [
+            "bukkit",
+            "paper",
+            "spigot"
+          ],
+          "name": "2.22.0 - The Tiny Copper Mayhem Update",
+          "project_id": "hXiIvTyT",
+          "version_number": "2.22.0",
+          "version_type": "release"
+        }
+      },
+      "server_side": "required",
+      "slug": "essentialsx",
+      "source": "modrinth",
+      "source_url": "https://github.com/EssentialsX/Essentials/",
+      "title": "EssentialsX",
+      "wiki_url": "https://essentialsx.net/wiki/Home.html"
+    },
+    "essentialsx-chat-module": {
+      "additional_categories": [
+        "game-mechanics"
+      ],
+      "categories": [
+        "management",
+        "social",
+        "utility"
+      ],
+      "client_side": "unsupported",
+      "color": 15486809,
+      "date_created": "2025-03-22T21:21:37.130928Z",
+      "date_modified": "2026-05-31T15:13:43.688132Z",
+      "description": "The chat formatting module for EssentialsX. (requires main module)",
+      "discord_url": "https://essentialsx.net/community.html",
+      "donation_urls": [
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/EssentialsX"
+        },
+        {
+          "id": "patreon",
+          "platform": "Patreon",
+          "url": "https://patreon.com/essentialsx"
+        }
+      ],
+      "downloads": 149775,
+      "followers": 96,
+      "game_versions": [
+        "1.8.7",
+        "1.8.8",
+        "1.8.9",
+        "1.9.4",
+        "1.10.2",
+        "1.11.2",
+        "1.12.2",
+        "1.13.2",
+        "1.14.4",
+        "1.15.2",
+        "1.16.5",
+        "1.17.1",
+        "1.18.2",
+        "1.19.4",
+        "1.20.6",
+        "1.21.4",
+        "1.21.5",
+        "1.21.8",
+        "1.21.11",
+        "26.1.2"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/2qgyQbO1/166d29c94a97092b4fd65df498a55b59de5ab0c9_96.webp",
+      "issues_url": "https://github.com/EssentialsX/Essentials/issues",
+      "license": {
+        "id": "GPL-3.0-only",
+        "name": "GNU General Public License v3.0 only",
+        "url": null
+      },
+      "loaders": [
+        "bukkit",
+        "paper",
+        "spigot"
+      ],
+      "page_url": "https://modrinth.com/mod/essentialsx-chat-module",
+      "project_id": "2qgyQbO1",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+paper": {
+          "date_published": "2026-05-31T15:13:43.688132Z",
+          "dependencies": [
+            {
+              "dependency_type": "required",
+              "project_id": "hXiIvTyT"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "T6TZJYX4"
+            }
+          ],
+          "downloads": 16993,
+          "file": {
+            "filename": "EssentialsXChat-2.22.0.jar",
+            "hashes": {
+              "sha512": "93d60889a463475f2a7ce204115f8f0cfb4be0347e6c060774cd4734ec0ba036c5789b0eef183cca735069063698ae99301056556f0511fb8e80eb0545366cd1"
+            },
+            "primary": true,
+            "size": 21800,
+            "url": "https://cdn.modrinth.com/data/2qgyQbO1/versions/2k7YvKOk/EssentialsXChat-2.22.0.jar"
+          },
+          "game_versions": [
+            "1.8.8",
+            "1.8.9",
+            "1.9.4",
+            "1.10.2",
+            "1.11.2",
+            "1.12.2",
+            "1.13.2",
+            "1.14.4",
+            "1.15.2",
+            "1.16.5",
+            "1.17.1",
+            "1.18.2",
+            "1.19.4",
+            "1.20.6",
+            "1.21.11",
+            "26.1.2"
+          ],
+          "id": "2k7YvKOk",
+          "loaders": [
+            "bukkit",
+            "paper",
+            "spigot"
+          ],
+          "name": "Chat 2.22.0 - The Tiny Copper Mayhem Update",
+          "project_id": "2qgyQbO1",
+          "version_number": "2.22.0",
+          "version_type": "release"
+        }
+      },
+      "server_side": "required",
+      "slug": "essentialsx-chat-module",
+      "source": "modrinth",
+      "source_url": "https://github.com/EssentialsX/Essentials/",
+      "title": "EssentialsX Chat",
+      "wiki_url": "https://essentialsx.net/wiki/Home.html"
+    },
+    "essentialsx-spawn": {
+      "additional_categories": [
+        "adventure"
+      ],
+      "categories": [
+        "management",
+        "utility"
+      ],
+      "client_side": "unsupported",
+      "color": 15486809,
+      "date_created": "2025-03-22T21:44:58.483108Z",
+      "date_modified": "2026-05-31T15:19:04.781805Z",
+      "description": "The player spawning control module for EssentialsX. (requires main module)",
+      "discord_url": "https://essentialsx.net/community.html",
+      "donation_urls": [
+        {
+          "id": "patreon",
+          "platform": "Patreon",
+          "url": "https://patreon.com/essentialsx"
+        },
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/EssentialsX"
+        }
+      ],
+      "downloads": 128703,
+      "followers": 87,
+      "game_versions": [
+        "1.8.8",
+        "1.8.9",
+        "1.9.4",
+        "1.10.2",
+        "1.11.2",
+        "1.12.2",
+        "1.13.2",
+        "1.14.4",
+        "1.15.2",
+        "1.16.5",
+        "1.17.1",
+        "1.18.2",
+        "1.19.4",
+        "1.20.6",
+        "1.21.4",
+        "1.21.5",
+        "1.21.8",
+        "1.21.11",
+        "26.1.2"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/sYpvDxGJ/166d29c94a97092b4fd65df498a55b59de5ab0c9_96.webp",
+      "issues_url": "https://github.com/EssentialsX/Essentials/issues",
+      "license": {
+        "id": "GPL-3.0-only",
+        "name": "GNU General Public License v3.0 only",
+        "url": null
+      },
+      "loaders": [
+        "bukkit",
+        "paper",
+        "spigot"
+      ],
+      "page_url": "https://modrinth.com/mod/essentialsx-spawn",
+      "project_id": "sYpvDxGJ",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+paper": {
+          "date_published": "2026-05-31T15:19:04.781805Z",
+          "dependencies": [
+            {
+              "dependency_type": "required",
+              "project_id": "hXiIvTyT"
+            }
+          ],
+          "downloads": 15625,
+          "file": {
+            "filename": "EssentialsXSpawn-2.22.0.jar",
+            "hashes": {
+              "sha512": "7097478ec02bc46e1dce326520e7dd0cf38bcce0f7810c1c89cfcc2fef8a88a7dc27c5a946d1256abad589185c5015c615e2cb4eab181ea7362428fac581b964"
+            },
+            "primary": true,
+            "size": 18661,
+            "url": "https://cdn.modrinth.com/data/sYpvDxGJ/versions/lc5JHiNJ/EssentialsXSpawn-2.22.0.jar"
+          },
+          "game_versions": [
+            "1.8.8",
+            "1.8.9",
+            "1.9.4",
+            "1.10.2",
+            "1.11.2",
+            "1.12.2",
+            "1.13.2",
+            "1.14.4",
+            "1.15.2",
+            "1.16.5",
+            "1.17.1",
+            "1.18.2",
+            "1.19.4",
+            "1.20.6",
+            "1.21.11",
+            "26.1.2"
+          ],
+          "id": "lc5JHiNJ",
+          "loaders": [
+            "bukkit",
+            "paper",
+            "spigot"
+          ],
+          "name": "Spawn 2.22.0 - The Tiny Copper Mayhem Update",
+          "project_id": "sYpvDxGJ",
+          "version_number": "2.22.0",
+          "version_type": "release"
+        }
+      },
+      "server_side": "required",
+      "slug": "essentialsx-spawn",
+      "source": "modrinth",
+      "source_url": "https://github.com/EssentialsX/Essentials/",
+      "title": "EssentialsX Spawn",
+      "wiki_url": "https://essentialsx.net/wiki/Home.html"
+    },
     "executableitems": {
       "additional_categories": [
         "adventure",
@@ -9407,11 +9723,11 @@
       "client_side": "unsupported",
       "color": 1951480,
       "date_created": "2024-11-19T18:47:58.517307Z",
-      "date_modified": "2026-05-17T19:13:34.039793Z",
+      "date_modified": "2026-06-22T18:20:35.465588Z",
       "description": "Custom Items, ExecutableItems plugin allows you to fully customize every aspect of your items, and adding unique activators on your items !",
-      "discord_url": "https://discord.com/invite/TRmSwJaYNv",
-      "downloads": 99033,
-      "followers": 95,
+      "discord_url": "https://discord.gg/splugins",
+      "downloads": 110631,
+      "followers": 103,
       "game_versions": [
         "1.8",
         "1.8.1",
@@ -9485,7 +9801,6 @@
         "1.21.11"
       ],
       "icon_url": "https://cdn.modrinth.com/data/g8Zwnnmn/6dc7b0d3d2042e7b3e6ba897c22ec026fef26780_96.webp",
-      "issues_url": "https://discord.com/invite/TRmSwJaYNv",
       "license": {
         "id": "LicenseRef-All-Rights-Reserved",
         "name": "",
@@ -9503,17 +9818,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-17T19:13:34.039793Z",
-          "downloads": 1105,
+          "date_published": "2026-06-22T18:20:35.465588Z",
+          "downloads": 2182,
           "file": {
-            "filename": "ExecutableItems-7.26.5.17.jar",
+            "filename": "ExecutableItems-7.26.6.22.jar",
             "hashes": {
-              "sha1": "adb49fa75f48cdf977e592974c7a33bba2450f20",
-              "sha512": "67a12e11eadcc47f672e77ab39b68f69753a18fc6d4b373edcf738eb725740e7f4578c289b64a893d136ea5e93e879982d8eb32a38d96242ec691a831a8abadc"
+              "sha512": "8018c5863045c7d057cdb1b721a16e3bf68917041a821ebc77f98cbec22bcbb52aae8889fb2208096193c51b4635366151d6e39b835b505ecff9ca25be0d2d03"
             },
             "primary": true,
-            "size": 837103,
-            "url": "https://cdn.modrinth.com/data/g8Zwnnmn/versions/YzKhzwRI/ExecutableItems-7.26.5.17.jar"
+            "size": 837744,
+            "url": "https://cdn.modrinth.com/data/g8Zwnnmn/versions/Hc1gqccS/ExecutableItems-7.26.6.22.jar"
           },
           "game_versions": [
             "1.12",
@@ -9566,7 +9880,7 @@
             "1.21.10",
             "1.21.11"
           ],
-          "id": "YzKhzwRI",
+          "id": "Hc1gqccS",
           "loaders": [
             "bukkit",
             "folia",
@@ -9574,17 +9888,18 @@
             "purpur",
             "spigot"
           ],
-          "name": "7.26.5.17",
+          "name": "7.26.6.22",
           "project_id": "g8Zwnnmn",
-          "version_number": "7.26.5.17",
+          "version_number": "7.26.6.22",
           "version_type": "release"
         }
       },
       "server_side": "required",
       "slug": "executableitems",
       "source": "modrinth",
+      "source_url": "https://github.com/SPlugins",
       "title": "ExecutableItems",
-      "wiki_url": "https://docs.ssomar.com/executableitems/information-ei"
+      "wiki_url": "https://splugins.net"
     },
     "explorers-compass": {
       "additional_categories": [
@@ -9600,7 +9915,7 @@
       "client_side": "required",
       "color": 5329233,
       "date_created": "2023-09-10T20:55:20.397318Z",
-      "date_modified": "2026-04-09T21:17:39.778866Z",
+      "date_modified": "2026-06-17T01:42:47.140166Z",
       "description": "Allows you to locate structures anywhere in the world.",
       "donation_urls": [
         {
@@ -9609,8 +9924,8 @@
           "url": "https://www.paypal.com/donate/?business=46ZL2PNVP4XKE"
         }
       ],
-      "downloads": 8654436,
-      "followers": 1217,
+      "downloads": 9431499,
+      "followers": 1292,
       "gallery": [
         {
           "created": "2023-09-10T22:52:54.912687Z",
@@ -9652,7 +9967,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/RV1qfVQ8/8f36254e98a4caa95684fcf4dbe72c2264c98cfc.png",
       "issues_url": "https://github.com/MattCzyr/ExplorersCompass/issues",
@@ -9672,11 +9988,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-04-09T21:17:16.978642Z",
-          "downloads": 13687,
+          "downloads": 24017,
           "file": {
             "filename": "ExplorersCompass-1.21.11-2.5.1-fabric.jar",
             "hashes": {
-              "sha1": "5544f44c2ddc1986a80da582e6c9be450d6312a6",
               "sha512": "86771761605af0841f3277a4150847552266be1ffeb95544b4ae7d0137d864ba6cc8e8e74ea23c4b930e5c2bdfa0c73702ea3b1b7f67f3c5391864cf18d1e664"
             },
             "primary": true,
@@ -9709,11 +10024,11 @@
       "client_side": "optional",
       "color": 12367004,
       "date_created": "2021-01-22T11:04:41.419169Z",
-      "date_modified": "2026-05-19T09:03:05.750770Z",
+      "date_modified": "2026-06-30T15:29:38.261159Z",
       "description": "Lightweight and modular API providing common hooks and intercompatibility measures utilized by mods using the Fabric toolchain.",
       "discord_url": "https://discord.gg/v6v4pMv",
-      "downloads": 173266487,
-      "followers": 30821,
+      "downloads": 195219144,
+      "followers": 32380,
       "game_versions": [
         "18w49a",
         "18w50a",
@@ -10078,7 +10393,17 @@
         "26.2-snapshot-5",
         "26.2-snapshot-6",
         "26.2-snapshot-7",
-        "26.2-snapshot-8"
+        "26.2-snapshot-8",
+        "26.2-pre-1",
+        "26.2-pre-2",
+        "26.2-pre-3",
+        "26.2-pre-4",
+        "26.2-pre-5",
+        "26.2-pre-6",
+        "26.2-rc-1",
+        "26.2",
+        "26.3-snapshot-1",
+        "26.3-snapshot-2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/P7dR8mSH/icon.png",
       "issues_url": "https://github.com/FabricMC/fabric/issues",
@@ -10096,11 +10421,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-05-11T12:31:47.864964Z",
-          "downloads": 916827,
+          "downloads": 4272995,
           "file": {
             "filename": "fabric-api-0.141.4+1.21.11.jar",
             "hashes": {
-              "sha1": "13d3885dfec40313e2b3bf9ee639353272b9b48a",
               "sha512": "c092d48c6453bec3264f80f6a35bb334aba3112b5cd6c0e0b2676ce4d81e702cb1e522337f3a732348e757cc2226da3c601a314ae8766334f16af71a13bcc98d"
             },
             "primary": true,
@@ -10120,66 +10444,63 @@
           "version_type": "release"
         },
         "26.1.2+26.2-snapshot-5+fabric": {
-          "date_published": "2026-05-19T08:57:59.778705Z",
-          "downloads": 334931,
+          "date_published": "2026-06-22T17:25:46.239574Z",
+          "downloads": 484697,
           "file": {
-            "filename": "fabric-api-0.149.1+26.1.2.jar",
+            "filename": "fabric-api-0.153.0+26.1.2.jar",
             "hashes": {
-              "sha1": "f07ace934b02896a8b77727efd03ce2ad32dc5da",
-              "sha512": "47ffa18369260c88ea847f6694ccb431a5aa9051c64e8d361186a767bb762dd9fcfbf4742ac65505eb60862900a1a3f1490994e7435376607de811eab8be4461"
+              "sha512": "4e31da3c796714d25ca079e5277980c5439bb09dcad33d1224cccdfec6000b776ba5d16323a9c312682e773bddedae75aa697a7c0f4ad2b77b5b11ba679b480a"
             },
             "primary": true,
-            "size": 2493299,
-            "url": "https://cdn.modrinth.com/data/P7dR8mSH/versions/BLz7ETCw/fabric-api-0.149.1%2B26.1.2.jar"
+            "size": 2504357,
+            "url": "https://cdn.modrinth.com/data/P7dR8mSH/versions/WC1KT7Yg/fabric-api-0.153.0%2B26.1.2.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
             "26.1.2"
           ],
-          "id": "BLz7ETCw",
+          "id": "WC1KT7Yg",
           "loaders": [
             "fabric"
           ],
-          "name": "[26.1.2] Fabric API 0.149.1+26.1.2",
+          "name": "[26.1.2] Fabric API 0.153.0+26.1.2",
           "project_id": "P7dR8mSH",
-          "version_number": "0.149.1+26.1.2",
+          "version_number": "0.153.0+26.1.2",
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-19T08:57:59.778705Z",
-          "downloads": 334931,
+          "date_published": "2026-06-22T17:25:46.239574Z",
+          "downloads": 484697,
           "file": {
-            "filename": "fabric-api-0.149.1+26.1.2.jar",
+            "filename": "fabric-api-0.153.0+26.1.2.jar",
             "hashes": {
-              "sha1": "f07ace934b02896a8b77727efd03ce2ad32dc5da",
-              "sha512": "47ffa18369260c88ea847f6694ccb431a5aa9051c64e8d361186a767bb762dd9fcfbf4742ac65505eb60862900a1a3f1490994e7435376607de811eab8be4461"
+              "sha512": "4e31da3c796714d25ca079e5277980c5439bb09dcad33d1224cccdfec6000b776ba5d16323a9c312682e773bddedae75aa697a7c0f4ad2b77b5b11ba679b480a"
             },
             "primary": true,
-            "size": 2493299,
-            "url": "https://cdn.modrinth.com/data/P7dR8mSH/versions/BLz7ETCw/fabric-api-0.149.1%2B26.1.2.jar"
+            "size": 2504357,
+            "url": "https://cdn.modrinth.com/data/P7dR8mSH/versions/WC1KT7Yg/fabric-api-0.153.0%2B26.1.2.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
             "26.1.2"
           ],
-          "id": "BLz7ETCw",
+          "id": "WC1KT7Yg",
           "loaders": [
             "fabric"
           ],
-          "name": "[26.1.2] Fabric API 0.149.1+26.1.2",
+          "name": "[26.1.2] Fabric API 0.153.0+26.1.2",
           "project_id": "P7dR8mSH",
-          "version_number": "0.149.1+26.1.2",
+          "version_number": "0.153.0+26.1.2",
           "version_type": "release"
         },
         "26.2-snapshot-5+fabric": {
           "date_published": "2026-04-28T15:53:04.261964Z",
-          "downloads": 16825,
+          "downloads": 17555,
           "file": {
             "filename": "fabric-api-0.147.1+26.2.jar",
             "hashes": {
-              "sha1": "71c575f77d82e9cff97675191079efe6e9799f8e",
               "sha512": "5400cd5e1be5072c9daadc2d0e3817a60abb13c00ac103d169e653a1f84165d470b9052e6a003abdd18afc57d1a49f65f8cf85d5b3642d4bdc6843294c3ee51d"
             },
             "primary": true,
@@ -10213,11 +10534,11 @@
       "client_side": "optional",
       "color": 12328164,
       "date_created": "2021-08-25T19:14:27.159100Z",
-      "date_modified": "2026-04-24T07:48:19.118369Z",
+      "date_modified": "2026-06-03T10:40:44.954667Z",
       "description": "This is a mod that enables usage of the Kotlin programming language for Fabric mods.",
       "discord_url": "https://discord.gg/v6v4pMv",
-      "downloads": 81580386,
-      "followers": 10061,
+      "downloads": 91971597,
+      "followers": 10516,
       "game_versions": [
         "18w44a",
         "18w45a",
@@ -10454,7 +10775,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Ha28R6CL/72c3d74aeb665e45aea93a945a01474cbce3b7da_96.webp",
       "issues_url": "https://github.com/FabricMC/fabric-language-kotlin/issues",
@@ -10471,17 +10793,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-04-24T07:48:19.118369Z",
-          "downloads": 3025582,
+          "date_published": "2026-06-03T10:40:44.954667Z",
+          "downloads": 4329072,
           "file": {
-            "filename": "fabric-language-kotlin-1.13.11+kotlin.2.3.21.jar",
+            "filename": "fabric-language-kotlin-1.13.12+kotlin.2.4.0.jar",
             "hashes": {
-              "sha1": "b6190b247c557c493dc4204121744f289a1d1837",
-              "sha512": "fa5ed2613f7216999cc0c5ddc71906f082a32b52507d7160acbdcf0eb8de12993ba302e5afde6681d025008ecc66c7533fc0c21deb672ef681b2194fb9be4245"
+              "sha512": "ca238ee480dfb237062200fd300be493d022e0837b6998c15807e01488b2a30d5ba4731e5c6d05a5333719c8923a1cb84c06fd6fa45aa88ced492ddb5b40906f"
             },
             "primary": true,
-            "size": 7813444,
-            "url": "https://cdn.modrinth.com/data/Ha28R6CL/versions/2i87JpYj/fabric-language-kotlin-1.13.11%2Bkotlin.2.3.21.jar"
+            "size": 8076848,
+            "url": "https://cdn.modrinth.com/data/Ha28R6CL/versions/Pd0xrHCw/fabric-language-kotlin-1.13.12%2Bkotlin.2.4.0.jar"
           },
           "game_versions": [
             "1.14",
@@ -10529,15 +10850,16 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "2i87JpYj",
+          "id": "Pd0xrHCw",
           "loaders": [
             "fabric"
           ],
-          "name": "Fabric Language Kotlin 1.13.11+kotlin.2.3.21",
+          "name": "Fabric Language Kotlin 1.13.12+kotlin.2.4.0",
           "project_id": "Ha28R6CL",
-          "version_number": "1.13.11+kotlin.2.3.21",
+          "version_number": "1.13.12+kotlin.2.4.0",
           "version_type": "release"
         }
       },
@@ -10555,7 +10877,7 @@
       "client_side": "optional",
       "color": 394500,
       "date_created": "2021-01-11T19:27:26.315086Z",
-      "date_modified": "2026-05-22T19:01:37.359040Z",
+      "date_modified": "2026-06-19T06:40:59.082690Z",
       "description": "Break down your trees by only cutting one piece of it",
       "discord_url": "https://discord.gg/uXWsRftdy7",
       "donation_urls": [
@@ -10565,8 +10887,8 @@
           "url": "https://github.com/sponsors/RakSrinaNa"
         }
       ],
-      "downloads": 9623169,
-      "followers": 3985,
+      "downloads": 10572734,
+      "followers": 4167,
       "game_versions": [
         "1.16.5",
         "1.17",
@@ -10614,7 +10936,8 @@
         "26.1-snapshot-6",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Fb4jn8m6/02610e2f41e1a4ea06b36ad5034be2b3d03b8f88_96.webp",
       "issues_url": "https://github.com/RakambdaOrg/FallingTree/issues",
@@ -10637,28 +10960,21 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "9s6osm5g"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 333589,
+          "downloads": 452499,
           "file": {
             "filename": "FallingTree-1.21.11-1.21.11.3.jar",
             "hashes": {
-              "sha1": "9daded812605231a5e1e9461a6e04258d0424761",
               "sha512": "56b8b86846e65f9e070ee08af1baf0b8871ea5eb233a43961d0f937a6147f039eed44794a6b3661b4748e4da037e40aa48b903936960585b626bc9f5e9e308d9"
             },
             "primary": true,
@@ -10695,7 +11011,7 @@
       "client_side": "unsupported",
       "color": 15642410,
       "date_created": "2023-03-18T16:37:11.562416Z",
-      "date_modified": "2026-05-21T19:08:27.711240Z",
+      "date_modified": "2026-06-22T11:34:17.613486Z",
       "description": "Create fancy looking text, item or block holograms with the new 1.19.4 text display entities",
       "discord_url": "https://discord.gg/ZUgYCEJUEx",
       "donation_urls": [
@@ -10705,8 +11021,8 @@
           "url": "https://www.buymeacoffee.com/realoliver"
         }
       ],
-      "downloads": 208355,
-      "followers": 344,
+      "downloads": 239185,
+      "followers": 362,
       "gallery": [
         {
           "created": "2023-05-30T12:52:30.431691Z",
@@ -10779,7 +11095,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/5QNgOj66/cc884d7e7e8e5f2febaff17898b3a6af9397060e_96.webp",
       "issues_url": "https://github.com/FancyInnovations/FancyPlugins/issues",
@@ -10797,20 +11114,18 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-18T19:52:06.973920Z",
-          "downloads": 11981,
+          "date_published": "2026-06-16T15:32:37.575936Z",
+          "downloads": 5714,
           "file": {
-            "filename": "FancyHolograms-2.10.0.jar",
+            "filename": "FancyHolograms-2.11.0.jar",
             "hashes": {
-              "sha1": "db9d5d3b827fc6e39fc593b55ad4ee1f721c8da3",
-              "sha512": "fad647aa3184195efbb4d7ab969b4ea5a18da2a82c3af9743af97c41194155da292f05985bafd7324c009d0d6f612aab93308af80992473ad68875b34b921bee"
+              "sha512": "ef2817552f96ea2ebb5635df5b6049cd9f66b00761ae2ccd1deb721feff2470a9131b12e52d43862f6fb2663ae54d87cee063ec6aad5d09d1df283133641fbc9"
             },
             "primary": true,
-            "size": 1192682,
-            "url": "https://cdn.modrinth.com/data/5QNgOj66/versions/vAt0Yiv3/FancyHolograms-2.10.0.jar"
+            "size": 1168379,
+            "url": "https://cdn.modrinth.com/data/5QNgOj66/versions/VgbsP5NO/FancyHolograms-2.11.0.jar"
           },
           "game_versions": [
-            "1.21.4",
             "1.21.5",
             "1.21.6",
             "1.21.7",
@@ -10818,16 +11133,17 @@
             "1.21.9",
             "1.21.10",
             "1.21.11",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "vAt0Yiv3",
+          "id": "VgbsP5NO",
           "loaders": [
             "folia",
             "paper"
           ],
-          "name": "2.10.0",
+          "name": "2.11.0",
           "project_id": "5QNgOj66",
-          "version_number": "2.10.0",
+          "version_number": "2.11.0",
           "version_type": "release"
         }
       },
@@ -10845,7 +11161,7 @@
       "client_side": "required",
       "color": 12780765,
       "date_created": "2022-11-23T22:38:44.903503Z",
-      "date_modified": "2026-05-15T18:36:15.198001Z",
+      "date_modified": "2026-06-28T09:26:47.430695Z",
       "description": "Customize Minecraft's menus with ease!",
       "discord_url": "https://discord.gg/rhayah27GC",
       "donation_urls": [
@@ -10860,8 +11176,8 @@
           "url": "https://www.patreon.com/keksuccino"
         }
       ],
-      "downloads": 46454601,
-      "followers": 1754,
+      "downloads": 51614020,
+      "followers": 1825,
       "gallery": [
         {
           "created": "2024-03-18T05:36:59.302729Z",
@@ -10971,7 +11287,8 @@
         "1.21.10",
         "1.21.11",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Wq5SjeWM/e4e82d028244a1326e6d346bf5b5336140576bb9_96.webp",
       "issues_url": "https://github.com/Keksuccino/FancyMenu/issues",
@@ -10990,48 +11307,41 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-14T20:32:50.965939Z",
+          "date_published": "2026-06-28T06:13:05.319077Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "CVT4pFB2",
-              "version_id": null
+              "project_id": "CVT4pFB2"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "J81TRJWm",
-              "version_id": null
+              "project_id": "J81TRJWm"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 12956,
+          "downloads": 5758,
           "file": {
-            "filename": "fancymenu_fabric_3.9.1_MC_1.21.11.jar",
+            "filename": "fancymenu_fabric_3.9.6_MC_1.21.11.jar",
             "hashes": {
-              "sha1": "6088dfa3d0f37acf3003321b3e6fcdeaa9a80af4",
-              "sha512": "3a8d62e5b89f6852bc42d4f6493e2916984c1317bd39642a0431b593c22b8a29f6e81f1c88f822b4990982fa011c792c79c9bacf68a33b43f8f1b69ac17079dd"
+              "sha512": "bb9e32d9102e69b3bbb483adbec4b1e33f48e5ca08e79b11cd0e6431b08bc479f19f32c29fbae2dcb12b5a9591972b80df2dcc5091f7397bf3f400e4d342a3be"
             },
             "primary": true,
-            "size": 25668026,
-            "url": "https://cdn.modrinth.com/data/Wq5SjeWM/versions/vKTyaZIK/fancymenu_fabric_3.9.1_MC_1.21.11.jar"
+            "size": 25676643,
+            "url": "https://cdn.modrinth.com/data/Wq5SjeWM/versions/UvucrFQM/fancymenu_fabric_3.9.6_MC_1.21.11.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "vKTyaZIK",
+          "id": "UvucrFQM",
           "loaders": [
             "fabric"
           ],
-          "name": "[Fabric] v3.9.1 MC 1.21.11",
+          "name": "[Fabric] v3.9.6 MC 1.21.11",
           "project_id": "Wq5SjeWM",
-          "version_number": "3.9.1-1.21.11-fabric",
+          "version_number": "3.9.6-1.21.11-fabric",
           "version_type": "release"
         }
       },
@@ -11054,7 +11364,7 @@
       "client_side": "unsupported",
       "color": 6560780,
       "date_created": "2023-02-12T14:13:27.163850Z",
-      "date_modified": "2026-05-21T19:08:20.211492Z",
+      "date_modified": "2026-06-23T07:50:33.763991Z",
       "description": "Simple, lightweight and fast NPC plugin using packets",
       "discord_url": "https://discord.gg/ZUgYCEJUEx",
       "donation_urls": [
@@ -11064,8 +11374,8 @@
           "url": "https://www.buymeacoffee.com/realoliver"
         }
       ],
-      "downloads": 294540,
-      "followers": 469,
+      "downloads": 339404,
+      "followers": 496,
       "gallery": [
         {
           "created": "2024-05-29T18:58:53.905336Z",
@@ -11160,7 +11470,9 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2-rc-2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/EeyAn23L/36f54e5fe22b6d6c23a72ebd589f78531e3ced51_96.webp",
       "issues_url": "https://github.com/FancyInnovations/FancyPlugins/issues",
@@ -11178,20 +11490,18 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-18T19:45:38.001778Z",
-          "downloads": 16118,
+          "date_published": "2026-06-16T15:32:37.003940Z",
+          "downloads": 9669,
           "file": {
-            "filename": "FancyNpcs-2.10.0.jar",
+            "filename": "FancyNpcs-2.11.0.jar",
             "hashes": {
-              "sha1": "c075b51f9b9dc5ebac162685b71e25c59d4727d5",
-              "sha512": "96392f5314d1bbb6426407cab533afbc032fa3fef0b4f7509fdbc1afbd90766eab62bdf444c98e49a99e82326154878f8cf603a1e2db4335fb3b94b282fc2ca8"
+              "sha512": "e275e9349d9357280438189487b121057c1b98b9b074a3a20a9ffc55f5903397c22443ac83cdc704a0acdb120e9a8ef54dccf73b4eef6349f39b2babad35b907"
             },
             "primary": true,
-            "size": 6680768,
-            "url": "https://cdn.modrinth.com/data/EeyAn23L/versions/9dy6tkBa/FancyNpcs-2.10.0.jar"
+            "size": 6588150,
+            "url": "https://cdn.modrinth.com/data/EeyAn23L/versions/zM6uZoPe/FancyNpcs-2.11.0.jar"
           },
           "game_versions": [
-            "1.21.4",
             "1.21.5",
             "1.21.6",
             "1.21.7",
@@ -11199,16 +11509,17 @@
             "1.21.9",
             "1.21.10",
             "1.21.11",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "9dy6tkBa",
+          "id": "zM6uZoPe",
           "loaders": [
             "folia",
             "paper"
           ],
-          "name": "2.10.0",
+          "name": "2.11.0",
           "project_id": "EeyAn23L",
-          "version_number": "2.10.0",
+          "version_number": "2.11.0",
           "version_type": "release"
         }
       },
@@ -11228,11 +11539,11 @@
       "client_side": "required",
       "color": 12887681,
       "date_created": "2024-03-27T01:59:37.106681Z",
-      "date_modified": "2026-05-16T05:11:32.339525Z",
+      "date_modified": "2026-06-25T19:22:26.749366Z",
       "description": "Modern Fabric port of the cooking and farming mod, \"Farmer's Delight\"",
       "discord_url": "https://discord.gg/qdKRTDf8Cv",
-      "downloads": 11159408,
-      "followers": 2559,
+      "downloads": 12455352,
+      "followers": 2773,
       "game_versions": [
         "1.20",
         "1.20.1",
@@ -11256,7 +11567,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/7vxePowz/26e8448993e9bda4dba92b6e7a1a13d9c4333138.png",
       "issues_url": "https://github.com/MehVahdJukaar/FarmersDelight/issues",
@@ -11277,28 +11589,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "u6dRKJwZ",
-              "version_id": null
+              "project_id": "5VolwT6c"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "5VolwT6c",
-              "version_id": null
+              "project_id": "u6dRKJwZ"
             }
           ],
-          "downloads": 194612,
+          "downloads": 258541,
           "file": {
             "filename": "FarmersDelight-1.21.11-3.4.9+refabricated.jar",
             "hashes": {
-              "sha1": "7c51a74bed32f4c55a22cc87690109c9379c682e",
               "sha512": "732255187fdb84f71a5e22cb331d068a1a513e51c90e5970f2d31c424973dda3c2c16da49b02df582e23f5af9b8080bef79ef8e627b8ede6ddfcaddccaf245da"
             },
             "primary": true,
@@ -11336,7 +11641,7 @@
       ],
       "client_side": "unsupported",
       "date_created": "2022-10-02T17:09:28.095757Z",
-      "date_modified": "2026-01-10T16:30:25.952585Z",
+      "date_modified": "2026-06-04T10:29:22.567871Z",
       "description": "Blazingly fast world manipulation for artists, builders and everyone else",
       "discord_url": "https://discord.gg/intellectualsites",
       "donation_urls": [
@@ -11346,8 +11651,8 @@
           "url": "https://github.com/sponsors/IntellectualSites"
         }
       ],
-      "downloads": 360516,
-      "followers": 507,
+      "downloads": 410891,
+      "followers": 532,
       "gallery": [
         {
           "created": "2023-08-18T12:05:28.868143Z",
@@ -11384,7 +11689,10 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/z4HZZnLr/1dab3e5596f37ade9a65f3587254ff61a9cf3c43.svg",
       "issues_url": "https://github.com/IntellectualSites/FastAsyncWorldEdit/issues",
@@ -11404,20 +11712,18 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-01-10T16:30:25.452842Z",
-          "downloads": 58391,
+          "date_published": "2026-06-04T10:29:15.182428Z",
+          "downloads": 20797,
           "file": {
-            "filename": "FastAsyncWorldEdit-Paper-2.15.0.jar",
+            "filename": "FastAsyncWorldEdit-Paper-2.15.2.jar",
             "hashes": {
-              "sha1": "c266c8fcaf877dac05fe7f6692b21fee4e83bbfe",
-              "sha512": "353cfb54600b90c5c30595e3357f680ec851319bcf95427b5ca319df4feee7b2b074f230b5b16a3d3f7dbd6d9ecc89b8e21941f645f1df08292c2dffa406db26"
+              "sha512": "d0114059318222187d484a2efa88c74a6997901e66cbfaeb870a671892bb6b39d75c604e7adc098c62e52357fdb99be1659fa4e33583f99a8c428f185390b19e"
             },
             "primary": true,
-            "size": 15064053,
-            "url": "https://cdn.modrinth.com/data/z4HZZnLr/versions/mHtmqIig/FastAsyncWorldEdit-Paper-2.15.0.jar"
+            "size": 14583468,
+            "url": "https://cdn.modrinth.com/data/z4HZZnLr/versions/tG0Vfeqx/FastAsyncWorldEdit-Paper-2.15.2.jar"
           },
           "game_versions": [
-            "1.20.6",
             "1.21.1",
             "1.21.4",
             "1.21.5",
@@ -11426,15 +11732,18 @@
             "1.21.8",
             "1.21.9",
             "1.21.10",
-            "1.21.11"
+            "1.21.11",
+            "26.1",
+            "26.1.1",
+            "26.1.2"
           ],
-          "id": "mHtmqIig",
+          "id": "tG0Vfeqx",
           "loaders": [
             "paper"
           ],
-          "name": "2.15.0",
+          "name": "2.15.2",
           "project_id": "z4HZZnLr",
-          "version_number": "2.15.0",
+          "version_number": "2.15.2",
           "version_type": "release"
         }
       },
@@ -11455,8 +11764,8 @@
       "date_created": "2021-04-03T07:04:43.971189Z",
       "date_modified": "2026-03-24T18:31:50.491773Z",
       "description": "Memory usage optimizations",
-      "downloads": 111046225,
-      "followers": 14352,
+      "downloads": 122617526,
+      "followers": 15075,
       "game_versions": [
         "1.16.5",
         "1.17",
@@ -11488,7 +11797,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/uXXizFIs/222a126f26f8f9ae1eb339f3b767677f18bff31f_96.webp",
       "issues_url": "https://github.com/malte0811/FerriteCore/issues",
@@ -11509,11 +11819,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-01-25T14:07:55.210010Z",
-          "downloads": 5340711,
+          "downloads": 7014585,
           "file": {
             "filename": "ferritecore-8.2.0-fabric.jar",
             "hashes": {
-              "sha1": "c2e2f5e008f5bc9f401dfad8ca94909917006b65",
               "sha512": "3210926a82eb32efd9bcebabe2f6c053daf5c4337eebc6d5bacba96d283510afbde646e7e195751de795ec70a2ea44fef77cb54bf22c8e57bb832d6217418869"
             },
             "primary": true,
@@ -11534,11 +11843,10 @@
         },
         "26.1.2+fabric": {
           "date_published": "2026-03-24T18:31:50.491773Z",
-          "downloads": 2051361,
+          "downloads": 4329588,
           "file": {
             "filename": "ferritecore-9.0.0-fabric.jar",
             "hashes": {
-              "sha1": "eac76ff0f3753422c61b2c44487d0d195d88d4bc",
               "sha512": "d81fa97e11784c19d42f89c2f433831d007603dd7193cee45fa177e4a6a9c52b384b198586e04a0f7f63cd996fed713322578bde9a8db57e1188854ae5cbe584"
             },
             "primary": true,
@@ -11548,7 +11856,8 @@
           "game_versions": [
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
           "id": "d5ddUdiB",
           "loaders": [
@@ -11567,13 +11876,16 @@
       "title": "FerriteCore"
     },
     "fokusapi": {
+      "categories": [
+        "library"
+      ],
       "client_side": "optional",
       "color": 5534852,
       "date_created": "2025-02-05T11:44:16.858182Z",
-      "date_modified": "2026-05-02T14:11:32.715948Z",
+      "date_modified": "2026-06-06T13:28:19.611086Z",
       "description": "> Fokus / Focus API - Library for CoffeeG's datapack/mod/plugin.",
-      "downloads": 112072,
-      "followers": 45,
+      "downloads": 125064,
+      "followers": 46,
       "game_versions": [
         "1.13",
         "1.13.1",
@@ -11648,17 +11960,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-02T14:11:32.715948Z",
-          "downloads": 869,
+          "date_published": "2026-06-06T13:28:19.611086Z",
+          "downloads": 1619,
           "file": {
-            "filename": "FokusAPI-4.2.jar",
+            "filename": "FokusAPI-4.4.jar",
             "hashes": {
-              "sha1": "07ba24b94683cd7717069671428998a17c6214b2",
-              "sha512": "2202cc21aa3376e770736b0bffe07f2b113b06660b01dbadd49c3a71a58d0453884f237a5388fd9301fcfcb01dc25e708773aeda86fc04fa0b6c60143dfee427"
+              "sha512": "7edbbd031c6f11faf44afd2731805657c507a6a97517e5e23fa8dd5d2c94ff1f400d7190c05d0086af0b7d726d893de6e6cda2a1a1b6330558b7dbc71bb5decd"
             },
             "primary": true,
-            "size": 5057,
-            "url": "https://cdn.modrinth.com/data/rvZnCrhx/versions/VqKppO1e/FokusAPI-4.2.jar"
+            "size": 5023,
+            "url": "https://cdn.modrinth.com/data/rvZnCrhx/versions/Qg0mVnrz/FokusAPI-4.4.jar"
           },
           "game_versions": [
             "1.14",
@@ -11708,16 +12019,16 @@
             "26.1.1",
             "26.1.2"
           ],
-          "id": "VqKppO1e",
+          "id": "Qg0mVnrz",
           "loaders": [
             "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "4.2 - Plugin",
+          "name": "4.4 - Plugin",
           "project_id": "rvZnCrhx",
-          "version_number": "4.2",
+          "version_number": "4.4",
           "version_type": "release"
         }
       },
@@ -11733,11 +12044,11 @@
       "client_side": "optional",
       "color": 11377989,
       "date_created": "2021-12-03T10:23:02.288424Z",
-      "date_modified": "2026-04-26T09:45:54.899024Z",
+      "date_modified": "2026-06-21T09:19:05.384665Z",
       "description": "NeoForge's & Forge's config systems provided to other modding ecosystems. Designed for a multiloader architecture.",
       "discord_url": "https://lunapixel.studio/discord",
-      "downloads": 47956614,
-      "followers": 4433,
+      "downloads": 52711504,
+      "followers": 4678,
       "gallery": [
         {
           "created": "2025-07-29T07:36:37.128156Z",
@@ -11781,7 +12092,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/ohNO6lps/cb3b942cc18a66a0f35f802e004713f134e46cc2_96.webp",
       "issues_url": "https://github.com/Fuzss/forgeconfigapiport/issues",
@@ -11804,22 +12116,17 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 4595976,
+          "downloads": 5399945,
           "file": {
             "filename": "ForgeConfigAPIPort-v21.11.1-mc1.21.11-Fabric.jar",
             "hashes": {
-              "sha1": "61aa1b5fafd75afc44552d0213cac39bc938bc2d",
               "sha512": "28791c992d613da14b8685505d3ef632ed53b5f1e1d517f0b41677d10f8419f192dfbde991308df6cda5d0f113c0aa8fc18ecf4a0834029403b16d2f68dc52d6"
             },
             "primary": true,
@@ -11857,8 +12164,8 @@
       "date_created": "2022-08-15T22:17:51.457470Z",
       "date_modified": "2026-05-04T03:02:37.443799Z",
       "description": "Liberate your server from the chat-reporting bourgeoisie! The best paper chat report disabler this side of the Mississippi",
-      "downloads": 105011,
-      "followers": 357,
+      "downloads": 111881,
+      "followers": 361,
       "game_versions": [
         "1.19.1",
         "1.19.2",
@@ -11903,11 +12210,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2025-12-22T20:57:50.828683Z",
-          "downloads": 8810,
+          "downloads": 9843,
           "file": {
             "filename": "FreedomChat-Paper-1.7.7.jar",
             "hashes": {
-              "sha1": "59bad5a3f067a257db4b68856f98af40938e111b",
               "sha512": "cd4df8be9b422d55bd8fffe3bfbcac9c75315685183b3cb5976ed5b1531f18a527776fc78ed931d037001e177840c0a4264d6a79abefabaddbbd181ebd7756c8"
             },
             "primary": true,
@@ -11943,7 +12249,7 @@
       "client_side": "required",
       "color": 8597257,
       "date_created": "2021-11-30T18:51:56.671504Z",
-      "date_modified": "2026-04-25T17:52:35.857638Z",
+      "date_modified": "2026-06-22T07:13:09.277142Z",
       "description": "Adds outvoted and forgotten mobs from the mob vote, expanding on their original concepts and adding new vanilla-like features. The mod includes: Copper Golem, Crab, Glare, Moobloom, Iceologer, Rascal, Tuff Golem, Wildfire, Illusioner, Zombie Horse",
       "discord_url": "https://discord.com/invite/QGwFvvMQCn",
       "donation_urls": [
@@ -11958,8 +12264,8 @@
           "url": "https://www.patreon.com/Faboslav"
         }
       ],
-      "downloads": 8889534,
-      "followers": 2522,
+      "downloads": 9636575,
+      "followers": 2643,
       "gallery": [
         {
           "created": "2024-09-29T11:44:40.916469Z",
@@ -12166,7 +12472,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/POQ2i9zu/0d5db692d86ca2f99935ebc01123d4c55a714122_96.webp",
       "issues_url": "https://github.com/Faboslav/friends-and-foes/issues",
@@ -12184,55 +12491,46 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-04-25T17:52:02.550102Z",
+          "date_published": "2026-05-27T14:23:57.821571Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "1eAoo2KR",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "1eAoo2KR"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "G1hIVOrD",
-              "version_id": null
+              "project_id": "G1hIVOrD"
             }
           ],
-          "downloads": 13160,
+          "downloads": 16103,
           "file": {
-            "filename": "friendsandfoes-fabric-4.0.25+mc1.21.11.jar",
+            "filename": "friendsandfoes-fabric-4.0.26+mc1.21.11.jar",
             "hashes": {
-              "sha1": "9c145da623e971acb244e34a21a876466130c1ea",
-              "sha512": "76045d1c60fef5f0711e39b0cf25402ca6adf4d7a63352ce0df2f949ebefd6cc68309189571b0c33352e904ba040cb2e08def4c3820f646c5829d819683963ca"
+              "sha512": "3f77d4025925cc0ccc5b9595f397e3592189a42a2135a08184af36e956b70f6cb0f13fc0ddf55b829daf103bf8f8ffb116e316e9723e5f7c69fb72b4d63e78fa"
             },
             "primary": true,
-            "size": 4397961,
-            "url": "https://cdn.modrinth.com/data/POQ2i9zu/versions/3RPbOceI/friendsandfoes-fabric-4.0.25%2Bmc1.21.11.jar"
+            "size": 4401500,
+            "url": "https://cdn.modrinth.com/data/POQ2i9zu/versions/Um3yVAYr/friendsandfoes-fabric-4.0.26%2Bmc1.21.11.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "3RPbOceI",
+          "id": "Um3yVAYr",
           "loaders": [
             "fabric",
             "quilt"
           ],
-          "name": "Friends&Foes 4.0.25",
+          "name": "Friends&Foes 4.0.26",
           "project_id": "POQ2i9zu",
-          "version_number": "fabric-4.0.25+mc1.21.11",
+          "version_number": "fabric-4.0.26+mc1.21.11",
           "version_type": "release"
         }
       },
@@ -12255,7 +12553,7 @@
       "client_side": "required",
       "color": 3158103,
       "date_created": "2024-04-19T17:14:53.663062Z",
-      "date_modified": "2026-03-24T22:23:35.693946Z",
+      "date_modified": "2026-06-16T22:50:12.582734Z",
       "description": "Config API with automatic GUIs, powerful validation options, server-client sync, and more!",
       "discord_url": "https://discord.gg/zDbaYmUba2",
       "donation_urls": [
@@ -12265,8 +12563,8 @@
           "url": "https://ko-fi.com/fzzyhmstrs"
         }
       ],
-      "downloads": 24644375,
-      "followers": 1243,
+      "downloads": 28615617,
+      "followers": 1357,
       "gallery": [
         {
           "created": "2024-04-19T17:33:52.054733Z",
@@ -12358,7 +12656,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/hYykXjDp/11f469b1bf1f201a95c2e3ddc09ca47d85c3ed53.png",
       "issues_url": "https://github.com/fzzyhmstrs/fconfig/issues",
@@ -12382,22 +12681,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "Ha28R6CL",
-              "version_id": null
+              "project_id": "Ha28R6CL"
             }
           ],
-          "downloads": 1106901,
+          "downloads": 1674431,
           "file": {
             "filename": "fzzy_config-0.7.6+1.21.11.jar",
             "hashes": {
-              "sha1": "9b064c8bd1d6414549f6a1adcadf678ffa0c96c8",
               "sha512": "cdd43ee1ae99838b05b87d186ee8c3c051fda1388456d5ca88bb03e8e445722421cb6b8f9c9a6c4bd0f111ddccf526a8373d7c3cab5edd0f5da1190a787bdf88"
             },
             "primary": true,
@@ -12434,11 +12728,11 @@
       "client_side": "required",
       "color": 287848,
       "date_created": "2022-08-07T03:30:16.186586Z",
-      "date_modified": "2026-04-12T03:22:22.258120Z",
+      "date_modified": "2026-06-27T05:30:18.670760Z",
       "description": "A 3D animation library for entities, blocks, items, armor, and more!",
       "discord_url": "https://discord.gg/pPEqBgJtZW",
-      "downloads": 49163402,
-      "followers": 2853,
+      "downloads": 54739947,
+      "followers": 3034,
       "gallery": [
         {
           "created": "2024-09-17T10:40:35.846436Z",
@@ -12480,7 +12774,8 @@
         "1.21.10",
         "1.21.11",
         "26.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/8BmcQJ2H/012d1aadbc754995de66e8c149a56aa10b63fe05_96.webp",
       "issues_url": "https://github.com/bernie-g/geckolib/issues",
@@ -12501,11 +12796,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-03-03T11:48:26.134901Z",
-          "downloads": 247896,
+          "downloads": 386737,
           "file": {
             "filename": "geckolib-fabric-1.21.11-5.4.5.jar",
             "hashes": {
-              "sha1": "41cd2e142e48a8b6604d85764a6466fe5edb70c3",
               "sha512": "e3fec3a07fd2a39af287cfa682f531913a6b82af5c23b60a231e8586ed1c5b1d2857f6714fa069315a1d7366c0d148d167178a9531b59629d488eb1cace6c97e"
             },
             "primary": true,
@@ -12539,7 +12833,7 @@
       "client_side": "unsupported",
       "color": 9213012,
       "date_created": "2023-03-20T15:01:56.168603Z",
-      "date_modified": "2026-05-21T15:13:23.912182Z",
+      "date_modified": "2026-06-29T17:38:26.892606Z",
       "description": "A bridge/proxy allowing you to connect to Minecraft: Java Edition servers with Minecraft: Bedrock Edition.",
       "discord_url": "https://discord.gg/geysermc",
       "donation_urls": [
@@ -12549,8 +12843,8 @@
           "url": "https://opencollective.com/GeyserMC"
         }
       ],
-      "downloads": 874359,
-      "followers": 1161,
+      "downloads": 1005726,
+      "followers": 1237,
       "game_versions": [
         "1.16.5",
         "1.17",
@@ -12606,17 +12900,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-21T15:13:16.892042Z",
-          "downloads": 2174,
+          "date_published": "2026-06-29T17:38:24.885046Z",
+          "downloads": 1729,
           "file": {
             "filename": "Geyser-Spigot.jar",
             "hashes": {
-              "sha1": "91fde75df341c31b5d59ef45f7f1bd0bd848a726",
-              "sha512": "5a1238704def5bbec769a359ce07150b1c6729b58358a21697592e672e78929972db0ae7864978642f1793a198ce22ee709406faa277b65ff7e20414709e2a23"
+              "sha512": "108e8404553242df0c262a7c66c0c1ac8ad777ac0b94bafb37a9e7c1504f2aa7c2a2033de5ebc39b5094c6cef9e447bc2fe0d51450f63e2f098b5431b343e7f1"
             },
             "primary": true,
-            "size": 18858171,
-            "url": "https://cdn.modrinth.com/data/wKkoqHrH/versions/dTPIQvjK/Geyser-Spigot.jar"
+            "size": 19144329,
+            "url": "https://cdn.modrinth.com/data/wKkoqHrH/versions/mGm9X2Fe/Geyser-Spigot.jar"
           },
           "game_versions": [
             "1.16.5",
@@ -12649,16 +12942,18 @@
             "1.21.9",
             "1.21.10",
             "1.21.11",
+            "26.1",
+            "26.1.1",
             "26.1.2"
           ],
-          "id": "dTPIQvjK",
+          "id": "mGm9X2Fe",
           "loaders": [
             "paper",
             "spigot"
           ],
-          "name": "Geyser-Spigot-2.10.0-b1153",
+          "name": "Geyser-Spigot-2.10.1-b1177",
           "project_id": "wKkoqHrH",
-          "version_number": "2.10.0-b1153",
+          "version_number": "2.10.1-b1177",
           "version_type": "beta"
         }
       },
@@ -12676,7 +12971,7 @@
       "client_side": "required",
       "color": 13456225,
       "date_created": "2023-12-29T21:46:47.121083Z",
-      "date_modified": "2026-05-18T17:16:32.742551Z",
+      "date_modified": "2026-06-28T04:20:58.138059Z",
       "description": "A library mod aimed at abstracting mod loaders and providing various utilities for our mods.",
       "discord_url": "https://discord.gg/GyyzU6T",
       "donation_urls": [
@@ -12686,8 +12981,8 @@
           "url": "https://www.paypal.com/donate/?business=AdubbzG@gmail.com&item_name=GlitchCore+(from+modrinth.com)&cy_code=USD"
         }
       ],
-      "downloads": 15549719,
-      "followers": 1210,
+      "downloads": 17508516,
+      "followers": 1272,
       "game_versions": [
         "1.10.2",
         "1.20.1",
@@ -12706,7 +13001,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/s3dmwKy5/76dd9e7bc737a02b723730ab34f536ab43936980.png",
       "issues_url": "https://github.com/Glitchfiend/GlitchCore/issues",
@@ -12726,11 +13022,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-03-06T20:02:11.753972Z",
-          "downloads": 201355,
+          "downloads": 295072,
           "file": {
             "filename": "GlitchCore-fabric-1.21.11-21.11.0.4.jar",
             "hashes": {
-              "sha1": "5c3d6333ff8c50d4b5c16c9185e020d8afcb4988",
               "sha512": "b0ea73e94647e5038a0a21f23357226a8767379e93a81c16bbfd8f87dead3ddeb768fc13bd557e94bb8f5e9b5c7e494fdc4f05d504227ba70af0ea4e6dd51187"
             },
             "primary": true,
@@ -12778,8 +13073,8 @@
           "url": "https://r.robomwm.com/patreon"
         }
       ],
-      "downloads": 128102,
-      "followers": 229,
+      "downloads": 149911,
+      "followers": 249,
       "game_versions": [
         "1.17",
         "1.17.1",
@@ -12809,7 +13104,10 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/O4o4mKaq/6aeade7ea5551c41dbe71e379ea893777356650d_96.webp",
       "issues_url": "https://github.com/GriefPrevention/GriefPrevention/issues",
@@ -12830,11 +13128,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-03-05T16:46:32.405428Z",
-          "downloads": 29175,
+          "downloads": 47440,
           "file": {
             "filename": "GriefPrevention.jar",
             "hashes": {
-              "sha1": "642c06bb3ef907a934e612914ad8397f56c7bbf4",
               "sha512": "c9bc692253ba3860327e5c38767ce3dc66c798264fe650a08b4ae888337ff75bc16e9bd1db7b39a514a275bf2cc2a3f1f8cd95cf080b89ae42a0f684fc2bfc66"
             },
             "primary": true,
@@ -12843,7 +13140,10 @@
           },
           "game_versions": [
             "1.21.10",
-            "1.21.11"
+            "1.21.11",
+            "26.1",
+            "26.1.1",
+            "26.1.2"
           ],
           "id": "dGfCZHqk",
           "loaders": [
@@ -12878,11 +13178,11 @@
       "client_side": "unknown",
       "color": 2631718,
       "date_created": "2024-03-22T20:37:05.089511Z",
-      "date_modified": "2026-05-22T22:51:13.042183Z",
+      "date_modified": "2026-06-30T23:48:35.940476Z",
       "description": "Fully async, multithreaded, predictive, open source, 3.01 reach, 1.005 timer, 0.01% speed, 99.99% antikb, \"bypassable\" 1.8-1.21 anticheat",
       "discord_url": "https://discord.grim.ac",
-      "downloads": 399258,
-      "followers": 384,
+      "downloads": 487191,
+      "followers": 431,
       "game_versions": [
         "1.7.2",
         "1.7.3",
@@ -12965,7 +13265,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/LJNGWSvH/3379356966ea4465a023f75d4f29073bfec2afc6_96.webp",
       "issues_url": "https://github.com/GrimAnticheat/Grim/issues",
@@ -12988,11 +13289,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-03-09T09:10:05.544421Z",
-          "downloads": 46479,
+          "downloads": 68898,
           "file": {
             "filename": "grimac-bukkit-2.3.73.jar",
             "hashes": {
-              "sha1": "f1cd0a6b8b4470dd10a542964784ec5937e0c19a",
               "sha512": "bf9be1194eb45afe1dec6bd8e98d078dacf41539025c8aabe24d31337cbea86625774e30842568b47f34ca174472c724c7876cc30793945e7408b03609672655"
             },
             "primary": true,
@@ -13094,25 +13394,22 @@
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-22T22:51:09.924296Z",
+          "date_published": "2026-06-30T23:48:33.414013Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 58,
+          "downloads": 1,
           "file": {
-            "filename": "grimac-fabric-2.3.74-635708a.jar",
+            "filename": "grimac-fabric-2.3.74-e454008.jar",
             "hashes": {
-              "sha1": "100111ccc7a20abcdf9f733db68cabd3edb1da2c",
-              "sha512": "aa7eb76303fce1368d48eaa69900a5bb2737a13add3d718c79477b3a274e5a9387d4594a46a884212df22d0675a9a323b8e215bf7930372c57195975cbc7284f"
+              "sha512": "ca7d94e7fafabc9df354d09ed26203bcd8e7b9ff9f9d2da5819192192a11c87801c5ca4cdeb0e5a1fa5885f5bfc455e1a6c02e4653f57eafdc5c69710d551191"
             },
             "primary": true,
-            "size": 8251586,
-            "url": "https://cdn.modrinth.com/data/LJNGWSvH/versions/Vy5RMuNR/grimac-fabric-2.3.74-635708a.jar"
+            "size": 14410304,
+            "url": "https://cdn.modrinth.com/data/LJNGWSvH/versions/VDYKAEly/grimac-fabric-2.3.74-e454008.jar"
           },
           "game_versions": [
             "1.16.1",
@@ -13149,17 +13446,15 @@
             "1.21.9",
             "1.21.10",
             "1.21.11",
-            "26.1",
-            "26.1.1",
             "26.1.2"
           ],
-          "id": "Vy5RMuNR",
+          "id": "VDYKAEly",
           "loaders": [
             "fabric"
           ],
-          "name": "Grim Anticheat (Fabric) 2.3.74-635708a",
+          "name": "Grim Anticheat (Fabric) 2.3.74-e454008",
           "project_id": "LJNGWSvH",
-          "version_number": "2.3.74-635708a",
+          "version_number": "2.3.74-e454008",
           "version_type": "alpha"
         }
       },
@@ -13169,6 +13464,105 @@
       "source_url": "https://github.com/GrimAnticheat/Grim",
       "title": "Grim Anticheat",
       "wiki_url": "https://github.com/GrimAnticheat/Grim/wiki"
+    },
+    "headpat": {
+      "categories": [
+        "magic",
+        "social"
+      ],
+      "client_side": "optional",
+      "color": 16302478,
+      "date_created": "2024-09-05T18:21:55.534552Z",
+      "date_modified": "2026-06-30T12:28:51.268990Z",
+      "description": "Give headpats to other players!",
+      "discord_url": "https://discord.gg/WcYsDDQtyR",
+      "donation_urls": [
+        {
+          "id": "ko-fi",
+          "platform": "Ko-fi",
+          "url": "https://ko-fi.com/enjarai"
+        }
+      ],
+      "downloads": 118111,
+      "followers": 302,
+      "gallery": [
+        {
+          "created": "2024-09-06T00:30:14.927065Z",
+          "featured": true,
+          "ordering": 0,
+          "url": "https://cdn.modrinth.com/data/vETxChiy/images/f793d0d3c7de8c1d2ca171f20c5402e3e735a3c1.gif"
+        }
+      ],
+      "game_versions": [
+        "1.21",
+        "1.21.1",
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8",
+        "1.21.9",
+        "1.21.10",
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/vETxChiy/8a0525ad1b8313cea130cc6b9a0d2cc2f575d658_96.webp",
+      "issues_url": "https://codeberg.org/enjarai/headpats/issues",
+      "license": {
+        "id": "MIT",
+        "name": "MIT License",
+        "url": null
+      },
+      "loaders": [
+        "fabric",
+        "paper"
+      ],
+      "page_url": "https://modrinth.com/mod/headpat",
+      "project_id": "vETxChiy",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+paper": {
+          "date_published": "2025-04-14T12:05:40.118784Z",
+          "downloads": 2695,
+          "file": {
+            "filename": "headpats-plugin-1.0.2+paper.jar",
+            "hashes": {
+              "sha512": "fea89b8adef9d2837af00efff22bcedbacfc0ae79d671af58b918c8eda4df0086e96f81897f30c0a5fdb40c877c6187721b58396ba561b66c6dba59b11686065"
+            },
+            "primary": true,
+            "size": 4854,
+            "url": "https://cdn.modrinth.com/data/vETxChiy/versions/Tawt2Pks/headpats-plugin-1.0.2%2Bpaper.jar"
+          },
+          "game_versions": [
+            "1.21.5",
+            "1.21.6",
+            "1.21.7",
+            "1.21.8",
+            "1.21.9",
+            "1.21.10",
+            "1.21.11",
+            "26.1",
+            "26.1.1",
+            "26.1.2"
+          ],
+          "id": "Tawt2Pks",
+          "loaders": [
+            "paper"
+          ],
+          "name": "1.0.2 for 1.21.5",
+          "project_id": "vETxChiy",
+          "version_number": "1.0.2+paper",
+          "version_type": "release"
+        }
+      },
+      "server_side": "optional",
+      "slug": "headpat",
+      "source": "modrinth",
+      "source_url": "https://codeberg.org/enjarai/headpats",
+      "title": "Headpat a Friend!"
     },
     "huskhomes": {
       "additional_categories": [
@@ -13182,23 +13576,23 @@
       "client_side": "unknown",
       "color": 793387,
       "date_created": "2022-08-14T20:07:33.488660Z",
-      "date_modified": "2026-03-02T22:47:05.562289Z",
+      "date_modified": "2026-06-29T07:13:48.610493Z",
       "description": "The powerful & intuitive set homes, warps, and teleports plugin/mod",
       "discord_url": "https://discord.gg/tVYhJfyDWG",
       "donation_urls": [
         {
-          "id": "bmac",
-          "platform": "Bmac",
-          "url": "https://buymeacoffee.com/William278"
-        },
-        {
           "id": "github",
           "platform": "Github",
           "url": "https://github.com/sponsors/WiIIiam278"
+        },
+        {
+          "id": "bmac",
+          "platform": "Bmac",
+          "url": "https://buymeacoffee.com/William278"
         }
       ],
-      "downloads": 170657,
-      "followers": 393,
+      "downloads": 185536,
+      "followers": 397,
       "gallery": [
         {
           "created": "2022-12-11T21:03:58.902027Z",
@@ -13258,7 +13652,9 @@
         "1.21.6",
         "1.21.7",
         "1.21.8",
-        "1.21.11"
+        "1.21.11",
+        "26.1.1",
+        "26.1.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/J6U9o3JG/55b11f564d93a8182036d60004dcc3206fbef016_96.webp",
       "issues_url": "https://github.com/WiIIiam278/HuskHomes/issues",
@@ -13284,34 +13680,25 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "34T8oVNY",
-              "version_id": null
+              "project_id": "fRQREgAc"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "fRQREgAc",
-              "version_id": null
+              "project_id": "34T8oVNY"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "wJQfHhxh",
-              "version_id": null
+              "project_id": "swbUV1cr"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "swbUV1cr",
-              "version_id": null
+              "project_id": "wJQfHhxh"
             }
           ],
-          "downloads": 7184,
+          "downloads": 9581,
           "file": {
             "filename": "HuskHomes-Paper-4.10.jar",
             "hashes": {
-              "sha1": "a8e58438d2a8add2a3b3aa3e1911e75f20857e03",
               "sha512": "65b6e42cf671d4937d3dab8c009ea9c787de3e4dd644aecd59f445e0ea347592c55cb79b8d85c18f7b2bd439249f1c5d644c79643414114251353fca5b1977a8"
             },
             "primary": true,
@@ -13370,7 +13757,7 @@
       "client_side": "required",
       "color": 5018852,
       "date_created": "2022-11-15T06:48:55.303423Z",
-      "date_modified": "2026-05-21T20:43:47.268692Z",
+      "date_modified": "2026-06-30T23:11:18.526022Z",
       "description": "A modding library that contains new events, helpers, and utilities to make modder's lives easier.",
       "discord_url": "https://discord.gg/S5NQjbXPnb",
       "donation_urls": [
@@ -13380,8 +13767,8 @@
           "url": "https://www.paypal.com/donate/?business=NYKUAV883JKA2&no_recurring=0&item_name=Thank+you+for+considering+a+donation.+It+helps+to+support+me+by+allowing+me+to+spend+more+time+making+mods+and+games.&currency_code=USD"
         }
       ],
-      "downloads": 28177184,
-      "followers": 1756,
+      "downloads": 30075493,
+      "followers": 1790,
       "game_versions": [
         "1.16.5",
         "1.18.2",
@@ -13400,7 +13787,11 @@
         "1.21.1",
         "1.21.3",
         "1.21.4",
-        "1.21.11"
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/5faXoLqX/88c9b9918841470dad995049244ef7a3cb2f34f5_96.webp",
       "issues_url": "https://discord.gg/UCKjnamDaW",
@@ -13419,36 +13810,33 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-21T20:43:04.338380Z",
+          "date_published": "2026-05-26T18:17:12.725016Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 1670,
+          "downloads": 54681,
           "file": {
-            "filename": "Iceberg-1.21.11-fabric-1.4.0.jar",
+            "filename": "Iceberg-1.21.11-fabric-1.4.0.1.jar",
             "hashes": {
-              "sha1": "812d49b9b5431827d8f9a81964b95b7b3eb92618",
-              "sha512": "5362fcc09d21fdaab22782244b0889eecbda01afd18a62144737adc6204c138cb85c671e6766370ca17fa48a017768993fd6ad9c000ac35e733de2ff7982cc73"
+              "sha512": "54b01f890ee6aab1bdb8aca32e5608246f844327216771402bbba86bb7b7fecea3979fae41435043fdca258c83751600976e1cf23c5e0c17026d4379f7742a69"
             },
             "primary": true,
-            "size": 375033,
-            "url": "https://cdn.modrinth.com/data/5faXoLqX/versions/zXaqF2QO/Iceberg-1.21.11-fabric-1.4.0.jar"
+            "size": 377185,
+            "url": "https://cdn.modrinth.com/data/5faXoLqX/versions/yRNBxEJF/Iceberg-1.21.11-fabric-1.4.0.1.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "zXaqF2QO",
+          "id": "yRNBxEJF",
           "loaders": [
             "fabric"
           ],
-          "name": "Fabric 1.4.0 (1.21.11)",
+          "name": "Fabric 1.4.0.1 (1.21.11)",
           "project_id": "5faXoLqX",
-          "version_number": "1.4.0",
+          "version_number": "1.4.0.1",
           "version_type": "release"
         }
       },
@@ -13468,7 +13856,7 @@
       "client_side": "unsupported",
       "color": 7973559,
       "date_created": "2022-12-15T20:46:58.448075Z",
-      "date_modified": "2026-05-06T20:19:55.307402Z",
+      "date_modified": "2026-06-29T19:55:25.255940Z",
       "description": "Put images on maps and walls!",
       "discord_url": "https://loohpjames.com/dev-discord",
       "donation_urls": [
@@ -13483,8 +13871,8 @@
           "url": "https://github.com/sponsors/LOOHP"
         }
       ],
-      "downloads": 190765,
-      "followers": 570,
+      "downloads": 209847,
+      "followers": 588,
       "game_versions": [
         "1.13",
         "1.13.1",
@@ -13526,7 +13914,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/lJFOpcEj/042a7acf702b707ccc076d587ee712d00cd90c50.png",
       "license": {
@@ -13545,25 +13934,22 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-06T20:19:55.307402Z",
+          "date_published": "2026-06-29T19:55:25.255940Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "7JSyQd4e",
-              "version_id": null
+              "project_id": "7JSyQd4e"
             }
           ],
-          "downloads": 7069,
+          "downloads": 739,
           "file": {
-            "filename": "ImageFrame-2026.1.2.0.jar",
+            "filename": "ImageFrame-2026.1.4.0.jar",
             "hashes": {
-              "sha1": "7ce49b08731f3850b523a23f583061950897cc19",
-              "sha512": "61254b3bcd500de5884f96c59d510ae64a359b0e56ab14ea06bebc6cabc3dfdc55038cd5f7314a825fa8dbdea8c71bbc063ecd7ec20bd17c670644e3ea977341"
+              "sha512": "2a510fa5906e26331351fb69da6b19ca08d82ffb3ea34781cde8de44eed25a18e43862e6144a3bcbc8bf2184ee3a975fe65ee10689ff07039d23076fda35f58a"
             },
             "primary": true,
-            "size": 4198219,
-            "url": "https://cdn.modrinth.com/data/lJFOpcEj/versions/uLDcMdEf/ImageFrame-2026.1.2.0.jar"
+            "size": 4749647,
+            "url": "https://cdn.modrinth.com/data/lJFOpcEj/versions/nt0GWT1y/ImageFrame-2026.1.4.0.jar"
           },
           "game_versions": [
             "1.16",
@@ -13603,18 +13989,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "uLDcMdEf",
+          "id": "nt0GWT1y",
           "loaders": [
             "folia",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "Improvements & Bug Fixes (2026.1.2)",
+          "name": "Hot Fixes (2026.1.4)",
           "project_id": "lJFOpcEj",
-          "version_number": "2026.1.2",
+          "version_number": "2026.1.4",
           "version_type": "release"
         }
       },
@@ -13623,6 +14010,133 @@
       "source": "modrinth",
       "source_url": "https://github.com/LOOHP/ImageFrame",
       "title": "ImageFrame"
+    },
+    "immersive-aircraft": {
+      "additional_categories": [
+        "game-mechanics",
+        "utility"
+      ],
+      "categories": [
+        "adventure",
+        "technology",
+        "transportation"
+      ],
+      "client_side": "required",
+      "color": 9139271,
+      "date_created": "2022-11-29T20:25:04.808037Z",
+      "date_modified": "2026-06-08T07:05:31.302372Z",
+      "description": "A bunch of rustic aircraft to travel, transport, and explore!",
+      "discord_url": "https://discord.gg/agxcvAdj2a",
+      "donation_urls": [
+        {
+          "id": "patreon",
+          "platform": "Patreon",
+          "url": "https://www.patreon.com/conczin"
+        }
+      ],
+      "downloads": 12577122,
+      "followers": 2283,
+      "gallery": [
+        {
+          "created": "2022-12-03T21:13:17.603497Z",
+          "featured": true,
+          "ordering": 0,
+          "title": "Multiplayer",
+          "url": "https://cdn.modrinth.com/data/x3HZvrj6/images/2f5c2d2293ecf7e298d1e477b7dd0b273fa4976c_350.webp"
+        },
+        {
+          "created": "2022-12-03T21:13:14.114984Z",
+          "featured": false,
+          "ordering": 0,
+          "title": "Multiplayer",
+          "url": "https://cdn.modrinth.com/data/x3HZvrj6/images/862f89303b3e86514ed6040c533949bb60d134e1_350.webp"
+        },
+        {
+          "created": "2022-12-03T21:13:07.200538Z",
+          "featured": false,
+          "ordering": 0,
+          "title": "Airship",
+          "url": "https://cdn.modrinth.com/data/x3HZvrj6/images/93d9c313e1bb8d740aefd490d69492801e0e9602_350.webp"
+        },
+        {
+          "created": "2022-12-03T21:13:09.328841Z",
+          "featured": false,
+          "ordering": 0,
+          "title": "Gyrodyne",
+          "url": "https://cdn.modrinth.com/data/x3HZvrj6/images/d540ee081236e7c2d149a53fde358e50e95eec17_350.webp"
+        },
+        {
+          "created": "2022-12-03T21:13:08.329260Z",
+          "featured": false,
+          "ordering": 0,
+          "title": "Biplane",
+          "url": "https://cdn.modrinth.com/data/x3HZvrj6/images/ef0947d09bc57e6febd326ba6659471acecdf56a_350.webp"
+        }
+      ],
+      "game_versions": [
+        "1.16.5",
+        "1.18.2",
+        "1.19.2",
+        "1.19.3",
+        "1.19.4",
+        "1.20",
+        "1.20.1",
+        "1.21",
+        "1.21.1",
+        "1.21.11"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/x3HZvrj6/08205d73c1e3e28eae9c4c6e272eaae34326e4b0_96.webp",
+      "issues_url": "https://github.com/Luke100000/ImmersiveAircraft/issues",
+      "license": {
+        "id": "GPL-3.0-only",
+        "name": "GNU General Public License v3.0 only",
+        "url": null
+      },
+      "loaders": [
+        "fabric",
+        "forge",
+        "neoforge"
+      ],
+      "page_url": "https://modrinth.com/mod/immersive-aircraft",
+      "project_id": "x3HZvrj6",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+fabric": {
+          "date_published": "2026-06-08T07:05:26.101785Z",
+          "dependencies": [
+            {
+              "dependency_type": "required",
+              "project_id": "P7dR8mSH"
+            }
+          ],
+          "downloads": 12668,
+          "file": {
+            "filename": "immersive_aircraft-1.4.7+1.21.11-fabric.jar",
+            "hashes": {
+              "sha512": "7fe80a4b63996e84b218f998df06d2cd759736acc10d59b4018bc284e40d0176f5b349a79adc0f197dc7447d11fb8a2bfd3c13bc34318c376ec01c853113e117"
+            },
+            "primary": true,
+            "size": 2459574,
+            "url": "https://cdn.modrinth.com/data/x3HZvrj6/versions/NshGBorp/immersive_aircraft-1.4.7%2B1.21.11-fabric.jar"
+          },
+          "game_versions": [
+            "1.21.11"
+          ],
+          "id": "NshGBorp",
+          "loaders": [
+            "fabric"
+          ],
+          "name": "[Fabric 1.21.11] Immersive Aircraft - 1.4.7",
+          "project_id": "x3HZvrj6",
+          "version_number": "1.4.7+1.21.11",
+          "version_type": "release"
+        }
+      },
+      "server_side": "required",
+      "slug": "immersive-aircraft",
+      "source": "modrinth",
+      "source_url": "https://github.com/Luke100000/ImmersiveAircraft",
+      "title": "Immersive Aircraft"
     },
     "infinite-villager-trading": {
       "additional_categories": [
@@ -13635,7 +14149,7 @@
       "client_side": "unsupported",
       "color": 11828324,
       "date_created": "2023-06-19T15:23:10.622809Z",
-      "date_modified": "2026-04-21T21:29:49.852009Z",
+      "date_modified": "2026-06-20T21:21:05.929006Z",
       "description": "A spigot plugin that allows villagers to trade infinitely",
       "donation_urls": [
         {
@@ -13644,8 +14158,8 @@
           "url": "https://github.com/sponsors/spartacus04"
         }
       ],
-      "downloads": 233589,
-      "followers": 209,
+      "downloads": 269105,
+      "followers": 221,
       "gallery": [
         {
           "created": "2023-07-04T12:20:23.784043Z",
@@ -13708,7 +14222,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/7pdfxYHV/bed0eb0a471fd45825ab613491de047ab8d2fa73.webp",
       "issues_url": "https://github.com/spartacus04/InstantRestock/issues",
@@ -13728,17 +14243,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-21T21:29:49.852009Z",
-          "downloads": 21509,
+          "date_published": "2026-06-20T21:21:05.929006Z",
+          "downloads": 10028,
           "file": {
-            "filename": "instantrestock_2.6.2.jar",
+            "filename": "instantrestock_2.6.3.jar",
             "hashes": {
-              "sha1": "280667b76c46d5afa9c574e85cca3f77a3a03e6b",
-              "sha512": "1ea0cdcc95c1466763d4e50091c3a1df17249fcb14c28925ccfce6e96e31d10dbe0d81ecc605ee3e480410074354e8ce92e3515ffc5bedc994c4e7ef4219f5cb"
+              "sha512": "ffa7e9c9f6647a566bba59255deb0179e9b9bebb15483b1e7e535ff5220bf857b805680f8ea838d78ed67980765a98a5dbf01c2cd33ea8aed96d5f8547fd9008"
             },
             "primary": true,
-            "size": 1483068,
-            "url": "https://cdn.modrinth.com/data/7pdfxYHV/versions/ZblOxPfl/instantrestock_2.6.2.jar"
+            "size": 1506810,
+            "url": "https://cdn.modrinth.com/data/7pdfxYHV/versions/3YZY0CRY/instantrestock_2.6.3.jar"
           },
           "game_versions": [
             "1.14",
@@ -13786,18 +14300,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "ZblOxPfl",
+          "id": "3YZY0CRY",
           "loaders": [
             "folia",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "2.6.2",
+          "name": "2.6.3",
           "project_id": "7pdfxYHV",
-          "version_number": "2.6.2",
+          "version_number": "2.6.3",
           "version_type": "release"
         }
       },
@@ -13817,7 +14332,7 @@
       "client_side": "unsupported",
       "color": 6561807,
       "date_created": "2025-05-16T17:35:07.312697Z",
-      "date_modified": "2026-03-08T02:13:39.126878Z",
+      "date_modified": "2026-06-25T14:15:34.217729Z",
       "description": "Each effect gives a different power",
       "discord_url": "https://discord.gg/RaZ296vjWc",
       "donation_urls": [
@@ -13827,8 +14342,8 @@
           "url": "https://www.paypal.com/paypalme/catadmirer"
         }
       ],
-      "downloads": 116781,
-      "followers": 168,
+      "downloads": 126949,
+      "followers": 192,
       "gallery": [
         {
           "created": "2025-07-27T19:49:51.697656Z",
@@ -13889,11 +14404,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-03-08T02:13:39.126878Z",
-          "downloads": 15684,
+          "downloads": 23654,
           "file": {
             "filename": "InfuseSMP-2.4.3.jar",
             "hashes": {
-              "sha1": "a9b5b83f06d1cd7f55c5919b253279b01b1f04d7",
               "sha512": "b4330166810ac67a345fa57aef054a1fca2dee7151c07a03c66c24b0a75be64f91c73c8d1673258203c880951c184d70ebdba7d5d57bfb3ca6380868f48036c0"
             },
             "primary": true,
@@ -13939,7 +14453,7 @@
       "client_side": "unsupported",
       "color": 6967327,
       "date_created": "2024-12-13T10:22:28.095270Z",
-      "date_modified": "2026-04-19T20:19:40.078409Z",
+      "date_modified": "2026-06-25T17:04:53.244139Z",
       "description": "Inventory Backup Plugin for Spigot / Paper / Purpur - 1.8 - 26.1.2 - Backup, Restore, Rollback Inventories!",
       "discord_url": "https://discord.gg/h7qJ9gRCwj",
       "donation_urls": [
@@ -13949,8 +14463,8 @@
           "url": "https://www.paypal.com/donate/?hosted_button_id=MDMJLRCACKKYS"
         }
       ],
-      "downloads": 96367,
-      "followers": 144,
+      "downloads": 110077,
+      "followers": 159,
       "gallery": [
         {
           "created": "2024-12-13T10:43:39.569778Z",
@@ -14067,7 +14581,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/XWKWAzd8/cc87a53f42d579ddfec87581e01f1c8231681d93_96.webp",
       "issues_url": "https://github.com/TechnicallyCoded/Inventory-Rollback-Plus/issues",
@@ -14087,17 +14602,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-19T20:19:40.078409Z",
-          "downloads": 9217,
+          "date_published": "2026-06-25T17:04:53.244139Z",
+          "downloads": 2148,
           "file": {
-            "filename": "InventoryRollbackPlus-1.8.3.jar",
+            "filename": "InventoryRollbackPlus-1.8.4.jar",
             "hashes": {
-              "sha1": "6e73140df54164098dcec4f24c2194bffefa83b2",
-              "sha512": "4cc38e98ccde6cfa99076dcb38186ecf9fa0e93e3a4ad449b51a6c06e240c7396cb3ce4fc1fc61a9839af071f75a8e0d524587016b8826005539ab76822bd81d"
+              "sha512": "5144bec1260673122f1bdc91c2743f26c7d20de47403c156898d299d0ae1a95f4aa6d58cfd283a547e51862c919b131bf09ccc380da215b70e4ee56b739c1b10"
             },
             "primary": true,
-            "size": 1200151,
-            "url": "https://cdn.modrinth.com/data/XWKWAzd8/versions/940BfkSq/InventoryRollbackPlus-1.8.3.jar"
+            "size": 1200252,
+            "url": "https://cdn.modrinth.com/data/XWKWAzd8/versions/2JWRgmoZ/InventoryRollbackPlus-1.8.4.jar"
           },
           "game_versions": [
             "1.8.9",
@@ -14163,17 +14677,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "940BfkSq",
+          "id": "2JWRgmoZ",
           "loaders": [
+            "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "InventoryRollbackPlus 1.8.3",
+          "name": "InventoryRollbackPlus 1.8.4",
           "project_id": "XWKWAzd8",
-          "version_number": "1.8.3",
+          "version_number": "1.8.4",
           "version_type": "release"
         }
       },
@@ -14192,7 +14708,7 @@
       "client_side": "unsupported",
       "color": 11782339,
       "date_created": "2023-08-07T19:39:49.807150Z",
-      "date_modified": "2026-05-17T18:43:00.672004Z",
+      "date_modified": "2026-06-16T23:15:01.634905Z",
       "description": "A bukkit plugin for manipulating player inventories.",
       "discord_url": "https://discord.gg/Z8WCDHHcdJ",
       "donation_urls": [
@@ -14202,8 +14718,8 @@
           "url": "https://paypal.me/JanBoerman"
         }
       ],
-      "downloads": 238758,
-      "followers": 400,
+      "downloads": 273162,
+      "followers": 430,
       "game_versions": [
         "1.8.8",
         "1.12.2",
@@ -14229,7 +14745,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/bYazc7fd/0cf6e7081b4c38dd8ed045b268fbca53712ac831_96.webp",
       "issues_url": "https://github.com/Jannyboy11/InvSee-plus-plus/issues",
@@ -14249,17 +14766,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-10T21:26:14.724358Z",
-          "downloads": 7213,
+          "date_published": "2026-06-16T23:15:01.634905Z",
+          "downloads": 11869,
           "file": {
             "filename": "InvSee++.jar",
             "hashes": {
-              "sha1": "936c5343eaf3d77014a8e73c18dba3f6a54a763b",
-              "sha512": "9c80df37d0fee4986abac20478ab0c4b62a1bb246b2bf0a3a36f9e3e234db5a1a3d9e9a56d21bb301bcadc6cad24a578b9f47a4e2249bef17ac9e415d84b3589"
+              "sha512": "01a01a23c961ddc2c749270e87da9d684ae455386c8ee8389baf75a43d2f935b2f4ad946428639e65596c199251c2a6bab259bf897d793b3708265734276c954"
             },
             "primary": true,
-            "size": 2003026,
-            "url": "https://cdn.modrinth.com/data/bYazc7fd/versions/lSyxYu9g/InvSee%2B%2B.jar"
+            "size": 2178689,
+            "url": "https://cdn.modrinth.com/data/bYazc7fd/versions/cAOIkpWF/InvSee%2B%2B.jar"
           },
           "game_versions": [
             "1.8.8",
@@ -14282,18 +14798,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "lSyxYu9g",
+          "id": "cAOIkpWF",
           "loaders": [
             "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "InvSee++ 0.31.12",
+          "name": "InvSee++ 0.31.15",
           "project_id": "bYazc7fd",
-          "version_number": "0.31.12",
+          "version_number": "0.31.15",
           "version_type": "release"
         }
       },
@@ -14320,7 +14837,7 @@
       "client_side": "unsupported",
       "color": 10394648,
       "date_created": "2024-12-28T16:54:15.037900Z",
-      "date_modified": "2025-12-10T03:37:57.526475Z",
+      "date_modified": "2026-06-27T09:53:29.669890Z",
       "description": "Fast edit, customize and manage items",
       "discord_url": "https://discord.gg/w5HVCDPtRp",
       "donation_urls": [
@@ -14335,8 +14852,8 @@
           "url": "https://www.paypal.me/FlavioLiponi/"
         }
       ],
-      "downloads": 132608,
-      "followers": 134,
+      "downloads": 154265,
+      "followers": 149,
       "game_versions": [
         "1.8",
         "1.8.1",
@@ -14410,7 +14927,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/yx81EHRu/51857f452c3f69790f13c003eef9b4d0180fde45.png",
       "issues_url": "https://github.com/emanondev/ItemEdit/issues",
@@ -14431,20 +14949,18 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2025-12-10T03:37:57.526475Z",
-          "downloads": 69158,
+          "date_published": "2026-06-27T09:53:29.669890Z",
+          "downloads": 1824,
           "file": {
-            "filename": "ItemEdit-3.7.8.jar",
+            "filename": "ItemEdit-3.7.10.jar",
             "hashes": {
-              "sha1": "f0219f6fa5ead75691a3cf508add9638da3f4798",
-              "sha512": "d8821e57e2a401e8afcbcad386d6da1bd96a282f0a7b20ae281e6c3a8246055b497b14ab5ae5ebdf7c1a992ca9e14ceb5ae7959bf0c3cf6281168ac14ec39020"
+              "sha512": "fe99b786afdafb2465164c3a5b91ee9307aad7bad5d95b4308e9aa550b26a11e03e2763a751793aef5ae08256cdbb18d4db7b9492198132365ce26de73af643e"
             },
             "primary": true,
-            "size": 565080,
-            "url": "https://cdn.modrinth.com/data/yx81EHRu/versions/8wBtoVLx/ItemEdit-3.7.8.jar"
+            "size": 565120,
+            "url": "https://cdn.modrinth.com/data/yx81EHRu/versions/ODZyheTG/ItemEdit-3.7.10.jar"
           },
           "game_versions": [
-            "1.8.8",
             "1.8.9",
             "1.9",
             "1.9.1",
@@ -14508,18 +15024,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "8wBtoVLx",
+          "id": "ODZyheTG",
           "loaders": [
             "folia",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "ItemEdit 3.7.8",
+          "name": "ItemEdit 3.7.10",
           "project_id": "yx81EHRu",
-          "version_number": "3.7.8",
+          "version_number": "3.7.10",
           "version_type": "release"
         }
       },
@@ -14540,22 +15057,22 @@
       "client_side": "optional",
       "color": 11322548,
       "date_created": "2021-09-18T08:14:16.544897Z",
-      "date_modified": "2026-05-10T12:57:05.603709Z",
+      "date_modified": "2026-06-30T17:23:06.362733Z",
       "description": "Shows information about what you are looking at. (Hwyla/Waila fork for Minecraft 1.16+)",
       "donation_urls": [
-        {
-          "id": "patreon",
-          "platform": "Patreon",
-          "url": "https://www.patreon.com/snownee"
-        },
         {
           "id": "ko-fi",
           "platform": "Ko-fi",
           "url": "https://ko-fi.com/snownee"
+        },
+        {
+          "id": "patreon",
+          "platform": "Patreon",
+          "url": "https://www.patreon.com/snownee"
         }
       ],
-      "downloads": 51200134,
-      "followers": 7707,
+      "downloads": 55993088,
+      "followers": 8196,
       "gallery": [
         {
           "created": "2022-12-11T09:22:23.125333Z",
@@ -14665,7 +15182,13 @@
         "26.1.1-rc-1",
         "26.1.1",
         "26w14a",
-        "26.1.2"
+        "26.1.2",
+        "26.2-pre-4",
+        "26.2-pre-5",
+        "26.2-pre-6",
+        "26.2-rc-1",
+        "26.2-rc-2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/nvQzSEkH/b04217bc2b7dc524c4d12f81ff42cc1cefb9b0fc_96.webp",
       "issues_url": "https://github.com/Snownee/Jade/issues?q=is%3Aissue",
@@ -14688,23 +15211,18 @@
           "date_published": "2026-04-06T20:21:23.585665Z",
           "dependencies": [
             {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "dependency_type": "optional",
+              "project_id": "u6dRKJwZ"
             },
             {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "u6dRKJwZ",
-              "version_id": null
+              "dependency_type": "required",
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 303541,
+          "downloads": 541042,
           "file": {
             "filename": "Jade-1.21.11-Fabric-21.1.6.jar",
             "hashes": {
-              "sha1": "b48b23fe3b9175641bd63ce5c3373977f8f15723",
               "sha512": "6dee10effa6d68c822c59b7704f5506fe674c50d6195da25171641decfa684dc4f14d919656f768fe8fc39003c6193126cb05bb59eed8a1a2bd354dc53875e6d"
             },
             "primary": true,
@@ -14738,7 +15256,7 @@
       "client_side": "required",
       "color": 1318157,
       "date_created": "2022-07-01T09:54:25.296438Z",
-      "date_modified": "2026-05-04T12:29:20.461153Z",
+      "date_modified": "2026-06-17T11:25:33.373553Z",
       "description": "The platform-agnostic, Architectury based library used in all of JamCoreModding's mods",
       "discord_url": "https://discord.jamalam.tech",
       "donation_urls": [
@@ -14748,8 +15266,8 @@
           "url": "https://ko-fi.com/jamalamdev"
         }
       ],
-      "downloads": 10738084,
-      "followers": 857,
+      "downloads": 11749110,
+      "followers": 888,
       "game_versions": [
         "1.18",
         "1.18.1",
@@ -14780,7 +15298,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/IYY9Siz8/7585f4d35b18467c2d0d9c496e3b7cd4919c413a_96.webp",
       "issues_url": "https://github.com/JamCoreModding/jam-lib/issues",
@@ -14804,16 +15323,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 26776,
+          "downloads": 71213,
           "file": {
             "filename": "jamlib-fabric-2.0.0+1.21.11.jar",
             "hashes": {
-              "sha1": "7fdbfecaa086bd2e198de409e5b4e0f9f9e8bcfa",
               "sha512": "c2b2d373a4ca48562e6af84e95c955635c0202ee007870202d9e6a8fb4991728c932476f0996df411ce32fd02a318bdba2e6f3f37ac716c293e6e5fefd58ba3e"
             },
             "primary": true,
@@ -14848,7 +15364,7 @@
       "client_side": "optional",
       "color": 9934998,
       "date_created": "2023-01-27T05:19:03.821699Z",
-      "date_modified": "2026-05-18T13:29:47.277735Z",
+      "date_modified": "2026-06-30T13:41:05.313692Z",
       "description": "View Items and Recipes",
       "discord_url": "https://discord.gg/sCQcWU2",
       "donation_urls": [
@@ -14858,8 +15374,8 @@
           "url": "https://www.patreon.com/mezz"
         }
       ],
-      "downloads": 53062714,
-      "followers": 9348,
+      "downloads": 59455354,
+      "followers": 10017,
       "gallery": [
         {
           "created": "2023-01-27T05:18:47.838148Z",
@@ -14954,7 +15470,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/u6dRKJwZ/4a3f18ac0d096c9f8e9176984c44be4e58f94c89_96.webp",
       "issues_url": "https://github.com/mezz/JustEnoughItems/issues?q=is%3Aissue",
@@ -14973,28 +15490,27 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-03-31T11:37:14.000187Z",
-          "downloads": 486189,
+          "date_published": "2026-06-21T09:33:25.904139Z",
+          "downloads": 79281,
           "file": {
-            "filename": "jei-1.21.11-fabric-27.4.0.22.jar",
+            "filename": "jei-1.21.11-fabric-27.4.0.24.jar",
             "hashes": {
-              "sha1": "dba6319ab4cad596d74f520ae608a5cae84ba245",
-              "sha512": "4de9d355a9a7325590b2064d84e93e217051dc44e2b38f063ad347998af3f0f3a4d1655a020b23d955d78cc66b5443d4f4d5f63a82ac2c0b206b23d9dc1d30ce"
+              "sha512": "ff78c00dc6f1bf2ff1532bd699cf662d4d7df42798f4840c287a132d08ca78bcb00b1e3a9fe2fd971563d1f15eb90c42eaae0f28b2092ad1e04461d1d0c74172"
             },
             "primary": true,
-            "size": 1530964,
-            "url": "https://cdn.modrinth.com/data/u6dRKJwZ/versions/oHe0elMI/jei-1.21.11-fabric-27.4.0.22.jar"
+            "size": 1531252,
+            "url": "https://cdn.modrinth.com/data/u6dRKJwZ/versions/XUzRNF8t/jei-1.21.11-fabric-27.4.0.24.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "oHe0elMI",
+          "id": "XUzRNF8t",
           "loaders": [
             "fabric"
           ],
-          "name": "27.4.0.22 for Fabric 1.21.11",
+          "name": "27.4.0.24 for Fabric 1.21.11",
           "project_id": "u6dRKJwZ",
-          "version_number": "27.4.0.22",
+          "version_number": "27.4.0.24",
           "version_type": "beta"
         }
       },
@@ -15013,11 +15529,11 @@
       "client_side": "optional",
       "color": 10930848,
       "date_created": "2022-05-29T14:44:24.607795Z",
-      "date_modified": "2026-05-21T21:54:02.080938Z",
+      "date_modified": "2026-06-29T17:17:31.258424Z",
       "description": "Real-time map used for mapping in-game or your browser as you explore.",
       "discord_url": "https://discord.gg/eP8gE69",
-      "downloads": 10964146,
-      "followers": 4386,
+      "downloads": 12074468,
+      "followers": 4594,
       "game_versions": [
         "1.7.10",
         "1.12.2",
@@ -15049,7 +15565,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/lfHFW1mp/a1c571a21a88f6fa59eab67829f216f65ab393ee_96.webp",
       "issues_url": "https://github.com/TeamJM/journeymap/issues",
@@ -15070,38 +15587,35 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-21T21:53:49.322003Z",
+          "date_published": "2026-06-26T19:55:21.738352Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 3458,
+          "downloads": 10081,
           "file": {
-            "filename": "journeymap-fabric-1.21.11-6.0.0-beta.79.jar",
+            "filename": "journeymap-fabric-1.21.11-6.0.0.jar",
             "hashes": {
-              "sha1": "49e9a338207a07a90171682ee33a20e5900e6c98",
-              "sha512": "b8fb37aa95b622498b06d81ec5c5fb93cfae3bfc3879ed5ef18d6f0b9b8de9fffb028a91e2ef342c7ca98ef1522cb86bbe1203673f56fa4c58a6e623d885ab12"
+              "sha512": "dc7a70d55fc3911dc53768e0790a3335dca7a7400e234e415b05654337b8bc739436631501ad011b27f75c4eaef87f43cfbee4fc6d1110a91b2f193524b5d212"
             },
             "primary": true,
-            "size": 4096138,
-            "url": "https://cdn.modrinth.com/data/lfHFW1mp/versions/42J4OASc/journeymap-fabric-1.21.11-6.0.0-beta.79.jar"
+            "size": 4193594,
+            "url": "https://cdn.modrinth.com/data/lfHFW1mp/versions/6Np0S5K2/journeymap-fabric-1.21.11-6.0.0.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "42J4OASc",
+          "id": "6Np0S5K2",
           "loaders": [
             "fabric",
             "quilt"
           ],
-          "name": "journeymap-1.21.11-6.0.0-beta.79+fabric",
+          "name": "journeymap-1.21.11-6.0.0+fabric",
           "project_id": "lfHFW1mp",
-          "version_number": "1.21.11-6.0.0-beta.79+fabric",
-          "version_type": "beta"
+          "version_number": "1.21.11-6.0.0+fabric",
+          "version_type": "release"
         }
       },
       "server_side": "optional",
@@ -15123,7 +15637,7 @@
       "client_side": "unsupported",
       "color": 305914,
       "date_created": "2023-06-13T03:48:34.447802Z",
-      "date_modified": "2025-02-21T00:26:32.956505Z",
+      "date_modified": "2026-06-25T01:20:27.316645Z",
       "description": "JustTPA is a simple tpa plugin where players can ask other players if they can teleport to them.",
       "discord_url": "https://discord.gg/EAGesvp",
       "donation_urls": [
@@ -15133,8 +15647,8 @@
           "url": "https://ko-fi.com/justplayer"
         }
       ],
-      "downloads": 151220,
-      "followers": 95,
+      "downloads": 171748,
+      "followers": 102,
       "game_versions": [
         "1.19",
         "1.19.1",
@@ -15159,7 +15673,11 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/GM9AuKjX/fb3bf78a7f6c32e0b835008ceb5378062926e38f_96.webp",
       "issues_url": "https://github.com/JustPlayerDE/just-tpa/issues",
@@ -15178,17 +15696,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2025-02-21T00:26:32.956505Z",
-          "downloads": 114660,
+          "date_published": "2026-06-25T01:20:27.316645Z",
+          "downloads": 3741,
           "file": {
-            "filename": "tpa-20250220c.jar",
+            "filename": "just-tpa-20260625-0111.jar",
             "hashes": {
-              "sha1": "d1c87accdedee734aae66f2e4f0193b467c612df",
-              "sha512": "f61ed2a6c79191455dfe932f4456ac2f6ce448aedaa2d5e6428df666c1fc654bbda7f0df4931d24e3a3cdae2488c865b324c5c23ecf68cfc7679bcfcaf165bca"
+              "sha512": "7451ee4dffb25c4ca6be886cc18524a42c14a7e39827223dfefb74214a8d2a3e8926d9864781a4e99a9f7f4906e5fe8d75d6b56f1d19dafd7e47a19e938af196"
             },
             "primary": true,
-            "size": 62240,
-            "url": "https://cdn.modrinth.com/data/GM9AuKjX/versions/adbR7c5l/tpa-20250220c.jar"
+            "size": 70649,
+            "url": "https://cdn.modrinth.com/data/GM9AuKjX/versions/5hfMKnoW/just-tpa-20260625-0111.jar"
           },
           "game_versions": [
             "1.19",
@@ -15214,17 +15731,21 @@
             "1.21.8",
             "1.21.9",
             "1.21.10",
-            "1.21.11"
+            "1.21.11",
+            "26.1",
+            "26.1.1",
+            "26.1.2",
+            "26.2"
           ],
-          "id": "adbR7c5l",
+          "id": "5hfMKnoW",
           "loaders": [
             "bukkit",
             "paper",
             "spigot"
           ],
-          "name": "JustPlayer TPA 20250220c",
+          "name": "Just TPA 20260625-0111",
           "project_id": "GM9AuKjX",
-          "version_number": "20250220c",
+          "version_number": "20260625-0111",
           "version_type": "release"
         }
       },
@@ -15241,11 +15762,11 @@
       "client_side": "optional",
       "color": 9540763,
       "date_created": "2022-11-13T22:15:04.878426Z",
-      "date_modified": "2026-05-14T19:44:23.958272Z",
+      "date_modified": "2026-06-26T04:03:59.908843Z",
       "description": "Just another boring library mod.",
       "discord_url": "https://discord.gg/UzmeWkD",
-      "downloads": 46460533,
-      "followers": 897,
+      "downloads": 50473041,
+      "followers": 955,
       "game_versions": [
         "1.12",
         "1.12.1",
@@ -15278,7 +15799,8 @@
         "1.21.10",
         "1.21.11",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/J81TRJWm/f27c753fd9ec7944b49f4fe2d7cfd32527340183_96.webp",
       "issues_url": "https://github.com/Keksuccino/Konkrete/issues",
@@ -15301,16 +15823,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 500236,
+          "downloads": 662824,
           "file": {
             "filename": "konkrete_fabric_1.9.18_MC_1.21.11.jar",
             "hashes": {
-              "sha1": "734866bdeed1af0b1fa23b131bd841648af96f69",
               "sha512": "44d787e88d9e3991df90d8926b93620b7e347a5f30c27bd6bfa58016f38d3e549f2eafe7c66d9654f22c5d5fdc32ad977aec3be7d488efb766f6ce1b89f1f2fd"
             },
             "primary": true,
@@ -15348,18 +15867,18 @@
       "description": "A mod to optimize the Minecraft networking stack",
       "donation_urls": [
         {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/astei"
-        },
-        {
           "id": "paypal",
           "platform": "Paypal",
           "url": "https://paypal.me/terminalvelocity1"
+        },
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/astei"
         }
       ],
-      "downloads": 31603791,
-      "followers": 5298,
+      "downloads": 34446618,
+      "followers": 5464,
       "game_versions": [
         "1.16.2",
         "1.16.3",
@@ -15413,11 +15932,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2025-10-05T19:06:22.210926Z",
-          "downloads": 2728252,
+          "downloads": 3486230,
           "file": {
             "filename": "krypton-0.2.10.jar",
             "hashes": {
-              "sha1": "94ddaeeae6ca7fecc79e54a0aa02a5438a775a99",
               "sha512": "4dcd7228d1890ddfc78c99ff284b45f9cf40aae77ef6359308e26d06fa0d938365255696af4cc12d524c46c4886cdcd19268c165a2bf0a2835202fe857da5cab"
             },
             "primary": true,
@@ -15440,11 +15958,10 @@
         },
         "26.1.2+fabric": {
           "date_published": "2026-04-21T21:42:30.331431Z",
-          "downloads": 157717,
+          "downloads": 458495,
           "file": {
             "filename": "krypton-0.3.0.jar",
             "hashes": {
-              "sha1": "2557a2dae9492ab98580a61fb9f209df7a90e733",
               "sha512": "14233210283a76f3cf435a3b8ddbcbd65a858d2b1a10b88ff643c0a01486dfd2bf1843bd3456cd4fb86cbb3b06f2dea0c4e663b1976a48e96de16d3b5a707ec9"
             },
             "primary": true,
@@ -15487,8 +16004,8 @@
       "date_modified": "2026-04-24T22:44:23.714576Z",
       "description": "Speed up your world loading by removing unneeded chunks.",
       "discord_url": "https://discord.gg/Q6saSVSuYQ",
-      "downloads": 5529250,
-      "followers": 1124,
+      "downloads": 6215486,
+      "followers": 1167,
       "game_versions": [
         "1.8",
         "1.8.1",
@@ -15564,13 +16081,9 @@
         "26.1.1",
         "26.2-snapshot-1",
         "26.1.2",
-        "26.2-snapshot-2",
-        "26.2-snapshot-3",
-        "26.2-snapshot-4",
-        "26.2-snapshot-5",
-        "26.2-snapshot-6",
-        "26.2-snapshot-7",
-        "26.2-snapshot-8"
+        "26.2",
+        "26.3-snapshot-1",
+        "26.3-snapshot-2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/2ecVyZ49/e7c3867d7a7da57f987bc0d6d37de88020c626a5_96.webp",
       "issues_url": "https://github.com/VidTu/Ksyxis/issues",
@@ -15593,11 +16106,10 @@
       "selected_versions": {
         "26.1.2+26.2-snapshot-5+fabric": {
           "date_published": "2026-04-24T22:44:23.714576Z",
-          "downloads": 290693,
+          "downloads": 803104,
           "file": {
             "filename": "Ksyxis-1.4.3.jar",
             "hashes": {
-              "sha1": "6f4b2ea7827da8136bdf436457a2ba3fcdb2120e",
               "sha512": "55b1ec940910a6c36fa40595b0d7b8617e3a817c55ecb2d5c1ee54c026936d6f1a4bbe63228c60ebf75195bb14f3c9128c913ba949df2c5877b9b99d21bab9a4"
             },
             "primary": true,
@@ -15679,13 +16191,9 @@
             "26.1.1",
             "26.2-snapshot-1",
             "26.1.2",
-            "26.2-snapshot-2",
-            "26.2-snapshot-3",
-            "26.2-snapshot-4",
-            "26.2-snapshot-5",
-            "26.2-snapshot-6",
-            "26.2-snapshot-7",
-            "26.2-snapshot-8"
+            "26.2",
+            "26.3-snapshot-1",
+            "26.3-snapshot-2"
           ],
           "id": "kL32PN9Q",
           "loaders": [
@@ -15725,8 +16233,8 @@
       "client_side": "unsupported",
       "color": 14409958,
       "date_created": "2024-05-15T22:23:34.921001Z",
-      "date_modified": "2026-05-01T01:57:55.756810Z",
-      "description": "\u26a1\ufe0f Best Performance Solution! \ud83d\uddc4\ufe0fTrusted by 2700+ servers! \u2705 Lightweight and highly Asynchronous!",
+      "date_modified": "2026-06-26T12:57:36.863580Z",
+      "description": "\u26a1\ufe0f Best Performance Solution! \ud83d\uddc4\ufe0fTrusted by 3000+ servers! \u2705 Lightweight and highly Asynchronous!",
       "discord_url": "https://discord.gg/CFmzJjgZdu",
       "donation_urls": [
         {
@@ -15735,8 +16243,8 @@
           "url": "https://ko-fi.com/lajczik"
         }
       ],
-      "downloads": 241296,
-      "followers": 387,
+      "downloads": 266506,
+      "followers": 411,
       "gallery": [
         {
           "created": "2024-05-15T22:38:08.963291Z",
@@ -15802,7 +16310,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/fD1X4Kwd/6d0fd71600895b2f67a3fc70bdb5e84916ee2ff4.png",
       "issues_url": "https://github.com/lajczik/lagfixer/issues",
@@ -15823,17 +16332,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-01T01:57:55.756810Z",
-          "downloads": 11695,
+          "date_published": "2026-06-26T12:57:05.514351Z",
+          "downloads": 2084,
           "file": {
-            "filename": "LagFixer.jar",
+            "filename": "LagFixer-1.6.5.jar",
             "hashes": {
-              "sha1": "8027fb20fc8afea490b87844086412228893b6e9",
-              "sha512": "9c675de11bacc256e094a9b11091810f93a4b3fd2e18161446e666209650d1e2e0d4515584eec3b0c59e21121677f1ebd7e46b33df80f9fcb080478cd4b09ec2"
+              "sha512": "8300eff9d7e848d23abeaaef99cfacde9e664b4afc744a867180ec8c73709dfffaee09b6058b58caeb14fa7fe58461f182929940b5fa18e36b87fc7e9cc2b93b"
             },
             "primary": true,
-            "size": 1940287,
-            "url": "https://cdn.modrinth.com/data/fD1X4Kwd/versions/u0I1B7HL/LagFixer.jar"
+            "size": 1904237,
+            "url": "https://cdn.modrinth.com/data/fD1X4Kwd/versions/XcyPTBv7/LagFixer-1.6.5.jar"
           },
           "game_versions": [
             "1.13",
@@ -15884,18 +16392,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "u0I1B7HL",
+          "id": "XcyPTBv7",
           "loaders": [
             "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "LagFixer 1.5.3 [build 142]",
+          "name": "LagFixer 1.6.5 [build 148]",
           "project_id": "fD1X4Kwd",
-          "version_number": "1.5.3",
+          "version_number": "1.6.5",
           "version_type": "release"
         }
       },
@@ -15916,11 +16425,11 @@
       "client_side": "unsupported",
       "color": 1848593,
       "date_created": "2022-10-06T10:59:22.189587Z",
-      "date_modified": "2026-05-04T06:39:47.313876Z",
+      "date_modified": "2026-06-17T23:05:04.593834Z",
       "description": "Quick leaf decay from cutting down trees. Built for fast performance and mod compat!",
       "discord_url": "https://lunapixel.studio/discord",
-      "downloads": 9980679,
-      "followers": 1399,
+      "downloads": 10727481,
+      "followers": 1488,
       "gallery": [
         {
           "created": "2025-07-29T07:37:57.490539Z",
@@ -15950,7 +16459,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/AVq17PqV/72915db87281bf57b62cc4ec7dc9ea75865b2f5f_96.webp",
       "issues_url": "https://github.com/Fuzss/leavesbegone/issues",
@@ -15973,28 +16483,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "QAGBst4M",
-              "version_id": null
+              "project_id": "ohNO6lps"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "ohNO6lps",
-              "version_id": null
+              "project_id": "QAGBst4M"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 136987,
+          "downloads": 154144,
           "file": {
             "filename": "LeavesBeGone-v21.11.0-mc1.21.11-Fabric.jar",
             "hashes": {
-              "sha1": "2d31e9d6f10766cd6cc99789fded577ca650e3f6",
               "sha512": "34b7218b973aad2ab079e58167a0d493dc0a57eda0ae1f980839e21411abf7fdda0d37bd6633f1b7c59aa7bc09d1043c6bdb2a6fab3f2ecadc1676448bad7385"
             },
             "primary": true,
@@ -16027,10 +16530,10 @@
       "client_side": "optional",
       "color": 263172,
       "date_created": "2021-05-15T16:15:55.233649Z",
-      "date_modified": "2026-03-30T14:19:15.953109Z",
+      "date_modified": "2026-06-17T12:23:04.218318Z",
       "description": "A library for my mods",
-      "downloads": 8619424,
-      "followers": 550,
+      "downloads": 10345741,
+      "followers": 598,
       "game_versions": [
         "1.16.5",
         "1.17",
@@ -16064,7 +16567,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/WKwQAwke/icon.png",
       "issues_url": "https://git.frohnmeyer-wds.de/JfMods/LibJF/issues",
@@ -16086,16 +16590,13 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 443653,
+          "downloads": 824733,
           "file": {
             "filename": "libjf-3.19.12.jar",
             "hashes": {
-              "sha1": "7124959999fbc14798030ced46af8fbdb4f7c6ed",
               "sha512": "ab441123a02af8a6ff59ed71145255c5a528240daa59579ee354681b9ee60aa745cdaaeeedcc323111433d4a9c78051b7b7086ff663f56a4d0a13f856bb9f0e5"
             },
             "primary": true,
@@ -16134,8 +16635,8 @@
       "date_modified": "2026-05-14T09:39:53.442327Z",
       "description": "LifeStealZ - The Ultimate LifeSteal SMP Plugin!",
       "discord_url": "https://strassburger.org/discord",
-      "downloads": 334544,
-      "followers": 323,
+      "downloads": 360849,
+      "followers": 338,
       "gallery": [
         {
           "created": "2024-09-08T21:07:38.723197Z",
@@ -16195,7 +16696,7 @@
         "26.1.1",
         "26.1.2"
       ],
-      "icon_url": "https://cdn.modrinth.com/data/l8Uv7FzS/fe2516bcf4b77eeb27a94a01a2050c29dbfb2701.gif",
+      "icon_url": "https://cdn.modrinth.com/data/l8Uv7FzS/8af3a6990fd946a207be8e6acfa092f161736811.gif",
       "issues_url": "https://github.com/ZetaPlugins/lifestealz/issues",
       "license": {
         "id": "GPL-3.0-only",
@@ -16213,11 +16714,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-05-14T09:39:53.442327Z",
-          "downloads": 5116,
+          "downloads": 28851,
           "file": {
             "filename": "lifestealz-2.21.1.jar",
             "hashes": {
-              "sha1": "80f8dbadc2ce05cdbb4d820b9e392b01f77af2f1",
               "sha512": "89c5986faf16b1fe4a5fb85c20c5af4533d86974fed6762a369502627c0070129735e1a286e11ec59bd73b6651bae9a4fc6ba1cb559fe6c63c7ce6af219d41c8"
             },
             "primary": true,
@@ -16268,11 +16768,11 @@
       "client_side": "unknown",
       "color": 920580,
       "date_created": "2024-10-03T06:32:23.463726Z",
-      "date_modified": "2026-04-15T14:34:12.775573Z",
+      "date_modified": "2026-06-27T14:48:51.734085Z",
       "description": "Anticheat Perfected | 3.0005 reach | 99.999% antikb. Fork of GrimAC that's faster, with better reach checks, interact checks, and numerous bug fixes.",
       "discord_url": "https://discord.gg/JF3SUfq26k",
-      "downloads": 110620,
-      "followers": 213,
+      "downloads": 123378,
+      "followers": 217,
       "game_versions": [
         "1.7.2",
         "1.7.3",
@@ -16352,7 +16852,11 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/yeJMtJfW/c3cc65f460bff606cfe15190b90cdc83fd54dd92_96.webp",
       "issues_url": "https://github.com/Axionize/LightningGrim/issues",
@@ -16374,17 +16878,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-15T14:34:08.847010Z",
-          "downloads": 6575,
+          "date_published": "2026-06-27T14:48:49.864823Z",
+          "downloads": 717,
           "file": {
-            "filename": "grimac-bukkit-2.3.74-65815fc.jar",
+            "filename": "grimac-bukkit-2.3.74-00dbb86.jar",
             "hashes": {
-              "sha1": "0abd3a2d52b5ad9866b001225f666f0c912e7624",
-              "sha512": "aa33cc15e59106e0016d1006d2e892599e963d82a491a2c972281f5cd3c802bcf97f3a151df26940a3bca197dafd819bceabd133f3bdfe65c96c10fadddc7fe8"
+              "sha512": "bb9607200021371c86478a0de950beb4a8ddca82ad46ff7571bdb3a0af42494abda6f40b6b05dc279d19307292693b103837540aa97f8f9c8f948f3019a622cd"
             },
             "primary": true,
-            "size": 10843154,
-            "url": "https://cdn.modrinth.com/data/yeJMtJfW/versions/PDeZA0cZ/grimac-bukkit-2.3.74-65815fc.jar"
+            "size": 12492655,
+            "url": "https://cdn.modrinth.com/data/yeJMtJfW/versions/GuA4nQtq/grimac-bukkit-2.3.74-00dbb86.jar"
           },
           "game_versions": [
             "1.7.2",
@@ -16465,9 +16968,13 @@
             "1.21.8",
             "1.21.9",
             "1.21.10",
-            "1.21.11"
+            "1.21.11",
+            "26.1",
+            "26.1.1",
+            "26.1.2",
+            "26.2"
           ],
-          "id": "PDeZA0cZ",
+          "id": "GuA4nQtq",
           "loaders": [
             "bukkit",
             "folia",
@@ -16475,9 +16982,9 @@
             "purpur",
             "spigot"
           ],
-          "name": "LightningGrim Anticheat (Bukkit) 2.3.74-65815fc-b98",
+          "name": "LightningGrim Anticheat (Bukkit) 2.3.74-00dbb86-b99",
           "project_id": "yeJMtJfW",
-          "version_number": "2.3.74-65815fc-b98",
+          "version_number": "2.3.74-00dbb86-b99",
           "version_type": "alpha"
         }
       },
@@ -16495,8 +17002,8 @@
       "client_side": "optional",
       "color": 15395571,
       "date_created": "2021-01-03T00:56:52.292581Z",
-      "date_modified": "2026-04-18T20:51:57.941352Z",
-      "description": "No-compromises game logic optimization mod. Well suited for clients and servers of all kinds. Now available for Fabric and NeoForge!",
+      "date_modified": "2026-06-27T17:13:54.562612Z",
+      "description": "No-compromises game logic optimization mod, useful for both single-player games and multi-player servers.",
       "discord_url": "https://caffeinemc.net/discord",
       "donation_urls": [
         {
@@ -16505,8 +17012,8 @@
           "url": "https://www.patreon.com/2No2Name"
         }
       ],
-      "downloads": 93694983,
-      "followers": 21401,
+      "downloads": 103690621,
+      "followers": 22246,
       "game_versions": [
         "1.16.2",
         "1.16.3",
@@ -16543,7 +17050,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/gvQqBUqZ/bcc8686c13af0143adf4285d741256af824f70b7_96.webp",
       "issues_url": "https://github.com/caffeinemc/lithium-fabric/issues",
@@ -16563,11 +17071,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-03-11T00:39:03.618667Z",
-          "downloads": 3196412,
+          "downloads": 4980802,
           "file": {
             "filename": "lithium-fabric-0.21.4+mc1.21.11.jar",
             "hashes": {
-              "sha1": "203bdcb26e97b3217b045e1182651a7d7b6462ec",
               "sha512": "f14a5c3d2fad786347ca25083f902139694f618b7c103947f2fd067a7c5ee88a63e1ef8926f7d693ea79ed7d00f57317bae77ef9c2d630bf5ed01ac97a752b94"
             },
             "primary": true,
@@ -16588,31 +17095,30 @@
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-04-18T20:51:57.906154Z",
-          "downloads": 1235582,
+          "date_published": "2026-06-16T20:19:24.538671Z",
+          "downloads": 361362,
           "file": {
-            "filename": "lithium-fabric-0.24.2+mc26.1.2.jar",
+            "filename": "lithium-fabric-0.24.6+mc26.1.2.jar",
             "hashes": {
-              "sha1": "a2575886c93255a73e5c583e89332b8bd56023d3",
-              "sha512": "9231ad05667d4eef0348c700bf5160929e0b723d9e145fd97c7fcef9387ac2e6d524fb15d99f47f8f838f1d235324fd750cdcb6603b63aab6085d79fbeaab31b"
+              "sha512": "fac351f5b6150889b9355a01889c35b5798147d4bedb291594a590a2d41909eb8dc494ef0051317bf55886f2fc7fe134abbe2e755098df38473edb2bf43357e9"
             },
             "primary": true,
-            "size": 882624,
-            "url": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/R7MxYvuW/lithium-fabric-0.24.2%2Bmc26.1.2.jar"
+            "size": 911415,
+            "url": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/fQBdPR1m/lithium-fabric-0.24.6%2Bmc26.1.2.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
             "26.1.2"
           ],
-          "id": "R7MxYvuW",
+          "id": "fQBdPR1m",
           "loaders": [
             "fabric",
             "quilt"
           ],
-          "name": "Lithium 0.24.2 for Fabric",
+          "name": "Lithium 0.24.6 for Fabric",
           "project_id": "gvQqBUqZ",
-          "version_number": "mc26.1.2-0.24.2-fabric",
+          "version_number": "mc26.1.2-0.24.6-fabric",
           "version_type": "release"
         }
       },
@@ -16631,7 +17137,7 @@
       "client_side": "unsupported",
       "color": 14471077,
       "date_created": "2023-08-03T19:55:34.133706Z",
-      "date_modified": "2026-05-17T05:22:42.287077Z",
+      "date_modified": "2026-06-26T03:12:25.358515Z",
       "description": "Library mod with new configurability and compatibility enhancements for worldgen",
       "donation_urls": [
         {
@@ -16640,8 +17146,8 @@
           "url": "https://ko-fi.com/apollodev"
         }
       ],
-      "downloads": 15888520,
-      "followers": 1280,
+      "downloads": 17781898,
+      "followers": 1388,
       "game_versions": [
         "1.20",
         "1.20.1",
@@ -16666,7 +17172,10 @@
         "26.1-rc-3",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2-pre-2",
+        "26.2-rc-2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/XaDC71GB/bc3425bcb318176adc7da99b6eec48787eed98d3.png",
       "issues_url": "https://github.com/Apollounknowndev/lithostitched/issues",
@@ -16689,16 +17198,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 65952,
+          "downloads": 178235,
           "file": {
             "filename": "lithostitched-1.7.2-fabric-21.11.jar",
             "hashes": {
-              "sha1": "d35f576f35115e406466fa426ec661a82b12e760",
               "sha512": "77e432cf8932f5a9e6caee5ed4e18d80e0782e5eb9852a0e14c3e2337f5f84ecc579277ac8b7cdbbeaf03ac2fd2b17b68e951a05355c7973df4fd9176774679f"
             },
             "primary": true,
@@ -16718,38 +17224,35 @@
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-17T05:22:40.797744Z",
+          "date_published": "2026-06-26T03:12:21.570303Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 23030,
+          "downloads": 15012,
           "file": {
-            "filename": "lithostitched-1.7.7-fabric-26.1.jar",
+            "filename": "lithostitched-1.7.12-fabric-26.1.jar",
             "hashes": {
-              "sha1": "9f7562a5447e102ee6edcb7c1cf767463aa2d755",
-              "sha512": "d93811321d7e1b11525ebcc326bab9dec0633b85ef3b0d4253dbe299af091b35d369c5e3ace5f8a58ac97a703d9351389b22c07a917cb004e65c268e582d066d"
+              "sha512": "6c677420ff01602a0000f90fa53fe81518c9eb56f2efcbd9ea12fece412334c62a51be082b694ce86ba8b977e85559bf9cf5e59984ddc16cbccf7fbc0f00cdde"
             },
             "primary": true,
-            "size": 828234,
-            "url": "https://cdn.modrinth.com/data/XaDC71GB/versions/dUL7i4Qf/lithostitched-1.7.7-fabric-26.1.jar"
+            "size": 858433,
+            "url": "https://cdn.modrinth.com/data/XaDC71GB/versions/7gxI2iZP/lithostitched-1.7.12-fabric-26.1.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
             "26.1.2"
           ],
-          "id": "dUL7i4Qf",
+          "id": "7gxI2iZP",
           "loaders": [
             "fabric"
           ],
-          "name": "v1.7.7 ~ Fabric 26.1",
+          "name": "v1.7.12 ~ Fabric 26.1",
           "project_id": "XaDC71GB",
-          "version_number": "1.7.7-fabric-26.1",
+          "version_number": "1.7.12-fabric-26.1",
           "version_type": "release"
         }
       },
@@ -16769,8 +17272,8 @@
       "date_created": "2022-08-21T22:24:10.240747Z",
       "date_modified": "2026-04-19T09:47:53.473403Z",
       "description": "Improves performance by tweaking mob despawn rules. Say bye to pesky unintentional persistent mobs.",
-      "downloads": 17583903,
-      "followers": 1970,
+      "downloads": 19287212,
+      "followers": 2048,
       "gallery": [
         {
           "created": "2022-08-22T00:00:04.243531Z",
@@ -16896,7 +17399,18 @@
         "26.2-snapshot-4",
         "26.2-snapshot-5",
         "26.2-snapshot-6",
-        "26.2-snapshot-7"
+        "26.2-snapshot-7",
+        "26.2-snapshot-8",
+        "26.2-pre-1",
+        "26.2-pre-2",
+        "26.2-pre-3",
+        "26.2-pre-4",
+        "26.2-pre-5",
+        "26.2-pre-6",
+        "26.2-rc-1",
+        "26.2-rc-2",
+        "26.2",
+        "26.3-snapshot-1"
       ],
       "icon_url": "https://cdn.modrinth.com/data/vE2FN5qn/2609f745e46bd92e57a67e1da07319eb2154c6f7.png",
       "issues_url": "https://github.com/frikinjay/let-me-despawn/issues",
@@ -16923,22 +17437,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "Gi02250Z",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "Gi02250Z"
             }
           ],
-          "downloads": 97318,
+          "downloads": 102116,
           "file": {
             "filename": "Letmedespawn-1.21.9-fabric-1.5.2b.jar",
             "hashes": {
-              "sha1": "e49702d6b9343814c9f9365c178424888fcef7bb",
               "sha512": "6f12cae1bb8ff5db6cab0eb51b2bf8a8f0ec838de5dc48d18ee6c96a6611e6049c2966a806e0191882b06a41f069c3da3e97369b06e3304e1852bab5eacd8f00"
             },
             "primary": true,
@@ -16976,22 +17485,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "Gi02250Z",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "Gi02250Z"
             }
           ],
-          "downloads": 31028,
+          "downloads": 96687,
           "file": {
             "filename": "letmedespawn-1.26.x-fabric-1.6.2.1.jar",
             "hashes": {
-              "sha1": "029d80308e7e4588829bfe175b965aed4a706a4c",
               "sha512": "da8bcb522a9fc74ef400d4b6bcfd1130d1dbd6458ebb152c1772eb6b7db39e09ad444e45d22208e8042fc7048da4f6584e2f510e8b8396c9eae81f7410fb5e05"
             },
             "primary": true,
@@ -17007,7 +17511,18 @@
             "26.2-snapshot-4",
             "26.2-snapshot-5",
             "26.2-snapshot-6",
-            "26.2-snapshot-7"
+            "26.2-snapshot-7",
+            "26.2-snapshot-8",
+            "26.2-pre-1",
+            "26.2-pre-2",
+            "26.2-pre-3",
+            "26.2-pre-4",
+            "26.2-pre-5",
+            "26.2-pre-6",
+            "26.2-rc-1",
+            "26.2-rc-2",
+            "26.2",
+            "26.3-snapshot-1"
           ],
           "id": "eW5P1rHo",
           "loaders": [
@@ -17033,7 +17548,7 @@
       "client_side": "required",
       "color": 4141090,
       "date_created": "2023-10-09T15:57:37.652215Z",
-      "date_modified": "2026-05-05T02:14:02.303602Z",
+      "date_modified": "2026-06-28T09:07:16.687643Z",
       "description": "A mod that makes it so nobody misses out on Loot! All loot chests are instanced per player and visually unique.",
       "discord_url": "https://discord.gg/9YVkaee",
       "donation_urls": [
@@ -17043,8 +17558,8 @@
           "url": "https://www.patreon.com/noobanidus"
         }
       ],
-      "downloads": 16985175,
-      "followers": 1202,
+      "downloads": 18495928,
+      "followers": 1284,
       "gallery": [
         {
           "created": "2023-10-09T15:57:14.650542Z",
@@ -17114,7 +17629,8 @@
         "1.21.10",
         "1.21.11",
         "26.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/EltpO5cN/3dc915eb1bbcd65654c17eb3870de4aba055d0c6_96.webp",
       "issues_url": "https://github.com/noobanidus/lootr/issues",
@@ -17137,22 +17653,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "9s6osm5g"
             }
           ],
-          "downloads": 10664,
+          "downloads": 40266,
           "file": {
             "filename": "lootr-fabric-1.21.11-1.20.34.104.jar",
             "hashes": {
-              "sha1": "4d6d935f87b0f269148cfe6079dbed332b9133b8",
               "sha512": "d0ef0981586691cd916471087f35614449a5b4638ec15ce129a4b293f0603d3731bc5db14ae7b28be2ef5f98fb1f1d7ef45e0bcfbc852e33dd9ddfcd3c841cbe"
             },
             "primary": true,
@@ -17187,7 +17698,7 @@
       "client_side": "unsupported",
       "color": 9623556,
       "date_created": "2021-01-05T13:18:36.857352Z",
-      "date_modified": "2026-03-26T22:46:44.645095Z",
+      "date_modified": "2026-06-18T21:16:30.938696Z",
       "description": "A permissions plugin/mod for Minecraft servers.",
       "discord_url": "https://discord.gg/luckperms",
       "donation_urls": [
@@ -17197,8 +17708,8 @@
           "url": "https://github.com/sponsors/lucko"
         }
       ],
-      "downloads": 1934361,
-      "followers": 1472,
+      "downloads": 2159131,
+      "followers": 1558,
       "game_versions": [
         "1.8.8",
         "1.8.9",
@@ -17264,7 +17775,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Vebnzrzj/90943902cc650e95b167265b8f2d7c893f82c8f4_96.webp",
       "issues_url": "https://github.com/lucko/LuckPerms/issues",
@@ -17277,6 +17789,7 @@
         "bukkit",
         "bungeecord",
         "fabric",
+        "folia",
         "forge",
         "neoforge",
         "paper",
@@ -17289,17 +17802,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2025-10-11T12:26:55.608887Z",
-          "downloads": 253906,
+          "date_published": "2026-05-27T07:14:37.365816Z",
+          "downloads": 73625,
           "file": {
-            "filename": "LuckPerms-Bukkit-5.5.17.jar",
+            "filename": "LuckPerms-Bukkit-5.5.53.jar",
             "hashes": {
-              "sha1": "af24a4fc61c4ae814ce9a280179b9c88ec614013",
-              "sha512": "773895644260b338818bfeff0c78f8d4f590f56b0f711c378a4eec91be6e8b37354099b5db1ea5b2dce4c02486213297a6da09675c9bf6f014f9a400b5772cf3"
+              "sha512": "a0e087adfc1c7b9fab8fdb5a430a3331a2ca30bfc72818bb7e65ce9baff051a1490834be8cbb9cbeda292f2e92c44cf03fb829ebeb233ade9d666ed908e49ad5"
             },
             "primary": true,
-            "size": 1480518,
-            "url": "https://cdn.modrinth.com/data/Vebnzrzj/versions/OrIs0S6b/LuckPerms-Bukkit-5.5.17.jar"
+            "size": 1490252,
+            "url": "https://cdn.modrinth.com/data/Vebnzrzj/versions/MBSY8toc/LuckPerms-Bukkit-5.5.53.jar"
           },
           "game_versions": [
             "1.8.9",
@@ -17365,44 +17877,46 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "OrIs0S6b",
+          "id": "MBSY8toc",
           "loaders": [
             "bukkit",
+            "folia",
             "paper",
             "spigot"
           ],
-          "name": "v5.5.17 (Bukkit)",
+          "name": "v5.5.53 (Bukkit)",
           "project_id": "Vebnzrzj",
-          "version_number": "v5.5.17-bukkit",
+          "version_number": "v5.5.53-bukkit",
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-03-26T22:46:44.645095Z",
-          "downloads": 20083,
+          "date_published": "2026-06-18T21:16:14.917799Z",
+          "downloads": 5614,
           "file": {
-            "filename": "LuckPerms-Fabric-5.5.42.jar",
+            "filename": "LuckPerms-Fabric-5.5.57.jar",
             "hashes": {
-              "sha1": "f2fee62e89bb3f341d91c7c76b4c29304fd8d5aa",
-              "sha512": "bfe9f0e0e2d9dfe3c1c456298dbd778af02310dabab5d7fb4a54fcc4a4e8c2653bae0be84151d7c52992065d9884cdab97ec1eea6607e7f7cf01126a13be8630"
+              "sha512": "6fedf31ff4d17710394463b7bfc97f2beba90eaa0327d6e718aab3195ec748bfba2835a9af804593fc1788e256dba79534da7f249411c8daec47b6e1e70e6f42"
             },
             "primary": true,
-            "size": 1586996,
-            "url": "https://cdn.modrinth.com/data/Vebnzrzj/versions/fTIdfb46/LuckPerms-Fabric-5.5.42.jar"
+            "size": 1621410,
+            "url": "https://cdn.modrinth.com/data/Vebnzrzj/versions/UHUghDkV/LuckPerms-Fabric-5.5.57.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "fTIdfb46",
+          "id": "UHUghDkV",
           "loaders": [
             "fabric"
           ],
-          "name": "v5.5.42 (Fabric 26.1)",
+          "name": "v5.5.57 (Fabric 26.2)",
           "project_id": "Vebnzrzj",
-          "version_number": "v5.5.42-fabric",
+          "version_number": "v5.5.57-fabric",
           "version_type": "release"
         }
       },
@@ -17413,174 +17927,6 @@
       "title": "LuckPerms",
       "wiki_url": "https://luckperms.net/wiki"
     },
-    "maintenance": {
-      "categories": [
-        "management",
-        "utility"
-      ],
-      "client_side": "unsupported",
-      "color": 12286272,
-      "date_created": "2022-12-19T17:36:31.525242Z",
-      "date_modified": "2026-05-17T08:08:38.456063Z",
-      "description": "The most customizable free maintenance plugin for your Minecraft server you can find. It runs on Paper, Velocity, Bungee, as well as Sponge.",
-      "discord_url": "https://discord.gg/vGCUzHq",
-      "donation_urls": [
-        {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/kennytv"
-        }
-      ],
-      "downloads": 82717,
-      "followers": 197,
-      "game_versions": [
-        "1.2.1",
-        "1.2.2",
-        "1.2.3",
-        "1.2.4",
-        "1.2.5",
-        "1.8.8",
-        "1.8.9",
-        "1.9",
-        "1.9.1",
-        "1.9.2",
-        "1.9.3",
-        "1.9.4",
-        "1.10",
-        "1.10.1",
-        "1.10.2",
-        "1.11",
-        "1.11.1",
-        "1.11.2",
-        "1.12",
-        "1.12.1",
-        "1.12.2",
-        "1.13",
-        "1.13.1",
-        "1.13.2",
-        "1.14",
-        "1.14.1",
-        "1.14.2",
-        "1.14.3",
-        "1.14.4",
-        "1.15",
-        "1.15.1",
-        "1.15.2",
-        "1.16",
-        "1.16.1",
-        "1.16.2",
-        "1.16.3",
-        "1.16.4",
-        "1.16.5",
-        "1.17",
-        "1.17.1",
-        "1.18",
-        "1.18.1",
-        "1.18.2",
-        "1.19",
-        "1.19.1",
-        "1.19.2",
-        "1.19.3",
-        "1.19.4",
-        "1.20",
-        "1.20.1",
-        "1.20.2",
-        "1.20.3",
-        "1.20.4",
-        "1.20.5",
-        "1.20.6",
-        "1.21",
-        "1.21.1",
-        "1.21.2",
-        "1.21.3",
-        "1.21.4",
-        "1.21.5",
-        "1.21.6",
-        "1.21.7",
-        "1.21.8",
-        "1.21.9",
-        "1.21.10",
-        "1.21.11",
-        "26.1",
-        "26.1.1",
-        "26.1.2"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/VCAqN1ln/fd4bb7bd72a2c4844a3d964cf2b38d35858487a1_96.webp",
-      "issues_url": "https://github.com/kennytv/Maintenance/issues",
-      "license": {
-        "id": "GPL-3.0-only",
-        "name": "GNU General Public License v3.0 only",
-        "url": null
-      },
-      "loaders": [
-        "bungeecord",
-        "folia",
-        "paper",
-        "sponge",
-        "velocity",
-        "waterfall"
-      ],
-      "page_url": "https://modrinth.com/mod/maintenance",
-      "project_id": "VCAqN1ln",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+paper": {
-          "date_published": "2026-05-17T08:07:58.045953Z",
-          "downloads": 1030,
-          "file": {
-            "filename": "Maintenance-Paper-5.1.0.jar",
-            "hashes": {
-              "sha1": "bf19795fee6e2431a7d6078b732d494a5095bccf",
-              "sha512": "b5c59f86b7cf8dd2e06d4ce1a45980121d4bbaef3e1fd9072945374c8435bc11d146db1c641f9cd147693a83992e05aa16d99470f40baccef1b810834f11e9e5"
-            },
-            "primary": true,
-            "size": 233744,
-            "url": "https://cdn.modrinth.com/data/VCAqN1ln/versions/PHVWydDH/Maintenance-Paper-5.1.0.jar"
-          },
-          "game_versions": [
-            "1.2.1",
-            "1.2.2",
-            "1.2.3",
-            "1.2.4",
-            "1.2.5",
-            "1.20",
-            "1.20.1",
-            "1.20.2",
-            "1.20.3",
-            "1.20.4",
-            "1.20.5",
-            "1.20.6",
-            "1.21",
-            "1.21.1",
-            "1.21.2",
-            "1.21.3",
-            "1.21.4",
-            "1.21.5",
-            "1.21.6",
-            "1.21.7",
-            "1.21.8",
-            "1.21.9",
-            "1.21.10",
-            "1.21.11"
-          ],
-          "id": "PHVWydDH",
-          "loaders": [
-            "folia",
-            "paper"
-          ],
-          "name": "5.1.0 - Paper",
-          "project_id": "VCAqN1ln",
-          "version_number": "5.1.0",
-          "version_type": "release"
-        }
-      },
-      "server_side": "required",
-      "slug": "maintenance",
-      "source": "modrinth",
-      "source_url": "https://github.com/kennytv/Maintenance",
-      "title": "Maintenance",
-      "wiki_url": "https://github.com/kennytv/Maintenance/wiki"
-    },
     "mclogs": {
       "categories": [
         "management",
@@ -17589,10 +17935,10 @@
       "client_side": "unknown",
       "color": 2894892,
       "date_created": "2022-11-15T16:11:41.802934Z",
-      "date_modified": "2026-03-30T15:54:03.106718Z",
+      "date_modified": "2026-06-22T11:03:25.208244Z",
       "description": "Paste, share & analyse your Minecraft logs",
-      "downloads": 400987,
-      "followers": 162,
+      "downloads": 416724,
+      "followers": 167,
       "game_versions": [
         "1.8.3",
         "1.8.4",
@@ -17666,7 +18012,10 @@
         "1.21.9",
         "1.21.10",
         "1.21.11",
-        "26.1"
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/6DdCzpTL/e5d2c630ecb45a41de5cdda386e0473d75d2086a_96.webp",
       "issues_url": "https://github.com/aternosorg/mclogs-integration/issues",
@@ -17694,11 +18043,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-02-18T11:23:11.358084Z",
-          "downloads": 1057,
+          "downloads": 1340,
           "file": {
             "filename": "mclogs-bukkit-1.21.11-3.1.1-all.jar",
             "hashes": {
-              "sha1": "8b4ceb8073c418750933f18320ea828c0f517776",
               "sha512": "b8e49bd7a9d79cc7ee17edf57bfa880bceea6ad4bf31ae395702dd91003ab3140cd1ae18fbe7a161e81aa98911a9a9e1309f087372b64e7ca802675111b1c913"
             },
             "primary": true,
@@ -17734,11 +18082,11 @@
       "client_side": "optional",
       "color": 9736865,
       "date_created": "2021-06-01T14:51:21.610099Z",
-      "date_modified": "2026-05-02T20:14:18.773870Z",
+      "date_modified": "2026-06-17T12:37:25.700185Z",
       "description": "Common library providing a lightweight configuration system",
       "discord_url": "https://discord.midnightdust.eu",
-      "downloads": 19705138,
-      "followers": 1551,
+      "downloads": 21816540,
+      "followers": 1580,
       "gallery": [
         {
           "created": "2024-07-03T08:51:05.339696Z",
@@ -17851,7 +18199,9 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2-pre-3",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/codAaoxh/76ce92742fea39dadbf9a68a389b4690f10ebd52_96.webp",
       "issues_url": "https://github.com/TeamMidnightDust/MidnightLib/issues/",
@@ -17875,16 +18225,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 95824,
+          "downloads": 287714,
           "file": {
             "filename": "midnightlib-fabric-1.9.3+1.21.11.jar",
             "hashes": {
-              "sha1": "5ff624cc3763a0cb9a25296ed3a442d1ace44d68",
               "sha512": "07155319e25dbcf17cf0253382a7dc8882edea650cab770328fbad91bf55f21ce043fd6e2a6a1680e765b14b89173f960a880511c78942ad3bb2f0200ddd6969"
             },
             "primary": true,
@@ -17920,7 +18267,7 @@
       "client_side": "unsupported",
       "color": 13487565,
       "date_created": "2021-02-15T03:11:09.328544Z",
-      "date_modified": "2026-04-15T02:35:22.385449Z",
+      "date_modified": "2026-06-30T18:03:21.544209Z",
       "description": "Minecraft plugin/mod to set the server list MOTD using MiniMessage for formatting, supporting RGB colors. ",
       "discord_url": "https://discord.gg/86Ekw8H",
       "donation_urls": [
@@ -17930,8 +18277,8 @@
           "url": "https://github.com/sponsors/jpenilla"
         }
       ],
-      "downloads": 184576,
-      "followers": 481,
+      "downloads": 204838,
+      "followers": 492,
       "gallery": [
         {
           "created": "2023-02-26T16:57:37.090237Z",
@@ -17990,7 +18337,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/16vhQOQN/dc967fb5410417c2311831f24f07b51ebe03629e_96.webp",
       "issues_url": "https://github.com/jpenilla/MiniMOTD/issues",
@@ -18013,25 +18361,22 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-15T02:35:22.134302Z",
+          "date_published": "2026-06-30T18:03:21.465111Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "HQyibRsN",
-              "version_id": null
+              "project_id": "HQyibRsN"
             }
           ],
-          "downloads": 6520,
+          "downloads": 0,
           "file": {
-            "filename": "minimotd-paper-2.2.3.jar",
+            "filename": "minimotd-paper-2.2.4.jar",
             "hashes": {
-              "sha1": "5c9d7a14e81c39f9b1a99b42af7fec1e65b9becb",
-              "sha512": "5066e310a487f9cbd163e4b192d85eaa7cd96222c9bd69067128aa28165fbe335f75000c4f7aa01503451305d9bf74f1dac98605f519430c99ada32a27f8cf3b"
+              "sha512": "d3fe7382c183a37119232fc1190d93ca8debe3bc35c74665d73cea56e7892391053926554ab7913ba3b1e192fd18a499737bb73a4af01ac002b797cc59e9606a"
             },
             "primary": true,
-            "size": 758780,
-            "url": "https://cdn.modrinth.com/data/16vhQOQN/versions/3OWY09pN/minimotd-paper-2.2.3.jar"
+            "size": 758774,
+            "url": "https://cdn.modrinth.com/data/16vhQOQN/versions/9IkdRgXS/minimotd-paper-2.2.4.jar"
           },
           "game_versions": [
             "1.21.8",
@@ -18040,16 +18385,17 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "3OWY09pN",
+          "id": "9IkdRgXS",
           "loaders": [
             "folia",
             "paper"
           ],
-          "name": "minimotd-paper 2.2.3",
+          "name": "minimotd-paper 2.2.4",
           "project_id": "16vhQOQN",
-          "version_number": "2.2.3",
+          "version_number": "2.2.4",
           "version_type": "release"
         }
       },
@@ -18077,8 +18423,8 @@
           "url": "https://ko-fi.com/mineblock11"
         }
       ],
-      "downloads": 13842942,
-      "followers": 1473,
+      "downloads": 15305476,
+      "followers": 1524,
       "gallery": [
         {
           "created": "2025-02-13T21:09:42.131590Z",
@@ -18141,7 +18487,10 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2-rc-1",
+        "26.2-rc-2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/SNVQ2c0g/82339bfc8a0a3a6a3c376f5c29555a378379cfa0_96.webp",
       "issues_url": "https://github.com/IMB11-Mods/MRU/issues",
@@ -18161,11 +18510,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-01-01T02:11:24.429007Z",
-          "downloads": 695079,
+          "downloads": 949869,
           "file": {
             "filename": "mru-1.0.26+edge+1.21.11-fabric.jar",
             "hashes": {
-              "sha1": "8b4d0803932c2edf6f521feb306bcd01a013a692",
               "sha512": "5da1641bc57d1e04e858fcfa7fe9fe69163e4216f94d5f28430371c98aba1958dc8994243dac816af083033e203df1b51a1a55cea8bf50eadc7dac47136e9ccf"
             },
             "primary": true,
@@ -18205,7 +18553,7 @@
       "client_side": "unsupported",
       "color": 11289668,
       "date_created": "2023-02-20T19:30:41.320503Z",
-      "date_modified": "2026-05-20T06:45:39.716949Z",
+      "date_modified": "2026-06-22T03:10:59.633356Z",
       "description": "The Bukkit World Management Plugin.",
       "discord_url": "https://discord.gg/NZtfKky",
       "donation_urls": [
@@ -18220,8 +18568,8 @@
           "url": "https://github.com/sponsors/Multiverse"
         }
       ],
-      "downloads": 581661,
-      "followers": 666,
+      "downloads": 647451,
+      "followers": 706,
       "gallery": [
         {
           "created": "2026-05-05T14:14:46.389456Z",
@@ -18297,7 +18645,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/3wmN97b8/3e3c705351a85c68b78a6131aff23f4674b2f71f_96.webp",
       "issues_url": "https://github.com/Multiverse/Multiverse-Core/issues",
@@ -18317,43 +18666,34 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-08T12:55:44.864696Z",
+          "date_published": "2026-06-21T03:56:19.274654Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "qvdtDX3s",
-              "version_id": null
+              "project_id": "qvdtDX3s"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "vtawPsTo",
-              "version_id": null
+              "project_id": "8VMk6P0I"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "8VMk6P0I",
-              "version_id": null
+              "project_id": "vtawPsTo"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "WuErDeI1",
-              "version_id": null
+              "project_id": "WuErDeI1"
             }
           ],
-          "downloads": 19170,
+          "downloads": 10145,
           "file": {
-            "filename": "multiverse-core-5.6.2.jar",
+            "filename": "multiverse-core-5.7.1.jar",
             "hashes": {
-              "sha1": "e37ee698e5d942c030153a2ac42be458ff32583d",
-              "sha512": "364df3e244c6344b00a3da1820262c1c62720ddac911d1de4eea7a3ce0e6f219442c1c1cd51746b78551c19f7fcbc934cd177516091e4d3d21f3a6c90cf84808"
+              "sha512": "482eff1a03922e1622c542eb1b0d30b9076b49550140c1e72804e820610f8565a08f3893581f908bf651fbeef9dfd6ffa43d488863ca8d9aad4f50f9494a004a"
             },
             "primary": true,
-            "size": 4347333,
-            "url": "https://cdn.modrinth.com/data/3wmN97b8/versions/g7LecP9j/multiverse-core-5.6.2.jar"
+            "size": 4429038,
+            "url": "https://cdn.modrinth.com/data/3wmN97b8/versions/kgxH7ZVB/multiverse-core-5.7.1.jar"
           },
           "game_versions": [
             "1.18.2",
@@ -18383,18 +18723,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "g7LecP9j",
+          "id": "kgxH7ZVB",
           "loaders": [
             "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "5.6.2",
+          "name": "5.7.1",
           "project_id": "3wmN97b8",
-          "version_number": "5.6.2",
+          "version_number": "5.7.1",
           "version_type": "release"
         }
       },
@@ -18418,7 +18759,7 @@
       "client_side": "unsupported",
       "color": 11289668,
       "date_created": "2023-02-20T22:01:23.684220Z",
-      "date_modified": "2026-05-08T12:58:26.721729Z",
+      "date_modified": "2026-06-22T03:09:23.117875Z",
       "description": "An inventory management plugin created to intertwine with Multiverse-Core",
       "discord_url": "https://discord.gg/NZtfKky",
       "donation_urls": [
@@ -18433,8 +18774,8 @@
           "url": "https://opencollective.com/multiverse-plugins"
         }
       ],
-      "downloads": 205288,
-      "followers": 279,
+      "downloads": 223590,
+      "followers": 294,
       "game_versions": [
         "1.13",
         "1.13.1",
@@ -18484,7 +18825,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/qvdtDX3s/3e3c705351a85c68b78a6131aff23f4674b2f71f_96.webp",
       "issues_url": "https://github.com/Multiverse/Multiverse-Inventories/issues",
@@ -18504,25 +18846,22 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-08T12:58:26.721729Z",
+          "date_published": "2026-06-07T07:52:33.560914Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "3wmN97b8",
-              "version_id": null
+              "project_id": "3wmN97b8"
             }
           ],
-          "downloads": 5543,
+          "downloads": 7945,
           "file": {
-            "filename": "multiverse-inventories-5.3.3.jar",
+            "filename": "multiverse-inventories-5.3.4.jar",
             "hashes": {
-              "sha1": "c7ff5b7a73ea7a47b6c3cc110b100bdd34ac038f",
-              "sha512": "f9b29eb381fdaf8768ce9df7bb67f3dd432ffc80929a75829023fe866e8a11a9c12e614ba1b73d04983ad3a119de16faaac85e9cb8914b650100b9174abdbc7e"
+              "sha512": "06bdfaf67d65fe6417c07c76979d1f68f0f2ca70480dd38394010907f4632af8a0479a5ac5e72117674a7383ef6e9b65602dd5ab7cfca13b44806551f5a2d0ac"
             },
             "primary": true,
-            "size": 1665056,
-            "url": "https://cdn.modrinth.com/data/qvdtDX3s/versions/JhEntL4p/multiverse-inventories-5.3.3.jar"
+            "size": 1665377,
+            "url": "https://cdn.modrinth.com/data/qvdtDX3s/versions/GIQ6bSwl/multiverse-inventories-5.3.4.jar"
           },
           "game_versions": [
             "1.18.2",
@@ -18554,16 +18893,16 @@
             "26.1.1",
             "26.1.2"
           ],
-          "id": "JhEntL4p",
+          "id": "GIQ6bSwl",
           "loaders": [
             "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "5.3.3",
+          "name": "5.3.4",
           "project_id": "qvdtDX3s",
-          "version_number": "5.3.3",
+          "version_number": "5.3.4",
           "version_type": "release"
         }
       },
@@ -18587,23 +18926,23 @@
       "client_side": "unsupported",
       "color": 11289668,
       "date_created": "2023-02-20T21:59:39.443141Z",
-      "date_modified": "2026-05-08T12:56:52.950741Z",
+      "date_modified": "2026-06-07T07:52:29.920878Z",
       "description": "Jump through a portal in to any Multiverse destination imaginable",
       "discord_url": "https://discord.gg/NZtfKky",
       "donation_urls": [
         {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/Multiverse"
-        },
-        {
           "id": "other",
           "platform": "Other",
           "url": "https://opencollective.com/multiverse-plugins"
+        },
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/Multiverse"
         }
       ],
-      "downloads": 105276,
-      "followers": 231,
+      "downloads": 116575,
+      "followers": 241,
       "gallery": [
         {
           "created": "2026-05-05T14:17:20.963768Z",
@@ -18682,25 +19021,22 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-08T12:56:52.950741Z",
+          "date_published": "2026-06-07T07:52:29.920878Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "3wmN97b8",
-              "version_id": null
+              "project_id": "3wmN97b8"
             }
           ],
-          "downloads": 3639,
+          "downloads": 6088,
           "file": {
-            "filename": "multiverse-portals-5.2.2.jar",
+            "filename": "multiverse-portals-5.2.3.jar",
             "hashes": {
-              "sha1": "3a8b96023e1171d1a39df26eead268b4d5a84246",
-              "sha512": "a24a537dff0416ed1ac109dcf7e9895475f39058456161c4565b453598e6588aede34074d5464171dd8795359c84e355cec8535e8810eaedfd47a665170d505c"
+              "sha512": "c23ac4618024116b946bc40d74b513836f68fa7aeb56a622ebb92756c670b0a034023b1672549398afaf15dc692f7cdb2252b789f9b0622941ca759b2b9bdb60"
             },
             "primary": true,
-            "size": 173457,
-            "url": "https://cdn.modrinth.com/data/8VMk6P0I/versions/BguzNJ3r/multiverse-portals-5.2.2.jar"
+            "size": 173532,
+            "url": "https://cdn.modrinth.com/data/8VMk6P0I/versions/b7zoWTL2/multiverse-portals-5.2.3.jar"
           },
           "game_versions": [
             "1.18.2",
@@ -18732,16 +19068,16 @@
             "26.1.1",
             "26.1.2"
           ],
-          "id": "BguzNJ3r",
+          "id": "b7zoWTL2",
           "loaders": [
             "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "5.2.2",
+          "name": "5.2.3",
           "project_id": "8VMk6P0I",
-          "version_number": "5.2.2",
+          "version_number": "5.2.3",
           "version_type": "release"
         }
       },
@@ -18766,7 +19102,7 @@
       "client_side": "required",
       "color": 11242324,
       "date_created": "2023-09-10T20:54:36.018780Z",
-      "date_modified": "2026-04-08T01:47:47.219161Z",
+      "date_modified": "2026-06-17T01:45:59.618652Z",
       "description": "Allows you to locate biomes anywhere in the world.",
       "donation_urls": [
         {
@@ -18775,8 +19111,8 @@
           "url": "https://www.paypal.com/donate/?business=46ZL2PNVP4XKE"
         }
       ],
-      "downloads": 20071555,
-      "followers": 2464,
+      "downloads": 21628501,
+      "followers": 2605,
       "gallery": [
         {
           "created": "2023-09-10T21:48:53.627162Z",
@@ -18829,7 +19165,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/fPetb5Kh/95e4110a4cf600843c4ba9d545cc1b60e2c00eaa.png",
       "issues_url": "https://github.com/MattCzyr/NaturesCompass/issues",
@@ -18849,11 +19186,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-03-25T01:20:29.953428Z",
-          "downloads": 40868,
+          "downloads": 61644,
           "file": {
             "filename": "NaturesCompass-1.21.11-2.5.0-fabric.jar",
             "hashes": {
-              "sha1": "c44dd594532e5eaa6b90831ab80f62b7bdb09f11",
               "sha512": "2cbf53044dcc0564da8098bbbc96e3c0dd49781f020a629642fe5345e1b2b2718ab61ba0bd50f631bae4b13081ee767a2fed29667f7793b44ba2eeed56799cb8"
             },
             "primary": true,
@@ -18889,8 +19225,8 @@
       "date_modified": "2026-04-06T14:15:16.385892Z",
       "description": "Add custom NBT tags to Items/Tiles/Entities without NMS",
       "discord_url": "https://discord.com/invite/yk4caxM",
-      "downloads": 285821,
-      "followers": 268,
+      "downloads": 300426,
+      "followers": 276,
       "game_versions": [
         "1.7.9",
         "1.7.10",
@@ -18958,7 +19294,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/nfGCP9fk/icon.png",
       "issues_url": "https://github.com/tr7zw/Item-NBT-API/issues",
@@ -18980,11 +19317,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-04-06T14:15:16.385892Z",
-          "downloads": 13414,
+          "downloads": 27256,
           "file": {
             "filename": "item-nbt-api-plugin-2.15.7.jar",
             "hashes": {
-              "sha1": "26d82ec9c37def4fbde5a135ee14bc2f4d4ae0c2",
               "sha512": "c022e9363815d09f9c85eba12e5e1fb56d7448f9637631a56d61178712d1d5f2a9f394ff70381522f8d1caf05c8f1e26a30640928d8dcadaedaf8bcaf4a98881"
             },
             "primary": true,
@@ -19056,7 +19392,8 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
           "id": "9zLThg7h",
           "loaders": [
@@ -19087,7 +19424,7 @@
       "client_side": "unsupported",
       "color": 7865862,
       "date_created": "2022-06-14T21:48:05.255247Z",
-      "date_modified": "2026-03-25T18:55:15.957493Z",
+      "date_modified": "2026-06-16T19:08:01.700236Z",
       "description": "Ensures correct destinations when travelling back and forth through Nether Portals in Multiplayer.",
       "discord_url": "https://discord.gg/VAfZ2Nau6j",
       "donation_urls": [
@@ -19097,8 +19434,8 @@
           "url": "https://www.patreon.com/BlayTheNinth"
         }
       ],
-      "downloads": 17720866,
-      "followers": 1303,
+      "downloads": 19292981,
+      "followers": 1363,
       "game_versions": [
         "1.12.2",
         "1.18",
@@ -19128,7 +19465,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/nPZr02ET/1496de70af297897258b7520aafc0886fa0ad918_96.webp",
       "issues_url": "https://github.com/TwelveIterations/NetherPortalFix/issues",
@@ -19151,22 +19489,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "MBAkmtvl",
-              "version_id": null
+              "project_id": "MBAkmtvl"
             }
           ],
-          "downloads": 114147,
+          "downloads": 143601,
           "file": {
             "filename": "netherportalfix-fabric-1.21.11-21.11.2.jar",
             "hashes": {
-              "sha1": "eafa6556784cd6a27b7bca48a846f445502a6519",
               "sha512": "9e385c30418e1eb80c2f74d1e319ed5bc45a19dfaa8408fba40b8afb6b4b49dc7a7951cb06fc3b4a1679bd818073300df56740ecee8224f47334e8dd6395bb49"
             },
             "primary": true,
@@ -19202,7 +19535,7 @@
       "client_side": "unsupported",
       "color": 4269861,
       "date_created": "2024-08-19T17:46:55.705251Z",
-      "date_modified": "2026-04-02T15:00:01.906920Z",
+      "date_modified": "2026-06-26T21:53:53.285002Z",
       "description": "The easy auction house plugin you've looked for, and for free!",
       "discord_url": "https://discord.com/invite/PQq5puV85k",
       "donation_urls": [
@@ -19212,8 +19545,8 @@
           "url": "https://ko-fi.com/synkdev"
         }
       ],
-      "downloads": 121520,
-      "followers": 43,
+      "downloads": 132446,
+      "followers": 48,
       "gallery": [
         {
           "created": "2025-06-03T22:11:00.182579Z",
@@ -19296,7 +19629,9 @@
         "1.21.10",
         "1.21.11",
         "26.1",
-        "26.1.1"
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/7jTY70FG/19fa16da1724f04b74050983f643ae8a47cc65d2_96.webp",
       "issues_url": "https://github.com/SynkMC/NexusAuctionHouse/issues",
@@ -19316,25 +19651,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-02T15:00:01.906920Z",
-          "dependencies": [
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "wdQpi4W8",
-              "version_id": null
-            }
-          ],
-          "downloads": 11350,
+          "date_published": "2026-06-26T21:53:53.285002Z",
+          "downloads": 1217,
           "file": {
-            "filename": "NexusAuctionHouse-2.2.7.jar",
+            "filename": "NexusAuctionHouse-2.3.jar",
             "hashes": {
-              "sha1": "79db1094cdad06939799f4afa5c50a9018ac0444",
-              "sha512": "83cc35333080369b732689cb9849d93f622d3240389318ebde82e1ff1247f623e51831344f12614663601e64e2bd94345d0bcd579ebaa5eb2113adaf911bb93a"
+              "sha512": "9ec52fa206a081b94c196cc5a4b59bf4d7ed07bf6b0159a66eac9fcc2b225d3c383f7e460821dac943de5ace854496bb92356a99b40a19533dfb1df407784d15"
             },
             "primary": true,
-            "size": 2051339,
-            "url": "https://cdn.modrinth.com/data/7jTY70FG/versions/gebeq35L/NexusAuctionHouse-2.2.7.jar"
+            "size": 134320,
+            "url": "https://cdn.modrinth.com/data/7jTY70FG/versions/vE1nXP38/NexusAuctionHouse-2.3.jar"
           },
           "game_versions": [
             "1.13",
@@ -19384,18 +19710,20 @@
             "1.21.10",
             "1.21.11",
             "26.1",
-            "26.1.1"
+            "26.1.1",
+            "26.1.2",
+            "26.2"
           ],
-          "id": "gebeq35L",
+          "id": "vE1nXP38",
           "loaders": [
             "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "NexusAuctionHouse 2.2.7",
+          "name": "NexusAuctionHouse 2.3",
           "project_id": "7jTY70FG",
-          "version_number": "2.2.7",
+          "version_number": "2.3",
           "version_type": "release"
         }
       },
@@ -19414,7 +19742,7 @@
       "client_side": "unsupported",
       "color": 1255242,
       "date_created": "2024-08-14T22:32:29.637483Z",
-      "date_modified": "2026-05-11T20:53:15.324724Z",
+      "date_modified": "2026-06-26T19:13:14.381838Z",
       "description": "The library required to use all of Nexus Studio plugins.",
       "discord_url": "https://discord.com/invite/PQq5puV85k",
       "donation_urls": [
@@ -19424,8 +19752,8 @@
           "url": "https://ko-fi.com/synkdev"
         }
       ],
-      "downloads": 121641,
-      "followers": 9,
+      "downloads": 129865,
+      "followers": 10,
       "gallery": [
         {
           "created": "2024-08-15T11:58:20.474868Z",
@@ -19509,7 +19837,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/wdQpi4W8/68c713be623a1d5539158ec8a47b438492dadfec_96.webp",
       "issues_url": "https://github.com/SynkMC/SynkLibs/issues",
@@ -19532,17 +19861,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-11T20:53:15.324724Z",
-          "downloads": 4382,
+          "date_published": "2026-06-26T19:13:14.381838Z",
+          "downloads": 1346,
           "file": {
-            "filename": "NexusCore-1.12.2.jar",
+            "filename": "NexusCore-2.0.jar",
             "hashes": {
-              "sha1": "32a8c3d074028a786d4e2ffc3e4c88e3451a159b",
-              "sha512": "2942988db8c50b0a520a9e773ae7acb618d3d072967c1dcd0760a29e8c14a7440eebcace5496f4a20784d6134eace2ea34970b43dd3d77ac7142adccfb30cb7a"
+              "sha512": "6e796b3dde68322c0e4c7da852fe594cf3f8b469fb5b3439ee1f5aff4249a10061a706c6d474917384574b47001d235e0f2e1e8e21d16fd98d45895f9ade5b97"
             },
             "primary": true,
-            "size": 3619149,
-            "url": "https://cdn.modrinth.com/data/wdQpi4W8/versions/MZZDzxNK/NexusCore-1.12.2.jar"
+            "size": 5077172,
+            "url": "https://cdn.modrinth.com/data/wdQpi4W8/versions/UpI8Uto8/NexusCore-2.0.jar"
           },
           "game_versions": [
             "1.13",
@@ -19593,9 +19921,10 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "MZZDzxNK",
+          "id": "UpI8Uto8",
           "loaders": [
             "bukkit",
             "folia",
@@ -19603,9 +19932,9 @@
             "purpur",
             "spigot"
           ],
-          "name": "NexusCore 1.12.2",
+          "name": "NexusCore 2.0",
           "project_id": "wdQpi4W8",
-          "version_number": "1.12.2",
+          "version_number": "2.0",
           "version_type": "release"
         }
       },
@@ -19625,7 +19954,7 @@
       "client_side": "unsupported",
       "color": 2059186,
       "date_created": "2024-12-14T21:57:19.884557Z",
-      "date_modified": "2026-04-24T22:11:01.326344Z",
+      "date_modified": "2026-06-08T15:44:56.917368Z",
       "description": "A lightweight library with a wide range of utilities and tools for faster and more efficient plugin development.",
       "discord_url": "https://discord.gg/EwNFGsnGaW",
       "donation_urls": [
@@ -19635,8 +19964,8 @@
           "url": "https://ko-fi.com/nightexpress"
         }
       ],
-      "downloads": 172357,
-      "followers": 104,
+      "downloads": 194203,
+      "followers": 115,
       "game_versions": [
         "1.19.4",
         "1.20.1",
@@ -19679,17 +20008,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-24T22:11:01.326344Z",
-          "downloads": 10362,
+          "date_published": "2026-06-08T15:44:56.917368Z",
+          "downloads": 9734,
           "file": {
-            "filename": "nightcore-2.15.2.jar",
+            "filename": "nightcore-2.16.2.jar",
             "hashes": {
-              "sha1": "c139c78c8cc5b7e0750f709ae59dc0a666132e66",
-              "sha512": "4946ad91b7671de6868fce786eeb2863e760ff2e7166c7cd9e7d2375ef8e172aad863b88e3cee387e3f8e15c05f6be63c5a8bb6b5e63bff6e5a91d7b27645e69"
+              "sha512": "06beb06e3a58b48cfe8260a7219e7f3a018fd05ba7b97621d0937e3c9438c2c3eddafd0153b65b7b75443db6908f7b1d64b9345bcf3b2fdbea4125c41cbf23be"
             },
             "primary": true,
-            "size": 1480948,
-            "url": "https://cdn.modrinth.com/data/Y4NRwMW5/versions/Pgcu4VkO/nightcore-2.15.2.jar"
+            "size": 1534179,
+            "url": "https://cdn.modrinth.com/data/Y4NRwMW5/versions/V3X0pOQr/nightcore-2.16.2.jar"
           },
           "game_versions": [
             "1.21.8",
@@ -19700,16 +20028,16 @@
             "26.1.1",
             "26.1.2"
           ],
-          "id": "Pgcu4VkO",
+          "id": "V3X0pOQr",
           "loaders": [
             "folia",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "NightCore 2.15.2",
+          "name": "NightCore 2.16.2",
           "project_id": "Y4NRwMW5",
-          "version_number": "2.15.2",
+          "version_number": "2.16.2",
           "version_type": "release"
         }
       },
@@ -19731,7 +20059,7 @@
       "client_side": "optional",
       "color": 12250606,
       "date_created": "2022-06-17T13:03:46.492544Z",
-      "date_modified": "2026-03-28T00:29:29.985943Z",
+      "date_modified": "2026-06-23T15:23:15.569955Z",
       "description": "Makes chat unreportable (where possible)",
       "discord_url": "https://discord.gg/fuWK8ns",
       "donation_urls": [
@@ -19741,8 +20069,8 @@
           "url": "https://www.buymeacoffee.com/aizistral"
         }
       ],
-      "downloads": 43671031,
-      "followers": 3155,
+      "downloads": 47446073,
+      "followers": 3246,
       "gallery": [
         {
           "created": "2022-12-16T18:24:22.776044Z",
@@ -19807,7 +20135,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/qQyHxfxd/icon.png",
       "issues_url": "https://github.com/Aizistral-Studios/No-Chat-Reports/issues",
@@ -19831,28 +20160,21 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "9s6osm5g"
             }
           ],
-          "downloads": 3295858,
+          "downloads": 3988019,
           "file": {
             "filename": "NoChatReports-FABRIC-1.21.11-v2.18.0.jar",
             "hashes": {
-              "sha1": "4e519507bdd81ce2520da33f497a5f12469f5b10",
               "sha512": "d2c35cc8d624616f441665aff67c0e366e4101dba243bad25ed3518170942c1a3c1a477b28805cd1a36c44513693b1c55e76bea627d3fced13927a3d67022ccc"
             },
             "primary": true,
@@ -19886,11 +20208,11 @@
       "client_side": "optional",
       "color": 4424944,
       "date_created": "2021-06-19T08:29:09.200737Z",
-      "date_modified": "2025-12-13T12:21:48.653628Z",
+      "date_modified": "2026-05-24T08:20:27.799246Z",
       "description": "When crashing, you can go back to the title screen and keep playing, without needing to restart, alongside other things to make crashes more pleasant.",
       "discord_url": "https://discord.gg/CFaCu97",
-      "downloads": 10825375,
-      "followers": 1986,
+      "downloads": 11928516,
+      "followers": 2016,
       "game_versions": [
         "1.16.5",
         "1.17",
@@ -19919,7 +20241,8 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/yM94ont6/0bd6cd7608cde62529c05ed19626029c062107ed_96.webp",
       "issues_url": "https://github.com/natanfudge/Not-Enough-Crashes/issues",
@@ -19940,11 +20263,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2025-12-13T12:21:48.641119Z",
-          "downloads": 256705,
+          "downloads": 325121,
           "file": {
             "filename": "notenoughcrashes-fabric-4.4.9+1.21.11.jar",
             "hashes": {
-              "sha1": "bd074fca3afb865fd21fccfc491056d1fe2c2e82",
               "sha512": "139a52aa93382ea127ff8cb1caf93274fb7336d2ddc2ee11140297bee0547eff8474064ccb819cc8ed5498b6f658e31c64da69b885fd796ad7af76bb8361db59"
             },
             "primary": true,
@@ -19971,90 +20293,6 @@
       "source_url": "https://github.com/natanfudge/Not-Enough-Crashes",
       "title": "Not Enough Crashes"
     },
-    "octo-lib": {
-      "categories": [
-        "library"
-      ],
-      "client_side": "required",
-      "color": 9206940,
-      "date_created": "2023-11-27T10:53:12.598219Z",
-      "date_modified": "2026-05-04T23:51:43.352160Z",
-      "description": "Collection of shared code for OctoStudios' mods",
-      "discord_url": "https://discord.com/invite/pHren9yxzW",
-      "downloads": 12030217,
-      "followers": 470,
-      "game_versions": [
-        "1.18.2",
-        "1.19.2",
-        "1.20.1",
-        "1.20.2",
-        "1.21",
-        "1.21.1",
-        "1.21.2",
-        "1.21.3",
-        "1.21.4",
-        "1.21.8",
-        "1.21.9",
-        "1.21.10",
-        "1.21.11"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/RH2KUdKJ/a4043436fa16d40de4faa032b08e0879b8397259_96.webp",
-      "issues_url": "https://github.com/Octo-Studios/octo-lib/issues",
-      "license": {
-        "id": "LicenseRef-All-Rights-Reserved",
-        "name": "",
-        "url": null
-      },
-      "loaders": [
-        "fabric",
-        "forge",
-        "neoforge",
-        "quilt"
-      ],
-      "page_url": "https://modrinth.com/mod/octo-lib",
-      "project_id": "RH2KUdKJ",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+fabric": {
-          "date_published": "2026-03-11T21:43:07.212698Z",
-          "dependencies": [
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "lhGA9TYQ",
-              "version_id": null
-            }
-          ],
-          "downloads": 195467,
-          "file": {
-            "filename": "ShatterLib-FABRIC-0.6.0.8+1.21.11.jar",
-            "hashes": {
-              "sha1": "2c591be8990702aca214ac19c922422fd6725b81",
-              "sha512": "c376889551345550d9b49f32be54f998ff8689495f12b043bb18a12afbc64abc48256e0df11b15c6c9acee5fff91f186606b10d1224c000a7f8f0077cac936ed"
-            },
-            "primary": true,
-            "size": 513942,
-            "url": "https://cdn.modrinth.com/data/RH2KUdKJ/versions/DtNaQNS2/ShatterLib-FABRIC-0.6.0.8%2B1.21.11.jar"
-          },
-          "game_versions": [
-            "1.21.11"
-          ],
-          "id": "DtNaQNS2",
-          "loaders": [
-            "fabric"
-          ],
-          "name": "OctoLib 0.6.0.8",
-          "project_id": "RH2KUdKJ",
-          "version_number": "0.6.0.8",
-          "version_type": "release"
-        }
-      },
-      "server_side": "required",
-      "slug": "octo-lib",
-      "source": "modrinth",
-      "source_url": "https://github.com/Octo-Studios/octo-lib",
-      "title": "ShatterLib | OctoLib"
-    },
     "oneblock_bukkit": {
       "categories": [
         "game-mechanics",
@@ -20073,8 +20311,8 @@
           "url": "https://boosty.to/marl/donate"
         }
       ],
-      "downloads": 203281,
-      "followers": 156,
+      "downloads": 215821,
+      "followers": 169,
       "gallery": [
         {
           "created": "2024-03-13T16:58:43.702148Z",
@@ -20174,7 +20412,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/gMMDcC2d/986cc09005ff89787d557b3e6b704984d6f1d6cc.gif",
       "issues_url": "https://github.com/MrMarL/OneBlock/issues",
@@ -20195,11 +20434,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-05-18T23:12:31.776540Z",
-          "downloads": 1225,
+          "downloads": 12869,
           "file": {
             "filename": "Oneblock-1.6.2.jar",
             "hashes": {
-              "sha1": "1090bedfc1c91b855dac36774574aa63d0a64f7e",
               "sha512": "03ced988cb14b1b283cbec7e326f2a3b23127f27e7ff15cf325ba13369cf6b39dfa989aae0853fbc4da01c8d54a409880d0db4006b3b0aad3d327372c8e14645"
             },
             "primary": true,
@@ -20279,7 +20517,8 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
           "id": "QeUlYXt7",
           "loaders": [
@@ -20308,7 +20547,7 @@
       "client_side": "optional",
       "color": 8707324,
       "date_created": "2022-06-24T17:33:07.453448Z",
-      "date_modified": "2026-05-15T09:20:31.061139Z",
+      "date_modified": "2026-06-29T16:45:39.670033Z",
       "description": "Adds the ability to claim chunks and make player parties, integrates with Xaero's Minimap and World Map",
       "donation_urls": [
         {
@@ -20317,8 +20556,8 @@
           "url": "https://www.patreon.com/xaero96"
         }
       ],
-      "downloads": 16182808,
-      "followers": 892,
+      "downloads": 17907438,
+      "followers": 913,
       "game_versions": [
         "1.18.2",
         "1.19",
@@ -20353,7 +20592,10 @@
         "1.21.9",
         "1.21.10",
         "1.21.11",
-        "26.1.2"
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/gF3BGWvG/410c5443b268912b11709e7d03dd9ec3fda38ea5.png",
       "issues_url": "https://github.com/thexaero/open-parties-and-claims/issues",
@@ -20373,43 +20615,38 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-15T09:19:25.812799Z",
+          "date_published": "2026-06-11T10:22:29.504533Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "ohNO6lps",
-              "version_id": null
+              "project_id": "ohNO6lps"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 5499,
+          "downloads": 15454,
           "file": {
-            "filename": "open-parties-and-claims-fabric-1.21.11-0.26.3.jar",
+            "filename": "open-parties-and-claims-fabric-1.21.11-0.27.5.jar",
             "hashes": {
-              "sha1": "650fbdbb3efdf1f38462a782071d521acb41f99a",
-              "sha512": "b4091b104b857d1684d6e84f5795055a88d4bdb94515ce201ec41930bc55fd9df7f4b0f98a795b2edc1f7303a13c3054c8e83ae7e4fb13deda2bc0032d308be8"
+              "sha512": "758f15e4a4f538dfe0a8b33f2e06352f0511b80e5da08d2cddd65f0ae1bf1e943897daac3c80c2c1014bc3e9ac5d461971c13dc74b5fd6c750ce9f630146693d"
             },
             "primary": true,
-            "size": 1649819,
-            "url": "https://cdn.modrinth.com/data/gF3BGWvG/versions/xBSO4bpz/open-parties-and-claims-fabric-1.21.11-0.26.3.jar"
+            "size": 1733277,
+            "url": "https://cdn.modrinth.com/data/gF3BGWvG/versions/DEb4IjSQ/open-parties-and-claims-fabric-1.21.11-0.27.5.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "xBSO4bpz",
+          "id": "DEb4IjSQ",
           "loaders": [
             "fabric",
             "quilt"
           ],
-          "name": "0.26.3",
+          "name": "0.27.5",
           "project_id": "gF3BGWvG",
-          "version_number": "fabric-1.21.11-0.26.3",
+          "version_number": "fabric-1.21.11-0.27.5",
           "version_type": "beta"
         }
       },
@@ -20427,10 +20664,10 @@
       "client_side": "unsupported",
       "color": 353505,
       "date_created": "2023-06-12T14:39:35.704302Z",
-      "date_modified": "2026-04-06T11:24:08.783349Z",
+      "date_modified": "2026-06-16T23:05:58.770638Z",
       "description": "High-Performance Anti X-Ray plugin",
-      "downloads": 161194,
-      "followers": 212,
+      "downloads": 178204,
+      "followers": 220,
       "gallery": [
         {
           "created": "2023-06-12T15:13:24.335874Z",
@@ -20512,7 +20749,9 @@
         "1.21.10",
         "1.21.11",
         "26.1",
-        "26.1.1"
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/XY7PHeei/95c3b30aa509bb595b2a711ac070f9ecb80be958_96.webp",
       "issues_url": "https://github.com/Imprex-Development/orebfuscator/issues",
@@ -20533,17 +20772,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-06T11:24:08.783349Z",
-          "downloads": 15776,
+          "date_published": "2026-06-16T23:05:58.770638Z",
+          "downloads": 6825,
           "file": {
-            "filename": "orebfuscator-plugin-5.6.0.jar",
+            "filename": "orebfuscator-plugin-5.6.1.jar",
             "hashes": {
-              "sha1": "717b3154f1e4f1361efecbb9964b56cb9c17c659",
-              "sha512": "2651cdaec3156612231dd8af4a5afc496dc1f74eb876e951d1f719b2808c287f23a4935bd1f7f73f1c8cb200d2ab565ab17571ffea72490196ed787d6f2b5e44"
+              "sha512": "fda045b8772b98e1c31b7bfb136b3a9fca90d21b33777d598d07cd2f1be3c7f15003ce359a0341d8c1956e47ab6648f87609d2e3b9691f13306effa42853d61a"
             },
             "primary": true,
-            "size": 4664417,
-            "url": "https://cdn.modrinth.com/data/XY7PHeei/versions/3zTdEn7B/orebfuscator-plugin-5.6.0.jar"
+            "size": 4667454,
+            "url": "https://cdn.modrinth.com/data/XY7PHeei/versions/pIlLMUO7/orebfuscator-plugin-5.6.1.jar"
           },
           "game_versions": [
             "1.16.5",
@@ -20577,9 +20815,11 @@
             "1.21.10",
             "1.21.11",
             "26.1",
-            "26.1.1"
+            "26.1.1",
+            "26.1.2",
+            "26.2"
           ],
-          "id": "3zTdEn7B",
+          "id": "pIlLMUO7",
           "loaders": [
             "bukkit",
             "folia",
@@ -20587,9 +20827,9 @@
             "purpur",
             "spigot"
           ],
-          "name": "Orebfuscator 5.6.0",
+          "name": "Orebfuscator 5.6.1",
           "project_id": "XY7PHeei",
-          "version_number": "5.6.0",
+          "version_number": "5.6.1",
           "version_type": "release"
         }
       },
@@ -20609,8 +20849,8 @@
       "client_side": "optional",
       "color": 14894084,
       "date_created": "2025-09-19T17:02:44.959153Z",
-      "date_modified": "2026-04-22T09:40:13.904538Z",
-      "description": "This DataPack/mod adds an orbital cannon, it can be called with a command/special fishing rod",
+      "date_modified": "2026-06-23T13:41:20.117963Z",
+      "description": "This datapack/mod/plugin adds an Orbital Strike Cannon like wemmbu!",
       "discord_url": "https://discord.gg/89dgfsCby3",
       "donation_urls": [
         {
@@ -20619,8 +20859,8 @@
           "url": "https://dalink.to/stepan1411"
         }
       ],
-      "downloads": 357538,
-      "followers": 172,
+      "downloads": 470862,
+      "followers": 215,
       "gallery": [
         {
           "created": "2026-01-05T12:55:59.981366Z",
@@ -20642,13 +20882,6 @@
           "ordering": 0,
           "title": "Nuke power 2",
           "url": "https://cdn.modrinth.com/data/Y1ZEvtor/images/74547b95e8c98587b6d462466077ff27e6199aa4_350.webp"
-        },
-        {
-          "created": "2025-11-17T14:39:26.347795Z",
-          "featured": false,
-          "ordering": 0,
-          "title": "OSC RENDER",
-          "url": "https://cdn.modrinth.com/data/Y1ZEvtor/images/7bc329b88754918c1266b52ef05cd4554d9f9eb6_350.webp"
         },
         {
           "created": "2025-11-10T09:28:48.487688Z",
@@ -20680,6 +20913,16 @@
         }
       ],
       "game_versions": [
+        "1.17",
+        "1.17.1",
+        "1.18",
+        "1.18.1",
+        "1.18.2",
+        "1.19",
+        "1.19.1",
+        "1.19.2",
+        "1.19.3",
+        "1.19.4",
         "1.20",
         "1.20.1",
         "1.20.2",
@@ -20701,7 +20944,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Y1ZEvtor/0cde7f139cc0204ca555d299611240e3315ab571_96.webp",
       "issues_url": "https://github.com/Stepan1411/Orbital-strike-cannon-datapack/issues",
@@ -20727,50 +20971,62 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-02-16T15:03:08.015769Z",
-          "dependencies": [
-            {
-              "dependency_type": "incompatible",
-              "file_name": null,
-              "project_id": "logqZuLk",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "T9B6Pk2h",
-              "version_id": null
-            }
-          ],
-          "downloads": 33428,
+          "date_published": "2026-06-23T13:41:20.117963Z",
+          "downloads": 3122,
           "file": {
-            "filename": "orbital-6.3.jar",
+            "filename": "OrbitalStrikeCannon-7.0.jar",
             "hashes": {
-              "sha1": "d7219fd6e1741b67fe1d38497d2d4255c6b2917d",
-              "sha512": "18b0233291d5c218896cef8b2a5e7cf582e6b5e7378c19b1f3f49d373984c0239797fb446434744591a3e785eb0fe4a3e62d7f1fdc0da781376f1c9a49a95f38"
+              "sha512": "1f90a2db8b72287b25a70f7afa103b4ad3384ccb0216028ad8cbee783028e2bb00980a18eff649c033abd014b7c22a1c649d113a64c73e5daf51928b4817c5b7"
             },
             "primary": true,
-            "size": 28081,
-            "url": "https://cdn.modrinth.com/data/Y1ZEvtor/versions/DtQa3QMN/orbital-6.3.jar"
+            "size": 36035,
+            "url": "https://cdn.modrinth.com/data/Y1ZEvtor/versions/pDM578r0/OrbitalStrikeCannon-7.0.jar"
           },
           "game_versions": [
+            "1.17",
+            "1.17.1",
+            "1.18",
+            "1.18.1",
+            "1.18.2",
+            "1.19",
+            "1.19.1",
+            "1.19.2",
+            "1.19.3",
+            "1.19.4",
+            "1.20",
+            "1.20.1",
+            "1.20.2",
+            "1.20.3",
+            "1.20.4",
+            "1.20.5",
+            "1.20.6",
+            "1.21",
+            "1.21.1",
+            "1.21.2",
+            "1.21.3",
+            "1.21.4",
+            "1.21.5",
             "1.21.6",
             "1.21.7",
             "1.21.8",
             "1.21.9",
             "1.21.10",
-            "1.21.11"
+            "1.21.11",
+            "26.1",
+            "26.1.1",
+            "26.1.2",
+            "26.2"
           ],
-          "id": "DtQa3QMN",
+          "id": "pDM578r0",
           "loaders": [
             "bukkit",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "V6.3+plugin",
+          "name": "V7.0+plugin",
           "project_id": "Y1ZEvtor",
-          "version_number": "V6.3+plugin",
+          "version_number": "V7.0+plugin",
           "version_type": "release"
         }
       },
@@ -20778,7 +21034,7 @@
       "slug": "osc-dp",
       "source": "modrinth",
       "source_url": "https://github.com/Stepan1411/Orbital-strike-cannon-datapack",
-      "title": "Orbital Strike Cannon | DataPack | Mod | Plugin"
+      "title": "Orbital Strike Cannon"
     },
     "owo-lib": {
       "categories": [
@@ -20790,8 +21046,8 @@
       "date_modified": "2026-04-29T10:41:06.572479Z",
       "description": "A general utility, GUI and config library for modding on Fabric and Quilt",
       "discord_url": "https://discord.gg/xrwHKktV2d",
-      "downloads": 36323153,
-      "followers": 2040,
+      "downloads": 39481200,
+      "followers": 2102,
       "game_versions": [
         "1.17",
         "1.17.1",
@@ -20849,16 +21105,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 460624,
+          "downloads": 670699,
           "file": {
             "filename": "owo-lib-0.13.0+1.21.11.jar",
             "hashes": {
-              "sha1": "5baf520ec1e69210ee430a8413a6493cc402764d",
               "sha512": "acdd14f068a1751ec9e9baa4c6febc1a807a522ada80c2d999abf07e4a5693892fc92497f13043fbb7fc6e04c1eb42fb59a364a6ef813302f60833355a489c2e"
             },
             "primary": true,
@@ -20894,11 +21147,11 @@
       "client_side": "optional",
       "color": 5526612,
       "date_created": "2022-11-02T15:48:56.445113Z",
-      "date_modified": "2026-04-22T17:38:16.341503Z",
+      "date_modified": "2026-06-17T21:14:21.598635Z",
       "description": "A simple mod to fix various problems with packets, nbt and timeouts.",
       "discord_url": "https://discord.gg/vWBP4P4Yd8",
-      "downloads": 20431490,
-      "followers": 1055,
+      "downloads": 22694053,
+      "followers": 1119,
       "game_versions": [
         "1.12.2",
         "1.15",
@@ -20935,7 +21188,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/c7m1mi73/388af00d61fa57e7e10612bcc099bf6ee0794e5e.png",
       "issues_url": "https://github.com/TonimatasDEV/PacketSizeDoublerForge/issues",
@@ -20956,11 +21210,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-04-22T17:38:16.341503Z",
-          "downloads": 84804,
+          "downloads": 308462,
           "file": {
             "filename": "packetfixer-fabric-3.3.5-1.21.11.jar",
             "hashes": {
-              "sha1": "087cd5f23680cacaa5841528fca815c8dbfe5999",
               "sha512": "c58d22675b4d31d05c12852b4546590cb1291515f7d4f63f5c81248419f307bdcfe4e99e7511edf6b802a62930af591da29996f6058e46ff7058d6c47b5a3cb2"
             },
             "primary": true,
@@ -20998,28 +21251,28 @@
       "client_side": "unknown",
       "color": 14245945,
       "date_created": "2023-08-22T16:22:45.744901Z",
-      "date_modified": "2026-04-19T00:53:44.397915Z",
+      "date_modified": "2026-06-22T09:39:48.673564Z",
       "description": "PacketEvents is a protocol library tailored to Minecraft Java Edition, designed to facilitate the processing and transmission of packets.",
       "discord_url": "https://discord.gg/prqzNg9tRU",
       "donation_urls": [
-        {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/retrooper/"
-        },
         {
           "id": "patreon",
           "platform": "Patreon",
           "url": "https://patreon.com/retrooper"
         },
         {
-          "id": "paypal",
-          "platform": "Paypal",
-          "url": "https://paypal.me/packetevents"
+          "id": "bmac",
+          "platform": "Bmac",
+          "url": " https://buymeacoffee.com/retrooper"
+        },
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/retrooper/"
         }
       ],
-      "downloads": 562503,
-      "followers": 325,
+      "downloads": 637366,
+      "followers": 347,
       "gallery": [
         {
           "created": "2023-08-22T16:56:41.690794Z",
@@ -21104,7 +21357,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/HYKaKraK/44165b1c0164f0a9fb3844559bb69b8957df35a8_96.webp",
       "issues_url": "https://github.com/retrooper/packetevents/issues",
@@ -21130,17 +21384,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-19T00:53:42.220896Z",
-          "downloads": 40097,
+          "date_published": "2026-06-22T09:39:39.294932Z",
+          "downloads": 12987,
           "file": {
-            "filename": "packetevents-spigot-2.12.1.jar",
+            "filename": "packetevents-spigot-2.13.0.jar",
             "hashes": {
-              "sha1": "02b316b57279f75f3f46ca037cac88ee69d865a7",
-              "sha512": "e195d7706dbdaa2ebf44feb284764aab5fbc3e59e471cb6bb779f2c3b816e18b6132e6de0f657c600dd3c021f8ca0827ec3649ccf3c1f9fc81a88f6ac23294a8"
+              "sha512": "f0f85e601855a5849418df807e116a369bfb70aa8b4c25b8904bdd04cf6a483ef5d2679a345e9d690dd2221f9daff6a25be17d8b3e63cf665e12a31b0124dd27"
             },
             "primary": true,
-            "size": 5140128,
-            "url": "https://cdn.modrinth.com/data/HYKaKraK/versions/ap8qHs7D/packetevents-spigot-2.12.1.jar"
+            "size": 5333748,
+            "url": "https://cdn.modrinth.com/data/HYKaKraK/versions/h0ncTpUP/packetevents-spigot-2.13.0.jar"
           },
           "game_versions": [
             "1.8.8",
@@ -21207,9 +21460,10 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "ap8qHs7D",
+          "id": "h0ncTpUP",
           "loaders": [
             "bukkit",
             "folia",
@@ -21217,9 +21471,9 @@
             "purpur",
             "spigot"
           ],
-          "name": "PacketEvents 2.12.1 Spigot",
+          "name": "PacketEvents 2.13.0 Spigot",
           "project_id": "HYKaKraK",
-          "version_number": "2.12.1+spigot",
+          "version_number": "2.13.0+spigot",
           "version_type": "release"
         }
       },
@@ -21243,7 +21497,7 @@
       "client_side": "unknown",
       "color": 6768450,
       "date_created": "2024-06-03T10:06:43.718943Z",
-      "date_modified": "2026-03-25T13:46:00.949876Z",
+      "date_modified": "2026-06-26T17:15:34.430304Z",
       "description": "Allows you to pat ANY loved and unloved living mobs in Minecraft!",
       "discord_url": "https://discord.gg/NZzxdkrV4s",
       "donation_urls": [
@@ -21253,8 +21507,8 @@
           "url": "https://boosty.to/lopymine/donate"
         }
       ],
-      "downloads": 998603,
-      "followers": 873,
+      "downloads": 1325568,
+      "followers": 993,
       "gallery": [
         {
           "created": "2024-09-22T04:39:03.611211Z",
@@ -21365,7 +21619,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/dw7LChq9/125417ed34406a044dd53fdf9a7fdfe210a6fcf0_96.webp",
       "issues_url": "https://github.com/LopyMine/PatPat/issues",
@@ -21391,11 +21646,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-02-17T18:39:14.850835Z",
-          "downloads": 23601,
+          "downloads": 35138,
           "file": {
             "filename": "patpat-plugin-1.2.5.jar",
             "hashes": {
-              "sha1": "00004de24feb430029c0c47103732d27a7becce9",
               "sha512": "29b178179e5749f68bb6e77f9d6e23d3af8aa8d1c7fbba6939bb20b44da5a554cd174d2ba82a7e87df2d08d397e6b204ad0a82feacf0dce091e2eafdbe533c1b"
             },
             "primary": true,
@@ -21432,7 +21686,10 @@
             "1.21.8",
             "1.21.9",
             "1.21.10",
-            "1.21.11"
+            "1.21.11",
+            "26.1",
+            "26.1.1",
+            "26.1.2"
           ],
           "id": "5GCMlK4e",
           "loaders": [
@@ -21460,13 +21717,13 @@
         "utility"
       ],
       "client_side": "required",
-      "color": 3816487,
+      "color": 3882023,
       "date_created": "2022-07-19T14:55:50.546530Z",
-      "date_modified": "2026-04-28T10:27:11.828404Z",
+      "date_modified": "2026-06-18T12:32:09.032042Z",
       "description": "Be notified about all the things you've just collected.",
       "discord_url": "https://lunapixel.studio/discord",
-      "downloads": 11854786,
-      "followers": 2666,
+      "downloads": 12816181,
+      "followers": 2783,
       "gallery": [
         {
           "created": "2025-07-29T07:40:29.971136Z",
@@ -21496,9 +21753,10 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
-      "icon_url": "https://cdn.modrinth.com/data/ZX66K16c/1c0ee069ad454ad084493cd927eb2c67b2dc2ad9_96.webp",
+      "icon_url": "https://cdn.modrinth.com/data/ZX66K16c/769d7c843339981c1f8e5eec5ff983294a3671fb_96.webp",
       "issues_url": "https://github.com/Fuzss/pickupnotifier/issues",
       "license": {
         "id": "MPL-2.0",
@@ -21519,28 +21777,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "ohNO6lps"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "ohNO6lps",
-              "version_id": null
+              "project_id": "QAGBst4M"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "QAGBst4M",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 218189,
+          "downloads": 250321,
           "file": {
             "filename": "PickUpNotifier-v21.11.0-mc1.21.11-Fabric.jar",
             "hashes": {
-              "sha1": "10047ff968823e49c5f0f97b2077a6654c74042f",
               "sha512": "49cf0053d20859584d05c02082225f26487c45682114d5022ffa00785132e455a56f28f988e507c37a8fa1941a56b91961b7bd81778ea6519475da09eb85447d"
             },
             "primary": true,
@@ -21579,8 +21830,8 @@
       "date_created": "2022-12-15T11:35:21.474596Z",
       "date_modified": "2026-04-26T20:43:57.780572Z",
       "description": "Allows players to temporarily mark locations and entities",
-      "downloads": 9297698,
-      "followers": 1141,
+      "downloads": 10357635,
+      "followers": 1209,
       "gallery": [
         {
           "created": "2022-12-15T11:45:58.386248Z",
@@ -21652,16 +21903,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 47233,
+          "downloads": 56792,
           "file": {
             "filename": "Ping-Wheel-1.12.1-fabric-1.21.11.jar",
             "hashes": {
-              "sha1": "a9b826a2f83e17246e003108500a70e0f3852a3d",
               "sha512": "f46041aa323178657249c2bcd7cfa1faed93806b273137c65e2ae62ad928d97f2eff837c2bb9ea4690614fd737984a9601d83a1ccae2acfce4974a467f14c135"
             },
             "primary": true,
@@ -21687,123 +21935,6 @@
       "source_url": "https://github.com/LukenSkyne/Minecraft-Ping-Wheel",
       "title": "Ping Wheel"
     },
-    "pl3xmap": {
-      "categories": [
-        "adventure",
-        "decoration",
-        "utility"
-      ],
-      "client_side": "optional",
-      "color": 6393173,
-      "date_created": "2023-10-24T03:32:29.827414Z",
-      "date_modified": "2026-05-21T02:28:41.209395Z",
-      "description": "Pl3xMap is a minimalistic and lightweight world map viewer for Minecraft servers using the vanilla Minecraft rendering style",
-      "discord_url": "https://granny.dev/discord",
-      "donation_urls": [
-        {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/granny"
-        }
-      ],
-      "downloads": 79907,
-      "followers": 283,
-      "gallery": [
-        {
-          "created": "2023-10-24T04:23:47.710438Z",
-          "featured": true,
-          "ordering": 0,
-          "title": "Pl3xMap Banner",
-          "url": "https://cdn.modrinth.com/data/34T8oVNY/images/ad4a7b79ee5ff9a7e686547ce783489d7b93d483_350.webp"
-        }
-      ],
-      "game_versions": [
-        "1.19.4",
-        "1.20",
-        "1.20.1",
-        "1.20.2",
-        "1.20.4",
-        "1.20.6",
-        "1.21",
-        "1.21.1",
-        "1.21.3",
-        "1.21.4",
-        "1.21.5",
-        "1.21.6",
-        "1.21.7",
-        "1.21.8",
-        "1.21.10",
-        "1.21.11",
-        "26.1.2"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/34T8oVNY/97d50559261b4ef4663cf0433346cb93462fabbb.jpeg",
-      "issues_url": "https://github.com/granny/Pl3xMap/issues",
-      "license": {
-        "id": "MIT",
-        "name": "MIT License",
-        "url": null
-      },
-      "loaders": [
-        "bukkit",
-        "fabric",
-        "folia",
-        "forge",
-        "paper",
-        "purpur",
-        "quilt",
-        "spigot"
-      ],
-      "page_url": "https://modrinth.com/mod/pl3xmap",
-      "project_id": "34T8oVNY",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+paper": {
-          "date_published": "2026-03-21T15:42:12.107327Z",
-          "dependencies": [
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
-            }
-          ],
-          "downloads": 2656,
-          "file": {
-            "filename": "Pl3xMap-1.21.11-544.jar",
-            "hashes": {
-              "sha1": "7deaa31845ada848ef105b766f19096591ab98ac",
-              "sha512": "c5537f4f94b4e02d1628125ea4b3c2ed48d6fb2c842747149a50f4b24d17dbaeec0d38f3d57538aed46d81ae4d3450e8338c3e3b9e3688f916f464255dfb8ce8"
-            },
-            "primary": true,
-            "size": 13042752,
-            "url": "https://cdn.modrinth.com/data/34T8oVNY/versions/1O4z4iPC/Pl3xMap-1.21.11-544.jar"
-          },
-          "game_versions": [
-            "1.21.11"
-          ],
-          "id": "1O4z4iPC",
-          "loaders": [
-            "bukkit",
-            "fabric",
-            "folia",
-            "paper",
-            "purpur",
-            "quilt",
-            "spigot"
-          ],
-          "name": "1.21.11-544",
-          "project_id": "34T8oVNY",
-          "version_number": "1.21.11-544",
-          "version_type": "beta"
-        }
-      },
-      "server_side": "required",
-      "slug": "pl3xmap",
-      "source": "modrinth",
-      "source_url": "https://github.com/granny/Pl3xMap",
-      "title": "Pl3xMap",
-      "wiki_url": "https://github.com/granny/Pl3xMap/wiki"
-    },
     "placeholder-api": {
       "additional_categories": [
         "management"
@@ -21814,7 +21945,7 @@
       "client_side": "optional",
       "color": 1842204,
       "date_created": "2023-05-07T07:16:09.821727Z",
-      "date_modified": "2026-04-11T07:52:55.577049Z",
+      "date_modified": "2026-05-27T20:57:38.795530Z",
       "description": "Placeholder and Text manipulation library for your Minecraft mods.",
       "discord_url": "https://pb4.eu/discord",
       "donation_urls": [
@@ -21824,8 +21955,8 @@
           "url": "https://ko-fi.com/patbox"
         }
       ],
-      "downloads": 40500756,
-      "followers": 1341,
+      "downloads": 46934861,
+      "followers": 1426,
       "game_versions": [
         "1.17",
         "1.17.1",
@@ -21874,7 +22005,9 @@
         "26.1",
         "26.1.1",
         "26w14a",
-        "26.1.2"
+        "26.1.2",
+        "26.2-pre-1",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/eXts2L7r/e9c9990896e6422bffc5f73d2c41b8f077348f83.png",
       "issues_url": "https://github.com/Patbox/TextPlaceholderAPI/issues",
@@ -21893,11 +22026,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-02-01T20:30:10.668511Z",
-          "downloads": 3916859,
+          "downloads": 5367377,
           "file": {
             "filename": "placeholder-api-2.8.2+1.21.10.jar",
             "hashes": {
-              "sha1": "bbdc920ecff993148cd6e81a208536132245ce40",
               "sha512": "507ab10b7938dcd14d33121b8462649bdbe575cef248e917dfdf7566078ab5d0195ca1add95eae4863de3f652eb56db0a8669a67d5b5344e094d086f9dab5a08"
             },
             "primary": true,
@@ -21943,8 +22075,8 @@
           "url": "https://github.com/sponsors/PlaceholderAPI"
         }
       ],
-      "downloads": 147365,
-      "followers": 191,
+      "downloads": 195353,
+      "followers": 231,
       "game_versions": [
         "1.8",
         "1.8.1",
@@ -22039,11 +22171,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-02-08T12:14:01.199969Z",
-          "downloads": 82311,
+          "downloads": 128477,
           "file": {
             "filename": "PlaceholderAPI-2.12.2.jar",
             "hashes": {
-              "sha1": "c4de624e5445f4ff2a09a3f133e99f0153921e15",
               "sha512": "94addf996ba45e16dbded3fcaf05e8b442212ce0d577f7edc42b743ad9532c1e24115263976126d36f27c0868ab1c03c40c2d13947985124b92dabca4527dddb"
             },
             "primary": true,
@@ -22154,7 +22285,7 @@
       "client_side": "required",
       "color": 1842204,
       "date_created": "2021-11-06T14:31:21.242214Z",
-      "date_modified": "2026-04-19T14:17:32.734168Z",
+      "date_modified": "2026-06-24T04:28:15.258766Z",
       "description": "A proximity voice chat mod with audio positioning and lots of features",
       "discord_url": "https://discord.com/invite/uueEqzwCJJ",
       "donation_urls": [
@@ -22164,8 +22295,8 @@
           "url": "https://patreon.com/plasmomc"
         }
       ],
-      "downloads": 3239013,
-      "followers": 2060,
+      "downloads": 3466108,
+      "followers": 2112,
       "game_versions": [
         "1.16.4",
         "1.16.5",
@@ -22200,7 +22331,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/1bZhdhsH/72c1641d4af92d93546958a2c87e0b5fd1c3f650_96.webp",
       "issues_url": "https://github.com/plasmoapp/plasmo-voice/issues",
@@ -22210,7 +22342,6 @@
         "url": null
       },
       "loaders": [
-        "bukkit",
         "bungeecord",
         "fabric",
         "folia",
@@ -22226,31 +22357,30 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-19T14:14:02.379081Z",
+          "date_published": "2026-06-24T04:26:18.877635Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "lKEzGugV",
-              "version_id": null
+              "project_id": "lKEzGugV"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "Vebnzrzj",
-              "version_id": null
+              "project_id": "Vebnzrzj"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "rabHya7R"
             }
           ],
-          "downloads": 9059,
+          "downloads": 1918,
           "file": {
-            "filename": "PlasmoVoice-Paper-2.1.9.jar",
+            "filename": "PlasmoVoice-Paper-2.1.13.jar",
             "hashes": {
-              "sha1": "da3b25602a715bd539fbb59361002caadd7b8d8b",
-              "sha512": "94570ca1c7f6e98ce8f88ebcbb4e2bbe19a66616817f87cd5b3c6adeec672cca69d00c8975336a4e2a908e50db3df419744fac2857555d8e66748ac21fb916eb"
+              "sha512": "981d26ca695fb65195ee8c0dbb0cf3283fc188a197c31ce43107e1c3eacbc9e4686a19d62ff8a48e1eb09398f861d7b3ca71276e4cfd8e2ae8de17a8dd51c862"
             },
             "primary": true,
-            "size": 8705436,
-            "url": "https://cdn.modrinth.com/data/1bZhdhsH/versions/9nJosuoO/PlasmoVoice-Paper-2.1.9.jar"
+            "size": 9087725,
+            "url": "https://cdn.modrinth.com/data/1bZhdhsH/versions/arX8C9vY/PlasmoVoice-Paper-2.1.13.jar"
           },
           "game_versions": [
             "1.16.5",
@@ -22274,17 +22404,18 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "9nJosuoO",
+          "id": "arX8C9vY",
           "loaders": [
             "folia",
             "paper",
             "spigot"
           ],
-          "name": "[Spigot] Plasmo Voice 2.1.9",
+          "name": "[Spigot] Plasmo Voice 2.1.13",
           "project_id": "1bZhdhsH",
-          "version_number": "spigot-2.1.9",
+          "version_number": "spigot-2.1.13",
           "version_type": "release"
         }
       },
@@ -22307,7 +22438,7 @@
       "client_side": "unsupported",
       "color": 3296575,
       "date_created": "2023-09-12T18:29:49.678250Z",
-      "date_modified": "2026-05-08T13:13:42.976092Z",
+      "date_modified": "2026-06-21T14:35:38.181701Z",
       "description": "An easy to use but powerful plugin to create survival kits and claim them on a GUI.",
       "donation_urls": [
         {
@@ -22316,8 +22447,8 @@
           "url": "https://ko-fi.com/ajneb97"
         }
       ],
-      "downloads": 227743,
-      "followers": 139,
+      "downloads": 252774,
+      "followers": 147,
       "game_versions": [
         "1.8.9",
         "1.9",
@@ -22382,7 +22513,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/VuKoQN3Q/a8df4612fdf9409222950af41955d6d64af6fdd6.jpeg",
       "license": {
@@ -22400,17 +22532,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-08T13:13:42.976092Z",
-          "downloads": 8931,
+          "date_published": "2026-06-21T14:35:38.181701Z",
+          "downloads": 6086,
           "file": {
-            "filename": "PlayerKits2-1.22.2.jar",
+            "filename": "PlayerKits2-1.23.1.jar",
             "hashes": {
-              "sha1": "8f923d397f1d0e0586ad900a63a59fb61279a76a",
-              "sha512": "7fb27d05a46878fc9e35047fd04ed8d13c00e6f7beec8ee0f7d890d341faf931d5f8b7cb048d557c6e848807640cf30c88939ee08a2bd09cd5c682adc2ce3651"
+              "sha512": "164973735c11df0a6feb5d44042a6e8762ed5a505a57a256e93b035bc8251529ffa2c387085767f868b67ddeb0a5f0fbd051e3e8d16038ebc05455393d60eccb"
             },
             "primary": true,
-            "size": 488431,
-            "url": "https://cdn.modrinth.com/data/VuKoQN3Q/versions/EuXnyaYX/PlayerKits2-1.22.2.jar"
+            "size": 489398,
+            "url": "https://cdn.modrinth.com/data/VuKoQN3Q/versions/l675kzHY/PlayerKits2-1.23.1.jar"
           },
           "game_versions": [
             "1.8.9",
@@ -22476,17 +22607,18 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "EuXnyaYX",
+          "id": "l675kzHY",
           "loaders": [
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "PlayerKits 2 1.22.2",
+          "name": "PlayerKits 2 1.23.1",
           "project_id": "VuKoQN3Q",
-          "version_number": "1.22.2",
+          "version_number": "1.23.1",
           "version_type": "release"
         }
       },
@@ -22508,8 +22640,8 @@
       "date_modified": "2026-03-08T13:55:50.651746Z",
       "description": "Plugin manager for Bukkit servers.",
       "discord_url": "https://discord.gg/GxEFhVY6ff",
-      "downloads": 80594,
-      "followers": 79,
+      "downloads": 96282,
+      "followers": 94,
       "game_versions": [
         "1.20.4",
         "1.20.5",
@@ -22548,11 +22680,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-03-08T13:55:50.651746Z",
-          "downloads": 14881,
+          "downloads": 24564,
           "file": {
             "filename": "PlugManX-3.0.4.jar",
             "hashes": {
-              "sha1": "cdd1b8b93d3c3c0fde9d2511a5f57b519af9c526",
               "sha512": "dafe5831bdb9bb76827d7d6a1879a59cde01c8c15c14b2ac4108d2240df1e9455d54e94d93b7d36262c1e9bc1545ad29e309634f970fe7dfa3ca2e6e77736442"
             },
             "primary": true,
@@ -22602,7 +22733,7 @@
       "client_side": "unsupported",
       "color": 263172,
       "date_created": "2024-08-12T17:11:30.558545Z",
-      "date_modified": "2026-05-07T19:20:45.233788Z",
+      "date_modified": "2026-06-26T17:04:49.190266Z",
       "description": "A very customisable plugin that adds gems with powerful abilities!",
       "discord_url": "https://discord.iseal.dev/",
       "donation_urls": [
@@ -22612,8 +22743,8 @@
           "url": "https://ko-fi.com/iseal"
         }
       ],
-      "downloads": 102916,
-      "followers": 94,
+      "downloads": 108021,
+      "followers": 102,
       "gallery": [
         {
           "created": "2025-10-02T13:07:34.791376Z",
@@ -22653,7 +22784,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/kCgEfc6s/9b7cc5441f9bcacd9345f26d8f517b21176a3e04_96.webp",
       "issues_url": "https://github.com/ISeal-plugin-developement/PowerGems/issues",
@@ -22672,17 +22804,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-07T19:20:45.233788Z",
-          "downloads": 1786,
+          "date_published": "2026-06-26T17:04:49.190266Z",
+          "downloads": 457,
           "file": {
-            "filename": "PowerGems-3.6.3.0.jar",
+            "filename": "PowerGems-3.6.4.3.jar",
             "hashes": {
-              "sha1": "d14a014841121ba5e8c8195774bfcb73bd2cc5ed",
-              "sha512": "72b1522df2ce8b6e6af333c3419247534adb44c27fc36f0505090647ee5320b7b3a61079195769a03dc73c6e6c3abfc7f4ddd8bbdbc091d195e8a90d5c1df014"
+              "sha512": "5b088ddf77bd73218ae483ad6164b23ddb24773c8b77f389b49f12fa155c14a46d818bea6588c04efad9dd1a5a68240d15ee807b4270bc36b89173349f68dc3b"
             },
             "primary": true,
-            "size": 218895,
-            "url": "https://cdn.modrinth.com/data/kCgEfc6s/versions/pLZ6IeE2/PowerGems-3.6.3.0.jar"
+            "size": 225594,
+            "url": "https://cdn.modrinth.com/data/kCgEfc6s/versions/Di5S3qjs/PowerGems-3.6.4.3.jar"
           },
           "game_versions": [
             "1.20.1",
@@ -22705,16 +22836,17 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "pLZ6IeE2",
+          "id": "Di5S3qjs",
           "loaders": [
             "paper",
             "purpur"
           ],
-          "name": "v3.6.3.0",
+          "name": "v3.6.4.3",
           "project_id": "kCgEfc6s",
-          "version_number": "3.6.3.0",
+          "version_number": "3.6.4.3",
           "version_type": "release"
         }
       },
@@ -22736,10 +22868,10 @@
       "client_side": "required",
       "color": 7097595,
       "date_created": "2024-08-20T03:21:14.110807Z",
-      "date_modified": "2026-04-19T01:26:21.534030Z",
+      "date_modified": "2026-06-18T01:00:52.138125Z",
       "description": "Prickle is a JSON based configuration file format brought to Minecraft.",
-      "downloads": 8768026,
-      "followers": 447,
+      "downloads": 9901554,
+      "followers": 523,
       "gallery": [
         {
           "created": "2024-08-24T07:20:11.981335Z",
@@ -22765,7 +22897,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/aaRl8GiW/36749d1d2d87d14d7f703b18e8726c7b78057abb.png",
       "issues_url": "https://github.com/Darkhax-Minecraft/PrickleMC/issues",
@@ -22789,16 +22922,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 265344,
+          "downloads": 336503,
           "file": {
             "filename": "prickle-fabric-1.21.11-21.11.1.jar",
             "hashes": {
-              "sha1": "ba448b0b274abd54ad24332055fbb1cdc66e43c0",
               "sha512": "4643cb5bae5c108eb18fac2270e85ea0adcfe5201f188dcd26a1c14129b7dde7c89bfadf9ab6fe0a048b7e05f39217e969548c1f5c1d212c86abbaec7203a3c3"
             },
             "primary": true,
@@ -22838,8 +22968,8 @@
       "date_created": "2023-08-13T09:12:09.284896Z",
       "date_modified": "2023-08-29T20:17:13.589991Z",
       "description": "Make yourself completely invisible with /vanish",
-      "downloads": 145900,
-      "followers": 145,
+      "downloads": 159431,
+      "followers": 156,
       "gallery": [
         {
           "created": "2023-08-23T12:19:16.905877Z",
@@ -22891,11 +23021,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2023-08-29T20:17:13.589991Z",
-          "downloads": 140749,
+          "downloads": 153780,
           "file": {
             "filename": "Vanish.jar",
             "hashes": {
-              "sha1": "7015cf32bd2e31dcc9d64d8425970dcf7651cb4a",
               "sha512": "f0eb22e333fd3baab3aa19553898c926b3535d37a923daedb6743f231844446d58c858fcbf59e8460c1cfed02253fbe1c815d4586bf715daf02fd4cf63a8324b"
             },
             "primary": true,
@@ -22950,11 +23079,11 @@
       "client_side": "optional",
       "color": 1778205,
       "date_created": "2022-07-06T18:55:14.270853Z",
-      "date_modified": "2026-05-21T08:58:28.728461Z",
-      "description": "Why it's called Puzzles, you ask? That's the puzzle!",
+      "date_modified": "2026-06-17T22:57:41.619326Z",
+      "description": "Why is it called Puzzles? That's the puzzle.",
       "discord_url": "https://lunapixel.studio/discord",
-      "downloads": 46022641,
-      "followers": 3490,
+      "downloads": 50441953,
+      "followers": 3669,
       "gallery": [
         {
           "created": "2025-07-29T07:41:15.035967Z",
@@ -22986,7 +23115,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/QAGBst4M/c78216c61f65b6ce82593e4e92e9c358402bb524_96.webp",
       "issues_url": "https://github.com/Fuzss/puzzleslib/issues",
@@ -23005,42 +23135,37 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-03-22T21:27:30.091928Z",
+          "date_published": "2026-05-30T07:11:40.956669Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "ohNO6lps",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "ohNO6lps"
             }
           ],
-          "downloads": 319729,
+          "downloads": 150402,
           "file": {
-            "filename": "PuzzlesLib-v21.11.12-mc1.21.11-Fabric.jar",
+            "filename": "PuzzlesLib-v21.11.13-mc1.21.11-Fabric.jar",
             "hashes": {
-              "sha1": "f502faff2063b34cfca40cfada13e4fecf69e7fc",
-              "sha512": "dbf4c97191455fe8e3c6801ddacc17d5157b5922f15a40e490ee0e2b172fe4718f4e5ec93ed244224aa077c7f53dcf30657ca68ac2d7f5692066ea7020af1542"
+              "sha512": "7b15baef432dbee4ac7d92ef404e18942cfdb3f718b3144f1f39a23b2834ae33340f035da7c1e24a6e43579a4847eae714763015b4fc60f5f30dc24c09c4b126"
             },
             "primary": true,
-            "size": 1124024,
-            "url": "https://cdn.modrinth.com/data/QAGBst4M/versions/owXZpJai/PuzzlesLib-v21.11.12-mc1.21.11-Fabric.jar"
+            "size": 1118666,
+            "url": "https://cdn.modrinth.com/data/QAGBst4M/versions/xTX7sOwU/PuzzlesLib-v21.11.13-mc1.21.11-Fabric.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "owXZpJai",
+          "id": "xTX7sOwU",
           "loaders": [
             "fabric"
           ],
-          "name": "[FABRIC] [1.21.11] PuzzlesLib v21.11.12",
+          "name": "[FABRIC] [1.21.11] PuzzlesLib v21.11.13",
           "project_id": "QAGBst4M",
-          "version_number": "21.11.12",
+          "version_number": "21.11.13",
           "version_type": "release"
         }
       },
@@ -23049,6 +23174,230 @@
       "source": "modrinth",
       "source_url": "https://github.com/Fuzss/puzzleslib",
       "title": "Puzzles Lib"
+    },
+    "quests.classic": {
+      "additional_categories": [
+        "economy",
+        "management",
+        "social"
+      ],
+      "categories": [
+        "adventure",
+        "game-mechanics"
+      ],
+      "client_side": "unsupported",
+      "color": 6110268,
+      "date_created": "2022-11-28T17:29:40.040447Z",
+      "date_modified": "2026-06-03T17:10:07.530769Z",
+      "description": "An extensive questing system",
+      "discord_url": "https://discordapp.com/invite/QdJAv2G7qg",
+      "donation_urls": [
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/PikaMug"
+        }
+      ],
+      "downloads": 114765,
+      "followers": 226,
+      "game_versions": [
+        "1.8",
+        "1.8.1",
+        "1.8.2",
+        "1.8.3",
+        "1.8.4",
+        "1.8.5",
+        "1.8.6",
+        "1.8.7",
+        "1.8.8",
+        "1.8.9",
+        "1.9",
+        "1.9.1",
+        "1.9.2",
+        "1.9.3",
+        "1.9.4",
+        "1.10",
+        "1.10.1",
+        "1.10.2",
+        "1.11",
+        "1.11.1",
+        "1.11.2",
+        "1.12",
+        "1.12.1",
+        "1.12.2",
+        "1.13",
+        "1.13.1",
+        "1.13.2",
+        "1.14",
+        "1.14.1",
+        "1.14.2",
+        "1.14.3",
+        "1.14.4",
+        "1.15",
+        "1.15.1",
+        "1.15.2",
+        "1.16",
+        "1.16.1",
+        "1.16.2",
+        "1.16.3",
+        "1.16.4",
+        "1.16.5",
+        "1.17",
+        "1.17.1",
+        "1.18",
+        "1.18.1",
+        "1.18.2",
+        "1.19",
+        "1.19.1",
+        "1.19.2",
+        "1.19.3",
+        "1.19.4",
+        "1.20",
+        "1.20.1",
+        "1.20.2",
+        "1.20.3",
+        "1.20.4",
+        "1.20.5",
+        "1.20.6",
+        "1.21",
+        "1.21.1",
+        "1.21.2",
+        "1.21.3",
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8",
+        "1.21.9",
+        "1.21.10",
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/T8iZG3U1/9dfb546c02fc6fc5f1bd3726e426b0e00e4a6022_96.webp",
+      "issues_url": "https://github.com/PikaMug/Quests/issues",
+      "license": {
+        "id": "MIT",
+        "name": "MIT License",
+        "url": "https://github.com/PikaMug/Quests/blob/main/LICENSE.txt"
+      },
+      "loaders": [
+        "paper",
+        "purpur",
+        "spigot"
+      ],
+      "page_url": "https://modrinth.com/mod/quests.classic",
+      "project_id": "T8iZG3U1",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+paper": {
+          "date_published": "2026-06-03T17:10:07.530769Z",
+          "downloads": 2040,
+          "file": {
+            "filename": "Quests-5.3.1.jar",
+            "hashes": {
+              "sha512": "de3e3f576b1761c62f584ac4e4843bb1caba238572df51776f938f5e707b88adb3c5d1427f4ea19ab698c7ab89a97ec0d27248466df2f96afe6ce376653b7e91"
+            },
+            "primary": true,
+            "size": 5301406,
+            "url": "https://cdn.modrinth.com/data/T8iZG3U1/versions/tsvzYi4C/Quests-5.3.1.jar"
+          },
+          "game_versions": [
+            "1.8",
+            "1.8.1",
+            "1.8.2",
+            "1.8.3",
+            "1.8.4",
+            "1.8.5",
+            "1.8.6",
+            "1.8.7",
+            "1.8.8",
+            "1.8.9",
+            "1.9",
+            "1.9.1",
+            "1.9.2",
+            "1.9.3",
+            "1.9.4",
+            "1.10",
+            "1.10.1",
+            "1.10.2",
+            "1.11",
+            "1.11.1",
+            "1.11.2",
+            "1.12",
+            "1.12.1",
+            "1.12.2",
+            "1.13",
+            "1.13.1",
+            "1.13.2",
+            "1.14",
+            "1.14.1",
+            "1.14.2",
+            "1.14.3",
+            "1.14.4",
+            "1.15",
+            "1.15.1",
+            "1.15.2",
+            "1.16",
+            "1.16.1",
+            "1.16.2",
+            "1.16.3",
+            "1.16.4",
+            "1.16.5",
+            "1.17",
+            "1.17.1",
+            "1.18",
+            "1.18.1",
+            "1.18.2",
+            "1.19",
+            "1.19.1",
+            "1.19.2",
+            "1.19.3",
+            "1.19.4",
+            "1.20",
+            "1.20.1",
+            "1.20.2",
+            "1.20.3",
+            "1.20.4",
+            "1.20.5",
+            "1.20.6",
+            "1.21",
+            "1.21.1",
+            "1.21.2",
+            "1.21.3",
+            "1.21.4",
+            "1.21.5",
+            "1.21.6",
+            "1.21.7",
+            "1.21.8",
+            "1.21.9",
+            "1.21.10",
+            "1.21.11",
+            "26.1",
+            "26.1.1",
+            "26.1.2",
+            "26.2"
+          ],
+          "id": "tsvzYi4C",
+          "loaders": [
+            "paper",
+            "purpur",
+            "spigot"
+          ],
+          "name": "Xanthisma Update",
+          "project_id": "T8iZG3U1",
+          "version_number": "5.3.1",
+          "version_type": "release"
+        }
+      },
+      "server_side": "required",
+      "slug": "quests.classic",
+      "source": "modrinth",
+      "source_url": "https://github.com/PikaMug/Quests",
+      "title": "Quests",
+      "wiki_url": "https://pikamug.gitbook.io/quests/"
     },
     "quickshop-hikari": {
       "categories": [
@@ -23060,8 +23409,8 @@
       "date_modified": "2026-02-14T01:23:59.624937Z",
       "description": "A shop plugin that allows players to easily sell/buy any items from a chest without any commands.",
       "discord_url": "https://discord.gg/Bu3dVtmsD3",
-      "downloads": 192284,
-      "followers": 434,
+      "downloads": 210049,
+      "followers": 450,
       "gallery": [
         {
           "created": "2022-12-23T13:52:10.190488Z",
@@ -23342,8 +23691,8 @@
       "icon_url": "https://cdn.modrinth.com/data/ijC5dDkD/1cc5f6d1bc74e07972a75ded8ad7ae7e7136d444.jpeg",
       "issues_url": "https://github.com/QuickShop-Community/QuickShop-Hikari/issues",
       "license": {
-        "id": "GPL-3.0-only",
-        "name": "GNU General Public License v3.0 only",
+        "id": "AGPL-3.0-only",
+        "name": "GNU Affero General Public License v3.0 only",
         "url": null
       },
       "loaders": [
@@ -23358,11 +23707,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-02-14T01:23:59.624937Z",
-          "downloads": 22340,
+          "downloads": 32516,
           "file": {
             "filename": "QuickShop-Hikari-6.2.0.11.jar",
             "hashes": {
-              "sha1": "8401eec4e179e9176a7f0c3cd41b619ca5f6305a",
               "sha512": "8d6f138891e8a95f3e680cc2c851d4e12ee94c329aa98a9522091c2436b30e829a04ec3aee34592289514efcbd5776c7910dbc4466ac1cdf681211309c9af596"
             },
             "primary": true,
@@ -23416,11 +23764,11 @@
       "client_side": "optional",
       "color": 13027014,
       "date_created": "2022-06-11T10:06:44.284284Z",
-      "date_modified": "2026-01-19T07:18:38.778024Z",
+      "date_modified": "2026-06-18T09:38:00.149452Z",
       "description": "Clean and Customizable. Alternative to Just Enough Items/JEI.",
       "discord_url": "https://discord.gg/Vs9AVkxjYY",
-      "downloads": 20411823,
-      "followers": 4298,
+      "downloads": 21905849,
+      "followers": 4373,
       "gallery": [
         {
           "created": "2023-03-16T15:39:51.410228Z",
@@ -23527,7 +23875,11 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/nfn13YXA/54ac5daa4166011bae713448e84413987316433a_96.webp",
       "issues_url": "https://github.com/shedaniel/RoughlyEnoughItems/discussions",
@@ -23547,48 +23899,41 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-01-19T07:18:26.964094Z",
+          "date_published": "2026-06-14T19:41:06.085552Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "lhGA9TYQ",
-              "version_id": null
+              "project_id": "9s6osm5g"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
+              "project_id": "lhGA9TYQ"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 642512,
+          "downloads": 70314,
           "file": {
-            "filename": "RoughlyEnoughItems-21.11.814-fabric.jar",
+            "filename": "RoughlyEnoughItems-21.11.816-fabric.jar",
             "hashes": {
-              "sha1": "2a5b25b4f3b48d5d08522b544c75b10c16a761c7",
-              "sha512": "65fed1a464034585adf664a33de17c06fb78c76c10b9042cf04d7c66fcc52f4401518af15d83a0f19b1735223b566e80488b4d33af5aa053b28c88e806f1867b"
+              "sha512": "148faa891db9868594dde20581530d76da88e15044ddf715c25f16a18399e9bff1ac368e947aff6be01efb05b28bc3872d1a44786e1ffeedd9f50733cb513a55"
             },
             "primary": true,
-            "size": 2469337,
-            "url": "https://cdn.modrinth.com/data/nfn13YXA/versions/zwCdgCLz/RoughlyEnoughItems-21.11.814-fabric.jar"
+            "size": 2480689,
+            "url": "https://cdn.modrinth.com/data/nfn13YXA/versions/QEiKPzyl/RoughlyEnoughItems-21.11.816-fabric.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "zwCdgCLz",
+          "id": "QEiKPzyl",
           "loaders": [
             "fabric"
           ],
-          "name": "[Fabric 1.21.11] v21.11.814",
+          "name": "[Fabric 1.21.11] v21.11.816",
           "project_id": "nfn13YXA",
-          "version_number": "21.11.814+fabric",
+          "version_number": "21.11.816+fabric",
           "version_type": "release"
         }
       },
@@ -23606,7 +23951,7 @@
       "client_side": "unsupported",
       "color": 4737859,
       "date_created": "2021-05-13T00:04:15.296146Z",
-      "date_modified": "2026-04-23T11:19:22.997768Z",
+      "date_modified": "2026-06-19T01:00:30.358030Z",
       "description": "Adds more variations of vanilla structures and features such as a Jungle Fortress!",
       "discord_url": "https://discord.gg/K8qRev3yKZ",
       "donation_urls": [
@@ -23616,8 +23961,8 @@
           "url": "https://ko-fi.com/telepathicgrunt"
         }
       ],
-      "downloads": 9916230,
-      "followers": 1082,
+      "downloads": 10995401,
+      "followers": 1118,
       "gallery": [
         {
           "created": "2023-01-08T18:29:57.357881Z",
@@ -23723,7 +24068,8 @@
         "1.21.9",
         "1.21.10",
         "1.21.11",
-        "26.1"
+        "26.1",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/muf0XoRe/icon.png",
       "issues_url": "https://github.com/TelepathicGrunt/RepurposedStructures/issues",
@@ -23745,22 +24091,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "codAaoxh",
-              "version_id": null
+              "project_id": "codAaoxh"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 11699,
+          "downloads": 34877,
           "file": {
             "filename": "repurposed_structures-7.6.2+1.21.11-fabric.jar",
             "hashes": {
-              "sha1": "dc88e4bea42a5e007eb5c2d0107271a43f1db363",
               "sha512": "b535e4247dfb71dec709ff021c2a40fad10c34c22a2950ee24b772d1841188f27f671050de88048684871cdfba84855ca7f65374768ba3b36ab8863c9b0697bc"
             },
             "primary": true,
@@ -23793,11 +24134,11 @@
       "client_side": "required",
       "color": 1185045,
       "date_created": "2022-11-28T01:11:50.632330Z",
-      "date_modified": "2026-04-04T11:52:58.104190Z",
+      "date_modified": "2026-06-18T03:50:08.539631Z",
       "description": "Resourceful Config is a mod that allows for developers to make cross-platform configs",
       "discord_url": "https://discord.gg/resourcefulbees",
-      "downloads": 18213169,
-      "followers": 708,
+      "downloads": 19944957,
+      "followers": 731,
       "game_versions": [
         "1.19.2",
         "1.19.3",
@@ -23821,7 +24162,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/M1953qlQ/cadcab644905f7e9ee92220d29f5c27113eb167b_96.webp",
       "issues_url": "https://github.com/Team-Resourceful/Resourceful-Config/issues",
@@ -23842,11 +24184,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-03-18T18:48:38.829765Z",
-          "downloads": 104440,
+          "downloads": 166868,
           "file": {
             "filename": "ResourcefulConfig-fabric-1.21.11-3.11.3.jar",
             "hashes": {
-              "sha1": "d4654702f7cdfcb3fcc62c6e84e397d19dda3044",
               "sha512": "c09556d4673f91953a14d719c5522380ec0756177f3f79cdbcabf2d5dda18eb400d22bed09aef784f15fbd3953f2be69ce6e1b65ac99ac36c461cbd2e50ca67d"
             },
             "primary": true,
@@ -23871,7 +24212,8 @@
       "slug": "resourceful-config",
       "source": "modrinth",
       "source_url": "https://github.com/Team-Resourceful/Resourceful-Config",
-      "title": "Resourceful Config"
+      "title": "Resourceful Config",
+      "wiki_url": "https://config.wiki.teamresourceful.com/"
     },
     "resourceful-lib": {
       "categories": [
@@ -23880,7 +24222,7 @@
       "client_side": "required",
       "color": 7029835,
       "date_created": "2022-09-02T15:50:16.129999Z",
-      "date_modified": "2026-04-14T20:01:45.617362Z",
+      "date_modified": "2026-06-20T15:04:28.184300Z",
       "description": "Resourceful Lib",
       "discord_url": "https://discord.gg/resourcefulbees",
       "donation_urls": [
@@ -23890,8 +24232,8 @@
           "url": "https://www.patreon.com/resourcefulbees"
         }
       ],
-      "downloads": 26778423,
-      "followers": 1118,
+      "downloads": 28977546,
+      "followers": 1162,
       "game_versions": [
         "1.19.2",
         "1.19.3",
@@ -23916,7 +24258,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/G1hIVOrD/52130f41d05162ce6d7d1832a47d3c238d102632_96.webp",
       "issues_url": "https://github.com/Team-Resourceful/ResourcefulLib/issues",
@@ -23939,16 +24282,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 203916,
+          "downloads": 249065,
           "file": {
             "filename": "ResourcefulLib-fabric-1.21.11-3.11.0.jar",
             "hashes": {
-              "sha1": "6a198fc18cdb7922b6be74d3ec165dc57729657a",
               "sha512": "7302cc0586b4ed079b4d87151c5b730940c0ded0b03f0b377f0bf6852bf6d28aed70b4a267365d6057c99cd2b24347f0d5eb52366c9b001d3b719505b8072313"
             },
             "primary": true,
@@ -23983,11 +24323,11 @@
       "client_side": "optional",
       "color": 2626366,
       "date_created": "2022-05-24T10:55:02.752080Z",
-      "date_modified": "2025-10-13T22:23:08.213734Z",
+      "date_modified": "2026-06-08T22:08:50.636541Z",
       "description": "A fork of Mozilla's Rhino library, modified for use in mods",
       "discord_url": "https://discord.gg/lat",
-      "downloads": 16135260,
-      "followers": 96,
+      "downloads": 17737871,
+      "followers": 100,
       "game_versions": [
         "1.18.2",
         "1.19",
@@ -24029,11 +24369,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2025-10-13T22:23:08.213734Z",
-          "downloads": 405987,
+          "downloads": 528322,
           "file": {
             "filename": "rhino-2101.2.7-build.81.jar",
             "hashes": {
-              "sha1": "480235a9f7749f68ce6fec3b9c3cac3428b92a4a",
               "sha512": "83a4f35cce9902b7175700aeccb8519716ff407dff2a936aa0215e162d81421d109c95f82ff88a84ccbe197caee0a4a76ca44d9c8b8ce954162596d7ede18c23"
             },
             "primary": true,
@@ -24066,7 +24405,7 @@
           "name": "Rhino 2101.2.7-build.81",
           "project_id": "sk9knFPE",
           "version_number": "2101.2.7-build.81+Rhino-1.21",
-          "version_type": "beta"
+          "version_type": "release"
         }
       },
       "server_side": "optional",
@@ -24078,12 +24417,14 @@
     },
     "rightclickharvest": {
       "categories": [
-        "food"
+        "food",
+        "game-mechanics",
+        "utility"
       ],
       "client_side": "unsupported",
       "color": 12231735,
       "date_created": "2022-06-27T07:44:09.333111Z",
-      "date_modified": "2026-05-04T12:33:32.729436Z",
+      "date_modified": "2026-06-16T19:44:54.134734Z",
       "description": "Allows you to harvest crops with right click",
       "discord_url": "https://discord.jamalam.tech",
       "donation_urls": [
@@ -24093,8 +24434,8 @@
           "url": "https://ko-fi.com/jamalamdev"
         }
       ],
-      "downloads": 9200251,
-      "followers": 2437,
+      "downloads": 10050814,
+      "followers": 2551,
       "game_versions": [
         "1.14",
         "1.14.1",
@@ -24138,7 +24479,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Cnejf5xM/b6e535989217836c2adc49b06f4b3c8f429afda3_96.webp",
       "issues_url": "https://github.com/Jamalam360/RightClickHarvestFabric/issues",
@@ -24162,28 +24504,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "IYY9Siz8",
-              "version_id": null
+              "project_id": "IYY9Siz8"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "lhGA9TYQ",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "lhGA9TYQ"
             }
           ],
-          "downloads": 141631,
+          "downloads": 172960,
           "file": {
             "filename": "rightclickharvest-fabric-4.6.1+1.21.11.jar",
             "hashes": {
-              "sha1": "cb615b809f6f4a101b884809c25f89843a46d5c7",
               "sha512": "7a5937969f0f1659cde27448d67779ceefe30744b7c95313c56271be3abf14def9217776d7abe473269f006f234edc83017062de78fc6ccf4eddf17f201ee829"
             },
             "primary": true,
@@ -24210,213 +24545,6 @@
       "source_url": "https://github.com/JamCoreModding/RightClickHarvest",
       "title": "RightClickHarvest"
     },
-    "score": {
-      "categories": [
-        "library",
-        "utility"
-      ],
-      "client_side": "unsupported",
-      "color": 15376930,
-      "date_created": "2024-11-24T16:38:38.482991Z",
-      "date_modified": "2026-05-17T19:20:34.888904Z",
-      "description": "A library plugin for all Ssomar's plugins",
-      "discord_url": "https://discord.com/invite/TRmSwJaYNv",
-      "downloads": 77758,
-      "followers": 33,
-      "game_versions": [
-        "1.8",
-        "1.8.1",
-        "1.8.2",
-        "1.8.3",
-        "1.8.4",
-        "1.8.5",
-        "1.8.6",
-        "1.8.7",
-        "1.8.8",
-        "1.8.9",
-        "1.9",
-        "1.9.1",
-        "1.9.2",
-        "1.9.3",
-        "1.9.4",
-        "1.10",
-        "1.10.1",
-        "1.10.2",
-        "1.11",
-        "1.11.1",
-        "1.11.2",
-        "1.12",
-        "1.12.1",
-        "1.12.2",
-        "1.13",
-        "1.13.1",
-        "1.13.2",
-        "1.14",
-        "1.14.1",
-        "1.14.2",
-        "1.14.3",
-        "1.14.4",
-        "1.15",
-        "1.15.1",
-        "1.15.2",
-        "1.16",
-        "1.16.1",
-        "1.16.2",
-        "1.16.3",
-        "1.16.4",
-        "1.16.5",
-        "1.17",
-        "1.17.1",
-        "1.18",
-        "1.18.1",
-        "1.18.2",
-        "1.19",
-        "1.19.1",
-        "1.19.2",
-        "1.19.3",
-        "1.19.4",
-        "1.20",
-        "1.20.1",
-        "1.20.2",
-        "1.20.3",
-        "1.20.4",
-        "1.20.5",
-        "1.20.6",
-        "1.21",
-        "1.21.1",
-        "1.21.2",
-        "1.21.3",
-        "1.21.4",
-        "1.21.5",
-        "1.21.6",
-        "1.21.7",
-        "1.21.8",
-        "1.21.9",
-        "1.21.10",
-        "1.21.11"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/ZfcV7L06/be971aa6c4a795004ac4f4c8dae4fac6b730acfd_96.webp",
-      "license": {
-        "id": "LicenseRef-All-Rights-Reserved",
-        "name": "",
-        "url": null
-      },
-      "loaders": [
-        "bukkit",
-        "folia",
-        "paper",
-        "purpur",
-        "spigot"
-      ],
-      "page_url": "https://modrinth.com/mod/score",
-      "project_id": "ZfcV7L06",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+paper": {
-          "date_published": "2026-05-17T19:20:34.888904Z",
-          "downloads": 960,
-          "file": {
-            "filename": "SCore-5.26.5.17.jar",
-            "hashes": {
-              "sha1": "26b068e9c9e41f4f9a7ce73b01ff45dae3b40e1b",
-              "sha512": "22de6b0aba0c8d5e2fcca33286da38cf537e1c2ff56f5d76c468fcc4134137ef2eae463d56f58f7050c79011182f994be8f015ee6069dd6004549ceb45c99bc5"
-            },
-            "primary": true,
-            "size": 6078675,
-            "url": "https://cdn.modrinth.com/data/ZfcV7L06/versions/ddOkhdsg/SCore-5.26.5.17.jar"
-          },
-          "game_versions": [
-            "1.8",
-            "1.8.1",
-            "1.8.2",
-            "1.8.3",
-            "1.8.4",
-            "1.8.5",
-            "1.8.6",
-            "1.8.7",
-            "1.8.8",
-            "1.8.9",
-            "1.9",
-            "1.9.1",
-            "1.9.2",
-            "1.9.3",
-            "1.9.4",
-            "1.10",
-            "1.10.1",
-            "1.10.2",
-            "1.11",
-            "1.11.1",
-            "1.11.2",
-            "1.12",
-            "1.12.1",
-            "1.12.2",
-            "1.13",
-            "1.13.1",
-            "1.13.2",
-            "1.14",
-            "1.14.1",
-            "1.14.2",
-            "1.14.3",
-            "1.14.4",
-            "1.15",
-            "1.15.1",
-            "1.15.2",
-            "1.16",
-            "1.16.1",
-            "1.16.2",
-            "1.16.3",
-            "1.16.4",
-            "1.16.5",
-            "1.17",
-            "1.17.1",
-            "1.18",
-            "1.18.1",
-            "1.18.2",
-            "1.19",
-            "1.19.1",
-            "1.19.2",
-            "1.19.3",
-            "1.19.4",
-            "1.20",
-            "1.20.1",
-            "1.20.2",
-            "1.20.3",
-            "1.20.4",
-            "1.20.5",
-            "1.20.6",
-            "1.21",
-            "1.21.1",
-            "1.21.2",
-            "1.21.3",
-            "1.21.4",
-            "1.21.5",
-            "1.21.6",
-            "1.21.7",
-            "1.21.8",
-            "1.21.9",
-            "1.21.10",
-            "1.21.11"
-          ],
-          "id": "ddOkhdsg",
-          "loaders": [
-            "bukkit",
-            "folia",
-            "paper",
-            "purpur",
-            "spigot"
-          ],
-          "name": "5.26.5.17",
-          "project_id": "ZfcV7L06",
-          "version_number": "5.26.5.17",
-          "version_type": "release"
-        }
-      },
-      "server_side": "required",
-      "slug": "score",
-      "source": "modrinth",
-      "title": "SCore",
-      "wiki_url": "https://docs.ssomar.com"
-    },
     "servercore": {
       "categories": [
         "optimization",
@@ -24425,11 +24553,11 @@
       "client_side": "unsupported",
       "color": 13730356,
       "date_created": "2021-09-26T09:44:54.800265Z",
-      "date_modified": "2026-05-19T16:41:54.338207Z",
+      "date_modified": "2026-06-24T12:58:51.451898Z",
       "description": "A mod that aims to optimize the minecraft server.",
       "discord_url": "https://discord.gg/Y9nC7Peq4m",
-      "downloads": 9403417,
-      "followers": 1347,
+      "downloads": 11157073,
+      "followers": 1400,
       "game_versions": [
         "1.17.1",
         "1.18-pre3",
@@ -24466,7 +24594,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/4WWQxlQP/5207e4657a1d0e929506a8c07491a42fa73b0a29_96.webp",
       "issues_url": "https://github.com/Wesley1808/ServerCore/issues",
@@ -24486,11 +24615,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2025-12-09T20:03:16.956582Z",
-          "downloads": 445393,
+          "downloads": 598675,
           "file": {
             "filename": "servercore-fabric-1.5.15+1.21.11.jar",
             "hashes": {
-              "sha1": "c3c6ec10b0ceddaa8f1ef53ffe57db57b4e8638f",
               "sha512": "964392769e53f9764466e26044552f60e91137f487b49d98a85bd4dc03ab8e965f0c69bc1a43e96ef5737cd8f1a9bb75cc0a0c09dd30bab6786d8ab4bbea6e01"
             },
             "primary": true,
@@ -24510,28 +24638,27 @@
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-19T16:41:54.337608Z",
-          "downloads": 2889,
+          "date_published": "2026-06-24T12:56:58.151806Z",
+          "downloads": 6080,
           "file": {
-            "filename": "servercore-fabric-1.5.17+26.1.2.jar",
+            "filename": "servercore-fabric-1.5.19+26.1.2.jar",
             "hashes": {
-              "sha1": "52b4b9d03ad49a05977f6a7042f7bf21e61f01c9",
-              "sha512": "b994f148565893024bd9e747d47396b30f2561d553cbae9849d2203066dbae5a45194b083955f6c98d217d0ad6b3b7027d1d9aedd823fb78a61768d3c228f525"
+              "sha512": "056d56d74508bf34f25ded9323a721be915b9273796100ee81c4a867717364539285b4ae9749e360d6699d485e3fba0561502a8c94979684b0cf79ce8e80afcd"
             },
             "primary": true,
-            "size": 920562,
-            "url": "https://cdn.modrinth.com/data/4WWQxlQP/versions/2siue87F/servercore-fabric-1.5.17%2B26.1.2.jar"
+            "size": 920689,
+            "url": "https://cdn.modrinth.com/data/4WWQxlQP/versions/H6TboTA2/servercore-fabric-1.5.19%2B26.1.2.jar"
           },
           "game_versions": [
             "26.1.2"
           ],
-          "id": "2siue87F",
+          "id": "H6TboTA2",
           "loaders": [
             "fabric"
           ],
-          "name": "ServerCore Fabric 1.5.17+26.1.2",
+          "name": "ServerCore Fabric 1.5.19+26.1.2",
           "project_id": "4WWQxlQP",
-          "version_number": "1.5.17+26.1.2",
+          "version_number": "1.5.19+26.1.2",
           "version_type": "release"
         }
       },
@@ -24548,8 +24675,8 @@
       "date_modified": "2026-05-18T19:17:56.658855Z",
       "description": "SetHome is a plugin that allows you to easily create homes",
       "discord_url": "https://discord.gg/y6gGNsBTux",
-      "downloads": 213526,
-      "followers": 135,
+      "downloads": 245981,
+      "followers": 149,
       "gallery": [
         {
           "created": "2023-08-23T11:59:08.584028Z",
@@ -24592,7 +24719,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/1apsbntF/54d485945aceef0f1fc6be8ef6ff3aba71a06489_96.webp",
       "license": {
@@ -24612,11 +24740,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-05-18T19:17:56.658855Z",
-          "downloads": 3369,
+          "downloads": 34992,
           "file": {
             "filename": "SetHome-6.2.jar",
             "hashes": {
-              "sha1": "31699530fab9f59b6e0a2495112a3f69919b3b50",
               "sha512": "9a9b6f064ca7e7454e38eb6367ed222549ef9853ccf13c3bdcd26480d9e57234ec6e4205c74020ef5d316c5c27818fb56d3f1bf9ed370058a033f847f73d52dd"
             },
             "primary": true,
@@ -24650,7 +24777,8 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
           "id": "j33t7krR",
           "loaders": [
@@ -24670,6 +24798,88 @@
       "source": "modrinth",
       "title": "SetHome"
     },
+    "shatterbyte-lib": {
+      "categories": [
+        "library"
+      ],
+      "client_side": "required",
+      "color": 9206940,
+      "date_created": "2023-11-27T10:53:12.598219Z",
+      "date_modified": "2026-06-15T13:45:42.092509Z",
+      "description": "Collection of shared code for OctoStudios' mods",
+      "discord_url": "https://discord.com/invite/pHren9yxzW",
+      "downloads": 13273187,
+      "followers": 492,
+      "game_versions": [
+        "1.18.2",
+        "1.19.2",
+        "1.20.1",
+        "1.20.2",
+        "1.21",
+        "1.21.1",
+        "1.21.2",
+        "1.21.3",
+        "1.21.4",
+        "1.21.8",
+        "1.21.9",
+        "1.21.10",
+        "1.21.11",
+        "26.1.2"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/RH2KUdKJ/a4043436fa16d40de4faa032b08e0879b8397259_96.webp",
+      "issues_url": "https://github.com/Octo-Studios/octo-lib/issues",
+      "license": {
+        "id": "LicenseRef-All-Rights-Reserved",
+        "name": "",
+        "url": null
+      },
+      "loaders": [
+        "fabric",
+        "forge",
+        "neoforge",
+        "quilt"
+      ],
+      "page_url": "https://modrinth.com/mod/shatterbyte-lib",
+      "project_id": "RH2KUdKJ",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+fabric": {
+          "date_published": "2026-03-11T21:43:07.212698Z",
+          "dependencies": [
+            {
+              "dependency_type": "required",
+              "project_id": "lhGA9TYQ"
+            }
+          ],
+          "downloads": 344089,
+          "file": {
+            "filename": "ShatterLib-FABRIC-0.6.0.8+1.21.11.jar",
+            "hashes": {
+              "sha512": "c376889551345550d9b49f32be54f998ff8689495f12b043bb18a12afbc64abc48256e0df11b15c6c9acee5fff91f186606b10d1224c000a7f8f0077cac936ed"
+            },
+            "primary": true,
+            "size": 513942,
+            "url": "https://cdn.modrinth.com/data/RH2KUdKJ/versions/DtNaQNS2/ShatterLib-FABRIC-0.6.0.8%2B1.21.11.jar"
+          },
+          "game_versions": [
+            "1.21.11"
+          ],
+          "id": "DtNaQNS2",
+          "loaders": [
+            "fabric"
+          ],
+          "name": "OctoLib 0.6.0.8",
+          "project_id": "RH2KUdKJ",
+          "version_number": "0.6.0.8",
+          "version_type": "release"
+        }
+      },
+      "server_side": "required",
+      "slug": "shatterbyte-lib",
+      "source": "modrinth",
+      "source_url": "https://github.com/Octo-Studios/octo-lib",
+      "title": "ShatterLib | OctoLib"
+    },
     "shulkerboxtooltip": {
       "categories": [
         "storage",
@@ -24678,10 +24888,10 @@
       "client_side": "required",
       "color": 4594692,
       "date_created": "2022-07-16T03:01:45.246757Z",
-      "date_modified": "2026-03-30T22:03:04.123853Z",
+      "date_modified": "2026-06-17T20:14:02.823509Z",
       "description": "View the contents of shulker boxes from your inventory",
-      "downloads": 26961039,
-      "followers": 9044,
+      "downloads": 29927548,
+      "followers": 9511,
       "gallery": [
         {
           "created": "2024-06-25T09:35:01.815034Z",
@@ -24770,7 +24980,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/2M01OLQq/bb490716cf2590cf84100a495931c3d4743bce43_96.webp",
       "issues_url": "https://github.com/MisterPeModder/ShulkerBoxTooltip/issues",
@@ -24792,23 +25003,18 @@
           "date_published": "2026-03-16T19:42:07.543120Z",
           "dependencies": [
             {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "dependency_type": "optional",
+              "project_id": "mOgUt4GM"
             },
             {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "dependency_type": "required",
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 976881,
+          "downloads": 1595811,
           "file": {
             "filename": "shulkerboxtooltip-fabric-5.2.16+1.21.11.jar",
             "hashes": {
-              "sha1": "3f889de77a0aec69ffcfd28bf6fb2c077443788a",
               "sha512": "98cd0950adafa086201d4595e558c15697ba1c9eda1b47c30803081ae48e2594e74cae5b743b3283990fa9d0da6caab87958bf2e97125bc3cb9107f6ab6f1882"
             },
             "primary": true,
@@ -24835,6 +25041,139 @@
       "title": "Shulker Box Tooltip",
       "wiki_url": "https://github.com/MisterPeModder/ShulkerBoxTooltip/wiki"
     },
+    "simple-login": {
+      "categories": [
+        "management",
+        "utility"
+      ],
+      "client_side": "unknown",
+      "color": 6389125,
+      "date_created": "2025-05-12T19:02:56.778680Z",
+      "date_modified": "2026-04-09T11:41:45.951198Z",
+      "description": "SimpleLogin is a plugin/mod that provides a secure login and registration system. It uses SQLite for storage, BCrypt for password hashing, and supports optional TOTP-based 2FA for added account security.",
+      "donation_urls": [
+        {
+          "id": "ko-fi",
+          "platform": "Ko-fi",
+          "url": "https://ko-fi.com/spicymike"
+        }
+      ],
+      "downloads": 97505,
+      "followers": 51,
+      "game_versions": [
+        "1.17",
+        "1.17.1",
+        "1.18",
+        "1.18.1",
+        "1.18.2",
+        "1.19",
+        "1.19.1",
+        "1.19.2",
+        "1.19.3",
+        "1.19.4",
+        "1.20",
+        "1.20.1",
+        "1.20.2",
+        "1.20.3",
+        "1.20.4",
+        "1.20.5",
+        "1.20.6",
+        "1.21",
+        "1.21.1",
+        "1.21.2",
+        "1.21.3",
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8",
+        "1.21.9",
+        "1.21.10",
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2"
+      ],
+      "icon_url": "https://cdn.modrinth.com/data/Gh3tnMca/35e032a7b47a1ec92c838cf0cb3a19143311e169.jpeg",
+      "issues_url": "https://t.me/spicymikehun",
+      "license": {
+        "id": "LicenseRef-All-Rights-Reserved",
+        "name": "",
+        "url": null
+      },
+      "loaders": [
+        "bukkit",
+        "fabric",
+        "folia",
+        "paper",
+        "purpur",
+        "spigot"
+      ],
+      "page_url": "https://modrinth.com/mod/simple-login",
+      "project_id": "Gh3tnMca",
+      "project_type": "mod",
+      "selected_versions": {
+        "1.21.11+paper": {
+          "date_published": "2026-04-09T11:41:45.951198Z",
+          "downloads": 32195,
+          "file": {
+            "filename": "SimpleLogin-1.16.5.jar",
+            "hashes": {
+              "sha512": "a96b201f034905bc59b5bafb30e5660d16723b7bb6876d53f97dbc03c03e869ebf1730deb119589bfa54cc686805222c07f5280e86761b2d6bb4e9151df4ba76"
+            },
+            "primary": true,
+            "size": 16150264,
+            "url": "https://cdn.modrinth.com/data/Gh3tnMca/versions/Q1bEKURZ/SimpleLogin-1.16.5.jar"
+          },
+          "game_versions": [
+            "1.17",
+            "1.17.1",
+            "1.18",
+            "1.18.1",
+            "1.18.2",
+            "1.19",
+            "1.19.1",
+            "1.19.2",
+            "1.19.3",
+            "1.19.4",
+            "1.20",
+            "1.20.1",
+            "1.20.2",
+            "1.20.3",
+            "1.20.4",
+            "1.20.5",
+            "1.20.6",
+            "1.21",
+            "1.21.1",
+            "1.21.2",
+            "1.21.3",
+            "1.21.4",
+            "1.21.5",
+            "1.21.6",
+            "1.21.7",
+            "1.21.8",
+            "1.21.9",
+            "1.21.10",
+            "1.21.11"
+          ],
+          "id": "Q1bEKURZ",
+          "loaders": [
+            "bukkit",
+            "paper",
+            "purpur",
+            "spigot"
+          ],
+          "name": "Simple Login Plugin 1.17.x-1.21.x-1.16.5",
+          "project_id": "Gh3tnMca",
+          "version_number": "1.16.5",
+          "version_type": "release"
+        }
+      },
+      "server_side": "unknown",
+      "slug": "simple-login",
+      "source": "modrinth",
+      "title": "Simple Login"
+    },
     "simple-voice-chat": {
       "categories": [
         "adventure",
@@ -24844,11 +25183,11 @@
       "client_side": "optional",
       "color": 2368556,
       "date_created": "2021-11-15T12:29:48.239701Z",
-      "date_modified": "2026-05-19T16:01:47.625773Z",
+      "date_modified": "2026-06-30T17:33:00.827650Z",
       "description": "A working voice chat in Minecraft!",
       "discord_url": "https://discord.gg/4dH2zwTmyX",
-      "downloads": 48020593,
-      "followers": 11929,
+      "downloads": 54378534,
+      "followers": 12665,
       "gallery": [
         {
           "created": "2023-01-12T13:24:04.701172Z",
@@ -25132,7 +25471,18 @@
         "26.2-snapshot-5",
         "26.2-snapshot-6",
         "26.2-snapshot-7",
-        "26.2-snapshot-8"
+        "26.2-snapshot-8",
+        "26.2-pre-1",
+        "26.2-pre-2",
+        "26.2-pre-3",
+        "26.2-pre-4",
+        "26.2-pre-5",
+        "26.2-pre-6",
+        "26.2-rc-1",
+        "26.2-rc-2",
+        "26.2",
+        "26.3-snapshot-1",
+        "26.3-snapshot-2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/9eGKb6K1/icon.png",
       "issues_url": "https://github.com/henkelmax/simple-voice-chat/issues",
@@ -25160,86 +25510,70 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-04T13:14:55.761673Z",
+          "date_published": "2026-06-21T13:03:29.194867Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "UL4bJFDY",
-              "version_id": null
+              "project_id": "9s6osm5g"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
+              "project_id": "qyVF9oeo"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "SRlzjEBS",
-              "version_id": null
+              "project_id": "UL4bJFDY"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "Vebnzrzj"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "qyVF9oeo",
-              "version_id": null
+              "project_id": "YlKdE5VK"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "Vebnzrzj",
-              "version_id": null
+              "project_id": "SRlzjEBS"
             }
           ],
-          "downloads": 370357,
+          "downloads": 263062,
           "file": {
-            "filename": "voicechat-fabric-1.21.11-2.6.17.jar",
+            "filename": "voicechat-fabric-1.21.11-2.6.20.jar",
             "hashes": {
-              "sha1": "201fcdaaad9a58c1c724def08b8c77624dbe68c2",
-              "sha512": "065018369c3cc206f83dd849543775dc601fc6ef48c54f989fa9e7b2ed0348bbcc16a7f7768336510041331bf2f7a92871a331c16e46482227888a6e5ca3774e"
+              "sha512": "cfc47ba01aa4aa61b3250f411a4beefc1e1eaabe3fcbf4473c8b05ba95ae7a95e83a6816a30b8704d4e54f1538c76852a7f8630a3219582b0960feb1eab9d448"
             },
             "primary": true,
-            "size": 5574940,
-            "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/ukcC8F72/voicechat-fabric-1.21.11-2.6.17.jar"
+            "size": 5583524,
+            "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/tiSyltLv/voicechat-fabric-1.21.11-2.6.20.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "ukcC8F72",
+          "id": "tiSyltLv",
           "loaders": [
             "fabric"
           ],
-          "name": "Simple Voice Chat 1.21.11-2.6.17",
+          "name": "Simple Voice Chat 1.21.11-2.6.20",
           "project_id": "9eGKb6K1",
-          "version_number": "fabric-1.21.11-2.6.17",
+          "version_number": "fabric-1.21.11-2.6.20",
           "version_type": "release"
         },
         "1.21.11+paper": {
-          "date_published": "2026-05-04T13:16:22.885614Z",
-          "downloads": 68423,
+          "date_published": "2026-06-21T13:09:09.137296Z",
+          "downloads": 40950,
           "file": {
-            "filename": "voicechat-bukkit-2.6.17.jar",
+            "filename": "voicechat-bukkit-2.6.20.jar",
             "hashes": {
-              "sha1": "bc1e32243e3ef1b4999ac9d15720fdaddc7a3622",
-              "sha512": "85d0751fe33a185dbb39e0c3086ce4fb958b0a62e5a5a9680b5cc16e5ca8ba6a9b87d1f8ed33fedb44f88e73bbb8e680230660574297a4e6de8ee546b62e3d48"
+              "sha512": "b4966ca5079481e1ca84c3dcde83ff133a2c64e816636abbd91178646e01b99a2293c2a925f0676549ee4278e4ae767908c7d2d9ce81fcfd0a87c09326db3eea"
             },
             "primary": true,
-            "size": 931431,
-            "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/Qnk9puxN/voicechat-bukkit-2.6.17.jar"
+            "size": 938745,
+            "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/7wUBXQ5w/voicechat-bukkit-2.6.20.jar"
           },
           "game_versions": [
             "1.8.8",
@@ -25283,9 +25617,10 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "Qnk9puxN",
+          "id": "7wUBXQ5w",
           "loaders": [
             "bukkit",
             "folia",
@@ -25293,80 +25628,65 @@
             "purpur",
             "spigot"
           ],
-          "name": "Simple Voice Chat 2.6.17",
+          "name": "Simple Voice Chat 2.6.20",
           "project_id": "9eGKb6K1",
-          "version_number": "bukkit-2.6.17",
+          "version_number": "bukkit-2.6.20",
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-04T13:20:24.420963Z",
+          "date_published": "2026-06-21T13:07:33.928864Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "qyVF9oeo",
-              "version_id": null
+              "project_id": "qyVF9oeo"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "Vebnzrzj",
-              "version_id": null
+              "project_id": "UL4bJFDY"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "SRlzjEBS",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "UL4bJFDY",
-              "version_id": null
+              "project_id": "Vebnzrzj"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
+              "project_id": "SRlzjEBS"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
+              "project_id": "9s6osm5g"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "YlKdE5VK"
             }
           ],
-          "downloads": 246040,
+          "downloads": 118789,
           "file": {
-            "filename": "voicechat-fabric-2.6.17+26.1.2.jar",
+            "filename": "voicechat-fabric-2.6.20+26.1.2.jar",
             "hashes": {
-              "sha1": "ce2569566a0ae5daf620fa093b7a66c39837d6a5",
-              "sha512": "1eb687a5210e7e15887e84a93195dd8ebcf45d85a2b657d27c711ad01ed8e9096f499fcb84d6564854989ed2c13b6a800665fbb382229977d1125e0d3eb5a836"
+              "sha512": "97a32d03d8e03ab5cc4b5fa89918c49f500d909946b0fe6ed114534a32bd9e13be36e90b47d85a5d1e60c2fb8c08bcccf66aa3ddf7dbd80ceaf21feb16eca964"
             },
             "primary": true,
-            "size": 5509570,
-            "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/gVPjsMto/voicechat-fabric-2.6.17%2B26.1.2.jar"
+            "size": 5518288,
+            "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/lT9C1Daj/voicechat-fabric-2.6.20%2B26.1.2.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
             "26.1.2"
           ],
-          "id": "gVPjsMto",
+          "id": "lT9C1Daj",
           "loaders": [
             "fabric"
           ],
-          "name": "Simple Voice Chat 2.6.17+26.1.2",
+          "name": "Simple Voice Chat 2.6.20+26.1.2",
           "project_id": "9eGKb6K1",
-          "version_number": "fabric-2.6.17+26.1.2",
+          "version_number": "fabric-2.6.20+26.1.2",
           "version_type": "release"
         }
       },
@@ -25386,208 +25706,13 @@
       "client_side": "unknown",
       "color": 853252,
       "date_created": "2022-11-27T23:34:50.120880Z",
-      "date_modified": "2026-04-02T23:58:43.235856Z",
+      "date_modified": "2026-06-19T17:43:53.921461Z",
       "description": "A mod and plugin to make a bridge between Simple Voice Chat and Discord to allow for players without the mod to hear and speak.",
-      "downloads": 203200,
-      "followers": 464,
+      "downloads": 224463,
+      "followers": 485,
       "game_versions": [
         "1.16.5",
         "1.18.2",
-        "1.19.2",
-        "1.19.3",
-        "1.19.4",
-        "1.20",
-        "1.20.1",
-        "1.20.2",
-        "1.20.3",
-        "1.20.4",
-        "1.20.5",
-        "1.20.6",
-        "1.21",
-        "1.21.1",
-        "1.21.2",
-        "1.21.3",
-        "1.21.4",
-        "1.21.5",
-        "1.21.6",
-        "1.21.7",
-        "1.21.8",
-        "1.21.9",
-        "1.21.10",
-        "1.21.11"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/S1jG5YV5/91bf0519b2fca6da79fb44ad9f2a1323ae04a17e_96.webp",
-      "issues_url": "https://github.com/amsam0/voicechat-discord/issues",
-      "license": {
-        "id": "MIT",
-        "name": "MIT License",
-        "url": null
-      },
-      "loaders": [
-        "bukkit",
-        "fabric",
-        "folia",
-        "paper",
-        "purpur",
-        "spigot"
-      ],
-      "page_url": "https://modrinth.com/mod/simple-voice-chat-discord-bridge",
-      "project_id": "S1jG5YV5",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+paper": {
-          "date_published": "2026-04-02T23:57:52.369653Z",
-          "dependencies": [
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "9eGKb6K1",
-              "version_id": null
-            }
-          ],
-          "downloads": 3743,
-          "file": {
-            "filename": "voicechat-discord-paper-3.1.4.jar",
-            "hashes": {
-              "sha1": "964512fe1bf234be0007db2b2bebed77177edf03",
-              "sha512": "2b1d3009ae927c607e8e2de9a29678cd1334e60c6c7d9f74fe214128032639e125f5ca838442b17b463840fbbe7ca279f1c4b391d3c74b316ed8c345258fefa9"
-            },
-            "primary": true,
-            "size": 24490701,
-            "url": "https://cdn.modrinth.com/data/S1jG5YV5/versions/cAaWO31V/voicechat-discord-paper-3.1.4.jar"
-          },
-          "game_versions": [
-            "1.16.5",
-            "1.18.2",
-            "1.19.2",
-            "1.20",
-            "1.20.1",
-            "1.20.2",
-            "1.20.3",
-            "1.20.4",
-            "1.20.5",
-            "1.20.6",
-            "1.21",
-            "1.21.1",
-            "1.21.2",
-            "1.21.3",
-            "1.21.4",
-            "1.21.5",
-            "1.21.6",
-            "1.21.7",
-            "1.21.8",
-            "1.21.9",
-            "1.21.10",
-            "1.21.11"
-          ],
-          "id": "cAaWO31V",
-          "loaders": [
-            "folia",
-            "paper",
-            "purpur"
-          ],
-          "name": "Simple Voice Chat Discord Bridge 3.1.4",
-          "project_id": "S1jG5YV5",
-          "version_number": "paper-3.1.4",
-          "version_type": "release"
-        }
-      },
-      "server_side": "unknown",
-      "slug": "simple-voice-chat-discord-bridge",
-      "source": "modrinth",
-      "source_url": "https://gitlab.com/amsam0/voicechat-discord",
-      "title": "Simple Voice Chat Discord Bridge"
-    },
-    "simplescore": {
-      "categories": [
-        "game-mechanics",
-        "utility"
-      ],
-      "client_side": "unsupported",
-      "color": 4665636,
-      "date_created": "2023-10-19T18:06:29.475863Z",
-      "date_modified": "2026-04-05T22:34:34.364564Z",
-      "description": "A simple animated scoreboard plugin for your server.",
-      "discord_url": "https://discord.gg/cJnzTDGphE",
-      "donation_urls": [
-        {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/RuiPereiraDev"
-        },
-        {
-          "id": "paypal",
-          "platform": "Paypal",
-          "url": "https://paypal.me/RageBaby"
-        }
-      ],
-      "downloads": 78065,
-      "followers": 55,
-      "gallery": [
-        {
-          "created": "2025-09-13T15:58:23.610171Z",
-          "featured": true,
-          "ordering": 0,
-          "title": "Default Layout",
-          "url": "https://cdn.modrinth.com/data/qG43Afem/images/95d8d3443d46209be4f50350e627e223770efa0e.png"
-        },
-        {
-          "created": "2023-10-19T18:12:20.425578Z",
-          "featured": false,
-          "ordering": 0,
-          "title": "Plugin Icon",
-          "url": "https://cdn.modrinth.com/data/qG43Afem/images/c017f78e090a85033cc8f45ae88191ee9651a986.png"
-        }
-      ],
-      "game_versions": [
-        "1.8",
-        "1.8.1",
-        "1.8.2",
-        "1.8.3",
-        "1.8.4",
-        "1.8.5",
-        "1.8.6",
-        "1.8.7",
-        "1.8.8",
-        "1.8.9",
-        "1.9",
-        "1.9.1",
-        "1.9.2",
-        "1.9.3",
-        "1.9.4",
-        "1.10",
-        "1.10.1",
-        "1.10.2",
-        "1.11",
-        "1.11.1",
-        "1.11.2",
-        "1.12",
-        "1.12.1",
-        "1.12.2",
-        "1.13",
-        "1.13.1",
-        "1.13.2",
-        "1.14",
-        "1.14.1",
-        "1.14.2",
-        "1.14.3",
-        "1.14.4",
-        "1.15",
-        "1.15.1",
-        "1.15.2",
-        "1.16",
-        "1.16.1",
-        "1.16.2",
-        "1.16.3",
-        "1.16.4",
-        "1.16.5",
-        "1.17",
-        "1.17.1",
-        "1.18",
-        "1.18.1",
-        "1.18.2",
-        "1.19",
-        "1.19.1",
         "1.19.2",
         "1.19.3",
         "1.19.4",
@@ -25611,96 +25736,49 @@
         "1.21.10",
         "1.21.11",
         "26.1",
-        "26.1.1"
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
-      "icon_url": "https://cdn.modrinth.com/data/qG43Afem/c017f78e090a85033cc8f45ae88191ee9651a986.png",
-      "issues_url": "https://github.com/RuiPereiraDev/SimpleScore/issues",
+      "icon_url": "https://cdn.modrinth.com/data/S1jG5YV5/91bf0519b2fca6da79fb44ad9f2a1323ae04a17e_96.webp",
+      "issues_url": "https://github.com/amsam0/voicechat-discord/issues",
       "license": {
         "id": "MIT",
         "name": "MIT License",
-        "url": "https://github.com/RuiPereiraDev/SimpleScore/blob/main/LICENSE"
+        "url": null
       },
       "loaders": [
         "bukkit",
+        "fabric",
         "folia",
+        "neoforge",
         "paper",
         "purpur",
         "spigot"
       ],
-      "page_url": "https://modrinth.com/mod/simplescore",
-      "project_id": "qG43Afem",
+      "page_url": "https://modrinth.com/mod/simple-voice-chat-discord-bridge",
+      "project_id": "S1jG5YV5",
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-05T22:34:34.364564Z",
-          "downloads": 8955,
+          "date_published": "2026-06-19T17:40:47.482684Z",
+          "dependencies": [
+            {
+              "dependency_type": "required",
+              "project_id": "9eGKb6K1"
+            }
+          ],
+          "downloads": 1128,
           "file": {
-            "filename": "SimpleScore-4.2.0.jar",
+            "filename": "voicechat-discord-paper-3.2.0.jar",
             "hashes": {
-              "sha1": "554c10dba7a24692d20a7abf1597be29e1759daa",
-              "sha512": "9a50c13de5d3b63ed590f1060b1512c764ecdfdae6b2fda3c2de6df37ade9561d6b437a46132157d0442e051d82c1fdb906a423fab0a6fa6a4624825a4e2e1ca"
+              "sha512": "62c99dae1e09fb79950d324d06f982796675c222c29454691b1f4607bf5ef1e1188a57754473388d3236c0526b0a860c14bb8ca1cbafd7c45f60acbe541b459a"
             },
             "primary": true,
-            "size": 2210551,
-            "url": "https://cdn.modrinth.com/data/qG43Afem/versions/SJs5GShg/SimpleScore-4.2.0.jar"
+            "size": 24418700,
+            "url": "https://cdn.modrinth.com/data/S1jG5YV5/versions/i6HuMktV/voicechat-discord-paper-3.2.0.jar"
           },
           "game_versions": [
-            "1.8",
-            "1.8.1",
-            "1.8.2",
-            "1.8.3",
-            "1.8.4",
-            "1.8.5",
-            "1.8.6",
-            "1.8.7",
-            "1.8.8",
-            "1.8.9",
-            "1.9",
-            "1.9.1",
-            "1.9.2",
-            "1.9.3",
-            "1.9.4",
-            "1.10",
-            "1.10.1",
-            "1.10.2",
-            "1.11",
-            "1.11.1",
-            "1.11.2",
-            "1.12",
-            "1.12.1",
-            "1.12.2",
-            "1.13",
-            "1.13.1",
-            "1.13.2",
-            "1.14",
-            "1.14.1",
-            "1.14.2",
-            "1.14.3",
-            "1.14.4",
-            "1.15",
-            "1.15.1",
-            "1.15.2",
-            "1.16",
-            "1.16.1",
-            "1.16.2",
-            "1.16.3",
-            "1.16.4",
-            "1.16.5",
-            "1.17",
-            "1.17.1",
-            "1.18",
-            "1.18.1",
-            "1.18.2",
-            "1.19",
-            "1.19.1",
-            "1.19.2",
-            "1.19.3",
-            "1.19.4",
-            "1.20",
-            "1.20.1",
-            "1.20.2",
-            "1.20.3",
-            "1.20.4",
             "1.20.5",
             "1.20.6",
             "1.21",
@@ -25716,28 +25794,27 @@
             "1.21.10",
             "1.21.11",
             "26.1",
-            "26.1.1"
+            "26.1.1",
+            "26.1.2",
+            "26.2"
           ],
-          "id": "SJs5GShg",
+          "id": "i6HuMktV",
           "loaders": [
-            "bukkit",
             "folia",
             "paper",
-            "purpur",
-            "spigot"
+            "purpur"
           ],
-          "name": "SimpleScore 4.2.0",
-          "project_id": "qG43Afem",
-          "version_number": "4.2.0",
+          "name": "Simple Voice Chat Discord Bridge 3.2.0",
+          "project_id": "S1jG5YV5",
+          "version_number": "paper-3.2.0",
           "version_type": "release"
         }
       },
-      "server_side": "required",
-      "slug": "simplescore",
+      "server_side": "unknown",
+      "slug": "simple-voice-chat-discord-bridge",
       "source": "modrinth",
-      "source_url": "https://github.com/RuiPereiraDev/SimpleScore",
-      "title": "SimpleScore",
-      "wiki_url": "https://github.com/RuiPereiraDev/SimpleScore/wiki"
+      "source_url": "https://gitlab.com/amsam0/voicechat-discord",
+      "title": "Simple Voice Chat Discord Bridge"
     },
     "skbee": {
       "categories": [
@@ -25746,7 +25823,7 @@
       "client_side": "unsupported",
       "color": 4996383,
       "date_created": "2025-01-30T06:03:54.314961Z",
-      "date_modified": "2026-05-10T12:55:56.639362Z",
+      "date_modified": "2026-06-21T15:08:01.844841Z",
       "description": "A Skript addon that picks up where Skript left off.",
       "donation_urls": [
         {
@@ -25755,8 +25832,8 @@
           "url": "https://ko-fi.com/shanebee"
         }
       ],
-      "downloads": 180749,
-      "followers": 80,
+      "downloads": 204040,
+      "followers": 88,
       "gallery": [
         {
           "created": "2025-01-30T06:11:55.528035Z",
@@ -25792,7 +25869,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/a0tlbHZO/acec17eb1d0a52bc741b5828bb2bb1c6e5bb34d7.png",
       "issues_url": "https://github.com/ShaneBeee/SkBee/issues",
@@ -25810,32 +25888,37 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-10T12:55:56.639362Z",
-          "downloads": 5004,
+          "date_published": "2026-06-21T15:08:01.844841Z",
+          "dependencies": [
+            {
+              "dependency_type": "required",
+              "project_id": "xFNYAvMk"
+            }
+          ],
+          "downloads": 4002,
           "file": {
-            "filename": "SkBee-3.23.0.jar",
+            "filename": "SkBee-3.25.0.jar",
             "hashes": {
-              "sha1": "34ace085812502421317a90fbe86d585f7a725e3",
-              "sha512": "26998b59fad4add1cce6ae915706bca8b91234f7593551df21baf9bea013f2953c7bcb2472810e9654e5be307189bb8ebdac33164511c1e650c4a1007da5ccfa"
+              "sha512": "204768ca3b986150b8fbb163c70cdeca98dc4dcbb7336aa5fe02667a1b821b8ed2b7d39fdd892339d2246aae41d999ed9a7167686726f88d27fa27fa06b80dde"
             },
             "primary": true,
-            "size": 2490450,
-            "url": "https://cdn.modrinth.com/data/a0tlbHZO/versions/NZNToX5l/SkBee-3.23.0.jar"
+            "size": 2592989,
+            "url": "https://cdn.modrinth.com/data/a0tlbHZO/versions/egIBnFfk/SkBee-3.25.0.jar"
           },
           "game_versions": [
-            "1.21.10",
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "NZNToX5l",
+          "id": "egIBnFfk",
           "loaders": [
             "paper"
           ],
-          "name": "Few New Things",
+          "name": "Small Update",
           "project_id": "a0tlbHZO",
-          "version_number": "3.23.0",
+          "version_number": "3.25.0",
           "version_type": "release"
         }
       },
@@ -25858,23 +25941,23 @@
       "client_side": "unknown",
       "color": 4768815,
       "date_created": "2025-02-07T16:15:56.563370Z",
-      "date_modified": "2026-04-11T19:28:37.669679Z",
+      "date_modified": "2026-06-28T10:19:13.202885Z",
       "description": "\ud83c\udfa8 Ability to restore/change skins on servers! (Offline and Online Mode)",
       "discord_url": "https://skinsrestorer.net/discord",
       "donation_urls": [
         {
-          "id": "ko-fi",
-          "platform": "Ko-fi",
-          "url": "https://ko-fi.com/skinsrestorer"
-        },
-        {
           "id": "paypal",
           "platform": "Paypal",
           "url": "https://skinsrestorer.net/donate"
+        },
+        {
+          "id": "ko-fi",
+          "platform": "Ko-fi",
+          "url": "https://ko-fi.com/skinsrestorer"
         }
       ],
-      "downloads": 1061207,
-      "followers": 513,
+      "downloads": 1235749,
+      "followers": 576,
       "gallery": [
         {
           "created": "2025-06-25T18:06:12.946451Z",
@@ -25990,7 +26073,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/TsLS8Py5/a23c71312561d40d0e182d88585b71be9b5e8d81.webp",
       "issues_url": "https://github.com/SkinsRestorer/SkinsRestorer/issues",
@@ -26016,17 +26100,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-11T19:28:33.761062Z",
-          "downloads": 118163,
+          "date_published": "2026-06-28T10:19:09.697314Z",
+          "downloads": 7823,
           "file": {
             "filename": "SkinsRestorer.jar",
             "hashes": {
-              "sha1": "be5aa8f1bc93c96b0da9b4fd187c2bcafef104e8",
-              "sha512": "789374eeff1b45bfb1a34dd37ebc24de68d69e393f833ccfb6662daa363a04ac33788f620a0bf1f4c75058bfb9a924e46af34458ccdd1b2dbbac73abef87276e"
+              "sha512": "5db2d7dd96e8b0d30f2344383fe6459b0c128db691c242ada04a84e9ffb940de27c69add81223fa0550fc8dc36612469d32d46ffa56e5328a70edb343697cb68"
             },
             "primary": true,
-            "size": 8202868,
-            "url": "https://cdn.modrinth.com/data/TsLS8Py5/versions/2PjHGlwd/SkinsRestorer.jar"
+            "size": 8027831,
+            "url": "https://cdn.modrinth.com/data/TsLS8Py5/versions/jPoqTGpe/SkinsRestorer.jar"
           },
           "game_versions": [
             "1.8",
@@ -26101,9 +26184,10 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "2PjHGlwd",
+          "id": "jPoqTGpe",
           "loaders": [
             "bukkit",
             "bungeecord",
@@ -26114,9 +26198,9 @@
             "velocity",
             "waterfall"
           ],
-          "name": "SkinsRestorer 15.12.0",
+          "name": "SkinsRestorer 15.12.4",
           "project_id": "TsLS8Py5",
-          "version_number": "15.12.0",
+          "version_number": "15.12.4",
           "version_type": "release"
         }
       },
@@ -26138,23 +26222,23 @@
       "client_side": "unsupported",
       "color": 2434341,
       "date_created": "2025-11-07T19:06:16.232755Z",
-      "date_modified": "2026-05-01T20:38:33.891031Z",
+      "date_modified": "2026-06-01T20:26:25.721719Z",
       "description": "Skript is a Paper plugin which allows server admins to customize their server easily, but without the hassle of programming a plugin or asking/paying someone to program a plugin for them.",
       "discord_url": "https://discord.gg/ZPsZAg6ygu",
       "donation_urls": [
         {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/SkriptLang"
-        },
-        {
           "id": "other",
           "platform": "Other",
           "url": "https://opencollective.com/skriptlang"
+        },
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/SkriptLang"
         }
       ],
-      "downloads": 98698,
-      "followers": 85,
+      "downloads": 135685,
+      "followers": 106,
       "gallery": [
         {
           "created": "2025-11-07T19:22:32.600883Z",
@@ -26191,25 +26275,23 @@
         "url": "https://github.com/SkriptLang/Skript/blob/master/LICENSE"
       },
       "loaders": [
-        "paper",
-        "purpur"
+        "paper"
       ],
       "page_url": "https://modrinth.com/mod/skript",
       "project_id": "xFNYAvMk",
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-01T20:38:33.891031Z",
-          "downloads": 14636,
+          "date_published": "2026-06-01T20:26:25.721719Z",
+          "downloads": 25702,
           "file": {
-            "filename": "Skript-2.15.2.jar",
+            "filename": "Skript-2.15.3.jar",
             "hashes": {
-              "sha1": "7e89987e25af6e11b1ce8f68cbcb9afc43f89839",
-              "sha512": "73bc0c078898b454023e6c288217d830b5c33b8dc0d2a9799f132fa4ec90da9d37c06db314ef508749fb4444d629d150af7df6063bfd0ba952feea1cc197bf63"
+              "sha512": "607c4092a03f3255c039263dd8b927d514465d16b3a758b25b4f0185880163a02c57e6c6e704bd609992afd55052cf1d6a5a4e7352ced17729831bbbf47c1d2f"
             },
             "primary": true,
-            "size": 5126671,
-            "url": "https://cdn.modrinth.com/data/xFNYAvMk/versions/uA0AEenw/Skript-2.15.2.jar"
+            "size": 5130213,
+            "url": "https://cdn.modrinth.com/data/xFNYAvMk/versions/HpdbRhER/Skript-2.15.3.jar"
           },
           "game_versions": [
             "1.21.1",
@@ -26227,13 +26309,13 @@
             "26.1.1",
             "26.1.2"
           ],
-          "id": "uA0AEenw",
+          "id": "HpdbRhER",
           "loaders": [
             "paper"
           ],
-          "name": "Emergency Patch Release 2.15.2",
+          "name": "Patch Release 2.15.3",
           "project_id": "xFNYAvMk",
-          "version_number": "2.15.2",
+          "version_number": "2.15.3",
           "version_type": "release"
         }
       },
@@ -26257,9 +26339,9 @@
       "client_side": "unsupported",
       "color": 855574,
       "date_created": "2024-11-17T08:35:29.736473Z",
-      "date_modified": "2026-05-03T07:13:06.192549Z",
+      "date_modified": "2026-06-25T06:20:24.037423Z",
       "description": "A GUI-based spawner plugin that generates items and experience without spawning mobs",
-      "discord_url": "https://dsc.gg/nighterdevelopment",
+      "discord_url": "https://discord.com/invite/FJN7hJKPyb",
       "donation_urls": [
         {
           "id": "paypal",
@@ -26269,11 +26351,11 @@
         {
           "id": "ko-fi",
           "platform": "Ko-fi",
-          "url": "https://ko-fi.com/nighterdevelopment"
+          "url": "https://ko-fi.com/openvdra"
         }
       ],
-      "downloads": 137655,
-      "followers": 123,
+      "downloads": 162291,
+      "followers": 133,
       "gallery": [
         {
           "created": "2026-04-10T17:42:21.326347Z",
@@ -26347,10 +26429,11 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/9tQwxSFr/f0f1cc267f587a39acd2c820cfe6b29d0f2ccae3.png",
-      "issues_url": "https://github.com/NighterDevelopment/smartspawner/issues",
+      "issues_url": "https://github.com/OpenVdra/SmartSpawner/issues",
       "license": {
         "id": "GPL-3.0-only",
         "name": "GNU General Public License v3.0 only",
@@ -26366,24 +26449,18 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-03T07:13:06.192549Z",
-          "downloads": 7261,
+          "date_published": "2026-06-25T06:20:24.037423Z",
+          "downloads": 2172,
           "file": {
-            "filename": "SmartSpawner-1.6.6.jar",
+            "filename": "SmartSpawner-1.7.0.1.jar",
             "hashes": {
-              "sha1": "f4571788f6e74119ecc4ef4e1193a2626d3c3a9a",
-              "sha512": "3c81612ed39c649279820b88c36f98b6220aae2b235743540a99115c663ec6fc646c33ec2175fbc81b809691c455719ebbd1db6fb8a18a5404dbbe178ced4b9b"
+              "sha512": "033332ec5274fefe388b717bb72e751b08981b3fd6241b34dd3f6d1e441e56a0a398eb5a78ac4c17e064146d09aa93de55a9d68c3d27ae8032f47d358ccc9d83"
             },
             "primary": true,
-            "size": 1759173,
-            "url": "https://cdn.modrinth.com/data/9tQwxSFr/versions/3kSCj1nw/SmartSpawner-1.6.6.jar"
+            "size": 1869972,
+            "url": "https://cdn.modrinth.com/data/9tQwxSFr/versions/aDguHjo0/SmartSpawner-1.7.0.1.jar"
           },
           "game_versions": [
-            "1.21",
-            "1.21.1",
-            "1.21.2",
-            "1.21.3",
-            "1.21.4",
             "1.21.5",
             "1.21.6",
             "1.21.7",
@@ -26393,24 +26470,25 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "3kSCj1nw",
+          "id": "aDguHjo0",
           "loaders": [
             "folia",
             "paper",
             "purpur"
           ],
-          "name": "SmartSpawner 1.6.6",
+          "name": "SmartSpawner 1.7.0.1",
           "project_id": "9tQwxSFr",
-          "version_number": "1.6.6",
+          "version_number": "1.7.0.1",
           "version_type": "release"
         }
       },
       "server_side": "required",
       "slug": "smartspawner",
       "source": "modrinth",
-      "source_url": "https://github.com/NighterDevelopment/smartspawner",
+      "source_url": "https://github.com/OpenVdra/SmartSpawner",
       "title": "SmartSpawner",
       "wiki_url": "https://docs.smartspawner.site/"
     },
@@ -26422,10 +26500,10 @@
       "client_side": "required",
       "color": 263172,
       "date_created": "2022-06-23T14:36:52.813391Z",
-      "date_modified": "2026-04-10T05:16:45.252623Z",
+      "date_modified": "2026-06-18T06:31:54.338735Z",
       "description": "A Minecraft mod that provides realistic sound attenuation, reverberation, and absorption through blocks.",
-      "downloads": 40317962,
-      "followers": 8544,
+      "downloads": 43902725,
+      "followers": 8939,
       "game_versions": [
         "1.19",
         "1.19.1",
@@ -26451,7 +26529,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/qyVF9oeo/798fbfae58ec95ad51f3e1d522b43227306c326c.png",
       "issues_url": "https://github.com/henkelmax/sound-physics-remastered/issues",
@@ -26475,28 +26554,21 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
+              "project_id": "9s6osm5g"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "9eGKb6K1"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "9eGKb6K1",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             }
           ],
-          "downloads": 1554396,
+          "downloads": 1895265,
           "file": {
             "filename": "sound-physics-remastered-fabric-1.21.11-1.5.1.jar",
             "hashes": {
-              "sha1": "f04c90b17094aaa849b147a42d4df9aa82d54ace",
               "sha512": "0413e8d654fa5d74dc32ab7c21a82cf8e44aec22c7392648f23a34e2cdb7255af5b34a6016d71bda226c251e5089838f2be9310360723f88e9080fd048efd25f"
             },
             "primary": true,
@@ -26530,11 +26602,11 @@
       "client_side": "optional",
       "color": 16567356,
       "date_created": "2021-06-04T13:36:54.735179Z",
-      "date_modified": "2026-03-26T08:30:20.700162Z",
+      "date_modified": "2026-06-18T21:12:32.814420Z",
       "description": "spark is a performance profiler for Minecraft clients, servers and proxies.",
       "discord_url": "https://discord.gg/PAGT2fu",
-      "downloads": 15897566,
-      "followers": 1952,
+      "downloads": 17554029,
+      "followers": 2020,
       "game_versions": [
         "1.16.5",
         "1.17.1",
@@ -26567,7 +26639,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/l6YH9Als/61a777dd08a8447ac93e8b6372e6d27d48cd1e1a_96.webp",
       "issues_url": "https://github.com/lucko/spark/issues",
@@ -26588,11 +26661,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-03-26T07:43:06.831770Z",
-          "downloads": 158495,
+          "downloads": 243558,
           "file": {
             "filename": "spark-1.10.170-fabric.jar",
             "hashes": {
-              "sha1": "2a3745baa44e11672c4befe3beeccef758581f80",
               "sha512": "7460ac92a1241f373238b7afe3c9e8dc67101d3cc6d95322f9a86b7db4dc3be5da5e3ce80ad9653bff682f796a79cd8384851e0ed757b468f2f52b6bde71cb00"
             },
             "primary": true,
@@ -26612,30 +26684,30 @@
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-03-26T08:29:59.675898Z",
-          "downloads": 96769,
+          "date_published": "2026-06-18T21:12:12.918302Z",
+          "downloads": 42331,
           "file": {
-            "filename": "spark-1.10.172-fabric.jar",
+            "filename": "spark-1.10.173-fabric.jar",
             "hashes": {
-              "sha1": "fc1dbd31d83599a9af17393e2c9b461521ac343f",
-              "sha512": "e0697663689c5459b7ed92f21d86b0191bbe7f6327ac7e8972ad9f6318ef7a8ca93da3a8495459ee6f1443cadff7656b150ea0efc81f8cf1300c9301483a2fb3"
+              "sha512": "1dcbf2b76ceacf07523afaeaf63d3625b0318077cc6ce588bb701aea4a494bc2a5179fd2ca5aeda9513c6a2248c2ec590387e8aec6ac9fd8e3d01760bbc3dbfb"
             },
             "primary": true,
             "size": 3887184,
-            "url": "https://cdn.modrinth.com/data/l6YH9Als/versions/J1GUYyGQ/spark-1.10.172-fabric.jar"
+            "url": "https://cdn.modrinth.com/data/l6YH9Als/versions/iYFOl6lQ/spark-1.10.173-fabric.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "J1GUYyGQ",
+          "id": "iYFOl6lQ",
           "loaders": [
             "fabric"
           ],
-          "name": "1.10.172 (Fabric 26.1)",
+          "name": "1.10.173 (Fabric 26.2)",
           "project_id": "l6YH9Als",
-          "version_number": "1.10.172-fabric",
+          "version_number": "1.10.173-fabric",
           "version_type": "release"
         }
       },
@@ -26658,7 +26730,7 @@
       "client_side": "unknown",
       "color": 9132863,
       "date_created": "2023-02-26T04:52:10.111912Z",
-      "date_modified": "2026-04-15T02:08:16.556479Z",
+      "date_modified": "2026-06-28T20:39:28.834450Z",
       "description": "squaremap is a minimalistic & lightweight world map viewer for Minecraft servers, using the vanilla map rendering style",
       "discord_url": "https://discord.gg/PHpuzZS",
       "donation_urls": [
@@ -26668,8 +26740,8 @@
           "url": "https://github.com/sponsors/jpenilla"
         }
       ],
-      "downloads": 98078,
-      "followers": 452,
+      "downloads": 105346,
+      "followers": 470,
       "gallery": [
         {
           "created": "2023-02-26T05:00:20.470196Z",
@@ -26712,7 +26784,8 @@
         "1.21.8",
         "1.21.10",
         "1.21.11",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/PFb7ZqK6/6074e26ea9600af2cf87f33d3566a425ef309287_96.webp",
       "issues_url": "https://github.com/jpenilla/squaremap/issues",
@@ -26735,11 +26808,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2025-12-11T23:26:20.150079Z",
-          "downloads": 7587,
+          "downloads": 8463,
           "file": {
             "filename": "squaremap-paper-mc1.21.11-1.3.12.jar",
             "hashes": {
-              "sha1": "2754e73b69cd66e9dd5914a4bdeb5f5e15f6f86b",
               "sha512": "b35306031aaec4d5cb32c52e0bde7e95321cbce24016e8e9fb9cc1161366c7ba352a864bf1f9a44240e35b886fd933f5fc1b20a2c02ea2ff0ca4b611e7259cd4"
             },
             "primary": true,
@@ -26785,6 +26857,11 @@
       "discord_url": "https://discord.gg/VV4bQEdGAd",
       "donation_urls": [
         {
+          "id": "bmac",
+          "platform": "Bmac",
+          "url": "https://www.buymeacoffee.com/usainsrht"
+        },
+        {
           "id": "github",
           "platform": "Github",
           "url": "https://github.com/sponsors/UsainSrht"
@@ -26793,15 +26870,10 @@
           "id": "paypal",
           "platform": "Paypal",
           "url": "https://www.paypal.com/donate/?hosted_button_id=ZNU73U8HY5J88"
-        },
-        {
-          "id": "bmac",
-          "platform": "Bmac",
-          "url": "https://www.buymeacoffee.com/usainsrht"
         }
       ],
-      "downloads": 185290,
-      "followers": 284,
+      "downloads": 200535,
+      "followers": 291,
       "gallery": [
         {
           "created": "2022-09-06T09:14:28.598106Z",
@@ -26929,11 +27001,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-04-09T04:27:54.112625Z",
-          "downloads": 16904,
+          "downloads": 31271,
           "file": {
             "filename": "sit-1.7.3.jar",
             "hashes": {
-              "sha1": "9c2b6b2f6440969c363d5a132050b5b5bf1e08a6",
               "sha512": "475a5aa494aa12631a8d890451f9353582fcfb91621d91b081d2a0f1a55f28e5aeac520981218b779658afaade15310a75074d74cf1e015014c05a72938d1b06"
             },
             "primary": true,
@@ -27009,115 +27080,6 @@
       "source_url": "https://github.com/UsainSrht/Sit",
       "title": "Sit"
     },
-    "starter-kit": {
-      "categories": [
-        "adventure",
-        "management",
-        "utility"
-      ],
-      "client_side": "optional",
-      "color": 2498063,
-      "date_created": "2022-08-31T18:56:28.424726Z",
-      "date_modified": "2026-05-01T12:06:15.220376Z",
-      "description": "\ud83d\udce6 Give all new players joining the world configurable starter gear, items and/or potion effects. It can overwrite the initial inventory, or add the items after. Compatible with FTB Team Islands.",
-      "donation_urls": [
-        {
-          "id": "patreon",
-          "platform": "Patreon",
-          "url": "https://patreon.com/serilum"
-        }
-      ],
-      "downloads": 8897658,
-      "followers": 415,
-      "game_versions": [
-        "1.16.5",
-        "1.18.2",
-        "1.19.2",
-        "1.19.3",
-        "1.19.4",
-        "1.20",
-        "1.20.1",
-        "1.20.2",
-        "1.20.3",
-        "1.20.4",
-        "1.20.5",
-        "1.20.6",
-        "1.21",
-        "1.21.1",
-        "1.21.2",
-        "1.21.3",
-        "1.21.4",
-        "1.21.5",
-        "1.21.6",
-        "1.21.7",
-        "1.21.8",
-        "1.21.9",
-        "1.21.10",
-        "1.21.11",
-        "26.1",
-        "26.1.1",
-        "26.1.2"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/6L3ydNi8/946acc868c947e5f3ff7a1c1ccb268d09a14f6e5_96.webp",
-      "issues_url": "https://github.com/Serilum/.issue-tracker/labels/Mod: Starter Kit",
-      "license": {
-        "id": "LicenseRef-All-Rights-Reserved",
-        "name": "",
-        "url": null
-      },
-      "loaders": [
-        "fabric",
-        "forge",
-        "neoforge",
-        "quilt"
-      ],
-      "page_url": "https://modrinth.com/mod/starter-kit",
-      "project_id": "6L3ydNi8",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+fabric": {
-          "date_published": "2026-05-01T12:05:51.507606Z",
-          "dependencies": [
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "e0M1UDsY",
-              "version_id": null
-            }
-          ],
-          "downloads": 2184,
-          "file": {
-            "filename": "starterkit-1.21.11-8.0.jar",
-            "hashes": {
-              "sha1": "1b6644481e4b1c7301d72d434482a6e38cc11e4e",
-              "sha512": "f74590c2a2aeaab1b1b3df061f5ab7b8d874054f78634390851c96e7e7a8e383042af31fb14607326244ed26387934b02caff3ca7fdce05b2e37c4eabdceba82"
-            },
-            "primary": true,
-            "size": 278976,
-            "url": "https://cdn.modrinth.com/data/6L3ydNi8/versions/tjxX9dzL/starterkit-1.21.11-8.0.jar"
-          },
-          "game_versions": [
-            "1.21.11"
-          ],
-          "id": "tjxX9dzL",
-          "loaders": [
-            "fabric",
-            "forge",
-            "neoforge",
-            "quilt"
-          ],
-          "name": "[Fabric/Forge/Neo] 1.21.11-8.0",
-          "project_id": "6L3ydNi8",
-          "version_number": "1.21.11-8.0-fabric+forge+neo",
-          "version_type": "release"
-        }
-      },
-      "server_side": "required",
-      "slug": "starter-kit",
-      "source": "modrinth",
-      "source_url": "https://github.com/Serilum/Starter-Kit",
-      "title": "Starter Kit"
-    },
     "streamotes": {
       "categories": [
         "cursed",
@@ -27126,10 +27088,10 @@
       "client_side": "required",
       "color": 7098424,
       "date_created": "2023-10-21T15:52:37.027318Z",
-      "date_modified": "2026-03-25T05:32:19.773280Z",
+      "date_modified": "2026-06-27T22:51:47.847245Z",
       "description": "Integrate popular emote/emoji systems from your favorite streamers into Minecraft chat! Twitch, BTTV, FFZ, 7tv, now with server config support!",
-      "downloads": 100706,
-      "followers": 158,
+      "downloads": 108587,
+      "followers": 167,
       "gallery": [
         {
           "created": "2023-10-26T17:45:18.699062Z",
@@ -27162,7 +27124,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/IAJz3K09/7851ef5421502493713523b2cb5bc3e82f047842.webp",
       "issues_url": "https://github.com/XspeedPL/Streamotes/issues",
@@ -27174,6 +27137,7 @@
       "loaders": [
         "fabric",
         "folia",
+        "neoforge",
         "paper",
         "purpur",
         "quilt"
@@ -27184,11 +27148,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-03-17T01:49:45.626835Z",
-          "downloads": 1047,
+          "downloads": 1510,
           "file": {
             "filename": "streamotes-paper-1.2.14.jar",
             "hashes": {
-              "sha1": "bbabdf267ca431a32fcc95ffdc5de5de93dde8b9",
               "sha512": "a1c85b05a5c6b03615ed2da7b7162cd7e9ecd315dc86761b5f321bb760de654065a6f1055944a8d0bb75495b40df0b45ddf4331c823426dbccd793b44080890a"
             },
             "primary": true,
@@ -27234,7 +27197,7 @@
       "client_side": "unknown",
       "color": 1787008,
       "date_created": "2025-03-10T12:00:55.727842Z",
-      "date_modified": "2026-04-09T15:55:39.224630Z",
+      "date_modified": "2026-06-16T21:48:23.802033Z",
       "description": "Brings back the functionality of traditional string dupers in 1.21.2+",
       "discord_url": "https://discord.gg/4zqwjbTthC",
       "donation_urls": [
@@ -27244,8 +27207,8 @@
           "url": "https://ko-fi.com/novinity"
         }
       ],
-      "downloads": 144113,
-      "followers": 62,
+      "downloads": 197809,
+      "followers": 79,
       "gallery": [
         {
           "created": "2025-03-10T12:13:44.530749Z",
@@ -27270,7 +27233,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/U6d1TJQm/561450be6452d12201517ccd329261d56e5f61bd_96.webp",
       "issues_url": "https://github.com/Novinity/String-Dupers-Return/issues",
@@ -27292,11 +27256,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2025-05-11T11:42:17.542755Z",
-          "downloads": 15426,
+          "downloads": 15460,
           "file": {
             "filename": "StringDupersReturn-1.0.1.jar",
             "hashes": {
-              "sha1": "6c270f29e36633a937b276d4d43ddd32a6dff560",
               "sha512": "b322971e5468336155d3679257955f2cce67741e9a686a255e6394b3ad41b262ce407d7009da36b775b11c57ea41708a72636ce06cc9ea4b8abf077d33aa2593"
             },
             "primary": true,
@@ -27340,11 +27303,11 @@
       "client_side": "optional",
       "color": 5541869,
       "date_created": "2022-07-15T17:18:43.675914Z",
-      "date_modified": "2025-12-25T11:51:54.770642Z",
+      "date_modified": "2026-06-23T17:01:01.307553Z",
       "description": "Config Lib makes dealing with config files just a bit easier.",
       "discord_url": "https://discord.gg/QEbGyUYB2e",
-      "downloads": 24316705,
-      "followers": 1221,
+      "downloads": 26280683,
+      "followers": 1248,
       "game_versions": [
         "1.12",
         "1.12.1",
@@ -27391,7 +27354,11 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/LN9BxssP/ad25597dd1b10b49cdfbc97c70d401e3158000f7_96.webp",
       "issues_url": "https://github.com/SuperMartijn642/SuperMartijn642sConfigLib/issues",
@@ -27415,16 +27382,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 402873,
+          "downloads": 491813,
           "file": {
             "filename": "supermartijn642configlib-1.1.8-fabric-mc1.21.11.jar",
             "hashes": {
-              "sha1": "c4236e8a850a6fe1c3ebca567f29888d569b4944",
               "sha512": "89330ac0aead9c906a845ca000dafcbacd84185609c306691f64734ef0cffb4b4f4c72d12c7aefad2de8169dcd5d5c25bd79bdfeedf81c0263488290a5f38000"
             },
             "primary": true,
@@ -27461,8 +27425,8 @@
       "date_modified": "2026-03-20T04:20:06.973883Z",
       "description": "SuperMartijn642's Core Lib adds lots of basic implementations that allow for similar code between different Minecraft versions!",
       "discord_url": "https://discord.gg/QEbGyUYB2e",
-      "downloads": 12756514,
-      "followers": 756,
+      "downloads": 13989627,
+      "followers": 768,
       "game_versions": [
         "1.12",
         "1.12.1",
@@ -27533,16 +27497,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 72404,
+          "downloads": 116116,
           "file": {
             "filename": "supermartijn642corelib-1.1.21-fabric-mc1.21.11.jar",
             "hashes": {
-              "sha1": "0c7c607960298ecd8e93897cdf3b7043f68eaaf0",
               "sha512": "60f918dae4767d60bbff063cf77e7998ff8018c83bc6408d1a8636c4e89bf3e55c5dfd2dabeed2f30d16b25710fbe4028b61445e96f30291274ec6846c68340e"
             },
             "primary": true,
@@ -27576,10 +27537,10 @@
       "client_side": "unknown",
       "color": 8028295,
       "date_created": "2022-08-15T23:23:17.532599Z",
-      "date_modified": "2026-04-25T16:54:51.685339Z",
+      "date_modified": "2026-06-18T16:06:06.207092Z",
       "description": "An all-in-one solution that works",
-      "downloads": 834095,
-      "followers": 1299,
+      "downloads": 947240,
+      "followers": 1353,
       "gallery": [
         {
           "created": "2025-01-18T18:20:10.699371Z",
@@ -27735,7 +27696,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/gG7VFbG0/4a7fcab5db748296adac920926efff93b1da416d_96.webp",
       "issues_url": "https://github.com/NEZNAMY/TAB/issues",
@@ -27764,46 +27726,29 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-25T16:54:51.685339Z",
-          "downloads": 53462,
+          "date_published": "2026-06-18T16:05:11.851861Z",
+          "downloads": 18122,
           "file": {
-            "filename": "TAB v6.0.2 - Vanilla.jar",
+            "filename": "TAB v6.1.0.jar",
             "hashes": {
-              "sha1": "22015994cf4816944374a48de79f82f57fe40f16",
-              "sha512": "a9818aebfb8a6ab97781da9570cd1f9731e561187126ce0ea51cf27242a022d985bf2bb26f9ef5cbd44be77587b17670af132abcd296e1c8bdede0b1436ba189"
+              "sha512": "91d53689e28d31881af6d20d3f1d05250c3fc0902ba7fb31bd8c11adc0b53ec0ef6c9492ed2214aff6390831044b83c31582aec2b1f6699d185afbf330ffce56"
             },
             "primary": true,
-            "size": 8356850,
-            "url": "https://cdn.modrinth.com/data/gG7VFbG0/versions/FewsxQmS/TAB%20v6.0.2%20-%20Vanilla.jar"
+            "size": 8396777,
+            "url": "https://cdn.modrinth.com/data/gG7VFbG0/versions/t5Bd9Ajx/TAB%20v6.1.0.jar"
           },
           "game_versions": [
             "1.7.10",
             "1.8.8",
             "1.8.9",
-            "1.9.3",
-            "1.9.4",
-            "1.10",
-            "1.10.1",
-            "1.10.2",
-            "1.11",
-            "1.11.1",
-            "1.11.2",
             "1.12",
             "1.12.1",
             "1.12.2",
-            "1.13.1",
-            "1.13.2",
-            "1.14",
-            "1.14.1",
-            "1.14.2",
-            "1.14.3",
-            "1.14.4",
-            "1.15",
-            "1.15.1",
-            "1.15.2",
             "1.16.5",
             "1.17",
             "1.17.1",
+            "1.18",
+            "1.18.1",
             "1.18.2",
             "1.19",
             "1.19.1",
@@ -27815,13 +27760,6 @@
             "1.20.2",
             "1.20.3",
             "1.20.4",
-            "1.20.5",
-            "1.20.6",
-            "1.21",
-            "1.21.1",
-            "1.21.2",
-            "1.21.3",
-            "1.21.4",
             "1.21.5",
             "1.21.6",
             "1.21.7",
@@ -27831,9 +27769,10 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "FewsxQmS",
+          "id": "t5Bd9Ajx",
           "loaders": [
             "bukkit",
             "bungeecord",
@@ -27844,9 +27783,9 @@
             "velocity",
             "waterfall"
           ],
-          "name": "6.0.2 (Vanilla)",
+          "name": "6.1.0",
           "project_id": "gG7VFbG0",
-          "version_number": "6.0.2",
+          "version_number": "6.1.0",
           "version_type": "release"
         }
       },
@@ -27864,7 +27803,7 @@
       "client_side": "unsupported",
       "color": 13557042,
       "date_created": "2021-02-21T08:35:35.584187Z",
-      "date_modified": "2026-04-15T02:44:36.586848Z",
+      "date_modified": "2026-06-30T17:17:29.349161Z",
       "description": "Monitor your server's performance in the tab menu, boss bar, and action bar",
       "discord_url": "https://discord.gg/qcJKgKS",
       "donation_urls": [
@@ -27874,8 +27813,8 @@
           "url": "https://github.com/sponsors/jpenilla"
         }
       ],
-      "downloads": 282121,
-      "followers": 630,
+      "downloads": 296456,
+      "followers": 641,
       "gallery": [
         {
           "created": "2023-02-26T16:58:42.741903Z",
@@ -27920,7 +27859,8 @@
         "1.21.8",
         "1.21.10",
         "1.21.11",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/cUhi3iB2/283290cdd5982e865a8eefcc63bab47f3b2676d8_96.webp",
       "issues_url": "https://github.com/jpenilla/TabTPS/issues",
@@ -27940,17 +27880,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-15T02:44:36.586848Z",
-          "downloads": 4294,
+          "date_published": "2026-06-30T17:17:29.030539Z",
+          "downloads": 0,
           "file": {
-            "filename": "tabtps-paper-1.3.31.jar",
+            "filename": "tabtps-paper-1.4.1.jar",
             "hashes": {
-              "sha1": "8767c5dcdf4f0b729313e001ccb9235d2f99eff5",
-              "sha512": "b67ba810a55f56477f93f702246088b1135b1cec831755d87360358d62cacf59fd621a0997f7448a2b2659edbc1caef27085118cfcb83780db560438be49bb06"
+              "sha512": "3809b44ab8cf0213e744c053f3b9c1b46a7f273a538ddd800dd6fd0cebf1ee46cc611f60d2891c0eb138898c301f9283369c49f610a6ae0bd9335708fc489901"
             },
             "primary": true,
-            "size": 3334327,
-            "url": "https://cdn.modrinth.com/data/cUhi3iB2/versions/YvY9J2Wb/tabtps-paper-1.3.31.jar"
+            "size": 3330141,
+            "url": "https://cdn.modrinth.com/data/cUhi3iB2/versions/y4Ns2oTP/tabtps-paper-1.4.1.jar"
           },
           "game_versions": [
             "1.8.8",
@@ -27968,15 +27907,16 @@
             "1.19.4",
             "1.20.6",
             "1.21.11",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "YvY9J2Wb",
+          "id": "y4Ns2oTP",
           "loaders": [
             "paper"
           ],
-          "name": "tabtps-paper 1.3.31",
+          "name": "tabtps-paper 1.4.1",
           "project_id": "cUhi3iB2",
-          "version_number": "1.3.31",
+          "version_number": "1.4.1",
           "version_type": "release"
         }
       },
@@ -27993,7 +27933,7 @@
       "client_side": "optional",
       "color": 7095718,
       "date_created": "2022-11-25T11:45:51.025251Z",
-      "date_modified": "2026-04-03T17:25:10.649502Z",
+      "date_modified": "2026-06-18T13:01:31.701398Z",
       "description": "TheCSDev's personal library mod for the Minecraft modding environment.",
       "donation_urls": [
         {
@@ -28002,8 +27942,8 @@
           "url": "https://thecsdev.com/fwd/support-me/"
         }
       ],
-      "downloads": 12181544,
-      "followers": 1189,
+      "downloads": 13362886,
+      "followers": 1223,
       "gallery": [
         {
           "created": "2026-02-08T12:11:49.558205Z",
@@ -28041,7 +27981,8 @@
         "26.1",
         "26.1.1",
         "26w14a",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Eldc1g37/36f2c7c76a7fc63e827bc20657853b7f1d9e4060.png",
       "issues_url": "https://github.com/TheCSDev/tcdcommons/issues",
@@ -28065,16 +28006,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 157554,
+          "downloads": 249042,
           "file": {
             "filename": "tcdcommons-5.1.0+fabric-1.21.11.jar",
             "hashes": {
-              "sha1": "c8acc1e0b48af47a98a13602719574e9793fb495",
               "sha512": "88b248ff84ce52bcb09ef5b8d7169f0de66dfed5f6860fb5799ab63deea2b81968c1af3adabfedbdf80025681c58ef1fd82c3e6a3624b7aaa43276d3133aca9f"
             },
             "primary": true,
@@ -28109,7 +28047,7 @@
       "client_side": "optional",
       "color": 4538421,
       "date_created": "2022-10-06T04:20:33.396078Z",
-      "date_modified": "2026-04-16T22:45:07.162792Z",
+      "date_modified": "2026-06-20T16:20:23.833103Z",
       "description": "Terrain shaping brought to new heights, grander and more varied than ever before!",
       "discord_url": "https://discord.gg/pA9EqZRJzn",
       "donation_urls": [
@@ -28119,8 +28057,8 @@
           "url": "https://ko-fi.com/apollodev"
         }
       ],
-      "downloads": 12953411,
-      "followers": 6510,
+      "downloads": 14010717,
+      "followers": 6829,
       "gallery": [
         {
           "created": "2025-05-29T15:35:24.879915Z",
@@ -28255,7 +28193,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/lWDHr9jE/d8b3413f797479dcc0d8764756613e449a358a2e_96.webp",
       "issues_url": "https://github.com/Apollounknowndev/tectonic/issues",
@@ -28277,11 +28216,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2025-12-23T00:39:43.685897Z",
-          "downloads": 345566,
+          "downloads": 451407,
           "file": {
             "filename": "tectonic-3.0.19-fabric-1.21.11.jar",
             "hashes": {
-              "sha1": "ab0ad94c096070d36a050ec2ad56f0525d280d8c",
               "sha512": "ce0643d45aac7b5e3f3a32fc01928371d97612a9dc6e8df721bf215bf90afa021b8e8d7e19c0d00060c3c98591aec90d2ea51f594fdc0012051f20657fae85ef"
             },
             "primary": true,
@@ -28301,44 +28239,39 @@
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-04-10T04:59:01.301232Z",
+          "date_published": "2026-06-19T15:16:35.813126Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "XaDC71GB",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "XaDC71GB"
             }
           ],
-          "downloads": 51909,
+          "downloads": 17529,
           "file": {
-            "filename": "tectonic-3.0.22-fabric-26.1.jar",
+            "filename": "tectonic-3.0.25-fabric-26.1.jar",
             "hashes": {
-              "sha1": "ab4b084bb24e02d546b62b1d6ea06526ec4aeda2",
-              "sha512": "1877b3e7956af4525eeb8758392719fea8c624b0b85c36fd3e37780af4aa5823a3bd6981cefff27364c999ab492abcfea02448a27a404bc41e3b9d924e1bc971"
+              "sha512": "5bf7e7d32fc13c287c528c3328feee29f3fc96864538c605d186f86db7bdc8dd71b33669cc369762994876747e71f42a4af97bd904d16a2d38169cdf35e9549f"
             },
             "primary": true,
-            "size": 334248,
-            "url": "https://cdn.modrinth.com/data/lWDHr9jE/versions/jL2ZsTzx/tectonic-3.0.22-fabric-26.1.jar"
+            "size": 442865,
+            "url": "https://cdn.modrinth.com/data/lWDHr9jE/versions/SlA5rCvn/tectonic-3.0.25-fabric-26.1.jar"
           },
           "game_versions": [
             "26.1",
             "26.1.1",
             "26.1.2"
           ],
-          "id": "jL2ZsTzx",
+          "id": "SlA5rCvn",
           "loaders": [
             "fabric"
           ],
-          "name": "v3.0.22 ~ Fabric 26.1",
+          "name": "v3.0.25 ~ Fabric 26.1",
           "project_id": "lWDHr9jE",
-          "version_number": "3.0.22-fabric-26.1",
+          "version_number": "3.0.25-fabric-26.1",
           "version_type": "release"
         }
       },
@@ -28357,7 +28290,7 @@
       "client_side": "required",
       "color": 10130574,
       "date_created": "2023-03-01T10:32:34.314130Z",
-      "date_modified": "2026-05-06T03:17:49.440824Z",
+      "date_modified": "2026-06-27T09:59:47.195670Z",
       "description": "A library mod for adding biomes in a simple and compatible manner!",
       "discord_url": "https://discord.gg/GyyzU6T",
       "donation_urls": [
@@ -28367,8 +28300,8 @@
           "url": "https://www.patreon.com/Adubbz"
         }
       ],
-      "downloads": 29593052,
-      "followers": 2091,
+      "downloads": 32469250,
+      "followers": 2180,
       "game_versions": [
         "1.18.1",
         "1.18.2",
@@ -28397,7 +28330,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/kkmrDlKT/ffe690c604b123c63ee77a5baf76cf008cb73663.png",
       "issues_url": "https://github.com/Glitchfiend/TerraBlender/",
@@ -28421,16 +28355,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 359269,
+          "downloads": 421354,
           "file": {
             "filename": "TerraBlender-fabric-1.21.11-21.11.0.0.jar",
             "hashes": {
-              "sha1": "e4bd1aee6bc8c56ae77647a06f31a3bd981962a6",
               "sha512": "05bed03e80351e7795cfbe1a9375e54a8a326552379737d8e5dcd400c4a36fefdf57f18468b95121556576d1ef549aa397a638114acd30eab69342d86b576814"
             },
             "primary": true,
@@ -28480,7 +28411,7 @@
       "client_side": "optional",
       "color": 4996660,
       "date_created": "2022-11-13T21:48:54.507121Z",
-      "date_modified": "2026-03-31T16:03:04.620760Z",
+      "date_modified": "2026-06-09T17:51:45.710718Z",
       "description": "Explore almost 100 new biomes consisting of both realism and light fantasy, using just Vanilla blocks. Complete with several immersive structures to compliment the overhauled terrain.",
       "discord_url": "https://discord.gg/stardustlabs",
       "donation_urls": [
@@ -28495,8 +28426,8 @@
           "url": "https://patreon.com/stardustlabs"
         }
       ],
-      "downloads": 17171507,
-      "followers": 7460,
+      "downloads": 18795820,
+      "followers": 7875,
       "gallery": [
         {
           "created": "2022-11-13T21:53:31.044672Z",
@@ -28567,11 +28498,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2025-12-16T05:15:15.946488Z",
-          "downloads": 282126,
+          "downloads": 290924,
           "file": {
             "filename": "Terralith_1.21.x_v2.5.14.jar",
             "hashes": {
-              "sha1": "07f2f1530196a40d2bdea8f5b67e87f8cf89554d",
               "sha512": "98a1fea21ccbeacdc2572eca51d7f0d50a7bd41d1408b01eff8eb5eec1cd5c46ce90da589b0652d9e28dcb222abe35a3ce9709c6caab4e4185f9ee4706157c8e"
             },
             "primary": true,
@@ -28598,16 +28528,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "XaDC71GB",
-              "version_id": null
+              "project_id": "XaDC71GB"
             }
           ],
-          "downloads": 98856,
+          "downloads": 229036,
           "file": {
             "filename": "Terralith_26.1_v2.6.2_Fabric.jar",
             "hashes": {
-              "sha1": "9f4a9a8de5c97718c276e16a698e423b48ef0762",
               "sha512": "5a3be2986a624446c82a8879e34e4c7b09f6f98a1937fd4d9bcf5356b8321f0b9cebb5e567e8d00ae8161d261b108fb7c9a80ebed61f2edb8cdb0852b33cbacc"
             },
             "primary": true,
@@ -28636,96 +28563,6 @@
       "title": "Terralith",
       "wiki_url": "https://stardustlabs.miraheze.org/wiki/Terralith"
     },
-    "threadtweak": {
-      "categories": [
-        "optimization",
-        "utility"
-      ],
-      "client_side": "optional",
-      "color": 7862355,
-      "date_created": "2023-07-03T02:50:18.851756Z",
-      "date_modified": "2026-02-20T19:14:37.990958Z",
-      "description": "Improve and tweak Minecraft thread scheduling. Fork of Smooth Boot for \u22651.20",
-      "downloads": 8839035,
-      "followers": 985,
-      "game_versions": [
-        "1.20",
-        "1.20.1",
-        "1.20.2",
-        "1.20.4",
-        "1.20.5",
-        "1.20.6",
-        "1.21",
-        "1.21.1",
-        "1.21.3",
-        "1.21.4",
-        "1.21.5",
-        "1.21.6",
-        "1.21.7",
-        "1.21.8",
-        "1.21.9",
-        "1.21.10",
-        "1.21.11"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/vSEH1ERy/a23fc8c2cbeadbea6df1957d3712eac571a56fcb_96.webp",
-      "issues_url": "https://github.com/getchoo/threadtweak/issues",
-      "license": {
-        "id": "MIT",
-        "name": "MIT License",
-        "url": null
-      },
-      "loaders": [
-        "fabric",
-        "quilt"
-      ],
-      "page_url": "https://modrinth.com/mod/threadtweak",
-      "project_id": "vSEH1ERy",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+fabric": {
-          "date_published": "2026-02-20T19:14:37.990958Z",
-          "dependencies": [
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
-            }
-          ],
-          "downloads": 220617,
-          "file": {
-            "filename": "threadtweak-fabric-0.1.8+mc1.21.11.jar",
-            "hashes": {
-              "sha1": "a9235996759e2aed144f2428c935d73e73d8c87d",
-              "sha512": "cab444eaecaa108b0d00eea9aa29415c4e2664ba64de3eedba3f63228686bc2d334f7de06bda22367244cfa0a4b21b7788e924108eef04bfe077bceff1c4b34e"
-            },
-            "primary": true,
-            "size": 61576,
-            "url": "https://cdn.modrinth.com/data/vSEH1ERy/versions/9t60vZ1h/threadtweak-fabric-0.1.8%2Bmc1.21.11.jar"
-          },
-          "game_versions": [
-            "1.21.9",
-            "1.21.10",
-            "1.21.11"
-          ],
-          "id": "9t60vZ1h",
-          "loaders": [
-            "fabric",
-            "quilt"
-          ],
-          "name": "ThreadTweak 0.1.8",
-          "project_id": "vSEH1ERy",
-          "version_number": "0.1.8",
-          "version_type": "release"
-        }
-      },
-      "server_side": "optional",
-      "slug": "threadtweak",
-      "source": "modrinth",
-      "source_url": "https://github.com/getchoo/threadtweak",
-      "title": "ThreadTweak",
-      "wiki_url": "https://github.com/UltimateBoomer/mc-smoothboot/wiki"
-    },
     "toms-storage": {
       "categories": [
         "storage"
@@ -28733,18 +28570,18 @@
       "client_side": "required",
       "color": 3749914,
       "date_created": "2022-03-19T16:02:49.136992Z",
-      "date_modified": "2026-05-02T13:32:57.810567Z",
+      "date_modified": "2026-06-17T17:13:53.957799Z",
       "description": "Simple vanilla style storage mod",
       "donation_urls": [
-        {
-          "id": "ko-fi",
-          "platform": "Ko-fi",
-          "url": "https://ko-fi.com/tom5454"
-        },
         {
           "id": "github",
           "platform": "Github",
           "url": "https://github.com/sponsors/tom5454"
+        },
+        {
+          "id": "ko-fi",
+          "platform": "Ko-fi",
+          "url": "https://ko-fi.com/tom5454"
         },
         {
           "id": "patreon",
@@ -28752,8 +28589,8 @@
           "url": "https://www.patreon.com/tom5454"
         }
       ],
-      "downloads": 14525562,
-      "followers": 1189,
+      "downloads": 15937543,
+      "followers": 1238,
       "game_versions": [
         "1.15.2",
         "1.16.4",
@@ -28809,7 +28646,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/XZNI4Cpy/1949d7adbf962ac86912608edfb93fa5342bffd6_96.webp",
       "issues_url": "https://github.com/tom5454/Toms-Storage/issues",
@@ -28833,52 +28671,37 @@
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "5aaWibi9",
-              "version_id": null
+              "project_id": "u6dRKJwZ"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "nfn13YXA",
-              "version_id": null
+              "project_id": "fRiHVvU7"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "u6dRKJwZ",
-              "version_id": null
+              "project_id": "tagwiZkJ"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "Orvt0mRa"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "5aaWibi9"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "nfn13YXA"
             },
             {
               "dependency_type": "embedded",
-              "file_name": null,
-              "project_id": "9s6osm5g",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "fRiHVvU7",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "Orvt0mRa",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "tagwiZkJ",
-              "version_id": null
+              "project_id": "9s6osm5g"
             }
           ],
-          "downloads": 46288,
+          "downloads": 60326,
           "file": {
             "filename": "toms_storage_fabric-1.21.11-2.8.0.jar",
             "hashes": {
-              "sha1": "45e9d67618d6a116b533d7aa7500f5415194f619",
               "sha512": "7c9cae7eec64e70edfbe12cd1ff5619b8ccb1e49a664ec6b28008cb866a658045cfc18960ab6574743cb5ce2af837509d851fc3702ab1cd9a2aae8228789ad69"
             },
             "primary": true,
@@ -28912,11 +28735,11 @@
       "client_side": "optional",
       "color": 12898007,
       "date_created": "2022-05-22T16:46:31.663599Z",
-      "date_modified": "2026-05-22T22:55:15.815539Z",
+      "date_modified": "2026-06-30T15:02:29.103619Z",
       "description": "Spice up your world with new villages, pillager outposts, and even new ships!",
       "discord_url": "https://discord.com/invite/yJng7sC44x",
-      "downloads": 13212372,
-      "followers": 4055,
+      "downloads": 14376709,
+      "followers": 4302,
       "gallery": [
         {
           "created": "2022-10-30T21:54:09.537419Z",
@@ -29039,7 +28862,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/DjLobEOy/f7f552ec019c9ad8b777c9ab5eecbb95da8707a0_96.webp",
       "license": {
@@ -29048,6 +28872,7 @@
         "url": null
       },
       "loaders": [
+        "datapack",
         "fabric",
         "forge",
         "neoforge",
@@ -29062,16 +28887,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "cl223EMc",
-              "version_id": null
+              "project_id": "cl223EMc"
             }
           ],
-          "downloads": 68379,
+          "downloads": 114540,
           "file": {
             "filename": "t_and_t-fabric-neoforge-1.13.9.jar",
             "hashes": {
-              "sha1": "8e3bfd88661311dcdde93b5bcb03ce919ad4ef1c",
               "sha512": "e0f743b746e78b271bca04c8684408eeb8e4a8570dccc4eebabc62a774c8404569963090f04056bb0f25bb39116a1b8ee47840dfd75a1c415ac5dfb41678b6c9"
             },
             "primary": true,
@@ -29107,10 +28929,10 @@
       "client_side": "unsupported",
       "color": 5417948,
       "date_created": "2024-02-15T17:39:47.384379Z",
-      "date_modified": "2026-05-12T14:55:23.017815Z",
+      "date_modified": "2026-06-08T18:15:19.452340Z",
       "description": "A simple teleportation plugin that supports Folia, compatible with Bukkit/Spigot/Paper/Folia.",
-      "downloads": 100507,
-      "followers": 62,
+      "downloads": 114434,
+      "followers": 65,
       "gallery": [
         {
           "created": "2024-02-15T18:09:35.095921Z",
@@ -29232,17 +29054,16 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-05-12T14:55:23.017815Z",
-          "downloads": 3901,
+          "date_published": "2026-06-08T18:15:19.452340Z",
+          "downloads": 6896,
           "file": {
-            "filename": "TPA-3.2.8.jar",
+            "filename": "TPA-3.2.9.jar",
             "hashes": {
-              "sha1": "c54667a33068ccd7826b17913f4aef124bf9caa0",
-              "sha512": "acd591596a61d858135ee83cd781b31b83ce2ae60fae8d40f4fe1430cd19bedf7fc4f40d57c3633735b75078b9ac13a819d5dc99d8f99b5bf6d6cc3e3b2d110f"
+              "sha512": "8525ad864216a8c3720c0cc5ff97be8ac59516c1d778267e1c02b498a6d30b2a8d65c0220748f7da347a5354c3ce2f3d41d7c9b52c09d0ccb0ad766eddf9af96"
             },
             "primary": true,
-            "size": 293612,
-            "url": "https://cdn.modrinth.com/data/t0Xh802L/versions/w7Dlp533/TPA-3.2.8.jar"
+            "size": 296084,
+            "url": "https://cdn.modrinth.com/data/t0Xh802L/versions/PYAXTWhK/TPA-3.2.9.jar"
           },
           "game_versions": [
             "1.8",
@@ -29319,7 +29140,7 @@
             "26.1.1",
             "26.1.2"
           ],
-          "id": "w7Dlp533",
+          "id": "PYAXTWhK",
           "loaders": [
             "bukkit",
             "folia",
@@ -29327,9 +29148,9 @@
             "purpur",
             "spigot"
           ],
-          "name": "TPA 3.2.8 FixUpdate",
+          "name": "TPA 3.2.9 Language Update",
           "project_id": "t0Xh802L",
-          "version_number": "3.2.8",
+          "version_number": "3.2.9",
           "version_type": "release"
         }
       },
@@ -29348,8 +29169,8 @@
       "date_created": "2022-04-14T09:21:07.818734Z",
       "date_modified": "2025-10-04T09:08:43.771556Z",
       "description": "A fully customizable mod for fabric that displays the servers tps.",
-      "downloads": 350820,
-      "followers": 122,
+      "downloads": 387016,
+      "followers": 123,
       "game_versions": [
         "1.18.2",
         "1.19-pre1",
@@ -29405,34 +29226,25 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "Ha28R6CL",
-              "version_id": null
+              "project_id": "P7dR8mSH"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "1eAoo2KR"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "Ha28R6CL"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "1eAoo2KR",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "mOgUt4GM",
-              "version_id": null
+              "project_id": "mOgUt4GM"
             }
           ],
-          "downloads": 228943,
+          "downloads": 257086,
           "file": {
             "filename": "tps-hud-1.9.0+1.21.9.jar",
             "hashes": {
-              "sha1": "0513912ddc29928c53bf4525550bc697d46c3a77",
               "sha512": "c4d3b2fb55e286f036aaa2e4e0e0fb2257e87e86d10905fa944786476d0dbdbca013d60e5d7577db7cf9a042d649e2b0a7a26c29dee1f494689143ad8fc28d88"
             },
             "primary": true,
@@ -29478,7 +29290,7 @@
       "client_side": "required",
       "color": 8668970,
       "date_created": "2021-10-16T11:34:57.033813Z",
-      "date_modified": "2026-05-20T22:19:54.585240Z",
+      "date_modified": "2026-05-31T15:04:34.190307Z",
       "description": "Unique and upgradeable backpacks with customisation, Curios API/Trinkets integration and more!",
       "discord_url": "https://discord.com/invite/f8Nnj5VuFj",
       "donation_urls": [
@@ -29493,8 +29305,8 @@
           "url": "https://www.paypal.com/donate/?hosted_button_id=KE52UJ7TAZAC4"
         }
       ],
-      "downloads": 15990943,
-      "followers": 6071,
+      "downloads": 17278779,
+      "followers": 6377,
       "gallery": [
         {
           "created": "2023-10-30T22:36:35.489288Z",
@@ -29609,89 +29421,62 @@
           "date_published": "2026-03-28T11:54:17.130036Z",
           "dependencies": [
             {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
-            },
-            {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "fRiHVvU7",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "u6dRKJwZ",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "nfn13YXA",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "HnD1GX6e",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "DMu0oBKf",
-              "version_id": null
+              "project_id": "SaCpeal4"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "ohNO6lps",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "5aaWibi9",
-              "version_id": null
+              "project_id": "tagwiZkJ"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "yn9u3ypm",
-              "version_id": null
+              "project_id": "yn9u3ypm"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "vRYk0bv7",
-              "version_id": null
+              "project_id": "fRiHVvU7"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "SaCpeal4",
-              "version_id": null
+              "project_id": "u6dRKJwZ"
+            },
+            {
+              "dependency_type": "required",
+              "project_id": "ohNO6lps"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "tagwiZkJ",
-              "version_id": null
+              "project_id": "HnD1GX6e"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "jtmvUHXj",
-              "version_id": null
+              "project_id": "jtmvUHXj"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "vRYk0bv7"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "5aaWibi9"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "DMu0oBKf"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "nfn13YXA"
             }
           ],
-          "downloads": 128839,
+          "downloads": 207668,
           "file": {
             "filename": "travelersbackpack-fabric-1.21.11-10.11.9.jar",
             "hashes": {
-              "sha1": "fb2d5a2fd919ee127d9a170e3e85f798edb852a5",
               "sha512": "308ae2d6b0118173fb17b18d1ada137d11de38190171962a4d763d948db30c54543f205a5d5d1c9c5415bab33b4e3a222bbab230be80eb0cf68c8b86593e3567"
             },
             "primary": true,
@@ -29730,7 +29515,7 @@
       "client_side": "unsupported",
       "color": 4202263,
       "date_created": "2023-02-01T15:18:13.751202Z",
-      "date_modified": "2026-04-05T16:17:56.246526Z",
+      "date_modified": "2026-06-14T17:59:08.179695Z",
       "description": "Typewriter is a plugin for paper Minecraft servers that allows for custom player interactions such as Quests,\nNPC chat, Create branching story with ease, and more. Configurable using the web panel custom designed.",
       "discord_url": "https://discord.gg/HtbKyuDDBw",
       "donation_urls": [
@@ -29740,8 +29525,8 @@
           "url": "https://github.com/sponsors/gabber235"
         }
       ],
-      "downloads": 127732,
-      "followers": 480,
+      "downloads": 135179,
+      "followers": 495,
       "gallery": [
         {
           "created": "2023-02-01T15:29:03.196508Z",
@@ -29783,7 +29568,10 @@
         "1.21.8",
         "1.21.9",
         "1.21.10",
-        "1.21.11"
+        "1.21.11",
+        "26.1",
+        "26.1.1",
+        "26.1.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/Vm7B3ymm/27df961b4e8f0d36287aae64a8c9872b090739ee.png",
       "issues_url": "https://discord.gg/p7WH9VvdMQ",
@@ -29801,192 +29589,32 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-05T16:17:56.246526Z",
+          "date_published": "2026-06-14T17:59:08.179695Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "lKEzGugV",
-              "version_id": null
-            },
-            {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "wKkoqHrH",
-              "version_id": null
+              "project_id": "lKEzGugV"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "HYKaKraK",
-              "version_id": null
+              "project_id": "HYKaKraK"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "wKkoqHrH"
             }
           ],
-          "downloads": 3075,
+          "downloads": 1256,
           "file": {
-            "filename": "Typewriter-0.9.0-beta-172.jar",
+            "filename": "Typewriter-0.9.0-beta-174.jar",
             "hashes": {
-              "sha1": "5866698bb3977c43b89011e2c135c83105be4308",
-              "sha512": "d8b80627a5f10d92787afe5e34fa04a4993eb8b01b01ca58371b942ceeeba2778227ce37e9d69dc5f41fe702d3829e6ed6c3ac19936157a140e935aa2ae2783a"
+              "sha512": "c27e83320286b2d17669b0c30f3a680e9a941a58a7a575fadbb6b9a9a4a53e9c7c5a572cd59d65cc99c311b9cc23f7b63d6bfb4a25029080dfb815a11807812f"
             },
             "primary": true,
-            "size": 32052683,
-            "url": "https://cdn.modrinth.com/data/Vm7B3ymm/versions/N6I8TLXv/Typewriter-0.9.0-beta-172.jar"
+            "size": 32203231,
+            "url": "https://cdn.modrinth.com/data/Vm7B3ymm/versions/9dultV1M/Typewriter-0.9.0-beta-174.jar"
           },
           "game_versions": [
-            "1.21.3",
-            "1.21.4",
-            "1.21.5",
-            "1.21.6",
-            "1.21.7",
-            "1.21.8",
-            "1.21.9",
-            "1.21.10",
-            "1.21.11"
-          ],
-          "id": "N6I8TLXv",
-          "loaders": [
-            "paper"
-          ],
-          "name": "Typewriter v0.9.0-beta-172 Build",
-          "project_id": "Vm7B3ymm",
-          "version_number": "0.9.0-beta-172",
-          "version_type": "beta"
-        }
-      },
-      "server_side": "required",
-      "slug": "typewriter",
-      "source": "modrinth",
-      "source_url": "https://github.com/gabber235/TypeWriter",
-      "title": "Typewriter",
-      "wiki_url": "https://github.com/gabber235/TypeWriter/wiki"
-    },
-    "uberenchant": {
-      "additional_categories": [
-        "economy",
-        "game-mechanics"
-      ],
-      "categories": [
-        "equipment",
-        "library",
-        "utility"
-      ],
-      "client_side": "unsupported",
-      "color": 9122094,
-      "date_created": "2023-06-11T15:23:45.315834Z",
-      "date_modified": "2026-05-22T13:28:03.937104Z",
-      "description": "UberEnchant adds the ability for servers to enchant any item with any enchantment up to level 255 (since 1.17), add names and lore to items (color support), add potion effects to items, extract enchantments to books, and economy support.",
-      "discord_url": "https://discord.gg/MrFWQsmdK5",
-      "downloads": 84802,
-      "followers": 72,
-      "gallery": [
-        {
-          "created": "2023-06-12T19:54:35.116907Z",
-          "featured": true,
-          "ordering": 0,
-          "url": "https://cdn.modrinth.com/data/PoPWpJ4U/images/46e3dde42625b995d106338efb7dfe344dd794f7.png"
-        },
-        {
-          "created": "2023-06-12T19:53:32.227611Z",
-          "featured": false,
-          "ordering": 0,
-          "url": "https://cdn.modrinth.com/data/PoPWpJ4U/images/fc7265656946c7eaafa064f8ae224bcd7796521b.jpeg"
-        },
-        {
-          "created": "2023-06-14T13:49:59.425518Z",
-          "featured": false,
-          "ordering": 0,
-          "url": "https://cdn.modrinth.com/data/PoPWpJ4U/images/fdceeb07bccf5a4ff6fec717f21814073b846de2_350.webp"
-        }
-      ],
-      "game_versions": [
-        "1.2.1",
-        "1.2.2",
-        "1.2.3",
-        "1.2.4",
-        "1.2.5",
-        "1.17",
-        "1.17.1",
-        "1.18",
-        "1.18.1",
-        "1.18.2",
-        "1.19",
-        "1.19.1",
-        "1.19.2",
-        "1.19.3",
-        "1.19.4",
-        "1.20",
-        "1.20.1",
-        "1.20.2",
-        "1.20.3",
-        "1.20.4",
-        "1.20.5",
-        "1.20.6",
-        "1.21",
-        "1.21.1",
-        "1.21.2",
-        "1.21.3",
-        "1.21.4",
-        "1.21.5",
-        "1.21.6",
-        "1.21.7",
-        "1.21.8",
-        "1.21.9",
-        "1.21.10",
-        "1.21.11",
-        "26.1",
-        "26.1.1",
-        "26.1.2"
-      ],
-      "icon_url": "https://cdn.modrinth.com/data/PoPWpJ4U/46e3dde42625b995d106338efb7dfe344dd794f7.png",
-      "issues_url": "https://dev.bukkit.org/projects/uberenchant/issues",
-      "license": {
-        "id": "MIT",
-        "name": "MIT License",
-        "url": null
-      },
-      "loaders": [
-        "bukkit",
-        "paper",
-        "purpur",
-        "spigot"
-      ],
-      "page_url": "https://modrinth.com/mod/uberenchant",
-      "project_id": "PoPWpJ4U",
-      "project_type": "mod",
-      "selected_versions": {
-        "1.21.11+paper": {
-          "date_published": "2026-05-22T13:28:03.937104Z",
-          "downloads": 82,
-          "file": {
-            "filename": "UberEnchant.jar",
-            "hashes": {
-              "sha1": "dacd93e6521e5d97e14f5608f32330fe5e0dc31e",
-              "sha512": "e6360c24af7eeaad0779e2934700a904277c99c92b9a96fdfff943c920f3e20f2284e2f0742b159c1da259f08a980b96e0135b8fe91f4d58cafa92eb738438dc"
-            },
-            "primary": true,
-            "size": 329403,
-            "url": "https://cdn.modrinth.com/data/PoPWpJ4U/versions/5sms5wg7/UberEnchant.jar"
-          },
-          "game_versions": [
-            "1.18",
-            "1.18.1",
-            "1.18.2",
-            "1.19",
-            "1.19.1",
-            "1.19.2",
-            "1.19.3",
-            "1.19.4",
-            "1.20",
-            "1.20.1",
-            "1.20.2",
-            "1.20.3",
-            "1.20.4",
-            "1.20.5",
-            "1.20.6",
-            "1.21",
-            "1.21.1",
-            "1.21.2",
             "1.21.3",
             "1.21.4",
             "1.21.5",
@@ -30000,34 +29628,70 @@
             "26.1.1",
             "26.1.2"
           ],
-          "id": "5sms5wg7",
+          "id": "9dultV1M",
           "loaders": [
-            "bukkit",
-            "paper",
-            "purpur",
-            "spigot"
+            "paper"
           ],
-          "name": "UberEnchant 8.12.6",
-          "project_id": "PoPWpJ4U",
-          "version_number": "8.12.6",
-          "version_type": "release"
+          "name": "Typewriter v0.9.0-beta-174 Build",
+          "project_id": "Vm7B3ymm",
+          "version_number": "0.9.0-beta-174",
+          "version_type": "beta"
         }
       },
       "server_side": "required",
-      "slug": "uberenchant",
+      "slug": "typewriter",
       "source": "modrinth",
-      "source_url": "https://github.com/Sciguymjm/UberEnchant",
-      "title": "UberEnchant"
+      "source_url": "https://github.com/gabber235/TypeWriter",
+      "title": "Typewriter",
+      "wiki_url": "https://github.com/gabber235/TypeWriter/wiki"
     },
     "vaultunlocked": {
       "client_side": "unsupported",
+      "color": 1947546,
       "date_created": "2024-06-13T00:54:20.685153Z",
-      "date_modified": "2026-04-27T00:02:05.183135Z",
+      "date_modified": "2026-06-22T23:05:51.638641Z",
       "description": "A modern drop-in Vault fork, with Folia support, and enhanced APIs.",
       "discord_url": "https://discord.gg/WNdwzpy",
-      "downloads": 83367,
-      "followers": 138,
+      "downloads": 98736,
+      "followers": 146,
       "game_versions": [
+        "1.1",
+        "1.2.1",
+        "1.2.2",
+        "1.2.3",
+        "1.2.4",
+        "1.2.5",
+        "1.3.1",
+        "1.3.2",
+        "1.4.2",
+        "1.4.4",
+        "1.4.5",
+        "1.4.6",
+        "1.4.7",
+        "1.5.1",
+        "1.5.2",
+        "1.6.1",
+        "1.6.2",
+        "1.6.4",
+        "1.7.2",
+        "1.7.3",
+        "1.7.4",
+        "1.7.5",
+        "1.7.6",
+        "1.7.7",
+        "1.7.8",
+        "1.7.9",
+        "1.7.10",
+        "1.8",
+        "1.8.1",
+        "1.8.2",
+        "1.8.3",
+        "1.8.4",
+        "1.8.5",
+        "1.8.6",
+        "1.8.7",
+        "1.8.8",
+        "1.8.9",
         "1.9",
         "1.9.1",
         "1.9.2",
@@ -30090,8 +29754,10 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
+      "icon_url": "https://cdn.modrinth.com/data/ayRaM8J7/75b4141b5e316a73a0372e895bb24e09122759f1_96.webp",
       "issues_url": "https://github.com/TheNewEconomy/VaultUnlockedAPI/issues",
       "license": {
         "id": "LGPL-3.0-or-later",
@@ -30110,19 +29776,69 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-04-27T00:02:05.183135Z",
-          "downloads": 8942,
+          "date_published": "2026-06-22T23:05:51.638641Z",
+          "downloads": 2578,
           "file": {
-            "filename": "VaultUnlocked-2.19.1.jar",
+            "filename": "VaultUnlocked-2.20.2.jar",
             "hashes": {
-              "sha1": "efc5488863f289ef84dab19cdbb005bda56e605d",
-              "sha512": "24a8bf1ac89e7bab803a4abb5d3085983671ceaf6cf1bc0ad8925f72987ef21aca82a44a176f83a52a8af78dce1d951751f7ca296debb8cd09a2f68df689c800"
+              "sha512": "9c5baefbe23ede10d00af580fc9d5d6da9a9baac40feef078bb951448b89df039131299bd5d3fe8ccd947367de8fe24b543dc9cce83fbf1687a3221baca8da8e"
             },
             "primary": true,
-            "size": 120900,
-            "url": "https://cdn.modrinth.com/data/ayRaM8J7/versions/ypDodbNn/VaultUnlocked-2.19.1.jar"
+            "size": 134928,
+            "url": "https://cdn.modrinth.com/data/ayRaM8J7/versions/cLNipSgw/VaultUnlocked-2.20.2.jar"
           },
           "game_versions": [
+            "1.1",
+            "1.2.1",
+            "1.2.2",
+            "1.2.3",
+            "1.2.4",
+            "1.2.5",
+            "1.3.1",
+            "1.3.2",
+            "1.4.2",
+            "1.4.4",
+            "1.4.5",
+            "1.4.6",
+            "1.4.7",
+            "1.5.1",
+            "1.5.2",
+            "1.6.1",
+            "1.6.2",
+            "1.6.4",
+            "1.7.2",
+            "1.7.3",
+            "1.7.4",
+            "1.7.5",
+            "1.7.6",
+            "1.7.7",
+            "1.7.8",
+            "1.7.9",
+            "1.7.10",
+            "1.8",
+            "1.8.1",
+            "1.8.2",
+            "1.8.3",
+            "1.8.4",
+            "1.8.5",
+            "1.8.6",
+            "1.8.7",
+            "1.8.8",
+            "1.8.9",
+            "1.9",
+            "1.9.1",
+            "1.9.2",
+            "1.9.3",
+            "1.9.4",
+            "1.10",
+            "1.10.1",
+            "1.10.2",
+            "1.11",
+            "1.11.1",
+            "1.11.2",
+            "1.12",
+            "1.12.1",
+            "1.12.2",
             "1.13",
             "1.13.1",
             "1.13.2",
@@ -30171,18 +29887,20 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "ypDodbNn",
+          "id": "cLNipSgw",
           "loaders": [
+            "bukkit",
             "folia",
             "paper",
             "purpur",
             "spigot"
           ],
-          "name": "2.19.1",
+          "name": "VaultUnlocked 2.20.2",
           "project_id": "ayRaM8J7",
-          "version_number": "2.19.1",
+          "version_number": "2.20.2",
           "version_type": "release"
         }
       },
@@ -30203,10 +29921,10 @@
         "utility"
       ],
       "client_side": "optional",
-      "color": 4014652,
+      "color": 4145467,
       "date_created": "2023-05-24T19:31:57.085345Z",
-      "date_modified": "2026-05-21T21:52:48.071125Z",
-      "description": "Mine the whole vein on mining a single ore. Known feature by modpacks and pvp games like UHC (quick mine)",
+      "date_modified": "2026-06-28T20:26:07.022662Z",
+      "description": "Mine the whole vein on mining a single ore/block. Make the tedious mining experience to something satisfying and fun!",
       "discord_url": "https://dc.mutils.net",
       "donation_urls": [
         {
@@ -30215,8 +29933,8 @@
           "url": "https://ko-fi.com/miraculixx"
         }
       ],
-      "downloads": 49083654,
-      "followers": 4782,
+      "downloads": 58333016,
+      "followers": 5240,
       "gallery": [
         {
           "created": "2024-07-05T10:35:35.132611Z",
@@ -30275,9 +29993,10 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
-      "icon_url": "https://cdn.modrinth.com/data/OhduvhIc/81f9db55f424ec42998ee1c6fa23cd934a96d0e5.webp",
+      "icon_url": "https://cdn.modrinth.com/data/OhduvhIc/5ea1f538e66ee4d4e5e571ad952cba0e06e0bd5c.png",
       "license": {
         "id": "AGPL-3.0-only",
         "name": "GNU Affero General Public License v3.0 only",
@@ -30300,58 +30019,50 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-03-31T16:51:57.832061Z",
+          "date_published": "2026-06-04T19:09:30.739782Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "aTaCgKLW",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "Ha28R6CL"
             },
             {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "Ha28R6CL",
-              "version_id": null
+              "dependency_type": "optional",
+              "project_id": "dxa0Bm8m"
             }
           ],
-          "downloads": 3013665,
+          "downloads": 1688883,
           "file": {
-            "filename": "veinminer-fabric-2.6.0.jar",
+            "filename": "veinminer-fabric-2.10.3+1.21.11.jar",
             "hashes": {
-              "sha1": "310a645ba625faa72231a41385c808d5932a6625",
-              "sha512": "80176d6881c1482fb25bd3472c398770430870bdb986bb0eb01b11c6607b80bf5a2078403c69f138c109159377af9f0d183d7c9d8136ac0a5f8651bd7bbc196f"
+              "sha512": "4c9a2e70924f08fd45304e800aa3d8228390c791adc292887b6a2c3d4891e87f5ca3bd18395721230a65fe81b78fd1d6e2e248046b23a72169c0956549986b39"
             },
             "primary": true,
-            "size": 685695,
-            "url": "https://cdn.modrinth.com/data/OhduvhIc/versions/g7E2sCkF/veinminer-fabric-2.6.0.jar"
+            "size": 618364,
+            "url": "https://cdn.modrinth.com/data/OhduvhIc/versions/ZSeTIqKE/veinminer-fabric-2.10.3%2B1.21.11.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "g7E2sCkF",
+          "id": "ZSeTIqKE",
           "loaders": [
             "fabric",
             "quilt"
           ],
-          "name": "Veinminer Fabric - 2.6.0",
+          "name": "Veinminer Fabric - 2.10.3",
           "project_id": "OhduvhIc",
-          "version_number": "2.6.0",
+          "version_number": "2.10.3",
           "version_type": "release"
         },
         "1.21.11+paper": {
           "date_published": "2026-03-31T16:53:55.240256Z",
-          "downloads": 636308,
+          "downloads": 761530,
           "file": {
             "filename": "veinminer-paper-2.6.0.jar",
             "hashes": {
-              "sha1": "4c59c59a0cf36ce4476053d93fad0f94742fc36a",
               "sha512": "26a985bbaad6534e6e9fa2db95fc487a3706437e7be64c1d30d290c118dff3949d5b0be999fdb74413a2800a826d1e0de3975f98f9b0d3441511c593a437d123"
             },
             "primary": true,
@@ -30401,7 +30112,7 @@
       "client_side": "optional",
       "color": 4211517,
       "date_created": "2024-09-14T13:26:24.954859Z",
-      "date_modified": "2026-05-20T17:13:17.866721Z",
+      "date_modified": "2026-06-04T19:15:08.447474Z",
       "description": "Veinminer Addon - Adds vineminer enchantment to enchanting tables. Only tools with the enchantment can veinmine",
       "discord_url": "https://dc.mutils.net",
       "donation_urls": [
@@ -30411,8 +30122,8 @@
           "url": "https://ko-fi.com/miraculixx"
         }
       ],
-      "downloads": 13984031,
-      "followers": 1075,
+      "downloads": 14931526,
+      "followers": 1133,
       "gallery": [
         {
           "created": "2024-09-15T13:21:29.011295Z",
@@ -30451,7 +30162,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/4sP0LXxp/1e37ba60062cf9455fc75d61c653a75d11825783.png",
       "license": {
@@ -30473,100 +30185,73 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2025-10-11T19:20:15.001217Z",
+          "date_published": "2026-06-04T19:10:28.110501Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "OhduvhIc",
-              "version_id": null
+              "project_id": "OhduvhIc"
             }
           ],
-          "downloads": 4242787,
+          "downloads": 247919,
           "file": {
-            "filename": "veinminer-enchant-2.3.0.jar",
+            "filename": "veinminer-enchant-2.10.3+1.21.11.jar",
             "hashes": {
-              "sha1": "b4192a1581b04344ca11b648c6e741f026968cbc",
-              "sha512": "151ddfbf7e9d56a964083497cc28e38a4c311cd9fbf43bb6ab7ee6ef6cb0fa11ef977d1244062d6343d5acb1b8b3ebfe2e87f00c9e5e4ffc9a4a06edbf04b65b"
+              "sha512": "1c5cf173ce5169d56d57762c092ffcae40f6911c8865f5266bbba29a9cd281cc0fee594e3dc2483e9eb2fef288a640e59e8f26684ba1216648cc96916c0970f6"
             },
             "primary": true,
-            "size": 35053,
-            "url": "https://cdn.modrinth.com/data/4sP0LXxp/versions/h5oKcjvq/veinminer-enchant-2.3.0.jar"
+            "size": 27450,
+            "url": "https://cdn.modrinth.com/data/4sP0LXxp/versions/cT44Msfn/veinminer-enchant-2.10.3%2B1.21.11.jar"
           },
           "game_versions": [
-            "1.21",
-            "1.21.1",
-            "1.21.2",
-            "1.21.3",
-            "1.21.4",
-            "1.21.5",
-            "1.21.6",
-            "1.21.7",
-            "1.21.8",
-            "1.21.9",
-            "1.21.10",
             "1.21.11"
           ],
-          "id": "h5oKcjvq",
+          "id": "cT44Msfn",
           "loaders": [
             "fabric",
             "folia",
+            "neoforge",
             "paper",
             "purpur",
             "quilt"
           ],
-          "name": "Veinminer Enchantment - 2.5.0",
+          "name": "Veinminer Enchantment - 2.10.3",
           "project_id": "4sP0LXxp",
-          "version_number": "2.5.0",
+          "version_number": "2.10.3",
           "version_type": "release"
         },
         "1.21.11+paper": {
-          "date_published": "2026-04-19T22:40:27.268664Z",
+          "date_published": "2026-06-04T19:10:28.110501Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "OhduvhIc",
-              "version_id": null
+              "project_id": "OhduvhIc"
             }
           ],
-          "downloads": 438567,
+          "downloads": 247919,
           "file": {
-            "filename": "veinminer-enchant-2.6.1.jar",
+            "filename": "veinminer-enchant-2.10.3+1.21.11.jar",
             "hashes": {
-              "sha1": "40e6aeeb2cfc91c8ac53f6d2a170515224a39d78",
-              "sha512": "90958ae196328a19e05391bcd49c595591714b6c5e45e6ffa0f4582e1ff660fb5685d2698beec5b0a0c2fc3e0f549b81a019525cf20562dd808aadd5ded339f8"
+              "sha512": "1c5cf173ce5169d56d57762c092ffcae40f6911c8865f5266bbba29a9cd281cc0fee594e3dc2483e9eb2fef288a640e59e8f26684ba1216648cc96916c0970f6"
             },
             "primary": true,
-            "size": 133903,
-            "url": "https://cdn.modrinth.com/data/4sP0LXxp/versions/UlNmwSGT/veinminer-enchant-2.6.1.jar"
+            "size": 27450,
+            "url": "https://cdn.modrinth.com/data/4sP0LXxp/versions/cT44Msfn/veinminer-enchant-2.10.3%2B1.21.11.jar"
           },
           "game_versions": [
-            "1.21",
-            "1.21.1",
-            "1.21.2",
-            "1.21.3",
-            "1.21.4",
-            "1.21.5",
-            "1.21.6",
-            "1.21.7",
-            "1.21.8",
-            "1.21.9",
-            "1.21.10",
-            "1.21.11",
-            "26.1",
-            "26.1.1",
-            "26.1.2"
+            "1.21.11"
           ],
-          "id": "UlNmwSGT",
+          "id": "cT44Msfn",
           "loaders": [
+            "fabric",
             "folia",
+            "neoforge",
             "paper",
-            "purpur"
+            "purpur",
+            "quilt"
           ],
-          "name": "Veinminer Enchantment Paper - 2.6.1",
+          "name": "Veinminer Enchantment - 2.10.3",
           "project_id": "4sP0LXxp",
-          "version_number": "2.6.1",
+          "version_number": "2.10.3",
           "version_type": "release"
         }
       },
@@ -30583,7 +30268,7 @@
       "client_side": "optional",
       "color": 14476775,
       "date_created": "2023-08-10T08:24:07.988560Z",
-      "date_modified": "2026-05-19T08:23:43.339610Z",
+      "date_modified": "2026-06-20T16:09:31.018722Z",
       "description": "Allow older Java Edition clients to connect to newer servers.",
       "discord_url": "https://discord.gg/viaversion",
       "donation_urls": [
@@ -30593,8 +30278,8 @@
           "url": "https://github.com/sponsors/kennytv"
         }
       ],
-      "downloads": 1429756,
-      "followers": 723,
+      "downloads": 1603049,
+      "followers": 766,
       "game_versions": [
         "1.10",
         "1.10.1",
@@ -30653,7 +30338,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/NpvuJQoq/c9fd86f343657c62206d5b82fee1d2b24f0b278d_96.webp",
       "issues_url": "https://github.com/ViaVersion/ViaBackwards/issues",
@@ -30675,37 +30361,30 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-04T18:44:51.565042Z",
+          "date_published": "2026-06-19T17:24:03.018890Z",
           "dependencies": [
             {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
-            },
-            {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P1OZGk5p",
-              "version_id": null
+              "project_id": "P1OZGk5p"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "TbHIxhx5",
-              "version_id": null
+              "project_id": "TbHIxhx5"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "YlKdE5VK"
             }
           ],
-          "downloads": 35958,
+          "downloads": 25957,
           "file": {
-            "filename": "ViaBackwards-5.9.1.jar",
+            "filename": "ViaBackwards-5.10.0.jar",
             "hashes": {
-              "sha1": "2cd2a94fe923e5de408cc46829e38352518431b2",
-              "sha512": "3dda968f438a1a5aa60c2856f0fa767db6501a27b1a8ebd1dc72ba09804456ee608cbd82ba66a1c7298a08c9f0e39d1ae3ae27cc16bdfacb2e333e93aff7ec75"
+              "sha512": "a301113283ff8dacb5f2ac4c45632b37ade79563689ee342c9e74bce16a5c805d72ec641b05f86fd772558312860f92f5fd52ae246cc28762534a4bed794beaa"
             },
             "primary": true,
-            "size": 1404679,
-            "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/W890fNPl/ViaBackwards-5.9.1.jar"
+            "size": 1422522,
+            "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/YjpKsm6j/ViaBackwards-5.10.0.jar"
           },
           "game_versions": [
             "1.10",
@@ -30765,52 +30444,46 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "W890fNPl",
+          "id": "YjpKsm6j",
           "loaders": [
             "fabric",
             "folia",
             "paper",
             "velocity"
           ],
-          "name": "5.9.1",
+          "name": "5.10.0",
           "project_id": "NpvuJQoq",
-          "version_number": "5.9.1",
+          "version_number": "5.10.0",
           "version_type": "release"
         },
         "1.21.11+paper": {
-          "date_published": "2026-05-04T18:44:51.565042Z",
+          "date_published": "2026-06-19T17:24:03.018890Z",
           "dependencies": [
             {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
-            },
-            {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P1OZGk5p",
-              "version_id": null
+              "project_id": "P1OZGk5p"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "TbHIxhx5",
-              "version_id": null
+              "project_id": "TbHIxhx5"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "YlKdE5VK"
             }
           ],
-          "downloads": 35958,
+          "downloads": 25957,
           "file": {
-            "filename": "ViaBackwards-5.9.1.jar",
+            "filename": "ViaBackwards-5.10.0.jar",
             "hashes": {
-              "sha1": "2cd2a94fe923e5de408cc46829e38352518431b2",
-              "sha512": "3dda968f438a1a5aa60c2856f0fa767db6501a27b1a8ebd1dc72ba09804456ee608cbd82ba66a1c7298a08c9f0e39d1ae3ae27cc16bdfacb2e333e93aff7ec75"
+              "sha512": "a301113283ff8dacb5f2ac4c45632b37ade79563689ee342c9e74bce16a5c805d72ec641b05f86fd772558312860f92f5fd52ae246cc28762534a4bed794beaa"
             },
             "primary": true,
-            "size": 1404679,
-            "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/W890fNPl/ViaBackwards-5.9.1.jar"
+            "size": 1422522,
+            "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/YjpKsm6j/ViaBackwards-5.10.0.jar"
           },
           "game_versions": [
             "1.10",
@@ -30870,52 +30543,46 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "W890fNPl",
+          "id": "YjpKsm6j",
           "loaders": [
             "fabric",
             "folia",
             "paper",
             "velocity"
           ],
-          "name": "5.9.1",
+          "name": "5.10.0",
           "project_id": "NpvuJQoq",
-          "version_number": "5.9.1",
+          "version_number": "5.10.0",
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-04T18:44:51.565042Z",
+          "date_published": "2026-06-19T17:24:03.018890Z",
           "dependencies": [
             {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
-            },
-            {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P1OZGk5p",
-              "version_id": null
+              "project_id": "P1OZGk5p"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "TbHIxhx5",
-              "version_id": null
+              "project_id": "TbHIxhx5"
+            },
+            {
+              "dependency_type": "optional",
+              "project_id": "YlKdE5VK"
             }
           ],
-          "downloads": 35958,
+          "downloads": 25957,
           "file": {
-            "filename": "ViaBackwards-5.9.1.jar",
+            "filename": "ViaBackwards-5.10.0.jar",
             "hashes": {
-              "sha1": "2cd2a94fe923e5de408cc46829e38352518431b2",
-              "sha512": "3dda968f438a1a5aa60c2856f0fa767db6501a27b1a8ebd1dc72ba09804456ee608cbd82ba66a1c7298a08c9f0e39d1ae3ae27cc16bdfacb2e333e93aff7ec75"
+              "sha512": "a301113283ff8dacb5f2ac4c45632b37ade79563689ee342c9e74bce16a5c805d72ec641b05f86fd772558312860f92f5fd52ae246cc28762534a4bed794beaa"
             },
             "primary": true,
-            "size": 1404679,
-            "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/W890fNPl/ViaBackwards-5.9.1.jar"
+            "size": 1422522,
+            "url": "https://cdn.modrinth.com/data/NpvuJQoq/versions/YjpKsm6j/ViaBackwards-5.10.0.jar"
           },
           "game_versions": [
             "1.10",
@@ -30975,18 +30642,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "W890fNPl",
+          "id": "YjpKsm6j",
           "loaders": [
             "fabric",
             "folia",
             "paper",
             "velocity"
           ],
-          "name": "5.9.1",
+          "name": "5.10.0",
           "project_id": "NpvuJQoq",
-          "version_number": "5.9.1",
+          "version_number": "5.10.0",
           "version_type": "release"
         }
       },
@@ -31003,22 +30671,22 @@
       "client_side": "optional",
       "color": 263172,
       "date_created": "2023-08-11T02:37:04.644788Z",
-      "date_modified": "2026-05-05T18:43:57.886148Z",
+      "date_modified": "2026-06-19T22:17:31.327369Z",
       "description": "ViaVersion addon to allow 1.8.x and 1.7.x clients on newer server versions.",
       "donation_urls": [
-        {
-          "id": "ko-fi",
-          "platform": "Ko-fi",
-          "url": "https://ko-fi.com/florianreuth"
-        },
         {
           "id": "github",
           "platform": "Github",
           "url": "https://github.com/sponsors/florianreuth"
+        },
+        {
+          "id": "ko-fi",
+          "platform": "Ko-fi",
+          "url": "https://ko-fi.com/florianreuth"
         }
       ],
-      "downloads": 451650,
-      "followers": 179,
+      "downloads": 502389,
+      "followers": 183,
       "game_versions": [
         "1.7.10",
         "1.8",
@@ -31093,7 +30761,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/TbHIxhx5/f59ffe031387b06a9b1efa736dbbb4db44284574_96.webp",
       "license": {
@@ -31114,37 +30783,30 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-05T18:43:57.886148Z",
+          "date_published": "2026-06-19T19:54:24.239430Z",
           "dependencies": [
             {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "NpvuJQoq",
-              "version_id": null
-            },
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P1OZGk5p",
-              "version_id": null
-            },
-            {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
+              "project_id": "YlKdE5VK"
+            },
+            {
+              "dependency_type": "required",
+              "project_id": "P1OZGk5p"
+            },
+            {
+              "dependency_type": "required",
+              "project_id": "NpvuJQoq"
             }
           ],
-          "downloads": 17696,
+          "downloads": 4843,
           "file": {
-            "filename": "ViaRewind-4.1.1.jar",
+            "filename": "ViaRewind-4.1.2.jar",
             "hashes": {
-              "sha1": "e2c06fa7faadc12cf185847cebdba6763e1b5cd7",
-              "sha512": "1c1f4db775d9dfbe288776bdbd2e0b2f4910643b9034607d813ee509da25fc45e84cfb0183cdfc30560b2632f24c75dcc51a4a9bb0de8ff29ac9e24bd89efc94"
+              "sha512": "e88b16de4e5cdffc06efe1807438f89c07f6e4bff9a8daf7596f93720e6ba4a4cebb0df27f567312d8d9f1da36a908bcfbaec803d58bf8e1e5c4bdeff25be5cd"
             },
             "primary": true,
-            "size": 387152,
-            "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/cOg14EE7/ViaRewind-4.1.1.jar"
+            "size": 388389,
+            "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/wzgBAvKl/ViaRewind-4.1.2.jar"
           },
           "game_versions": [
             "1.8.8",
@@ -31211,52 +30873,46 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "cOg14EE7",
+          "id": "wzgBAvKl",
           "loaders": [
             "fabric",
             "folia",
             "paper",
             "velocity"
           ],
-          "name": "4.1.1",
+          "name": "4.1.2",
           "project_id": "TbHIxhx5",
-          "version_number": "4.1.1",
+          "version_number": "4.1.2",
           "version_type": "release"
         },
         "1.21.11+paper": {
-          "date_published": "2026-05-05T18:43:57.886148Z",
+          "date_published": "2026-06-19T19:54:24.239430Z",
           "dependencies": [
             {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "NpvuJQoq",
-              "version_id": null
-            },
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P1OZGk5p",
-              "version_id": null
-            },
-            {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
+              "project_id": "YlKdE5VK"
+            },
+            {
+              "dependency_type": "required",
+              "project_id": "P1OZGk5p"
+            },
+            {
+              "dependency_type": "required",
+              "project_id": "NpvuJQoq"
             }
           ],
-          "downloads": 17696,
+          "downloads": 4843,
           "file": {
-            "filename": "ViaRewind-4.1.1.jar",
+            "filename": "ViaRewind-4.1.2.jar",
             "hashes": {
-              "sha1": "e2c06fa7faadc12cf185847cebdba6763e1b5cd7",
-              "sha512": "1c1f4db775d9dfbe288776bdbd2e0b2f4910643b9034607d813ee509da25fc45e84cfb0183cdfc30560b2632f24c75dcc51a4a9bb0de8ff29ac9e24bd89efc94"
+              "sha512": "e88b16de4e5cdffc06efe1807438f89c07f6e4bff9a8daf7596f93720e6ba4a4cebb0df27f567312d8d9f1da36a908bcfbaec803d58bf8e1e5c4bdeff25be5cd"
             },
             "primary": true,
-            "size": 387152,
-            "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/cOg14EE7/ViaRewind-4.1.1.jar"
+            "size": 388389,
+            "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/wzgBAvKl/ViaRewind-4.1.2.jar"
           },
           "game_versions": [
             "1.8.8",
@@ -31323,52 +30979,46 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "cOg14EE7",
+          "id": "wzgBAvKl",
           "loaders": [
             "fabric",
             "folia",
             "paper",
             "velocity"
           ],
-          "name": "4.1.1",
+          "name": "4.1.2",
           "project_id": "TbHIxhx5",
-          "version_number": "4.1.1",
+          "version_number": "4.1.2",
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-05T18:43:57.886148Z",
+          "date_published": "2026-06-19T19:54:24.239430Z",
           "dependencies": [
             {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "NpvuJQoq",
-              "version_id": null
-            },
-            {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P1OZGk5p",
-              "version_id": null
-            },
-            {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
+              "project_id": "YlKdE5VK"
+            },
+            {
+              "dependency_type": "required",
+              "project_id": "P1OZGk5p"
+            },
+            {
+              "dependency_type": "required",
+              "project_id": "NpvuJQoq"
             }
           ],
-          "downloads": 17696,
+          "downloads": 4843,
           "file": {
-            "filename": "ViaRewind-4.1.1.jar",
+            "filename": "ViaRewind-4.1.2.jar",
             "hashes": {
-              "sha1": "e2c06fa7faadc12cf185847cebdba6763e1b5cd7",
-              "sha512": "1c1f4db775d9dfbe288776bdbd2e0b2f4910643b9034607d813ee509da25fc45e84cfb0183cdfc30560b2632f24c75dcc51a4a9bb0de8ff29ac9e24bd89efc94"
+              "sha512": "e88b16de4e5cdffc06efe1807438f89c07f6e4bff9a8daf7596f93720e6ba4a4cebb0df27f567312d8d9f1da36a908bcfbaec803d58bf8e1e5c4bdeff25be5cd"
             },
             "primary": true,
-            "size": 387152,
-            "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/cOg14EE7/ViaRewind-4.1.1.jar"
+            "size": 388389,
+            "url": "https://cdn.modrinth.com/data/TbHIxhx5/versions/wzgBAvKl/ViaRewind-4.1.2.jar"
           },
           "game_versions": [
             "1.8.8",
@@ -31435,18 +31085,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "cOg14EE7",
+          "id": "wzgBAvKl",
           "loaders": [
             "fabric",
             "folia",
             "paper",
             "velocity"
           ],
-          "name": "4.1.1",
+          "name": "4.1.2",
           "project_id": "TbHIxhx5",
-          "version_number": "4.1.1",
+          "version_number": "4.1.2",
           "version_type": "release"
         }
       },
@@ -31463,7 +31114,7 @@
       "client_side": "optional",
       "color": 14212575,
       "date_created": "2023-08-10T08:23:44.094983Z",
-      "date_modified": "2026-05-21T18:04:48.977402Z",
+      "date_modified": "2026-06-27T11:51:00.150652Z",
       "description": "Allow newer Java Edition clients to connect to older servers.",
       "discord_url": "https://discord.gg/viaversion",
       "donation_urls": [
@@ -31473,8 +31124,8 @@
           "url": "https://github.com/sponsors/kennytv"
         }
       ],
-      "downloads": 2092800,
-      "followers": 1088,
+      "downloads": 2350099,
+      "followers": 1149,
       "game_versions": [
         "1.8.9",
         "1.9",
@@ -31539,7 +31190,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/P1OZGk5p/ad14260a7308dc9e4c3385f3f6b5bdabfe17f295_96.webp",
       "issues_url": "https://github.com/ViaVersion/ViaVersion/issues",
@@ -31561,37 +31213,30 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-04T18:39:52.823419Z",
+          "date_published": "2026-06-19T17:20:53.898670Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
+              "project_id": "NpvuJQoq"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "NpvuJQoq",
-              "version_id": null
+              "project_id": "TbHIxhx5"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "TbHIxhx5",
-              "version_id": null
+              "project_id": "YlKdE5VK"
             }
           ],
-          "downloads": 54811,
+          "downloads": 37432,
           "file": {
-            "filename": "ViaVersion-5.9.1.jar",
+            "filename": "ViaVersion-5.10.0.jar",
             "hashes": {
-              "sha1": "a736ac3ba340cde150cc1b774c93a94e68d54480",
-              "sha512": "7b89f2779c487342f8a77db27583a98868bb20117a4fa68a2e07da0bb62da5aef446bbbc01720a0a983a1ea2e91a6bd26fc947befee140ff1e4e251ebf602cf8"
+              "sha512": "3b9df4f3660e027311aeee2f69eee89b6c00110bb6a719b1eb78567df5f003f8fe9e457457b417741017ed689a960a7956ea32b0ea712f481f2b9a3bde935501"
             },
             "primary": true,
-            "size": 6378917,
-            "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/OGj9YIQN/ViaVersion-5.9.1.jar"
+            "size": 6434343,
+            "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/ruzmiBqe/ViaVersion-5.10.0.jar"
           },
           "game_versions": [
             "1.8.9",
@@ -31657,52 +31302,46 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "OGj9YIQN",
+          "id": "ruzmiBqe",
           "loaders": [
             "fabric",
             "folia",
             "paper",
             "velocity"
           ],
-          "name": "5.9.1",
+          "name": "5.10.0",
           "project_id": "P1OZGk5p",
-          "version_number": "5.9.1",
+          "version_number": "5.10.0",
           "version_type": "release"
         },
         "1.21.11+paper": {
-          "date_published": "2026-05-04T18:39:52.823419Z",
+          "date_published": "2026-06-19T17:20:53.898670Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
+              "project_id": "NpvuJQoq"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "NpvuJQoq",
-              "version_id": null
+              "project_id": "TbHIxhx5"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "TbHIxhx5",
-              "version_id": null
+              "project_id": "YlKdE5VK"
             }
           ],
-          "downloads": 54811,
+          "downloads": 37432,
           "file": {
-            "filename": "ViaVersion-5.9.1.jar",
+            "filename": "ViaVersion-5.10.0.jar",
             "hashes": {
-              "sha1": "a736ac3ba340cde150cc1b774c93a94e68d54480",
-              "sha512": "7b89f2779c487342f8a77db27583a98868bb20117a4fa68a2e07da0bb62da5aef446bbbc01720a0a983a1ea2e91a6bd26fc947befee140ff1e4e251ebf602cf8"
+              "sha512": "3b9df4f3660e027311aeee2f69eee89b6c00110bb6a719b1eb78567df5f003f8fe9e457457b417741017ed689a960a7956ea32b0ea712f481f2b9a3bde935501"
             },
             "primary": true,
-            "size": 6378917,
-            "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/OGj9YIQN/ViaVersion-5.9.1.jar"
+            "size": 6434343,
+            "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/ruzmiBqe/ViaVersion-5.10.0.jar"
           },
           "game_versions": [
             "1.8.9",
@@ -31768,52 +31407,46 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "OGj9YIQN",
+          "id": "ruzmiBqe",
           "loaders": [
             "fabric",
             "folia",
             "paper",
             "velocity"
           ],
-          "name": "5.9.1",
+          "name": "5.10.0",
           "project_id": "P1OZGk5p",
-          "version_number": "5.9.1",
+          "version_number": "5.10.0",
           "version_type": "release"
         },
         "26.1.2+fabric": {
-          "date_published": "2026-05-04T18:39:52.823419Z",
+          "date_published": "2026-06-19T17:20:53.898670Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "YlKdE5VK",
-              "version_id": null
+              "project_id": "NpvuJQoq"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "NpvuJQoq",
-              "version_id": null
+              "project_id": "TbHIxhx5"
             },
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "TbHIxhx5",
-              "version_id": null
+              "project_id": "YlKdE5VK"
             }
           ],
-          "downloads": 54811,
+          "downloads": 37432,
           "file": {
-            "filename": "ViaVersion-5.9.1.jar",
+            "filename": "ViaVersion-5.10.0.jar",
             "hashes": {
-              "sha1": "a736ac3ba340cde150cc1b774c93a94e68d54480",
-              "sha512": "7b89f2779c487342f8a77db27583a98868bb20117a4fa68a2e07da0bb62da5aef446bbbc01720a0a983a1ea2e91a6bd26fc947befee140ff1e4e251ebf602cf8"
+              "sha512": "3b9df4f3660e027311aeee2f69eee89b6c00110bb6a719b1eb78567df5f003f8fe9e457457b417741017ed689a960a7956ea32b0ea712f481f2b9a3bde935501"
             },
             "primary": true,
-            "size": 6378917,
-            "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/OGj9YIQN/ViaVersion-5.9.1.jar"
+            "size": 6434343,
+            "url": "https://cdn.modrinth.com/data/P1OZGk5p/versions/ruzmiBqe/ViaVersion-5.10.0.jar"
           },
           "game_versions": [
             "1.8.9",
@@ -31879,18 +31512,19 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "OGj9YIQN",
+          "id": "ruzmiBqe",
           "loaders": [
             "fabric",
             "folia",
             "paper",
             "velocity"
           ],
-          "name": "5.9.1",
+          "name": "5.10.0",
           "project_id": "P1OZGk5p",
-          "version_number": "5.9.1",
+          "version_number": "5.10.0",
           "version_type": "release"
         }
       },
@@ -31924,8 +31558,8 @@
           "url": "https://ko-fi.com/justdoom"
         }
       ],
-      "downloads": 330570,
-      "followers": 356,
+      "downloads": 360367,
+      "followers": 373,
       "gallery": [
         {
           "created": "2024-03-01T07:37:57.828643Z",
@@ -32038,11 +31672,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-02-04T04:16:19.848030Z",
-          "downloads": 23062,
+          "downloads": 32824,
           "file": {
             "filename": "VillagerInABukkit-paper-1.5.0.jar",
             "hashes": {
-              "sha1": "80f2e8326a9ecad07ca57c5a48864de7d901b6b1",
               "sha512": "9e0e9b3bb43c5d781a2bd65adba3a09f227afd7755eba48366a5bcab5088eab948a9f4ca7cd45d02558de943f57f8fb888509f22da692256d0b9fd468cace5ea"
             },
             "primary": true,
@@ -32081,7 +31714,7 @@
       "client_side": "optional",
       "color": 6181178,
       "date_created": "2022-09-01T16:22:54.147555Z",
-      "date_modified": "2026-05-01T15:23:26.937428Z",
+      "date_modified": "2026-06-18T11:01:01.016596Z",
       "description": "\ud83e\uddd1\u200d\ud83c\udf3e Gives all villager entities a default or custom name to liven up the world.",
       "donation_urls": [
         {
@@ -32090,8 +31723,8 @@
           "url": "https://patreon.com/serilum"
         }
       ],
-      "downloads": 9343510,
-      "followers": 1644,
+      "downloads": 10067133,
+      "followers": 1715,
       "game_versions": [
         "1.16.5",
         "1.18.2",
@@ -32119,7 +31752,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/gqRXDo8B/44a24693e277ae99295054691d0acbbbf0d56774_96.webp",
       "issues_url": "https://github.com/Serilum/.issue-tracker/labels/Mod: Villager Names",
@@ -32139,39 +31773,36 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-01T15:23:04.254051Z",
+          "date_published": "2026-06-07T15:52:08.235991Z",
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "e0M1UDsY",
-              "version_id": null
+              "project_id": "e0M1UDsY"
             }
           ],
-          "downloads": 8967,
+          "downloads": 11252,
           "file": {
-            "filename": "villagernames-1.21.11-8.4.jar",
+            "filename": "villagernames-1.21.11-8.5.jar",
             "hashes": {
-              "sha1": "7352da01a265f31b56d13d54aa4916ddae60838c",
-              "sha512": "d47c1c2b959444432ed2eaf704560a233e0ec3a88b79c70eb50c4fcfbf6985a3e03e64427e4922dd9a907a34010549c36ce6a59d15b1bd82d40508a0ab7dbb21"
+              "sha512": "0374d8d13ebbcc13b814042a016582c9dc3b4a51b8622e9453943ea0faf498b27032c883348bca74456a82360cf8cf1f5bb7dcfa814b58b7031ae71e246853cb"
             },
             "primary": true,
-            "size": 80131,
-            "url": "https://cdn.modrinth.com/data/gqRXDo8B/versions/O8m9nvv4/villagernames-1.21.11-8.4.jar"
+            "size": 79983,
+            "url": "https://cdn.modrinth.com/data/gqRXDo8B/versions/b0Qmm0lk/villagernames-1.21.11-8.5.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "O8m9nvv4",
+          "id": "b0Qmm0lk",
           "loaders": [
             "fabric",
             "forge",
             "neoforge",
             "quilt"
           ],
-          "name": "[Fabric/Forge/Neo] 1.21.11-8.4",
+          "name": "[Fabric/Forge/Neo] 1.21.11-8.5",
           "project_id": "gqRXDo8B",
-          "version_number": "1.21.11-8.4-fabric+forge+neo",
+          "version_number": "1.21.11-8.5-fabric+forge+neo",
           "version_type": "release"
         }
       },
@@ -32188,11 +31819,11 @@
       "client_side": "required",
       "color": 1841940,
       "date_created": "2022-07-19T14:58:04.326694Z",
-      "date_modified": "2026-04-28T11:35:46.775798Z",
+      "date_modified": "2026-06-21T10:49:40.442648Z",
       "description": "Items stay inside of crafting tables and are also rendered on top. It's really fancy!",
       "discord_url": "https://lunapixel.studio/discord",
-      "downloads": 20207392,
-      "followers": 2461,
+      "downloads": 21765824,
+      "followers": 2567,
       "gallery": [
         {
           "created": "2025-07-29T14:46:13.969745Z",
@@ -32223,7 +31854,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/kfqD1JRw/e56a31e890d21c82cc454593e023df09f5ae3c36_96.webp",
       "issues_url": "https://github.com/Fuzss/visualworkbench/issues",
@@ -32246,28 +31878,21 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "ohNO6lps",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "QAGBst4M"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "QAGBst4M",
-              "version_id": null
+              "project_id": "ohNO6lps"
             }
           ],
-          "downloads": 196518,
+          "downloads": 240985,
           "file": {
             "filename": "VisualWorkbench-v21.11.1-mc1.21.11-Fabric.jar",
             "hashes": {
-              "sha1": "9e8066fdaa041f8466e7e5eaf3fcf4b0653fa018",
               "sha512": "36ec9c91d686111cb133f9879a46a76a5c87fe4822c8d76e8a6ab94b11dcb98c284d3b9e91d27ce5092dd914b45a4efa9a5c8f97d23745bfb3a5bff9a9f796a8"
             },
             "primary": true,
@@ -32300,11 +31925,11 @@
       "client_side": "optional",
       "color": 3091234,
       "date_created": "2021-12-05T03:00:09.272223Z",
-      "date_modified": "2026-04-09T12:17:55.663410Z",
+      "date_modified": "2026-06-14T13:17:58.856636Z",
       "description": "A Fabric mod designed to improve server performance at high playercounts.",
       "discord_url": "https://discord.relativitymc.org/",
-      "downloads": 12569745,
-      "followers": 1908,
+      "downloads": 13634218,
+      "followers": 1972,
       "game_versions": [
         "1.18",
         "1.18.1-pre1",
@@ -32420,7 +32045,9 @@
         "26.1-rc-3",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2-rc-2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/wnEe9KBa/0bb4b66e80c6cca9c37f6f1021a94670d6f820dc_96.webp",
       "issues_url": "https://github.com/RelativityMC/VMP-fabric/issues",
@@ -32438,11 +32065,10 @@
       "selected_versions": {
         "1.21.11+fabric": {
           "date_published": "2026-02-14T12:33:38.693877Z",
-          "downloads": 567668,
+          "downloads": 897007,
           "file": {
             "filename": "vmp-fabric-mc1.21.11-0.2.0+beta.7.227-all.jar",
             "hashes": {
-              "sha1": "6d665e488ea4f301d639cdf9fd4abf3ffdb44e0d",
               "sha512": "5534a5b0ec88b58f1a395753e4810dde9a8f0f97a88898f4b61e960bd219ec28ea60c6676d7ee24d5b465939a4ff9470520d9015bb9cdb10d9357ff82c36fdab"
             },
             "primary": true,
@@ -32463,11 +32089,10 @@
         },
         "26.1.2+fabric": {
           "date_published": "2026-04-09T12:17:55.663410Z",
-          "downloads": 90650,
+          "downloads": 230887,
           "file": {
             "filename": "vmp-fabric-mc26.1.2-0.2.0+beta.7.234-all.jar",
             "hashes": {
-              "sha1": "9a7ad0973bdb06d2eb8d66827bbafd56d6af87fb",
               "sha512": "24a0df2407893b1cfb55e27dc1c1fef008df53518d118aa3245924d37b642a27d7b6afde950fbf5d07c4111c44ac264d9ae56b8d8c6a9b55acdfb91ba0a15f16"
             },
             "primary": true,
@@ -32502,7 +32127,7 @@
       "client_side": "required",
       "color": 11316396,
       "date_created": "2025-06-13T21:28:40.327644Z",
-      "date_modified": "2026-04-04T17:40:38.840634Z",
+      "date_modified": "2026-06-18T07:49:37.979865Z",
       "description": "Voice messages in minecraft chat",
       "donation_urls": [
         {
@@ -32516,8 +32141,8 @@
           "url": "https://boosty.to/dimaskama/donate"
         }
       ],
-      "downloads": 159929,
-      "followers": 199,
+      "downloads": 206580,
+      "followers": 213,
       "game_versions": [
         "1.21.1",
         "1.21.3",
@@ -32531,7 +32156,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/WWLeFuHa/755d0a7e838752c525c19e906c91e8d34c7ef60e.png",
       "issues_url": "https://github.com/DimasKama/VoiceMessages/issues",
@@ -32559,16 +32185,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "9eGKb6K1",
-              "version_id": null
+              "project_id": "9eGKb6K1"
             }
           ],
-          "downloads": 9971,
+          "downloads": 13242,
           "file": {
             "filename": "voicemessages-paper-1.0.12.jar",
             "hashes": {
-              "sha1": "a9720608f2d8ed95d63f2061d471ece7b558d8c0",
               "sha512": "b9cba3ce273ec71be8e1052334fbdda996a7921ca111459172632ab4d74792d9afc5c0f8c370dbe93434e0d38f73775d1ee1413cb31a8fbed347700a7706119e"
             },
             "primary": true,
@@ -32587,7 +32210,8 @@
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
           "id": "mBsQhubX",
           "loaders": [
@@ -32621,7 +32245,7 @@
       "client_side": "required",
       "color": 2764106,
       "date_created": "2022-06-15T19:00:57.637340Z",
-      "date_modified": "2026-05-22T07:48:51.209082Z",
+      "date_modified": "2026-06-27T07:10:03.411688Z",
       "description": "Teleport back to activated waystones. For Survival, Adventure or Servers.",
       "discord_url": "https://discord.gg/VAfZ2Nau6j",
       "donation_urls": [
@@ -32631,8 +32255,8 @@
           "url": "https://www.patreon.com/BlayTheNinth"
         }
       ],
-      "downloads": 18380159,
-      "followers": 4601,
+      "downloads": 20180185,
+      "followers": 4903,
       "game_versions": [
         "1.16.5",
         "1.18",
@@ -32660,7 +32284,8 @@
         "1.21.9",
         "1.21.10",
         "1.21.11",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/LOpKHB2A/6c81041b60d525d63c0b9da497db66cfda215e16_96.webp",
       "issues_url": "https://github.com/TwelveIterations/Waystones/issues",
@@ -32683,22 +32308,17 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "MBAkmtvl",
-              "version_id": null
+              "project_id": "MBAkmtvl"
             }
           ],
-          "downloads": 130768,
+          "downloads": 184818,
           "file": {
             "filename": "waystones-fabric-1.21.11-21.11.9.jar",
             "hashes": {
-              "sha1": "5b7c5a3348b0c2a436c9b679fd33d42653ada53f",
               "sha512": "047049d8c97c2acdf33c9abaaa6fa2da0ac4c57f81a4961a25c3d58addc6adfcdcc793a7bf6ca1b379312ace69f48b0d7c383b5f1d4309919178632b46ded978"
             },
             "primary": true,
@@ -32734,23 +32354,23 @@
       "client_side": "unsupported",
       "color": 14961708,
       "date_created": "2023-10-17T11:17:40.236375Z",
-      "date_modified": "2026-05-04T11:32:44.505155Z",
+      "date_modified": "2026-06-18T11:05:21.521701Z",
       "description": "A Minecraft Map Editor... that runs in-game!\nWith selections, schematics, copy and paste, brushes, and scripting.\nUse it in creative, or use it temporarily in survival.",
       "discord_url": "https://discord.gg/enginehub",
       "donation_urls": [
         {
-          "id": "github",
-          "platform": "Github",
-          "url": "https://github.com/sponsors/EngineHub"
-        },
-        {
           "id": "other",
           "platform": "Other",
           "url": "https://opencollective.com/enginehub"
+        },
+        {
+          "id": "github",
+          "platform": "Github",
+          "url": "https://github.com/sponsors/EngineHub"
         }
       ],
-      "downloads": 7523498,
-      "followers": 4252,
+      "downloads": 8460117,
+      "followers": 4454,
       "game_versions": [
         "1.17.1",
         "1.18.2",
@@ -32776,7 +32396,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/1u6JkXh5/30698991048ced77e60c4e8284007d3782f2e6a3_96.webp",
       "issues_url": "https://github.com/EngineHub/WorldEdit/issues",
@@ -32800,11 +32421,10 @@
       "selected_versions": {
         "1.21.11+paper": {
           "date_published": "2026-05-04T11:32:44.505155Z",
-          "downloads": 58142,
+          "downloads": 169903,
           "file": {
             "filename": "worldedit-bukkit-7.4.3.jar",
             "hashes": {
-              "sha1": "cec544771acacf4d15d6ec618d153dc746ff868e",
               "sha512": "43d2f8865a06d63c71d2b8bc0ded66c2c7f5e413db1a64bc2f665db3bf25ec28ae40789884af4bdaf40740a6632196494d2897fa77675f0babfaf79f18400853"
             },
             "primary": true,
@@ -32853,7 +32473,7 @@
       "client_side": "unsupported",
       "color": 281828,
       "date_created": "2024-09-10T23:38:45.613070Z",
-      "date_modified": "2026-03-24T09:04:34.181505Z",
+      "date_modified": "2026-05-30T03:15:30.010759Z",
       "description": "WorldGuard lets you and players guard areas of land against griefers and undesirables as well as tweak and disable various gameplay features of Minecraft.",
       "discord_url": "https://discord.gg/enginehub",
       "donation_urls": [
@@ -32863,8 +32483,8 @@
           "url": "https://github.com/sponsors/EngineHub"
         }
       ],
-      "downloads": 520717,
-      "followers": 549,
+      "downloads": 609072,
+      "followers": 593,
       "game_versions": [
         "1.21",
         "1.21.1",
@@ -32878,7 +32498,8 @@
         "1.21.11",
         "26.1",
         "26.1.1",
-        "26.1.2"
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/DKY9btbd/e1281ffadc4e194780bd31eb89ae6ea2537ec41b_96.webp",
       "issues_url": "https://github.com/EngineHub/WorldGuard/issues",
@@ -32898,34 +32519,40 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+paper": {
-          "date_published": "2026-03-24T09:04:34.181505Z",
-          "downloads": 75795,
+          "date_published": "2026-05-30T03:15:30.010759Z",
+          "dependencies": [
+            {
+              "dependency_type": "required",
+              "project_id": "1u6JkXh5"
+            }
+          ],
+          "downloads": 52225,
           "file": {
-            "filename": "worldguard-bukkit-7.0.16.jar",
+            "filename": "worldguard-bukkit-7.0.17.jar",
             "hashes": {
-              "sha1": "a6f04d4b16f5d880f8465fc8188f2731b2e6aeae",
-              "sha512": "70ed07f145a1b686e270bad3ba235a3a5e70005d8357c13e3130bf032b048add1aa1dd000f5521f77409c53a141111da2f6bf3eb610654c05f47666769d11d4c"
+              "sha512": "5da539cf8618079f9e7f5a0ab578c62d31ebd88e35b39ca047a2f9115e397e0d4dd781a94ca373e93333fce3371f7eaf503cd0b6abb6363085e3f4968ea51e4b"
             },
             "primary": true,
-            "size": 1172160,
-            "url": "https://cdn.modrinth.com/data/DKY9btbd/versions/EZl3moba/worldguard-bukkit-7.0.16.jar"
+            "size": 1177934,
+            "url": "https://cdn.modrinth.com/data/DKY9btbd/versions/pI4UHLJL/worldguard-bukkit-7.0.17.jar"
           },
           "game_versions": [
             "1.21.11",
             "26.1",
             "26.1.1",
-            "26.1.2"
+            "26.1.2",
+            "26.2"
           ],
-          "id": "EZl3moba",
+          "id": "pI4UHLJL",
           "loaders": [
             "bukkit",
             "folia",
             "paper",
             "spigot"
           ],
-          "name": "WorldGuard 7.0.16 (MC 1.21.11-26.1.2)",
+          "name": "WorldGuard 7.0.17 (MC 1.21.11-26.2)",
           "project_id": "DKY9btbd",
-          "version_number": "7.0.16",
+          "version_number": "7.0.17",
           "version_type": "release"
         }
       },
@@ -32945,7 +32572,7 @@
       "client_side": "required",
       "color": 3359430,
       "date_created": "2023-04-21T18:24:45.476148Z",
-      "date_modified": "2026-05-18T09:53:37.426954Z",
+      "date_modified": "2026-06-29T16:30:32.894355Z",
       "description": "Displays a map of the nearby world terrain, players, mobs, entities in the corner of your screen. Lets you create waypoints which help you find the locations you've marked.",
       "donation_urls": [
         {
@@ -32954,8 +32581,8 @@
           "url": "https://www.patreon.com/xaero96"
         }
       ],
-      "downloads": 80420456,
-      "followers": 15748,
+      "downloads": 89019160,
+      "followers": 16655,
       "game_versions": [
         "1.7.10",
         "1.8.9",
@@ -32993,7 +32620,10 @@
         "1.21.9",
         "1.21.10",
         "1.21.11",
-        "26.1.2"
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/1bokaNcj/354080f65407e49f486fcf9c4580e82c45ae63b8_96.webp",
       "issues_url": "https://curseforge.com/minecraft/mc-mods/xaeros-minimap/issues",
@@ -33013,43 +32643,38 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-05T09:14:01.786617Z",
+          "date_published": "2026-06-22T08:06:04.071010Z",
           "dependencies": [
             {
               "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "gF3BGWvG",
-              "version_id": null
+              "project_id": "gF3BGWvG"
             },
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 344598,
+          "downloads": 208243,
           "file": {
-            "filename": "xaerominimap-fabric-1.21.11-25.3.12.jar",
+            "filename": "xaerominimap-fabric-1.21.11-26.1.4.jar",
             "hashes": {
-              "sha1": "c17e50a44669f04e5e051ed87db4c05f0eb5923f",
-              "sha512": "5072fe7d02471956d227b834ee1fa5b1a752f7546cf880c99e32790f09b3b13143c5c16c99b3ba39e0de8a8e6d46f37f1bb3a88ff0fa41207ccce5deae45681b"
+              "sha512": "d782ed65dadcd1e7b99a4779cac303e377cda2f0287e1054c0bcafd6bf2765fc15638736c737448bff913ebb4819e78ea88df05e78fcf529922fc776bcb665f6"
             },
             "primary": true,
-            "size": 2152212,
-            "url": "https://cdn.modrinth.com/data/1bokaNcj/versions/q5DQinHS/xaerominimap-fabric-1.21.11-25.3.12.jar"
+            "size": 2152173,
+            "url": "https://cdn.modrinth.com/data/1bokaNcj/versions/rLF2AwoN/xaerominimap-fabric-1.21.11-26.1.4.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "q5DQinHS",
+          "id": "rLF2AwoN",
           "loaders": [
             "fabric",
             "quilt"
           ],
-          "name": "25.3.12",
+          "name": "26.1.4",
           "project_id": "1bokaNcj",
-          "version_number": "fabric-1.21.11-25.3.12",
+          "version_number": "fabric-1.21.11-26.1.4",
           "version_type": "release"
         }
       },
@@ -33067,7 +32692,7 @@
       "client_side": "required",
       "color": 3359430,
       "date_created": "2023-04-22T09:32:10.659737Z",
-      "date_modified": "2026-05-20T09:04:29.068596Z",
+      "date_modified": "2026-06-29T16:30:49.846715Z",
       "description": "Adds a full screen world map which shows you what you have explored in the world. Works great together with Xaero's Minimap.",
       "donation_urls": [
         {
@@ -33076,8 +32701,8 @@
           "url": "https://www.patreon.com/xaero96"
         }
       ],
-      "downloads": 70963688,
-      "followers": 11980,
+      "downloads": 78209992,
+      "followers": 12685,
       "game_versions": [
         "1.7.10",
         "1.8.9",
@@ -33115,7 +32740,10 @@
         "1.21.9",
         "1.21.10",
         "1.21.11",
-        "26.1.2"
+        "26.1",
+        "26.1.1",
+        "26.1.2",
+        "26.2"
       ],
       "icon_url": "https://cdn.modrinth.com/data/NcUtCpym/354080f65407e49f486fcf9c4580e82c45ae63b8_96.webp",
       "issues_url": "https://curseforge.com/minecraft/mc-mods/xaeros-world-map/issues",
@@ -33135,43 +32763,38 @@
       "project_type": "mod",
       "selected_versions": {
         "1.21.11+fabric": {
-          "date_published": "2026-05-05T09:27:02.570273Z",
+          "date_published": "2026-06-22T08:15:38.640196Z",
           "dependencies": [
             {
-              "dependency_type": "optional",
-              "file_name": null,
-              "project_id": "gF3BGWvG",
-              "version_id": null
+              "dependency_type": "required",
+              "project_id": "P7dR8mSH"
             },
             {
-              "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "dependency_type": "optional",
+              "project_id": "gF3BGWvG"
             }
           ],
-          "downloads": 288866,
+          "downloads": 174772,
           "file": {
-            "filename": "xaeroworldmap-fabric-1.21.11-1.40.16.jar",
+            "filename": "xaeroworldmap-fabric-1.21.11-1.41.2.jar",
             "hashes": {
-              "sha1": "7e8f4cf756a5ea8d9ab0583aa7ea69723ace8ab6",
-              "sha512": "70bb88a05f8b36dfa39ef971d3e757beeb6845e674d2cfa337fa0a48f003bdc7fe4f6af1f0fa0dfd0ab17593df4f4348528d7952781abeb6a46cff00d693520b"
+              "sha512": "a51a6b0529871f07afeeedca1785724da4ca619c23356f3fbd53907c67940565f97c0a5a1d0599fa3acee7789d63623017ca3271af4ae25f8d5b0233b0fda54c"
             },
             "primary": true,
-            "size": 1435689,
-            "url": "https://cdn.modrinth.com/data/NcUtCpym/versions/vOQ76ooY/xaeroworldmap-fabric-1.21.11-1.40.16.jar"
+            "size": 1431996,
+            "url": "https://cdn.modrinth.com/data/NcUtCpym/versions/1rgcnGza/xaeroworldmap-fabric-1.21.11-1.41.2.jar"
           },
           "game_versions": [
             "1.21.11"
           ],
-          "id": "vOQ76ooY",
+          "id": "1rgcnGza",
           "loaders": [
             "fabric",
             "quilt"
           ],
-          "name": "1.40.16",
+          "name": "1.41.2",
           "project_id": "NcUtCpym",
-          "version_number": "fabric-1.21.11-1.40.16",
+          "version_number": "fabric-1.21.11-1.41.2",
           "version_type": "release"
         }
       },
@@ -33189,7 +32812,7 @@
       "client_side": "optional",
       "color": 2236961,
       "date_created": "2022-09-02T11:05:20.777780Z",
-      "date_modified": "2026-04-10T12:26:44.326058Z",
+      "date_modified": "2026-06-23T16:04:11.873289Z",
       "description": "A builder-based configuration library for Minecraft!",
       "discord_url": "https://short.isxander.dev/discord",
       "donation_urls": [
@@ -33199,8 +32822,8 @@
           "url": "https://patreon.com/isxander"
         }
       ],
-      "downloads": 87127762,
-      "followers": 8527,
+      "downloads": 97036482,
+      "followers": 8962,
       "gallery": [
         {
           "created": "2024-10-19T16:23:04.212763Z",
@@ -33250,7 +32873,9 @@
         "26.1",
         "26.1.1",
         "26.1.2",
-        "26.2-snapshot-2"
+        "26.2-snapshot-2",
+        "26.2",
+        "26.3-snapshot-1"
       ],
       "icon_url": "https://cdn.modrinth.com/data/1eAoo2KR/08c0cd32515e260f4bb20bbc0696510041523f9a_96.webp",
       "issues_url": "https://github.com/isXander/YetAnotherConfigLib/issues",
@@ -33274,16 +32899,13 @@
           "dependencies": [
             {
               "dependency_type": "required",
-              "file_name": null,
-              "project_id": "P7dR8mSH",
-              "version_id": null
+              "project_id": "P7dR8mSH"
             }
           ],
-          "downloads": 6461314,
+          "downloads": 8156828,
           "file": {
             "filename": "yet_another_config_lib_v3-3.8.2+1.21.11-fabric.jar",
             "hashes": {
-              "sha1": "f99cda70903f16dd6927a276150b2762b4d5ab66",
               "sha512": "392db7d471030cca27483ecf58c626a14cd73d71a18afe6d4173c6b030948b8a925b36e708d4cc2c897dfa3f20a7f23b999fc18aa6d36c156da29037601153ac"
             },
             "primary": true,
@@ -33351,14 +32973,14 @@
         "xaeros-world-map",
         "appleskin",
         "jei",
-        "jade",
-        "collective",
-        "geckolib",
         "veinminer",
+        "jade",
+        "geckolib",
         "simple-voice-chat",
+        "collective",
         "forge-config-api-port",
-        "konkrete",
         "fancymenu",
+        "konkrete",
         "puzzles-lib",
         "balm",
         "no-chat-reports",
@@ -33368,80 +32990,80 @@
         "owo-lib",
         "krypton",
         "terrablender",
-        "iceberg",
+        "enchantment-descriptions",
         "clumps",
+        "iceberg",
         "shulkerboxtooltip",
         "resourceful-lib",
-        "debugify",
         "c2me-fabric",
-        "distanthorizons",
+        "debugify",
         "fzzy-config",
-        "supermartijn642s-config-lib",
+        "distanthorizons",
         "biomes-o-plenty",
+        "supermartijn642s-config-lib",
         "packet-fixer",
         "rei",
+        "midnightlib",
         "visual-workbench",
         "natures-compass",
-        "midnightlib",
         "carry-on",
         "waystones",
         "resourceful-config",
         "netherportalfix",
         "lmd",
-        "attributefix",
         "terralith",
+        "attributefix",
+        "e4mc",
         "lootr",
         "comforts",
-        "e4mc",
-        "open-parties-and-claims",
-        "rhino",
         "controlify",
-        "travelersbackpack",
-        "spark",
+        "open-parties-and-claims",
         "lithostitched",
+        "rhino",
+        "spark",
         "glitchcore",
+        "travelersbackpack",
         "better-stats",
         "toms-storage",
-        "veinminer-enchantment",
-        "mru",
         "almanac",
+        "mru",
+        "veinminer-enchantment",
         "cristel-lib",
-        "better-combat",
         "towns-and-towers",
+        "enhancedvisuals",
+        "better-combat",
+        "chunky",
         "tectonic",
         "supermartijn642s-core-lib",
-        "chunky",
         "vmp-fabric",
-        "enhancedvisuals",
         "easy-anvils",
-        "cardinal-components-api",
-        "cicada",
         "tcdcommons",
-        "octo-lib",
+        "cicada",
+        "shatterbyte-lib",
+        "cardinal-components-api",
         "pick-up-notifier",
         "corgilib",
+        "immersive-aircraft",
         "farmers-delight-refabricated",
         "journeymap",
         "notenoughcrashes",
         "jamlib",
         "easy-magic",
-        "artifacts",
-        "leaves-be-gone",
-        "repurposed-structures-fabric",
-        "fallingtree",
         "servercore",
-        "villager-names-serilum",
+        "artifacts",
+        "repurposed-structures-fabric",
+        "leaves-be-gone",
+        "fallingtree",
         "ping-wheel",
+        "libjf",
+        "villager-names-serilum",
         "rightclickharvest",
-        "starter-kit",
-        "friends-and-foes",
-        "threadtweak",
         "prickle",
-        "do-a-barrel-roll",
-        "explorers-compass",
-        "libjf"
+        "axiom",
+        "friends-and-foes",
+        "explorers-compass"
       ],
-      "total_hits": 6881
+      "total_hits": 7677
     },
     "paper-1.21.11-server-popular": {
       "config": {
@@ -33479,96 +33101,96 @@
         "viaversion",
         "luckperms",
         "viabackwards",
-        "skinsrestorer",
         "patpat",
+        "skinsrestorer",
         "geyser",
         "tab-was-taken",
         "multiverse-core",
         "packetevents",
         "worldguard",
+        "essentialsx",
         "viarewind",
-        "discordsrv",
-        "mclogs",
         "grimac",
+        "osc-dp",
+        "discordsrv",
+        "clickvillagers",
+        "mclogs",
         "coreprotect",
         "fastasyncworldedit",
-        "osc-dp",
         "bluemap",
         "tps-hud",
-        "clickvillagers",
         "lifestealz",
         "villager-in-a-bucket",
-        "chunkyborder",
         "fancynpcs",
+        "chunkyborder",
         "nbtapi",
         "tabtps",
         "crazycrates",
-        "lagfixer",
         "invsee++",
         "infinite-villager-trading",
+        "lagfixer",
         "playerkits-2",
         "sethome",
         "buildpaste",
         "fancyholograms",
+        "authmerereloaded",
+        "simple-voice-chat-discord-bridge",
         "multiverse-inventories",
         "oneblock_bukkit",
-        "simple-voice-chat-discord-bridge",
-        "authmerereloaded",
         "quickshop-hikari",
         "imageframe",
-        "axiom-paper-plugin",
-        "stairsit",
-        "minimotd",
-        "skbee",
-        "crazyenchantments",
-        "nightcore",
-        "auraskills",
-        "huskhomes",
-        "decentholograms",
-        "orebfuscator",
         "voicemessages",
-        "just-tpa",
-        "placeholderapi",
-        "axgraves",
-        "provanish",
+        "minimotd",
+        "axiom-paper-plugin",
+        "skbee",
+        "stairsit",
         "string-dupers-return",
-        "smartspawner",
+        "decentholograms",
+        "placeholderapi",
+        "nightcore",
+        "huskhomes",
+        "auraskills",
+        "crazyenchantments",
+        "orebfuscator",
+        "just-tpa",
         "clickmobs",
+        "axgraves",
+        "smartspawner",
+        "provanish",
         "itemedit",
         "griefprevention",
+        "essentialsx-chat-module",
+        "skript",
         "typewriter",
-        "nexuscore",
+        "clearlag++",
         "nexusauctionhouse",
-        "bending",
+        "nexuscore",
+        "essentialsx-spawn",
         "infusesmp",
-        "crazyauctions",
         "fokusapi",
         "lightning-grim-anticheat",
-        "clearlag++",
+        "bending",
+        "crazyauctions",
+        "headpat",
         "multiverse-portals",
-        "freedomchat",
-        "powergems",
-        "drop-head",
-        "streamotes",
+        "quests.classic",
         "tpa.66666",
+        "drop-head",
+        "freedomchat",
         "executableitems",
-        "skript",
-        "squaremap",
         "inventoryrollbackplus",
+        "streamotes",
+        "powergems",
+        "squaremap",
         "deluxehub",
-        "advanced-portals",
         "ajleaderboards",
-        "advancedserverlist",
-        "autotreechop",
-        "uberenchant",
+        "advanced-portals",
         "vaultunlocked",
-        "maintenance",
-        "plugmanx",
-        "pl3xmap",
-        "simplescore",
-        "score"
+        "simple-login",
+        "autotreechop",
+        "plugmanx"
       ],
-      "total_hits": 7428
+      "total_hits": 8755
     }
   }
 }

--- a/packages/minecraft/minecraft/sound/sounds/lock.json
+++ b/packages/minecraft/minecraft/sound/sounds/lock.json
@@ -1,13 +1,13 @@
 {
-  "minecraftVersion": "26.1.2",
-  "assetIndexId": "30",
+  "minecraftVersion": "26.2",
+  "assetIndexId": "32",
   "assetIndex": {
-    "url": "https://piston-meta.mojang.com/v1/packages/2866ab0411f8507bf88d81513a08956a2474403f/30.json",
-    "hash": "sha1-KGarBBH4UHv4jYFROgiVaiR0QD8="
+    "url": "https://piston-meta.mojang.com/v1/packages/981aab8147520cdc1f0d4a84f46c161929021fee/32.json",
+    "hash": "sha1-mBqrgUdSDNwfDUqE9GwWGSkCH+4="
   },
   "excludePrefixes": [
     "music",
     "records"
   ],
-  "packHash": "sha256-Km+bbcgu5+x7PYLHEZlJftq8bym+uYlXNCenQk/Zig8="
+  "packHash": "sha256-W6xyCTkRdd/7VKzUxQ0aNiVD2Gp+xw+jO+Y/yq6pX+E="
 }

--- a/packages/minecraft/tools/update-sounds.nu
+++ b/packages/minecraft/tools/update-sounds.nu
@@ -53,7 +53,7 @@ def main [
 
   let system = (^nix eval --impure --raw --expr "builtins.currentSystem")
   let expr = $"let f = builtins.getFlake \"path:($root)\"; in f.inputs.nixpkgs.legacyPackages.\"($system)\".callPackage ($sounds_nix) { }"
-  print $"building sound pack for ($mc_version) to compute packHash (downloads from Mojang)..."
+  print $"building sound pack for ($mc_version) to compute packHash, downloads from Mojang..."
   let res = (do { ^nix build --impure --no-link --expr $expr } | complete)
 
   let got = (

--- a/packages/yc/manifest.json
+++ b/packages/yc/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "0.0.8",
+  "version": "0.0.16",
   "platforms": {
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-1vuQ1i881evjhlPtBjofbUzT5Gm5SYmHtv2Yd9l78Pg="
+      "hash": "sha256-dEZ7c6K4awwU/g0i/m/z6dbDw/sIJ3AAvxhFhxETbNY="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-jpeeJwSp0zcVjY5LzKvxjOCfZpkKFrQKkTCyl64ZvZg="
+      "hash": "sha256-Uy0nrCCgGPISgStI7BQGtZVTDXJDJrTP06WPV+mfx7o="
     },
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-+aRxT8HfYnXrD3dgdf5yaftZR+UGK1gGxnFGm1RiP7E="
+      "hash": "sha256-gS+PAS96EoIp0viANq0RxfQ6tJ/jsgIqBgWPfXxB20I="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-sI3Pr2lK4c6JOiVUBcghdrN+bPEZTs1kDgUmwGVIz34="
+      "hash": "sha256-nGCFIZZpqPmKmjSpzMUN7wwIgjZynwXRq/c1NjMRfrM="
     }
   }
 }


### PR DESCRIPTION
Fixes #1654.

What changed:
- Fixed the `update-sounds` Nushell interpolation bug that made `(downloads from Mojang)` run as a command.
- Set `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` in `writePythonApplication` wrappers so Python HTTPS updaters can verify upstream certificates.
- Re-ran `nix run .#update` and committed the refreshed content outputs.

Validation:
- `nix run .#update`: 7 succeeded, 0 failed.
- `nix run .#update -- --only mods,loaders`: 2 succeeded, 0 failed.
- `nix build .#claude-code .#dia .#humanlayer .#yc .#minecraft-sound`: passed.
- `nix run .#lint`: passed.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix content updaters by refreshing catalog metadata, package versions, and SSL cert handling
> - Updates mod catalogs ([26.1.2.json](https://github.com/indexable-inc/index/pull/1655/files#diff-877076588dafe14fffaaf10b6b64b14e93058659d9978a0ad79683607db7cf10), [1.21.11.json](https://github.com/indexable-inc/index/pull/1655/files#diff-6d3ed55df172b4035a04c13e65435ab23dbc43745cc903ef1935a7abb0d6d257)) with newer mod versions and download URLs for many mods including BlueMap, DistantHorizons, LuckPerms, and ViaVersion.
> - Refreshes [catalog.json](https://github.com/indexable-inc/index/pull/1655/files#diff-a1193a25813e8996add36e9089147d464a550acbddeb2454b0bc8dfb554c0ca6) with Minecraft 26.2 support, adds new projects (Axiom, EssentialsX, Headpat, Immersive Aircraft), removes others (AdvancedServerList, Do a Barrel Roll, Maintenance, Octo Lib), and updates version metadata and hashes across many entries.
> - Bumps Paper builds for 1.21.11 (69→132) and 26.1.2 (64→72), and Velocity to build 563.
> - Bumps package manifests for `claude-code` (2.1.183→2.1.197), `humanlayer` (0.27.12→0.27.23), `dia` (1.34.1→1.37.1), and `yc` (0.0.8→0.0.16).
> - Fixes Python writer in [writers.nix](https://github.com/indexable-inc/index/pull/1655/files#diff-0623e72dad4f8369a1e1c6c92bceea5b8671425268aa161961e3d52950e07d3a) to set `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` so HTTPS requests use the system CA bundle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c72c79c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->