### PR TITLE
cross: cache-push the cross lane's eval-time IFD closure (#1687)

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -680,6 +680,36 @@ let
       ) crossEntries
     )
   );
+  # The eval-time IFD closure of each cross target's unit graph. A Mac cannot
+  # *build* a Linux→Darwin cross output, but the Darwin package aliases force it
+  # to *evaluate* the cross derivation, and that eval imports the rendered
+  # `cargo-units.nix` (which is generated from `cargo-unit-graph.json`, itself
+  # generated from the vendor dir). Those three are build-time deps of the cross
+  # outputs, so `attic push` of the outputs' *runtime* closures never carries
+  # them (RFC 0009's substitute-or-nothing trap: #1687). Publishing them lets a
+  # Mac substitute the IFD outputs instead of trying to build x86_64-linux drvs
+  # at eval; because these are input-addressed drvs, their eval-time out paths
+  # are known, so cache-push's probe sees the same paths a Mac's eval demands.
+  # Keyed by distinct cross target (the unit graph is shared per target, not per
+  # package), derived from `crossEntries` so a new cross target or entry joins
+  # this set with no hand-kept list. Same Linux-host gate as `crossPackages`:
+  # the cross graphs only build on the Linux host that owns the cross lane.
+  crossIfdRoots = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (
+    let
+      crossTargets = lib.unique (lib.concatMap (entry: entry.cross.targets) crossEntries);
+      rootsForTarget =
+        target:
+        let
+          units = crossWorkspace.unitsFor { inherit target; };
+        in
+        {
+          "cross-ifd-${target}-units-nix" = units.unitsNix;
+          "cross-ifd-${target}-unit-graph" = units.unitGraphJson;
+          "cross-ifd-${target}-vendor-dir" = units.vendorDir;
+        };
+    in
+    lib.mergeAttrsList (map rootsForTarget crossTargets)
+  );
   darwinPackageAliases = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (
     lib.genAttrs (lib.attrNames darwinTargetsBySystem) (
       darwinSystem:
@@ -1288,6 +1318,11 @@ in
   #      so realising them would rebuild ~all the archives. Drop them and add the
   #      fleet node `toplevel` closures directly, so the closures those checks used
   #      to drag in stay cached without ever building a tar.
+  #   3. The cross lane's eval-time IFD outputs (`crossIfdRoots`): the rendered
+  #      `cargo-units.nix`, its `cargo-unit-graph.json`, and the vendor dir a Mac
+  #      forces at eval when it substitutes a Darwin cross output. These are
+  #      build-time deps of the cross packages, so they are absent from those
+  #      packages' runtime closures; adding them as roots is the fix for #1687.
   cachePushRoots =
     let
       # Per-node `health-check-*` lifecycle packages and the two
@@ -1305,7 +1340,7 @@ in
         ) fleet.systemPackages
       ) exampleFleets;
     in
-    imagesAsClosures // exampleNodeToplevels;
+    imagesAsClosures // exampleNodeToplevels // crossIfdRoots;
 
   inherit darwinPackageAliases;
 

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -702,6 +702,13 @@ let
         let
           units = crossWorkspace.unitsFor { inherit target; };
         in
+        # These three ARE the whole eval-time closure: the `import unitsNix`
+        # forces `unitsNix`, which references only `unitGraphJson` and `vendorDir`
+        # (the cargo-lock it also reads is a plain flake source path, always
+        # present). `cargo-vendor-config.toml` is not a fourth root: it is a
+        # build input of the `unitGraphJson` builder, not on the import path and
+        # not in `vendorDir`'s closure, so substituting `unitGraphJson`'s output
+        # makes it moot -- the Mac never runs that builder.
         {
           "cross-ifd-${target}-units-nix" = units.unitsNix;
           "cross-ifd-${target}-unit-graph" = units.unitGraphJson;


### PR DESCRIPTION
## What

Adds the cross lane's eval-time IFD closure to `cachePushRoots.x86_64-linux` so cache-push publishes it, fixing the substitute-or-nothing failure a Mac hits when it evaluates a Darwin cross output.

## Why (#1687)

The #1680 Darwin aliases only work if a Mac can *evaluate* the cross derivation. That eval forces the Rust unit-graph IFD: it `import`s the rendered `cargo-units.nix` (← `cargo-unit-graph.json` ← vendor dir). Those are **build-time** deps of the cross outputs, so `attic push` of the outputs' *runtime* closures never carries them. A Mac then falls into RFC 0009's substitute-or-nothing trap:

```
error: Cannot build '/nix/store/…-cargo-unit-graph.json.drv'
error: Cannot build '/nix/store/…-rust-minimal-1.96.0.drv'
… while evaluating the attribute 'dag-runner-aarch64-apple-darwin'
```

## How

New `crossIfdRoots` merged into `cachePushRoots.x86_64-linux`, exposing per-cross-target `unitsNix` / `unitGraphJson` / `vendorDir`. Keyed by distinct cross target (the unit graph is shared per target, not per package) and derived from `crossEntries`, so a new target/entry joins with no hand-kept list. Same Linux-host gate as `crossPackages`. These are input-addressed drvs, so their eval-time out paths are known and cache-push's probe publishes exactly the paths a Mac's eval demands.

## Validation

- `nix eval .#cachePushRoots.x86_64-linux --apply builtins.attrNames` on vin-compute-1 includes the new `cross-ifd-*` roots.
- The new roots realise (build) on vin.
- drv-path comparison: the IFD drvs vin realises match what a Mac's eval demands (input-addressed → identical paths).

End-to-end Mac substitution proof waits on ix#5994 (cache.ix.dev 404s freshly pushed narinfos), tracked separately; this PR does not gate on a live Mac test.

🤖 Filed by Claude Code (Opus 4.8) on Andrew's behalf


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cross-lane eval-time IFD closure roots to `cachePushRoots` on Linux
> - Introduces `crossIfdRoots` in [per-system.nix](https://github.com/indexable-inc/index/pull/1751/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683), computed only on Linux hosts, that collects per-target IFD outputs (`unitsNix`, `unitGraphJson`, `vendorDir`) for all discovered cross targets.
> - Appends `crossIfdRoots` to `cachePushRoots` so these derivations are included in cache push alongside existing image closures and example node toplevels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e028d81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->