### PR TITLE
packages/mcp: kernel job/accessor fixes + partial fsearch results + per-cell type checking

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1271,6 +1271,13 @@ let
   # embedders poll. So there is no committed UI artifact and no Svelte build here.
   dashboardHubBin = ix.rustWorkspace.units.binaries."dashboard";
 
+  # `ty` (astral-sh's Rust type checker) drives the per-cell static type check the
+  # kernel runs before every `python_exec` cell (see ix_notebook_mcp/typecheck.py).
+  # It is a nix-provided dependency baked onto the wrapper env (IX_MCP_TY_BIN), not
+  # fetched at runtime, and it checks against `mcpPython` (IX_MCP_TY_PYTHON) so a
+  # cell importing a bundled module resolves that module's real types.
+  tyBin = lib.getExe pkgs.ty;
+
   package =
     pkgs.runCommand "ix-mcp"
       {
@@ -1291,6 +1298,8 @@ let
           --set IX_GCAL_BIN ${lib.escapeShellArg "${gcalBin}/bin/gcal"} \
           --set IX_DASHBOARD_BIN ${lib.escapeShellArg (lib.getExe' dashboardHubBin "dashboard")} \
           --set SCIPQL_SOUFFLE ${lib.escapeShellArg (lib.getExe' pkgs.souffle "souffle")} \
+          --set IX_MCP_TY_BIN ${lib.escapeShellArg tyBin} \
+          --set IX_MCP_TY_PYTHON ${lib.escapeShellArg mcpPython.interpreter} \
           --prefix PATH : ${
             lib.makeBinPath [
               pkgs.ripgrep
@@ -1309,6 +1318,8 @@ let
           --set IX_GCAL_BIN ${lib.escapeShellArg "${gcalBin}/bin/gcal"} \
           --set IX_DASHBOARD_BIN ${lib.escapeShellArg (lib.getExe' dashboardHubBin "dashboard")} \
           --set SCIPQL_SOUFFLE ${lib.escapeShellArg (lib.getExe' pkgs.souffle "souffle")} \
+          --set IX_MCP_TY_BIN ${lib.escapeShellArg tyBin} \
+          --set IX_MCP_TY_PYTHON ${lib.escapeShellArg mcpPython.interpreter} \
           --prefix PATH : ${
             lib.makeBinPath [
               pkgs.ripgrep
@@ -1511,6 +1522,34 @@ let
                 assert "macOS" in str(exc), exc
             else:
                 raise AssertionError("spotlight should raise off macOS")
+
+        # issue #1754 bug 3: limit= short-circuits and flags the partial scan.
+        # Plant a tree with many matches so a small limit truncates it.
+        big = tempfile.mkdtemp()
+        for i in range(50):
+            with open(os.path.join(big, f"f{i}.txt"), "w") as fh:
+                fh.write("needle here\n" * 20)  # 20 matches per file, 1000 total
+        capped = await fsearch.grep("needle", big, limit=5)
+        assert isinstance(capped, pl.DataFrame), type(capped)  # still a usable frame
+        assert isinstance(capped, fsearch.PartialFrame), "a capped scan must be a PartialFrame"
+        assert capped.truncated is True
+        assert capped.height == 5, capped.height
+        assert "limit" in capped.reason, capped.reason
+        assert "partial" in repr(capped).lower(), "the repr must surface truncation"
+
+        # A full scan under the limit is a plain frame with no truncated flag.
+        full = await fsearch.grep("needle", big, limit=100_000)
+        assert full.height == 1000, full.height
+        assert not isinstance(full, fsearch.PartialFrame)
+        assert not hasattr(full, "truncated")
+
+        # A timeout returns the matches found before the deadline, not nothing.
+        # A tiny timeout over the big tree is very likely to trip; if the machine
+        # is fast enough to finish, the assertion below tolerates a complete scan.
+        timed = await fsearch.grep("needle", big, limit=10_000_000, timeout=0.001)
+        if isinstance(timed, fsearch.PartialFrame):
+            assert timed.truncated is True
+            assert "timed out" in timed.reason, timed.reason
 
         print("fsearch-ok", fsearch.__version__)
 
@@ -2832,6 +2871,50 @@ let
           cat stdout stderr >&2
           exit 1
         }
+        mkdir -p "$out"
+      '';
+
+  # Issue #1754: per-cell static type checking (ty) before execution, plus the
+  # bug 1-3 regressions (await-a-failed-job re-raises; Job/Result accessor
+  # symmetry; fsearch partial-on-timeout + limit short-circuit). The type-check
+  # tests need ty resolvable and its diagnostics stable, so ty is provided on the
+  # env exactly as the wrapper sets it; rg/fd back the fsearch limit assertion.
+  # A dedicated interpreter adds pytest (the bare mcpPython omits it).
+  typecheckTestPython = mcpPythonInterp.withPackages (
+    ps: (mcpPythonPackages ps) ++ [ ps.pytest ]
+  );
+  typecheckSmoke =
+    pkgs.runCommand "ix-mcp-typecheck-smoke"
+      {
+        nativeBuildInputs = [
+          typecheckTestPython
+          pkgs.ty
+          pkgs.ripgrep
+          pkgs.fd
+        ];
+        strictDeps = true;
+        meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions";
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        export IX_MCP_TY_BIN=${lib.escapeShellArg tyBin}
+        export IX_MCP_TY_PYTHON=${lib.escapeShellArg mcpPython.interpreter}
+        # The edited ix_notebook_mcp / fsearch / sh live in the interpreter's
+        # site-packages (built from this worktree's source), so the tests import
+        # them from there; only the test files are copied in (a bare store path of
+        # a single .py is read by pytest as a directory).
+        cp ${./tests/test_typecheck.py} test_typecheck.py
+        cp ${./tests/test_job_await_errors.py} test_job_await_errors.py
+        cp ${./tests/test_fsearch_partial.py} test_fsearch_partial.py
+        ${lib.getExe typecheckTestPython} -m pytest \
+          test_typecheck.py test_job_await_errors.py test_fsearch_partial.py \
+          -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp typecheck smoke failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
         mkdir -p "$out"
       '';
 
@@ -5521,6 +5604,7 @@ package.overrideAttrs (old: {
         serverTools
         evalSmoke
         runtimeSmoke
+        typecheckSmoke
         sessionSmoke
         sessionIdentitySmoke
         feedSmoke

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -87,6 +87,12 @@ class Config:
     # the kernel, and returning an actionable summary. See ``kernel.python_exec``.
     wedge_grace: float = 15.0
 
+    # Per-cell static type checking (ty) before a cell executes: default on, so a
+    # type error is caught and returned instead of blowing up at runtime. The
+    # ``IX_MCP_TYPECHECK`` env var overrides this at the kernel (see
+    # ``runtime._typecheck_enabled``); set this False to disable it server-wide.
+    typecheck: bool = True
+
     # Hard ceiling on a single ``python_exec`` foreground ``budget``. The budget is
     # how long the ONE shared shell channel is held before the run backgrounds, so
     # an oversized budget (a 15-minute ``await jobs['x']``) wedges every other call

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -223,7 +223,11 @@ class Job:
         # can re-raise it (with its original traceback) instead of handing back a
         # misleading None -- the documented "raises rather than return a
         # misleading None" contract. None while running, done, or cancelled.
+        # `_exc_tb` pins the traceback as captured at failure time: each re-raise
+        # restores it first, so awaiting the same failed job repeatedly does not
+        # keep growing the shared exception object's traceback chain.
         self._exc: BaseException | None = None
+        self._exc_tb: types.TracebackType | None = None
         self._buf: list[str] = []
         self._buflen = 0
         # Rich outputs (mime bundles) display()-ed while this job runs.
@@ -412,7 +416,10 @@ class Job:
                 # Re-raise the original exception object, so its type, message,
                 # and traceback (the cell's own frames) all reach the caller --
                 # the same failure they would have seen running the code inline.
-                raise self._exc
+                # Restore the traceback captured at failure time first, so a
+                # repeated await re-raises from the same baseline instead of
+                # accreting one more raise-frame chain per await.
+                raise self._exc.with_traceback(self._exc_tb)
             return self._result
 
         return _await_result().__await__()
@@ -2016,6 +2023,7 @@ async def _runner(job: Job, ns: dict) -> None:
             job.error = _user_traceback(_kexc)
             job.error_line = _error_line(_kexc, job)
             job._exc = _kexc
+        job._exc_tb = _kexc.__traceback__
         job._append(job.error)
     except (Exception, SystemExit) as _exc:
         # Isolate user code from the kernel: a job's SyntaxError, exception, or
@@ -2033,6 +2041,7 @@ async def _runner(job: Job, ns: dict) -> None:
         # Keep the exception object itself, so `await jobs['<id>']` re-raises it
         # (type + message + the cell's own traceback) instead of yielding None.
         job._exc = _exc
+        job._exc_tb = _exc.__traceback__
         job._append(job.error)
     finally:
         job.ended = time.time()

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1936,7 +1936,11 @@ async def _runner(job: Job, ns: dict) -> None:
         # returned as the result -- the cell never executes -- so the agent fixes
         # it and retries instead of hitting it three lines into a side-effecting
         # cell. The checker's own failures never block a cell (see typecheck.check).
-        if _typecheck_enabled():
+        # Replays are exempt: a session reopen re-runs cells that ALREADY executed
+        # successfully (kind="replay", see store.replayable), and blocking one on
+        # a checker finding would silently drop its bindings from the restored
+        # namespace -- the check already had its chance when the cell first ran.
+        if job.kind != "replay" and _typecheck_enabled():
             verdict = await typecheck.check(job.code, ns)
             if not verdict.ok:
                 # Record it like any other failed cell: `error` (the dashboard's
@@ -2240,6 +2244,14 @@ def _df_llm_text(df: Any) -> str:
         schema = ", ".join(f"{name}:{dtype}" for name, dtype in zip(df.columns, df.dtypes, strict=False))
         body = _nuon_table(list(head.columns), head.to_dicts())
         more = f"\n... ({rows - _DF_LLM_ROWS} more rows)" if rows > _DF_LLM_ROWS else ""
+        # A frame flagging an incomplete scan (fsearch's PartialFrame: `truncated`
+        # + `reason`, duck-typed so the runtime stays decoupled) must SAY so in
+        # the model text: this NUON render is what the agent reads, and its repr
+        # banner never reaches this path, so without the note a timed-out search
+        # would read as a complete result.
+        if getattr(df, "truncated", False):
+            reason = getattr(df, "reason", "") or "scan incomplete"
+            return f"[partial results: {reason}]\nshape: ({rows}, {cols}) | {schema}\n{body}{more}"
         return f"shape: ({rows}, {cols}) | {schema}\n{body}{more}"
     except Exception:
         # An exotic frame that resists row iteration falls back to safe NUON text.

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -50,7 +50,7 @@ import uuid
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, overload
 
-from . import registry
+from . import registry, typecheck
 
 _ix_current: contextvars.ContextVar = contextvars.ContextVar("ix_current_job", default=None)
 
@@ -219,6 +219,11 @@ class Job:
         # than hand back a misleading None.
         self._result = None
         self.error: str | None = None
+        # The actual exception a failed cell raised, kept so `await jobs['<id>']`
+        # can re-raise it (with its original traceback) instead of handing back a
+        # misleading None -- the documented "raises rather than return a
+        # misleading None" contract. None while running, done, or cancelled.
+        self._exc: BaseException | None = None
         self._buf: list[str] = []
         self._buflen = 0
         # Rich outputs (mime bundles) display()-ed while this job runs.
@@ -246,6 +251,18 @@ class Job:
     @property
     def output(self) -> str:
         return "".join(self._buf)
+
+    @property
+    def text(self) -> str:
+        """The finished run's model-facing result text (its `Result.llm_result`).
+
+        The sibling of `.output` (stdout): `sh()`'s Output and a `Result` both
+        answer `.text`, so a job handle does too, letting `jobs['id'].text` page
+        the returned value without first reaching through `.result`. Empty while
+        the job is still running (background it and `await jobs['id']` for the
+        value); on a failed job it is empty too (the failure is in `.error`, and
+        `await`-ing the job re-raises it)."""
+        return _result_text(self)
 
     @property
     def pageable(self) -> str:
@@ -382,9 +399,20 @@ class Job:
 
     def __await__(self) -> Any:
         # `await jobs['id']` should yield the job's result, but the runner task
-        # returns None, so wait for it then hand back the captured result.
+        # returns None (it swallows the cell's exception to keep the shared kernel
+        # alive), so wait for it then hand back the captured result -- or, if the
+        # cell FAILED, re-raise the exception it raised. Returning `self._result`
+        # unconditionally handed back None on a failed job, so `(await
+        # jobs[id]).text` then died with an opaque AttributeError; the documented
+        # contract is that awaiting raises rather than return a misleading None.
         async def _await_result() -> Result | None:
-            await self.task
+            if self.task is not None:
+                await self.task
+            if self._exc is not None:
+                # Re-raise the original exception object, so its type, message,
+                # and traceback (the cell's own frames) all reach the caller --
+                # the same failure they would have seen running the code inline.
+                raise self._exc
             return self._result
 
         return _await_result().__await__()
@@ -730,6 +758,17 @@ class Result:
         images = [img for img in (_coerce_image(i) for i in self.llm_images) if img]
         bundle[IX_LLM_MIME] = {"text": self.llm_result or "", "images": images}
         return bundle
+
+    @property
+    def output(self) -> str:
+        """Alias for the model text (same as ``.text`` / ``.llm_result``).
+
+        A live/errored job handle exposes ``.output`` (its captured stdout) and
+        ``sh()``'s Output exposes ``.output`` too; a finished ``Result`` is the
+        third thing an agent pages, so it answers the same attribute -- reading a
+        result via ``.output`` returns its model text instead of dying with an
+        AttributeError and a guessing game about which surface owns which name."""
+        return self.llm_result or ""
 
     def __call__(self) -> Result:
         """Calling a Result returns it unchanged. ``Job.result`` is a property,
@@ -1854,6 +1893,23 @@ def _error_line(exc: BaseException, job: Job) -> int | None:
     return line
 
 
+def _typecheck_enabled() -> bool:
+    """Whether per-cell type checking runs. Default ON; the escape hatch is the
+    ``IX_MCP_TYPECHECK`` env var (``0``/``false``/``no``/``off`` disables it) or,
+    when a Config is set, its ``typecheck`` flag. The env var wins if present, so
+    a session can toggle it without a config rebuild."""
+    raw = os.environ.get("IX_MCP_TYPECHECK")
+    if raw is not None:
+        return raw.strip().lower() not in ("0", "false", "no", "off")
+    try:
+        from . import config as _config_mod
+
+        return _config_mod.config().typecheck
+    except Exception:
+        # No config set (one-shot eval, bare kernel, tests): default on.
+        return True
+
+
 async def _runner(job: Job, ns: dict) -> None:
     token = _ix_current.set(job)
     if _store is not None and _store_conn is not None:
@@ -1868,6 +1924,23 @@ async def _runner(job: Job, ns: dict) -> None:
                 kind=job.kind,
             )
     try:
+        # Static type check BEFORE running (default on; IX_MCP_TYPECHECK=0 or the
+        # `typecheck` config flag disables it). A type error is caught here and
+        # returned as the result -- the cell never executes -- so the agent fixes
+        # it and retries instead of hitting it three lines into a side-effecting
+        # cell. The checker's own failures never block a cell (see typecheck.check).
+        if _typecheck_enabled():
+            verdict = await typecheck.check(job.code, ns)
+            if not verdict.ok:
+                # Record it like any other failed cell: `error` (the dashboard's
+                # error highlight, and what the summary carries), and the report as
+                # the result so the model's reply is the diagnostic to fix. No
+                # `_exc`: the agent should read and fix the diagnostic, not have
+                # `await jobs['<id>']` raise an opaque error.
+                job.status = "error"
+                job.error = verdict.report
+                job._result = Result.of(verdict.report)
+                return
         # Compile inside the runner so a SyntaxError is recorded as a job error
         # (status + traceback in the store/dashboard) instead of escaping __ix_run.
         mode, code_obj = _compile(job.code, f"<job {job.id}>")
@@ -1933,11 +2006,16 @@ async def _runner(job: Job, ns: dict) -> None:
                 "it in `await asyncio.to_thread(...)` or use an async API, and run "
                 "anything slow as a background job."
             )
+            # Keep the interrupt as the job's exception (with the actionable
+            # message) so `await jobs['<id>']` re-raises rather than yielding None.
+            job._exc = _kexc
+            _kexc.args = (job.error,)
         else:
             # The user's own code raised KeyboardInterrupt; keep its real
             # traceback (trimmed to the cell's frames) and the failing line.
             job.error = _user_traceback(_kexc)
             job.error_line = _error_line(_kexc, job)
+            job._exc = _kexc
         job._append(job.error)
     except (Exception, SystemExit) as _exc:
         # Isolate user code from the kernel: a job's SyntaxError, exception, or
@@ -1952,6 +2030,9 @@ async def _runner(job: Job, ns: dict) -> None:
         job.error_line = _error_line(_exc, job)
         hint = _type_error_hint(_exc) if isinstance(_exc, TypeError) else ""
         job.error = tb + hint
+        # Keep the exception object itself, so `await jobs['<id>']` re-raises it
+        # (type + message + the cell's own traceback) instead of yielding None.
+        job._exc = _exc
         job._append(job.error)
     finally:
         job.ended = time.time()

--- a/packages/mcp/ix_notebook_mcp/typecheck.py
+++ b/packages/mcp/ix_notebook_mcp/typecheck.py
@@ -70,7 +70,7 @@ class TypeCheckResult:
     report: str = ""
 
 
-def _stub_type(value: Any) -> str:
+def _stub_type(value: object) -> str:
     """The annotation to stub ``value`` with: its real builtin type where cheap
     and safe (an exact-type match on a simple scalar/container), else ``Any``.
     Anything unusual -- a subclass, an instance of some class, a module -- is

--- a/packages/mcp/ix_notebook_mcp/typecheck.py
+++ b/packages/mcp/ix_notebook_mcp/typecheck.py
@@ -247,18 +247,31 @@ def _ty_bin() -> str | None:
     return shutil.which("ty")
 
 
-def _remap(output: str, synthetic_path: str, offset: int) -> tuple[str, bool]:
+def _remap(output: str, synthetic_path: pathlib.Path, offset: int) -> tuple[str, bool]:
     """Rewrite ty's diagnostics to reference cell lines, and report whether any is
     an ``error`` (only errors block). Non-diagnostic lines (the ``Found N
     diagnostics`` footer, blank lines) are dropped so the report is just the
-    findings the agent must fix."""
+    findings the agent must fix.
+
+    ty prints the diagnostic path RELATIVE to its own cwd when the file sits
+    under it (the common case: ty runs with ``cwd=`` the temp dir holding
+    ``cell.py``) and absolute otherwise (observed when the temp dir is reached
+    through a symlinked prefix, macOS ``/var`` -> ``/private/var``, so the
+    prefixes do not string-match). A relative path must resolve against the
+    synthetic file's own directory: resolving it against the *kernel process's*
+    cwd silently dropped every finding inside the nix build sandbox, whose cwd
+    has no symlink prefix -- which made the whole gate pass vacuously there."""
+    target = synthetic_path.resolve()
     findings: list[str] = []
     had_error = False
     for raw in output.splitlines():
         m = _DIAG_RE.match(raw)
         if m is None:
             continue
-        if str(pathlib.Path(m.group("path")).resolve()) != synthetic_path:
+        diag = pathlib.Path(m.group("path"))
+        if not diag.is_absolute():
+            diag = synthetic_path.parent / diag
+        if diag.resolve() != target:
             continue
         cell_line = int(m.group("line")) - offset
         # A diagnostic on the preamble/wrapper (cell_line < 1) is an artifact of
@@ -343,7 +356,7 @@ async def check(code: str, namespace: dict, *, timeout: float = 10.0) -> TypeChe
             # the loop's child watcher reaps the killed process.
             _kill(proc)
             raise
-        report, had_error = _remap(stdout.decode("utf-8", "replace"), str(path.resolve()), offset)
+        report, had_error = _remap(stdout.decode("utf-8", "replace"), path, offset)
         if not had_error:
             return TypeCheckResult(ok=True)
         header = (

--- a/packages/mcp/ix_notebook_mcp/typecheck.py
+++ b/packages/mcp/ix_notebook_mcp/typecheck.py
@@ -1,0 +1,306 @@
+"""Per-cell static type checking, run BEFORE a cell executes.
+
+Every ``python_exec`` cell is type-checked first, so a type error is caught and
+returned as the run result (with the checker's own diagnostic) instead of blowing
+up at runtime three lines in. The checker is `ty` (astral-sh's Rust type checker):
+a single fast binary, provided by the nix package (``IX_MCP_TY_BIN`` on the
+wrapper's env, or ``ty`` on PATH), so nothing is fetched at runtime.
+
+The hard part is the kernel's persistent namespace: names defined in earlier cells
+and the injected helpers (``sh``, ``api``, ``jobs``, ``grep``, ``Result``, ...) are
+all live objects, not something in the cell's source, so a naive check would flag
+every one as an undefined name. The fix is to synthesize a tiny typed *preamble*
+from the live namespace -- one declaration per name, its real builtin type where
+that is cheap and safe, ``Any`` otherwise -- and prepend it to the cell before
+checking. False positives that block a valid cell are worse than no checking, so
+the preamble errs toward ``Any``: the worst case is a missed error, never a
+spurious one.
+
+The cell body is wrapped in ``async def __ix_cell__():`` (so top-level ``await``
+and ``yield`` are legal, exactly as the real compile path allows) with a ``global``
+declaration for every name it binds (so an assignment writes module scope and a
+read resolves to the stubbed global, matching how the cell really runs). Line and
+column numbers in the diagnostics are mapped back from the synthetic module to the
+cell the caller wrote.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import builtins
+import keyword
+import os
+import pathlib
+import re
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass
+
+# A name is stubbed with its real type only for these simple, always-importable
+# builtins; every other value (a module, a helper, an instance of some class) is
+# stubbed as ``Any``. Real types here are what make prior-cell scalars actually
+# check (``x = 5`` then ``x.upper()`` is caught); anything fancier risks a false
+# positive, so it degrades to ``Any``.
+_SIMPLE_SCALARS = (bool, int, float, complex, str, bytes)
+_SIMPLE_CONTAINERS = {
+    list: "list[Any]",
+    dict: "dict[Any, Any]",
+    tuple: "tuple[Any, ...]",
+    set: "set[Any]",
+    frozenset: "frozenset[Any]",
+}
+
+_BUILTIN_NAMES = frozenset(dir(builtins))
+
+# `ty check` emits `path:line:col: severity[rule] message`. We only block on
+# `error`-level diagnostics; warnings never fail a cell (a warning that blocked a
+# valid cell would be exactly the false positive this feature must avoid).
+_DIAG_RE = re.compile(r"^(?P<path>.*?):(?P<line>\d+):(?P<col>\d+): (?P<sev>\w+)\[(?P<rule>[\w-]+)\] (?P<msg>.*)$")
+
+
+@dataclass(frozen=True)
+class TypeCheckResult:
+    """The outcome of checking one cell. ``ok`` is True when nothing blocks
+    execution (no error-level diagnostics, or the checker was unavailable/skipped);
+    ``report`` is the human/model-facing diagnostic text when ``ok`` is False."""
+
+    ok: bool
+    report: str = ""
+
+
+def _stub_type(value: Any) -> str:
+    """The annotation to stub ``value`` with: its real builtin type where cheap
+    and safe (an exact-type match on a simple scalar/container), else ``Any``.
+    Anything unusual -- a subclass, an instance of some class, a module -- is
+    ``Any``, which never produces a false positive."""
+    tp = type(value)
+    if tp in _SIMPLE_SCALARS:
+        return tp.__name__
+    return _SIMPLE_CONTAINERS.get(tp, "Any")
+
+
+def _stubbable(name: str) -> bool:
+    """Whether ``name`` should get a preamble declaration. Skip dunders and
+    private introspection names, non-identifiers, keywords, and anything that
+    shadows a builtin (``list``, ``print``): ty already knows the builtins, and
+    redeclaring one as ``Any`` would blind the check to it."""
+    return (
+        name.isidentifier()
+        and not keyword.iskeyword(name)
+        and not name.startswith("_")
+        and name not in _BUILTIN_NAMES
+    )
+
+
+def _assigned_names(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """The top-level names a cell binds, as ``(global_names, all_names)``.
+
+    ``all_names`` is every binding -- assignment targets, ``for``/``with``
+    bindings, ``def``/``class``/``import`` names, walrus targets -- and each gets
+    a preamble declaration (so a brand-new name is defined rather than flagged,
+    and a ``global`` has a binding to point at). ``global_names`` is the subset
+    that gets a ``global`` in the wrapper (so the cell writes module scope, as it
+    really does at the kernel's module level). It excludes annotated targets
+    (``x: int = ...``): Python forbids ``global`` on a name annotated in the same
+    scope, and an annotated binding already lands in the right place."""
+    names: set[str] = set()
+    annotated: set[str] = set()
+
+    def add_target(target: ast.expr) -> None:
+        if isinstance(target, ast.Name):
+            names.add(target.id)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                add_target(elt)
+        elif isinstance(target, ast.Starred):
+            add_target(target.value)
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                add_target(target)
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name):
+                names.add(node.target.id)
+                annotated.add(node.target.id)
+        elif isinstance(node, (ast.AugAssign, ast.For, ast.AsyncFor)):
+            add_target(node.target)
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                if item.optional_vars is not None:
+                    add_target(item.optional_vars)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                names.add((alias.asname or alias.name).split(".")[0])
+    # Walrus (:=) anywhere in the cell also binds at the enclosing scope.
+    for sub in ast.walk(tree):
+        if isinstance(sub, ast.NamedExpr) and isinstance(sub.target, ast.Name):
+            names.add(sub.target.id)
+    return names - annotated, names
+
+
+def _preamble(namespace: dict, bound: set[str]) -> tuple[str, int]:
+    """Build the typed preamble for ``namespace`` plus any ``bound`` cell-bound
+    names not already in it. Returns ``(source, line_count)`` -- the line count is
+    what the diagnostic line-mapping subtracts.
+
+    A namespaced name the cell REASSIGNS is stubbed ``Any``, not its concrete
+    type: the cell is about to rebind it (Python allows a new type), and a
+    concrete stub would make ty flag that legitimate rebind. A name the cell only
+    reads keeps its real type, so a prior-cell scalar still catches a genuine
+    misuse (``x = 5`` in an earlier cell, then ``x.upper()`` here). ``from
+    __future__ import annotations`` keeps the stub annotations lazy (a forward
+    reference never has to resolve), and ``Any`` is imported once for the fallback.
+    """
+    lines = ["from __future__ import annotations", "from typing import Any"]
+    declared: set[str] = set()
+    for name, value in namespace.items():
+        if not _stubbable(name):
+            continue
+        annotation = "Any" if name in bound else _stub_type(value)
+        lines.append(f"{name}: {annotation}")
+        declared.add(name)
+    lines.extend(
+        f"{name}: Any" for name in sorted(bound) if name not in declared and _stubbable(name)
+    )
+    body = "\n".join(lines) + "\n"
+    return body, body.count("\n")
+
+
+def _synthesize(code: str, namespace: dict) -> tuple[str, int] | None:
+    """Turn a cell into a checkable synthetic module, or None if the cell does not
+    parse (a SyntaxError is left for the real compile path to report, unchanged).
+
+    Returns ``(source, cell_line_offset)`` where a diagnostic on synthetic line L
+    maps to cell line ``L - cell_line_offset``."""
+    try:
+        tree = ast.parse(code, "<cell>", "exec")
+    except SyntaxError:
+        return None
+    global_names, all_bound = _assigned_names(tree)
+    # Only names that ALREADY live in the namespace need a ``global`` -- those are
+    # the prior-cell globals a read must resolve to and an assignment must write
+    # back. A brand-new name stays a wrapper-local: harmless for the check, and it
+    # sidesteps ty narrowing a global to its first literal type and then flagging a
+    # legitimate same-cell rebind to another type (``y = 5`` then ``y = "s"``) --
+    # which Python allows and must never block a cell.
+    global_names = {n for n in global_names if n in namespace}
+    preamble, preamble_lines = _preamble(namespace, all_bound)
+    header = "async def __ix_cell__():\n"
+    global_decl = f"    global {', '.join(sorted(global_names))}\n" if global_names else ""
+    # Indent the cell verbatim (line count preserved 1:1; a constant column shift
+    # of 4). Indenting inside a string literal only changes that literal's value,
+    # never a type, so it cannot affect the check.
+    indented = "".join("    " + line if line.strip() else line for line in code.splitlines(keepends=True))
+    if indented and not indented.endswith("\n"):
+        indented += "\n"
+    source = preamble + header + global_decl + indented
+    # Lines before the cell body: the preamble, the `async def` header (1), and
+    # the optional `global` line (1). A diagnostic column subtracts the 4-space
+    # indent.
+    offset = preamble_lines + 1 + (1 if global_decl else 0)
+    return source, offset
+
+
+def _ty_bin() -> str | None:
+    """The ty binary: ``IX_MCP_TY_BIN`` (set on the nix wrapper) or ``ty`` on PATH.
+    None when neither resolves, so the checker degrades to a no-op rather than
+    erroring."""
+    explicit = os.environ.get("IX_MCP_TY_BIN")
+    if explicit and pathlib.Path(explicit).exists():
+        return explicit
+    return shutil.which("ty")
+
+
+def _remap(output: str, synthetic_path: str, offset: int) -> tuple[str, bool]:
+    """Rewrite ty's diagnostics to reference cell lines, and report whether any is
+    an ``error`` (only errors block). Non-diagnostic lines (the ``Found N
+    diagnostics`` footer, blank lines) are dropped so the report is just the
+    findings the agent must fix."""
+    findings: list[str] = []
+    had_error = False
+    for raw in output.splitlines():
+        m = _DIAG_RE.match(raw)
+        if m is None:
+            continue
+        if str(pathlib.Path(m.group("path")).resolve()) != synthetic_path:
+            continue
+        cell_line = int(m.group("line")) - offset
+        # A diagnostic on the preamble/wrapper (cell_line < 1) is an artifact of
+        # the synthesis, not the user's code; drop it rather than point at a line
+        # they cannot see.
+        if cell_line < 1:
+            continue
+        cell_col = max(int(m.group("col")) - 4, 1)
+        sev = m.group("sev")
+        if sev == "error":
+            had_error = True
+        findings.append(f"line {cell_line}:{cell_col}: {sev}[{m.group('rule')}] {m.group('msg')}")
+    return "\n".join(findings), had_error
+
+
+async def check(code: str, namespace: dict, *, timeout: float = 10.0) -> TypeCheckResult:
+    """Type-check ``code`` against the live ``namespace``. Returns an ``ok`` result
+    when nothing blocks (clean, checker unavailable, unparseable cell, or the
+    checker itself failed to run) -- the feature never turns its own failure into a
+    blocked cell. A blocking result carries the remapped diagnostic in ``report``.
+    """
+    ty = _ty_bin()
+    if ty is None:
+        return TypeCheckResult(ok=True)
+    synthesized = _synthesize(code, namespace)
+    if synthesized is None:
+        # Unparseable: let the real compile path report the SyntaxError.
+        return TypeCheckResult(ok=True)
+    source, offset = synthesized
+    with tempfile.TemporaryDirectory(prefix="ix-typecheck-") as tmp:
+        path = pathlib.Path(tmp) / "cell.py"
+        path.write_text(source, encoding="utf-8")
+        argv = [
+            ty,
+            "check",
+            # Resolve third-party imports against the kernel's own interpreter, so
+            # a cell importing a bundled module (polars, httpx, ...) checks with
+            # that module's real types rather than tripping unresolved-import.
+            "--python",
+            os.environ.get("IX_MCP_TY_PYTHON", sys.executable),
+            "--output-format",
+            "concise",
+            "--no-progress",
+            "--color",
+            "never",
+            str(path),
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=tmp,
+            )
+        except OSError:
+            # The checker could not be spawned: never block a cell on our own
+            # tooling failing to start.
+            return TypeCheckResult(ok=True)
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout)
+        except TimeoutError:
+            # The checker hung past its own budget: kill it and let the cell run
+            # (its own failures never block a cell).
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+            return TypeCheckResult(ok=True)
+        report, had_error = _remap(stdout.decode("utf-8", "replace"), str(path.resolve()), offset)
+        if not had_error:
+            return TypeCheckResult(ok=True)
+        header = (
+            "Type check failed (ty) -- the cell was not run. Fix the type error and "
+            "retry, or set IX_MCP_TYPECHECK=0 to disable per-cell checking:\n"
+        )
+        return TypeCheckResult(ok=False, report=header + report)

--- a/packages/mcp/ix_notebook_mcp/typecheck.py
+++ b/packages/mcp/ix_notebook_mcp/typecheck.py
@@ -38,6 +38,7 @@ import shutil
 import signal
 import sys
 import tempfile
+from collections.abc import Iterator
 from dataclasses import dataclass
 
 # A name is stubbed with its real type only for these simple, always-importable
@@ -84,26 +85,67 @@ def _stub_type(value: object) -> str:
 
 
 def _stubbable(name: str) -> bool:
-    """Whether ``name`` should get a preamble declaration. Skip dunders and
-    private introspection names, non-identifiers, keywords, and anything that
-    shadows a builtin (``list``, ``print``): ty already knows the builtins, and
-    redeclaring one as ``Any`` would blind the check to it."""
+    """Whether a live namespace ``name`` should get a preamble declaration.
+
+    Everything a cell could legitimately read gets one: helper objects, user
+    variables -- including single-underscore names (``_df`` is a real prior-cell
+    binding) and names that shadow a builtin (``id = 'abc'``: the namespace
+    binding is what the cell reads at runtime, so the stub must shadow the
+    builtin for the check exactly as the binding shadows it at runtime). Skipped
+    are non-identifiers, keywords, and Python-managed dunders (``__name__``,
+    ``__builtins__``); the runtime's own ``__ix_*`` entrypoints are NOT dunders
+    (no trailing underscores) and stay stubbable -- the ``read`` tool submits
+    ``await __ix_read(...)`` cells that must resolve."""
     return (
-        name.isidentifier()
+        isinstance(name, str)
+        and name.isidentifier()
         and not keyword.iskeyword(name)
-        and not name.startswith("_")
-        and name not in _BUILTIN_NAMES
+        and not (name.startswith("__") and name.endswith("__"))
+    )
+
+
+def _scope_statements(body: list[ast.stmt]) -> Iterator[ast.stmt]:
+    """Every statement that executes in the cell's own scope: the top level plus
+    the bodies of top-level compound statements (``if``/``for``/``while``/
+    ``with``/``try``/``match``), recursively -- but never the body of a
+    ``def``/``class``, which is its own scope. An assignment inside a top-level
+    ``if`` binds the cell's scope just like a bare one, so the wrapper's
+    ``global``/stub bookkeeping must see it (missing it turned the name into a
+    wrapper-local and flagged the earlier read as undefined)."""
+    for node in body:
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue  # its own scope; only its NAME binds the cell's scope
+        for field in ("body", "orelse", "finalbody"):
+            inner = getattr(node, field, None)
+            if inner:
+                yield from _scope_statements(inner)
+        for handler in getattr(node, "handlers", []) or []:
+            yield from _scope_statements(handler.body)
+        for case in getattr(node, "cases", []) or []:
+            yield from _scope_statements(case.body)
+
+
+def _has_star_import(tree: ast.Module) -> bool:
+    """True when any statement executing at the cell's scope is a
+    ``from x import *`` -- including one nested in a top-level ``if``/``try``,
+    which is legal at the kernel's module scope but a SyntaxError inside the
+    ``async def`` wrapper."""
+    return any(
+        isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
+        for node in _scope_statements(tree.body)
     )
 
 
 def _assigned_names(tree: ast.Module) -> tuple[set[str], set[str]]:
-    """The top-level names a cell binds, as ``(global_names, all_names)``.
+    """The names a cell binds at its own scope, as ``(global_names, all_names)``.
 
     ``all_names`` is every binding -- assignment targets, ``for``/``with``
-    bindings, ``def``/``class``/``import`` names, walrus targets -- and each gets
-    a preamble declaration (so a brand-new name is defined rather than flagged,
-    and a ``global`` has a binding to point at). ``global_names`` is the subset
-    that gets a ``global`` in the wrapper (so the cell writes module scope, as it
+    bindings, ``def``/``class``/``import`` names, walrus targets, at the top
+    level or inside a top-level compound statement -- and each gets a preamble
+    declaration (so a brand-new name is defined rather than flagged, and a
+    ``global`` has a binding to point at). ``global_names`` is the subset that
+    gets a ``global`` in the wrapper (so the cell writes module scope, as it
     really does at the kernel's module level). It excludes annotated targets
     (``x: int = ...``): Python forbids ``global`` on a name annotated in the same
     scope, and an annotated binding already lands in the right place."""
@@ -119,7 +161,14 @@ def _assigned_names(tree: ast.Module) -> tuple[set[str], set[str]]:
         elif isinstance(target, ast.Starred):
             add_target(target.value)
 
-    for node in tree.body:
+    def add_pattern(pattern: ast.pattern) -> None:
+        # A `match` case pattern binds its capture names at the cell's scope.
+        for sub in ast.walk(pattern):
+            capture = getattr(sub, "name", None) or getattr(sub, "rest", None)
+            if isinstance(capture, str):
+                names.add(capture)
+
+    for node in _scope_statements(tree.body):
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 add_target(target)
@@ -145,6 +194,9 @@ def _assigned_names(tree: ast.Module) -> tuple[set[str], set[str]]:
         elif isinstance(node, (ast.Import, ast.ImportFrom)):
             for alias in node.names:
                 names.add((alias.asname or alias.name).split(".")[0])
+        elif isinstance(node, ast.Match):
+            for case in node.cases:
+                add_pattern(case.pattern)
     # Walrus (:=) anywhere in the cell also binds at the enclosing scope.
     for sub in ast.walk(tree):
         if isinstance(sub, ast.NamedExpr) and isinstance(sub.target, ast.Name):
@@ -173,8 +225,15 @@ def _preamble(namespace: dict, bound: set[str]) -> tuple[str, int]:
         annotation = "Any" if name in bound else _stub_type(value)
         lines.append(f"{name}: {annotation}")
         declared.add(name)
+    # A cell-local extra that shadows a builtin (`list = [...]` in THIS cell) gets
+    # no declaration: it is a wrapper-local whose own assignment binds it, and a
+    # module-level `list: Any` stub would blind the check to the real builtin for
+    # every other use. (A namespaced shadowing name IS declared above: there the
+    # live binding is what the cell reads, exactly as at runtime.)
     lines.extend(
-        f"{name}: Any" for name in sorted(bound) if name not in declared and _stubbable(name)
+        f"{name}: Any"
+        for name in sorted(bound)
+        if name not in declared and _stubbable(name) and name not in _BUILTIN_NAMES
     )
     body = "\n".join(lines) + "\n"
     return body, body.count("\n")
@@ -192,18 +251,24 @@ def _synthesize(code: str, namespace: dict) -> tuple[str, int] | None:
         tree = ast.parse(code, "<cell>", "exec")
     except SyntaxError:
         return None
-    # A top-level `from x import *` is legal in the real cell (it executes at
-    # module scope via PyCF_ALLOW_TOP_LEVEL_AWAIT) but a SyntaxError inside the
+    # A `from x import *` at the cell's scope (top level, or nested in a
+    # top-level `if`/`try`) is legal in the real cell (it executes at module
+    # scope via PyCF_ALLOW_TOP_LEVEL_AWAIT) but a SyntaxError inside the
     # `async def` wrapper, so ty would flag a valid cell (confirmed on ty 0.0.40:
     # error[invalid-syntax] on the cell's own line). Star-imports also make the
     # bound-name set unknowable statically, so skip the check for such a cell
     # rather than block it.
-    if any(
-        isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
-        for node in tree.body
-    ):
+    if _has_star_import(tree):
         return None
     global_names, all_bound = _assigned_names(tree)
+    annotated = all_bound - global_names
+    if annotated & namespace.keys():
+        # The cell annotates a name that already lives in the namespace
+        # (`print(x)` then `x: int = 2`): Python forbids `global` on a name
+        # annotated in the same scope, so the wrapper cannot both resolve the
+        # earlier read to the live global AND keep the annotation. Rather than
+        # mis-scope it and flag a valid read, fail open for this (rare) shape.
+        return None
     # Only names that ALREADY live in the namespace need a ``global`` -- those are
     # the prior-cell globals a read must resolve to and an assignment must write
     # back. A brand-new name stays a wrapper-local: harmless for the check, and it
@@ -214,10 +279,19 @@ def _synthesize(code: str, namespace: dict) -> tuple[str, int] | None:
     preamble, preamble_lines = _preamble(namespace, all_bound)
     header = "async def __ix_cell__():\n"
     global_decl = f"    global {', '.join(sorted(global_names))}\n" if global_names else ""
+    # A user `from __future__ import ...` is legal at the cell's real module scope
+    # but a SyntaxError inside the wrapper; the preamble already opens with
+    # `from __future__ import annotations`, so blank those lines (preserving the
+    # line count for diagnostics) instead of indenting them into the function.
+    lines = code.splitlines(keepends=True)
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            for lineno in range(node.lineno, (node.end_lineno or node.lineno) + 1):
+                lines[lineno - 1] = "\n"
     # Indent the cell verbatim (line count preserved 1:1; a constant column shift
     # of 4). Indenting inside a string literal only changes that literal's value,
     # never a type, so it cannot affect the check.
-    indented = "".join("    " + line if line.strip() else line for line in code.splitlines(keepends=True))
+    indented = "".join("    " + line if line.strip() else line for line in lines)
     if indented and not indented.endswith("\n"):
         indented += "\n"
     source = preamble + header + global_decl + indented
@@ -321,6 +395,13 @@ async def check(code: str, namespace: dict, *, timeout: float = 10.0) -> TypeChe
             # that module's real types rather than tripping unresolved-import.
             "--python",
             os.environ.get("IX_MCP_TY_PYTHON", sys.executable),
+            # The synthetic module lives in a private temp dir, but the CELL runs
+            # with the kernel's working directory on sys.path: a first-party
+            # module sitting next to the notebook (`import mymodule`) resolves at
+            # runtime, so it must resolve for the checker too or a valid import
+            # would be flagged unresolved.
+            "--extra-search-path",
+            str(pathlib.Path.cwd()),
             "--output-format",
             "concise",
             "--no-progress",

--- a/packages/mcp/ix_notebook_mcp/typecheck.py
+++ b/packages/mcp/ix_notebook_mcp/typecheck.py
@@ -29,11 +29,13 @@ from __future__ import annotations
 import ast
 import asyncio
 import builtins
+import contextlib
 import keyword
 import os
 import pathlib
 import re
 import shutil
+import signal
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -127,6 +129,13 @@ def _assigned_names(tree: ast.Module) -> tuple[set[str], set[str]]:
                 annotated.add(node.target.id)
         elif isinstance(node, (ast.AugAssign, ast.For, ast.AsyncFor)):
             add_target(node.target)
+        elif isinstance(node, ast.Delete):
+            # `del name` binds (well, unbinds) at the cell's scope: without a
+            # `global`, the wrapper would treat a deleted prior-cell name as an
+            # unbound local. Treat delete targets like assignments so a
+            # namespaced one gets the `global` and a new one a stub.
+            for target in node.targets:
+                add_target(target)
         elif isinstance(node, (ast.With, ast.AsyncWith)):
             for item in node.items:
                 if item.optional_vars is not None:
@@ -172,14 +181,27 @@ def _preamble(namespace: dict, bound: set[str]) -> tuple[str, int]:
 
 
 def _synthesize(code: str, namespace: dict) -> tuple[str, int] | None:
-    """Turn a cell into a checkable synthetic module, or None if the cell does not
-    parse (a SyntaxError is left for the real compile path to report, unchanged).
+    """Turn a cell into a checkable synthetic module, or None to skip the check:
+    either the cell does not parse (a SyntaxError is left for the real compile
+    path to report, unchanged) or it cannot be represented in the wrapper without
+    false positives (a top-level star-import).
 
     Returns ``(source, cell_line_offset)`` where a diagnostic on synthetic line L
     maps to cell line ``L - cell_line_offset``."""
     try:
         tree = ast.parse(code, "<cell>", "exec")
     except SyntaxError:
+        return None
+    # A top-level `from x import *` is legal in the real cell (it executes at
+    # module scope via PyCF_ALLOW_TOP_LEVEL_AWAIT) but a SyntaxError inside the
+    # `async def` wrapper, so ty would flag a valid cell (confirmed on ty 0.0.40:
+    # error[invalid-syntax] on the cell's own line). Star-imports also make the
+    # bound-name set unknowable statically, so skip the check for such a cell
+    # rather than block it.
+    if any(
+        isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
+        for node in tree.body
+    ):
         return None
     global_names, all_bound = _assigned_names(tree)
     # Only names that ALREADY live in the namespace need a ``global`` -- those are
@@ -204,6 +226,15 @@ def _synthesize(code: str, namespace: dict) -> tuple[str, int] | None:
     # indent.
     offset = preamble_lines + 1 + (1 if global_decl else 0)
     return source, offset
+
+
+def _kill(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL the checker's whole process group (best-effort; a race where it
+    already exited is ignored). ``start_new_session`` made it a group leader."""
+    if proc.returncode is not None:
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(proc.pid, signal.SIGKILL)
 
 
 def _ty_bin() -> str | None:
@@ -248,13 +279,22 @@ async def check(code: str, namespace: dict, *, timeout: float = 10.0) -> TypeChe
     when nothing blocks (clean, checker unavailable, unparseable cell, or the
     checker itself failed to run) -- the feature never turns its own failure into a
     blocked cell. A blocking result carries the remapped diagnostic in ``report``.
+
+    Known race, accepted: ``namespace`` is the live dict, so a concurrent cell
+    rebinding a shared name to a different type mid-check can make its stub stale
+    and flag (or miss) one run spuriously. The exact-type allowlist bounds the
+    blast radius -- only simple builtin scalars/containers ever get a concrete
+    stub, everything else is ``Any`` -- and per-session namespaces (the default on
+    the HTTP transport) keep parallel agents out of each other's names, so a
+    snapshot/lock here would buy little for its cost.
     """
     ty = _ty_bin()
     if ty is None:
         return TypeCheckResult(ok=True)
     synthesized = _synthesize(code, namespace)
     if synthesized is None:
-        # Unparseable: let the real compile path report the SyntaxError.
+        # Unparseable (the real compile path reports the SyntaxError) or
+        # unrepresentable in the wrapper (a star-import): run the cell unchecked.
         return TypeCheckResult(ok=True)
     source, offset = synthesized
     with tempfile.TemporaryDirectory(prefix="ix-typecheck-") as tmp:
@@ -281,6 +321,7 @@ async def check(code: str, namespace: dict, *, timeout: float = 10.0) -> TypeChe
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=tmp,
+                start_new_session=True,  # own process group: a kill reaps ty and any child
             )
         except OSError:
             # The checker could not be spawned: never block a cell on our own
@@ -291,11 +332,17 @@ async def check(code: str, namespace: dict, *, timeout: float = 10.0) -> TypeChe
         except TimeoutError:
             # The checker hung past its own budget: kill it and let the cell run
             # (its own failures never block a cell).
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-            with contextlib.suppress(Exception):
-                await proc.wait()
+            _kill(proc)
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(proc.wait(), 2.0)
             return TypeCheckResult(ok=True)
+        except asyncio.CancelledError:
+            # The awaiting cell was cancelled mid-check: take ty down with it so a
+            # cancelled cell never leaves an orphaned checker running. No await
+            # here (the cancellation would be re-delivered at the next await);
+            # the loop's child watcher reaps the killed process.
+            _kill(proc)
+            raise
         report, had_error = _remap(stdout.decode("utf-8", "replace"), str(path.resolve()), offset)
         if not had_error:
             return TypeCheckResult(ok=True)

--- a/packages/mcp/src/fsearch/fsearch/__init__.py
+++ b/packages/mcp/src/fsearch/fsearch/__init__.py
@@ -24,8 +24,10 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json as _json
 import os
+import signal
 import stat as _stat
 import sys
 from datetime import UTC, datetime
@@ -33,14 +35,18 @@ from pathlib import Path
 from typing import Any
 
 import polars as pl
-from sh import Output, sh as _sh  # the bundled async shell-out helper; `sh.sh` is the function
+from sh import sh as _sh  # the bundled async shell-out helper; `sh.sh` is the function
 
-__all__ = ["FsearchError", "find", "grep", "spotlight"]
+__all__ = ["FsearchError", "PartialFrame", "find", "grep", "spotlight"]
 
 __version__ = "0.1.0"
 
 DEFAULT_LIMIT = 10_000
 DEFAULT_TIMEOUT = 30.0
+# StreamReader buffer for the rg --json line stream (one JSON event per line). A
+# match on a very long line makes that event large; 64 MiB keeps a legitimate
+# long-line hit parseable where the asyncio default (64 KiB) would raise.
+_STREAM_LINE_LIMIT = 64 * 1024 * 1024
 
 _GREP_SCHEMA = {
     "path": pl.Utf8,
@@ -64,6 +70,32 @@ class FsearchError(Exception):
     """A search backend exited with an error (or, for spotlight, is unavailable)."""
 
 
+class PartialFrame(pl.DataFrame):
+    """A search-result frame whose scan did not finish, so the rows are only the
+    matches found before the cut-off (a timeout, or the ``limit`` cap).
+
+    It IS a ``polars.DataFrame`` -- ``.filter``/``.sort``/``.head`` all work -- so
+    a caller that ignores the truncation still gets usable rows. Two things flag
+    the incompleteness so a caller cannot silently mistake a partial scan for a
+    complete one: ``.truncated`` is ``True`` (a plain frame has no such
+    attribute), and ``.reason`` explains the cut-off; the ``repr`` (what the
+    dashboard/model see) leads with a one-line warning. A polars operation that
+    builds a new frame returns a plain ``DataFrame`` -- the flag describes THIS
+    scan, not a derived view, so it deliberately does not propagate."""
+
+    # Class default so `getattr(frame, "truncated", False)` is safe on any frame
+    # (a plain DataFrame returns the False default; a PartialFrame overrides it).
+    truncated = True
+
+    def __init__(self, data: object = None, *args: object, reason: str = "", **kwargs: object) -> None:
+        super().__init__(data, *args, **kwargs)
+        self.reason = reason
+
+    def __repr__(self) -> str:
+        banner = f"[partial results: {self.reason}]\n" if self.reason else "[partial results]\n"
+        return banner + super().__repr__()
+
+
 def _expand(root: str | os.PathLike[str]) -> str:
     """Expand a leading ``~`` to an absolute path. Sync on purpose: ``expanduser``
     only reads ``$HOME`` / the passwd db (no event-loop I/O), and keeping it out
@@ -71,19 +103,26 @@ def _expand(root: str | os.PathLike[str]) -> str:
     return str(Path(root).expanduser())
 
 
-async def _run(argv: list[str], *, timeout: float, ok_codes: tuple[int, ...] = (0,)) -> Output:
+async def _run(argv: list[str], *, timeout: float, ok_codes: tuple[int, ...] = (0,)) -> tuple[str, bool]:
     """Run a search CLI off the event loop with color disabled (so its output is
-    clean, never SGR-corrupted). A non-success exit or a timeout surfaces as
-    FsearchError, so callers have one error type to catch (the timeout is the
-    safety net: a runaway search is killed at the deadline, never wedging the
-    kernel)."""
+    clean, never SGR-corrupted) and return ``(output_text, timed_out)``.
+
+    On a timeout the search is killed at the deadline (the safety net: a runaway
+    search never wedges the kernel), but its output-so-far is NOT discarded --
+    ``sh`` attaches it to the ``TimeoutError`` as ``partial_output``, so this
+    returns that text with ``timed_out=True`` and the caller parses the matches
+    found before the cut-off. A non-success exit (other than the expected codes)
+    still surfaces as FsearchError."""
     try:
         out = await _sh(argv, timeout=timeout, color=False)
     except TimeoutError as exc:
-        raise FsearchError(f"{argv[0]} timed out after {timeout}s") from exc
+        # Recover whatever the child wrote before the deadline (see sh.sh); an
+        # older sh without the attribute yields "" -- an empty partial, not a
+        # crash.
+        return (getattr(exc, "partial_output", "") or "", True)
     if out.code not in ok_codes:
         raise FsearchError(f"{argv[0]} exited {out.code}: {out.text.strip()[:500]}")
-    return out
+    return (out.text, False)
 
 
 def _rg_str(field: dict[str, Any] | None) -> str:
@@ -180,37 +219,137 @@ async def grep(
     if glob:
         argv += ["-g", glob]
     argv += ["--", pattern, _expand(root)]
-    out = await _run(argv, timeout=timeout, ok_codes=(0, 1))  # rg exits 1 on no matches
-    rows: list[dict[str, Any]] = []
-    for raw in out.text.splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            event = _json.loads(line)
-        except ValueError:
-            continue  # a non-JSON line (e.g. a stderr warning merged in) — skip it
-        if event.get("type") != "match":
-            continue
-        data = event["data"]
-        path = _rg_str(data.get("path"))
-        line_number = data.get("line_number")
-        text = _rg_str(data.get("lines")).rstrip("\n")
-        abs_offset = data.get("absolute_offset")
-        for sm in data.get("submatches", []):
-            rows.append(
-                {
-                    "path": path,
-                    "line_number": line_number,
-                    "col": sm.get("start"),
-                    "match": _rg_str(sm.get("match")),
-                    "line": text,
-                    "abs_offset": abs_offset,
-                }
-            )
-            if len(rows) >= limit:
-                return pl.DataFrame(rows, schema=_GREP_SCHEMA)
+    rows, timed_out, hit_limit = await _stream_rg(argv, limit=limit, timeout=timeout)
+    if timed_out:
+        return PartialFrame(
+            rows,
+            schema=_GREP_SCHEMA,
+            reason=f"rg timed out after {timeout}s; {len(rows)} match(es) found before the deadline",
+        )
+    if hit_limit:
+        # The scan stopped at `limit` (rg was killed once enough matches were
+        # parsed, rather than left to scan the whole tree): the rows are complete
+        # up to the cap but the search did not exhaust `root`, so flag it.
+        return PartialFrame(
+            rows,
+            schema=_GREP_SCHEMA,
+            reason=f"stopped at limit={limit}; raise limit= to scan further",
+        )
     return pl.DataFrame(rows, schema=_GREP_SCHEMA)
+
+
+def _parse_rg_match(event: dict[str, Any]) -> list[dict[str, Any]]:
+    """The submatch rows for one ripgrep ``--json`` ``match`` event (empty for a
+    non-match event)."""
+    if event.get("type") != "match":
+        return []
+    data = event["data"]
+    path = _rg_str(data.get("path"))
+    line_number = data.get("line_number")
+    text = _rg_str(data.get("lines")).rstrip("\n")
+    abs_offset = data.get("absolute_offset")
+    return [
+        {
+            "path": path,
+            "line_number": line_number,
+            "col": sm.get("start"),
+            "match": _rg_str(sm.get("match")),
+            "line": text,
+            "abs_offset": abs_offset,
+        }
+        for sm in data.get("submatches", [])
+    ]
+
+
+async def _stream_rg(
+    argv: list[str], *, limit: int, timeout: float
+) -> tuple[list[dict[str, Any]], bool, bool]:
+    """Run ripgrep and parse its ``--json`` stream line by line, killing the
+    process group as soon as ``limit`` match rows are collected.
+
+    Returns ``(rows, timed_out, hit_limit)``. ripgrep has no global "stop after N
+    total matches" flag (``--max-count`` is per file), so bounding a ``limit=``
+    query means terminating rg once enough rows are parsed instead of letting it
+    scan the whole tree and discarding the tail -- otherwise a broad pattern over
+    a huge root pays the full-tree cost for a handful of wanted rows. The scan is
+    still a separate process bounded by ``timeout`` (a process-group kill, like
+    ``sh``), so a runaway never wedges the kernel's event loop."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+        start_new_session=True,  # own process group, so the kill reaps rg's children too
+        # One rg --json event is a whole line; a match on a very long line (a
+        # minified bundle, a data file) makes that line large, and the default
+        # 64 KiB StreamReader buffer raises LimitOverrunError on it. Give the
+        # buffer room so a legitimate long-line match parses instead of crashing
+        # the search.
+        limit=_STREAM_LINE_LIMIT,
+    )
+    rows: list[dict[str, Any]] = []
+    hit_limit = False
+
+    async def _read() -> None:
+        nonlocal hit_limit
+        assert proc.stdout is not None
+        while True:
+            try:
+                raw = await proc.stdout.readline()
+            except ValueError:
+                # A single line still exceeded the (generous) buffer: skip past it
+                # rather than abort the whole search. readline() consumed the
+                # buffer, so the next read resumes after the oversized line.
+                continue
+            if not raw:
+                break
+            line = raw.decode("utf-8", "replace").strip()
+            if not line:
+                continue
+            try:
+                event = _json.loads(line)
+            except ValueError:
+                continue  # a non-JSON line (e.g. a stderr warning merged in) — skip it
+            rows.extend(_parse_rg_match(event))
+            if len(rows) >= limit:
+                del rows[limit:]
+                hit_limit = True
+                return  # stop reading; the finally-block kills rg's whole group
+
+    timed_out = False
+    try:
+        await asyncio.wait_for(_read(), timeout)
+    except TimeoutError:
+        timed_out = True
+    finally:
+        _kill_group(proc)
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(proc.wait(), 2.0)
+    return (rows, timed_out, hit_limit)
+
+
+def _kill_group(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL the child's whole process group (best-effort). ``start_new_session``
+    made the child a group leader, so one signal reaps rg and anything it spawned;
+    a race where it already exited is ignored."""
+    if proc.returncode is not None:
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(proc.pid, signal.SIGKILL)
+
+
+async def _paths_frame(text: str, *, limit: int, timed_out: bool, tool: str, timeout: float) -> pl.DataFrame:
+    """The shared tail of ``find``/``spotlight``: parse the tool's NUL-separated
+    paths, lstat them off the event loop into the find/spotlight frame, cap at
+    ``limit``, and wrap it as a :class:`PartialFrame` when the scan timed out (so
+    the paths found before the deadline are returned, flagged, not discarded)."""
+    paths = [p for p in text.split("\0") if p]
+    frame = (await asyncio.to_thread(_lstat_rows, paths)).head(limit)
+    if timed_out:
+        return PartialFrame(
+            frame,
+            reason=f"{tool} timed out after {timeout}s; {frame.height} path(s) found before the deadline",
+        )
+    return frame
 
 
 async def find(
@@ -248,10 +387,8 @@ async def find(
         argv += ["--max-depth", str(max_depth)]
     argv += ["--max-results", str(limit)]  # cap at the source (limit applies to real hits)
     argv += ["--", pattern, _expand(root)]
-    out = await _run(argv, timeout=timeout)
-    paths = [p for p in out.text.split("\0") if p]
-    # lstat off the event loop (up to `limit` stat syscalls), then cap rows.
-    return (await asyncio.to_thread(_lstat_rows, paths)).head(limit)
+    text, timed_out = await _run(argv, timeout=timeout)
+    return await _paths_frame(text, limit=limit, timed_out=timed_out, tool="fd", timeout=timeout)
 
 
 async def spotlight(
@@ -277,7 +414,6 @@ async def spotlight(
     if literal:
         argv.append("-literal")
     argv.append(query)
-    out = await _run(argv, timeout=timeout)
-    paths = [p for p in out.text.split("\0") if p]
-    # mdfind has no result cap, so lstat all (off-loop) then cap real rows.
-    return (await asyncio.to_thread(_lstat_rows, paths)).head(limit)
+    # mdfind has no result cap, so _paths_frame lstats all (off-loop) then caps.
+    text, timed_out = await _run(argv, timeout=timeout)
+    return await _paths_frame(text, limit=limit, timed_out=timed_out, tool="mdfind", timeout=timeout)

--- a/packages/mcp/src/fsearch/fsearch/__init__.py
+++ b/packages/mcp/src/fsearch/fsearch/__init__.py
@@ -87,6 +87,9 @@ class PartialFrame(pl.DataFrame):
     # (a plain DataFrame returns the False default; a PartialFrame overrides it).
     truncated = True
 
+    # `PartialFrame(existing_frame, ...)` relies on polars accepting a DataFrame
+    # as the `data` argument (DataFrame-from-DataFrame init); the typecheckSmoke
+    # nix test exercises this path, so a polars bump that drops it fails CI.
     def __init__(self, data: object = None, *args: object, reason: str = "", **kwargs: object) -> None:
         super().__init__(data, *args, **kwargs)
         self.reason = reason
@@ -273,11 +276,17 @@ async def _stream_rg(
     scan the whole tree and discarding the tail -- otherwise a broad pattern over
     a huge root pays the full-tree cost for a handful of wanted rows. The scan is
     still a separate process bounded by ``timeout`` (a process-group kill, like
-    ``sh``), so a runaway never wedges the kernel's event loop."""
+    ``sh``), so a runaway never wedges the kernel's event loop.
+
+    A backend failure is an error, not an empty result: rg exits 2 on a bad
+    pattern, an unreadable root, or an invalid glob, and that raises
+    :class:`FsearchError` carrying rg's own stderr -- an empty frame would be
+    indistinguishable from a legitimate "no matches". A kill we initiated (the
+    timeout, or the limit) is not a failure."""
     proc = await asyncio.create_subprocess_exec(
         *argv,
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
         start_new_session=True,  # own process group, so the kill reaps rg's children too
         # One rg --json event is a whole line; a match on a very long line (a
         # minified bundle, a data file) makes that line large, and the default
@@ -288,6 +297,17 @@ async def _stream_rg(
     )
     rows: list[dict[str, Any]] = []
     hit_limit = False
+    stderr_chunks: list[bytes] = []
+
+    async def _drain_stderr() -> None:
+        # Drained concurrently so a chatty rg can never fill the stderr pipe and
+        # deadlock against the stdout reader; the text feeds the failure message.
+        assert proc.stderr is not None
+        while True:
+            block = await proc.stderr.read(8192)
+            if not block:
+                break
+            stderr_chunks.append(block)
 
     async def _read() -> None:
         nonlocal hit_limit
@@ -315,6 +335,7 @@ async def _stream_rg(
                 hit_limit = True
                 return  # stop reading; the finally-block kills rg's whole group
 
+    stderr_task = asyncio.ensure_future(_drain_stderr())
     timed_out = False
     try:
         await asyncio.wait_for(_read(), timeout)
@@ -324,6 +345,15 @@ async def _stream_rg(
         _kill_group(proc)
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(proc.wait(), 2.0)
+        stderr_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await stderr_task
+    # rg's contract: 0 = matches, 1 = no matches, anything else = a real failure
+    # (bad regex, unreadable root, invalid glob). Only a run WE cut short (the
+    # deadline or the limit kill) is exempt.
+    if not timed_out and not hit_limit and proc.returncode not in (0, 1):
+        detail = b"".join(stderr_chunks).decode("utf-8", "replace").strip()
+        raise FsearchError(f"{argv[0]} exited {proc.returncode}: {detail[:500]}")
     return (rows, timed_out, hit_limit)
 
 

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -588,7 +588,13 @@ async def sh(
         # bound it anyway so a wedged reap can never hang the job past its timeout.
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(proc.wait(), 2.0)
-        raise TimeoutError(f"command timed out after {timeout}s: {shown}") from None
+        exc = TimeoutError(f"command timed out after {timeout}s: {shown}")
+        # Attach whatever the child had already written before the deadline, so a
+        # caller catching the timeout can still recover partial results (fsearch
+        # parses this to return the matches found so far) instead of discarding a
+        # long scan's work. It is the same merged stdout+stderr text `.raw` holds.
+        exc.partial_output = "".join(chunks)  # type: ignore[attr-defined]
+        raise exc from None
     except asyncio.CancelledError:
         # The awaiting task was cancelled (jobs['<id>'].cancel()): take the child
         # and its whole group down with it, so a cancelled cell never leaves an

--- a/packages/mcp/tests/test_fsearch_partial.py
+++ b/packages/mcp/tests/test_fsearch_partial.py
@@ -85,6 +85,18 @@ def test_find_recovers_partial_paths_on_timeout(monkeypatch: pytest.MonkeyPatch,
     _ = os  # keep the import used
 
 
+def test_grep_backend_failure_raises_not_empty_frame(tmp_path: object) -> None:
+    # rg exits 2 on a bad pattern (also: unreadable root, invalid glob); that must
+    # surface as FsearchError carrying rg's stderr, never as an empty frame
+    # indistinguishable from "no matches". Skips cleanly if rg is not on PATH.
+    import shutil
+
+    if shutil.which("rg") is None:
+        pytest.skip("ripgrep not on PATH")
+    with pytest.raises(fsearch.FsearchError, match="exited 2"):
+        asyncio.run(fsearch.grep("(", str(tmp_path)))  # type: ignore[arg-type]
+
+
 def test_grep_short_circuits_at_limit(tmp_path: object) -> None:
     # Real ripgrep: plant many matches, cap at 5, and assert the scan stops there
     # and is flagged partial. Skips cleanly if rg is not on PATH.

--- a/packages/mcp/tests/test_fsearch_partial.py
+++ b/packages/mcp/tests/test_fsearch_partial.py
@@ -17,21 +17,17 @@ import pytest
 import fsearch
 
 
-def _rg_match_line(path: str, line_number: int, text: str) -> str:
-    """One ripgrep ``--json`` ``match`` event line, as `_run`'s parser expects."""
-    import json
-
-    event = {
-        "type": "match",
-        "data": {
-            "path": {"text": path},
-            "lines": {"text": text + "\n"},
-            "line_number": line_number,
-            "absolute_offset": 0,
-            "submatches": [{"match": {"text": "needle"}, "start": 0}],
-        },
+def _grep_row(path: str, line_number: int, text: str) -> dict[str, object]:
+    """One parsed grep result row, the shape `_stream_rg` yields and `grep`
+    wraps into the ``_GREP_SCHEMA`` frame."""
+    return {
+        "path": path,
+        "line_number": line_number,
+        "col": 0,
+        "match": "needle",
+        "line": text,
+        "abs_offset": 0,
     }
-    return json.dumps(event)
 
 
 def test_partial_frame_is_a_dataframe_that_flags_truncation() -> None:
@@ -46,14 +42,16 @@ def test_partial_frame_is_a_dataframe_that_flags_truncation() -> None:
 
 
 def test_grep_recovers_partial_matches_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
-    partial = "\n".join(_rg_match_line(f"f{i}.txt", i + 1, "needle here") for i in range(3))
+    # `grep` streams ripgrep via `_stream_rg`, so the timeout recovery lives there:
+    # on a deadline it returns the rows parsed before the kill with `timed_out=True`,
+    # and `grep` wraps them in a `PartialFrame`. Fake that return (patching `_sh`
+    # would miss the path entirely, since `_stream_rg` calls the subprocess directly).
+    rows = [_grep_row(f"f{i}.txt", i + 1, "needle here") for i in range(3)]
 
-    async def fake_sh(*_args: object, **_kwargs: object) -> object:
-        exc = TimeoutError("command timed out")
-        exc.partial_output = partial  # type: ignore[attr-defined]
-        raise exc
+    async def fake_stream_rg(*_args: object, **_kwargs: object) -> object:
+        return (rows, True, False)  # (rows, timed_out, hit_limit)
 
-    monkeypatch.setattr(fsearch, "_sh", fake_sh)
+    monkeypatch.setattr(fsearch, "_stream_rg", fake_stream_rg)
 
     frame = asyncio.run(fsearch.grep("needle", "."))
     assert isinstance(frame, fsearch.PartialFrame)

--- a/packages/mcp/tests/test_fsearch_partial.py
+++ b/packages/mcp/tests/test_fsearch_partial.py
@@ -1,0 +1,100 @@
+"""fsearch returns partial results on a timeout instead of discarding them, and
+short-circuits a ``limit=`` scan (issue #1754, bug 3).
+
+The timeout path is made deterministic by faking the backend: ``sh`` attaches
+whatever the child wrote before the deadline to the ``TimeoutError`` as
+``partial_output``, and ``_run`` parses that instead of losing the work. The
+``limit`` short-circuit and the ``PartialFrame`` surface are exercised directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import polars as pl
+import pytest
+
+import fsearch
+
+
+def _rg_match_line(path: str, line_number: int, text: str) -> str:
+    """One ripgrep ``--json`` ``match`` event line, as `_run`'s parser expects."""
+    import json
+
+    event = {
+        "type": "match",
+        "data": {
+            "path": {"text": path},
+            "lines": {"text": text + "\n"},
+            "line_number": line_number,
+            "absolute_offset": 0,
+            "submatches": [{"match": {"text": "needle"}, "start": 0}],
+        },
+    }
+    return json.dumps(event)
+
+
+def test_partial_frame_is_a_dataframe_that_flags_truncation() -> None:
+    frame = fsearch.PartialFrame({"a": [1, 2]}, reason="stopped early")
+    assert isinstance(frame, pl.DataFrame)
+    assert frame.truncated is True
+    assert frame.reason == "stopped early"
+    assert "partial results: stopped early" in repr(frame)
+    # A plain frame has no such attribute, so `getattr(x, "truncated", False)` is
+    # a safe truncation check across both.
+    assert not hasattr(pl.DataFrame({"a": [1]}), "truncated")
+
+
+def test_grep_recovers_partial_matches_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    partial = "\n".join(_rg_match_line(f"f{i}.txt", i + 1, "needle here") for i in range(3))
+
+    async def fake_sh(*_args: object, **_kwargs: object) -> object:
+        exc = TimeoutError("command timed out")
+        exc.partial_output = partial  # type: ignore[attr-defined]
+        raise exc
+
+    monkeypatch.setattr(fsearch, "_sh", fake_sh)
+
+    frame = asyncio.run(fsearch.grep("needle", "."))
+    assert isinstance(frame, fsearch.PartialFrame)
+    assert frame.truncated is True
+    assert frame.height == 3, frame.height  # the matches found before the deadline
+    assert "timed out" in frame.reason
+
+
+def test_find_recovers_partial_paths_on_timeout(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    # fd writes NUL-separated real paths; plant two so lstat resolves them.
+    import os
+
+    a = tmp_path / "a.txt"  # type: ignore[operator]
+    b = tmp_path / "b.txt"  # type: ignore[operator]
+    a.write_text("x")
+    b.write_text("y")
+    partial = f"{a}\0{b}\0"
+
+    async def fake_sh(*_args: object, **_kwargs: object) -> object:
+        exc = TimeoutError("command timed out")
+        exc.partial_output = partial  # type: ignore[attr-defined]
+        raise exc
+
+    monkeypatch.setattr(fsearch, "_sh", fake_sh)
+    frame = asyncio.run(fsearch.find(root=str(tmp_path)))  # type: ignore[arg-type]
+    assert isinstance(frame, fsearch.PartialFrame)
+    assert frame.height == 2, frame.height
+    assert "timed out" in frame.reason
+    _ = os  # keep the import used
+
+
+def test_grep_short_circuits_at_limit(tmp_path: object) -> None:
+    # Real ripgrep: plant many matches, cap at 5, and assert the scan stops there
+    # and is flagged partial. Skips cleanly if rg is not on PATH.
+    import shutil
+
+    if shutil.which("rg") is None:
+        pytest.skip("ripgrep not on PATH")
+    for i in range(20):
+        (tmp_path / f"f{i}.txt").write_text("needle here\n" * 10)  # type: ignore[operator]
+    frame = asyncio.run(fsearch.grep("needle", str(tmp_path), limit=5))  # type: ignore[arg-type]
+    assert isinstance(frame, fsearch.PartialFrame)
+    assert frame.height == 5
+    assert "limit" in frame.reason

--- a/packages/mcp/tests/test_fsearch_partial.py
+++ b/packages/mcp/tests/test_fsearch_partial.py
@@ -41,6 +41,18 @@ def test_partial_frame_is_a_dataframe_that_flags_truncation() -> None:
     assert not hasattr(pl.DataFrame({"a": [1]}), "truncated")
 
 
+def test_partial_frame_truncation_reaches_the_model_text() -> None:
+    # A cell returning a PartialFrame renders through Result.of's NUON path, not
+    # repr(), so the truncation note must ride the model text itself -- otherwise
+    # a timed-out scan reads as a complete result.
+    from ix_notebook_mcp import runtime
+
+    partial = fsearch.PartialFrame({"a": [1]}, reason="stopped early")
+    assert "[partial results: stopped early]" in runtime.Result.of(partial).llm_result
+    # A plain frame carries no note.
+    assert "[partial results" not in runtime.Result.of(pl.DataFrame({"a": [1]})).llm_result
+
+
 def test_grep_recovers_partial_matches_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     # `grep` streams ripgrep via `_stream_rg`, so the timeout recovery lives there:
     # on a deadline it returns the rows parsed before the kill with `timed_out=True`,

--- a/packages/mcp/tests/test_job_await_errors.py
+++ b/packages/mcp/tests/test_job_await_errors.py
@@ -1,0 +1,104 @@
+"""Awaiting a failed job re-raises, and the Job/Result accessor surfaces line up
+(issue #1754, bugs 1-2).
+
+Bug 1: a job that failed used to yield ``None`` from ``await jobs[id]`` -- so
+``(await jobs[id]).text`` blew up with an opaque ``AttributeError`` -- which
+inverts the documented "raises rather than return a misleading None" contract.
+Awaiting a failed job now re-raises the original exception (type, message, and the
+cell's own traceback).
+
+Bug 2: a live/errored ``Job`` exposes ``.output``; a finished ``Result`` exposes
+``.text``. Each now also answers its sibling (``Result.output``, ``Job.text``), so
+an agent paging a returned value does not have to guess which surface owns which
+name.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ix_notebook_mcp import runtime
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+
+
+def _run(code: str) -> runtime.Job:
+    return asyncio.run(runtime.__ix_run(code, budget=5.0))
+
+
+def test_awaiting_a_failed_job_reraises_the_original_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+    job = _run("raise ValueError('boom')")
+    assert job.status == "error"
+
+    async def await_it() -> object:
+        return await runtime.jobs[job.id]
+
+    with pytest.raises(ValueError, match="boom"):
+        asyncio.run(await_it())
+
+
+def test_the_reproduced_production_failure_no_longer_gives_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The exact prod shape: a cell fails, then `r = await jobs[id]; r.text`. The
+    # await must raise, never hand back a None whose `.text` dies with AttributeError.
+    _wire(monkeypatch, {})
+    job = _run("raise RuntimeError('rg exploded')")
+
+    async def await_and_read_text() -> str:
+        r = await runtime.jobs[job.id]
+        return r.text  # this used to be `None.text` -> AttributeError
+
+    with pytest.raises(RuntimeError, match="rg exploded"):
+        asyncio.run(await_and_read_text())
+
+
+def test_awaiting_a_successful_job_yields_the_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {"Result": runtime.Result})
+    job = _run("Result.text('done well')")
+
+    async def await_it() -> runtime.Result:
+        return await runtime.jobs[job.id]
+
+    result = asyncio.run(await_it())
+    assert isinstance(result, runtime.Result)
+    assert result.text == "done well"
+
+
+def test_result_output_aliases_text_and_llm_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {"Result": runtime.Result})
+    job = _run("Result.text('hello')")
+    result = job.result
+    assert result.output == result.text == result.llm_result == "hello"
+
+
+def test_job_text_is_the_result_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {"Result": runtime.Result})
+    job = _run("Result.text('rendered')")
+    # `.text` is the sibling of `.output` (stdout): the finished run's result text.
+    assert job.text == "rendered"
+    assert job.output == ""  # the cell printed nothing to stdout
+
+
+def test_a_watchdog_interrupt_reraises_with_the_actionable_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Simulate the wedge watchdog: a job flagged interrupted_by_watchdog whose
+    # KeyboardInterrupt is caught should keep the actionable message AND re-raise.
+    _wire(monkeypatch, {})
+
+    async def run_wedged() -> runtime.Job:
+        job = runtime.Job("raise KeyboardInterrupt()", budget=5.0)
+        job.interrupted_by_watchdog = True
+        runtime.jobs[job.id] = job
+        job.task = asyncio.ensure_future(runtime._runner(job, {}))
+        await job.task
+        return job
+
+    job = asyncio.run(run_wedged())
+    assert job.status == "error"
+    assert job._exc is not None
+    assert "blocking the" in (job.error or "")

--- a/packages/mcp/tests/test_typecheck.py
+++ b/packages/mcp/tests/test_typecheck.py
@@ -13,6 +13,7 @@ wrapper still collects them; the nix ``typecheckSmoke`` build provides ty.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import pytest
 
@@ -89,6 +90,57 @@ def test_an_unparseable_cell_is_left_to_the_compile_path() -> None:
     # A SyntaxError is the real compile path's job to report; the checker must not
     # pre-empt it (returns ok so the runner surfaces the SyntaxError normally).
     assert _check("def broken(:\n    pass").ok
+
+
+def test_a_star_import_cell_is_not_blocked() -> None:
+    # `from x import *` is legal at the kernel's module scope but a SyntaxError
+    # inside the `async def` wrapper (confirmed on ty 0.0.40: error[invalid-syntax]
+    # on the cell's own line), so the checker skips such a cell instead of
+    # blocking it.
+    assert _check("from math import *\nx = sqrt(4)").ok
+
+
+def test_deleting_a_prior_cell_name_is_not_flagged() -> None:
+    # `del prior_name` unbinds the module-scope name; without a `global` in the
+    # wrapper it would read as an unbound-local delete.
+    assert _check("del prior_name", {"prior_name": 5}).ok
+
+
+# --------------------------------------------------------------------------- #
+# the checker's own failure never blocks a cell
+# --------------------------------------------------------------------------- #
+
+
+def _install_hung_ty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point IX_MCP_TY_BIN at a stub that sleeps far past any test budget."""
+    stub = tmp_path / "ty"
+    stub.write_text("#!/bin/sh\nsleep 60\n")
+    stub.chmod(0o755)
+    monkeypatch.setenv("IX_MCP_TY_BIN", str(stub))
+
+
+def test_a_hung_checker_reports_ok(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_hung_ty(tmp_path, monkeypatch)
+    result = asyncio.run(typecheck.check("x = 1", {}, timeout=0.3))
+    assert result.ok
+
+
+def test_a_hung_checker_still_lets_the_cell_execute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The regression this guards: the timeout handler raising (e.g. the missing
+    # contextlib import) propagated into _runner and recorded the cell as FAILED.
+    # With a ty that hangs, the check must give up quietly and the cell must run.
+    _install_hung_ty(tmp_path, monkeypatch)
+    real_check = typecheck.check
+
+    async def fast_check(code: str, namespace: dict) -> typecheck.TypeCheckResult:
+        return await real_check(code, namespace, timeout=0.3)
+
+    monkeypatch.setattr(typecheck, "check", fast_check)
+    ns: dict = {"Result": runtime.Result}
+    _wire(monkeypatch, ns)
+    job = asyncio.run(runtime.__ix_run("ran_anyway = True\nResult.ok('ran')", budget=5.0))
+    assert job.status == "done", (job.status, job.error)
+    assert ns.get("ran_anyway") is True
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/mcp/tests/test_typecheck.py
+++ b/packages/mcp/tests/test_typecheck.py
@@ -1,0 +1,130 @@
+"""Per-cell static type checking before execution (issue #1754, new feature).
+
+Every ``python_exec`` cell is type-checked first; a type error blocks the cell
+(it never runs) and the diagnostic is returned so the agent can fix and retry.
+The hard constraint is zero false positives on the persistent namespace: prior-cell
+names and injected helpers must not be flagged as undefined. These tests exercise
+the checker directly (``typecheck.check``) and end to end through the runner.
+
+They skip when ``ty`` is not resolvable, so a bare dev checkout without the nix
+wrapper still collects them; the nix ``typecheckSmoke`` build provides ty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ix_notebook_mcp import runtime, typecheck
+
+_HAS_TY = typecheck._ty_bin() is not None
+pytestmark = pytest.mark.skipif(not _HAS_TY, reason="ty not resolvable (IX_MCP_TY_BIN / PATH)")
+
+
+def _check(code: str, namespace: dict | None = None) -> typecheck.TypeCheckResult:
+    return asyncio.run(typecheck.check(code, namespace or {}))
+
+
+# --------------------------------------------------------------------------- #
+# the checker in isolation: clean passes, real errors block, no false positives
+# --------------------------------------------------------------------------- #
+
+
+def test_a_clean_cell_passes() -> None:
+    assert _check("x = 1 + 2\ny = str(x)").ok
+
+
+def test_a_type_error_is_caught() -> None:
+    result = _check("n: int = 'not an int'")
+    assert not result.ok
+    assert "invalid-assignment" in result.report
+    assert "line 1:" in result.report  # mapped back to the cell's own line
+
+
+def test_an_undefined_name_is_caught() -> None:
+    result = _check("print(totally_undefined_name)")
+    assert not result.ok
+    assert "unresolved-reference" in result.report
+
+
+def test_injected_helpers_are_not_flagged_as_undefined() -> None:
+    # sh/jobs/grep/Result/api are live objects, not in the cell source; stubbed as
+    # Any, they must not trip unresolved-reference.
+    ns = {"sh": object(), "jobs": {}, "grep": object(), "Result": runtime.Result, "api": object()}
+    assert _check("out = await sh('echo hi')\nn = len(jobs)\nr = Result.ok('x')", ns).ok
+
+
+def test_prior_cell_names_are_not_flagged() -> None:
+    ns = {"prior_value": 42, "helper_fn": (lambda a: a)}
+    assert _check("doubled = prior_value * 2\nresult = helper_fn(doubled)", ns).ok
+
+
+def test_prior_scalar_still_catches_a_real_misuse() -> None:
+    # A read-only prior int keeps its real type, so `.upper()` on it is caught --
+    # the checking is real, not everything-is-Any.
+    result = _check("prior_count.upper()", {"prior_count": 5})
+    assert not result.ok
+    assert "unresolved-attribute" in result.report
+
+
+def test_reassigning_a_prior_name_to_a_new_type_is_allowed() -> None:
+    # Python allows rebinding; a concrete stub would flag it. The reassigned name
+    # degrades to Any so the legitimate rebind passes.
+    assert _check("x = 'now a string'", {"x": 5}).ok
+
+
+def test_top_level_await_and_yield_are_legal() -> None:
+    assert _check("out = await sh('hi')", {"sh": object()}).ok
+    assert _check("for i in range(3):\n    yield i").ok
+
+
+def test_comprehensions_fstrings_and_imports_do_not_false_positive() -> None:
+    assert _check("nums = [i * 2 for i in range(5)]\ntotal = sum(nums)").ok
+    assert _check("name = 'x'\ng = f'hi {name} {1 + 2}'").ok
+    assert _check("import os\np = os.path.join('a', 'b')").ok
+
+
+def test_an_unparseable_cell_is_left_to_the_compile_path() -> None:
+    # A SyntaxError is the real compile path's job to report; the checker must not
+    # pre-empt it (returns ok so the runner surfaces the SyntaxError normally).
+    assert _check("def broken(:\n    pass").ok
+
+
+# --------------------------------------------------------------------------- #
+# end to end through the runner: a type error blocks execution
+# --------------------------------------------------------------------------- #
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+
+
+def test_a_type_error_cell_is_blocked_before_it_executes(monkeypatch: pytest.MonkeyPatch) -> None:
+    ns: dict = {"Result": runtime.Result}
+    _wire(monkeypatch, ns)
+    # The cell would set a side effect if it ran; it must not.
+    job = asyncio.run(runtime.__ix_run("side_effect = 1\nbad: int = 'nope'", budget=5.0))
+    assert job.status == "error"
+    assert "Type check failed" in (job.error or "")
+    assert "side_effect" not in ns, "the cell ran despite the type error"
+
+
+def test_a_clean_cell_runs_through_the_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    ns: dict = {"Result": runtime.Result}
+    _wire(monkeypatch, ns)
+    job = asyncio.run(runtime.__ix_run("value = 6 * 7\nResult.text(str(value))", budget=5.0))
+    assert job.status == "done", (job.status, job.error)
+    assert job.result.llm_result == "42"
+
+
+def test_the_escape_hatch_disables_checking(monkeypatch: pytest.MonkeyPatch) -> None:
+    ns: dict = {"Result": runtime.Result}
+    _wire(monkeypatch, ns)
+    monkeypatch.setenv("IX_MCP_TYPECHECK", "0")
+    # A type error now runs (and simply fails or succeeds at runtime), rather than
+    # being blocked by the checker. This cell is a valid assignment at runtime.
+    job = asyncio.run(runtime.__ix_run("bad: int = 'nope'\nResult.ok('ran')", budget=5.0))
+    assert job.status == "done", (job.status, job.error)

--- a/packages/mcp/tests/test_typecheck.py
+++ b/packages/mcp/tests/test_typecheck.py
@@ -106,6 +106,79 @@ def test_deleting_a_prior_cell_name_is_not_flagged() -> None:
     assert _check("del prior_name", {"prior_name": 5}).ok
 
 
+def test_a_nested_star_import_is_not_blocked() -> None:
+    # `from x import *` under a top-level `if` is still module-scope at runtime
+    # but a SyntaxError inside the wrapper; the skip must see nested statements.
+    assert _check("if True:\n    from math import *").ok
+
+
+def test_internal_helper_cells_are_not_flagged() -> None:
+    # The read MCP tool submits `await __ix_read(...)` through the same runner
+    # path; the runtime's __ix_* entrypoints live in the namespace and must be
+    # stubbed (they are not Python-managed dunders), or every read() is blocked.
+    assert _check("await __ix_read('x', None, None, session=None)", {"__ix_read": object()}).ok
+
+
+def test_single_underscore_prior_names_are_stubbed() -> None:
+    # `_df` is a real prior-cell binding, not an introspection artifact.
+    assert _check("_out = _df", {"_df": object()}).ok
+
+
+def test_a_prior_name_shadowing_a_builtin_uses_the_binding() -> None:
+    # `id = 'abc'` in a prior cell shadows the builtin at runtime, so the stub
+    # must shadow it for the check too: reading the str is fine, and calling it
+    # like the builtin is now the real error it would be at runtime.
+    assert _check("id.upper()", {"id": "abc"}).ok
+    assert not _check("id(5)", {"id": "abc"}).ok
+
+
+def test_a_user_future_import_is_not_blocked() -> None:
+    # Legal at the cell's real module scope; a SyntaxError if indented into the
+    # wrapper, so it is hoisted (blanked; the preamble already carries one).
+    assert _check("from __future__ import annotations\nx: 'int' = 1").ok
+
+
+def test_assignments_inside_compound_statements_bind_the_cell_scope() -> None:
+    # `print(x)` then a conditional `x = 2`: the nested assignment binds the
+    # cell's module scope, so the earlier read must resolve to the prior global
+    # (missing the nested binding made x a wrapper-local, flagging the read).
+    assert _check("print(prior)\nif True:\n    prior = 2", {"prior": 5}).ok
+
+
+def test_annotating_a_prior_name_fails_open() -> None:
+    # `print(x)` then `x: int = 2`: Python forbids `global` on a name annotated
+    # in the same scope, so the wrapper cannot scope this shape correctly; the
+    # checker skips the cell rather than flag the valid read.
+    assert _check("print(prior)\nprior: int = 2", {"prior": 5}).ok
+
+
+def test_workspace_modules_next_to_the_notebook_resolve(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A first-party module in the kernel's working directory imports fine at
+    # runtime (cwd is on sys.path), so the checker must resolve it too.
+    (tmp_path / "myworkmod.py").write_text("VALUE: int = 7\n")
+    monkeypatch.chdir(tmp_path)
+    assert _check("import myworkmod\nprint(myworkmod.VALUE)").ok
+
+
+def test_a_replayed_session_cell_is_never_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Session reopen re-runs already-successful cells (kind="replay"); blocking
+    # one on a checker finding would silently drop its bindings from the
+    # restored namespace.
+    ns: dict = {"Result": runtime.Result}
+    _wire(monkeypatch, ns)
+
+    async def replay() -> runtime.Job:
+        job = runtime.Job("replayed_flag = True\nbad: int = 'nope'", budget=5.0, kind="replay")
+        runtime.jobs[job.id] = job
+        job.task = asyncio.ensure_future(runtime._runner(job, ns))
+        await job.task
+        return job
+
+    job = asyncio.run(replay())
+    assert job.status == "done", (job.status, job.error)
+    assert ns.get("replayed_flag") is True
+
+
 # --------------------------------------------------------------------------- #
 # the checker's own failure never blocks a cell
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

MCP kernel fixes (issue #1754) plus per-cell static type checking (issue #1757).

### #1754 — three production papercuts
1. **`await jobs[id]` on a failed job re-raises** the cell's original exception (type, message, cell traceback) instead of returning `None` — which had made `(await jobs[id]).text` blow up with an opaque `AttributeError`, inverting the documented "raises rather than a misleading None" contract. The Job now keeps the exception object.
2. **Unified Job/Result accessor surface.** `Result.output` aliases the model text (matching `sh`'s `Output.output` and `Job.output`); `Job.text` is the finished run's result text (sibling of `.output`). No more guessing which surface owns a name.
3. **fsearch returns partial results on timeout** instead of discarding them: `sh` attaches the pre-deadline output to the `TimeoutError`, and grep/find/spotlight wrap it in a `PartialFrame` (`.truncated` / `.reason` + a repr banner). `grep` also **streams rg's `--json` and kills the process group once `limit` rows are parsed**, so a capped query no longer scans the whole tree.

### #1757 — per-cell static type checking (new feature)
Every `python_exec` cell is type-checked with `ty` **before** it runs (default on; `IX_MCP_TYPECHECK=0` or `Config.typecheck` to disable). A type error blocks the cell and returns the diagnostic so the agent fixes and retries, instead of hitting it three lines into a side-effecting cell.

**Namespace strategy (the hard part):** the kernel namespace persists and helpers (`sh`, `jobs`, `grep`, `Result`, `api`, ...) are live objects, not in the cell source — a naive check flags them all as undefined. So the checker synthesizes a typed preamble from the live namespace (real builtin types where cheap, `Any` otherwise) and wraps the cell in `async def __ix_cell__():` (so top-level `await`/`yield` stay legal) with a `global` for prior-cell names, then checks that synthetic module and maps diagnostics back to cell lines. False positives that block a valid cell are worse than no checking, so:
- names that shadow builtins are never stubbed (ty already knows them);
- a namespaced name the cell **reassigns** degrades to `Any` (Python allows rebinding to a new type — a concrete stub would false-positive);
- brand-new names stay wrapper-locals (avoids ty narrowing them to their first literal type);
- a read-only prior scalar keeps its real type, so a genuine misuse (`x = 5` earlier, `x.upper()` now) is still caught.

`ty` is a **nix-provided dependency** (`IX_MCP_TY_BIN` on the wrapper, checked against the kernel interpreter), ~40–120ms/cell, never fetched at runtime. The checker's own failures (unavailable, hung, unparseable cell) never block a cell.

## Tests
- `tests/test_job_await_errors.py` — reproduces the exact prod failure (await → `.text`), the re-raise, and the accessor symmetry.
- `tests/test_fsearch_partial.py` — `PartialFrame` surface, partial-on-timeout (deterministic, faked backend), and the real-rg `limit` short-circuit.
- `tests/test_typecheck.py` — clean passes, type-error blocked pre-exec (side effect proven absent), prior-cell names + injected helpers don't false-positive, escape hatch, top-level await/yield, comprehensions/f-strings/imports.
- nix `mcp.tests.typecheckSmoke` passthru wires the three suites with `ty` provided; `fsearchBundled` gains partial/limit assertions.

`nix run .#lint` clean over the changed files (verified with the repo's exact ruff select). Python logic validated in a live kernel. The full darwin `mcp` build compiles the whole Rust cdylib workspace locally (tui/search/nu), which is slow on this machine; CI (linux builders + substituters) runs the passthru builds.

_Disclosure: authored by an AI agent (Claude Code)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-cell static type checking, fsearch partial results, and kernel job error fixes
> - Adds a new [`typecheck.py`](https://github.com/indexable-inc/index/pull/1758/files#diff-cbfce87bcc71992ff78b6d76debfeb9900ee922abe1f35cddf31279031e73af7) module that runs the `ty` type checker against cell code before execution, mapping diagnostics back to cell line numbers; type errors block execution and return a diagnostic result instead.
> - Introduces `PartialFrame` in [`fsearch`](https://github.com/indexable-inc/index/pull/1758/files#diff-d49cbee7af25fcd8a29d12e63297e2d875f7609698886e1aec71033697a75bac) — a `polars.DataFrame` subclass that signals truncated results; `grep`, `find`, and `spotlight` now return `PartialFrame` on timeout or limit hit instead of raising, and `grep` supports early termination at the match limit via streaming ripgrep JSON output.
> - The LLM text rendering for dataframes now prefixes output with a `[partial results: reason]` banner when a frame carries a `truncated` attribute.
> - Failed kernel jobs now retain the original exception and traceback (`_exc`, `_exc_tb`) so `await job` re-raises the original error; `Result` gains an `.output` alias for `.text`.
> - Behavioral Change: type checking is enabled by default (`typecheck: bool = True` in config, overridable via `IX_MCP_TYPECHECK` env var); cells with type errors are blocked from execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b4701c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->