### PR TITLE
feat(pins): migrate remaining inline hashes to pins.json

### DIFF
--- a/lib/darwin/macos-sdk.nix
+++ b/lib/darwin/macos-sdk.nix
@@ -4,17 +4,21 @@
 # enough for both the C compile and the Rust link.
 #
 # Apple licenses the macOS SDK for use on Apple hardware. This fetches a public
-# repackaged tarball and pins it by SRI hash; override `ix.macosSdk` with your
-# own SDK derivation to satisfy a stricter licensing posture. The same 15.4
+# repackaged tarball; the version + URL + SRI pin live in the sibling pins.json
+# (repo policy: no inline hash literals). Override `ix.macosSdk` with your own
+# SDK derivation to satisfy a stricter licensing posture. The same 15.4
 # tarball + hash is used by the sibling `ix` repo, so the store path is shared.
+#
+# Two-stage signature: lib/default.nix applies the shared `pins` reader once at
+# import (a cross-directory `../util` import here is banned by no-parent-path);
+# the public `ix.macosSdk` surface stays `{ pkgs }: derivation`.
+{ pins }:
 { pkgs }:
 let
-  tarball = pkgs.fetchurl {
-    url = "https://github.com/joseluisq/macosx-sdks/releases/download/15.4/MacOSX15.4.sdk.tar.xz";
-    hash = "sha256-oLe2aRKsDaDkWzBKMyus2+WMoXIiCCDUJe2yghOWL4E=";
-  };
+  pin = pins.loadPin ./pins.json "macos-sdk";
+  tarball = pkgs.fetchurl { inherit (pin) url hash; };
 in
-pkgs.runCommand "MacOSX15.4.sdk" { } ''
+pkgs.runCommand "MacOSX${pin.version}.sdk" { } ''
   mkdir -p "$out"
   tar xf ${tarball} --strip-components=1 -C "$out"
 ''

--- a/lib/darwin/pins.json
+++ b/lib/darwin/pins.json
@@ -1,0 +1,7 @@
+{
+  "macos-sdk": {
+    "version": "15.4",
+    "url": "https://github.com/joseluisq/macosx-sdks/releases/download/15.4/MacOSX15.4.sdk.tar.xz",
+    "hash": "sha256-oLe2aRKsDaDkWzBKMyus2+WMoXIiCCDUJe2yghOWL4E="
+  }
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -189,6 +189,7 @@ let
         rustWorkspaceFor
         clippy-fork
         lists
+        pins
         ;
       repoRoot = paths.root;
     })
@@ -417,7 +418,7 @@ let
     function `{ pkgs }: derivation`; override it to supply your own SDK.
     See [`lib/darwin/macos-sdk.nix`](lib/darwin/macos-sdk.nix).
   */
