### PR TITLE
agent: add pi fusion harness

### DIFF
--- a/doc/pi-harnesses/overview.md
+++ b/doc/pi-harnesses/overview.md
@@ -13,6 +13,7 @@ launcher.
 | `base/` | `pi-base` | base UX pack: live tok/s, git status widget, `/diff`, `/lg`. No agent behavior change. |
 | `prosecutor/` | `pi-prosecutor` | executor under a skeptical, context-isolated supervisor with earned-trust check-ins. |
 | `beam/` | `pi-beam` | executor that turns a hard decision into a bounded [beam search](beam.md) over isolated worktree branches. |
+| `fusion/` | `pi-fusion` | Fable primary agent delegating bounded work to a `gpt-5.5` low sidekick. |
 
 This is ONE component directory; each member package is documented here, with the
 beam-search executor on its own page ([beam.md](beam.md)).
@@ -45,18 +46,20 @@ template `wrapper.sh.in` resolves the model alias to `PI_PROVIDER`/`PI_MODEL`/
 
 One canonical table (`shared/models.nix`): `claude` = anthropic
 `claude-opus-4-8` (no thinking level; 4.8 is adaptive-only), `codex` = openai
-`gpt-5.5` at `thinking = medium`. Aliases map straight to `pi --provider --model
-[--thinking]`. API keys are NOT stored here: each harness receives them from the
-caller's environment (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`) and Pi reads the
-named var itself. The harness owns model selection only, not secret lookup. The
-engine keeps its own copy (`engine/models.nix`) rendered into C until the two
-converge.
+`gpt-5.5` at `thinking = medium`, `fable` = anthropic `fable-5`, and
+`codex-low` = openai `gpt-5.5` at `thinking = low`. Aliases map straight to
+`pi --provider --model [--thinking]`. API keys are NOT stored here: each harness
+receives them from the caller's environment (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`)
+and Pi reads the named var itself. The harness owns model selection only, not
+secret lookup. The engine keeps its own copy (`engine/models.nix`) rendered into
+C until the two converge.
 
 Select a model per run with `PI_HARNESS_MODEL`:
 
 ```
 nix run .#pi-prosecutor -- "your task"               # claude (opus-4-8)
 PI_HARNESS_MODEL=codex nix run .#pi-beam -- "..."    # gpt-5.5 medium
+nix run .#pi-fusion -- "your task"                   # fable primary + gpt-5.5 low sidekick
 ```
 
 ## engine (`pi-harness`)
@@ -145,6 +148,13 @@ the first user message). Built via `mk-pi-harness.nix` with `lockdown = false`
 ## beam (`pi-beam`)
 
 The bounded beam-search executor: see [beam.md](beam.md).
+
+## fusion (`pi-fusion`)
+
+Fusion-style primary/sidekick harness (`fusion/README.md`). The primary defaults
+to `fable` and gets a `delegate` tool for bounded sidekick work. The sidekick
+defaults to OpenAI `gpt-5.5` with `thinking=low`, runs headless in an isolated
+worktree, and returns a summary plus patch for the primary to review/apply.
 
 ## Building
 

--- a/packages/agent/pi-harnesses/README.md
+++ b/packages/agent/pi-harnesses/README.md
@@ -17,6 +17,7 @@ pi-harnesses/
   base/                   # id: pi-base       - base UX pack: live tok/s, git widget, /diff, /lg
   prosecutor/             # id: pi-prosecutor - executor under a skeptical, earned-trust supervisor
   beam/                   # id: pi-beam       - executor with beam search over isolated worktree branches
+  fusion/                 # id: pi-fusion     - primary agent delegating to a gpt-5.5-low sidekick
 ```
 
 `engine/` is the original `packages/pi-harness` (ENG-2261/2262), moved here
@@ -45,6 +46,7 @@ work and the child agents must probe real state.
 ```
 nix run .#pi-prosecutor -- "your task"          # opus-4-8 executor + prosecutor (same model)
 nix run .#pi-beam       -- "your task"
