### PR TITLE
vmkit: bump libkrun-efi 1.18.0 -> 1.19.3 for the vsock TX descriptor fix (#1719)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -408,6 +408,7 @@ let
       writeBashApplication
       macosSdk
       appleSdkToolchain
+      pins
       ;
     rustToolchainFor = languages.rust.toolchain;
   };

--- a/lib/rust/pins.json
+++ b/lib/rust/pins.json
@@ -4,5 +4,18 @@
     "repo": "advisory-db",
     "rev": "f2ae5fc8e5d208373b6c838f9676434525327a72",
     "hash": "sha256-iqXYpuCoWoGypnpM5ceXN748QlYeBXDtZx0uI98qFLo="
+  },
+  "libkrun-efi-src": {
+    "owner": "libkrun",
+    "repo": "libkrun",
+    "version": "1.19.3",
+    "url": "https://github.com/libkrun/libkrun/archive/refs/tags/v1.19.3.tar.gz",
+    "hash": "sha256-mDko5fRcjnb3BI6cINr4gm6DiCghUlkIn1ZiQeHxyaE=",
+    "prefetch": "unpack"
+  },
+  "libkrun-efi-cargo-vendor": {
+    "version": "1.19.3",
+    "hash": "sha256-PE8xO8T5TFuGnL+95Y1BAz9EdJVUrxgVtVssAgStW+8=",
+    "prefetch": "manual"
   }
 }

--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -13,6 +13,10 @@
   rustToolchainFor,
   appleSdkToolchain,
   macosSdk,
+  # The shared pins reader (lib/util/pins.nix), threaded down from
+  # lib/default.nix so the libkrun-efi 1.19.3 pins load from the sibling
+  # pins.json without a cross-directory `../` import (no-parent-path).
+  pins,
 }:
 workspacePkgs:
 let
@@ -88,8 +92,61 @@ let
   # below because a build script's link-search does not reach the final unit link.
   # Only referenced under `buildHostIsAarch64Darwin`, so non-darwin hosts never
   # force the (host-only) package.
-  libkrunEfiLibDir = "${workspacePkgs.libkrun-efi}/lib";
-  krunEfiFirmware = "${workspacePkgs.libkrun-efi.src}/edk2/KRUN_EFI.silent.fd";
+  #
+  # nixpkgs pins libkrun-efi 1.18.0, whose vsock `from_tx_virtq_head` accepts
+  # only the exact two-descriptor hdr+data TX layout; the combined or split
+  # descriptor chains modern guest kernels emit are silently dropped mid
+  # SOCK_STREAM (upstream containers/libkrun#535/#579), which desyncs the panes
+  # guest->host frame stream (#1719). 1.19.3's packet.rs rewrite handles those
+  # chains, so rebuild the same nixpkgs expression against the 1.19.3 source
+  # until the nixpkgs pin catches up (nixpkgs master already carries this exact
+  # bump; both hashes below match its pkgs/by-name/li/libkrun-efi). Version
+  # deltas the override must carry: the upstream repo moved orgs
+  # (containers -> libkrun), the guest init the vendored `init_blob` crate
+  # embeds moved from `init/` to `src/init_blob/init/`, and the EFI firmware
+  # moved from `edk2/` to `src/vmm/edk2/`.
+  libkrunEfiSrcPin = pins.loadPin ./pins.json "libkrun-efi-src";
+  libkrunEfiSrc = workspacePkgs.fetchFromGitHub {
+    inherit (libkrunEfiSrcPin) owner repo hash;
+    tag = "v${libkrunEfiSrcPin.version}";
+  };
+  # Same recipe as the `initBinary` in nixpkgs' libkrun-efi expression, rebuilt
+  # here because the pinned 1.18.0 one compiles from `init/` in the old source.
+  libkrunEfiInit = workspacePkgs.pkgsCross.aarch64-multiplatform.pkgsStatic.stdenv.mkDerivation {
+    pname = "libkrun-init";
+    inherit (libkrunEfiSrcPin) version;
+    src = libkrunEfiSrc;
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      # shell
+      runHook preBuild
+      cd src/init_blob/init
+      $CC -O2 -static -Wall -o init init.c dhcp.c
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      # shell
+      runHook preInstall
+      install -D init $out/init
+      runHook postInstall
+    '';
+  };
+  libkrunEfi = workspacePkgs.libkrun-efi.overrideAttrs (old: {
+    inherit (libkrunEfiSrcPin) version;
+    src = libkrunEfiSrc;
+    cargoDeps = workspacePkgs.rustPlatform.fetchCargoVendor {
+      src = libkrunEfiSrc;
+      inherit (pins.loadPin ./pins.json "libkrun-efi-cargo-vendor") hash;
+    };
+    env = (old.env or { }) // {
+      KRUN_INIT_BINARY_PATH = "${libkrunEfiInit}/init";
+    };
+  });
+  libkrunEfiLibDir = "${libkrunEfi}/lib";
+  krunEfiFirmware = "${libkrunEfi.src}/src/vmm/edk2/KRUN_EFI.silent.fd";
 
   # Linux host: classic KVM libkrun (no firmware). It boots a rootfs over virtiofs
   # under its bundled libkrunfw kernel, so the core path needs no block/net


### PR DESCRIPTION
Bumps libkrun-efi 1.18.0 -> 1.19.3 via overrideAttrs in the rust workspace (dies when the nixpkgs pin catches up; master already carries 1.19.3).

Fixes the #1719 root cause: 1.18.0's vsock `from_tx_virtq_head` silently drops bytes on split TX descriptor chains, corrupting the panes stream under load (varint/Serde desyncs, black-holed connections). 1.19.3's packet.rs owned_buf rewrite handles multi-descriptor chains.

Validated on aarch64-darwin: `otool -L` shows the 1.19.3 dylib; panes guest boot + compositor + host soak with zero deserialization errors (vs minutes-to-failure on 1.18.0); this build also powered the Minecraft 26.2 title-screen demo (#1686) with zero watchdog fires over 20+ minutes. Hashes pinned in lib/rust/pins.json per the pins policy, cross-checked against nixpkgs master and a local `nix hash path` of the upstream tree.

Closes the transport half of #1719 (reconnect-leak items remain upstream). (sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `libkrun-efi` from 1.18.0 to 1.19.3 for the vsock TX descriptor fix
> - Updates [pins.json](https://github.com/indexable-inc/index/pull/1723/files#diff-c19b3a8da02ba8382b570c281b0066560ac80ed96385b9a06dda0d71e4416799) with new source and cargo vendor hashes for `libkrun-efi` v1.19.3.
> - Adds a `libkrunEfiInit` derivation in [workspace.nix](https://github.com/indexable-inc/index/pull/1723/files#diff-ea594f8bfd460f458ce6b01ce873abb2ff3a3cf89d789587a70728ef478b4ceb) that cross-compiles a static `init` binary for `aarch64` and injects `KRUN_INIT_BINARY_PATH` into the build environment.
> - Updates the firmware path to `src/vmm/edk2/KRUN_EFI.silent.fd` to match the new v1.19.3 source tree layout.
> - Exposes `pins` in [lib/default.nix](https://github.com/indexable-inc/index/pull/1723/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) so downstream modules can access shared pins via dependency injection instead of relative imports.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d3ce55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->