### PR TITLE
darwin: remove opal cask

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -39,7 +39,6 @@
       "notion"
       "obs@beta"
       "obsidian"
-      "opal-app"
       "postico"
       "prismlauncher"
       "raycast"


### PR DESCRIPTION
## Summary
- remove `opal-app` from Andrew's shared Darwin Homebrew casks

## Validation
- `nix eval --json --impure --expr 'let m = import ./users/andrewgazelka/darwin.nix; in { casks = m.homebrew.casks; hasOpal = builtins.elem "opal-app" m.homebrew.casks; }'` → `hasOpal = false`
- `nix run .#lint`

Refs #1658
Refs andrewgazelka/nix#32

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `opal-app` cask from darwin configuration
> Removes the `opal-app` entry from the list of applications in [darwin.nix](https://github.com/indexable-inc/index/pull/1660/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3adcf64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->