### PR TITLE
panes: occlusion downshift + watchdog backoff (PR #1714 review follow-ups)

### DIFF
--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -60,6 +60,14 @@ const FALLBACK_TICK: Duration = Duration::from_millis(100);
 /// permanently.
 const INFLIGHT_WATCHDOG_TICKS: u32 = 10;
 
+/// Ceiling for the watchdog's exponential backoff (~8s of `FALLBACK_TICK`s).
+/// Every watchdog fire resends a FULL frame -- the largest message on the
+/// wire -- so a fixed 1s period on a congested or slow link is a positive
+/// feedback loop: each rescue adds the traffic that made the ack late.
+/// Consecutive fires double the threshold up to this cap; a real ack resets
+/// it to `INFLIGHT_WATCHDOG_TICKS`.
+const INFLIGHT_WATCHDOG_MAX_TICKS: u32 = 80;
+
 /// One exported `xdg_toplevel`.
 struct Pane {
     id: WindowId,
@@ -74,6 +82,10 @@ struct Pane {
     /// Fallback ticks the current in-flight frame has gone unacked; drives
     /// the `INFLIGHT_WATCHDOG_TICKS` rescue in `on_tick`.
     inflight_ticks: u32,
+    /// Ticks the watchdog currently waits before firing. Doubles on each
+    /// consecutive fire (see `INFLIGHT_WATCHDOG_MAX_TICKS`); reset by a
+    /// real ack.
+    watchdog_ticks: u32,
     title: String,
     app_id: String,
     min: Option<(u32, u32)>,
@@ -92,6 +104,7 @@ impl Pane {
             seq: 0,
             inflight: None,
             inflight_ticks: 0,
+            watchdog_ticks: INFLIGHT_WATCHDOG_TICKS,
             title: String::new(),
             app_id: String::new(),
             min: None,
@@ -436,6 +449,9 @@ impl App {
                     for pane in &mut self.panes {
                         pane.inflight = None;
                         pane.inflight_ticks = 0;
+                        // A reconnect is a fresh link; backoff earned on the
+                        // old one says nothing about it.
+                        pane.watchdog_ticks = INFLIGHT_WATCHDOG_TICKS;
                         pane.announced = false;
                         pane.store.invalidate();
                     }
@@ -549,6 +565,8 @@ impl App {
         }
         self.panes[idx].inflight = None;
         self.panes[idx].inflight_ticks = 0;
+        // A live ack ends any backoff: the link is moving again.
+        self.panes[idx].watchdog_ticks = INFLIGHT_WATCHDOG_TICKS;
         // The host presented: let the client draw the next frame.
         fire_frame_callbacks(self.panes[idx].toplevel.wl_surface(), now);
         // And if commits accumulated while this frame was in flight, send
@@ -625,12 +643,18 @@ impl App {
                     continue;
                 }
                 pane.inflight_ticks += 1;
-                if pane.inflight_ticks < INFLIGHT_WATCHDOG_TICKS {
+                if pane.inflight_ticks < pane.watchdog_ticks {
                     continue;
                 }
+                // Back off before the next rescue: if this full frame also
+                // goes unacked, flooding a struggling link with more fulls
+                // only pushes the ack further out.
+                pane.watchdog_ticks =
+                    (pane.watchdog_ticks * 2).min(INFLIGHT_WATCHDOG_MAX_TICKS);
                 warn!(
                     id = pane.id,
                     seq = pane.inflight,
+                    next_wait_ticks = pane.watchdog_ticks,
                     "ack never arrived; releasing pacing and resending full"
                 );
                 pane.inflight = None;

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -278,6 +278,29 @@ pub fn window_closed(id: WindowId) {
     });
 }
 
+/// Occlusion change: a fully covered window keeps presenting and acking at
+/// the full display rate on its own (`CAMetalDisplayLink` does not stop for
+/// occlusion), so downshift it to ack-only ticks; see
+/// [`PaneWindow::set_occluded`].
+pub fn window_occlusion_changed(id: WindowId) {
+    with_app(|app| {
+        let Some(window) = app.windows.get_mut(&id) else {
+            return;
+        };
+        // A window not yet ordered in reports "not visible"; that is not
+        // occlusion, just the pre-show state.
+        if !window.shown {
+            return;
+        }
+        let visible = window.occlusion_visible();
+        eprintln!(
+            "panes-host: window {id}: {}",
+            if visible { "visible; presents resume" } else { "occluded; presents paused" }
+        );
+        window.set_occluded(!visible);
+    });
+}
+
 pub fn window_geometry_changed(id: WindowId) {
     with_app(|app| {
         let Some(window) = app.windows.get_mut(&id) else {

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -5,13 +5,16 @@
 //! 120Hz on `ProMotion`) and hands us the drawable; we only encode/present when
 //! a new guest frame (or a resize) made the window dirty, and the frame's
 //! `seq` is acked right after the present is scheduled. The guest renders its
-//! next frame off that ack, genlocking it to the display.
+//! next frame off that ack, genlocking it to the display. A fully occluded
+//! window downshifts to slow ack-only ticks instead (see
+//! [`PaneWindow::set_occluded`]): presents would be invisible, but a
+//! withheld ack would wedge the guest.
 
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2::{AllocAnyThread, DefinedClass, MainThreadOnly, define_class};
 use objc2_app_kit::{
-    NSBackingStoreType, NSWindow, NSWindowDelegate, NSWindowStyleMask,
+    NSBackingStoreType, NSWindow, NSWindowDelegate, NSWindowOcclusionState, NSWindowStyleMask,
 };
 use objc2_foundation::{
     MainThreadMarker, NSNotification, NSObjectProtocol, NSPoint, NSRect, NSRunLoop, NSSize,
@@ -33,6 +36,15 @@ use crate::view::PanesView;
 /// must sit inside [minimum, maximum]).
 const FRAME_RATE_RANGE: CAFrameRateRange =
     CAFrameRateRange { minimum: 60.0, maximum: 120.0, preferred: 120.0 };
+
+/// Tick rate while the window is fully occluded. The link keeps running as
+/// the ack pacer, just slowly: pausing it and acking frames on receipt
+/// instead was measured to unthrottle the guest to ~1700 frames/s (each ack
+/// immediately releases the next frame), which burns far more CPU on both
+/// sides than the presents it saves. ~10Hz keeps a covered window's stream
+/// alive and cheap; occluded ticks skip the encode/present entirely.
+const OCCLUDED_RATE_RANGE: CAFrameRateRange =
+    CAFrameRateRange { minimum: 8.0, maximum: 12.0, preferred: 10.0 };
 
 /// Ticks with nothing to present before the display link re-pauses (~250ms
 /// at 120Hz). Pausing immediately after every present would put an unpause
@@ -125,6 +137,23 @@ impl Surface {
         self.log.push(PendingTile { rect, bytes });
     }
 
+    /// Upload the pending log into every slot whose last draw has drained,
+    /// then compact. Used on occluded ticks: no present absorbs the log
+    /// there, and an animated window would grow it without bound while
+    /// covered. Keeping the textures current also makes the un-occlusion
+    /// redraw show the latest frame, not stale pixels.
+    fn absorb_drained(&mut self) {
+        for slot in &mut self.slots {
+            if slot.absorbed < self.log.len() && !slot.in_flight() {
+                for tile in &self.log[slot.absorbed..] {
+                    Renderer::upload(&slot.texture, tile.rect, &tile.bytes);
+                }
+                slot.absorbed = self.log.len();
+            }
+        }
+        self.compact();
+    }
+
     /// Drop the log prefix every slot has absorbed. With one guest frame in
     /// flight and alternating presents this keeps the log a frame or two
     /// long.
@@ -162,6 +191,12 @@ pub struct PaneWindow {
     guest_scale: u32,
     pending_ack: Option<u64>,
     dirty: bool,
+    /// The window is fully covered (occlusion state lost `Visible`).
+    /// `CAMetalDisplayLink` does not stop on its own when the window is
+    /// occluded (measured: a covered `--mock` window keeps presenting and
+    /// acking at the full 120Hz), so occlusion downshifts the link to
+    /// [`OCCLUDED_RATE_RANGE`] and ticks stop presenting; see `present`.
+    occluded: bool,
     /// Consecutive presentable ticks with nothing to draw; drives the idle
     /// re-pause (see [`IDLE_TICKS_TO_PAUSE`]).
     idle_ticks: u32,
@@ -268,6 +303,7 @@ impl PaneWindow {
             guest_scale: params.scale.max(1),
             pending_ack: None,
             dirty: false,
+            occluded: false,
             idle_ticks: 0,
             shown: false,
             closing: false,
@@ -407,6 +443,24 @@ impl PaneWindow {
         true
     }
 
+    /// Occlusion change from the window delegate. The link must never be
+    /// paused here outright: with one-frame-in-flight guest pacing the tick
+    /// is what releases the pending ack, and a withheld ack wedges the guest
+    /// window (its compositor watchdog then resends full frames forever). So
+    /// occlusion only downshifts the tick rate; the occluded branch of
+    /// `present` turns those ticks into ack-only ticks.
+    pub fn set_occluded(&mut self, occluded: bool) {
+        self.occluded = occluded;
+        if occluded {
+            self.link.setPreferredFrameRateRange(OCCLUDED_RATE_RANGE);
+        } else {
+            self.link.setPreferredFrameRateRange(FRAME_RATE_RANGE);
+            // Re-expose shows the freshest guest frame: occluded ticks kept
+            // the textures current but never drew them.
+            self.mark_dirty();
+        }
+    }
+
     /// Present on a display-link tick if anything changed. Returns the seq to
     /// ack, which the caller sends only after the present was scheduled.
     pub fn present(
@@ -424,6 +478,17 @@ impl PaneWindow {
             return None;
         }
         let surface = self.surface.as_mut()?;
+        if self.occluded {
+            // Ack-only tick for a covered window: keep the textures current
+            // (re-expose must show the latest frame) and release the ack so
+            // the guest stays paced, but never encode/present invisible
+            // pixels. The downshifted tick rate (see OCCLUDED_RATE_RANGE) is
+            // what throttles the stream while covered.
+            surface.absorb_drained();
+            self.dirty = false;
+            self.idle_ticks = 0;
+            return self.pending_ack.take();
+        }
         // Pick the texture to draw. A caught-up current slot means nothing
         // new arrived (a pure redraw, e.g. the live-resize stretch): sample
         // it again, no CPU write, no race. Otherwise flip to the other slot
@@ -464,6 +529,12 @@ impl PaneWindow {
         self.dirty = false;
         self.idle_ticks = 0;
         self.pending_ack.take()
+    }
+
+    /// True while any part of the window is on screen (`AppKit` occlusion
+    /// state contains `Visible`).
+    pub fn occlusion_visible(&self) -> bool {
+        self.ns.occlusionState().contains(NSWindowOcclusionState::Visible)
     }
 
     /// Redraw (stretching the stale texture) on the next tick; used during
@@ -557,6 +628,11 @@ define_class!(
         #[unsafe(method(windowDidEndLiveResize:))]
         fn window_did_end_live_resize(&self, _notification: &NSNotification) {
             app::window_live_resize(self.ivars().id, false);
+        }
+
+        #[unsafe(method(windowDidChangeOcclusionState:))]
+        fn window_did_change_occlusion_state(&self, _notification: &NSNotification) {
+            app::window_occlusion_changed(self.ivars().id);
         }
 
         #[unsafe(method(windowDidBecomeKey:))]


### PR DESCRIPTION
Implements the two deferred performance findings from the PR #1714 review (index#1686).

**panes-host: occlusion downshift (c4613d49).** CAMetalDisplayLink does not stop when its window is occluded -- measured on an M-series/ProMotion Mac, a `--mock` window fully covered by an opaque full-screen window kept presenting + acking at a steady 120 acks/s for the whole 20s cover. Simply pausing the link is ruled out by the pacing contract (a withheld ack wedges the guest; its 1s watchdog then resends fulls forever), and pause + ack-on-receipt measured *worse*: the unpaced ack loop ran at ~1700 acks/s, 14x the guest render + host decode work of the visible path. So occlusion keeps the link running but downshifts it to ~10Hz ack-only ticks: damage is still decoded and absorbed into the textures (re-expose shows current content, log stays bounded), the ack still rides the tick, nothing is encoded or presented. Validated live: 120.0 -> 10.0 acks/s within a second of cover, back to 120.0 on un-cover, no watchdog fire.

**panes-compositor: watchdog exponential backoff (55b400c1).** Each watchdog fire resends a FULL frame (the biggest message on the wire), so the fixed 1s rescue is a positive feedback loop on a congested link. Consecutive fires now double the per-pane threshold, 1s -> 2s -> 4s -> 8s cap; a real ack or a host reconnect resets to base. `next_wait_ticks` added to the warn.

**Validation**: `cargo build`/`test -p panes-host` green, live `--mock` occlusion runs above, `cargo check -p panes-compositor` green on darwin, `nix run .#lint` green. The compositor change is compile-checked but not runtime-validated (aarch64-linux target, local builder down).

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add occlusion-based present throttling and watchdog exponential backoff for panes
> - When a pane window becomes occluded, the display link rate drops to ~10Hz (`OCCLUDED_RATE_RANGE`) and frame encoding/presenting is skipped; acks are still issued to keep the guest paced.
> - A new `Surface.absorb_drained` method advances GPU texture state without issuing presents, keeping textures current during occluded ticks.
> - The inflight watchdog now backs off exponentially (doubling the threshold up to `INFLIGHT_WATCHDOG_MAX_TICKS`) on consecutive fires instead of using a fixed interval; the threshold resets to the base on a real ack or host disconnect.
> - Behavioral Change: watchdog resend intervals now grow over time when frames are consistently delayed, reducing redundant retransmissions under sustained congestion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55b400c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->