### PR TITLE
fix(mcp): surface fire-and-forget task failures; Result.output alias

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -5142,6 +5142,35 @@ let
         mkdir -p "$out"
       '';
 
+  # Background-task failure reporting (packages/mcp/tests/test_task_errors.py):
+  # a fire-and-forget task that dies with an unretrieved exception must be
+  # reported at completion into `task_errors` (asyncio's own warning only fires
+  # at GC, and never for a task a namespace variable keeps alive -- the exact
+  # watcher pattern that starved monitors silently on 2026-07-02), plus the
+  # `Result.output` alias that AttributeError'd that watcher.
+  taskErrorsTestSource = builtins.path {
+    name = "ix-mcp-task-errors-test";
+    path = ./tests/test_task_errors.py;
+  };
+  taskErrorsTests =
+    pkgs.runCommand "ix-mcp-task-errors-tests"
+      {
+        nativeBuildInputs = [ channelTestPython ];
+        strictDeps = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        cp ${taskErrorsTestSource} "$TMPDIR/test_task_errors.py"
+        ${lib.getExe channelTestPython} -m pytest "$TMPDIR/test_task_errors.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp task-errors tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
+
   # The Claude Code channel + interactive resource actions
   # (packages/mcp/tests/test_channel.py): the store outbox/events queues, the
   # kernel's notify() + action dispatch, the transport pump emitting
@@ -5527,6 +5556,7 @@ package.overrideAttrs (old: {
         apiSmoke
         inputsTests
         channelTests
+        taskErrorsTests
         inputBrowserSmoke
         svelteBundled
         svelteTests

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -32,6 +32,7 @@ import ast
 import asyncio
 import base64
 import binascii
+import collections
 import contextlib
 import contextvars
 import dataclasses
@@ -58,6 +59,76 @@ _ix_current: contextvars.ContextVar = contextvars.ContextVar("ix_current_job", d
 # and the dashboard). A chatty/runaway job keeps only the most recent slice, so
 # memory, store writes, and poll payloads all stay bounded.
 _MAX_OUTPUT_CHARS = 256_000
+
+# Bounded record of background-task failures, newest last; bound into the user
+# namespace as `task_errors`. asyncio only reports a failed, never-awaited task
+# at garbage collection, and never reports one a namespace variable keeps alive
+# -- which is exactly the fire-and-forget watcher pattern this kernel invites
+# (`asyncio.create_task(...)` bound to a name). One such watcher died on an
+# AttributeError on 2026-07-02 and starved its monitors for 90 minutes with no
+# trace anywhere. The task factory below reports at completion instead.
+task_errors: collections.deque[str] = collections.deque(maxlen=50)
+
+# The namespace-install flusher task (see _install), module-held so it cannot
+# be garbage-collected mid-flight.
+_flusher_task: asyncio.Task | None = None
+
+# Grace period between a task finishing with an exception and the failure being
+# reported: a parent that promptly retrieves it (`await task`, `gather`,
+# `.exception()`) wins the race and nothing is reported; a task nobody checks
+# within this window is treated as fire-and-forget and surfaced. A parent that
+# retrieves *later* still gets the exception raised normally -- it just also
+# left a (harmless) report behind.
+_TASK_FAILURE_GRACE_S = 2.0
+
+
+def _report_task_failure(task: asyncio.Task) -> None:
+    exc = task.exception()  # also clears the interpreter's own GC-time warning, which this report replaces
+    if exc is None:
+        return
+    tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    coro = task.get_coro()
+    where = getattr(coro, "__qualname__", None) or repr(coro)
+    msg = f"[task_errors] background task {task.get_name()!r} ({where}) died unhandled:\n{tb}"
+    task_errors.append(msg)
+    # Tasks copy the spawning cell's context, so the job that created this task
+    # is reachable and its buffer is where the model will look first.
+    job = task.get_context().get(_ix_current)
+    if job is not None:
+        job._append(msg)
+    with contextlib.suppress(Exception):  # reporting must never take the loop down
+        print(msg, file=sys.__stderr__, flush=True)
+
+
+def _on_task_done(task: asyncio.Task) -> None:
+    if task.cancelled():
+        return
+    with contextlib.suppress(RuntimeError):  # loop already closed: nowhere left to report
+        task.get_loop().call_later(
+            _TASK_FAILURE_GRACE_S,
+            # `_log_traceback` is the interpreter's own "exception not yet
+            # retrieved" flag (cleared by `await`/`.result()`/`.exception()`);
+            # private, but it is precisely the signal CPython's GC-time
+            # warning keys on, and there is no public completion-time
+            # equivalent.
+            lambda: getattr(task, "_log_traceback", False) and _report_task_failure(task),
+        )
+
+
+def _install_task_failure_watch(loop: asyncio.AbstractEventLoop) -> None:
+    """Report every task that finishes with an unretrieved exception (see
+    `task_errors`). Installed as a task factory because a done-callback is the
+    only completion-time hook asyncio offers, and wrapping the factory is the
+    only way to attach one to every task, including ones third-party code
+    spawns."""
+    prior = loop.get_task_factory()
+
+    def factory(loop: asyncio.AbstractEventLoop, coro: Any, **kwargs: Any) -> asyncio.Task:
+        task = prior(loop, coro, **kwargs) if prior is not None else asyncio.Task(coro, loop=loop, **kwargs)
+        task.add_done_callback(_on_task_done)
+        return task
+
+    loop.set_task_factory(factory)
 
 # Longest edge (px) of an image returned to the model. A full-page screenshot or
 # hi-DPI figure otherwise spends vision tokens scaling with its resolution for no
@@ -601,6 +672,17 @@ class Result:
     # returned the bound constructor, a guessing-game error when inspecting a
     # finished job.
     text = _TextDescriptor()
+
+    @property
+    def output(self) -> str:
+        """The rendered model text, under the name ``Job.output`` and ``sh()``'s
+        ``Output.output`` already answer to. ``await jobs['id']`` yields a
+        Result while the un-awaited handle is a Job, so paging code holding
+        "whichever one finished" reaches ``.output`` either way; before this
+        alias that exact access died with an AttributeError, and inside a
+        fire-and-forget watcher task it died silently (2026-07-02, 90 minutes
+        of starved monitors -- the incident behind ``task_errors``)."""
+        return self.llm_result or ""
 
     @classmethod
     def ok(cls, message: str = "done") -> Result:
@@ -3621,6 +3703,10 @@ def install(user_ns: dict | None = None) -> None:
 
         target["pl"] = _polars_mod
     target["api"] = api
+    # Failures of fire-and-forget tasks, newest last (see the deque's comment).
+    # A report also lands in the spawning job's output, tagged `[task_errors]`,
+    # which is how the name advertises itself.
+    target["task_errors"] = task_errors
 
     # Everything in the namespace up to here is the runtime's own surface plus
     # the kernel preamble -- not user state. Session checkpoints cover only the
@@ -3644,5 +3730,11 @@ def install(user_ns: dict | None = None) -> None:
     # user names; refs accumulate as runs touch them).
     _name_refs.clear()
 
-    with contextlib.suppress(RuntimeError):  # no event loop yet (sync context): flusher is optional
-        asyncio.get_event_loop().create_task(_flusher())
+    with contextlib.suppress(RuntimeError):  # no event loop yet (sync context): flusher and task watch are optional
+        loop = asyncio.get_event_loop()
+        # Held in a global so the flusher can never be garbage-collected
+        # mid-flight (RUF006) -- the exact fire-and-forget hazard
+        # _install_task_failure_watch exists to surface.
+        global _flusher_task
+        _flusher_task = loop.create_task(_flusher())
+        _install_task_failure_watch(loop)

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -89,7 +89,14 @@ def _report_task_failure(task: asyncio.Task) -> None:
     tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
     coro = task.get_coro()
     where = getattr(coro, "__qualname__", None) or repr(coro)
-    msg = f"[task_errors] background task {task.get_name()!r} ({where}) died unhandled:\n{tb}"
+    # "unretrieved after Ns", not "crashed": a parent that awaits this task
+    # later than the grace window still gets the exception raised normally --
+    # this report then just flagged it early, it is not a second failure.
+    msg = (
+        f"[task_errors] background task {task.get_name()!r} ({where}) failed and nothing "
+        f"retrieved the exception within {_TASK_FAILURE_GRACE_S:g}s (a later `await` "
+        f"still raises it):\n{tb}"
+    )
     task_errors.append(msg)
     # Tasks copy the spawning cell's context, so the job that created this task
     # is reachable and its buffer is where the model will look first.
@@ -103,16 +110,17 @@ def _report_task_failure(task: asyncio.Task) -> None:
 def _on_task_done(task: asyncio.Task) -> None:
     if task.cancelled():
         return
+
+    def check() -> None:
+        # `_log_traceback` is the interpreter's own "exception not yet
+        # retrieved" flag (cleared by `await`/`.result()`/`.exception()`);
+        # private, but it is precisely the signal CPython's GC-time warning
+        # keys on, and there is no public completion-time equivalent.
+        if getattr(task, "_log_traceback", False):
+            _report_task_failure(task)
+
     with contextlib.suppress(RuntimeError):  # loop already closed: nowhere left to report
-        task.get_loop().call_later(
-            _TASK_FAILURE_GRACE_S,
-            # `_log_traceback` is the interpreter's own "exception not yet
-            # retrieved" flag (cleared by `await`/`.result()`/`.exception()`);
-            # private, but it is precisely the signal CPython's GC-time
-            # warning keys on, and there is no public completion-time
-            # equivalent.
-            lambda: getattr(task, "_log_traceback", False) and _report_task_failure(task),
-        )
+        task.get_loop().call_later(_TASK_FAILURE_GRACE_S, check)
 
 
 def _install_task_failure_watch(loop: asyncio.AbstractEventLoop) -> None:
@@ -120,7 +128,10 @@ def _install_task_failure_watch(loop: asyncio.AbstractEventLoop) -> None:
     `task_errors`). Installed as a task factory because a done-callback is the
     only completion-time hook asyncio offers, and wrapping the factory is the
     only way to attach one to every task, including ones third-party code
-    spawns."""
+    spawns. Idempotent: re-running `install()` on the same loop must not stack
+    watchers (each stack would double the per-task callback and 2s timer)."""
+    if getattr(loop.get_task_factory(), "_ix_task_watch", False):
+        return
     prior = loop.get_task_factory()
 
     def factory(loop: asyncio.AbstractEventLoop, coro: Any, **kwargs: Any) -> asyncio.Task:
@@ -128,6 +139,7 @@ def _install_task_failure_watch(loop: asyncio.AbstractEventLoop) -> None:
         task.add_done_callback(_on_task_done)
         return task
 
+    factory._ix_task_watch = True  # our own sentinel, read back by the guard above
     loop.set_task_factory(factory)
 
 # Longest edge (px) of an image returned to the model. A full-page screenshot or

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -103,6 +103,12 @@ def _report_task_failure(task: asyncio.Task) -> None:
     job = task.get_context().get(_ix_current)
     if job is not None:
         job._append(msg)
+        # The common fire-and-forget case dies AFTER its spawning cell
+        # finished, i.e. after _persist_final already wrote the store row; a
+        # bare _append would then be visible to `jobs[id].output` but never
+        # reach the dashboard card. Re-persist so the stored row carries it.
+        if not job.running():
+            _persist_final(job)
     with contextlib.suppress(Exception):  # reporting must never take the loop down
         print(msg, file=sys.__stderr__, flush=True)
 
@@ -1950,6 +1956,12 @@ def _error_line(exc: BaseException, job: Job) -> int | None:
 
 async def _runner(job: Job, ns: dict) -> None:
     token = _ix_current.set(job)
+    # (Re-)arm the task-failure watch on the loop actually running jobs.
+    # `install()` may have run in a sync context where `get_event_loop()`
+    # handed back a dormant default loop that is not this one; installing
+    # here (idempotent, sentinel-guarded) guarantees every task a cell spawns
+    # is watched regardless of how the kernel was embedded.
+    _install_task_failure_watch(asyncio.get_running_loop())
     if _store is not None and _store_conn is not None:
         with contextlib.suppress(Exception):  # best-effort: store write must not abort the job
             _store.start(
@@ -3744,9 +3756,9 @@ def install(user_ns: dict | None = None) -> None:
 
     with contextlib.suppress(RuntimeError):  # no event loop yet (sync context): flusher and task watch are optional
         loop = asyncio.get_event_loop()
-        # Held in a global so the flusher can never be garbage-collected
-        # mid-flight (RUF006) -- the exact fire-and-forget hazard
-        # _install_task_failure_watch exists to surface.
+        # Watch first, then spawn: the flusher must itself be a watched task,
+        # and its module-global reference (which prevents GC, RUF006) is
+        # exactly what would otherwise keep a crashed flusher silent forever.
+        _install_task_failure_watch(loop)
         global _flusher_task
         _flusher_task = loop.create_task(_flusher())
-        _install_task_failure_watch(loop)

--- a/packages/mcp/tests/test_task_errors.py
+++ b/packages/mcp/tests/test_task_errors.py
@@ -1,0 +1,71 @@
+"""A fire-and-forget task that dies must be reported at completion, not GC.
+
+Regression for 2026-07-02: a watcher task held by a namespace variable raised
+an AttributeError and was never reported (CPython only warns at GC, and a live
+reference prevents GC forever), starving external monitors for 90 minutes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ix_notebook_mcp import runtime
+
+
+def test_result_output_aliases_rendered_text() -> None:
+    result = runtime.Result.text("hello")
+    assert result.output == "hello"
+    assert result.output == result.llm_result
+
+
+def test_unretrieved_task_failure_is_reported_even_with_live_reference() -> None:
+    async def scenario() -> list[str]:
+        runtime._install_task_failure_watch(asyncio.get_running_loop())
+        runtime.task_errors.clear()
+
+        async def boom() -> None:
+            raise AttributeError("'Result' object has no attribute 'output'")
+
+        # The failure mode under test: a strong reference keeps the task alive,
+        # so the GC-time warning would never fire.
+        held = asyncio.create_task(boom(), name="watcher")
+        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 0.5)
+        assert held is not None  # keep the reference genuinely live past the grace period
+        return list(runtime.task_errors)
+
+    reports = asyncio.run(scenario())
+    assert len(reports) == 1
+    assert "'watcher'" in reports[0]
+    assert "AttributeError" in reports[0]
+
+
+def test_retrieved_task_failure_is_not_reported() -> None:
+    async def scenario() -> list[str]:
+        runtime._install_task_failure_watch(asyncio.get_running_loop())
+        runtime.task_errors.clear()
+
+        async def boom() -> None:
+            raise ValueError("handled")
+
+        task = asyncio.create_task(boom())
+        with pytest.raises(ValueError, match="handled"):
+            await task  # prompt retrieval: the parent owns this failure
+        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 0.5)
+        return list(runtime.task_errors)
+
+    assert asyncio.run(scenario()) == []
+
+
+def test_cancelled_task_is_not_reported() -> None:
+    async def scenario() -> list[str]:
+        runtime._install_task_failure_watch(asyncio.get_running_loop())
+        runtime.task_errors.clear()
+
+        task = asyncio.create_task(asyncio.sleep(60))
+        task.cancel()
+        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 0.5)
+        return list(runtime.task_errors)
+
+    assert asyncio.run(scenario()) == []

--- a/packages/mcp/tests/test_task_errors.py
+++ b/packages/mcp/tests/test_task_errors.py
@@ -94,3 +94,19 @@ def test_install_is_idempotent() -> None:
     assert len(reports) == 1
     assert factory is not None
     assert getattr(factory, "_ix_task_watch", False)
+
+
+def test_second_install_leaves_factory_untouched() -> None:
+    """A double-wrap would produce a NEW factory object that also carries the
+    sentinel and still deduplicates reports, so only object identity catches
+    an accidental re-wrap."""
+
+    async def scenario() -> tuple[object, object]:
+        loop = asyncio.get_running_loop()
+        runtime._install_task_failure_watch(loop)
+        first = loop.get_task_factory()
+        runtime._install_task_failure_watch(loop)
+        return first, loop.get_task_factory()
+
+    first, second = asyncio.run(scenario())
+    assert second is first

--- a/packages/mcp/tests/test_task_errors.py
+++ b/packages/mcp/tests/test_task_errors.py
@@ -31,7 +31,7 @@ def test_unretrieved_task_failure_is_reported_even_with_live_reference() -> None
         # The failure mode under test: a strong reference keeps the task alive,
         # so the GC-time warning would never fire.
         held = asyncio.create_task(boom(), name="watcher")
-        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 0.5)
+        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 1.0)
         assert held is not None  # keep the reference genuinely live past the grace period
         return list(runtime.task_errors)
 
@@ -52,7 +52,7 @@ def test_retrieved_task_failure_is_not_reported() -> None:
         task = asyncio.create_task(boom())
         with pytest.raises(ValueError, match="handled"):
             await task  # prompt retrieval: the parent owns this failure
-        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 0.5)
+        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 1.0)
         return list(runtime.task_errors)
 
     assert asyncio.run(scenario()) == []
@@ -65,7 +65,32 @@ def test_cancelled_task_is_not_reported() -> None:
 
         task = asyncio.create_task(asyncio.sleep(60))
         task.cancel()
-        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 0.5)
+        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 1.0)
         return list(runtime.task_errors)
 
     assert asyncio.run(scenario()) == []
+
+
+def test_install_is_idempotent() -> None:
+    """Re-running install() must not stack watcher factories (a stack doubles
+    the per-task callbacks and timers, and a report per stacked layer)."""
+
+    async def scenario() -> tuple[object, list[str]]:
+        loop = asyncio.get_running_loop()
+        runtime._install_task_failure_watch(loop)
+        first = loop.get_task_factory()
+        runtime._install_task_failure_watch(loop)
+        runtime.task_errors.clear()
+
+        async def boom() -> None:
+            raise RuntimeError("once")
+
+        held = asyncio.create_task(boom())
+        await asyncio.sleep(runtime._TASK_FAILURE_GRACE_S + 1.0)
+        assert held is not None
+        return loop.get_task_factory(), list(runtime.task_errors)
+
+    factory, reports = asyncio.run(scenario())
+    assert len(reports) == 1
+    assert factory is not None
+    assert getattr(factory, "_ix_task_watch", False)


### PR DESCRIPTION
`asyncio` only reports a failed, never-awaited task at GC, and never while a reference keeps it alive -- the exact fire-and-forget watcher pattern the kernel invites. On 2026-07-02 a watcher died instantly on `(await jobs[id]).output` (`Result` has `.text`, not `.output`) and starved its monitors for ~90 minutes with zero trace anywhere.

- task factory + done-callback: an exception still unretrieved 2s after completion is reported into the spawning job's output (tagged `[task_errors]`, recovered via the task's copied context) and a namespace-visible `task_errors` deque (maxlen 50); prompt retrieval (`await`/`gather`) wins the race and reports nothing; cancellation is ignored
- `Result.output` aliases the rendered model text, matching `Job.output` / `Output.output`, killing the AttributeError footgun
- flusher task now module-held (RUF006; it was itself un-referenced)
- new nix check `taskErrorsTests` (4 tests: report-on-live-reference, no-report-on-retrieval, no-report-on-cancel, alias)

Validated: `nix run .#lint` 7/7; `.#packages.aarch64-darwin.mcp.passthru.tests.{taskErrorsTests,runtimeSmoke}` green.

Closes #1759

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface fire-and-forget asyncio task failures in the MCP runtime and add `Result.output` alias
> - Installs a task factory wrapper on the event loop (via `_install_task_failure_watch`) that attaches a done-callback to every asyncio task, detecting un-retrieved exceptions after a 2-second grace period.
> - Failed tasks are recorded in a module-level `task_errors` deque (maxlen=50), printed to stderr, and appended to the spawning job's output, re-persisting the job if it has already finished.
> - Cancelled tasks and tasks whose exceptions are promptly retrieved are not reported.
> - Adds `Result.output` as an alias for `Result.llm_result`, returning the rendered text or an empty string, fixing `AttributeError` for callers that access `.output`.
> - Adds tests in [test_task_errors.py](https://github.com/indexable-inc/index/pull/1760/files#diff-bd5d66430cffe37df7e67d2741dd7c2a0b71cd24fd6e6ff2553b7a8f76931489) covering failure reporting, prompt retrieval suppression, cancellation, and idempotent factory installation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 914bb60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->