### PR TITLE
Make MCP dashboard detail sections collapsible

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -249,6 +249,16 @@ let
       '';
     }
     {
+      structuredConcurrency = ''
+        Prefer structured concurrency for independent work. When kernel commands do
+        not depend on each other and do not mutate the same resource, run them in
+        parallel inside one `python_exec` with `asyncio.gather` or `asyncio.TaskGroup`.
+
+        Keep dependent commands sequential. Do not parallelize shared-checkout writes,
+        ordered git operations, prompts, or probes whose timing would change the result.
+      '';
+    }
+    {
       backgroundSubagents = ''
         Delegate by default with named subagents. Use them frequently whenever
         independent work can run in parallel, and split real work into clear phases

--- a/packages/dashboard/dashboard-core/site/src/components/FeedView.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/FeedView.svelte
@@ -376,42 +376,45 @@
               </div>
             {/if}
             {#if traced}
-              <!-- Inline trace: source with each line's output beside it — one
+              <!-- Inline trace: source with each line's output beside it, one
                    combined view, so no separate output box (it would duplicate). -->
-              <div class="detail-section">
-                <div class="detail-label">code · output</div>
+              <details class="detail-section" open>
+                <summary class="detail-label">code · output</summary>
                 <div class="entry-box entry-trace-box">
                   <InlineTrace source={p.source ?? ''} lang={p.lang ?? 'text'} trace={traceArr} />
                   {#if p.stderr}<pre class="exec-out err trace-stderr">{stripAnsi(p.stderr)}</pre>{/if}
                 </div>
-              </div>
+              </details>
               {#if selectedOut}
                 {@const OutBody = rendererFor(selectedOut.kind, selectedOut.renderer)}
-                <div class="entry-box pane entry-body detail-out">
-                  <div class="body html-body"><OutBody pane={selectedOut} /></div>
-                </div>
-              {/if}
-            {:else}
-              {#if hasSource}
-                <div class="detail-section first">
-                  <div class="detail-label">code</div>
-                  <div class="entry-box entry-code"><CodeBlock code={p.source ?? ''} lang={p.lang ?? 'text'} /></div>
-                </div>
-              {/if}
-              {#if hasStreamOut || resultIsPrimary || ledRun(p)}
-                <div class="detail-section">
-                  <div class="detail-label">output</div>
-                  <div class="entry-box cell cell-out"><ExecBody pane={p} chrome={false} expanded hideResult={!resultIsPrimary} /></div>
-                </div>
-              {/if}
-              {#if selectedOut}
-                {@const OutBody = rendererFor(selectedOut.kind, selectedOut.renderer)}
-                <div class="detail-section">
-                  <div class="detail-label">rich output</div>
+                <details class="detail-section" open>
+                  <summary class="detail-label">rich output</summary>
                   <div class="entry-box pane entry-body detail-out">
                     <div class="body html-body"><OutBody pane={selectedOut} /></div>
                   </div>
-                </div>
+                </details>
+              {/if}
+            {:else}
+              {#if hasSource}
+                <details class="detail-section first" open>
+                  <summary class="detail-label">code</summary>
+                  <div class="entry-box entry-code"><CodeBlock code={p.source ?? ''} lang={p.lang ?? 'text'} /></div>
+                </details>
+              {/if}
+              {#if hasStreamOut || resultIsPrimary || ledRun(p)}
+                <details class="detail-section" open>
+                  <summary class="detail-label">output</summary>
+                  <div class="entry-box cell cell-out"><ExecBody pane={p} chrome={false} expanded hideResult={!resultIsPrimary} /></div>
+                </details>
+              {/if}
+              {#if selectedOut}
+                {@const OutBody = rendererFor(selectedOut.kind, selectedOut.renderer)}
+                <details class="detail-section" open>
+                  <summary class="detail-label">rich output</summary>
+                  <div class="entry-box pane entry-body detail-out">
+                    <div class="body html-body"><OutBody pane={selectedOut} /></div>
+                  </div>
+                </details>
               {/if}
             {/if}
             <!-- Model view (hidden by default): the result the model received.

--- a/packages/dashboard/dashboard-core/site/src/style.css
+++ b/packages/dashboard/dashboard-core/site/src/style.css
@@ -499,10 +499,20 @@ body {
 .detail-section { margin-top: 16px; }
 .detail-section.first { margin-top: 0; }
 .detail-label {
+  display: flex; align-items: center; gap: 5px;
   margin: 0 0 5px 2px;
   font-family: var(--mono); font-size: 10px; letter-spacing: 0.07em;
   text-transform: uppercase; color: var(--ink-faint);
+  cursor: pointer; user-select: none;
 }
+.detail-label::marker { content: ""; }
+.detail-label::-webkit-details-marker { display: none; }
+.detail-label::before {
+  content: "▾"; font-size: 10px; line-height: 1; color: var(--ink-faint);
+}
+.detail-section:not([open]) > .detail-label::before { content: "▸"; }
+.detail-section:not([open]) > .detail-label { margin-bottom: 0; }
+.detail-label:hover { color: var(--ink-dim); }
 
 /* The `code` toggle in the detail panel: a quiet bordered chip. */
 .entry-code-toggle {


### PR DESCRIPTION
## Summary
- Make MCP dashboard detail sections collapsible with native disclosure controls.
- Add matching disclosure styling for code, output, and rich output sections.
- Update the system prompt to prefer structured concurrency for independent kernel commands.

## Verification
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`
- `npm run check` in `packages/dashboard/dashboard-core/site`
- `npm run build` in `packages/dashboard/dashboard-core/site`
- `git diff --check -- packages/agent/system-prompt.nix packages/dashboard/dashboard-core/site/src/components/FeedView.svelte packages/dashboard/dashboard-core/site/src/style.css`

## Note
- `nix run .#lint` did not reach repo linting because a Nix dependency build failed while installing `tree-sitter-bash`: `cp: cannot create regular file '/nix/store/9vbzpzsfgk2ldxyk39d5bw8fxnci2s68-build-script-build-0.25.1/bin/build-script-build': Permission denied`.

Refs #1657

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make MCP dashboard detail sections collapsible by default
> - Wraps `code`, `output`, `rich output`, and `code · output` sections in `<details>` elements in [FeedView.svelte](https://github.com/indexable-inc/index/pull/1659/files#diff-299efa94d7c1e14167867dd904b46de36edccb3740e7b4c37f2de65a206c66e5), making them collapsible disclosure panels that render open by default.
> - Updates [style.css](https://github.com/indexable-inc/index/pull/1659/files#diff-fb2c1239e1b0fc19cff65c15124557437fbd813ae5f982d538301120b0398bf3) to add a custom disclosure triangle, hover color, and adjusted spacing for collapsed state.
> - Also adds a `structuredConcurrency` guideline to the agent system prompt in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1659/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df), advising use of `asyncio.gather`/`TaskGroup` for independent kernel commands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa2d76e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->