### PR TITLE
cve-scan: never let a deriver-less store path sink the scan

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -98,7 +98,7 @@ jobs:
           # JSON so it cannot disagree with the issue body.
           jq -r '
             def cvss: if .max_cvss == null then "-" else (.max_cvss | tostring) end;
-            "CVE scan of \(.closure_roots_scanned) closure root(s) on \(.system): \(.vulnerable_packages) vulnerable package(s), \(.advisory_matches) active advisory match(es), \(.whitelisted_matches) whitelisted.",
+            "CVE scan of \(.closure_roots_scanned) closure root(s) on \(.system): \(.vulnerable_packages) vulnerable package(s), \(.advisory_matches) active advisory match(es), \(.whitelisted_matches) whitelisted, \(.paths_skipped_no_deriver) path(s) skipped (no local deriver).",
             (.packages[] | "  \(.package)  \(cvss)  \(.advisories | join(", "))")
           ' cve-scan.json
 
@@ -114,12 +114,16 @@ jobs:
           vuln=$(jq -r '.vulnerable_packages' cve-scan.json)
           matches=$(jq -r '.advisory_matches' cve-scan.json)
           masked=$(jq -r '.whitelisted_matches' cve-scan.json)
+          noderiver=$(jq -r '.paths_skipped_no_deriver' cve-scan.json)
           {
             printf '<!-- cve-scan-tracking -->\n'
             printf '# Nix closure CVE scan\n\n'
             printf 'Whole-closure CVE scan of `.#cachePushRoots.x86_64-linux` (%s roots) via `vulnix`, run by [.github/workflows/cve-scan.yml](../blob/main/.github/workflows/cve-scan.yml). See #1697.\n\n' "$scanned"
             printf '**%s vulnerable package(s), %s active advisory match(es), %s whitelisted** (see [packages/cve-scan/whitelist.toml](../blob/main/packages/cve-scan/whitelist.toml)). Last scanned: %s (run [%s](../actions/runs/%s)).\n\n' \
               "$vuln" "$matches" "$masked" "$(date -u +'%Y-%m-%d %H:%M UTC')" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ID}"
+            if [ "$noderiver" -gt 0 ]; then
+              printf '_%s store path(s) skipped: no local deriver (unscanned, not clean; see the run log)._\n\n' "$noderiver"
+            fi
             if [ "$vuln" -eq 0 ]; then
               printf 'No active CVEs found in the scanned closures.\n'
             else

