### PR TITLE
panes: ghostty-style hidden titlebar by default

### DIFF
--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -39,6 +39,9 @@ struct App {
     windows: HashMap<WindowId, PaneWindow>,
     out: Option<mpsc::Sender<ToGuest>>,
     title_prefix: String,
+    /// `--native-titlebar`: stock macOS chrome instead of the default
+    /// hidden-titlebar style (see `window::apply_hidden_titlebar`).
+    native_titlebar: bool,
     quitting: bool,
     /// Per-window ack counters behind the periodic acks/s log: the real-path
     /// equivalent of mock's rate line, and the 120Hz-genlock evidence
@@ -116,7 +119,7 @@ impl Deferred {
     }
 }
 
-pub fn run(target: Target, title_prefix: String) -> ExitCode {
+pub fn run(target: Target, title_prefix: String, native_titlebar: bool) -> ExitCode {
     let Some(mtm) = MainThreadMarker::new() else {
         eprintln!("panes-host: must start on the main thread");
         return ExitCode::FAILURE;
@@ -147,6 +150,7 @@ pub fn run(target: Target, title_prefix: String) -> ExitCode {
             windows: HashMap::new(),
             out: None,
             title_prefix,
+            native_titlebar,
             quitting: false,
             ack_stats: HashMap::new(),
             peer_minor: 0,
@@ -218,7 +222,13 @@ fn handle_msg(app: &mut App, msg: ToHost) -> Deferred {
                 return Deferred::default();
             }
             let params = WindowParams { id, title, app_id, width, height, scale };
-            let window = PaneWindow::new(app.mtm, &app.renderer, &params, &app.title_prefix);
+            let window = PaneWindow::new(
+                app.mtm,
+                &app.renderer,
+                &params,
+                &app.title_prefix,
+                app.native_titlebar,
+            );
             app.windows.insert(id, window);
             Deferred::default()
         }

--- a/packages/vm/panes/host/src/main.rs
+++ b/packages/vm/panes/host/src/main.rs
@@ -46,6 +46,11 @@ struct Cli {
     #[arg(long, value_name = "PREFIX", default_value = "")]
     title_prefix: String,
 
+    /// Use the stock macOS titlebar (title text + traffic lights) instead of
+    /// the default ghostty-style hidden titlebar.
+    #[arg(long)]
+    native_titlebar: bool,
+
     /// Serve the built-in mock guest on a temp socket and connect to it:
     /// one animated test window, received input logged to stderr.
     #[arg(long, conflicts_with_all = ["connect", "tcp"])]
@@ -94,7 +99,7 @@ fn run_host(cli: Cli) -> ExitCode {
         return ExitCode::FAILURE;
     };
 
-    app::run(target, cli.title_prefix)
+    app::run(target, cli.title_prefix, cli.native_titlebar)
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/packages/vm/panes/host/src/view.rs
+++ b/packages/vm/panes/host/src/view.rs
@@ -53,7 +53,7 @@ pub struct ViewIvars {
     /// meaningless while dissociated).
     relative: Cell<bool>,
     /// Identity (timestamp, eventNumber) of the last relative-forwarded
-    /// event. AppKit delivers each mouseMoved TWICE here -- once to the
+    /// event. `AppKit` delivers each mouseMoved TWICE here -- once to the
     /// first responder (`acceptsMouseMovedEvents`) and once to the tracking
     /// area's owner (`MouseMoved` option), the same view (measured live: 4
     /// posted moves, 8 arrivals). Absolute coordinates absorb the duplicate;

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -14,7 +14,8 @@ use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2::{AllocAnyThread, DefinedClass, MainThreadOnly, define_class};
 use objc2_app_kit::{
-    NSBackingStoreType, NSWindow, NSWindowDelegate, NSWindowOcclusionState, NSWindowStyleMask,
+    NSBackingStoreType, NSView, NSWindow, NSWindowButton, NSWindowDelegate,
+    NSWindowOcclusionState, NSWindowStyleMask, NSWindowTabbingMode, NSWindowTitleVisibility,
 };
 use objc2_foundation::{
     MainThreadMarker, NSNotification, NSObjectProtocol, NSPoint, NSRect, NSRunLoop, NSSize,
@@ -211,6 +212,10 @@ pub struct PaneWindow {
     /// only while this window is also key (see `app::sync_capture`), so the
     /// intent survives focus round-trips and re-engages on return.
     pub wants_lock: bool,
+    /// Stock macOS chrome (`--native-titlebar`) instead of the default
+    /// hidden-titlebar style; kept so title updates know whether to re-apply
+    /// the hidden style (see [`PaneWindow::set_title`]).
+    native_titlebar: bool,
 }
 
 impl PaneWindow {
@@ -219,16 +224,29 @@ impl PaneWindow {
         renderer: &Renderer,
         params: &WindowParams,
         title_prefix: &str,
+        native_titlebar: bool,
     ) -> Self {
         let scale = f64::from(params.scale.max(1));
         let content = NSRect::new(
             NSPoint::new(0.0, 0.0),
             NSSize::new(f64::from(params.width) / scale, f64::from(params.height) / scale),
         );
-        let style = NSWindowStyleMask::Titled
+        // `Titled` stays in the mask in both chrome modes: it is what gives
+        // the window a normal frame and the standard accessibility window
+        // role that tiling WMs (AeroSpace) manage; ghostty's hidden-titlebar
+        // style keeps it for the same reason (HiddenTitlebarTerminalWindow.
+        // swift: "We need `titled` in the mask to get the normal window
+        // frame"). The default minimal chrome adds `FullSizeContentView` so
+        // the content view (and the Metal layer sized off its bounds) spans
+        // the full frame, including the strip the titlebar chrome would
+        // have occupied.
+        let mut style = NSWindowStyleMask::Titled
             | NSWindowStyleMask::Closable
             | NSWindowStyleMask::Miniaturizable
             | NSWindowStyleMask::Resizable;
+        if !native_titlebar {
+            style |= NSWindowStyleMask::FullSizeContentView;
+        }
         // SAFETY: standard initializer; `defer: false` so the window backing
         // exists immediately (the Metal layer needs a real backing scale).
         let ns = unsafe {
@@ -244,6 +262,15 @@ impl PaneWindow {
         // ObjC object under our `Retained` on close.
         unsafe { ns.setReleasedWhenClosed(false) };
         ns.setTitle(&NSString::from_str(&format!("{title_prefix}{}", params.title)));
+        if !native_titlebar {
+            apply_hidden_titlebar(&ns);
+        }
+        // Window placement belongs to the tiler (AeroSpace), and a draggable
+        // background would turn guest-bound clicks into window moves in
+        // floating mode; ghostty likewise leaves this off for terminal
+        // windows. Floating windows still move via option-drag on the frame
+        // edges (standard macOS) or the tiler's move commands.
+        ns.setMovableByWindowBackground(false);
         ns.setAcceptsMouseMovedEvents(true);
         ns.center();
 
@@ -316,6 +343,7 @@ impl PaneWindow {
             shown: false,
             closing: false,
             wants_lock: false,
+            native_titlebar,
         }
     }
 
@@ -327,6 +355,12 @@ impl PaneWindow {
 
     pub fn set_title(&self, title_prefix: &str, title: &str) {
         self.ns.setTitle(&NSString::from_str(&format!("{title_prefix}{title}")));
+        // Setting the title re-reveals the native title view on macOS 15+;
+        // ghostty re-applies the hidden style from its `title` override for
+        // exactly this reason (HiddenTitlebarTerminalWindow.swift).
+        if !self.native_titlebar {
+            apply_hidden_titlebar(&self.ns);
+        }
     }
 
     pub fn set_min_max(&self, min: Option<(u32, u32)>, max: Option<(u32, u32)>) {
@@ -591,6 +625,57 @@ impl PaneWindow {
         self.ns.setDelegate(None);
         self.ns.close();
     }
+}
+
+/// Ghostty's `macos-titlebar-style = hidden` recipe
+/// (`HiddenTitlebarTerminalWindow.swift`), the default chrome: the window
+/// keeps its `Titled` frame but every piece of titlebar chrome goes away, so
+/// the guest surface fills a flat, edge-to-edge rectangle. Ghostty keeps the
+/// native shadow and rounded corners in this style deliberately: truly
+/// square corners require removing `Titled` (its `window-decoration = none`
+/// path), which downgrades the accessibility role and stops tiling WMs from
+/// managing the window; ghostty's own config docs steer users to the hidden
+/// style instead. Idempotent; re-applied after every title change.
+fn apply_hidden_titlebar(ns: &NSWindow) {
+    // The title string stays set (Mission Control, the app switcher, and
+    // AeroSpace's window list read it); only its rendering is hidden.
+    ns.setTitleVisibility(NSWindowTitleVisibility::Hidden);
+    ns.setTitlebarAppearsTransparent(true);
+    for kind in
+        [NSWindowButton::CloseButton, NSWindowButton::MiniaturizeButton, NSWindowButton::ZoomButton]
+    {
+        if let Some(button) = ns.standardWindowButton(kind) {
+            button.setHidden(true);
+        }
+    }
+    // No titlebar means nowhere to render a native tab bar (ghostty
+    // disallows tabbing in its hidden style for the same reason).
+    ns.setTabbingMode(NSWindowTabbingMode::Disallowed);
+    // Even transparent, NSTitlebarContainerView sits above the content view
+    // and turns clicks in the top strip into a window drag instead of guest
+    // input. Ghostty hides the container outright ("nuke it from orbit");
+    // same here, so the full frame delivers events to the guest.
+    // SAFETY: superview is a plain accessor; main thread only.
+    if let Some(frame) = ns.contentView().and_then(|view| unsafe { view.superview() }) {
+        hide_titlebar_container(&frame);
+    }
+}
+
+/// Depth-first search for the private `NSTitlebarContainerView` (a child of
+/// the theme frame; the walk is recursive only as cheap insurance against
+/// `AppKit` reshuffling the hierarchy). Matching on the class name is the same
+/// unavoidable private-API touch ghostty ships.
+fn hide_titlebar_container(view: &NSView) -> bool {
+    for subview in view.subviews() {
+        if subview.class().name().to_bytes() == b"NSTitlebarContainerView" {
+            subview.setHidden(true);
+            return true;
+        }
+        if hide_titlebar_container(&subview) {
+            return true;
+        }
+    }
+    false
 }
 
 struct DelegateIvars {


### PR DESCRIPTION
Default panes-host windows to ghostty's hidden-titlebar chrome. Refs #1686.

## Technique (copied from ghostty `HiddenTitlebarTerminalWindow.swift`)
- keep `Titled` in the styleMask (normal frame + standard AX window role, so tiling WMs keep managing the window) and add `FullSizeContentView` so the Metal layer spans the full frame
- `titleVisibility = hidden`, `titlebarAppearsTransparent = true`, hide the three `standardWindowButton`s, `tabbingMode = disallowed`
- hide the private `NSTitlebarContainerView` outright (ghostty's "nuke it from orbit") so the top strip delivers mouse input to the guest instead of acting as a drag region
- re-apply the style after every title change (macOS 15 re-reveals the native title view; ghostty overrides `title` for the same reason)
- shadow and rounded corners stay native, matching ghostty: square corners require dropping `Titled` (ghostty's `window-decoration = none` path), which downgrades the AX role and breaks tiling; ghostty's own config docs steer users to the hidden style instead
- `isMovableByWindowBackground = false`: placement belongs to the tiler, and a draggable background would eat guest-bound clicks in floating mode

## Escape hatch
`--native-titlebar` restores stock chrome (data-only flag, in `--help`). Default is hidden.

## Live validation (screenshot evidence)
Booted a fresh guest from the prebuilt panes-guest image on its own vsock socket and ran the newly built host with a `[1686test] ` title prefix; the operator's running session was untouched.

- **AeroSpace tiles it**: `aerospace list-windows --all` lists both test windows (`[1686test] Flower`, `[1686test] root@term: /`) on workspace 2; weston-flower requested 200x200 and was stretched to fill its tile, foot was resized into its column - tiler-driven resize works end to end (Configure -> guest reframe)
- **Screenshot**: both test windows render edge-to-edge with zero titlebar, directly alongside a main-built panes-host window still showing the stock titlebar + traffic lights (before/after in one frame)
- **Key input**: focused the foot test window and typed `echo titlebar-hidden-key-input-ok`; it echoed in the terminal
- **Cmd-W path**: `aerospace close` on the flower window went through `windowShouldClose` -> guest `CloseRequest` -> `WindowGone`; the window left the WM cleanly
- **Occlusion**: transitions still fire ("occluded; presents paused" / "visible; presents resume" in the host log)

`nix build .#panes-host` and the darwin clippy gate (`.#packages.aarch64-darwin.panes-host.passthru.tests.clippy`) are green; lint green. The clippy run also surfaced one pre-existing `doc_markdown` miss in view.rs, fixed in a separate commit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use hidden titlebar style by default in pane windows with `--native-titlebar` opt-out
> - Introduces `apply_hidden_titlebar` in [window.rs](https://github.com/indexable-inc/index/pull/1776/files#diff-91e8bbe22c0fe147e26ba583bb5c25111e8a7dca4acd2ca6f022bfac0e25a0b9) to hide all macOS titlebar chrome, make the titlebar transparent, hide window buttons, disallow tabbing, and remove the private `NSTitlebarContainerView` so the full frame receives input.
> - Re-applies hidden titlebar style on every `set_title` call to prevent macOS from re-showing title elements after title changes.
> - Adds a `--native-titlebar` CLI flag in [main.rs](https://github.com/indexable-inc/index/pull/1776/files#diff-adda0cd8a1794fa8144aecdb55f36628bd191a3f615180f5ddbd570ef47e885a) to opt back into the stock macOS chrome; hidden titlebar is now the default.
> - Behavioral Change: background window dragging is explicitly disabled for all windows regardless of titlebar mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70363b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->