+nix run .#pi-fusion     -- "your task"          # fable-5 primary + gpt-5.5-low sidekick
 PI_HARNESS_MODEL=codex nix run .#pi-prosecutor -- "..."   # gpt-5.5 medium
 ```
 

--- a/packages/agent/pi-harnesses/fusion/README.md
+++ b/packages/agent/pi-harnesses/fusion/README.md
@@ -1,0 +1,50 @@
+# pi-fusion
+
+Pi primary agent with a delegated sidekick model.
+
+## How it works
+
+1. The primary session runs on the normal harness model alias, defaulting to
+   `fable` (`fable-5`).
+2. The primary delegates bounded work with
+   `delegate({ task, acceptance?, mode?, timeoutSec? })`.
+3. The sidekick runs as a headless Pi worker, defaulting to OpenAI `gpt-5.5`
+   with `thinking=low`.
+4. The sidekick works in an isolated git worktree off `HEAD`, returns a concise
+   summary plus a patch, and the primary decides whether to apply or revise it.
+
+The intended posture is Fusion-style: the primary should do planning,
+ambiguity-resolution, monitoring, and final review; the sidekick should do bulk
+inspection, mechanical edits, and test loops.
+
+## Config
+
+- `PI_HARNESS_MODEL` - primary model alias; defaults to `fable`.
+- `PI_FUSION_SIDEKICK_MODEL` - sidekick model id; defaults to `gpt-5.5`.
+- `PI_FUSION_SIDEKICK_PROVIDER` - sidekick provider; defaults to `openai`.
+- `PI_FUSION_SIDEKICK_THINKING` - sidekick thinking level; defaults to `low`.
+- `PI_FUSION_GOAL` - optional explicit goal; otherwise captured from the first
+  user message.
+
+Sonnet can be tried later without changing the harness:
+
+```
+PI_FUSION_SIDEKICK_PROVIDER=anthropic \
+PI_FUSION_SIDEKICK_MODEL=sonnet-5 \
+PI_FUSION_SIDEKICK_THINKING= \
+nix run .#pi-fusion -- "your task"
+```
+
+## Run
+
+```
+ANTHROPIC_API_KEY=... OPENAI_API_KEY=... nix run .#pi-fusion -- "make the failing test pass"
+```
+
+## Current limit
+
+This first cut delegates headless sidekick turns and keeps sidekick file changes
+isolated until the primary applies the returned patch. It does not yet keep a
+durable sidekick process with a cached long-lived context. The next step is to
+replace `runner/sidekick.js` with a session runner while preserving the same
+`delegate` tool contract.

--- a/packages/agent/pi-harnesses/fusion/default.nix
+++ b/packages/agent/pi-harnesses/fusion/default.nix
@@ -1,0 +1,36 @@
+{
+  callPackage,
+  git,
+  ix,
+  pi-coding-agent,
+  # Pinned bare pi binary (see the shared mk-pi-harness.nix). Override here
+  # to swap the pi the wrapper execs.
+  pi ? pi-coding-agent,
+}:
+let
+  shared = ix.paths.packagesRoot + "/agent/pi-harnesses/shared";
+  mkPiHarness = callPackage (shared + "/mk-pi-harness.nix") { inherit pi; };
+  models = import (shared + "/models.nix");
+in
+mkPiHarness {
+  name = "pi-fusion";
+  description = "Pi primary agent with a delegated gpt-5.5-low sidekick.";
+
+  extensions = [ ./extension/fusion.ts ];
+  libFiles = [
+    ./runner/sidekick.js
+  ];
+
+  inherit models;
+  defaultModel = "fable";
+
+  # The primary keeps a limited-but-real tool surface: it delegates bulk work,
+  # monitors results, and applies/rejects patches.
+  lockdown = false;
+  session = true;
+
+  runtimeInputs = [ git ];
+
+  checkFiles = [ ./test/sidekick.test.mjs ];
+  checkLib = [ ./runner/sidekick.js ];
+}

--- a/packages/agent/pi-harnesses/fusion/extension/fusion.ts
+++ b/packages/agent/pi-harnesses/fusion/extension/fusion.ts
@@ -1,0 +1,117 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const delegateSchema = {
+  type: "object",
+  properties: {
+    task: {
+      type: "string",
+      description: "The concrete work to delegate to the sidekick.",
+    },
+    acceptance: {
+      type: "string",
+      description: "Optional check, command, or success criteria for the sidekick.",
+    },
+    mode: {
+      type: "string",
+      enum: ["edit", "inspect"],
+      default: "edit",
+      description: "Use inspect for research-only delegation; edit allows file changes in the sidekick worktree.",
+    },
+    timeoutSec: {
+      type: "integer",
+      default: 300,
+      description: "Hard wall-clock cap for the sidekick run.",
+    },
+  },
+  required: ["task"],
+  additionalProperties: false,
+} as const;
+
+function sidekickSelection() {
+  const alias = process.env.PI_FUSION_SIDEKICK_ALIAS ?? "codex-low";
+  return {
+    alias,
+    provider: process.env.PI_FUSION_SIDEKICK_PROVIDER ?? "openai",
+    model: process.env.PI_FUSION_SIDEKICK_MODEL ?? "gpt-5.5",
+    thinking: process.env.PI_FUSION_SIDEKICK_THINKING ?? "low",
+  };
+}
+
+export default function (pi: ExtensionAPI): void {
+  let goal = process.env.PI_FUSION_GOAL ?? "";
+
+  pi.on("agent_start", (event: any) => {
+    if (goal) return;
+    const messages = event?.messages;
+    if (!Array.isArray(messages)) return;
+    const first = messages.find((m: any) => m?.role === "user");
+    if (first && typeof first.content === "string") goal = first.content;
+  });
+
+  const updateStatus = (ctx: any) => {
+    if (!ctx?.hasUI) return;
+    const theme = ctx.ui.theme;
+    const sidekick = sidekickSelection();
+    ctx.ui.setStatus(
+      "fusion",
+      theme.fg("accent", "fusion") + " " + theme.fg("dim", "sidekick " + sidekick.alias),
+    );
+  };
+
+  pi.on("session_start", (_event: any, ctx: any) => updateStatus(ctx));
+
+  pi.registerTool({
+    name: "delegate",
+    description:
+      "Delegate bounded work to the fusion sidekick. The primary agent should use this for bulk edits, broad inspection, and test loops, then review the returned summary and patch before applying anything.",
+    parameters: delegateSchema as never,
+    async execute(_toolCallId: string, params: any, _signal: unknown, _onUpdate: unknown, ctx: any) {
+      if (ctx?.hasUI) ctx.ui.setWorkingMessage("fusion sidekick working...");
+      const root = await pi
+        .exec("git", ["rev-parse", "--show-toplevel"], { timeout: 10000 })
+        .then((r: any) => r.stdout.trim())
+        .catch(() => "");
+      const repoRoot = root || ctx?.cwd;
+      const sidekick = sidekickSelection();
+
+      try {
+        const { runSidekick, formatSidekickResult } = await import("./lib/sidekick.js");
+        const result = await runSidekick({
+          goal,
+          task: params.task,
+          acceptance: params.acceptance,
+          mode: params.mode ?? "edit",
+          repoRoot,
+          provider: sidekick.provider,
+          model: sidekick.model,
+          thinking: sidekick.thinking,
+          timeoutSec: params.timeoutSec ?? 300,
+          isolatedWorktree: true,
+        });
+
+        pi.appendEntry("fusion", {
+          goal,
+          task: params.task,
+          acceptance: params.acceptance,
+          mode: params.mode ?? "edit",
+          sidekick,
+          exitCode: result.exitCode,
+          diffLines: result.diffLines,
+        });
+
+        if (ctx?.hasUI) {
+          const level = result.exitCode === 0 ? "info" : "warning";
+          ctx.ui.notify("Sidekick returned " + result.diffLines + " diff line(s)", level);
+        }
+
+        return {
+          content: [{ type: "text", text: formatSidekickResult(result) }],
+          details: { isError: result.exitCode !== 0 },
+        };
+      } finally {
+        if (ctx?.hasUI) ctx.ui.setWorkingMessage(undefined);
+        updateStatus(ctx);
+      }
+    },
+  });
+}

--- a/packages/agent/pi-harnesses/fusion/package.nix
+++ b/packages/agent/pi-harnesses/fusion/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "pi-fusion";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+}

--- a/packages/agent/pi-harnesses/fusion/runner/sidekick.js
+++ b/packages/agent/pi-harnesses/fusion/runner/sidekick.js
@@ -1,0 +1,132 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function sh(cmd, args, opts = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, opts);
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (d) => {
+      stdout += d;
+    });
+    child.stderr?.on("data", (d) => {
+      stderr += d;
+    });
+    child.on("error", (err) => resolve({ code: 127, stdout, stderr: String(err) }));
+    child.on("close", (code) => resolve({ code: code ?? 0, stdout, stderr }));
+  });
+}
+
+export function buildSidekickPrompt({ goal, task, acceptance, mode }) {
+  const parts = [
+    "Goal: " + (goal || "(not captured)"),
+    "",
+    "Delegated task: " + task,
+    "",
+    "You are the sidekick worker in a fusion harness. Do the delegated work, gather only the context you need, and keep the primary agent's context clean.",
+    "Prefer small, directly relevant changes. Run cheap verification when possible.",
+  ];
+  if (acceptance) {
+    parts.push("", "Acceptance check or success criteria: " + acceptance);
+  }
+  if (mode === "inspect") {
+    parts.push("", "Inspection mode: do not edit files. Return findings, risks, and the exact files or commands the primary should inspect.");
+  } else {
+    parts.push("", "Edit mode: make the necessary file changes. End with a concise summary and the commands you ran.");
+  }
+  return parts.join("\n");
+}
+
+export function countDiffLines(numstat) {
+  return numstat
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .reduce((total, line) => {
+      const [added, removed] = line.split("\t");
+      const a = Number.parseInt(added, 10);
+      const r = Number.parseInt(removed, 10);
+      return total + (Number.isFinite(a) ? a : 0) + (Number.isFinite(r) ? r : 0);
+    }, 0);
+}
+
+export function formatSidekickResult(result) {
+  const status = result.exitCode === 0 ? "completed" : "failed (exit " + result.exitCode + ")";
+  const patch = result.patch?.trim() ? result.patch : "(no file changes produced)";
+  const summary = result.stdout?.trim() ? result.stdout.trim().slice(-4000) : "(no sidekick stdout)";
+  const stderr = result.stderr?.trim() ? "\n\n--- sidekick stderr ---\n" + result.stderr.trim().slice(-2000) : "";
+  return (
+    "Sidekick " + status + ". Diff lines: " + result.diffLines + ".\n\n" +
+    "--- sidekick summary ---\n" + summary + stderr + "\n\n" +
+    "--- sidekick patch ---\n" + patch
+  );
+}
+
+export async function runSidekick({
+  goal,
+  task,
+  acceptance,
+  mode = "edit",
+  repoRoot,
+  provider,
+  model,
+  thinking,
+  timeoutSec = 300,
+  isolatedWorktree = true,
+}) {
+  const cwd = repoRoot;
+  const prompt = buildSidekickPrompt({ goal, task, acceptance, mode });
+  let worktree = cwd;
+  let tempDir;
+  let addedWorktree = false;
+
+  if (isolatedWorktree) {
+    tempDir = await mkdtemp(join(tmpdir(), "fusion-sidekick-"));
+    const added = await sh("git", ["-C", cwd, "worktree", "add", "-q", "--detach", tempDir, "HEAD"]);
+    if (added.code !== 0) {
+      return {
+        exitCode: added.code,
+        stdout: "",
+        stderr: "worktree add failed: " + added.stderr,
+        diffLines: 0,
+        patch: "",
+        prompt,
+      };
+    }
+    worktree = tempDir;
+    addedWorktree = true;
+  }
+
+  try {
+    const piArgs = ["--print"];
+    if (provider) piArgs.push("--provider", provider);
+    if (model) piArgs.push("--model", model);
+    if (thinking) piArgs.push("--thinking", thinking);
+    piArgs.push(prompt);
+
+    const sidekick = await sh("timeout", [String(timeoutSec) + "s", "pi", ...piArgs], {
+      cwd: worktree,
+      env: process.env,
+    });
+    const diff = await sh("git", ["-C", worktree, "diff", "--no-color"]);
+    const numstat = await sh("git", ["-C", worktree, "diff", "--numstat"]);
+
+    return {
+      exitCode: sidekick.code,
+      stdout: sidekick.stdout,
+      stderr: sidekick.stderr,
+      diffLines: countDiffLines(numstat.stdout),
+      patch: diff.stdout,
+      prompt,
+    };
+  } finally {
+    if (addedWorktree) {
+      await sh("git", ["-C", cwd, "worktree", "remove", "--force", worktree]);
+    }
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+}

--- a/packages/agent/pi-harnesses/fusion/test/sidekick.test.mjs
+++ b/packages/agent/pi-harnesses/fusion/test/sidekick.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildSidekickPrompt, countDiffLines, formatSidekickResult } from "./sidekick.js";
+
+test("buildSidekickPrompt includes goal, task, acceptance, and mode", () => {
+  const prompt = buildSidekickPrompt({
+    goal: "ship fusion",
+    task: "edit the harness",
+    acceptance: "nix build passes",
+    mode: "inspect",
+  });
+  assert.match(prompt, /Goal: ship fusion/);
+  assert.match(prompt, /Delegated task: edit the harness/);
+  assert.match(prompt, /Acceptance check or success criteria: nix build passes/);
+  assert.match(prompt, /Inspection mode: do not edit files/);
+});
+
+test("countDiffLines sums text numstat rows and ignores binary markers", () => {
+  assert.equal(countDiffLines("3\t2\tfoo.ts\n-\t-\timage.png\n10\t0\tbar.js\n"), 15);
+});
+
+test("formatSidekickResult includes empty patch marker", () => {
+  const text = formatSidekickResult({
+    exitCode: 0,
+    stdout: "done",
+    stderr: "",
+    diffLines: 0,
+    patch: "",
+  });
+  assert.match(text, /Sidekick completed/);
+  assert.match(text, /\(no file changes produced\)/);
+});

--- a/packages/agent/pi-harnesses/shared/models.nix
+++ b/packages/agent/pi-harnesses/shared/models.nix
@@ -23,4 +23,20 @@
     thinking = "medium";
     apiKeyEnv = "OPENAI_API_KEY";
   };
+
+  # Fable primary for fusion-style harnesses. Kept as a normal alias so model
+  # availability can move without changing harness logic.
+  fable = {
+    provider = "anthropic";
+    model = "fable-5";
+    apiKeyEnv = "ANTHROPIC_API_KEY";
+  };
+
+  # Cheap delegated worker for fusion-style harnesses.
+  codex-low = {
+    provider = "openai";
+    model = "gpt-5.5";
+    thinking = "low";
+    apiKeyEnv = "OPENAI_API_KEY";
+  };
 }


### PR DESCRIPTION
## Summary
- add a new `pi-fusion` harness with a Fable primary and delegated sidekick tool
- add `fable` and `codex-low` model aliases, with `gpt-5.5` low as the default sidekick
- document interactive usage and the current limitation that sidekick work is headless/isolated, not yet a durable cached sidekick session

## Interactive usage
```sh
# Open the interactive TUI with the default Fable primary and gpt-5.5-low sidekick
nix run .#pi-fusion

