### PR TITLE
cve-scan: whole-closure Nix CVE scanning app + scheduled workflow (#1697)

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -1,0 +1,138 @@
+name: CVE scan
+
+# Whole-closure Nix CVE scan (issue #1697). cargoAudit covers only the workspace
+# Cargo.lock; this scans the full Nix closure of the repo's key outputs
+# (`.#cachePushRoots.x86_64-linux`: every package, images as their `toplevel`
+# closure, plus each example fleet node's system closure) with `vulnix` against
+# the NIST NVD feed, and files the findings into a single tracking issue.
+#
+# Advisory data is impure and fresh, so this is a scheduled app run, not a
+# blocking flake check: a new CVE published against an already-merged closure
+# must not retroactively fail an unrelated PR's `flake-check`.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily, not hourly: the NVD feed refreshes about once a day and the scan
+    # realizes ~230 closure roots, so an hourly run would be wasteful. Minute 23
+    # / hour 05 UTC is unique among the repo's crons (17/37/47 hourly,
+    # `17 4 * * 1` weekly scorecard) so the schedules never collide on a runner.
+    - cron: "23 5 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cve-scan
+  cancel-in-progress: false
+
+jobs:
+  cve-scan:
+    # The org-wide ix-ci-dispatcher runner (vin-compute-1), same as check.yml: it
+    # has a warm /nix/store and daemon-owned cache.ix.dev substituter, so the
+    # closure roots are mostly cache hits rather than cold builds. vulnix still
+    # needs outbound network to pull/refresh the NVD feed at runtime.
+    runs-on: ["${{ format('ix-ci-run-{0}-{1}-cve-scan', github.run_id, github.run_attempt) }}"]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      # Read+write on issues so the job can find, create, and update the single
+      # tracking issue. GITHUB_TOKEN carries issue write; unlike opening a PR (see
+      # update.yml), writing an issue does not need AUTOBUMP_TOKEN because there is
+      # no `pull_request` workflow to re-trigger.
+      issues: write
+    env:
+      # Match check.yml: the self-hosted daemon owns substituters, so the job only
+      # sets client-side eval knobs. ca-derivations because the package/closure set
+      # resolves floating content-addressed rust units.
+      NIX_CONFIG: |-
+        experimental-features = nix-command flakes ca-derivations
+        accept-flake-config = true
+        max-jobs = auto
+        cores = 1
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Realize every closure root and scan it with vulnix. `--json` emits the
+      # machine-readable findings document (see packages/cve-scan/cve-scan.py); the
+      # human table goes to the step log for a quick eyeball. cve-scan mirrors
+      # vulnix's exit contract (2 = vulnerabilities found, 0 = clean), so `|| true`
+      # keeps a findings result from failing the job -- the findings are the
+      # product, delivered to the tracking issue, not a build failure.
+      - name: Run cve-scan
+        run: |
+          set -uo pipefail
+          nix run .#cve-scan >cve-scan.txt || true
+          cat cve-scan.txt
+          nix run .#cve-scan -- --json >cve-scan.json || true
+
+      # Build the issue body from the JSON document. A hidden HTML marker keys the
+      # find-or-update below so exactly one tracking issue is ever maintained. The
+      # table is capped at the 100 highest-scoring packages to stay well under
+      # GitHub's 65536-char issue-body limit even on a large finding set; the JSON
+      # artifact carries the complete list.
+      - name: Render issue body
+        run: |
+          set -euo pipefail
+          scanned=$(jq -r '.closure_roots_scanned' cve-scan.json)
+          vuln=$(jq -r '.vulnerable_packages' cve-scan.json)
+          matches=$(jq -r '.advisory_matches' cve-scan.json)
+          {
+            printf '<!-- cve-scan-tracking -->\n'
+            printf '# Nix closure CVE scan\n\n'
+            printf 'Whole-closure CVE scan of `.#cachePushRoots.x86_64-linux` (%s roots) via `vulnix`, run by [.github/workflows/cve-scan.yml](../blob/main/.github/workflows/cve-scan.yml). See #1697.\n\n' "$scanned"
+            printf '**%s vulnerable package(s), %s advisory match(es).** Last scanned: %s (run [%s](../actions/runs/%s)).\n\n' \
+              "$vuln" "$matches" "$(date -u +'%Y-%m-%d %H:%M UTC')" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ID}"
+            if [ "$vuln" -eq 0 ]; then
+              printf 'No known CVEs found in the scanned closures.\n'
+            else
+            printf '| package | max CVSS | advisories |\n|---|---|---|\n'
+            # One markdown row per package. The `|` between cells are literal
+            # characters inside jq's format string; the `|` in `join(", ")` /
+            # `tostring` are jq operators. jq disambiguates by position (inside vs
+            # outside `\( )`), so no escaping is needed.
+            jq -r '
+              def cvss: if .max_cvss == null then "-" else (.max_cvss | tostring) end;
+              .packages[:100][] | "| \(.package) | \(cvss) | \(.advisories | join(", ")) |"
+            ' cve-scan.json
+            extra=$((vuln - 100))
+            if [ "$extra" -gt 0 ]; then
+              printf '\n_+%s more package(s) omitted; see the run cve-scan.json artifact for the full list._\n' "$extra"
+            fi
+            fi
+            printf '\n_Advisory data is fetched fresh from the NVD each run, so this issue reflects the latest scan, not a merge gate. Made with Claude Opus 4.8._\n'
+          } >issue-body.md
+          cat issue-body.md
+
+      # Upload the complete machine-readable findings so the issue body can stay
+      # capped while the full list is still retrievable.
+      - name: Upload cve-scan.json
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cve-scan-${{ github.run_id }}
+          path: cve-scan.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      # Find-or-update a single tracking issue by its hidden marker, so the scan
+      # maintains one living issue rather than opening a new one each day. `gh
+      # issue list --search` matches the marker in the body; an existing open issue
+      # is edited in place, otherwise a new one is created.
+      - name: File or update tracking issue
+        run: |
+          set -euo pipefail
+          title="Nix closure CVE scan"
+          number="$(gh issue list --repo "${REPOSITORY}" --state open \
+                      --search 'in:body "<!-- cve-scan-tracking -->"' \
+                      --json number --jq '.[0].number // empty')"
+          if [ -n "${number}" ]; then
+            echo "updating tracking issue #${number}"
+            gh issue edit "${number}" --repo "${REPOSITORY}" --body-file issue-body.md
+          else
+            echo "creating tracking issue"
+            gh issue create --repo "${REPOSITORY}" --title "${title}" --body-file issue-body.md
+          fi

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -57,17 +57,36 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Realize every closure root and scan it with vulnix. `--json` emits the
-      # machine-readable findings document (see packages/cve-scan/cve-scan.py); the
-      # human table goes to the step log for a quick eyeball. cve-scan mirrors
-      # vulnix's exit contract (2 = vulnerabilities found, 0 = clean), so `|| true`
-      # keeps a findings result from failing the job -- the findings are the
-      # product, delivered to the tracking issue, not a build failure.
+      # machine-readable findings document (see packages/cve-scan/cve-scan.py);
+      # a summary table is echoed to the step log from the same document.
       - name: Run cve-scan
         run: |
           set -uo pipefail
