### PR TITLE
cve-scan: runner tool provisioning + first-scan whitelist triage

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -62,6 +62,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Flake-pinned tools onto PATH for every later step: the self-hosted
+      # runner carries coreutils + nix but neither jq nor gh (run 28598889924
+      # completed its whole scan and then died on `jq: command not found`).
+      # Same `nix build .#<tool>` pattern as cache-push.yml; `^bin`/`^out` pick
+      # one output from multi-output packages. $GITHUB_PATH applies to
+      # subsequent steps, hence a dedicated step.
+      - name: Put jq and gh on PATH
+        run: |
+          set -euo pipefail
+          {
+            echo "$(nix build '.#jq^bin' --no-link --print-out-paths)/bin"
+            echo "$(nix build '.#gh^out' --no-link --print-out-paths)/bin"
+          } >>"$GITHUB_PATH"
+
       # Realize every closure root and scan it with vulnix. `--json` emits the
       # machine-readable findings document (see packages/cve-scan/cve-scan.py);
       # a summary table is echoed to the step log from the same document.

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1250,14 +1250,19 @@ let
       agents = agentsDir;
       skills = skillsDir;
       claude-plugin = claudePluginDir;
-      # The attic binary cache client, jq, and findutils (xargs), used by
-      # cache-push.yml to publish index's package closure to the public
-      # `ix-public` atticd cache. Pinned to the flake's nixpkgs so the workflow
-      # resolves them with `nix build .#attic-client` / `.#jq` / `.#findutils`
+      # The attic binary cache client, jq, findutils (xargs), and gh, used by
+      # cache-push.yml (attic/jq/xargs) and cve-scan.yml (jq/gh). Pinned to the
+      # flake's nixpkgs so the workflows resolve them with `nix build .#<tool>`
       # rather than depending on a tool being on the runner PATH or a floating
-      # `nixpkgs#` registry reference. The runner PATH carries coreutils + nix
-      # but not findutils, so bare `xargs` is `command not found`.
-      inherit (pkgs) attic-client jq findutils;
+      # `nixpkgs#` registry reference. The self-hosted runner PATH carries
+      # coreutils + nix but not findutils, jq, or gh, so the bare commands are
+      # `command not found` (cve-scan run 28598889924 died on exactly that).
+      inherit (pkgs)
+        attic-client
+        jq
+        findutils
+        gh
+        ;
     }
     // repoFlakePackages
     // examplePackages

--- a/packages/cve-scan/whitelist.toml
+++ b/packages/cve-scan/whitelist.toml
@@ -19,3 +19,133 @@
 #
 # Keep entries scoped (pname + explicit cve list); a bare section with no `cve`
 # masks EVERY advisory for that pname, which hides future findings too.
