### PR TITLE
lint: add --json machine-readable output mode

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -139,37 +139,26 @@ let
     '';
   };
 
+  # One stage list drives both the dag spec (default human path) and the
+  # `--json` runner inside `lint`, so adding a stage cannot update one path
+  # and silently miss the other.
+  lintStages = [
+    "nixfmt"
+    "statix"
+    "deadnix"
+    "astlog"
+    "astlog-rust"
+    "astlog-elixir"
+    "ruff"
+  ];
+
   lintSpec = (pkgs.formats.json { }).generate "lint-dag.json" {
-    nodes = {
-      nixfmt.command = [
+    nodes = lib.genAttrs lintStages (stage: {
+      command = [
         (lib.getExe lintStage)
-        "nixfmt"
+        stage
       ];
-      statix.command = [
-        (lib.getExe lintStage)
-        "statix"
-      ];
-      deadnix.command = [
-        (lib.getExe lintStage)
-        "deadnix"
-      ];
-      astlog.command = [
-        (lib.getExe lintStage)
-        "astlog"
-      ];
-      "astlog-rust".command = [
-        (lib.getExe lintStage)
-        "astlog-rust"
-      ];
-      "astlog-elixir".command = [
-        (lib.getExe lintStage)
-        "astlog-elixir"
-      ];
-      ruff.command = [
-        (lib.getExe lintStage)
-        "ruff"
-      ];
-    };
+    });
   };
 
   lint = ix.writeNushellApplication pkgs {
@@ -178,7 +167,38 @@ let
     runtimeInputs = [ repoPackages.dag-runner ];
     text = ''
       # nu
+      const stages = ${builtins.toJSON lintStages}
+      const stage_bin = "${lib.getExe lintStage}"
+
       def --wrapped main [...args] {
+        # `--json` (#1683) emits one JSON document — [{check, ok, output}] —
+        # so agents can load lint results as a dataframe instead of grepping
+        # the human log. It runs the same stage binary the dag spec points
+        # at; dag-runner is bypassed only because its json mode is an NDJSON
+        # event stream that drops the captured diagnostics. Exit code matches
+        # the dag-runner contract: the worst stage exit code.
+        if "--json" in $args {
+          if ($args | length) > 1 {
+            error make { msg: "--json takes no other arguments" }
+          }
+          let runs = (
+            $stages
+            | par-each --keep-order {|stage|
+                let r = (do { ^$stage_bin $stage } | complete)
+                {
+                  check: $stage
+                  ok: ($r.exit_code == 0)
+                  # `ansi strip` because the stages color their diagnostics and
+                  # nushell's `to json` passes raw ESC bytes through unescaped,
+                  # which strict parsers (jq) reject as invalid JSON.
+                  output: (($r.stdout + $r.stderr) | ansi strip)
+                  exit_code: $r.exit_code
+                }
+              }
+          )
+          print ($runs | reject exit_code | to json)
+          exit ($runs | get exit_code | math max)
+        }
         exec dag-runner ...$args ${lintSpec}
       }
     '';

--- a/packages/agent/skills/linting/SKILL.md
+++ b/packages/agent/skills/linting/SKILL.md
@@ -13,6 +13,11 @@ The tracked pre-commit hook runs the same lint app. CI runs the same check
 through the flake. Keep one lint entry point so local and CI failures mean the
 same thing.
 
+For machine consumption (loading results as a dataframe rather than grepping
+the log), `nix run .#lint -- --json` prints one JSON array with a record per
+check — `{check, ok, output}`, where `output` carries the stage's diagnostics
+on failure — and still exits nonzero when any check fails.
+
 Always lint through `nix run .#lint` (or build the package), never an ad-hoc
 `nix shell nixpkgs#ruff -c ruff check`. The flake pins ruff and passes a fixed
 `--target-version`; an ambient ruff is a different version with a different


### PR DESCRIPTION
Adds an additive machine-readable mode to the repo lint entry point, per #1683.

- `nix run .#lint -- --json` prints **one JSON document** to stdout: an array of `{check, ok, output}` records, one per lint stage (`nixfmt`, `statix`, `deadnix`, `astlog`, `astlog-rust`, `astlog-elixir`, `ruff`). `output` carries the stage's captured diagnostics (ANSI-stripped, since nushell `to json` emits raw ESC bytes that strict parsers like jq reject). Exit code stays the worst stage exit code, so nonzero on any failure.
- **Default behavior unchanged**: without the flag, `lint` still `exec`s dag-runner over the same spec, so the pre-commit hook and the CI `lint` check are untouched (validated: human run passes byte-identical format).
- One nix-level `lintStages` list now generates both the dag spec and the `--json` runner, so a new stage cannot be added to one path and missed by the other.
- Documents the flag in the `linting` skill.

Validation on this branch:
- `nix run .#lint` — 7/7 succeed, exit 0, output format unchanged.
- `nix run .#lint -- --json | jq -e 'type == "array" and length == 7 and all(.[]; has("check") and has("ok") and has("output"))'` — true.
- Injected an unformatted `.nix` file: `--json` exits 1 and reports `{"check": "nixfmt", "ok": false, "output": "...: not formatted"}`; removed the probe.

Closes #1683.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--json` machine-readable output mode to the `lint` CLI
> - Adds a `--json` flag to the lint Nushell script that runs each lint stage directly, captures output, strips ANSI codes, and prints a JSON array of `{check, ok, output}` objects.
> - Exits with the worst stage exit code across all checks; errors if combined with other arguments.
> - Refactors stage enumeration in [per-system.nix](https://github.com/indexable-inc/index/pull/1684/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) to use a single `lintStages` list as the source of truth for both the DAG spec and the new JSON path.
> - Documents the new interface in [SKILL.md](https://github.com/indexable-inc/index/pull/1684/files#diff-860661f27e555fe1ccf4455b1f5e7ddcb4765014954bfe84b2de6e5c4756a8fb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 754abb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->