### PR TITLE
system-prompt: name large dep trees and API churn as non-concerns

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -154,6 +154,15 @@ let
       '';
     }
     {
+      dependencyNonConcerns = ''
+        When weighing a dependency or architecture, two non-concerns: a large
+        dependency tree (Nix builds and caches it once; judge runtime properties
+        such as isolation, cancellation, correctness, and fidelity, not compile
+        weight) and upstream API churn (mechanical migrations are cheap for AI
+        agents; judge whether the API is the correct one, not how often it moves).
+      '';
+    }
+    {
       oneImplementation = ''
         Keep one concept to one implementation. Consolidate duplicated logic into one
         composable path.


### PR DESCRIPTION
Names two non-concerns in the agent system prompt so agents stop treating them as blockers when weighing designs or dependencies:

1. A large dependency tree: Nix builds and caches it once; judge runtime properties (isolation, cancellation, correctness, fidelity), not compile weight.
2. Upstream API churn: mechanical migrations are cheap for AI agents; judge whether the API is the correct one, not how often it moves.

One fragment (`dependencyNonConcerns`), placed after `preV1`. Render validated with `nix eval --raw --impure` and `nix run .#lint` passes.

Fixes #1678

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add guidance to system prompt to de-prioritize large dependency trees and API churn as concerns
> Adds a `dependencyNonConcerns` block to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1679/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to judge dependencies by runtime properties (isolation, cancellation, correctness, fidelity) rather than tree size or upstream API churn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0b68cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->