### PR TITLE
cross: input-address the cross unit graph so darwin substitutes it (#1755)

### DIFF
--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -342,6 +342,17 @@ let
       }
       // lib.optionalAttrs isCross {
         inherit target;
+        # Input-address the cross graph (the native graph keeps cargo-unit's
+        # `contentAddressed = true` default). A floating-CA output has no
+        # eval-time path, so substituting it requires the substituter's
+        # `/realisations` build trace to map drv hash -> output path -- and
+        # cache.ix.dev (atticd behind ncps) serves narinfos only, 404ing that
+        # endpoint. A Mac evaluating a Darwin cross alias therefore planned a
+        # local x86_64-linux cross build it cannot run (#1755). Input-addressed
+        # drvs carry concrete out paths at eval, so the Mac substitutes via
+        # plain narinfo, and cache-push's probe can skip already-pushed cross
+        # roots instead of always re-realising them.
+        contentAddressed = false;
         # rust-overlay toolchain carrying the cross target's `rust-std`. The
         # native graph keeps `cargo-unit`'s default (nixpkgs cargo + rustc).
         rustToolchain = rustToolchainFor workspacePkgs {

--- a/packages/site/src/lib/rfcs/0009-cross-compiled-darwin-packages.svx
+++ b/packages/site/src/lib/rfcs/0009-cross-compiled-darwin-packages.svx
@@ -151,7 +151,7 @@ The merge covers both Darwin systems, but with the Apple-silicon-only default th
 
 ### Substitution
 
-The `cache-push` workflow realises `.#cachePushRoots.x86_64-linux` and pushes closures to the public `ix-public` atticd cache at `cache.ix.dev` on every merge to main. The triple-suffixed cross outputs are part of that roots set. Because the Darwin aliases *are* those derivations, a Mac's `nix build .#dag-runner` resolves to a store path CI already pushed: substitution, not compilation. Publication is by derivation, not eval-time output path, because the Rust workspace defaults to floating content-addressed outputs that have no path until realised.
+The `cache-push` workflow realises `.#cachePushRoots.x86_64-linux` and pushes closures to the public `ix-public` atticd cache at `cache.ix.dev` on every merge to main. The triple-suffixed cross outputs are part of that roots set. Because the Darwin aliases *are* those derivations, a Mac's `nix build .#dag-runner` resolves to a store path CI already pushed: substitution, not compilation. The cross unit graph is input-addressed (unlike the native workspace's floating content-addressed default), so every cross output path is known at eval and the Mac substitutes it via a plain narinfo lookup — the cache serves no `/realisations` build trace, which a floating content-addressed output would need to map its derivation to an output path (#1755).
 
 ### Proved in CI, on every push
 


### PR DESCRIPTION
Fixes #1755.

With #1687's eval-time IFD closure cached (#1751), a Mac gets through eval of `github:indexable-inc/index#dag-runner` but the final cross output still does not substitute: the workspace unit drvs and the final `dag-runner-0.1.0` cross drv were floating content-addressed, so darwin must resolve drv->output through the substituter's `/realisations/<id>.doi` build trace, and cache.ix.dev (atticd behind ncps) 404s that endpoint (attic has no build-trace support; `nix copy` does not propagate realisations either, NixOS/nix#6623). The output NAR itself was in the cache; only the drv->output mapping was missing, so nix planned a ~96-drv local cross build and died on x86_64-linux-only apple-sdk toolchain drvs.

Fix: input-address the cross lane only. `mkUnits` passes `contentAddressed = false` into `cargoUnit.buildWorkspace` when `isCross`, so every cross out path is known at eval and darwin substitutes via plain narinfo. Side benefit: cache-push's already-cached probe can now skip pushed cross roots instead of always re-realising them (CA roots have no eval-time path).

The native graph and its unit identities are unchanged (`contentAddressed` is read only by the `units.nix` render stage; the native default stays `true`). Cross drv hashes change, including the #1687 `cross-ifd-*` roots' units-nix render; that is expected.

Verified on vin-compute-1 (x86_64-linux):
- `nix eval .#packages.x86_64-linux.dag-runner-aarch64-apple-darwin.drvPath` -> input-addressed `57pjsqpb...-dag-runner-0.1.0.drv`; `nix derivation show` gives `outputs.out.path = fzhlaxbq...-dag-runner-0.1.0`
- `nix eval .#cachePushRoots.x86_64-linux --apply builtins.attrNames` still lists the three `cross-ifd-aarch64-apple-darwin-*` roots and all three build
- full cross build of `dag-runner-aarch64-apple-darwin` (in progress at PR-open time; will confirm before merge)

Post-merge: will run the live end-to-end Mac test (`nix build github:indexable-inc/index#dag-runner`) after the cache-push run for the merge commit and post proof on #1755.

(Claude Code, Opus 4.8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Input-address the cross unit graph so Darwin can substitute derivations
> - Sets `contentAddressed = false` in [workspace.nix](https://github.com/indexable-inc/index/pull/1756/files#diff-ea594f8bfd460f458ce6b01ce873abb2ff3a3cf89d789587a70728ef478b4ceb) for cross-target derivations, switching them from content-addressed to input-addressed.
> - Input-addressing allows macOS builders to substitute cross-compiled outputs via plain narinfo, since the binary cache does not serve `/realisations` for floating content-addressed outputs.
> - Updates the RFC doc [0009-cross-compiled-darwin-packages.svx](https://github.com/indexable-inc/index/pull/1756/files#diff-1f52716c7d8c080b68cbe3e31c58a346d8015463afea754cc390386fcbecc550) to document this substitution behavior.
> - Behavioral Change: cross-target Rust workspace derivations are no longer content-addressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25e5b42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->