### PR TITLE
mcp: bundle nu, an embedded nushell engine returning polars frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.8.52",
 ]
 
 [[package]]
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alphanumeric-sort"
+version = "1.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97de3ad85c4425a2c267a5e91adbe49f9f14e650bd9c78e96b6bc00e5f6673a"
+
+[[package]]
 name = "alsa"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +105,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi-str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
+dependencies = [
+ "nom 7.1.3",
+ "vte",
 ]
 
 [[package]]
@@ -198,6 +223,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +254,12 @@ name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -597,7 +646,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -806,6 +855,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+dependencies = [
+ "debug_unsafe",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1024,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1076,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitmaps"
@@ -999,6 +1096,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1074,6 +1185,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "bracoxide"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daeb5b71668c934a1db0c7b07317a3564f2558c5e9155c70d7d6823c01f2ddcd"
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf-trait"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eaafc770e8c073d6c3facafe7617e774305d4954aa6351b9c452eb37ee17b4"
+dependencies = [
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "build-version"
 version = "0.1.0"
 dependencies = [
@@ -1125,6 +1261,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1149,6 +1291,21 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "bytesize"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
+
+[[package]]
+name = "byteyarn"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93e51d26468a15ea59f8525e0c13dc405db43e644a0b1e6d44346c72cf4cf7b"
+dependencies = [
+ "buf-trait",
+]
 
 [[package]]
 name = "cairo-rs"
@@ -1176,6 +1333,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "calamine"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8822fe6253ca47aa5ad9a3be09f6fe7cd20c6a74e41b0aa42e8f4e3d523508df"
+dependencies = [
+ "atoi_simd",
+ "byteorder",
+ "chrono",
+ "codepage",
+ "encoding_rs",
+ "fast-float2",
+ "log",
+ "quick-xml 0.39.4",
+ "serde",
+ "zip",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,7 +1368,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1198,6 +1382,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "cfg-expr"
@@ -1233,6 +1426,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,9 +1445,29 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "pure-rust-locales",
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "chrono-humanize"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799627e6b4d27827a814e837b9d8a504832086081806d45b1afa34dc982b023b"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1274,6 +1498,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1528,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1335,11 +1571,20 @@ dependencies = [
  "axum",
  "clap",
  "color-eyre",
- "git2",
+ "git2 0.21.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -1477,6 +1722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,7 +1815,7 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1598,6 +1852,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,8 +1902,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1697,7 +1997,7 @@ dependencies = [
  "jni 0.21.1",
  "js-sys",
  "libc",
- "mach2",
+ "mach2 0.5.0",
  "ndk",
  "ndk-context",
  "num-derive",
@@ -1796,6 +2096,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,9 +2120,11 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio",
+ "filedescriptor",
+ "mio 1.2.1",
  "parking_lot",
  "rustix",
+ "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1862,7 +2173,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -2108,6 +2419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
 name = "defmt"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,7 +2464,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -2224,6 +2541,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.118",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2267,11 +2585,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2282,7 +2621,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2348,6 +2687,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,9 +2724,24 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf 0.11.3",
+]
 
 [[package]]
 name = "dpi"
@@ -2396,6 +2762,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
+]
+
+[[package]]
+name = "dtparse"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb403c0926d35af2cc54d961bc2696a10d40725c08360ef69db04a4c201fd7"
+dependencies = [
+ "chrono",
+ "lazy_static",
+ "num-traits",
+ "rust_decimal",
 ]
 
 [[package]]
@@ -2521,6 +2899,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "etcetera"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2975,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,12 +3016,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fff-grep"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68286213d07412846c0010a0b227b79c08fbc214cf7822f85cabd9e3f36606ae"
+dependencies = [
+ "bstr",
+ "memchr",
+]
+
+[[package]]
+name = "fff-notify-debouncer-full"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a4ebea7b8a2840cd59358bbf396f6f04313ce8eae84ac79703ce80298b8731"
+dependencies = [
+ "file-id",
+ "log",
+ "notify 9.0.0-rc.4",
+ "notify-types",
+ "rustc-hash",
+ "walkdir",
+]
+
+[[package]]
+name = "fff-query-parser"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5eb0a0363657b57a3a60d12a76a41f799406514b238123487e54290a6f1a62f"
+
+[[package]]
+name = "fff-search"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b4517eb8a9b87a46d09e9958f2ddbc036440a9fb5d5ddfc05e6dcf4655ce2"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "blake3",
+ "dirs 5.0.1",
+ "dunce",
+ "fff-grep",
+ "fff-notify-debouncer-full",
+ "fff-query-parser",
+ "git2 0.20.4",
+ "glidesort",
+ "globset",
+ "heed",
+ "ignore",
+ "libc",
+ "memchr",
+ "memmap2",
+ "neo_frizbee",
+ "notify 9.0.0-rc.4",
+ "parking_lot",
+ "pathdiff",
+ "rayon",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2620,6 +3110,15 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2640,6 +3139,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "filesize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,6 +3173,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -2704,6 +3229,51 @@ dependencies = [
  "flecs-query-core",
  "pyo3",
  "pythonize",
+]
+
+[[package]]
+name = "fluent"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash",
+ "self_cell",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2785,6 +3355,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -2872,6 +3451,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -3013,6 +3601,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,9 +3644,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3108,13 +3708,26 @@ dependencies = [
  "clap",
  "color-eyre",
  "devicons",
- "git2",
+ "git2 0.21.0",
  "github-avatar",
  "kitty",
  "strip-ansi-escapes",
  "tempfile",
  "terminal-theme",
  "tokio",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -3187,6 +3800,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glidesort"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,7 +3870,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "base64",
- "dirs",
+ "dirs 6.0.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3420,7 +4039,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "zerocopy",
+ "zerocopy 0.8.52",
 ]
 
 [[package]]
@@ -3481,6 +4100,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -3538,6 +4159,44 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "heed"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad82d6598ccf1dac15c8b758a1bd282b755b6776be600429176757190a1b0202"
+dependencies = [
+ "bitflags 2.13.0",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "hegeltest"
@@ -3673,6 +4332,19 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "human-date-parser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406f83c56de4b2c9183be52ae9a4fefa22c0e0c3d3d7ef80be26eaee11c7110e"
+dependencies = [
+ "chrono",
+ "pest",
+ "pest_consume",
+ "pest_derive",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "humantime"
@@ -4063,7 +4735,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
+ "dirs 6.0.0",
  "iceberg",
  "lake-iceberg",
  "mixedbread",
@@ -4120,9 +4792,40 @@ checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fda9741ca16536952da2ecaa6105c2f4653fa6f0724681df6d2414c4106d0b0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4130,6 +4833,25 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
 
 [[package]]
 name = "inventory"
@@ -4147,10 +4869,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "is_debug"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -4437,6 +5184,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+]
+
+[[package]]
 name = "lake-iceberg"
 version = "0.1.0"
 dependencies = [
@@ -4483,6 +5265,18 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lean_string"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385ba1b8a25159d816b62eea948cf3c6b38c5050c92ca901c570deead00316e5"
+dependencies = [
+ "castaway",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
 
 [[package]]
 name = "leb128"
@@ -4607,6 +5401,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libproc"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4639,6 +5444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4655,6 +5469,17 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lmdb-master-sys"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
 
 [[package]]
 name = "lock_api"
@@ -4834,10 +5659,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lscolors"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60e266dfb1426eb2d24792602e041131fdc0236bb7007abc0e589acafd60929"
+dependencies = [
+ "aho-corasick",
+ "nu-ansi-term",
+]
 
 [[package]]
 name = "lz4_flex"
@@ -4873,6 +5717,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
+name = "markdown"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
+dependencies = [
+ "unicode-id",
 ]
 
 [[package]]
@@ -4971,6 +5830,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5002,7 +5889,7 @@ name = "minecraft-sound"
 version = "0.1.0"
 dependencies = [
  "clap",
- "dirs",
+ "dirs 6.0.0",
  "rodio",
  "serde",
  "serde_json",
@@ -5037,6 +5924,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
@@ -5052,7 +5951,7 @@ name = "mixedbread"
 version = "0.1.0"
 dependencies = [
  "axum",
- "dirs",
+ "dirs 6.0.0",
  "percent-encoding",
  "reqwest 0.12.28",
  "serde",
@@ -5092,6 +5991,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mq-markdown"
+version = "0.5.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc96ff6f0490a589fae25145cbc61b883c7fd2d4b042f545eab954c37ed3a167"
+dependencies = [
+ "itertools 0.14.0",
+ "markdown",
+ "miette",
+ "rustc-hash",
+ "smol_str",
+]
+
+[[package]]
+name = "multipart-rs"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cae00e7e52aa5072342ef9a2ccd71669be913c2176a81a665b1f9cd79345f2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "memchr",
+ "mime",
+ "uuid",
+]
+
+[[package]]
 name = "murmur3"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5109,7 +6035,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
+ "dirs 6.0.0",
  "reqwest 0.12.28",
  "rodio",
  "tokio",
@@ -5219,6 +6145,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "neo_frizbee"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd76fab81213d184cc28a7757791775bdcfd7f2a15e3558d7a4f7e4ee7de864"
+dependencies = [
+ "itertools 0.14.0",
+ "raw-cpuid",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5281,10 +6217,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify 0.9.6",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify"
+version = "9.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44b771d4dd781ef14c84078693e67495da6b47f609f72e8a4da8420a861240e"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify 0.11.2",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 1.2.1",
+ "notify-types",
+ "objc2-core-foundation",
+ "objc2-core-services",
+ "walkdir",
+ "windows-sys 0.61.2",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb7fd166739789c9ff169e654dc1501373db9d80a4c3f972817c8a4d7cf8f34e"
+dependencies = [
+ "file-id",
+ "log",
+ "notify 6.1.1",
+ "parking_lot",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -5293,6 +6308,429 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-cmd-base"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05a6f201ed06b75baa43da7742b9047693b57b0805f321e15430bd192b5bdbff"
+dependencies = [
+ "indexmap 2.14.0",
+ "miette",
+ "nu-engine",
+ "nu-parser",
+ "nu-path",
+ "nu-protocol",
+]
+
+[[package]]
+name = "nu-cmd-extra"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4870383a98ee8419b806fbc072e9eee887a2874fb60ffe814c2da6690302eb8f"
+dependencies = [
+ "fancy-regex",
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "mime",
+ "nu-ansi-term",
+ "nu-cmd-base",
+ "nu-engine",
+ "nu-heavy-utils",
+ "nu-json",
+ "nu-parser",
+ "nu-pretty-hex",
+ "nu-protocol",
+ "nu-utils",
+ "num-traits",
+ "quote",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "v_htmlescape",
+]
+
+[[package]]
+name = "nu-cmd-lang"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9393fedf882e1563c82707addc76d8fabe90e92634b9b7a60b317e64a1de2ba2"
+dependencies = [
+ "itertools 0.14.0",
+ "nu-cmd-base",
+ "nu-engine",
+ "nu-experimental",
+ "nu-parser",
+ "nu-protocol",
+ "nu-utils",
+ "semver",
+ "shadow-rs",
+]
+
+[[package]]
+name = "nu-color-config"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147e32860f85faca80861cc5e7461aa047468ec0d16a611dced4d788da06b891"
+dependencies = [
+ "nu-ansi-term",
+ "nu-engine",
+ "nu-json",
+ "nu-protocol",
+ "serde",
+]
+
+[[package]]
+name = "nu-command"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790b4740e5a7a73d4bca356bdb4a827e0ac7fa33c289ebe8eb7508e524f32276"
+dependencies = [
+ "alphanumeric-sort",
+ "arboard",
+ "base64",
+ "bracoxide",
+ "brotli",
+ "byteorder",
+ "bytesize",
+ "calamine",
+ "chardetng",
+ "chrono",
+ "chrono-humanize",
+ "chrono-tz",
+ "crossterm",
+ "csv",
+ "data-encoding",
+ "devicons",
+ "digest 0.10.7",
+ "dns-lookup",
+ "dtparse",
+ "encoding_rs",
+ "fancy-regex",
+ "fff-search",
+ "filesize",
+ "filetime",
+ "fluent",
+ "fuzzy-matcher",
+ "getrandom 0.4.3",
+ "http",
+ "human-date-parser",
+ "indexmap 2.14.0",
+ "indicatif",
+ "itertools 0.14.0",
+ "log",
+ "lscolors",
+ "md-5 0.10.6",
+ "mime",
+ "mime_guess",
+ "mq-markdown",
+ "multipart-rs",
+ "nix",
+ "notify-debouncer-full",
+ "nu-ansi-term",
+ "nu-cmd-base",
+ "nu-color-config",
+ "nu-engine",
+ "nu-experimental",
+ "nu-glob",
+ "nu-heavy-utils",
+ "nu-json",
+ "nu-parser",
+ "nu-path",
+ "nu-pretty-hex",
+ "nu-protocol",
+ "nu-system",
+ "nu-table",
+ "nu-term-grid",
+ "nu-utils",
+ "num-format",
+ "num-traits",
+ "nuon",
+ "oem_cp",
+ "open",
+ "os_pipe",
+ "pathdiff",
+ "percent-encoding",
+ "print-positions",
+ "procfs",
+ "quick-xml 0.40.1",
+ "rand 0.10.1",
+ "rayon",
+ "reedline",
+ "rmp",
+ "roxmltree",
+ "rustls",
+ "rustls-native-certs",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "serde_yaml",
+ "sha2 0.10.9",
+ "strum",
+ "sysinfo",
+ "tabled",
+ "titlecase",
+ "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
+ "umask",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+ "update-informer",
+ "ureq",
+ "url",
+ "uu_cp",
+ "uu_mkdir",
+ "uu_mktemp",
+ "uu_mv",
+ "uu_touch",
+ "uu_uname",
+ "uu_whoami",
+ "uucore",
+ "uuid",
+ "v_htmlescape",
+ "wax",
+ "web-time",
+ "webpki-roots",
+ "which",
+ "win_uds",
+ "windows 0.62.2",
+ "winreg",
+]
+
+[[package]]
+name = "nu-derive-value"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004a7d24d151037d1df4d5372e1910f775f32403a3d828031d4feba6fd916149"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "nu-engine"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4e7c93ccfce77a2e29fffdf0662d83dfc3773c8fdd98e0397a422c7cfd4a79"
+dependencies = [
+ "fancy-regex",
+ "log",
+ "nu-experimental",
+ "nu-glob",
+ "nu-path",
+ "nu-protocol",
+ "nu-utils",
+]
+
+[[package]]
+name = "nu-experimental"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d0b987b882ac91d5e306afa0845f2601bb8fc483ee8e59d766842571c8302"
+dependencies = [
+ "itertools 0.14.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "nu-glob"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c10023a62f5c90f22b4977878b7a25fac8dc2091639ddee2e3b7b9a47d52ff"
+
+[[package]]
+name = "nu-heavy-utils"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be0e66c3238f78c807ade0f521e201445012b5940784fb8140fa40011050696"
+dependencies = [
+ "nu-protocol",
+]
+
+[[package]]
+name = "nu-json"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d664096864c9fc825f7da6185bcc3b288869aedfe8d70580d41fa96f90661d71"
+dependencies = [
+ "linked-hash-map",
+ "nu-protocol",
+ "nu-utils",
+ "num-traits",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "nu-parser"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "289adfd6662908b7885babe261b10e2357406a490b0634b084eee0817903d26d"
+dependencies = [
+ "bytesize",
+ "chrono",
+ "itertools 0.14.0",
+ "log",
+ "nu-engine",
+ "nu-experimental",
+ "nu-path",
+ "nu-protocol",
+ "nu-utils",
+ "serde_json",
+]
+
+[[package]]
+name = "nu-path"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d64ea11090ecdc8f2ee2eb2d383ae2481ac2e35040c59d36fde4c0d948daf1"
+dependencies = [
+ "dirs 6.0.0",
+ "omnipath",
+ "pwd",
+ "ref-cast",
+]
+
+[[package]]
+name = "nu-pretty-hex"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4583646503707ba75b26e69c4fa1e9f08b461844a80fded61f3c67edc84fe84"
+dependencies = [
+ "nu-ansi-term",
+]
+
+[[package]]
+name = "nu-protocol"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0c58828aa058bdf74dc69ae7e882815ae5612f88a5c876f37f2d680fa86e3f"
+dependencies = [
+ "bytes",
+ "chrono",
+ "chrono-humanize",
+ "derive_more",
+ "dirs 6.0.0",
+ "dirs-sys 0.5.0",
+ "fancy-regex",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "log",
+ "lru 0.18.0",
+ "memchr",
+ "miette",
+ "nix",
+ "nu-derive-value",
+ "nu-experimental",
+ "nu-glob",
+ "nu-path",
+ "nu-system",
+ "nu-utils",
+ "num-format",
+ "os_pipe",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "typetag",
+ "web-time",
+ "windows 0.62.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-py"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "nu-cmd-extra",
+ "nu-cmd-lang",
+ "nu-command",
+ "nu-engine",
+ "nu-parser",
+ "nu-protocol",
+ "pyo3",
+ "pyo3-async-runtimes",
+ "tokio",
+]
+
+[[package]]
+name = "nu-system"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357a3b782dcb203ec8e05d0176e60b9bcb956c5d98f094cd3c3a117bc98b928d"
+dependencies = [
+ "chrono",
+ "itertools 0.14.0",
+ "libc",
+ "libproc",
+ "log",
+ "mach2 0.6.0",
+ "nix",
+ "ntapi",
+ "nu-utils",
+ "procfs",
+ "sysinfo",
+ "uucore",
+ "web-time",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "nu-table"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382690f65bbcf610f329a5452c6586a991fd3991c48debfeb7ca8708a41579c"
+dependencies = [
+ "fancy-regex",
+ "nu-ansi-term",
+ "nu-color-config",
+ "nu-engine",
+ "nu-protocol",
+ "nu-utils",
+ "tabled",
+]
+
+[[package]]
+name = "nu-term-grid"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0104b3e5ea8be5d489c89431f758b9e52f82e25cde3ac5b31ba0fdaf510514"
+dependencies = [
+ "nu-utils",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "nu-utils"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec685be6fcc963735a023948a38e7e39e03a32fedc09649c30019ce8f85fbfc8"
+dependencies = [
+ "byteyarn",
+ "crossterm",
+ "crossterm_winapi",
+ "derive_more",
+ "fancy-regex",
+ "lean_string",
+ "log",
+ "lscolors",
+ "memchr",
+ "nix",
+ "num-format",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "strip-ansi-escapes",
+ "sys-locale",
+ "unicase",
+ "web-time",
 ]
 
 [[package]]
@@ -5344,6 +6782,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -5439,6 +6887,18 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "rustc-hash",
+]
+
+[[package]]
+name = "nuon"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "544911d346d654afb6057696a1ac7144ea4bbb027cb40b6d7426dbccc1cf4617"
+dependencies = [
+ "nu-engine",
+ "nu-parser",
+ "nu-protocol",
+ "nu-utils",
 ]
 
 [[package]]
@@ -5589,6 +7049,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5638,6 +7108,16 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -5839,6 +7319,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oem_cp"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7959d3349f484aec36462f98226983578bf7d33f9b034c32967489c7000e1f"
+dependencies = [
+ "phf 0.11.3",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5846,6 +7335,12 @@ checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
+
+[[package]]
+name = "omnipath"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80adb31078122c880307e9cdfd4e3361e6545c319f9b9dcafcb03acd3b51a575"
 
 [[package]]
 name = "once_cell"
@@ -5864,6 +7359,16 @@ name = "oneshot"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
+name = "open"
+version = "5.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
+dependencies = [
+ "is-wsl",
+ "libc",
+]
 
 [[package]]
 name = "opendal"
@@ -5944,6 +7449,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_display"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ownedbytes"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5957,6 +7481,16 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pango"
@@ -5981,6 +7515,19 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "bytecount",
+ "fnv",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6081,6 +7628,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse_datetime"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413775a7eac2261d2211a79d10ef275e5b6f7b527eec42ad09adce2ffa92b6e5"
+dependencies = [
+ "jiff",
+ "num-traits",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6091,6 +7649,12 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -6106,6 +7670,28 @@ checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_consume"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79447402d15d18e7142e14c72f2e63fa3d155be1bc5b70b3ccbb610ac55f536b"
+dependencies = [
+ "pest",
+ "pest_consume_macros",
+ "pest_derive",
+]
+
+[[package]]
+name = "pest_consume_macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8630a7a899cb344ec1c16ba0a6b24240029af34bdc0a21f84e411d7f793f29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6142,13 +7728,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -6158,8 +7774,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6169,7 +7795,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6178,11 +7817,29 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -6213,6 +7870,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "platform-info"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9368d62437c8cbb7c31ee37fd8c08a7d390e09a3ff75698a674953f46705ffcb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6233,6 +7900,15 @@ dependencies = [
  "pyo3",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "pori"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -6317,7 +7993,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.52",
 ]
 
 [[package]]
@@ -6344,6 +8020,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "print-positions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df593470e3ef502e48cb0cfc9a3a61e5f61e967b78e1ed35a67ac615cfbd208"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -6431,6 +8116,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
+dependencies = [
+ "bitflags 2.13.0",
+ "chrono",
+ "flate2",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
+dependencies = [
+ "bitflags 2.13.0",
+ "chrono",
+ "hex",
+]
+
+[[package]]
 name = "progress-style"
 version = "0.1.0"
 dependencies = [
@@ -6468,6 +8177,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pure-rust-locales"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
+
+[[package]]
+name = "pwd"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c71c0c79b9701efe4e1e4b563b2016dd4ee789eb99badcb09d61ac4b92e4a2"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6479,6 +8204,7 @@ version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
+ "chrono",
  "libc",
  "once_cell",
  "portable-atomic",
@@ -6610,6 +8336,16 @@ checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -6797,6 +8533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6839,6 +8584,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -6846,6 +8602,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reedline"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201e8e0160cbe7bb5eb2caccf281e178e77fac95115ab31a2c29edc5593603c8"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "fd-lock",
+ "itertools 0.13.0",
+ "nu-ansi-term",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "thiserror 2.0.18",
+ "unicase",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7018,7 +8794,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -7128,6 +8904,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7173,6 +8955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7199,7 +8991,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -7222,6 +9014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -7250,6 +9043,27 @@ checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7478,9 +9292,9 @@ dependencies = [
 name = "search-core"
 version = "0.1.0"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
  "futures",
- "git2",
+ "git2 0.21.0",
  "hex",
  "mixedbread",
  "rayon",
@@ -7540,13 +9354,19 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -7757,6 +9577,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7775,6 +9608,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -7799,6 +9638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-rs"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd39b4b2077bd36e60ca28c31d494046e747759cb9b507a7d177bb64787c39e"
+dependencies = [
+ "const_format",
+ "is_debug",
+ "jiff",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7806,6 +9656,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -7830,7 +9686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.2.1",
  "signal-hook",
 ]
 
@@ -7956,6 +9812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
 name = "snafu"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7990,6 +9856,17 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -8193,7 +10070,7 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.13.1",
  "precomputed-hash",
 ]
 
@@ -8203,8 +10080,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -8289,6 +10166,24 @@ checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
  "is_ci",
 ]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
@@ -8393,6 +10288,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8401,6 +10305,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -8414,6 +10341,18 @@ dependencies = [
  "pkg-config",
  "toml 0.8.2",
  "version-compare",
+]
+
+[[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "papergrid",
+ "testing_table",
 ]
 
 [[package]]
@@ -8461,7 +10400,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "datasketches",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "fastdivide",
  "fnv",
  "fs4",
@@ -8469,7 +10408,7 @@ dependencies = [
  "itertools 0.14.0",
  "levenshtein_automata",
  "log",
- "lru",
+ "lru 0.16.4",
  "lz4_flex 0.13.1",
  "measure_time",
  "memmap2",
@@ -8513,7 +10452,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
 dependencies = [
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "fastdivide",
  "itertools 0.14.0",
  "serde",
@@ -8554,7 +10493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "ordered-float 5.3.0",
  "serde",
  "serde_json",
@@ -8710,6 +10649,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "ansitok",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8815,6 +10784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -8834,6 +10804,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "titlecase"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb567088a91d59b492520c8149e2be5ce10d5deb2d9a383f3378df3259679d40"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8841,7 +10820,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -8875,7 +10854,7 @@ dependencies = [
  "log",
  "parking_lot",
  "percent-encoding",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
@@ -8951,10 +10930,12 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.3",
 ]
 
@@ -9009,6 +10990,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.3",
 ]
 
@@ -9020,6 +11002,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -9103,6 +11091,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -9501,6 +11502,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9573,6 +11585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9591,6 +11612,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -9635,6 +11662,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "umask"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9a46c2549e35c054e0ffe281a3a6ec0007793db4df106604d37ed3f4d73d1c"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "tinystr",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9647,10 +11701,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-id"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -9675,15 +11741,33 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsafe-libyaml-norway"
@@ -9696,6 +11780,55 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "update-informer"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b27dcf766dc6ad64c2085201626e1a7955dc1983532bfc8406d552903ace2a"
+dependencies = [
+ "etcetera",
+ "reqwest 0.12.28",
+ "semver",
+ "serde",
+ "serde_json",
+ "ureq",
+]
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "encoding_rs",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.6.2",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -9722,6 +11855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9734,16 +11873,168 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uu_cp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ee02f3f636a8623ec3ed03c54d615070da244dc0f4651956c01532cce8181b"
+dependencies = [
+ "clap",
+ "filetime",
+ "fluent",
+ "indicatif",
+ "libc",
+ "nix",
+ "thiserror 2.0.18",
+ "uucore",
+ "walkdir",
+]
+
+[[package]]
+name = "uu_mkdir"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f996d7f444f1bc97e0c5410f4be5a5bfc5716946535d62b201a828af75e633"
+dependencies = [
+ "clap",
+ "fluent",
+ "rustix",
+ "uucore",
+]
+
+[[package]]
+name = "uu_mktemp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db4a418f8212d898746703cbc394c6731af4be0584dfb015ecd6edbbe9c227c"
+dependencies = [
+ "clap",
+ "fluent",
+ "rand 0.10.1",
+ "tempfile",
+ "thiserror 2.0.18",
+ "uucore",
+]
+
+[[package]]
+name = "uu_mv"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21327f17773efe1b736d9129016985d5ad2faf3aebc723d25e7590414b37f64e"
+dependencies = [
+ "clap",
+ "fluent",
+ "fs_extra",
+ "indicatif",
+ "libc",
+ "rustc-hash",
+ "thiserror 2.0.18",
+ "uucore",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "uu_touch"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af40dcd9620f96ec09f2439d29d0ed8b5afc496bb25d1b7a4970416bf4c5b72b"
+dependencies = [
+ "clap",
+ "filetime",
+ "fluent",
+ "jiff",
+ "libc",
+ "parse_datetime",
+ "rustix",
+ "thiserror 2.0.18",
+ "uucore",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "uu_uname"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26927e94535497b1ebe69e83a3ab36418524b610e55c205ee338999126f4315"
+dependencies = [
+ "clap",
+ "fluent",
+ "platform-info",
+ "uucore",
+]
+
+[[package]]
+name = "uu_whoami"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87bf65bdd9e21258dd484aeb7567f5f833c486ed84ba5aa4fe3b1a93a20e7cee"
+dependencies = [
+ "clap",
+ "fluent",
+ "uucore",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "uucore"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d779636d827cde4100f0e65ff3fd23b0b1f1195055475c6e6813d425f30c8e"
+dependencies = [
+ "bigdecimal",
+ "clap",
+ "dunce",
+ "fluent",
+ "fluent-bundle",
+ "fluent-syntax",
+ "glob",
+ "itertools 0.14.0",
+ "libc",
+ "nix",
+ "num-traits",
+ "os_display",
+ "procfs",
+ "rustc-hash",
+ "rustix",
+ "thiserror 2.0.18",
+ "unic-langid",
+ "uucore_procs",
+ "walkdir",
+ "wild",
+ "winapi-util",
+ "windows-sys 0.61.2",
+ "xattr",
+]
+
+[[package]]
+name = "uucore_procs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da865e8a648b260dbd89fca76d0801995877ab27a4e259b6dec30ba9743b86ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "uuid"
 version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
+ "atomic",
  "getrandom 0.4.3",
  "js-sys",
+ "md-5 0.10.6",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "v_htmlescape"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8257fbc510f0a46eb602c10215901938b5c2a7d5e70fc11483b1d3c9b5b18c"
 
 [[package]]
 name = "valuable"
@@ -9799,6 +12090,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
+ "arrayvec",
  "memchr",
 ]
 
@@ -9936,6 +12228,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "wax"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8cbf8125142b9b30321ac8721f54c52fbcd6659f76cf863d5e2e38c07a3d7b"
+dependencies = [
+ "const_format",
+ "itertools 0.14.0",
+ "nom 7.1.3",
+ "pori",
+ "regex",
+ "thiserror 2.0.18",
+ "walkdir",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs 1.2.1",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9961,7 +12338,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -10072,6 +12449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10082,6 +12468,24 @@ dependencies = [
  "objc2-system-configuration",
  "wasite",
  "web-sys",
+]
+
+[[package]]
+name = "wild"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "win_uds"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd30a1a28a3799479cbf4e17284a220ea9ff6bad098a9d0224543a5d1efe1da"
+dependencies = [
+ "socket2",
 ]
 
 [[package]]
@@ -10307,6 +12711,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -10354,6 +12767,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -10424,6 +12852,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -10442,6 +12876,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -10457,6 +12897,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10490,6 +12936,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -10505,6 +12957,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10526,6 +12984,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -10541,6 +13005,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10565,6 +13035,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -10573,10 +13052,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
 
 [[package]]
 name = "writeable"
@@ -10594,7 +13101,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",
@@ -10650,6 +13157,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10659,7 +13183,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -10724,11 +13248,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.52",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10786,6 +13331,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -10803,6 +13349,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10813,6 +13373,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
   "packages/minecraft/minecraft/sync-managed",
   "packages/search/mixedbread",
   "packages/mynoise",
+  "packages/nu-py",
   "packages/nix/nix-web-monitor/parser",
   "packages/nix/nix-web-monitor/server",
   "packages/nix/oci-image-builder",
@@ -200,6 +201,21 @@ napi-derive = "3"
 ndarray = "0.17"
 nix = "0.31"
 nix-web-monitor-parser = { path = "packages/nix/nix-web-monitor/parser" }
+# The embedded nushell engine nu-py wraps. One version for the whole family,
+# aligned with pkgs.nushell so embedded semantics match the CLI on PATH.
+# nu-command drops its default `sqlite` feature (`stor`, `into sqlite`): its
+# rusqlite 0.37 pins libsqlite3-sys 0.35, which collides with source-atuin's
+# rusqlite 0.40 on the one-per-graph `links = "sqlite3"` native library.
+nu-cmd-extra = "0.113.1"
+nu-cmd-lang = "0.113.1"
+nu-command = { version = "0.113.1", default-features = false, features = [
+  "os",
+  "network",
+  "rustls-tls",
+] }
+nu-engine = "0.113.1"
+nu-parser = "0.113.1"
+nu-protocol = "0.113.1"
 numpy = "0.28"
 objc2 = "0.6"
 objc2-app-kit = "0.3"

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -93,6 +93,48 @@ let
       ''
   );
 
+  # The embedded nushell engine, baked into the pinned interpreter so every
+  # session can `await nu("ls | where size > 1kb")` and get a polars frame.
+  # Same shape as `searchModule`: the PyO3 cdylib comes from the shared
+  # workspace graph (packages/nu-py), so it works on Linux and macOS dev alike.
+  # In-process, not a subprocess: one persistent engine per kernel, cancellable
+  # through nushell's own interrupt signal.
+  nuPyPythonSource = builtins.path {
+    name = "nu-py-python-source";
+    path = ix.paths.packagesRoot + "/nu-py/python";
+  };
+  nuPyModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-nu-python-module"
+      {
+        strictDeps = true;
+        meta.description = "Embedded nushell engine (nu-py PyO3 module) bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/nu"
+        mkdir -p "$site"
+        cp -r ${nuPyPythonSource}/nu/. "$site/"
+
+        cdylib=""
+        for candidate in \
+          ${ix.rustWorkspace.units.libraries.nu_py}/lib/libnu_py.so \
+          ${ix.rustWorkspace.units.libraries.nu_py}/lib/libnu_py-*.so \
+          ${ix.rustWorkspace.units.libraries.nu_py}/lib/libnu_py.dylib \
+          ${ix.rustWorkspace.units.libraries.nu_py}/lib/libnu_py-*.dylib
+        do
+          if [ -f "$candidate" ]; then
+            cdylib="$candidate"
+            break
+          fi
+        done
+        if [ -z "$cdylib" ]; then
+          echo "nu-py module: no cdylib under ${ix.rustWorkspace.units.libraries.nu_py}/lib" >&2
+          ls -la ${ix.rustWorkspace.units.libraries.nu_py}/lib >&2 || true
+          exit 1
+        fi
+        install -m555 "$cdylib" "$site/_nu.abi3.so"
+      ''
+  );
+
   # The astlog package, baked into the pinned interpreter so every session can
   # `import astlog` and run Datalog queries/rewrites over tree-sitter ASTs with
   # no setup. Same shape as `searchModule`: the PyO3 cdylib comes from the
@@ -1142,6 +1184,7 @@ let
       ps.pypdf
       tuiModule
       searchModule
+      nuPyModule
       astlogModule
       scipqlModule
       flecsQueryModule
@@ -5140,6 +5183,39 @@ let
         cat stdout
         mkdir -p "$out"
       '';
+  nuBundled = importTest "nu" "import nu; print('nu-ok', callable(nu), callable(nu.value), nu.NuError.__name__ == 'NuError', nu.__version__)";
+  # Behavior tests for the embedded nushell engine: the normalization matrix,
+  # persistent REPL state, native datetime/duration crossing, the NuError
+  # diagnostic surface, `exit` safety, and interrupt-based timeout. Everything
+  # runs in-process against the real engine, so the sandbox needs no nushell
+  # binary and no network.
+  nuTestPython = pkgs.python3.withPackages (ps: [
+    ps.pytest
+    ps.polars
+    nuPyModule
+  ]);
+  nuTestSource = builtins.path {
+    name = "ix-mcp-nu-test";
+    path = ./tests/test_nu.py;
+  };
+  nuTests =
+    pkgs.runCommand "ix-mcp-nu-tests"
+      {
+        nativeBuildInputs = [ nuTestPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        cp ${nuTestSource} "$TMPDIR/test_nu.py"
+        ${lib.getExe nuTestPython} -m pytest "$TMPDIR/test_nu.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp nu tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
   noxAutotriageBundled = importTest "nox-autotriage" "import nox_autotriage; print('nox-autotriage-ok', callable(nox_autotriage.findings_from_conformance))";
   linearTriageTestPython = pkgs.python3.withPackages (ps: [
     ps.pytest
@@ -5357,6 +5433,8 @@ package.overrideAttrs (old: {
         browserVdomSmoke
         vdomPropertiesSmoke
         xBundled
+        nuBundled
+        nuTests
         linearBundled
         linearTriageTests
         notionBundled

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1783,7 +1783,10 @@ let
   serverTools = importTest "server" (
     "import asyncio; from ix_notebook_mcp.tools import mcp; "
     + "names = sorted(t.name for t in asyncio.run(mcp.list_tools())); "
-    + "expected = {'python_exec','read','kernel_trace','tui_act'}; "
+    # session_set_name joined the surface in #1615 but this expected set was
+    # not updated with it; the stale drv kept passing from cache on main until
+    # this package's inputs changed and forced a rebuild.
+    + "expected = {'python_exec','read','kernel_trace','tui_act','session_set_name'}; "
     + "assert set(names) == expected, ('tool surface drifted: %r' % (names,)); "
     + "from ix_notebook_mcp import registry; instr = mcp._mcp_server.instructions; "
     + "assert 'root=' not in instr, 'a parameter/signature leaked into the instructions'; "

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -173,6 +173,22 @@ NO_SHELL = (
     "shell parsing entirely, or write the text to a temp file and use `git commit -F <file>`."
 )
 
+NU = (
+    "When you want a command's DATA and the CLI has no JSON mode, reach for `nu` before `sh` + "
+    "jq/awk/sed text munging: `await nu(\"ls | where size > 1kb | sort-by size\")` runs a "
+    "nushell pipeline — structured end to end (`ls`, `ps`, `open Cargo.toml`, `from csv`, "
+    "`http get`, `where`, `group-by`) — and every result comes back as a polars DataFrame "
+    "(a record is one row, a scalar a one-cell `value` column; dates and durations arrive as "
+    "real Datetime/Duration columns, filesize as bytes). The engine is embedded and "
+    "persistent, a REPL: a `let`, a `def`, or a `cd` in one call is visible to the next, so "
+    "bind an expensive fetch once and query it across calls. Pipe a frame THROUGH a pipeline "
+    "with `await nu(\"where a > 1\", input=df)`. A failing pipeline raises NuError carrying "
+    "nushell's own diagnostic (span + 'did you mean'), so read it and fix the pipeline. "
+    "Division of labor: `nu` for data-shaped commands, `sh` for side-effectful ones "
+    "(`git`/`nix`/`gh` writes), long externals, and raw logs, `sh(...).df()` when the CLI "
+    "already speaks `--json`."
+)
+
 VERIFY = (
     "Verify a change by its actual effect, not by a proxy: when you change "
     "something whose result a static check cannot see — an interactive UI, a "

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -66,6 +66,16 @@ MODULES: tuple[Module, ...] = (
         preimport=True,
     ),
     Module(
+        "nu",
+        "structured shell (an embedded, persistent nushell engine): run a pipeline and get a "
+        'polars DataFrame back, always -- `await nu("ls | where size > 1kb | sort-by size")`, '
+        "`open Cargo.toml`, `from csv`, `http get`; `let`/`def`/`cd` persist across calls like "
+        "a REPL; `input=df` pipes a frame through a pipeline; a failure raises NuError carrying "
+        "nushell's own diagnostic. Prefer it over `sh` + jq/awk/sed whenever you want a "
+        "command's data",
+        preimport=True,
+    ),
+    Module(
         "nix",
         "run a nix build and get its internals as polars (`.events` / `.activities`) plus a live "
         "build DAG; `nix.attrs()` catalogs the flake's buildable attrs",

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -64,6 +64,7 @@ _KERNEL_GUIDE = guide.compose(
     guide.NAMESPACE,
     guide.DISCOVER,
     guide.NO_SHELL,
+    guide.NU,
     guide.POLARS,
     guide.RESULT_CONTRACT,
     guide.JOBS,

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -154,13 +154,29 @@ _STRUCTURED_OWNER = {
 }
 
 
+# A pipe into one of these means the command is scraping text apart. The
+# bundled `nu` module owns that shape: a nushell pipeline is structured end to
+# end and lands as a polars frame.
+_TEXT_MUNGERS = re.compile(r"\|\s*(?:jq|awk|sed|cut|tr|sort|uniq|wc)\b")
+
+
 def _structured_hint(cmd: str | list[str]) -> str | None:
     """A redirect hint when ``cmd`` starts with a tool a bundled module owns."""
     if isinstance(cmd, str):
         first = cmd.strip().split(None, 1)[0] if cmd.strip() else ""
     else:
         first = str(cmd[0]) if cmd else ""
-    return _STRUCTURED_OWNER.get(first.rsplit("/", 1)[-1])
+    first = first.rsplit("/", 1)[-1]
+    owner = _STRUCTURED_OWNER.get(first)
+    if owner is not None:
+        return owner
+    # ssh runs the pipeline remotely, where the local nu cannot see the data.
+    if isinstance(cmd, str) and first != "ssh" and _TEXT_MUNGERS.search(cmd):
+        return (
+            "await nu('<pipeline>') runs a structured (nushell) pipeline and returns a "
+            "polars frame -- prefer it over scraping text apart with jq/awk/sed/cut"
+        )
+    return None
 
 
 class ShellError(RuntimeError):

--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -105,6 +105,40 @@ def test_input_scalars_and_datetimes_cross_into_nu() -> None:
     assert run(nu.value("$in + 1", input=41)) == 42
 
 
+def test_int_list_input_stays_a_list_not_binary() -> None:
+    # extract::<Vec<u8>> would have eaten [1, 2, 3] as binary.
+    assert run(nu.value("$in | math sum", input=[1, 2, 3])) == 6
+
+
+def test_bytes_input_arrives_as_binary() -> None:
+    assert run(nu.value("$in | decode", input=b"hi")) == "hi"
+
+
+def test_oversized_int_input_errors_instead_of_rounding() -> None:
+    with pytest.raises(nu.NuError, match="out of range"):
+        run(nu.value("$in", input=2**80))
+
+
+def test_mixed_type_results_still_frame() -> None:
+    assert run(nu("[1, 2.5]"))["value"].to_list() == [1.0, 2.5]
+    df = run(nu("[{a: 1}, {a: 'x'}]"))
+    assert df.height == 2
+
+
+def test_trailing_external_output_is_collected(tmp_path: pathlib.Path) -> None:
+    # Stack::collect_value(): a bare external at the end of the pipeline must
+    # come back as the value, not leak to the host process stdout (which under
+    # MCP stdio transport is the protocol stream). `nu --testbin cococo` is a
+    # cross-platform echo shipped inside the nushell binary itself... which the
+    # embedded engine does not have on PATH; use the interpreter binary we
+    # certainly have: python3 printing a marker.
+    import sys
+
+    out = run(nu.value(f"^{sys.executable} -c 'print(\"collected\")'"))
+    assert isinstance(out, str)
+    assert out.strip() == "collected"
+
+
 def test_naive_datetime_input_gets_a_clear_error() -> None:
     naive = datetime.datetime(2024, 1, 2, 3, 4, 5)  # noqa: DTZ001 -- naive on purpose: it IS the case under test
     with pytest.raises(nu.NuError, match="naive datetime"):

--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -1,0 +1,125 @@
+"""Behavior tests for the bundled `nu` module (the embedded nushell engine).
+
+Everything drives the real in-process engine (the `nu._nu` PyO3 cdylib), so
+what is defended is the module's contract, not a mock: the frame
+normalization matrix, persistent REPL state, native datetime/duration
+crossing, the df -> nu -> df roundtrip, the NuError diagnostic surface,
+`exit` safety, and interrupt-based timeout.
+"""
+
+import asyncio
+import datetime
+import inspect
+import pathlib
+
+import polars as pl
+import pytest
+
+import nu
+
+
+def run(coro: object) -> object:
+    return asyncio.run(coro)
+
+
+def test_callable_module_signature_keeps_code_argument() -> None:
+    assert "code" in inspect.signature(nu).parameters
+    assert inspect.signature(nu) == inspect.signature(nu.nu)
+
+
+def test_table_becomes_frame() -> None:
+    df = run(nu("[{a: 1, b: 'x'}, {a: 2, b: 'y'}] | where a > 1"))
+    assert isinstance(df, pl.DataFrame)
+    assert df.to_dicts() == [{"a": 2, "b": "y"}]
+
+
+def test_record_becomes_one_row_frame() -> None:
+    df = run(nu("{name: 'ix', stars: 7}"))
+    assert df.shape == (1, 2)
+    assert df["name"].item() == "ix"
+
+
+def test_scalar_and_list_become_value_column() -> None:
+    assert run(nu("2 + 2"))["value"].item() == 4
+    assert run(nu("[1, 2, 3]"))["value"].to_list() == [1, 2, 3]
+
+
+def test_null_and_empty_become_empty_frames() -> None:
+    assert run(nu("null")).is_empty()
+    assert run(nu("[] | where true")).is_empty()
+
+
+def test_multi_statement_code_is_one_result() -> None:
+    df = run(nu("let n = 3; seq 1 $n | each {|i| {n: $i, sq: ($i * $i)}}"))
+    assert df["sq"].to_list() == [1, 4, 9]
+
+
+def test_state_persists_across_calls_like_a_repl() -> None:
+    run(nu("let repl_answer = 42"))
+    run(nu("def double [x] { $x * 2 }"))
+    assert run(nu.value("double $repl_answer")) == 84
+
+
+def test_dataframe_roundtrip_through_pipeline() -> None:
+    src = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    df = run(nu("where a > 1 | sort-by a --reverse", input=src))
+    assert df.to_dicts() == [{"a": 3, "b": "z"}, {"a": 2, "b": "y"}]
+
+
+def test_native_types_cross_exactly() -> None:
+    df = run(nu("[{size: 1.5mb, dur: 3sec, when: 2024-01-02T03:04:05-05:00}]"))
+    assert df["size"].item() == 1_500_000
+    assert df.schema["dur"] == pl.Duration("us")
+    assert df["dur"].item() == datetime.timedelta(seconds=3)
+    when = df.schema["when"]
+    assert isinstance(when, pl.Datetime)
+    assert when.time_zone == "UTC"
+    # -05:00 offsets normalize to one UTC timeline.
+    assert df["when"].dt.hour().item() == 8
+
+
+def test_error_carries_nushell_diagnostic() -> None:
+    with pytest.raises(nu.NuError) as err:
+        run(nu("[{a: 1}] | wherex a > 0"))
+    message = str(err.value)
+    assert "wherex" in message
+
+
+def test_exit_raises_instead_of_killing_the_process() -> None:
+    # eval_ir_block surfaces `exit` as an error; eval_block would have called
+    # std::process::exit and taken the whole kernel down.
+    with pytest.raises(nu.NuError):
+        run(nu("exit 3"))
+    # The engine is still usable afterwards.
+    assert run(nu.value("1 + 1")) == 2
+
+
+def test_value_escape_hatch_returns_plain_python() -> None:
+    assert run(nu.value("{a: {b: [1, 2]}}")) == {"a": {"b": [1, 2]}}
+    assert run(nu.value("'plain'")) == "plain"
+
+
+def test_input_scalars_and_datetimes_cross_into_nu() -> None:
+    stamp = datetime.datetime(2024, 1, 2, 3, 4, 5, tzinfo=datetime.UTC)
+    assert run(nu.value("$in | format date '%Y'", input=stamp)) == "2024"
+    assert run(nu.value("$in + 1", input=41)) == 42
+
+
+def test_cwd_is_respected(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "hello.txt").write_text("hi")
+    df = run(nu("ls | get name", cwd=tmp_path))
+    assert df["value"].to_list() == ["hello.txt"]
+
+
+def test_timeout_interrupts_a_runaway_pipeline() -> None:
+    with pytest.raises(TimeoutError):
+        run(nu("loop { }", timeout=0.5))
+    # The interrupt leaves the engine healthy for the next call.
+    assert run(nu.value("2 + 2")) == 4
+
+
+def test_reset_discards_state() -> None:
+    run(nu("let doomed = 1"))
+    nu.reset()
+    with pytest.raises(nu.NuError):
+        run(nu("$doomed"))

--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -105,17 +105,34 @@ def test_input_scalars_and_datetimes_cross_into_nu() -> None:
     assert run(nu.value("$in + 1", input=41)) == 42
 
 
+def test_naive_datetime_input_gets_a_clear_error() -> None:
+    naive = datetime.datetime(2024, 1, 2, 3, 4, 5)
+    with pytest.raises(nu.NuError, match="naive datetime"):
+        run(nu.value("$in", input=naive))
+
+
+def test_empty_record_is_one_row_zero_columns() -> None:
+    # Pins the degenerate corner of the record -> 1-row contract so a polars
+    # behavior change is caught here, not by a confused caller.
+    df = run(nu("{}"))
+    assert df.shape == (1, 0)
+
+
 def test_cwd_is_respected(tmp_path: pathlib.Path) -> None:
     (tmp_path / "hello.txt").write_text("hi")
     df = run(nu("ls | get name", cwd=tmp_path))
     assert df["value"].to_list() == ["hello.txt"]
 
 
-def test_timeout_interrupts_a_runaway_pipeline() -> None:
+def test_timeout_interrupts_and_discards_engine_state() -> None:
+    run(nu("let survivor = 'no'"))
     with pytest.raises(TimeoutError):
         run(nu("loop { }", timeout=0.5))
-    # The interrupt leaves the engine healthy for the next call.
+    # The next call gets a FRESH engine (a stuck element could hold the old
+    # one indefinitely), so it works immediately but persistent state is gone.
     assert run(nu.value("2 + 2")) == 4
+    with pytest.raises(nu.NuError):
+        run(nu("$survivor"))
 
 
 def test_reset_discards_state() -> None:

--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -106,7 +106,7 @@ def test_input_scalars_and_datetimes_cross_into_nu() -> None:
 
 
 def test_naive_datetime_input_gets_a_clear_error() -> None:
-    naive = datetime.datetime(2024, 1, 2, 3, 4, 5)
+    naive = datetime.datetime(2024, 1, 2, 3, 4, 5)  # noqa: DTZ001 -- naive on purpose: it IS the case under test
     with pytest.raises(nu.NuError, match="naive datetime"):
         run(nu.value("$in", input=naive))
 

--- a/packages/nu-py/Cargo.toml
+++ b/packages/nu-py/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "nu-py"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Python bindings for an embedded nushell engine: persistent state, async eval, native value conversion"
+
+[lib]
+name = "nu_py"
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+chrono.workspace = true
+nu-cmd-extra.workspace = true
+nu-cmd-lang.workspace = true
+nu-command.workspace = true
+nu-engine.workspace = true
+nu-parser.workspace = true
+nu-protocol.workspace = true
+pyo3 = { workspace = true, features = ["extension-module", "chrono"] }
+pyo3-async-runtimes.workspace = true
+tokio = { workspace = true, features = ["rt"] }

--- a/packages/nu-py/build.rs
+++ b/packages/nu-py/build.rs
@@ -1,0 +1,12 @@
+//! Emit the macOS-only `-undefined dynamic_lookup` link flag that `PyO3`
+//! extension modules need: macOS rejects undefined symbols in a dylib, while
+//! Linux allows them. `pyo3` 0.28 does not emit it and the shared cargo-unit
+//! graph does not add it, so emit it here, scoped to the cdylib via the
+//! single-colon `rustc-cdylib-link-arg` directive that both `cargo` and
+//! `nix-cargo-unit` honor. This mirrors what tui-py's build.rs does.
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-cdylib-link-arg=-undefined");
+        println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+    }
+}

--- a/packages/nu-py/package.nix
+++ b/packages/nu-py/package.nix
@@ -1,0 +1,4 @@
+{
+  id = "nu-py";
+  inRustWorkspace = true;
+}

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -42,11 +42,20 @@ Contract:
 - A failing pipeline raises :class:`NuError` whose message is nushell's own
   rendered diagnostic (span, label, and "did you mean" hints) -- read it,
   fix the pipeline, retry. ``exit`` raises too; it never ends this process.
-- ``timeout=`` interrupts the evaluation the way ctrl-c would (nushell
-  checks the flag between pipeline elements) and raises ``TimeoutError``;
-  cancelling the awaiting task interrupts the same way. An external command
-  the pipeline already spawned finishes on its own; for long externals
-  prefer ``sh``, which group-kills on timeout.
+- ``timeout=`` REQUESTS a stop the way ctrl-c would (nushell checks the
+  flag between pipeline elements), raises ``TimeoutError``, and abandons
+  the shared engine for a fresh one: a single stuck element (a hung
+  ``http get``, an external that ignores the flag) may hold the old engine
+  arbitrarily long, and abandoning it keeps later ``nu()`` calls from
+  queueing behind the runaway. Persistent state is therefore LOST on a
+  timeout. Cancelling the awaiting task interrupts the same way but keeps
+  the engine (state survives); after cancelling a truly stuck pipeline,
+  ``nu.reset()`` unwedges. An external the pipeline already spawned
+  finishes on its own; for long externals prefer ``sh``, which group-kills
+  on timeout.
+- Calls against the shared engine run one at a time (REPL state needs
+  ordered evaluation); for parallel pipelines, construct separate
+  ``nu.Engine()`` instances.
 - ``nu.reset()`` discards the persistent state for a fresh engine.
 """
 
@@ -129,7 +138,16 @@ async def _run(
         return await asyncio.wait_for(asyncio.ensure_future(coroutine), timeout)
     except TimeoutError:
         engine.interrupt()
-        raise TimeoutError(f"nu pipeline timed out after {timeout}s: {code}") from None
+        # Abandon the engine, don't just interrupt it: the interrupt is only
+        # honored between pipeline elements, so a stuck element could hold
+        # this engine's lock indefinitely and every later nu() would queue
+        # behind it. A fresh engine costs the persistent state (documented);
+        # the abandoned one stops (and drops) whenever its element finishes.
+        if engine is _engine:
+            reset()
+        raise TimeoutError(
+            f"nu pipeline timed out after {timeout}s (engine state discarded): {code}"
+        ) from None
     except asyncio.CancelledError:
         engine.interrupt()
         raise
@@ -167,9 +185,10 @@ async def nu(
     Multi-statement source is fine; the last pipeline's output is the result,
     and ``let``/``def``/``cd`` persist to later calls (REPL semantics).
     ``input`` pipes a value in as ``$in`` -- a polars DataFrame, list, dict,
-    or scalar. ``cwd`` sets ``PWD`` (persistently, like ``cd``); ``env`` adds
-    environment variables; ``timeout`` interrupts the evaluation; ``name``
-    labels the running job in the dashboard.
+    or scalar (datetimes must be tz-aware). ``cwd`` sets ``PWD``
+    (persistently, like ``cd``); ``env`` adds environment variables;
+    ``timeout`` interrupts the evaluation and discards the engine state (see
+    the module docstring); ``name`` labels the running job in the dashboard.
 
     Shape normalization: table -> frame; record -> 1-row frame; list of
     scalars / scalar -> a single ``value`` column; no output -> empty frame.

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -1,0 +1,218 @@
+"""An embedded nushell engine; every pipeline result is a polars DataFrame.
+
+Bundled like ``sh``/``view`` so every session can ``await nu(...)`` with no
+setup. The point: ``sh`` + ``.json()/.df()`` only speaks structured data when
+the CLI has a JSON mode; everything else decays into jq/awk/sed text
+scraping. Nushell's pipelines are structured end to end (``ls``, ``ps``,
+``open``, ``from csv|toml|yaml``, ``where``, ``group-by``), so ``nu()`` is
+the bridge from "shell pipeline" to "typed frame" for any data-shaped
+command::
+
+    df = await nu("ls | where size > 1kb | sort-by size")
+    df = await nu("ps | where cpu > 5 | sort-by cpu")
+    df = await nu("open Cargo.toml | get package")          # record -> 1-row frame
+    df = await nu("http get https://api.github.com/repos/nushell/nushell")
+
+This is not a subprocess: the engine (PyO3 bindings over nu-engine) lives in
+this process and its state is persistent, like a REPL. A ``let``, a ``def``,
+or a ``cd`` in one call is visible to the next::
+
+    await nu("let prs = (http get $url)")
+    await nu("$prs | where author.login == 'andrewgazelka'")
+
+A DataFrame (or list/dict/scalar) can be piped THROUGH a pipeline: pass
+``input=`` and the code sees it as its pipeline input (``$in``)::
+
+    df = await nu("where size > 1kb | sort-by size", input=df)
+
+Prefer ``nu()`` over ``sh`` whenever you want a command's *data*. ``sh``
+remains the tool for side-effectful commands (``git``/``nix``/``gh`` writes)
+and raw logs, and ``sh(...).df()`` for CLIs with a native ``--json`` mode.
+
+Contract:
+
+- ``await nu(code)`` returns a ``pl.DataFrame``, always: a table maps
+  directly, a record becomes one row, a list of scalars / a scalar become a
+  single ``value`` column, no output (``null``) an empty frame.
+- ``await nu.value(code)`` is the escape hatch when you want the plain
+  Python value (a scalar, a nested dict) instead of a frame.
+- Values cross natively, not as JSON: dates arrive as UTC ``Datetime``
+  columns, durations as ``Duration`` columns, filesize as ``int`` bytes,
+  binary as ``bytes``.
+- A failing pipeline raises :class:`NuError` whose message is nushell's own
+  rendered diagnostic (span, label, and "did you mean" hints) -- read it,
+  fix the pipeline, retry. ``exit`` raises too; it never ends this process.
+- ``timeout=`` interrupts the evaluation the way ctrl-c would (nushell
+  checks the flag between pipeline elements) and raises ``TimeoutError``;
+  cancelling the awaiting task interrupts the same way. An external command
+  the pipeline already spawned finishes on its own; for long externals
+  prefer ``sh``, which group-kills on timeout.
+- ``nu.reset()`` discards the persistent state for a fresh engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect as _inspect
+import os
+from typing import TYPE_CHECKING
+
+from ._nu import Engine, NuError
+
+if TYPE_CHECKING:
+    import polars as pl
+
+__all__ = ["Engine", "NuError", "nu", "reset", "value"]
+
+__version__ = "0.1.0"
+
+# Job renaming mirrors sh: inside the kernel, `name=` labels the running job in
+# the dashboard. Outside (plain `import nu` in a test), it is silently ignored.
+try:
+    from ix_notebook_mcp.runtime import _ix_current, _rename_current_job
+except Exception:  # pragma: no cover - exercised only outside the kernel
+    _ix_current = None
+    _rename_current_job = None
+
+_engine: Engine | None = None
+
+
+def _default_engine() -> Engine:
+    """The shared engine behind module-level calls, created on first use."""
+    global _engine
+    if _engine is None:
+        _engine = Engine()
+    return _engine
+
+
+def reset() -> None:
+    """Discard the persistent engine state (bindings, defs, cwd, env)."""
+    global _engine
+    _engine = None
+
+
+def _serialize_input(input: object) -> object:
+    """``input=`` as plain Python the engine can convert to a nushell value.
+
+    A polars frame becomes its rows (``to_dicts``), so nushell sees the same
+    table shape it would produce itself; everything else passes through.
+    """
+    to_dicts = getattr(input, "to_dicts", None)
+    if callable(to_dicts):  # a polars DataFrame, without importing polars here
+        return to_dicts()
+    return input
+
+
+async def _run(
+    code: str,
+    *,
+    input: object | None = None,
+    cwd: str | os.PathLike | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+    name: str | None = None,
+) -> object:
+    """Evaluate ``code`` on the shared engine; return the plain Python value."""
+    if name is not None and _rename_current_job is not None and (
+        _ix_current is not None and _ix_current.get() is not None
+    ):
+        _rename_current_job(name)
+
+    engine = _default_engine()
+    coroutine = engine.eval(
+        code,
+        input=_serialize_input(input) if input is not None else None,
+        cwd=os.fspath(cwd) if cwd is not None else None,
+        env=env,
+    )
+    try:
+        return await asyncio.wait_for(asyncio.ensure_future(coroutine), timeout)
+    except TimeoutError:
+        engine.interrupt()
+        raise TimeoutError(f"nu pipeline timed out after {timeout}s: {code}") from None
+    except asyncio.CancelledError:
+        engine.interrupt()
+        raise
+
+
+def _to_frame(decoded: object) -> pl.DataFrame:
+    """Normalize any pipeline value into a ``pl.DataFrame``."""
+    import polars as pl
+
+    if decoded is None:
+        return pl.DataFrame()
+    if isinstance(decoded, list) and decoded and all(isinstance(r, dict) for r in decoded):
+        # infer_schema_length=None: scan every row, so a column that starts
+        # null (or int) and later carries strings still gets one usable dtype.
+        return pl.from_dicts(decoded, infer_schema_length=None)
+    if isinstance(decoded, dict):
+        return pl.from_dicts([decoded], infer_schema_length=None)
+    if isinstance(decoded, list):
+        return pl.DataFrame({"value": pl.Series("value", decoded)})
+    return pl.DataFrame({"value": [decoded]})
+
+
+async def nu(
+    code: str,
+    *,
+    input: object | None = None,
+    cwd: str | os.PathLike | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+    name: str | None = None,
+) -> pl.DataFrame:
+    """Run ``code`` as nushell source and return the result as a polars
+    DataFrame.
+
+    Multi-statement source is fine; the last pipeline's output is the result,
+    and ``let``/``def``/``cd`` persist to later calls (REPL semantics).
+    ``input`` pipes a value in as ``$in`` -- a polars DataFrame, list, dict,
+    or scalar. ``cwd`` sets ``PWD`` (persistently, like ``cd``); ``env`` adds
+    environment variables; ``timeout`` interrupts the evaluation; ``name``
+    labels the running job in the dashboard.
+
+    Shape normalization: table -> frame; record -> 1-row frame; list of
+    scalars / scalar -> a single ``value`` column; no output -> empty frame.
+    A failure raises :class:`NuError` carrying nushell's diagnostic.
+    """
+    decoded = await _run(code, input=input, cwd=cwd, env=env, timeout=timeout, name=name)
+    return _to_frame(decoded)
+
+
+async def value(
+    code: str,
+    *,
+    input: object | None = None,
+    cwd: str | os.PathLike | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+    name: str | None = None,
+) -> object:
+    """Like :func:`nu`, but return the plain Python value un-framed.
+
+    The escape hatch for a scalar (``await nu.value("sys host | get
+    hostname")``) or a nested structure you want as plain dicts/lists.
+    """
+    return await _run(code, input=input, cwd=cwd, env=env, timeout=timeout, name=name)
+
+
+# Make the module itself callable (same pattern as the bundled `sh`), so the
+# documented `await nu(...)` works bare while `nu.value` / `nu.NuError` stay
+# reachable as attributes.
+import sys as _sys
+import types as _types
+
+import functools as _functools
+
+
+class _CallableModule(_types.ModuleType):
+    @_functools.wraps(nu)
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        return nu(*args, **kwargs)
+
+
+_module = _sys.modules[__name__]
+_module.__class__ = _CallableModule
+# Publish the real callable signature so api() shows `code` and the kwargs
+# instead of introspecting the bound __call__.
+_module.__signature__ = _inspect.signature(nu)  # type: ignore[attr-defined]

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -37,8 +37,13 @@ Contract:
 - ``await nu.value(code)`` is the escape hatch when you want the plain
   Python value (a scalar, a nested dict) instead of a frame.
 - Values cross natively, not as JSON: dates arrive as UTC ``Datetime``
-  columns, durations as ``Duration`` columns, filesize as ``int`` bytes,
+  columns, durations as ``Duration`` columns (microsecond resolution --
+  Python's ``timedelta`` is the carrier, so a sub-microsecond remainder like
+  ``1500ns`` truncates to the microsecond), filesize as ``int`` bytes,
   binary as ``bytes``.
+- Each kernel session gets its OWN engine (stored in the session's
+  namespace), so one agent's ``let``/``cd``/``def`` never leaks into or
+  clobbers another session's pipelines.
 - A failing pipeline raises :class:`NuError` whose message is nushell's own
   rendered diagnostic (span, label, and "did you mean" hints) -- read it,
   fix the pipeline, retry. ``exit`` raises too; it never ends this process.
@@ -85,19 +90,52 @@ except Exception:  # pragma: no cover - exercised only outside the kernel
 
 _engine: Engine | None = None
 
+# The per-session slot: engines live INSIDE the session's namespace dict, so
+# an engine's lifetime is exactly its session's and one agent's `let`/`cd`
+# never leaks into another session (module globals are shared across all
+# session namespaces; the namespace dict itself is not).
+_ENGINE_KEY = "__ix_nu_engine__"
+
+
+def _session_slot() -> dict | None:
+    """The current kernel job's session namespace, or None outside a job."""
+    if _ix_current is None:
+        return None
+    job = _ix_current.get()
+    ns = getattr(job, "_ns", None) if job is not None else None
+    return ns if isinstance(ns, dict) else None
+
 
 def _default_engine() -> Engine:
-    """The shared engine behind module-level calls, created on first use."""
+    """This session's engine, created on first use (module-global fallback
+    outside a kernel job, e.g. tests and plain scripts)."""
+    ns = _session_slot()
+    if ns is not None:
+        engine = ns.get(_ENGINE_KEY)
+        if not isinstance(engine, Engine):
+            engine = Engine()
+            ns[_ENGINE_KEY] = engine
+        return engine
     global _engine
     if _engine is None:
         _engine = Engine()
     return _engine
 
 
-def reset() -> None:
-    """Discard the persistent engine state (bindings, defs, cwd, env)."""
+def _discard_engine(engine: Engine) -> None:
+    """Drop ``engine`` from whichever slot holds it, so the next call gets a
+    fresh one (the abandoned engine finishes and frees itself off-thread)."""
     global _engine
-    _engine = None
+    if _engine is engine:
+        _engine = None
+    ns = _session_slot()
+    if ns is not None and ns.get(_ENGINE_KEY) is engine:
+        del ns[_ENGINE_KEY]
+
+
+def reset() -> None:
+    """Discard this session's persistent engine state (bindings, defs, cwd)."""
+    _discard_engine(_default_engine())
 
 
 def _serialize_input(input: object) -> object:
@@ -128,7 +166,7 @@ async def _run(
         _rename_current_job(name)
 
     engine = _default_engine()
-    coroutine = engine.eval(
+    coroutine, handle = engine.eval(
         code,
         input=_serialize_input(input) if input is not None else None,
         cwd=os.fspath(cwd) if cwd is not None else None,
@@ -137,20 +175,38 @@ async def _run(
     try:
         return await asyncio.wait_for(asyncio.ensure_future(coroutine), timeout)
     except TimeoutError:
-        engine.interrupt()
+        # The handle targets THIS eval only, so a timeout that fires while we
+        # are still queued behind another pipeline can never interrupt it.
+        handle.interrupt()
         # Abandon the engine, don't just interrupt it: the interrupt is only
         # honored between pipeline elements, so a stuck element could hold
         # this engine's lock indefinitely and every later nu() would queue
         # behind it. A fresh engine costs the persistent state (documented);
         # the abandoned one stops (and drops) whenever its element finishes.
-        if engine is _engine:
-            reset()
+        _discard_engine(engine)
         raise TimeoutError(
             f"nu pipeline timed out after {timeout}s (engine state discarded): {code}"
         ) from None
     except asyncio.CancelledError:
-        engine.interrupt()
+        handle.interrupt()
         raise
+
+
+def _rows_frame(rows: list[dict]) -> pl.DataFrame:
+    """Rows -> frame, surviving mixed-type columns.
+
+    infer_schema_length=None scans every row so a column that starts null (or
+    int) and later carries strings still gets one usable dtype; when even the
+    full scan cannot unify (nushell data is legitimately heterogeneous, e.g.
+    an `open`'d JSON with an int-then-string field), strict=False coerces to
+    a supertype instead of breaking the always-a-DataFrame contract.
+    """
+    import polars as pl
+
+    try:
+        return pl.from_dicts(rows, infer_schema_length=None)
+    except (TypeError, pl.exceptions.PolarsError):
+        return pl.DataFrame(rows, infer_schema_length=None, strict=False)
 
 
 def _to_frame(decoded: object) -> pl.DataFrame:
@@ -160,13 +216,16 @@ def _to_frame(decoded: object) -> pl.DataFrame:
     if decoded is None:
         return pl.DataFrame()
     if isinstance(decoded, list) and decoded and all(isinstance(r, dict) for r in decoded):
-        # infer_schema_length=None: scan every row, so a column that starts
-        # null (or int) and later carries strings still gets one usable dtype.
-        return pl.from_dicts(decoded, infer_schema_length=None)
+        return _rows_frame(decoded)
     if isinstance(decoded, dict):
-        return pl.from_dicts([decoded], infer_schema_length=None)
+        return _rows_frame([decoded])
     if isinstance(decoded, list):
-        return pl.DataFrame({"value": pl.Series("value", decoded)})
+        try:
+            series = pl.Series("value", decoded)
+        except (TypeError, pl.exceptions.PolarsError):
+            # Mixed scalars ([1, 2.5], [1, 'x']): supertype, not a crash.
+            series = pl.Series("value", decoded, strict=False)
+        return pl.DataFrame({"value": series})
     return pl.DataFrame({"value": [decoded]})
 
 

--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -51,6 +51,11 @@ fn initial_engine_state() -> EngineState {
     engine_state.history_enabled = false;
     engine_state.is_interactive = false;
     engine_state.is_login = false;
+    // This engine lives inside an MCP server process: run_external gives an
+    // external with empty pipeline input a NULL stdin only when is_mcp is set
+    // (run_external.rs); otherwise the child inherits the process stdin and a
+    // prompting CLI could hang on -- or consume -- the MCP stdio transport.
+    engine_state.is_mcp = true;
     engine_state.generate_nu_constant();
 
     // Plain diagnostics: the consumer is a model reading an exception message,
@@ -92,11 +97,18 @@ impl EngineInner {
         input: Option<Value>,
         cwd: Option<String>,
         env: Option<HashMap<String, String>>,
+        interrupt: &Arc<AtomicBool>,
     ) -> Result<Value, String> {
         let Self {
             engine_state,
             stack,
         } = self;
+
+        // Each eval carries its OWN interrupt flag (see EvalHandle): installing
+        // it here, under the engine lock, means an interrupt can only ever stop
+        // the eval it was issued for -- a queued eval can neither erase nor
+        // receive a signal aimed at the one currently running.
+        engine_state.set_signals(Signals::new(Arc::clone(interrupt)));
 
         if let Some(dir) = cwd {
             stack.add_env_var("PWD".into(), Value::string(dir, Span::unknown()));
@@ -206,7 +218,7 @@ fn value_to_py(py: Python<'_>, value: Value) -> PyResult<Py<PyAny>> {
                 .into_range_iter(span, Signals::empty())
                 .take(MAX_RANGE_ELEMENTS + 1)
             {
-                if list.len() > MAX_RANGE_ELEMENTS {
+                if list.len() >= MAX_RANGE_ELEMENTS {
                     return Err(NuError::new_err(
                         "range is unbounded or has more than 1,000,000 elements; \
                          collect it in nushell first (e.g. `| first 1000`)",
@@ -238,8 +250,16 @@ fn py_to_value(object: &Bound<'_, PyAny>) -> PyResult<Value> {
     if let Ok(val) = object.extract::<bool>() {
         return Ok(Value::bool(val, span));
     }
-    if let Ok(val) = object.extract::<i64>() {
-        return Ok(Value::int(val, span));
+    // Guard ints as a TYPE, not by extraction fallthrough: a Python int past
+    // i64 would otherwise fall to the f64 branch and arrive silently rounded.
+    if object.is_instance_of::<pyo3::types::PyInt>() {
+        return match object.extract::<i64>() {
+            Ok(val) => Ok(Value::int(val, span)),
+            Err(_) => Err(NuError::new_err(
+                "integer out of range for a nushell int (i64); pass it as a string \
+                 or a float explicitly if lossy is acceptable",
+            )),
+        };
     }
     if let Ok(val) = object.extract::<f64>() {
         return Ok(Value::float(val, span));
@@ -265,8 +285,14 @@ fn py_to_value(object: &Bound<'_, PyAny>) -> PyResult<Value> {
     if let Ok(val) = object.extract::<String>() {
         return Ok(Value::string(val, span));
     }
-    if let Ok(val) = object.extract::<Vec<u8>>() {
-        return Ok(Value::binary(val, span));
+    // Real bytes objects only: extract::<Vec<u8>> would also accept ANY
+    // sequence of byte-sized ints, turning a documented list input like
+    // [1, 2, 3] into binary before the list branch below could see it.
+    if let Ok(bytes) = object.cast::<PyBytes>() {
+        return Ok(Value::binary(bytes.as_bytes().to_vec(), span));
+    }
+    if let Ok(bytes) = object.cast::<pyo3::types::PyByteArray>() {
+        return Ok(Value::binary(bytes.to_vec(), span));
     }
     if let Ok(dict) = object.cast::<PyDict>() {
         let mut record = Record::new();
@@ -289,35 +315,56 @@ fn py_to_value(object: &Bound<'_, PyAny>) -> PyResult<Value> {
     )))
 }
 
+/// One eval's interrupt token, returned by [`Engine::eval`] next to the
+/// awaitable. Flipping it stops THAT eval (at its next pipeline-element
+/// boundary, ctrl-c semantics) and no other: an engine-wide flag could hit a
+/// different eval than the one that timed out, or be erased by a queued one.
+#[pyclass]
+struct EvalHandle {
+    flag: Arc<AtomicBool>,
+}
+
+#[pymethods]
+impl EvalHandle {
+    /// Ask this eval to stop at its next pipeline-element boundary. Safe to
+    /// call before the eval has started (it will stop immediately once it
+    /// acquires the engine).
+    fn interrupt(&self) {
+        self.flag.store(true, Ordering::Relaxed);
+    }
+}
+
 /// A persistent embedded nushell engine.
 #[pyclass]
 struct Engine {
     inner: Arc<Mutex<EngineInner>>,
-    interrupt: Arc<AtomicBool>,
 }
 
 #[pymethods]
 impl Engine {
     #[new]
     fn new() -> Self {
-        let mut engine_state = initial_engine_state();
-        let interrupt = Arc::new(AtomicBool::new(false));
-        engine_state.set_signals(Signals::new(interrupt.clone()));
         Self {
             inner: Arc::new(Mutex::new(EngineInner {
-                engine_state,
-                stack: Stack::new(),
+                engine_state: initial_engine_state(),
+                // collect_value marks the last command's stdout as
+                // OutDest::Value: a trailing external (or `print`) collects
+                // into the returned value instead of writing to the host
+                // process stdio, which under MCP stdio transport IS the
+                // protocol stream.
+                stack: Stack::new().collect_value(),
             })),
-            interrupt,
         }
     }
 
     /// Evaluate nushell source against the persistent state.
     ///
-    /// Returns an awaitable resolving to the pipeline's output as native
-    /// Python objects. `input` becomes the pipeline's `$in`; `cwd`/`env` set
-    /// `PWD` / environment variables for this and later calls (the stack is
-    /// persistent). Raises `NuError` with nushell's rendered diagnostic.
+    /// Returns `(awaitable, handle)`: the awaitable resolves to the pipeline's
+    /// output as native Python objects; `handle.interrupt()` stops this eval
+    /// (and only this eval) the way ctrl-c would. `input` becomes the
+    /// pipeline's `$in`; `cwd`/`env` set `PWD` / environment variables for
+    /// this and later calls (the stack is persistent). Raises `NuError` with
+    /// nushell's rendered diagnostic.
     #[pyo3(signature = (code, input=None, cwd=None, env=None))]
     fn eval<'py>(
         &self,
@@ -326,23 +373,18 @@ impl Engine {
         input: Option<Bound<'py, PyAny>>,
         cwd: Option<String>,
         env: Option<HashMap<String, String>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    ) -> PyResult<(Bound<'py, PyAny>, EvalHandle)> {
         // Convert under the GIL now; the blocking task must not touch Python.
         let input = input.as_ref().map(py_to_value).transpose()?;
         let inner = Arc::clone(&self.inner);
-        let interrupt = Arc::clone(&self.interrupt);
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let flag = Arc::new(AtomicBool::new(false));
+        let interrupt = Arc::clone(&flag);
+        let future = pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let result = tokio::task::spawn_blocking(move || {
                 let mut guard = inner
                     .lock()
                     .map_err(|_| "a previous eval panicked; create a fresh Engine".to_owned())?;
-                // Reset the interrupt only AFTER winning the lock: resetting
-                // before it could erase an interrupt aimed at the eval still
-                // holding the mutex (which would then never stop, wedging
-                // both). Inside the guard, the reset provably applies to this
-                // eval alone.
-                interrupt.store(false, Ordering::Relaxed);
-                guard.eval(&code, input, cwd, env)
+                guard.eval(&code, input, cwd, env, &interrupt)
             })
             .await
             .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
@@ -350,19 +392,15 @@ impl Engine {
                 Ok(value) => Python::attach(|py| value_to_py(py, value)),
                 Err(diagnostic) => Err(NuError::new_err(diagnostic)),
             }
-        })
-    }
-
-    /// Ask the running evaluation to stop at the next pipeline-element
-    /// boundary (the same mechanism as ctrl-c in the nushell CLI).
-    fn interrupt(&self) {
-        self.interrupt.store(true, Ordering::Relaxed);
+        })?;
+        Ok((future, EvalHandle { flag }))
     }
 }
 
 #[pymodule]
 fn _nu(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<Engine>()?;
+    module.add_class::<EvalHandle>()?;
     module.add("NuError", module.py().get_type::<NuError>())?;
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())

--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -199,10 +199,14 @@ fn value_to_py(py: Python<'_>, value: Value) -> PyResult<Py<PyAny>> {
         // finite Python shape, so refuse it rather than loop forever (the
         // range iterator itself never checks signals here).
         Value::Range { ref val, .. } => {
+            const MAX_RANGE_ELEMENTS: usize = 1_000_000;
             let span = value.span();
             let list = PyList::empty(py);
-            for item in val.into_range_iter(span, Signals::empty()).take(1_000_001) {
-                if list.len() > 1_000_000 {
+            for item in val
+                .into_range_iter(span, Signals::empty())
+                .take(MAX_RANGE_ELEMENTS + 1)
+            {
+                if list.len() > MAX_RANGE_ELEMENTS {
                     return Err(NuError::new_err(
                         "range is unbounded or has more than 1,000,000 elements; \
                          collect it in nushell first (e.g. `| first 1000`)",
@@ -242,6 +246,15 @@ fn py_to_value(object: &Bound<'_, PyAny>) -> PyResult<Value> {
     }
     if let Ok(val) = object.extract::<DateTime<FixedOffset>>() {
         return Ok(Value::date(val, span));
+    }
+    // A tz-naive datetime would otherwise fall through every branch and hit
+    // the generic type error; name the actual problem instead of guessing a
+    // timezone (assuming UTC or local silently would corrupt data).
+    if object.extract::<chrono::NaiveDateTime>().is_ok() {
+        return Err(NuError::new_err(
+            "naive datetime: nushell dates carry a timezone; attach one first, \
+             e.g. stamp.replace(tzinfo=datetime.UTC)",
+        ));
     }
     if let Ok(val) = object.extract::<TimeDelta>() {
         let nanos = val
@@ -320,10 +333,15 @@ impl Engine {
         let interrupt = Arc::clone(&self.interrupt);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let result = tokio::task::spawn_blocking(move || {
-                interrupt.store(false, Ordering::Relaxed);
                 let mut guard = inner
                     .lock()
                     .map_err(|_| "a previous eval panicked; create a fresh Engine".to_owned())?;
+                // Reset the interrupt only AFTER winning the lock: resetting
+                // before it could erase an interrupt aimed at the eval still
+                // holding the mutex (which would then never stop, wedging
+                // both). Inside the guard, the reset provably applies to this
+                // eval alone.
+                interrupt.store(false, Ordering::Relaxed);
                 guard.eval(&code, input, cwd, env)
             })
             .await

--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -1,0 +1,351 @@
+//! Python bindings for an embedded nushell engine.
+//!
+//! One [`Engine`] holds a persistent `EngineState` + `Stack`, so `let`
+//! bindings, `def`s, and `cd` survive across `eval` calls the way they do in a
+//! REPL. `eval` returns a native asyncio coroutine (bridged through
+//! pyo3-async-runtimes); the synchronous nushell evaluation runs on tokio's
+//! blocking pool, never on the caller's event loop.
+//!
+//! Cancellation: the engine's `Signals` share one `AtomicBool` with
+//! [`Engine::interrupt`]; flipping it makes the evaluator stop between
+//! pipeline elements, so a Python-side timeout can end a runaway pipeline
+//! without killing the process. (An external command the pipeline already
+//! spawned still runs to completion; nushell only checks the flag between
+//! elements.)
+//!
+//! Values cross the boundary natively, not as JSON: date -> `datetime`
+//! (normalized to UTC so a column mixes no offsets), duration -> `timedelta`,
+//! filesize -> `int` bytes, binary -> `bytes`, record -> `dict`, list ->
+//! `list`. The `nu` Python package turns those into polars frames.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, FixedOffset, TimeDelta, Utc};
+use nu_protocol::debugger::WithoutDebug;
+use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
+use nu_protocol::{
+    ErrorStyle, PipelineData, Record, ShellError, Signals, Span, Value,
+    report_error::format_cli_error,
+};
+use pyo3::create_exception;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PyList};
+
+create_exception!(
+    _nu,
+    NuError,
+    pyo3::exceptions::PyException,
+    "A nushell pipeline failed; the message is nushell's own rendered diagnostic."
+);
+
+/// The engine state a fresh [`Engine`] starts from: the full shell command
+/// set, the host environment, and REPL-free configuration.
+fn initial_engine_state() -> EngineState {
+    let mut engine_state = nu_cmd_lang::create_default_context();
+    engine_state = nu_command::add_shell_command_context(engine_state);
+    engine_state = nu_cmd_extra::add_extra_command_context(engine_state);
+
+    engine_state.history_enabled = false;
+    engine_state.is_interactive = false;
+    engine_state.is_login = false;
+    engine_state.generate_nu_constant();
+
+    // Plain diagnostics: the consumer is a model reading an exception message,
+    // so drop the fancy unicode/ANSI rendering at the source instead of
+    // stripping escapes after the fact.
+    {
+        let config = Arc::make_mut(&mut engine_state.config);
+        config.error_style = ErrorStyle::Plain;
+    }
+
+    // The host environment, so `$env`, externals, and path lookups behave like
+    // a normal shell session. PWD seeds cwd-relative commands (`ls`, `open`).
+    for (key, value) in std::env::vars() {
+        engine_state.add_env_var(key, Value::string(value, Span::unknown()));
+    }
+    if let Ok(current_dir) = std::env::current_dir() {
+        engine_state.add_env_var(
+            "PWD".into(),
+            Value::string(current_dir.to_string_lossy(), Span::unknown()),
+        );
+    }
+
+    engine_state
+}
+
+/// The mutable half of an [`Engine`], locked for the duration of one eval.
+struct EngineInner {
+    engine_state: EngineState,
+    stack: Stack,
+}
+
+impl EngineInner {
+    /// Parse and evaluate `code` against the persistent state, returning the
+    /// pipeline's collected output value. Every error path returns nushell's
+    /// rendered diagnostic (span, label, help) as the message.
+    fn eval(
+        &mut self,
+        code: &str,
+        input: Option<Value>,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
+    ) -> Result<Value, String> {
+        let Self {
+            engine_state,
+            stack,
+        } = self;
+
+        if let Some(dir) = cwd {
+            stack.add_env_var("PWD".into(), Value::string(dir, Span::unknown()));
+        }
+        for (key, value) in env.into_iter().flatten() {
+            stack.add_env_var(key, Value::string(value, Span::unknown()));
+        }
+
+        let block = {
+            let mut working_set = StateWorkingSet::new(engine_state);
+            let block = nu_parser::parse(&mut working_set, Some("nu()"), code.as_bytes(), false);
+            if let Some(error) = working_set.parse_errors.first() {
+                return Err(format_cli_error(
+                    Some(stack),
+                    &working_set,
+                    error,
+                    Some("nu::parser::error"),
+                ));
+            }
+            if let Some(error) = working_set.compile_errors.first() {
+                return Err(format_cli_error(
+                    Some(stack),
+                    &working_set,
+                    error,
+                    Some("nu::compile::error"),
+                ));
+            }
+            let delta = working_set.render();
+            engine_state
+                .merge_delta(delta)
+                .map_err(|error| render_shell_error(engine_state, stack, &error))?;
+            block
+        };
+
+        let input = input.map_or_else(PipelineData::empty, |value| PipelineData::value(value, None));
+        // eval_ir_block, NOT eval_block: eval_block maps a user's `exit` to
+        // std::process::exit, which would take the whole embedding process
+        // (the kernel) down. Here `exit` surfaces as ShellError::Exit and
+        // becomes a raised NuError like any other failure.
+        let executed =
+            nu_engine::eval_ir_block::<WithoutDebug>(engine_state, stack, &block, input)
+                .map_err(|error| render_shell_error(engine_state, stack, &error))?;
+        let value = executed
+            .body
+            .into_value(Span::unknown())
+            .map_err(|error| render_shell_error(engine_state, stack, &error))?;
+        if let Value::Error { error, .. } = value {
+            return Err(render_shell_error(engine_state, stack, &error));
+        }
+        Ok(value)
+    }
+}
+
+/// Render a `ShellError` exactly the way the nushell CLI would (minus color:
+/// the engine config pins the plain style).
+fn render_shell_error(engine_state: &EngineState, stack: &Stack, error: &ShellError) -> String {
+    let working_set = StateWorkingSet::new(engine_state);
+    format_cli_error(Some(stack), &working_set, error, Some("nu::shell::error"))
+}
+
+/// Convert a nushell [`Value`] into the natural Python object.
+fn value_to_py(py: Python<'_>, value: Value) -> PyResult<Py<PyAny>> {
+    let object = match value {
+        Value::Nothing { .. } => py.None(),
+        Value::Bool { val, .. } => val.into_pyobject(py)?.to_owned().unbind().into_any(),
+        Value::Int { val, .. } => val.into_pyobject(py)?.unbind().into_any(),
+        Value::Float { val, .. } => val.into_pyobject(py)?.unbind().into_any(),
+        Value::String { val, .. } | Value::Glob { val, .. } => {
+            val.into_pyobject(py)?.unbind().into_any()
+        }
+        // Bytes, not a unit-carrying type: polars sums/filters plain ints.
+        Value::Filesize { val, .. } => i64::from(val).into_pyobject(py)?.unbind().into_any(),
+        // Nanoseconds -> timedelta (polars maps it to a Duration column).
+        Value::Duration { val, .. } => TimeDelta::nanoseconds(val)
+            .into_pyobject(py)?
+            .unbind()
+            .into_any(),
+        // Normalize to UTC so a frame column never mixes fixed offsets.
+        Value::Date { val, .. } => val
+            .with_timezone(&Utc)
+            .into_pyobject(py)?
+            .unbind()
+            .into_any(),
+        Value::Binary { val, .. } => PyBytes::new(py, &val).unbind().into_any(),
+        Value::Record { val, .. } => {
+            let dict = PyDict::new(py);
+            for (key, item) in val.into_owned() {
+                dict.set_item(key, value_to_py(py, item)?)?;
+            }
+            dict.unbind().into_any()
+        }
+        Value::List { vals, .. } => {
+            let list = PyList::empty(py);
+            for item in vals {
+                list.append(value_to_py(py, item)?)?;
+            }
+            list.unbind().into_any()
+        }
+        // A bounded range expands to its values; an unbounded one has no
+        // finite Python shape, so refuse it rather than loop forever (the
+        // range iterator itself never checks signals here).
+        Value::Range { ref val, .. } => {
+            let span = value.span();
+            let list = PyList::empty(py);
+            for item in val.into_range_iter(span, Signals::empty()).take(1_000_001) {
+                if list.len() > 1_000_000 {
+                    return Err(NuError::new_err(
+                        "range is unbounded or has more than 1,000,000 elements; \
+                         collect it in nushell first (e.g. `| first 1000`)",
+                    ));
+                }
+                list.append(value_to_py(py, item)?)?;
+            }
+            list.unbind().into_any()
+        }
+        // An error embedded in otherwise-successful data still fails the call:
+        // silently stringifying it would hide the failure in a frame cell.
+        Value::Error { error, .. } => return Err(NuError::new_err(error.to_string())),
+        // No natural Python shape: hand back the value's own string rendering.
+        other @ (Value::Closure { .. } | Value::CellPath { .. } | Value::Custom { .. }) => other
+            .to_expanded_string(", ", &nu_protocol::Config::default())
+            .into_pyobject(py)?
+            .unbind()
+            .into_any(),
+    };
+    Ok(object)
+}
+
+/// Convert a Python object into a nushell [`Value`] (the `input=` direction).
+fn py_to_value(object: &Bound<'_, PyAny>) -> PyResult<Value> {
+    let span = Span::unknown();
+    if object.is_none() {
+        return Ok(Value::nothing(span));
+    }
+    if let Ok(val) = object.extract::<bool>() {
+        return Ok(Value::bool(val, span));
+    }
+    if let Ok(val) = object.extract::<i64>() {
+        return Ok(Value::int(val, span));
+    }
+    if let Ok(val) = object.extract::<f64>() {
+        return Ok(Value::float(val, span));
+    }
+    if let Ok(val) = object.extract::<DateTime<FixedOffset>>() {
+        return Ok(Value::date(val, span));
+    }
+    if let Ok(val) = object.extract::<TimeDelta>() {
+        let nanos = val
+            .num_nanoseconds()
+            .ok_or_else(|| NuError::new_err("timedelta too large for a nushell duration"))?;
+        return Ok(Value::duration(nanos, span));
+    }
+    if let Ok(val) = object.extract::<String>() {
+        return Ok(Value::string(val, span));
+    }
+    if let Ok(val) = object.extract::<Vec<u8>>() {
+        return Ok(Value::binary(val, span));
+    }
+    if let Ok(dict) = object.cast::<PyDict>() {
+        let mut record = Record::new();
+        for (key, item) in dict {
+            record.push(key.extract::<String>()?, py_to_value(&item)?);
+        }
+        return Ok(Value::record(record, span));
+    }
+    if let Ok(list) = object.try_iter() {
+        let mut vals = Vec::new();
+        for item in list {
+            vals.push(py_to_value(&item?)?);
+        }
+        return Ok(Value::list(vals, span));
+    }
+    Err(NuError::new_err(format!(
+        "cannot pipe a {} into nushell; pass None/bool/int/float/str/bytes/datetime/timedelta \
+         or a list/dict of those",
+        object.get_type().name()?,
+    )))
+}
+
+/// A persistent embedded nushell engine.
+#[pyclass]
+struct Engine {
+    inner: Arc<Mutex<EngineInner>>,
+    interrupt: Arc<AtomicBool>,
+}
+
+#[pymethods]
+impl Engine {
+    #[new]
+    fn new() -> Self {
+        let mut engine_state = initial_engine_state();
+        let interrupt = Arc::new(AtomicBool::new(false));
+        engine_state.set_signals(Signals::new(interrupt.clone()));
+        Self {
+            inner: Arc::new(Mutex::new(EngineInner {
+                engine_state,
+                stack: Stack::new(),
+            })),
+            interrupt,
+        }
+    }
+
+    /// Evaluate nushell source against the persistent state.
+    ///
+    /// Returns an awaitable resolving to the pipeline's output as native
+    /// Python objects. `input` becomes the pipeline's `$in`; `cwd`/`env` set
+    /// `PWD` / environment variables for this and later calls (the stack is
+    /// persistent). Raises `NuError` with nushell's rendered diagnostic.
+    #[pyo3(signature = (code, input=None, cwd=None, env=None))]
+    fn eval<'py>(
+        &self,
+        py: Python<'py>,
+        code: String,
+        input: Option<Bound<'py, PyAny>>,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        // Convert under the GIL now; the blocking task must not touch Python.
+        let input = input.as_ref().map(py_to_value).transpose()?;
+        let inner = Arc::clone(&self.inner);
+        let interrupt = Arc::clone(&self.interrupt);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let result = tokio::task::spawn_blocking(move || {
+                interrupt.store(false, Ordering::Relaxed);
+                let mut guard = inner
+                    .lock()
+                    .map_err(|_| "a previous eval panicked; create a fresh Engine".to_owned())?;
+                guard.eval(&code, input, cwd, env)
+            })
+            .await
+            .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+            match result {
+                Ok(value) => Python::attach(|py| value_to_py(py, value)),
+                Err(diagnostic) => Err(NuError::new_err(diagnostic)),
+            }
+        })
+    }
+
+    /// Ask the running evaluation to stop at the next pipeline-element
+    /// boundary (the same mechanism as ctrl-c in the nushell CLI).
+    fn interrupt(&self) {
+        self.interrupt.store(true, Ordering::Relaxed);
+    }
+}
+
+#[pymodule]
+fn _nu(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<Engine>()?;
+    module.add("NuError", module.py().get_type::<NuError>())?;
+    module.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}


### PR DESCRIPTION
Embedded, persistent nushell engine for the index kernel: `await nu("ls | where size > 1kb | sort-by size")` returns a polars DataFrame, always.

**Architecture** (per discussion): a Rust PyO3 crate (`packages/nu-py`) embedding nu-engine 0.113.1, async via pyo3-async-runtimes + tokio blocking pool, values crossing natively (Datetime/Duration/bytes), NOT a subprocess. Persistent REPL state: `let`/`def`/`cd` survive across calls. Interrupt-based timeout/cancel via nushell's own `Signals`; `eval_ir_block` so `exit` raises instead of killing the kernel.

**Validated**: lint 7/7; `nix build .#mcp` + `.#mcp.tests.nuBundled` + `.#mcp.tests.nuTests` green on aarch64-darwin (16 behavior tests: normalization matrix, persistence, df roundtrip, native dtypes, NuError diagnostics, `exit` safety, interrupt timeout, reset); live smoke against the built interpreter.

**Guidance**: new `guide.NU` fragment + registry preimport steer agents to `nu()` over `sh` + jq/awk/sed for data-shaped commands; `sh` Outputs now carry a hint when a string command pipes through text mungers.

Fixes #1676

(sent by an AI agent via Claude Code, Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle an embedded nushell engine as the `nu` Python module returning polars DataFrames
> - Adds a new `nu-py` Rust crate ([Cargo.toml](https://github.com/indexable-inc/index/pull/1685/files#diff-bc0bee8ec7e096b7aeb00ba74698db7d22fe14fb5f251423a4430097c2b8c4de), [lib.rs](https://github.com/indexable-inc/index/pull/1685/files#diff-424ce210c45fc8f162c45814067651d48d245471a2e86b63c39b71c370ffe7fe)) that embeds nushell via PyO3, exposing `Engine`, `EvalHandle`, and `NuError` to Python.
> - Wraps the extension in a Python package ([__init__.py](https://github.com/indexable-inc/index/pull/1685/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4)) with an async `nu(code, ...)` call that runs nushell in-process, normalizes output to polars DataFrames, supports `input=df` piping, timeouts with per-eval interrupt, and persistent state across calls.
> - Registers `nu` as a preimported module in the MCP catalog and embeds usage guidance in kernel instructions so clients can use it without an explicit import.
> - Adds a hint in `sh._structured_hint` that redirects pipelines using text-munging tools (`jq`, `awk`, `sed`, etc.) toward `await nu(...)` for structured output.
> - Risk: nushell crates are pinned at 0.113.1 with specific feature flags to avoid a `rusqlite` version collision with other workspace dependencies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae198ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->