+#
+# The entries below are CPE name collisions from the first full scan (run
+# 28598889924): vulnix matches bare pname+version against NVD CPEs, so a Rust /
+# Haskell / Python library whose name collides with an unrelated product
+# inherits that product's CVEs. Each entry lists the exact colliding ids;
+# anything new against the same pname still surfaces.
+
+["network-3.2.8.0"]
+cve = ["CVE-2021-35047", "CVE-2021-35048", "CVE-2021-35049", "CVE-2021-35050", "CVE-2022-0486", "CVE-2022-0997", "CVE-2022-24388", "CVE-2022-24389", "CVE-2022-24390", "CVE-2022-24391", "CVE-2022-24392", "CVE-2022-24393", "CVE-2022-24394"]
+comment = "Haskell network library; these CVEs target Zoho/Cisco 'network' appliance products"
+
+["glib-0.18.5"]
+cve = ["CVE-2021-27218", "CVE-2021-27219", "CVE-2021-28153", "CVE-2021-3800", "CVE-2023-29499", "CVE-2023-32611", "CVE-2023-32636", "CVE-2023-32643", "CVE-2023-32665", "CVE-2024-34397", "CVE-2024-52533", "CVE-2025-13601", "CVE-2025-14087", "CVE-2025-14512", "CVE-2025-4056", "CVE-2026-58014", "CVE-2026-58015", "CVE-2026-58016"]
+comment = "Rust gtk-rs glib crate 0.18.5; these CVEs target GNOME C glib (2.x)"
+
+["gdk-pixbuf-0.18.5"]
+cve = ["CVE-2021-20240", "CVE-2021-46829"]
+comment = "Rust gtk-rs gdk-pixbuf crate; CVEs target C gdk-pixbuf, fixed in 2.42.x"
+
+["zlib-0.7.1.1"]
+cve = ["CVE-2022-37434", "CVE-2023-45853", "CVE-2023-6992", "CVE-2026-22184", "CVE-2026-27820"]
+comment = "Haskell zlib bindings; CVEs target C zlib/minizip (the C zlib closure entry is tracked separately)"
+
+["Diff-1.0.2"]
+cve = ["CVE-2024-13278"]
+comment = "Haskell Diff library; CVE targets an unrelated 'diff' product"
+
+["diff-0.1.13"]
+cve = ["CVE-2024-13278"]
+comment = "Rust diff crate; same collision as Diff-1.0.2"
+
+["loom-0.7.2"]
+cve = ["CVE-2024-23742"]
+comment = "Rust loom concurrency-testing crate; CVE targets the Loom screen-recorder macOS app"
+
+["hyper-1.10.1"]
+cve = ["CVE-2024-23741"]
+comment = "Rust hyper HTTP library; CVE targets the Hyper terminal-emulator macOS app (CVE-2025-7074 left active pending triage)"
+
+["focus-1.0.3.2"]
+cve = ["CVE-2023-29533", "CVE-2023-29535", "CVE-2023-29536", "CVE-2023-29537", "CVE-2023-29538", "CVE-2023-29539", "CVE-2023-29540", "CVE-2023-29541", "CVE-2023-29543", "CVE-2023-29544", "CVE-2023-29547", "CVE-2023-29548", "CVE-2023-29549", "CVE-2023-29550", "CVE-2023-29551", "CVE-2026-11799"]
+comment = "Haskell focus library; CVEs target the Firefox Focus browser"
+
+["snappy-1.2.2"]
+cve = ["CVE-2023-28115", "CVE-2023-41330"]
+comment = "Google C snappy compression; both CVEs target the KnpLabs PHP Snappy PDF library"
+
+["tar"]
+cve = ["CVE-2021-20193", "CVE-2021-32803", "CVE-2021-32804", "CVE-2021-37701", "CVE-2021-37712", "CVE-2021-37713", "CVE-2022-48303", "CVE-2023-39804", "CVE-2024-28863", "CVE-2025-45582", "CVE-2026-23745", "CVE-2026-23950", "CVE-2026-24842", "CVE-2026-26960", "CVE-2026-29786", "CVE-2026-31802", "CVE-2026-53655"]
+comment = "Rust tar crate + Haskell tar library; CVEs target GNU tar / node-tar (nixpkgs GNU tar is pname gnutar, not covered by this entry)"
+
+["home-0.5.12"]
+cve = ["CVE-2021-25264", "CVE-2023-3612", "CVE-2024-52327", "CVE-2024-52329"]
+comment = "Rust home crate (cargo home dir lookup); CVEs target 'Home' branded products"
+
+["h2-0.4.15"]
+cve = ["CVE-2022-45868"]
+comment = "Rust h2 HTTP/2 crate; CVE targets the H2 Java database web console"
+
+["async-2.2.6"]
+cve = ["CVE-2021-43138"]
+comment = "Haskell async library; CVE targets the npm async package"
+
+["regex-1.1.0.2"]
+cve = ["CVE-2022-24713"]
+comment = "Haskell regex package; CVE targets the Rust regex crate < 1.5.5 (the workspace's real rust regex is far newer)"
+
+["safe-0.3.21"]
+cve = ["CVE-2021-33594", "CVE-2021-33595", "CVE-2021-33596", "CVE-2021-40834", "CVE-2021-40835", "CVE-2021-44751", "CVE-2022-28868", "CVE-2022-28869", "CVE-2022-28870", "CVE-2022-28872", "CVE-2022-28873", "CVE-2022-38163", "CVE-2022-38164", "CVE-2022-47524"]
+comment = "Haskell safe library; CVEs target 'Safe' branded security products"
+
+["yaml-0.11.11.2"]
+cve = ["CVE-2021-4235", "CVE-2022-3064"]
+comment = "Haskell yaml library; CVEs target Go gopkg.in/yaml"
+
+["numpy-0.28.0"]
+cve = ["CVE-2021-34141", "CVE-2021-41495", "CVE-2021-41496"]
+comment = "Rust numpy (pyo3) crate 0.28; CVEs target Python NumPy, fixed in 1.22"
+
+["protobuf"]
+cve = ["CVE-2021-22570", "CVE-2024-7254"]
+comment = "CVE-2021-22570 is C++ protobuf fixed in 3.15, CVE-2024-7254 is protobuf-java; matched against the Rust protobuf crate 3.7.2. CVE-2026-0994 left active on both protobuf entries."
+
+["nix-0.31.3"]
+cve = ["CVE-2024-27297"]
+comment = "Rust nix crate; CVE targets the Nix package manager (fixed 2.18.1+, closure ships 2.34)"
+
+["semver-1.0.28"]
+cve = ["CVE-2022-25883"]
+comment = "Rust semver crate; CVE targets the npm semver package"
+
+["paste-1.0.15"]
+cve = ["CVE-2022-21948"]
+comment = "Rust paste macro crate; CVE targets the openSUSE paste service"
+
+["git"]
+cve = ["CVE-2021-21684", "CVE-2022-30947", "CVE-2022-36882", "CVE-2022-36883", "CVE-2022-36884", "CVE-2022-38663"]
+comment = "All six target the Jenkins Git/Git-client plugins, not git itself"
+
+["lapack-3"]
+cve = ["CVE-2021-4048"]
+comment = "Fixed in LAPACK 3.10.1; the nixpkgs wrapper's version string '3' matches the stale CPE range"
+
+["ninja-1.13.2"]
+cve = ["CVE-2021-4336"]
+comment = "CVE targets the WordPress Ninja Forms plugin, not the ninja build tool"
+
+["tokio-1.52.3"]
+cve = ["CVE-2024-27308"]
+comment = "mio named-pipe race, fixed in mio 0.8.11 (2024); tokio 1.52 ships far past it -- stale CPE range"
+
+["codex-0.136.0"]
+cve = ["CVE-2021-43635"]
+comment = "2021 CVE against an unrelated 'codex' product; predates the OpenAI codex CLI entirely"
+
+["clone-0.1.0"]
+cve = ["CVE-2023-0958", "CVE-2023-3977", "CVE-2023-6750", "CVE-2024-43297", "CVE-2024-43298"]
+comment = "Repo-owned clone-detect crate; CVEs target unrelated 'Clone' WordPress plugins"
+
+["dashboard-0.1.0"]
+cve = ["CVE-2021-30144"]
+comment = "Repo-owned dashboard package; CVE targets an unrelated 'Dashboard' product"
+
+["dbus"]
+cve = ["CVE-2022-42010", "CVE-2022-42011", "CVE-2022-42012"]
+comment = "Fixed in dbus daemon 1.14.4 (nixpkgs ships 1.16.x); flagged names are the Rust dbus crate 0.9.11 and a version-parse artifact 'dbus-1'"
+
+["kotlin-2.3.21"]
+cve = ["CVE-2023-26154"]
+comment = "CVE targets the PubNub Kotlin SDK, not the Kotlin compiler (CVE-2026-53914 left active)"


