### PR TITLE
fix(image): lock the guest nixpkgs registry pin with narHash

### DIFF
--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -66,6 +66,27 @@ let
       specialArgs.ix = ixSpecialArgs;
       modules = [
         { nixpkgs.pkgs = imagePkgs; }
+        {
+          # Pin the system flake registry so `nix shell nixpkgs#foo` resolves
+          # against the nixpkgs bundled in the image instead of fetching a
+          # fresh tarball from GitHub on every invocation (~40 MB download,
+          # 100k files extracted, 20+ minutes on VCFS).
+          #
+          # `narHash` locks the pin. Without it nix treats the `path:` input
+          # as mutable and re-hashes AND re-copies the whole ~45k-file tree
+          # into /nix/store on every eval; through the guest's virtiofs/VCFS
+          # store that is ~3 minutes per `nix eval`/`nix run`, ~1 s locked
+          # (measured in an `ix new` VM, 2026-07-02). `outPath` (a string)
+          # rather than the path value also keeps `toJSON` from copying a
+          # duplicate nixpkgs tree into the image closure. Lives here, not
+          # platform.nix, because only this scope sees the flake input's
+          # `narHash`.
+          nix.registry.nixpkgs.to = {
+            type = "path";
+            path = nixpkgs.outPath;
+            inherit (nixpkgs) narHash;
+          };
+        }
         ./platform.nix
         ./oci-layer.nix
         # Home Manager as a NixOS module. Per-tool XDG config (Nushell,

--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -525,20 +525,13 @@ in
     # keeps recent results for repeat invocations and bounds disk growth.
     # Optimise hardlinks duplicate store paths so the savings compound.
     nix = {
-      # Pin the system flake registry so `nix shell nixpkgs#foo` resolves
-      # against the nixpkgs bundled in the image instead of fetching a
-      # fresh tarball from GitHub on every invocation. Without this pin,
-      # the global registry's `github:NixOS/nixpkgs/nixpkgs-unstable`
-      # entry wins: nix downloads ~40 MB, extracts 100k files into
-      # /nix/store, and evaluates the entire tree — 20+ minutes on VCFS
-      # vs ~1 second with the pin. Every production NixOS VM deployment
-      # (microvm.nix, Devbox, fleet images) pins this.
-      registry.nixpkgs.to = {
-        type = "path";
-        inherit (pkgs) path;
-      };
-      # Also set NIX_PATH so legacy nix-shell / <nixpkgs> imports resolve
-      # without a channel subscription or network fetch.
+      # The system flake registry pin for `nixpkgs` lives in
+      # lib/image/default.nix (an inline module next to `nixpkgs.pkgs`),
+      # because locking it needs the flake input's `narHash`, which only
+      # that scope has.
+      #
+      # NIX_PATH so legacy nix-shell / <nixpkgs> imports resolve without a
+      # channel subscription or network fetch.
       nixPath = [ "nixpkgs=${pkgs.path}" ];
       settings = {
         experimental-features = [

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2903,6 +2903,17 @@ let
         assertion = lib.elemAt base.config.nix.settings.substituters 0 == "https://cache.ix.dev";
         message = "base profile should route Nix through cache.ix.dev before fallback substituters";
       }
+      {
+        assertion =
+          let
+            pin = base.config.nix.registry.nixpkgs.to;
+          in
+          pin.type == "path"
+          && pin.path == nixpkgs.outPath
+          && pin.narHash == nixpkgs.narHash
+          && builtins.isString pin.path;
+        message = "image nixpkgs registry pin must carry the input's narHash (an unlocked path: pin makes every in-VM nix eval re-copy the whole tree through VCFS, ~3 min per invocation) and use the outPath string so toJSON does not bake a duplicate nixpkgs into the image";
+      }
     ];
 
     factions = [


### PR DESCRIPTION
`nix run nixpkgs#hello` in a fresh `ix new` VM took 4m05s for a 7.6 MiB substitution; even a warm `nix eval nixpkgs#cowsay.outPath` was ~2m45s **per invocation**.

The system registry pinned nixpkgs as a bare `path:` flakeref. Unlocked path inputs are treated as mutable, so every flake command re-reads all ~45k nixpkgs files and streams a full copy back into `/nix/store` (guest kernel stacks: FUSE `create_new_entry`/`fuse_create_open` dominate). Through virtiofs->VCFS that is minutes; on ext4 it hides as ~1s, which is why nobody noticed.

Changes:
- move the registry pin from `platform.nix` to `lib/image/default.nix` (the only scope that sees the flake input's `narHash`) and lock it: `path = nixpkgs.outPath; inherit (nixpkgs) narHash;`
- `outPath` (string) instead of the path value also stops `toJSON` from copying a duplicate nixpkgs tree (`v6c6...-pfwrb65...-source`) into every image closure
- eval test asserting the pin carries the input's narHash and a string path

Validation:
- in-guest (VM `slownix-debug`): `nix registry add` with the same narHash pin -> eval drops 2m45s -> **1.0s**, still 1.0s with a wiped fetcher cache (no first-run penalty)
- `nix eval .#lib --apply` on this branch renders `etc/nix/registry.json` with `narHash` matching flake.lock and the direct `-source` path
- `nix run .#lint` green

Closes #1748

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lock guest nixpkgs registry pin with `narHash` in image config
> - Moves `nix.registry.nixpkgs.to` from [platform.nix](https://github.com/indexable-inc/index/pull/1749/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7) into a new inline NixOS module in [default.nix](https://github.com/indexable-inc/index/pull/1749/files#diff-3883253618b080892e770f4ceb96188ed814f4f588df529f7a82d338874c14bd), setting `type = "path"`, `path = nixpkgs.outPath`, and `narHash = nixpkgs.narHash`.
> - The `narHash` lock ensures registry lookups resolve to the exact store path without network access and with content verification.
> - Adds an assertion in [tests/default.nix](https://github.com/indexable-inc/index/pull/1749/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that validates the pin carries the correct `narHash`, `outPath`, and `type`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1141bbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->