### PR TITLE
fix(claude-code): bias towards finding best solution

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -206,9 +206,11 @@ let
     }
     {
       fixAtSource = ''
-        Fix problems at their source. If the cause is upstream, fix it upstream and
-        open a PR. Use local workarounds only as a last resort, linked to the upstream
-        issue or PR.
+        Fix problems at their source. Always choose the best long-term solution
+        and consider if architectural changes can be made to avoid an entire
+        class of bugs rather than fixing one bug at a time. Never write
+        workarounds or add timeouts since these do not address the core bug.
+        If the cause is upstream, fix it upstream and open a PR.
       '';
     }
     {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Bias the Claude Code agent system prompt toward long-term solutions over workarounds
Updates the `fixAtSource` guidance in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1721/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to instruct the agent to always pursue the best long-term solution, consider architectural changes that eliminate classes of bugs, and fix issues upstream with a PR. Explicitly forbids writing workarounds or adding arbitrary timeouts. Removes prior guidance that allowed local workarounds as a last resort.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccc5e7b.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->