### PR TITLE
Make agent CLI defaults Home Manager-first

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -286,6 +286,7 @@
             nixpkgs
             paths
             rust-overlay
+            home-manager
             ;
         }
       );
@@ -315,6 +316,14 @@
         # `programs.raycast.focus = { enable = true; ... }`. See
         # modules/home/raycast.nix.
         raycast = ./modules/home/raycast.nix;
+        # Agent CLI modules: Home Manager is the user-facing configuration
+        # surface, while the package wrappers remain the implementation detail.
+        claude-code = import ./packages/agent/home-manager/claude-code.nix {
+          indexPackages = system: (collect "packages").${system};
+        };
+        codex = import ./packages/agent/home-manager/codex.nix {
+          indexPackages = system: (collect "packages").${system};
+        };
         # Personal-but-shareable workstation module for github:andrewgazelka: the
         # ix.dev downtime watcher + boss bar overlay + the shared say-detached
         # sound helper, all as portable services. Closed over the per-system
@@ -323,6 +332,9 @@
         andrewgazelka = import ./users/andrewgazelka/home.nix {
           indexPackages = system: (collect "packages").${system};
           portableServicesModule = ix.portableServices.homeModule;
+          claudeCodeModule = import ./packages/agent/home-manager/claude-code.nix {
+            indexPackages = system: (collect "packages").${system};
+          };
           inherit ix;
         };
         # Reusable workstation module: draw one Minecraft boss bar per in-flight

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -12,6 +12,7 @@
   nixpkgs,
   paths,
   rust-overlay,
+  home-manager,
 }:
 let
   inherit (nixpkgs) lib;
@@ -686,7 +687,14 @@ let
     fileset = fs.intersection (fs.gitTracked paths.root) (paths.root + "/astlog-rules");
   };
 
-  tests = import paths.tests { inherit nixpkgs ix paths; };
+  tests = import paths.tests {
+    inherit
+      nixpkgs
+      ix
+      paths
+      home-manager
+      ;
+  };
 
   exampleFleets = ix.exampleFleetsFor { hostSystem = system; };
 

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -29,6 +29,11 @@
   # fallback the claude-code wrapper uses).
   repoPackages ? { },
 
+  # Rule names dropped from the default house prompt. Only affects the computed
+  # `systemPrompt` default below; ignored when `systemPrompt` is passed
+  # explicitly.
+  omitRules ? [ ],
+
   # Forced config: codex `-c key=value` overrides applied on EVERY invocation.
   # `-c` is codex's highest-precedence layer (above ~/.codex/config.toml), so use
   # this ONLY for wrapper INVARIANTS the user must not silently lose. The one we
@@ -63,18 +68,35 @@
     agents.max_depth = 3;
   },
 
-  # The house model/base instructions Codex should run with. Kept outside the
-  # overridable `settings` default so callers that replace `settings` for their
-  # own soft defaults do not silently drop the prompt.
+  # MCP servers rendered as soft Codex defaults. A user's own
+  # `[mcp_servers.<name>]` config wins per-key through config-launch.
+  mcpServers ?
+    (import (ix.paths.packagesRoot + "/agent/common.nix") {
+      inherit lib ix repoPackages;
+      promptOmitRules = omitRules;
+    }).defaultServers,
+
+  # The house model/base instructions Codex should run with. This becomes a
+  # store-backed `model_instructions_file` soft default. Null bakes no default.
+  systemPrompt ?
+    (import (ix.paths.packagesRoot + "/agent/common.nix") {
+      inherit lib ix repoPackages;
+      promptOmitRules = omitRules;
+    }).systemPromptFor
+      "codex",
+
+  # Existing prompt file to use instead of materializing `systemPrompt`.
+  # Overrides `systemPrompt` when non-null.
   modelInstructionsFile ? null,
 }:
 let
-  common = import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; };
   effectiveModelInstructionsFile =
     if modelInstructionsFile != null then
       modelInstructionsFile
+    else if systemPrompt != null then
+      builtins.toFile "codex-system-prompt.txt" systemPrompt
     else
