### PR TITLE
agent: structure home-manager prompt settings

### DIFF
--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -10,6 +10,11 @@ let
   jsonFormat = pkgs.formats.json { };
   pathLike = lib.types.either lib.types.path lib.types.str;
   indexPkgs = indexPackages pkgs.stdenv.hostPlatform.system;
+  systemPromptSource = lib.types.enum [
+    "house"
+    "stock"
+    "text"
+  ];
 
   optionalOverride =
     condition: name: value:
@@ -18,16 +23,16 @@ let
     inherit (cfg)
       addDirs
       dangerouslySkipPermissions
-      omitRules
       personalStartupContext
       pluginDirs
       primaryCheckouts
       ;
+    omitRules = cfg.systemPrompt.omitRules;
     extraSettings = cfg.defaults;
   }
   // optionalOverride (cfg.defaultMcpServers != null) "mcpServers" cfg.defaultMcpServers
-  // optionalOverride (cfg.systemPrompt != null) "systemPrompt" cfg.systemPrompt
-  // optionalOverride cfg.useStockSystemPrompt "systemPrompt" null;
+  // optionalOverride (cfg.systemPrompt.source == "text") "systemPrompt" cfg.systemPrompt.text
+  // optionalOverride (cfg.systemPrompt.source == "stock") "systemPrompt" null;
   defaultedPackage = cfg.basePackage.override packageOverrides;
 in
 {
@@ -93,34 +98,56 @@ in
       '';
     };
 
-    omitRules = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "Rule names omitted from the default house system prompt.";
-    };
-
     systemPrompt = lib.mkOption {
-      type = lib.types.nullOr lib.types.lines;
-      default = null;
-      description = ''
-        Replacement Claude Code system prompt. Null keeps the package default
-        house prompt. Set {option}`programs.claude-code.useStockSystemPrompt` to
-        run Claude Code without the house prompt wrapper.
-      '';
-    };
+      type = lib.types.submodule {
+        options = {
+          source = lib.mkOption {
+            type = systemPromptSource;
+            default = "house";
+            description = ''
+              Which system prompt the wrapper bakes: `house` renders the
+              structured house prompt, `stock` bakes no prompt flag, and `text`
+              uses {option}`programs.claude-code.systemPrompt.text`.
+            '';
+          };
 
-    useStockSystemPrompt = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Do not bake the house system prompt into the Claude Code wrapper.";
+          text = lib.mkOption {
+            type = lib.types.nullOr lib.types.lines;
+            default = null;
+            description = ''
+              Replacement Claude Code system prompt when
+              {option}`programs.claude-code.systemPrompt.source` is `text`.
+            '';
+          };
+
+          omitRules = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = ''
+              Rule names omitted from the generated house system prompt. Only
+              valid when {option}`programs.claude-code.systemPrompt.source` is
+              `house`.
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Structured control for the system prompt baked into the Claude Code
+        wrapper.
+      '';
     };
   };
 
   config = {
     assertions = [
       {
-        assertion = !(cfg.useStockSystemPrompt && cfg.systemPrompt != null);
-        message = "programs.claude-code: systemPrompt and useStockSystemPrompt are mutually exclusive.";
+        assertion = (cfg.systemPrompt.source == "text") == (cfg.systemPrompt.text != null);
+        message = "programs.claude-code.systemPrompt: source = \"text\" requires text, and text requires source = \"text\".";
+      }
+      {
+        assertion = cfg.systemPrompt.source == "house" || cfg.systemPrompt.omitRules == [ ];
+        message = "programs.claude-code.systemPrompt.omitRules only applies when source = \"house\".";
       }
     ];
 

--- a/packages/agent/home-manager/codex.nix
+++ b/packages/agent/home-manager/codex.nix
@@ -11,6 +11,12 @@ let
   jsonFormat = pkgs.formats.json { };
   pathLike = lib.types.either lib.types.path lib.types.str;
   indexPkgs = indexPackages pkgs.stdenv.hostPlatform.system;
+  systemPromptSource = lib.types.enum [
+    "house"
+    "stock"
+    "text"
+    "file"
+  ];
 
   optionalOverride =
     condition: name: value:
@@ -25,10 +31,11 @@ let
   }
   // optionalOverride (cfg.mcpServers != null) "mcpServers" cfg.mcpServers
   // optionalOverride (
-    cfg.modelInstructionsFile != null
-  ) "modelInstructionsFile" cfg.modelInstructionsFile
-  // optionalOverride (cfg.systemPrompt != null) "systemPrompt" cfg.systemPrompt
-  // optionalOverride cfg.disableModelInstructions "systemPrompt" null;
+    cfg.systemPrompt.source == "file"
+  ) "modelInstructionsFile" cfg.systemPrompt.file
+  // optionalOverride (cfg.systemPrompt.source == "text") "systemPrompt" cfg.systemPrompt.text
+  // optionalOverride (cfg.systemPrompt.source == "stock") "systemPrompt" null
+  // optionalOverride (cfg.systemPrompt.source == "house") "omitRules" cfg.systemPrompt.omitRules;
   finalPackage = cfg.basePackage.override packageOverrides;
 in
 {
@@ -97,28 +104,54 @@ in
       '';
     };
 