-          nix run .#cve-scan >cve-scan.txt || true
-          cat cve-scan.txt
-          nix run .#cve-scan -- --json >cve-scan.json || true
+          # Run the scan ONCE with --json (realizing ~230 closures is expensive;
+          # rendering both surfaces from one artifact avoids a second full scan).
+          # cve-scan mirrors vulnix's exit contract: 0 = clean, 2 = vulnerabilities
+          # found, other = the scan itself could not run. Findings (2) are the
+          # product, not a failure, so tolerate 0 and 2; any other code is a real
+          # failure (NVD unreachable, an eval error, a vulnix crash) and must fail
+          # the job rather than post a stale or empty issue.
+          rc=0
+          nix run .#cve-scan -- --json >cve-scan.json || rc=$?
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "cve-scan failed with exit ${rc}; not updating the tracking issue" >&2
+            exit "$rc"
+          fi
+          set -e
+          # Guard the downstream jq/bash: a truncated or empty document must fail
+          # loudly here, not silently render a malformed issue body (jq without -e
+          # exits 0 on empty input).
+          jq -e 'has("vulnerable_packages")' cve-scan.json >/dev/null
+          # Human table to the step log for a quick eyeball, rendered from the same
+          # JSON so it cannot disagree with the issue body.
+          jq -r '
+            def cvss: if .max_cvss == null then "-" else (.max_cvss | tostring) end;
+            "CVE scan of \(.closure_roots_scanned) closure root(s) on \(.system): \(.vulnerable_packages) vulnerable package(s), \(.advisory_matches) active advisory match(es), \(.whitelisted_matches) whitelisted.",
+            (.packages[] | "  \(.package)  \(cvss)  \(.advisories | join(", "))")
+          ' cve-scan.json
 
       # Build the issue body from the JSON document. A hidden HTML marker keys the
       # find-or-update below so exactly one tracking issue is ever maintained. The
@@ -80,28 +99,29 @@ jobs:
           scanned=$(jq -r '.closure_roots_scanned' cve-scan.json)
           vuln=$(jq -r '.vulnerable_packages' cve-scan.json)
           matches=$(jq -r '.advisory_matches' cve-scan.json)
+          masked=$(jq -r '.whitelisted_matches' cve-scan.json)
           {
             printf '<!-- cve-scan-tracking -->\n'
             printf '# Nix closure CVE scan\n\n'
             printf 'Whole-closure CVE scan of `.#cachePushRoots.x86_64-linux` (%s roots) via `vulnix`, run by [.github/workflows/cve-scan.yml](../blob/main/.github/workflows/cve-scan.yml). See #1697.\n\n' "$scanned"
-            printf '**%s vulnerable package(s), %s advisory match(es).** Last scanned: %s (run [%s](../actions/runs/%s)).\n\n' \
-              "$vuln" "$matches" "$(date -u +'%Y-%m-%d %H:%M UTC')" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ID}"
+            printf '**%s vulnerable package(s), %s active advisory match(es), %s whitelisted** (see [packages/cve-scan/whitelist.toml](../blob/main/packages/cve-scan/whitelist.toml)). Last scanned: %s (run [%s](../actions/runs/%s)).\n\n' \
+              "$vuln" "$matches" "$masked" "$(date -u +'%Y-%m-%d %H:%M UTC')" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ID}"
             if [ "$vuln" -eq 0 ]; then
-              printf 'No known CVEs found in the scanned closures.\n'
+              printf 'No active CVEs found in the scanned closures.\n'
             else
-            printf '| package | max CVSS | advisories |\n|---|---|---|\n'
-            # One markdown row per package. The `|` between cells are literal
-            # characters inside jq's format string; the `|` in `join(", ")` /
-            # `tostring` are jq operators. jq disambiguates by position (inside vs
-            # outside `\( )`), so no escaping is needed.
-            jq -r '
-              def cvss: if .max_cvss == null then "-" else (.max_cvss | tostring) end;
-              .packages[:100][] | "| \(.package) | \(cvss) | \(.advisories | join(", ")) |"
-            ' cve-scan.json
-            extra=$((vuln - 100))
-            if [ "$extra" -gt 0 ]; then
-              printf '\n_+%s more package(s) omitted; see the run cve-scan.json artifact for the full list._\n' "$extra"
-            fi
+              printf '| package | max CVSS | advisories |\n|---|---|---|\n'
+              # One markdown row per package. The `|` between cells are literal
+              # characters inside jq's format string; the `|` in `join(", ")` /
+              # `tostring` are jq operators. jq disambiguates by position (inside
+              # vs outside `\( )`), so no escaping is needed.
+              jq -r '
+                def cvss: if .max_cvss == null then "-" else (.max_cvss | tostring) end;
+                .packages[:100][] | "| \(.package) | \(cvss) | \(.advisories | join(", ")) |"
+              ' cve-scan.json
+              extra=$((vuln - 100))
+              if [ "$extra" -gt 0 ]; then
+                printf '\n_+%s more package(s) omitted; see the run cve-scan.json artifact for the full list._\n' "$extra"
+              fi
             fi
             printf '\n_Advisory data is fetched fresh from the NVD each run, so this issue reflects the latest scan, not a merge gate. Made with Claude Opus 4.8._\n'
           } >issue-body.md

