### PR TITLE
panes guest: native venus sync2 + Vulkan 1.3 via mesa fork (driver-side sync fd semaphores) (#1686)

### DIFF
--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -157,16 +157,15 @@ in
       # virtio-gpu PCI device (1af4:1050) if more than one ICD is visible.
       VK_DRIVER_FILES = "${pkgs.mesa}/share/vulkan/icd.d/virtio_icd.aarch64.json";
       MESA_VK_DEVICE_SELECT = "1af4:1050!";
-      # 26.2's Vulkan backend hard-requires VK_KHR_synchronization2, which
-      # venus can never pass through on this host stack: mesa's venus driver
-      # (vn_physical_device.c, vn_physical_device_get_passthrough_extensions)
-      # gates sync2 on renderer-side SYNC_FD semaphore import, and the
-      # macOS/MoltenVK renderer has no sync files — no virglrenderer/MoltenVK
-      # pin bump changes that (MoltenVK itself has had sync2 since 1.2.6).
-      # Khronos' emulation layer advertises the extension and translates
-      # sync2 calls onto the core 1.2 venus device instead. The manifest's
-      # library_path is store-absolute, so VK_LAYER_PATH alone is enough for
-      # the loader inside the container.
+      # 26.2's Vulkan backend hard-requires VK_KHR_synchronization2. The
+      # guest mesa (indexable-inc/mesa fork, see ../guest-image/default.nix
+      # and index#1742) now exposes sync2 natively by handling temporary sync
+      # fd semaphore imports driver-side, so Khronos' emulation layer is a
+      # passthrough no-op here: with force_enable unset it self-retires when
+      # the driver advertises the extension. It stays wired as the fallback
+      # if the driver ever masks sync2 again (e.g. a mesa bump without the
+      # rebased fork patch). The manifest's library_path is store-absolute,
+      # so VK_LAYER_PATH alone is enough for the loader inside the container.
       VK_LAYER_PATH = "${pkgs.vulkan-extension-layer}/share/vulkan/explicit_layer.d";
       VK_INSTANCE_LAYERS = "VK_LAYER_KHRONOS_synchronization2";
       XDG_SESSION_TYPE = "wayland";

--- a/packages/vm/panes/guest-image/default.nix
+++ b/packages/vm/panes/guest-image/default.nix
@@ -67,6 +67,10 @@ let
                 pin = ix.pins.loadPin ./pins.json "mesa-src";
               in
               prev.mesa.overrideAttrs (old: {
+                # The version assert only catches upstream version bumps; a
+                # nixpkgs change to mesa's own patch set can also stop
+                # applying against the fork tree and force a rebase, and only
+                # the build failure catches that case.
                 src =
                   assert lib.assertMsg (old.version == pin.version)
                     "panes-guest-image: mesa fork pin is ${pin.version} but nixpkgs mesa is ${old.version}; rebase indexable-inc/mesa branch ix/venus-driver-side-semaphore onto the new upstream tag and re-pin";

--- a/packages/vm/panes/guest-image/default.nix
+++ b/packages/vm/panes/guest-image/default.nix
@@ -38,15 +38,40 @@ let
       # outside apps.nix (see ./lwjgl-natives.nix).
       {
         nixpkgs.overlays = [
-          (final: _prev: {
+          (final: prev: {
             inherit (repoPackages) panes-compositor;
+            # ./pins.json also carries the mesa src pin, so hand
+            # lwjgl-natives.nix only the lwjgl-* entries (it asserts one
+            # shared LWJGL version across its pins).
             lwjgl-natives-linux-arm64 = final.callPackage ./lwjgl-natives.nix {
-              pins = ix.pins.loadPins ./pins.json;
+              pins = lib.filterAttrs (name: _: lib.hasPrefix "lwjgl" name) (ix.pins.loadPins ./pins.json);
             };
             # The checked bash writer, threaded through the overlay because
             # `ix` is not in module scope; apps.nix uses it for the Minecraft
             # launch wrapper instead of the unchecked writeShellScript.
             writeBashApplication = ix.writeBashApplication final;
+            # Venus (virtio-gpu Vulkan) with the mesa fork's driver-side
+            # external-semaphore patch (index#1742): MoltenVK hosts never
+            # support SYNC_FD semaphore import, so stock mesa masks
+            # VK_KHR_synchronization2 (clamping the device to Vulkan 1.2) and
+            # VK_KHR_swapchain. Only `src` is swapped; the fork is upstream
+            # tag mesa-26.1.2 plus the patch commit, so nixpkgs' recipe and
+            # patches still apply. The fork branch is the single source of
+            # truth for the patch (rather than an in-tree .patch file): its
+            # history carries the upstreamable commit and the pinned tree is
+            # what upstream review sees. `hardware.graphics.enable` in
+            # ./nixos.nix consumes `pkgs.mesa`, so this override is what
+            # /run/opengl-driver (and the container ICDs) get.
+            mesa =
+              let
+                pin = ix.pins.loadPin ./pins.json "mesa-src";
+              in
+              prev.mesa.overrideAttrs (old: {
+                src =
+                  assert lib.assertMsg (old.version == pin.version)
+                    "panes-guest-image: mesa fork pin is ${pin.version} but nixpkgs mesa is ${old.version}; rebase indexable-inc/mesa branch ix/venus-driver-side-semaphore onto the new upstream tag and re-pin";
+                  final.fetchzip { inherit (pin) url hash; };
+              });
           })
         ];
         # The builder-chosen root login key (see the sshAuthorizedKey package

--- a/packages/vm/panes/guest-image/pins.json
+++ b/packages/vm/panes/guest-image/pins.json
@@ -1,4 +1,11 @@
 {
+  "mesa-src": {
+    "version": "26.1.2",
+    "url": "https://github.com/indexable-inc/mesa/archive/838b14a367e84d8c9dd353e8417776d4bf1e1d7f.tar.gz",
+    "branch": "ix/venus-driver-side-semaphore",
+    "hash": "sha256-UZ1wCXczDFHxFZmwmwdCFuew6P/20sIXqtfTjUsWaNM=",
+    "prefetch": "unpack"
+  },
   "lwjgl": {
     "version": "3.4.1",
     "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.4.1/lwjgl-3.4.1-natives-linux-arm64.jar",

--- a/packages/vm/panes/guest-image/pins.json
+++ b/packages/vm/panes/guest-image/pins.json
@@ -1,9 +1,9 @@
 {
   "mesa-src": {
     "version": "26.1.2",
-    "url": "https://github.com/indexable-inc/mesa/archive/838b14a367e84d8c9dd353e8417776d4bf1e1d7f.tar.gz",
+    "url": "https://github.com/indexable-inc/mesa/archive/41e040d437beca9c34994fe3d14b213c2bad59ea.tar.gz",
     "branch": "ix/venus-driver-side-semaphore",
-    "hash": "sha256-UZ1wCXczDFHxFZmwmwdCFuew6P/20sIXqtfTjUsWaNM=",
+    "hash": "sha256-c9oAynAK6kbCt2A6VYL/VEChIsYJvinzcXmDqILTeX8=",
     "prefetch": "unpack"
   },
   "lwjgl": {


### PR DESCRIPTION
Implements the real fix from #1742: the guest mesa now exposes `VK_KHR_synchronization2` (and Vulkan 1.3) natively on the MoltenVK host stack, replacing the renderer-side SYNC_FD dependency the #1741 emulation layer worked around (the layer stays wired and self-retires).

## What

- **Mesa fork**: [`indexable-inc/mesa` branch `ix/venus-driver-side-semaphore`](https://github.com/indexable-inc/mesa/tree/ix/venus-driver-side-semaphore) — upstream `mesa-26.1.2` snapshot + one venus patch: when the renderer cannot import sync fd semaphores (MoltenVK never can), temporary sync fd imports (wsi acquire) are handled purely driver-side — the guest waits on the sync fd at submit time and the then-satisfied semaphore wait is elided from the renderer submission (compacted wait arrays in the existing temp-batch storage, VkSubmitInfo and VkSubmitInfo2, incl. timeline-value/device-group companion arrays). Venus then exposes sync2 + the WSI extensions, stops advertising SYNC_FD binary semaphore handles it cannot service (`vkWait/ImportSemaphoreResourceMESA` are fatal on MoltenVK), gates the host-side `VK_KHR_external_semaphore_fd` force-enable, and extends the vtest-style present out-fence CPU wait. Linux hosts keep the current renderer-side path (all new paths gated on `!renderer_sync_fd.semaphore_importable`).
- **Guest image**: overlay overrides `mesa` (only `src` swapped; nixpkgs recipe + patches unchanged, version asserted equal) via a `pins.json` entry (`prefetch: unpack`, joins `nix run .#update`). `hardware.graphics.enable` consumes `pkgs.mesa`, so /run/opengl-driver and the container ICDs get the patched driver.

## Validation (aarch64 builder VM build + `vmkit boot-linux --gpu` smoke, M5 Max host, libkrun-efi 1.19.3 / virglrenderer venus / MoltenVK 1.4.1)

Scratch oneshots (dropped from this branch after validation, per the PR #1741 pattern) printed to the serial console, `VK_INSTANCE_LAYERS=unset`, venus ICD pinned:

```
panes-sync2-scratch: VK_INSTANCE_LAYERS=unset
panes-sync2-scratch: 	apiVersion        = 1.3.0 (4206592)
panes-sync2-scratch: 	deviceName        = Virtio-GPU Venus (Apple M5 Max)
panes-sync2-scratch:       1 VK_KHR_incremental_present
panes-sync2-scratch:       1 VK_KHR_swapchain
panes-sync2-scratch:       1 VK_KHR_swapchain_maintenance1
panes-sync2-scratch:       1 VK_KHR_swapchain_mutable_format
panes-sync2-scratch:       1 VK_KHR_synchronization2
```

(previously: Vulkan 1.2, sync2 and swapchain both masked — the exact two extensions MC 26.2 reported missing in #1686)

- No `VK_KHR_external_semaphore_fd`/`external_fence_fd` advertised (correct: the renderer cannot service them).
- No regression: compositor starts, `GPU readback ready; linux-dmabuf advertised` (#1739), vsock 7100 listening, no failed units in the boot report.
- WSI acquire path (the elided-wait logic) exercised live: a scratch oneshot ran `vkcube --c 300` on the guest against the compositor (venus ICD pinned, wayland WSI via the #1739 linux-dmabuf global):

  ```
  panes-wsi-scratch: PANES-WSI-SCRATCH: vkcube OK (300 frames presented over venus WSI)
  ```

  300 swapchain acquires -> temporary sync fd import -> guest-side wait + elided renderer wait -> present, no hang, no device-lost, clean exit.

## Upstream

The patch is written to be upstreamable (kept behind the `!semaphore_importable` gate, implements the TODO comment mesa itself carries in `vn_physical_device_get_passthrough_extensions`). Draft MR description below (submission gated on human sign-off).

<details><summary>Upstream MR draft</summary>

## Upstream mesa MR draft (NOT submitted — gated on human confirmation)

**Target:** gitlab.freedesktop.org/mesa/mesa, `main`
**Title:** venus: handle temporary sync fd semaphore imports driver-side

### Description

When the renderer cannot import sync fd semaphores (renderer-side
`vkGetPhysicalDeviceExternalSemaphoreProperties` reports no SYNC_FD import),
venus masks `VK_KHR_synchronization2` — clamping the device to Vulkan 1.2 —
and every WSI extension. This is the normal state on macOS hosts
(virglrenderer venus renderer on top of MoltenVK, as shipped by
libkrun/krunkit): `MVKPhysicalDevice::getExternalSemaphoreProperties` returns
empty properties for every handle type, so no MoltenVK or virglrenderer
update changes the answer.

The masking exists because a temporary SYNC_FD import on a semaphore
(`vn_ImportSemaphoreFdKHR`, used by wsi acquire) is resolved at submit time
by fixing the renderer-side payload with `vkImportSemaphoreResourceMESA`,
which the renderer services with host `vkImportSemaphoreFdKHR(fd = -1)`.
The existing comment in `vn_physical_device_get_passthrough_extensions`
already notes the alternative:

> This requirement can be dropped by implementing external semaphore purely
> on the driver side (aka no corresponding renderer side object).

This MR implements that: when the renderer lacks sync fd import, the guest
waits on the sync fd at submit time and the then-satisfied semaphore wait is
elided from the host submission (wait arrays are compacted in the temp batch
storage that already exists for the feedback machinery, including the
timeline-value / device-group-index companion arrays for VkSubmitInfo).
Waiting the temporary payload restores the permanent payload per temporary
import semantics. The renderer-side path is kept when import is available.

Nothing about sync2 or the WSI acquire actually needs a renderer-side sync
object on such hosts: sync2 is pure command encoding (the host executes it
natively), and the fences/sync-files involved in wsi acquire live entirely
in the guest kernel.

Supporting changes:
- only force-enable renderer-side `VK_KHR_external_semaphore_fd` for wsi
  when the renderer supports sync fd import
- stop advertising SYNC_FD external binary semaphore handles when the
  renderer cannot service `vn_GetSemaphoreFdKHR`
  (`vkWait/ImportSemaphoreResourceMESA`); common wsi keys its dma-buf
  implicit out-fence path off this query
- extend the `vn_wsi_fence_wait` CPU-wait fallback (previously vtest-only)
  to any configuration where common wsi cannot install the implicit out
  fence

### Testing

- aarch64 Linux guest (mesa 26.1.2 + this patch backported) under
  libkrun/krunkit + virglrenderer venus + MoltenVK 1.4.1 on an Apple M5 Max:
  device reports Vulkan 1.3 with VK_KHR_synchronization2 and
  VK_KHR_swapchain exposed natively (previously 1.2, both masked);
  vulkaninfo, compositor bring-up and a Vulkan client exercising the wsi
  acquire path run without hangs or validation errors.
- Linux-host behavior is unchanged by construction: every new path is gated
  on `!renderer_sync_fd.semaphore_importable` (or equivalent), which is
  always true there.

</details>
 Refs #1686, closes #1742 once upstreamed or accepted as carried patch.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build guest Mesa from a forked source to enable native `VK_KHR_synchronization2` and Vulkan 1.3
> - Pins a forked Mesa source (`indexable-inc/mesa`, branch `ix/venus-driver-side-semaphore`) in [pins.json](https://github.com/indexable-inc/index/pull/1763/files#diff-f0a73585141d55f7db2ede77306e1bfc35185e89c4417a500a98dff339878da5) and overrides `pkgs.mesa` in [default.nix](https://github.com/indexable-inc/index/pull/1763/files#diff-5387531d78c5e6f1ef0e82ea770d5c1f36bbae27f41fe4da470808ee954cf0b7) to build from it, while retaining nixpkgs' patches and recipe.
> - The fork adds driver-side sync fd semaphore support to the venus driver, exposing `VK_KHR_synchronization2` natively without relying on Khronos' emulation layer.
> - Updates [apps.nix](https://github.com/indexable-inc/index/pull/1763/files#diff-a890cdfbf1cce913a32f1824d8badb40d6b06eb50aee87abc0bbdf1772968b64) comments to reflect that the explicit sync2 layer env vars are now a fallback, not a requirement.
> - Risk: the fork pin asserts the nixpkgs Mesa version matches the pin version (26.1.2); a nixpkgs Mesa bump will break the build until the pin is updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6951065.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->