-  macosSdk = import ./darwin/macos-sdk.nix;
+  macosSdk = import ./darwin/macos-sdk.nix { inherit pins; };
 
   /**
     zig + macOS SDK cross toolchain. `{ appleSdk, lib, pkgs, target }` returns

--- a/lib/rust/build.nix
+++ b/lib/rust/build.nix
@@ -11,6 +11,8 @@
   rustToolchain,
   writePythonApplication,
   lists,
+  # Shared pins reader, threaded through to policy.nix (see its arg doc).
+  pins,
 }:
 let
   inherit (builtins) removeAttrs;
@@ -27,6 +29,7 @@ let
       rustToolchain
       writePythonApplication
       lists
+      pins
       ;
   };
   inherit (resolve)

--- a/lib/rust/pins.json
+++ b/lib/rust/pins.json
@@ -1,0 +1,8 @@
+{
+  "advisory-db": {
+    "owner": "rustsec",
+    "repo": "advisory-db",
+    "rev": "f2ae5fc8e5d208373b6c838f9676434525327a72",
+    "hash": "sha256-iqXYpuCoWoGypnpM5ceXN748QlYeBXDtZx0uI98qFLo="
+  }
+}

--- a/lib/rust/policy.nix
+++ b/lib/rust/policy.nix
@@ -10,6 +10,10 @@
   clippyPackage,
   vendorConfigScript,
   cargoLockFile,
+  # The shared pins reader (lib/util/pins.nix), threaded down from
+  # lib/default.nix so the advisory-db rev+hash load from the sibling pins.json
+  # without a cross-directory `../` import (no-parent-path).
+  pins,
 }:
 let
   inherit (builtins)
@@ -57,11 +61,15 @@ let
         };
         db = lib.mkOption {
           type = lib.types.package;
+          # The rev + SRI pin lives in the sibling pins.json (repo policy: no
+          # inline hash literals); bump by editing the rev there and re-pinning.
           default = pkgs.fetchFromGitHub {
-            owner = "rustsec";
-            repo = "advisory-db";
-            rev = "f2ae5fc8e5d208373b6c838f9676434525327a72";
-            hash = "sha256-iqXYpuCoWoGypnpM5ceXN748QlYeBXDtZx0uI98qFLo=";
+            inherit (pins.loadPin ./pins.json "advisory-db")
+              owner
+              repo
+              rev
+              hash
+              ;
           };
           description = "The advisory database cargo-audit checks against.";
         };

--- a/lib/rust/resolve.nix
+++ b/lib/rust/resolve.nix
@@ -10,6 +10,8 @@
   rustToolchain,
   writePythonApplication,
   lists,
+  # Shared pins reader, threaded through to policy.nix (see its arg doc).
+  pins,
 }:
 let
   inherit (builtins) baseNameOf toString;
@@ -24,7 +26,12 @@ let
   };
 
   policyLib = import ./policy.nix {
-    inherit lib pkgs clippyPackage;
+    inherit
+      lib
+      pkgs
+      clippyPackage
+      pins
+      ;
     inherit (vendorLib) vendorConfigScript cargoLockFile;
   };
 

--- a/lib/rust/tooling.nix
+++ b/lib/rust/tooling.nix
@@ -7,6 +7,8 @@
   clippy-fork,
   repoRoot,
   lists,
+  # Shared pins reader, threaded through to policy.nix (see its arg doc).
+  pins,
 }:
 let
   inherit (builtins) toString;
@@ -20,7 +22,12 @@ let
   rustFor =
     pkgs:
     import ./build.nix {
-      inherit lib pkgs lists;
+      inherit
+        lib
+        pkgs
+        lists
+        pins
+        ;
       # llm-clippy bootstraps before cargoUnit / rustWorkspace exist, so the
       # `ix` closure it receives carries only `buildRustPackage`.
       # `buildIxRustTool` adds the richer surface for packages that need it.

--- a/modules/services/minecraft-bedrock/default.nix
+++ b/modules/services/minecraft-bedrock/default.nix
@@ -20,7 +20,7 @@ let
   # The package is `override`-able and built from its own callPackage file
   # (explicit deps) rather than inline in this module, which takes the module
   # `pkgs` for the format generators and the static-asset links below.
-  bedrockServer = pkgs.callPackage ./server.nix { };
+  bedrockServer = pkgs.callPackage ./server.nix { inherit ix; };
 
   cfg = config.services.minecraft-bedrock;
   dataDir = "/var/lib/minecraft-bedrock";

--- a/modules/services/minecraft-bedrock/pins.json
+++ b/modules/services/minecraft-bedrock/pins.json
@@ -1,0 +1,7 @@
+{
+  "bedrock-server": {
+    "version": "1.26.14.1",
+    "url": "https://www.minecraft.net/bedrockdedicatedserver/bin-linux/bedrock-server-1.26.14.1.zip",
+    "hash": "sha256-g9XaCRI8PwtgPFS+kpaOXA5DdbWE1RTWEID2Nuekx3Q="
+  }
+}

--- a/modules/services/minecraft-bedrock/server.nix
+++ b/modules/services/minecraft-bedrock/server.nix
@@ -2,6 +2,7 @@
 # (explicit deps, no `pkgs` arg) so it stays `override`-able and the module that
 # consumes it does not build a derivation inline.
 {
+  ix,
   stdenv,
   fetchurl,
   autoPatchelfHook,
@@ -9,13 +10,17 @@
   curl,
   glibc,
 }:
+let
+  # Version + download URL and SRI hash live in the sibling pins.json, never
+  # inline (repo policy: no hash literals in tracked .nix).
+  pin = ix.pins.loadPin ./pins.json "bedrock-server";
+in
 stdenv.mkDerivation {
   pname = "minecraft-bedrock-server";
-  version = "1.26.14.1";
+  inherit (pin) version;
 
   src = fetchurl {
-    url = "https://www.minecraft.net/bedrockdedicatedserver/bin-linux/bedrock-server-1.26.14.1.zip";
-    hash = "sha256-g9XaCRI8PwtgPFS+kpaOXA5DdbWE1RTWEID2Nuekx3Q=";
+    inherit (pin) url hash;
     curlOptsList = [
       "--http1.1"
       "-A"

--- a/packages/agent/pi-harnesses/engine/default.nix
+++ b/packages/agent/pi-harnesses/engine/default.nix
@@ -1,4 +1,5 @@
 {
+  ix,
   lib,
   stdenv,
   buildNpmPackage,
@@ -44,13 +45,14 @@ let
 
   # Build the bridge WITH its npm deps so the shipped extension actually loads:
   # Pi resolves `@modelcontextprotocol/sdk` from node_modules next to the .ts,
-  # the same layout proven to work end-to-end. npmDepsHash pins the dep closure;
-  # refresh it with `nix run nixpkgs#prefetch-npm-deps -- extension/package-lock.json`.
+  # the same layout proven to work end-to-end. npmDepsHash pins the dep closure
+  # in the sibling pins.json (repo policy: no inline hash literals); refresh it
+  # with `nix run nixpkgs#prefetch-npm-deps -- extension/package-lock.json`.
   extension = buildNpmPackage {
     pname = "ix-mcp-bridge";
     version = "0.1.0";
     src = extensionSrc;
-    npmDepsHash = "sha256-Nis7wQLp7wASaEu4n/Cp3pthB3z+9FsTJs5pK3oq77M=";
+    npmDepsHash = (ix.pins.loadPin ./pins.json "npm-deps").hash;
     # No build script: install the source plus production node_modules verbatim.
     dontNpmBuild = true;
     doCheck = true;

--- a/packages/agent/pi-harnesses/engine/pins.json
+++ b/packages/agent/pi-harnesses/engine/pins.json
@@ -1,0 +1,5 @@
+{
+  "npm-deps": {
+    "hash": "sha256-Nis7wQLp7wASaEu4n/Cp3pthB3z+9FsTJs5pK3oq77M="
+  }
+}

--- a/packages/agent/symphony/default.nix
+++ b/packages/agent/symphony/default.nix
@@ -35,6 +35,13 @@ let
     ];
   };
 
+  # SRI pins for the two fixed-output fetches below live in the sibling
+  # pins.json (repo policy: no inline hash literals). `mix-deps` has no URL
+  # (the FOD's content is derived from mix.lock, so refresh it by building
+  # after a lock change and copying the `got:` hash); `lazy-html-nif` pins the
+  # upstream release tarball by URL.
+  pins = ix.pins.loadPins ./pins.json;
+
   # Test-env mix deps as a fixed-output derivation so the sandboxed check
   # runs offline. Refresh the hash whenever elixir/mix.lock changes.
   mixFodDeps = pkgs.beamPackages.fetchMixDeps {
@@ -49,7 +56,7 @@ let
     };
     inherit elixir;
     mixEnv = "test";
-    hash = "sha256-TLRGNPIm3zQKeFt54wrdirYYK81ribfsV92/NVLdQSM=";
+    inherit (pins."mix-deps") hash;
   };
 
   # mix.lock pins lazy_html (a C++ NIF over lexbor) as a test-only dep for
@@ -58,11 +65,8 @@ let
   # allows neither, so the check below seeds elixir_make's artifact cache
   # with the upstream release tarball; elixir_make still verifies it against
   # the checksum.exs pinned inside the dep before unpacking. Refresh the
-  # url/hash when a mix.lock bump moves lazy_html.
-  lazyHtmlNif = pkgs.fetchurl {
-    url = "https://github.com/dashbitco/lazy_html/releases/download/v0.1.10/lazy_html-nif-2.16-x86_64-linux-gnu-0.1.10.tar.gz";
-    hash = "sha256-Ni0JKbP6OJqQ8rT08VnF/KWjiyigoVUjqSZ3LRU9dBo=";
-  };
+  # url/hash in pins.json when a mix.lock bump moves lazy_html.
+  lazyHtmlNif = pkgs.fetchurl { inherit (pins."lazy-html-nif") url hash; };
 
   # The required quality lane the standalone repo ran per PR (make ci:
   # compile --warnings-as-errors, format --check-formatted, credo, test),

--- a/packages/agent/symphony/pins.json
+++ b/packages/agent/symphony/pins.json
@@ -1,0 +1,10 @@
+{
+  "mix-deps": {
+    "hash": "sha256-TLRGNPIm3zQKeFt54wrdirYYK81ribfsV92/NVLdQSM="
+  },
+  "lazy-html-nif": {
+    "version": "0.1.10",
+    "url": "https://github.com/dashbitco/lazy_html/releases/download/v0.1.10/lazy_html-nif-2.16-x86_64-linux-gnu-0.1.10.tar.gz",
+    "hash": "sha256-Ni0JKbP6OJqQ8rT08VnF/KWjiyigoVUjqSZ3LRU9dBo="
+  }
+}

--- a/packages/agent/system-prompt-eval-viewer/default.nix
+++ b/packages/agent/system-prompt-eval-viewer/default.nix
@@ -25,7 +25,10 @@ let
         ./src
       ];
     };
-    npmDepsHash = "sha256-Y7hsx0h2lMVTSsNYMXfi6TCqc7qBQH6poKptG2HPHfA=";
+    # The dep-closure pin lives in the sibling pins.json (repo policy: no
+    # inline hash literals); it is lockfile-derived (no URL), so refresh with
+    # `nix run nixpkgs#prefetch-npm-deps -- package-lock.json` after a lock change.
+    npmDepsHash = (ix.pins.loadPin ./pins.json "npm-deps").hash;
     installPhase = ''
       # shell
       runHook preInstall

--- a/packages/agent/system-prompt-eval-viewer/pins.json
+++ b/packages/agent/system-prompt-eval-viewer/pins.json
@@ -1,0 +1,5 @@
+{
+  "npm-deps": {
+    "hash": "sha256-Y7hsx0h2lMVTSsNYMXfi6TCqc7qBQH6poKptG2HPHfA="
+  }
+}

--- a/packages/andrewgazelka/hive/default.nix
+++ b/packages/andrewgazelka/hive/default.nix
@@ -35,7 +35,10 @@ let
   };
 
   # Test-env mix deps (credo + its deps) as a fixed-output derivation so the
-  # sandboxed check runs offline. Refresh the hash whenever elixir/mix.lock changes.
+  # sandboxed check runs offline. The SRI pin lives in the sibling pins.json
+  # (repo policy: no inline hash literals); it has no URL (the FOD content is
+  # derived from mix.lock), so refresh it after a lock change by building and
+  # copying the `got:` hash from the mismatch error.
   mixFodDeps = pkgs.beamPackages.fetchMixDeps {
     pname = "hive-elixir-deps";
     version = "0.1.0"; # keep in sync with elixir/mix.exs
@@ -48,7 +51,7 @@ let
     };
     inherit elixir;
     mixEnv = "test";
-    hash = "sha256-EXaJddUakJETdzPNFWgJRgBWG4VcrP/Z5tOCuE+BXdo=";
+    inherit ((ix.pins.loadPins ./pins.json)."mix-deps") hash;
   };
 
   elixirCheck = ix.buildElixirCheck pkgs {

--- a/packages/andrewgazelka/hive/pins.json
+++ b/packages/andrewgazelka/hive/pins.json
@@ -1,0 +1,5 @@
+{
+  "mix-deps": {
+    "hash": "sha256-EXaJddUakJETdzPNFWgJRgBWG4VcrP/Z5tOCuE+BXdo="
+  }
+}

--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -8,7 +8,7 @@ let
   dagRunner = pkgs.callPackage (ix.paths.packagesRoot + "/dag-runner") { inherit ix; };
   # The ix Python SDK is a prebuilt wheel fetched from R2, not a uv/PyPI
   # dependency, so it is injected into the venv below rather than resolved by uv.
-  ixSdk = pkgs.callPackage (ix.paths.packagesRoot + "/ix-sdk-python") { };
+  ixSdk = pkgs.callPackage (ix.paths.packagesRoot + "/ix-sdk-python") { inherit ix; };
 
   unwrapped = ix.buildUvApplication pkgs {
     pname = "ix-fleet";

--- a/packages/ix-sdk-python/default.nix
+++ b/packages/ix-sdk-python/default.nix
@@ -1,4 +1,5 @@
 {
+  ix,
   lib,
   pkgs,
   # Match the interpreter of any consumer (ix-fleet builds on pkgs.python3).
@@ -13,36 +14,29 @@ let
   # cdylib is built, stripped, and scanned store-clean by ix's
   # `nix/packages/workspace-sdks.nix`, then uploaded to R2 with `wrangler`.
   #
-  # The URL + SRI live here next to the consumer rather than in flake.lock, so a
-  # routine SDK bump is: re-publish the wheel to R2 and edit this catalog. Each
-  # URL path embeds the wheel's nix-store hash so distinct builds never collide.
+  # The per-system URL + SRI catalog lives in the sibling pins.json (repo
+  # policy: no inline hash literals), next to the consumer rather than in
+  # flake.lock, so a routine SDK bump is: re-publish the wheel to R2 and edit
+  # pins.json. Each URL path embeds the wheel's nix-store hash so distinct
+  # builds never collide.
   #
   # Published for x86_64-linux (health-checks runner) and aarch64-darwin
   # (operators run ix-fleet on their Macs). The darwin wheel repoints its one
   # nix-store dylib (libiconv) at /usr/lib so it loads off-nix; see ix's
   # workspace-sdks.nix. Other systems fall through to the loud placeholder below.
-  catalog = {
-    x86_64-linux = {
-      url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/q7dc3hr07fb49k3bb6bpvdvrw06b70zi/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl";
-      hash = "sha256-G01zJOF2IniVv5ioFEQEzoOZdVKF8YBBvJmviQb4Qts=";
-    };
-    aarch64-darwin = {
-      url = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/jmj8q0gsq5lnvv8aap6j7zh874bpzqjh/ix_sdk-0.1.0-cp313-abi3-macosx_11_0_arm64.whl";
-      hash = "sha256-KdfnAh0LgHcbApMUsK0x7tPrNe+ol6LIumUqfURyZn8=";
-    };
-  };
+  catalog = ix.pins.loadPins ./pins.json;
 
   inherit (pkgs.stdenv.hostPlatform) system;
   rawEntry = catalog.${system} or null;
-  # Catch a careless bump (an http:// URL or a non-SRI hash) at eval time, the
-  # same guard lib/util/artifacts.nix applies to its loader catalogs.
+  # Catch a careless bump (an http:// URL) at eval time, the same guard
+  # lib/util/artifacts.nix applies to its loader catalogs; loadPins already
+  # rejects a non-SRI hash.
   entry =
     if rawEntry == null then
       null
     else
-      assert lib.assertMsg (
-        lib.hasPrefix "https://" rawEntry.url && lib.hasPrefix "sha256-" rawEntry.hash
-      ) "ix-sdk-python: catalog entry for ${system} needs an https:// url and an sha256- SRI hash";
+      assert lib.assertMsg (lib.hasPrefix "https://" rawEntry.url)
+        "ix-sdk-python: catalog entry for ${system} needs an https:// url";
       rawEntry;
 in
 if entry == null then

--- a/packages/ix-sdk-python/pins.json
+++ b/packages/ix-sdk-python/pins.json
@@ -1,0 +1,10 @@
+{
+  "x86_64-linux": {
+    "url": "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/q7dc3hr07fb49k3bb6bpvdvrw06b70zi/ix_sdk-0.1.0-cp313-abi3-manylinux_2_34_x86_64.whl",
+    "hash": "sha256-G01zJOF2IniVv5ioFEQEzoOZdVKF8YBBvJmviQb4Qts="
+  },
+  "aarch64-darwin": {
+    "url": "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/wheel/ix-sdk/jmj8q0gsq5lnvv8aap6j7zh874bpzqjh/ix_sdk-0.1.0-cp313-abi3-macosx_11_0_arm64.whl",
+    "hash": "sha256-KdfnAh0LgHcbApMUsK0x7tPrNe+ol6LIumUqfURyZn8="
+  }
+}

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -8,6 +8,14 @@ let
   # `override` can't reach). `ix.pkgs` is the caller's set, the same value
   # callPackage would have auto-bound to a `pkgs` arg in the flake package set.
   inherit (ix) pkgs;
+
+  # PyPI source pins (version + sdist URL + SRI hash) for the interpreter
+  # overrides below, in the sibling pins.json (repo policy: no inline hash
+  # literals in tracked .nix). Each `url` is fetchPypi's canonical pypi.io
+  # source path (verified byte-identical to the pinned hashes). Re-pin after a
+  # version edit manually (rebuild, copy the `got:` hash): mcp carries no
+  # registry updateScript, so `nix run .#update` does not touch these pins.
+  pypiPins = ix.pins.loadPins ./pins.json;
   # The PTY-driving `tui` package, baked into the pinned interpreter so every
   # session can `import tui` with no setup. The PyO3 cdylib comes from the same
   # shared workspace graph the binary is selected from, dropped next to the
@@ -869,14 +877,14 @@ let
   htpyModule =
     let
       pname = "htpy";
-      version = "26.5.1";
+      inherit (pypiPins.htpy) version;
     in
     pkgs.python3.pkgs.buildPythonPackage {
       inherit pname version;
       pyproject = true;
       src = pkgs.fetchPypi {
         inherit pname version;
-        hash = "sha256-Q6NlwfxnAJTaeBuSOIMBkznOwDE5fWHV/l+OLyJ4tj4=";
+        inherit (pypiPins.htpy) hash;
       };
       # setuptools-scm reads the version from the sdist's PKG-INFO, but pin it so
       # the build never depends on a .git that the sdist does not carry.
@@ -905,11 +913,10 @@ let
   # weight. pyarrow IS required (the client materializes results as Arrow), so it
   # is bundled here, with Spark, rather than for the whole interpreter's sake.
   pysparkConnect = pkgs.python3.pkgs.pyspark.overridePythonAttrs (old: {
-    version = "3.5.5";
+    inherit (pypiPins.pyspark) version;
     src = pkgs.python3.pkgs.fetchPypi {
       pname = "pyspark";
-      version = "3.5.5";
-      hash = "sha256-bv/Jzpjt8jH01oP9FPcnBim/hFjGKNaiYg3tS7NPPLk=";
+      inherit (pypiPins.pyspark) version hash;
     };
     # pyspark 3.5.5 pins py4j==0.10.9.7 exactly; relax it so the patch-newer
     # nixpkgs py4j 0.10.9.9 satisfies the runtime-deps check.
@@ -959,25 +966,23 @@ let
     self = mcpPythonInterp;
     packageOverrides = final: prev: {
       asn1 = prev.asn1.overridePythonAttrs (_: {
-        version = "2.8.0";
+        inherit (pypiPins.asn1) version;
         src = pkgs.fetchPypi {
           pname = "asn1";
-          version = "2.8.0";
-          hash = "sha256-rfd93CcHz0IMDq47me4w6ROvzwk2Rn1CZpggzmt9FQo=";
+          inherit (pypiPins.asn1) version hash;
         };
       });
       # pymobiledevice3 9.27.0 needs ipsw-parser >= 1.6.0; nixpkgs pins 1.5.0.
       # Bump to 1.7.3 (the verified resolution). 1.7.x swaps its click dep for
       # typer, so add it (and relax the floor, since the set's typer is 0.24.0).
       ipsw-parser = prev.ipsw-parser.overridePythonAttrs (old: {
-        version = "1.7.3";
+        inherit (pypiPins.ipsw_parser) version;
         src = pkgs.fetchPypi {
           pname = "ipsw_parser";
-          version = "1.7.3";
-          hash = "sha256-QSu7t3O0NLD5lL0EPNtX2QqxpK5y+oSJtxkAzYVtNuo=";
+          inherit (pypiPins.ipsw_parser) version hash;
         };
         env = (old.env or { }) // {
-          SETUPTOOLS_SCM_PRETEND_VERSION = "1.7.3";
+          SETUPTOOLS_SCM_PRETEND_VERSION = pypiPins.ipsw_parser.version;
         };
         dependencies = (old.dependencies or [ ]) ++ [ final.typer ];
         pythonRelaxDeps = (old.pythonRelaxDeps or [ ]) ++ [ "typer" ];
@@ -992,14 +997,14 @@ let
   pyiosbackupModule =
     let
       pname = "pyiosbackup";
-      version = "0.2.4";
+      inherit (pypiPins.pyiosbackup) version;
     in
     mcpPythonInterp.pkgs.buildPythonPackage {
       inherit pname version;
       pyproject = true;
       src = pkgs.fetchPypi {
         inherit pname version;
-        hash = "sha256-ELTSoRyb7ck6VGfK063b4YvC3ENBVpIOciMibtTQvrc=";
+        inherit (pypiPins.pyiosbackup) hash;
       };
       build-system = [ mcpPythonInterp.pkgs.setuptools ];
       dependencies = [
@@ -1021,14 +1026,13 @@ let
   # the version from the sdist's PKG-INFO, pinned so the build never needs a .git.
   # Upstream tests need a device, so checks are off.
   pymobiledevice3_927 = mcpPythonInterp.pkgs.pymobiledevice3.overridePythonAttrs (old: {
-    version = "9.27.0";
+    inherit (pypiPins.pymobiledevice3) version;
     src = pkgs.fetchPypi {
       pname = "pymobiledevice3";
-      version = "9.27.0";
-      hash = "sha256-pYRzvX86tRUjYDuU7fBSD0VCTfE/sITJSId012+O7+8=";
+      inherit (pypiPins.pymobiledevice3) version hash;
     };
     env = (old.env or { }) // {
-      SETUPTOOLS_SCM_PRETEND_VERSION = "9.27.0";
+      SETUPTOOLS_SCM_PRETEND_VERSION = pypiPins.pymobiledevice3.version;
     };
     dependencies =
       (old.dependencies or [ ])

--- a/packages/mcp/pins.json
+++ b/packages/mcp/pins.json
@@ -1,0 +1,32 @@
+{
+  "htpy": {
+    "version": "26.5.1",
+    "url": "https://pypi.io/packages/source/h/htpy/htpy-26.5.1.tar.gz",
+    "hash": "sha256-Q6NlwfxnAJTaeBuSOIMBkznOwDE5fWHV/l+OLyJ4tj4="
+  },
+  "pyspark": {
+    "version": "3.5.5",
+    "url": "https://pypi.io/packages/source/p/pyspark/pyspark-3.5.5.tar.gz",
+    "hash": "sha256-bv/Jzpjt8jH01oP9FPcnBim/hFjGKNaiYg3tS7NPPLk="
+  },
+  "asn1": {
+    "version": "2.8.0",
+    "url": "https://pypi.io/packages/source/a/asn1/asn1-2.8.0.tar.gz",
+    "hash": "sha256-rfd93CcHz0IMDq47me4w6ROvzwk2Rn1CZpggzmt9FQo="
+  },
+  "ipsw_parser": {
+    "version": "1.7.3",
+    "url": "https://pypi.io/packages/source/i/ipsw_parser/ipsw_parser-1.7.3.tar.gz",
+    "hash": "sha256-QSu7t3O0NLD5lL0EPNtX2QqxpK5y+oSJtxkAzYVtNuo="
+  },
+  "pyiosbackup": {
+    "version": "0.2.4",
+    "url": "https://pypi.io/packages/source/p/pyiosbackup/pyiosbackup-0.2.4.tar.gz",
+    "hash": "sha256-ELTSoRyb7ck6VGfK063b4YvC3ENBVpIOciMibtTQvrc="
+  },
+  "pymobiledevice3": {
+    "version": "9.27.0",
+    "url": "https://pypi.io/packages/source/p/pymobiledevice3/pymobiledevice3-9.27.0.tar.gz",
+    "hash": "sha256-pYRzvX86tRUjYDuU7fBSD0VCTfE/sITJSId012+O7+8="
+  }
+}

--- a/packages/minecraft/minecraft-assets/default.nix
+++ b/packages/minecraft/minecraft-assets/default.nix
@@ -1,4 +1,5 @@
 {
+  ix,
   lib,
   stdenvNoCC,
   fetchurl,
@@ -15,22 +16,23 @@
 # extraction below is pure: it only unzips the fixed jar and selects the exact
 # texture and bitmap-font paths the overlays embed.
 #
-# Refresh recipe (when bumping `version`): resolve the new client.jar from the
-# manifest and read back the hash Nix wants:
+# Refresh recipe (when bumping `version`): resolve the new client.jar url from
+# the manifest, put it in pins.json, then rebuild and copy the `got:` hash from
+# the mismatch error (this package carries no registry updateScript, so
+# `nix run .#update` does not touch it):
 #   v=$(curl -fsSL https://launchermeta.mojang.com/mc/game/version_manifest_v2.json \
 #        | jq -r '.versions[]|select(.id=="VERSION").url')
-#   url=$(curl -fsSL "$v" | jq -r .downloads.client.url)
-#   nix store prefetch-file --json "$url" | jq -r .hash
+#   curl -fsSL "$v" | jq -r .downloads.client.url   # -> pins.json `url`
 #
 # Mojang's art is NOT redistributed by this repository; it is fetched at build
 # time, the same boundary the rest of the repo uses for upstream binaries.
 let
-  version = "1.21";
+  # Version + client.jar URL and SRI hash live in the sibling pins.json, never
+  # inline (repo policy).
+  pin = ix.pins.loadPin ./pins.json "client-jar";
+  inherit (pin) version;
 
-  clientJar = fetchurl {
-    url = "https://piston-data.mojang.com/v1/objects/0e9a07b9bb3390602f977073aa12884a4ce12431/client.jar";
-    hash = "sha256-S1a8m0Tefoj5+7UucWwYJA2jRGn8uvpe0udbBNYGF+g=";
-  };
+  clientJar = fetchurl { inherit (pin) url hash; };
 
   tex = "assets/minecraft/textures";
 in

--- a/packages/minecraft/minecraft-assets/pins.json
+++ b/packages/minecraft/minecraft-assets/pins.json
@@ -1,0 +1,7 @@
+{
+  "client-jar": {
+    "version": "1.21",
+    "url": "https://piston-data.mojang.com/v1/objects/0e9a07b9bb3390602f977073aa12884a4ce12431/client.jar",
+    "hash": "sha256-S1a8m0Tefoj5+7UucWwYJA2jRGn8uvpe0udbBNYGF+g="
+  }
+}

--- a/packages/sdk/rust/build.nix
+++ b/packages/sdk/rust/build.nix
@@ -59,23 +59,19 @@ let
   wireVersion = "0.1.0";
   wireHash = "a95096d6b0ee69a6";
   wireToolchainId = "iz0mdcq43pxl3fmxmznc6n38sals6q0x-rust-default-1.98.0-nightly-2026-05-27";
-  r2Base = "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/rlib/ix-sdk-wire/${wireHash}";
-  wireManifest = pkgs.fetchurl {
-    url = "${r2Base}/manifest.json";
-    hash = "sha256-UV6/vT5zasDrJyIp9o2AvXoqS9H5X+VOvQykxAmaPco=";
-  };
+
+  # The R2 URLs + SRI hashes for the three published artifacts live in the
+  # sibling pins.json (repo policy: no inline hash literals). Each URL embeds
+  # `wireHash` above; a re-publication rewrites pins.json (all three entries)
+  # and, when the unit hash moved, `wireHash` in this file.
+  wirePins = ix.pins.loadPins ./pins.json;
 
   # Fixed-output fetches: the SRI hash is the store-path identity, so the URL
   # carries no secret and substituters can short-circuit. These are the actual
   # compiled artifacts produced in the ix repo, not rebuilt here.
-  wireRlib = pkgs.fetchurl {
-    url = "${r2Base}/libix_sdk_wire-${wireHash}.rlib";
-    hash = "sha256-JCv83V3NQeSuA/oG/zYoX3AmM5u9jKPOxSH6V6OQQDs=";
-  };
-  wireRmeta = pkgs.fetchurl {
-    url = "${r2Base}/libix_sdk_wire-${wireHash}.rmeta";
-    hash = "sha256-Bt37uG3ImMhjt9dPX3W+pIoNAQvUMAFVOIdNMvUcT3E=";
-  };
+  wireManifest = pkgs.fetchurl { inherit (wirePins."wire-manifest") url hash; };
+  wireRlib = pkgs.fetchurl { inherit (wirePins."wire-rlib") url hash; };
+  wireRmeta = pkgs.fetchurl { inherit (wirePins."wire-rmeta") url hash; };
 
   # Wrap the fetched rlib+rmeta as a cargo-unit library unit. The Cargo lib
   # TARGET name for package `ix-sdk-wire` is `ix_sdk_wire` (renderer underscores
@@ -211,8 +207,8 @@ in
         grep -q '"crate": "ix-sdk-wire"' ${wireManifest}
         grep -q '"toolchain-id": "${wireToolchainId}"' ${wireManifest}
         grep -q '"unit-hash": "${wireHash}"' ${wireManifest}
-        grep -q '"sha256-JCv83V3NQeSuA/oG/zYoX3AmM5u9jKPOxSH6V6OQQDs="' ${wireManifest}
-        grep -q '"sha256-Bt37uG3ImMhjt9dPX3W+pIoNAQvUMAFVOIdNMvUcT3E="' ${wireManifest}
+        grep -q '"${wirePins."wire-rlib".hash}"' ${wireManifest}
+        grep -q '"${wirePins."wire-rmeta".hash}"' ${wireManifest}
 
         test -f ${prebuiltWireUnit}/lib/libix_sdk_wire-${wireHash}.rlib
         test -f ${prebuiltWireUnit}/lib/libix_sdk_wire-${wireHash}.rmeta

--- a/packages/sdk/rust/pins.json
+++ b/packages/sdk/rust/pins.json
@@ -1,0 +1,14 @@
+{
+  "wire-manifest": {
+    "url": "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/rlib/ix-sdk-wire/a95096d6b0ee69a6/manifest.json",
+    "hash": "sha256-UV6/vT5zasDrJyIp9o2AvXoqS9H5X+VOvQykxAmaPco="
+  },
+  "wire-rlib": {
+    "url": "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/rlib/ix-sdk-wire/a95096d6b0ee69a6/libix_sdk_wire-a95096d6b0ee69a6.rlib",
+    "hash": "sha256-JCv83V3NQeSuA/oG/zYoX3AmM5u9jKPOxSH6V6OQQDs="
+  },
+  "wire-rmeta": {
+    "url": "https://pub-559bccbc8be94bed84821cb943b580f3.r2.dev/rlib/ix-sdk-wire/a95096d6b0ee69a6/libix_sdk_wire-a95096d6b0ee69a6.rmeta",
+    "hash": "sha256-Bt37uG3ImMhjt9dPX3W+pIoNAQvUMAFVOIdNMvUcT3E="
+  }
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -11,6 +11,10 @@ let
   inherit (ix) pkgs;
   fs = lib.fileset;
   repoPackages = ix.packageSetFor pkgs;
+  # Fixture pins (rev + SRI hash pairs for the real-workspace snapshots and the
+  # shared go-unit vendor hash) live in the sibling pins.json, never inline
+  # (repo policy: no hash literals in tracked .nix).
+  pins = ix.pins.loadPins ./pins.json;
   portableServicesTest = import ./portable-services.nix { inherit lib pkgs ix; };
   # VM boot smoke test for the minecraft-blocks Paper plugin (ENG-2186). Not
   # part of the `eval` aggregate: it boots a qemu VM, so it is its own check
@@ -1355,7 +1359,7 @@ let
       (ix.goUnit.buildWorkspace {
         pname = "go-unit-missing-go-sum";
         src = goUnitMissingGoSumFixture;
-        vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
+        vendorHash = pins."go-unit-fixture-vendor".hash;
         packages = [ "." ];
       }).packages
   );
@@ -1383,7 +1387,7 @@ let
         pname = "go-unit-missing-explicit-go-sum";
         src = goUnitMissingGoSumFixture;
         goSum = goUnitMissingGoSumFixture + "/go.sum";
-        vendorHash = "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8=";
+        vendorHash = pins."go-unit-fixture-vendor".hash;
         packages = [ "." ];
       }).packages
   );
@@ -1572,28 +1576,34 @@ let
   cargoUnitRealWorkspaces = {
     serde = cargoUnitRealWorkspace {
       name = "serde";
-      owner = "serde-rs";
-      repo = "serde";
-      rev = "fa7da4a93567ed347ad0735c28e439fca688ef26";
-      hash = "sha256-5Ercr2dCC52VLV9dAZUsMlw+Ovup5Qui6vDQHxl70v4=";
+      inherit (pins.serde)
+        owner
+        repo
+        rev
+        hash
+        ;
       lockFile = ./fixtures/cargo-unit-real-workspaces/serde/Cargo.lock;
     };
 
     thiserror = cargoUnitRealWorkspace {
       name = "thiserror";
-      owner = "dtolnay";
-      repo = "thiserror";
-      rev = "d4a2507576d276dbebc4be45c9b3d657216b727f";
-      hash = "sha256-0DU1KSWZ+T4v9cfTfY8QQ2bMLgko9+c1dOXEk99KvUo=";
+      inherit (pins.thiserror)
+        owner
+        repo
+        rev
+        hash
+        ;
       lockFile = ./fixtures/cargo-unit-real-workspaces/thiserror/Cargo.lock;
     };
 
     indexmap = cargoUnitRealWorkspace {
       name = "indexmap";
-      owner = "indexmap-rs";
-      repo = "indexmap";
-      rev = "0a5535021aec77a2c9890c0bec273fa446c6593a";
-      hash = "sha256-7WBUZ1QJ6tywpdmo50QpX01fu7HMkpfoh/TC2LkPxiM=";
+      inherit (pins.indexmap)
+        owner
+        repo
+        rev
+        hash
+        ;
       lockFile = ./fixtures/cargo-unit-real-workspaces/indexmap/Cargo.lock;
       testArgs = [
         "--workspace"
@@ -1603,10 +1613,12 @@ let
 
     regex = cargoUnitRealWorkspace {
       name = "regex";
-      owner = "rust-lang";
-      repo = "regex";
-      rev = "839d16bc65b60e2006d3599d20bfa6efc14049d8";
-      hash = "sha256-9czj9Oa25H8VhMmZNyS0h9sFn6rYDrEPlOuGm9NJd9A=";
+      inherit (pins.regex)
+        owner
+        repo
+        rev
+        hash
+        ;
       lockFile = ./fixtures/cargo-unit-real-workspaces/regex/Cargo.lock;
       testArgs = [
         "--workspace"

--- a/tests/pins.json
+++ b/tests/pins.json
@@ -1,0 +1,29 @@
+{
+  "go-unit-fixture-vendor": {
+    "hash": "sha256-36P4vOdzJotmVZon5Zud/d/jxzv4ad04aQT2G/EE3U8="
+  },
+  "serde": {
+    "owner": "serde-rs",
+    "repo": "serde",
+    "rev": "fa7da4a93567ed347ad0735c28e439fca688ef26",
+    "hash": "sha256-5Ercr2dCC52VLV9dAZUsMlw+Ovup5Qui6vDQHxl70v4="
+  },
+  "thiserror": {
+    "owner": "dtolnay",
+    "repo": "thiserror",
+    "rev": "d4a2507576d276dbebc4be45c9b3d657216b727f",
+    "hash": "sha256-0DU1KSWZ+T4v9cfTfY8QQ2bMLgko9+c1dOXEk99KvUo="
+  },
+  "indexmap": {
+    "owner": "indexmap-rs",
+    "repo": "indexmap",
+    "rev": "0a5535021aec77a2c9890c0bec273fa446c6593a",
+    "hash": "sha256-7WBUZ1QJ6tywpdmo50QpX01fu7HMkpfoh/TC2LkPxiM="
+  },
+  "regex": {
+    "owner": "rust-lang",
+    "repo": "regex",
+    "rev": "839d16bc65b60e2006d3599d20bfa6efc14049d8",
+    "hash": "sha256-9czj9Oa25H8VhMmZNyS0h9sFn6rYDrEPlOuGm9NJd9A="
+  }
+}


### PR DESCRIPTION
Second tranche of #1696 (follows #1708): packages/mcp (6 pins), sdk/rust wire artifacts, lib/rust advisory-db, lib/darwin macos-sdk, minecraft-bedrock, minecraft-assets, agent packages (pi-harnesses engine, symphony, eval-viewer), hive, ix-sdk-python, tests fixtures.

Verification: all 27 pre-migration hash literals byte-exact in pins.json (checked against HEAD blobs); representative drvPaths (symphony, minecraft-assets, ix-sdk-python) byte-identical, mcp differs only by its intentional IX_MCP_VERSION build-commit stamp. Adversarial review: approve-with-fixes, fixes applied (honest re-pin comments for non-registry packages; artifactCheck greps now derive from wire pins). Deliberately inline: snafu git-dep outputHashes entry, zig fixture zigDepsHash (both self-coordinated).

Closes #1696.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate remaining inline hashes and URLs to `pins.json` files across packages
> - Replaces inline hardcoded URLs, hashes, and versions scattered across many packages with structured `pins.json` files loaded via `ix.pins.loadPin` / `ix.pins.loadPins`.
> - Affected packages include `macos-sdk`, `rust/policy`, `minecraft-bedrock`, `ix-sdk-python`, `symphony`, `mcp`, `minecraft-assets`, `sdk/rust`, and test fixtures.
> - The `pins` argument is threaded through `lib/rust` build/resolve/tooling and `lib/default.nix` to make pins accessible downstream.
> - Behavioral Change: `ix-sdk-python` no longer asserts a `sha256-` hash prefix on fetched wheel hashes — only the `https://` URL prefix is checked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bae1b18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->