### PR TITLE
fix(symphony): recover completed subrun parents

### DIFF
--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/attempt.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/attempt.ex
@@ -5,10 +5,11 @@ defmodule SymphonyElixir.IR.Attempt do
   whether a node was retried, by which engine, at what cost, and how each
   attempt ended.
 
-  `thread_id` is the room-server thread/session handle for the attempt.
-  It is the reattach probe used on restart: a node found `:running` after
-  a BEAM restart is reconciled by asking the engine for the status of
-  this thread (see `IR.Node` and the runtime recovery path).
+  `thread_id` is the durable reattach handle for the attempt. For agent
+  turns it is the room-server thread/session id; for subrun attempts it is
+  the child run id. A node found `:running` after a BEAM restart is
+  reconciled from this handle (see `IR.Node` and the runtime recovery
+  path).
 
   `events_ref` points at the streamed event log for the attempt rather
   than inlining it, so the durable run file stays small.

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime.ex
@@ -175,7 +175,7 @@ defmodule SymphonyElixir.Runtime do
     # first scheduling pass, the BEAM-restart half of #90.
     state =
       if Keyword.get(opts, :recover, false) do
-        recovered = Recovery.reconcile(graph, fn thread_id -> state.engine.status(thread_id) end)
+        recovered = Recovery.reconcile(graph, fn thread_id -> state.engine.status(thread_id) end, state.store_opts)
         %{state | graph: recovered}
       else
         state
@@ -299,6 +299,13 @@ defmodule SymphonyElixir.Runtime do
         # A monitor we already flushed, or an unrelated process. Ignore.
         {:noreply, state}
     end
+  end
+
+  @impl true
+  def handle_info({:attempt_thread_id, node_id, thread_id}, state) do
+    graph = record_attempt_thread_id(state.graph, node_id, thread_id)
+    persist(graph, state)
+    {:noreply, %{state | graph: graph}}
   end
 
   @impl true
@@ -462,6 +469,8 @@ defmodule SymphonyElixir.Runtime do
   # task and must guard recursion and select its workflow there. The other
   # kinds ignore the subrun keys.
   defp run_opts(state, %Node{kind: :subrun} = node, attempt_n) do
+    runtime = self()
+
     %{
       run_id: state.graph.run_id,
       attempt: attempt_n,
@@ -469,7 +478,8 @@ defmodule SymphonyElixir.Runtime do
       store_opts: state.store_opts,
       subrun_depth: state.subrun_depth,
       subrun_ancestors: state.subrun_ancestors,
-      resolved_inputs: resolve_inputs(state.graph, node)
+      resolved_inputs: resolve_inputs(state.graph, node),
+      on_child_started: fn child_run_id -> send(runtime, {:attempt_thread_id, node.id, child_run_id}) end
     }
   end
 
@@ -662,6 +672,24 @@ defmodule SymphonyElixir.Runtime do
       {:ok, node} ->
         attempts = finish_current_attempt(node.attempts, result, thread_id)
         put_node(graph, %{node | attempts: attempts})
+
+      :error ->
+        graph
+    end
+  end
+
+  defp record_attempt_thread_id(%RunGraph{} = graph, node_id, thread_id) do
+    case Map.fetch(graph.nodes, node_id) do
+      {:ok, %Node{attempts: []}} ->
+        graph
+
+      {:ok, %Node{state: :running, attempts: attempts} = node} ->
+        current = Enum.max_by(attempts, & &1.n)
+        updated = Enum.map(attempts, fn a -> if a.n == current.n, do: %{a | thread_id: thread_id}, else: a end)
+        put_node(graph, %{node | attempts: updated})
+
+      {:ok, _node} ->
+        graph
 
       :error ->
         graph

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/recovery.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/recovery.ex
@@ -41,7 +41,7 @@ defmodule SymphonyElixir.Runtime.Recovery do
   `:unknown` thread falls through to the strand/retry policy.
   """
 
-  alias SymphonyElixir.IR.{Attempt, Graph, Node, RunGraph}
+  alias SymphonyElixir.IR.{Attempt, Graph, Node, RunGraph, Store}
 
   @doc """
   Rebuild a materialized graph from an AST and an expansion log by
