### PR TITLE
ci: add scheduled Rust nightly bump workflow

### DIFF
--- a/.github/scripts/bump-rust-nightly.py
+++ b/.github/scripts/bump-rust-nightly.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Bump rust-toolchain.toml to the latest Rust nightly, if it is safe to do so.
+
+Run from the repo root. Rewrites the `channel` line in place when a newer
+nightly is available AND every component/target this repo's
+rust-toolchain.toml requires is present in that nightly's manifest. Exits 0
+(no file change) when there's nothing to bump or the newer nightly is
+missing something this repo needs -- create-pull-request no-ops on an empty
+diff, so a no-op run here just means no PR (or an existing rolling PR is left
+untouched).
+"""
+
+import re
+import sys
+import tomllib
+import urllib.request
+
+MANIFEST_URL = "https://static.rust-lang.org/dist/channel-rust-nightly.toml"
+TOOLCHAIN_PATH = "rust-toolchain.toml"
+
+# rustup's component short names (as written in rust-toolchain.toml) don't
+# always match the manifest's package keys: some ship as "-preview" packages
+# upstream even though rustup exposes them under the short name.
+COMPONENT_PKG_NAME = {
+    "rust-src": "rust-src",
+    "rust-analyzer": "rust-analyzer-preview",
+    "rustc-dev": "rustc-dev",
+    "llvm-tools": "llvm-tools-preview",
+}
+
+# Host platforms this repo's CI actually builds the toolchain on. A `targets`
+# entry in rust-toolchain.toml is a cross-compile target: rustup only needs
+# `rust-std` for it, not every component, so it is checked separately below.
+HOST_PLATFORMS = ["x86_64-unknown-linux-musl", "aarch64-apple-darwin"]
+
+
+def main() -> int:
+    with open(TOOLCHAIN_PATH, "rb") as f:
+        toolchain = tomllib.load(f)["toolchain"]
+
+    current_channel = toolchain["channel"]
+    m = re.fullmatch(r"nightly-(\d{4}-\d{2}-\d{2})", current_channel)
+    if not m:
+        print(f"channel {current_channel!r} is not a dated nightly pin, nothing to do")
+        return 0
+    current_date = m.group(1)
+
+    components = toolchain.get("components", [])
+    targets = toolchain.get("targets", [])
+
+    with urllib.request.urlopen(MANIFEST_URL, timeout=30) as resp:
+        manifest = tomllib.loads(resp.read().decode())
+
+    manifest_date = manifest["date"]
+    if manifest_date <= current_date:
+        print(f"pinned {current_date} is already >= manifest {manifest_date}, nothing to do")
+        return 0
+
+    pkgs = manifest["pkg"]
+
+    # Every component must be available for every host platform this repo
+    # builds on, or the bump would break that platform's toolchain fetch.
+    for component in components:
+        pkg_name = COMPONENT_PKG_NAME.get(component, component)
+        pkg = pkgs.get(pkg_name)
+        if pkg is None:
+            print(f"skip: component {component!r} (pkg {pkg_name!r}) not present in manifest {manifest_date}")
+            return 0
+        pkg_targets = pkg.get("target", {})
+        for host in HOST_PLATFORMS:
+            info = pkg_targets.get(host) or pkg_targets.get("*")
+            if info is None or not info.get("available", False):
+                print(f"skip: component {component!r} unavailable for {host} in manifest {manifest_date}")
+                return 0
+
+    # A cross-compile target only needs `rust-std` to be available on it.
+    rust_std_targets = pkgs["rust-std"]["target"]
+    for target in targets:
+        info = rust_std_targets.get(target)
+        if info is None or not info.get("available", False):
+            print(f"skip: target {target!r} has no available rust-std in manifest {manifest_date}")
+            return 0
+
+    with open(TOOLCHAIN_PATH, encoding="utf-8") as f:
+        content = f.read()
+    new_content = content.replace(f'"{current_channel}"', f'"nightly-{manifest_date}"')
+    if new_content == content:
+        print(f"could not find channel line for {current_channel!r} to rewrite")
+        return 1
+    with open(TOOLCHAIN_PATH, "w", encoding="utf-8") as f:
+        f.write(new_content)
+
+    print(f"bumped nightly {current_date} -> {manifest_date}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/update-rust-nightly.yml
+++ b/.github/workflows/update-rust-nightly.yml
@@ -1,0 +1,68 @@
+name: Update Rust nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly ships once a day, so a daily check is enough (unlike the hourly
+    # cargo/flake-lock/content updaters). The minute+hour is offset from
+    # those (:17, :37, :47) so no two updaters start in the same tick.
+    - cron: "23 6 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-rust-nightly
+  cancel-in-progress: false
+
+jobs:
+  update-rust-nightly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # rust-overlay resolves the toolchain straight from rust-toolchain.toml,
+      # so rewriting the `channel` line here is the only file that needs to
+      # change. python3's stdlib tomllib parses both the pin and the upstream
+      # manifest properly instead of grepping dates out of TOML by hand.
+      - name: Compute latest available nightly
+        run: python3 .github/scripts/bump-rust-nightly.py
+
+      # Opens (or updates) a single PR, and only when something changed:
+      # create-pull-request no-ops on an empty diff (which is also what the
+      # script above produces when the manifest isn't newer, or when the
+      # newer nightly is missing a component this repo's rust-toolchain.toml
+      # requires). It reuses the `update-rust-nightly` branch so each run
+      # advances the same PR.
+      #
+      # `token`: a PR opened with the default GITHUB_TOKEN does not trigger
+      # the `pull_request` workflows (`flake-check`), so branch protection
+      # would block the merge. Set an `AUTOBUMP_TOKEN` repo secret (a PAT or
+      # GitHub App token) to make the PR run CI; without it this falls back
+      # to GITHUB_TOKEN and a maintainer must re-trigger `flake-check`.
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          base: main
+          branch: update-rust-nightly
+          delete-branch: true
+          commit-message: "rust-toolchain: bump nightly"
+          title: "rust-toolchain: bump nightly"
+          body: |
+            Automated bump of the pinned nightly in `rust-toolchain.toml` to the latest date published in [`channel-rust-nightly.toml`](https://static.rust-lang.org/dist/channel-rust-nightly.toml).
+
+            The bump is skipped (no PR, or the rolling PR is left as-is) whenever the newer nightly is missing a component or target this repo's `rust-toolchain.toml` requires, so this never lands a toolchain the repo can't actually install.
+
+            rust-overlay resolves the toolchain straight from `rust-toolchain.toml`, so no other file needs to change.
+
+            `flake-check` is what proves the new toolchain actually builds, so review its result before merging.
+
+            Refs indexable-inc/index#1698.
+
+            (sent by an AI agent via Claude Code)


### PR DESCRIPTION
Adds a scheduled workflow (`update-rust-nightly.yml`) that checks `https://static.rust-lang.org/dist/channel-rust-nightly.toml` daily and bumps the `channel` in `rust-toolchain.toml` to the latest nightly date, opening/updating a rolling PR on the `update-rust-nightly` branch — same pattern as `update-cargo.yml` (unique cron offset, `peter-evans/create-pull-request`, `AUTOBUMP_TOKEN` fallback to `github.token`).

The bump script (`.github/scripts/bump-rust-nightly.py`) parses both the pin and the upstream manifest with `tomllib` (no grep) and only proposes a bump when:
- the manifest date is strictly newer than the pinned date, and
- every component listed in `rust-toolchain.toml` (`rust-src`, `rust-analyzer`) is available in that nightly for the host platforms this repo builds on.

rust-overlay resolves the toolchain straight from `rust-toolchain.toml`, so no other file needs touching.

Refs indexable-inc/index#1698.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add scheduled GitHub Actions workflow to bump Rust nightly pin
> - Adds [bump-rust-nightly.py](https://github.com/indexable-inc/index/pull/1706/files#diff-71ebbcb357a9a114bb9beb420bb999e02e782bc3615c97fe2bf45bd309d42b23) which fetches the latest nightly manifest, verifies all required components and cross-targets are available on the configured host platforms, and rewrites the channel date in `rust-toolchain.toml` if safe.
> - Adds [update-rust-nightly.yml](https://github.com/indexable-inc/index/pull/1706/files#diff-cf696d2660726bae80ed40c9f87efdfe28069953ce07c375f29ab1d393b09355) which runs daily via cron (and on manual dispatch), executes the script, and opens or updates a rolling PR on `update-rust-nightly` when the toolchain file changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ffe4a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->