### PR TITLE
system-prompt: add timeouts + background monitoring for slow operations

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -314,7 +314,10 @@ let
           handoff on the issue. Skip the spawn when the issue already has an
           active owner or handoff note, or when pursuing it would silently expand
           a deliberately bounded task the user gave you. File-and-stop only when
-          the fix needs a human decision or is genuinely out of your reach.
+          the fix needs a human decision or is genuinely out of your reach. If a
+          spawned agent makes no progress in 2 hours (stuck CI, blocked upstream,
+          dependency issues), report the blocker on the issue and mark the agent
+          inactive.
         '';
         reason = ''
           Found problems were filed and forgotten instead of fixed; a named agent
@@ -416,9 +419,11 @@ let
           Fix problems at their source. Choose the best long-term solution and prefer
           architectural changes that remove a class of bugs over fixing one bug at a
           time. Never write workarounds or add timeouts that mask the core bug. If the
-          cause is upstream, fix it upstream and open a PR. When the same anomaly
-          interrupts your task a second time, stop patching inline: give it a dedicated
-          root-cause deep-dive, with a subagent where available.
+          cause is upstream, fix it upstream and open a PR. For long-running builds or
+          deployments (>10 min), spawn a background agent to monitor them: use Monitor
+          or tail a log file and act on completion, errors, or timeout. Do not sit
+          polling. When the same anomaly interrupts your task a second time, stop
+          patching inline: give it a dedicated root-cause deep-dive, with a subagent.
         '';
         reason = ''
           Workarounds and timeout bumps masked root causes that kept resurfacing; the
@@ -522,8 +527,11 @@ let
         text = ''
           Complete tasks autonomously. A task is done when tests pass and the change
           lands on `origin/main`. Prefer a PR; push directly to `main` only if it is
-          genuinely unprotected. Own PRs through merge: push, watch CI, fix failures,
-          resolve review, rebase, and re-queue until landed or truly blocked.
+          genuinely unprotected. Own PRs through merge: push, watch CI (background it
+          with Monitor if >2 min), fix failures, resolve review, rebase, and re-queue
+          until landed or truly blocked. If a PR is green for >10 min and not merging,
+          spawn a named background agent to investigate and merge (queue stuck, missing
+          approvals, etc.).
         '';
         reason = ''
           Tasks were reported done at an open PR that never landed; done means merged

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -420,10 +420,11 @@ let
           architectural changes that remove a class of bugs over fixing one bug at a
           time. Never write workarounds or add timeouts that mask the core bug. If the
           cause is upstream, fix it upstream and open a PR. For long-running builds or
-          deployments (>10 min), spawn a background agent to monitor them: use Monitor
-          or tail a log file and act on completion, errors, or timeout. Do not sit
-          polling. When the same anomaly interrupts your task a second time, stop
-          patching inline: give it a dedicated root-cause deep-dive, with a subagent.
+          deployments (>10 min), spawn a background agent to monitor them: use the
+          runtime's background-task mechanism or tail a log file and act on completion,
+          errors, or timeout. Do not sit polling. When the same anomaly interrupts your
+          task a second time, stop patching inline: give it a dedicated root-cause
+          deep-dive, with a subagent.
         '';
         reason = ''
           Workarounds and timeout bumps masked root causes that kept resurfacing; the
@@ -527,11 +528,11 @@ let
         text = ''
           Complete tasks autonomously. A task is done when tests pass and the change
           lands on `origin/main`. Prefer a PR; push directly to `main` only if it is
-          genuinely unprotected. Own PRs through merge: push, watch CI (background it
-          with Monitor if >2 min), fix failures, resolve review, rebase, and re-queue
-          until landed or truly blocked. If a PR is green for >10 min and not merging,
-          spawn a named background agent to investigate and merge (queue stuck, missing
-          approvals, etc.).
+          genuinely unprotected. Own PRs through merge: push, watch CI (move the
+          watch to the background if >2 min), fix failures, resolve review, rebase,
+          and re-queue until landed or truly blocked. If a PR is green for >10 min
+          and not merging, spawn a named background agent to investigate and merge
+          (queue stuck, missing approvals, etc.).
         '';
         reason = ''
           Tasks were reported done at an open PR that never landed; done means merged


### PR DESCRIPTION
Encode three concrete timeout expectations to prevent silent failures and impatient blocking:

1. **PR merge**: Background Monitor if CI >2min; spawn agent if green >10min (prevents stuck green PRs)
2. **Long builds (>10min)**: Spawn background agent with Monitor, never sit polling (prevents silent build death)  
3. **Issue agents**: Report blocker after 2h with no progress, mark inactive (prevents unbounded agent work)

This addresses three incidents:
- Mesa recompile dying silently while monitor never fired
- PR #1735 sitting green for 45 min without merge
- Foreground stalls >30s where agent should have backgrounded work

The core insight: replace vague "wait/own/handle" language with concrete timeouts and explicit agent-spawning triggers.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add timeout rules and background monitoring guidance to agent system prompt
> Updates [system-prompt.nix](https://github.com/indexable-inc/index/pull/1764/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) with three new behavioral rules for agents:
> - Mark spawned agents inactive and report blockers (stuck CI, upstream blocks, dependency issues) if no progress is made within 2 hours
> - Spawn a background agent to monitor long-running builds/deployments (>10 min) instead of actively polling
> - Move CI watching to the background if it exceeds 2 minutes; spawn a named background agent to investigate and merge PRs that stay green for more than 10 minutes without merging
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 009f218.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->