--- a/flake.nix
+++ b/flake.nix
@@ -243,6 +243,7 @@
         };
         # Repo maintenance scripts and package-owned source updaters.
         tools = {
+          cveScan = ./packages/cve-scan/cve-scan.py;
           ixShellSyncIgnored = ./packages/maintainers/scripts/ix-shell-sync-ignored.py;
           mcSource = ./packages/minecraft/tools/mc-source.nu;
           updateSounds = ./packages/minecraft/tools/update-sounds.nu;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -431,6 +431,38 @@ let
     meta.description = "Copy git-ignored files into an ix shell workspace";
   };
 
+  # `nix run .#cve-scan`: scan the whole Nix closure of the repo's key outputs
+  # for known CVEs (issue #1697). cargoAudit (lib/rust/policy.nix) only covers the
+  # workspace Cargo.lock against RustSec; nothing scanned the closure for a
+  # vulnerable system lib, a stale OpenSSL in an image, or a C dependency of a
+  # tool. This wraps `vulnix` -- the Nix-native NVD closure scanner (chosen over
+  # sbomnix/vulnxscan: leaner, first-class `--json`, caches the NVD feed locally
+  # so only the first/refresh run needs network, and works on both x86_64-linux
+  # and aarch64-darwin). The scan target is `.#cachePushRoots.<system>`: the
+  # registry- and example-fleet-derived roots cache-push.yml publishes (every
+  # package, images as their `toplevel` closure, plus each example fleet node's
+  # system closure), so the closure list grows with the repo rather than being
+  # hardcoded, and it is exactly "the repo's key outputs" a consumer substitutes.
+  #
+  # Advisory data is impure and fresh, so this is an app plus a scheduled workflow
+  # that files a tracking issue (.github/workflows/cve-scan.yml), NOT a blocking
+  # flake check. `vulnix` needs `nix-store` (and `nix build`) on PATH; both come
+  # from the runtime `pkgs.nix`. The wrapper forces a UTF-8 locale (vulnix decodes
+  # NVD text and aborts under the C locale); see cve-scan.py.
+  cveScan = ix.writePythonApplication pkgs {
+    name = "cve-scan";
+    src = paths.tools.cveScan;
+    pyChecker = "zuban";
+    runtimeInputs = [
+      pkgs.vulnix
+      pkgs.nix
+    ];
+    # pydantic validates vulnix's --json output at the boundary so an upstream
+    # schema drift fails with a path-precise error rather than a bare KeyError.
+    python = pkgs.python314.withPackages (ps: [ ps.pydantic ]);
+    meta.description = "Scan the Nix closure of the repo's key outputs for CVEs (vulnix)";
+  };
+
   # One symlink-free directory holding every skill under `skills/`, ready to
   # copy into `.claude/skills`.
   skillsDir = ix.skills.mkSkillsDir { inherit pkgs; };
@@ -1197,6 +1229,7 @@ let
       bench-filesystem = benchFilesystem;
       update-mods = updateMods;
       update-loaders = updateLoaders;
+      cve-scan = cveScan;
       inherit update;
       ix-shell-sync-ignored = ixShellSyncIgnored;
       mc-source = mcSource;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -453,6 +453,15 @@ let
     name = "cve-scan";
     src = paths.tools.cveScan;
     pyChecker = "zuban";
