### PR TITLE
ci: drop redundant extra-system-features from Nix CI config

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -21,12 +21,15 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Client-side eval knobs shared with check.yml; the runner daemon owns the
-  # substituters. See check.yml for the rationale.
+  # Client-side eval knobs shared with check.yml. The ci-dispatcher runs each job
+  # as an untrusted DynamicUser and the daemon owns substituters + system-features,
+  # so any restricted setting specified here is ignored with a warning. We omit
+  # extra-system-features because the znver5 host already advertises
+  # gccarch-znver5 daemon-side (ix hardware/znver5.nix); setting it here only
+  # produced a "restricted setting ... not a trusted user" warning. See check.yml.
   NIX_CONFIG: |-
     experimental-features = nix-command flakes ca-derivations
     accept-flake-config = true
-    extra-system-features = gccarch-znver5
     max-jobs = auto
     cores = 1
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,11 +30,12 @@ env:
   # `accept-flake-config`: consume the flake's nixConfig (the cache.ix.dev
   # substituter) without an interactive prompt.
   #
-  # `extra-system-features = gccarch-znver5`: every image pins
-  # `nixpkgs.hostPlatform.gcc.arch = "znver5"`, marking each derivation in the
-  # closure as needing the `gccarch-znver5` system feature. The runner host
-  # must advertise it (daemon `system-features`); otherwise the build aborts
-  # with `missing system features ... Required features: {gccarch-znver5}`.
+  # We do NOT set `extra-system-features = gccarch-znver5` here: every image
+  # pins `nixpkgs.hostPlatform.gcc.arch = "znver5"`, so each derivation needs
+  # the `gccarch-znver5` system feature -- but the runner host advertises it
+  # daemon-side (ix hardware/znver5.nix), which is the layer Nix actually
+  # consults. As a restricted setting from the untrusted CI runner user it was
+  # ignored regardless, emitting only a "not a trusted user" warning.
   #
   # `max-jobs = auto` builds one derivation per core; `cores = 1` keeps each
   # build single-threaded. The closure is wide, so parallelism comes from
@@ -50,7 +51,6 @@ env:
   NIX_CONFIG: |-
     experimental-features = nix-command flakes ca-derivations
     accept-flake-config = true
-    extra-system-features = gccarch-znver5
     max-jobs = auto
     cores = 1
 


### PR DESCRIPTION
## What

Removes `extra-system-features = gccarch-znver5` from the `NIX_CONFIG` env in both `cache-push.yml` and `check.yml`.

## Why

CI jobs run on the ix ci-dispatcher as an untrusted `DynamicUser` (`trusted-users = ["root" "@wheel"]`), so Nix **discards any client-specified restricted setting** — the dispatcher documents this as intended (`ci-dispatcher/module.nix:382`: *"per-workflow NIX_CONFIG from the CI runner user is ignored. CI hosts own the shared daemon policy."*).

`gccarch-znver5` is already advertised **daemon-side** by the znver5 CI host (`ix hardware/znver5.nix` → `nix.settings.system-features = lib.mkAfter ["gccarch-znver5"]`, pulled in via `vin-compute-1`'s `ovh-scale-a5` hardware class). So the workflow line was pure redundancy that only produced this on every run:

```
warning: ignoring the client-specified setting 'system-features', because it is a restricted setting and you are not a trusted user
```

Because the setting was already being ignored, removing it **cannot change build behavior** — the builds still get `gccarch-znver5` from the daemon exactly as before. Recent cache-push/check runs are green, confirming the daemon provides it.

## Scope / not addressed

The other two warnings —

```
warning: ignoring untrusted substituter 'https://cache.ix.dev', you are not a trusted user.
warning: ignoring the client-specified setting 'trusted-public-keys', ...
```

— are **left in place on purpose**. They originate from `flake.nix`'s own `nixConfig` (the public `cache.ix.dev` front + `ix-workspace` key), which is kept for local-developer convenience. The CI daemon already substitutes the same content internally via `http://cache.ix.dev:8501` and trusts the signing keys, so these are benign. Silencing them would require either dropping the flake's `nixConfig` (regressing local dev) or trusting the CI user (rejected by dispatcher design) — neither is worth it.

## Verification

- Both workflow files parse as valid YAML (`yq eval`).
- No behavior change: the removed setting was already discarded for the untrusted runner user.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop redundant `extra-system-features = gccarch-znver5` from Nix CI config
> Removes the `extra-system-features = gccarch-znver5` line from `NIX_CONFIG` in both [cache-push.yml](https://github.com/indexable-inc/index/pull/1670/files#diff-56c6f531ecd11b28cb14d6aa2ec8abf63b2cb701d82ce2f772c5a324c3bbbfb8) and [check.yml](https://github.com/indexable-inc/index/pull/1670/files#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428). This setting is redundant because the Nix daemon already advertises it, and client-side restricted settings are ignored for untrusted users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8cf45b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->