### PR DESCRIPTION
The first COMPLETE whole-closure scan (run [28598889924](https://github.com/indexable-inc/index/actions/runs/28598889924), after #1715's deriver fix) worked end to end -- **251 roots scanned, 99 vulnerable packages, 423 advisory matches, 18 paths visibly skipped (no local deriver)** -- and then died at the render step on `jq: command not found`: the self-hosted runner PATH carries coreutils + nix but neither `jq` nor `gh`.

Two changes:

1. **Runner tool provisioning**: a dedicated step puts flake-pinned `jq` and `gh` on `$GITHUB_PATH` (same `nix build '.#jq^bin'` pattern cache-push.yml uses; `gh` newly exposed through the package set next to `attic-client`/`jq`/`findutils` with the shared rationale comment).
2. **First-scan triage into the whitelist**: 31 entries in `packages/cve-scan/whitelist.toml`, every one an explicit per-CVE list with its reason. All are CPE name collisions or stale version-range artifacts: Haskell `focus` vs Firefox Focus, Haskell `network` vs Zoho/Cisco appliances, Rust `h2` vs the H2 Java database, Rust `loom`/`hyper` crates vs the Loom/Hyper macOS apps, `git` vs six Jenkins Git-plugin CVEs, npm `async`/`semver` collisions, gtk-rs `glib`/`gdk-pixbuf` crates vs C GNOME libraries, stale ranges for `lapack`/`tokio`/`ninja`, and the repo-owned `clone`/`dashboard` 0.1.0 crates vs unrelated commercial products. The whitelist was validated against vulnix's own `Whitelist.load` parser (31 entries load).

Masked advisories stay visible as counts on all three surfaces (table footer, `whitelisted_matches` in JSON, tracking-issue summary). The genuinely current findings -- `openssl 3.6.2/4.0.0` (17-18 CVEs), `glibc 2.42`, `unbound 1.25` (11 CVEs, one 10.0), `seaweedfs` (10.0), `thrift`, `gstreamer`, `pnpm`, `aiohttp`, `rsync`, and friends -- stay ACTIVE for the tracking issue, which is the designed home for them while nixpkgs (auto-bumped hourly) absorbs upstream fixes.

Refs #1697. I will re-dispatch the validation run after this merges; with these fixes it should complete all six steps and file the tracking issue.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cve-scan runner by provisioning `jq` and `gh` and triage false-positive CVEs
> - Adds a new step in [cve-scan.yml](.github/workflows/cve-scan.yml) that builds `jq` and `gh` via `nix build` and appends their bin paths to `$GITHUB_PATH`, fixing prior 'command not found' failures.
> - Exposes a flake-pinned `gh` package in [per-system.nix](lib/per-system.nix) so it can be referenced as `.#gh` in the workflow.
> - Adds whitelist entries in [whitelist.toml](packages/cve-scan/whitelist.toml) to suppress CVE IDs that are false positives caused by CPE name collisions between Rust/Haskell crates and unrelated products.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4d2926.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->