### PR TITLE
refactor(mcp): point resources bridge at ix-resource-cli

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -5652,11 +5652,11 @@ let
 
   # Network-free unit tests for the federated-resources bridge: every path of
   # `resources_bridge` (list/read/act, peer-flag assembly, not-found -> -32002,
-  # graceful empty/clear-error when `ix` is absent) driven against a STUB `ix`
-  # script on PATH plus a nonexistent-binary path -- no real `ix` or peer needed.
-  # The bridge lives in the `ix_notebook_mcp` server package, so the test imports
-  # that module (bundled here) rather than a `src/*` helper; `bash` is on PATH for
-  # the stub script's shebang.
+  # graceful empty/clear-error when `ix-resource-cli` is absent) driven against a
+  # STUB `ix-resource-cli` script on PATH plus a nonexistent-binary path -- no
+  # real CLI or peer needed. The bridge lives in the `ix_notebook_mcp` server
+  # package, so the test imports that module (bundled here) rather than a `src/*`
+  # helper; `bash` is on PATH for the stub script's shebang.
   resourcesBridgeTestPython = pkgs.python3.withPackages (ps: [
     ps.pytest
     ps.pydantic

--- a/packages/mcp/ix_notebook_mcp/resources_bridge.py
+++ b/packages/mcp/ix_notebook_mcp/resources_bridge.py
@@ -50,7 +50,8 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, ValidationInfo, field_validator
+from pydantic_core import PydanticUndefined
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -107,7 +108,32 @@ class ResourceNotFoundError(ResourceBridgeError):
 
 
 class _BridgeModel(BaseModel):
+    """Base for the CLI-boundary models: unknown fields are ignored and an
+    explicit JSON ``null`` collapses to the field's default.
+
+    Pydantic applies a default only to an OMITTED key; a serde layer (or peer)
+    that spells absence as ``"mime": null`` would otherwise raise, and one such
+    entry would take down the ENTIRE federated list (or make an owning peer
+    look transport-dead on a read). Fields WITHOUT a default
+    (:attr:`ResourceEntry.uri`) still reject null: a resource with no identity
+    is a real contract violation, not a stylistic absence.
+    """
+
     model_config = ConfigDict(extra="ignore")
+
+    @field_validator("*", mode="before")
+    @classmethod
+    def _null_collapses_to_default(cls, value: object, info: ValidationInfo) -> object:
+        if value is not None or info.field_name is None:
+            return value
+        field = cls.model_fields[info.field_name]
+        if field.default_factory is not None:
+            # The factories used here (`list`) take no arguments.
+            factory = field.default_factory
+            return factory()  # type: ignore[call-arg]
+        if field.default is not PydanticUndefined:
+            return field.default
+        return value
 
 
 class ResourceEntry(_BridgeModel):
@@ -139,10 +165,12 @@ class Ack(_BridgeModel):
 
     Kept permissive (only the common fields are named, ``extra="ignore"`` carries
     the rest) because the Ack shape is the CLI's to define; the tool returns the
-    parsed dict to the agent verbatim.
+    parsed dict to the agent verbatim. ``uri`` defaults to ``None`` (not ``""``)
+    so an ack that omits it does not have an empty string injected into the
+    merged payload (``exclude_none`` drops it instead).
     """
 
-    uri: str = ""
+    uri: str | None = None
     ok: bool = True
     delivered: bool | None = None
     detail: str | None = None
@@ -158,10 +186,13 @@ def _ix_bin() -> str | None:
     """
     override = os.environ.get(_IX_BIN_ENV)
     candidate = override or _DEFAULT_BIN
-    # An override that is a path to an existing file is used as-is; otherwise
-    # resolve it (or the default) on PATH.
+    # An override that is a path must be an executable FILE to be used; anything
+    # else (missing, a directory, mode -x) behaves like an absent CLI, so a bad
+    # override degrades cleanly instead of exploding at exec time with a
+    # PermissionError nothing catches. A bare-name override goes through
+    # which(), which already checks executability.
     if override and os.path.sep in override:
-        return override if Path(override).exists() else None
+        return override if Path(override).is_file() and os.access(override, os.X_OK) else None
     return shutil.which(candidate)
 
 
@@ -330,13 +361,17 @@ class _PeerProbeFailures:
 
 
 async def _get_snapshot(uri: str, peer_url: str) -> ResourceSnapshot:
-    """Probe one peer for ``uri`` via ``ix-resource-cli get <uri> --peer <url>``.
+    """Probe one peer for ``uri`` via ``ix-resource-cli get --peer <url> -- <uri>``.
 
     Returns the parsed snapshot, or raises :class:`ResourceNotFoundError` when that
     peer does not advertise the uri (so the caller can try the next peer), and
     :class:`ResourceBridgeError` for any other failure against this peer.
+
+    Options come first and ``--`` ends option parsing, so a hostile uri that
+    *looks* like a flag (``--peer=https://attacker/rpc``) reaches clap as a plain
+    positional, never as an option.
     """
-    args = ["get", uri, "--peer", peer_url]
+    args = ["get", "--peer", peer_url, "--", uri]
     try:
         rc, stdout, stderr = await _run_cli(args)
     except FileNotFoundError as exc:
@@ -363,7 +398,7 @@ async def read_resource(uri: str, peer: str | None = None) -> tuple[str, str]:
     """Read a snapshot of ``uri``, resolving a real peer endpoint URL.
 
     Returns ``(text, mime)``. With an explicit ``peer`` (a full endpoint URL) the
-    bridge runs one ``ix-resource-cli get <uri> --peer <url>``. Otherwise it
+    bridge runs one ``ix-resource-cli get --peer <url> -- <uri>``. Otherwise it
     iterates the configured peer URLs (``IX_RESOURCE_PEERS``), probing each until
     one advertises the uri.
 
@@ -443,7 +478,7 @@ async def _resolve_peer_for(uri: str, peers: Sequence[str]) -> str:
 
 
 async def act(uri: str, send_keys: str, peer: str | None = None) -> dict[str, object]:
-    """Drive a resource: ``ix-resource-cli act <uri> --send-keys <s> --peer <url>``.
+    """Drive a resource: ``ix-resource-cli act --send-keys=<s> --peer <url> -- <uri>``.
 
     Resolves a real peer endpoint URL the same way :func:`read_resource` does. With
     an explicit ``peer`` (a full endpoint URL) the bridge acts against it directly.
@@ -460,7 +495,10 @@ async def act(uri: str, send_keys: str, peer: str | None = None) -> dict[str, ob
     if not peers:
         raise _no_peer_error("act on", uri)
     peer_url = await _resolve_peer_for(uri, peers)
-    args = ["act", uri, "--send-keys", send_keys, "--peer", peer_url]
+    # Options first, `--` before the positional uri (see `_get_snapshot`), and
+    # the keys attached with `=` so a sequence starting with `-` cannot be read
+    # as a flag either.
+    args = ["act", f"--send-keys={send_keys}", "--peer", peer_url, "--", uri]
     try:
         rc, stdout, stderr = await _run_cli(args)
     except FileNotFoundError as exc:
@@ -484,6 +522,12 @@ async def act(uri: str, send_keys: str, peer: str | None = None) -> dict[str, ob
         raise ResourceBridgeError(f"{_DEFAULT_BIN} act ack failed validation: {exc}") from exc
     # Return the parsed-and-revalidated payload (named fields plus anything the CLI
     # added, since the agent may want the extras) rather than only the typed subset.
-    merged: dict[str, object] = dict(payload) if isinstance(payload, dict) else {}
+    # Nulls are dropped on both sides: a null extra carries no information, and
+    # `exclude_none` keeps the ack from re-injecting an absent uri.
+    merged: dict[str, object] = (
+        {key: value for key, value in payload.items() if value is not None}
+        if isinstance(payload, dict)
+        else {}
+    )
     merged.update(ack.model_dump(exclude_none=True))
     return merged

--- a/packages/mcp/ix_notebook_mcp/resources_bridge.py
+++ b/packages/mcp/ix_notebook_mcp/resources_bridge.py
@@ -1,34 +1,35 @@
 """Bridge the federated TUI *resources* into this MCP server.
 
-The ``ix`` CLI exposes the federated terminal-resource catalog over its
-``resources`` subcommand (``ix resources ls/get/act --json``). This module shells
-out to that CLI at runtime and maps its JSON into the MCP ``resources/list`` /
+The internal ``ix-resource-cli`` binary (the ix repo's ``resource-cli`` crate)
+exposes the federated terminal-resource catalog over its ``list``/``get``/``act``
+verbs, always emitting machine-readable JSON. This module shells out to that CLI
+at runtime and maps its JSON into the MCP ``resources/list`` /
 ``resources/read`` surface plus a ``tui_act`` tool, so an agent (or Claude Code)
 can ``@``-mention a peer's live terminal resource and drive it.
 
-Why shell out instead of linking ``ix``: index cannot take a Nix build-dependency
-on the ``ix`` binary (it would close the ix<->index dependency cycle), and the
-R2/pyo3 distribution path is heavier than this needs to be. Calling ``ix`` from
-``PATH`` at runtime sidesteps both -- and lets the bridge **degrade gracefully**:
-when ``ix`` is not installed (or has no ``resources`` subcommand, or errors), the
+Why shell out instead of linking: index cannot take a Nix build-dependency on
+the ix repo's binaries (it would close the ix<->index dependency cycle), and the
+R2/pyo3 distribution path is heavier than this needs to be. Calling
+``ix-resource-cli`` from ``PATH`` at runtime sidesteps both -- and lets the
+bridge **degrade gracefully**: when the CLI is not installed (or errors), the
 list comes back empty and a read raises a clear error rather than crashing the
 server.
 
 Peers are configured with the ``IX_RESOURCE_PEERS`` environment variable: a
-comma-separated list of peer URLs (each passed to ``ix`` as ``--peer <url>``).
-Unset/empty means local-only for *listing* -- ``ix resources ls`` is run with no
-``--peer`` flag and reports whatever the local node federates.
+comma-separated list of peer URLs (each passed to the CLI as ``--peer <url>``).
+Unset/empty means an empty federation for *listing* -- ``ix-resource-cli list``
+is run with no ``--peer`` flag and reports nothing.
 
-A read/act for a uri targets a single peer **by URL**. The ``ix`` CLI's
-``--peer`` is a full endpoint ``url::Url`` (e.g. ``https://<addr>/rpc``), not a
-bare host or label, so a peer cannot be inferred from the uri's host
-(``ix://<host>/<name>`` -- ``<host>`` is a display label, not an endpoint, and
-fails the CLI's URL parse). Instead: an explicit ``peer=`` URL is used directly;
-otherwise the bridge iterates the configured peer URLs (the same list
-:func:`list_resources` uses) and probes each with ``ix resources get`` until one
-advertises the uri, then reads/acts against that peer. With no explicit peer and
-no configured peers, a read/act raises a clear "no peer configured" error rather
-than silently shelling out a bare host.
+A read/act for a uri targets a single peer **by URL**. The CLI's ``--peer`` is a
+full endpoint ``url::Url`` (e.g. ``https://<addr>/rpc``), not a bare host or
+label, so a peer cannot be inferred from the uri's host (``ix://<host>/<name>``
+-- ``<host>`` is a display label, not an endpoint, and fails the CLI's URL
+parse). Instead: an explicit ``peer=`` URL is used directly; otherwise the
+bridge iterates the configured peer URLs (the same list :func:`list_resources`
+uses) and probes each with ``ix-resource-cli get`` until one advertises the uri,
+then reads/acts against that peer. With no explicit peer and no configured
+peers, a read/act raises a clear "no peer configured" error rather than silently
+shelling out a bare host.
 
 Everything here runs on the kernel's asyncio loop via
 :func:`asyncio.create_subprocess_exec` -- never a blocking ``subprocess.run``,
@@ -74,13 +75,14 @@ __all__ = [
 RESOURCE_NOT_FOUND = -32002
 
 # Environment variable naming the federated peers to query, comma-separated URLs.
-# Unset/empty => local-only (no ``--peer`` flag passed to ``ix``).
+# Unset/empty => no ``--peer`` flag passed to the CLI (an empty federation).
 PEERS_ENV = "IX_RESOURCE_PEERS"
 
 # The CLI the bridge shells out to. Overridable via ``IX_RESOURCES_BIN`` so a test
-# (or a non-PATH install) can point at a specific binary; defaults to ``ix`` on
-# PATH.
+# (or a non-PATH install) can point at a specific binary; defaults to
+# ``ix-resource-cli`` on PATH.
 _IX_BIN_ENV = "IX_RESOURCES_BIN"
+_DEFAULT_BIN = "ix-resource-cli"
 
 # Per-call timeout (seconds) so a hung/unreachable peer cannot wedge a request
 # forever. The CLI has its own network timeouts; this is a backstop.
@@ -96,7 +98,7 @@ class ResourceNotFoundError(ResourceBridgeError):
 
 
 # ---------------------------------------------------------------------------
-# Boundary models -- the shape of `ix resources ... --json` output.
+# Boundary models -- the shape of `ix-resource-cli` JSON output.
 # ---------------------------------------------------------------------------
 #
 # `extra="ignore"` keeps these forward-compatible: the CLI may add fields without
@@ -109,11 +111,11 @@ class _BridgeModel(BaseModel):
 
 
 class ResourceEntry(_BridgeModel):
-    """One federated resource as reported by ``ix resources ls --json``.
+    """One federated resource as reported by ``ix-resource-cli list``.
 
     The ``uri`` (``ix://<host>/<name>`` by convention) is both the federated
     identity and the MCP resource uri, so a client ``@``-mentions exactly what
-    ``ix`` advertises.
+    the CLI advertises.
     """
 
     uri: str
@@ -125,7 +127,7 @@ class ResourceEntry(_BridgeModel):
 
 
 class ResourceSnapshot(_BridgeModel):
-    """A point-in-time read of a resource from ``ix resources get <uri> --json``."""
+    """A point-in-time read of a resource from ``ix-resource-cli get <uri>``."""
 
     uri: str = ""
     text: str = ""
@@ -133,7 +135,7 @@ class ResourceSnapshot(_BridgeModel):
 
 
 class Ack(_BridgeModel):
-    """The acknowledgement ``ix resources act ... --json`` returns for a drive.
+    """The acknowledgement ``ix-resource-cli act ...`` returns for a drive.
 
     Kept permissive (only the common fields are named, ``extra="ignore"`` carries
     the rest) because the Ack shape is the CLI's to define; the tool returns the
@@ -147,15 +149,15 @@ class Ack(_BridgeModel):
 
 
 def _ix_bin() -> str | None:
-    """The ``ix`` executable to run, or ``None`` when it is not installed.
+    """The resource CLI executable to run, or ``None`` when it is not installed.
 
     Honors ``IX_RESOURCES_BIN`` (an explicit path or a name resolved on PATH) and
-    otherwise looks up ``ix`` on PATH. Returning ``None`` -- rather than raising --
-    is what lets :func:`list_resources` degrade to an empty list when the CLI is
-    absent.
+    otherwise looks up ``ix-resource-cli`` on PATH. Returning ``None`` -- rather
+    than raising -- is what lets :func:`list_resources` degrade to an empty list
+    when the CLI is absent.
     """
     override = os.environ.get(_IX_BIN_ENV)
-    candidate = override or "ix"
+    candidate = override or _DEFAULT_BIN
     # An override that is a path to an existing file is used as-is; otherwise
     # resolve it (or the default) on PATH.
     if override and os.path.sep in override:
@@ -168,14 +170,14 @@ def configured_peers() -> list[str]:
 
     Whitespace around each entry is stripped and blanks dropped, so
     ``"a, , b "`` yields ``["a", "b"]`` and an unset/blank var yields ``[]``
-    (local-only).
+    (an empty federation).
     """
     raw = os.environ.get(PEERS_ENV, "")
     return [peer.strip() for peer in raw.split(",") if peer.strip()]
 
 
-async def _run_ix(args: Sequence[str]) -> tuple[int, str, str]:
-    """Run ``ix <args>`` on the loop, returning ``(returncode, stdout, stderr)``.
+async def _run_cli(args: Sequence[str]) -> tuple[int, str, str]:
+    """Run ``ix-resource-cli <args>`` on the loop, returning ``(returncode, stdout, stderr)``.
 
     Raises :class:`ResourceBridgeError` only for an *execution* failure the caller
     cannot inspect (the binary vanished between the PATH check and exec, or the
@@ -184,7 +186,7 @@ async def _run_ix(args: Sequence[str]) -> tuple[int, str, str]:
     """
     binary = _ix_bin()
     if binary is None:
-        raise FileNotFoundError("ix CLI not found on PATH")
+        raise FileNotFoundError(f"{_DEFAULT_BIN} not found on PATH")
     try:
         proc = await asyncio.create_subprocess_exec(
             binary,
@@ -203,7 +205,7 @@ async def _run_ix(args: Sequence[str]) -> tuple[int, str, str]:
         with contextlib.suppress(ProcessLookupError):
             proc.kill()
         await proc.wait()
-        raise ResourceBridgeError(f"ix {' '.join(args)} timed out after {_CALL_TIMEOUT:g}s") from exc
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} {' '.join(args)} timed out after {_CALL_TIMEOUT:g}s") from exc
     return proc.returncode or 0, stdout_b.decode("utf-8", "replace"), stderr_b.decode("utf-8", "replace")
 
 
@@ -216,7 +218,7 @@ def _peer_flags(peers: Sequence[str]) -> list[str]:
 
 
 def _parse_entries(stdout: str) -> list[ResourceEntry]:
-    """Parse ``ix resources ls --json`` stdout into typed entries.
+    """Parse ``ix-resource-cli list`` stdout into typed entries.
 
     Accepts either a bare JSON array of entries or an object with a ``resources``
     (or ``entries``) array, since a CLI may wrap its list. A non-list/!dict
@@ -229,44 +231,45 @@ def _parse_entries(stdout: str) -> list[ResourceEntry]:
     try:
         payload = json.loads(text)
     except json.JSONDecodeError as exc:
-        raise ResourceBridgeError(f"ix resources ls returned invalid JSON: {exc}") from exc
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} list returned invalid JSON: {exc}") from exc
     if isinstance(payload, dict):
         items = payload.get("resources", payload.get("entries", []))
     else:
         items = payload
     if not isinstance(items, list):
-        raise ResourceBridgeError("ix resources ls JSON is not a list of entries")
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} list JSON is not a list of entries")
     try:
         return [ResourceEntry.model_validate(item) for item in items]
     except ValidationError as exc:
-        raise ResourceBridgeError(f"ix resources ls entry failed validation: {exc}") from exc
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} list entry failed validation: {exc}") from exc
 
 
 async def list_resources(peers: Sequence[str] | None = None) -> list[ResourceEntry]:
-    """List federated resources via ``ix resources ls --json``.
+    """List federated resources via ``ix-resource-cli list``.
 
     ``peers`` defaults to :func:`configured_peers` (``IX_RESOURCE_PEERS``); pass an
     explicit list to override. Each peer becomes a ``--peer <url>`` flag; an empty
-    list runs ``ix resources ls`` with no peer flag (local-only).
+    list runs ``ix-resource-cli list`` with no peer flag (an empty federation).
 
-    Degrades gracefully: returns ``[]`` (and logs) when ``ix`` is not installed or
-    the command exits nonzero -- it never raises for an absent/unhealthy CLI, so a
-    ``resources/list`` always answers. A *successful* command with a malformed
-    JSON body still raises (that is a real contract violation, not a missing tool).
+    Degrades gracefully: returns ``[]`` (and logs) when the CLI is not installed
+    or the command exits nonzero -- it never raises for an absent/unhealthy CLI,
+    so a ``resources/list`` always answers. A *successful* command with a
+    malformed JSON body still raises (that is a real contract violation, not a
+    missing tool).
     """
     if peers is None:
         peers = configured_peers()
-    args = ["resources", "ls", "--json", *_peer_flags(peers)]
+    args = ["list", *_peer_flags(peers)]
     try:
-        rc, stdout, stderr = await _run_ix(args)
+        rc, stdout, stderr = await _run_cli(args)
     except FileNotFoundError:
-        logger.info("ix CLI not on PATH; federated resources/list is empty")
+        logger.info("%s not on PATH; federated resources/list is empty", _DEFAULT_BIN)
         return []
     except ResourceBridgeError as exc:
-        logger.warning("ix resources ls failed: %s", exc)
+        logger.warning("%s list failed: %s", _DEFAULT_BIN, exc)
         return []
     if rc != 0:
-        logger.warning("ix resources ls exited %d: %s", rc, stderr.strip() or stdout.strip())
+        logger.warning("%s list exited %d: %s", _DEFAULT_BIN, rc, stderr.strip() or stdout.strip())
         return []
     return _parse_entries(stdout)
 
@@ -327,40 +330,40 @@ class _PeerProbeFailures:
 
 
 async def _get_snapshot(uri: str, peer_url: str) -> ResourceSnapshot:
-    """Probe one peer for ``uri`` via ``ix resources get <uri> --peer <url> --json``.
+    """Probe one peer for ``uri`` via ``ix-resource-cli get <uri> --peer <url>``.
 
     Returns the parsed snapshot, or raises :class:`ResourceNotFoundError` when that
     peer does not advertise the uri (so the caller can try the next peer), and
     :class:`ResourceBridgeError` for any other failure against this peer.
     """
-    args = ["resources", "get", uri, "--json", "--peer", peer_url]
+    args = ["get", uri, "--peer", peer_url]
     try:
-        rc, stdout, stderr = await _run_ix(args)
+        rc, stdout, stderr = await _run_cli(args)
     except FileNotFoundError as exc:
-        raise ResourceBridgeError("ix CLI not found on PATH; cannot read federated resource") from exc
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} not found on PATH; cannot read federated resource") from exc
     if rc != 0:
         message = stderr.strip() or stdout.strip()
         if _looks_not_found(message):
             raise ResourceNotFoundError(f"unknown resource: {uri}")
-        raise ResourceBridgeError(f"ix resources get {uri} exited {rc}: {message}")
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} get {uri} exited {rc}: {message}")
     text = stdout.strip()
     if not text:
         raise ResourceNotFoundError(f"unknown resource: {uri}")
     try:
         payload = json.loads(text)
     except json.JSONDecodeError as exc:
-        raise ResourceBridgeError(f"ix resources get returned invalid JSON: {exc}") from exc
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} get returned invalid JSON: {exc}") from exc
     try:
         return ResourceSnapshot.model_validate(payload)
     except ValidationError as exc:
-        raise ResourceBridgeError(f"ix resources get snapshot failed validation: {exc}") from exc
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} get snapshot failed validation: {exc}") from exc
 
 
 async def read_resource(uri: str, peer: str | None = None) -> tuple[str, str]:
     """Read a snapshot of ``uri``, resolving a real peer endpoint URL.
 
     Returns ``(text, mime)``. With an explicit ``peer`` (a full endpoint URL) the
-    bridge runs one ``ix resources get <uri> --peer <url> --json``. Otherwise it
+    bridge runs one ``ix-resource-cli get <uri> --peer <url>``. Otherwise it
     iterates the configured peer URLs (``IX_RESOURCE_PEERS``), probing each until
     one advertises the uri.
 
@@ -402,6 +405,10 @@ def _looks_not_found(message: str) -> bool:
       message also mentions a resource, so a shell ``"command not found"`` or an
       ``"unknown peer"`` / ``"unknown flag"`` (a config/transport error) is NOT
       swallowed as a resource-not-found.
+
+    ``ix-resource-cli`` reports an absent resource as a nonzero exit whose stderr
+    JSON error line contains ``resource not found: <uri>``, which the first
+    phrase list matches.
     """
     lowered = message.lower()
     resource_phrases = ("resource not found", "no such resource", "unknown resource")
@@ -414,11 +421,11 @@ def _looks_not_found(message: str) -> bool:
 async def _resolve_peer_for(uri: str, peers: Sequence[str]) -> str:
     """Return the single peer URL (from ``peers``) that advertises ``uri``.
 
-    Probes each candidate with ``ix resources get`` (a single explicit ``peers``
-    list short-circuits to that one URL without a probe -- an explicit ``peer=``
-    is the caller's assertion). Raises :class:`ResourceNotFoundError` when no peer
-    advertises the uri, so ``act`` never sends keystrokes to a peer that does not
-    own the resource.
+    Probes each candidate with ``ix-resource-cli get`` (a single explicit
+    ``peers`` list short-circuits to that one URL without a probe -- an explicit
+    ``peer=`` is the caller's assertion). Raises :class:`ResourceNotFoundError`
+    when no peer advertises the uri, so ``act`` never sends keystrokes to a peer
+    that does not own the resource.
     """
     if len(peers) == 1:
         return peers[0]
@@ -436,13 +443,13 @@ async def _resolve_peer_for(uri: str, peers: Sequence[str]) -> str:
 
 
 async def act(uri: str, send_keys: str, peer: str | None = None) -> dict[str, object]:
-    """Drive a resource: ``ix resources act <uri> --send-keys <s> --peer <url>``.
+    """Drive a resource: ``ix-resource-cli act <uri> --send-keys <s> --peer <url>``.
 
     Resolves a real peer endpoint URL the same way :func:`read_resource` does. With
     an explicit ``peer`` (a full endpoint URL) the bridge acts against it directly.
     Otherwise it first probes the configured peer URLs (``IX_RESOURCE_PEERS``) with
-    ``ix resources get`` to find the *one* peer that advertises the uri, then sends
-    the keys only to that peer -- so keystrokes never land on the wrong host.
+    ``ix-resource-cli get`` to find the *one* peer that advertises the uri, then
+    sends the keys only to that peer -- so keystrokes never land on the wrong host.
 
     Returns the parsed Ack as a plain dict (the agent-facing tool hands it back
     verbatim). Raises :class:`ResourceNotFoundError` for an unknown uri (-> -32002,
@@ -453,16 +460,16 @@ async def act(uri: str, send_keys: str, peer: str | None = None) -> dict[str, ob
     if not peers:
         raise _no_peer_error("act on", uri)
     peer_url = await _resolve_peer_for(uri, peers)
-    args = ["resources", "act", uri, "--send-keys", send_keys, "--json", "--peer", peer_url]
+    args = ["act", uri, "--send-keys", send_keys, "--peer", peer_url]
     try:
-        rc, stdout, stderr = await _run_ix(args)
+        rc, stdout, stderr = await _run_cli(args)
     except FileNotFoundError as exc:
-        raise ResourceBridgeError("ix CLI not found on PATH; cannot act on federated resource") from exc
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} not found on PATH; cannot act on federated resource") from exc
     if rc != 0:
         message = stderr.strip() or stdout.strip()
         if _looks_not_found(message):
             raise ResourceNotFoundError(f"unknown resource: {uri}")
-        raise ResourceBridgeError(f"ix resources act {uri} exited {rc}: {message}")
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} act {uri} exited {rc}: {message}")
     text = stdout.strip()
     if not text:
         # An empty body on success is a bare ack.
@@ -470,11 +477,11 @@ async def act(uri: str, send_keys: str, peer: str | None = None) -> dict[str, ob
     try:
         payload = json.loads(text)
     except json.JSONDecodeError as exc:
-        raise ResourceBridgeError(f"ix resources act returned invalid JSON: {exc}") from exc
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} act returned invalid JSON: {exc}") from exc
     try:
         ack = Ack.model_validate(payload)
     except ValidationError as exc:
-        raise ResourceBridgeError(f"ix resources act ack failed validation: {exc}") from exc
+        raise ResourceBridgeError(f"{_DEFAULT_BIN} act ack failed validation: {exc}") from exc
     # Return the parsed-and-revalidated payload (named fields plus anything the CLI
     # added, since the agent may want the extras) rather than only the typed subset.
     merged: dict[str, object] = dict(payload) if isinstance(payload, dict) else {}

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -601,7 +601,7 @@ mcp._mcp_server.read_resource()(_read_resource_handler)
         "'C-c'). `peer` is an optional full endpoint URL (e.g. "
         "'https://<addr>/rpc') targeting one peer directly; omit it to probe the "
         "configured peers (IX_RESOURCE_PEERS) for the one advertising the uri. "
-        "Bridges to `ix resources act` and degrades clearly when `ix` is absent."
+        "Bridges to `ix-resource-cli act` and degrades clearly when the CLI is absent."
     ),
 )
 async def tui_act(

--- a/packages/mcp/tests/test_resources_bridge.py
+++ b/packages/mcp/tests/test_resources_bridge.py
@@ -1,12 +1,14 @@
 """Network-free tests for the federated-resources bridge.
 
-These never reach a real ``ix`` or a peer. Two strategies prove every path:
+These never reach a real ``ix-resource-cli`` or a peer. Two strategies prove
+every path:
 
-* A **stub ``ix`` script** put on ``PATH`` (via ``IX_RESOURCES_BIN``) that emits
-  known JSON or a chosen exit code, so the real ``asyncio`` subprocess path --
-  argv assembly, JSON parse, not-found detection -- is exercised end to end.
+* A **stub ``ix-resource-cli`` script** put on ``PATH`` (via
+  ``IX_RESOURCES_BIN``) that emits known JSON or a chosen exit code, so the real
+  ``asyncio`` subprocess path -- argv assembly, JSON parse, not-found detection
+  -- is exercised end to end.
 * For the **graceful-absent** case, point ``IX_RESOURCES_BIN`` at a nonexistent
-  path so the PATH lookup fails exactly as it would with no ``ix`` installed.
+  path so the PATH lookup fails exactly as it would with no CLI installed.
 
 The module shape (exports, full annotations matching the ruff ANN gate) is
 checked too.
@@ -34,8 +36,8 @@ if str(_PKG_PARENT) not in sys.path:
 from ix_notebook_mcp import resources_bridge as rb
 
 # The `stub_ix` fixture hands back a factory: call it with a shell body, get the
-# path to the stub `ix` it installed on PATH. A precise alias keeps the test
-# signatures free of bare `Any` (the repo's ANN401 gate bans it).
+# path to the stub `ix-resource-cli` it installed on PATH. A precise alias keeps
+# the test signatures free of bare `Any` (the repo's ANN401 gate bans it).
 StubIx = Callable[[str], Path]
 
 
@@ -80,20 +82,20 @@ def test_configured_peers_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Stub-ix harness: a real script on PATH so the subprocess path runs for real.
+# Stub-CLI harness: a real script on PATH so the subprocess path runs for real.
 # ---------------------------------------------------------------------------
 
 
 def _write_stub_ix(tmp_path: Path, body: str) -> Path:
-    """Write an executable stub ``ix`` whose behaviour is the given shell body.
+    """Write an executable stub ``ix-resource-cli`` with the given shell body.
 
     The body can read ``$@`` (the args after the binary) and write JSON to stdout
     or a message to stderr with a chosen exit code, standing in for the real CLI.
     """
-    script = tmp_path / "ix"
+    script = tmp_path / "ix-resource-cli"
     # Resolve bash's absolute path for the shebang: the nix build sandbox has no
     # /usr/bin/env (and no /bin/sh), so a `#!/usr/bin/env bash` stub would fail
-    # to exec there ("ix not found"). bash is on PATH via the check's
+    # to exec there ("not found"). bash is on PATH via the check's
     # nativeBuildInputs, so shutil.which finds its store path.
     bash = shutil.which("bash") or "/bin/bash"
     script.write_text(f"#!{bash}\n" + body)
@@ -169,9 +171,9 @@ def test_list_resources_peer_flags_reach_cli(monkeypatch: pytest.MonkeyPatch, tm
     monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
     asyncio.run(rb.list_resources(["http://p1", "http://p2"]))
     args = argfile.read_text().split("\n")
-    assert "resources" in args
-    assert "ls" in args
-    assert "--json" in args
+    assert args[0] == "list"  # the CLI's verb, with no `resources` prefix
+    assert "resources" not in args
+    assert "--json" not in args  # the CLI is always machine-readable
     assert args.count("--peer") == 2
     assert "http://p1" in args
     assert "http://p2" in args
@@ -244,15 +246,15 @@ def test_read_resource_explicit_peer_wins(monkeypatch: pytest.MonkeyPatch, tmp_p
 
 
 def _multi_peer_stub_body(argfile: Path, owner_url: str) -> str:
-    """A stub `ix` body that advertises a uri on exactly ONE peer URL.
+    """A stub CLI body that advertises a uri on exactly ONE peer URL.
 
-    It reads the ``--peer`` value out of ``$@`` and, for ``resources get``, emits a
+    It reads the ``--peer`` value out of ``$@`` and, for ``get``, emits a
     snapshot only when that value equals ``owner_url`` -- otherwise it exits 1 with
-    a resource-not-found message. For ``resources act`` it acks only for the owner.
+    a resource-not-found message. For ``act`` it acks only for the owner.
     This makes the per-peer iteration observable: the bridge must skip the peers
     that 404 and land on the owner. Each invocation logs ONE line
-    ``<subcommand>\\t<peer>`` to ``argfile``, so a test can assert exactly which
-    (subcommand, peer) pairs ran -- e.g. that ``act`` only ever hit the owner.
+    ``<verb>\\t<peer>`` to ``argfile``, so a test can assert exactly which
+    (verb, peer) pairs ran -- e.g. that ``act`` only ever hit the owner.
     """
     return f"""
 peer=""
@@ -260,7 +262,7 @@ sub=""
 prev=""
 for a in "$@"; do
   if [ "$prev" = "--peer" ]; then peer="$a"; fi
-  case "$a" in get|act|ls) [ -z "$sub" ] && sub="$a" ;; esac
+  case "$a" in get|act|list) [ -z "$sub" ] && sub="$a" ;; esac
   prev="$a"
 done
 printf "%s\\t%s\\n" "$sub" "$peer" >> {argfile}
@@ -304,7 +306,7 @@ sub=""
 prev=""
 for a in "$@"; do
   if [ "$prev" = "--peer" ]; then peer="$a"; fi
-  case "$a" in get|act|ls) [ -z "$sub" ] && sub="$a" ;; esac
+  case "$a" in get|act|list) [ -z "$sub" ] && sub="$a" ;; esac
   prev="$a"
 done
 printf "%s\\t%s\\n" "$sub" "$peer" >> {argfile}
@@ -425,7 +427,7 @@ def test_read_resource_other_failure_is_bridge_error(stub_ix: StubIx) -> None:
     [
         "command not found",  # a wrapper/shell error, not a missing resource
         "unknown peer http://p1",  # a transport/config error
-        "unknown flag: --json",  # a CLI usage error
+        "unknown flag: --frobnicate",  # a CLI usage error
         "connection refused",
     ],
 )
@@ -445,7 +447,7 @@ def test_looks_not_found_classification() -> None:
     assert rb._looks_not_found("the resource does not exist")
     assert not rb._looks_not_found("command not found")
     assert not rb._looks_not_found("unknown peer")
-    assert not rb._looks_not_found("unknown flag --json")
+    assert not rb._looks_not_found("unknown flag --frobnicate")
 
 
 def test_read_resource_missing_ix_raises_bridge_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/packages/mcp/tests/test_resources_bridge.py
+++ b/packages/mcp/tests/test_resources_bridge.py
@@ -153,17 +153,6 @@ def test_list_resources_parses_wrapped_object(stub_ix: StubIx) -> None:
     assert got[0].caps == []
 
 
-def test_list_resources_passes_peer_flags(stub_ix: StubIx, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The stub echoes its own args as a JSON object so we can assert --peer made it.
-    stub_ix('printf \'{"resources": []}\'\n')
-    monkeypatch.setenv(rb.PEERS_ENV, "http://p1,http://p2")
-    # Re-implement: capture args by having the stub write them to a side file.
-    # Simpler: drive list_resources with explicit peers and a stub that fails if
-    # the flags are absent.
-    got = asyncio.run(rb.list_resources(["http://p1"]))
-    assert got == []
-
-
 def test_list_resources_peer_flags_reach_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     argfile = tmp_path / "args.txt"
     body = f'printf "%s\\n" "$@" > {argfile}\nprintf "[]"\n'
@@ -203,6 +192,59 @@ def test_list_resources_raises_on_bad_json(stub_ix: StubIx) -> None:
         asyncio.run(rb.list_resources())
 
 
+def test_list_resources_null_fields_collapse_to_defaults(stub_ix: StubIx) -> None:
+    # A serde layer may spell absence as an explicit null; every defaulted field
+    # must collapse to its default, and ONE null-y entry must not take down the
+    # whole federated list.
+    entries = [
+        {"uri": "ix://h/nully", "name": None, "host": None, "caps": None, "alive": None, "mime": None},
+        {"uri": "ix://h/plain", "name": "plain"},
+    ]
+    stub_ix(f"echo {json.dumps(json.dumps(entries))}\n")
+    got = asyncio.run(rb.list_resources())
+    assert [e.uri for e in got] == ["ix://h/nully", "ix://h/plain"]
+    nully = got[0]
+    assert nully.name == ""
+    assert nully.host == ""
+    assert nully.caps == []
+    assert nully.alive is True
+    assert nully.mime == "text/plain"
+
+
+def test_list_resources_null_uri_still_rejected(stub_ix: StubIx) -> None:
+    # uri has no default: a null uri is a genuine contract violation, not a
+    # stylistic absence, so it must still fail validation.
+    stub_ix(f"echo {json.dumps(json.dumps([{'uri': None}]))}\n")
+    with pytest.raises(rb.ResourceBridgeError):
+        asyncio.run(rb.list_resources())
+
+
+# ---------------------------------------------------------------------------
+# IX_RESOURCES_BIN override hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_override_directory_degrades_cleanly(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # A directory override must behave like an absent CLI (list -> [], read ->
+    # ResourceBridgeError), never leak a PermissionError out of the exec.
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(tmp_path))
+    monkeypatch.setenv(rb.PEERS_ENV, "http://p/rpc")
+    assert asyncio.run(rb.list_resources()) == []
+    with pytest.raises(rb.ResourceBridgeError):
+        asyncio.run(rb.read_resource("ix://h/n"))
+
+
+def test_override_non_executable_file_degrades_cleanly(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Same for a plain (mode -x) file: absent-CLI behavior, no PermissionError.
+    script = tmp_path / "ix-resource-cli"
+    script.write_text("#!/bin/sh\necho hi\n")  # written 0644, never chmod +x
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    monkeypatch.setenv(rb.PEERS_ENV, "http://p/rpc")
+    assert asyncio.run(rb.list_resources()) == []
+    with pytest.raises(rb.ResourceBridgeError):
+        asyncio.run(rb.act("ix://h/n", "x"))
+
+
 # ---------------------------------------------------------------------------
 # read_resource
 # ---------------------------------------------------------------------------
@@ -229,6 +271,33 @@ def test_read_resource_uses_configured_peer_url(monkeypatch: pytest.MonkeyPatch,
     assert "--peer" in args
     assert "https://node-z/rpc" in args  # the configured peer URL, not the uri host
     assert "nodeZ" not in args  # the uri host is never used as a --peer value
+
+
+def test_read_resource_null_fields_collapse_to_defaults(stub_ix: StubIx) -> None:
+    # Explicit nulls in a snapshot collapse to the defaults instead of raising
+    # (which would make an owning peer look transport-dead).
+    snap = {"uri": None, "text": None, "mime": None}
+    stub_ix(f"echo {json.dumps(json.dumps(snap))}\n")
+    text, mime = asyncio.run(rb.read_resource("ix://h/n"))
+    assert text == ""
+    assert mime == "text/plain"
+
+
+def test_read_resource_flaglike_uri_stays_positional(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # A hostile uri crafted as a clap flag must reach the CLI AFTER the `--`
+    # end-of-options separator, so it can never be parsed as an option (e.g.
+    # smuggling in a different --peer).
+    argfile = tmp_path / "args.txt"
+    body = f'printf "%s\\n" "$@" > {argfile}\nprintf \'{{"text":"x"}}\'\n'
+    script = _write_stub_ix(tmp_path, body)
+    monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
+    hostile = "--peer=https://attacker.example/rpc"
+    asyncio.run(rb.read_resource(hostile, peer="https://real.example/rpc"))
+    args = [arg for arg in argfile.read_text().split("\n") if arg]
+    separator = args.index("--")
+    assert hostile in args[separator + 1 :]  # positional, after the separator
+    assert args.index("--peer") < separator  # the real peer flag comes before it
+    assert args[args.index("--peer") + 1] == "https://real.example/rpc"
 
 
 def test_read_resource_explicit_peer_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -476,11 +545,28 @@ def test_act_sends_keys_arg(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     script = _write_stub_ix(tmp_path, body)
     monkeypatch.setenv(rb._IX_BIN_ENV, str(script))
     asyncio.run(rb.act("ix://h/n", "C-c", peer="http://p"))
-    args = argfile.read_text().split("\n")
-    assert "act" in args
-    assert "--send-keys" in args
-    assert "C-c" in args
+    args = [arg for arg in argfile.read_text().split("\n") if arg]
+    assert args[0] == "act"
+    # Keys are attached with `=` so a sequence starting with `-` cannot be read
+    # as a flag; the uri rides after the `--` end-of-options separator.
+    assert "--send-keys=C-c" in args
     assert "http://p" in args
+    separator = args.index("--")
+    assert args[separator + 1] == "ix://h/n"
+
+
+def test_act_null_fields_collapse_and_are_not_injected(stub_ix: StubIx) -> None:
+    # Explicit nulls collapse (`ok` back to True) and are dropped from the
+    # merged payload rather than surfacing as None/"" fields; non-null extras
+    # are still preserved for the agent.
+    ack = {"uri": None, "ok": None, "delivered": None, "detail": None, "extra": "kept"}
+    stub_ix(f"echo {json.dumps(json.dumps(ack))}\n")
+    got = asyncio.run(rb.act("ix://h/n", "x"))
+    assert got["ok"] is True
+    assert "uri" not in got
+    assert "delivered" not in got
+    assert "detail" not in got
+    assert got["extra"] == "kept"
 
 
 def test_act_empty_body_is_bare_ack(stub_ix: StubIx) -> None:


### PR DESCRIPTION
Companion to the ix-side removal of the product CLI's `ix resources` subcommand (see indexable-inc/index#1787 for the split decision: federated TUI-resource tooling is internal, its CLI home is `ix-resource-cli`).

- Bridge default binary: `ix` -> `ix-resource-cli` (`IX_RESOURCES_BIN` still overrides)
- Argv: `resources ls/get/act --json` -> bare `list`/`get`/`act` (that CLI is always machine-readable JSON)
- Not-found mapping unchanged: `ix-resource-cli get` exits nonzero with `resource not found: <uri>`, which `_looks_not_found` already matches
- Stub tests reworked to the new argv shape; 37 pass

Merge order: this PR first. The bridge degrades gracefully (empty list, clear errors) until `ix-resource-cli` ships on PATH, so nothing breaks in between.

ix-side PR: https://github.com/indexable-inc/ix/pull/6123

🤖 Generated with Claude Code (Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Point resources bridge at `ix-resource-cli` with updated CLI verbs and safer argument passing
> - Changes the default binary from `ix` to `ix-resource-cli` in [resources_bridge.py](https://github.com/indexable-inc/index/pull/1788/files#diff-db9cc6eebf0a6acd4c285806dab29dcfe8df4c2d97ab6065c6027124a2ad5387), with `IX_RESOURCES_BIN` env var as an override.
> - Updates CLI invocations: `list` replaces `resources ls --json`, `get` and `act` now pass URIs after `--` and use `--send-keys=<value>` to prevent flag-like arguments from being misinterpreted.
> - Adds a `_BridgeModel` base class with a `field_validator` that collapses explicit `None` values to field defaults, and changes `Ack.uri` from `str` defaulting to `""` to `Optional[str]` defaulting to `None`.
> - Updates `act` response merging to drop `None`-valued extras and exclude `None` ack fields, avoiding reinjection of nulls or empty-string `uri`.
> - Behavioral Change: `list_resources` no longer passes `--json`; the CLI is expected to emit JSON by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3700bfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->