### PR TITLE
panes guest: VK_KHR_synchronization2 emulation layer for the MC container (#1686)

### DIFF
--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -103,6 +103,18 @@ in
       # virtio-gpu PCI device (1af4:1050) if more than one ICD is visible.
       VK_DRIVER_FILES = "${pkgs.mesa}/share/vulkan/icd.d/virtio_icd.aarch64.json";
       MESA_VK_DEVICE_SELECT = "1af4:1050!";
+      # 26.2's Vulkan backend hard-requires VK_KHR_synchronization2, which
+      # venus can never pass through on this host stack: mesa's venus driver
+      # (vn_physical_device.c, vn_physical_device_get_passthrough_extensions)
+      # gates sync2 on renderer-side SYNC_FD semaphore import, and the
+      # macOS/MoltenVK renderer has no sync files — no virglrenderer/MoltenVK
+      # pin bump changes that (MoltenVK itself has had sync2 since 1.2.6).
+      # Khronos' emulation layer advertises the extension and translates
+      # sync2 calls onto the core 1.2 venus device instead. The manifest's
+      # library_path is store-absolute, so VK_LAYER_PATH alone is enough for
+      # the loader inside the container.
+      VK_LAYER_PATH = "${pkgs.vulkan-extension-layer}/share/vulkan/explicit_layer.d";
+      VK_INSTANCE_LAYERS = "VK_LAYER_KHRONOS_synchronization2";
       XDG_SESSION_TYPE = "wayland";
       # nixpkgs openal (the portablemc wrapper's LD_LIBRARY_PATH provides it;
       # Maven's arm64 libopenal.so SIGSEGVs, so ./lwjgl-natives.nix omits it


### PR DESCRIPTION
Follow-up to #1739 (do not merge that first — independent branches): MC 26.2's Vulkan startup requires `VK_KHR_synchronization2`, which guest mesa venus can never offer over the MoltenVK host stack. Ship Khronos' emulation layer in the MC container so the device advertises it.

## What
`packages/vm/panes/guest-image/apps.nix`: add `VK_LAYER_PATH` (nixpkgs `vulkan-extension-layer`, manifests are store-absolute so the path alone suffices) and `VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_synchronization2` to the minecraft container env.

## Why a layer and not a mesa patch/fork (long-term rationale)
- The gate is structural: mesa `vn_physical_device.c` exposes sync2 only when the renderer imports SYNC_FD external semaphores; macOS/MoltenVK has no sync files. MoltenVK (>= 1.2.6) and the krunkit virglrenderer fork both already support sync2, so no pin bump helps.
- Force-patching `can_sync2 = true` in mesa would enable exactly the WSI+sync2 code paths mesa's comment warns rely on sync-fd import — risky for the swapchain work (#1739 stack), diverges from upstream, and drags a full local mesa rebuild + rebase across every nixpkgs bump.
- The Khronos layer is the supported mechanism for exactly this (1.3-feature apps on 1.2 drivers), is maintained upstream, and **self-retires**: `force_enable` defaults to false, so if a future mesa exposes sync2 natively the layer passes through and the env becomes inert.
- The real long-term fix is upstream mesa implementing driver-side external semaphores (their comment says the requirement "can be dropped"); this change is forward-compatible with that.

## Validation
- `nix run .#lint` green (7/7).
- Built the image on the aarch64 builder VM, booted under vmkit `--gpu` (fresh disk, vsock 7102; live demo untouched), and ran `vulkaninfo` **inside the minecraft container** with exactly this env via a scratch boot oneshot (not part of this PR). Console log:
```
VK_LAYER_KHRONOS_synchronization2 (Khronos Synchronization2 layer) Vulkan version 1.4.341, layer version 1:
        VK_KHR_synchronization2 : extension revision 1
deviceName        = Virtio-GPU Venus (Apple M5 Max)
driverName        = venus
VK_KHR_synchronization2 : extension revision 1   <- now in the venus device's extension list
```

Advances #1686 (with #1739, both MC-blocking extensions are now addressed).

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable VK_KHR_synchronization2 emulation layer in the MC container guest image
> Sets `VK_LAYER_PATH` and `VK_INSTANCE_LAYERS` environment variables in [apps.nix](https://github.com/indexable-inc/index/pull/1741/files#diff-a890cdfbf1cce913a32f1824d8badb40d6b06eb50aee87abc0bbdf1772968b64) to load the Khronos `VK_LAYER_KHRONOS_synchronization2` extension layer for Vulkan apps running in the guest environment. This causes the Vulkan loader to advertise and translate synchronization2 functionality via the emulation layer when the host GPU does not natively expose the extension.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1714426.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->