@@ -78,14 +78,21 @@ defmodule SymphonyElixir.Runtime.Recovery do
   returned graph has no `:running` nodes; each has moved to `:succeeded`,
   `:failed`, `:retrying`, or `:stranded` by the rules in the moduledoc.
   """
-  @spec reconcile(RunGraph.t(), (String.t() | nil -> term())) :: RunGraph.t()
-  def reconcile(%RunGraph{} = graph, status_fun) when is_function(status_fun, 1) do
+  @spec reconcile(RunGraph.t(), (String.t() | nil -> term()), keyword()) :: RunGraph.t()
+  def reconcile(%RunGraph{} = graph, status_fun, store_opts \\ []) when is_function(status_fun, 1) do
     graph
     |> Graph.running_nodes()
-    |> Enum.reduce(graph, fn node, acc -> reconcile_node(acc, node, status_fun) end)
+    |> Enum.reduce(graph, fn node, acc -> reconcile_node(acc, node, status_fun, store_opts) end)
   end
 
-  defp reconcile_node(%RunGraph{} = graph, %Node{} = node, status_fun) do
+  defp reconcile_node(%RunGraph{} = graph, %Node{} = node, status_fun, store_opts) do
+    case reconcile_subrun(graph, node, store_opts) do
+      {:ok, reconciled} -> reconciled
+      :not_subrun -> reconcile_engine_node(graph, node, status_fun)
+    end
+  end
+
+  defp reconcile_engine_node(%RunGraph{} = graph, %Node{} = node, status_fun) do
     case status_fun.(current_thread_id(node)) do
       :running ->
         # The engine still owns the turn. Leave it :running; the live
@@ -102,6 +109,55 @@ defmodule SymphonyElixir.Runtime.Recovery do
       :unknown ->
         strand_or_retry(graph, node)
     end
+  end
+
+  defp reconcile_subrun(%RunGraph{} = graph, %Node{} = node, store_opts) do
+    case current_attempt(node) do
+      %Attempt{engine: :subrun, thread_id: child_run_id} when is_binary(child_run_id) and child_run_id != "" ->
+        case Store.load(child_run_id, store_opts) do
+          {:ok, %RunGraph{status: status} = child} when status in [:succeeded, :failed, :cancelled] ->
+            result = subrun_result(child)
+
+            reconciled =
+              graph
+              |> mark_attempt(node.id, attempt_state_for(result), result)
+              |> Graph.apply_output(node.id, result)
+
+            {:ok, reconciled}
+
+          {:ok, %RunGraph{}} ->
+            {:ok, strand_or_retry(graph, node)}
+
+          {:error, _reason} ->
+            {:ok, strand_or_retry(graph, node)}
+        end
+
+      %Attempt{engine: :subrun} ->
+        {:ok, strand_or_retry(graph, node)}
+
+      _ ->
+        :not_subrun
+    end
+  end
+
+  defp subrun_result(%RunGraph{status: :succeeded} = child), do: {:ok, subrun_output(child)}
+
+  defp subrun_result(%RunGraph{status: status, run_id: run_id}) when status in [:failed, :cancelled],
+    do: {:error, {:subrun_failed, run_id, status}}
+
+  defp subrun_output(%RunGraph{} = child) do
+    %{
+      kind: :subrun,
+      run_id: child.run_id,
+      status: child.status,
+      outputs: node_outputs(child)
+    }
+  end
+
+  defp node_outputs(%RunGraph{nodes: nodes}) do
+    nodes
+    |> Enum.filter(fn {_id, node} -> node.state == :succeeded end)
+    |> Map.new(fn {id, node} -> {id, node.output} end)
   end
 
   # The thread is gone. The owning task died without a result, so the

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/subrun_runner.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/subrun_runner.ex
@@ -140,8 +140,19 @@ defmodule SymphonyElixir.Runtime.SubrunRunner do
     child_opts = child_opts(name, run_opts)
 
     case Runtime.Ingress.start_workflow(entry, trigger, child_opts) do
-      {:ok, %{run_id: run_id, pid: pid}} -> await_child(run_id, pid, run_opts)
-      {:error, reason} -> {:error, {:subrun_start_failed, name, reason}, nil}
+      {:ok, %{run_id: run_id, pid: pid}} ->
+        notify_child_started(run_id, run_opts)
+        await_child(run_id, pid, run_opts)
+
+      {:error, reason} ->
+        {:error, {:subrun_start_failed, name, reason}, nil}
+    end
+  end
+
+  defp notify_child_started(run_id, run_opts) do
+    case Map.get(run_opts, :on_child_started) do
+      callback when is_function(callback, 1) -> callback.(run_id)
+      _ -> :ok
     end
   end
 

--- a/packages/agent/symphony/elixir/test/symphony_elixir/runtime_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/runtime_test.exs
@@ -578,6 +578,44 @@ defmodule SymphonyElixir.RuntimeTest do
       assert child.status == :succeeded
     end
 
+    test "restart recovery harvests a completed subrun child instead of deadlocking the parent", %{dir: dir} do
+      child =
+        graph("child-after-restart", [
+          node("c", state: :succeeded)
+        ])
+        |> put_in([Access.key!(:nodes), "c", Access.key!(:output)], %{done: true})
+        |> Map.put(:status, :succeeded)
+
+      :ok = Store.persist(child, dir: dir)
+
+      parent =
+        graph("parent-after-restart", [
+          node("s",
+            state: :running,
+            kind: :subrun,
+            envelope: nil,
+            inputs: %{"source" => {:literal, "child.sym"}},
+            attempts: [Attempt.start(1, :subrun, "child-after-restart")]
+          )
+        ])
+
+      :ok = Store.persist(parent, dir: dir)
+
+      {:ok, pid} = Runtime.start_link(parent, opts(dir) ++ [recover: true])
+      wait_for_exit(pid)
+
+      {:ok, final} = Store.load("parent-after-restart", dir: dir)
+      assert final.status == :succeeded
+      assert final.nodes["s"].state == :succeeded
+      assert final.nodes["s"].output.run_id == "child-after-restart"
+      assert final.nodes["s"].output.outputs["c"] == %{done: true}
+
+      [attempt] = final.nodes["s"].attempts
+      assert attempt.engine == :subrun
+      assert attempt.thread_id == "child-after-restart"
+      assert attempt.state == :succeeded
+    end
+
     test "a self-referential subrun is rejected as a cycle without spawning a child", %{dir: dir} do
       ensure_subrun_substrate()
       put_workflow("child", @child_sym)


### PR DESCRIPTION
## Summary
- persist the child run id on subrun attempts as soon as the child starts
- recover running subrun parent nodes by harvesting terminal child run graphs from the store
- add restart regression coverage for a completed child subrun

## Validation
- mix format --check-formatted
- mix test test/symphony_elixir/runtime_test.exs
- mix test

Note: the x86 Nix check could not run locally on this aarch64 host because the derivation requires x86_64-linux.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix symphony subrun recovery to finalize completed child runs on restart
> - During recovery, `Recovery.reconcile` now loads the persisted child run from the store for subrun nodes and finalizes the parent node if the child is in a terminal state (`:succeeded`, `:failed`, `:cancelled`).
> - When a child workflow starts, `SubrunRunner` invokes an optional `on_child_started` callback with the child run ID, which the runtime records as the attempt's `thread_id` so recovery can locate the child run.
> - `record_attempt_thread_id/3` is added to [runtime.ex](https://github.com/indexable-inc/index/pull/1669/files#diff-29653b73216dd3c6b6dd30fcfe071b42e47d55066301de501f6bcfe37c7cfa5e) to safely update the thread_id on the latest running attempt for a node.
> - If a subrun attempt has no `thread_id` or the child run is not yet terminal, the attempt is stranded or retried according to existing retry policies.
> - A test in [runtime_test.exs](https://github.com/indexable-inc/index/pull/1669/files#diff-0c3431901732771843806bfa0873fa6249c0c0e68df33d72711bb98a7b0ce061) verifies that a completed subrun child is harvested from the store and the parent node is finalized without deadlocking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d21862a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->