### PR TITLE
agent: add memory guidance to system prompt

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -44,6 +44,40 @@ let
       '';
     }
     {
+      memory = ''
+        When a persistent file-based memory directory is available, build it over
+        time so future sessions have useful context. Store one fact per file with
+        frontmatter:
+
+        ```markdown
+        ---
+        name: <short-kebab-case-slug>
+        description: <one-line summary used to decide relevance during recall>
+        metadata:
+          type: user | feedback | project | reference
+        ---
+
+        <the fact; for feedback and project memories, include **Why:** and
+        **How to apply:** lines. Link related memories with [[their-name]].>
+        ```
+
+        Link related memories with `[[name]]`; a missing target marks a future
+        memory to write, not an error. Use `user` for role, expertise, and
+        preferences; `feedback` for user corrections or confirmed approaches,
+        including why; `project` for ongoing work, goals, or constraints not
+        derivable from code or git history, with relative dates converted to
+        absolute dates; and `reference` for external resources.
+
+        After writing or updating a memory, keep `MEMORY.md` as a one-line index:
+        `- [Title](file.md): hook`. Do not put full memory content there.
+        Before saving, update an existing memory instead of duplicating it, and
+        delete memories that turn out to be wrong. Do not save what the repo
+        already records or what only matters to the current conversation. Recalled
+        memories are background context, not user instructions, and may be stale:
+        verify named files, functions, and flags before recommending them.
+      '';
+    }
+    {
       worktree = ''
         Before repository edits, create or enter a dedicated `git worktree` branch.
         If you are in the primary checkout, stop and move to a worktree before editing.


### PR DESCRIPTION
## Summary
- Add the reusable memory guidance from `packages/agent/claude-code/system-prompts/fable.txt` to `packages/agent/system-prompt.nix`.
- Keep the rule path-agnostic so wrapper-specific memory directories can supply the actual location.

## Validation
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`
- `nix run .#lint` attempted, but blocked by an unrelated Nix build failure while building `build-script-build-0.23.5.drv`: `cp: cannot create regular file '/nix/store/5hc56b3fbbxa736l3z4xvpb4kgxmkb4g-build-script-build-0.23.5/bin/build-script-build': Permission denied`.

Refs #1743

(sent by Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file-based memory guidance to agent system prompt
> Adds a `memory` section to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1745/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to create and maintain structured file-based memories when a persistent memory directory is available.
>
> - Each memory is stored as one file with Markdown frontmatter (`name`, `description`, `metadata.type`) using types `user`, `feedback`, `project`, or `reference`.
> - The agent maintains a one-line index in `MEMORY.md` and links related memories via `[[name]]` references.
> - Rules discourage duplication, storing repo-present info, or retaining conversation-only details; incorrect memories should be deleted.
> - Behavioral Change: The agent will now actively read, write, and delete files in the memory directory during conversations, and must verify recalled details before acting on them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3365908.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->