### PR TITLE
panes: bake the validated MC 26.2 arm64 launch recipe into the guest image

### DIFF
--- a/packages/vm/panes/README.md
+++ b/packages/vm/panes/README.md
@@ -45,8 +45,11 @@ nix build .#packages.aarch64-linux.panes-guest-image
 # (boot.growPartition + autoResize). Minecraft downloads land in that space.
 cp --sparse=always ./result /tmp/panes-guest.raw && chmod +w /tmp/panes-guest.raw
 truncate -s 8G /tmp/panes-guest.raw
-nix run .#vmkit -- boot-linux --disk /tmp/panes-guest.raw --gpu --net
+nix run .#vmkit -- boot-linux --disk /tmp/panes-guest.raw --gpu --net --memory-mib 6144 --cpus 6
 ```
+
+Size the guest for Minecraft: it OOMs under ~4 GiB of guest RAM and crawls on
+2 vCPUs; `--memory-mib 6144 --cpus 6` is the validated boot line.
 
 GPU: `--gpu` attaches libkrun's virtio-gpu **venus** device (Vulkan on the
 Mac's GPU via MoltenVK). The image loads `virtio_gpu`, ships mesa's venus ICD

--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -25,7 +25,19 @@ let
   # ~1.9 GiB); its package.nix exposes `jvms` exactly to cut that closure.
   # MC 26.2 requires Java SE 25 minimum, so ship exactly jdk25 (the full JDK,
   # not headless: the client needs the AWT/X11 libs headless builds drop).
-  portablemc = pkgs.portablemc.override { jvms = [ pkgs.jdk25 ]; };
+  portablemc = pkgs.portablemc.override {
+    jvms = [ pkgs.jdk25 ];
+    # Keep flite OUT of the wrapper's LD_LIBRARY_PATH: MC's narrator speaks
+    # through flite -> pulse, and with no audio stack in the guest
+    # pa_simple_write aborts the whole client (validated live). Dropping the
+    # lib beats a narrator=off option: nothing to load, nothing to abort.
+    textToSpeechSupport = false;
+  };
+
+  # Mojang ships no linux-arm64 LWJGL natives; ./lwjgl-natives.nix supplies
+  # LWJGL's own Maven builds, injected via the overlay in ./default.nix,
+  # where the ./pins.json hashes live.
+  lwjglNatives = pkgs.lwjgl-natives-linux-arm64;
 in
 {
   # Software (wl_shm) client: proves compositor + container + socket plumbing
@@ -64,6 +76,24 @@ in
       "start"
       # 26.2 requires Java SE 25 minimum (see the portablemc jvms override).
       "--jvm ${pkgs.jdk25}/bin/java"
+      # LWJGL loads its JNI natives from here instead of the (absent)
+      # manifest-provided linux-arm64 ones.
+      "--jvm-arg=-Dorg.lwjgl.librarypath=${lwjglNatives}"
+      # Make blaze3d pick the Wayland GLFW platform: left alone it requests
+      # X11 even under Wayland ("GLFW error 0x1000E X11: DISPLAY missing").
+      # MC 26.2's built-in debug switches (SharedConstants reads
+      # MC_DEBUG_*-prefixed system properties, all gated on MC_DEBUG_ENABLED;
+      # decompiled from 26.2 GLX/SharedConstants) flip the preference with
+      # the stock Maven libglfw.so above, which is wayland-capable and
+      # carries the preedit/IME API blaze3d binds. Validated live end-to-end:
+      # the window maps on the host titled "Minecraft 26.2". If Mojang ever
+      # drops the debug flag, the fallback is a Wayland-only glfw (X11
+      # compiled out; openSUSE home:DarkWav glfw-minecraft recipe on
+      # clear-code/glfw im-support) via -Dorg.lwjgl.glfw.libname; this repo
+      # carried a packaged version of that until the debug flags landed (see
+      # index#1686 and this file's history).
+      "--jvm-arg=-DMC_DEBUG_ENABLED=true"
+      "--jvm-arg=-DMC_DEBUG_PREFER_WAYLAND=true"
       # Offline session: no Microsoft account in the guest.
       "-u Panes"
       "26.2"
@@ -74,13 +104,19 @@ in
       VK_DRIVER_FILES = "${pkgs.mesa}/share/vulkan/icd.d/virtio_icd.aarch64.json";
       MESA_VK_DEVICE_SELECT = "1af4:1050!";
       XDG_SESSION_TYPE = "wayland";
-      # No LD_LIBRARY_PATH needed: the portablemc wrapper already prefixes it
-      # with /run/opengl-driver/lib plus prismlauncher's runtime libs,
-      # including glfw3-minecraft (GLFW 3.4 with Wayland) and vulkan-loader.
+      # nixpkgs openal (the portablemc wrapper's LD_LIBRARY_PATH provides it;
+      # Maven's arm64 libopenal.so SIGSEGVs, so ./lwjgl-natives.nix omits it
+      # and LWJGL falls through to this one) defaults to the pulse backend,
+      # and the guest has no audio stack at all: force the null backend so
+      # OpenAL initializes and MC runs silent instead of erroring (validated
+      # live).
+      ALSOFT_DRIVERS = "null";
       # If Vulkan crashes at startup, 26.2 flips itself to "Prefer OpenGL"
       # (rewriting options.txt); that GL path should land on software
-      # rendering, forceable as a diagnostic by adding
-      # LIBGL_ALWAYS_SOFTWARE = "1" here (data-only toggle, no module change).
+      # rendering. Diagnostic-only, data-only toggles (venus is the intended
+      # renderer, do NOT set these by default):
+      #   LIBGL_ALWAYS_SOFTWARE = "1";
+      #   GALLIUM_DRIVER = "llvmpipe";
     };
     binds = [ "/var/lib/minecraft" ];
     gpu = true;

--- a/packages/vm/panes/guest-image/default.nix
+++ b/packages/vm/panes/guest-image/default.nix
@@ -8,8 +8,15 @@
 # builds on any plain aarch64-linux builder, same as
 # packages/vm/chrome-vm-image. `path` is `pkgs.path` from the package autoArgs.
 {
+  lib,
   path,
   repoPackages,
+  ix,
+  nix,
+  # Writer for `passthru.updateScript`, bound only on the flake-package path
+  # (lib/packages.nix); the overlay path leaves it null so `pkgs.*` carries no
+  # updater. Same nullable-writer pattern as vector-bin.
+  updateScriptWriter ? null,
 }:
 let
   nixos = import "${path}/nixos/lib/eval-config.nix" {
@@ -19,17 +26,41 @@ let
       # Inject the repo-built compositor through the package set so the guest
       # module reads it as `pkgs.panes-compositor` (same pattern as
       # packages/vm/vz-linux-guest); its meta lives in one place,
-      # packages/vm/panes/compositor.
+      # packages/vm/panes/compositor. Minecraft's LWJGL natives ride the same
+      # overlay because their pins (./pins.json, loaded through `ix`) live
+      # outside apps.nix (see ./lwjgl-natives.nix).
       {
         nixpkgs.overlays = [
-          (_final: _prev: { inherit (repoPackages) panes-compositor; })
+          (final: _prev: {
+            inherit (repoPackages) panes-compositor;
+            lwjgl-natives-linux-arm64 = final.callPackage ./lwjgl-natives.nix {
+              pins = ix.pins.loadPins ./pins.json;
+            };
+          })
         ];
       }
     ];
   };
+  # Mechanically re-pins the ./pins.json jar hashes from their URLs
+  # (`nix run .#update`); bumping the LWJGL version is the human edit.
+  updateScript =
+    if updateScriptWriter == null then
+      null
+    else
+      ix.pins.mkUpdater {
+        writeNushellApplication = updateScriptWriter;
+        inherit nix;
+        pname = "panes-guest-image";
+        relPath = "packages/vm/panes/guest-image/pins.json";
+      };
 in
 # Expose the raw disk directly as the package output (the repart module
 # produces it at `${system.build.image}/${image.filePath}`).
