### PR TITLE
prompt: add scopedNaming rule against restating enclosing scope

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -127,6 +127,16 @@ let
       '';
     }
     {
+      scopedNaming = ''
+        Name things by what they add to their enclosing scope, never by
+        restating it. A path, crate, module, option, field, or function is
+        always read with its context: `packages/minecraft/assets`, not
+        `packages/minecraft/minecraft-assets`. When siblings share a prefix,
+        that prefix is a missing parent scope: introduce it and drop the
+        prefix from the leaves.
+      '';
+    }
+    {
       rustCollectStyle = ''
         In Rust, type collection results with a local annotation, not turbofish forms
         like `.collect::<HashSet<_>>()`.


### PR DESCRIPTION
Closes #1689.

Adds a `scopedNaming` rule to the house system prompt: name things by what they add to their enclosing scope, never by restating it (`packages/minecraft/assets`, not `packages/minecraft/minecraft-assets`); a shared sibling prefix is a missing parent scope.

Rendered output verified via `nix eval --raw --impure`.

(sent by an AI agent via Claude Code, Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `scopedNaming` rule to system prompt to avoid restating enclosing scope
> Adds a `scopedNaming` guideline to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1690/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to name entities by their contribution to the enclosing scope rather than restating it. When siblings share a common prefix, the rule suggests introducing a parent scope and dropping the prefix from leaf names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f660e90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->