### PR TITLE
panes guest: bake the Vulkan startup switch into the MC launch (#1686)

### DIFF
--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -21,6 +21,8 @@
 #                           with baked config it can still rewrite at runtime
 { pkgs }:
 let
+  inherit (pkgs) lib;
+
   # portablemc's default wrapper bundles four full OpenJDKs (25/21/17/8,
   # ~1.9 GiB); its package.nix exposes `jvms` exactly to cut that closure.
   # MC 26.2 requires Java SE 25 minimum, so ship exactly jdk25 (the full JDK,
@@ -38,6 +40,61 @@ let
   # LWJGL's own Maven builds, injected via the overlay in ./default.nix,
   # where the ./pins.json hashes live.
   lwjglNatives = pkgs.lwjgl-natives-linux-arm64;
+
+  # Everything after `start` that both portablemc invocations below share.
+  mcStartArgs = builtins.concatStringsSep " " [
+    # 26.2 requires Java SE 25 minimum (see the portablemc jvms override).
+    "--jvm ${pkgs.jdk25}/bin/java"
+    # LWJGL loads its JNI natives from here instead of the (absent)
+    # manifest-provided linux-arm64 ones.
+    "--jvm-arg=-Dorg.lwjgl.librarypath=${lwjglNatives}"
+    # Make blaze3d pick the Wayland GLFW platform: left alone it requests
+    # X11 even under Wayland ("GLFW error 0x1000E X11: DISPLAY missing").
+    # MC 26.2's built-in debug switches (SharedConstants reads
+    # MC_DEBUG_*-prefixed system properties, all gated on MC_DEBUG_ENABLED;
+    # decompiled from 26.2 GLX/SharedConstants) flip the preference with
+    # the stock Maven libglfw.so above, which is wayland-capable and
+    # carries the preedit/IME API blaze3d binds. Validated live end-to-end:
+    # the window maps on the host titled "Minecraft 26.2". If Mojang ever
+    # drops the debug flag, the fallback is a Wayland-only glfw (X11
+    # compiled out; openSUSE home:DarkWav glfw-minecraft recipe on
+    # clear-code/glfw im-support) via -Dorg.lwjgl.glfw.libname; this repo
+    # carried a packaged version of that until the debug flags landed (see
+    # index#1686 and this file's history).
+    "--jvm-arg=-DMC_DEBUG_ENABLED=true"
+    "--jvm-arg=-DMC_DEBUG_PREFER_WAYLAND=true"
+    # Offline session: no Microsoft account in the guest.
+    "-u Panes"
+    "26.2"
+  ];
+
+  # 26.2 selects its startup renderer from the `--graphicsBackend vulkan`
+  # GAME argument (joptsimple in net.minecraft.client.main.Main; the official
+  # launcher passes it) — the options.txt `preferredGraphicsBackend` seed
+  # below alone does not flip the startup backend (validated live: with only
+  # the seed the game boots GL). portablemc 5.0.3 has no game-arg
+  # passthrough, so inject the argument into the fetched version manifest's
+  # `arguments.game`: the first run prepares every download with `--dry`,
+  # jq appends the pair idempotently, and the real launch passes
+  # `--fetch-exclude 26.2` so portablemc does not re-fetch the manifest over
+  # the injection.
+  mcLaunch = pkgs.writeBashApplication {
+    name = "panes-mc-launch";
+    runtimeInputs = [ pkgs.jq ];
+    text = ''
+      json=/var/lib/minecraft/versions/26.2/26.2.json
+      if [ ! -e "$json" ]; then
+        ${portablemc}/bin/portablemc --main-dir /var/lib/minecraft start --dry ${mcStartArgs}
+      fi
+      jq \
+        'if (.arguments.game | index("--graphicsBackend")) == null
+         then .arguments.game += ["--graphicsBackend", "vulkan"]
+         else . end' "$json" > "$json.tmp"
+      mv "$json.tmp" "$json"
+      exec ${portablemc}/bin/portablemc --main-dir /var/lib/minecraft start --fetch-exclude 26.2 ${mcStartArgs}
+    '';
+    meta.description = "Minecraft 26.2 launcher forcing the Vulkan startup backend (index#1686)";
+  };
 in
 {
   # Software (wl_shm) client: proves compositor + container + socket plumbing
@@ -69,37 +126,11 @@ in
   # guest mounts /dev/vdb there, surviving image swaps; see ../README.md),
   # else the image's writable root fs.
   minecraft = {
-    command = builtins.concatStringsSep " " [
-      "${portablemc}/bin/portablemc"
-      # Keep every download out of the ephemeral container root. This
-      # portablemc build has no separate --work-dir; everything follows
-      # --main-dir.
-      "--main-dir /var/lib/minecraft"
-      "start"
-      # 26.2 requires Java SE 25 minimum (see the portablemc jvms override).
-      "--jvm ${pkgs.jdk25}/bin/java"
-      # LWJGL loads its JNI natives from here instead of the (absent)
-      # manifest-provided linux-arm64 ones.
-      "--jvm-arg=-Dorg.lwjgl.librarypath=${lwjglNatives}"
-      # Make blaze3d pick the Wayland GLFW platform: left alone it requests
-      # X11 even under Wayland ("GLFW error 0x1000E X11: DISPLAY missing").
-      # MC 26.2's built-in debug switches (SharedConstants reads
-      # MC_DEBUG_*-prefixed system properties, all gated on MC_DEBUG_ENABLED;
-      # decompiled from 26.2 GLX/SharedConstants) flip the preference with
-      # the stock Maven libglfw.so above, which is wayland-capable and
-      # carries the preedit/IME API blaze3d binds. Validated live end-to-end:
-      # the window maps on the host titled "Minecraft 26.2". If Mojang ever
-      # drops the debug flag, the fallback is a Wayland-only glfw (X11
-      # compiled out; openSUSE home:DarkWav glfw-minecraft recipe on
-      # clear-code/glfw im-support) via -Dorg.lwjgl.glfw.libname; this repo
-      # carried a packaged version of that until the debug flags landed (see
-      # index#1686 and this file's history).
-      "--jvm-arg=-DMC_DEBUG_ENABLED=true"
-      "--jvm-arg=-DMC_DEBUG_PREFER_WAYLAND=true"
-      # Offline session: no Microsoft account in the guest.
-      "-u Panes"
-      "26.2"
-    ];
+    # All downloads stay out of the ephemeral container root: this portablemc
+    # build has no separate --work-dir; everything follows --main-dir (the
+    # /var/lib/minecraft bind below). The wrapper exists solely to inject the
+    # --graphicsBackend game argument (see mcLaunch above).
+    command = lib.getExe mcLaunch;
     env = {
       # Pin the venus ICD so the loader cannot pick lavapipe, and prefer the
       # virtio-gpu PCI device (1af4:1050) if more than one ICD is visible.

--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -41,6 +41,13 @@ let
   # where the ./pins.json hashes live.
   lwjglNatives = pkgs.lwjgl-natives-linux-arm64;
 
+  # One binding for every place the version appears (positional arg, manifest
+  # path, --fetch-exclude): a bump that misses one of them would silently let
+  # portablemc re-fetch the manifest over the injection below. The paired
+  # manual edit on a bump is options.txt's `version:` data-version (files
+  # below).
+  mcVersion = "26.2";
+
   # Everything after `start` that both portablemc invocations below share.
   mcStartArgs = builtins.concatStringsSep " " [
     # 26.2 requires Java SE 25 minimum (see the portablemc jvms override).
@@ -65,7 +72,7 @@ let
     "--jvm-arg=-DMC_DEBUG_PREFER_WAYLAND=true"
     # Offline session: no Microsoft account in the guest.
     "-u Panes"
-    "26.2"
+    mcVersion
   ];
 
   # 26.2 selects its startup renderer from the `--graphicsBackend vulkan`
@@ -80,20 +87,34 @@ let
   # the injection.
   mcLaunch = pkgs.writeBashApplication {
     name = "panes-mc-launch";
-    runtimeInputs = [ pkgs.jq ];
+    runtimeInputs = [
+      pkgs.jq
+      # `mv` below: pinned rather than inherited from the service PATH, like
+      # everything else in this file.
+      pkgs.coreutils
+    ];
     text = ''
-      json=/var/lib/minecraft/versions/26.2/26.2.json
-      if [ ! -e "$json" ]; then
+      json=/var/lib/minecraft/versions/${mcVersion}/${mcVersion}.json
+      # Re-fetch when the manifest is missing OR unparseable: a launch killed
+      # mid-write leaves a truncated file that an existence-only guard would
+      # accept, wedging the container in a jq-fail restart loop that never
+      # re-downloads.
+      if ! jq -e . "$json" >/dev/null 2>&1; then
+        rm -f "$json"
         ${portablemc}/bin/portablemc --main-dir /var/lib/minecraft start --dry ${mcStartArgs}
+        if [ ! -e "$json" ]; then
+          echo "portablemc --dry did not produce $json" >&2
+          exit 1
+        fi
       fi
       jq \
         'if (.arguments.game | index("--graphicsBackend")) == null
          then .arguments.game += ["--graphicsBackend", "vulkan"]
          else . end' "$json" > "$json.tmp"
       mv "$json.tmp" "$json"
-      exec ${portablemc}/bin/portablemc --main-dir /var/lib/minecraft start --fetch-exclude 26.2 ${mcStartArgs}
+      exec ${portablemc}/bin/portablemc --main-dir /var/lib/minecraft start --fetch-exclude ${mcVersion} ${mcStartArgs}
     '';
-    meta.description = "Minecraft 26.2 launcher forcing the Vulkan startup backend (index#1686)";
+    meta.description = "Minecraft ${mcVersion} launcher forcing the Vulkan startup backend (index#1686)";
   };
 in
 {

--- a/packages/vm/panes/guest-image/default.nix
+++ b/packages/vm/panes/guest-image/default.nix
@@ -43,6 +43,10 @@ let
             lwjgl-natives-linux-arm64 = final.callPackage ./lwjgl-natives.nix {
               pins = ix.pins.loadPins ./pins.json;
             };
+            # The checked bash writer, threaded through the overlay because
+            # `ix` is not in module scope; apps.nix uses it for the Minecraft
+            # launch wrapper instead of the unchecked writeShellScript.
+            writeBashApplication = ix.writeBashApplication final;
           })
         ];
         # The builder-chosen root login key (see the sshAuthorizedKey package


### PR DESCRIPTION
26.2 selects its startup renderer from the `--graphicsBackend vulkan` game argument (the official launcher passes it; joptsimple in Main) — the baked options.txt `preferredGraphicsBackend` seed alone boots GL, validated live during the venus bring-up. portablemc 5.0.3 has no game-arg passthrough, so the MC container's ExecStart becomes a checked wrapper (`writeBashApplication` via the guest overlay): first run prepares all downloads with `start --dry`, jq idempotently appends the pair to the version manifest's `arguments.game`, and the real launch passes `--fetch-exclude 26.2` so portablemc doesn't re-fetch the manifest over the injection.

Part of #1686 — the last piece of the GPU Minecraft path after #1739/#1741. Runtime validation on the real guest to follow on this PR.

🤖 Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bake Vulkan backend flag into the Minecraft launch wrapper in panes guest
> - Adds `mcLaunch`, a bash wrapper in [apps.nix](https://github.com/indexable-inc/index/pull/1762/files#diff-a890cdfbf1cce913a32f1824d8badb40d6b06eb50aee87abc0bbdf1772968b64) that injects `--graphicsBackend vulkan` into the Minecraft version manifest's `.arguments.game` via `jq` before each launch, ensuring Vulkan is always used without manual configuration.
> - Self-heals missing or malformed version manifests by re-fetching with `portablemc start --dry` before launch; subsequent launches skip re-downloading via `--fetch-exclude`.
> - Centralizes portablemc arguments (JDK 25 path, LWJGL natives, Wayland flags, offline user) into a shared `mcStartArgs` binding to avoid duplication.
> - Exposes `writeBashApplication` through the overlay in [default.nix](https://github.com/indexable-inc/index/pull/1762/files#diff-5387531d78c5e6f1ef0e82ea770d5c1f36bbae27f41fe4da470808ee954cf0b7) to support the new wrapper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c7f398.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->