-nixos.pkgs.runCommand "panes-guest.raw" { } ''
-  cp --sparse=always "${nixos.config.system.build.image}/${nixos.config.image.filePath}" "$out"
-''
+nixos.pkgs.runCommand "panes-guest.raw"
+  {
+    __structuredAttrs = true;
+    passthru = lib.optionalAttrs (updateScript != null) { inherit updateScript; };
+  }
+  ''
+    cp --sparse=always "${nixos.config.system.build.image}/${nixos.config.image.filePath}" "$out"
+  ''

--- a/packages/vm/panes/guest-image/lwjgl-natives.nix
+++ b/packages/vm/panes/guest-image/lwjgl-natives.nix
@@ -1,0 +1,61 @@
+# Flat directory of LWJGL linux-arm64 JNI natives for Minecraft 26.2
+# (index#1686). Mojang's version manifest ships no linux-arm64 natives at all,
+# so the guest supplies LWJGL's own builds from Maven Central and the launch
+# command points `-Dorg.lwjgl.librarypath` here (recipe validated in the live
+# guest, 2026-07-01). MC 26.2 pins LWJGL 3.4.1; the module list and hashes
+# live in ./pins.json (bump the version/urls there alongside the game
+# version, then re-pin via the image's updateScript).
+#
+# Deliberately absent modules:
+#   - lwjgl-openal: Maven's arm64 libopenal.so SIGSEGVs in this audio-less
+#     guest. nixpkgs `openal` on the portablemc wrapper's LD_LIBRARY_PATH
+#     works instead, so no libopenal.so may appear in this directory (LWJGL
+#     prefers librarypath over the system path).
+#   - lwjgl-vulkan: publishes no linux natives at all (the Vulkan binding
+#     goes through libvulkan via GLFW, not a JNI native).
+{
+  lib,
+  runCommand,
+  fetchurl,
+  unzip,
+  # `loadPins ./pins.json` map, one entry per LWJGL module; injected by
+  # ./default.nix (this file is data for the guest image, not a registry
+  # package, so `ix` is not an autoArg here).
+  pins,
+}:
+let
+  versions = lib.unique (lib.mapAttrsToList (_: pin: pin.version) pins);
+  version =
+    assert lib.assertMsg (
+      builtins.length versions == 1
+    ) "lwjgl-natives: pins.json entries must share one LWJGL version, got ${toString versions}";
+    builtins.head versions;
+  jars = lib.mapAttrsToList (_: pin: fetchurl { inherit (pin) url hash; }) pins;
+in
+runCommand "lwjgl-natives-linux-arm64-${version}"
+  {
+    nativeBuildInputs = [ unzip ];
+    inherit jars;
+    strictDeps = true;
+    __structuredAttrs = true;
+    meta = {
+      description = "LWJGL ${version} linux-arm64 natives extracted flat for -Dorg.lwjgl.librarypath";
+      homepage = "https://www.lwjgl.org/";
+      # The LWJGL natives themselves; the jars also bundle the upstream
+      # libraries they bind (glfw, jemalloc, freetype, ...), each under its
+      # own permissive license.
+      license = lib.licenses.bsd3;
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+      platforms = [ "aarch64-linux" ];
+    };
+  }
+  ''
+    mkdir -p "$out" extract
+    for jar in "''${jars[@]}"; do
+      unzip -qo -d extract "$jar"
+    done
+    # The .so files sit under linux/arm64/org/lwjgl/** inside each jar
+    # (META-INF carries same-named .so.git/.so.sha1 stamps, hence the filters).
+    find extract -path '*/linux/arm64/*' -name '*.so' -not -path '*/META-INF/*' \
+      -exec cp -t "$out" {} +
+  ''

