### PR TITLE
skills: add zero-tech-debt shared skill

### DIFF
--- a/packages/agent/skills/zero-tech-debt/SKILL.md
+++ b/packages/agent/skills/zero-tech-debt/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: zero-tech-debt
+description: Rework a change as if the intended UX and architecture existed from day one, deleting compatibility cruft and accidental complexity. Use when the user asks for zero tech debt, no legacy path, a clean end-state refactor, or wants a patch reshaped around the intended final product surface instead of the historical path that produced it.
+---
+
+# Zero Tech Debt
+
+Rework the change from the intended end state, not from the historical path that produced the current patch.
+
+## Steps
+
+1. State the intended end state in one or two sentences.
+
+2. Search for real callers before preserving compatibility.
+   If a mode, prop, wrapper, route alias, or fallback has no current caller, delete it.
+
+3. Reshape around the final product surface.
+   Prefer one clean component or flow over mode flags. Split only when it creates an obvious boundary such as state, layout, controls, or domain commands.
+
+4. Move shared rules to one place.
+   Feature flags, permissions, route gating, URL state, and command naming should not be duplicated across pages or hidden in view components.
+
+5. Verify the intended flow.
+   Test the new behavior and any deleted assumptions that affect navigation, permissions, or persisted state.
+
+## Rules
+
+- Optimize for the code that should exist, not the smallest diff from the old shape.
+- Delete dead compatibility paths instead of making them better.
+- Do not invent a generic framework for one feature.
+- Keep the refactor scoped to what makes the final shape coherent.
+- Prefer names that describe product intent over implementation history.


### PR DESCRIPTION
Copies the zero-tech-debt skill from ix `skills/` into the shared skill set so index consumers get it. The skill is fully generic (end-state refactor discipline; no ix-specific content). Auto-discovered by `lib/skills.nix`, so no registration change is needed.

ix keeps its local copy under `skills/zero-tech-debt` for now.