### PR TITLE
feat(mcp): tailnet auto-mesh — /mesh endpoint, mesh module, Ray head probe (#1787)

### DIFF
--- a/modules/services/ray/default.nix
+++ b/modules/services/ray/default.nix
@@ -47,6 +47,7 @@ let
     mkIf
     mkOption
     mkPackageOption
+    optional
     optionalAttrs
     optionals
     types
@@ -182,6 +183,7 @@ let
   notebookEnv = {
     IX_MCP_DASHBOARD_PORT = toString cfg.execPort;
     IX_FLEET_EXEC_PORT = toString cfg.execPort;
+    IX_MCP_MESH_PORT = toString cfg.meshPort;
   }
   // optionalAttrs cfg.execTrustNetwork {
     IX_MCP_EXEC_TRUST_NETWORK = "1";
@@ -286,6 +288,19 @@ in
       '';
     };
 
+    meshPort = mkOption {
+      type = types.port;
+      default = 8798;
+      description = ''
+        Port the node's ix-mcp serves its tailnet `/mesh` discovery card on
+        (ix-mcp's DEFAULT_MESH_PORT). Exported to the engine as
+        `IX_MCP_MESH_PORT` so the service and the firewall rule below cannot
+        drift, and opened by {option}`services.ix-ray.openFirewall` when the
+        notebook engine runs -- a firewall that guards the tailscale interface
+        would otherwise silently blind mesh discovery.
+      '';
+    };
+
     objectStoreMemory = mkOption {
       type = types.nullOr types.ints.positive;
       default = null;
@@ -337,7 +352,8 @@ in
       default = false;
       description = ''
         Open the inter-node Ray ports (node/object manager, worker range), the
-        exec port, and on the head the GCS + client-server ports. Usually
+        exec port, the mesh discovery port (when the notebook engine runs),
+        and on the head the GCS + client-server ports. Usually
         unnecessary on a tailnet where peers reach each other directly, but
         required if a firewall guards the tailscale interface.
       '';
@@ -366,6 +382,9 @@ in
         cfg.nodeManagerPort
         cfg.objectManagerPort
       ]
+      # The notebook engine also serves the tailnet `/mesh` discovery card
+      # (index#1787); a firewalled tailscale interface must not blind it.
+      ++ optional cfg.notebook.enable cfg.meshPort
       ++ optionals (cfg.role == "head") [
         cfg.gcsPort
         cfg.clientServerPort

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -451,6 +451,27 @@ let
         cp -r ${fleetPythonSource}/fleet/. "$site/"
       ''
   );
+  # Tailnet mesh discovery (index#1787): `await mesh.peers()` sweeps tailscale
+  # peers for live ix-mcp `/mesh` endpoints (served by ix_notebook_mcp.mesh on
+  # the well-known mesh port) and returns one polars row per responding server;
+  # `mesh.sessions()` flattens to (host, session). Pure Python over the bundled
+  # httpx + polars; cross-platform.
+  meshPythonSource = builtins.path {
+    name = "ix-mcp-mesh-python-source";
+    path = ./src/mesh;
+  };
+  meshModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-mesh-python-module"
+      {
+        strictDeps = true;
+        meta.description = "Tailnet mesh discovery of live ix-mcp servers, bundled into the ix-mcp interpreter";
+      }
+      ''
+        site="$out/${pkgs.python3.sitePackages}/mesh"
+        mkdir -p "$site"
+        cp -r ${meshPythonSource}/mesh/. "$site/"
+      ''
+  );
   # Async shell-out helper: `import sh`, then `out = await sh("gh run list")`.
   # Runs on the kernel's loop (never blocks it like a bare subprocess.run) and
   # returns an Output that IS a Result, so the dashboard sees the command's ANSI
@@ -1225,6 +1246,7 @@ let
       viewModule
       nixModule
       fleetModule
+      meshModule
       shModule
       svelteModule
       worktreeModule
@@ -1381,6 +1403,7 @@ let
     "beeper"
     "view"
     "worktree"
+    "mesh"
   ];
   strictTypecheck =
     let
@@ -5454,6 +5477,7 @@ let
   imessageBundled = importTest "imessage" "import imessage; print('imessage-ok', all(callable(getattr(imessage, n)) for n in ('messages', 'chats', 'contacts', 'send')))";
   ghosttyBundled = importTest "ghostty" "import ghostty; print('ghostty-ok', all(callable(getattr(ghostty, n)) for n in ('surfaces', 'my_tty', 'my_surface', 'close', 'close_me', 'focus', 'activate', 'is_running')), ghostty.__version__)";
   xBundled = importTest "x" "import x; print('x-ok', callable(x.posts), x.__version__)";
