### PR TITLE
agent: own filed issues with a named agent per issue

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -199,8 +199,10 @@ let
         issue you could properly resolve yourself, also spawn a named background
         agent per issue (name it after the issue, e.g.
         `issue-1687-cross-ifd-roots`) to drive it to a merged fix, and note the
-        handoff on the issue. File-and-stop only when the fix needs a human
-        decision or is genuinely out of your reach.
+        handoff on the issue. Skip the spawn when the issue already has an
+        active owner or handoff note, or when pursuing it would silently expand
+        a deliberately bounded task the user gave you. File-and-stop only when
+        the fix needs a human decision or is genuinely out of your reach.
       '';
     }
     {

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -194,6 +194,16 @@ let
       '';
     }
     {
+      agentPerIssue = ''
+        Filing an issue is not the end of ownership. When you find or file an
+        issue you could properly resolve yourself, also spawn a named background
+        agent per issue (name it after the issue, e.g.
+        `issue-1687-cross-ifd-roots`) to drive it to a merged fix, and note the
+        handoff on the issue. File-and-stop only when the fix needs a human
+        decision or is genuinely out of your reach.
+      '';
+    }
+    {
       preV1 = ''
         This codebase is pre-v1. Prefer the correct API over compatibility. Migrate
         every call site in the same change. Add aliases, shims, or deprecated paths


### PR DESCRIPTION
Adds an `agentPerIssue` rule to the house system prompt, next to `tieToIssue`:

> Filing an issue is not the end of ownership. When you find or file an issue you could properly resolve yourself, also spawn a named background agent per issue (name it after the issue) to drive it to a merged fix, and note the handoff on the issue. File-and-stop only when the fix needs a human decision or is genuinely out of your reach.

Rendered output verified via the promptEval recipe (`nix eval --raw --impure ...`); rule key is omittable like its siblings; nixfmt clean.

🤖 Opened with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent-per-issue spawning instructions to system prompt
> Adds a new `agentPerIssue` entry to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1746/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) instructing the agent to spawn a named background agent for each resolvable issue it finds or files, named after the issue, with a handoff note recorded on the issue. The agent skips spawning if an active owner or handoff note already exists, or if doing so would expand a deliberately bounded task.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e08791.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->