### PR TITLE
panes: true 2x HiDPI: surfaces enter the scaled output (#1686)

### DIFF
--- a/packages/vm/panes/compositor/src/compositor/handlers.rs
+++ b/packages/vm/panes/compositor/src/compositor/handlers.rs
@@ -115,10 +115,7 @@ impl CompositorHandler for App {
         }
 
         // Only the toplevel's own buffer becomes window content; subsurface
-        // pixels are not composited yet (README: known gaps). Buffer intake
-        // must run before the min/max sync: it updates `pane.scale`, and a
-        // commit that changes buffer_scale would otherwise ship WindowMinMax
-        // converted at the stale scale.
+        // pixels are not composited yet (README: known gaps).
         if *surface == root {
             self.intake_buffer(idx);
         }
@@ -139,21 +136,24 @@ impl CompositorHandler for App {
 
 impl App {
     /// `xdg_toplevel` min/max live in double-buffered surface state, not in a
-    /// dedicated event, so they are re-read on every commit and diffed. The
-    /// xdg values are logical; the wire wants buffer pixels at the window's
-    /// current scale (the host divides by scale for `NSWindow` min/max points).
+    /// dedicated event, so they are re-read on every commit and diffed
+    /// (logically: a buffer-scale change with the same logical bounds is not
+    /// a change). The xdg values are logical; the wire wants buffer pixels at
+    /// the scale this connection's `WindowNew` carried (the host divides by
+    /// that same scale for `NSWindow` min/max points), NOT the current buffer
+    /// scale: a client that re-renders 2x after Hello raised the output scale
+    /// would otherwise double its min/max points host-side.
     // significant_drop_tightening misfires here: the guard is dropped right
     // after its two field reads already, and the suggested
     // `get::<_>().current()` chain borrows a temporary and does not compile.
     #[allow(clippy::significant_drop_tightening)]
     fn sync_min_max(&mut self, idx: usize, root: &WlSurface) {
-        let scale = self.panes[idx].scale.max(1);
         let mm = with_states(root, |states| {
             let mut guard = states.cached_state.get::<SurfaceCachedState>();
             let current = guard.current();
             SizeBounds {
-                min: size_to_opt(current.min_size, scale),
-                max: size_to_opt(current.max_size, scale),
+                min: size_to_opt(current.min_size),
+                max: size_to_opt(current.max_size),
             }
         });
         let pane = &mut self.panes[idx];
@@ -167,8 +167,8 @@ impl App {
         {
             host.send(ToHost::WindowMinMax {
                 id: pane.id,
-                min: pane.min,
-                max: pane.max,
+                min: super::wire_bounds(pane.min, pane.announced_scale),
+                max: super::wire_bounds(pane.max, pane.announced_scale),
             });
         }
     }
@@ -294,22 +294,22 @@ fn copy_shm(ptr: *const u8, len: usize, data: &BufferData) -> Option<CopiedFrame
     })
 }
 
-/// Min/max as the wire wants them: `None` = unconstrained (xdg uses 0).
+/// Logical min/max bounds: `None` = unconstrained (xdg uses 0).
 struct SizeBounds {
     min: Option<(u32, u32)>,
     max: Option<(u32, u32)>,
 }
 
-/// Logical xdg size -> buffer pixels at `scale` (saturating: a hostile
-/// client-supplied size must not overflow, and `u32::MAX` is "unbounded"
-/// anyway).
-fn size_to_opt(size: Size<i32, smithay::utils::Logical>, scale: u32) -> Option<(u32, u32)> {
+/// Logical xdg size as an optional bound (`None` = unconstrained, xdg uses 0).
+/// Stays logical here; the wire conversion happens at send time with
+/// [`super::wire_bounds`].
+fn size_to_opt(size: Size<i32, smithay::utils::Logical>) -> Option<(u32, u32)> {
     if size.w <= 0 || size.h <= 0 {
         return None;
     }
     let w = u32::try_from(size.w).expect("checked positive");
     let h = u32::try_from(size.h).expect("checked positive");
-    Some((w.saturating_mul(scale), h.saturating_mul(scale)))
+    Some((w, h))
 }
 
 struct BufferIntake {
@@ -417,6 +417,13 @@ impl XdgShellHandler for App {
             state.decoration_mode = Some(zxdg_toplevel_decoration_v1::Mode::ServerSide);
             state.bounds = Some(super::VIRTUAL_SIZE.into());
         });
+        // Enter the virtual output before the first configure:
+        // wl_output.scale only applies to outputs a surface entered, so
+        // skipping this leaves every client at buffer scale 1 (blurry 1x
+        // stretched over the Retina drawable). smithay replays the enter to
+        // wl_output resources the client binds later, so ordering is safe.
+        self.output.enter(surface.wl_surface());
+        self.send_preferred_scale(surface.wl_surface());
         let id = self.next_window_id;
         self.next_window_id += 1;
         debug!(id, "new toplevel");
@@ -454,6 +461,7 @@ impl XdgShellHandler for App {
             return;
         };
         let pane = self.panes.remove(idx);
+        self.output.leave(pane.toplevel.wl_surface());
         debug!(id = pane.id, "toplevel destroyed");
         if pane.announced
             && let Some(host) = &self.host

--- a/packages/vm/panes/compositor/src/compositor/handlers.rs
+++ b/packages/vm/panes/compositor/src/compositor/handlers.rs
@@ -422,6 +422,9 @@ impl XdgShellHandler for App {
         // skipping this leaves every client at buffer scale 1 (blurry 1x
         // stretched over the Retina drawable). smithay replays the enter to
         // wl_output resources the client binds later, so ordering is safe.
+        // TODO(index#1686): popups and subsurfaces need the same enter (+ the
+        // preferred scale below) once their content is exported (README:
+        // known gaps); today only toplevel buffers reach the host.
         self.output.enter(surface.wl_surface());
         self.send_preferred_scale(surface.wl_surface());
         let id = self.next_window_id;

--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -31,7 +31,7 @@ use smithay::reexports::wayland_server::{Display, DisplayHandle};
 use smithay::utils::{SERIAL_COUNTER, Transform};
 use smithay::wayland::compositor::{
     CompositorClientState, CompositorState, SurfaceAttributes, TraversalAction,
-    with_surface_tree_downward,
+    send_surface_state, with_states, with_surface_tree_downward,
 };
 use smithay::wayland::output::OutputManagerState;
 use smithay::wayland::pointer_constraints::{
@@ -94,10 +94,18 @@ struct Pane {
     watchdog_ticks: u32,
     title: String,
     app_id: String,
+    /// Logical (surface-coordinate) min/max from the last commit; converted
+    /// to buffer pixels at `announced_scale` on the wire.
     min: Option<(u32, u32)>,
     max: Option<(u32, u32)>,
     /// Buffer scale of the last commit (forwarded in `WindowNew`).
     scale: u32,
+    /// The scale `WindowNew` carried on the current connection: the fixed
+    /// unit for this window's wire min/max (protocol contract). Kept apart
+    /// from `scale` because a client may change buffer scale mid-connection
+    /// (e.g. re-render 2x after the host's Hello raised the output scale)
+    /// and the wire has no per-window scale update to tell the host.
+    announced_scale: u32,
 }
 
 impl Pane {
@@ -116,6 +124,7 @@ impl Pane {
             min: None,
             max: None,
             scale: 1,
+            announced_scale: 1,
         }
     }
 }
@@ -257,7 +266,9 @@ fn listen_spec(cli: &Cli) -> ListenSpec {
 
 impl App {
     fn new(dh: &DisplayHandle, cli: &Cli) -> Self {
-        let compositor_state = CompositorState::new::<Self>(dh);
+        // v6: wl_surface.preferred_buffer_scale tells HiDPI-aware clients
+        // their scale directly (see send_preferred_scale).
+        let compositor_state = CompositorState::new_v6::<Self>(dh);
         let xdg_shell_state = XdgShellState::new::<Self>(dh);
         let decoration_state = XdgDecorationState::new::<Self>(dh);
         // No extra formats beyond the mandatory ARGB8888/XRGB8888: those are
@@ -287,7 +298,12 @@ impl App {
         seat.add_pointer();
 
         // One virtual output. Refresh/scale get overwritten by the host's
-        // Hello; until then a bland 60Hz/1x default.
+        // Hello; until then a bland 60Hz/1x default. Every toplevel enters
+        // this output on map (see `new_toplevel`): wl_output.scale only
+        // applies to outputs a surface entered, so without the enter a
+        // Retina host's scale-2 advertisement would reach no client and
+        // everything would render 1x (measured: GLFW/Minecraft and the
+        // weston demos stay at buffer scale 1 without it).
         let output = Output::new(
             "panes".into(),
             PhysicalProperties {
@@ -386,6 +402,17 @@ impl App {
             .map(|idx| self.panes[idx].toplevel.wl_surface().clone())
     }
 
+    /// Tell one surface the scale it should render at, both ways Wayland can
+    /// say it: `wl_surface.preferred_buffer_scale` (v6, per surface, what
+    /// modern toolkits watch) rides on top of the output scale + enter that
+    /// covers older clients. smithay dedups, so re-sends are free.
+    fn send_preferred_scale(&self, surface: &WlSurface) {
+        let scale = self.output.current_scale().integer_scale();
+        with_states(surface, |states| {
+            send_surface_state(surface, states, scale, Transform::Normal);
+        });
+    }
+
     /// Try to move one frame onto the wire for `panes[idx]`, announcing the
     /// window first if this connection has not seen it. When there is
     /// nothing to send, release the window's frame callbacks instead: no
@@ -411,6 +438,10 @@ impl App {
             return;
         }
         if !pane.announced {
+            // This connection's WindowNew scale is the unit every later
+            // WindowMinMax for this window is converted at (the host divides
+            // by it; there is no per-window scale update message).
+            pane.announced_scale = pane.scale;
             host.send(ToHost::WindowNew {
                 id: pane.id,
                 title: pane.title.clone(),
@@ -422,8 +453,8 @@ impl App {
             if pane.min.is_some() || pane.max.is_some() {
                 host.send(ToHost::WindowMinMax {
                     id: pane.id,
-                    min: pane.min,
-                    max: pane.max,
+                    min: wire_bounds(pane.min, pane.announced_scale),
+                    max: wire_bounds(pane.max, pane.announced_scale),
                 });
             }
             pane.announced = true;
@@ -585,6 +616,13 @@ impl App {
             host.scale = scale.max(1);
             host.minor = minor;
         }
+        // The output scale just changed for clients that mapped before the
+        // host connected (guest apps autostart at boot, the host attaches
+        // later): re-advertise per surface so v6 clients re-render at the
+        // host's real scale.
+        for pane in &self.panes {
+            self.send_preferred_scale(pane.toplevel.wl_surface());
+        }
         for idx in 0..self.panes.len() {
             self.pump(idx);
         }
@@ -633,9 +671,13 @@ impl App {
         // the window's scale or a Retina client that honors the advertised
         // output scale renders a buffer scale^2 the drawable. div_ceil keeps a
         // stray pixel row covered rather than letterboxed.
-        // TODO(index#1686): wl_output's scale is still global (from Hello);
-        // honoring a per-window scale that differs from it needs
-        // wp_fractional_scale or per-surface preferred scale.
+        // Scale advertisement stays global (wl_output + preferred_buffer_scale
+        // both derive from Hello): a per-window Configure scale that differs
+        // (window dragged to a non-Retina external display) is not re-echoed
+        // per surface, so that window's content is host-rescaled until it
+        // returns. Fractional scale is out of scope by design: macOS backing
+        // factors are 1 or 2, and wp_fractional_scale would buy softness at
+        // readback bandwidth the vsock budget cannot spare.
         let scale = scale.max(1);
         let size_valid = width > 0 && height > 0;
         self.panes[idx].toplevel.with_pending_state(|state| {
@@ -808,6 +850,13 @@ impl App {
             fire_frame_callbacks(popup.wl_surface(), now);
         }
     }
+}
+
+/// Logical min/max -> wire buffer pixels at `scale` (saturating: a hostile
+/// client-supplied size must not overflow, and `u32::MAX` is "unbounded"
+/// anyway).
+fn wire_bounds(bounds: Option<(u32, u32)>, scale: u32) -> Option<(u32, u32)> {
+    bounds.map(|(w, h)| (w.saturating_mul(scale), h.saturating_mul(scale)))
 }
 
 /// Host-provided u32s land in i32-typed smithay fields. Clamp before the

--- a/packages/vm/panes/host/src/view.rs
+++ b/packages/vm/panes/host/src/view.rs
@@ -53,7 +53,7 @@ pub struct ViewIvars {
     /// meaningless while dissociated).
     relative: Cell<bool>,
     /// Identity (timestamp, eventNumber) of the last relative-forwarded
-    /// event. AppKit delivers each mouseMoved TWICE here -- once to the
+    /// event. `AppKit` delivers each mouseMoved TWICE here -- once to the
     /// first responder (`acceptsMouseMovedEvents`) and once to the tracking
     /// area's owner (`MouseMoved` option), the same view (measured live: 4
     /// posted moves, 8 arrivals). Absolute coordinates absorb the duplicate;

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -398,12 +398,13 @@ impl PaneWindow {
         };
 
         // A frame that mismatches the drawable presents scaled (the render
-        // pass samples, it never crops), which must never happen silently:
-        // transiently fine mid-resize (the guest's matching frame is in
-        // flight; live resize is skipped because there per-tick mismatch is
-        // the norm), but persistent for a client whose buffer scale differs
-        // from the window's backing scale (a 1x-only client on Retina renders
-        // soft). Once per buffer size change, so a steady stream stays quiet.
+        // pass samples, it never crops), which must never happen silently.
+        // Logged once per settled buffer size (fresh surface, outside live
+        // resize where per-tick mismatch is the norm) and worded as a state
+        // note, not an error: one line per window is the EXPECTED startup
+        // transition when a client that mapped at 1x re-renders 2x after the
+        // host's scale reaches it. Only a persistent repeat (every resize
+        // settles mismatched) means a scale-blind client rendering soft.
         if fresh_surface && !self.view.inLiveResize() {
             let drawable = self.layer.drawableSize();
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -411,8 +412,9 @@ impl PaneWindow {
                 (drawable.width.round().max(0.0) as u32, drawable.height.round().max(0.0) as u32);
             if (width, height) != (dw, dh) {
                 eprintln!(
-                    "panes-host: window {}: {width}x{height} frame scaled onto {dw}x{dh} \
-                     drawable (guest buffer scale != window backing scale?)",
+                    "panes-host: window {}: presenting {width}x{height} frames scaled onto the \
+                     {dw}x{dh} drawable (brief while the guest adopts a scale change; persistent \
+                     only for a client stuck at another buffer scale)",
                     self.id
                 );
             }

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -189,8 +189,9 @@ pub struct PaneWindow {
     _win_delegate: Retained<WinDelegate>,
     _link_delegate: Retained<LinkDelegate>,
     surface: Option<Surface>,
-    /// Guest render scale from `WindowNew`, used to convert protocol pixel
-    /// sizes to window points.
+    /// Scale from `WindowNew`: the fixed unit for this window's protocol
+    /// min/max sizes (protocol contract; the guest converts `WindowMinMax`
+    /// at the same announced scale even if the client rescales later).
     guest_scale: u32,
     pending_ack: Option<u64>,
     dirty: bool,
@@ -395,6 +396,27 @@ impl PaneWindow {
         let Some(surface) = self.surface.as_mut() else {
             unreachable!("unpresentable path returned above");
         };
+
+        // A frame that mismatches the drawable presents scaled (the render
+        // pass samples, it never crops), which must never happen silently:
+        // transiently fine mid-resize (the guest's matching frame is in
+        // flight; live resize is skipped because there per-tick mismatch is
+        // the norm), but persistent for a client whose buffer scale differs
+        // from the window's backing scale (a 1x-only client on Retina renders
+        // soft). Once per buffer size change, so a steady stream stays quiet.
+        if fresh_surface && !self.view.inLiveResize() {
+            let drawable = self.layer.drawableSize();
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let (dw, dh) =
+                (drawable.width.round().max(0.0) as u32, drawable.height.round().max(0.0) as u32);
+            if (width, height) != (dw, dh) {
+                eprintln!(
+                    "panes-host: window {}: {width}x{height} frame scaled onto {dw}x{dh} \
+                     drawable (guest buffer scale != window backing scale?)",
+                    self.id
+                );
+            }
+        }
 
         let in_bounds = |rect: Rect| {
             rect.w > 0

--- a/packages/vm/panes/protocol/src/lib.rs
+++ b/packages/vm/panes/protocol/src/lib.rs
@@ -83,16 +83,22 @@ pub enum ToHost {
         app_id: String,
         width: u32,
         height: u32,
-        /// Buffer scale the guest renders at (host `backingScaleFactor` echoed
-        /// back through `ToGuest::Configure`).
+        /// Buffer scale the guest renders at when this window was announced
+        /// (the host `backingScaleFactor` echoed back through
+        /// `ToGuest::Configure` when the client honors it, 1 for a
+        /// scale-blind client). Also the fixed unit for this window's
+        /// `WindowMinMax` sizes: a client that changes buffer scale
+        /// mid-connection changes only its frame dimensions, there is no
+        /// per-window scale update message.
         scale: u32,
     },
     WindowTitle {
         id: WindowId,
         title: String,
     },
-    /// Sizes are buffer pixels at the scale from `WindowNew`/`Configure`
-    /// (the host divides by scale for `NSWindow` `contentMin/MaxSize` points).
+    /// Sizes are buffer pixels at the scale this connection's `WindowNew`
+    /// carried (the host divides by that scale for `NSWindow`
+    /// `contentMin/MaxSize` points), NOT the current buffer scale.
     WindowMinMax {
         id: WindowId,
         min: Option<(u32, u32)>,


### PR DESCRIPTION
Part of #1686. HiDPI audit of the panes scale path.

## Verdict: blurry (1x buffers stretched over the 2x drawable), not pixel-perfect

The plumbing was almost all there — `on_hello` sets the `wl_output` scale from the host's Hello, `on_configure` divides wire pixels into logical xdg sizes, input divides by scale, the host maps points/contentsScale/drawableSize correctly — but **no surface ever entered the output**. `wl_output.scale` only applies to surfaces that received `wl_surface.enter`, so scale-by-entered-outputs clients (GLFW/Minecraft, weston demos) stayed at buffer scale 1 forever, and the host's fullscreen-triangle pass linearly upscaled every frame 2x.

Evidence (live session, `backingScaleFactor=2`):

- host log: `window 4 mapped: app_id= 854x480@1` (Minecraft), `window 2 mapped: app_id=foot 693x494@1` — 1x buffers on a 2x host
- Minecraft F3 reports `Display: 1002x797`, which equals the NSWindow **point** size; the drawable is 2004x1594, so every frame is presented scaled 2x
- an earlier session logged foot remapping at `1386x988@2` (foot's all-monitors fallback heuristic) — the `@2` path already worked end to end whenever a client actually picked scale 2

## Fix

- **`Output::enter` on toplevel map, `leave` on destroy** (compositor). smithay replays the enter to `wl_output` resources the client binds later, so ordering is safe.
- **`wl_compositor` v6 + `wl_surface.preferred_buffer_scale`** per surface, sent on map and re-sent after Hello raises the output scale — the direct per-surface path for modern toolkits; enter/output-scale covers the rest.
- **`WindowMinMax` units pinned to the announced `WindowNew` scale.** Guest apps autostart before the host attaches, so "client re-renders 2x after Hello" is the common order; converting min/max at the *current* buffer scale would then double the NSWindow min/max points (the host divides by the WindowNew scale, which is fixed per connection). Min/max are now stored logically and converted at the announced scale. Wire format unchanged, still protocol 1.1; the protocol docs now state the unit precisely.
- **Host visibility:** log once per settled buffer size when a frame is scaled onto a mismatched drawable (skipped during live resize, where transient mismatch is the norm). Silent stretching is now diagnosable from the host log.

Out of scope by design: fractional scale (macOS backing factors are 1 or 2, and supersampling pays 4x readback bandwidth for softness) and per-window scale on mixed-DPI setups — both documented at the configure path.

Also fixes a pre-existing `doc_markdown` clippy failure in `view.rs` that blocked the darwin clippy gate.

## Validation

- `nix build .#panes-host` + `.#panes-host.passthru.tests.clippy` + `.#panes-host.passthru.tests.panes-host-all` green on aarch64-darwin; `nix run .#lint` green.
- `panes-compositor` is aarch64-linux-only and the local linux builder VM is down, so guest-side compile/runtime validation is gated on CI and the next guest-image boot (expected result: foot/weston/MC log `...@2` in the host's `mapped:` lines and the new mismatch log stays silent).



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix HiDPI 2x scaling for pane surfaces by entering surfaces into the virtual output
> - Newly mapped toplevel surfaces are entered into the virtual output and sent a `preferred_buffer_scale` advertisement via a new `send_preferred_scale` helper; on destruction, surfaces leave the output.
> - `size_to_opt` now returns logical sizes without multiplying by scale; wire conversion is deferred to a new `wire_bounds` helper that uses the scale captured at `WindowNew` announcement time (`pane.announced_scale`).
> - The compositor is upgraded to `CompositorState::new_v6` to support `wl_surface.preferred_buffer_scale` (v6).
> - On host reconnect (`on_hello`), already-mapped surfaces receive a `preferred_buffer_scale` re-advertisement.
> - Behavioral Change: `WindowMinMax` wire values are now in buffer pixels at the `WindowNew`-announced scale rather than the current buffer scale.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fb6c22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

**Rollout note:** once this merges, the next guest-image rebuild has Minecraft (and every scale-aware client) rendering 4x the pixels (true 2x buffers). The frame-transport latency measurements account for this.

(sent by an AI agent via Claude Code)