-      builtins.toFile "codex-system-prompt.txt" (common.systemPromptFor "codex");
+      null;
 
   # The compiled Rust launcher (packages/config-launch): reads IX_LAUNCH_SPEC
   # (a baked JSON file describing the target binary, config path, forced flags,
@@ -88,12 +110,6 @@ let
       value = ix.toml.scalar v;
     }) flat;
 
-  # The default MCP servers, baked as soft `-c mcp_servers.*` defaults from the
-  # shared default server set (../common.nix `defaultServers`, the same source the
-  # claude-code wrapper renders), so Codex gets only the index MCP server and
-  # the Exa MCP server. Soft, so a user's own `[mcp_servers.<name>]` in
-  # config.toml wins per the per-leaf presence check.
-  mcpServers = common.defaultServers;
   sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
     inherit lib mcpServers;
   };
@@ -113,7 +129,10 @@ let
     soft =
       entriesOf (
         ix.attrs.flattenToDotted (
-          { model_instructions_file = toString effectiveModelInstructionsFile; } // settings
+          lib.optionalAttrs (effectiveModelInstructionsFile != null) {
+            model_instructions_file = toString effectiveModelInstructionsFile;
+          }
+          // settings
         )
       )
       ++ ix.mcp.toCodexEntries mcpServers;

--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -1,0 +1,129 @@
+{ indexPackages }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.claude-code;
+  jsonFormat = pkgs.formats.json { };
+  pathLike = lib.types.either lib.types.path lib.types.str;
+  indexPkgs = indexPackages pkgs.stdenv.hostPlatform.system;
+
+  optionalOverride =
+    condition: name: value:
+    lib.optionalAttrs condition { ${name} = value; };
+  packageOverrides = {
+    inherit (cfg)
+      addDirs
+      dangerouslySkipPermissions
+      omitRules
+      personalStartupContext
+      pluginDirs
+      primaryCheckouts
+      ;
+    extraSettings = cfg.defaults;
+  }
+  // optionalOverride (cfg.defaultMcpServers != null) "mcpServers" cfg.defaultMcpServers
+  // optionalOverride (cfg.systemPrompt != null) "systemPrompt" cfg.systemPrompt
+  // optionalOverride cfg.useStockSystemPrompt "systemPrompt" null;
+  defaultedPackage = cfg.basePackage.override packageOverrides;
+in
+{
+  options.programs.claude-code = {
+    basePackage = lib.mkOption {
+      type = lib.types.package;
+      default = indexPkgs.claude-code;
+      defaultText = lib.literalExpression "inputs.index.packages.\${pkgs.stdenv.hostPlatform.system}.claude-code";
+      description = "Base index Claude Code wrapper package before Home Manager applies defaults.";
+    };
+
+    defaults = lib.mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      description = ''
+        Lower-priority Claude Code settings passed through the wrapper's
+        read-only default layer. Runtime user settings are still managed by
+        Home Manager's native {option}`programs.claude-code.settings` option.
+      '';
+    };
+
+    dangerouslySkipPermissions = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Bake Claude Code's bypass-permissions flag into the wrapper.";
+    };
+
+    addDirs = lib.mkOption {
+      type = lib.types.listOf pathLike;
+      default = [ ];
+      description = "Directories baked as Claude Code {command}`--add-dir=<dir>` flags.";
+    };
+
+    pluginDirs = lib.mkOption {
+      type = lib.types.listOf pathLike;
+      default = [ ];
+      description = "Directories baked as Claude Code {command}`--plugin-dir=<dir>` flags.";
+    };
+
+    primaryCheckouts = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "/home/*/index"
+        "/home/*/ix"
+      ];
+      description = "Shell globs protected by the shared worktree guard hook.";
+    };
+
+    personalStartupContext = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable Andrew-only startup context hooks in the rendered Claude Code policy.";
+    };
+
+    defaultMcpServers = lib.mkOption {
+      type = lib.types.nullOr jsonFormat.type;
+      default = null;
+      description = ''
+        MCP server JSON to bake into the wrapper's default MCP layer. Null keeps
+        the package default; `{ }` intentionally bakes no default MCP config.
+        Home Manager's native {option}`programs.claude-code.mcpServers` remains
+        the user config layer.
+      '';
+    };
+
+    omitRules = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Rule names omitted from the default house system prompt.";
+    };
+
+    systemPrompt = lib.mkOption {
+      type = lib.types.nullOr lib.types.lines;
+      default = null;
+      description = ''
+        Replacement Claude Code system prompt. Null keeps the package default
+        house prompt. Set {option}`programs.claude-code.useStockSystemPrompt` to
+        run Claude Code without the house prompt wrapper.
+      '';
+    };
+
+    useStockSystemPrompt = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Do not bake the house system prompt into the Claude Code wrapper.";
+    };
+  };
+
+  config = {
+    assertions = [
+      {
+        assertion = !(cfg.useStockSystemPrompt && cfg.systemPrompt != null);
+        message = "programs.claude-code: systemPrompt and useStockSystemPrompt are mutually exclusive.";
+      }
+    ];
+
+    programs.claude-code.package = lib.mkDefault defaultedPackage;
+  };
+}