+  meshBundled = importTest "mesh" "import mesh, asyncio; print('mesh-ok', all(asyncio.iscoroutinefunction(getattr(mesh, n)) for n in ('peers', 'sessions')), mesh.__version__)";
   linearBundled = importTest "linear" "import linear; print('linear-ok', all(callable(getattr(linear, n)) for n in ('issue', 'issue_update', 'issue_create', 'issue_search', 'comment_create', 'project_create')), linear.__version__)";
   notionBundled = importTest "notion" "import notion, asyncio; print('notion-ok', all(asyncio.iscoroutinefunction(getattr(notion, n)) for n in ('search', 'page', 'blocks', 'db_query', 'page_create', 'blocks_append', 'page_update')), notion.__version__)";
   notionTestPython = pkgs.python3.withPackages (ps: [
@@ -5687,6 +5711,52 @@ let
         cat stdout
         mkdir -p "$out"
       '';
+
+  # Network-free tests for the tailnet auto-mesh (index#1787): the `/mesh`
+  # route and its skip paths (IX_MCP_MESH=0, no tailscale IP, bind conflict),
+  # the bundled `mesh` module's peer sweep against a STUB `tailscale` script
+  # plus a real loopback server, and fleet.connect's zero-config Ray-head
+  # probe against a fake GCS listener. asyncssh rides along because importing
+  # `fleet` pulls it; `bash` backs the stub script's shebang.
+  meshTestPython = pkgs.python3.withPackages (ps: [
+    ps.pytest
+    ps.aiohttp
+    ps.httpx
+    ps.polars
+    ps.asyncssh
+    ixNotebookMcpModule
+    meshModule
+    fleetModule
+  ]);
+  meshTestSource = builtins.path {
+    name = "ix-mcp-mesh-test";
+    path = ./tests/test_mesh.py;
+  };
+  meshTests =
+    pkgs.runCommand "ix-mcp-mesh-tests"
+      {
+        nativeBuildInputs = [
+          meshTestPython
+          pkgs.bash
+        ];
+        strictDeps = true;
+        # The tests bind loopback sockets (a real mesh server + a fake GCS
+        # listener); the darwin sandbox denies all binds without this. Linux
+        # sandboxes already provide a private loopback, so it is a no-op there.
+        __darwinAllowLocalNetworking = true;
+      }
+      ''
+        export HOME=$TMPDIR/home
+        mkdir -p "$HOME"
+        cp ${meshTestSource} "$TMPDIR/test_mesh.py"
+        ${lib.getExe meshTestPython} -m pytest "$TMPDIR/test_mesh.py" -q -p no:cacheprovider >stdout 2>stderr || {
+          echo "ix-mcp mesh tests failed:" >&2
+          cat stdout stderr >&2
+          exit 1
+        }
+        cat stdout
+        mkdir -p "$out"
+      '';
 in
 package.overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
@@ -5706,6 +5776,8 @@ package.overrideAttrs (old: {
         slackBundled
         slackTests
         resourcesBridgeTests
+        meshBundled
+        meshTests
         beeperBundled
         requirementsSmoke
         engineBundled

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -5717,13 +5717,17 @@ let
   # the bundled `mesh` module's peer sweep against a STUB `tailscale` script
   # plus a real loopback server, and fleet.connect's zero-config Ray-head
   # probe against a fake GCS listener. asyncssh rides along because importing
-  # `fleet` pulls it; `bash` backs the stub script's shebang.
+  # `fleet` pulls it; `bash` backs the stub script's shebang. The session-label
+  # tests import `ix_notebook_mcp.tools`, whose import chain needs the mcp SDK
+  # (pydantic rides along) and nbformat (via `outputs`).
   meshTestPython = pkgs.python3.withPackages (ps: [
     ps.pytest
     ps.aiohttp
     ps.httpx
     ps.polars
     ps.asyncssh
+    ps.mcp
+    ps.nbformat
     ixNotebookMcpModule
     meshModule
     fleetModule

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -43,7 +43,15 @@ import webbrowser
 from collections.abc import Callable
 from pathlib import Path
 
-from .config import Config, hub_state_path, live_hub, port_open, runtime_dir, set_config
+from .config import (
+    Config,
+    hub_state_path,
+    is_tailnet_ipv4,
+    live_hub,
+    port_open,
+    runtime_dir,
+    set_config,
+)
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 _WILDCARD_HOSTS = {"0.0.0.0", "::"}  # noqa: S104 -- deliberate set of wildcard host strings for comparison
@@ -181,9 +189,19 @@ def _store_path(dashboard_port: int) -> Path:
     return runtime_dir() / f"store-{dashboard_port}.db"
 
 
+def _stat_exists(path: str) -> bool:
+    """``Path.exists`` that treats an unstatable path as absent: a sandboxed
+    or hardened host can deny even ``stat`` on ``/usr`` (PermissionError, not
+    False), and tailscale discovery must degrade to "none", never crash."""
+    try:
+        return Path(path).exists()
+    except OSError:
+        return False
+
+
 def _tailscale_status() -> dict | None:
     tailscale = shutil.which("tailscale") or next(
-        (p for p in ("/usr/local/bin/tailscale", "/usr/bin/tailscale") if Path(p).exists()), None
+        (p for p in ("/usr/local/bin/tailscale", "/usr/bin/tailscale") if _stat_exists(p)), None
     )
     if not tailscale:
         return None
@@ -214,7 +232,10 @@ def _tailscale_ip() -> str | None:
     if status.get("BackendState") != "Running":
         return None
     for ip in status.get("Self", {}).get("TailscaleIPs", []) or []:
-        if isinstance(ip, str) and "." in ip and ":" not in ip:
+        # CGNAT-only (100.64.0.0/10): a malformed or spoofed status must not be
+        # able to steer a bind to 0.0.0.0 or a LAN address (index#1789 review).
+        # Every real tailscale IPv4 is CGNAT, so nothing legitimate is lost.
+        if isinstance(ip, str) and is_tailnet_ipv4(ip):
             return ip
     return None
 

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -424,6 +424,11 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
         advertised_host=advertised_host,
         dashboard_port=dashboard_port,
         hub_port=hub_port,
+        # The `/mesh` endpoint binds ONLY the tailscale IP (index#1787): unlike
+        # `bind_host` above there is no loopback fallback, because a
+        # loopback-only mesh card is unreachable by every peer and a wider bind
+        # would leave the trust boundary. None -> mesh.start skips serving.
+        mesh_host=_tailscale_ip(),
         auto_dashboard=_auto_dashboard(),
         store_path=store_path,
         session_path=session_path,
@@ -513,7 +518,7 @@ def _spawn_hub(cfg: Config) -> subprocess.Popen | None:
 
 
 async def _run(cfg: Config) -> None:
-    from . import dashboard, pane_bridge, tools, transport
+    from . import dashboard, mesh, pane_bridge, tools, transport
     from .kernel import Kernel, set_kernel
 
     kernel = Kernel(cfg)
@@ -543,6 +548,10 @@ async def _run(cfg: Config) -> None:
         await locked.wait()
 
     runner = await dashboard.start(cfg)
+    # Advertise this server on the tailnet mesh (`GET /mesh`, index#1787):
+    # default-on and best-effort -- no tailscale, an occupied port, or
+    # IX_MCP_MESH=0 log one line and skip, never blocking the MCP itself.
+    mesh_runner = await mesh.start(cfg, tools.session_names)
     # Always publish this server's runs/resources/namespace as panes into the
     # shared discovery dir; a single standalone `dashboard` (run separately,
     # `nix run .#dashboard`) renders every producer behind one stable URL.
@@ -591,6 +600,8 @@ async def _run(cfg: Config) -> None:
             # Final checkpoint so the last cells' state reopens instantly even
             # when the debounced checkpoint had not fired yet.
             await kernel.snapshot_session()
+        if mesh_runner is not None:
+            await mesh_runner.cleanup()
         await runner.cleanup()
         await kernel.shutdown()
 

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -569,10 +569,6 @@ async def _run(cfg: Config) -> None:
         await locked.wait()
 
     runner = await dashboard.start(cfg)
-    # Advertise this server on the tailnet mesh (`GET /mesh`, index#1787):
-    # default-on and best-effort -- no tailscale, an occupied port, or
-    # IX_MCP_MESH=0 log one line and skip, never blocking the MCP itself.
-    mesh_runner = await mesh.start(cfg, tools.session_names)
     # Always publish this server's runs/resources/namespace as panes into the
     # shared discovery dir; a single standalone `dashboard` (run separately,
     # `nix run .#dashboard`) renders every producer behind one stable URL.
@@ -589,6 +585,14 @@ async def _run(cfg: Config) -> None:
     # Bake the live URL into the MCP instructions before serving, so the client
     # gets it in the `initialize` response -- no tool call to discover it.
     tools.set_dashboard_url(url)
+    # Advertise this server on the tailnet mesh (`GET /mesh`, index#1787):
+    # default-on and best-effort -- no tailscale, an occupied port, or
+    # IX_MCP_MESH=0 log one line and skip, never blocking the MCP itself.
+    # Started only now, AFTER the hub-spawn decision resolved `url`, so the
+    # card advertises the URL a human can actually open (a failed auto hub
+    # falls back to the data API here, not to a dead pre-spawn hub URL --
+    # index#1789 review).
+    mesh_runner = await mesh.start(cfg, tools.session_names, url)
     if hub is not None:
         print(f"[ix-mcp] dashboard (all running things + output): {url}", file=sys.stderr, flush=True)
     else:

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -16,6 +16,36 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+# The well-known port every ix-mcp serves its tailnet `/mesh` discovery
+# endpoint on (index#1787), adjacent to the fleet's fixed `/api/exec` port 8799
+# (src/fleet/fleet/cluster.py EXEC_PORT). The one definition: the server bind
+# (ix_notebook_mcp.mesh) and the bundled `mesh` module's peer probes both read
+# it through :func:`mesh_port`, so the two sides cannot drift.
+DEFAULT_MESH_PORT = 8798
+
+
+def mesh_port() -> int:
+    """The mesh port; ``IX_MCP_MESH_PORT`` overrides the well-known default."""
+    return int(os.environ.get("IX_MCP_MESH_PORT") or DEFAULT_MESH_PORT)
+
+
+def mesh_enabled() -> bool:
+    """Whether this server should advertise itself on the tailnet mesh.
+
+    Default ON: joining the mesh must need zero config (index#1787), so the env
+    var is an opt-out only. ``IX_MCP_MESH=0`` (or false/no/off) disables it.
+    """
+    return os.environ.get("IX_MCP_MESH", "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def server_version() -> str:
+    """The build's source revision. The nix wrapper sets ``IX_MCP_VERSION`` to
+    the flake rev (``<commit>`` / ``<commit>-dirty``); a bare run reads "dev".
+    Both the MCP ``serverInfo.version`` (tools.py) and the ``/mesh`` payload
+    report this one value, so a client and a mesh peer see the same commit."""
+    return os.environ.get("IX_MCP_VERSION") or "dev"
+
+
 @dataclass(frozen=True)
 class Config:
     # Directory the kernel runs in and notebooks/files are resolved against.
@@ -52,6 +82,13 @@ class Config:
     # True when the session file already existed at launch, so the server must
     # restore (load the checkpoint, replay the gap) before running new cells.
     session_resume: bool = False
+
+    # This machine's tailscale IPv4, resolved once by the CLI, or None when
+    # tailscale is absent or its backend is down. The `/mesh` endpoint binds
+    # ONLY this address (index#1787): the tailnet is the trust boundary, and
+    # with no tailnet there is nothing to mesh over, so mesh serving is skipped
+    # rather than widened to a LAN or wildcard bind.
+    mesh_host: str | None = None
 
     # "stdio" (the default; what an MCP client launches), "http", or "none"
     # (the standalone notebook engine: kernel + dashboard, no MCP transport).

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -8,12 +8,34 @@ keeps the wiring simple. The object is frozen so nothing mutates after launch.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import socket
 import stat
 from dataclasses import dataclass
 from pathlib import Path
+
+# Every tailscale IPv4 lives in the CGNAT range; anything else claiming to be
+# one is malformed or hostile output. See `is_tailnet_ipv4`.
+_TAILNET_V4 = ipaddress.ip_network("100.64.0.0/10")
+
+
+def is_tailnet_ipv4(value: str) -> bool:
+    """Whether ``value`` is an IPv4 literal in tailscale's CGNAT range
+    (100.64.0.0/10).
+
+    The defense-in-depth gate on every address taken from ``tailscale status``
+    output (index#1789 review): a malformed or spoofed status must not be able
+    to hand ``0.0.0.0`` or a LAN address to a bind or a peer probe. Real
+    parsing (``ipaddress``), not string sniffing, so ``0.0.0.0``, IPv6, and
+    junk all read as False.
+    """
+    try:
+        addr = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return isinstance(addr, ipaddress.IPv4Address) and addr in _TAILNET_V4
 
 
 # The well-known port every ix-mcp serves its tailnet `/mesh` discovery

--- a/packages/mcp/ix_notebook_mcp/mesh.py
+++ b/packages/mcp/ix_notebook_mcp/mesh.py
@@ -1,0 +1,105 @@
+"""The tailnet mesh endpoint: ``GET /mesh`` on every live ix-mcp (index#1787).
+
+Each ix-mcp answers ``GET /mesh`` with a small read-only JSON identity card --
+hostname, pid, build version, start time, the labels of its named sessions, its
+dashboard URL, and the kernel's working directory -- on the well-known mesh
+port (:data:`ix_notebook_mcp.config.DEFAULT_MESH_PORT`), bound ONLY to this
+machine's tailscale IP. The bundled ``mesh`` kernel module (``src/mesh``) is
+the client side: it sweeps the tailnet's online peers and collects these
+cards, so starting ix-mcp anywhere on the tailnet means joining one visible
+mesh with zero configuration.
+
+Serving is default-on but never load-bearing: no tailscale, a stopped backend,
+a bind race, or ``IX_MCP_MESH=0`` each skip the endpoint with one stderr line
+and the MCP comes up exactly as before. Session NAMES are the only per-session
+data exposed; code, outputs, and store contents stay behind the data API's own
+network boundary.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from aiohttp import web
+
+from .config import Config, mesh_enabled, mesh_port, server_version
+
+
+def build_app(
+    cfg: Config,
+    session_names: Callable[[], list[str]],
+    started_at: str,
+) -> web.Application:
+    """Assemble the one-route mesh app over an injected session-name source.
+
+    Split from :func:`start` so tests can drive the route without binding a
+    socket (mirrors ``dashboard.build_app``); ``session_names`` is a callable
+    (``tools.session_names`` in production) so this module never reaches into
+    another module's private state.
+    """
+    app = web.Application()
+
+    async def mesh(_request: web.Request) -> web.Response:
+        # Session names are read per request: clients name themselves at any
+        # point in their lifetime and the card must reflect the live set.
+        return web.json_response(
+            {
+                "host": socket.gethostname(),
+                "pid": os.getpid(),
+                "version": server_version(),
+                "started_at": started_at,
+                "sessions": session_names(),
+                # The CLI exports IX_MCP_DASHBOARD_URL before the kernel spawns
+                # (see cli._serve); fall back to the config-derived data API so
+                # an embedder that scrubbed the env still gets a usable URL.
+                "dashboard_url": os.environ.get("IX_MCP_DASHBOARD_URL") or cfg.dashboard_url(),
+                "cwd": str(cfg.workdir),
+            }
+        )
+
+    app.router.add_get("/mesh", mesh)
+    return app
+
+
+def _skip(reason: str) -> None:
+    print(f"[ix-mcp] mesh endpoint disabled: {reason}", file=sys.stderr, flush=True)
+
+
+async def start(
+    cfg: Config,
+    session_names: Callable[[], list[str]],
+) -> web.AppRunner | None:
+    """Serve ``/mesh`` on the tailscale IP, or skip (returning ``None``).
+
+    Every skip path logs exactly one stderr line and never raises: the mesh is
+    a discovery nicety, and it must not be able to take the MCP down
+    (index#1787).
+    """
+    if not mesh_enabled():
+        _skip("IX_MCP_MESH=0")
+        return None
+    if not cfg.mesh_host:
+        # No usable tailscale IPv4 (no binary, or backend not Running): there
+        # is no tailnet to mesh over, and any wider bind (LAN/wildcard) would
+        # serve the card beyond the trust boundary, so skip entirely.
+        _skip("no tailscale IPv4 to bind (the mesh serves the tailnet only)")
+        return None
+    started_at = datetime.now(UTC).isoformat()
+    runner = web.AppRunner(build_app(cfg, session_names, started_at))
+    await runner.setup()
+    port = mesh_port()
+    try:
+        await web.TCPSite(runner, cfg.mesh_host, port).start()
+    except OSError as error:
+        # A held port (a second ix-mcp on this box: the first keeps
+        # advertising, which is correct for a per-machine well-known port) or
+        # a tailscale-went-down race between IP resolution and the bind.
+        await runner.cleanup()
+        _skip(f"cannot bind {cfg.mesh_host}:{port} ({error})")
+        return None
+    print(f"[ix-mcp] mesh: http://{cfg.mesh_host}:{port}/mesh", file=sys.stderr, flush=True)
+    return runner

--- a/packages/mcp/ix_notebook_mcp/mesh.py
+++ b/packages/mcp/ix_notebook_mcp/mesh.py
@@ -33,13 +33,18 @@ def build_app(
     cfg: Config,
     session_names: Callable[[], list[str]],
     started_at: str,
+    dashboard_url: str,
 ) -> web.Application:
     """Assemble the one-route mesh app over an injected session-name source.
 
     Split from :func:`start` so tests can drive the route without binding a
     socket (mirrors ``dashboard.build_app``); ``session_names`` is a callable
     (``tools.session_names`` in production) so this module never reaches into
-    another module's private state.
+    another module's private state. ``dashboard_url`` is the URL the server
+    actually advertises (``cli._run`` resolves it AFTER the hub-spawn decision,
+    so a failed auto-dashboard hub cannot leave a dead pre-spawn URL on the
+    card -- index#1789 review); it is injected rather than read from the
+    ``IX_MCP_DASHBOARD_URL`` env, which is the pre-kernel value.
     """
     app = web.Application()
 
@@ -53,10 +58,7 @@ def build_app(
                 "version": server_version(),
                 "started_at": started_at,
                 "sessions": session_names(),
-                # The CLI exports IX_MCP_DASHBOARD_URL before the kernel spawns
-                # (see cli._serve); fall back to the config-derived data API so
-                # an embedder that scrubbed the env still gets a usable URL.
-                "dashboard_url": os.environ.get("IX_MCP_DASHBOARD_URL") or cfg.dashboard_url(),
+                "dashboard_url": dashboard_url,
                 "cwd": str(cfg.workdir),
             }
         )
@@ -72,6 +74,7 @@ def _skip(reason: str) -> None:
 async def start(
     cfg: Config,
     session_names: Callable[[], list[str]],
+    dashboard_url: str,
 ) -> web.AppRunner | None:
     """Serve ``/mesh`` on the tailscale IP, or skip (returning ``None``).
 
@@ -89,7 +92,7 @@ async def start(
         _skip("no tailscale IPv4 to bind (the mesh serves the tailnet only)")
         return None
     started_at = datetime.now(UTC).isoformat()
-    runner = web.AppRunner(build_app(cfg, session_names, started_at))
+    runner = web.AppRunner(build_app(cfg, session_names, started_at, dashboard_url))
     await runner.setup()
     port = mesh_port()
     try:

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -82,6 +82,13 @@ MODULES: tuple[Module, ...] = (
     ),
     Module("fleet", "async polars SSH fan-out across hosts (`read_ndjson` / `scan`)"),
     Module(
+        "mesh",
+        "tailnet mesh of live ix-mcp servers, zero config: `await mesh.peers()` is one polars "
+        "row per reachable server (host, version, named sessions, dashboard URL) discovered "
+        "via tailscale; `await mesh.sessions()` flattens to one row per (host, session)",
+        preimport=True,
+    ),
+    Module(
         "search",
         "meaning-based recall across the fleet corpus (code + agent/shell history): "
         "`await search.semantic(q, since='7d', compact=True)` / `grep(pattern)` / "

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -92,16 +92,13 @@ mcp = FastMCP("ix-mcp")
 _session_ids: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 
-def _session_id(ctx: Context | None) -> str | None:
-    """The kernel-side namespace key for this call's MCP session, or None.
+def _http_session(ctx: Context | None) -> object | None:
+    """This call's live MCP session object under the HTTP transport, else None.
 
     Only the HTTP transport multiplexes several client sessions onto the one
-    shared kernel, so only there does each session get its own namespace (the
-    kernel runtime keys per-session globals on this id -- see
-    ``runtime._session_ns``). The stdio transport serves exactly one client per
-    process: its state stays in the shared user namespace, which is also what
-    session checkpoint/restore (``serve --session FILE``) covers, so that
-    contract is untouched.
+    shared kernel, so only there is the session object a useful key. The stdio
+    transport (and an embedder driving the tools directly, which has no config)
+    serves exactly one client per process, reported here as None.
     """
     try:
         if config().transport != "http":
@@ -110,10 +107,22 @@ def _session_id(ctx: Context | None) -> str | None:
         # No config (an embedder driving the tools directly): single client.
         return None
     try:
-        session = ctx.session if ctx is not None else None
+        return ctx.session if ctx is not None else None
     except ValueError:
         # No request context on this call.
-        session = None
+        return None
+
+
+def _session_id(ctx: Context | None) -> str | None:
+    """The kernel-side namespace key for this call's MCP session, or None.
+
+    Each HTTP session gets its own namespace (the kernel runtime keys
+    per-session globals on this id -- see ``runtime._session_ns``). The stdio
+    transport's state stays in the shared user namespace, which is also what
+    session checkpoint/restore (``serve --session FILE``) covers, so that
+    contract is untouched.
+    """
+    session = _http_session(ctx)
     if session is None:
         return None
     sid = _session_ids.get(session)
@@ -127,10 +136,33 @@ def _session_id(ctx: Context | None) -> str | None:
 # session label defaults to it (see runtime.Session). A latch, not per-call work.
 _client_identified = False
 _dashboard_started = False
-# Session key -> the label the client chose via `session_set_name`. Keys gate
-# the acting tools (a session must name itself once); the values are what the
+# The label each client chose via `session_set_name`. A set label gates the
+# acting tools (a session must name itself once); the labels are what the
 # tailnet `/mesh` endpoint advertises (index#1787), read via `session_names`.
-_named_sessions: dict[str, str] = {}
+# HTTP sessions are keyed WEAKLY by the live session object (like
+# `_session_ids` above), so a disconnected client's label vanishes with its
+# session instead of a long-lived `serve --http` advertising it forever
+# (index#1789 review). The one stdio/embedder client has no session object to
+# key on; its label lives in `_solo_session_name` and dies with the process.
+_session_labels: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+_solo_session_name: str | None = None
+
+
+def _session_label(ctx: Context | None) -> str | None:
+    """The label this call's session chose, or None until it names itself."""
+    session = _http_session(ctx)
+    if session is None:
+        return _solo_session_name
+    return _session_labels.get(session)
+
+
+def _set_session_label(ctx: Context | None, name: str) -> None:
+    global _solo_session_name
+    session = _http_session(ctx)
+    if session is None:
+        _solo_session_name = name
+    else:
+        _session_labels[session] = name
 
 
 def session_names() -> list[str]:
@@ -141,7 +173,10 @@ def session_names() -> list[str]:
     tool-side map and are deliberately not included: the mesh card is the
     server's own view of its clients (index#1787).
     """
-    return sorted(set(_named_sessions.values()))
+    names = set(_session_labels.values())
+    if _solo_session_name:
+        names.add(_solo_session_name)
+    return sorted(names)
 
 
 async def _start_dashboard_once() -> None:
@@ -204,11 +239,6 @@ async def _identify_client_once(ctx: Context | None) -> None:
         await current_kernel().set_client(label)
 
 
-def _session_key(ctx: Context | None) -> str:
-    """Stable key for the MCP session that must explicitly name itself."""
-    return _session_id(ctx) or "__stdio__"
-
-
 def _session_name_required() -> bool:
     """Whether acting tools must be preceded by ``session_set_name``."""
     return os.environ.get("IX_MCP_REQUIRE_SESSION_NAME", "1").strip().lower() not in (
@@ -221,7 +251,7 @@ def _session_name_required() -> bool:
 
 async def _require_session_name(ctx: Context | None, *, intent: str | None = None) -> None:
     """Fail fast until this MCP session has named its dashboard group."""
-    if not _session_name_required() or _session_key(ctx) in _named_sessions:
+    if not _session_name_required() or _session_label(ctx) is not None:
         return
     suggestion = f" Suggested name from this call: {intent!r}." if intent else ""
     raise McpError(
@@ -324,7 +354,7 @@ async def session_set_name(
             )
         )
     await current_kernel().set_session_name(clean)
-    _named_sessions[_session_key(ctx)] = clean
+    _set_session_label(ctx, clean)
     return [outputs.text(f"dashboard session named: {clean}")]
 
 

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -47,7 +47,7 @@ from mcp.types import ErrorData
 from pydantic import AnyUrl, Field
 
 from . import guide, outputs, resources_bridge
-from .config import config
+from .config import config, server_version
 from .kernel import current_kernel
 
 logger = logging.getLogger(__name__)
@@ -127,7 +127,21 @@ def _session_id(ctx: Context | None) -> str | None:
 # session label defaults to it (see runtime.Session). A latch, not per-call work.
 _client_identified = False
 _dashboard_started = False
-_named_sessions: set[str] = set()
+# Session key -> the label the client chose via `session_set_name`. Keys gate
+# the acting tools (a session must name itself once); the values are what the
+# tailnet `/mesh` endpoint advertises (index#1787), read via `session_names`.
+_named_sessions: dict[str, str] = {}
+
+
+def session_names() -> list[str]:
+    """The labels live MCP sessions gave themselves, for the mesh endpoint.
+
+    Names only, sorted and deduplicated -- never code, outputs, or session
+    keys. Labels set kernel-side (``session.name = ...`` in a cell) bypass this
+    tool-side map and are deliberately not included: the mesh card is the
+    server's own view of its clients (index#1787).
+    """
+    return sorted(set(_named_sessions.values()))
 
 
 async def _start_dashboard_once() -> None:
@@ -271,11 +285,10 @@ def set_dashboard_url(url: str) -> None:
 _dashboard_url: str | None = None
 
 # Report the build's source revision as the MCP `serverInfo.version` so a client
-# can see exactly which commit of the server it is talking to. The nix wrapper
-# sets `IX_MCP_VERSION` to the flake rev (`<commit>` / `<commit>-dirty` / "dev");
-# FastMCP does not take a version, so stamp the low-level server directly. Absent
-# the env var (a bare `python -m ix_notebook_mcp`) it falls back to "dev".
-mcp._mcp_server.version = os.environ.get("IX_MCP_VERSION") or "dev"
+# can see exactly which commit of the server it is talking to. FastMCP does not
+# take a version, so stamp the low-level server directly. The derivation lives
+# in `config.server_version` so the `/mesh` endpoint reports the same value.
+mcp._mcp_server.version = server_version()
 
 Content = list[outputs.Content]
 
@@ -311,7 +324,7 @@ async def session_set_name(
             )
         )
     await current_kernel().set_session_name(clean)
-    _named_sessions.add(_session_key(ctx))
+    _named_sessions[_session_key(ctx)] = clean
     return [outputs.text(f"dashboard session named: {clean}")]
 
 

--- a/packages/mcp/src/fleet/fleet/cluster.py
+++ b/packages/mcp/src/fleet/fleet/cluster.py
@@ -184,14 +184,18 @@ def _resolve_auto_target(budget: float = 1.5) -> tuple[str | None, str]:
 
     Split from :func:`connect` so the zero-config resolution is testable
     against a fake GCS listener without importing (or starting) Ray.
+
+    An AMBIGUOUS probe (several heads, i.e. several clusters) raises instead
+    of returning ``None``: the no-target fallback chain ends in a private
+    local Ray, and silently computing on one laptop in exactly the case where
+    the operator has two clusters to choose from is the worst possible guess
+    (index#1789 review). The operator must pick via ``IX_FLEET_RAY_ADDRESS``.
     """
     heads = _probe_ray_heads(budget=budget)
     if len(heads) == 1:
         return f"ray://{heads[0]}:{_ray_client_port()}", ""
     if heads:
-        # Two heads means two clusters; guessing would silently compute on the
-        # wrong one, so leave the choice to the operator.
-        return None, (
+        raise RuntimeError(
             f"tailnet probe found {len(heads)} Ray heads ({', '.join(heads)}); "
             "set IX_FLEET_RAY_ADDRESS to pick one"
         )
@@ -213,8 +217,11 @@ def connect(address: str | None = None, *, local: bool = False, **kw: Any) -> No
     which on a fleet node attaches to the local raylet. With ``local=True``, or
     if the target is unreachable, a private single-node Ray is started (with
     one loud stderr line saying so and why) so the same code still runs on a
-    box with no fleet. Safe to call repeatedly; the Ray-using functions here
-    call it for you.
+    box with no fleet. The one hard failure: a probe that finds SEVERAL Ray
+    heads raises (``RuntimeError`` naming every hit) rather than fall back --
+    a silent local Ray is the worst answer to "which of my clusters?"; set
+    ``IX_FLEET_RAY_ADDRESS`` to pick one. Safe to call repeatedly; the
+    Ray-using functions here call it for you.
     """
     import ray
 

--- a/packages/mcp/src/fleet/fleet/cluster.py
+++ b/packages/mcp/src/fleet/fleet/cluster.py
@@ -84,11 +84,16 @@ SPARK_CONNECT_PORT = int(os.environ.get("IX_FLEET_SPARK_CONNECT_PORT", "15002"))
 RAY_CLIENT_PORT = 10001
 
 
-def _gcs_port() -> int:
-    """The fleet Ray head's GCS port (`modules/services/ray` ``gcsPort``,
-    default 6379). Read per call, not at import, so tests can point the
-    tailnet probe at a fake listener via ``IX_FLEET_RAY_GCS_PORT``."""
-    return int(os.environ.get("IX_FLEET_RAY_GCS_PORT", "6379"))
+def _ray_client_port() -> int:
+    """The Ray Client port the tailnet probe checks AND the resolved
+    ``ray://`` target dials -- one port for both on purpose, because a
+    connectable Client port is the liveness signal for the exact endpoint we
+    would use. Probing the GCS (6379) instead was wrong: redis defaults to
+    6379, so any redis on a tag:server host read as a Ray head, and two of
+    them silently disabled zero-config connect fleet-wide (index#1789 review).
+    Read per call, not at import, so tests can point the probe at a fake
+    listener via ``IX_FLEET_RAY_CLIENT_PORT``."""
+    return int(os.environ.get("IX_FLEET_RAY_CLIENT_PORT", str(RAY_CLIENT_PORT)))
 
 
 class ClusterError(Exception):
@@ -127,14 +132,15 @@ def _tailscale_status_sync(timeout: float = 1.0) -> dict[str, Any] | None:
 
 
 def _probe_ray_heads(budget: float = 1.5) -> list[str]:
-    """Tailscale IPs of online ``tag:server`` peers with a listening Ray GCS.
+    """Tailscale IPs of online ``tag:server`` peers with a listening Ray
+    Client port.
 
     The zero-config leg of :func:`connect`'s resolution (index#1787): with no
     explicit address and no env var, sweep the fleet's server-tagged tailnet
-    peers for a GCS listener, concurrently, spending at most ``budget`` seconds
-    in total. Only ``tag:server`` peers are probed: that is how the fleet marks
-    its service hosts on the tailnet, and probing every phone and laptop would
-    waste the budget on guaranteed misses.
+    peers for a Ray Client listener, concurrently, spending at most ``budget``
+    seconds in total. Only ``tag:server`` peers are probed: that is how the
+    fleet marks its service hosts on the tailnet, and probing every phone and
+    laptop would waste the budget on guaranteed misses.
     """
     status = _tailscale_status_sync()
     if not status:
@@ -152,9 +158,9 @@ def _probe_ray_heads(budget: float = 1.5) -> list[str]:
                 candidates.append(ip)
     if not candidates:
         return []
-    port = _gcs_port()
+    port = _ray_client_port()
 
-    def gcs_open(ip: str) -> bool:
+    def client_port_open(ip: str) -> bool:
         try:
             with socket.create_connection((ip, port), timeout=budget):
                 return True
@@ -166,7 +172,7 @@ def _probe_ray_heads(budget: float = 1.5) -> list[str]:
     # without joining so a straggler socket never stretches past the budget.
     pool = concurrent.futures.ThreadPoolExecutor(max_workers=min(len(candidates), 32))
     try:
-        futures = {pool.submit(gcs_open, ip): ip for ip in candidates}
+        futures = {pool.submit(client_port_open, ip): ip for ip in candidates}
         done, _not_done = concurrent.futures.wait(futures, timeout=budget)
         return sorted(futures[f] for f in done if f.result())
     finally:
@@ -181,7 +187,7 @@ def _resolve_auto_target(budget: float = 1.5) -> tuple[str | None, str]:
     """
     heads = _probe_ray_heads(budget=budget)
     if len(heads) == 1:
-        return f"ray://{heads[0]}:{RAY_CLIENT_PORT}", ""
+        return f"ray://{heads[0]}:{_ray_client_port()}", ""
     if heads:
         # Two heads means two clusters; guessing would silently compute on the
         # wrong one, so leave the choice to the operator.
@@ -189,7 +195,7 @@ def _resolve_auto_target(budget: float = 1.5) -> tuple[str | None, str]:
             f"tailnet probe found {len(heads)} Ray heads ({', '.join(heads)}); "
             "set IX_FLEET_RAY_ADDRESS to pick one"
         )
-    return None, "tailnet probe found no tag:server peer with a listening Ray GCS"
+    return None, "tailnet probe found no tag:server peer with a listening Ray Client port"
 
 
 def connect(address: str | None = None, *, local: bool = False, **kw: Any) -> None:  # noqa: ANN401 -- forwarded to ray.init
@@ -201,9 +207,9 @@ def connect(address: str | None = None, *, local: bool = False, **kw: Any) -> No
     Client, the supported thin cross-environment path); else ``RAY_ADDRESS``
     (the fleet's NixOS service sets this to the head GCS, since the daemon's
     non-default temp-dir defeats ``"auto"`` discovery); else a tailnet
-    auto-probe (index#1787): online ``tag:server`` peers are TCP-probed for a
-    Ray GCS, and exactly one hit becomes ``ray://<ip>:10001`` -- the Ray Client
-    path, since an off-cluster box cannot join as a raylet; else ``"auto"``,
+    auto-probe (index#1787): online ``tag:server`` peers are TCP-probed on the
+    Ray Client port, and exactly one hit becomes ``ray://<ip>:10001`` -- the
+    Ray Client path, since an off-cluster box cannot join as a raylet; else ``"auto"``,
     which on a fleet node attaches to the local raylet. With ``local=True``, or
     if the target is unreachable, a private single-node Ray is started (with
     one loud stderr line saying so and why) so the same code still runs on a

--- a/packages/mcp/src/fleet/fleet/cluster.py
+++ b/packages/mcp/src/fleet/fleet/cluster.py
@@ -41,9 +41,13 @@ defense in depth, ``in_kernel`` carries it automatically.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import os
 import shutil
+import socket
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 from collections.abc import Callable, Sequence
@@ -74,6 +78,18 @@ EXEC_PORT = int(os.environ.get("IX_FLEET_EXEC_PORT", "8799"))
 # `fleet.spark` client dials `sc://<master>:<this>`.
 SPARK_CONNECT_PORT = int(os.environ.get("IX_FLEET_SPARK_CONNECT_PORT", "15002"))
 
+# The Ray Client server on the fleet head (`ray://<head>:<this>`): the
+# supported path for an off-cluster box (e.g. darwin, which cannot join the
+# linux cluster as a raylet -- mixed-OS clusters are unsupported by Ray).
+RAY_CLIENT_PORT = 10001
+
+
+def _gcs_port() -> int:
+    """The fleet Ray head's GCS port (`modules/services/ray` ``gcsPort``,
+    default 6379). Read per call, not at import, so tests can point the
+    tailnet probe at a fake listener via ``IX_FLEET_RAY_GCS_PORT``."""
+    return int(os.environ.get("IX_FLEET_RAY_GCS_PORT", "6379"))
+
 
 class ClusterError(Exception):
     """A cluster operation could not be carried out (Ray unreachable, a peer
@@ -81,6 +97,99 @@ class ClusterError(Exception):
 
 
 # --- Ray bootstrap ---------------------------------------------------------
+
+
+def _tailscale_status_sync(timeout: float = 1.0) -> dict[str, Any] | None:
+    """``tailscale status --json`` synchronously, or None when unavailable.
+
+    :func:`connect` is a sync function whose ``ray.init`` already blocks, so
+    its pre-probe shells out directly (with a hard timeout) instead of going
+    through the async helper below.
+    """
+    try:
+        # _find_tailscale inside the try too: its /usr fallback probe raises
+        # PermissionError under the darwin nix sandbox (stat on /usr is
+        # denied), and the probe must degrade to "no tailscale", never crash.
+        binary = _find_tailscale()
+        if not binary:
+            return None
+        out = subprocess.run(
+            [binary, "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=True,
+        ).stdout
+        parsed: dict[str, Any] | None = json.loads(out) if out else None
+        return parsed
+    except Exception:
+        return None
+
+
+def _probe_ray_heads(budget: float = 1.5) -> list[str]:
+    """Tailscale IPs of online ``tag:server`` peers with a listening Ray GCS.
+
+    The zero-config leg of :func:`connect`'s resolution (index#1787): with no
+    explicit address and no env var, sweep the fleet's server-tagged tailnet
+    peers for a GCS listener, concurrently, spending at most ``budget`` seconds
+    in total. Only ``tag:server`` peers are probed: that is how the fleet marks
+    its service hosts on the tailnet, and probing every phone and laptop would
+    waste the budget on guaranteed misses.
+    """
+    status = _tailscale_status_sync()
+    if not status:
+        return []
+    candidates: list[str] = []
+    peers_field = status.get("Peer") or {}
+    if isinstance(peers_field, dict):
+        for peer in peers_field.values():
+            if not isinstance(peer, dict) or not peer.get("Online"):
+                continue
+            if "tag:server" not in (peer.get("Tags") or []):
+                continue
+            ip = _ipv4(peer.get("TailscaleIPs"))
+            if ip:
+                candidates.append(ip)
+    if not candidates:
+        return []
+    port = _gcs_port()
+
+    def gcs_open(ip: str) -> bool:
+        try:
+            with socket.create_connection((ip, port), timeout=budget):
+                return True
+        except OSError:
+            return False
+
+    # Threads, not asyncio: connect() runs synchronously (possibly ON the
+    # kernel's loop, where asyncio.run is unusable), and the pool is torn down
+    # without joining so a straggler socket never stretches past the budget.
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=min(len(candidates), 32))
+    try:
+        futures = {pool.submit(gcs_open, ip): ip for ip in candidates}
+        done, _not_done = concurrent.futures.wait(futures, timeout=budget)
+        return sorted(futures[f] for f in done if f.result())
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+
+def _resolve_auto_target(budget: float = 1.5) -> tuple[str | None, str]:
+    """The tailnet-probed Ray Client target, or ``(None, why-not)``.
+
+    Split from :func:`connect` so the zero-config resolution is testable
+    against a fake GCS listener without importing (or starting) Ray.
+    """
+    heads = _probe_ray_heads(budget=budget)
+    if len(heads) == 1:
+        return f"ray://{heads[0]}:{RAY_CLIENT_PORT}", ""
+    if heads:
+        # Two heads means two clusters; guessing would silently compute on the
+        # wrong one, so leave the choice to the operator.
+        return None, (
+            f"tailnet probe found {len(heads)} Ray heads ({', '.join(heads)}); "
+            "set IX_FLEET_RAY_ADDRESS to pick one"
+        )
+    return None, "tailnet probe found no tag:server peer with a listening Ray GCS"
 
 
 def connect(address: str | None = None, *, local: bool = False, **kw: Any) -> None:  # noqa: ANN401 -- forwarded to ray.init
@@ -91,11 +200,15 @@ def connect(address: str | None = None, *, local: bool = False, **kw: Any) -> No
     off-cluster box -- e.g. a laptop -- so it drives the fleet via the Ray
     Client, the supported thin cross-environment path); else ``RAY_ADDRESS``
     (the fleet's NixOS service sets this to the head GCS, since the daemon's
-    non-default temp-dir defeats ``"auto"`` discovery); else ``"auto"``, which on
-    a fleet node attaches to the local raylet. With ``local=True``, or if the
-    target is unreachable, a private single-node Ray is started so the same code
-    still runs on a box with no fleet. Safe to call repeatedly; the Ray-using
-    functions here call it for you.
+    non-default temp-dir defeats ``"auto"`` discovery); else a tailnet
+    auto-probe (index#1787): online ``tag:server`` peers are TCP-probed for a
+    Ray GCS, and exactly one hit becomes ``ray://<ip>:10001`` -- the Ray Client
+    path, since an off-cluster box cannot join as a raylet; else ``"auto"``,
+    which on a fleet node attaches to the local raylet. With ``local=True``, or
+    if the target is unreachable, a private single-node Ray is started (with
+    one loud stderr line saying so and why) so the same code still runs on a
+    box with no fleet. Safe to call repeatedly; the Ray-using functions here
+    call it for you.
     """
     import ray
 
@@ -106,18 +219,27 @@ def connect(address: str | None = None, *, local: bool = False, **kw: Any) -> No
     if local:
         ray.init(**common)
         return
-    target = (
-        address
-        or os.environ.get("IX_FLEET_RAY_ADDRESS")
-        or os.environ.get("RAY_ADDRESS")
-        or "auto"
-    )
+    target = address or os.environ.get("IX_FLEET_RAY_ADDRESS") or os.environ.get("RAY_ADDRESS")
+    probe_note = ""
+    if not target:
+        target, probe_note = _resolve_auto_target()
+    if not target:
+        target = "auto"
     try:
         ray.init(address=target, **common)
-    except Exception:
+    except Exception as error:
         # No cluster to attach to (a dev box, the head is down, or a `ray://`
         # client could not reach it): fall back to a local Ray so `fleet.run`
-        # still works rather than hard-failing.
+        # still works rather than hard-failing -- but LOUDLY (index#1787): a
+        # silent single-node Ray looks exactly like the fleet until a job runs
+        # on one machine instead of twelve.
+        detail = f"; {probe_note}" if probe_note else ""
+        print(
+            f"[fleet] no reachable Ray cluster (address={target!r}: "
+            f"{type(error).__name__}){detail}; started a private single-node Ray",
+            file=sys.stderr,
+            flush=True,
+        )
         ray.init(**common)
 
 

--- a/packages/mcp/src/mesh/mesh/__init__.py
+++ b/packages/mcp/src/mesh/mesh/__init__.py
@@ -1,0 +1,219 @@
+"""Tailnet mesh discovery: every live ix-mcp on the tailnet as polars frames.
+
+Each ix-mcp serves a small identity card at ``GET /mesh`` on the well-known
+mesh port, bound to its tailscale IP (``ix_notebook_mcp.mesh``, index#1787).
+This module is the client side: sweep the tailnet's online peers from
+``tailscale status --json``, fetch each card concurrently under a bounded
+timeout, and return one polars row per responding server -- so "who else is
+running ix-mcp, and what are their sessions working on" is one await with zero
+configuration.
+
+Usage::
+
+    import mesh
+
+    await mesh.peers()      # one row per live ix-mcp: host, ip, version, ...
+    await mesh.sessions()   # flattened: one row per (host, session label)
+
+Everything network-touching is ``async def`` because the kernel is one shared
+event loop: the tailscale subprocess and the HTTP sweep must never block it.
+Deliberately decoupled from ``fleet`` (its own tailscale helper, no import):
+mesh discovery must work on any tailnet box, fleet or not (index#1787).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+# The mesh port constant is owned by the server package (the bind and the
+# probes must agree); this module rides in the same bundled interpreter, so
+# the import is satisfiable wherever `import mesh` itself is.
+from ix_notebook_mcp.config import mesh_port
+
+__version__ = "0.1.0"
+
+__all__ = ["peers", "sessions"]
+
+# Test seam: a stub script standing in for the real CLI (mirrors the
+# resources_bridge IX_RESOURCES_BIN pattern), so tests never hit a real tailnet.
+_TAILSCALE_BIN_ENV = "IX_MESH_TAILSCALE_BIN"
+
+_PEERS_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
+    "host": pl.String,
+    "ip": pl.String,
+    "version": pl.String,
+    "sessions": pl.List(pl.String),
+    "dashboard_url": pl.String,
+    "started_at": pl.String,
+    "cwd": pl.String,
+    "pid": pl.Int64,
+}
+
+
+def _exists(path: str) -> bool:
+    """``Path.exists`` that treats an unstatable path as absent: the darwin nix
+    build sandbox denies even ``stat`` on ``/usr`` (PermissionError, not
+    False), and discovery must degrade to "no tailscale", never crash."""
+    try:
+        return Path(path).exists()
+    except OSError:
+        return False
+
+
+def _find_tailscale() -> str | None:
+    """The tailscale binary, honoring the test override, or None."""
+    override = os.environ.get(_TAILSCALE_BIN_ENV)
+    if override:
+        return override if _exists(override) else None
+    # macOS installs outside PATH-managed prefixes; same probe as the server's
+    # cli._tailscale_status.
+    return shutil.which("tailscale") or next(
+        (p for p in ("/usr/local/bin/tailscale", "/usr/bin/tailscale") if _exists(p)),
+        None,
+    )
+
+
+async def _tailscale_status() -> dict[str, Any] | None:
+    """``tailscale status --json`` on the loop, or None when unavailable."""
+    binary = await asyncio.to_thread(_find_tailscale)
+    if not binary:
+        return None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            binary,
+            "status",
+            "--json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=4)
+        parsed: dict[str, Any] | None = json.loads(out) if out else None
+        return parsed
+    except Exception:
+        return None
+
+
+def _ipv4(ips: object) -> str | None:
+    """The first IPv4 in a TailscaleIPs list, or None."""
+    if not isinstance(ips, list):
+        return None
+    for ip in ips:
+        if isinstance(ip, str) and "." in ip and ":" not in ip:
+            return ip
+    return None
+
+
+def _online_nodes(status: dict[str, Any]) -> list[tuple[str, str]]:
+    """(host, ipv4) for Self plus every online peer.
+
+    Self is always included: this very server's own card is part of the mesh
+    view (and the one row a single-node tailnet still gets).
+    """
+    nodes: list[tuple[str, str]] = []
+    entries: list[dict[str, Any]] = [status.get("Self") or {}]
+    peer_map: dict[str, Any] = status.get("Peer") or {}
+    if isinstance(peer_map, dict):
+        entries += [p for p in peer_map.values() if isinstance(p, dict) and p.get("Online")]
+    for entry in entries:
+        ip = _ipv4(entry.get("TailscaleIPs"))
+        if ip:
+            host = str(entry.get("DNSName") or entry.get("HostName") or ip).rstrip(".")
+            nodes.append((host, ip))
+    return nodes
+
+
+async def peers(timeout: float = 1.0) -> pl.DataFrame:
+    """Every ix-mcp answering ``/mesh`` on the tailnet, one polars row each.
+
+    Columns: ``host`` (the card's own hostname), ``ip`` (tailscale IPv4),
+    ``version`` (build commit), ``sessions`` (named session labels),
+    ``dashboard_url``, ``started_at``, ``cwd``, and ``pid``. Peers that are
+    offline, not running ix-mcp, or slower than ``timeout`` seconds simply
+    contribute no row -- discovery is a sweep, not a health check.
+
+    Example::
+
+        df = await mesh.peers()
+        df.select("host", "version", "sessions")
+    """
+    # httpx is bundled but heavy; imported per call like fleet.in_kernel so
+    # `import mesh` (preimported at kernel startup) stays light.
+    import httpx
+
+    status = await _tailscale_status()
+    if not status:
+        return pl.DataFrame(schema=_PEERS_SCHEMA)
+    port = mesh_port()
+
+    # verify=False: every card URL is plain `http://` inside the tailnet (the
+    # transport itself is encrypted), so no TLS verification ever happens --
+    # and building the default SSL context needs a CA bundle that hermetic
+    # environments (the nix sandbox) do not provide.
+    async with httpx.AsyncClient(timeout=timeout, verify=False) as client:  # noqa: S501 -- http-only client, see comment above
+
+        async def one(host: str, ip: str) -> dict[str, Any] | None:
+            try:
+                resp = await client.get(f"http://{ip}:{port}/mesh")
+                if resp.status_code != 200:
+                    return None
+                card = resp.json()
+            except Exception:
+                # A closed port, a timeout, or junk JSON all mean "no ix-mcp
+                # here", which is a normal state for most tailnet peers.
+                return None
+            if not isinstance(card, dict):
+                return None
+            sessions_field = card.get("sessions")
+            return {
+                "host": str(card.get("host") or host),
+                "ip": ip,
+                "version": str(card.get("version") or ""),
+                "sessions": [str(s) for s in sessions_field]
+                if isinstance(sessions_field, list)
+                else [],
+                "dashboard_url": str(card.get("dashboard_url") or ""),
+                "started_at": str(card.get("started_at") or ""),
+                "cwd": str(card.get("cwd") or ""),
+                "pid": int(card["pid"]) if isinstance(card.get("pid"), int) else None,
+            }
+
+        cards = await asyncio.gather(*(one(host, ip) for host, ip in _online_nodes(status)))
+
+    rows = [card for card in cards if card is not None]
+    if not rows:
+        return pl.DataFrame(schema=_PEERS_SCHEMA)
+    return pl.DataFrame(rows, schema=_PEERS_SCHEMA).sort("host")
+
+
+async def sessions(timeout: float = 1.0) -> pl.DataFrame:
+    """Every named session across the mesh: one row per (host, session).
+
+    The flattened view of :func:`peers` for "what is everyone working on":
+    columns ``host``, ``session``, ``dashboard_url``, ``ip``. A server with no
+    named sessions contributes no rows here (it still shows in ``peers()``).
+    """
+    df = await peers(timeout=timeout)
+    if df.is_empty():
+        return pl.DataFrame(
+            schema={
+                "host": pl.String,
+                "session": pl.String,
+                "dashboard_url": pl.String,
+                "ip": pl.String,
+            }
+        )
+    return (
+        df.explode("sessions")
+        # A no-sessions server explodes to one null row; drop it, keeping the
+        # contract "one row per actual named session".
+        .drop_nulls("sessions")
+        .rename({"sessions": "session"})
+        .select("host", "session", "dashboard_url", "ip")
+    )

--- a/packages/mcp/src/mesh/mesh/__init__.py
+++ b/packages/mcp/src/mesh/mesh/__init__.py
@@ -166,7 +166,12 @@ async def peers(timeout: float = 1.0) -> pl.DataFrame:
     # transport itself is encrypted), so no TLS verification ever happens --
     # and building the default SSL context needs a CA bundle that hermetic
     # environments (the nix sandbox) do not provide.
-    async with httpx.AsyncClient(timeout=timeout, verify=False) as client:  # noqa: S501 -- http-only client, see comment above
+    # trust_env=False: HTTP_PROXY/ALL_PROXY must never route these probes --
+    # tailnet CGNAT addresses are unreachable through a proxy (every probe
+    # would fail, and the sweep would leak tailnet IPs to it), and honoring a
+    # NO_PROXY exemption per box is exactly the zero-config burden the mesh
+    # exists to avoid (index#1789 review). Peers are dialed directly.
+    async with httpx.AsyncClient(timeout=timeout, verify=False, trust_env=False) as client:  # noqa: S501 -- http-only client, see comment above
 
         async def one(host: str, ip: str) -> dict[str, Any] | None:
             try:

--- a/packages/mcp/src/mesh/mesh/__init__.py
+++ b/packages/mcp/src/mesh/mesh/__init__.py
@@ -32,10 +32,11 @@ from typing import Any
 
 import polars as pl
 
-# The mesh port constant is owned by the server package (the bind and the
-# probes must agree); this module rides in the same bundled interpreter, so
-# the import is satisfiable wherever `import mesh` itself is.
-from ix_notebook_mcp.config import mesh_port
+# The mesh port constant and the tailnet-address gate are owned by the server
+# package (the bind and the probes must agree on both); this module rides in
+# the same bundled interpreter, so the import is satisfiable wherever
+# `import mesh` itself is.
+from ix_notebook_mcp.config import is_tailnet_ipv4, mesh_port
 
 __version__ = "0.1.0"
 
@@ -101,11 +102,20 @@ async def _tailscale_status() -> dict[str, Any] | None:
 
 
 def _ipv4(ips: object) -> str | None:
-    """The first IPv4 in a TailscaleIPs list, or None."""
+    """The first probeable IPv4 in a TailscaleIPs list, or None.
+
+    Accepts only tailscale's CGNAT range plus loopback: a malformed or spoofed
+    status must not steer the sweep at a LAN or arbitrary address
+    (index#1789 review, mirroring cli._tailscale_ip's bind gate). Loopback is
+    allowed because it is this very machine (harmless to probe) and it is what
+    the hermetic tests stand peers up on.
+    """
     if not isinstance(ips, list):
         return None
     for ip in ips:
-        if isinstance(ip, str) and "." in ip and ":" not in ip:
+        if not isinstance(ip, str):
+            continue
+        if is_tailnet_ipv4(ip) or ip == "127.0.0.1":
             return ip
     return None
 

--- a/packages/mcp/tests/test_mesh.py
+++ b/packages/mcp/tests/test_mesh.py
@@ -170,9 +170,13 @@ def _fetch_card(app: web.Application) -> dict[str, Any]:
 
 def test_mesh_card_fields(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("IX_MCP_VERSION", "deadbeef")
-    monkeypatch.setenv("IX_MCP_DASHBOARD_URL", "http://100.1.2.3:4567/")
     cfg = Config(workdir=tmp_path)
-    app = server_mesh.build_app(cfg, lambda: ["fix the build", "triage 1787"], "2026-07-03T00:00:00+00:00")
+    app = server_mesh.build_app(
+        cfg,
+        lambda: ["fix the build", "triage 1787"],
+        "2026-07-03T00:00:00+00:00",
+        "http://100.1.2.3:4567/",
+    )
     card = _fetch_card(app)
     assert card["host"] == socket.gethostname()
     assert card["pid"] == os.getpid()
@@ -183,12 +187,16 @@ def test_mesh_card_fields(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     assert card["cwd"] == str(tmp_path)
 
 
-def test_mesh_card_dashboard_url_falls_back_to_config(
+def test_mesh_card_dashboard_url_is_injected_not_env(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    monkeypatch.delenv("IX_MCP_DASHBOARD_URL", raising=False)
+    # The card must advertise the URL cli._run resolved AFTER the hub-spawn
+    # decision, not the pre-kernel IX_MCP_DASHBOARD_URL env (which points at a
+    # hub that may never have come up -- index#1789 review). The env decoy
+    # here must lose to the injected value.
+    monkeypatch.setenv("IX_MCP_DASHBOARD_URL", "http://100.0.0.1:1/dead-hub/")
     cfg = Config(workdir=tmp_path, advertised_host="100.9.9.9", dashboard_port=7777)
-    app = server_mesh.build_app(cfg, list, "t")
+    app = server_mesh.build_app(cfg, list, "t", cfg.dashboard_url())
     assert _fetch_card(app)["dashboard_url"] == "http://100.9.9.9:7777/"
 
 
@@ -196,7 +204,7 @@ def test_mesh_card_sessions_are_live(tmp_path: Path) -> None:
     # The card reflects names set AFTER the server came up: names arrive at
     # any point in a client's lifetime, so the SAME app must serve both reads.
     names: list[str] = []
-    app = server_mesh.build_app(Config(workdir=tmp_path), lambda: sorted(names), "t")
+    app = server_mesh.build_app(Config(workdir=tmp_path), lambda: sorted(names), "t", "u")
 
     async def go() -> tuple[list[str], list[str]]:
         async with TestClient(TestServer(app)) as client:
@@ -211,6 +219,49 @@ def test_mesh_card_sessions_are_live(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# session_names(): labels live exactly as long as their session
+# ---------------------------------------------------------------------------
+
+
+def test_session_labels_die_with_their_http_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A long-lived `serve --http` must not advertise a disconnected client's
+    # label on /mesh forever (index#1789 review): labels are keyed weakly by
+    # the live session object, so they vanish with it.
+    import gc
+    import weakref
+
+    from ix_notebook_mcp import tools
+
+    monkeypatch.setattr(tools, "_session_labels", weakref.WeakKeyDictionary())
+    monkeypatch.setattr(tools, "_solo_session_name", None)
+
+    class FakeSession:
+        """Stands in for the mcp ServerSession (weakref-able, hashable)."""
+
+    session = FakeSession()
+    tools._session_labels[session] = "ephemeral client"
+    assert tools.session_names() == ["ephemeral client"]
+    del session
+    gc.collect()
+    assert tools.session_names() == []
+
+
+def test_solo_session_label_via_set_and_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No config (an embedder) means one client and no session object to key
+    # on: the label lands in the solo slot, gates naming, and is advertised.
+    import weakref
+
+    from ix_notebook_mcp import tools
+
+    monkeypatch.setattr(tools, "_session_labels", weakref.WeakKeyDictionary())
+    monkeypatch.setattr(tools, "_solo_session_name", None)
+    assert tools._session_label(None) is None
+    tools._set_session_label(None, "triage 1787")
+    assert tools._session_label(None) == "triage 1787"
+    assert tools.session_names() == ["triage 1787"]
+
+
+# ---------------------------------------------------------------------------
 # start(): the skip paths must log one line and never raise
 # ---------------------------------------------------------------------------
 
@@ -220,7 +271,7 @@ def test_start_disabled_by_env(
 ) -> None:
     monkeypatch.setenv("IX_MCP_MESH", "0")
     cfg = Config(workdir=tmp_path, mesh_host="127.0.0.1")
-    assert asyncio.run(server_mesh.start(cfg, list)) is None
+    assert asyncio.run(server_mesh.start(cfg, list, "u")) is None
     assert "mesh endpoint disabled" in capsys.readouterr().err
 
 
@@ -229,7 +280,7 @@ def test_start_skips_without_tailscale(
 ) -> None:
     monkeypatch.delenv("IX_MCP_MESH", raising=False)
     cfg = Config(workdir=tmp_path, mesh_host=None)
-    assert asyncio.run(server_mesh.start(cfg, list)) is None
+    assert asyncio.run(server_mesh.start(cfg, list, "u")) is None
     assert "no tailscale" in capsys.readouterr().err
 
 
@@ -239,13 +290,12 @@ def test_start_serves_on_override_port(monkeypatch: pytest.MonkeyPatch, tmp_path
     port = _free_port()
     monkeypatch.delenv("IX_MCP_MESH", raising=False)
     monkeypatch.setenv("IX_MCP_MESH_PORT", str(port))
-    monkeypatch.delenv("IX_MCP_DASHBOARD_URL", raising=False)
     cfg = Config(workdir=tmp_path, mesh_host="127.0.0.1")
 
     async def go() -> dict[str, Any]:
         import aiohttp
 
-        runner = await server_mesh.start(cfg, lambda: ["smoke"])
+        runner = await server_mesh.start(cfg, lambda: ["smoke"], "u")
         assert runner is not None
         try:
             async with (
@@ -271,7 +321,7 @@ def test_start_skips_on_bind_conflict(
         port = holder.getsockname()[1]
         monkeypatch.setenv("IX_MCP_MESH_PORT", str(port))
         cfg = Config(workdir=tmp_path, mesh_host="127.0.0.1")
-        assert asyncio.run(server_mesh.start(cfg, list)) is None
+        assert asyncio.run(server_mesh.start(cfg, list, "u")) is None
     assert "cannot bind" in capsys.readouterr().err
 
 
@@ -292,7 +342,7 @@ def test_wildcard_host_env_never_reaches_mesh_bind(
     if not _system_tailscale_present():
         assert cli._tailscale_ip() is None
     cfg = Config(workdir=tmp_path, mesh_host=None)
-    assert asyncio.run(server_mesh.start(cfg, list)) is None
+    assert asyncio.run(server_mesh.start(cfg, list, "u")) is None
     assert "no tailscale" in capsys.readouterr().err
 
 
@@ -326,13 +376,12 @@ def test_peers_and_sessions_discover_live_server(
     monkeypatch.delenv("IX_MCP_MESH", raising=False)
     monkeypatch.setenv("IX_MCP_MESH_PORT", str(port))
     monkeypatch.setenv("IX_MCP_VERSION", "cafebabe")
-    monkeypatch.setenv("IX_MCP_DASHBOARD_URL", "http://127.0.0.1:9999/")
     stub = _write_stub_tailscale(tmp_path, _status(self_ip="127.0.0.1"))
     monkeypatch.setenv(mesh_client._TAILSCALE_BIN_ENV, str(stub))
     cfg = Config(workdir=tmp_path, mesh_host="127.0.0.1")
 
     async def go() -> tuple[pl.DataFrame, pl.DataFrame]:
-        runner = await server_mesh.start(cfg, lambda: ["alpha", "beta"])
+        runner = await server_mesh.start(cfg, lambda: ["alpha", "beta"], "http://127.0.0.1:9999/")
         assert runner is not None
         try:
             return await mesh_client.peers(), await mesh_client.sessions()
@@ -435,9 +484,11 @@ def test_probe_refuses_multiple_heads_loudly(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     # TWO tag:server peers both answering on the probed port (index#1789 C5):
-    # connect() must refuse to guess, and the loud note must name every hit so
-    # the operator can pick one. Both peers point at loopback (the one address
-    # the sandbox can serve), so the note names it twice.
+    # connect() must refuse to guess -- and it must HARD-FAIL, not fall back
+    # to a private local Ray, which in exactly this ambiguous case would
+    # silently compute on one laptop (index#1789 review). The error names
+    # every hit so the operator can pick one. Both peers point at loopback
+    # (the one address the sandbox can serve), so it is named twice.
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
         listener.bind(("127.0.0.1", 0))
         listener.listen(8)
@@ -445,8 +496,9 @@ def test_probe_refuses_multiple_heads_loudly(
         status = _status(peers=[_server_peer("127.0.0.1"), _server_peer("127.0.0.1")])
         _stub_tailscale_on_path(monkeypatch, tmp_path, status)
         assert cluster._probe_ray_heads() == ["127.0.0.1", "127.0.0.1"]
-        target, note = cluster._resolve_auto_target()
-        assert target is None
+        with pytest.raises(RuntimeError) as excinfo:
+            cluster._resolve_auto_target()
+        note = str(excinfo.value)
         assert "2 Ray heads" in note
         assert "127.0.0.1, 127.0.0.1" in note  # every hit is named
         assert "IX_FLEET_RAY_ADDRESS" in note  # and the remedy

--- a/packages/mcp/tests/test_mesh.py
+++ b/packages/mcp/tests/test_mesh.py
@@ -11,9 +11,9 @@ Nothing here reaches a real tailnet, tailscale daemon, or Ray cluster:
   script via ``IX_MESH_TAILSCALE_BIN`` (the resources_bridge stub pattern)
   whose JSON points at loopback, where a real mesh server (or nothing) runs.
 * The **fleet probe** (``fleet.cluster``) gets a stub ``tailscale`` on PATH
-  plus a fake GCS listener on an ephemeral loopback port selected through
-  ``IX_FLEET_RAY_GCS_PORT``, proving ``connect()``'s zero-config resolution
-  without importing Ray.
+  plus a fake Ray Client listener on an ephemeral loopback port selected
+  through ``IX_FLEET_RAY_CLIENT_PORT``, proving ``connect()``'s zero-config
+  resolution without importing Ray.
 """
 
 from __future__ import annotations
@@ -43,10 +43,12 @@ for _p in (_PKG_PARENT, _PKG_PARENT / "src" / "mesh", _PKG_PARENT / "src" / "fle
 
 import mesh as mesh_client
 from fleet import cluster
+from ix_notebook_mcp import cli
 from ix_notebook_mcp import mesh as server_mesh
 from ix_notebook_mcp.config import (
     DEFAULT_MESH_PORT,
     Config,
+    is_tailnet_ipv4,
     mesh_enabled,
     mesh_port,
     server_version,
@@ -131,6 +133,23 @@ def test_server_version_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert server_version() == "dev"
     monkeypatch.setenv("IX_MCP_VERSION", "abc123")
     assert server_version() == "abc123"
+
+
+def test_is_tailnet_ipv4_gate() -> None:
+    # The defense-in-depth gate on addresses taken from tailscale output
+    # (index#1789 review, S1): only CGNAT 100.64.0.0/10 passes; wildcards,
+    # LAN/loopback addresses, IPv6, and junk are all rejected by real parsing.
+    assert is_tailnet_ipv4("100.64.0.0")
+    assert is_tailnet_ipv4("100.115.233.43")
+    assert is_tailnet_ipv4("100.127.255.255")
+    assert not is_tailnet_ipv4("100.63.255.255")  # just below the range
+    assert not is_tailnet_ipv4("100.128.0.0")  # just above the range
+    assert not is_tailnet_ipv4("0.0.0.0")  # noqa: S104 -- asserting the wildcard is REJECTED
+    assert not is_tailnet_ipv4("127.0.0.1")
+    assert not is_tailnet_ipv4("192.168.1.10")
+    assert not is_tailnet_ipv4("fd7a:115c:a1e0::1")
+    assert not is_tailnet_ipv4("not-an-ip")
+    assert not is_tailnet_ipv4("")
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +275,38 @@ def test_start_skips_on_bind_conflict(
     assert "cannot bind" in capsys.readouterr().err
 
 
+def test_wildcard_host_env_never_reaches_mesh_bind(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The headline bind property (index#1789 review, C4): IX_MCP_HOST steers
+    # the dashboard bind only; the mesh bind host comes solely from tailscale.
+    # With IX_MCP_HOST=0.0.0.0 the tailscale-derived value is unchanged, and
+    # with no tailscale at all the mesh SKIPS rather than widening to the env.
+    monkeypatch.setenv("IX_MCP_HOST", "0.0.0.0")  # noqa: S104 -- asserting the wildcard CANNOT reach the bind
+    _stub_tailscale_on_path(monkeypatch, tmp_path, _status(self_ip="100.99.1.1"))
+    assert cli._tailscale_ip() == "100.99.1.1"
+
+    # No tailscale: mesh_host resolves to None and start() must skip; the env
+    # wildcard must not become a fallback bind host.
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    if not _system_tailscale_present():
+        assert cli._tailscale_ip() is None
+    cfg = Config(workdir=tmp_path, mesh_host=None)
+    assert asyncio.run(server_mesh.start(cfg, list)) is None
+    assert "no tailscale" in capsys.readouterr().err
+
+
+def test_tailscale_ip_rejects_non_cgnat_addresses(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A spoofed/malformed status handing out a wildcard, LAN, or IPv6 address
+    # must not produce a bind host (index#1789 review, S1).
+    bad = _status(self_ip=None)
+    bad["Self"] = {"TailscaleIPs": ["0.0.0.0", "192.168.1.7", "fd7a:115c:a1e0::1", "junk"]}  # noqa: S104 -- hostile input under test, asserting it is rejected
+    _stub_tailscale_on_path(monkeypatch, tmp_path, bad)
+    assert cli._tailscale_ip() is None
+
+
 # ---------------------------------------------------------------------------
 # mesh.peers() / mesh.sessions(): stub tailscale + a real loopback server
 # ---------------------------------------------------------------------------
@@ -323,8 +374,21 @@ def test_peers_skips_offline_and_unresponsive(
     assert df.is_empty()
 
 
+def test_peers_never_probes_non_tailnet_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Spoofed/malformed peer addresses (wildcard, LAN, junk) are dropped by
+    # the CGNAT gate before any probe (index#1789 review, S1); loopback is the
+    # one non-CGNAT address allowed (it is this machine, and the test seam).
+    assert mesh_client._ipv4(["0.0.0.0", "192.168.7.7", "junk"]) is None  # noqa: S104 -- hostile input under test, asserting it is rejected
+    assert mesh_client._ipv4(["fd7a:115c:a1e0::1"]) is None
+    assert mesh_client._ipv4(["100.86.202.115"]) == "100.86.202.115"
+    assert mesh_client._ipv4(["0.0.0.0", "100.86.202.115"]) == "100.86.202.115"  # noqa: S104 -- hostile input under test, asserting it is skipped
+    assert mesh_client._ipv4(["127.0.0.1"]) == "127.0.0.1"
+    assert mesh_client._ipv4("not-a-list") is None
+
+
 # ---------------------------------------------------------------------------
-# fleet.connect() zero-config probe: stub tailscale on PATH + a fake GCS
+# fleet.connect() zero-config probe: stub tailscale on PATH + a fake Ray
+# Client listener
 # ---------------------------------------------------------------------------
 
 
@@ -348,28 +412,53 @@ def _server_peer(ip: str, *, online: bool = True, tags: list[str] | None = None)
     }
 
 
-def test_probe_finds_single_gcs_head(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as gcs:
-        gcs.bind(("127.0.0.1", 0))
+def test_probe_finds_single_ray_client_head(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
         # Backlog > 1: the listener never accept()s, and each probe's completed
         # handshake occupies a queue slot; both probes below must get through.
-        gcs.listen(8)
-        monkeypatch.setenv("IX_FLEET_RAY_GCS_PORT", str(gcs.getsockname()[1]))
+        listener.listen(8)
+        port = listener.getsockname()[1]
+        monkeypatch.setenv("IX_FLEET_RAY_CLIENT_PORT", str(port))
         _stub_tailscale_on_path(monkeypatch, tmp_path, _status(peers=[_server_peer("127.0.0.1")]))
         assert cluster._probe_ray_heads() == ["127.0.0.1"]
-        # connect()'s resolution turns the one head into a Ray Client URL.
+        # connect()'s resolution turns the one head into a Ray Client URL on
+        # the SAME port it just probed (probe what you dial, index#1789 C1).
         target, note = cluster._resolve_auto_target()
-        assert target == f"ray://127.0.0.1:{cluster.RAY_CLIENT_PORT}"
+        assert target == f"ray://127.0.0.1:{port}"
         assert note == ""
+
+
+def test_probe_refuses_multiple_heads_loudly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # TWO tag:server peers both answering on the probed port (index#1789 C5):
+    # connect() must refuse to guess, and the loud note must name every hit so
+    # the operator can pick one. Both peers point at loopback (the one address
+    # the sandbox can serve), so the note names it twice.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(8)
+        monkeypatch.setenv("IX_FLEET_RAY_CLIENT_PORT", str(listener.getsockname()[1]))
+        status = _status(peers=[_server_peer("127.0.0.1"), _server_peer("127.0.0.1")])
+        _stub_tailscale_on_path(monkeypatch, tmp_path, status)
+        assert cluster._probe_ray_heads() == ["127.0.0.1", "127.0.0.1"]
+        target, note = cluster._resolve_auto_target()
+        assert target is None
+        assert "2 Ray heads" in note
+        assert "127.0.0.1, 127.0.0.1" in note  # every hit is named
+        assert "IX_FLEET_RAY_ADDRESS" in note  # and the remedy
 
 
 def test_probe_requires_server_tag_and_online(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as gcs:
-        gcs.bind(("127.0.0.1", 0))
-        gcs.listen(1)
-        monkeypatch.setenv("IX_FLEET_RAY_GCS_PORT", str(gcs.getsockname()[1]))
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        monkeypatch.setenv("IX_FLEET_RAY_CLIENT_PORT", str(listener.getsockname()[1]))
         status = _status(
             peers=[
                 _server_peer("127.0.0.1", tags=[]),  # untagged: never probed
@@ -383,9 +472,10 @@ def test_probe_requires_server_tag_and_online(
 def test_probe_no_listener_yields_loud_note(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    # A tagged online peer with a CLOSED GCS port: the probe returns nothing
-    # and the resolution hands connect() the why-line it prints on fallback.
-    monkeypatch.setenv("IX_FLEET_RAY_GCS_PORT", str(_free_port()))
+    # A tagged online peer with a CLOSED Ray Client port: the probe returns
+    # nothing and the resolution hands connect() the why-line it prints on
+    # fallback.
+    monkeypatch.setenv("IX_FLEET_RAY_CLIENT_PORT", str(_free_port()))
     _stub_tailscale_on_path(monkeypatch, tmp_path, _status(peers=[_server_peer("127.0.0.1")]))
     target, note = cluster._resolve_auto_target(budget=0.5)
     assert target is None

--- a/packages/mcp/tests/test_mesh.py
+++ b/packages/mcp/tests/test_mesh.py
@@ -1,0 +1,415 @@
+"""Network-free tests for the tailnet auto-mesh (index#1787).
+
+Nothing here reaches a real tailnet, tailscale daemon, or Ray cluster:
+
+* The **server side** (``ix_notebook_mcp.mesh``) is driven through aiohttp's
+  in-process ``TestClient`` and, for the bind paths, real sockets on loopback
+  only. Env overrides (``IX_MCP_MESH=0``, ``IX_MCP_MESH_PORT``), the
+  no-tailscale skip, and the bind-conflict skip are all asserted to log one
+  line and return ``None`` instead of raising.
+* The **client side** (the bundled ``mesh`` module) gets a stub ``tailscale``
+  script via ``IX_MESH_TAILSCALE_BIN`` (the resources_bridge stub pattern)
+  whose JSON points at loopback, where a real mesh server (or nothing) runs.
+* The **fleet probe** (``fleet.cluster``) gets a stub ``tailscale`` on PATH
+  plus a fake GCS listener on an ephemeral loopback port selected through
+  ``IX_FLEET_RAY_GCS_PORT``, proving ``connect()``'s zero-config resolution
+  without importing Ray.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import os
+import shutil
+import socket
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+# Prefer the bundled packages (the nix check installs them into the
+# interpreter); fall back to the source tree for a dev run.
+_PKG_PARENT = Path(__file__).resolve().parents[1]
+for _p in (_PKG_PARENT, _PKG_PARENT / "src" / "mesh", _PKG_PARENT / "src" / "fleet"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import mesh as mesh_client
+from fleet import cluster
+from ix_notebook_mcp import mesh as server_mesh
+from ix_notebook_mcp.config import (
+    DEFAULT_MESH_PORT,
+    Config,
+    mesh_enabled,
+    mesh_port,
+    server_version,
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _write_stub_tailscale(tmp_path: Path, status: dict[str, Any]) -> Path:
+    """An executable stub ``tailscale`` that prints ``status`` for any args.
+
+    Shebang resolved to bash's absolute path: the nix build sandbox has no
+    /usr/bin/env, and bash is on PATH via the check's nativeBuildInputs.
+    """
+    bash = shutil.which("bash") or "/bin/bash"
+    script = tmp_path / "tailscale"
+    script.write_text(f"#!{bash}\ncat <<'IXEOF'\n{json.dumps(status)}\nIXEOF\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return script
+
+
+def _status(
+    self_ip: str | None = "127.0.0.1",
+    peers: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    status: dict[str, Any] = {"BackendState": "Running", "Self": {}, "Peer": {}}
+    if self_ip:
+        status["Self"] = {"DNSName": "self.example.ts.net.", "TailscaleIPs": [self_ip]}
+    for i, peer in enumerate(peers or []):
+        status["Peer"][f"key{i}"] = peer
+    return status
+
+
+# ---------------------------------------------------------------------------
+# Shape (mirrors the resources_bridge shape tests / the ruff ANN gate)
+# ---------------------------------------------------------------------------
+
+
+def test_all_names_exist() -> None:
+    for name in mesh_client.__all__:
+        assert hasattr(mesh_client, name), f"{name} in __all__ but missing from module"
+
+
+def test_public_async_funcs_annotated() -> None:
+    for name in ("peers", "sessions"):
+        func = getattr(mesh_client, name)
+        assert asyncio.iscoroutinefunction(func)
+        sig = inspect.signature(func)
+        assert sig.return_annotation is not inspect.Signature.empty
+        for pname, param in sig.parameters.items():
+            assert param.annotation is not inspect.Parameter.empty, f"{name}({pname})"
+
+
+# ---------------------------------------------------------------------------
+# Config knobs
+# ---------------------------------------------------------------------------
+
+
+def test_mesh_port_default_and_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("IX_MCP_MESH_PORT", raising=False)
+    assert mesh_port() == DEFAULT_MESH_PORT == 8798
+    monkeypatch.setenv("IX_MCP_MESH_PORT", "9123")
+    assert mesh_port() == 9123
+
+
+def test_mesh_enabled_default_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("IX_MCP_MESH", raising=False)
+    assert mesh_enabled()
+    for value in ("0", "false", "no", "off", " OFF "):
+        monkeypatch.setenv("IX_MCP_MESH", value)
+        assert not mesh_enabled(), f"IX_MCP_MESH={value!r} must disable the mesh"
+    monkeypatch.setenv("IX_MCP_MESH", "1")
+    assert mesh_enabled()
+
+
+def test_server_version_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("IX_MCP_VERSION", raising=False)
+    assert server_version() == "dev"
+    monkeypatch.setenv("IX_MCP_VERSION", "abc123")
+    assert server_version() == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# The /mesh route (no socket: aiohttp TestClient)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_card(app: web.Application) -> dict[str, Any]:
+    async def go() -> dict[str, Any]:
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/mesh")
+            assert resp.status == 200
+            card: dict[str, Any] = await resp.json()
+            return card
+
+    return asyncio.run(go())
+
+
+def test_mesh_card_fields(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("IX_MCP_VERSION", "deadbeef")
+    monkeypatch.setenv("IX_MCP_DASHBOARD_URL", "http://100.1.2.3:4567/")
+    cfg = Config(workdir=tmp_path)
+    app = server_mesh.build_app(cfg, lambda: ["fix the build", "triage 1787"], "2026-07-03T00:00:00+00:00")
+    card = _fetch_card(app)
+    assert card["host"] == socket.gethostname()
+    assert card["pid"] == os.getpid()
+    assert card["version"] == "deadbeef"
+    assert card["started_at"] == "2026-07-03T00:00:00+00:00"
+    assert card["sessions"] == ["fix the build", "triage 1787"]
+    assert card["dashboard_url"] == "http://100.1.2.3:4567/"
+    assert card["cwd"] == str(tmp_path)
+
+
+def test_mesh_card_dashboard_url_falls_back_to_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("IX_MCP_DASHBOARD_URL", raising=False)
+    cfg = Config(workdir=tmp_path, advertised_host="100.9.9.9", dashboard_port=7777)
+    app = server_mesh.build_app(cfg, list, "t")
+    assert _fetch_card(app)["dashboard_url"] == "http://100.9.9.9:7777/"
+
+
+def test_mesh_card_sessions_are_live(tmp_path: Path) -> None:
+    # The card reflects names set AFTER the server came up: names arrive at
+    # any point in a client's lifetime, so the SAME app must serve both reads.
+    names: list[str] = []
+    app = server_mesh.build_app(Config(workdir=tmp_path), lambda: sorted(names), "t")
+
+    async def go() -> tuple[list[str], list[str]]:
+        async with TestClient(TestServer(app)) as client:
+            first = (await (await client.get("/mesh")).json())["sessions"]
+            names.append("late namer")
+            second = (await (await client.get("/mesh")).json())["sessions"]
+            return first, second
+
+    first, second = asyncio.run(go())
+    assert first == []
+    assert second == ["late namer"]
+
+
+# ---------------------------------------------------------------------------
+# start(): the skip paths must log one line and never raise
+# ---------------------------------------------------------------------------
+
+
+def test_start_disabled_by_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("IX_MCP_MESH", "0")
+    cfg = Config(workdir=tmp_path, mesh_host="127.0.0.1")
+    assert asyncio.run(server_mesh.start(cfg, list)) is None
+    assert "mesh endpoint disabled" in capsys.readouterr().err
+
+
+def test_start_skips_without_tailscale(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("IX_MCP_MESH", raising=False)
+    cfg = Config(workdir=tmp_path, mesh_host=None)
+    assert asyncio.run(server_mesh.start(cfg, list)) is None
+    assert "no tailscale" in capsys.readouterr().err
+
+
+def test_start_serves_on_override_port(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # mesh_host is normally a tailscale IP; loopback here keeps the test
+    # network-free while exercising the real bind + HTTP round trip.
+    port = _free_port()
+    monkeypatch.delenv("IX_MCP_MESH", raising=False)
+    monkeypatch.setenv("IX_MCP_MESH_PORT", str(port))
+    monkeypatch.delenv("IX_MCP_DASHBOARD_URL", raising=False)
+    cfg = Config(workdir=tmp_path, mesh_host="127.0.0.1")
+
+    async def go() -> dict[str, Any]:
+        import aiohttp
+
+        runner = await server_mesh.start(cfg, lambda: ["smoke"])
+        assert runner is not None
+        try:
+            async with (
+                aiohttp.ClientSession() as session,
+                session.get(f"http://127.0.0.1:{port}/mesh") as resp,
+            ):
+                assert resp.status == 200
+                card: dict[str, Any] = await resp.json()
+                return card
+        finally:
+            await runner.cleanup()
+
+    assert asyncio.run(go())["sessions"] == ["smoke"]
+
+
+def test_start_skips_on_bind_conflict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("IX_MCP_MESH", raising=False)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as holder:
+        holder.bind(("127.0.0.1", 0))
+        holder.listen(1)
+        port = holder.getsockname()[1]
+        monkeypatch.setenv("IX_MCP_MESH_PORT", str(port))
+        cfg = Config(workdir=tmp_path, mesh_host="127.0.0.1")
+        assert asyncio.run(server_mesh.start(cfg, list)) is None
+    assert "cannot bind" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# mesh.peers() / mesh.sessions(): stub tailscale + a real loopback server
+# ---------------------------------------------------------------------------
+
+
+def test_peers_empty_without_tailscale(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(mesh_client._TAILSCALE_BIN_ENV, str(tmp_path / "missing-tailscale"))
+    df = asyncio.run(mesh_client.peers())
+    assert df.is_empty()
+    assert set(df.columns) >= {"host", "ip", "version", "sessions", "dashboard_url"}
+
+
+def test_peers_and_sessions_discover_live_server(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    port = _free_port()
+    monkeypatch.delenv("IX_MCP_MESH", raising=False)
+    monkeypatch.setenv("IX_MCP_MESH_PORT", str(port))
+    monkeypatch.setenv("IX_MCP_VERSION", "cafebabe")
+    monkeypatch.setenv("IX_MCP_DASHBOARD_URL", "http://127.0.0.1:9999/")
+    stub = _write_stub_tailscale(tmp_path, _status(self_ip="127.0.0.1"))
+    monkeypatch.setenv(mesh_client._TAILSCALE_BIN_ENV, str(stub))
+    cfg = Config(workdir=tmp_path, mesh_host="127.0.0.1")
+
+    async def go() -> tuple[pl.DataFrame, pl.DataFrame]:
+        runner = await server_mesh.start(cfg, lambda: ["alpha", "beta"])
+        assert runner is not None
+        try:
+            return await mesh_client.peers(), await mesh_client.sessions()
+        finally:
+            await runner.cleanup()
+
+    peers_df, sessions_df = asyncio.run(go())
+    assert peers_df.height == 1
+    row = peers_df.to_dicts()[0]
+    assert row["host"] == socket.gethostname()  # the card's hostname wins over DNSName
+    assert row["ip"] == "127.0.0.1"
+    assert row["version"] == "cafebabe"
+    assert row["sessions"] == ["alpha", "beta"]
+    assert row["dashboard_url"] == "http://127.0.0.1:9999/"
+    assert row["pid"] == os.getpid()
+    # sessions() flattens to one row per (host, session label).
+    assert sessions_df.height == 2
+    assert sessions_df["session"].to_list() == ["alpha", "beta"]
+    assert set(sessions_df.columns) == {"host", "session", "dashboard_url", "ip"}
+
+
+def test_peers_skips_offline_and_unresponsive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # One offline peer (never probed) and one online peer with nothing
+    # listening on the mesh port: both contribute no row, and neither raises.
+    port = _free_port()
+    monkeypatch.setenv("IX_MCP_MESH_PORT", str(port))
+    status = _status(
+        self_ip=None,
+        peers=[
+            {"HostName": "offline-box", "Online": False, "TailscaleIPs": ["127.0.0.1"]},
+            {"HostName": "no-mcp-box", "Online": True, "TailscaleIPs": ["127.0.0.1"]},
+        ],
+    )
+    stub = _write_stub_tailscale(tmp_path, status)
+    monkeypatch.setenv(mesh_client._TAILSCALE_BIN_ENV, str(stub))
+    df = asyncio.run(mesh_client.peers(timeout=0.5))
+    assert df.is_empty()
+
+
+# ---------------------------------------------------------------------------
+# fleet.connect() zero-config probe: stub tailscale on PATH + a fake GCS
+# ---------------------------------------------------------------------------
+
+
+def _stub_tailscale_on_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, status: dict[str, Any]
+) -> None:
+    # cluster._find_tailscale resolves via shutil.which, so the stub goes on
+    # PATH (prepended: bash and friends stay resolvable for the shebang).
+    bin_dir = tmp_path / "stub-bin"
+    bin_dir.mkdir(exist_ok=True)
+    _write_stub_tailscale(bin_dir, status)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
+def _server_peer(ip: str, *, online: bool = True, tags: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "HostName": "fleet-node",
+        "Online": online,
+        "Tags": ["tag:server"] if tags is None else tags,
+        "TailscaleIPs": [ip],
+    }
+
+
+def test_probe_finds_single_gcs_head(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as gcs:
+        gcs.bind(("127.0.0.1", 0))
+        # Backlog > 1: the listener never accept()s, and each probe's completed
+        # handshake occupies a queue slot; both probes below must get through.
+        gcs.listen(8)
+        monkeypatch.setenv("IX_FLEET_RAY_GCS_PORT", str(gcs.getsockname()[1]))
+        _stub_tailscale_on_path(monkeypatch, tmp_path, _status(peers=[_server_peer("127.0.0.1")]))
+        assert cluster._probe_ray_heads() == ["127.0.0.1"]
+        # connect()'s resolution turns the one head into a Ray Client URL.
+        target, note = cluster._resolve_auto_target()
+        assert target == f"ray://127.0.0.1:{cluster.RAY_CLIENT_PORT}"
+        assert note == ""
+
+
+def test_probe_requires_server_tag_and_online(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as gcs:
+        gcs.bind(("127.0.0.1", 0))
+        gcs.listen(1)
+        monkeypatch.setenv("IX_FLEET_RAY_GCS_PORT", str(gcs.getsockname()[1]))
+        status = _status(
+            peers=[
+                _server_peer("127.0.0.1", tags=[]),  # untagged: never probed
+                _server_peer("127.0.0.1", online=False),  # offline: never probed
+            ]
+        )
+        _stub_tailscale_on_path(monkeypatch, tmp_path, status)
+        assert cluster._probe_ray_heads() == []
+
+
+def test_probe_no_listener_yields_loud_note(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A tagged online peer with a CLOSED GCS port: the probe returns nothing
+    # and the resolution hands connect() the why-line it prints on fallback.
+    monkeypatch.setenv("IX_FLEET_RAY_GCS_PORT", str(_free_port()))
+    _stub_tailscale_on_path(monkeypatch, tmp_path, _status(peers=[_server_peer("127.0.0.1")]))
+    target, note = cluster._resolve_auto_target(budget=0.5)
+    assert target is None
+    assert "no tag:server peer" in note
+
+
+def _system_tailscale_present() -> bool:
+    # Path.exists can raise PermissionError under the darwin nix sandbox
+    # (stat on /usr is denied); that hermetic case is exactly "not present".
+    for p in ("/usr/local/bin/tailscale", "/usr/bin/tailscale"):
+        try:
+            if Path(p).exists():
+                return True
+        except OSError:
+            continue
+    return False
+
+
+@pytest.mark.skipif(
+    _system_tailscale_present(),
+    reason="a system tailscale shadows the empty-PATH case (dev box); the nix sandbox has neither",
+)
+def test_probe_without_tailscale(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # An empty PATH: shutil.which finds no tailscale, and the hardcoded
+    # /usr/{local/,}bin fallbacks are absent in the build sandbox.
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    assert cluster._probe_ray_heads() == []


### PR DESCRIPTION
Implements the MCP-native mesh decided in #1787: ix-mcp itself is the mesh node, default on, env vars are overrides only.

## What

- **`GET /mesh`** served by the MCP server process (same aiohttp stack as the data API) on well-known port **8798**, bound ONLY to the machine's tailscale IPv4. JSON card: host, pid, build version (same derivation as `serverInfo.version`), start time, named session labels, dashboard URL, workdir. `IX_MCP_MESH_PORT` overrides the port, `IX_MCP_MESH=0` disables; no tailscale = one stderr line, MCP starts normally.
- **Bundled `mesh` kernel module** (preimported, in `api('mesh')`): `await mesh.peers()` sweeps online tailscale peers concurrently (httpx, bounded timeout) into one polars row per live ix-mcp; `await mesh.sessions()` flattens to (host, session). Decoupled from `fleet`.
- **`fleet.connect()` Ray-head auto-probe**: with no explicit address and neither `IX_FLEET_RAY_ADDRESS` nor `RAY_ADDRESS`, online `tag:server` peers are TCP-probed for a GCS listener (default 6379, total budget 1.5s); exactly one head becomes `ray://<ip>:10001` (Ray Client, off-cluster). The private single-node fallback now prints one loud stderr line saying what happened and why.

One source of truth: the port constant, env knobs, and version derivation live in `ix_notebook_mcp.config`; session labels are exposed through a `tools.session_names()` accessor.

## Verified

- `nix run .#lint` green.
- New `meshTests` check (19 network-free pytest cases: card fields, env overrides, no-tailscale and bind-conflict skips, stub-`tailscale` peer sweep against a real loopback server, fake-GCS `connect()` probe) plus `meshBundled` and `strictTypecheck` (mesh added to the strict-green set) all build.
- Affected existing checks rebuilt green: serverTools, sessionSmoke, sessionIdentitySmoke, bindingsSmoke, fleetSmoke, requirementsSmoke, typecheckSmoke, resourcesBridgeTests. (apiSmoke/evalSmoke/dashboardLauncherSmoke/bindDefaultSmoke/fleetClusterSmoke fail identically on clean origin/main on darwin: the sandbox denies loopback binds; CI runs them on linux.)
- Real smoke: launched the built `ix-mcp` against a throwaway dir and curled the tailscale IP:

```
$ curl http://100.115.233.43:8798/mesh
{"host": "hydra", "pid": 85315, "version": "bb960680d74e57429b1dd9b6508f99724257776e-dirty", "started_at": "2026-07-03T08:56:47.891654+00:00", "sessions": [], "dashboard_url": "http://127.0.0.1:64794/", "cwd": "/private/var/folders/2z/.../mesh-smoke-wftoyaaw"}
```

Notes: the 8799 EXEC_PORT constant lives in `fleet/cluster.py` (not cli.py as the issue sketch said), so the mesh constant went to `config.py` where both sides can import it; `cwd` reports the kernel workdir (identical to process cwd except under `--workdir`, where it is the meaningful one); the new `meshTests` derivation sets `__darwinAllowLocalNetworking` because the darwin sandbox denies even loopback binds.

Closes #1787

🤖 Generated with Claude Code (Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tailnet auto-mesh `/mesh` discovery endpoint and fleet Ray head auto-discovery
> - Adds a new `mesh` Python module exposing `peers()` and `sessions()` async functions that discover live `ix-mcp` servers across the tailnet by probing each peer's `/mesh` HTTP endpoint, returning Polars DataFrames.
> - Adds [`mesh.py`](https://github.com/indexable-inc/index/pull/1789/files#diff-e1f7a794ceea7d46366320d65532c0b1668e723ffdaefea130f829effdb28aee) to serve `GET /mesh` on the tailscale IPv4, returning JSON with host, pid, version, session names, dashboard URL, and cwd; the server starts best-effort on MCP startup and is cleaned up on exit.
> - Updates [`fleet/cluster.py`](https://github.com/indexable-inc/index/pull/1789/files#diff-d033f4f676d2a0af130d27862d2976e8e4294e5ac9702e2c21c873cd4aa77a5b) so `connect()` auto-discovers a reachable Ray head on the tailnet when no explicit address is provided, falling back to local Ray with a diagnostic warning.
> - Extends the Ray Nix module to expose `IX_MCP_MESH_PORT` (default 8798) in the notebook environment and open the mesh port in the firewall when `openFirewall` is enabled.
> - Behavioral Change: `_tailscale_ip()` now rejects non-CGNAT IPv4 addresses; `_tailscale_status()` degrades to 'no tailscale' on sandbox `OSError` instead of raising.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08a5727.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->