### PR TITLE
system prompt: updateable pins + derive-dont-enumerate rules

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -179,6 +179,23 @@ let
       '';
     }
     {
+      updateablePins = ''
+        Never inline a pinned artifact identity (hash, digest, rev, pinned
+        version of something fetched) in source. Keep each pin next to its
+        coordinates in a generated lock file read as data, and wire an updater
+        into the repo's update entry point so the pin refreshes mechanically.
+      '';
+    }
+    {
+      deriveDontEnumerate = ''
+        When code restates structure that already exists (directory contents,
+        sibling names, a list kept elsewhere), derive it from that source of
+        truth via discovery, `readDir`, globs, or generated data. Hand-kept
+        enumerations drift; add an explicit exclude list only with a
+        why-comment per exclusion.
+      '';
+    }
+    {
       separateDefinitions = ''
         Keep declarative definitions separate from machinery that renders, executes,
         or adapts them. Put registries, schemas, fixtures, and policy data where they


### PR DESCRIPTION
Two general rules distilled from the repo-hygiene sweep: pins live in generated lock files with a wired updater (never inline), and lists that restate existing structure are derived from it. Rendered via the documented `nix eval --raw --impure` check and reread.

Closes #1702.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `updateablePins` and `deriveDontEnumerate` rules to agent system prompt
> Adds two new guidance blocks to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1704/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df):
> - `updateablePins`: instructs the agent to keep pinned artifact identities in generated lock files and wire an updater
> - `deriveDontEnumerate`: instructs the agent to derive structure from sources of truth rather than maintaining hand-kept enumerations, with explicit excludes requiring justification
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4a895f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->