--- a/packages/agent/home-manager/codex.nix
+++ b/packages/agent/home-manager/codex.nix
@@ -1,0 +1,159 @@
+{ indexPackages }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.codex;
+  tomlFormat = pkgs.formats.toml { };
+  jsonFormat = pkgs.formats.json { };
+  pathLike = lib.types.either lib.types.path lib.types.str;
+  indexPkgs = indexPackages pkgs.stdenv.hostPlatform.system;
+
+  optionalOverride =
+    condition: name: value:
+    lib.optionalAttrs condition { ${name} = value; };
+  packageOverrides = {
+    inherit (cfg)
+      forcedSettings
+      personalStartupContext
+      primaryCheckouts
+      ;
+    settings = cfg.defaults;
+  }
+  // optionalOverride (cfg.mcpServers != null) "mcpServers" cfg.mcpServers
+  // optionalOverride (
+    cfg.modelInstructionsFile != null
+  ) "modelInstructionsFile" cfg.modelInstructionsFile
+  // optionalOverride (cfg.systemPrompt != null) "systemPrompt" cfg.systemPrompt
+  // optionalOverride cfg.disableModelInstructions "systemPrompt" null;
+  finalPackage = cfg.basePackage.override packageOverrides;
+in
+{
+  options.programs.codex = {
+    basePackage = lib.mkOption {
+      type = lib.types.package;
+      default = indexPkgs.codex;
+      defaultText = lib.literalExpression "inputs.index.packages.\${pkgs.stdenv.hostPlatform.system}.codex";
+      description = "Base index Codex wrapper package before Home Manager applies defaults.";
+    };
+
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      description = "Codex package after Home Manager defaults are applied.";
+    };
+
+    defaults = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = {
+        features.multi_agent_v2 = {
+          enabled = true;
+          max_concurrent_threads_per_session = 16;
+        };
+        agents.max_depth = 3;
+      };
+      description = ''
+        Lower-priority Codex config rendered through the wrapper's default
+        layer. These values are used only when the user's
+        {file}`config.toml` does not already set the same key.
+      '';
+    };
+
+    forcedSettings = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = {
+        check_for_update_on_startup = false;
+      };
+      description = ''
+        Codex settings rendered as highest-precedence forced {command}`-c`
+        wrapper flags. Use this for invariants, not user-overridable defaults.
+      '';
+    };
+
+    primaryCheckouts = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "/home/*/index"
+        "/home/*/ix"
+      ];
+      description = "Shell globs threaded into the shared agent hook policy.";
+    };
+
+    personalStartupContext = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable Andrew-only startup context hooks in the rendered Codex policy.";
+    };
+
+    mcpServers = lib.mkOption {
+      type = lib.types.nullOr jsonFormat.type;
+      default = null;
+      description = ''
+        MCP server declarations rendered as soft Codex config defaults. Null
+        keeps the package default; `{ }` intentionally bakes no MCP defaults.
+      '';
+    };
+
+    modelInstructionsFile = lib.mkOption {
+      type = lib.types.nullOr pathLike;
+      default = null;
+      description = ''
+        Existing file to use for Codex's {option}`model_instructions_file`.
+        Null keeps the package default generated from the house prompt.
+      '';
+    };
+
+    systemPrompt = lib.mkOption {
+      type = lib.types.nullOr lib.types.lines;
+      default = null;
+      description = ''
+        Replacement Codex model instructions text. Null keeps the package
+        default house prompt.
+      '';
+    };
+
+    disableModelInstructions = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Do not bake a {option}`model_instructions_file` default into the Codex wrapper.";
+    };
+
+    installHooks = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Install the shared Codex hook policy into the configured Codex home.";
+    };
+
+    configDir = lib.mkOption {
+      type = lib.types.str;
+      default = ".codex";
+      description = "Codex config directory, relative to the Home Manager home directory.";
+    };
+  };
+
+  config = {
+    assertions = [
+      {
+        assertion =
+          lib.count (x: x) [
+            cfg.disableModelInstructions
+            (cfg.modelInstructionsFile != null)
+            (cfg.systemPrompt != null)
+          ] <= 1;
+        message = "programs.codex: choose only one of disableModelInstructions, modelInstructionsFile, or systemPrompt.";
+      }
+    ];
+
+    programs.codex = {
+      package = lib.mkDefault finalPackage;
+      inherit finalPackage;
+    };
+
+    home.file."${cfg.configDir}/hooks.json" = lib.mkIf (cfg.enable && cfg.installHooks) {
+      source = cfg.finalPackage.hooksJson;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -173,7 +173,7 @@ let
     config = {
       allowUnfreePredicate = pkg: lib.getName pkg == "claude-code";
     };
-    overlays = [ ];
+    overlays = [ ix.overlay ];
   };
   homeAgentIndexPackages = _: ix.packageSetFor homeAgentPkgs;
   homeAgentConfig =

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,6 +4,7 @@
   nixpkgs,
   ix,
   paths,
+  home-manager,
 }:
 let
   inherit (nixpkgs) lib;
