### PR TITLE
panes: reconcile pointer lock on tick; release capture via sync_capture on disconnect

### DIFF
--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -790,6 +790,15 @@ impl App {
                 fire_frame_callbacks(pane.toplevel.wl_surface(), now);
                 self.pump(idx);
             }
+            // smithay 0.7's PointerConstraintsHandler has no
+            // constraint-destroyed callback, so a client tearing down its
+            // zwp_locked_pointer with neither a commit nor an input event
+            // following (e.g. it crashed while holding the grab) reaches no
+            // sync_pointer_lock call site and would leave the host cursor
+            // captured forever. The tick is the backstop; both calls
+            // early-return when nothing changed.
+            self.maybe_activate_constraint();
+            self.sync_pointer_lock();
         } else {
             for pane in &self.panes {
                 fire_frame_callbacks(pane.toplevel.wl_surface(), now);

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -192,8 +192,11 @@ pub fn on_event(event: Event) {
             app.out = None;
             app.ack_stats.clear();
             app.peer_minor = 0;
-            // The capture cannot outlive the lock-holding guest.
-            app.capture = None;
+            // The capture cannot outlive the lock-holding guest. peer_minor
+            // is 0 now, so reconciling releases it through the one shared
+            // path (the view leaves relative mode too) while the windows
+            // still exist, before they are torn down below.
+            sync_capture(app);
             // Guest windows cannot outlive the guest connection.
             let close = app.windows.drain().map(|(_, window)| window).collect();
             Deferred { show: None, close }


### PR DESCRIPTION
Fixes two findings from the post-merge adversarial review of #1729 (#1724, part of #1686):

**[C1] compositor: pointer-lock reconciliation gap.** smithay 0.7's `PointerConstraintsHandler` has no constraint-destroyed callback, so a client destroying its `zwp_locked_pointer` with no following commit or input event (e.g. crashing while holding the grab) left `locked_pane` stale and the host cursor captured forever. The 10Hz tick now backstops reconciliation (`maybe_activate_constraint` + `sync_pointer_lock`, both early-return when nothing changed).

**[M1] host: disconnect bypassed `sync_capture`.** `Event::Disconnected` cleared `app.capture` directly, skipping `view.set_relative(false)` and breaking the single-reconciliation-point invariant. It now routes through `sync_capture` (after `peer_minor` resets to 0), while the windows still exist.

**Validated on darwin:** `cargo build`/`cargo test -p panes-host -p panes-protocol` green (10 tests); `cargo check -p panes-compositor --target aarch64-unknown-linux-gnu` green; `nix run .#lint` green. Local cross-target clippy couldn't run (workspace lint set expects a newer clippy than the local toolchain); CI's x86_64-linux clippy is the arbiter.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile pointer lock on tick and release capture via `sync_capture` on disconnect
> - Adds unconditional calls to `maybe_activate_constraint()` and `sync_pointer_lock()` in the compositor tick loop as a backstop for smithay 0.7 lacking a constraint-destroyed callback, ensuring pointer lock state is reconciled even when no commit or input event occurs.
> - On disconnect, replaces direct `app.capture = None` teardown with a call to `sync_capture()` so capture state is reconciled through the shared path while `peer_minor` is 0 and before windows are torn down.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cc9b0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->