### PR TITLE
packages/mcp: Claude Code channel support (notify push + interactive resource actions + reply)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1790,7 +1790,7 @@ let
     # session_set_name joined the surface in #1615 but this expected set was
     # not updated with it; the stale drv kept passing from cache on main until
     # this package's inputs changed and forced a rebuild.
-    + "expected = {'python_exec','read','kernel_trace','tui_act','session_set_name'}; "
+    + "expected = {'python_exec','read','kernel_trace','tui_act','session_set_name','reply'}; "
     + "assert set(names) == expected, ('tool surface drifted: %r' % (names,)); "
     + "from ix_notebook_mcp import registry; instr = mcp._mcp_server.instructions; "
     + "assert 'root=' not in instr, 'a parameter/signature leaked into the instructions'; "

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -5113,6 +5113,42 @@ let
         mkdir -p "$out"
       '';
 
+  # The Claude Code channel + interactive resource actions
+  # (packages/mcp/tests/test_channel.py): the store outbox/events queues, the
+  # kernel's notify() + action dispatch, the transport pump emitting
+  # notifications/claude/channel, the reply tool, and the dashboard's SSE feed.
+  # Same interpreter needs as inputsTests (ix_notebook_mcp + aiohttp + the mcp
+  # SDK) plus pytest.
+  channelTestPython = mcpPythonInterp.withPackages (
+    ps:
+    mcpPythonPackages ps
+    ++ [
+      ps.pytest
+    ]
+  );
+  channelTestSource = builtins.path {
+    name = "ix-mcp-channel-test";
+    path = ./tests/test_channel.py;
+  };
+  channelTests =
+    pkgs.runCommand "ix-mcp-channel-tests"
+      {
+        nativeBuildInputs = [ channelTestPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        cp ${channelTestSource} "$TMPDIR/test_channel.py"
+        ${lib.getExe channelTestPython} -m pytest "$TMPDIR/test_channel.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp channel tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
+
   # End-to-end browser proof of the interactive-input path: a real headless
   # Chromium mounts an `Input`'s HTML in a sandboxed, opaque-origin srcdoc iframe
   # (as HtmlBody.svelte does), clicks the button, and the cross-origin `ixSubmit`
@@ -5422,6 +5458,7 @@ package.overrideAttrs (old: {
         feedSmoke
         apiSmoke
         inputsTests
+        channelTests
         inputBrowserSmoke
         wedgeSmoke
         richSmoke

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -246,10 +246,47 @@ def build_app(config: Config, conn: sqlite3.Connection) -> web.Application:
         store.add_input(conn, channel=channel, payload=json.dumps(body["payload"]))
         return web.json_response({"ok": True}, headers=_CORS_HEADERS)
 
+    async def resource_events(request: web.Request) -> web.StreamResponse:
+        # The live event feed behind an interactive resource: action results and
+        # errors (kernel handlers) plus the agent's `reply` messages, streamed as
+        # SSE so the resource's page updates without polling. A read endpoint
+        # like /api/resources (which already serves the same resource's HTML to
+        # anyone on the bind), so no extra gate; CORS because the subscriber is
+        # the sandboxed, opaque-origin iframe. Subscribers start at the CURRENT
+        # tail (no history replay): the feed is a live stream, not a log.
+        rid = request.match_info["id"]
+        resp = web.StreamResponse(
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                **_CORS_HEADERS,
+            }
+        )
+        await resp.prepare(request)
+        # A comment frame so EventSource sees bytes immediately (open fires).
+        await resp.write(b": connected\n\n")
+        last = store.latest_event_seq(conn, rid)
+        try:
+            while True:
+                for row in store.events_after(conn, rid, last):
+                    last = row["seq"]
+                    try:
+                        body = json.loads(row["body"])
+                    except (ValueError, TypeError):
+                        body = {"raw": row["body"]}
+                    event = {"seq": row["seq"], "kind": row["kind"], **body}
+                    await resp.write(f"data: {json.dumps(event)}\n\n".encode())
+                await asyncio.sleep(0.5)
+        except (ConnectionError, asyncio.CancelledError):
+            # Subscriber went away (tab closed, dashboard reloaded): just stop.
+            pass
+        return resp
+
     app.router.add_get("/", index)
     app.router.add_get("/api/jobs", jobs)
     app.router.add_get("/api/jobs/{id}", job)
     app.router.add_get("/api/resources", resources)
+    app.router.add_get("/api/resources/{id}/events", resource_events)
     app.router.add_get("/api/cells", cells)
     app.router.add_get("/api/snapshot", snapshot)
     app.router.add_post("/api/exec", exec_run)

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -270,6 +270,22 @@ READABLE = (
     "final `Result(...)` name what it returns rather than wrap one dense expression."
 )
 
+CHANNEL = (
+    "This server is also a Claude Code channel (research preview). When the client session was "
+    "launched with the channel enabled (`claude --dangerously-load-development-channels "
+    "server:<name>`), kernel code can push events into the running agent session with `await "
+    "notify(content, **meta)`: each event arrives in the session as <channel source=\"...\" "
+    "key=\"val\">content</channel>, with each meta kwarg a tag attribute (identifier keys only). "
+    "Delivery is fire-and-forget — a session without the channel enabled drops events silently — "
+    "so never treat a notify as confirmed-read. Interactive resources close the loop: "
+    "`register_resource(render=..., actions={'name': handler})` serves the HTML with "
+    "`ix.act(name, payload)` (queues the payload for the named in-kernel handler) and "
+    "`ix.events(fn)` (subscribes the page to handler results, errors, and your replies) "
+    "pre-wired. A handler that calls `notify(..., resource=<id>)` wakes you when the page acts; "
+    "when a <channel> tag carries a `resource` attribute, answer it with the `reply` tool, "
+    "passing that resource id — your transcript output never reaches the page."
+)
+
 CELLS = (
     "Three dashboard panes show the session live: every running/finished run under executions, "
     "every live view (a terminal, a widget) under resources, and your curated highlight reel "
@@ -318,6 +334,14 @@ TRACE = (
     "channel, so it returns while the loop is still frozen. Use it to see WHERE a wedged or slow "
     "cell is stuck, then fix the blocking call (wrap it in `await asyncio.to_thread(...)` and "
     "background it)."
+)
+
+REPLY = (
+    "Send a message to the page behind an interactive resource. Use it to answer a channel event "
+    "that carries a resource attribute (<channel resource=\"...\">): pass that resource id and "
+    "your text, and the page receives it on its live event feed (`ix.events`). The page's viewer "
+    "reads the page, not this session — anything you want them to see must go through this tool; "
+    "your transcript output never reaches them. Fails when the resource is closed or unknown."
 )
 
 

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -278,6 +278,13 @@ BUILTINS: tuple[Builtin, ...] = (
         "have the markup call `ixSubmit(payload)`, then `await` the submission (or `async for`)",
     ),
     Builtin(
+        "notify",
+        "push a channel event into the connected agent session (Claude Code channels): "
+        "`await notify('build failed', severity='high')`; each kwarg becomes a <channel> tag "
+        "attribute (identifier keys only). Fire-and-forget: a session without the channel "
+        "enabled drops it silently",
+    ),
+    Builtin(
         "sh",
         "shell out on the loop; use sh([...]) for argv-list/no shell parsing and sh('...') "
         "only when shell parsing is intended; the Output IS a Result (ANSI as HTML for the "

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -828,9 +828,23 @@ class Resource:
     latest HTML to the store every flush tick and the dashboard sidebar shows
     all live resources updating in place. The resource closes itself (leaves the
     sidebar) when its ``alive`` predicate reports the source is gone.
+
+    Pass ``actions={"name": handler}`` to make the resource interactive: its HTML
+    gets ``ix.act(name, payload)`` and ``ix.events(fn)`` injected (see
+    :attr:`script`), each ``act`` runs the named in-kernel handler, and every
+    handler result/error -- plus any agent ``reply`` -- streams back to the page
+    over the resource's live event feed.
     """
 
-    def __init__(self, id: str, title: str, kind: str, render: Any, alive: Any = None) -> None:
+    def __init__(
+        self,
+        id: str,
+        title: str,
+        kind: str,
+        render: Any,
+        alive: Any = None,
+        actions: Mapping[str, Any] | None = None,
+    ) -> None:
         self.id = id
         self.title = title
         self.kind = kind
@@ -840,13 +854,26 @@ class Resource:
         self.created = time.time()
         self.html = ""
         self.error: str | None = None
+        self.actions: dict[str, Any] = dict(actions) if actions else {}
+        self._action_channel: Input | None = None
+        self._dispatcher: asyncio.Task | None = None
+        if self.actions:
+            self._start_actions()
 
     def closed(self) -> bool:
         return self.status == "closed"
 
     def close(self) -> Resource:
-        """Close the resource so the sidebar drops it on the next tick."""
+        """Close the resource so the sidebar drops it on the next tick (and tear
+        down its action channel/dispatcher, so a stale page can no longer queue
+        work for it)."""
         self.status = "closed"
+        if self._dispatcher is not None:
+            self._dispatcher.cancel()
+            self._dispatcher = None
+        if self._action_channel is not None:
+            self._action_channel.close()
+            self._action_channel = None
         return self
 
     def alive(self) -> bool:
@@ -861,18 +888,118 @@ class Resource:
             return False
 
     async def render_html(self) -> str:
-        """The current HTML for this resource (awaits the render if it is async)."""
+        """The current HTML for this resource (awaits the render if it is async).
+        An interactive resource gets its wiring script prepended, so the page's
+        markup can call ``ix.act``/``ix.events`` without including anything."""
         out = self._render() if callable(self._render) else self._render
         if inspect.iscoroutine(out):
             out = await out
-        return out if isinstance(out, str) else str(out)
+        html = out if isinstance(out, str) else str(out)
+        script = self.script
+        return script + html if script else html
+
+    @property
+    def script(self) -> str:
+        """The ``<script>`` an interactive resource's HTML is served with ("" for
+        a plain resource). It extends the shared ``window.ix`` object with:
+
+        - ``ix.act(name, payload) -> Promise``: queue ``payload`` for the named
+          in-kernel action handler (rides the existing ``/api/input`` write path,
+          so it shares that endpoint's network-boundary authorization). Resolves
+          with ``{ok, call}``; the handler's return value arrives on the event
+          feed as ``{kind: 'action_result', call, value}``.
+        - ``ix.events(fn) -> EventSource``: subscribe to this resource's live
+          feed (action results, errors, and agent ``reply`` messages), invoking
+          ``fn(event)`` per event.
+        """
+        channel = self._action_channel
+        if channel is None:
+            return ""
+        base = os.environ.get("IX_MCP_DATA_API_URL", "").rstrip("/")
+        events_url = f"{base}/api/resources/{self.id}/events"
+        # These interpolate into a <script> body. channel.endpoint is env-derived
+        # and channel.id is a secrets token; self.id is validated to [A-Za-z0-9._-]
+        # at register_resource (an interactive resource), so none can carry a
+        # `</script>` breakout. json.dumps still quotes them as JS string literals.
+        return (
+            "<script>(function(){"
+            f"var E={json.dumps(channel.endpoint)},C={json.dumps(channel.id)},"
+            f"S={json.dumps(events_url)};"
+            "var x=(window.ix=window.ix||{});"
+            "x.act=function(a,p){var id=Math.random().toString(36).slice(2,10);"
+            "return fetch(E,{method:'POST',"
+            "headers:{'Content-Type':'text/plain;charset=UTF-8'},"
+            "body:JSON.stringify({channel:C,payload:{action:a,call:id,"
+            "payload:p===undefined?null:p}})})"
+            ".then(function(r){return r.json();})"
+            ".then(function(j){j.call=id;return j;});};"
+            "x.events=function(f){var s=new EventSource(S);"
+            "s.onmessage=function(e){try{f(JSON.parse(e.data));}catch(_){}};"
+            "return s;};"
+            "})();</script>"
+        )
+
+    def _start_actions(self) -> None:
+        """Open the action channel and start the dispatcher consuming it."""
+        self._action_channel = Input(title=f"{self.title} actions")
+        with contextlib.suppress(RuntimeError):  # no loop (sync test context): actions need the kernel loop
+            self._dispatcher = asyncio.get_event_loop().create_task(self._dispatch_actions())
+
+    def _emit_event(self, kind: str, body: dict) -> None:
+        """Append one event to this resource's live feed (best-effort: the page
+        stream is a convenience; a store failure must not abort the handler)."""
+        if _store is None or _store_conn is None:
+            return
+        with contextlib.suppress(Exception):  # best-effort: a store write must not abort user code
+            _store.add_event(
+                _store_conn,
+                resource=self.id,
+                kind=kind,
+                body=json.dumps(body, default=_safe_repr),
+            )
+
+    async def _dispatch_actions(self) -> None:
+        """Consume the action channel: run each queued ``ix.act`` submission's
+        handler and stream its result (or error) back on the event feed."""
+        channel = self._action_channel
+        if channel is None:
+            return
+        async for submission in channel:
+            name = submission.get("action") if isinstance(submission, dict) else None
+            call = submission.get("call") if isinstance(submission, dict) else None
+            handler = self.actions.get(name)
+            if handler is None:
+                self._emit_event("error", {"action": name, "call": call, "error": f"no such action {name!r}"})
+                continue
+            try:
+                out = handler(submission.get("payload") if isinstance(submission, dict) else None)
+                if inspect.isawaitable(out):
+                    out = await out
+            except Exception as exc:
+                self._emit_event(
+                    "error",
+                    {
+                        "action": name,
+                        "call": call,
+                        "error": "".join(traceback.format_exception_only(type(exc), exc)).strip(),
+                    },
+                )
+                continue
+            self._emit_event("action_result", {"action": name, "call": call, "value": out})
 
     def __repr__(self) -> str:
         return f"<Resource {self.id} ({self.title}) [{self.status}] {self.kind}>"
 
 
 def register_resource(
-    source: Any = None, *, title: str | None = None, render: Any = None, id: str | None = None, kind: str = "html", alive: Any = None
+    source: Any = None,
+    *,
+    title: str | None = None,
+    render: Any = None,
+    id: str | None = None,
+    kind: str = "html",
+    alive: Any = None,
+    actions: Mapping[str, Any] | None = None,
 ) -> Resource:
     """Register a live HTML resource: a view the dashboard shows in its sidebar.
 
@@ -905,11 +1032,28 @@ def register_resource(
     close. Move one by dragging its card chrome (the padding around the content);
     it is not resizable (size follows the content).
 
-    Interactive (a form the human fills in): pair the resource with an
-    :class:`Input`, drop its ``.script`` into the HTML, and ``await`` the reply --
-    or just use :func:`ask` for a ready-made form. A cross-origin ``fetch`` to the
-    data API DOES work from the sandbox (that is how input flows back); only
-    *same-origin* access to the embedding page is blocked.
+    Interactive (buttons/forms that run python): pass ``actions`` -- a dict of
+    name -> handler (sync or async, called with the submitted payload). The HTML
+    is served with ``ix.act(name, payload)`` and ``ix.events(fn)`` pre-wired::
+
+        async def on_deploy(payload):
+            run = await start_deploy(payload["env"])
+            await notify(f"deploy requested: {run}", resource="deploy-panel")
+            return {"run": run}
+
+        register_resource(
+            render=lambda: '<button onclick="ix.act(\\'deploy\\', {env: \\'prod\\'})">ship</button>',
+            id="deploy-panel", actions={"deploy": on_deploy},
+        )
+
+    Each ``ix.act`` queues its payload for the handler; the handler's return value
+    (or error) streams back to the page as ``{kind: 'action_result', call, value}``
+    on the feed ``ix.events(fn)`` subscribes to, alongside any agent ``reply``.
+    Pair a handler with :func:`notify` to wake the agent session on a click. For a
+    simple one-question form, :func:`ask` is still the shortcut; the lower-level
+    :class:`Input` + ``.script`` path also still works. A cross-origin ``fetch``
+    to the data API DOES work from the sandbox (that is how input flows back);
+    only *same-origin* access to the embedding page is blocked.
 
     Prefer SELF-CONTAINED HTML. The body is rendered inside a sandboxed,
     opaque-origin ``<iframe>`` (``sandbox="allow-scripts"``, no
@@ -943,13 +1087,37 @@ def register_resource(
             type(source).__name__ if source is not None else "resource"
         )
     rid = id or uuid.uuid4().hex[:8]
-    res = Resource(rid, str(title), kind, render, alive)
+    # An interactive resource's id is interpolated into the injected <script> and
+    # into its `/api/resources/{id}/events` SSE route, so it must be a safe token:
+    # `json.dumps` does NOT escape `</script>` or `/`, so an id carrying `</script>`
+    # would break out of the script tag (XSS in the pane), and a `/` would silently
+    # miss the SSE route. Restrict it to url/path-safe characters -- random ids
+    # (uuid hex) and Input tokens (`secrets.token_urlsafe`) already satisfy this;
+    # an agent-supplied id built from external data (a repo/branch/chat id) is the
+    # one that could smuggle markup. Non-interactive resources never reach either
+    # sink, so they keep accepting any id.
+    if actions and not _RESOURCE_ID_RE.fullmatch(rid):
+        raise ValueError(
+            f"an interactive resource id must match [A-Za-z0-9._-]+ (it is embedded "
+            f"in a <script> and a URL path); got {rid!r}"
+        )
+    # Re-registering an id REPLACES that resource; close the old one first so its
+    # action channel/dispatcher never outlives the pane it served.
+    old = resources.get(rid)
+    if old is not None:
+        old.close()
+    res = Resource(rid, str(title), kind, render, alive, actions=actions)
     resources[rid] = res
     return res
 
 
 jobs: dict[str, Job] = {}
 resources: dict[str, Resource] = {}
+
+# A safe id for an INTERACTIVE resource: it is interpolated into the injected
+# <script> body and into the `/api/resources/{id}/events` URL path, so it must
+# carry no HTML/JS or path metacharacters (see register_resource).
+_RESOURCE_ID_RE = re.compile(r"[A-Za-z0-9._-]+")
 
 
 # --------------------------------------------------------------------------- #
@@ -1197,6 +1365,51 @@ async def ask(
     if fields is None and isinstance(payload, dict) and set(payload) == {"value"}:
         return payload["value"]
     return payload
+
+
+# Claude Code drops <channel> tag attributes whose keys are not identifiers
+# ([A-Za-z0-9_]) -- silently. Validate at the source instead, so a typo'd key is
+# a loud ValueError here rather than a missing attribute there.
+_META_KEY_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
+async def notify(content: str, **meta: Any) -> None:
+    """Push a channel event into the connected agent session.
+
+    This server is a Claude Code channel (research preview): when the client
+    session was launched with the channel enabled (``claude
+    --dangerously-load-development-channels server:<name>``), the event lands in
+    the agent's context as ``<channel source="<name>" key="val">content</channel>``
+    and wakes it. Each keyword becomes a tag attribute (values are stringified)::
+
+        await notify("CI run 1234 failed on main", severity="high", run_id="1234")
+
+    Pass ``resource=<id>`` when the event belongs to an interactive resource, so
+    the agent knows to answer with the ``reply`` tool (its text streams back to
+    that resource's page).
+
+    Fire-and-forget: delivery is not acknowledged, and a client session running
+    WITHOUT the channel enabled drops events silently (Claude Code's documented
+    behavior), so never treat a notify as confirmed-read. Keys must be
+    identifiers (``[A-Za-z0-9_]``); anything else raises here rather than being
+    silently dropped client-side.
+    """
+    bad = [key for key in meta if not _META_KEY_RE.fullmatch(key)]
+    if bad:
+        raise ValueError(
+            f"notify() meta keys must match [A-Za-z0-9_]+ (Claude Code silently "
+            f"drops others); got {bad!r}"
+        )
+    if _store is None or _store_conn is None:
+        raise RuntimeError(
+            "notify() needs the server-managed kernel (no store is configured), "
+            "so there is no channel to deliver to"
+        )
+    _store.add_outbox(
+        _store_conn,
+        content=str(content),
+        meta=json.dumps({key: str(value) for key, value in meta.items()}),
+    )
 
 
 @dataclasses.dataclass
@@ -2471,6 +2684,9 @@ async def _sweep_resources() -> None:
     now = time.time()
     for res in list(resources.values()):
         if not res.alive():
+            # close() also tears down an interactive resource's action channel
+            # and dispatcher, so a dead pane cannot keep accepting ix.act posts.
+            res.close()
             with contextlib.suppress(Exception):  # best-effort: store write must not kill the loop
                 _store.close_resource(_store_conn, id=res.id, updated_at=now)
             resources.pop(res.id, None)
@@ -3350,6 +3566,7 @@ def install(user_ns: dict | None = None) -> None:
     target["register_resource"] = register_resource
     target["Input"] = Input
     target["ask"] = ask
+    target["notify"] = notify
     target["input_channels"] = input_channels
     target["__ix_run"] = __ix_run
     target["__ix_exec"] = __ix_exec

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -116,6 +116,35 @@ CREATE TABLE IF NOT EXISTS inputs (
     created_at  REAL NOT NULL
 );
 CREATE INDEX IF NOT EXISTS inputs_channel ON inputs (channel, seq);
+
+-- Outbox: kernel -> agent push queue behind the Claude Code channel. The kernel's
+-- `notify()` appends one row per event; the MCP transport drains them on its poll
+-- tick and emits each as a `notifications/claude/channel` MCP notification, so
+-- kernel code can wake the connected agent session. Same transient-message
+-- discipline as `inputs`: the drain DELETEs what it delivers, so the table stays
+-- empty between events. `meta` is a JSON object of identifier-keyed strings (they
+-- become attributes on the client's <channel> tag).
+CREATE TABLE IF NOT EXISTS outbox (
+    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+    content     TEXT NOT NULL,
+    meta        TEXT NOT NULL DEFAULT '{}',
+    created_at  REAL NOT NULL
+);
+
+-- Resource events: the kernel/server -> browser stream behind interactive
+-- resources. Action results and errors (kernel) and agent `reply` messages (MCP
+-- server) append here; the dashboard's SSE endpoint streams rows to every page
+-- subscribed to that resource. Append-only with age-based pruning rather than
+-- delete-on-read, because several pages may subscribe to one resource and each
+-- reads forward from its own seq.
+CREATE TABLE IF NOT EXISTS events (
+    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource    TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    body        TEXT NOT NULL,
+    created_at  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS events_resource ON events (resource, seq);
 """
 
 
@@ -494,6 +523,88 @@ def delete_inputs(conn: sqlite3.Connection, seqs: list[int]) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Outbox + events: the kernel -> agent and kernel/server -> browser push paths
+# behind the Claude Code channel and interactive resource actions. The kernel
+# writes `outbox` (notify()) and `events` (action results); the MCP transport
+# drains `outbox` into channel notifications; the MCP `reply` tool writes
+# `events`; the dashboard's SSE endpoint reads `events`.
+# --------------------------------------------------------------------------- #
+
+# Events older than this are pruned on write. The stream is a live feed, not
+# history: a page subscribes and reads forward, so a row only matters for as long
+# as a subscriber might still be catching up on a slow poll tick.
+_EVENT_MAX_AGE_SECONDS = 3600.0
+
+
+def add_outbox(conn: sqlite3.Connection, *, content: str, meta: str) -> None:
+    """Queue one channel event (``meta`` is a JSON object of identifier-keyed
+    strings). The kernel is the sole inserter; the MCP transport drains."""
+    conn.execute(
+        "INSERT INTO outbox (content, meta, created_at) VALUES (?, ?, ?)",
+        (content, meta, _now()),
+    )
+
+
+def take_outbox(conn: sqlite3.Connection) -> list[dict]:
+    """Every queued channel event, oldest first, consuming the rows. Like
+    ``_drain_inputs``: DELETE before delivering, so an event can never be emitted
+    twice; a crash between the delete and the send loses at most one batch."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT seq, content, meta FROM outbox ORDER BY seq ASC"
+    ).fetchall()
+    if not rows:
+        return []
+    placeholders = ",".join("?" for _ in rows)
+    conn.execute(
+        f"DELETE FROM outbox WHERE seq IN ({placeholders})",  # noqa: S608 -- placeholders are bound params
+        [r["seq"] for r in rows],
+    )
+    return [dict(r) for r in rows]
+
+
+def add_event(conn: sqlite3.Connection, *, resource: str, kind: str, body: str) -> None:
+    """Append one resource event (``body`` is a JSON object) and prune rows past
+    the age cap, so the live feed never grows the store without bound."""
+    now = _now()
+    conn.execute(
+        "INSERT INTO events (resource, kind, body, created_at) VALUES (?, ?, ?, ?)",
+        (resource, kind, body, now),
+    )
+    conn.execute(
+        "DELETE FROM events WHERE created_at < ?", (now - _EVENT_MAX_AGE_SECONDS,)
+    )
+
+
+def latest_event_seq(conn: sqlite3.Connection, resource: str) -> int:
+    """The newest event seq for ``resource`` (0 when none): where a fresh SSE
+    subscriber starts, so it streams new events only, never replayed history."""
+    row = conn.execute(
+        "SELECT MAX(seq) FROM events WHERE resource = ?", (resource,)
+    ).fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def events_after(conn: sqlite3.Connection, resource: str, seq: int) -> list[dict]:
+    """The events for ``resource`` with seq > ``seq``, oldest first."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT seq, kind, body, created_at FROM events "
+        "WHERE resource = ? AND seq > ? ORDER BY seq ASC",
+        (resource, seq),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def resource_live(conn: sqlite3.Connection, id: str) -> bool:
+    """Whether ``id`` names a resource not yet closed: the `reply` tool's gate, so
+    a reply to a finished or mistyped resource fails loudly instead of streaming
+    into a feed no page reads."""
+    row = conn.execute("SELECT status FROM resources WHERE id = ?", (id,)).fetchone()
+    return row is not None and row[0] != "closed"
+
+
+# --------------------------------------------------------------------------- #
 # Sessions: the pieces that make one store file a reopenable notebook.
 #
 # A session file carries three things: the execution log (the cells and their
@@ -567,6 +678,11 @@ def mark_interrupted(conn: sqlite3.Connection, *, ended_at: float) -> int:
         (ended_at,),
     )
     conn.execute("DELETE FROM inputs")
+    # A dead kernel's undelivered channel pushes and its resources' event feed
+    # describe state that no longer exists; a reopened session must not fire
+    # stale notifications into a fresh agent session or replay them to a page.
+    conn.execute("DELETE FROM outbox")
+    conn.execute("DELETE FROM events")
     return cur.rowcount
 
 

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -34,6 +34,7 @@ import contextlib
 import json
 import logging
 import os
+import sqlite3
 import uuid
 import weakref
 from typing import Annotated
@@ -80,6 +81,7 @@ _KERNEL_GUIDE = guide.compose(
     guide.RESULT_VARIANTS,
     guide.READABLE,
     guide.CELLS,
+    guide.CHANNEL,
 )
 
 
@@ -450,6 +452,54 @@ async def kernel_trace(ctx: Context | None = None) -> str:
     await _identify_client_once(ctx)
     await _require_session_name(ctx, intent="kernel trace")
     return await current_kernel().dump_trace()
+
+
+# The reply tool's store connection, opened lazily on first reply. The tool runs
+# in the server process (the kernel's `events` writes come from its own
+# connection), so it needs its own handle on the shared WAL store.
+_reply_conn: sqlite3.Connection | None = None
+
+
+def _reply_store() -> sqlite3.Connection:
+    global _reply_conn
+    if _reply_conn is None:
+        try:
+            path = config().store_path
+        except RuntimeError as exc:
+            raise McpError(
+                ErrorData(code=types.INTERNAL_ERROR, message="no store configured; reply needs `ix-mcp serve`")
+            ) from exc
+        from . import store
+
+        _reply_conn = store.connect(path)
+    return _reply_conn
+
+
+@mcp.tool(structured_output=False, description=guide.REPLY)
+async def reply(
+    resource: Annotated[
+        str,
+        Field(description='The resource id from the channel event\'s resource="..." attribute'),
+    ],
+    text: Annotated[str, Field(description="The message to show on that resource's page")],
+    ctx: Context | None = None,
+) -> Content:
+    await _start_dashboard_once()
+    await _identify_client_once(ctx)
+    # Deliberately not gated on session_set_name: a reply answers a channel event
+    # (often the session's very first act) and creates no dashboard run to label.
+    from . import store
+
+    conn = _reply_store()
+    if not store.resource_live(conn, resource):
+        raise McpError(
+            ErrorData(
+                code=types.INVALID_PARAMS,
+                message=f"no live resource {resource!r}; pass the id from the <channel resource=...> attribute",
+            )
+        )
+    store.add_event(conn, resource=resource, kind="reply", body=json.dumps({"text": text}))
+    return [outputs.text("sent")]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/mcp/ix_notebook_mcp/transport.py
+++ b/packages/mcp/ix_notebook_mcp/transport.py
@@ -3,16 +3,47 @@
 stdio is the transport our clients launch: the CLI dups the real stdin/stdout to
 private fds and points fd 0/1 at /dev/null and stderr before anything else can
 write to them, so here we hand the MCP protocol those private fds exclusively.
+
+The stdio transport is also a Claude Code channel (research preview,
+https://code.claude.com/docs/en/channels-reference): it advertises the
+``claude/channel`` experimental capability and pumps the store's ``outbox``
+(what the kernel's ``notify()`` writes) as ``notifications/claude/channel``
+events, so kernel code can push into the running agent session. Channels are
+stdio-only by contract (Claude Code spawns the channel server as a subprocess
+and a session opts in per-entry via ``--channels`` /
+``--dangerously-load-development-channels``), so the HTTP transport does not
+grow one. A client that did not opt in ignores both the capability and the
+notifications, so this costs nothing when unused.
 """
 
 from __future__ import annotations
 
+import functools
+import json
+import logging
 import os
+from contextlib import AsyncExitStack
 
 import anyio
+from anyio.abc import ObjectSendStream
+from mcp.server.session import InitializationState, ServerSession
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCMessage, JSONRPCNotification
 
+from . import store
 from .config import config
 from .tools import mcp
+
+logger = logging.getLogger(__name__)
+
+# The capability that makes this MCP server a channel: presence of the key is the
+# whole contract (the value is always {}), and it is what tells Claude Code to
+# register a listener for our channel notifications.
+CHANNEL_CAPABILITIES = {"claude/channel": {}}
+
+# How often the pump drains the outbox. Matches the kernel flusher's cadence:
+# a notify() reaches the client within ~this bound.
+_OUTBOX_POLL_SECONDS = 0.5
 
 
 async def serve() -> None:
@@ -32,8 +63,121 @@ async def _serve_stdio() -> None:
     stdin = anyio.wrap_file(os.fdopen(cfg.stdin_fd, "r", encoding="utf-8"))
     stdout = anyio.wrap_file(os.fdopen(cfg.stdout_fd, "w", encoding="utf-8", buffering=1))
     server = mcp._mcp_server
+    init_options = server.create_initialization_options(
+        experimental_capabilities=CHANNEL_CAPABILITIES,
+    )
     async with stdio_server(stdin, stdout) as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, server.create_initialization_options())
+        await _run_with_channel_pump(server, read_stream, write_stream, init_options)
+
+
+def _can_hold_session(server: object) -> bool:
+    """Whether we can safely mirror ``Server.run`` to hold the live session (so the
+    pump can gate on the client's ``initialized``). Guards every SDK internal the
+    mirror touches; if a future SDK version drops or renames one -- or enables the
+    experimental task-support path we do not model -- we fall back to the plain
+    ``server.run`` (which never dropped a message; it just cannot gate the pump).
+    """
+    return (
+        getattr(server, "_experimental_handlers", "unset") is None
+        and all(hasattr(server, attr) for attr in ("lifespan", "_handle_message"))
+        and hasattr(ServerSession, "incoming_messages")
+    )
+
+
+async def _run_with_channel_pump(server, read_stream, write_stream, init_options) -> None:  # noqa: ANN001 -- SDK stream/server types are internal
+    """Run the MCP protocol loop with the channel outbox pump alongside it.
+
+    The pump must not emit ``notifications/claude/channel`` before the client's
+    ``initialized`` (the MCP lifecycle SHOULD-NOT send server notifications
+    before then), so it needs the live ``ServerSession`` to check state.
+    ``Server.run`` owns that session and does not expose it, so mirror its exact
+    steps (lifespan -> session -> dispatch each incoming message) and hand the
+    session to the pump. If the SDK internals this relies on are unavailable
+    (see :func:`_can_hold_session`), fall back to the plain ``run`` with an
+    ungated pump -- correct today because nothing writes the outbox before init
+    (the store's outbox is cleared at startup), just not future-proofed.
+    """
+    if not _can_hold_session(server):
+        logger.warning("channel pump: SDK internals unavailable; running without the initialized gate")
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(pump_outbox, write_stream, None)
+            await server.run(read_stream, write_stream, init_options)
+            tg.cancel_scope.cancel()
+        return
+    async with AsyncExitStack() as stack:
+        lifespan_context = await stack.enter_async_context(server.lifespan(server))
+        session = await stack.enter_async_context(
+            ServerSession(read_stream, write_stream, init_options)
+        )
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(pump_outbox, write_stream, session)
+            async for message in session.incoming_messages:
+                tg.start_soon(
+                    functools.partial(
+                        server._handle_message, message, session, lifespan_context, raise_exceptions=False
+                    )
+                )
+            tg.cancel_scope.cancel()
+
+
+def _session_initialized(session: ServerSession | None) -> bool:
+    """Whether the client has completed the initialize handshake. None session
+    (the fallback path) reports True: there is nothing to gate on there."""
+    if session is None:
+        return True
+    return getattr(session, "_initialization_state", None) is InitializationState.Initialized
+
+
+async def pump_outbox(
+    write_stream: ObjectSendStream[SessionMessage],
+    session: ServerSession | None,
+) -> None:
+    """Drain the store's outbox into ``notifications/claude/channel`` events.
+
+    Custom notification methods are not in the SDK's typed ``ServerNotification``
+    union, so the JSON-RPC message is built directly and sent on the transport's
+    write stream -- the same bytes ``ServerSession.send_notification`` would
+    produce. Holds every send until the client is ``initialized`` (see
+    :func:`_session_initialized`), so a startup/replay ``notify()`` never emits a
+    notification before the handshake completes. Best-effort per tick: a store
+    hiccup retries next tick, and a closed transport ends the pump (the task
+    group tears it down anyway).
+    """
+    cfg = config()
+    if not cfg.store_path:
+        return
+    conn = store.connect(cfg.store_path)
+    try:
+        while True:
+            # Wait for the handshake before draining, so rows that accrue during
+            # startup are held (not dropped) until the client can receive them.
+            if not _session_initialized(session):
+                await anyio.sleep(_OUTBOX_POLL_SECONDS)
+                continue
+            try:
+                rows = store.take_outbox(conn)
+            except Exception:
+                rows = []  # best-effort: a read error this tick just retries next tick
+            for row in rows:
+                try:
+                    meta = json.loads(row["meta"] or "{}")
+                except ValueError:
+                    meta = {}
+                params: dict = {"content": row["content"]}
+                if meta:
+                    params["meta"] = meta
+                notification = JSONRPCNotification(
+                    jsonrpc="2.0",
+                    method="notifications/claude/channel",
+                    params=params,
+                )
+                try:
+                    await write_stream.send(SessionMessage(message=JSONRPCMessage(notification)))
+                except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                    return
+            await anyio.sleep(_OUTBOX_POLL_SECONDS)
+    finally:
+        conn.close()
 
 
 async def _serve_http() -> None:

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -1,0 +1,383 @@
+"""The Claude Code channel + interactive resource actions, end to end within one
+process: the store outbox/events queues, the kernel's `notify()` and action
+dispatch, the transport pump that turns outbox rows into
+`notifications/claude/channel` events, the `reply` tool, and the dashboard's SSE
+feed a resource's page subscribes to."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+import anyio
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from ix_notebook_mcp import dashboard, runtime, store, transport
+from ix_notebook_mcp.config import Config
+
+# --------------------------------------------------------------------------- #
+# store: the outbox and event queues
+# --------------------------------------------------------------------------- #
+
+
+def test_outbox_roundtrip_consumes_in_order(tmp_path: Path) -> None:
+    conn = store.connect(tmp_path / "c.db")
+    store.add_outbox(conn, content="first", meta="{}")
+    store.add_outbox(conn, content="second", meta=json.dumps({"severity": "high"}))
+    rows = store.take_outbox(conn)
+    assert [r["content"] for r in rows] == ["first", "second"]
+    assert json.loads(rows[1]["meta"]) == {"severity": "high"}
+    # take consumes: a second drain sees nothing (an event is emitted once).
+    assert store.take_outbox(conn) == []
+
+
+def test_events_stream_after_seq_and_live_gate(tmp_path: Path) -> None:
+    conn = store.connect(tmp_path / "c.db")
+    assert store.latest_event_seq(conn, "res1") == 0
+    store.add_event(conn, resource="res1", kind="reply", body=json.dumps({"text": "hi"}))
+    store.add_event(conn, resource="other", kind="reply", body=json.dumps({"text": "x"}))
+    start = store.latest_event_seq(conn, "res1")
+    store.add_event(conn, resource="res1", kind="action_result", body=json.dumps({"value": 1}))
+    rows = store.events_after(conn, "res1", start)
+    # Only res1's rows past the subscription point, never another resource's.
+    assert [r["kind"] for r in rows] == ["action_result"]
+
+    # The reply tool's gate: only a not-closed resource is live.
+    assert store.resource_live(conn, "res1") is False
+    store.upsert_resource(
+        conn, id="res1", title="t", kind="html", html="", status="live", created_at=1.0, updated_at=1.0
+    )
+    assert store.resource_live(conn, "res1") is True
+    store.close_resource(conn, id="res1", updated_at=2.0)
+    assert store.resource_live(conn, "res1") is False
+
+
+def test_mark_interrupted_clears_outbox_and_events(tmp_path: Path) -> None:
+    conn = store.connect(tmp_path / "c.db")
+    store.add_outbox(conn, content="stale", meta="{}")
+    store.add_event(conn, resource="r", kind="reply", body="{}")
+    store.mark_interrupted(conn, ended_at=123.0)
+    # A reopened session must not fire a dead kernel's pushes or replay its feed.
+    assert store.take_outbox(conn) == []
+    assert store.events_after(conn, "r", 0) == []
+
+
+# --------------------------------------------------------------------------- #
+# runtime: notify() and interactive resource actions (the kernel end)
+# --------------------------------------------------------------------------- #
+
+
+def _wire_runtime(monkeypatch: pytest.MonkeyPatch, conn: sqlite3.Connection) -> None:
+    monkeypatch.setattr(runtime, "_store", store)
+    monkeypatch.setattr(runtime, "_store_conn", conn)
+    runtime.input_channels.clear()
+    runtime.resources.clear()
+
+
+def test_notify_queues_event_with_stringified_meta(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+        await runtime.notify("build failed", severity="high", run_id=1234)
+        rows = store.take_outbox(conn)
+        assert len(rows) == 1
+        assert rows[0]["content"] == "build failed"
+        # Values are stringified: they become <channel> tag attributes.
+        assert json.loads(rows[0]["meta"]) == {"severity": "high", "run_id": "1234"}
+
+    asyncio.run(run())
+
+
+def test_notify_rejects_non_identifier_meta_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+        # Claude Code silently drops hyphenated keys; we fail loudly at source.
+        with pytest.raises(ValueError, match="meta keys"):
+            await runtime.notify("x", **{"run-id": "1"})
+        assert store.take_outbox(conn) == []
+
+    asyncio.run(run())
+
+
+def test_notify_without_store_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        monkeypatch.setattr(runtime, "_store", None)
+        monkeypatch.setattr(runtime, "_store_conn", None)
+        with pytest.raises(RuntimeError, match="no store"):
+            await runtime.notify("x")
+
+    asyncio.run(run())
+
+
+def test_interactive_resource_injects_wiring_script(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        monkeypatch.setenv("IX_MCP_DATA_API_URL", "http://node:9000/")
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+        res = runtime.register_resource(
+            render=lambda: "<button>go</button>", id="panel", actions={"go": lambda p: p}
+        )
+        html = await res.render_html()
+        # The page gets ix.act/ix.events without including anything itself.
+        assert "x.act=function" in html
+        assert "x.events=function" in html
+        assert "http://node:9000/api/input" in html
+        assert "http://node:9000/api/resources/panel/events" in html
+        # Pin the ix.act POST body shape: the kernel dispatcher reads exactly these
+        # keys (action/call/payload), so a rename in the injected script that this
+        # substring misses would break the real browser path while the dispatch
+        # test (which hand-builds the same dict) still passed.
+        assert "body:JSON.stringify({channel:C,payload:{action:a,call:id," in html
+        assert html.endswith("<button>go</button>")
+        # A plain resource stays untouched.
+        plain = runtime.register_resource(render=lambda: "<p>hi</p>", id="plain")
+        assert await plain.render_html() == "<p>hi</p>"
+        res.close()
+
+    asyncio.run(run())
+
+
+def test_interactive_resource_id_must_be_script_safe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+        # An id carrying </script> would break out of the injected <script> (XSS in
+        # the pane) and a slash would miss the SSE route, so an interactive id is
+        # restricted to [A-Za-z0-9._-].
+        with pytest.raises(ValueError, match="interactive resource id"):
+            runtime.register_resource(
+                render=lambda: "x", id="a</script><img src=x>", actions={"go": lambda p: p}
+            )
+        with pytest.raises(ValueError, match="interactive resource id"):
+            runtime.register_resource(render=lambda: "x", id="a/b", actions={"go": lambda p: p})
+        # A plain (non-interactive) resource never reaches the script/route, so it
+        # still accepts any id.
+        plain = runtime.register_resource(render=lambda: "x", id="a/b weird")
+        assert plain.id == "a/b weird"
+        plain.close()
+
+    asyncio.run(run())
+
+
+def test_action_dispatch_runs_handler_and_streams_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+
+        async def double(payload: dict) -> dict:
+            return {"doubled": payload["n"] * 2}
+
+        def boom(_payload: object) -> None:
+            raise RuntimeError("kaput")
+
+        res = runtime.register_resource(
+            render=lambda: "x", id="panel", actions={"double": double, "boom": boom}
+        )
+        channel = res._action_channel
+        assert channel is not None
+
+        async def act(name: str, payload: object) -> None:
+            # Simulate the page's ix.act landing via /api/input, then the drain.
+            store.add_input(
+                conn,
+                channel=channel.id,
+                payload=json.dumps({"action": name, "call": "c1", "payload": payload}),
+            )
+            runtime._drain_inputs()
+
+        async def feed_after(start: int) -> list[dict]:
+            for _ in range(200):
+                rows = store.events_after(conn, "panel", start)
+                if rows:
+                    return rows
+                await asyncio.sleep(0.005)
+            raise AssertionError("no event arrived")
+
+        seq = store.latest_event_seq(conn, "panel")
+        await act("double", {"n": 21})
+        rows = await feed_after(seq)
+        body = json.loads(rows[-1]["body"])
+        assert rows[-1]["kind"] == "action_result"
+        assert body == {"action": "double", "call": "c1", "value": {"doubled": 42}}
+
+        # A raising handler streams an error event, and the dispatcher survives.
+        seq = store.latest_event_seq(conn, "panel")
+        await act("boom", None)
+        rows = await feed_after(seq)
+        assert rows[-1]["kind"] == "error"
+        assert "kaput" in json.loads(rows[-1]["body"])["error"]
+
+        # An unknown action is an error event too, never a silent drop.
+        seq = store.latest_event_seq(conn, "panel")
+        await act("ghost", None)
+        rows = await feed_after(seq)
+        assert "no such action" in json.loads(rows[-1]["body"])["error"]
+
+        # close() tears down the channel so a stale page cannot queue more work.
+        res.close()
+        assert channel.closed()
+
+    asyncio.run(run())
+
+
+def test_reregistering_id_closes_previous_action_channel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+        first = runtime.register_resource(render=lambda: "a", id="panel", actions={"a": lambda p: p})
+        old_channel = first._action_channel
+        assert old_channel is not None
+        second = runtime.register_resource(render=lambda: "b", id="panel", actions={"b": lambda p: p})
+        # The replaced resource's channel is closed; the new one is live.
+        assert old_channel.closed()
+        assert first.closed()
+        assert second._action_channel is not None
+        assert not second._action_channel.closed()
+        second.close()
+
+    asyncio.run(run())
+
+
+# --------------------------------------------------------------------------- #
+# transport: the outbox pump emits notifications/claude/channel
+# --------------------------------------------------------------------------- #
+
+
+def test_channel_capability_is_advertised() -> None:
+    from ix_notebook_mcp.tools import mcp
+
+    opts = mcp._mcp_server.create_initialization_options(
+        experimental_capabilities=transport.CHANNEL_CAPABILITIES
+    )
+    assert opts.capabilities.experimental is not None
+    assert "claude/channel" in opts.capabilities.experimental
+
+
+class _FakeSession:
+    """Just enough of ServerSession for the pump's initialized gate."""
+
+    def __init__(self, *, initialized: bool) -> None:
+        from mcp.server.session import InitializationState
+
+        self._initialization_state = (
+            InitializationState.Initialized if initialized else InitializationState.NotInitialized
+        )
+
+
+def test_pump_outbox_emits_channel_notifications(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        db = tmp_path / "p.db"
+        conn = store.connect(db)
+        cfg = Config(workdir=tmp_path, store_path=db)
+        monkeypatch.setattr("ix_notebook_mcp.transport.config", lambda: cfg)
+        store.add_outbox(conn, content="hello agent", meta=json.dumps({"severity": "high"}))
+        send, receive = anyio.create_memory_object_stream(8)
+        pump = asyncio.ensure_future(transport.pump_outbox(send, _FakeSession(initialized=True)))
+        try:
+            message = await asyncio.wait_for(receive.receive(), timeout=5.0)
+        finally:
+            pump.cancel()
+        wire = message.message.root
+        assert wire.method == "notifications/claude/channel"
+        assert wire.params == {"content": "hello agent", "meta": {"severity": "high"}}
+        # The row was consumed: a redelivery cannot happen.
+        assert store.take_outbox(conn) == []
+
+    asyncio.run(run())
+
+
+def test_pump_outbox_holds_events_until_initialized(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        db = tmp_path / "p.db"
+        conn = store.connect(db)
+        cfg = Config(workdir=tmp_path, store_path=db)
+        monkeypatch.setattr("ix_notebook_mcp.transport.config", lambda: cfg)
+        store.add_outbox(conn, content="early", meta="{}")
+        send, receive = anyio.create_memory_object_stream(8)
+        # An un-initialized session must not have the row emitted: the MCP lifecycle
+        # forbids server notifications before `initialized`, and the row must be held
+        # (not dropped) for later delivery.
+        pump = asyncio.ensure_future(transport.pump_outbox(send, _FakeSession(initialized=False)))
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(receive.receive(), timeout=1.0)
+            # The event is still queued, waiting for the handshake.
+            assert len(store.take_outbox(conn)) == 1
+        finally:
+            pump.cancel()
+
+    asyncio.run(run())
+
+
+# --------------------------------------------------------------------------- #
+# dashboard: the SSE feed a resource's page subscribes to
+# --------------------------------------------------------------------------- #
+
+
+def test_sse_streams_new_events_only(tmp_path: Path) -> None:
+    async def run() -> None:
+        db = tmp_path / "sse.db"
+        conn = store.connect(db)
+        cfg = Config(workdir=tmp_path, store_path=db)
+        # History from before the subscription must not replay.
+        store.add_event(conn, resource="panel", kind="reply", body=json.dumps({"text": "old"}))
+        client = TestClient(TestServer(dashboard.build_app(cfg, conn)))
+        await client.start_server()
+        try:
+            async with client.get("/api/resources/panel/events") as resp:
+                assert resp.status == 200
+                assert resp.headers["Content-Type"].startswith("text/event-stream")
+                assert resp.headers["Access-Control-Allow-Origin"] == "*"
+                # The comment frame arrives first (EventSource open).
+                line = await asyncio.wait_for(resp.content.readline(), timeout=5.0)
+                assert line.startswith(b":")
+                store.add_event(conn, resource="panel", kind="reply", body=json.dumps({"text": "new"}))
+                while True:
+                    line = await asyncio.wait_for(resp.content.readline(), timeout=5.0)
+                    if line.startswith(b"data: "):
+                        break
+                event = json.loads(line[len(b"data: "):])
+                assert event["kind"] == "reply"
+                assert event["text"] == "new"
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+# --------------------------------------------------------------------------- #
+# tools: the reply tool writes to the feed, gated on a live resource
+# --------------------------------------------------------------------------- #
+
+
+def test_reply_tool_appends_event_for_live_resource(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        from mcp.shared.exceptions import McpError
+
+        from ix_notebook_mcp import tools
+
+        db = tmp_path / "reply.db"
+        conn = store.connect(db)
+        cfg = Config(workdir=tmp_path, store_path=db)
+        monkeypatch.setattr("ix_notebook_mcp.tools.config", lambda: cfg)
+        monkeypatch.setattr(tools, "_reply_conn", None)
+        monkeypatch.setattr(tools, "_dashboard_started", True)
+
+        # An unknown/closed resource is refused loudly, and nothing is written.
+        with pytest.raises(McpError, match="no live resource"):
+            await tools.reply(resource="ghost", text="hi")
+        assert store.events_after(conn, "ghost", 0) == []
+
+        store.upsert_resource(
+            conn, id="panel", title="t", kind="html", html="", status="live", created_at=1.0, updated_at=1.0
+        )
+        out = await tools.reply(resource="panel", text="deployed ✓")
+        assert out[0].text == "sent"
+        rows = store.events_after(conn, "panel", 0)
+        assert [(r["kind"], json.loads(r["body"])["text"]) for r in rows] == [("reply", "deployed ✓")]
+
+    asyncio.run(run())


### PR DESCRIPTION
## What

Makes the index MCP server a **Claude Code channel** (research preview, v2.1.80+): kernel code can push events into the running agent session, and interactive resources can run Python from a button click and converse back with the agent. Closes #1728.

Contract verified against [channels-reference](https://code.claude.com/docs/en/channels-reference) and the official `fakechat` plugin source.

## How it works

- **`notify(content, **meta)`** builtin → a store `outbox` row → the stdio transport pumps it as a `notifications/claude/channel` event, which lands in the session as `<channel source="index" key="val">content</channel>`. Meta keys are validated `[A-Za-z0-9_]+` (Claude Code silently drops non-identifier keys), values stringified.
- The transport advertises `capabilities.experimental["claude/channel"]` and **holds every push until the client's `initialized`** (MCP lifecycle SHOULD-NOT emit server notifications before then). To gate, it mirrors `Server.run` to hold the live `ServerSession`, with a `_can_hold_session` guard that falls back to plain `run()` if SDK internals ever move.
- **`register_resource(..., actions={name: handler})`** serves the resource HTML with `ix.act(name, payload)` and `ix.events(fn)` (SSE) pre-injected: a click queues the payload for the in-kernel handler (riding the existing `/api/input` network-gated path), the handler can `notify(..., resource=<id>)` to wake the agent, and its result streams back to the page. Interactive resource ids are restricted to `[A-Za-z0-9._-]` (they land in a `<script>` body and a URL path).
- **`reply(resource, text)`** MCP tool writes to the resource's event feed (the standard two-way channel reply), gated on a live resource. `dashboard.py` serves the feed at `GET /api/resources/{id}/events` (SSE).

## Testing

- `tests/test_channel.py` — 15 tests: store queues (delete-before-deliver), `notify` + meta-key validation, action dispatch + error/unknown paths, interactive-id safety, pump wire shape **and the initialized gate**, reply-tool gate, SSE new-events-only.
- **Live e2e** against a spawned `ix-mcp serve`: `initialize` advertises `experimental: {"claude/channel": {}}`, and after the real handshake a `notify('e2e hello', severity='high', run_id='42')` emitted a real `notifications/claude/channel` frame with `{content, meta}` intact.
- `strictTypecheck` + repo lint green. (The aiohttp-`TestServer` tests can't bind a loopback socket under the nix Darwin sandbox — same as the existing `inputsTests` — so `channelTests` was validated with `--option sandbox false`; it runs sandboxed in CI on Linux.)

Reviewed by two adversarial passes; both confirmed blockers (a `</script>` XSS breakout via resource id, and the pre-`initialized` send) are fixed.

## Launch (research preview)

```
claude --dangerously-load-development-channels server:index
```

Custom channels aren't on Anthropic's allowlist yet, so the dev flag is required; a session without it drops events silently (additive — the server is unchanged when unused).

_(opened by Claude Code on Andrew's behalf)_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude Code channel support with push notifications, interactive resource actions, and reply tool to ix-mcp
> - Adds a `notify()` kernel builtin that enqueues channel events to the store's `outbox` table, which the stdio transport drains and delivers as `notifications/claude/channel` MCP notifications once the session is initialized.
> - Adds interactive resource support in [runtime.py](https://github.com/indexable-inc/index/pull/1731/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95): resources registered with an `actions` map serve HTML pre-wired with `ix.act` and `ix.events`, accept POSTed action submissions, dispatch them to kernel handlers, and stream results/errors via a new SSE endpoint at `/api/resources/{id}/events`.
> - Adds a `reply` MCP tool in [tools.py](https://github.com/indexable-inc/index/pull/1731/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) that sends a text message to a live interactive resource page by appending a `reply` event to the store.
> - Extends [store.py](https://github.com/indexable-inc/index/pull/1731/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976) with `outbox` and `events` tables, plus helpers to enqueue, drain, append, and page through events; stale rows are cleared on kernel interruption.
> - Risk: the transport's `pump_outbox` loop introduces a background polling task on every stdio session; the channel notification method `notifications/claude/channel` is non-standard and requires Claude Code client support.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f845c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->