### PR TITLE
perf(cache-push): publish image toplevel closures, not the OCI tars

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -56,6 +56,10 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Per-phase wall-clock, surfaced as run annotations so a slow phase
+          # (eval / realise / push) is visible without re-timing by hand.
+          phase() { echo "::notice::cache-push phase '$1' took $(( SECONDS - $2 ))s"; }
+
           # The dispatcher exposes the push token as an env-file credential and
           # names it in IX_PUBLIC_PUSH_CREDENTIAL_NAME. Absent => not yet
           # provisioned/deployed; skip without failing (mirrors the old gate).
@@ -98,6 +102,7 @@ jobs:
           # runner PATH carries coreutils + nix but not findutils, so bare
           # `xargs` is `command not found`. (nix-store and nix build come with
           # the runner's nix.)
+          tools_t=$SECONDS
           eval_jobs="$(nix build .#nix-eval-jobs --no-link --print-out-paths)/bin/nix-eval-jobs"
           attic="$(nix build .#attic-client --no-link --print-out-paths)/bin/attic"
           # jq is multi-output; select its `bin` output explicitly so the path
@@ -106,7 +111,16 @@ jobs:
           # findutils is multi-output (out info locate); select `out` (where
           # xargs lives) so the path resolves to a single store path.
           xargs="$(nix build '.#findutils^out' --no-link --print-out-paths)/bin/xargs"
+          phase tools "$tools_t"
 
+          # Enumerate `.#cachePushRoots`, not `.#packages`: it publishes the
+          # closures `ix up` substitutes with the monolithic `*-oci.tar` archives
+          # stripped out (NixOS images reduced to their `toplevel`, the tar-pinning
+          # health-checks dropped in favour of the node closures directly). Each
+          # archive is cold every run (check.yml only eval-validates packages) and,
+          # being one uncompressed blob, never dedups, so building and re-uploading
+          # them used to dominate the run. See lib/per-system.nix.
+          #
           # Publish to ix-public by DERIVATION, not by eval-time output path: a
           # floating content-addressed output (the rust workspace defaults to CA)
           # has no path until it is realised, so nix-eval-jobs reports
@@ -121,12 +135,14 @@ jobs:
           # paths. The shared warm host store keeps this cheap across runs.
           drvs="$workdir/drvs.txt"
           outs="$workdir/outs.txt"
+          eval_t=$SECONDS
           "$eval_jobs" \
-            --flake .#packages.x86_64-linux \
+            --flake .#cachePushRoots.x86_64-linux \
             --workers 16 \
             --max-memory-size 6144 \
             2>"$workdir/eval.err" \
             | "$jq" -r '.drvPath // empty' | sort -u > "$drvs" || true
+          phase eval "$eval_t"
 
           # Realise one drv per invocation (-n1), 16 in parallel (-P16). This is
           # deliberate, not the obvious batch: a single `nix-store --realise` of
@@ -137,12 +153,17 @@ jobs:
           # drops only its own path; --keep-going finishes the rest of that drv's
           # closure; -P16 keeps build/substitute parallelism (matches the eval
           # workers). xargs exits non-zero if any child failed; surfaced below.
+          realise_t=$SECONDS
           "$xargs" -a "$drvs" -r -P16 -n1 nix-store --realise --keep-going > "$outs" 2>"$workdir/realise.err" \
             || echo "::warning::some derivations failed to realise; publishing the rest"
+          phase realise "$realise_t"
 
           if [ -s "$outs" ]; then
-            "$xargs" -a "$outs" -r "$attic" push ix-public \
+            push_t=$SECONDS
+            # --jobs 16 matches the realise fan-out (attic defaults to 5).
+            "$xargs" -a "$outs" -r "$attic" push --jobs 16 ix-public \
               || echo "::warning::some paths failed to push to ix-public"
+            phase push "$push_t"
           else
             echo "::warning::no output paths resolved for ix-public; eval/realise logs follow"
             tail -n 20 "$workdir/eval.err" "$workdir/realise.err" >&2 || true

--- a/flake.nix
+++ b/flake.nix
@@ -356,6 +356,11 @@
       # `recurseForDerivations` groups are not derivations, which the flake
       # `checks` schema requires.
       ciChecks = collect "ciChecks";