@@ -167,6 +168,43 @@ let
   agentCommon = import (paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; };
   sampleClaudeSystemPrompt = agentCommon.systemPromptFor "claude";
   sampleCodexSystemPrompt = agentCommon.systemPromptFor "codex";
+  homeAgentPkgs = import nixpkgs {
+    inherit (pkgs.stdenv.hostPlatform) system;
+    config = {
+      allowUnfreePredicate = pkg: lib.getName pkg == "claude-code";
+    };
+    overlays = [ ];
+  };
+  homeAgentIndexPackages = _: ix.packageSetFor homeAgentPkgs;
+  homeAgentConfig =
+    (home-manager.lib.homeManagerConfiguration {
+      pkgs = homeAgentPkgs;
+      modules = [
+        (import (paths.packagesRoot + "/agent/home-manager/claude-code.nix") {
+          indexPackages = homeAgentIndexPackages;
+        })
+        (import (paths.packagesRoot + "/agent/home-manager/codex.nix") {
+          indexPackages = homeAgentIndexPackages;
+        })
+        {
+          home = {
+            username = "agent";
+            homeDirectory = "/home/agent";
+            stateVersion = "25.05";
+          };
+          programs.claude-code = {
+            enable = true;
+            omitRules = [ "reportToPlaybook" ];
+            personalStartupContext = true;
+          };
+          programs.codex = {
+            enable = true;
+            configDir = ".config/codex-test";
+            defaults.agents.max_depth = 4;
+          };
+        }
+      ];
+    }).config;
 
   minecraft =
     let
@@ -3549,6 +3587,25 @@ let
           in
           managed.permissions.defaultMode == "bypassPermissions" && managed.skipDangerousModePermissionPrompt;
         message = "dev base should enforce root's Claude Code bypass via managed-settings.json";