# Start interactively with an initial task
nix run .#pi-fusion -- "make the failing test pass"

# Try a different sidekick later, without changing the harness
PI_FUSION_SIDEKICK_PROVIDER=anthropic \
PI_FUSION_SIDEKICK_MODEL=sonnet-5 \
PI_FUSION_SIDEKICK_THINKING= \
nix run .#pi-fusion -- "make the failing test pass"
```

Inside the session, the primary model gets a `delegate` tool. Use it for bounded sidekick work; the sidekick returns a summary plus patch from an isolated worktree for the primary to review/apply.

## Validation
- `nix build .#pi-fusion --show-trace`
- `./result/bin/pi-fusion --help`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pi-fusion harness with a primary/sidekick agent delegation tool
> - Introduces a new `pi-fusion` harness ([fusion/default.nix](https://github.com/indexable-inc/index/pull/1668/files#diff-81fb3df964dbefad3f69c6f7073a3569c6d15e16119fa1bb29a1b101b441ab1a)) that exposes a `delegate` tool allowing the primary agent to spin up a headless sidekick agent for subtasks.
> - The sidekick ([runner/sidekick.js](https://github.com/indexable-inc/index/pull/1668/files#diff-c24e34c6fa5535cedf212d26b69ce5061fd6238cffa2b7d20b0a0fa45f4f72b0)) runs in an isolated git worktree with a configurable timeout, collects stdout/stderr, computes a unified diff, and returns a structured result with diff line count.
> - The fusion extension ([extension/fusion.ts](https://github.com/indexable-inc/index/pull/1668/files#diff-a0f1128b3058a0e72f08de3b04acc82ebdff97a1b9ebad72a88dc27bebcd87b7)) reads sidekick provider/model/thinking from environment variables, defaulting to `codex-low` (openai `gpt-5.5`, thinking=low), and updates UI status with fusion and sidekick alias.
> - Adds `fable` and `codex-low` model aliases to the shared model table in [shared/models.nix](https://github.com/indexable-inc/index/pull/1668/files#diff-8c3ff77bd3f53b8d36106cb062322084e095b604e1669ca5308a7816154b1c8e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15f993c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->