### PR TITLE
packages/mcp: Svelte 5 environment for interactive dashboard resources

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -472,6 +472,27 @@ let
         cp -r ${shPythonSource}/sh/. "$site/"
       ''
   );
+  # Svelte 5 components as live interactive resources: `import svelte`, then
+  # `await svelte.component("Board.svelte", id=..., actions=...)` compiles via
+  # the svelte-bundle CLI and registers the result, with the virtual `ix`
+  # module (`data`/`act`/`replies`) wired to the resource event feed. Pure
+  # Python; the compiler is the wrapped Node CLI above.
+  sveltePythonSource = builtins.path {
+    name = "ix-mcp-svelte-python-source";
+    path = ./src/svelte;
+  };
+  svelteModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-svelte-python-module"
+      {
+        strictDeps = true;
+        meta.description = "Svelte 5 resource components bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/svelte"
+        mkdir -p "$site"
+        cp -r ${sveltePythonSource}/svelte/. "$site/"
+      ''
+  );
   # Browser automation over CDP: `import browser`, then `await browser.goto(url)`
   # / `await browser.shot()` drive a Chromium-family browser already running with
   # --remote-debugging-port (the standard 9222 by default). Pure Python over the
@@ -769,6 +790,11 @@ let
   # the google-calendar crate (packages/google/calendar), so the MCP binding
   # carries no calendar logic of its own (RFC 0003).
   gcalBin = ix.rustWorkspace.units.binaries."gcal";
+
+  # The Svelte 5 -> one-IIFE-bundle compiler the `svelte` module spawns
+  # (IX_SVELTE_BUNDLE_BIN): esbuild + esbuild-svelte from the lockfile pin in
+  # ./svelte-bundle, so resource components need no network at view time.
+  svelteBundleBin = import ./svelte-bundle { inherit ix pkgs; };
 
   # `import CoreLocation` on Darwin: the pyobjc binding for Apple's Core Location
   # framework, so a session can read the Mac's current location with no install
@@ -1200,6 +1226,7 @@ let
       nixModule
       fleetModule
       shModule
+      svelteModule
       worktreeModule
       browserModule
       xModule
@@ -1260,6 +1287,7 @@ let
           --add-flags "-m ix_notebook_mcp" \
           --set IX_MCP_VERSION ${lib.escapeShellArg ix.rev} \
           --set PLAYWRIGHT_BROWSERS_PATH ${lib.escapeShellArg playwrightBrowsers} \
+          --set IX_SVELTE_BUNDLE_BIN ${lib.escapeShellArg (lib.getExe svelteBundleBin)} \
           --set IX_GCAL_BIN ${lib.escapeShellArg "${gcalBin}/bin/gcal"} \
           --set IX_DASHBOARD_BIN ${lib.escapeShellArg (lib.getExe' dashboardHubBin "dashboard")} \
           --set SCIPQL_SOUFFLE ${lib.escapeShellArg (lib.getExe' pkgs.souffle "souffle")} \
@@ -1277,6 +1305,7 @@ let
           --add-flags "-m ix_notebook_mcp notebook" \
           --set IX_MCP_VERSION ${lib.escapeShellArg ix.rev} \
           --set PLAYWRIGHT_BROWSERS_PATH ${lib.escapeShellArg playwrightBrowsers} \
+          --set IX_SVELTE_BUNDLE_BIN ${lib.escapeShellArg (lib.getExe svelteBundleBin)} \
           --set IX_GCAL_BIN ${lib.escapeShellArg "${gcalBin}/bin/gcal"} \
           --set IX_DASHBOARD_BIN ${lib.escapeShellArg (lib.getExe' dashboardHubBin "dashboard")} \
           --set SCIPQL_SOUFFLE ${lib.escapeShellArg (lib.getExe' pkgs.souffle "souffle")} \
@@ -5187,6 +5216,44 @@ let
         mkdir -p "$out"
       '';
 
