### PR TITLE
agent: own filed issues with a named agent per issue

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -305,6 +305,25 @@ let
       };
     }
     {
+      agentPerIssue = {
+        text = ''
+          Filing an issue is not the end of ownership. When you find or file an
+          issue you could properly resolve yourself, also spawn a named background
+          agent per issue (name it after the issue, e.g.
+          `issue-1687-cross-ifd-roots`) to drive it to a merged fix, and note the
+          handoff on the issue. Skip the spawn when the issue already has an
+          active owner or handoff note, or when pursuing it would silently expand
+          a deliberately bounded task the user gave you. File-and-stop only when
+          the fix needs a human decision or is genuinely out of your reach.
+        '';
+        reason = ''
+          Found problems were filed and forgotten instead of fixed; a named agent
+          per issue keeps ownership through merge. The owner and scope gates stop
+          duplicate agents racing one ticket and silent expansion of bounded tasks.
+        '';
+      };
+    }
+    {
       preV1 = {
         text = ''
           This codebase is pre-v1. Prefer the correct API over compatibility. Migrate


### PR DESCRIPTION
Supersedes #1746 (its Actions event delivery wedged; checks never ran on the amended head).

Adds an `agentPerIssue` rule to the house system prompt, next to `tieToIssue`: filing an issue is not the end of ownership — spawn a named background agent per resolvable issue to drive it to a merged fix, note the handoff on the issue; skip when the issue already has an active owner or when pursuing it would silently expand a bounded task (both per AI review on #1746, already applied here).

Rendered via the promptEval recipe; rule key omittable; nixfmt clean.

🤖 Opened with Claude Code (Opus 4.8)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add system prompt rule to spawn a named background agent per filed issue
> Adds an `agentPerIssue` rule to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1761/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to spawn a named background agent for each issue it finds or files that it could resolve itself. The rule includes naming guidance and gating conditions: skip if there is an active owner or handoff note, skip if it would expand a bounded task, and file-and-stop when a human decision is needed or the issue is out of reach.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9cfc7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->