### PR TITLE
zed: language mapping for .astlog files

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,7 +1,13 @@
 {
+  // astlog rules are S-expressions (no dedicated grammar/LSP yet, #1703):
+  // Scheme gives paren matching + sexp highlighting via the auto-installed extension.
+  "auto_install_extensions": {
+    "scheme": true
+  },
   "file_types": {
     "Nu": ["nu"],
-    "JSONC": ["common.json", "*-mods.json"]
+    "JSONC": ["common.json", "*-mods.json"],
+    "Scheme": ["astlog"]
   },
   "languages": {
     "Nix": {


### PR DESCRIPTION
Maps `.astlog` to Scheme (S-expression highlighting + paren matching) and auto-installs the extension. No astlog LSP exists yet; follow-up tracked in #1703.

Closes #1703 near-term scope.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Map `.astlog` files to the Scheme language in Zed settings
> Adds a `Scheme: ["astlog"]` entry to [.zed/settings.json](https://github.com/indexable-inc/index/pull/1705/files#diff-abb804d570c3104a261c81b34f0ad1c1d5edb2f62e1318fa5030dbe6ffbdf3d4), so `.astlog` files get Scheme syntax highlighting and sexp features. Also enables auto-install of the Scheme extension.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea63a37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->