### PR TITLE
packages/mcp: recommend notify() in interactive action handlers by default

### DIFF
--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -281,8 +281,10 @@ CHANNEL = (
     "`register_resource(render=..., actions={'name': handler})` serves the HTML with "
     "`ix.act(name, payload)` (queues the payload for the named in-kernel handler) and "
     "`ix.events(fn)` (subscribes the page to handler results, errors, and your replies) "
-    "pre-wired. A handler that calls `notify(..., resource=<id>)` wakes you when the page acts; "
-    "when a <channel> tag carries a `resource` attribute, answer it with the `reply` tool, "
+    "pre-wired. Call `notify(..., resource=<id>)` in every action handler by default: without "
+    "it the page↔kernel loop runs silently and you only learn the human acted by polling kernel "
+    "state. Skip it only when a click is purely page-local (a filter toggle, a re-render). "
+    "When a <channel> tag carries a `resource` attribute, answer it with the `reply` tool, "
     "passing that resource id — your transcript output never reaches the page."
 )
 

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1049,7 +1049,11 @@ def register_resource(
     Each ``ix.act`` queues its payload for the handler; the handler's return value
     (or error) streams back to the page as ``{kind: 'action_result', call, value}``
     on the feed ``ix.events(fn)`` subscribes to, alongside any agent ``reply``.
-    Pair a handler with :func:`notify` to wake the agent session on a click. For a
+    Call :func:`notify` (with ``resource=<id>``) in every handler by default, as
+    above: it is the only way the agent session learns the human acted (the
+    page<->kernel loop runs without the agent, so an unwired handler means the
+    agent must poll kernel state). Skip it only for purely page-local
+    interactions. For a
     simple one-question form, :func:`ask` is still the shortcut; the lower-level
     :class:`Input` + ``.script`` path also still works. A cross-origin ``fetch``
     to the data API DOES work from the sandbox (that is how input flows back);


### PR DESCRIPTION
Closes #1736.

Interactive resources' page↔kernel loop runs without the agent; unless a handler calls `notify(..., resource=<id>)` the agent only learns the human acted by polling kernel state (observed live with a tic-tac-toe resource). Make wiring `notify` the default guidance in the `register_resource` docstring and the CHANNEL server instructions; purely page-local interactions are the stated exception.

Docs/prompt only, no behavior change.

🤖 Generated with Claude Code (Opus)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recommend calling `notify()` by default in interactive action handlers
> Updates guidance text in [guide.py](https://github.com/indexable-inc/index/pull/1738/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) and the `register_resource` docstring in [runtime.py](https://github.com/indexable-inc/index/pull/1738/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) to recommend calling `notify(resource=<id>)` in every action handler by default. Previously, `notify` was described as optional; without it, the page↔kernel loop runs silently and the agent must poll for updates. The exception for purely page-local interactions is retained.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56ea1eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->