### PR TITLE
panes: cut mouse-look latency (immediate presents, pinned per-screen link rate, uncoalesced capture deltas, MC low-latency seed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7650,6 +7650,7 @@ dependencies = [
 name = "panes-host"
 version = "0.1.0"
 dependencies = [
+ "block2",
  "clap",
  "dispatch2",
  "lz4_flex 0.13.1",

--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -186,15 +186,43 @@ in
     binds = [ "/var/lib/minecraft" ];
     gpu = true;
     files = {
-      # Pre-seed the instance options so first launch renders through Vulkan
-      # ("Prefer Vulkan" in Video Settings; key/values per minecraft.wiki
-      # Options.txt, added in 26.2-snapshot-1). The `version` line is 26.2's
-      # data version and is mandatory: the game discards an options.txt that
-      # lacks it and would fall back to the "Default" backend (OpenGL in the
-      # 26.2 release).
+      # Pre-seed the instance options. Seeded by a tmpfiles `C` rule, so
+      # FIRST BOOT ONLY: an existing data disk keeps whatever the user
+      # changed in-game. Every key/value below matches the serialization MC
+      # 26.2 itself writes -- taken verbatim from the game-REWRITTEN
+      # options.txt on the live data disk (the game rewrites the file on any
+      # settings change, so its output is the authoritative grammar,
+      # including `version:4903`, 26.2's data version; without that line the
+      # game discards the file and falls back to the "Default" backend).
+      #
+      # Beyond the Vulkan backend, these are latency-opinionated defaults
+      # (index#1686): MC's frames reach glass through the compositor's
+      # ack-paced stream plus the host's display link, so anything that adds
+      # in-game frame time or a second pacing loop stacks straight onto
+      # mouse-look latency.
+      # - enableVsync:false -- the dominant term, validated live by A/B:
+      #   MC's vsync waits on the swapchain, stacking a second frame of
+      #   pacing on top of the compositor's ack genlock (double vsync).
+      # - maxFps:260 -- the slider's "Unlimited" stop (valid range 10-260).
+      #   Uncapped, the frame the compositor ships is always the freshest
+      #   sample; the ack pacing is what actually bounds the shipped rate.
+      # - rawMouseInput:true -- GLFW raw relative motion (the default,
+      #   pinned against stale instance state): pairs with
+      #   zwp_relative_pointer fed by the host's uncoalesced deltas.
+      # - graphicsPreset:"fancy" -- 26.2 replaced graphics *modes* with
+      #   presets (the rewritten file has no `graphicsMode` key at all);
+      #   fancy guards against Fabulous!, whose post-processing pipeline is
+      #   pure added frame time, i.e. latency, on venus.
+      # - narrator:0 -- off; belt and braces with the flite-less portablemc
+      #   above (the narrator's TTS stack aborts the client without audio).
       "/var/lib/minecraft/options.txt" = pkgs.writeText "panes-mc-options.txt" ''
         version:4903
         preferredGraphicsBackend:"vulkan"
+        enableVsync:false
+        maxFps:260
+        rawMouseInput:true
+        graphicsPreset:"fancy"
+        narrator:0
       '';
     };
   };

--- a/packages/vm/panes/host/Cargo.toml
+++ b/packages/vm/panes/host/Cargo.toml
@@ -19,6 +19,9 @@ lz4_flex = "0.13"
 panes-protocol.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
+# `RcBlock` for the trace-only MTLDrawable presented handler (tick-to-glass
+# ground truth, see src/trace.rs).
+block2 = "0.6"
 # Main-queue handoff: the socket reader thread owns the stream and
 # `exec_async`s decoded messages onto the AppKit main thread.
 dispatch2 = "0.3"

--- a/packages/vm/panes/host/README.md
+++ b/packages/vm/panes/host/README.md
@@ -24,8 +24,11 @@ Three thread roles, one owner per resource:
 
 Per `WindowNew` the host builds: a titled/closable/miniaturizable/resizable
 `NSWindow` (content size = buffer px / scale), an input `NSView` subclass
-hosting a `CAMetalLayer` (`framebufferOnly`, `displaySyncEnabled`,
-`maximumDrawableCount = 3`, `contentsScale = backingScaleFactor`), two
+hosting a `CAMetalLayer` (`framebufferOnly`, `displaySyncEnabled = false`:
+synced presents measured a constant ~40ms tick-to-glass through the windowed
+compositing path vs ~24-32ms immediate, and presents stay tick-paced so
+nothing free-runs (index#1686); `maximumDrawableCount = 2`,
+`contentsScale = backingScaleFactor`), two
 surface `MTLTexture`s (double-buffered: `replaceRegion` does not synchronize
 against GPU access, so uploads must never touch the texture a still-executing
 present is sampling), and a per-window `CAMetalDisplayLink`. The window is
@@ -41,8 +44,11 @@ into whichever texture is not in flight (each texture replays the damage it
 missed while the other was on screen), and the layer flips to it.
 
 `CAMetalDisplayLink` (macOS 14+, from `objc2-quartz-core` 0.3, added to the
-main run loop in common modes with `preferredFrameRateRange` {min 60, max
-120, preferred 120}) ticks at the panel rate and hands us the drawable. If
+main run loop in common modes with `preferredFrameRateRange` pinned to the
+window's own panel max rate -- min == max == preferred, recomputed on
+`windowDidChangeScreen:`; the adaptive 60..120 range measured downshift
+stretches on borderline streams, index#1686) ticks at the panel rate and
+hands us the drawable. If
 the window is dirty we encode one fullscreen-triangle pass sampling the
 texture into the drawable (a render pass, not a blit, because
 `framebufferOnly` drawables are render-target-only, and sampling stretches
@@ -55,6 +61,13 @@ to seq". A frame the host cannot take at all (zero-size, texture allocation
 failure) is still acked immediately so the guest's one-in-flight loop never
 wedges on it. The link starts paused, unpauses on content/resize, and
 re-pauses after ~250ms of idle ticks so a quiet window stops costing CPU.
+
+`PANES_TRACE=1` emits one parseable stderr line per input event, frame
+ingest, and present (plus `MTLDrawable.presentedTime` glass ground truth),
+all on the `NSEvent.timestamp` clock; `tools/latency_probe.py` is the
+matching synthetic guest that drives ack-paced load and reports present RTT
+percentiles. Together they are the before/after evidence for the numbers
+above (index#1686).
 
 ### Resize
 

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -17,11 +17,12 @@ use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2::{MainThreadMarker, MainThreadOnly, define_class};
 use objc2_app_kit::{
-    NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate, NSCursor, NSScreen,
-    NSWindow,
+    NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate, NSCursor, NSEvent,
+    NSScreen, NSWindow,
 };
 use objc2_core_graphics::{CGAssociateMouseAndMouseCursorPosition, CGError};
 use objc2_foundation::{NSNotification, NSObjectProtocol};
+use objc2_metal::MTLDrawable as _;
 use objc2_quartz_core::CAMetalDisplayLinkUpdate;
 use panes_protocol::{MINOR_POINTER_LOCK, ToGuest, ToHost, WindowId};
 
@@ -75,6 +76,13 @@ impl CursorCapture {
         if err != CGError::Success {
             eprintln!("panes-host: window {id}: cursor dissociation failed: {err:?}");
         }
+        // Coalescing merges queued mouse-moved events (summed deltas, so no
+        // motion is lost) but delays delivery to the queue drain; measured
+        // at ~21% of a 1kHz delta stream merged under frame load
+        // (index#1686). Mouse-look wants every delta as fresh as the queue
+        // can hand it over, so coalescing is off exactly while captured;
+        // absolute-cursor mode keeps the AppKit default.
+        NSEvent::setMouseCoalescingEnabled(false);
         Self { id }
     }
 }
@@ -82,6 +90,7 @@ impl CursorCapture {
 impl Drop for CursorCapture {
     fn drop(&mut self) {
         eprintln!("panes-host: window {}: pointer capture released", self.id);
+        NSEvent::setMouseCoalescingEnabled(true);
         let err = CGAssociateMouseAndMouseCursorPosition(true);
         if err != CGError::Success {
             eprintln!("panes-host: window {}: cursor re-association failed: {err:?}", self.id);
@@ -205,14 +214,14 @@ pub fn on_event(event: Event) {
             let close = app.windows.drain().map(|(_, window)| window).collect();
             Deferred { show: None, close }
         }
-        Event::Msg(msg) => handle_msg(app, msg),
+        Event::Msg { msg, recv } => handle_msg(app, msg, recv),
     });
     if let Some(deferred) = deferred {
         deferred.run(mtm);
     }
 }
 
-fn handle_msg(app: &mut App, msg: ToHost) -> Deferred {
+fn handle_msg(app: &mut App, msg: ToHost, recv: f64) -> Deferred {
     match msg {
         // The reader consumes Hello during version negotiation.
         ToHost::Hello { .. } | ToHost::Pong { .. } => Deferred::default(),
@@ -245,11 +254,26 @@ fn handle_msg(app: &mut App, msg: ToHost) -> Deferred {
             Deferred::default()
         }
         ToHost::WindowFrame { id, seq, width, height, full, tiles } => {
+            let trace_bytes = crate::trace::enabled()
+                .then(|| (tiles.len(), tiles.iter().map(|tile| tile.payload.len()).sum::<usize>()));
             let Some(window) = app.windows.get_mut(&id) else {
                 eprintln!("panes-host: frame for unknown window {id}");
                 return Deferred::default();
             };
-            if !window.apply_frame(&app.renderer, seq, width, height, full, tiles) {
+            let applied = window.apply_frame(&app.renderer, seq, width, height, full, tiles);
+            if let Some((tiles, bytes)) = trace_bytes {
+                // recv is stamped on the reader thread right after the wire
+                // decode (see conn::read_loop), so recv..done spans the
+                // main-queue wait plus the damage-log ingest: the time a
+                // frame occupies or waits on the main thread that input
+                // events share.
+                eprintln!(
+                    "panes-trace frame id={id} seq={seq} recv={recv:.6} done={:.6} \
+                     tiles={tiles} bytes={bytes}",
+                    crate::trace::now(),
+                );
+            }
+            if !applied {
                 // Frame the host could not take (zero-size / texture alloc
                 // failure): ack immediately anyway. With one-frame-in-flight
                 // guest pacing, an ack held hostage to a texture we never
@@ -354,6 +378,18 @@ pub fn display_tick(id: WindowId, update: &CAMetalDisplayLinkUpdate) {
         if let Some(seq) = window.present(&app.renderer, update)
             && let Some(out) = &app.out
         {
+            if crate::trace::enabled() {
+                // `target - now` is how far ahead of glass this tick runs
+                // (index#1686 latency work); did/dc expose the drawable pool
+                // (drawableID cycling and the layer's claimed cap).
+                eprintln!(
+                    "panes-trace present id={id} seq={seq} now={:.6} target={:.6} did={} dc={}",
+                    crate::trace::now(),
+                    update.targetPresentationTimestamp(),
+                    update.drawable().drawableID(),
+                    window.max_drawable_count(),
+                );
+            }
             let _ = out.send(ToGuest::Ack { id, seq });
             let stat = app
                 .ack_stats
@@ -421,6 +457,19 @@ pub fn window_occlusion_changed(id: WindowId) {
             if visible { "visible; presents resume" } else { "occluded; presents paused" }
         );
         window.set_occluded(!visible);
+    });
+}
+
+/// The window landed on a different display (`windowDidChangeScreen:`): the
+/// pinned streaming tick range must chase that panel's rate, or a window
+/// dragged from a 60Hz external onto the 120Hz panel would stay capped at
+/// 60 for its lifetime (and one dragged the other way would tick uselessly
+/// fast).
+pub fn window_screen_changed(id: WindowId) {
+    with_app(|app| {
+        if let Some(window) = app.windows.get_mut(&id) {
+            window.refresh_stream_rate(app.mtm);
+        }
     });
 }
 

--- a/packages/vm/panes/host/src/conn.rs
+++ b/packages/vm/panes/host/src/conn.rs
@@ -27,7 +27,10 @@ pub enum Event {
     /// we emit (postcard has no unknown-variant tolerance, see the protocol
     /// crate), so the main thread must know it.
     Hello { minor: u16 },
-    Msg(ToHost),
+    /// `recv` is the trace clock (`trace::now`) right after the wire decode
+    /// on the reader thread, so `PANES_TRACE` frame lines can separate
+    /// main-queue wait from ingest work; costs one timestamp per message.
+    Msg { msg: ToHost, recv: f64 },
     Disconnected,
 }
 
@@ -128,7 +131,7 @@ fn read_loop(read: Box<dyn Read + Send>) {
                     return;
                 }
             }
-            Ok(msg) => post(Event::Msg(msg)),
+            Ok(msg) => post(Event::Msg { msg, recv: crate::trace::now() }),
             Err(error) => {
                 eprintln!("panes-host: connection lost: {error}");
                 return;

--- a/packages/vm/panes/host/src/main.rs
+++ b/packages/vm/panes/host/src/main.rs
@@ -22,6 +22,8 @@ mod keymap;
 #[cfg(target_os = "macos")]
 mod render;
 #[cfg(target_os = "macos")]
+mod trace;
+#[cfg(target_os = "macos")]
 mod view;
 #[cfg(target_os = "macos")]
 mod window;

--- a/packages/vm/panes/host/src/trace.rs
+++ b/packages/vm/panes/host/src/trace.rs
@@ -1,0 +1,34 @@
+//! Env-gated latency instrumentation: `PANES_TRACE=1` emits one parseable
+//! stderr line per forwarded input event, ingested frame, and present, for
+//! the mouse-look latency work (index#1686). Timestamps are
+//! `CACurrentMediaTime()` seconds -- the same mach clock `NSEvent.timestamp`
+//! and `CAMetalDisplayLinkUpdate` targets use, and the domain macOS Python's
+//! `time.monotonic()` reads -- so an external probe on the same machine
+//! correlates its clock with these lines with no conversion.
+//!
+//! Off (the default), each call site costs one atomic load and no
+//! formatting, cheap enough to live in the 120Hz paths permanently.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use objc2_quartz_core::CACurrentMediaTime;
+
+/// 0 = unresolved, 1 = off, 2 = on. A plain atomic (not `OnceLock`) keeps
+/// the hot-path read a single relaxed load.
+static STATE: AtomicU8 = AtomicU8::new(0);
+
+pub fn enabled() -> bool {
+    match STATE.load(Ordering::Relaxed) {
+        0 => {
+            let on = std::env::var_os("PANES_TRACE").is_some_and(|value| value != "0");
+            STATE.store(if on { 2 } else { 1 }, Ordering::Relaxed);
+            on
+        }
+        state => state == 2,
+    }
+}
+
+/// Seconds on the `NSEvent.timestamp` clock (mach time since boot).
+pub fn now() -> f64 {
+    CACurrentMediaTime()
+}

--- a/packages/vm/panes/host/src/view.rs
+++ b/packages/vm/panes/host/src/view.rs
@@ -298,6 +298,16 @@ impl PanesView {
         if dx == 0.0 && dy == 0.0 {
             return;
         }
+        if crate::trace::enabled() {
+            // `now - ev` is the HID-to-handler delay: event-queue wait plus
+            // AppKit coalescing, the main-thread contention under test.
+            eprintln!(
+                "panes-trace input id={} ev={:.6} now={:.6} dx={dx} dy={dy}",
+                self.ivars().id,
+                event.timestamp(),
+                crate::trace::now(),
+            );
+        }
         app::send(ToGuest::PointerRelative { id: self.ivars().id, dx, dy });
     }
 

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -21,7 +21,7 @@ use objc2_foundation::{
     MainThreadMarker, NSNotification, NSObjectProtocol, NSPoint, NSRect, NSRunLoop, NSSize,
     NSString,
 };
-use objc2_metal::{MTLCommandBuffer, MTLCommandBufferStatus, MTLTexture};
+use objc2_metal::{MTLCommandBuffer, MTLCommandBufferStatus, MTLDrawable, MTLTexture};
 use objc2_quartz_core::{
     CAFrameRateRange, CAMetalDisplayLink, CAMetalDisplayLinkDelegate, CAMetalDisplayLinkUpdate,
     CAMetalLayer,
@@ -32,11 +32,22 @@ use crate::app;
 use crate::render::Renderer;
 use crate::view::PanesView;
 
-/// `ProMotion` range: let the system drop to 60 when we present nothing, chase
-/// 120 when frames flow (Apple TN3178 / `CAFrameRateRange` docs: preferred
-/// must sit inside [minimum, maximum]).
-const FRAME_RATE_RANGE: CAFrameRateRange =
-    CAFrameRateRange { minimum: 60.0, maximum: 120.0, preferred: 120.0 };
+/// The streaming tick range is pinned to a panel's max rate (min == max ==
+/// preferred), not a 60..max span: with the adaptive range, a guest whose
+/// ack-to-frame turnaround hovered near one period measured stretches of
+/// downshifted ticks (probe guest, 2ms simulated render: ~99fps and p99 ack
+/// RTT of 16ms adaptive vs ~116fps and 13.7ms pinned, index#1686). Ticks
+/// only run while frames flow -- idle windows stop entirely via
+/// [`IDLE_TICKS_TO_PAUSE`], which is where the power saving actually is --
+/// so there is nothing for the adaptive range to win. Derived per window
+/// from its own display (falling back to the main screen before placement)
+/// and refreshed on `windowDidChangeScreen:`, so a window dragged between a
+/// 60Hz external and the 120Hz panel chases whichever it is on.
+fn stream_rate_range(screen: Option<&objc2_app_kit::NSScreen>) -> CAFrameRateRange {
+    #[allow(clippy::cast_precision_loss)] // realistic refresh rates are tiny integers
+    let max_fps = screen.map_or(60.0, |screen| screen.maximumFramesPerSecond() as f32);
+    CAFrameRateRange { minimum: max_fps, maximum: max_fps, preferred: max_fps }
+}
 
 /// Tick rate while the window is fully occluded. The link keeps running as
 /// the ack pacer, just slowly: pausing it and acking frames on receipt
@@ -185,6 +196,11 @@ pub struct PaneWindow {
     view: Retained<PanesView>,
     layer: Retained<CAMetalLayer>,
     link: Retained<CAMetalDisplayLink>,
+    /// Tick range while frames flow (the window's panel max rate, pinned;
+    /// see [`stream_rate_range`]); occlusion swaps it for
+    /// [`OCCLUDED_RATE_RANGE`], re-expose restores it, and a display change
+    /// recomputes it ([`PaneWindow::refresh_stream_rate`]).
+    stream_rate: CAFrameRateRange,
     // The window and the display link both hold their delegates weakly
     // (AppKit convention); these fields are the strong references.
     _win_delegate: Retained<WinDelegate>,
@@ -283,13 +299,27 @@ impl PaneWindow {
         // CoreAnimation scan out the drawable directly (Apple, CAMetalLayer
         // docs); we never blit into or sample from them.
         layer.setFramebufferOnly(true);
-        // displaySyncEnabled keeps presents vsynced; the ack loop, not a
-        // free-running present queue, is our pacing mechanism.
-        layer.setDisplaySyncEnabled(true);
-        // 3 drawables (the default, pinned explicitly): 2 starves 120Hz when
-        // CPU encode and scanout overlap, more only adds latency (Apple,
-        // "Reduce Drawable Count" / maximumDrawableCount docs).
-        layer.setMaximumDrawableCount(3);
+        // Present immediately instead of queueing for vsync. Measured with
+        // the latency probe (index#1686): synced presents through the
+        // windowed-compositing path hit glass a constant ~40.6ms after the
+        // display-link tick -- ~5 frames, immovable by maximumDrawableCount
+        // or preferredFrameLatency -- while immediate presents measure
+        // 23.7-32.1ms (`MTLDrawable.presentedTime` ground truth), the
+        // WindowServer sampling floor, at an unchanged 120fps. There is no
+        // tearing exposure on macOS: WindowServer still composites whole
+        // surfaces; and no free-running present loop either, because
+        // presents stay display-link-tick-paced (the ack loop is the
+        // throttle), so "sync off" only stops presents from queueing behind
+        // extra vsyncs.
+        layer.setDisplaySyncEnabled(false);
+        // 2 drawables (the documented minimum), not the default 3: the third
+        // only buys headroom when CPU encode approaches a full frame, and
+        // ours is one fullscreen triangle. Measured either way at a steady
+        // 120fps with the probe guest (index#1686) -- with immediate
+        // presents (displaySyncEnabled false above) the count does not touch
+        // glass latency either -- so the smaller pool just saves one
+        // window-sized surface.
+        layer.setMaximumDrawableCount(2);
         let backing = ns.backingScaleFactor();
         layer.setContentsScale(backing);
         layer.setDrawableSize(NSSize::new(
@@ -312,7 +342,11 @@ impl PaneWindow {
         let link_delegate = LinkDelegate::new(mtm, params.id);
         let link = CAMetalDisplayLink::initWithMetalLayer(CAMetalDisplayLink::alloc(), &layer);
         link.setDelegate(Some(ProtocolObject::from_ref(&*link_delegate)));
-        link.setPreferredFrameRateRange(FRAME_RATE_RANGE);
+        // Before the window is ordered in, `screen()` is None; the main
+        // screen is where `center()` will place it.
+        let stream_rate =
+            stream_rate_range(ns.screen().or_else(|| objc2_app_kit::NSScreen::mainScreen(mtm)).as_deref());
+        link.setPreferredFrameRateRange(stream_rate);
         // Common modes include NSEventTrackingRunLoopMode, so ticks keep
         // coming during live resize (where presentsWithTransaction needs
         // per-tick redraws) and menu tracking.
@@ -333,6 +367,7 @@ impl PaneWindow {
             view,
             layer,
             link,
+            stream_rate,
             _win_delegate: win_delegate,
             _link_delegate: link_delegate,
             surface: None,
@@ -352,6 +387,24 @@ impl PaneWindow {
     /// (they send protocol messages, which re-enters app state).
     pub fn view_handle(&self) -> Retained<PanesView> {
         self.view.clone()
+    }
+
+    /// Re-pin the streaming tick range to the display the window is now on
+    /// (`windowDidChangeScreen:`); applied immediately unless occluded (the
+    /// occlusion path restores `stream_rate` itself on re-expose).
+    pub fn refresh_stream_rate(&mut self, mtm: MainThreadMarker) {
+        self.stream_rate = stream_rate_range(
+            self.ns.screen().or_else(|| objc2_app_kit::NSScreen::mainScreen(mtm)).as_deref(),
+        );
+        if !self.occluded {
+            self.link.setPreferredFrameRateRange(self.stream_rate);
+        }
+    }
+
+    /// Trace-only: what the layer currently claims as its drawable cap
+    /// (`CAMetalDisplayLink` may manage the pool behind our back).
+    pub fn max_drawable_count(&self) -> usize {
+        self.layer.maximumDrawableCount()
     }
 
     pub fn set_title(&self, title_prefix: &str, title: &str) {
@@ -521,7 +574,7 @@ impl PaneWindow {
         if occluded {
             self.link.setPreferredFrameRateRange(OCCLUDED_RATE_RANGE);
         } else {
-            self.link.setPreferredFrameRateRange(FRAME_RATE_RANGE);
+            self.link.setPreferredFrameRateRange(self.stream_rate);
             // Re-expose shows the freshest guest frame: occluded ticks kept
             // the textures current but never drew them.
             self.mark_dirty();
@@ -581,6 +634,26 @@ impl PaneWindow {
             slot.absorbed = surface.log.len();
         }
         let drawable = update.drawable();
+        if crate::trace::enabled()
+            && let Some(seq) = self.pending_ack
+        {
+            // Ground truth for tick-to-glass latency: presentedTime is the
+            // host time the drawable actually hit the screen, reported by
+            // Metal after the fact (registered before the present below, as
+            // the API requires). Trace-only; the block costs nothing when
+            // tracing is off.
+            let block = block2::RcBlock::new(
+                move |presented: core::ptr::NonNull<ProtocolObject<dyn MTLDrawable>>| {
+                    // SAFETY: Metal passes the presented drawable, valid for
+                    // the duration of the handler.
+                    let time = unsafe { presented.as_ref() }.presentedTime();
+                    eprintln!("panes-trace glass seq={seq} presented={time:.6}");
+                },
+            );
+            // SAFETY: as_ptr yields a valid block pointer; Metal copies the
+            // block, so it need not outlive this call.
+            unsafe { drawable.addPresentedHandler(block2::RcBlock::as_ptr(&block)) };
+        }
         let Some(commands) =
             renderer.draw(&slot.texture, &drawable, self.layer.presentsWithTransaction())
         else {
@@ -751,6 +824,12 @@ define_class!(
         #[unsafe(method(windowDidChangeOcclusionState:))]
         fn window_did_change_occlusion_state(&self, _notification: &NSNotification) {
             app::window_occlusion_changed(self.ivars().id);
+        }
+
+        #[unsafe(method(windowDidChangeScreen:))]
+        fn window_did_change_screen(&self, _notification: &NSNotification) {
+            // The pinned tick range chases the display the window is on.
+            app::window_screen_changed(self.ivars().id);
         }
 
         #[unsafe(method(windowDidBecomeKey:))]

--- a/packages/vm/panes/host/tools/latency_probe.py
+++ b/packages/vm/panes/host/tools/latency_probe.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Synthetic panes guest for host-side latency measurement (index#1686).
+
+Listens on a unix socket, speaks the panes wire protocol (postcard frames,
+see panes-protocol), maps one toplevel, and streams ack-paced damage while
+recording the send-to-ack round trip of every frame. Point a host at it:
+
+    python3 tools/latency_probe.py /tmp/panes-probe.sock --render-ms 4 &
+    PANES_TRACE=1 panes-host --connect /tmp/panes-probe.sock
+
+Knobs map to the pipeline under test:
+  --render-ms  sleep between receiving an ack and sending the next frame,
+               simulating guest render time (the compositor's dmabuf
+               readback + encode sits in the same position).
+  --credit     frames allowed in flight before waiting for an ack. 1 is the
+               compositor's pacing today; 2 measures the pipelined regime
+               the host's cumulative acks already permit.
+  --width/--height/--scale
+               buffer size (payload volume) and the advertised buffer scale.
+
+Every frame damages the full buffer with incompressible bands (worst-case
+transport), LZ4-encoded when the `lz4` module is importable, Raw otherwise
+(both always legal on the wire). The host side of each stage comes from its
+`PANES_TRACE=1` stderr lines; timestamps there share the clock of
+`time.monotonic()` here, so the two logs correlate directly.
+
+Stdlib-only on purpose (optional lz4), same as gen_keymap.py.
+"""
+
+import argparse
+import os
+import queue
+import random
+import socket
+import struct
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    import lz4.block as _lz4
+except ImportError:
+    _lz4 = None
+
+
+def _compress(raw: bytes) -> bytes | None:
+    """LZ4 block (the wire's Lz4 encoding), or None when lz4 is absent."""
+    if _lz4 is None:
+        return None
+    return _lz4.compress(raw, store_size=False)
+
+
+# ToHost variant indices (postcard encodes the declaration order).
+TOHOST_HELLO = 0
+TOHOST_WINDOW_NEW = 1
+TOHOST_WINDOW_FRAME = 4
+TOHOST_WINDOW_GONE = 5
+TOHOST_PONG = 7
+
+# ToGuest variant indices.
+TOGUEST_HELLO = 0
+TOGUEST_ACK = 1
+TOGUEST_CONFIGURE = 2
+TOGUEST_CLOSE = 3
+TOGUEST_PING = 9
+
+WINDOW_ID = 1
+BAND_ROWS = 256
+
+
+def uvarint(value: int) -> bytes:
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            return bytes(out)
+
+
+def read_uvarint(buf: bytes, pos: int) -> tuple[int, int]:
+    shift = 0
+    value = 0
+    while True:
+        byte = buf[pos]
+        pos += 1
+        value |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return value, pos
+        shift += 7
+
+
+def wire_frame(payload: bytes) -> bytes:
+    """`[u32 LE len][postcard bytes]`, the panes-protocol framing."""
+    return struct.pack("<I", len(payload)) + payload
+
+
+def msg_hello() -> bytes:
+    return uvarint(TOHOST_HELLO) + uvarint(1) + uvarint(1)
+
+
+def msg_window_new(width: int, height: int, scale: int) -> bytes:
+    title = b"latency probe"
+    app_id = b"dev.ix.panes.probe"
+    return (
+        uvarint(TOHOST_WINDOW_NEW)
+        + uvarint(WINDOW_ID)
+        + uvarint(len(title))
+        + title
+        + uvarint(len(app_id))
+        + app_id
+        + uvarint(width)
+        + uvarint(height)
+        + uvarint(scale)
+    )
+
+
+def msg_window_gone() -> bytes:
+    return uvarint(TOHOST_WINDOW_GONE) + uvarint(WINDOW_ID)
+
+
+def msg_pong(nonce: int) -> bytes:
+    return uvarint(TOHOST_PONG) + uvarint(nonce)
+
+
+@dataclass
+class Band:
+    y: int
+    height: int
+    encoding: int  # 0 = Raw, 1 = Lz4
+    payload: bytes
+
+
+def make_bands(width: int, height: int, variant: int) -> list[Band]:
+    """Full-height damage in incompressible BAND_ROWS bands."""
+    rng = random.Random(variant)
+    bands = []
+    y = 0
+    while y < height:
+        band_h = min(BAND_ROWS, height - y)
+        raw_len = width * band_h * 4
+        # Half noise, half a repeated chunk: compresses ~2x like real content.
+        chunk = bytes(rng.randrange(256) for _ in range(4096))
+        noise = os.urandom(raw_len // 2)
+        raw = noise + (chunk * (raw_len // 4096 + 1))[: raw_len - len(noise)]
+        compressed = _compress(raw)
+        if compressed is None:
+            bands.append(Band(y, band_h, 0, raw))
+        else:
+            bands.append(Band(y, band_h, 1, compressed))
+        y += band_h
+    return bands
+
+
+def msg_window_frame(
+    seq: int, width: int, height: int, *, full: bool, bands: list[Band]
+) -> bytes:
+    out = bytearray(
+        uvarint(TOHOST_WINDOW_FRAME)
+        + uvarint(WINDOW_ID)
+        + uvarint(seq)
+        + uvarint(width)
+        + uvarint(height)
+        + (b"\x01" if full else b"\x00")
+        + uvarint(len(bands))
+    )
+    for band in bands:
+        out += uvarint(0) + uvarint(band.y) + uvarint(width) + uvarint(band.height)
+        out += uvarint(band.encoding) + uvarint(len(band.payload)) + band.payload
+    return bytes(out)
+
+
+@dataclass
+class Event:
+    kind: str
+    seq: int = 0
+    nonce: int = 0
+
+
+@dataclass
+class Stats:
+    send_at: dict[int, float] = field(default_factory=dict)
+    presented_at: dict[int, float] = field(default_factory=dict)
+    coalesced: set[int] = field(default_factory=set)
+
+    def report(self, skip: int = 20) -> str:
+        """Acks are cumulative ("presented up to seq"), so with credit > 1 an
+        ack can cover older frames whose present was skipped. Only the
+        exactly acked seq was presented: those alone feed the RTT
+        distribution and presented_fps; covered-but-skipped frames count as
+        `coalesced` (the guest-side produce rate, not a display rate)."""
+        pairs = sorted(
+            (seq, self.send_at[seq], at)
+            for seq, at in self.presented_at.items()
+            if seq in self.send_at
+        )[skip:]
+        if len(pairs) < 2:
+            return "too few acked frames"
+        rtts = sorted((ack - sent) * 1000 for _, sent, ack in pairs)
+        span = pairs[-1][2] - pairs[0][2]
+        presented_fps = (len(pairs) - 1) / span if span > 0 else 0.0
+        produced = len(pairs) + len(self.coalesced)
+        produced_fps = (produced - 1) / span if span > 0 else 0.0
+
+        def pick(quantile: float) -> float:
+            return rtts[min(len(rtts) - 1, int(len(rtts) * quantile))]
+
+        return (
+            f"n={len(rtts)} presented_fps={presented_fps:.1f} "
+            f"produced_fps~={produced_fps:.1f} coalesced={len(self.coalesced)} "
+            f"present_rtt_ms p50={pick(0.5):.2f} p90={pick(0.9):.2f} "
+            f"p99={pick(0.99):.2f} max={rtts[-1]:.2f}"
+        )
+
+
+def decode_toguest(buf: bytes) -> Event:
+    disc, pos = read_uvarint(buf, 0)
+    if disc == TOGUEST_HELLO:
+        return Event("hello")
+    if disc == TOGUEST_ACK:
+        _, pos = read_uvarint(buf, pos)
+        seq, _ = read_uvarint(buf, pos)
+        return Event("ack", seq=seq)
+    if disc == TOGUEST_CLOSE:
+        return Event("close")
+    if disc == TOGUEST_PING:
+        nonce, _ = read_uvarint(buf, pos)
+        return Event("ping", nonce=nonce)
+    return Event("other")
+
+
+def read_loop(conn: socket.socket, events: "queue.Queue[Event]") -> None:
+    stream = conn.makefile("rb")
+    while True:
+        header = stream.read(4)
+        if len(header) < 4:
+            events.put(Event("eof"))
+            return
+        (length,) = struct.unpack("<I", header)
+        events.put(decode_toguest(stream.read(length)))
+
+
+def drive(conn: socket.socket, args: argparse.Namespace) -> Stats:
+    events: queue.Queue[Event] = queue.Queue()
+    threading.Thread(target=read_loop, args=(conn, events), daemon=True).start()
+    conn.sendall(wire_frame(msg_hello()))
+    while events.get().kind != "hello":
+        pass
+    conn.sendall(wire_frame(msg_window_new(args.width, args.height, args.scale)))
+
+    variants = [make_bands(args.width, args.height, v) for v in range(4)]
+    stats = Stats()
+    seq = 0
+    deadline = time.monotonic() + args.seconds
+
+    def send_next(*, full: bool) -> None:
+        nonlocal seq
+        seq += 1
+        frame = msg_window_frame(
+            seq, args.width, args.height, full=full, bands=variants[seq % len(variants)]
+        )
+        stats.send_at[seq] = time.monotonic()
+        conn.sendall(wire_frame(frame))
+
+    for _ in range(args.credit):
+        send_next(full=seq == 0)
+    inflight = seq
+    while time.monotonic() < deadline:
+        try:
+            event = events.get(timeout=2.0)
+        except queue.Empty:
+            continue
+        if event.kind == "eof":
+            break
+        if event.kind == "ping":
+            conn.sendall(wire_frame(msg_pong(event.nonce)))
+        elif event.kind == "close":
+            conn.sendall(wire_frame(msg_window_gone()))
+            break
+        elif event.kind == "ack":
+            now = time.monotonic()
+            # Exactly acked = presented; older seqs the cumulative ack covers
+            # were coalesced away, never presented (see Stats.report).
+            if event.seq in stats.send_at:
+                stats.presented_at.setdefault(event.seq, now)
+            for pending in stats.send_at:
+                if pending < event.seq and pending not in stats.presented_at:
+                    stats.coalesced.add(pending)
+            inflight = seq - event.seq
+            while inflight < args.credit:
+                if args.render_ms:
+                    time.sleep(args.render_ms / 1000)
+                send_next(full=False)
+                inflight += 1
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("socket_path")
+    parser.add_argument("--width", type=int, default=1728)
+    parser.add_argument("--height", type=int, default=1080)
+    parser.add_argument("--scale", type=int, default=2)
+    parser.add_argument("--credit", type=int, default=1)
+    parser.add_argument("--render-ms", type=float, default=0.0)
+    parser.add_argument("--seconds", type=float, default=10.0)
+    args = parser.parse_args()
+
+    # A stale socket file from a previous run would fail the bind.
+    Path(args.socket_path).unlink(missing_ok=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(args.socket_path)
+    listener.listen(1)
+    print(f"probe: listening on {args.socket_path}", flush=True)
+    conn, _ = listener.accept()
+    print("probe: host connected", flush=True)
+    stats = drive(conn, args)
+    print(f"probe: {stats.report()}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reduces end-to-end mouse-look latency for GPU apps (Minecraft) in panes. Rebased onto #1775 (HiDPI) + #1776 (hidden titlebar); the pinned link rate is per-window-screen and refreshes on `windowDidChangeScreen:`. Measure-first: every change here is backed by numbers from a synthetic guest (`host/tools/latency_probe.py`, committed) driving a `PANES_TRACE=1` instrumented host on the real 120Hz panel, 1728x1080 buffer (~ today's 1x-scale MC window; #1775 will 4x the byte volume), LZ4 bands ~3.8MB/frame over a unix socket.

## Where the milliseconds actually were (baseline)

| stage | measured |
|---|---|
| in-game vsync stacked on ack genlock (H4) | dominant — confirmed live by A/B (vsync off + uncapped = "way better") |
| **tick -> glass** (present queue) | **constant 40.6ms (~5 frames)**, ground-truthed via `MTLDrawable.presentedTime` (== `targetPresentationTimestamp` ±10µs); immovable by `maximumDrawableCount` 3->2 or `preferredFrameLatency` 3..0.5 |
| frame send -> ack RTT | p50 7.9ms at 120fps steady (mostly waiting for the next tick; wire+decode ~1.5ms; main-thread ingest of 3.8MB is only 0.24ms p50) |
| adaptive 60..120 link range | near the one-period boundary (2ms simulated guest render) the link downshifts: 98.6fps, p99 RTT 16.2ms |
| input HID->handler | p50 0.35ms, p99 4.2ms under frame load; AppKit coalescing merged **21% of a 1kHz delta stream** |
| credit=1 pacing cliff | 4ms simulated guest turnaround -> hard 60fps lock (frame finishes ~0.4ms after the tick, waits a full period) |

H-ranking vs the original hypotheses: H4 (dominant, user-confirmed) > present queue (not on the list; found by instrumentation) > H1 (real, but only in the marginal regime — live MC sustains 115-120 acks/s today) > H3 (small) > H2 (no measurable effect).

## Host fixes (all measured, this PR)

- **`displaySyncEnabled = false`** (`window.rs`): presents no longer queue behind vsyncs in the windowed-compositing path. tick->glass **40.6ms -> 23.7-32.1ms** (bimodal, run-locked phase to WindowServer's compose; p10 23.7). fps and RTT unchanged (119.7). No tearing exposure: WindowServer still composites whole surfaces, and presents stay tick-paced (the ack loop is the throttle), so nothing free-runs.
- **Pinned stream rate range** (min=max=preferred=panel max): kills the adaptive downshift. 2ms-render probe: **98.6 -> 117.9fps**, p99 RTT 16.2 -> 13.4ms.
- **Mouse coalescing off while pointer-captured** (`app.rs` `CursorCapture`): **100% of a 1kHz delta stream delivered (was 79%)**, HID->handler p50 0.35 -> 0.18ms. Restored on release; absolute-cursor mode keeps the AppKit default.
- `maximumDrawableCount = 2`: measured no throughput or latency change either way; keeps one fewer window-sized surface.
- **`PANES_TRACE=1`** env-gated instrumentation (one relaxed atomic load when off): input HID->handler delay, frame ingest span, present target, and `presentedTime` glass ground truth, all on the `NSEvent.timestamp` clock so an external probe correlates directly.

After (probe, same instrumentation): 120fps steady holds; ack RTT p50 7.9ms p99 8.4 (was 12.2); motion->photon estimate drops from ~50-60ms to **~33-45ms**, dominated by the residual WindowServer compose floor.

## Guest seed (rides the next image rebuild)

`guest-image/apps.nix` options.txt seed (first boot only; existing data disks keep user settings), each line justified inline: `enableVsync:false` (the confirmed dominant term), `maxFps:260` (slider "Unlimited"; freshest sample, ack pacing bounds the shipped rate), `rawMouseInput:true`, `graphicsPreset:"fancy"` (26.2 replaced graphics modes with presets -- serialization taken from the game-rewritten options.txt on the live data disk; fancy guards against Fabulous!'s post pipeline), `narrator:0`. Every key/value matches MC 26.2's own writer byte-for-byte (ground-truth evidence in the review round-up comment).

## Follow-ups (compositor-side; aarch64 builder is down, so not compile-checkable today)

- **Credit-2 pacing**: the host's cumulative acks already tolerate >=2 frames in flight (measured: probe at credit=2 holds 120fps at 4ms guest turnaround where credit=1 locks to 60, and degrades gracefully after). Worth doing guest-side once the builder is back — 4x more relevant after #1775 doubles the buffer scale.
- **Defer dmabuf readback from commit-time to send-time**: uncapped MC commits >120/s but only ~120 ship; every commit currently costs a full GPU readback on the event-loop thread that also dispatches input.
- **Present-on-arrival**: would cut the remaining 0-8.3ms tick-alignment wait, but needs presents decoupled from `CAMetalDisplayLink`-vended drawables.
- Optional per-app render-scale knob once #1775 lands (crispness vs latency).

Live MC validation needs a session restart onto this binary (the running demo was left untouched); the probe numbers above are the before/after evidence.

Part of #1686.
