### PR TITLE
fix(minecraft-sound): retry CDN connection resets when fetching sounds

### DIFF
--- a/packages/minecraft/minecraft/sound/sounds.nix
+++ b/packages/minecraft/minecraft/sound/sounds.nix
@@ -74,9 +74,12 @@ stdenvNoCC.mkDerivation {
     done
 
     export out
+    # --retry alone only covers timeouts and 408/429/5xx; Mojang's CDN sheds
+    # 16-way parallel load with TLS-level connection resets (curl exit 35),
+    # which need --retry-all-errors to be retried at all.
     xargs -P 16 -n 2 bash -c '
       hash="$1"; name="$2"
-      curl -sSfL --retry 3 \
+      curl -sSfL --retry 5 --retry-all-errors \
         "https://resources.download.minecraft.net/''${hash:0:2}/$hash" \
         -o "$out/sounds/$name"
     ' _ < "$list"

--- a/packages/minecraft/minecraft/sound/sounds.nix
+++ b/packages/minecraft/minecraft/sound/sounds.nix
@@ -79,7 +79,7 @@ stdenvNoCC.mkDerivation {
     # which need --retry-all-errors to be retried at all.
     xargs -P 16 -n 2 bash -c '
       hash="$1"; name="$2"
-      curl -sSfL --retry 5 --retry-all-errors \
+      curl -sSfL --retry 5 --retry-all-errors --retry-max-time 60 \
         "https://resources.download.minecraft.net/''${hash:0:2}/$hash" \
         -o "$out/sounds/$name"
     ' _ < "$list"


### PR DESCRIPTION
Closes #1674

## Problem

Deploying a host failed building `minecraft-sound-assets-26.2`:

```
downloading 4779 Minecraft sounds from Mojang's CDN...
curl: (35) Recv failure: Connection reset by peer
```

The FOD fetches 4779 files with `xargs -P 16` + `curl --retry 3`. Mojang's CDN sheds parallel load with TLS-level connection resets (curl exit 35), and curl's `--retry` only covers "transient" errors (timeouts, 408/429/5xx), so the retry never fires: one reset fails the whole build and the system closure with it. The CDN serves the same objects fine serially.

## Fix

Add `--retry-all-errors` (and bump to `--retry 5`) so resets are retried with curl's default exponential backoff.

## Verification

Built `.#minecraft-sound` from this branch on wyatt-compute-1: all 4779 sounds downloaded, FOD output hash matched (`sha256-W6xyCTkRdd/7VKzUxQ0aNiVD2Gp+xw+jO+Y/yq6pX+E=`), so the previously failing deploy closure is now satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry CDN connection resets when fetching Minecraft sounds
> Increases curl retries from 3 to 5 and adds `--retry-all-errors` and `--retry-max-time 60` to the parallel sound download step in [sounds.nix](https://github.com/indexable-inc/index/pull/1675/files#diff-b7f0d57d5d474bf91a3ed21100111e01cec038b90aa2b042e475cf638e3fa82c). Previously, retries only triggered for timeouts and select HTTP status codes, missing connection resets that occur under parallel load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2dd97a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->