### PR TITLE
panes guest: ship a monospace font in the app containers (#1686)

### DIFF
--- a/packages/vm/panes/guest-image/nixos.nix
+++ b/packages/vm/panes/guest-image/nixos.nix
@@ -108,6 +108,12 @@ let
       # /run/opengl-driver inside the container: mesa's venus vulkan ICD plus
       # the zink GL driver for clients that go through the loader.
       hardware.graphics.enable = true;
+      # The containers ship no fonts at all, so fontconfig resolved foot's
+      # "monospace" request to proportional DejaVu Sans (foot warned on every
+      # launch and text rendered wide-spaced, observed live). One real mono
+      # family makes the generic "monospace" pattern resolve correctly for
+      # every terminal-class app.
+      fonts.packages = [ pkgs.dejavu_fonts ];
       systemd.services."panes-app-${name}" = {
         description = "panes app: ${name}";
         wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
Containers shipped zero fonts; foot's `monospace` resolved to proportional DejaVu Sans (warning on every launch + wide-spaced text, observed live). One mono family fixes the generic pattern for all terminal apps. Part of #1686.

🤖 Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ship DejaVu monospace font in NixOS app containers
> Adds `pkgs.dejavu_fonts` to the fonts packages in the NixOS container configuration in [nixos.nix](https://github.com/indexable-inc/index/pull/1780/files#diff-547f31c0eac033ab8d65e4bb0e3c4ce6a6b52121e137f9ad93b16366dcf3af76), making fonts available to containerized applications via fontconfig.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e937967.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->