### PR TITLE
panes guest: demo/term containers no longer autostart (#1686)

### DIFF
--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -19,6 +19,9 @@
 #   files   : attrset       host path -> store source, seeded once by host
 #                           tmpfiles (`C`, first boot only) so an app starts
 #                           with baked config it can still rewrite at runtime
+#   autoStart : bool        start the container (and thus map its window) at
+#                           boot; default true. Debug scaffolding sets false
+#                           and is started on demand from the guest console.
 { pkgs }:
 let
   inherit (pkgs) lib;
@@ -121,21 +124,28 @@ in
   # Software (wl_shm) client: proves compositor + container + socket plumbing
   # with zero GPU involvement. weston-flower exists because nixpkgs builds
   # weston with -Ddemo-clients=true (weston-simple-shm does not: the pin sets
-  # -Dsimple-clients= empty).
+  # -Dsimple-clients= empty). Debug scaffolding, not a product surface: the
+  # container ships but does not autostart (the bring-up era popped these
+  # windows onto the desktop on every boot); start on the guest console with
+  # `systemctl start container@demo` when debugging the shm path.
   demo = {
     command = "${pkgs.weston}/bin/weston-flower";
     env = { };
     binds = [ ];
     gpu = false;
+    autoStart = false;
   };
 
   # A real interactive app: foot renders CPU-side into shm buffers, so it also
-  # works with no GPU while exercising keyboard focus and resize.
+  # works with no GPU while exercising keyboard focus and resize. Same debug
+  # scaffolding policy as `demo`: `systemctl start container@term` for an
+  # interactive terminal window into the guest.
   term = {
     command = "${pkgs.foot}/bin/foot";
     env = { };
     binds = [ ];
     gpu = false;
+    autoStart = false;
   };
 
   # Minecraft Java 26.2 ("Chaos Cubed"): ships a first-party experimental

--- a/packages/vm/panes/guest-image/nixos.nix
+++ b/packages/vm/panes/guest-image/nixos.nix
@@ -52,7 +52,7 @@ let
   # host /nix/store, and sees the compositor socket + the venus render node
   # via bind mounts.
   mkAppContainer = name: app: {
-    autoStart = true;
+    autoStart = app.autoStart or true;
     bindMounts = {
       ${runtimeDir} = {
         hostPath = runtimeDir;


### PR DESCRIPTION
The bring-up scaffolding windows (foot, weston-flower) mapped onto the desktop on every boot/reconnect; user expects only their app. New per-app `autoStart` field (default true); demo/term set false, start on demand via `systemctl start container@term`. Part of #1686.

🤖 Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable autostart for `demo` and `term` containers in guest panes
> - Sets `autoStart = false` on the `demo` and `term` app definitions in [apps.nix](https://github.com/indexable-inc/index/pull/1783/files#diff-a890cdfbf1cce913a32f1824d8badb40d6b06eb50aee87abc0bbdf1772968b64), marking them as debug scaffolding that should be started manually.
> - Updates `mkAppContainer` in [nixos.nix](https://github.com/indexable-inc/index/pull/1783/files#diff-547f31c0eac033ab8d65e4bb0e3c4ce6a6b52121e137f9ad93b16366dcf3af76) to read `app.autoStart` instead of hardcoding `true`, defaulting to `true` for apps that don't set the field.
> - Behavioral Change: `demo` and `term` containers no longer start at boot; other containers are unaffected due to the `or true` default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad97ab9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->