+  # The whole Svelte resource path (packages/mcp/tests/test_svelte.py): the
+  # nix-built svelte-bundle CLI compiles a Svelte 5 component, a real sandboxed
+  # iframe renders the kernel-embedded state, `act` rides the real /api/input,
+  # and the action_result re-renders the page. Same interpreter + browser needs
+  # as inputBrowserSmoke, plus the CLI on IX_SVELTE_BUNDLE_BIN.
+  svelteTestPython = mcpPythonInterp.withPackages (
+    ps:
+    mcpPythonPackages ps
+    ++ [
+      ps.pytest
+    ]
+  );
+  svelteTestSource = builtins.path {
+    name = "ix-mcp-svelte-test";
+    path = ./tests/test_svelte.py;
+  };
+  svelteTests =
+    pkgs.runCommand "ix-mcp-svelte-tests"
+      {
+        nativeBuildInputs = [ svelteTestPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        export PLAYWRIGHT_BROWSERS_PATH=${lib.escapeShellArg playwrightBrowsers}
+        export FONTCONFIG_FILE=${fontsConf}
+        export IX_SVELTE_BUNDLE_BIN=${lib.escapeShellArg (lib.getExe svelteBundleBin)}
+        cp ${svelteTestSource} "$TMPDIR/test_svelte.py"
+        ${lib.getExe svelteTestPython} -m pytest "$TMPDIR/test_svelte.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp svelte tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
+
   screenBundled = importTest "screen" "import screen; print('screen-ok', all(callable(getattr(screen, n)) for n in ('capture', 'click', 'write', 'press', 'key_down', 'key_up', 'apps', 'frontmost', 'launch', 'activate', 'terminate', 'accessibility_trusted')))";
   coreLocationBundled = importTest "corelocation" "import CoreLocation; print('corelocation-ok', callable(CoreLocation.CLLocationManager.alloc))";
   scriptingBridgeBundled = importTest "scriptingbridge" "import ScriptingBridge; print('scriptingbridge-ok', callable(ScriptingBridge.SBApplication.applicationWithBundleIdentifier_))";
@@ -5460,6 +5527,7 @@ package.overrideAttrs (old: {
         inputsTests
         channelTests
         inputBrowserSmoke
+        svelteTests
         wedgeSmoke
         richSmoke
         yieldSmoke

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -5221,6 +5221,7 @@ let
   # iframe renders the kernel-embedded state, `act` rides the real /api/input,
   # and the action_result re-renders the page. Same interpreter + browser needs
   # as inputBrowserSmoke, plus the CLI on IX_SVELTE_BUNDLE_BIN.
+  svelteBundled = importTest "svelte" "import svelte; print('svelte-ok', callable(svelte.bundle), callable(svelte.component))";
   svelteTestPython = mcpPythonInterp.withPackages (
     ps:
     mcpPythonPackages ps
@@ -5527,6 +5528,7 @@ package.overrideAttrs (old: {
         inputsTests
         channelTests
         inputBrowserSmoke
+        svelteBundled
         svelteTests
         wedgeSmoke
         richSmoke

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -285,7 +285,12 @@ CHANNEL = (
     "it the page↔kernel loop runs silently and you only learn the human acted by polling kernel "
     "state. Skip it only when a click is purely page-local (a filter toggle, a re-render). "
     "When a <channel> tag carries a `resource` attribute, answer it with the `reply` tool, "
-    "passing that resource id — your transcript output never reaches the page."
+    "passing that resource id — your transcript output never reaches the page. For any "
+    "non-trivial UI, author a real Svelte 5 component instead of hand-rolled HTML/JS strings: "
+    "`await svelte.component(\"Board.svelte\", id=..., state=..., actions=...)` (module "
+    "`svelte`) compiles it to one self-contained bundle; the component imports "
+    "`{ data, act } from 'ix'` and re-renders reactively from the dict each handler returns, "
+    "so there is one renderer and kernel state stays the single source of truth."
 )
 
 CELLS = (

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1034,7 +1034,11 @@ def register_resource(
 
     Interactive (buttons/forms that run python): pass ``actions`` -- a dict of
     name -> handler (sync or async, called with the submitted payload). The HTML
-    is served with ``ix.act(name, payload)`` and ``ix.events(fn)`` pre-wired::
+    is served with ``ix.act(name, payload)`` and ``ix.events(fn)`` pre-wired.
+    For any non-trivial UI prefer ``svelte.component(...)`` (module ``svelte``)
+    over hand-written HTML/JS strings: it compiles a real Svelte 5 component to
+    a self-contained bundle over this same wiring, with one reactive renderer
+    instead of a server template plus a hand-rolled ``ix.events`` redraw. ::
 
         async def on_deploy(payload):
             run = await start_deploy(payload["env"])

--- a/packages/mcp/src/svelte/svelte/__init__.py
+++ b/packages/mcp/src/svelte/svelte/__init__.py
@@ -34,9 +34,9 @@ build step at view time.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import os
+import re
 import shutil
 import tempfile
 from collections.abc import Callable, Mapping
@@ -63,45 +63,65 @@ def _bin() -> str:
     return exe
 
 
-def _entry_path(source: str | os.PathLike[str]) -> Path:
+def _entry_path(source: str | os.PathLike[str]) -> tuple[Path, Path | None]:
     """An existing ``.svelte`` file passes through; anything that reads as
-    markup is written to a content-addressed temp file (inline components
-    cannot use relative imports; put multi-file components on disk)."""
+    markup is written into a fresh private ``mkdtemp`` dir (mode 0700,
+    unguessable: a predictable shared-/tmp path would be a symlink/TOCTOU
+    vector and a concurrent-write race). Returns ``(entry, tmpdir-to-delete)``.
+    Inline components cannot use relative imports; put multi-file components
+    on disk."""
     p = Path(source)
     try:
         if p.is_file():
-            return p
+            return p, None
     except OSError:  # a long inline source is not a valid path
         pass
     text = str(source)
     if "<" not in text and "{" not in text:
         raise SvelteError(f"no such .svelte file: {source!r}")
-    digest = hashlib.sha256(text.encode()).hexdigest()[:16]
-    out = Path(tempfile.gettempdir()) / f"ix-svelte-{digest}" / "Component.svelte"
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(text)
-    return out
+    tmpdir = Path(tempfile.mkdtemp(prefix="ix-svelte-"))
+    entry = tmpdir / "Component.svelte"
+    entry.write_text(text)
+    return entry, tmpdir
 
 
 async def bundle(source: str | os.PathLike[str], *, minify: bool = False) -> str:
     """Compile a Svelte 5 component to one self-contained IIFE bundle (JS text)."""
-    entry = _entry_path(source)
+    entry, tmpdir = _entry_path(source)
     argv = [_bin(), str(entry), *(["--minify"] if minify else [])]
-    proc = await asyncio.create_subprocess_exec(
-        *argv,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    out, err = await proc.communicate()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await proc.communicate()
+    finally:
+        if tmpdir is not None:
+            shutil.rmtree(tmpdir, ignore_errors=True)
     if proc.returncode != 0:
         raise SvelteError(f"svelte-bundle failed for {entry}:\n{err.decode(errors='replace')}")
     return out.decode()
 
 
-def _inline_safe(text: str) -> str:
-    # `</script` inside an inline <script> ends the tag early; `<\/script` is
-    # byte-identical inside JS/JSON strings.
-    return text.replace("</script", "<\\/script")
+def _inline_js_safe(js: str) -> str:
+    # Two HTML script-data sequences can escape an inline <script>: `</script`
+    # (case-insensitive) closes it, and `<!--` enters the escaped state where a
+    # later `<script` swallows following tags. Both rewrites are byte-identical
+    # inside JS strings; outside a string either sequence is (at worst) a loud
+    # syntax error instead of silent tag breakout. The bundle is author-trusted
+    # (same trust domain as kernel code), so this guards accidents, not attacks;
+    # untrusted data belongs in the state seed, which `_seed_json` fully escapes.
+    return re.sub(r"(?i)<(/script)", r"<\\\1", js).replace("<!--", "<\\!--")
+
+
+def _seed_json(value: object) -> str:
+    # In JSON output `<` only ever occurs inside string literals, so escaping
+    # it as `\u003c` is always valid and blocks every script-data breakout
+    # (`</script`, `<!--`, `<script`) regardless of case or context. State may
+    # carry untrusted bytes (handlers fold in external data), so this is the
+    # real injection boundary.
+    return json.dumps(value, default=str).replace("<", "\\u003c")
 
 
 async def component(
@@ -120,15 +140,14 @@ async def component(
     callable re-read on each pane refresh. Re-calling with the same ``id``
     recompiles and replaces the resource (the edit loop).
     """
-    js = _inline_safe(await bundle(source, minify=minify))
+    js = _inline_js_safe(await bundle(source, minify=minify))
     state_fn = state if callable(state) else (lambda: state or {})
 
     async def _render() -> str:
         s = state_fn()
         if asyncio.iscoroutine(s):
             s = await s
-        seed = _inline_safe(json.dumps(s, default=str))
-        return f"<script>window.__IX_STATE__ = {seed};</script><script>{js}</script>"
+        return f"<script>window.__IX_STATE__ = {_seed_json(s)};</script><script>{js}</script>"
 
     from ix_notebook_mcp.runtime import register_resource
 

--- a/packages/mcp/src/svelte/svelte/__init__.py
+++ b/packages/mcp/src/svelte/svelte/__init__.py
@@ -1,0 +1,135 @@
+"""Svelte 5 components as live interactive dashboard resources.
+
+Author real components instead of hand-rolled HTML/JS strings::
+
+    import svelte
+
+    res = await svelte.component(
+        "Board.svelte",              # a .svelte file, or inline component source
+        id="checkers", title="checkers",
+        state=lambda: game_state,    # dict (or callable returning one)
+        actions={"move": on_move},   # same contract as register_resource
+    )
+
+The component imports the virtual ``ix`` module::
+
+    <script>
+      import { data, act, replies, error } from 'ix';
+    </script>
+    <h1>count: {$data.count}</h1>
+    <button onclick={() => act('bump', { by: 1 })}>+1</button>
+
+``$data`` is the resource state: seeded from ``state`` at render, replaced by
+every action handler's returned dict (the ``action_result`` event the page
+already receives). ``act`` queues a payload for the named in-kernel handler,
+``replies`` collects agent ``reply`` messages, ``error`` is the last action
+error. One renderer, kernel state as the single source of truth.
+
+Compilation shells out to the ``svelte-bundle`` CLI (esbuild + esbuild-svelte,
+``IX_SVELTE_BUNDLE_BIN`` on the wrapper): one self-contained IIFE bundle with
+injected CSS, so the sandboxed opaque-origin iframe needs no network and no
+build step at view time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ix_notebook_mcp.runtime import Resource
+
+__all__ = ["SvelteError", "bundle", "component"]
+
+
+class SvelteError(RuntimeError):
+    """svelte-bundle failed (compile error, or the CLI is not wired up)."""
+
+
+def _bin() -> str:
+    exe = os.environ.get("IX_SVELTE_BUNDLE_BIN") or shutil.which("svelte-bundle")
+    if not exe:
+        raise SvelteError(
+            "svelte-bundle CLI not found: IX_SVELTE_BUNDLE_BIN is unset and no "
+            "`svelte-bundle` on PATH (it is set on the ix-mcp wrapper)"
+        )
+    return exe
+
+
+def _entry_path(source: str | os.PathLike[str]) -> Path:
+    """An existing ``.svelte`` file passes through; anything that reads as
+    markup is written to a content-addressed temp file (inline components
+    cannot use relative imports; put multi-file components on disk)."""
+    p = Path(source)
+    try:
+        if p.is_file():
+            return p
+    except OSError:  # a long inline source is not a valid path
+        pass
+    text = str(source)
+    if "<" not in text and "{" not in text:
+        raise SvelteError(f"no such .svelte file: {source!r}")
+    digest = hashlib.sha256(text.encode()).hexdigest()[:16]
+    out = Path(tempfile.gettempdir()) / f"ix-svelte-{digest}" / "Component.svelte"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text)
+    return out
+
+
+async def bundle(source: str | os.PathLike[str], *, minify: bool = False) -> str:
+    """Compile a Svelte 5 component to one self-contained IIFE bundle (JS text)."""
+    entry = _entry_path(source)
+    argv = [_bin(), str(entry), *(["--minify"] if minify else [])]
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    if proc.returncode != 0:
+        raise SvelteError(f"svelte-bundle failed for {entry}:\n{err.decode(errors='replace')}")
+    return out.decode()
+
+
+def _inline_safe(text: str) -> str:
+    # `</script` inside an inline <script> ends the tag early; `<\/script` is
+    # byte-identical inside JS/JSON strings.
+    return text.replace("</script", "<\\/script")
+
+
+async def component(
+    source: str | os.PathLike[str],
+    *,
+    id: str,
+    title: str | None = None,
+    state: Mapping[str, Any] | Callable[[], Any] | None = None,
+    actions: Mapping[str, Any] | None = None,
+    minify: bool = False,
+) -> Resource:
+    """Compile ``source`` and register it as a live interactive resource.
+
+    ``state`` seeds ``window.__IX_STATE__`` (the ``data`` store's initial
+    value) on every render: pass the dict your action handlers return, or a
+    callable re-read on each pane refresh. Re-calling with the same ``id``
+    recompiles and replaces the resource (the edit loop).
+    """
+    js = _inline_safe(await bundle(source, minify=minify))
+    state_fn = state if callable(state) else (lambda: state or {})
+
+    async def _render() -> str:
+        s = state_fn()
+        if asyncio.iscoroutine(s):
+            s = await s
+        seed = _inline_safe(json.dumps(s, default=str))
+        return f"<script>window.__IX_STATE__ = {seed};</script><script>{js}</script>"
+
+    from ix_notebook_mcp.runtime import register_resource
+
+    return register_resource(render=_render, id=id, title=title or id, actions=actions)

--- a/packages/mcp/svelte-bundle/cli.mjs
+++ b/packages/mcp/svelte-bundle/cli.mjs
@@ -38,14 +38,21 @@ if (!fs.existsSync(entryAbs)) {
   process.exit(2);
 }
 
-// Generated wrapper entry: mount the component on the iframe body. Svelte 5
-// `mount` replaces the class-component `new App(...)` API. Resource HTML is
-// often scripts-only, which the parser executes from <head> before <body>
-// exists, so defer the mount until the DOM is ready.
+// Generated wrapper entry. Svelte 5 `mount` replaces the class-component
+// `new App(...)` API. Resource HTML is often scripts-only, which the parser
+// executes from <head> before <body> exists, so defer the mount until the DOM
+// is ready. Mount into the script's containing element when it sits in the
+// body (ix-windows wraps producer HTML in a measured #ix-content div, and a
+// body-mounted app would land outside it and size the window to nothing);
+// scripts hoisted into <head> fall back to document.body.
 const wrapper = `
   import { mount } from "svelte";
   import App from ${JSON.stringify(entryAbs)};
-  const boot = () => mount(App, { target: document.body });
+  const script = document.currentScript;
+  const boot = () => {
+    const host = script?.parentElement;
+    mount(App, { target: host && document.body.contains(host) ? host : document.body });
+  };
   if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);
   else boot();
 `;

--- a/packages/mcp/svelte-bundle/cli.mjs
+++ b/packages/mcp/svelte-bundle/cli.mjs
@@ -46,8 +46,8 @@ const wrapper = `
   import { mount } from "svelte";
   import App from ${JSON.stringify(entryAbs)};
   const boot = () => mount(App, { target: document.body });
-  if (document.body) boot();
-  else document.addEventListener("DOMContentLoaded", boot);
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);
+  else boot();
 `;
 
 const ixModule = {

--- a/packages/mcp/svelte-bundle/cli.mjs
+++ b/packages/mcp/svelte-bundle/cli.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// svelte-bundle: compile one Svelte 5 component into a self-contained IIFE
+// bundle for the sandboxed (opaque-origin, no network) resource iframe.
+//
+//   svelte-bundle Entry.svelte            # bundle JS on stdout
+//   svelte-bundle Entry.svelte --out f.js # write to file
+//   svelte-bundle Entry.svelte --json     # {"js": ..., "warnings": [...]} on stdout
+//
+// The entry component is mounted on document.body. CSS is injected at runtime
+// (compilerOptions.css "injected"), so the output is exactly one <script>
+// payload. The virtual `ix` module (see ./ix.js) resolves to the runtime
+// wiring around window.ix / window.__IX_STATE__.
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs";
+import { parseArgs } from "node:util";
+import esbuild from "esbuild";
+import sveltePlugin from "esbuild-svelte";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const { values: opts, positionals } = parseArgs({
+  allowPositionals: true,
+  options: {
+    out: { type: "string" },
+    json: { type: "boolean", default: false },
+    minify: { type: "boolean", default: false },
+  },
+});
+const entry = positionals[0];
+if (!entry || positionals.length !== 1) {
+  console.error("usage: svelte-bundle <Entry.svelte> [--out file] [--json] [--minify]");
+  process.exit(2);
+}
+const entryAbs = path.resolve(entry);
+if (!fs.existsSync(entryAbs)) {
+  console.error(`svelte-bundle: no such file: ${entryAbs}`);
+  process.exit(2);
+}
+
+// Generated wrapper entry: mount the component on the iframe body. Svelte 5
+// `mount` replaces the class-component `new App(...)` API. Resource HTML is
+// often scripts-only, which the parser executes from <head> before <body>
+// exists, so defer the mount until the DOM is ready.
+const wrapper = `
+  import { mount } from "svelte";
+  import App from ${JSON.stringify(entryAbs)};
+  const boot = () => mount(App, { target: document.body });
+  if (document.body) boot();
+  else document.addEventListener("DOMContentLoaded", boot);
+`;
+
+const ixModule = {
+  name: "ix-virtual-module",
+  setup(build) {
+    build.onResolve({ filter: /^ix$/ }, () => ({
+      path: path.join(here, "ix.js"),
+    }));
+  },
+};
+
+let result;
+try {
+  result = await esbuild.build({
+    stdin: {
+      contents: wrapper,
+      resolveDir: path.dirname(entryAbs),
+      sourcefile: "__ix_mount__.js",
+      loader: "js",
+    },
+    bundle: true,
+    write: false,
+    format: "iife",
+    target: "es2020",
+    minify: opts.minify,
+    // Resolve `svelte` (and the compiled output's svelte/internal imports)
+    // against OUR locked node_modules regardless of where the entry component
+    // lives; node_modules never exists next to a kernel temp file.
+    nodePaths: [path.join(here, "node_modules")],
+    // Resolve the `svelte` export condition first so component libraries ship
+    // their uncompiled source to our compiler (per esbuild-svelte docs).
+    mainFields: ["svelte", "browser", "module", "main"],
+    conditions: ["svelte", "browser"],
+    plugins: [
+      ixModule,
+      sveltePlugin({ compilerOptions: { css: "injected" } }),
+    ],
+    logLevel: "silent",
+  });
+} catch (err) {
+  // esbuild already formats its errors; print them and fail loudly.
+  for (const e of err.errors ?? []) {
+    const loc = e.location ? `${e.location.file}:${e.location.line}:${e.location.column}: ` : "";
+    console.error(`error: ${loc}${e.text}`);
+  }
+  if (!err.errors?.length) console.error(String(err));
+  process.exit(1);
+}
+
+const js = result.outputFiles[0].text;
+const warnings = result.warnings.map((w) => ({
+  text: w.text,
+  file: w.location?.file ?? null,
+  line: w.location?.line ?? null,
+}));
+for (const w of warnings) {
+  console.error(`warning: ${w.file ?? "?"}:${w.line ?? "?"}: ${w.text}`);
+}
+
+if (opts.json) {
+  process.stdout.write(JSON.stringify({ js, warnings }));
+} else if (opts.out) {
+  fs.writeFileSync(opts.out, js);
+} else {
+  process.stdout.write(js);
+}

--- a/packages/mcp/svelte-bundle/default.nix
+++ b/packages/mcp/svelte-bundle/default.nix
@@ -1,0 +1,35 @@
+# svelte-bundle: compile a Svelte 5 component into one self-contained IIFE
+# bundle for the sandboxed resource iframe (opaque origin, no network), with
+# the virtual `ix` module wired to window.ix / window.__IX_STATE__.
+#
+# Deps come from the lockfile pin in this directory via the same importNpmLock
+# machinery the web trees use (see packages/wrangler-cli); cli.mjs and ix.js
+# are ours and run with Node from the store.
+{
+  ix,
+  pkgs,
+}:
+let
+  nodeModules = pkgs.importNpmLock.buildNodeModules {
+    npmRoot = ./.;
+    nodejs = pkgs.nodejs_22;
+    derivationArgs = {
+      pname = "svelte-bundle-node-modules";
+      strictDeps = true;
+    };
+  };
+  source = pkgs.runCommand "svelte-bundle-src" { strictDeps = true; } ''
+    mkdir -p "$out"
+    cp ${./cli.mjs} "$out/cli.mjs"
+    cp ${./ix.js} "$out/ix.js"
+    ln -s ${nodeModules}/node_modules "$out/node_modules"
+  '';
+in
+ix.writeBashApplication pkgs {
+  name = "svelte-bundle";
+  runtimeInputs = [ pkgs.nodejs_22 ];
+  text = ''
+    exec node ${source}/cli.mjs "$@"
+  '';
+  meta.description = "Svelte 5 component -> one self-contained IIFE bundle for dashboard resources";
+}

--- a/packages/mcp/svelte-bundle/ix.js
+++ b/packages/mcp/svelte-bundle/ix.js
@@ -1,0 +1,45 @@
+// The virtual `ix` module Svelte resource components import. Resolved at
+// bundle time by cli.mjs, so `import { data, act, replies } from 'ix'` works
+// inside any component with no package install.
+//
+// It rides the wiring `Resource.script` injects into interactive resource
+// HTML (`window.ix.act` / `window.ix.events`, see
+// ix_notebook_mcp/runtime.py) and the initial state the kernel embeds as
+// `window.__IX_STATE__`. Event shapes come from `Resource._dispatch_actions`
+// and the `reply` tool:
+//   {kind:'action_result', action, call, value}
+//   {kind:'error',         action, call, error}
+//   {kind:'reply',         text}
+//
+// Named `data`, not `state`: `$state` is a rune in Svelte 5, while `$data`
+// stays free for the store auto-subscription syntax.
+import { writable } from "svelte/store";
+
+/** Current resource state: seeded from the kernel's embedded initial state,
+ * replaced by every action handler's returned dict. Subscribe with `$data`. */
+export const data = writable(globalThis.__IX_STATE__ ?? {});
+
+/** Agent `reply` messages, newest last. Subscribe with `$replies`. */
+export const replies = writable([]);
+
+/** Last action error (string) or null. Cleared on the next successful action. */
+export const error = writable(null);
+
+/** Queue `payload` for the named in-kernel action handler. */
+export function act(name, payload = {}) {
+  return globalThis.ix.act(name, payload);
+}
+
+globalThis.ix.events((ev) => {
+  if (!ev || typeof ev !== "object") return;
+  if (ev.kind === "action_result") {
+    error.set(null);
+    if (ev.value && typeof ev.value === "object" && !Array.isArray(ev.value)) {
+      data.set(ev.value);
+    }
+  } else if (ev.kind === "error") {
+    error.set(ev.error ?? String(ev));
+  } else if (ev.kind === "reply") {
+    replies.update((r) => [...r, ev.text ?? ""]);
+  }
+});

--- a/packages/mcp/svelte-bundle/ix.js
+++ b/packages/mcp/svelte-bundle/ix.js
@@ -27,10 +27,16 @@ export const error = writable(null);
 
 /** Queue `payload` for the named in-kernel action handler. */
 export function act(name, payload = {}) {
+  if (!globalThis.ix?.act) {
+    throw new Error(`ix.act(${JSON.stringify(name)}): this resource was registered without actions`);
+  }
   return globalThis.ix.act(name, payload);
 }
 
-globalThis.ix.events((ev) => {
+// A state-only component (svelte.component(..., actions=None)) gets no wiring
+// script, so window.ix never exists: its `data` store just keeps the embedded
+// seed and there is no event feed to subscribe to.
+globalThis.ix?.events((ev) => {
   if (!ev || typeof ev !== "object") return;
   if (ev.kind === "action_result") {
     error.set(null);

--- a/packages/mcp/svelte-bundle/package-lock.json
+++ b/packages/mcp/svelte-bundle/package-lock.json
@@ -1,0 +1,684 @@
+{
+  "name": "ix-svelte-bundle",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ix-svelte-bundle",
+      "version": "0.1.0",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "esbuild-svelte": "^0.9.3",
+        "svelte": "^5.0.0"
+      },
+      "bin": {
+        "svelte-bundle": "cli.mjs"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esbuild-svelte": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/esbuild-svelte/-/esbuild-svelte-0.9.5.tgz",
+      "integrity": "sha512-16FUSj64aiS28CCxYeK3hVxCyU4PwGBSkeArawAtnWSV7l0Gc+frIOP88MNj8Q7tDAGyEJAHT6OpOvM24BG46w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.19"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.17.0",
+        "svelte": ">=4.2.1 <6"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.13.tgz",
+      "integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/mcp/svelte-bundle/package.json
+++ b/packages/mcp/svelte-bundle/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ix-svelte-bundle",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Compile a Svelte 5 component into one self-contained IIFE bundle for sandboxed dashboard resources",
+  "bin": { "svelte-bundle": "cli.mjs" },
+  "dependencies": {
+    "esbuild": "^0.25.0",
+    "esbuild-svelte": "^0.9.3",
+    "svelte": "^5.0.0"
+  }
+}

--- a/packages/mcp/svelte-bundle/package.nix
+++ b/packages/mcp/svelte-bundle/package.nix
@@ -1,0 +1,3 @@
+{
+  id = "svelte-bundle";
+}

--- a/packages/mcp/tests/test_svelte.py
+++ b/packages/mcp/tests/test_svelte.py
@@ -42,6 +42,16 @@ COUNTER = """
 """
 
 
+# State-only: imports `data` but wires no actions, so the resource HTML
+# carries no window.ix wiring script at all.
+DISPLAY = """
+<script>
+  import { data } from 'ix';
+</script>
+<p id="msg">{$data.msg}</p>
+"""
+
+
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -68,6 +78,47 @@ def test_seed_json_blocks_script_data_breakout() -> None:
 def test_bundle_reports_compile_errors() -> None:
     with pytest.raises(svelte.SvelteError, match="svelte-bundle failed"):
         asyncio.run(svelte.bundle("<h1>{unclosed</h1>"))
+
+
+def test_state_only_component_mounts_inside_container(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No actions -> no window.ix wiring: the ix module must not throw on load,
+    and the app must mount inside the script's containing element (ix-windows
+    measures #ix-content for native window sizing, so a body-level mount would
+    render outside the measured wrapper)."""
+    pytest.importorskip("playwright")
+    from playwright.async_api import async_playwright
+
+    async def run() -> None:
+        conn = store.connect(tmp_path / "svelte.db")
+        monkeypatch.setattr(runtime, "_store", store)
+        monkeypatch.setattr(runtime, "_store_conn", conn)
+
+        res = await svelte.component(DISPLAY, id="svelte-test-display", state={"msg": "hello"})
+        body = await res.render_html()
+        assert "window.ix=window.ix" not in body  # state-only: no wiring script
+        wrapped = f'<div id="ix-content">{body}</div>'
+
+        try:
+            async with async_playwright() as p:
+                browser = await p.chromium.launch()
+                try:
+                    page = await browser.new_page()
+                    await page.set_content('<iframe id="f" sandbox="allow-scripts"></iframe>')
+                    await page.eval_on_selector("#f", "(el, html) => { el.srcdoc = html; }", wrapped)
+                    frame = page.frame_locator("#f")
+                    # the guarded ix module survived the missing window.ix and
+                    # rendered the kernel-embedded seed
+                    assert await frame.locator("#msg").text_content() == "hello"
+                    # mounted INSIDE the measured wrapper, not on document.body
+                    assert await frame.locator("#ix-content #msg").count() == 1
+                finally:
+                    await browser.close()
+        finally:
+            res.close()
+
+    asyncio.run(run())
 
 
 def test_component_click_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/mcp/tests/test_svelte.py
+++ b/packages/mcp/tests/test_svelte.py
@@ -12,6 +12,7 @@ re-renders from the ``action_result`` the real dispatcher emits.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import socket
 from pathlib import Path
@@ -50,7 +51,18 @@ def _free_port() -> int:
 def test_bundle_compiles_inline_component() -> None:
     js = asyncio.run(svelte.bundle(COUNTER))
     assert "__IX_STATE__" in js  # the virtual ix module got bundled in
-    assert "</script" not in svelte._inline_safe(js)
+    safe = svelte._inline_js_safe(js)
+    assert "</script" not in safe
+    assert "<!--" not in safe
+
+
+def test_seed_json_blocks_script_data_breakout() -> None:
+    # `<!--<script>` in a state string enters script-data-double-escaped and
+    # swallows the following bundle <script> if emitted verbatim (WHATWG
+    # tokenizer); the seed must never contain a raw `<`.
+    seed = svelte._seed_json({"note": "<!--<script></script>"})
+    assert "<" not in seed
+    assert json.loads(seed) == {"note": "<!--<script></script>"}
 
 
 def test_bundle_reports_compile_errors() -> None:

--- a/packages/mcp/tests/test_svelte.py
+++ b/packages/mcp/tests/test_svelte.py
@@ -1,0 +1,130 @@
+"""The Svelte resource environment, compile to click, through a REAL browser.
+
+``svelte.bundle`` shells out to the nix-built ``svelte-bundle`` CLI
+(``IX_SVELTE_BUNDLE_BIN``), so these tests skip when it is not wired up (plain
+`pytest` outside the nix sandbox without the wrapper env). What they close that
+no unit test can: a Svelte 5 component compiled by our CLI, mounted in the same
+sandboxed opaque-origin iframe the dashboard uses, renders the kernel-embedded
+initial state, sends ``ix.act`` through the REAL ``/api/input``, and reactively
+re-renders from the ``action_result`` the real dispatcher emits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+
+from ix_notebook_mcp import dashboard, runtime, store
+from ix_notebook_mcp.config import Config
+
+import svelte
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("IX_SVELTE_BUNDLE_BIN"),
+    reason="IX_SVELTE_BUNDLE_BIN not set (svelte-bundle CLI not wired up)",
+)
+
+COUNTER = """
+<script>
+  import { data, act } from 'ix';
+</script>
+<h1 id="count">{$data.count}</h1>
+<button id="bump" onclick={() => act('bump', { by: 1 })}>+1</button>
+<style>
+  h1 { color: rgb(158, 206, 106); }
+</style>
+"""
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def test_bundle_compiles_inline_component() -> None:
+    js = asyncio.run(svelte.bundle(COUNTER))
+    assert "__IX_STATE__" in js  # the virtual ix module got bundled in
+    assert "</script" not in svelte._inline_safe(js)
+
+
+def test_bundle_reports_compile_errors() -> None:
+    with pytest.raises(svelte.SvelteError, match="svelte-bundle failed"):
+        asyncio.run(svelte.bundle("<h1>{unclosed</h1>"))
+
+
+def test_component_click_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("playwright")
+    from playwright.async_api import async_playwright
+
+    async def run() -> None:
+        db = tmp_path / "svelte.db"
+        conn = store.connect(db)
+        port = _free_port()
+        base = f"http://127.0.0.1:{port}"
+        cfg = Config(workdir=tmp_path, store_path=db, host="127.0.0.1", dashboard_port=port)
+        runner = web.AppRunner(dashboard.build_app(cfg, conn))
+        await runner.setup()
+        await web.TCPSite(runner, "127.0.0.1", port).start()
+
+        monkeypatch.setenv("IX_MCP_DATA_API_URL", base)
+        monkeypatch.setattr(runtime, "_store", store)
+        monkeypatch.setattr(runtime, "_store_conn", conn)
+        runtime.input_channels.clear()
+
+        game = {"count": 41}
+
+        async def bump(payload: dict) -> dict:
+            game["count"] += int(payload["by"])
+            return dict(game)
+
+        res = await svelte.component(
+            COUNTER, id="svelte-test-counter", state=lambda: game, actions={"bump": bump}
+        )
+        body = await res.render_html()
+
+        try:
+            async with async_playwright() as p:
+                browser = await p.chromium.launch()
+                try:
+                    page = await browser.new_page()
+                    await page.set_content('<iframe id="f" sandbox="allow-scripts"></iframe>')
+                    await page.eval_on_selector("#f", "(el, html) => { el.srcdoc = html; }", body)
+                    frame = page.frame_locator("#f")
+
+                    # kernel-embedded initial state rendered by the component
+                    assert await frame.locator("#count").text_content() == "41"
+
+                    await frame.locator("#bump").click()
+                    # cross-origin fetch -> /api/input -> kernel drain -> handler
+                    for _ in range(100):
+                        runtime._drain_inputs()
+                        if game["count"] == 42:
+                            break
+                        await asyncio.sleep(0.05)
+                    assert game["count"] == 42, "act('bump') never reached the handler"
+
+                    # action_result streams back over SSE; $data re-renders
+                    for _ in range(100):
+                        if await frame.locator("#count").text_content() == "42":
+                            break
+                        await asyncio.sleep(0.05)
+                    assert await frame.locator("#count").text_content() == "42"
+
+                    # injected (scoped) CSS came along in the one bundle
+                    color = await frame.locator("#count").evaluate(
+                        "el => getComputedStyle(el).color"
+                    )
+                    assert color == "rgb(158, 206, 106)"
+                finally:
+                    await browser.close()
+        finally:
+            res.close()
+            await runner.cleanup()
+
+    asyncio.run(run())


### PR DESCRIPTION
Closes #1740.

Author interactive resources as real Svelte 5 components instead of HTML/JS in Python strings:

- **`svelte-bundle` CLI** (esbuild + esbuild-svelte, lockfile-pinned): `.svelte` → one self-contained IIFE bundle (CSS injected), safe for the sandboxed opaque-origin iframe, no network at view time.
- **Virtual `ix` module**: components `import { data, act, replies, error } from 'ix'`; `$data` re-renders reactively from the dict each action handler returns — one renderer, kernel state as the single source of truth.
- **`svelte` kernel module**: `await svelte.component(src, id=..., state=..., actions=...)` compiles + registers; inline source or `.svelte` files.
- **`svelteTests`** (in passthru.tests) proves compile → sandboxed-iframe mount → `ix.act` through the real `/api/input` → `action_result` SSE re-render → scoped CSS, in the nix sandbox.

Root-caused two mount gotchas (nodePaths for kernel temp-dir entries; DOMContentLoaded defer for scripts-only srcdoc executing from `<head>`).

Validated: `mcp` build, `strictTypecheck`, `channelTests`, `inputBrowserSmoke`, `svelteTests` all green locally on aarch64-darwin.

🤖 Generated with Claude Code (Opus)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Svelte 5 component support for interactive MCP dashboard resources
> - Adds a `svelte` Python module to the MCP interpreter that compiles Svelte 5 components to self-contained IIFE bundles and registers them as interactive resources via `svelte.component()`.
> - Adds a `svelte-bundle` CLI ([cli.mjs](https://github.com/indexable-inc/index/pull/1744/files#diff-e3d01654f28f4e2b7d5d8e801d77b1faa1c12800e8b567cc861fc6e9f06cef90)) built with esbuild and esbuild-svelte, packaged as a Nix derivation and injected into server/notebook wrappers via `IX_SVELTE_BUNDLE_BIN`.
> - Adds a virtual `ix` JS module ([ix.js](https://github.com/indexable-inc/index/pull/1744/files#diff-434c17c32a29415ddc60893b3916057d77f763f68c4499dce5beb2ed3f94d87e)) that exposes `{ data, act, replies, error }` Svelte stores, seeding state from `window.__IX_STATE__` and proxying actions through `window.ix.act`.
> - Includes HTML safety escaping for inline `<script>` injection and a pytest+Playwright end-to-end test covering compile, mount, and SSE-driven re-render.
> - Updates the CHANNEL guidance in [guide.py](https://github.com/indexable-inc/index/pull/1744/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) to document the new `svelte.component()` API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4797ac3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->