--- a/packages/vm/panes/guest-image/pins.json
+++ b/packages/vm/panes/guest-image/pins.json
@@ -1,0 +1,52 @@
+{
+  "lwjgl": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.4.1/lwjgl-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-ihES7nWZr/ld5DZK5wSDKdkpdTgBIsUZ/u4xNCvbZ4s="
+  },
+  "lwjgl-freetype": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-freetype/3.4.1/lwjgl-freetype-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-cRd8TpVVHVD2mIa/I6Dr2TB+vJLgTCZooTt5f5J40Aw="
+  },
+  "lwjgl-glfw": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.4.1/lwjgl-glfw-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-K5/YKf8mcibddodKR+u+odXHDnfksJ39i1B1U6WsrDQ="
+  },
+  "lwjgl-jemalloc": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.4.1/lwjgl-jemalloc-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-RX2K3HxDiRslR102IYkQVOxprD5yPSVu6uM6CNQVvJI="
+  },
+  "lwjgl-opengl": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.4.1/lwjgl-opengl-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-TBVnJoLYKsSu+fxGxj1ymvAFYP6TerJbDzpH+A2WazI="
+  },
+  "lwjgl-shaderc": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-shaderc/3.4.1/lwjgl-shaderc-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-BIrklnzBk/g536FsFkPqt377Lucp6S8AuH/EeWFLhiw="
+  },
+  "lwjgl-spvc": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-spvc/3.4.1/lwjgl-spvc-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-aYExZEhWZdncL+npe+tUkQaq0jzIYK4YYiWMBK3doQI="
+  },
+  "lwjgl-stb": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.4.1/lwjgl-stb-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-sWuOOZNoX2uTDVBbSqU0s53VUTlH9gPDn6GKNtowIE4="
+  },
+  "lwjgl-tinyfd": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.4.1/lwjgl-tinyfd-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-y2G5t001C7hKrX1ApDQ9mj+WP/6StKMgG1kFttroPtQ="
+  },
+  "lwjgl-vma": {
+    "version": "3.4.1",
+    "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-vma/3.4.1/lwjgl-vma-3.4.1-natives-linux-arm64.jar",
+    "hash": "sha256-6iHfa/KxwFQ0orHTGhSjYJzjIvIcNPxbyLoNBxuBqNE="
+  }
+}