+      # CI-only view of `packages` with each NixOS image swapped for its
+      # `toplevel` closure; cache-push.yml publishes this instead of the
+      # monolithic `*-oci.tar` archives, which nothing substitutes. Non-schema,
+      # so surfaced through `collect` like `ciChecks`. See lib/per-system.nix.
+      cachePushRoots = collect "cachePushRoots";
       formatter = collect "formatter";
       apps = collect "apps";
       devShells = collect "devShells";

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1143,9 +1143,9 @@ in
   #      to drag in stay cached without ever building a tar.
   cachePushRoots =
     let
-      isHealthCheck =
-        name:
-        lib.hasPrefix "health-check-" name || name == "health-checks" || name == "health-checks-zellij";
+      # Per-node `health-check-*` lifecycle packages and the two
+      # `health-checks{,-zellij}` runners all share the `health-check` prefix.
+      isHealthCheck = lib.hasPrefix "health-check";
       imagesAsClosures = lib.mapAttrs (_: p: p.passthru.toplevel or p) (
         lib.filterAttrs (name: _: !isHealthCheck name) packageSet
       );

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1088,9 +1088,7 @@ let
         "checks: duplicate names across explicit/rust sets: ${lib.concatStringsSep ", " checkNameCollisions}";
       explicitChecks // rustChecks
     );
