### PR TITLE
panes: Wayland pointer lock + relative motion so mouse-look works (#1724)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7156,10 +7156,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -7652,6 +7655,7 @@ dependencies = [
  "lz4_flex 0.13.1",
  "objc2",
  "objc2-app-kit",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
  "objc2-quartz-core",

--- a/packages/vm/panes/README.md
+++ b/packages/vm/panes/README.md
@@ -22,7 +22,11 @@ macOS host                          aarch64-linux guest (libkrun-efi, vmkit)
   byte stream (guest vsock port 7100 to a host unix socket) carrying
   length-prefixed postcard frames: damage-tiled window contents up, input and
   configure events down, ack-driven pacing genlocked to the host display. The
-  crate doc comments are the protocol spec.
+  crate doc comments are the protocol spec. Minor 1 (v1.1) adds pointer lock
+  for mouse-look apps (index#1724): `ToHost::PointerLock` when a surface's
+  `zwp_locked_pointer_v1` (de)activates, `ToGuest::PointerRelative` for the
+  raw deltas the host forwards while its cursor is captured; both are gated
+  on the peer's Hello minor (postcard tolerates no unknown variants).
 - [`compositor/`](compositor/) (`panes-compositor`): guest-side headless
   Wayland compositor. Each `xdg_toplevel` becomes a window on the host; no
   DRM output, no seat, no logind, it composites nothing and only exports.

--- a/packages/vm/panes/compositor/README.md
+++ b/packages/vm/panes/compositor/README.md
@@ -46,7 +46,14 @@ Wayland clients ──commit──> FrameStore (packed BGRA copy per window)
   Coordinates are surface-local, so pointer focus is handed to smithay
   explicitly per event. Keys are evdev codes fed through an xkb keymap
   (`--xkb-layout`, "us" default); the host never forwards OS auto-repeats,
-  clients repeat from `wl_keyboard.repeat_info`.
+  clients repeat from `wl_keyboard.repeat_info`. Pointer lock (index#1724):
+  `zwp_pointer_constraints_v1` + `zwp_relative_pointer_manager_v1` are
+  advertised; a locked-pointer constraint activates when its surface holds
+  pointer focus, the host is told via `ToHost::PointerLock` (gated on its
+  Hello minor >= 1), and the `ToGuest::PointerRelative` deltas it then
+  forwards feed `pointer.relative_motion`. Lock state is reconciled after
+  every input message and every commit, which is where a client destroying
+  its lock (GLFW's ungrab) surfaces.
 
 ## Pacing (no timer)
 
@@ -105,5 +112,9 @@ WAYLAND_DISPLAY=wayland-1 foot            # any client, in another shell
   is global); needs wp_fractional_scale or per-surface preferred scale.
 - Cursor: `ToHost::Cursor` is always sent with `image: None` (host keeps its
   native cursor); serializing the client cursor surface is a TODO.
+- `zwp_confined_pointer` constraints are accepted but never activated: the
+  host cannot fence its cursor to an NSWindow, and a fake activation would
+  tell the client its pointer is confined when it is not. Only locked
+  pointers (all a mouse-look app needs) are honored.
 - The whole-buffer memcmp diff is simple and fast enough for v1; client
   damage hints could bound it later.

--- a/packages/vm/panes/compositor/src/compositor/handlers.rs
+++ b/packages/vm/panes/compositor/src/compositor/handlers.rs
@@ -3,7 +3,7 @@
 //! decorations.
 
 use panes_protocol::ToHost;
-use smithay::input::pointer::CursorImageStatus;
+use smithay::input::pointer::{CursorImageStatus, PointerHandle};
 use smithay::input::{Seat, SeatHandler, SeatState};
 use smithay::reexports::wayland_protocols::xdg::decoration::zv1::server::zxdg_toplevel_decoration_v1;
 use smithay::reexports::wayland_server::{Client, Resource as _};
@@ -11,12 +11,13 @@ use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
 use smithay::reexports::wayland_server::protocol::wl_seat::WlSeat;
 use smithay::reexports::wayland_server::protocol::wl_shm;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
-use smithay::utils::{Serial, Size};
+use smithay::utils::{Logical, Point, Serial, Size};
 use smithay::wayland::buffer::BufferHandler;
 use smithay::wayland::compositor::{
     BufferAssignment, CompositorClientState, CompositorHandler, CompositorState, SurfaceAttributes,
     get_parent, is_sync_subsurface, with_states,
 };
+use smithay::wayland::pointer_constraints::{PointerConstraintsHandler, with_pointer_constraint};
 use smithay::wayland::shell::xdg::decoration::XdgDecorationHandler;
 use smithay::wayland::shell::xdg::{
     PopupSurface, PositionerState, SurfaceCachedState, ToplevelSurface, XdgShellHandler,
@@ -29,8 +30,9 @@ use smithay::wayland::selection::data_device::{
 };
 use smithay::wayland::shm::{BufferData, ShmHandler, ShmState, with_buffer_contents};
 use smithay::{
-    delegate_compositor, delegate_data_device, delegate_output, delegate_seat, delegate_shm,
-    delegate_xdg_decoration, delegate_xdg_shell,
+    delegate_compositor, delegate_data_device, delegate_output, delegate_pointer_constraints,
+    delegate_relative_pointer, delegate_seat, delegate_shm, delegate_xdg_decoration,
+    delegate_xdg_shell,
 };
 use tracing::{debug, warn};
 
@@ -126,6 +128,12 @@ impl CompositorHandler for App {
         // Send now if pacing allows, or release the frame callbacks if there
         // is nothing to send (pump handles both).
         self.pump(idx);
+
+        // A commit is also where a client-destroyed pointer lock surfaces
+        // (GLFW releases the grab by destroying the zwp_locked_pointer, with
+        // no input event to follow it), so reconcile the host here too.
+        self.maybe_activate_constraint();
+        self.sync_pointer_lock();
     }
 }
 
@@ -350,6 +358,34 @@ impl SeatHandler for App {
     }
 }
 
+impl PointerConstraintsHandler for App {
+    fn new_constraint(&mut self, _surface: &WlSurface, _pointer: &PointerHandle<Self>) {
+        // Activate immediately when the constraint's surface already holds
+        // pointer focus (the common case: MC locks in response to a click,
+        // which put focus there); otherwise it stays pending until focus
+        // arrives via PointerMotion.
+        self.maybe_activate_constraint();
+        self.sync_pointer_lock();
+    }
+
+    fn cursor_position_hint(
+        &mut self,
+        surface: &WlSurface,
+        pointer: &PointerHandle<Self>,
+        location: Point<f64, Logical>,
+    ) {
+        let active =
+            with_pointer_constraint(surface, pointer, |constraint| {
+                constraint.is_some_and(|constraint| constraint.is_active())
+            });
+        if active {
+            // Surface-local == global here (every surface anchors at the
+            // origin), so the hint is where the pointer resumes on unlock.
+            pointer.set_location(location);
+        }
+    }
+}
+
 // Guest-internal clipboard only (see `App::data_device_state`): selections
 // move between guest apps through smithay's built-in plumbing; nothing is
 // bridged to the macOS pasteboard yet (protocol gap, see README).
@@ -430,6 +466,9 @@ impl XdgShellHandler for App {
         if self.key_focus == Some(pane.id) {
             self.key_focus = None;
         }
+        // A locked pane dying must release the host cursor (the host also
+        // releases on its own window close; this covers the message anyway).
+        self.sync_pointer_lock();
     }
 
     fn popup_destroyed(&mut self, surface: PopupSurface) {
@@ -570,6 +609,8 @@ delegate_seat!(App);
 delegate_output!(App);
 delegate_xdg_shell!(App);
 delegate_xdg_decoration!(App);
+delegate_pointer_constraints!(App);
+delegate_relative_pointer!(App);
 
 #[cfg(feature = "gpu")]
 smithay::delegate_dmabuf!(App);

--- a/packages/vm/panes/compositor/src/compositor/input.rs
+++ b/packages/vm/panes/compositor/src/compositor/input.rs
@@ -9,7 +9,7 @@
 use panes_protocol::{AxisSource as WireAxisSource, ButtonState as WireButtonState, ToGuest};
 use smithay::backend::input::{Axis, AxisSource, ButtonState, KeyState};
 use smithay::input::keyboard::{FilterResult, Keycode};
-use smithay::input::pointer::{AxisFrame, ButtonEvent, MotionEvent};
+use smithay::input::pointer::{AxisFrame, ButtonEvent, MotionEvent, RelativeMotionEvent};
 use smithay::utils::{Point, SERIAL_COUNTER};
 
 use super::App;
@@ -17,6 +17,7 @@ use super::App;
 pub fn handle(app: &mut App, msg: &ToGuest) {
     match msg {
         ToGuest::PointerMotion { id, x, y } => pointer_motion(app, *id, *x, *y),
+        ToGuest::PointerRelative { id, dx, dy } => pointer_relative(app, *id, *dx, *dy),
         ToGuest::PointerButton { id, button, state } => pointer_button(app, *id, *button, *state),
         ToGuest::PointerAxis {
             id,
@@ -56,6 +57,37 @@ fn pointer_motion(app: &mut App, id: panes_protocol::WindowId, x: f64, y: f64) {
             location: (x / scale, y / scale).into(),
             serial: SERIAL_COUNTER.next_serial(),
             time,
+        },
+    );
+    pointer.frame(app);
+}
+
+/// Relative deltas while `id` holds the pointer lock. The pointer does not
+/// move: focus is pinned on the locked surface (the host stops sending
+/// absolute motion while captured) and only `zwp_relative_pointer` listeners
+/// see the event.
+fn pointer_relative(app: &mut App, id: panes_protocol::WindowId, dx: f64, dy: f64) {
+    let Some(surface) = app.pane_surface(id) else {
+        return;
+    };
+    let Some(pointer) = app.seat.get_pointer() else {
+        return;
+    };
+    // Wire deltas are buffer pixels (same convention as PointerMotion), so
+    // the same pixel->logical division applies.
+    let scale = host_scale(app);
+    let delta = Point::from((dx / scale, dy / scale));
+    let utime = app.now_us();
+    pointer.relative_motion(
+        app,
+        Some((surface, Point::default())),
+        &RelativeMotionEvent {
+            delta,
+            // NSEvent deltas are already pointer-accelerated and macOS
+            // exposes no raw counterpart, so mirror the accelerated vector
+            // (the usual compositor fallback for non-libinput sources).
+            delta_unaccel: delta,
+            utime,
         },
     );
     pointer.frame(app);

--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -17,7 +17,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
-use panes_protocol::{Encoding, ToGuest, ToHost, VERSION_MAJOR, VERSION_MINOR, WindowId};
+use panes_protocol::{
+    Encoding, MINOR_POINTER_LOCK, ToGuest, ToHost, VERSION_MAJOR, VERSION_MINOR, WindowId,
+};
 use smithay::input::{Seat, SeatState};
 use smithay::output::{Mode, Output, PhysicalProperties, Scale, Subpixel};
 use smithay::reexports::calloop::generic::Generic;
@@ -32,6 +34,10 @@ use smithay::wayland::compositor::{
     with_surface_tree_downward,
 };
 use smithay::wayland::output::OutputManagerState;
+use smithay::wayland::pointer_constraints::{
+    PointerConstraint, PointerConstraintsState, with_pointer_constraint,
+};
+use smithay::wayland::relative_pointer::RelativePointerManagerState;
 use smithay::wayland::selection::data_device::DataDeviceState;
 use smithay::wayland::shell::xdg::decoration::XdgDecorationState;
 use smithay::wayland::shell::xdg::{PopupSurface, ToplevelSurface, XdgShellState};
@@ -123,6 +129,10 @@ pub struct App {
     // Held only to keep their globals alive: neither trait has an accessor.
     _decoration_state: XdgDecorationState,
     _output_manager_state: OutputManagerState,
+    // Same: pointer-constraints/relative-pointer live in surface/pointer
+    // user data, the state objects only own the globals.
+    _pointer_constraints_state: PointerConstraintsState,
+    _relative_pointer_state: RelativePointerManagerState,
     shm_state: ShmState,
     /// Clipboard between guest apps. The pixels never leave the guest, but
     /// the global must exist: foot (and other toolkits) hard-fail at startup
@@ -144,6 +154,10 @@ pub struct App {
     pointer_focus: Option<WindowId>,
     /// Window holding `wl_keyboard` focus (last activated / keyed window).
     key_focus: Option<WindowId>,
+    /// Window the host was last told holds an active pointer lock
+    /// (`ToHost::PointerLock { locked: true }` without a matching false yet);
+    /// diffed against the live constraint state by `sync_pointer_lock`.
+    locked_pane: Option<WindowId>,
 
     #[cfg(feature = "gpu")]
     gpu: Option<gpu::Gpu>,
@@ -251,6 +265,11 @@ impl App {
         let shm_state = ShmState::new::<Self>(dh, Vec::new());
         let output_manager_state = OutputManagerState::new_with_xdg_output::<Self>(dh);
         let data_device_state = DataDeviceState::new::<Self>(dh);
+        // Pointer lock + relative motion for mouse-look apps (index#1724):
+        // both globals are always advertised; whether an activated lock does
+        // anything host-side is gated on the host's Hello minor instead.
+        let pointer_constraints_state = PointerConstraintsState::new::<Self>(dh);
+        let relative_pointer_state = RelativePointerManagerState::new::<Self>(dh);
         let mut seat_state = SeatState::new();
 
         let mut seat: Seat<Self> = seat_state.new_wl_seat(dh, "panes");
@@ -317,6 +336,8 @@ impl App {
             xdg_shell_state,
             _decoration_state: decoration_state,
             _output_manager_state: output_manager_state,
+            _pointer_constraints_state: pointer_constraints_state,
+            _relative_pointer_state: relative_pointer_state,
             shm_state,
             data_device_state,
             seat_state,
@@ -328,6 +349,7 @@ impl App {
             host: None,
             pointer_focus: None,
             key_focus: None,
+            locked_pane: None,
             #[cfg(feature = "gpu")]
             gpu,
             #[cfg(feature = "gpu")]
@@ -341,6 +363,12 @@ impl App {
         // wl frame callback time wraps at u32 milliseconds by protocol design.
         u32::try_from(self.start.elapsed().as_millis() & u128::from(u32::MAX))
             .expect("masked to 32 bits")
+    }
+
+    fn now_us(&self) -> u64 {
+        // zwp_relative_pointer timestamps are 64-bit microseconds.
+        u64::try_from(self.start.elapsed().as_micros() & u128::from(u64::MAX))
+            .expect("masked to 64 bits")
     }
 
     fn pane_index(&self, id: WindowId) -> Option<usize> {
@@ -446,6 +474,10 @@ impl App {
                     .is_some_and(|h| h.generation == generation)
                 {
                     self.host = None;
+                    // The host releases its cursor capture on disconnect; a
+                    // still-active guest lock is re-announced by the
+                    // sync_pointer_lock call in on_hello.
+                    self.locked_pane = None;
                     for pane in &mut self.panes {
                         pane.inflight = None;
                         pane.inflight_ticks = 0;
@@ -504,7 +536,14 @@ impl App {
                     host.send(ToHost::Pong { nonce });
                 }
             }
-            other => input::handle(self, &other),
+            other => {
+                input::handle(self, &other);
+                // Pointer focus may have moved: activate a pending lock that
+                // just gained focus, and reconcile the host (smithay
+                // auto-deactivates constraints on focus loss).
+                self.maybe_activate_constraint();
+                self.sync_pointer_lock();
+            }
         }
     }
 
@@ -544,10 +583,15 @@ impl App {
             host.ready = true;
             host.lz4 = encodings.contains(&Encoding::Lz4);
             host.scale = scale.max(1);
+            host.minor = minor;
         }
         for idx in 0..self.panes.len() {
             self.pump(idx);
         }
+        // A lock that stayed active across a host reconnect must be
+        // re-announced: the new connection starts with no capture.
+        self.maybe_activate_constraint();
+        self.sync_pointer_lock();
     }
 
     fn on_ack(&mut self, id: WindowId, seq: u64) {
@@ -620,6 +664,89 @@ impl App {
             }
             self.key_focus = None;
         }
+    }
+
+    /// True when the connected host decodes the pointer-lock messages
+    /// (Hello minor >= [`MINOR_POINTER_LOCK`]); locks are never activated for
+    /// an older host, so clients keep a plain cursor instead of a lock that
+    /// silently produces no relative motion.
+    fn host_has_pointer_lock(&self) -> bool {
+        self.host
+            .as_ref()
+            .is_some_and(|h| h.ready && h.minor >= MINOR_POINTER_LOCK)
+    }
+
+    /// Activate the focused pane's pending pointer lock. Activation rule
+    /// (`zwp_pointer_constraints` leaves the policy to the compositor): a
+    /// lock activates when its surface holds pointer focus. Confined pointers
+    /// stay pending: the host cannot fence its cursor to an `NSWindow`, and
+    /// activating one would falsely tell the client its pointer is confined
+    /// (README: known gaps).
+    fn maybe_activate_constraint(&self) {
+        if !self.host_has_pointer_lock() {
+            return;
+        }
+        let Some(id) = self.pointer_focus else {
+            return;
+        };
+        let Some(surface) = self.pane_surface(id) else {
+            return;
+        };
+        let Some(pointer) = self.seat.get_pointer() else {
+            return;
+        };
+        with_pointer_constraint(&surface, &pointer, |constraint| {
+            if let Some(constraint) = constraint
+                && !constraint.is_active()
+                && matches!(&*constraint, PointerConstraint::Locked(_))
+            {
+                constraint.activate();
+            }
+        });
+    }
+
+    /// The pointer-focused pane whose surface holds an ACTIVE lock right now.
+    fn active_locked_pane(&self) -> Option<WindowId> {
+        let id = self.pointer_focus?;
+        let surface = self.pane_surface(id)?;
+        let pointer = self.seat.get_pointer()?;
+        with_pointer_constraint(&surface, &pointer, |constraint| {
+            constraint.is_some_and(|constraint| {
+                constraint.is_active() && matches!(&*constraint, PointerConstraint::Locked(_))
+            })
+        })
+        .then_some(id)
+    }
+
+    /// Diff the live constraint state against what the host was told and send
+    /// the `PointerLock` transitions. Runs after every input message and
+    /// every commit, so all three unlock paths surface here: our own
+    /// activation, smithay's automatic deactivate on focus loss, and the
+    /// client destroying its `zwp_locked_pointer` (how GLFW apps release the
+    /// grab; only a commit, not an input event, may follow that).
+    fn sync_pointer_lock(&mut self) {
+        // `locked_pane` tracks what the HOST believes, so it only advances
+        // while a lock-capable host is listening (it resets to None with the
+        // connection); updating it host-less would swallow the re-announce
+        // on reconnect.
+        if !self.host_has_pointer_lock() {
+            return;
+        }
+        let active = self.active_locked_pane();
+        if active == self.locked_pane {
+            return;
+        }
+        let Some(host) = &self.host else {
+            return;
+        };
+        if let Some(old) = self.locked_pane {
+            host.send(ToHost::PointerLock { id: old, locked: false });
+        }
+        if let Some(new) = active {
+            host.send(ToHost::PointerLock { id: new, locked: true });
+        }
+        info!(from = ?self.locked_pane, to = ?active, "pointer lock changed");
+        self.locked_pane = active;
     }
 
     /// 10Hz fallback: with no ready host nothing acks, so release frame

--- a/packages/vm/panes/compositor/src/compositor/transport.rs
+++ b/packages/vm/panes/compositor/src/compositor/transport.rs
@@ -46,6 +46,10 @@ pub struct HostLink {
     pub lz4: bool,
     /// Host backingScaleFactor from Hello.
     pub scale: u32,
+    /// Host protocol minor from Hello: postcard has no unknown-variant
+    /// tolerance, so 1.x messages are only emitted once this says the host
+    /// decodes them.
+    pub minor: u16,
     tx: mpsc::Sender<ToHost>,
     /// A clone of the socket kept purely to force-shutdown a connection we
     /// refuse (second host) or that failed the version handshake; dropping
@@ -223,6 +227,7 @@ fn wire_up(
         ready: false,
         lz4: false,
         scale: 1,
+        minor: 0,
         tx,
         conn,
     })

--- a/packages/vm/panes/host/Cargo.toml
+++ b/packages/vm/panes/host/Cargo.toml
@@ -24,6 +24,10 @@ panes-protocol.workspace = true
 dispatch2 = "0.3"
 objc2.workspace = true
 objc2-app-kit.workspace = true
+# Pointer capture for guest pointer locks (index#1724):
+# CGAssociateMouseAndMouseCursorPosition parks the cursor while NSEvent
+# deltas keep flowing. Already in the tree as an objc2-app-kit dependency.
+objc2-core-graphics = "0.3"
 objc2-foundation.workspace = true
 objc2-metal = "0.3"
 objc2-quartz-core = "0.3"

--- a/packages/vm/panes/host/README.md
+++ b/packages/vm/panes/host/README.md
@@ -91,6 +91,19 @@ compositor).
   per detent plus `v120 = delta * 120`. Both axes are negated
   (`scrollingDelta*` is positive-up, Wayland axis is positive-down). A
   momentum-phase end sends an axis `stop`.
+- **Pointer lock** (index#1724): on `ToHost::PointerLock { locked: true }`
+  for a window that is key (and while the app is active) the host captures
+  the mouse: `NSCursor.hide()` +
+  `CGAssociateMouseAndMouseCursorPosition(false)` park the cursor while
+  `NSEvent` deltas keep flowing, and the view forwards them as
+  `ToGuest::PointerRelative` (x scale) instead of absolute motion. The
+  capture's release lives in a `Drop` impl and `sync_capture` is called on
+  every transition -- unlock message, resign-key, window close, app
+  deactivate, disconnect, Cmd+Q -- so no path leaves the user's cursor
+  dissociated. A lock for a non-key window is remembered (`wants_lock`) and
+  engages when the window becomes key. AppKit delivers each mouseMoved twice
+  (first responder + tracking area); relative deltas dedupe by event
+  identity, absolute coordinates never cared.
 
 ## Mock guest
 
@@ -99,7 +112,10 @@ connects to it: one 800x600-point toplevel with a moving gradient and a
 blocky frame counter, full-damage-tiled in 256px tiles, LZ4 when the host
 advertises it. It renders the next frame when the previous seq is acked
 (exactly one frame in flight, like the real compositor) and logs every input
-event plus a once-a-second ack rate:
+event plus a once-a-second ack rate. A right-click into the window toggles
+`ToHost::PointerLock`, exercising the host's cursor capture without a VM:
+the cursor hides and freezes, motion arrives in the log as `PointerRelative`
+deltas, a second right-click releases it:
 
 ```
 panes-host --mock                       # everything in one process

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -13,11 +13,17 @@ use std::process::ExitCode;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
-use objc2::MainThreadMarker;
 use objc2::rc::Retained;
-use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSScreen, NSWindow};
+use objc2::runtime::ProtocolObject;
+use objc2::{MainThreadMarker, MainThreadOnly, define_class};
+use objc2_app_kit::{
+    NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate, NSCursor, NSScreen,
+    NSWindow,
+};
+use objc2_core_graphics::{CGAssociateMouseAndMouseCursorPosition, CGError};
+use objc2_foundation::{NSNotification, NSObjectProtocol};
 use objc2_quartz_core::CAMetalDisplayLinkUpdate;
-use panes_protocol::{ToGuest, ToHost, WindowId};
+use panes_protocol::{MINOR_POINTER_LOCK, ToGuest, ToHost, WindowId};
 
 use crate::conn::{self, Event, HostInfo, Target};
 use crate::render::Renderer;
@@ -38,6 +44,47 @@ struct App {
     /// equivalent of mock's rate line, and the 120Hz-genlock evidence
     /// (index#1686 M6). An entry resets on each report.
     ack_stats: HashMap<WindowId, AckStat>,
+    /// Guest protocol minor from its Hello; gates `PointerRelative` (a 1.1
+    /// message postcard-decodes to an error on a 1.0 guest). 0 until known.
+    peer_minor: u16,
+    /// The engaged cursor capture, at most one. `Option` assignment is the
+    /// whole engage/release mechanism: dropping the old value restores the
+    /// cursor (see [`CursorCapture`]).
+    capture: Option<CursorCapture>,
+}
+
+/// An engaged pointer capture: cursor hidden and dissociated from mouse
+/// movement so `NSEvent` deltas drive the guest's relative pointer while the
+/// real cursor stays parked. The un-capture lives in `Drop`, so no path can
+/// release the window without also giving the user their cursor back (the
+/// failure mode to be paranoid about).
+struct CursorCapture {
+    id: WindowId,
+}
+
+impl CursorCapture {
+    fn engage(id: WindowId) -> Self {
+        eprintln!("panes-host: window {id}: pointer captured (cursor hidden, relative deltas)");
+        // Hide/unhide nest globally, so exactly one hide per capture,
+        // balanced by the one unhide in Drop.
+        NSCursor::hide();
+        let err = CGAssociateMouseAndMouseCursorPosition(false);
+        if err != CGError::Success {
+            eprintln!("panes-host: window {id}: cursor dissociation failed: {err:?}");
+        }
+        Self { id }
+    }
+}
+
+impl Drop for CursorCapture {
+    fn drop(&mut self) {
+        eprintln!("panes-host: window {}: pointer capture released", self.id);
+        let err = CGAssociateMouseAndMouseCursorPosition(true);
+        if err != CGError::Success {
+            eprintln!("panes-host: window {}: cursor re-association failed: {err:?}", self.id);
+        }
+        NSCursor::unhide();
+    }
 }
 
 struct AckStat {
@@ -102,8 +149,16 @@ pub fn run(target: Target, title_prefix: String) -> ExitCode {
             title_prefix,
             quitting: false,
             ack_stats: HashMap::new(),
+            peer_minor: 0,
+            capture: None,
         });
     });
+
+    // App activation delegate: a deactivated app must never hold the user's
+    // cursor hostage, so capture is released on resign-active and re-engaged
+    // (if the guest still wants it) on reactivation.
+    let delegate = AppDelegate::new(mtm);
+    ns_app.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
 
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let host = HostInfo {
@@ -129,9 +184,16 @@ pub fn on_event(event: Event) {
             app.out = Some(tx);
             Deferred::default()
         }
+        Event::Hello { minor } => {
+            app.peer_minor = minor;
+            Deferred::default()
+        }
         Event::Disconnected => {
             app.out = None;
             app.ack_stats.clear();
+            app.peer_minor = 0;
+            // The capture cannot outlive the lock-holding guest.
+            app.capture = None;
             // Guest windows cannot outlive the guest connection.
             let close = app.windows.drain().map(|(_, window)| window).collect();
             Deferred { show: None, close }
@@ -200,12 +262,58 @@ fn handle_msg(app: &mut App, msg: ToHost) -> Deferred {
                 window.closing = true;
                 deferred.close.push(window);
             }
+            // A locked window that vanished must release the capture.
+            sync_capture(app);
             deferred
         }
         ToHost::Cursor { .. } => {
             // v1 keeps the host cursor; guest cursor imagery is a follow-up.
             Deferred::default()
         }
+        ToHost::PointerLock { id, locked } => {
+            if let Some(window) = app.windows.get_mut(&id) {
+                window.wants_lock = locked;
+            } else {
+                eprintln!("panes-host: pointer lock for unknown window {id}");
+            }
+            sync_capture(app);
+            Deferred::default()
+        }
+    }
+}
+
+/// Reconcile the engaged cursor capture with what the guest wants and what
+/// the user is looking at: capture exactly when a lock-holding window is the
+/// key window of the active app (and the guest speaks 1.1, so the
+/// `PointerRelative` stream it implies is legal to send). Idempotent, called
+/// from every transition that can change an input: `PointerLock`, key-window
+/// changes, window close, app (de)activation, disconnect.
+fn sync_capture(app: &mut App) {
+    let desired = if app.peer_minor >= MINOR_POINTER_LOCK
+        && NSApplication::sharedApplication(app.mtm).isActive()
+    {
+        app.windows
+            .iter()
+            .find(|(_, window)| window.wants_lock && window.ns.isKeyWindow())
+            .map(|(id, _)| *id)
+    } else {
+        None
+    };
+    if app.capture.as_ref().map(|capture| capture.id) == desired {
+        return;
+    }
+    if let Some(capture) = app.capture.take() {
+        // The window may already be gone (WindowGone/close paths).
+        if let Some(window) = app.windows.get(&capture.id) {
+            window.view_handle().set_relative(false);
+        }
+        // `capture` drops here: cursor re-associated and unhidden.
+    }
+    if let Some(id) = desired
+        && let Some(window) = app.windows.get(&id)
+    {
+        window.view_handle().set_relative(true);
+        app.capture = Some(CursorCapture::engage(id));
     }
 }
 
@@ -275,6 +383,8 @@ pub fn window_closed(id: WindowId) {
         // Normally removed already (WindowGone / disconnect); this catches
         // AppKit-initiated closes so state cannot leak.
         app.windows.remove(&id);
+        // Never leave the cursor dissociated for a window that closed.
+        sync_capture(app);
     });
 }
 
@@ -361,6 +471,9 @@ pub fn window_activation(id: WindowId, activated: bool) {
                 activated,
             });
         }
+        // Key-window changes gate the cursor capture: resign releases it,
+        // become re-engages it when the guest still holds the lock.
+        sync_capture(app);
     });
 }
 
@@ -378,6 +491,8 @@ pub fn request_quit() {
             return true;
         }
         app.quitting = true;
+        // The exit below skips Drop; give the cursor back explicitly.
+        app.capture = None;
         if let Some(out) = &app.out {
             for id in app.windows.keys() {
                 let _ = out.send(ToGuest::CloseRequest { id: *id });
@@ -393,4 +508,35 @@ pub fn request_quit() {
         std::thread::sleep(Duration::from_millis(300));
         std::process::exit(0);
     });
+}
+
+define_class!(
+    #[unsafe(super(objc2_foundation::NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "PanesAppDelegate"]
+    struct AppDelegate;
+
+    unsafe impl NSObjectProtocol for AppDelegate {}
+
+    unsafe impl NSApplicationDelegate for AppDelegate {
+        #[unsafe(method(applicationDidResignActive:))]
+        fn application_did_resign_active(&self, _notification: &NSNotification) {
+            // Belt and braces on top of windowDidResignKey: whatever order
+            // AppKit resigns things in, deactivation always ends with the
+            // cursor released.
+            with_app(sync_capture);
+        }
+
+        #[unsafe(method(applicationDidBecomeActive:))]
+        fn application_did_become_active(&self, _notification: &NSNotification) {
+            with_app(sync_capture);
+        }
+    }
+);
+
+impl AppDelegate {
+    fn new(mtm: MainThreadMarker) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(());
+        unsafe { objc2::msg_send![super(this), init] }
+    }
 }

--- a/packages/vm/panes/host/src/conn.rs
+++ b/packages/vm/panes/host/src/conn.rs
@@ -23,6 +23,10 @@ pub enum Target {
 /// is what lets the writer thread exit.
 pub enum Event {
     Connected(mpsc::Sender<ToGuest>),
+    /// The guest's major-validated Hello. Its minor gates every 1.x message
+    /// we emit (postcard has no unknown-variant tolerance, see the protocol
+    /// crate), so the main thread must know it.
+    Hello { minor: u16 },
     Msg(ToHost),
     Disconnected,
 }
@@ -116,6 +120,7 @@ fn read_loop(read: Box<dyn Read + Send>) {
             Ok(ToHost::Hello { major, minor }) => {
                 if major == VERSION_MAJOR {
                     eprintln!("panes-host: guest speaks protocol {major}.{minor}");
+                    post(Event::Hello { minor });
                 } else {
                     eprintln!(
                         "panes-host: guest protocol major {major} != {VERSION_MAJOR}, hanging up"

--- a/packages/vm/panes/host/src/mock.rs
+++ b/packages/vm/panes/host/src/mock.rs
@@ -2,6 +2,11 @@
 //! protocol on a unix socket, maps one toplevel with an animated test pattern
 //! (moving gradient + frame counter), and logs every input event it receives.
 //!
+//! Pointer lock: a right-click press toggles `ToHost::PointerLock` for the
+//! window (gated on the host's Hello minor), exercising the host's cursor
+//! capture end to end; the `PointerRelative` deltas it produces land in the
+//! same input log as everything else.
+//!
 //! Pacing mirrors the real compositor: exactly one frame in flight, the next
 //! render starts when the host acks the previous seq. On a `ProMotion` panel
 //! the ack loop should settle at ~120 acks/s; the rate is logged every
@@ -18,11 +23,13 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use panes_protocol::{
-    Encoding, Rect, Tile, ToGuest, ToHost, VERSION_MAJOR, VERSION_MINOR, WindowId, WireError,
-    read_msg, write_msg,
+    ButtonState, Encoding, MINOR_POINTER_LOCK, Rect, Tile, ToGuest, ToHost, VERSION_MAJOR,
+    VERSION_MINOR, WindowId, WireError, read_msg, write_msg,
 };
 
 const WINDOW_ID: WindowId = 1;
+/// evdev right button (input-event-codes.h); a right-click toggles the lock.
+const BTN_RIGHT: u32 = 0x111;
 /// Window size in points; the buffer is this times the host's scale.
 const LOGICAL_WIDTH: u32 = 800;
 const LOGICAL_HEIGHT: u32 = 600;
@@ -54,11 +61,13 @@ pub fn serve(path: &Path) -> std::io::Result<()> {
 
 /// What the reader thread distills from host messages for the render loop.
 enum HostEvent {
-    Hello { scale: u32, lz4: bool },
+    Hello { scale: u32, lz4: bool, minor: u16 },
     Ack(u64),
     Resize { width: u32, height: u32, scale: u32 },
     Close,
     Ping(u64),
+    /// Right-click pressed: flip the window's pointer lock.
+    LockToggle,
 }
 
 fn handle_conn(stream: UnixStream) -> Result<(), WireError> {
@@ -89,9 +98,17 @@ fn read_host(stream: UnixStream, tx: &mpsc::Sender<HostEvent>) {
                     eprintln!("mock: protocol major mismatch, hanging up");
                     return;
                 }
-                HostEvent::Hello { scale: scale.max(1), lz4: encodings.contains(&Encoding::Lz4) }
+                HostEvent::Hello {
+                    scale: scale.max(1),
+                    lz4: encodings.contains(&Encoding::Lz4),
+                    minor,
+                }
             }
             Ok(ToGuest::Ack { seq, .. }) => HostEvent::Ack(seq),
+            Ok(ToGuest::PointerButton { button: BTN_RIGHT, state: ButtonState::Pressed, id }) => {
+                eprintln!("mock: right click on window {id}: toggling pointer lock");
+                HostEvent::LockToggle
+            }
             Ok(ToGuest::Configure { id, width, height, scale, activated }) => {
                 eprintln!(
                     "mock: configure window {id}: {width}x{height} scale {scale} \
@@ -126,9 +143,9 @@ fn drive(
 ) -> Result<(), WireError> {
     // The host advertises capabilities first; nothing to size buffers on
     // until then.
-    let (mut scale, lz4) = loop {
+    let (mut scale, lz4, host_minor) = loop {
         match rx.recv_timeout(HELLO_TIMEOUT) {
-            Ok(HostEvent::Hello { scale, lz4 }) => break (scale, lz4),
+            Ok(HostEvent::Hello { scale, lz4, minor }) => break (scale, lz4, minor),
             Ok(_) => {}
             Err(_) => {
                 eprintln!("mock: no hello from host, giving up");
@@ -172,6 +189,7 @@ fn drive(
 
     let mut acked_in_window: u32 = 0;
     let mut window_start = Instant::now();
+    let mut locked = false;
     loop {
         let Ok(event) = rx.recv() else {
             return Ok(()); // host disconnected
@@ -213,6 +231,19 @@ fn drive(
             }
             HostEvent::Ping(nonce) => {
                 write_msg(writer, &ToHost::Pong { nonce })?;
+                writer.flush()?;
+            }
+            HostEvent::LockToggle => {
+                // Same negotiation rule as the real compositor: PointerLock
+                // is a 1.1 message, never sent to a host that did not
+                // advertise it.
+                if host_minor < MINOR_POINTER_LOCK {
+                    eprintln!("mock: host minor {host_minor} lacks pointer lock; ignoring");
+                    continue;
+                }
+                locked = !locked;
+                eprintln!("mock: sending PointerLock locked={locked}");
+                write_msg(writer, &ToHost::PointerLock { id: WINDOW_ID, locked })?;
                 writer.flush()?;
             }
             HostEvent::Hello { .. } => {}
@@ -440,6 +471,26 @@ mod tests {
             panic!("expected incremental WindowFrame, got a different message");
         };
         assert_eq!(next_seq, seq + 1);
+
+        // Right-click press toggles the pointer lock on, a second press
+        // toggles it off; releases and other buttons must not toggle.
+        let press = |writer: &mut BufWriter<UnixStream>, button: u32, state: ButtonState| {
+            write_msg(&mut *writer, &ToGuest::PointerButton { id, button, state })
+                .expect("send button");
+            writer.flush().expect("flush");
+        };
+        press(&mut writer, BTN_RIGHT, ButtonState::Pressed);
+        let lock: ToHost = read_msg(&mut reader).expect("pointer lock");
+        assert!(matches!(lock, ToHost::PointerLock { id: WINDOW_ID, locked: true }));
+        press(&mut writer, BTN_RIGHT, ButtonState::Released);
+        // Relative deltas while locked are logged, never answered; the next
+        // wire message after the release-then-press must be the unlock.
+        write_msg(&mut writer, &ToGuest::PointerRelative { id, dx: 3.0, dy: -2.0 })
+            .expect("send relative");
+        writer.flush().expect("flush");
+        press(&mut writer, BTN_RIGHT, ButtonState::Pressed);
+        let unlock: ToHost = read_msg(&mut reader).expect("pointer unlock");
+        assert!(matches!(unlock, ToHost::PointerLock { id: WINDOW_ID, locked: false }));
 
         write_msg(&mut writer, &ToGuest::CloseRequest { id }).expect("close request");
         writer.flush().expect("flush");

--- a/packages/vm/panes/host/src/view.rs
+++ b/packages/vm/panes/host/src/view.rs
@@ -9,7 +9,7 @@
 //! right/down (scroll wheel up), while Wayland's axis is positive for a
 //! downward scroll, so both axes are negated on the way out.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 
 use objc2::rc::Retained;
@@ -47,6 +47,19 @@ pub struct ViewIvars {
     /// press and release alike; toggling membership tells them apart without
     /// hardcoding Apple's device-dependent left/right flag bits.
     held_modifiers: RefCell<HashSet<u16>>,
+    /// Pointer capture engaged for this window (`app::sync_capture`): motion
+    /// goes out as `PointerRelative` deltas, and the absolute re-anchor
+    /// before buttons/scrolls is skipped (the frozen cursor position is
+    /// meaningless while dissociated).
+    relative: Cell<bool>,
+    /// Identity (timestamp, eventNumber) of the last relative-forwarded
+    /// event. AppKit delivers each mouseMoved TWICE here -- once to the
+    /// first responder (`acceptsMouseMovedEvents`) and once to the tracking
+    /// area's owner (`MouseMoved` option), the same view (measured live: 4
+    /// posted moves, 8 arrivals). Absolute coordinates absorb the duplicate;
+    /// summed deltas would double mouse-look sensitivity, so duplicates are
+    /// dropped by identity.
+    last_relative: Cell<(f64, isize)>,
 }
 
 define_class!(
@@ -225,8 +238,17 @@ impl PanesView {
             id,
             tracking: RefCell::new(None),
             held_modifiers: RefCell::new(HashSet::new()),
+            relative: Cell::new(false),
+            last_relative: Cell::new((f64::NEG_INFINITY, 0)),
         });
         unsafe { msg_send![super(this), initWithFrame: frame] }
+    }
+
+    /// Switch the motion path between absolute coordinates and relative
+    /// deltas; owned by `app::sync_capture`, always in step with the cursor
+    /// capture.
+    pub fn set_relative(&self, relative: bool) {
+        self.ivars().relative.set(relative);
     }
 
     /// Focus left this window: release every held modifier guest-side and
@@ -249,8 +271,34 @@ impl PanesView {
     }
 
     fn send_motion(&self, event: &NSEvent) {
+        if self.ivars().relative.get() {
+            self.send_relative(event);
+            return;
+        }
         let point = self.surface_point(event);
         app::send(ToGuest::PointerMotion { id: self.ivars().id, x: point.x, y: point.y });
+    }
+
+    /// Motion while captured: `NSEvent` deltas keep flowing after
+    /// `CGAssociateMouseAndMouseCursorPosition(false)` froze the cursor
+    /// (that is the whole point of dissociation). Scaled to buffer pixels
+    /// like every other pointer coordinate; signs already match Wayland
+    /// (positive = right/down, same as the flipped view).
+    fn send_relative(&self, event: &NSEvent) {
+        // Drop the tracking-area duplicate of this event (see
+        // `ViewIvars::last_relative`); distinct events never share a
+        // (timestamp, eventNumber) identity.
+        let identity = (event.timestamp(), event.eventNumber());
+        if self.ivars().last_relative.get() == identity {
+            return;
+        }
+        self.ivars().last_relative.set(identity);
+        let scale = self.window().map_or(1.0, |window| window.backingScaleFactor());
+        let (dx, dy) = (event.deltaX() * scale, event.deltaY() * scale);
+        if dx == 0.0 && dy == 0.0 {
+            return;
+        }
+        app::send(ToGuest::PointerRelative { id: self.ivars().id, dx, dy });
     }
 
     fn send_button(&self, event: &NSEvent, state: ButtonState) {

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -175,6 +175,9 @@ pub struct SurfaceSize {
     pub scale: u32,
 }
 
+// The bools are independent presentation/lifecycle flags, each owned by a
+// different AppKit event path, not an encoded state machine.
+#[allow(clippy::struct_excessive_bools)]
 pub struct PaneWindow {
     pub id: WindowId,
     pub ns: Retained<NSWindow>,
@@ -203,6 +206,11 @@ pub struct PaneWindow {
     pub shown: bool,
     /// Set once `WindowGone` arrived; the next `windowShouldClose` says yes.
     pub closing: bool,
+    /// The guest surface holds an active pointer lock
+    /// (`ToHost::PointerLock`); the host engages the actual cursor capture
+    /// only while this window is also key (see `app::sync_capture`), so the
+    /// intent survives focus round-trips and re-engages on return.
+    pub wants_lock: bool,
 }
 
 impl PaneWindow {
@@ -307,6 +315,7 @@ impl PaneWindow {
             idle_ticks: 0,
             shown: false,
             closing: false,
+            wants_lock: false,
         }
     }
 

--- a/packages/vm/panes/protocol/src/lib.rs
+++ b/packages/vm/panes/protocol/src/lib.rs
@@ -26,9 +26,14 @@ use serde::{Deserialize, Serialize};
 /// Postcard has no unknown-variant fallback (an unrecognized enum discriminant
 /// is a decode error), so ANY additive message/variant change bumps
 /// `VERSION_MINOR` and must only be emitted once the peer's Hello advertised a
-/// minor that has it.
+/// minor that has it. For the same reason new variants are append-only:
+/// postcard encodes the variant index, so inserting one mid-enum renumbers
+/// everything after it.
 pub const VERSION_MAJOR: u16 = 1;
-pub const VERSION_MINOR: u16 = 0;
+pub const VERSION_MINOR: u16 = 1;
+
+/// Minor that introduced [`ToHost::PointerLock`] / [`ToGuest::PointerRelative`].
+pub const MINOR_POINTER_LOCK: u16 = 1;
 
 /// Guest vsock port the compositor listens on.
 pub const VSOCK_PORT: u32 = 7100;
@@ -122,6 +127,17 @@ pub enum ToHost {
     Pong {
         nonce: u64,
     },
+    /// The window's surface acquired (`locked: true`) or released
+    /// (`locked: false`) a `zwp_locked_pointer_v1` lock while holding pointer
+    /// focus (mouse-look apps: Minecraft, any GLFW "disabled cursor" client).
+    /// While locked the host hides its cursor, dissociates it from mouse
+    /// movement, and forwards deltas as [`ToGuest::PointerRelative`] instead
+    /// of absolute `PointerMotion`. Since minor 1 ([`MINOR_POINTER_LOCK`]);
+    /// only sent once the host's Hello advertised it.
+    PointerLock {
+        id: WindowId,
+        locked: bool,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -213,6 +229,17 @@ pub enum ToGuest {
     },
     Ping {
         nonce: u64,
+    },
+    /// Relative pointer motion while `id` holds a pointer lock (see
+    /// [`ToHost::PointerLock`]). Deltas are buffer pixels, the same unit as
+    /// `PointerMotion` coordinates, positive right/down; the compositor feeds
+    /// them to `zwp_relative_pointer_v1`. Since minor 1
+    /// ([`MINOR_POINTER_LOCK`]); only sent once the guest's Hello advertised
+    /// it.
+    PointerRelative {
+        id: WindowId,
+        dx: f64,
+        dy: f64,
     },
 }
 
@@ -306,6 +333,22 @@ mod tests {
         write_msg(&mut buf, &ToHost::Pong { nonce: 0 }).unwrap();
         let back: ToHost = read_msg(&mut buf.as_slice()).unwrap();
         assert!(matches!(back, ToHost::Pong { nonce: 0 }));
+    }
+
+    #[test]
+    fn pointer_lock_and_relative_roundtrip() {
+        let mut buf = Vec::new();
+        write_msg(&mut buf, &ToHost::PointerLock { id: 3, locked: true }).unwrap();
+        let back: ToHost = read_msg(&mut buf.as_slice()).unwrap();
+        assert!(matches!(back, ToHost::PointerLock { id: 3, locked: true }));
+
+        let mut buf = Vec::new();
+        write_msg(&mut buf, &ToGuest::PointerRelative { id: 3, dx: -1.5, dy: 2.25 }).unwrap();
+        let back: ToGuest = read_msg(&mut buf.as_slice()).unwrap();
+        let ToGuest::PointerRelative { id: 3, dx, dy } = back else {
+            panic!("wrong variant");
+        };
+        assert!((dx - -1.5).abs() < f64::EPSILON && (dy - 2.25).abs() < f64::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
Implements #1724 (part of #1686): Wayland pointer-constraints + relative-pointer through the whole panes stack, so mouse-look apps (Minecraft's cursor grab via `zwp_pointer_constraints_v1` + `zwp_relative_pointer_manager_v1`) actually move the camera instead of the pointer.

- **protocol 1.0 -> 1.1**: `ToHost::PointerLock { id, locked }` + `ToGuest::PointerRelative { id, dx, dy }` (buffer-pixel deltas), appended postcard-safely; both sides gate emission on the peer's Hello minor (`MINOR_POINTER_LOCK`).
- **compositor** (aarch64-linux): smithay `PointerConstraintsState`/`RelativePointerManagerState`. A locked pointer activates when its surface holds pointer focus (never against a pre-1.1 host; confined pointers stay pending -- the host can't fence its cursor to an NSWindow). Lock state is reconciled after every input message *and* every commit, because a GLFW ungrab is a `zwp_locked_pointer` destroy with no input event following it. `PointerRelative` feeds `pointer.relative_motion` on the focused surface.
- **panes-host**: `PointerLock{true}` for the key window engages a capture: `NSCursor.hide()` + `CGAssociateMouseAndMouseCursorPosition(false)`, and the view switches to forwarding `NSEvent` deltas. Release is a `Drop` impl and `sync_capture` runs on every transition (unlock, resign-key, close, app deactivate, disconnect, Cmd+Q) so no path can leave the user's cursor dissociated; lock intent survives focus loss and re-engages on return. AppKit delivers each `mouseMoved` twice (first responder + tracking area -- measured 4 posted moves = 8 arrivals), so relative deltas dedupe by event identity or sensitivity would double.
- **mock**: right-click toggles `PointerLock`, so `--mock` exercises the capture path without a VM; socketpair e2e test covers the toggle.

**Validated on darwin**: `cargo test -p panes-protocol -p panes-host` green; live `--mock` run: right-click -> `pointer captured (cursor hidden, relative deltas)`, synthetic moves arrive as `PointerRelative { dx: 24.0, dy: -14.0 }` (12,-7 pts x scale 2), second right-click -> `pointer capture released` and absolute motion resumes; both Hellos negotiate 1.1.
**Compile-checked only**: `cargo check` + clippy `-p panes-compositor --target aarch64-unknown-linux-gnu` green (a plain darwin check never compiles the smithay half). `nix run .#lint` green.
**Awaiting hardware/e2e**: real Minecraft mouse-look in the guest image (aarch64 builder), and physical-mouse confirmation of the mouseMoved double-delivery dedupe.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Wayland pointer lock and relative motion support to panes
> - Bumps the panes protocol to v1.1, adding `ToHost::PointerLock` (guest→host lock state) and `ToGuest::PointerRelative` (host→guest delta motion) with a `MINOR_POINTER_LOCK` feature gate.
> - The compositor advertises `zwp_pointer_constraints_v1` and `zwp_relative_pointer_manager_v1`, auto-activates locked-pointer constraints on focus, and syncs lock state to the host via `sync_pointer_lock` after every commit and input event.
> - The macOS host captures the cursor using `NSCursor.hide` and `CGAssociateMouseAndMouseCursorPosition` when the guest requests a lock, and releases it on app deactivation, window close, or disconnect.
> - The host view switches to relative-delta mode during capture, deduplicating `mouseMoved` events and forwarding scaled deltas as `ToGuest::PointerRelative`.
> - Risk: hosts running protocol minor < 1 receive no pointer lock messages; the compositor skips confined-pointer constraints entirely (only locked pointers are supported).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f801882.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->