### PR DESCRIPTION
Bakes tonight's live-guest Minecraft 26.2 launch recipe into the panes guest image (index#1686), so the MC app container comes up declaratively instead of via hand-poked jvm args.

- **LWJGL natives**: Mojang ships no linux-arm64 natives; fetch LWJGL 3.4.1's own Maven `natives-linux-arm64` jars (hashes in `pins.json`, `updateScript` re-pins) and extract the `.so`s flat for `-Dorg.lwjgl.librarypath`. `lwjgl-openal` is deliberately excluded (Maven's arm64 `libopenal.so` SIGSEGVs; nixpkgs `openal` + `ALSOFT_DRIVERS=null` works in the audio-less guest) and `lwjgl-vulkan` has no linux natives (SPIRV-Cross is `lwjgl-spvc`, not `lwjgl-spirv-cross`).
- **Wayland**: blaze3d 26.1+ requests X11 even under Wayland; MC 26.2's built-in debug switches `-DMC_DEBUG_ENABLED=true -DMC_DEBUG_PREFER_WAYLAND=true` (SharedConstants `MC_DEBUG_*` system properties) flip the preference with the stock wayland-capable Maven `libglfw.so`. Validated live end-to-end: the window maps on the host titled "Minecraft 26.2". The patched Wayland-only glfw from this branch's first cut is dropped; the fallback recipe stays documented in `apps.nix`.
- **Narrator**: `portablemc.override { textToSpeechSupport = false; }` — flite -> `pa_simple_write` aborts the client with no audio stack.
- **README**: guest sizing (MC OOMs under ~4 GiB, crawls on 2 vCPUs); validated boot line `--memory-mib 6144 --cpus 6`.

Validation (aarch64 builder is down, so eval-only): full aarch64-linux image drv instantiates with only `panes-compositor` stubbed (its crate-registry IFD needs the builder); rendered container `ExecStart` carries the librarypath + both debug flags; jar hashes prefetched for real; `nix run .#lint` green. Runtime re-verification on the merged 16K-kernel image once the builder returns.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bake validated Minecraft 26.2 arm64 launch recipe into the panes guest image
> - Adds a new [`lwjgl-natives-linux-arm64`](https://github.com/indexable-inc/index/pull/1722/files#diff-ba69142b74a4895eeab477a06fc2242899e0e190159cfe2b8237112370bc9bf5) derivation that fetches LWJGL 3.4.1 native JARs for linux/arm64, unzips them, and exposes a flat `.so` directory for use with `-Dorg.lwjgl.librarypath`.
> - Pins the 10 required LWJGL module JARs in [`pins.json`](https://github.com/indexable-inc/index/pull/1722/files#diff-f0a73585141d55f7db2ede77306e1bfc35185e89c4417a500a98dff339878da5) and injects the package via a nixpkgs overlay in [`default.nix`](https://github.com/indexable-inc/index/pull/1722/files#diff-5387531d78c5e6f1ef0e82ea770d5c1f36bbae27f41fe4da470808ee954cf0b7).
> - Configures the Minecraft start command in [`apps.nix`](https://github.com/indexable-inc/index/pull/1722/files#diff-a890cdfbf1cce913a32f1824d8badb40d6b06eb50aee87abc0bbdf1772968b64) to use JDK 25, load the arm64 LWJGL natives, prefer Wayland GLFW, and force OpenAL to the null driver to avoid audio init failures.
> - Removes flite from portablemc's `LD_LIBRARY_PATH`, disabling in-client text-to-speech native loading.
> - Adds a `passthru.updateScript` to the guest image package for pin maintenance via `ix.pins.mkUpdater`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 691ea01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->