### PR TITLE
panes: guest audio out to the macOS host (PCM over vsock 7102)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7633,6 +7633,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "panes-audio"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "panes-protocol",
+ "tracing",
+ "tracing-subscriber",
+ "vsock",
+]
+
+[[package]]
 name = "panes-compositor"
 version = "0.1.0"
 dependencies = [
@@ -7650,8 +7662,10 @@ dependencies = [
 name = "panes-host"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "block2",
  "clap",
+ "cpal",
  "dispatch2",
  "lz4_flex 0.13.1",
  "objc2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ members = [
   "packages/tui/tui",
   "packages/tui/tui-node",
   "packages/tui/tui-py",
+  "packages/vm/panes/audio",
   "packages/vm/panes/compositor",
   "packages/vm/panes/host",
   "packages/vm/panes/protocol",

--- a/packages/vm/panes/README.md
+++ b/packages/vm/panes/README.md
@@ -13,8 +13,12 @@ macOS host                          aarch64-linux guest (libkrun-efi, vmkit)
 |  one NSWindow    |  panes-protocol|   socket: /run/panes/wayland-1       |
 |  per toplevel,   |  postcard      +--------------------------------------+
 |  input forwarded |  frames        | nspawn containers, one per app       |
-+------------------+                |   demo | term | minecraft | ...      |
-                                    |   each binds /run/panes + /dev/dri   |
+|                  |                |   demo | term | minecraft | ...      |
+|  CoreAudio out   |   vsock 7102   |   each binds /run/panes + /dev/dri   |
+|  (jitter buffer) |<---------------|     + /run/pipewire                  |
++------------------+   s16le PCM    +--------------------------------------+
+                                    | pipewire (system-wide): null sink    |
+                                    |   "panes-sink" -> panes-audio pump   |
                                     +--------------------------------------+
 ```
 
@@ -31,7 +35,12 @@ macOS host                          aarch64-linux guest (libkrun-efi, vmkit)
   Wayland compositor. Each `xdg_toplevel` becomes a window on the host; no
   DRM output, no seat, no logind, it composites nothing and only exports.
 - [`host/`](host/) (`panes-host`): macOS agent that owns the NSWindows and
-  forwards input back.
+  forwards input back; with `--audio-connect` it also plays the guest's PCM
+  stream on the default CoreAudio output through a small jitter buffer.
+- [`audio/`](audio/) (`panes-audio`): guest daemon pumping the PipeWire mix
+  (raw s16le PCM from a `module-protocol-simple` tap) to the host over vsock
+  port 7102. Its wire contract is the protocol crate's `audio` module: same
+  framing, separate versioning, so the window protocol never changes.
 - [`guest-image/`](guest-image/) (`panes-guest-image`): the bootable
   aarch64-linux NixOS raw-efi disk wiring it all up: the compositor as a
   systemd service plus one autostarted systemd-nspawn container per app.
@@ -55,7 +64,10 @@ truncate -s 8G /tmp/panes-guest.raw
 # mounts it nofail, so booting without it still works.
 truncate -s 10G /tmp/panes-data.raw
 nix run .#vmkit -- boot-linux --disk /tmp/panes-guest.raw --disk /tmp/panes-data.raw \
-  --gpu --net --memory-mib 6144 --cpus 6 --timeout-secs 0
+  --gpu --net --memory-mib 6144 --cpus 6 --timeout-secs 0 \
+  --vsock-port 7100:/tmp/panes.sock --vsock-port 7102:/tmp/panes-audio.sock
+# Then, on the host:
+nix run .#panes-host -- --connect /tmp/panes.sock --audio-connect /tmp/panes-audio.sock
 ```
 
 `--disk` is repeatable: the first is the boot disk (guest `/dev/vda`), each
@@ -131,6 +143,32 @@ Details: [`vmkit/docs/linux-libkrun.md`](../vmkit/docs/linux-libkrun.md).
 > plumbing above (16K kernel, ICD, `/dev/dri` binds) is ready; enabling the
 > feature in the guest-image build is the remaining step for accelerated
 > window content (index#1686).
+
+## Audio
+
+Sound from guest apps plays on the Mac (index#1686). libkrun has no usable
+sound device on macOS (1.19.3's virtio-snd is PipeWire-host-only, absent from
+the `efi` feature set, and deleted upstream in 2.0), so audio rides a second
+vsock port instead, end to end:
+
+```
+app (openal, ALSOFT_DRIVERS=pipewire)
+  -> pipewire (system-wide) null sink "panes-sink"     guest mixer
+  -> module-protocol-simple tap (raw s16le, tcp:127.0.0.1:7103)
+  -> panes-audio (frames PCM, vsock port 7102)
+  -> panes-host --audio-connect (jitter buffer ~24 ms -> CoreAudio)
+```
+
+Boot with `--vsock-port 7102:/tmp/panes-audio.sock` and point
+`panes-host --audio-connect` at that socket (see the boot line above); both
+ends reconnect with backoff, and a host without `--audio-connect` (or a guest
+without the daemon) just runs silent. Latency budget: ~10.7 ms PipeWire
+quantum + 24 ms host jitter-buffer target + ~10 ms CoreAudio output buffer,
+under 50 ms end to end; the jitter buffer trades continuity for latency
+(underrun plays silence and re-primes, overrun drops the oldest audio) as
+game sound wants. On the serial console, `panes-boot-report` prints the
+PipeWire node list (`panes-sink` must appear; `PANES-AUDIO-NODES-ABSENT`
+means the audio graph is down).
 
 Networking: `--net` runs gvproxy (`192.168.127.0/24`); the image DHCPs its
 NIC. App containers share the host network namespace, so e.g. Minecraft can

--- a/packages/vm/panes/audio/Cargo.toml
+++ b/packages/vm/panes/audio/Cargo.toml
@@ -1,0 +1,28 @@
+# Guest-side audio pump: reads the raw PCM mix from PipeWire's
+# protocol-simple tap and ships it to panes-host over vsock port 7102 with
+# panes-protocol's audio framing (see that crate's `audio` module for the wire
+# contract and index#1686 for the design).
+#
+# Like the compositor, the Linux-only transport (AF_VSOCK) is target-gated so
+# the portable core (handshake + pump + framing) compiles and unit-tests on
+# any development host, which also keeps the Linux clippy pass meaningful.
+[package]
+name = "panes-audio"
+version = "0.1.0"
+edition = "2024"
+description = "Guest daemon shipping the PipeWire PCM mix to the macOS host over vsock"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+panes-protocol.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# AF_VSOCK listener for libkrun's vsock port map (std has no vsock support).
+vsock = "0.5"
+
+[lints]
+workspace = true

--- a/packages/vm/panes/audio/default.nix
+++ b/packages/vm/panes/audio/default.nix
@@ -1,0 +1,18 @@
+# The audio daemon binary out of the shared workspace unit graph (dag-runner
+# pattern): package.nix carries the registry metadata, this file only selects
+# the target. Same selection pattern as ../compositor.
+{ ix, ... }:
+
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "panes-audio";
+  meta = {
+    description = "Guest daemon shipping the PipeWire PCM mix to the macOS host over vsock";
+    mainProgram = "panes-audio";
+    # The guest is aarch64; x86_64 exists so CI's x86_64-linux-only graph
+    # compiles and tests the crate (see package.nix).
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/packages/vm/panes/audio/package.nix
+++ b/packages/vm/panes/audio/package.nix
@@ -1,0 +1,18 @@
+{
+  id = "panes-audio";
+  inRustWorkspace = true;
+  # Guest-side: runs inside the aarch64-linux VM. x86_64-linux is in the set
+  # because the crate is arch-generic Linux and CI's flake-check builds only
+  # the x86_64-linux graph (check.yml): without it, nothing would compile,
+  # lint, or test this crate pre-merge (unlike panes-compositor, whose
+  # aarch64-only smithay stack is validated on the local builder instead).
+  flake.systems = [
+    "aarch64-linux"
+    "x86_64-linux"
+  ];
+  packageSet.systems = [
+    "aarch64-linux"
+    "x86_64-linux"
+  ];
+  passthruTests = true;
+}

--- a/packages/vm/panes/audio/src/cli.rs
+++ b/packages/vm/panes/audio/src/cli.rs
@@ -1,0 +1,52 @@
+//! CLI surface, in the compositor's style: long flags, doc comments as help
+//! text. The defaults are the production values the guest image passes
+//! explicitly (one source of truth for the numbers lives in
+//! `guest-image/nixos.nix`, which must keep the `PipeWire` tap's format in sync
+//! with `--rate`/`--channels`).
+
+use std::path::PathBuf;
+
+#[derive(Debug, clap::Parser)]
+#[command(
+    name = "panes-audio",
+    about = "Ship the guest's PipeWire PCM mix to the macOS host over a byte stream"
+)]
+pub struct Cli {
+    /// `AF_VSOCK` port to listen on: the production transport inside the VM
+    /// (panes-host reaches it through libkrun's vsock port map). Ignored when
+    /// --listen-unix or --listen-tcp is given.
+    #[arg(long, value_name = "PORT", default_value_t = panes_protocol::audio::VSOCK_PORT)]
+    pub listen_vsock: u32,
+
+    /// Listen on a unix socket instead of vsock (off-VM development; a stale
+    /// socket file at PATH is removed).
+    #[arg(long, value_name = "PATH", conflicts_with = "listen_tcp")]
+    pub listen_unix: Option<PathBuf>,
+
+    /// Listen on TCP instead of vsock (off-VM development), e.g.
+    /// "127.0.0.1:7102".
+    #[arg(long, value_name = "ADDR")]
+    pub listen_tcp: Option<String>,
+
+    /// TCP address of `PipeWire`'s protocol-simple capture socket (raw PCM in
+    /// the `--rate`/`--channels` format, s16le). TCP because the module's unix
+    /// accept path is dead code in `PipeWire` 1.6 (`module-protocol-simple.c`
+    /// rejects unix clients with `goto error`); loopback-bound in the guest.
+    #[arg(long, value_name = "ADDR", default_value = "127.0.0.1:7103")]
+    pub pcm_tcp: String,
+
+    /// Sample rate (Hz) the tap is configured to produce; advertised to the
+    /// host in the audio Hello.
+    #[arg(long, default_value_t = 48000)]
+    pub rate: u32,
+
+    /// Interleaved channel count the tap is configured to produce; advertised
+    /// to the host in the audio Hello.
+    #[arg(long, default_value_t = 2)]
+    pub channels: u16,
+
+    /// Log filter: a level ("info") or tracing directives
+    /// ("info,panes_audio=debug").
+    #[arg(long, default_value = "info")]
+    pub log_level: String,
+}

--- a/packages/vm/panes/audio/src/cli.rs
+++ b/packages/vm/panes/audio/src/cli.rs
@@ -46,7 +46,7 @@ pub struct Cli {
     pub channels: u16,
 
     /// Log filter: a level ("info") or tracing directives
-    /// ("info,panes_audio=debug").
+    /// (`info,panes_audio=debug`).
     #[arg(long, default_value = "info")]
     pub log_level: String,
 }

--- a/packages/vm/panes/audio/src/main.rs
+++ b/packages/vm/panes/audio/src/main.rs
@@ -27,24 +27,13 @@ fn main() -> anyhow::Result<()> {
     } else if let Some(addr) = cli.listen_tcp {
         serve::ListenSpec::Tcp(addr)
     } else {
-        vsock_listen_spec(cli.listen_vsock)?
+        // Binding this is Linux-only; serve::run rejects it with a legible
+        // error on a non-Linux development host (only unix/TCP work there).
+        serve::ListenSpec::Vsock(cli.listen_vsock)
     };
     serve::run(
         &listen,
         &cli.pcm_tcp,
         &serve::StreamFormat { rate: cli.rate, channels: cli.channels },
     )
-}
-
-#[cfg(target_os = "linux")]
-fn vsock_listen_spec(port: u32) -> anyhow::Result<serve::ListenSpec> {
-    Ok(serve::ListenSpec::Vsock(port))
-}
-
-/// The daemon has no host-side role (playback lives in panes-host); this stub
-/// keeps `cargo test` for the portable pump/handshake logic working on
-/// non-Linux development hosts, where only the unix/TCP listeners exist.
-#[cfg(not(target_os = "linux"))]
-fn vsock_listen_spec(_port: u32) -> anyhow::Result<serve::ListenSpec> {
-    anyhow::bail!("AF_VSOCK is Linux-only; use --listen-unix or --listen-tcp on a development host")
 }

--- a/packages/vm/panes/audio/src/main.rs
+++ b/packages/vm/panes/audio/src/main.rs
@@ -1,0 +1,50 @@
+//! Guest audio pump: `PipeWire`'s protocol-simple PCM tap -> `panes-host` over
+//! vsock port 7102 (or a unix/TCP socket for off-VM development). The wire
+//! contract lives in `panes-protocol`'s `audio` module; the `PipeWire` side
+//! (null sink + protocol-simple tap) is configured by
+//! `packages/vm/panes/guest-image/nixos.nix`. See index#1686.
+
+mod cli;
+mod serve;
+
+use clap::Parser as _;
+
+fn main() -> anyhow::Result<()> {
+    let cli = cli::Cli::parse();
+    // EnvFilter accepts full tracing directives, so `--log-level` takes a bare
+    // level ("debug") or a filter string ("info,panes_audio=debug").
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::try_new(&cli.log_level)?)
+        .init();
+
+    // The pump divides by the sample-frame size (channels * 2 bytes); a zero
+    // would panic deep in the loop instead of failing legibly here.
+    anyhow::ensure!(cli.channels >= 1, "--channels must be at least 1");
+    anyhow::ensure!(cli.rate >= 1, "--rate must be at least 1");
+
+    let listen = if let Some(path) = cli.listen_unix {
+        serve::ListenSpec::Unix(path)
+    } else if let Some(addr) = cli.listen_tcp {
+        serve::ListenSpec::Tcp(addr)
+    } else {
+        vsock_listen_spec(cli.listen_vsock)?
+    };
+    serve::run(
+        &listen,
+        &cli.pcm_tcp,
+        &serve::StreamFormat { rate: cli.rate, channels: cli.channels },
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn vsock_listen_spec(port: u32) -> anyhow::Result<serve::ListenSpec> {
+    Ok(serve::ListenSpec::Vsock(port))
+}
+
+/// The daemon has no host-side role (playback lives in panes-host); this stub
+/// keeps `cargo test` for the portable pump/handshake logic working on
+/// non-Linux development hosts, where only the unix/TCP listeners exist.
+#[cfg(not(target_os = "linux"))]
+fn vsock_listen_spec(_port: u32) -> anyhow::Result<serve::ListenSpec> {
+    anyhow::bail!("AF_VSOCK is Linux-only; use --listen-unix or --listen-tcp on a development host")
+}

--- a/packages/vm/panes/audio/src/serve.rs
+++ b/packages/vm/panes/audio/src/serve.rs
@@ -1,0 +1,428 @@
+//! Accept loop and per-connection pump.
+//!
+//! Layout: the accept loop serves ONE host connection at a time (panes has
+//! exactly one host agent; a second connect waits in the OS backlog until the
+//! current connection dies). Per connection: Hellos are exchanged first (both
+//! sides send immediately on connect, majors validated before any PCM), then
+//! a watchdog thread parks in `read_msg` to notice the host hanging up, while
+//! this thread pumps the `PipeWire` tap into framed [`ToHost::Pcm`] messages.
+//! The watchdog exists because the pump would otherwise only notice a dead
+//! host on its next write -- and while `PipeWire` is down the pump writes
+//! nothing, which would wedge the accept loop behind a corpse.
+
+use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::Context as _;
+use panes_protocol::audio::{self, SampleFormat, ToGuest, ToHost};
+use panes_protocol::{WireError, read_msg_bounded, write_msg};
+use tracing::{debug, info, warn};
+#[cfg(target_os = "linux")]
+use vsock::{VMADDR_CID_ANY, VsockListener, VsockStream};
+
+/// Where to accept the (single) host connection.
+pub enum ListenSpec {
+    #[cfg(target_os = "linux")]
+    Vsock(u32),
+    Unix(PathBuf),
+    Tcp(String),
+}
+
+/// The fixed stream format advertised in the audio Hello. The sample format
+/// is always [`SampleFormat::S16le`]: it is what the `PipeWire` tap is
+/// configured to emit (guest-image `nixos.nix`) and the only variant v1
+/// defines.
+pub struct StreamFormat {
+    pub rate: u32,
+    pub channels: u16,
+}
+
+/// PCM-tap reconnect backoff. Starts low because the common case is the
+/// daemon racing `pipewire.service` at boot; capped so a long `PipeWire` outage
+/// does not turn into a tight loop.
+const PCM_BACKOFF_START: Duration = Duration::from_millis(250);
+const PCM_BACKOFF_MAX: Duration = Duration::from_secs(5);
+
+/// Tap read buffer: ~10 ms of 48 kHz s16le stereo. Small enough that a chunk
+/// is forwarded as soon as the tap produces a quantum (never waiting to fill
+/// the buffer: `read` returns whatever is available), large enough that the
+/// per-message framing overhead is noise.
+const READ_BUF_BYTES: usize = 4096;
+
+/// Object-safe stream, mirroring the compositor's transport: the accept-side
+/// types only share Read/Write, and the watchdog thread needs its own handle
+/// plus a shutdown lever that reaches the shared socket (dropping one dup'd
+/// fd does not unblock a reader parked on another).
+trait Conn: Read + Write + Send {
+    fn try_clone_conn(&self) -> std::io::Result<Box<dyn Conn>>;
+    fn shutdown_conn(&self);
+}
+
+impl Conn for TcpStream {
+    fn try_clone_conn(&self) -> std::io::Result<Box<dyn Conn>> {
+        Ok(Box::new(self.try_clone()?))
+    }
+    fn shutdown_conn(&self) {
+        let _ = self.shutdown(std::net::Shutdown::Both);
+    }
+}
+
+impl Conn for UnixStream {
+    fn try_clone_conn(&self) -> std::io::Result<Box<dyn Conn>> {
+        Ok(Box::new(self.try_clone()?))
+    }
+    fn shutdown_conn(&self) {
+        let _ = self.shutdown(std::net::Shutdown::Both);
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Conn for VsockStream {
+    fn try_clone_conn(&self) -> std::io::Result<Box<dyn Conn>> {
+        Ok(Box::new(self.try_clone()?))
+    }
+    fn shutdown_conn(&self) {
+        let _ = self.shutdown(std::net::Shutdown::Both);
+    }
+}
+
+enum Acceptor {
+    #[cfg(target_os = "linux")]
+    Vsock(VsockListener),
+    Unix(UnixListener),
+    Tcp(TcpListener),
+}
+
+impl Acceptor {
+    fn bind(spec: &ListenSpec) -> anyhow::Result<Self> {
+        match spec {
+            #[cfg(target_os = "linux")]
+            ListenSpec::Vsock(port) => {
+                let listener = VsockListener::bind_with_cid_port(VMADDR_CID_ANY, *port)
+                    .with_context(|| format!("bind vsock port {port}"))?;
+                info!(port, "listening on vsock");
+                Ok(Self::Vsock(listener))
+            }
+            ListenSpec::Unix(path) => {
+                // A previous run's socket file would fail the bind with
+                // EADDRINUSE even though nothing is listening.
+                match std::fs::remove_file(path) {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == ErrorKind::NotFound => {}
+                    Err(err) => {
+                        return Err(err)
+                            .with_context(|| format!("remove stale {}", path.display()));
+                    }
+                }
+                let listener = UnixListener::bind(path)
+                    .with_context(|| format!("bind unix socket {}", path.display()))?;
+                info!(path = %path.display(), "listening on unix socket");
+                Ok(Self::Unix(listener))
+            }
+            ListenSpec::Tcp(addr) => {
+                let listener =
+                    TcpListener::bind(addr).with_context(|| format!("bind tcp {addr}"))?;
+                info!(addr, "listening on tcp");
+                Ok(Self::Tcp(listener))
+            }
+        }
+    }
+
+    fn accept(&self) -> std::io::Result<Box<dyn Conn>> {
+        match self {
+            #[cfg(target_os = "linux")]
+            Self::Vsock(listener) => {
+                let (stream, _addr) = listener.accept()?;
+                Ok(Box::new(stream))
+            }
+            Self::Unix(listener) => {
+                let (stream, _addr) = listener.accept()?;
+                Ok(Box::new(stream))
+            }
+            Self::Tcp(listener) => {
+                let (stream, _addr) = listener.accept()?;
+                Ok(Box::new(stream))
+            }
+        }
+    }
+}
+
+/// Bind (fatal so a misconfigured transport fails loudly under systemd
+/// `Restart=on-failure`) and serve host connections forever.
+///
+/// # Errors
+/// Only on bind failure; per-connection and PCM-tap failures are retried.
+pub fn run(spec: &ListenSpec, pcm_addr: &str, fmt: &StreamFormat) -> anyhow::Result<()> {
+    let acceptor = Acceptor::bind(spec)?;
+    loop {
+        let conn = match acceptor.accept() {
+            Ok(conn) => conn,
+            Err(err) => {
+                // Transient accept errors (EMFILE, aborted handshakes) must
+                // not kill the only accept loop; back off and retry.
+                warn!(%err, "accept failed; retrying");
+                std::thread::sleep(Duration::from_millis(200));
+                continue;
+            }
+        };
+        info!("host connected");
+        if let Err(err) = serve_conn(&*conn, pcm_addr, fmt) {
+            info!(%err, "host connection ended");
+        }
+        // Unblocks the watchdog thread parked in read_msg on its dup'd fd;
+        // dropping our handle alone would leave it parked forever.
+        conn.shutdown_conn();
+    }
+}
+
+/// Drive one host connection until either side dies. `Ok` means the host hung
+/// up cleanly (watchdog saw EOF); `Err` carries the handshake or write
+/// failure.
+fn serve_conn(conn: &dyn Conn, pcm_addr: &str, fmt: &StreamFormat) -> anyhow::Result<()> {
+    let mut writer = BufWriter::new(conn.try_clone_conn().context("clone for writer")?);
+    let mut reader = BufReader::new(conn.try_clone_conn().context("clone for reader")?);
+    exchange_hellos(&mut reader, &mut writer, fmt)?;
+
+    let host_gone = Arc::new(AtomicBool::new(false));
+    {
+        let host_gone = Arc::clone(&host_gone);
+        std::thread::Builder::new()
+            .name("panes-audio-watch".into())
+            .spawn(move || watch_host(reader, &host_gone))
+            .context("spawn watchdog thread")?;
+    }
+
+    let frame_bytes = usize::from(fmt.channels) * SampleFormat::S16le.bytes_per_sample();
+    let mut backoff = PCM_BACKOFF_START;
+    while !host_gone.load(Ordering::Relaxed) {
+        let mut pcm = match TcpStream::connect(pcm_addr) {
+            Ok(stream) => stream,
+            Err(err) => {
+                // The tap is pipewire's listener: absent while the service
+                // (re)starts. Keep the host connection and retry; the host
+                // plays silence from an empty jitter buffer meanwhile.
+                warn!(%err, pcm_addr, "PCM tap unreachable; retrying");
+                std::thread::sleep(backoff);
+                backoff = (backoff * 2).min(PCM_BACKOFF_MAX);
+                continue;
+            }
+        };
+        backoff = PCM_BACKOFF_START;
+        info!(pcm_addr, "PCM tap connected");
+        match pump(&mut pcm, &mut writer, frame_bytes, &host_gone) {
+            // Tap ended (pipewire restart): reconnect, host stays.
+            Ok(PumpEnd::PcmEnded) => debug!("PCM tap ended; reconnecting"),
+            Ok(PumpEnd::HostGone) => break,
+            Err(err) => return Err(err).context("write to host"),
+        }
+    }
+    Ok(())
+}
+
+/// Send our Hello, then read and validate the host's (protocol rule: both
+/// sides send immediately on connect, so reading second cannot deadlock).
+fn exchange_hellos(
+    read: &mut impl Read,
+    write: &mut impl Write,
+    fmt: &StreamFormat,
+) -> anyhow::Result<()> {
+    write_msg(
+        write,
+        &ToHost::Hello {
+            major: audio::VERSION_MAJOR,
+            minor: audio::VERSION_MINOR,
+            rate: fmt.rate,
+            channels: fmt.channels,
+            format: SampleFormat::S16le,
+        },
+    )
+    .context("send hello")?;
+    write.flush().context("flush hello")?;
+    let hello: ToGuest = read_msg_bounded(read, audio::MAX_FRAME).context("read host hello")?;
+    let ToGuest::Hello { major, minor } = hello;
+    anyhow::ensure!(
+        major == audio::VERSION_MAJOR,
+        "host audio protocol major {major} != {}, hanging up",
+        audio::VERSION_MAJOR
+    );
+    info!(major, minor, "host speaks audio protocol");
+    Ok(())
+}
+
+/// Park in `read_msg` until the host hangs up (or sends garbage), then raise
+/// the flag the pump polls. v1.0 defines no post-Hello host->guest messages
+/// and the host gates future ones on our advertised minor, so anything that
+/// still decodes is ignored at debug level rather than treated as fatal.
+fn watch_host(mut reader: impl Read, host_gone: &AtomicBool) {
+    loop {
+        match read_msg_bounded::<ToGuest>(&mut reader, audio::MAX_FRAME) {
+            Ok(msg) => debug!(?msg, "ignoring unexpected host message"),
+            Err(err) => {
+                debug!(%err, "host read ended");
+                host_gone.store(true, Ordering::Relaxed);
+                return;
+            }
+        }
+    }
+}
+
+/// Why [`pump`] stopped without a host-side error.
+enum PumpEnd {
+    /// Tap EOF or read error: reconnect the tap, keep the host connection.
+    PcmEnded,
+    /// The watchdog flagged the host connection dead.
+    HostGone,
+}
+
+/// Copy raw PCM from `pcm` into framed [`ToHost::Pcm`] messages on `sink`
+/// until one side ends, forwarding each read immediately (no batching beyond
+/// what the kernel returned: latency beats throughput here, and flushing per
+/// chunk keeps the jitter buffer fed at the tap's own cadence).
+///
+/// The wire contract requires whole interleaved sample frames per message, so
+/// a read that splits a frame keeps the remainder as carry for the next read.
+/// On [`PumpEnd::PcmEnded`] any final sub-frame carry is dropped: a torn tap
+/// connection loses under one sample frame of audio.
+///
+/// # Errors
+/// Only for sink (host connection) failures; `pcm` errors and EOF are the
+/// [`PumpEnd::PcmEnded`] reconnect signal, logged by the caller.
+fn pump(
+    pcm: &mut impl Read,
+    sink: &mut impl Write,
+    frame_bytes: usize,
+    stop: &AtomicBool,
+) -> Result<PumpEnd, WireError> {
+    let mut buf = vec![0u8; READ_BUF_BYTES];
+    let mut carry: Vec<u8> = Vec::with_capacity(frame_bytes);
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            return Ok(PumpEnd::HostGone);
+        }
+        let n = match pcm.read(&mut buf) {
+            Ok(0) => return Ok(PumpEnd::PcmEnded),
+            Ok(n) => n,
+            Err(err) => {
+                debug!(%err, "PCM tap read failed");
+                return Ok(PumpEnd::PcmEnded);
+            }
+        };
+        carry.extend_from_slice(&buf[..n]);
+        let whole = (carry.len() / frame_bytes) * frame_bytes;
+        if whole == 0 {
+            continue;
+        }
+        let rest = carry.split_off(whole);
+        let payload = std::mem::replace(&mut carry, rest);
+        write_msg(sink, &ToHost::Pcm { payload })?;
+        sink.flush()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reader that returns its script one slice at a time, then EOF; slice
+    /// sizes are deliberately not frame-aligned to exercise the carry.
+    struct Scripted {
+        chunks: Vec<Vec<u8>>,
+    }
+
+    impl Read for Scripted {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.chunks.is_empty() {
+                return Ok(0);
+            }
+            let chunk = self.chunks.remove(0);
+            buf[..chunk.len()].copy_from_slice(&chunk);
+            Ok(chunk.len())
+        }
+    }
+
+    fn decode_payloads(mut wire: &[u8]) -> Vec<Vec<u8>> {
+        let mut payloads = Vec::new();
+        while !wire.is_empty() {
+            let msg: ToHost = read_msg_bounded(&mut wire, audio::MAX_FRAME).unwrap();
+            let ToHost::Pcm { payload } = msg else {
+                panic!("expected Pcm");
+            };
+            payloads.push(payload);
+        }
+        payloads
+    }
+
+    #[test]
+    fn pump_keeps_frames_whole_across_unaligned_reads() {
+        // 11 bytes in 3+3+3+2 chunks with 4-byte frames: the pump must emit
+        // 8 bytes (two whole frames) in original order and drop the 3-byte
+        // tail as sub-frame carry at EOF.
+        let source: Vec<u8> = (0..11).collect();
+        let mut pcm = Scripted {
+            chunks: vec![
+                source[0..3].to_vec(),
+                source[3..6].to_vec(),
+                source[6..9].to_vec(),
+                source[9..11].to_vec(),
+            ],
+        };
+        let mut wire = Vec::new();
+        let stop = AtomicBool::new(false);
+        let end = pump(&mut pcm, &mut wire, 4, &stop).unwrap();
+        assert!(matches!(end, PumpEnd::PcmEnded));
+        let bytes: Vec<u8> = decode_payloads(&wire).concat();
+        assert_eq!(bytes, source[0..8]);
+        for payload in decode_payloads(&wire) {
+            assert_eq!(payload.len() % 4, 0, "every message is whole frames");
+        }
+    }
+
+    #[test]
+    fn pump_stops_before_reading_when_host_gone() {
+        let mut pcm = Scripted { chunks: vec![vec![0u8; 4]] };
+        let mut wire = Vec::new();
+        let stop = AtomicBool::new(true);
+        let end = pump(&mut pcm, &mut wire, 4, &stop).unwrap();
+        assert!(matches!(end, PumpEnd::HostGone));
+        assert!(wire.is_empty(), "nothing may be sent after the host died");
+    }
+
+    #[test]
+    fn hellos_exchange_and_validate_major() {
+        let mut host_to_guest = Vec::new();
+        write_msg(&mut host_to_guest, &ToGuest::Hello { major: audio::VERSION_MAJOR, minor: 0 })
+            .unwrap();
+        let mut sent = Vec::new();
+        exchange_hellos(
+            &mut host_to_guest.as_slice(),
+            &mut sent,
+            &StreamFormat { rate: 48000, channels: 2 },
+        )
+        .unwrap();
+        let hello: ToHost = read_msg_bounded(&mut sent.as_slice(), audio::MAX_FRAME).unwrap();
+        let ToHost::Hello { rate: 48000, channels: 2, format: SampleFormat::S16le, .. } = hello
+        else {
+            panic!("wrong hello");
+        };
+    }
+
+    #[test]
+    fn hellos_reject_mismatched_major() {
+        let mut host_to_guest = Vec::new();
+        write_msg(&mut host_to_guest, &ToGuest::Hello { major: audio::VERSION_MAJOR + 1, minor: 0 })
+            .unwrap();
+        let mut sent = Vec::new();
+        let err = exchange_hellos(
+            &mut host_to_guest.as_slice(),
+            &mut sent,
+            &StreamFormat { rate: 48000, channels: 2 },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("major"));
+    }
+}

--- a/packages/vm/panes/audio/src/serve.rs
+++ b/packages/vm/panes/audio/src/serve.rs
@@ -27,7 +27,10 @@ use vsock::{VMADDR_CID_ANY, VsockListener, VsockStream};
 
 /// Where to accept the (single) host connection.
 pub enum ListenSpec {
-    #[cfg(target_os = "linux")]
+    /// `AF_VSOCK` port, the production transport. The variant exists on
+    /// every platform (so the CLI needs no cfg), but binding it outside
+    /// Linux fails with a legible error: the daemon has no host-side role
+    /// there, only the unix/TCP dev listeners.
     Vsock(u32),
     Unix(PathBuf),
     Tcp(String),
@@ -98,16 +101,26 @@ enum Acceptor {
     Tcp(TcpListener),
 }
 
+/// The Linux half of [`ListenSpec::Vsock`]'s contract.
+#[cfg(target_os = "linux")]
+fn bind_vsock(port: u32) -> anyhow::Result<Acceptor> {
+    let listener = VsockListener::bind_with_cid_port(VMADDR_CID_ANY, port)
+        .with_context(|| format!("bind vsock port {port}"))?;
+    info!(port, "listening on vsock");
+    Ok(Acceptor::Vsock(listener))
+}
+
+/// The non-Linux half: `AF_VSOCK` does not exist here, and pretending would
+/// only defer the failure to accept time.
+#[cfg(not(target_os = "linux"))]
+fn bind_vsock(_port: u32) -> anyhow::Result<Acceptor> {
+    anyhow::bail!("AF_VSOCK is Linux-only; use --listen-unix or --listen-tcp on a development host")
+}
+
 impl Acceptor {
     fn bind(spec: &ListenSpec) -> anyhow::Result<Self> {
         match spec {
-            #[cfg(target_os = "linux")]
-            ListenSpec::Vsock(port) => {
-                let listener = VsockListener::bind_with_cid_port(VMADDR_CID_ANY, *port)
-                    .with_context(|| format!("bind vsock port {port}"))?;
-                info!(port, "listening on vsock");
-                Ok(Self::Vsock(listener))
-            }
+            ListenSpec::Vsock(port) => bind_vsock(*port),
             ListenSpec::Unix(path) => {
                 // A previous run's socket file would fail the bind with
                 // EADDRINUSE even though nothing is listening.

--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -181,11 +181,16 @@ in
       XDG_SESSION_TYPE = "wayland";
       # nixpkgs openal (the portablemc wrapper's LD_LIBRARY_PATH provides it;
       # Maven's arm64 libopenal.so SIGSEGVs, so ./lwjgl-natives.nix omits it
-      # and LWJGL falls through to this one) defaults to the pulse backend,
-      # and the guest has no audio stack at all: force the null backend so
-      # OpenAL initializes and MC runs silent instead of erroring (validated
-      # live).
-      ALSOFT_DRIVERS = "null";
+      # and LWJGL falls through to this one) is built with the native
+      # pipewire backend linked in (ALSOFT_DLOPEN=false, so libpipewire
+      # resolves through the store rpath, no loader help needed). Pin that
+      # backend: the guest's ONLY audio path is the PipeWire graph
+      # (panes-sink -> vsock 7102 -> host CoreAudio, see ./nixos.nix), and
+      # alsoft's other compiled-in backends (pulse, alsa) are dead ends
+      # here -- its pulse probe once aborted the whole client via flite
+      # (see textToSpeechSupport above). The container reaches the socket
+      # through the /run/pipewire bind + PIPEWIRE_RUNTIME_DIR from clientEnv.
+      ALSOFT_DRIVERS = "pipewire";
       # If Vulkan crashes at startup, 26.2 flips itself to "Prefer OpenGL"
       # (rewriting options.txt); that GL path should land on software
       # rendering. Diagnostic-only, data-only toggles (venus is the intended

--- a/packages/vm/panes/guest-image/default.nix
+++ b/packages/vm/panes/guest-image/default.nix
@@ -39,7 +39,7 @@ let
       {
         nixpkgs.overlays = [
           (final: prev: {
-            inherit (repoPackages) panes-compositor;
+            inherit (repoPackages) panes-compositor panes-audio;
             # ./pins.json also carries the mesa src pin, so hand
             # lwjgl-natives.nix only the lwjgl-* entries (it asserts one
             # shared LWJGL version across its pins).

--- a/packages/vm/panes/guest-image/nixos.nix
+++ b/packages/vm/panes/guest-image/nixos.nix
@@ -28,11 +28,32 @@ let
   runtimeDir = "/run/panes";
   waylandDisplay = "wayland-1";
 
+  # Audio: one fixed PCM format end to end. The PipeWire graph clock, the
+  # protocol-simple tap, and the format panes-audio advertises to the host
+  # must all agree, and these bindings are the single source of truth.
+  audioRate = 48000;
+  audioChannels = 2;
+  # The tap is loopback TCP, not a unix socket, because
+  # module-protocol-simple's unix accept path is dead code in PipeWire 1.6
+  # (module-protocol-simple.c rejects unix clients with `goto error`). App
+  # containers share the guest netns, so loopback keeps it guest-internal.
+  # 7103 continues the panes port numbering (7100 windows, 7102 audio vsock)
+  # even though this one is guest TCP, purely for legibility.
+  audioTapAddr = "127.0.0.1:7103";
+  # The system-wide PipeWire runtime dir (upstream unit: RuntimeDirectory=
+  # pipewire, i.e. %t/pipewire with %t=/run for system units); clients find
+  # the core socket through PIPEWIRE_RUNTIME_DIR.
+  pipewireRuntimeDir = "/run/pipewire";
+
   # Environment every Wayland client container gets; per-app env from apps.nix
   # is merged on top and wins.
   clientEnv = {
     WAYLAND_DISPLAY = waylandDisplay;
     XDG_RUNTIME_DIR = runtimeDir;
+    # Every app gets the audio socket dir too: audio is part of the desktop
+    # contract (like the Wayland socket), and a client that plays nothing
+    # simply never dials it.
+    PIPEWIRE_RUNTIME_DIR = pipewireRuntimeDir;
   };
 
   # Host paths apps want persisted (e.g. /var/lib/minecraft downloads); the
@@ -73,6 +94,17 @@ let
       "/etc/resolv.conf" = {
         hostPath = "/etc/resolv.conf";
         isReadOnly = true;
+      };
+      # The system-wide PipeWire socket dir, for app audio (MC's openal). The
+      # DIR is bound, not the socket file, so a pipewire restart -- which
+      # recreates the socket inside the preserved directory
+      # (RuntimeDirectoryPreserve=yes in the upstream unit) -- stays visible
+      # to running containers. The tmpfiles rule below guarantees the bind
+      # source exists even while pipewire is down (a missing source fails the
+      # whole container).
+      ${pipewireRuntimeDir} = {
+        hostPath = pipewireRuntimeDir;
+        isReadOnly = false;
       };
     }
     # Only GPU apps bind /dev/dri: nspawn fails the whole container when a
@@ -282,26 +314,111 @@ in
   # the .1 gateway; without DHCP the guest has no route out.
   networking.useDHCP = true;
 
-  # Root autologin on the serial console: this guest is a local dev appliance,
-  # and headless debugging (venus state, container journals, poking the MC
-  # launcher) needs a shell on hvc0 even when the network is down.
-  services.getty.autologinUser = "root";
+  services = {
+    # Root autologin on the serial console: this guest is a local dev
+    # appliance, and headless debugging (venus state, container journals,
+    # poking the MC launcher) needs a shell on hvc0 even when the network is
+    # down.
+    getty.autologinUser = "root";
 
-  # sshd is what makes the guest iterable without a full image rebuild + fresh
-  # disk (which wipes /var/lib/minecraft): build the toplevel, `nix copy` it in
-  # over ssh, run its switch-to-configuration (README, "Iterating on the
-  # guest"). gvproxy (`--net`) forwards host 127.0.0.1:2222 -> guest :22 by
-  # default (its -ssh-port flag, default 2222; the guest holds a static DHCP
-  # lease at 192.168.127.2), so no vmkit flag is needed. Root's authorized key
-  # comes from the builder through the `sshAuthorizedKey` package arg
-  # (./default.nix); the stock image bakes NO key on purpose (a repo-built,
-  # cacheable image must not ship a static root credential), so out of the box
-  # nothing can log in.
-  services.openssh = {
-    enable = true;
-    # Key-only root login; the forward is loopback-bound on the host, but a
-    # password prompt on root is still wrong.
-    settings.PermitRootLogin = "prohibit-password";
+    # sshd is what makes the guest iterable without a full image rebuild +
+    # fresh disk (which wipes /var/lib/minecraft): build the toplevel, `nix
+    # copy` it in over ssh, run its switch-to-configuration (README,
+    # "Iterating on the guest"). gvproxy (`--net`) forwards host
+    # 127.0.0.1:2222 -> guest :22 by default (its -ssh-port flag, default
+    # 2222; the guest holds a static DHCP lease at 192.168.127.2), so no
+    # vmkit flag is needed. Root's authorized key comes from the builder
+    # through the `sshAuthorizedKey` package arg (./default.nix); the stock
+    # image bakes NO key on purpose (a repo-built, cacheable image must not
+    # ship a static root credential), so out of the box nothing can log in.
+    openssh = {
+      enable = true;
+      # Key-only root login; the forward is loopback-bound on the host, but a
+      # password prompt on root is still wrong.
+      settings.PermitRootLogin = "prohibit-password";
+    };
+
+    # The guest audio stack (index#1686): PipeWire is the mixer, a null sink
+    # is the guest's one "output device" (libkrun-efi exposes no sound
+    # hardware: its virtio-snd was PipeWire-backend/Linux-host-only, never in
+    # the efi feature set, and is deleted upstream in 2.0), and
+    # module-protocol-simple taps that sink's monitor as raw PCM on loopback
+    # TCP. panes-audio (below) pumps the tap to the macOS host over vsock
+    # 7102, where panes-host plays it on CoreAudio. Apps reach PipeWire
+    # through the /run/pipewire bind + PIPEWIRE_RUNTIME_DIR in clientEnv;
+    # nixpkgs openal links the native pipewire backend directly
+    # (ALSOFT_DLOPEN=false), so no ALSA emulation and no PulseAudio shim is
+    # enabled.
+    pipewire = {
+      enable = true;
+      # No user sessions in this guest: the compositor and app containers run
+      # as system units, so the sound server must too.
+      systemWide = true;
+      extraConfig.pipewire."60-panes-audio" = {
+        "context.properties" = {
+          # Graph clock. 512/48000 ~= 10.7 ms: small enough that the tap (and
+          # so the host jitter buffer) is fed well inside the <50 ms budget,
+          # big enough that a non-realtime VM vCPU (no rtkit in the guest)
+          # does not xrun on every scheduling hiccup.
+          "default.clock.rate" = audioRate;
+          "default.clock.quantum" = 512;
+          "default.clock.min-quantum" = 256;
+          "default.clock.max-quantum" = 1024;
+        };
+        "context.objects" = [
+          {
+            # The virtual output device. Present from boot (unlike a
+            # protocol-simple `media.class = Audio/Sink` stream, which would
+            # exist only while the tap client is connected), so app audio
+            # init never depends on the daemon being up.
+            factory = "adapter";
+            args = {
+              "factory.name" = "support.null-audio-sink";
+              "node.name" = "panes-sink";
+              "node.description" = "panes host audio";
+              "media.class" = "Audio/Sink";
+              "audio.rate" = audioRate;
+              "audio.channels" = audioChannels;
+              "audio.position" = [
+                "FL"
+                "FR"
+              ];
+            };
+          }
+        ];
+        "context.modules" = [
+          {
+            # Raw-PCM tap on the sink's monitor: each client connecting to
+            # server.address is fed the mix as s16le with NO protocol around
+            # it. This is what lets panes-audio be a dumb framing pump with
+            # no audio-library dependency in the Rust workspace.
+            name = "libpipewire-module-protocol-simple";
+            args = {
+              capture = true;
+              playback = false;
+              "audio.format" = "S16LE";
+              "audio.rate" = audioRate;
+              "audio.channels" = audioChannels;
+              "audio.position" = [
+                "FL"
+                "FR"
+              ];
+              "server.address" = [ "tcp:${audioTapAddr}" ];
+              "capture.props" = {
+                "target.object" = "panes-sink";
+                # Capture what the sink plays (its monitor), not an input.
+                "stream.capture.sink" = true;
+                "node.name" = "panes-pcm-tap";
+              };
+            };
+          }
+        ];
+      };
+    };
+
+    # pipewire.service is `BindsTo=dbus.service` (upstream unit) and nothing
+    # else in this headless guest enables dbus.
+    dbus.enable = true;
   };
 
   # Populates /run/opengl-driver (lib + share/vulkan/icd.d) with mesa, which
@@ -320,6 +437,10 @@ in
     # db) did not run. Nothing runs nix inside the containers.
     "d /nix/var/nix/db 0755 root root -"
     "d /nix/var/nix/daemon-socket 0755 root root -"
+    # Bind source for the app containers' audio socket dir (see mkAppContainer)
+    # regardless of pipewire's state; ownership matches the upstream unit's
+    # RuntimeDirectory=pipewire so the service adopts it unchanged.
+    "d ${pipewireRuntimeDir} 0755 pipewire pipewire -"
   ]
   ++ map (bind: "d ${bind} 0755 root root -") appBinds
   ++ lib.mapAttrsToList (dest: source: "C ${dest} 0644 root root - ${source}") appSeedFiles;
@@ -379,6 +500,34 @@ in
         };
       };
 
+      panes-audio = {
+        description = "panes audio pump (PipeWire mix -> vsock 7102)";
+        wantedBy = [ "multi-user.target" ];
+        # The PCM tap is pipewire's own TCP listener, and system-wide
+        # pipewire is otherwise only socket-activated (first core-socket
+        # client would start it): pull it up at boot so audio does not wait
+        # for an app to touch /run/pipewire first. The daemon still retries
+        # the tap with backoff, so the ordering is comfort, not correctness.
+        wants = [ "pipewire.service" ];
+        after = [ "pipewire.service" ];
+        serviceConfig = {
+          # Flags restate the format bindings at the top of this file: the
+          # daemon advertises exactly what the tap is configured to emit.
+          ExecStart = builtins.concatStringsSep " " [
+            (lib.getExe pkgs.panes-audio)
+            "--pcm-tcp ${audioTapAddr}"
+            "--rate ${toString audioRate}"
+            "--channels ${toString audioChannels}"
+          ];
+          Restart = "on-failure";
+          RestartSec = 2;
+          # Mirror to the serial console like the compositor: the boot smoke
+          # reads service state off hvc0.
+          StandardOutput = "journal+console";
+          StandardError = "journal+console";
+        };
+      };
+
       # Boot-time diagnostic kept on purpose: prints the Vulkan device list to
       # the serial console so a headless `vmkit boot-linux --gpu` smoke run can
       # assert the venus path end to end. With --gpu it must show a
@@ -424,6 +573,8 @@ in
         path = [
           pkgs.systemd
           pkgs.iproute2
+          # pw-cli, for the audio-graph evidence below.
+          pkgs.pipewire
         ];
         serviceConfig = {
           Type = "oneshot";
@@ -445,6 +596,12 @@ in
           ip route show default || true
           ls -la /run/panes 2>&1 || true
           df -h / || true
+          # Audio evidence: services up, and the graph shows the null sink +
+          # protocol-simple tap (grep for their node.names). A headless smoke
+          # run asserts on PANES-AUDIO-NODES-ABSENT never appearing.
+          systemctl is-active pipewire panes-audio || true
+          PIPEWIRE_RUNTIME_DIR=/run/pipewire pw-cli ls Node 2>&1 \
+            | grep -E "node.name|media.class" || echo "PANES-AUDIO-NODES-ABSENT"
           echo "===PANES-BOOT-REPORT-END==="
         '';
       };
@@ -452,10 +609,12 @@ in
 
   containers = lib.mapAttrs mkAppContainer apps;
 
-  # For live poking at the GPU stack over the serial console.
+  # For live poking at the GPU and audio stacks over the serial console
+  # (pw-cli/pw-top need PIPEWIRE_RUNTIME_DIR=/run/pipewire, system-wide mode).
   environment.systemPackages = [
     pkgs.vulkan-tools
     pkgs.pciutils
+    pkgs.pipewire
   ];
 
   # Trim the image; the compositor is the UI, there is no doc consumer.

--- a/packages/vm/panes/host/Cargo.toml
+++ b/packages/vm/panes/host/Cargo.toml
@@ -19,9 +19,16 @@ lz4_flex = "0.13"
 panes-protocol.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
+# Error plumbing for the audio connection path only; the window path keeps
+# its original log-and-return style.
+anyhow.workspace = true
 # `RcBlock` for the trace-only MTLDrawable presented handler (tick-to-glass
 # ground truth, see src/trace.rs).
 block2 = "0.6"
+# CoreAudio playback for the guest's PCM stream (vsock port 7102, the
+# protocol crate's `audio` module). Already vendored in the workspace lock
+# via minecraft-sound's rodio.
+cpal = "0.17"
 # Main-queue handoff: the socket reader thread owns the stream and
 # `exec_async`s decoded messages onto the AppKit main thread.
 dispatch2 = "0.3"

--- a/packages/vm/panes/host/src/audio.rs
+++ b/packages/vm/panes/host/src/audio.rs
@@ -1,0 +1,192 @@
+//! Audio playback: connect to the guest's audio vsock port (7102, see the
+//! protocol crate's `audio` module), decode the PCM stream, and play it on
+//! the default `CoreAudio` output through a jitter buffer.
+//!
+//! Process shape mirrors `conn`: a supervisor thread owns the socket and
+//! reconnects with backoff. Unlike the window stream nothing crosses to the
+//! main thread -- samples go straight from the reader into the jitter buffer
+//! the `CoreAudio` render callback drains, because every queue hop is latency.
+
+use std::io::{BufReader, Read, Write};
+use std::net::TcpStream;
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use cpal::traits::{DeviceTrait as _, HostTrait as _, StreamTrait as _};
+use panes_protocol::audio::{MAX_FRAME, SampleFormat, ToGuest, ToHost, VERSION_MAJOR, VERSION_MINOR};
+use panes_protocol::{read_msg_bounded, write_msg};
+
+use crate::jitter::JitterBuffer;
+
+pub enum Target {
+    Unix(PathBuf),
+    Tcp(String),
+}
+
+const BACKOFF_START: Duration = Duration::from_millis(250);
+const BACKOFF_MAX: Duration = Duration::from_secs(5);
+
+/// Jitter buffer sizing, in milliseconds of the guest's advertised stream.
+///
+/// - Target 24 ms: mid-range of the 20-40 ms the design budget allows
+///   (index#1686). Below ~20 ms the vsock + `PipeWire` quantum jitter causes
+///   audible underruns; above 40 ms the added latency starts to read as lag
+///   in a game. Combined with the guest's ~10 ms `PipeWire` quantum and
+///   `CoreAudio`'s ~10 ms default output buffer, end-to-end sits under 50 ms.
+/// - Max 96 ms (4x target): enough headroom that slow guest-fast clock drift
+///   takes minutes to hit the overrun resync (one dropped-oldest
+///   discontinuity) instead of tripping it on every scheduling hiccup.
+const TARGET_MS: usize = 24;
+const MAX_MS: usize = 96;
+
+pub fn spawn(target: Target) {
+    std::thread::spawn(move || supervise(&target));
+}
+
+fn supervise(target: &Target) -> ! {
+    let mut backoff = BACKOFF_START;
+    loop {
+        // Connect failures stay quiet: they are the steady state while the
+        // guest boots, and the window stream's supervisor already logs its
+        // own connect errors for the same endpoint lifecycle.
+        if let Ok(stream) = connect(target) {
+            // A completed connection resets the backoff: the guest side is
+            // probably restarting, not gone.
+            backoff = BACKOFF_START;
+            if let Err(error) = run_connection(stream) {
+                eprintln!("panes-host: audio: {error:#}");
+            }
+        }
+        std::thread::sleep(backoff);
+        backoff = (backoff * 2).min(BACKOFF_MAX);
+    }
+}
+
+struct Stream {
+    read: Box<dyn Read + Send>,
+    write: Box<dyn Write + Send>,
+}
+
+fn connect(target: &Target) -> std::io::Result<Stream> {
+    match target {
+        Target::Unix(path) => {
+            let stream = UnixStream::connect(path)?;
+            let read = stream.try_clone()?;
+            Ok(Stream { read: Box::new(read), write: Box::new(stream) })
+        }
+        Target::Tcp(addr) => {
+            let stream = TcpStream::connect(addr.as_str())?;
+            // ~10 ms PCM chunks must not sit in Nagle's buffer waiting for a
+            // second chunk; that alone would double the transport latency.
+            stream.set_nodelay(true)?;
+            let read = stream.try_clone()?;
+            Ok(Stream { read: Box::new(read), write: Box::new(stream) })
+        }
+    }
+}
+
+/// One connection: handshake, build the output stream from the guest's
+/// advertised format, then feed the jitter buffer until the stream ends.
+///
+/// `Ok(())` is a clean end (guest hung up); `Err` carries protocol
+/// violations and `CoreAudio` failures for the supervisor to log before
+/// retrying.
+fn run_connection(stream: Stream) -> anyhow::Result<()> {
+    let mut write = stream.write;
+    // Both sides send their Hello immediately on connect (audio protocol
+    // rule), so writing first cannot deadlock against the guest doing the
+    // same.
+    write_msg(&mut write, &ToGuest::Hello { major: VERSION_MAJOR, minor: VERSION_MINOR })
+        .context("send hello")?;
+    write.flush().context("flush hello")?;
+
+    let mut reader = BufReader::new(stream.read);
+    let first: ToHost = read_msg_bounded(&mut reader, MAX_FRAME).context("read guest hello")?;
+    let ToHost::Hello { major, minor, rate, channels, format } = first else {
+        anyhow::bail!("guest spoke before Hello");
+    };
+    anyhow::ensure!(major == VERSION_MAJOR, "guest audio protocol major {major} != {VERSION_MAJOR}");
+    anyhow::ensure!(channels >= 1, "guest advertised zero channels");
+    // Single-variant enum today; matching keeps a future format addition
+    // from being silently played as the wrong encoding.
+    let SampleFormat::S16le = format;
+    eprintln!(
+        "panes-host: audio: guest speaks {major}.{minor}, {rate} Hz x{channels} s16le"
+    );
+
+    let per_ms = usize::try_from(rate).context("rate")? * usize::from(channels) / 1000;
+    let jitter = Arc::new(JitterBuffer::new(TARGET_MS * per_ms, MAX_MS * per_ms));
+    // Bind the stream for the connection's lifetime: dropping it stops
+    // playback, which is exactly right when the guest goes away (the jitter
+    // buffer would only feed it silence).
+    let _output = build_output(rate, channels, Arc::clone(&jitter))?;
+
+    let frame_bytes = usize::from(channels) * format.bytes_per_sample();
+    loop {
+        match read_msg_bounded::<ToHost>(&mut reader, MAX_FRAME) {
+            Ok(ToHost::Pcm { payload }) => {
+                anyhow::ensure!(
+                    payload.len() % frame_bytes == 0,
+                    "PCM payload of {} bytes is not whole {frame_bytes}-byte sample frames",
+                    payload.len()
+                );
+                let samples: Vec<i16> = payload
+                    .chunks_exact(2)
+                    .map(|pair| i16::from_le_bytes([pair[0], pair[1]]))
+                    .collect();
+                jitter.push(&samples);
+            }
+            Ok(ToHost::Hello { .. }) => anyhow::bail!("guest sent a second Hello"),
+            Err(error) => {
+                let stats = jitter.stats();
+                eprintln!(
+                    "panes-host: audio: connection ended ({error}); {} underruns, {} samples dropped",
+                    stats.underruns, stats.dropped_samples
+                );
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Open the default output device at the guest's format. `CoreAudio`'s AUHAL
+/// converts our client format (rate/channels) to whatever the device runs,
+/// so requesting 48 kHz stereo works on a 44.1 kHz or multichannel device;
+/// f32 samples because that is the only client format macOS output units
+/// accept natively (cpal does no conversion itself).
+fn build_output(
+    rate: u32,
+    channels: u16,
+    jitter: Arc<JitterBuffer>,
+) -> anyhow::Result<cpal::Stream> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .context("no default audio output device")?;
+    let config = cpal::StreamConfig {
+        channels,
+        // `cpal::SampleRate` is a plain u32 alias in 0.17.
+        sample_rate: rate,
+        // The device default (~10 ms on macOS): small enough for the latency
+        // budget, and not fighting whatever quantum other apps negotiated.
+        buffer_size: cpal::BufferSize::Default,
+    };
+    let stream = device
+        .build_output_stream(
+            &config,
+            move |data: &mut [f32], _info: &cpal::OutputCallbackInfo| {
+                // Outcomes are counted inside the buffer; no logging here,
+                // this closure runs on the realtime render thread.
+                let _ = jitter.pop_f32(data);
+            },
+            // cpal invokes this off the render path, so logging is safe.
+            |error| eprintln!("panes-host: audio: output stream error: {error}"),
+            None,
+        )
+        .context("build CoreAudio output stream")?;
+    stream.play().context("start CoreAudio output stream")?;
+    Ok(stream)
+}

--- a/packages/vm/panes/host/src/jitter.rs
+++ b/packages/vm/panes/host/src/jitter.rs
@@ -1,0 +1,215 @@
+//! Jitter buffer between the audio socket thread (producer) and the `CoreAudio`
+//! render callback (consumer).
+//!
+//! The guest ships PCM at its own real-time rate; the device consumes at the
+//! host clock. This buffer absorbs transport jitter and the slow drift between
+//! the two clocks with three rules, all chosen for game audio (latency over
+//! continuity, see index#1686):
+//!
+//! - **Prime before playing**: output silence until `target` samples are
+//!   buffered, so playback starts with a full jitter margin instead of
+//!   crackling through a cold start.
+//! - **Underrun -> silence and re-prime**: the callback NEVER blocks (a
+//!   `CoreAudio` render callback that waits can glitch the whole output
+//!   device); missing samples are zeroed and the buffer re-primes, trading
+//!   one audible gap for a restored margin.
+//! - **Overrun -> drop the OLDEST audio back to `target`**: if the producer
+//!   runs ahead (device stall, guest clock fast), keeping everything would
+//!   pin latency at the cap forever; dropping the oldest samples snaps
+//!   latency back to `target` in one discontinuity and keeps the newest
+//!   (most current) audio.
+//!
+//! A `Mutex<VecDeque>` rather than a lock-free ring on purpose: both sides
+//! touch it for a bounded memcpy of a few KiB every 5-10 ms, so the callback
+//! waits at worst a few microseconds -- far under a render quantum -- while a
+//! hand-rolled atomic SPSC ring would be `unsafe` the house rules require
+//! Miri/loom validation for, and no vendored crate provides one.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+/// What one [`JitterBuffer::pop_f32`] call observed; the caller may count or
+/// log these, the buffer already handled them (silence written, state moved).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopOutcome {
+    /// Still filling toward `target`; the whole output was silence.
+    Priming,
+    /// The output was fully satisfied from buffered samples.
+    Playing,
+    /// Buffered audio ran out mid-output: the tail was silence and the buffer
+    /// went back to priming.
+    Underrun,
+}
+
+/// Cumulative producer/consumer incidents, for end-of-connection logging.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Stats {
+    pub underruns: u64,
+    /// Samples discarded by the overrun rule. `usize` because each increment
+    /// is a buffer length; wrap-around would take centuries at audio rates.
+    pub dropped_samples: usize,
+}
+
+struct Inner {
+    queue: VecDeque<i16>,
+    primed: bool,
+    stats: Stats,
+}
+
+pub struct JitterBuffer {
+    inner: Mutex<Inner>,
+    /// Fill level (samples) at which playback starts and to which an overrun
+    /// resyncs.
+    target: usize,
+    /// Fill cap (samples); a push that would exceed it triggers the overrun
+    /// rule. Must be > `target`.
+    max: usize,
+}
+
+impl JitterBuffer {
+    /// # Panics
+    /// If `target >= max` or `target == 0`: both would make the overrun and
+    /// priming rules meaningless, and both are compile-time constants at the
+    /// only call site.
+    #[must_use]
+    pub fn new(target: usize, max: usize) -> Self {
+        assert!(target > 0 && target < max, "need 0 < target < max");
+        Self {
+            inner: Mutex::new(Inner {
+                queue: VecDeque::with_capacity(max),
+                primed: false,
+                stats: Stats::default(),
+            }),
+            target,
+            max,
+        }
+    }
+
+    /// Producer side: append decoded samples, applying the overrun rule.
+    pub fn push(&self, samples: &[i16]) {
+        let mut inner = self.inner.lock().expect("audio jitter mutex poisoned");
+        let total = inner.queue.len() + samples.len();
+        if total > self.max {
+            // Bring the post-push fill back to `target`: drop the oldest
+            // buffered samples first, then (only if the incoming chunk alone
+            // exceeds `target`) the oldest of the incoming chunk.
+            let excess = total - self.target;
+            let from_queue = excess.min(inner.queue.len());
+            inner.queue.drain(..from_queue);
+            // `excess - from_queue` <= samples.len() by construction:
+            // when from_queue is the whole queue, excess - queue.len()
+            // = samples.len() - target < samples.len().
+            let from_new = excess - from_queue;
+            inner.queue.extend(&samples[from_new..]);
+            inner.stats.dropped_samples += excess;
+        } else {
+            inner.queue.extend(samples);
+        }
+    }
+
+    /// Consumer side (the render callback): fill `out` with buffered samples
+    /// converted to f32 (i16 full scale -> [-1.0, 1.0)), silence where the
+    /// buffer cannot, per the priming/underrun rules. Never blocks beyond the
+    /// short producer critical section.
+    pub fn pop_f32(&self, out: &mut [f32]) -> PopOutcome {
+        // Explicit `drop(inner)` on every exit path keeps the producer
+        // unblocked while this thread zero-fills (significant_drop_tightening).
+        let mut inner = self.inner.lock().expect("audio jitter mutex poisoned");
+        if !inner.primed {
+            if inner.queue.len() >= self.target {
+                inner.primed = true;
+            } else {
+                drop(inner);
+                out.fill(0.0);
+                return PopOutcome::Priming;
+            }
+        }
+        let n = inner.queue.len().min(out.len());
+        for (slot, sample) in out[..n].iter_mut().zip(inner.queue.drain(..n)) {
+            *slot = f32::from(sample) / 32768.0;
+        }
+        if n < out.len() {
+            inner.primed = false;
+            inner.stats.underruns += 1;
+            drop(inner);
+            out[n..].fill(0.0);
+            return PopOutcome::Underrun;
+        }
+        drop(inner);
+        PopOutcome::Playing
+    }
+
+    #[must_use]
+    pub fn stats(&self) -> Stats {
+        self.inner.lock().expect("audio jitter mutex poisoned").stats
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ramp(start: i16, len: usize) -> Vec<i16> {
+        (0..len).map(|i| start + i16::try_from(i).unwrap()).collect()
+    }
+
+    #[test]
+    fn primes_with_silence_until_target() {
+        let buf = JitterBuffer::new(4, 16);
+        buf.push(&ramp(1, 3)); // below target
+        let mut out = [1.0f32; 2];
+        assert_eq!(buf.pop_f32(&mut out), PopOutcome::Priming);
+        // Silence is bit-exact zero, so exact comparison is intended (Vec
+        // form because float_cmp rejects strict `==` on float arrays).
+        assert_eq!(out.to_vec(), vec![0.0f32; 2]);
+        // The buffered samples were NOT consumed while priming.
+        buf.push(&ramp(4, 1)); // reaches target
+        let mut out = [0.0f32; 4];
+        assert_eq!(buf.pop_f32(&mut out), PopOutcome::Playing);
+        let expected: Vec<f32> = [1i16, 2, 3, 4].iter().map(|&s| f32::from(s) / 32768.0).collect();
+        assert_eq!(out.to_vec(), expected);
+    }
+
+    #[test]
+    fn underrun_fills_silence_and_reprimes() {
+        let buf = JitterBuffer::new(2, 16);
+        buf.push(&ramp(1, 3));
+        let mut out = [9.0f32; 5];
+        assert_eq!(buf.pop_f32(&mut out), PopOutcome::Underrun);
+        assert_eq!(&out[3..], &[0.0, 0.0], "missing tail is silence");
+        assert_eq!(buf.stats().underruns, 1);
+        // Re-primed: the next pop is silence until target is reached again.
+        buf.push(&ramp(1, 1));
+        let mut out = [9.0f32; 1];
+        assert_eq!(buf.pop_f32(&mut out), PopOutcome::Priming);
+        assert_eq!(out.to_vec(), vec![0.0f32]);
+    }
+
+    #[test]
+    fn overrun_drops_oldest_back_to_target() {
+        let buf = JitterBuffer::new(4, 8);
+        buf.push(&ramp(1, 8)); // exactly max: kept in full
+        // 8 + 2 > max: drop the oldest 6 so the post-push fill is target (4),
+        // leaving the newest samples [7, 8] ++ [9, 10].
+        buf.push(&ramp(9, 2));
+        assert_eq!(buf.stats().dropped_samples, 6);
+        let mut out = [0.0f32; 4];
+        assert_eq!(buf.pop_f32(&mut out), PopOutcome::Playing);
+        let expected: Vec<f32> = [7i16, 8, 9, 10].iter().map(|&s| f32::from(s) / 32768.0).collect();
+        assert_eq!(out.to_vec(), expected);
+    }
+
+    #[test]
+    fn giant_push_keeps_only_newest_target_samples() {
+        let buf = JitterBuffer::new(4, 8);
+        buf.push(&ramp(1, 2));
+        // 2 + 20 samples against max 8: everything but the newest 4 goes.
+        buf.push(&ramp(100, 20));
+        assert_eq!(buf.stats().dropped_samples, 18);
+        let mut out = [0.0f32; 4];
+        assert_eq!(buf.pop_f32(&mut out), PopOutcome::Playing);
+        let expected: Vec<f32> =
+            [116i16, 117, 118, 119].iter().map(|&s| f32::from(s) / 32768.0).collect();
+        assert_eq!(out.to_vec(), expected);
+    }
+}

--- a/packages/vm/panes/host/src/main.rs
+++ b/packages/vm/panes/host/src/main.rs
@@ -16,7 +16,14 @@ mod mock;
 #[cfg(target_os = "macos")]
 mod app;
 #[cfg(target_os = "macos")]
+mod audio;
+#[cfg(target_os = "macos")]
 mod conn;
+// The jitter buffer is pure logic and compiles everywhere so its unit tests
+// run on any development host; outside macOS nothing calls it, hence the
+// dead_code allow (the compositor's `frame` module pattern).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+mod jitter;
 #[cfg(target_os = "macos")]
 mod keymap;
 #[cfg(target_os = "macos")]
@@ -43,6 +50,18 @@ struct Cli {
     /// TCP address to connect to instead of a unix socket (debugging).
     #[arg(long, value_name = "ADDR", conflicts_with = "connect")]
     tcp: Option<String>,
+
+    /// Unix socket for the guest's audio stream (the host side of vsock port
+    /// 7102, `--vsock-port 7102:PATH` on the vmkit boot line). Optional: with
+    /// no audio flag the guest runs silent, exactly as before the audio
+    /// channel existed.
+    #[arg(long, value_name = "PATH", conflicts_with = "audio_tcp")]
+    audio_connect: Option<PathBuf>,
+
+    /// TCP address for the guest's audio stream instead of a unix socket
+    /// (debugging, e.g. against `panes-audio --listen-tcp`).
+    #[arg(long, value_name = "ADDR")]
+    audio_tcp: Option<String>,
 
     /// Prefix prepended to every window title.
     #[arg(long, value_name = "PREFIX", default_value = "")]
@@ -100,6 +119,15 @@ fn run_host(cli: Cli) -> ExitCode {
         eprintln!("panes-host: one of --connect, --tcp, --mock, --mock-serve is required");
         return ExitCode::FAILURE;
     };
+
+    // The audio stream rides its own socket (vsock 7102) with its own
+    // supervisor thread; window presentation neither waits for it nor learns
+    // about it.
+    if let Some(path) = cli.audio_connect {
+        audio::spawn(audio::Target::Unix(path));
+    } else if let Some(addr) = cli.audio_tcp {
+        audio::spawn(audio::Target::Tcp(addr));
+    }
 
     app::run(target, cli.title_prefix, cli.native_titlebar)
 }

--- a/packages/vm/panes/protocol/src/audio.rs
+++ b/packages/vm/panes/protocol/src/audio.rs
@@ -1,0 +1,143 @@
+//! Audio side-channel: the guest's mixed PCM output, played on the macOS
+//! host (index#1686).
+//!
+//! A SECOND vsock port ([`VSOCK_PORT`], 7102) carries the same
+//! `[u32 LE len][postcard]` framing as the window stream (via
+//! [`crate::write_msg`] / [`crate::read_msg_bounded`]) but its own message
+//! enums and its own version pair: the window protocol on port 7100 stays
+//! untouched at 1.x, and a peer built without the audio half simply never
+//! connects this port. Same handshake discipline as the window stream: both
+//! sides send their Hello immediately on connect (no speak-first ordering),
+//! each validates the peer major before anything else and hangs up on
+//! mismatch; the append-only postcard variant rules from the crate root apply
+//! here too.
+//!
+//! Design constraints this encodes:
+//! - The guest is the clock: `PipeWire`'s null sink drives capture, so PCM
+//!   flows at a steady real-time rate (48 kHz s16le stereo is ~188 KiB/s,
+//!   negligible next to the frame stream). The host paces nothing back; its
+//!   jitter buffer absorbs transport jitter and clock drift (see
+//!   `panes-host`). No acks, no timestamps: game audio wants the lowest
+//!   latency the buffer allows, not A/V sync (index#1686).
+//! - The stream format rides in the guest's Hello and is fixed for the
+//!   connection's lifetime; a format change is a reconnect. That keeps the
+//!   host side free of mid-stream renegotiation state.
+
+use serde::{Deserialize, Serialize};
+
+/// Peers refuse a mismatched major and hang up (see the crate-root rules on
+/// postcard's unknown-variant intolerance; new variants are append-only and
+/// gated on the peer's advertised minor).
+pub const VERSION_MAJOR: u16 = 1;
+pub const VERSION_MINOR: u16 = 0;
+
+/// Guest vsock port the audio daemon listens on. Distinct from the window
+/// stream's 7100 so the window protocol needs no change at all; 7101 is taken
+/// by smoke tests.
+pub const VSOCK_PORT: u32 = 7102;
+
+/// Cap one audio message at 256 KiB: the daemon sends PCM in ~10 ms chunks
+/// (a few KiB), so this fits any legitimate frame with two orders of
+/// magnitude of headroom while keeping what a hostile length prefix can make
+/// a reader allocate far below the window stream's 64 MB [`crate::MAX_FRAME`].
+pub const MAX_FRAME: usize = 256 * 1024;
+
+/// Encoding of one PCM sample on the wire. Explicitly little-endian: both
+/// current peers are LE, but the wire format must not depend on that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SampleFormat {
+    /// Signed 16-bit little-endian, interleaved by channel.
+    S16le,
+}
+
+impl SampleFormat {
+    #[must_use]
+    pub const fn bytes_per_sample(self) -> usize {
+        match self {
+            Self::S16le => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ToHost {
+    /// Sent once, immediately on connect. `rate`/`channels`/`format` describe
+    /// every following [`ToHost::Pcm`] payload for the connection's lifetime.
+    Hello {
+        major: u16,
+        minor: u16,
+        /// Sample rate in Hz (48000 in the shipped guest).
+        rate: u32,
+        /// Interleaved channel count (2 in the shipped guest).
+        channels: u16,
+        format: SampleFormat,
+    },
+    /// One chunk of the guest mix, in the Hello's format. Chunk size is the
+    /// sender's choice (whatever the capture socket produced, ~10 ms in
+    /// practice); the payload must be a whole number of interleaved sample
+    /// frames, i.e. a multiple of `channels * format.bytes_per_sample()`.
+    Pcm {
+        #[serde(with = "serde_bytes")]
+        payload: Vec<u8>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ToGuest {
+    /// Sent once, immediately on connect.
+    Hello { major: u16, minor: u16 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{WireError, read_msg_bounded, write_msg};
+
+    #[test]
+    fn hello_roundtrips() {
+        let mut buf = Vec::new();
+        let msg = ToHost::Hello {
+            major: VERSION_MAJOR,
+            minor: VERSION_MINOR,
+            rate: 48000,
+            channels: 2,
+            format: SampleFormat::S16le,
+        };
+        write_msg(&mut buf, &msg).unwrap();
+        let back: ToHost = read_msg_bounded(&mut buf.as_slice(), MAX_FRAME).unwrap();
+        let ToHost::Hello { major: 1, minor: 0, rate: 48000, channels: 2, format } = back else {
+            panic!("wrong variant");
+        };
+        assert_eq!(format, SampleFormat::S16le);
+    }
+
+    #[test]
+    fn pcm_roundtrips() {
+        let mut buf = Vec::new();
+        let payload: Vec<u8> = (0..=255).collect();
+        write_msg(&mut buf, &ToHost::Pcm { payload: payload.clone() }).unwrap();
+        let back: ToHost = read_msg_bounded(&mut buf.as_slice(), MAX_FRAME).unwrap();
+        let ToHost::Pcm { payload: got } = back else {
+            panic!("wrong variant");
+        };
+        assert_eq!(got, payload);
+    }
+
+    #[test]
+    fn bounded_read_rejects_prefix_past_audio_cap() {
+        // A prefix legal for the window stream (< 64 MB) must still be
+        // rejected by an audio reader without allocating.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&u32::try_from(MAX_FRAME + 1).expect("fits u32").to_le_bytes());
+        let err = read_msg_bounded::<ToHost>(&mut buf.as_slice(), MAX_FRAME).unwrap_err();
+        assert!(matches!(err, WireError::TooLarge(n) if n == MAX_FRAME + 1));
+    }
+
+    #[test]
+    fn to_guest_hello_roundtrips() {
+        let mut buf = Vec::new();
+        write_msg(&mut buf, &ToGuest::Hello { major: 1, minor: 0 }).unwrap();
+        let back: ToGuest = read_msg_bounded(&mut buf.as_slice(), MAX_FRAME).unwrap();
+        assert!(matches!(back, ToGuest::Hello { major: 1, minor: 0 }));
+    }
+}

--- a/packages/vm/panes/protocol/src/audio.rs
+++ b/packages/vm/panes/protocol/src/audio.rs
@@ -36,10 +36,12 @@ pub const VERSION_MINOR: u16 = 0;
 /// by smoke tests.
 pub const VSOCK_PORT: u32 = 7102;
 
-/// Cap one audio message at 256 KiB: the daemon sends PCM in ~10 ms chunks
-/// (a few KiB), so this fits any legitimate frame with two orders of
-/// magnitude of headroom while keeping what a hostile length prefix can make
-/// a reader allocate far below the window stream's 64 MB [`crate::MAX_FRAME`].
+/// Cap one audio message at 256 KiB.
+///
+/// The daemon sends PCM in ~10 ms chunks (a few KiB), so this fits any
+/// legitimate frame with two orders of magnitude of headroom while keeping
+/// what a hostile length prefix can make a reader allocate far below the
+/// window stream's 64 MB [`crate::MAX_FRAME`].
 pub const MAX_FRAME: usize = 256 * 1024;
 
 /// Encoding of one PCM sample on the wire. Explicitly little-endian: both

--- a/packages/vm/panes/protocol/src/lib.rs
+++ b/packages/vm/panes/protocol/src/lib.rs
@@ -19,6 +19,8 @@
 //!   speak-first ordering); each validates the peer major before any other
 //!   message and hangs up on mismatch.
 
+pub mod audio;
+
 use serde::{Deserialize, Serialize};
 
 /// Peers refuse a mismatched major and hang up.
@@ -292,13 +294,29 @@ pub fn write_msg<T: Serialize>(w: &mut impl std::io::Write, msg: &T) -> Result<(
 /// [`WireError::TooLarge`] for a length prefix past [`MAX_FRAME`] (nothing is
 /// allocated), and [`WireError::Codec`] if the payload fails to decode.
 pub fn read_msg<T: for<'de> Deserialize<'de>>(r: &mut impl std::io::Read) -> Result<T, WireError> {
+    read_msg_bounded(r, MAX_FRAME)
+}
+
+/// [`read_msg`] with a caller-chosen frame cap.
+///
+/// The audio stream's biggest legitimate message is a few KiB of PCM (see
+/// [`audio::MAX_FRAME`]), so its readers bound a hostile length prefix far
+/// below the window stream's 64 MB.
+///
+/// # Errors
+/// As [`read_msg`], with [`WireError::TooLarge`] against `cap` instead of
+/// [`MAX_FRAME`].
+pub fn read_msg_bounded<T: for<'de> Deserialize<'de>>(
+    r: &mut impl std::io::Read,
+    cap: usize,
+) -> Result<T, WireError> {
     let mut len = [0u8; 4];
     r.read_exact(&mut len)?;
     // u32 -> usize only narrows on 16-bit targets the workspace does not
     // support; mapping that impossibility to TooLarge (the same rejection an
     // over-cap prefix gets) keeps this panic-free without a lossy fallback.
     let len = usize::try_from(u32::from_le_bytes(len)).map_err(|_| WireError::TooLarge(usize::MAX))?;
-    if len > MAX_FRAME {
+    if len > cap {
         return Err(WireError::TooLarge(len));
     }
     let mut buf = vec![0u8; len];


### PR DESCRIPTION
Adds sound output to panes (#1686): audio from guest apps (Minecraft first) now plays on the macOS host.

## Design decision: PCM over vsock (option B), not virtio-snd (option A)

Researched libkrun v1.19.3 (clone at the tag, `src/devices/src/virtio/snd/`):

- A virtio-snd device **exists** in 1.19.3 (`krun_set_snd_device`, `KRUN_FEATURE_SND`), but its only host backend is **PipeWire** (`audio_backends.rs` matches exactly one variant; `pw`/`pipewire-sys` link `libpipewire-0.3` via pkg-config, which doesn't exist on macOS; zero `cfg(target_os = "macos")` gating anywhere under `snd/`).
- It is **not in the `efi` feature set** (`efi = ["blk", "net", ...]`, sound needs a separate `SND=1` make flag), so the libkrun-efi vmkit links has it compiled out entirely.
- Upstream **deleted it** on master (`7e5c6c4 "Remove builtin virtio-snd device"`, ~Apr 2026, "not actively maintained or tested... superseded by vhost-user-snd") as part of libkrun 2.0. History since the 2024 import is clippy fixes only.

So option A means writing a new CoreAudio backend for a device upstream just removed. Option B is the house architecture instead: a second vsock port, both ends already speak that transport.

## How it works

```
app (openal, ALSOFT_DRIVERS=pipewire)
  -> pipewire (system-wide) null sink "panes-sink"        guest mixer
  -> module-protocol-simple tap (raw s16le 48k stereo, tcp:127.0.0.1:7103)
  -> panes-audio (new crate: frames PCM, listens vsock 7102)
  -> panes-host --audio-connect (jitter buffer -> CoreAudio via cpal)
```

- **`panes-protocol` `audio` module**: same `[u32 LE len][postcard]` framing on a NEW port (7102) with its own Hello/major-minor, so window protocol 1.1 is untouched. `read_msg_bounded` caps hostile length prefixes at 256 KiB for audio readers. Guest Hello carries the fixed format (48 kHz, 2ch, s16le).
- **`panes-audio` (new, packages/vm/panes/audio)**: a dumb pump with **zero audio-library deps** — PipeWire's `module-protocol-simple` already emits raw PCM on a socket, so the daemon just reframes it. Tap is loopback TCP because the module's unix accept path is dead code in PipeWire 1.6 (`goto error` on unix clients). Watchdog reader notices a dead host even while PipeWire is down; sub-frame carry keeps wire messages whole-sample-frame aligned.
- **`panes-host --audio-connect PATH`** (optional; absent = silent, exactly as before): supervisor thread with backoff, cpal/CoreAudio output built from the guest's Hello. Jitter buffer targets **24 ms** (prime-then-play; underrun plays silence and re-primes; overrun drops oldest back to target so latency never pins at the cap). End-to-end budget: ~10.7 ms guest quantum + 24 ms jitter target + ~10 ms CoreAudio buffer ≈ **<50 ms**. No buffering beyond the jitter buffer, no A/V sync coupling.
- **Guest image**: system-wide PipeWire (headless guest, no user sessions) + dbus, null sink + tap via `extraConfig`, `/run/pipewire` bound into every app container (dir-level bind survives pipewire restarts: upstream unit has `RuntimeDirectoryPreserve=yes`), `PIPEWIRE_RUNTIME_DIR` in clientEnv, and MC flips `ALSOFT_DRIVERS=null` -> `pipewire` (nixpkgs openal links libpipewire directly, `ALSOFT_DLOPEN=false`). `panes-boot-report` now prints pipewire/panes-audio state and the node list (`PANES-AUDIO-NODES-ABSENT` = graph down).
- `panes-audio` includes **x86_64-linux** in its systems on purpose: CI's flake-check only builds the x86_64-linux graph, and the crate is arch-generic Linux — without this nothing would compile/lint/test it pre-merge (the aarch64 builder VM is currently down).

## Tests

- protocol: audio Hello/Pcm round-trips, bounded-read rejection past the audio cap.
- panes-audio: pump keeps sample frames whole across unaligned reads, stops cleanly when the host dies, hello exchange validates majors.
- panes-host: jitter buffer priming / underrun-reprime / overrun-drop-oldest / giant-push clamp.

## Validation status

- Done here (aarch64-darwin): `nix build .#panes-host` + its full test set + clippy + unusedCrateDependencies green; `nix run .#lint` green; guest NixOS config evaluates to a toplevel with the rust packages stubbed (rendered unit/drop-in/env inspected and correct).
- CI (x86_64-linux): compiles/lints/tests `panes-audio` + protocol.
- **Gated on the aarch64 builder VM (currently down, vmnet wedge)**: building the guest image and the runtime end-to-end smoke (boot with `--vsock-port 7102:... `, hear MC on the host, measure latency). Alternative once ready: in-guest `nixos-rebuild` on the demo guest per the README's switch-in-place loop — deliberately not attempted against the live Minecraft session.

Closes nothing on its own; part of #1686.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add guest-to-host audio path streaming PCM over vsock 7102 to CoreAudio
> - Introduces a new `panes-audio` guest-side daemon ([packages/vm/panes/audio/src/serve.rs](https://github.com/indexable-inc/index/pull/1778/files#diff-edc68664659024568178ce22e1c49e6ad28e339994f75ea6bfd5182de50e6bec)) that listens on vsock port 7102, connects to a PipeWire `protocol-simple` TCP tap at port 7103, and forwards s16le PCM frames to the host
> - Configures the guest NixOS image ([packages/vm/panes/guest-image/nixos.nix](https://github.com/indexable-inc/index/pull/1778/files#diff-547f31c0eac033ab8d65e4bb0e3c4ce6a6b52121e137f9ad93b16366dcf3af76)) with a system-wide PipeWire null sink, a protocol-simple PCM tap, and a systemd service running `panes-audio`; app containers get `/run/pipewire` bind-mounted so OpenAL/PipeWire audio works
> - Adds a macOS-side audio supervisor in `panes-host` ([packages/vm/panes/host/src/audio.rs](https://github.com/indexable-inc/index/pull/1778/files#diff-642dbefcb2e10fa8efdb282306078a79b76d0aac84d49ccc97ce739d8cb178f4)) that connects to the guest, reads framed PCM, feeds a jitter buffer ([packages/vm/panes/host/src/jitter.rs](https://github.com/indexable-inc/index/pull/1778/files#diff-0da9a06259bb4ef2f8f2fb874780ddbbc4e1c7d2308020ce695feeddf9472feb)), and renders via CoreAudio using `cpal`; enabled with new `--audio-connect` CLI flag
> - Defines a versioned audio wire protocol (`VERSION_MAJOR=1`, `VSOCK_PORT=7102`) in `panes-protocol` ([packages/vm/panes/protocol/src/audio.rs](https://github.com/indexable-inc/index/pull/1778/files#diff-5eb188656cc7e00eb4a736d879cb9c003d48d51fa8f0e2f61144149d038cb40b)) separate from the window protocol, with `Hello`/`Pcm` message types and a bounded frame reader
> - Risk: audio output is unconditionally routed through PipeWire in the guest; the jitter buffer silences and re-primes on underrun, which may produce audible gaps under load
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2d0b3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->