### PR TITLE
lint: enforce strict deadnix (drop --no-lambda-pattern-names)

### DIFF
--- a/examples/east-west/firewall/service.nix
+++ b/examples/east-west/firewall/service.nix
@@ -1,5 +1,4 @@
 {
-  config,
   lib,
   pkgs,
   ...

--- a/examples/minecraft/blocks/producer.nix
+++ b/examples/minecraft/blocks/producer.nix
@@ -16,7 +16,6 @@
     the separate collector leg.
 */
 {
-  config,
   ix,
   lib,
   nodes,

--- a/examples/multi-client/file-sharing/server.nix
+++ b/examples/multi-client/file-sharing/server.nix
@@ -1,8 +1,4 @@
-{
-  config,
-  lib,
-  ...
-}:
+_:
 let
   sambaPort = 445;
   shareDir = "/var/lib/file-share";

--- a/examples/nginx/lifecycle/service.nix
+++ b/examples/nginx/lifecycle/service.nix
@@ -1,5 +1,4 @@
 {
-  config,
   lib,
   pkgs,
   ...

--- a/examples/ray/cluster/cluster-node.nix
+++ b/examples/ray/cluster/cluster-node.nix
@@ -23,7 +23,7 @@
   extraStartArgs,
   rayAddress,
 }:
-{ config, ... }:
+_:
 let
   package = import ./package.nix { inherit ix lib pkgs; };
   rayCli = import ./cli.nix {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -394,7 +394,6 @@ let
       buildSvelteSite
       buildLibghosttyVt
       ghostty
-      writeNushellApplication
       writeBashApplication
       macosSdk
       appleSdkToolchain

--- a/lib/dev/shared-mount.nix
+++ b/lib/dev/shared-mount.nix
@@ -22,7 +22,7 @@
   systemd `LoadCredential` (RFC 0007, and the shape `python-daily-scraper`
   uses for AWS keys).
 */
-{ lib }:
+_:
 let
   sambaPort = 445;
 in

--- a/lib/image/dev.nix
+++ b/lib/image/dev.nix
@@ -33,7 +33,7 @@
   evalImageConfig,
 }:
 let
-  inherit (import (paths.root + "/lib/dev/shared-mount.nix") { inherit lib; })
+  inherit (import (paths.root + "/lib/dev/shared-mount.nix") { })
     serverModule
     clientModule
     ;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -53,7 +53,12 @@ let
         nixfmt --check ...$nix_files
       }
       def "main statix" [] { statix check . }
-      def "main deadnix" [] { deadnix --fail --no-lambda-pattern-names . }
+      # Strict: no `-L`/`--no-lambda-pattern-names`. That flag exists because
+      # dropping a pattern name is unsafe without `...` in the pattern (it
+      # narrows the callable signature); an unused name here must be deleted
+      # (migrating call sites) or kept behind `...`, matching what the LSP
+      # already flags as unused.
+      def "main deadnix" [] { deadnix --fail . }
       # The Nix style rules as astlog lint declarations
       # (astlog-rules/nix.astlog, #1060/#1062). `astlog scan` emits one
       # finding per lint-declared relation row and exits nonzero on any
@@ -451,7 +456,6 @@ let
     inherit
       ix
       lib
-      pkgs
       repoPackages
       ;
   };

--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -6,7 +6,6 @@
   buildSvelteSite,
   buildLibghosttyVt,
   ghostty,
-  writeNushellApplication,
   writeBashApplication,
   # Cross-compilation leaves, threaded in so `unitsFor { target }` can build a
   # second unit graph for a non-host triple without `workspace.nix` having

--- a/modules/services/minecraft-bedrock/server.nix
+++ b/modules/services/minecraft-bedrock/server.nix
@@ -2,7 +2,6 @@
 # (explicit deps, no `pkgs` arg) so it stays `override`-able and the module that
 # consumes it does not build a derivation inline.
 {
-  lib,
   stdenv,
   fetchurl,
   autoPatchelfHook,

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -189,7 +189,6 @@ let
           inherit
             ix
             lib
-            pkgs
             repoPackages
             ;
         };

--- a/packages/agent/subagents.nix
+++ b/packages/agent/subagents.nix
@@ -3,7 +3,6 @@
 {
   ix,
   lib,
-  pkgs,
   repoPackages,
 }:
 let

--- a/packages/fff/default.nix
+++ b/packages/fff/default.nix
@@ -4,7 +4,6 @@
   ix,
   cmake,
   pkg-config,