-    modelInstructionsFile = lib.mkOption {
-      type = lib.types.nullOr pathLike;
-      default = null;
-      description = ''
-        Existing file to use for Codex's {option}`model_instructions_file`.
-        Null keeps the package default generated from the house prompt.
-      '';
-    };
-
     systemPrompt = lib.mkOption {
-      type = lib.types.nullOr lib.types.lines;
-      default = null;
-      description = ''
-        Replacement Codex model instructions text. Null keeps the package
-        default house prompt.
-      '';
-    };
+      type = lib.types.submodule {
+        options = {
+          source = lib.mkOption {
+            type = systemPromptSource;
+            default = "house";
+            description = ''
+              Which model instructions the wrapper bakes: `house` renders the
+              structured house prompt, `stock` bakes no default instructions,
+              `text` materializes {option}`programs.codex.systemPrompt.text`,
+              and `file` points at {option}`programs.codex.systemPrompt.file`.
+            '';
+          };
 
-    disableModelInstructions = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Do not bake a {option}`model_instructions_file` default into the Codex wrapper.";
+          text = lib.mkOption {
+            type = lib.types.nullOr lib.types.lines;
+            default = null;
+            description = ''
+              Replacement Codex model instructions when
+              {option}`programs.codex.systemPrompt.source` is `text`.
+            '';
+          };
+
+          file = lib.mkOption {
+            type = lib.types.nullOr pathLike;
+            default = null;
+            description = ''
+              Existing file to use for Codex's {option}`model_instructions_file`
+              when {option}`programs.codex.systemPrompt.source` is `file`.
+            '';
+          };
+
+          omitRules = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = ''
+              Rule names omitted from the generated house system prompt. Only
+              valid when {option}`programs.codex.systemPrompt.source` is
+              `house`.
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Structured control for the system prompt rendered as Codex model
+        instructions.
+      '';
     };
 
     installHooks = lib.mkOption {
@@ -137,13 +170,16 @@ in
   config = {
     assertions = [
       {
-        assertion =
-          lib.count (x: x) [
-            cfg.disableModelInstructions
-            (cfg.modelInstructionsFile != null)
-            (cfg.systemPrompt != null)
-          ] <= 1;
-        message = "programs.codex: choose only one of disableModelInstructions, modelInstructionsFile, or systemPrompt.";
+        assertion = (cfg.systemPrompt.source == "text") == (cfg.systemPrompt.text != null);
+        message = "programs.codex.systemPrompt: source = \"text\" requires text, and text requires source = \"text\".";
+      }
+      {
+        assertion = (cfg.systemPrompt.source == "file") == (cfg.systemPrompt.file != null);
+        message = "programs.codex.systemPrompt: source = \"file\" requires file, and file requires source = \"file\".";
+      }
+      {
+        assertion = cfg.systemPrompt.source == "house" || cfg.systemPrompt.omitRules == [ ];
+        message = "programs.codex.systemPrompt.omitRules only applies when source = \"house\".";
       }
     ];
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -194,13 +194,14 @@ let
           };
           programs.claude-code = {
             enable = true;
-            omitRules = [ "reportToPlaybook" ];
+            systemPrompt.omitRules = [ "reportToPlaybook" ];
             personalStartupContext = true;
           };
           programs.codex = {
             enable = true;
             configDir = ".config/codex-test";
             defaults.agents.max_depth = 4;
+            systemPrompt.omitRules = [ "reportToPlaybook" ];
           };
         }
       ];
@@ -3606,6 +3607,13 @@ let
           value = "4";
         } homeAgentConfig.programs.codex.finalPackage.passthru.specValue.soft;
         message = "Codex Home Manager module should pass soft settings through the package wrapper";
+      }
+      {
+        assertion =
+          !lib.strings.hasInfix "Publish durable writeups" (
+            builtins.readFile homeAgentConfig.programs.codex.finalPackage.passthru.modelInstructionsFile
+          );
+        message = "Codex Home Manager module should thread systemPrompt.omitRules into the package wrapper";
       }
     ];
 


### PR DESCRIPTION
## Summary
- restructure Claude Code Home Manager prompt settings under `systemPrompt`
- restructure Codex Home Manager prompt settings under `systemPrompt`, including `omitRules`, text, stock, and file sources
- update eval coverage for nested `systemPrompt.omitRules`

## Checks
- `nix run .#lint`
- targeted Home Manager evals for `systemPrompt.source = "text"`, `"stock"`, and nested `omitRules`

Refs #1665

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure home-manager system prompt settings into a submodule for claude-code and codex
> - Replaces top-level `systemPrompt`, `omitRules`, `useStockSystemPrompt`, `modelInstructionsFile`, and `disableModelInstructions` options in [claude-code.nix](https://github.com/indexable-inc/index/pull/1666/files#diff-b941f4c92dd8de3d70290f80abe17e83e8710287c6a7430cad3d5f1c81cdbdab) and [codex.nix](https://github.com/indexable-inc/index/pull/1666/files#diff-fa4eb9472b4a8e65174c3cc1db7317dbe279f7d3c22a5a688cdb437e2a6e6628) with a single `systemPrompt` submodule containing `source`, `text`, `file`, and `omitRules` fields.
> - The `source` enum (`house`, `stock`, `text`, and `file` for codex) controls which prompt is used; the package wrapper derives the correct override from this structured value.
> - Assertions enforce that `text` is set iff `source=="text"`, `file` is set iff `source=="file"`, and `omitRules` is only non-empty when `source=="house"`.
> - Risk: this is a breaking schema change — existing configs using the old top-level options will fail to evaluate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6bade7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->