### PR TITLE
agent: spawn named agents to fix discovered issues

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -285,6 +285,14 @@ let
       '';
     }
     {
+      proactiveIssueResolution = ''
+        When discovering an issue that you can reasonably resolve, spawn a named agent
+        to own and fix it rather than just filing it. Use Agent with a descriptive name
+        and targeted prompt. This keeps discovered problems from lingering and makes
+        progress visible to the user.
+      '';
+    }
+    {
       harness = ''
         Know the ${agentName} runtime. Text outside tools renders as GitHub-flavored
         Markdown. Cite code as `file_path:line_number`. Batch independent native tool

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -286,10 +286,10 @@ let
     }
     {
       proactiveIssueResolution = ''
-        When discovering an issue that you can reasonably resolve, spawn a named agent
-        to own and fix it rather than just filing it. Use Agent with a descriptive name
-        and targeted prompt. This keeps discovered problems from lingering and makes
-        progress visible to the user.
+        When discovering an issue that you can reasonably resolve, spawn a named
+        subagent with a descriptive name and targeted prompt to own and fix it
+        rather than just filing it. This keeps discovered problems from lingering
+        and makes progress visible to the user.
       '';
     }
     {


### PR DESCRIPTION
Add a new system prompt rule encouraging agents to spawn named agents to resolve discovered issues proactively rather than just filing them.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `proactiveIssueResolution` rule to agent system prompt to spawn named subagents for fixes
> Adds a new `proactiveIssueResolution` directive to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1747/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to spawn a named subagent with a descriptive name and targeted prompt when it discovers an issue it can reasonably fix, rather than just filing it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78d880a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->