+      }
+      {
+        assertion =
+          builtins.elem homeAgentConfig.programs.claude-code.finalPackage homeAgentConfig.home.packages
+          && builtins.elem homeAgentConfig.programs.codex.finalPackage homeAgentConfig.home.packages;
+        message = "agent Home Manager modules should install their configured packages when enabled";
+      }
+      {
+        assertion =
+          homeAgentConfig.home.file.".config/codex-test/hooks.json".source
+          == homeAgentConfig.programs.codex.finalPackage.hooksJson;
+        message = "Codex Home Manager module should install the shared hook policy under the configured Codex home";
+      }
+      {
+        assertion = builtins.elem {
+          key = "agents.max_depth";
+          value = "4";
+        } homeAgentConfig.programs.codex.finalPackage.passthru.specValue.soft;
+        message = "Codex Home Manager module should pass soft settings through the package wrapper";
       }
     ];
 

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -51,6 +51,7 @@
 {
   indexPackages,
   portableServicesModule,
+  claudeCodeModule,
   ix,
 }:
 {
@@ -67,12 +68,11 @@ let
   # `pkgs.claude-code` carries an x86_64-linux `config-launch` even on an
   # aarch64-darwin host, so its install-check drags the whole x86_64-linux cargo
   # unit graph (alsa-sys et al.) into a Mac home build, which real nix cannot
-  # place. `indexPkgs.claude-code` is the correctly host-targeted build.
+  # place. The agent Home Manager modules use `indexPackages` for the same
+  # host-targeted package selection.
   # See indexable-inc/index#1085.
   indexPkgs = indexPackages pkgs.stdenv.hostPlatform.system;
-  claudeCode = indexPkgs.claude-code.override {
-    personalStartupContext = true;
-  };
+  claudeCode = config.programs.claude-code.finalPackage;
 
   isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
 
@@ -183,6 +183,7 @@ in
   imports = [
     portableServicesModule
     ciBarsModule
+    claudeCodeModule
   ];
 
   options.users.andrewgazelka = {
@@ -479,6 +480,11 @@ in
       enable = true;
       repos = cfg.prWatch.repos;
       inherit (cfg) logDir;
+    };
+
+    programs.claude-code = {
+      enable = true;
+      personalStartupContext = true;
     };
   };
 }


### PR DESCRIPTION
## Summary
- Add Home Manager modules for Claude Code and Codex that expose `programs.<agent>.defaults` as the declarative lower layer.
- Keep package wrapper overrides as the implementation detail by defaulting Home Manager's native `package` options to configured index wrappers.
- Wire Andrew's personal Home Manager module through the new Claude Code module.
- Make Codex's wrapper prompt/MCP defaults configurable so Home Manager can drive them.

## Validation
- `nix run .#lint`
- `nix eval --json --impure --expr <Home Manager composition smoke test>`
- `nix eval .#packages.x86_64-linux.check.drvPath`

Refs #1661

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Home Manager modules for claude-code and codex agents with configurable defaults
> - Adds new Home Manager modules in [packages/agent/home-manager/](https://github.com/indexable-inc/index/pull/1662/files#diff-863fafc69794c8a4b3e6586ef386bcbe306efa46c22ad196e4843491be04d06a) for `programs.claude-code` and `programs.codex`, exposing options for system prompt, MCP servers, hooks, and soft/forced settings.
> - The codex wrapper in [packages/agent/codex/default.nix](https://github.com/indexable-inc/index/pull/1662/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5) now conditionally injects `model_instructions_file` only when a system prompt or explicit path is provided, rather than unconditionally.
> - Both modules compute a `finalPackage` with overridable defaults and expose it for use in home configurations; the codex module also materializes `hooks.json` into the configured config directory when `installHooks` is enabled.
> - The andrewgazelka home config in [users/andrewgazelka/home.nix](https://github.com/indexable-inc/index/pull/1662/files#diff-b9c7bb705f699ec210f648820aef5c561583845b682d07d6e1dc19de7685cb0f) is updated to use `config.programs.claude-code.finalPackage` instead of a direct package override.
> - Behavioral Change: codex wrappers built without an explicit `systemPrompt` or `modelInstructionsFile` no longer include `model_instructions_file` in their soft config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 506c011.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->