-  stdenv,
 }:
 # External-Rust-tool house style: a standalone third-party binary built from a
 # pinned flake source input with `rustPlatform.buildRustPackage`. See

--- a/packages/tui/tui-node/default.nix
+++ b/packages/tui/tui-node/default.nix
@@ -1,6 +1,5 @@
 {
   ix,
-  lib,
   pkgs ? ix.pkgs,
 }:
 let

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -77,19 +77,17 @@ let
       };
     };
 
-  minecraftBedrockModule =
-    { config, ... }:
-    {
-      ix.image.name = "minecraft-bedrock";
+  minecraftBedrockModule = _: {
+    ix.image.name = "minecraft-bedrock";
 
-      services.minecraft-bedrock = {
-        enable = true;
-        settings = {
-          server-name = "ix-powered Bedrock";
-          max-players = 20;
-        };
+    services.minecraft-bedrock = {
+      enable = true;
+      settings = {
+        server-name = "ix-powered Bedrock";
+        max-players = 20;
       };
     };
+  };
 
   remoteDesktopImageModule =
     { pkgs, ... }:


### PR DESCRIPTION
Removes the `--no-lambda-pattern-names` escape hatch from the deadnix lint stage (`lib/per-system.nix`) and fixes every hit strict mode surfaces.

## Hits fixed

| File | Binding | Fix |
|---|---|---|
| `tests/default.nix:81` | `config` (module pattern) | deleted — pattern collapsed to bare `_:` |
| `examples/multi-client/file-sharing/server.nix:1-4` | `config`, `lib` (module pattern, had `...`) | deleted — pattern collapsed to bare `_:` |
| `examples/east-west/firewall/service.nix:2` | `config` | deleted from pattern (kept `...`) |
| `examples/nginx/lifecycle/service.nix:2` | `config` | deleted from pattern (kept `...`) |
| `examples/minecraft/blocks/producer.nix:19` | `config` | deleted from pattern (kept `...`) |
| `examples/ray/cluster/cluster-node.nix:26` | `config` (inner module pattern) | deleted — pattern collapsed to bare `_:` |
| `packages/tui/tui-node/default.nix:3` | `lib` | deleted (callPackage-consumed, no `...`; callPackage rebinds by name so this is safe) |
| `packages/agent/subagents.nix:6` | `pkgs` | deleted from pattern; call sites in `lib/per-system.nix` and `packages/agent/claude-code/default.nix` updated to stop passing `pkgs` |
| `packages/fff/default.nix:7` | `stdenv` | deleted (callPackage-consumed, no `...`) |
| `lib/rust/workspace.nix:9` | `writeNushellApplication` | deleted from pattern; call site in `lib/default.nix` updated to stop passing it |
| `lib/dev/shared-mount.nix:25` | `lib` (whole pattern, no `...`) | deleted — pattern collapsed to bare `_:`; call site in `lib/image/dev.nix` updated to stop passing `lib` |
| `modules/services/minecraft-bedrock/server.nix:5` | `lib` | deleted (callPackage-consumed, no `...`) |

No `_`-prefix fixes were used: deadnix's default strict mode (no `--no-underscore`) still flags underscore-prefixed lambda pattern names as unused, so `_`-prefixing alone does not satisfy `--fail`. Every hit was either deleted (migrating call sites where the pattern had no `...`) or the pattern collapsed to a bare `_:`/`...` where the whole attrset argument was unused. No `# deadnix: skip` was needed.

Also added a short comment above the `deadnix` invocation explaining why strict mode (no `-L`) is intentional and what future removals must do (migrate call sites or keep `...`).

Validated with `nix run .#lint` (all 7 stages pass) and targeted `nix eval` smoke checks on every package/module whose lambda pattern changed (`packages.aarch64-darwin` full enumeration, `packages.aarch64-linux.tui-node`), since a full `nix flake check`/`nix flake show` build hits an unrelated pre-existing x86_64-linux-on-aarch64-darwin cross-build issue on this machine.

Fixes #1701

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce strict `deadnix` by removing unused lambda pattern names across the codebase
> Drops the `--no-lambda-pattern-names` flag from the `deadnix` lint task in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1707/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683), enabling detection of unused destructured lambda arguments. All callsites are updated to comply: unused parameters like `config`, `lib`, `pkgs`, and `stdenv` are removed or replaced with `_` across example, library, module, and package files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3182a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->