### PR TITLE
system-prompt: machine-readable first, fix the interface not the parse

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -185,6 +185,17 @@ let
       '';
     }
     {
+      machineReadableInterfaces = ''
+        Machine-readable first: prefer structured interfaces end to end, and ask
+        every tool for its structured mode (`--json` and similar) instead of
+        scraping human-oriented text. When a tool we control lacks one, add it
+        upstream (a `--json` flag, structured output) rather than parsing prose:
+        fix the interface, not the parse. Treat any interface friction the same
+        way (a missing flag, missing structured output, missing helper): improve
+        it or file an issue or PR instead of silently working around it.
+      '';
+    }
+    {
       shellCwd = ''
         The kernel `sh()` has no persistent cwd or shell state. Pass `cwd=<abs path>`
         on every call, or use `git -C <worktree>`. Use argv-list form for commands


### PR DESCRIPTION
Adds one `machineReadableInterfaces` fragment to `packages/agent/system-prompt.nix`, placed right after `fixAtSource` (it concretizes that rule for interfaces):

- machine-readable first: prefer structured interfaces end to end, ask every tool for its structured mode (`--json` and similar) instead of scraping human-oriented text
- when a tool we control lacks a structured mode, add it upstream rather than parsing prose: fix the interface, not the parse
- treat interface friction (missing flag, structured output, helper) as something to improve or file/PR, not silently work around

`structuredPrimitives` already covers consuming existing JSON modes in the kernel and `fixAtSource` covers the general fix-upstream principle, so this stays one fragment rather than duplicating either.

Validated: `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'` renders cleanly; `nix run .#lint` 7/7 succeeded.

Fixes #1681

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add system prompt guidance to prefer machine-readable interfaces over parsing human-oriented text
> Adds a new `machineReadableInterfaces` entry to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1682/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to use structured outputs (e.g., `--json` flags) when available, and to add or upstream such interfaces rather than parsing prose output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16827cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->