### PR TITLE
panes: enable compositor gpu feature in the guest image (linux-dmabuf for venus WSI, #1686)

### DIFF
--- a/packages/vm/panes/compositor/Cargo.toml
+++ b/packages/vm/panes/compositor/Cargo.toml
@@ -38,13 +38,17 @@ smithay = { version = "0.7", default-features = false, features = [
 vsock = "0.5"
 
 [features]
+# `gpu` is a default feature because the guest image is the sole consumer of
+# this binary and its venus Vulkan clients need the linux-dmabuf global for
+# Wayland WSI (VK_KHR_swapchain, index#1686); the cargo unit graph builds
+# with default features, so this is the knob that puts the dmabuf path in
+# the image. GPU-less runs (CI, plain boots) still work: the GLES/EGL stack
+# loads libEGL at runtime through `libloading` (no link-time GL dependency),
+# and without a render node the compositor logs and stays shm-only (no
+# dmabuf global, so clients fall back to shm themselves).
+default = ["gpu"]
 # linux-dmabuf readback for GL/Vulkan clients via a surfaceless GLES context
-# on a DRM render node (/dev/dri/renderD128). Off by default: CI and the
-# first integration run without a GPU, and the shm path must never depend on
-# GL. The GLES/EGL stack loads libEGL at runtime through `libloading`, so
-# even with the feature on there is no link-time GL dependency; without a
-# render node the compositor logs and stays shm-only (no dmabuf global, so
-# clients fall back to shm themselves).
+# on a DRM render node (/dev/dri/renderD128).
 gpu = ["smithay/backend_drm", "smithay/backend_egl", "smithay/renderer_gl"]
 
 [lints]

--- a/packages/vm/panes/compositor/src/compositor/gpu.rs
+++ b/packages/vm/panes/compositor/src/compositor/gpu.rs
@@ -10,6 +10,8 @@
 //! `libloading`), so a GPU-less machine still runs the shm-only binary.
 
 use anyhow::Context as _;
+// `Dmabuf::format` comes from the allocator `Buffer` trait.
+use smithay::backend::allocator::Buffer as _;
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::allocator::format::FormatSet;

--- a/packages/vm/panes/compositor/src/compositor/gpu.rs
+++ b/packages/vm/panes/compositor/src/compositor/gpu.rs
@@ -7,7 +7,9 @@
 //! `EGL_EXT_platform_device`): no DRM master, no KMS, no output, so it works
 //! on a bare render node like virtio-gpu's /dev/dri/renderD128 inside the
 //! VM. libEGL is dlopen'd at runtime (smithay's `backend_egl` uses
-//! `libloading`), so a GPU-less machine still runs the shm-only binary.
+//! `libloading`), and `Gpu::try_new` degrades gracefully, so the same binary
+//! (built with this feature, the default) runs shm-only on a GPU-less
+//! machine: no render node means no linux-dmabuf global is advertised.
 
 use anyhow::Context as _;
 // `Dmabuf::format` comes from the allocator `Buffer` trait.
@@ -73,11 +75,29 @@ impl Gpu {
         Ok(Self { renderer })
     }
 
-    /// Formats to advertise on the linux-dmabuf global: exactly what the
-    /// GLES renderer can import, so a client-created buffer is importable by
-    /// construction.
+    /// Formats to advertise on the linux-dmabuf global: the renderer's
+    /// importable set restricted to the 32-bpp RGBA family `readback` can
+    /// actually serve. The renderer imports far more (10/16-bit, YUV), but a
+    /// client that picked one of those would hit a readback error and show a
+    /// permanently black window — dmabuf clients don't fall back to shm once
+    /// they've bound the global.
     pub fn formats(&self) -> FormatSet {
-        self.renderer.dmabuf_formats()
+        const SERVABLE: [Fourcc; 8] = [
+            Fourcc::Argb8888,
+            Fourcc::Xrgb8888,
+            Fourcc::Abgr8888,
+            Fourcc::Xbgr8888,
+            Fourcc::Rgba8888,
+            Fourcc::Rgbx8888,
+            Fourcc::Bgra8888,
+            Fourcc::Bgrx8888,
+        ];
+        self.renderer
+            .dmabuf_formats()
+            .iter()
+            .filter(|format| SERVABLE.contains(&format.code))
+            .copied()
+            .collect()
     }
 
     /// Validation import for `DmabufHandler::dmabuf_imported`.
@@ -111,18 +131,23 @@ impl Gpu {
             .context("copy texture")?;
         let bytes = self.renderer.map_texture(&mapping).context("map texture")?;
         let mut bgra = bytes.to_vec();
+        // Everything downstream (row repack, force-opaque, FrameStore::commit)
+        // assumes tightly packed width*height*4; commit's debug_assert is
+        // stripped in release, so this is the only guard between a padded or
+        // truncated readback and a corrupt frame on the wire.
+        let stride = usize::try_from(width).context("texture width exceeds usize")? * 4;
+        let expected = stride * usize::try_from(height).context("texture height exceeds usize")?;
+        anyhow::ensure!(
+            stride > 0 && bgra.len() == expected,
+            "readback of {} bytes is not tightly packed {width}x{height}x4",
+            bgra.len()
+        );
         // GLES readback is bottom-up (smithay's `GlesMapping::flipped()` is
         // unconditionally true) while the wire is top-down; ship it as-is and
         // every dmabuf window renders upside down on the host. Repack rows in
         // reverse, keyed on `flipped()` so a future non-flipped mapping stays
         // correct.
         if mapping.flipped() {
-            let stride = usize::try_from(width).context("texture width exceeds usize")? * 4;
-            anyhow::ensure!(
-                stride > 0 && bgra.len() % stride == 0,
-                "readback of {} bytes is not whole {stride}-byte rows",
-                bgra.len()
-            );
             let mut top_down = Vec::with_capacity(bgra.len());
             for row in bgra.rchunks_exact(stride) {
                 top_down.extend_from_slice(row);

--- a/packages/vm/panes/guest-image/nixos.nix
+++ b/packages/vm/panes/guest-image/nixos.nix
@@ -245,7 +245,17 @@ in
       # The socket dir is a tmpfiles.d entry (see above), not a
       # RuntimeDirectory; order after tmpfiles so it exists on first start.
       after = [ "systemd-tmpfiles-setup.service" ];
-      environment = clientEnv;
+      environment = clientEnv // {
+        # The compositor's `gpu` readback path dlopens `libEGL.so.1` at
+        # runtime (smithay's `backend_egl` via libloading; deliberately no
+        # link-time GL dep, so no rpath to resolve it). That soname is
+        # libglvnd's dispatcher, which nixpkgs compiles with
+        # /run/opengl-driver/share/glvnd/egl_vendor.d as its vendor-config
+        # default and mesa's vendor JSON points at the store absolutely, so
+        # the dispatcher alone is enough to land in the venus EGL driver
+        # hardware.graphics provides.
+        LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.libglvnd ];
+      };
       serviceConfig = {
         ExecStart = lib.getExe pkgs.panes-compositor;
         Restart = "on-failure";


### PR DESCRIPTION
Enables the panes-compositor `gpu` cargo feature in the guest image so venus Vulkan clients get a `linux-dmabuf` global — the Wayland-WSI-over-dma-buf half of the missing `VK_KHR_swapchain` (see the latest #1686 comment for the measured gap).

## What
- **`gpu` is now a default feature** of `panes-compositor`. The cargo unit graph (`lib/rust/cargo-unit.nix`) generates `cargo build --unit-graph` with no `--no-default-features` and has no per-package feature knob, so default features ARE the graph's feature selection; no build-system plumbing needed. The guest image is the sole consumer and needs the dmabuf path; GPU-less runs still degrade to shm-only at runtime (libEGL via libloading, no link-time GL dep).
- **Fix a latent compile error** in the never-CI-built gpu path (`Dmabuf::format` needs `smithay::backend::allocator::Buffer` in scope).
- **Put libglvnd on the compositor service's loader path**: smithay dlopens `libEGL.so.1` (the glvnd dispatcher), which nothing else provided; nixpkgs libglvnd defaults its vendor search to `/run/opengl-driver/share/glvnd/egl_vendor.d` and mesa's vendor JSON is store-absolute, so `LD_LIBRARY_PATH=libglvnd/lib` is the whole fix. Without it the gpu init panics-and-degrades to shm-only (observed on the first boot smoke).

## Validation (aarch64 builder VM + boot smoke on hydra)
- `nix build .#packages.aarch64-linux.panes-compositor` and `.#packages.aarch64-linux.panes-guest-image` via `ssh-ng://vm`: green.
- Booted the image with `vmkit boot-linux --disk /tmp/gpu-test.raw --gpu ...` (fresh copy, distinct vsock socket; live demo untouched). Console log:
  - `panes-compositor[966]: INFO panes_compositor::compositor: GPU readback ready; linux-dmabuf advertised`
  - venus intact: `deviceName = Virtio-GPU Venus (Apple M5 Max)`, `driverName = venus`, `/dev/dri/renderD128` present.
- `nix run .#lint`: 7/7 green.

## VK_KHR_synchronization2 investigation (report-only, the other missing extension)
Versions in the stack (nixpkgs pin `a799d3e3`, what vmkit's rebuilt libkrun-efi 1.19.3 links):
- **MoltenVK 1.4.1** — supports sync2 since 1.2.6 (KhronosGroup/MoltenVK#2021, Sep 2023). **Not the blocker; no bump needed.**
- **virglrenderer `slp/virglrenderer` fork `0.10.4d-krunkit`** (vendored inside the nixpkgs libkrun-efi expression; newest fork tag `0.10.4e` only reverts a MoltenVK search-path change) — its venus protocol DOES support sync2 (`{"VK_KHR_synchronization2", 315, 1}` in `vn_protocol_renderer_info.h`, commands decoded in `vkr_command_buffer.c`). **Also not the blocker.**
- **Guest mesa 26.1.2 venus driver is the gate**: in `vn_physical_device_get_passthrough_extensions` (mesa `src/virtio/vulkan/vn_physical_device.c`), with WSI compiled in, `KHR_synchronization2 = can_sync2` where `can_sync2 = renderer_sync_fd.semaphore_importable` — i.e. the renderer must import SYNC_FD external semaphores. The macOS/MoltenVK host stack has no dma_fence/sync-file, so this is false, mesa masks sync2 and (same file, ~line 542) clamps the device to Vulkan 1.2. This is structural, not a version pin.

What a fix would take, in increasing effort:
1. **Guest-side sync2 emulation layer** (`VK_LAYER_KHRONOS_synchronization2` from Vulkan-ExtensionLayer, packaged in nixpkgs as `vulkan-extension-layer`): add it to the MC app container and enable the layer; it advertises the extension and translates sync2 to sync1 calls. No pin bumps, purely a guest-image/apps.nix change — the practical next step.
2. **Upstream mesa**: drop the sync-fd requirement per mesa's own code comment ("can be dropped by implementing external semaphore purely on the driver side").
3. **Renderer-side external sync on macOS** (venus renderer + libkrun): biggest lift, nothing actionable in our pins today.

Closes nothing; advances #1686.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable GPU/dmabuf support in the panes compositor guest image for Venus WSI
> - Enables the `gpu` feature by default in [compositor/Cargo.toml](https://github.com/indexable-inc/index/pull/1739/files#diff-1af2afa091810f2b5aaefb6b4fb7587a2b6e2e2995e14202d35ad08468105e39), so dmabuf/GLES readback support is compiled in without explicit feature flags.
> - Restricts advertised linux-dmabuf formats in `Gpu::formats` to 32-bpp RGBA-family codes (ARGB/XRGB/ABGR/XBGR/RGBA/RGBX/BGRA/BGRX), dropping 10/16-bit and YUV formats that readback cannot serve.
> - Adds strict validation in `Gpu::readback` requiring the mapped texture to be exactly `width * height * 4` bytes, preventing corrupt frames from padded or truncated mappings.
> - Sets `LD_LIBRARY_PATH` to libglvnd's library path in the guest compositor systemd service so `libEGL.so.1` is found at runtime via vendor dispatch.
> - Behavioral Change: the compositor now builds with GPU support by default; previously GPU was opt-in.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27ce548.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->