### PR TITLE
packages/agent/claude-code: load the index MCP server as a channel by default

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -122,6 +122,25 @@
       (import (ix.paths.packagesRoot + "/agent/common.nix") { inherit lib ix repoPackages; })
       .defaultServers,
 
+  # Claude Code "channels" (research preview, needs claude-code >= 2.1.80): MCP
+  # servers whose events push into the running session, so the agent reacts to
+  # things that happen while you are away. Our `index` server (baked above via
+  # `mcpServers`, packages/mcp) is a channel: kernel `notify(...)` and
+  # interactive-resource actions emit `notifications/claude/channel` events. It
+  # is our OWN stdio server, not on Anthropic's curated preview allowlist, so it
+  # loads with `--dangerously-load-development-channels` rather than `--channels`
+  # (the "dangerous" name is because a channel injects text into the session's
+  # context — a trust decision; here the source is our own baked server). Each
+  # entry is a channel spec: `server:<mcpServersKey>` or
+  # `plugin:<name>@<marketplace>`; baked as
+  # `--dangerously-load-development-channels <spec>...`. Defaults to the `index`
+  # server WHEN it is baked (so notify()/interactive resources reach a session
+  # with no per-launch flag), and to nothing otherwise (the overlay build has no
+  # `index` server, so referencing it would be a dead flag). A session whose org
+  # policy (`channelsEnabled`) disables channels, or that never receives a push,
+  # is unaffected. `[ ]` bakes no flag.
+  developmentChannels ? lib.optional (mcpServers ? index) "server:index",
+
   # Rule names dropped from the default house prompt (forwarded to
   # ../system-prompt.nix's `omitRules`). Only affects the computed `systemPrompt`
   # default below; ignored when `systemPrompt` is passed explicitly. Lets a
@@ -286,6 +305,16 @@ let
   wrapperFlags = [
     # Write ~/.claude/debug telemetry; cleanupPeriodDays controls retention.
     "--debug"
+  ]
+  # Load our own MCP servers as channels (research preview). This flag is
+  # VARIADIC (it consumes every following non-`--` token as a spec), so it must
+  # be followed by a `--`-prefixed flag — never placed last, where it would
+  # swallow the user's argv (a prompt, a subcommand). It sits here so the always-
+  # present `--thinking-display=` below terminates the spec list.
+  ++ lib.optionals (developmentChannels != [ ]) (
+    [ "--dangerously-load-development-channels" ] ++ developmentChannels
+  )
+  ++ [
     # Opus 4.7+ otherwise omits thinking from the UI/transcript.
     "--thinking-display=summarized"
   ]


### PR DESCRIPTION
## What

Load the **`index` MCP server as a Claude Code channel by default** in the wrapper, so kernel `notify(...)` and interactive-resource actions (added in #1731) push events into every normal session with no per-launch flag.

`index` is our own stdio server (baked via `mcpServers`), not on Anthropic's research-preview allowlist, so it must load with `--dangerously-load-development-channels` rather than `--channels`.

## How

- New `developmentChannels` option on `packages/agent/claude-code`, baked as `--dangerously-load-development-channels <spec>...`.
- Defaults to `server:index` **only when the `index` server is in `mcpServers`** (`lib.optional (mcpServers ? index) "server:index"`), so it's automatic in the flake package build and a no-op in the overlay build (where `index` isn't baked, referencing it would be a dead flag).
- The flag is **variadic** (consumes following non-`--` tokens as specs), so it's placed before the always-present `--thinking-display=` — never last, where it would swallow the user's argv.

A session whose org policy (`channelsEnabled`) disables channels, or that never receives a push, is unaffected.

## Testing

- `claude-code` build passes, including its `installCheck` `doctor` smoke that runs the **real binary with the flag baked** — proving arg parsing is intact.
- Headless `claude -p` through the built wrapper completes cleanly (exit 0) with the flag baked — no org-policy hard-fail.
- The argv install-check derives its expected argv from `wrapperFlags`, so it covers the new flag's ordering/tokenization automatically.
- Lint green.

## Note

Depends on the channel server support merged in #1731 (already on main). After this lands, a flake-update + home-manager switch picks it up; sessions then treat `index` as a channel automatically.

_(opened by Claude Code on Andrew's behalf)_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load the index MCP server as a development channel by default in claude-code wrapper
> - Adds a `developmentChannels` parameter to [default.nix](https://github.com/indexable-inc/index/pull/1733/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), defaulting to `["server:index"]` when an `index` entry exists in `mcpServers`, otherwise empty.
> - When `developmentChannels` is non-empty, appends `--dangerously-load-development-channels <specs>` to the wrapper flags at launch time.
> - Behavioral Change: any claude-code wrapper built with an `index` MCP server will now pass `--dangerously-load-development-channels server:index` by default without explicit configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f12b18a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->