-in
-{
-  packages =
+  packageSet =
     lib.optionalAttrs (system == ix.system) {
       base = baseImage;
       vcfs-guest-eval = vcfsGuestEvalImage;
@@ -1125,6 +1123,42 @@ in
     // nonNixExampleDescriptions
     // crossPackages
     // healthChecks.lifecyclePackages;
+in
+{
+  packages = packageSet;
+
+  # CI-only push roots for cache-push.yml. Two adjustments to `packages` keep the
+  # cache useful to `ix up` while cutting the monolithic `*-oci.tar` archives that
+  # dominate the run -- each is one uncompressed blob that never dedups, cold
+  # every run since check.yml only eval-validates packages:
+  #
+  #   1. Every NixOS image is replaced by its `toplevel` closure -- the artifact
+  #      `ix up` substitutes (consumers reconstruct the archive on demand via
+  #      streamLayeredImage). Non-image packages, and non-NixOS OCI images (which
+  #      expose no `toplevel`), pass through unchanged. See lib/image/oci-layer.nix.
+  #   2. The `health-check-*` packages (and the `health-checks{,-zellij}` runners)
+  #      pin every fleet node's OCI *tar* as a build dep (lib/image/health-checks.nix),
+  #      so realising them would rebuild ~all the archives. Drop them and add the
+  #      fleet node `toplevel` closures directly, so the closures those checks used
+  #      to drag in stay cached without ever building a tar.
+  cachePushRoots =
+    let
+      isHealthCheck =
+        name:
+        lib.hasPrefix "health-check-" name || name == "health-checks" || name == "health-checks-zellij";
+      imagesAsClosures = lib.mapAttrs (_: p: p.passthru.toplevel or p) (
+        lib.filterAttrs (name: _: !isHealthCheck name) packageSet
+      );
+      # `fleet.systemPackages` keys each node's toplevel as `<node>-system`; the
+      # fleet-name prefix keeps nodes sharing a name across fleets distinct.
+      exampleNodeToplevels = lib.concatMapAttrs (
+        fleetName: fleet:
+        lib.mapAttrs' (
+          node: toplevel: lib.nameValuePair "${fleetName}-${node}" toplevel
+        ) fleet.systemPackages
+      ) exampleFleets;
+    in
+    imagesAsClosures // exampleNodeToplevels;
 
   # Flat keying: one derivation per `checks.<system>.<name>`, as the flake schema
   # and `nix flake check` require. The `.#check` gate and blast-radius consume


### PR DESCRIPTION
## Problem

`cache-push.yml` realises `.#packages.x86_64-linux` and pushes the closure to `ix-public`. Runs take **45–80 min** (one profiled run, `28532327960`, took 1h19m). The premise is that this is mostly cache hits and should be near-instant — and it is, except for ~39 monolithic `*-oci.tar` archives that blow up both halves of the job:

- **Realise ~36 min** — the archives are cold every run. `check.yml` builds `.#ciChecks` (rust test-sets) and only *eval-validates* `.#packages`, so nothing pre-builds the tars.
- **Push ~27 min** — each archive is one uncompressed blob, so attic's chunker finds ~0 shared chunks and re-uploads the whole thing every run. In `28532327960`'s push, of 611 paths only 42 uploaded real bytes and **39 were `*-oci.tar`**.

Where the tars come from:
- `base` / `vcfs-guest-eval` — direct top-level image packages.
- ~37 fleet-node images — dragged in by the `health-check-*` packages, which pin every node's OCI **tar** as a build dep (`lib/image/health-checks.nix:79,103`) so `nix run .#health-checks` realises them up front.

An `ix up` consumer never pulls the archive: it substitutes the NixOS `toplevel` closure through ncps (`cache.ix.dev:8501`) and reconstructs the image on demand via `streamLayeredImage` (confirmed against the `ix` repo — `ix up .#<node>` resolves `nixosConfigurations.<node>.config.system.build.toplevel`). So the tars are pure waste in this path.

## Change

Add a CI-only `cachePushRoots` flake output (surfaced via `collect`, like `ciChecks`) that publishes the same closures with the archives stripped out:

1. Every NixOS image is reduced to its `passthru.toplevel` closure. Non-image packages and non-NixOS OCI images (no `toplevel`) pass through unchanged.
2. The tar-pinning `health-check-*` / `health-checks{,-zellij}` packages are dropped, and the fleet-node `toplevel` closures are added back directly — so the closures those checks used to drag in stay cached **without ever building a tar**. `lib/image/health-checks.nix` is untouched.

`cache-push.yml` enumerates `.#cachePushRoots` instead of `.#packages`. Also adds per-phase (`tools`/`eval`/`realise`/`push`) timers and `attic push --jobs 16` to match the realise fan-out.

Expected: ~1h20m → a few minutes. Because runs serialize under `concurrency: cache-push` (never-cancel), this also clears the pending pileup.

## Why this is a strict improvement, not a regression

`oci-image-builder` writes **uncompressed** layers (`main.rs:1441`, `mediaType …v1.tar`), so today's tars retain plaintext `/nix/store/…` refs and their closures already carry the toplevel. i.e. cache-push is *already* caching the image closures — via the tars. This change caches those same closures directly and drops only the redundant, never-deduping archive. The 36 added `*-system` node toplevels match the ~37 empirical tar names one-to-one.

## Verification

Local (this darwin host can't build x86_64/znver5, so eval-level only):
- `.#cachePushRoots.x86_64-linux` evaluates: **252 entries, zero `health-check-*`, 36 `*-system` node toplevels added, `base` present**.
- `nixfmt --check` clean; `actionlint` clean (workflow schema + shellcheck of the added bash).

Needs CI / an x86_64 runner:
- A `workflow_dispatch` cache-push run — the new phase timers should show `realise` and `push` collapse, and the push summary's `*-oci.tar` real-uploads should drop to ~0.
- `ix up .#<node>` still substitutes (closure present; only the tar wrapper is gone).

## Note for review

Only the 2 `non-nix-*` OCI images remain pushed as tars — they have no NixOS `toplevel` to substitute them with. They're small, stable prebuilt base images. Easy to drop from the set too if we'd rather not cache them at all.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish toplevel closures instead of OCI tars in cache-push workflow
> - Adds `cachePushRoots` as a new flake output in [flake.nix](https://github.com/indexable-inc/index/pull/1672/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) and [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1672/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683), replacing NixOS image derivations with their `passthru.toplevel` closures and excluding `health-check*` packages.
> - Switches [cache-push.yml](https://github.com/indexable-inc/index/pull/1672/files#diff-56c6f531ecd11b28cb14d6aa2ec8abf63b2cb701d82ce2f772c5a324c3bbbfb8) to evaluate `.#cachePushRoots.x86_64-linux` instead of `.#packages.x86_64-linux`, so OCI tar archives are no longer pushed to the cache.
> - Adds example fleet node toplevels (keyed as `<fleetName>-<node>`) to `cachePushRoots` so those closures are also cached.
> - Adds `--jobs 16` to the `attic push` invocation and emits per-phase timing notices (tools, eval, realise, push) in the workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2efedee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->