--- a/packages/cve-scan/cve-scan.py
+++ b/packages/cve-scan/cve-scan.py
@@ -166,6 +166,67 @@ def realize_closures(
     return (out_paths, skipped)
 
 
+def instantiate_drvs(nix: str, flake: str, system: str) -> None:
+    """Register every root's .drv in the local store (best-effort).
+
+    vulnix resolves each output path back to its deriver. A root substituted
+    from a binary cache arrives WITHOUT its .drv registered locally, and vulnix
+    raises DeriverLookupError on the first such path, sinking the whole scan
+    (observed on `ix-fleet` in run 28592906325). Forcing every root's `drvPath`
+    in one evaluation instantiates the .drvs into the local store, which rescues
+    substituted roots. `tryEval` keeps a root that fails to evaluate on this
+    system (e.g. `check` on darwin) from aborting the instantiation of the rest;
+    whatever still lacks a deriver afterwards is filtered out visibly by
+    `filter_paths_with_deriver`, so a failure here degrades, never crashes.
+    """
+    apply = (
+        "rs: builtins.attrValues (builtins.mapAttrs "
+        "(_: p: (builtins.tryEval p.drvPath).value) rs)"
+    )
+    proc = run(
+        [nix, "eval", "--json", f"{flake}#cachePushRoots.{system}", "--apply", apply]
+    )
+    if proc.returncode != 0:
+        print(
+            "cve-scan: drv instantiation failed (continuing; paths without a "
+            f"deriver will be skipped):\n{proc.stderr.strip()}",
+            file=sys.stderr,
+        )
+
+
+def filter_paths_with_deriver(store_paths: list[str]) -> tuple[list[str], list[str]]:
+    """Split store paths into (scannable, no-deriver) for vulnix.
+
+    vulnix crashes with DeriverLookupError on any output path whose deriver is
+    unknown to the local store or whose .drv file is absent, so such paths are
+    excluded up front and reported as a visible count instead. One bulk
+    `nix-store -q --deriver` answers for all paths (one line per path, in
+    order); per-path fallback if the bulk query itself fails.
+    """
+
+    def deriver_ok(deriver: str) -> bool:
+        return deriver.startswith("/") and Path(deriver).exists()
+
+    bulk = run(["nix-store", "-q", "--deriver", *store_paths])
+    derivers = bulk.stdout.splitlines()
+    if bulk.returncode != 0 or len(derivers) != len(store_paths):
+        scannable: list[str] = []
+        missing: list[str] = []
+        for path in store_paths:
+            proc = run(["nix-store", "-q", "--deriver", path])
+            deriver = proc.stdout.strip()
+            if proc.returncode == 0 and deriver_ok(deriver):
+                scannable.append(path)
+            else:
+                missing.append(path)
+        return (scannable, missing)
+    paired = list(zip(store_paths, derivers, strict=True))
+    return (
+        [p for p, d in paired if deriver_ok(d)],
+        [p for p, d in paired if not deriver_ok(d)],
+    )
+
+
 def scan(
     vulnix: str,
     cache_dir: Path,
@@ -216,12 +277,16 @@ def whitelisted_matches(findings: list[Finding]) -> int:
     return sum(len(f.whitelisted) for f in findings)
 
 
-def render_table(findings: list[Finding], system: str, root_count: int) -> str:
+def render_table(
+    findings: list[Finding], system: str, root_count: int, no_deriver: int
+) -> str:
     """Render findings as a human-readable table (the default surface).
 
     Table rows are packages with ACTIVE advisories; fully-whitelisted packages
     are folded into the visible whitelisted count in the footer so acknowledged
-    advisories stay auditable without burying the actionable rows.
+    advisories stay auditable without burying the actionable rows. Store paths
+    excluded for lacking a local deriver are likewise a visible count: an
+    unscanned path must never look like a clean one.
     """
     header = (
         f"CVE scan of {root_count} closure root(s) on {system} "
@@ -233,9 +298,14 @@ def render_table(findings: list[Finding], system: str, root_count: int) -> str:
         f"{masked} advisory match(es) whitelisted"
         " (packages/cve-scan/whitelist.toml)."
     )
+    deriver_note = f"{no_deriver} store path(s) skipped: no local deriver."
     if not active:
-        clean = f"{header}\n\nNo active CVEs found in the scanned closures."
-        return f"{clean}\n{masked_note}" if masked else clean
+        lines = [f"{header}\n\nNo active CVEs found in the scanned closures."]
+        if masked:
+            lines.append(masked_note)
+        if no_deriver:
+            lines.append(deriver_note)
+        return "\n".join(lines)
 
     # Sort worst-first by max CVSS score so the most urgent rows lead; unscored
     # advisories sort last within their package.
@@ -277,10 +347,14 @@ def render_table(findings: list[Finding], system: str, root_count: int) -> str:
     ]
     if masked:
         lines.append(masked_note)
+    if no_deriver:
+        lines.append(deriver_note)
     return "\n".join(lines)
 
 
-def render_json(findings: list[Finding], system: str, root_count: int) -> str:
+def render_json(
+    findings: list[Finding], system: str, root_count: int, no_deriver: int
+) -> str:
     """Render findings as the machine-readable document.
 
     Emits a stable shape (not vulnix's raw output) so the workflow issue body
@@ -308,6 +382,9 @@ def render_json(findings: list[Finding], system: str, root_count: int) -> str:
         "vulnerable_packages": len(active),
         "advisory_matches": sum(len(f.affected_by) for f in active),
         "whitelisted_matches": whitelisted_matches(findings),
+        # Store paths excluded because no deriver is registered locally (see
+        # filter_paths_with_deriver): unscanned, NOT clean.
+        "paths_skipped_no_deriver": no_deriver,
         "packages": packages,
     }
     return json.dumps(doc, indent=2)
@@ -383,6 +460,20 @@ def main() -> int:
     store_paths = list(dict.fromkeys(store_paths))
     if not store_paths:
         sys.exit("cve-scan: no store paths to scan (every closure root failed)")
+    # Register every root's .drv locally, then exclude any path that still has
+    # no resolvable deriver: vulnix crashes on the first deriver-less path
+    # (substituted from cache), which would sink the whole scan.
+    print("cve-scan: instantiating root derivations …", file=sys.stderr)
+    instantiate_drvs(nix, args.flake, system)
+    store_paths, no_deriver_paths = filter_paths_with_deriver(store_paths)
+    if no_deriver_paths:
+        print(
+            f"cve-scan: skipping {len(no_deriver_paths)} store path(s) with no "
+            f"local deriver: {', '.join(sorted(no_deriver_paths))}",
+            file=sys.stderr,
+        )
+    if not store_paths:
+        sys.exit("cve-scan: no scannable store paths (all lack a local deriver)")
     print(
         f"cve-scan: scanning {len(store_paths)} store path(s) with vulnix "
         "(first run downloads the NVD feed) …",
@@ -391,11 +482,12 @@ def main() -> int:
     whitelists = [Path(w) for w in args.whitelist]
     findings = scan(vulnix, cache_dir, store_paths, whitelists)
     scanned = len(names) - len(skipped)
+    no_deriver = len(no_deriver_paths)
 
     if args.json:
-        print(render_json(findings, system, scanned))
+        print(render_json(findings, system, scanned, no_deriver))
     else:
-        print(render_table(findings, system, scanned))
+        print(render_table(findings, system, scanned, no_deriver))
 
     active = [f for f in findings if f.affected_by]
     return VULNIX_EXIT_VULNERABLE if active else 0


### PR DESCRIPTION
Validation run [28592906325](https://github.com/indexable-inc/index/actions/runs/28592906325) got past the old 60-minute ceiling (#1712 worked: closure realization and the NVD parse completed) and then crashed with a real bug: vulnix raised `DeriverLookupError` on `/nix/store/...-ix-fleet-0.1.0` -- the out-path was substituted from cache without its `.drv` being registered locally, and vulnix aborts the ENTIRE scan on the first such path. All 252 realized roots were lost to one unresolvable deriver.

Two layers (belt and suspenders):

1. **`instantiate_drvs`**: after realization, force every root's `drvPath` in one `nix eval` -- instantiation registers the `.drv`s in the local store, rescuing substituted roots like `ix-fleet` outright. Best-effort by design: on a system where some root does not evaluate (`check` on darwin) the eval fails with a warning and layer 2 still guards correctness.
2. **`filter_paths_with_deriver`**: bulk `nix-store -q --deriver` over the realized paths; any path whose deriver is unknown or whose `.drv` file is absent is **excluded with a visible count** -- "N store path(s) skipped: no local deriver" in the human table, `paths_skipped_no_deriver` in the JSON, and an explicit italic line in the tracking-issue body. Unscanned is never presented as clean.

Verified locally (aarch64-darwin): a substituted output with an absent `.drv` (`vulnix-1.12.4-man` -- deriver path known, file missing, exactly the ix-fleet failure shape) is filtered out while locally-built and registered paths pass; the darwin instantiation failure degrades to a warning, not a crash. `nix build .#cve-scan` (zuban strict + ruff) and `nix run .#lint` green.

FYI from the same run log, already handled correctly by the existing skip-reporting: `jupyter`, `nu-jupyter-kernel`, and `snix` fail to *build* on x86_64-linux; filing a separate issue for those.

Refs #1697. I will re-dispatch the validation run after this merges and post the findings table.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip deriver-less store paths in cve-scan to prevent vulnix crashes
> - Adds `instantiate_drvs` to best-effort register `.drv` files locally before scanning, reducing missing-deriver failures.
> - Adds `filter_paths_with_deriver` to split store paths into scannable and skipped sets; paths without a valid local deriver are excluded and logged.
> - The CLI exits with an error if all paths lack a deriver, otherwise proceeds with the scannable subset.
> - Skipped path counts are surfaced in both the human-readable table output and the JSON field `paths_skipped_no_deriver`.
> - The GitHub Actions workflow conditionally appends a note to the tracking issue body when any paths were skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef0f97c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->