+    # The committed whitelist of acknowledged advisories is baked in as a store
+    # path so `nix run .#cve-scan` applies it from any working directory; extra
+    # `--whitelist` flags at the CLI add to it (argparse append). Masked
+    # advisories stay visible as a count (vulnix --show-whitelisted), never
+    # silently dropped.
+    args = [
+      "--whitelist"
+      "${paths.packagesRoot + "/cve-scan/whitelist.toml"}"
+    ];
     runtimeInputs = [
       pkgs.vulnix
       pkgs.nix

--- a/packages/cve-scan/cve-scan.py
+++ b/packages/cve-scan/cve-scan.py
@@ -182,9 +182,12 @@ def scan(
     surface a visible whitelisted count instead of silently dropping them.
 
     vulnix exits 2 on active vulnerabilities, 1 when only whitelisted matches
-    remain (with --show-whitelisted), and 0 when clean; all three still print the
-    JSON document, so the parse below is the success path. A nonzero exit with no
-    output is a real failure.
+    remain (with --show-whitelisted), and 0 when clean; all three print the JSON
+    document (`[]` when clean), so the parsed document is the ONLY success
+    signal. Empty stdout under --json is always a scan failure regardless of
+    exit code: vulnix 1.12.4's RuntimeError handler also exits 2, before any
+    JSON is emitted, so trusting the exit code alone would turn e.g. an
+    unreadable root path into a false "no findings".
     """
     cache_dir.mkdir(parents=True, exist_ok=True)
     whitelist_args = [arg for wl in whitelists for arg in ("--whitelist", str(wl))]
@@ -201,9 +204,10 @@ def scan(
     proc = run(cmd)
     stdout = proc.stdout.strip()
     if not stdout:
-        if proc.returncode not in (0, 1, VULNIX_EXIT_VULNERABLE):
-            sys.exit(f"cve-scan: vulnix failed ({proc.returncode}):\n{proc.stderr.strip()}")
-        return []
+        sys.exit(
+            f"cve-scan: vulnix produced no JSON (exit {proc.returncode}):\n"
+            + proc.stderr.strip()
+        )
     return FindingList.validate_json(stdout)
 
 

--- a/packages/cve-scan/cve-scan.py
+++ b/packages/cve-scan/cve-scan.py
@@ -21,7 +21,7 @@ workflow that files a tracking issue, NOT a blocking flake check. See
 .github/workflows/cve-scan.yml and issue #1697.
 
 Human-readable table by default; `--json` emits the machine-readable findings for
-agents, the scheduled workflow's issue body, and tests. `nix` (providing
+agents and the scheduled workflow's issue body. `nix` (providing
 `nix-store` and `nix build`) is expected on PATH -- this is always invoked as
 `nix run .#cve-scan`, so the host's nix is already present.
 """
@@ -35,22 +35,11 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field, TypeAdapter
 
-# vulnix exits 2 when it finds at least one non-whitelisted vulnerability, 0 when
-# the closure is clean, and 1 on an internal error. We mirror that contract:
-# `cve-scan` exits 2 on findings so the scheduled workflow can branch on it, 0
-# when clean, and non-zero(1) if the scan itself could not run.
+# vulnix's exit contract (man page): 0 = clean, 1 = only-whitelisted advisories,
+# 2 = active vulnerabilities found, 3 = internal error. We mirror the 2: `cve-scan`
+# exits 2 on findings so the scheduled workflow can branch on it, 0 when clean, and
+# exits with a message (code 1 via sys.exit) if the scan itself could not run.
 VULNIX_EXIT_VULNERABLE = 2
-
-
-class CvssScore(BaseModel):
-    """One CVSS v3 base score for an advisory, as vulnix reports it.
-
-    vulnix keys `cvssv3_basescore` by CVE id; the value is the numeric base
-    score (or absent when the NVD record carries no v3 score).
-    """
-
-    cve: str
-    score: float | None
 
 
 class Finding(BaseModel):
@@ -63,15 +52,25 @@ class Finding(BaseModel):
     name: str
     pname: str
     version: str
-    # The advisory ids (CVE-… / GHSA-…) matched against this derivation's
-    # pname+version. vulnix omits already-whitelisted ids from this list.
+    # The ACTIVE advisory ids (CVE-… / GHSA-…) matched against this derivation's
+    # pname+version; whitelisted ids are moved out of this list by vulnix.
     affected_by: list[str] = Field(default_factory=list)
+    # Advisory ids masked by a whitelist rule. Populated because the scan runs
+    # vulnix with --show-whitelisted, so acknowledged advisories stay visible
+    # (as a count) instead of silently vanishing from the report.
+    whitelisted: list[str] = Field(default_factory=list)
     # Per-CVE CVSS v3 base scores; keyed by CVE id in vulnix's output. Absent
     # entries mean the NVD record had no v3 score.
     cvssv3_basescore: dict[str, float] = Field(default_factory=dict)
 
     def max_score(self) -> float | None:
-        scores = list(self.cvssv3_basescore.values())
+        # Score only the active advisories: a whitelisted CVE's score must not
+        # bubble a fully-acknowledged package to the top of the table.
+        scores = [
+            score
+            for cve, score in self.cvssv3_basescore.items()
+            if cve in self.affected_by
+        ]
         return max(scores) if scores else None
 
 
@@ -119,9 +118,8 @@ def realize_closures(
     """Build every closure root, returning (out paths, names that could not build).
 
     One bulk `nix build` over all roots lets the daemon parallelize and
-    substitute; `--print-out-paths` gives the store paths vulnix scans. Roots are
-    built as `.drvPath^*` installables so a build failure is per-root and
-    `--keep-going` still realizes the rest.
+    substitute; `--print-out-paths` gives the store paths vulnix scans, and
+    `--keep-going` realizes the roots that build even when a sibling fails.
 
     A root can also fail to *evaluate* on some systems -- e.g. `cachePushRoots`
     carries the repo's own `check` app, which references the linux-only
@@ -168,47 +166,77 @@ def realize_closures(
     return (out_paths, skipped)
 
 
-def scan(vulnix: str, cache_dir: Path, store_paths: list[str]) -> list[Finding]:
+def scan(
+    vulnix: str,
+    cache_dir: Path,
+    store_paths: list[str],
+    whitelists: list[Path],
+) -> list[Finding]:
     """Run vulnix over the closures of the given store paths, parsed to Findings.
 
     `--closure` scans each path's runtime dependency closure (the shipped
     artifact), `--cache-dir` persists the parsed NVD archive between runs so only
     the first/refresh run hits the network, and `--json` gives the machine shape.
-    vulnix exits 2 when it finds vulnerabilities and 0 when clean; both are
-    success for us. A different nonzero exit with no parseable JSON is a real
-    failure.
+    Each whitelist file masks acknowledged advisories (vulnix TOML whitelist);
+    `--show-whitelisted` keeps the masked entries in the JSON so the report can
+    surface a visible whitelisted count instead of silently dropping them.
+
+    vulnix exits 2 on active vulnerabilities, 1 when only whitelisted matches
+    remain (with --show-whitelisted), and 0 when clean; all three still print the
+    JSON document, so the parse below is the success path. A nonzero exit with no
+    output is a real failure.
     """
     cache_dir.mkdir(parents=True, exist_ok=True)
+    whitelist_args = [arg for wl in whitelists for arg in ("--whitelist", str(wl))]
     cmd = [
         vulnix,
         "--closure",
         "--json",
+        "--show-whitelisted",
         "--cache-dir",
         str(cache_dir),
+        *whitelist_args,
         *store_paths,
     ]
     proc = run(cmd)
     stdout = proc.stdout.strip()
     if not stdout:
-        if proc.returncode not in (0, VULNIX_EXIT_VULNERABLE):
+        if proc.returncode not in (0, 1, VULNIX_EXIT_VULNERABLE):
             sys.exit(f"cve-scan: vulnix failed ({proc.returncode}):\n{proc.stderr.strip()}")
         return []
     return FindingList.validate_json(stdout)
 
 
+def whitelisted_matches(findings: list[Finding]) -> int:
+    """Total advisory matches masked by the whitelist, across all packages."""
+    return sum(len(f.whitelisted) for f in findings)
+
+
 def render_table(findings: list[Finding], system: str, root_count: int) -> str:
-    """Render findings as a human-readable table (the default surface)."""
+    """Render findings as a human-readable table (the default surface).
+
+    Table rows are packages with ACTIVE advisories; fully-whitelisted packages
+    are folded into the visible whitelisted count in the footer so acknowledged
+    advisories stay auditable without burying the actionable rows.
+    """
     header = (
         f"CVE scan of {root_count} closure root(s) on {system} "
         f"(vulnix over .#cachePushRoots.{system})"
     )
-    if not findings:
-        return f"{header}\n\nNo known CVEs found in the scanned closures."
+    active = [f for f in findings if f.affected_by]
+    masked = whitelisted_matches(findings)
+    masked_note = (
+        f"{masked} advisory match(es) whitelisted"
+        " (packages/cve-scan/whitelist.toml)."
+    )
+    if not active:
+        clean = f"{header}\n\nNo active CVEs found in the scanned closures."
+        return f"{clean}\n{masked_note}" if masked else clean
 
     # Sort worst-first by max CVSS score so the most urgent rows lead; unscored
     # advisories sort last within their package.
     ordered = sorted(
-        findings,
+        active,
         key=lambda f: (f.max_score() is None, -(f.max_score() or 0.0), f.pname),
     )
     rows = [
@@ -231,7 +259,7 @@ def render_table(findings: list[Finding], system: str, root_count: int) -> str:
             cells[i].ljust(widths[i]) if i < 2 else cells[i] for i in range(3)
         )
 
-    total_cves = sum(len(f.affected_by) for f in findings)
+    total_cves = sum(len(f.affected_by) for f in active)
     lines = [
         header,
         "",
@@ -241,18 +269,21 @@ def render_table(findings: list[Finding], system: str, root_count: int) -> str:
     lines += [fmt(r) for r in rows]
     lines += [
         "",
-        f"{len(findings)} vulnerable package(s), {total_cves} advisory match(es).",
+        f"{len(active)} vulnerable package(s), {total_cves} active advisory match(es).",
     ]
+    if masked:
+        lines.append(masked_note)
     return "\n".join(lines)
 
 
 def render_json(findings: list[Finding], system: str, root_count: int) -> str:
     """Render findings as the machine-readable document.
 
-    Emits a stable shape (not vulnix's raw output) so the workflow issue body and
-    tests key off documented fields: a summary plus one entry per vulnerable
-    package with its worst score and the advisory ids.
+    Emits a stable shape (not vulnix's raw output) so the workflow issue body
+    keys off documented fields: a summary plus one entry per package with active
+    advisories (worst score first) and the visible whitelisted totals.
     """
+    active = [f for f in findings if f.affected_by]
     packages = sorted(
         (
             {
@@ -261,16 +292,18 @@ def render_json(findings: list[Finding], system: str, root_count: int) -> str:
                 "version": f.version,
                 "max_cvss": f.max_score(),
                 "advisories": sorted(f.affected_by),
+                "whitelisted": sorted(f.whitelisted),
             }
-            for f in findings
+            for f in active
         ),
         key=lambda p: (p["max_cvss"] is None, -(p["max_cvss"] or 0.0), p["pname"]),
     )
     doc = {
         "system": system,
         "closure_roots_scanned": root_count,
-        "vulnerable_packages": len(findings),
-        "advisory_matches": sum(len(f.affected_by) for f in findings),
+        "vulnerable_packages": len(active),
+        "advisory_matches": sum(len(f.affected_by) for f in active),
+        "whitelisted_matches": whitelisted_matches(findings),
         "packages": packages,
     }
     return json.dumps(doc, indent=2)
@@ -301,6 +334,17 @@ def main() -> int:
         default=None,
         help="Directory for vulnix's parsed NVD archive (default: $XDG_CACHE_HOME/vulnix).",
     )
+    parser.add_argument(
+        "--whitelist",
+        action="append",
+        default=[],
+        metavar="FILE",
+        help=(
+            "vulnix TOML whitelist of acknowledged advisories (repeatable). "
+            "The Nix wrapper always passes the committed "
+            "packages/cve-scan/whitelist.toml first; flags add to it."
+        ),
+    )
     args = parser.parse_args()
 
     nix = "nix"
@@ -330,12 +374,18 @@ def main() -> int:
             f"{system}: {', '.join(sorted(skipped))}",
             file=sys.stderr,
         )
+    # Several roots can alias the same output (e.g. a package exposed under two
+    # names); scan each store path once. Order-preserving dedupe.
+    store_paths = list(dict.fromkeys(store_paths))
+    if not store_paths:
+        sys.exit("cve-scan: no store paths to scan (every closure root failed)")
     print(
         f"cve-scan: scanning {len(store_paths)} store path(s) with vulnix "
         "(first run downloads the NVD feed) …",
         file=sys.stderr,
     )
-    findings = scan(vulnix, cache_dir, store_paths)
+    whitelists = [Path(w) for w in args.whitelist]
+    findings = scan(vulnix, cache_dir, store_paths, whitelists)
     scanned = len(names) - len(skipped)
 
     if args.json:
@@ -343,7 +393,8 @@ def main() -> int:
     else:
         print(render_table(findings, system, scanned))
 
-    return VULNIX_EXIT_VULNERABLE if findings else 0
+    active = [f for f in findings if f.affected_by]
+    return VULNIX_EXIT_VULNERABLE if active else 0
 
 
 if __name__ == "__main__":

--- a/packages/cve-scan/cve-scan.py
+++ b/packages/cve-scan/cve-scan.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Scan the whole Nix closure of the repo's key outputs for known CVEs.
+
+cargoAudit (lib/rust/policy.nix) covers only the workspace `Cargo.lock` against
+the RustSec advisory DB. Nothing scanned the full Nix closure -- a vulnerable
+OpenSSL baked into an image, a system library pulled in transitively, a C
+dependency of a Python tool. This wraps `vulnix` (the Nix-native NVD closure
+scanner) over a registry-driven set of closures and reports per-package CVEs.
+
+The closure set is `.#cachePushRoots.<system>`: the exact roots cache-push.yml
+publishes to the public cache (every repo package, with NixOS images swapped for
+their `toplevel` closure, plus every example fleet node's system closure). That
+set is derived from the package registry and the example fleets in
+lib/per-system.nix, so it is data-driven and grows with the repo rather than a
+hardcoded list. It is also the principled definition of "the repo's key outputs":
+the artifacts a consumer actually substitutes via `ix up`.
+
+Advisory data is inherently impure and fresh (vulnix pulls the NIST NVD feed and
+caches it locally), so this is an app -- `nix run .#cve-scan` -- and a scheduled
+workflow that files a tracking issue, NOT a blocking flake check. See
+.github/workflows/cve-scan.yml and issue #1697.
+
+Human-readable table by default; `--json` emits the machine-readable findings for
+agents, the scheduled workflow's issue body, and tests. `nix` (providing
+`nix-store` and `nix build`) is expected on PATH -- this is always invoked as
+`nix run .#cve-scan`, so the host's nix is already present.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from pydantic import BaseModel, Field, TypeAdapter
+
+# vulnix exits 2 when it finds at least one non-whitelisted vulnerability, 0 when
+# the closure is clean, and 1 on an internal error. We mirror that contract:
+# `cve-scan` exits 2 on findings so the scheduled workflow can branch on it, 0
+# when clean, and non-zero(1) if the scan itself could not run.
+VULNIX_EXIT_VULNERABLE = 2
+
+
+class CvssScore(BaseModel):
+    """One CVSS v3 base score for an advisory, as vulnix reports it.
+
+    vulnix keys `cvssv3_basescore` by CVE id; the value is the numeric base
+    score (or absent when the NVD record carries no v3 score).
+    """
+
+    cve: str
+    score: float | None
+
+
+class Finding(BaseModel):
+    """One vulnerable derivation in the scanned closure, from `vulnix --json`.
+
+    vulnix emits a list of these; we model only the fields the report renders so
+    upstream additions do not break parsing and a dropped field fails loudly.
+    """
+
+    name: str
+    pname: str
+    version: str
+    # The advisory ids (CVE-… / GHSA-…) matched against this derivation's
+    # pname+version. vulnix omits already-whitelisted ids from this list.
+    affected_by: list[str] = Field(default_factory=list)
+    # Per-CVE CVSS v3 base scores; keyed by CVE id in vulnix's output. Absent
+    # entries mean the NVD record had no v3 score.
+    cvssv3_basescore: dict[str, float] = Field(default_factory=dict)
+
+    def max_score(self) -> float | None:
+        scores = list(self.cvssv3_basescore.values())
+        return max(scores) if scores else None
+
+
+FindingList = TypeAdapter(list[Finding])
+
+
+def run(cmd: list[str], *, capture: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess, returning the completed process without raising.
+
+    Callers inspect returncode themselves because vulnix's nonzero exit on
+    findings is expected, not an error.
+    """
+    return subprocess.run(
+        cmd,
+        capture_output=capture,
+        text=True,
+        check=False,
+    )
+
+
+def current_system(nix: str) -> str:
+    proc = run([nix, "eval", "--impure", "--raw", "--expr", "builtins.currentSystem"])
+    if proc.returncode != 0:
+        sys.exit(f"cve-scan: could not resolve current system: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def closure_attr_names(nix: str, flake: str, system: str) -> list[str]:
+    """Enumerate the `cachePushRoots.<system>` attribute names from the flake.
+
+    This is the registry-driven closure set; evaluating attr names is cheap
+    (no build), and building happens in `realize_closures`.
+    """
+    attr = f"{flake}#cachePushRoots.{system}"
+    proc = run([nix, "eval", "--json", attr, "--apply", "builtins.attrNames"])
+    if proc.returncode != 0:
+        sys.exit(f"cve-scan: could not enumerate {attr}: {proc.stderr.strip()}")
+    names: list[str] = json.loads(proc.stdout)
+    return names
+
+
+def realize_closures(
+    nix: str, flake: str, system: str, names: list[str]
+) -> tuple[list[str], list[str]]:
+    """Build every closure root, returning (out paths, names that could not build).
+
+    One bulk `nix build` over all roots lets the daemon parallelize and
+    substitute; `--print-out-paths` gives the store paths vulnix scans. Roots are
+    built as `.drvPath^*` installables so a build failure is per-root and
+    `--keep-going` still realizes the rest.
+
+    A root can also fail to *evaluate* on some systems -- e.g. `cachePushRoots`
+    carries the repo's own `check` app, which references the linux-only
+    `nix-fast-build` and does not evaluate on darwin. An eval error aborts the
+    whole bulk `nix build`, so on a nonzero exit we fall back to building each
+    root on its own and skip the ones that fail (reported to the caller), rather
+    than letting one un-evaluable root sink the entire scan.
+    """
+    def installable(name: str) -> str:
+        return f"{flake}#cachePushRoots.{system}.{name}"
+
+    bulk = run(
+        [
+            nix,
+            "build",
+            "--no-link",
+            "--keep-going",
+            "--print-out-paths",
+            *(installable(n) for n in names),
+        ]
+    )
+    if bulk.returncode == 0:
+        return ([line for line in bulk.stdout.splitlines() if line], [])
+
+    # Bulk build failed (a build or an eval error): fall back to per-root so a
+    # single bad root does not lose all the others.
+    print(
+        "cve-scan: bulk build hit a failure; retrying roots individually …",
+        file=sys.stderr,
+    )
+    out_paths: list[str] = []
+    skipped: list[str] = []
+    for name in names:
+        proc = run([nix, "build", "--no-link", "--print-out-paths", installable(name)])
+        if proc.returncode != 0:
+            skipped.append(name)
+            continue
+        out_paths += [line for line in proc.stdout.splitlines() if line]
+    if not out_paths:
+        sys.exit(
+            "cve-scan: no closure root could be built; last error:\n"
+            + bulk.stderr.strip()
+        )
+    return (out_paths, skipped)
+
+
+def scan(vulnix: str, cache_dir: Path, store_paths: list[str]) -> list[Finding]:
+    """Run vulnix over the closures of the given store paths, parsed to Findings.
+
+    `--closure` scans each path's runtime dependency closure (the shipped
+    artifact), `--cache-dir` persists the parsed NVD archive between runs so only
+    the first/refresh run hits the network, and `--json` gives the machine shape.
+    vulnix exits 2 when it finds vulnerabilities and 0 when clean; both are
+    success for us. A different nonzero exit with no parseable JSON is a real
+    failure.
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        vulnix,
+        "--closure",
+        "--json",
+        "--cache-dir",
+        str(cache_dir),
+        *store_paths,
+    ]
+    proc = run(cmd)
+    stdout = proc.stdout.strip()
+    if not stdout:
+        if proc.returncode not in (0, VULNIX_EXIT_VULNERABLE):
+            sys.exit(f"cve-scan: vulnix failed ({proc.returncode}):\n{proc.stderr.strip()}")
+        return []
+    return FindingList.validate_json(stdout)
+
+
+def render_table(findings: list[Finding], system: str, root_count: int) -> str:
+    """Render findings as a human-readable table (the default surface)."""
+    header = (
+        f"CVE scan of {root_count} closure root(s) on {system} "
+        f"(vulnix over .#cachePushRoots.{system})"
+    )
+    if not findings:
+        return f"{header}\n\nNo known CVEs found in the scanned closures."
+
+    # Sort worst-first by max CVSS score so the most urgent rows lead; unscored
+    # advisories sort last within their package.
+    ordered = sorted(
+        findings,
+        key=lambda f: (f.max_score() is None, -(f.max_score() or 0.0), f.pname),
+    )
+    rows = [
+        (
+            f"{f.pname}-{f.version}",
+            f"{f.max_score():.1f}" if f.max_score() is not None else "-",
+            ", ".join(sorted(f.affected_by)),
+        )
+        for f in ordered
+    ]
+    cols = ("package", "max cvss", "advisories")
+    widths = [
+        max(len(cols[i]), max((len(r[i]) for r in rows), default=0)) for i in range(3)
+    ]
+    # The advisories column is free-flowing; do not pad it to a fixed width.
+    widths[2] = len(cols[2])
+
+    def fmt(cells: tuple[str, str, str]) -> str:
+        return "  ".join(
+            cells[i].ljust(widths[i]) if i < 2 else cells[i] for i in range(3)
+        )
+
+    total_cves = sum(len(f.affected_by) for f in findings)
+    lines = [
+        header,
+        "",
+        fmt(cols),
+        fmt(tuple("-" * w for w in widths)),  # type: ignore[arg-type]  # 3-tuple by construction
+    ]
+    lines += [fmt(r) for r in rows]
+    lines += [
+        "",
+        f"{len(findings)} vulnerable package(s), {total_cves} advisory match(es).",
+    ]
+    return "\n".join(lines)
+
+
+def render_json(findings: list[Finding], system: str, root_count: int) -> str:
+    """Render findings as the machine-readable document.
+
+    Emits a stable shape (not vulnix's raw output) so the workflow issue body and
+    tests key off documented fields: a summary plus one entry per vulnerable
+    package with its worst score and the advisory ids.
+    """
+    packages = sorted(
+        (
+            {
+                "package": f"{f.pname}-{f.version}",
+                "pname": f.pname,
+                "version": f.version,
+                "max_cvss": f.max_score(),
+                "advisories": sorted(f.affected_by),
+            }
+            for f in findings
+        ),
+        key=lambda p: (p["max_cvss"] is None, -(p["max_cvss"] or 0.0), p["pname"]),
+    )
+    doc = {
+        "system": system,
+        "closure_roots_scanned": root_count,
+        "vulnerable_packages": len(findings),
+        "advisory_matches": sum(len(f.affected_by) for f in findings),
+        "packages": packages,
+    }
+    return json.dumps(doc, indent=2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="cve-scan",
+        description="Scan the Nix closure of the repo's key outputs for CVEs (vulnix).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the human table.",
+    )
+    parser.add_argument(
+        "--system",
+        default=None,
+        help="Nix system to scan (default: the host's builtins.currentSystem).",
+    )
+    parser.add_argument(
+        "--flake",
+        default=".",
+        help="Flake reference whose cachePushRoots are scanned (default: the cwd flake).",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help="Directory for vulnix's parsed NVD archive (default: $XDG_CACHE_HOME/vulnix).",
+    )
+    args = parser.parse_args()
+
+    nix = "nix"
+    vulnix = "vulnix"
+
+    # vulnix decodes NVD advisory text and aborts under the C locale; force a
+    # UTF-8 locale unless the caller set one. setdefault leaves an existing
+    # value (a real user locale) untouched.
+    os.environ.setdefault("LANG", "C.UTF-8")
+    os.environ.setdefault("LC_ALL", "C.UTF-8")
+
+    system = args.system or current_system(nix)
+    if args.cache_dir is not None:
+        cache_dir = Path(args.cache_dir)
+    else:
+        xdg = os.environ.get("XDG_CACHE_HOME")
+        cache_dir = (Path(xdg) if xdg else Path.home() / ".cache") / "vulnix"
+
+    # Progress goes to stderr so `--json` stdout stays a clean single document.
+    print(f"cve-scan: enumerating .#cachePushRoots.{system} …", file=sys.stderr)
+    names = closure_attr_names(nix, args.flake, system)
+    print(f"cve-scan: realizing {len(names)} closure root(s) …", file=sys.stderr)
+    store_paths, skipped = realize_closures(nix, args.flake, system, names)
+    if skipped:
+        print(
+            f"cve-scan: skipped {len(skipped)} root(s) that failed to build on "
+            f"{system}: {', '.join(sorted(skipped))}",
+            file=sys.stderr,
+        )
+    print(
+        f"cve-scan: scanning {len(store_paths)} store path(s) with vulnix "
+        "(first run downloads the NVD feed) …",
+        file=sys.stderr,
+    )
+    findings = scan(vulnix, cache_dir, store_paths)
+    scanned = len(names) - len(skipped)
+
+    if args.json:
+        print(render_json(findings, system, scanned))
+    else:
+        print(render_table(findings, system, scanned))
+
+    return VULNIX_EXIT_VULNERABLE if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/cve-scan/whitelist.toml
+++ b/packages/cve-scan/whitelist.toml
@@ -1,0 +1,21 @@
+# Acknowledged advisories for `nix run .#cve-scan` (vulnix TOML whitelist).
+#
+# An entry here masks an advisory from the ACTIVE findings; the scan still
+# reports a visible whitelisted count, so acknowledgements are auditable, never
+# silent. Whitelist only with a reason: a false positive (vulnix matches on
+# pname+version, so a patched-in-nixpkgs CVE can still match), a vulnerability
+# in a code path the closure never exercises, or an accepted risk with an
+# issue link.
+#
+# Format (see `vulnix --help` / the vulnix README):
+#
+#   ["openssl"]                      # every version of a pname
+#   cve = ["CVE-2024-1234"]
+#   comment = "patched in nixpkgs; see <issue url>"
+#
+#   ["openssl-3.0.1"]                # one specific version
+#   cve = ["CVE-2024-5678"]
+#   until = "2026-12-31"             # optional expiry: re-surfaces after this date
+#
+# Keep entries scoped (pname + explicit cve list); a bare section with no `cve`
+# masks EVERY advisory for that pname, which hides future findings too.


### PR DESCRIPTION
## What

Add `nix run .#cve-scan`: a whole-closure Nix CVE scanner, plus a daily scheduled workflow that files a single tracking issue with the findings. Closes #1697.

`cargoAudit` (lib/rust/policy.nix) covers only the workspace `Cargo.lock` against RustSec. Nothing scanned the full Nix closure for a vulnerable system lib, a stale OpenSSL baked into an image, or a C dependency of a tool. This does.

## Tool: vulnix

Chosen over sbomnix / `vulnxscan`:

- **Nix-native**: takes store paths and matches the NIST NVD feed against the derivations in each output's runtime closure (`--closure`). Purpose-built for exactly this.
- **First-class `--json`**; the app parses that (pydantic model at the boundary) and re-renders a stable shape.
- **Caches the NVD feed locally** (`--cache-dir`), so only the first/refresh run needs network.
- **Works on both x86_64-linux and aarch64-darwin** (`meta.available` true, non-broken, `__darwinAllowLocalNetworking = true`). Not gated per-system.

## Closure set: `.#cachePushRoots.<system>` (registry- and fleet-driven, not hardcoded)

`cachePushRoots` (lib/per-system.nix) is the exact set cache-push.yml already publishes: every repo package (from the package registry), each NixOS image swapped for its `toplevel` closure, plus every example fleet node's system closure. It is derived from `packages/registry.nix` and the example fleets, so it grows with the repo. It is also the principled definition of "the repo's key outputs": the artifacts a consumer actually substitutes via `ix up`. On x86_64-linux this includes the `base` / `vcfs-guest-eval` images.

## Not a blocking flake check

Advisory data is impure and fresh (a CVE published today against an already-merged closure must not retroactively fail an unrelated PR's `flake-check`). So this is an app + a **daily** scheduled workflow (`.github/workflows/cve-scan.yml`, unique cron minute `23 5 * * *`) that runs the scan on x86_64-linux and creates/updates a single tracking issue by a hidden `<!-- cve-scan-tracking -->` marker. `GITHUB_TOKEN` carries issue write (no AUTOBUMP_TOKEN needed — there is no `pull_request` workflow to re-trigger).

## Validation

- `nix build .#cve-scan` passes on aarch64-darwin (zuban `--strict` + the shared ruff selector run at build time).
- `nix run .#lint` — all 7 stages green.
- Flake evaluates on x86_64-linux (`.#packages.x86_64-linux.cve-scan`, and `cve-scan` is present in `.#cachePushRoots.x86_64-linux`).
- The app enumerates and realizes the closure roots and invokes vulnix end to end. The parse + human/JSON render paths were validated against vulnix's exact `output_json` schema (from its `output.py`): sorted worst-CVSS-first table, machine JSON, and the clean/empty path.
- **The live NVD download could not complete from the dev sandbox** — `nvd.nist.gov` is severely throttled here (HTTP 200 but ~44 KB/s: 2.6 MB of 24.8 MB in 60s). This is a network constraint of the sandbox, **not** a platform limit — vulnix runs fine on darwin. The scheduled workflow runs on the self-hosted x86_64-linux runner, which has outbound network for the feed.
- `realize_closures` is resilient: it bulk-builds with `--keep-going`, and on any failure falls back to building each root individually and skipping ones that fail (verified locally: `cachePushRoots.aarch64-darwin.check` references the linux-only `nix-fast-build` and cannot evaluate on darwin, so the fallback engaged and continued rather than aborting the scan).

## Whitelist (acknowledged advisories)

`packages/cve-scan/whitelist.toml` (vulnix TOML whitelist) is baked into the wrapper and applied on every run. vulnix runs with `--show-whitelisted`, so acknowledged advisories stay **visible as a count** in the table footer, the JSON (`whitelisted_matches`), and the tracking-issue summary — never silently dropped. Exit code 2 keys off ACTIVE advisories only, so a fully-acknowledged scan is green while still auditable.

## Sample output

```
CVE scan of 230 closure root(s) on x86_64-linux (vulnix over .#cachePushRoots.x86_64-linux)

package        max cvss  advisories
-------------  --------  ----------
openssl-3.0.1  9.8       CVE-2022-3602, CVE-2022-3786
zlib-1.2.11    -         CVE-2018-25032

2 vulnerable package(s), 3 active advisory match(es).
```

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add whole-closure Nix CVE scanning app and scheduled GitHub Actions workflow
> - Adds [cve-scan.py](https://github.com/indexable-inc/index/pull/1709/files#diff-93de13e8c5505ec8c70e1783ccefff62dd5ce22e8676eb0e810310831d1924f8), a Python CLI wrapping `vulnix` that enumerates `cachePushRoots`, realizes closures, runs a scan, and outputs either a formatted table or machine-readable JSON. Returns exit code 2 when active vulnerabilities exist.
> - Exposes the scanner as a flake app via `nix run .#cve-scan`, with a baked-in [whitelist.toml](https://github.com/indexable-inc/index/pull/1709/files#diff-a2b2953b4f97bd9070bd815ad4f5ec8d13d0312768fbd8788cbc7810286a15fd) and runtime dependencies (`vulnix`, `nix`, `pydantic`).
> - Adds a [cve-scan.yml](https://github.com/indexable-inc/index/pull/1709/files#diff-b9a3df5364290d7430a379df61028521a5934e6a5f93b1530a2802f1ed9d7e26) workflow that runs daily at 05:23 UTC, uploads the JSON as an artifact, and creates or updates a single GitHub issue titled 'Nix closure CVE scan' with a table of the highest-scoring vulnerabilities.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab22423.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->