### PR TITLE
panes: match guest key repeat to macOS; fix stuck Cmd-key repeats and pointer-lock cursor flash

### DIFF
--- a/packages/vm/panes/compositor/README.md
+++ b/packages/vm/panes/compositor/README.md
@@ -46,7 +46,9 @@ Wayland clients ──commit──> FrameStore (packed BGRA copy per window)
   Coordinates are surface-local, so pointer focus is handed to smithay
   explicitly per event. Keys are evdev codes fed through an xkb keymap
   (`--xkb-layout`, "us" default); the host never forwards OS auto-repeats,
-  clients repeat from `wl_keyboard.repeat_info`. Pointer lock (index#1724):
+  clients repeat from `wl_keyboard.repeat_info`, whose rate/delay come from
+  the host's macOS System Settings (`ToGuest::KeyRepeat`, protocol 1.2;
+  macOS factory defaults until a 1.2 host sends it). Pointer lock (index#1724):
   `zwp_pointer_constraints_v1` + `zwp_relative_pointer_manager_v1` are
   advertised; a locked-pointer constraint activates when its surface holds
   pointer focus, the host is told via `ToHost::PointerLock` (gated on its

--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, Instant};
 use anyhow::Context as _;
 use panes_protocol::{
     Encoding, MINOR_POINTER_LOCK, ToGuest, ToHost, VERSION_MAJOR, VERSION_MINOR, WindowId,
+    wl_repeat_info,
 };
 use smithay::input::{Seat, SeatState};
 use smithay::output::{Mode, Output, PhysicalProperties, Scale, Subpixel};
@@ -288,12 +289,21 @@ impl App {
             layout: &cli.xkb_layout,
             ..smithay::input::keyboard::XkbConfig::default()
         };
-        // repeat_info(delay=400ms, rate=30/s): the host never forwards OS key
-        // repeats, so clients must auto-repeat from this advertisement.
-        if let Err(err) = seat.add_keyboard(xkb, 400, 30) {
+        // The host never forwards OS key repeats, so clients auto-repeat
+        // from this advertisement alone. A 1.2 host overwrites it with the
+        // user's actual macOS timing (`ToGuest::KeyRepeat` ->
+        // `on_key_repeat`); until then, and for a 1.1 host forever, advertise
+        // the macOS factory defaults (delay 375ms, 90ms interval = 11/s)
+        // rather than a Linux-flavored 25-30/s that no Mac keyboard uses.
+        let (repeat_rate, repeat_delay) = wl_repeat_info(375, 90);
+        if let Err(err) = seat.add_keyboard(xkb, repeat_delay, repeat_rate) {
             warn!(%err, layout = %cli.xkb_layout, "xkb keymap failed; falling back to defaults");
-            seat.add_keyboard(smithay::input::keyboard::XkbConfig::default(), 400, 30)
-                .expect("default xkb keymap must compile");
+            seat.add_keyboard(
+                smithay::input::keyboard::XkbConfig::default(),
+                repeat_delay,
+                repeat_rate,
+            )
+            .expect("default xkb keymap must compile");
         }
         seat.add_pointer();
 
@@ -567,6 +577,7 @@ impl App {
                     host.send(ToHost::Pong { nonce });
                 }
             }
+            ToGuest::KeyRepeat { delay_ms, interval_ms } => self.on_key_repeat(delay_ms, interval_ms),
             other => {
                 input::handle(self, &other);
                 // Pointer focus may have moved: activate a pending lock that
@@ -630,6 +641,18 @@ impl App {
         // re-announced: the new connection starts with no capture.
         self.maybe_activate_constraint();
         self.sync_pointer_lock();
+    }
+
+    /// The host user's macOS repeat timing -> `wl_keyboard.repeat_info` for
+    /// every keyboard client, current and future (smithay re-announces on
+    /// bind). Makes the host's System Settings the one repeat authority:
+    /// clients auto-repeat with exactly the Mac's delay and rate.
+    fn on_key_repeat(&mut self, delay_ms: u32, interval_ms: u32) {
+        let (rate, delay) = wl_repeat_info(delay_ms, interval_ms);
+        info!(delay_ms, interval_ms, rate, delay, "key repeat timing from host");
+        if let Some(keyboard) = self.seat.get_keyboard() {
+            keyboard.change_repeat_info(rate, delay);
+        }
     }
 
     fn on_ack(&mut self, id: WindowId, seq: u64) {

--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -295,15 +295,11 @@ impl App {
         // `on_key_repeat`); until then, and for a 1.1 host forever, advertise
         // the macOS factory defaults (delay 375ms, 90ms interval = 11/s)
         // rather than a Linux-flavored 25-30/s that no Mac keyboard uses.
-        let (repeat_rate, repeat_delay) = wl_repeat_info(375, 90);
-        if let Err(err) = seat.add_keyboard(xkb, repeat_delay, repeat_rate) {
+        let repeat = wl_repeat_info(375, 90);
+        if let Err(err) = seat.add_keyboard(xkb, repeat.delay, repeat.rate) {
             warn!(%err, layout = %cli.xkb_layout, "xkb keymap failed; falling back to defaults");
-            seat.add_keyboard(
-                smithay::input::keyboard::XkbConfig::default(),
-                repeat_delay,
-                repeat_rate,
-            )
-            .expect("default xkb keymap must compile");
+            seat.add_keyboard(smithay::input::keyboard::XkbConfig::default(), repeat.delay, repeat.rate)
+                .expect("default xkb keymap must compile");
         }
         seat.add_pointer();
 
@@ -648,10 +644,10 @@ impl App {
     /// bind). Makes the host's System Settings the one repeat authority:
     /// clients auto-repeat with exactly the Mac's delay and rate.
     fn on_key_repeat(&mut self, delay_ms: u32, interval_ms: u32) {
-        let (rate, delay) = wl_repeat_info(delay_ms, interval_ms);
-        info!(delay_ms, interval_ms, rate, delay, "key repeat timing from host");
+        let repeat = wl_repeat_info(delay_ms, interval_ms);
+        info!(delay_ms, interval_ms, rate = repeat.rate, delay = repeat.delay, "key repeat timing from host");
         if let Some(keyboard) = self.seat.get_keyboard() {
-            keyboard.change_repeat_info(rate, delay);
+            keyboard.change_repeat_info(repeat.rate, repeat.delay);
         }
     }
 

--- a/packages/vm/panes/host/README.md
+++ b/packages/vm/panes/host/README.md
@@ -129,7 +129,9 @@ compositor).
   holding right-click in a pointer-locked game showed the cursor -- plus
   screenshot mode and dock hover, glfw#2648/#2656), so while captured every
   button event re-checks `CGCursorIsVisible` and re-hides, immediately and
-  once more from the back of the main queue.
+  once more from the back of the main queue; release unhides until the
+  cursor is actually visible, so the (undocumented) hide-nesting counter can
+  never strand a hidden cursor.
 
 ## Mock guest
 

--- a/packages/vm/panes/host/README.md
+++ b/packages/vm/panes/host/README.md
@@ -86,11 +86,19 @@ compositor).
 - **Keyboard**: `keyDown`/`keyUp` map `NSEvent.keyCode` (kVK) to evdev codes
   via `src/keymap.rs`, generated from the keycodemapdb project by
   `tools/gen_keymap.py` (same dataset QEMU/libvirt use). `isARepeat` events
-  are dropped: guests auto-repeat from `wl_keyboard.repeat_info`.
+  are dropped: guests auto-repeat from `wl_keyboard.repeat_info`, and the
+  user's actual macOS repeat timing is shipped once per connection
+  (`ToGuest::KeyRepeat`, from `NSEvent.keyRepeatDelay/Interval`; protocol
+  1.2) so guest repeat matches System Settings exactly.
   `flagsChanged` turns into modifier press/release by toggling a held-set
   keyed on kVK; caps lock (one event per toggle) synthesizes press+release.
-  On resign-key every held modifier is released guest-side and the set
-  cleared (AppKit stops delivering flagsChanged to a non-key window).
+  Forwarded key presses are tracked in a second held-set: keyUps only go
+  out for tracked keys, and on resign-key every held key and modifier is
+  released guest-side (AppKit stops delivering keyUp/flagsChanged to a
+  non-key window; a key stuck down guest-side would auto-repeat forever).
+  The `NSWindow` subclass reroutes Cmd keyUps to the view -- AppKit
+  swallows them as key-equivalent processing, which used to stick e.g.
+  Cmd-Backspace down forever guest-side.
   Cmd+W (CloseRequest) and Cmd+Q (CloseRequest to all, then exit) stay
   host-side; other Cmd chords are forwarded.
 - **Pointer**: the view is flipped (top-left origin) and multiplies points
@@ -116,7 +124,12 @@ compositor).
   dissociated. A lock for a non-key window is remembered (`wants_lock`) and
   engages when the window becomes key. AppKit delivers each mouseMoved twice
   (first responder + tracking area); relative deltas dedupe by event
-  identity, absolute coordinates never cared.
+  identity, absolute coordinates never cared. macOS spontaneously unhides a
+  hidden cursor on paths of its own (right-mouse-down menu preparation --
+  holding right-click in a pointer-locked game showed the cursor -- plus
+  screenshot mode and dock hover, glfw#2648/#2656), so while captured every
+  button event re-checks `CGCursorIsVisible` and re-hides, immediately and
+  once more from the back of the main queue.
 
 ## Mock guest
 

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -20,11 +20,12 @@ use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate, NSCursor, NSEvent,
     NSScreen, NSWindow,
 };
+use dispatch2::DispatchQueue;
 use objc2_core_graphics::{CGAssociateMouseAndMouseCursorPosition, CGError};
 use objc2_foundation::{NSNotification, NSObjectProtocol};
 use objc2_metal::MTLDrawable as _;
 use objc2_quartz_core::CAMetalDisplayLinkUpdate;
-use panes_protocol::{MINOR_POINTER_LOCK, ToGuest, ToHost, WindowId};
+use panes_protocol::{MINOR_KEY_REPEAT, MINOR_POINTER_LOCK, ToGuest, ToHost, WindowId};
 
 use crate::conn::{self, Event, HostInfo, Target};
 use crate::render::Renderer;
@@ -199,6 +200,7 @@ pub fn on_event(event: Event) {
         }
         Event::Hello { minor } => {
             app.peer_minor = minor;
+            send_key_repeat(app);
             Deferred::default()
         }
         Event::Disconnected => {
@@ -319,6 +321,68 @@ fn handle_msg(app: &mut App, msg: ToHost, recv: f64) -> Deferred {
     }
 }
 
+/// Tell the guest the user's actual macOS key-repeat timing (System
+/// Settings, via `NSEvent`'s class getters) so `wl_keyboard.repeat_info`
+/// matches the host exactly. The host drops `isARepeat` keyDowns, so this
+/// advertisement is the guest's only repeat authority. Sent once per
+/// connection (a mid-session System Settings change applies on reconnect);
+/// gated on the guest speaking 1.2, postcard cannot skip an unknown variant.
+fn send_key_repeat(app: &App) {
+    if app.peer_minor < MINOR_KEY_REPEAT {
+        return;
+    }
+    let Some(out) = &app.out else {
+        return;
+    };
+    let msg = ToGuest::KeyRepeat {
+        delay_ms: whole_ms(NSEvent::keyRepeatDelay()),
+        interval_ms: whole_ms(NSEvent::keyRepeatInterval()),
+    };
+    eprintln!("panes-host: key repeat: {msg:?}");
+    let _ = out.send(msg);
+}
+
+/// Seconds (`NSTimeInterval`) to whole milliseconds. `as` saturates: a
+/// negative or NaN interval becomes 0 (the guest disables repeat for it, see
+/// `panes_protocol::wl_repeat_info`), and macOS "Key Repeat: Off" reports a
+/// minutes-long interval that stays finite here.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn whole_ms(seconds: f64) -> u32 {
+    (seconds * 1000.0).round() as u32
+}
+
+/// Re-hide the cursor when macOS revealed it behind an engaged capture's
+/// back, now and once more after `AppKit` finishes the current event.
+/// `AppKit` spontaneously unhides a hidden cursor on paths of its own -- the
+/// right-mouse-down menu-preparation path is the one guests actually hit
+/// (holding right-click in a pointer-locked game showed the cursor); GLFW
+/// catalogs more (screenshot mode, dock hover: glfw#2648, glfw#2656). Each
+/// such unhide pops one `NSCursor.hide`, so re-hiding only while the cursor
+/// is actually visible keeps hide/unhide balanced: every extra hide matches
+/// one OS-initiated unhide, and the capture's `Drop` still releases cleanly.
+/// The deferred second look exists because the OS unhide lands during event
+/// processing, ordered unpredictably against the view handler that calls
+/// this; the back of the main queue is reliably after both.
+pub fn reassert_capture_cursor() {
+    fn rehide_if_visible(app: &mut App) {
+        if app.capture.is_none() {
+            return;
+        }
+        // CGCursorIsVisible is deprecated without a replacement, and there
+        // is no event for "the OS unhid your cursor": visibility can only
+        // be polled. GLFW ships the same call for the same reason.
+        #[allow(deprecated)]
+        if objc2_core_graphics::CGCursorIsVisible() {
+            eprintln!("panes-host: OS unhid the cursor while captured; re-hiding");
+            NSCursor::hide();
+        }
+    }
+    with_app(rehide_if_visible);
+    DispatchQueue::main().exec_async(|| {
+        with_app(rehide_if_visible);
+    });
+}
+
 /// Reconcile the engaged cursor capture with what the guest wants and what
 /// the user is looking at: capture exactly when a lock-holding window is the
 /// key window of the active app (and the guest speaks 1.1, so the
@@ -351,6 +415,12 @@ fn sync_capture(app: &mut App) {
     {
         window.view_handle().set_relative(true);
         app.capture = Some(CursorCapture::engage(id));
+        // macOS ignores a hide issued while the cursor hovers the dock
+        // (glfw#2656: refocus-over-dock), so double-check once this engage's
+        // event settles. Deferred: we are inside the APP borrow here.
+        DispatchQueue::main().exec_async(|| {
+            reassert_capture_cursor();
+        });
     }
 }
 
@@ -510,13 +580,13 @@ pub fn window_live_resize(id: WindowId, active: bool) {
 
 pub fn window_activation(id: WindowId, activated: bool) {
     if !activated {
-        // Held modifiers must not outlive key status: AppKit stops sending
-        // flagsChanged after resign-key, so release them guest-side before
-        // the deactivated Configure. Outside the with_app borrow because the
-        // view sends protocol messages through app state.
+        // Held keys must not outlive key status: AppKit stops sending
+        // flagsChanged and keyUp after resign-key, so release them
+        // guest-side before the deactivated Configure. Outside the with_app
+        // borrow because the view sends protocol messages through app state.
         let view = with_app(|app| app.windows.get(&id).map(PaneWindow::view_handle)).flatten();
         if let Some(view) = view {
-            view.release_held_modifiers();
+            view.release_held_keys();
         }
     }
     with_app(|app| {

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -96,7 +96,21 @@ impl Drop for CursorCapture {
         if err != CGError::Success {
             eprintln!("panes-host: window {}: cursor re-association failed: {err:?}", self.id);
         }
-        NSCursor::unhide();
+        // NSCursor.hide nests, and the engage-side re-hides
+        // (`reassert_capture_cursor`) may have raised the count past one:
+        // whether the OS-forced show on right-mouse-down decrements the
+        // counter is undocumented, so a single unhide here could strand the
+        // cursor hidden system-wide, the worst failure this struct exists to
+        // prevent. Unhide until the cursor is actually visible; bounded as
+        // paranoia against a wedged visibility query, and stopping at
+        // visible avoids driving the counter needlessly negative.
+        #[allow(deprecated)] // CGCursorIsVisible: see reassert_capture_cursor.
+        for _ in 0..16 {
+            NSCursor::unhide();
+            if objc2_core_graphics::CGCursorIsVisible() {
+                break;
+            }
+        }
     }
 }
 
@@ -357,9 +371,11 @@ fn whole_ms(seconds: f64) -> u32 {
 /// right-mouse-down menu-preparation path is the one guests actually hit
 /// (holding right-click in a pointer-locked game showed the cursor); GLFW
 /// catalogs more (screenshot mode, dock hover: glfw#2648, glfw#2656). Each
-/// such unhide pops one `NSCursor.hide`, so re-hiding only while the cursor
-/// is actually visible keeps hide/unhide balanced: every extra hide matches
-/// one OS-initiated unhide, and the capture's `Drop` still releases cleanly.
+/// such show may or may not decrement the `NSCursor.hide` nesting counter
+/// (undocumented), so the guard only re-hides while the cursor is actually
+/// visible, and the capture's `Drop` symmetrically unhides until visible:
+/// correct under either counter semantic, and release can never strand a
+/// hidden cursor.
 /// The deferred second look exists because the OS unhide lands during event
 /// processing, ordered unpredictably against the view handler that calls
 /// this; the back of the main queue is reliably after both.

--- a/packages/vm/panes/host/src/mock.rs
+++ b/packages/vm/panes/host/src/mock.rs
@@ -121,6 +121,12 @@ fn read_host(stream: UnixStream, tx: &mpsc::Sender<HostEvent>) {
                 HostEvent::Close
             }
             Ok(ToGuest::Ping { nonce }) => HostEvent::Ping(nonce),
+            Ok(ToGuest::KeyRepeat { delay_ms, interval_ms }) => {
+                // Functional evidence the 1.2 negotiation ran: the host only
+                // sends this after our Hello advertised minor >= 2.
+                eprintln!("mock: key repeat: delay {delay_ms} ms, interval {interval_ms} ms");
+                continue;
+            }
             // The point of the mock: prove input arrives, with coordinates.
             Ok(input) => {
                 eprintln!("mock: input: {input:?}");

--- a/packages/vm/panes/host/src/view.rs
+++ b/packages/vm/panes/host/src/view.rs
@@ -47,6 +47,13 @@ pub struct ViewIvars {
     /// press and release alike; toggling membership tells them apart without
     /// hardcoding Apple's device-dependent left/right flag bits.
     held_modifiers: RefCell<HashSet<u16>>,
+    /// Non-modifier keys whose press was forwarded, keyed by kVK. Two jobs:
+    /// releasing on focus loss (a keyUp after Cmd-Tab never reaches this
+    /// view, so a key held across it would stay pressed guest-side and
+    /// auto-repeat forever), and gating keyUp forwarding to keys the guest
+    /// actually saw pressed (the host-consumed Cmd-W/Q must not leak a
+    /// stray release).
+    held_keys: RefCell<HashSet<u16>>,
     /// Pointer capture engaged for this window (`app::sync_capture`): motion
     /// goes out as `PointerRelative` deltas, and the absolute re-anchor
     /// before buttons/scrolls is skipped (the frozen cursor position is
@@ -199,12 +206,19 @@ define_class!(
                     _ => {}
                 }
             }
+            self.ivars().held_keys.borrow_mut().insert(code);
             self.send_key(code, ButtonState::Pressed);
         }
 
         #[unsafe(method(keyUp:))]
         fn key_up(&self, event: &NSEvent) {
-            self.send_key(event.keyCode(), ButtonState::Released);
+            let code = event.keyCode();
+            // Only keys whose press was forwarded: a release for a key the
+            // guest never saw pressed (host-consumed shortcut, focus gained
+            // mid-hold) would be noise.
+            if self.ivars().held_keys.borrow_mut().remove(&code) {
+                self.send_key(code, ButtonState::Released);
+            }
         }
 
         #[unsafe(method(flagsChanged:))]
@@ -238,6 +252,7 @@ impl PanesView {
             id,
             tracking: RefCell::new(None),
             held_modifiers: RefCell::new(HashSet::new()),
+            held_keys: RefCell::new(HashSet::new()),
             relative: Cell::new(false),
             last_relative: Cell::new((f64::NEG_INFINITY, 0)),
         });
@@ -251,13 +266,20 @@ impl PanesView {
         self.ivars().relative.set(relative);
     }
 
-    /// Focus left this window: release every held modifier guest-side and
-    /// forget them. `AppKit` stops delivering `flagsChanged` once the window
-    /// resigns key, so a modifier held across a Cmd-Tab would otherwise stay
-    /// pressed in the guest forever, and the toggle heuristic would invert
-    /// press/release on its next use.
-    pub fn release_held_modifiers(&self) {
-        let held: Vec<u16> = self.ivars().held_modifiers.borrow_mut().drain().collect();
+    /// Focus left this window: release every held key guest-side and forget
+    /// them. `AppKit` stops delivering `flagsChanged` and `keyUp` once the
+    /// window resigns key, so anything held across a Cmd-Tab would otherwise
+    /// stay pressed in the guest forever (a stuck regular key auto-repeats
+    /// forever via `wl_keyboard.repeat_info`; a stuck modifier also inverts
+    /// the `flagsChanged` toggle heuristic on its next use).
+    pub fn release_held_keys(&self) {
+        let ivars = self.ivars();
+        let held: Vec<u16> = ivars
+            .held_modifiers
+            .borrow_mut()
+            .drain()
+            .chain(ivars.held_keys.borrow_mut().drain())
+            .collect();
         for kvk in held {
             self.send_key(kvk, ButtonState::Released);
         }
@@ -326,6 +348,12 @@ impl PanesView {
         // wl_pointer.button carries no position; re-anchor the pointer first
         // so a click after focus change lands where the user clicked.
         self.send_motion(event);
+        // AppKit unhides a captured (hidden) cursor on its right-mouse-down
+        // menu-preparation path; re-hide around every button so holding
+        // right-click in a pointer-locked game never shows the cursor.
+        if self.ivars().relative.get() {
+            app::reassert_capture_cursor();
+        }
         app::send(ToGuest::PointerButton { id: self.ivars().id, button, state });
     }
 

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -14,8 +14,9 @@ use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2::{AllocAnyThread, DefinedClass, MainThreadOnly, define_class};
 use objc2_app_kit::{
-    NSBackingStoreType, NSView, NSWindow, NSWindowButton, NSWindowDelegate,
-    NSWindowOcclusionState, NSWindowStyleMask, NSWindowTabbingMode, NSWindowTitleVisibility,
+    NSBackingStoreType, NSEvent, NSEventModifierFlags, NSEventType, NSView, NSWindow,
+    NSWindowButton, NSWindowDelegate, NSWindowOcclusionState, NSWindowStyleMask,
+    NSWindowTabbingMode, NSWindowTitleVisibility,
 };
 use objc2_foundation::{
     MainThreadMarker, NSNotification, NSObjectProtocol, NSPoint, NSRect, NSRunLoop, NSSize,
@@ -72,6 +73,59 @@ pub struct WindowParams {
     pub width: u32,
     pub height: u32,
     pub scale: u32,
+}
+
+define_class!(
+    // `NSWindow` subclass whose only job is un-swallowing Cmd keyUps: AppKit
+    // routes a keyUp with Command held into key-equivalent processing and
+    // never delivers it to the responder chain, so the guest would see the
+    // key stuck down and its clients would auto-repeat it until focus is
+    // lost (one Cmd-Backspace tap in a guest editor deleted forever). Hand
+    // those keyUps to the content view like any other key event; the view's
+    // held-key set drops the ones whose press the guest never saw.
+    #[unsafe(super(NSWindow))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "PanesWindow"]
+    struct PanesNSWindow;
+
+    impl PanesNSWindow {
+        #[unsafe(method(sendEvent:))]
+        fn send_event(&self, event: &NSEvent) {
+            if event.r#type() == NSEventType::KeyUp
+                && event.modifierFlags().contains(NSEventModifierFlags::Command)
+                && let Some(view) = self.contentView()
+            {
+                view.keyUp(event);
+                return;
+            }
+            let _: () = unsafe { objc2::msg_send![super(self), sendEvent: event] };
+        }
+    }
+);
+
+impl PanesNSWindow {
+    /// Returns the upcast `NSWindow`: callers only need the base interface
+    /// (the subclass adds behavior, not API).
+    fn new_ns_window(
+        mtm: MainThreadMarker,
+        content: NSRect,
+        style: NSWindowStyleMask,
+    ) -> Retained<NSWindow> {
+        let this = Self::alloc(mtm).set_ivars(());
+        // SAFETY: NSWindow's designated initializer on our subclass;
+        // `defer: false` so the window backing exists immediately (the Metal
+        // layer needs a real backing scale).
+        let window: Retained<Self> = unsafe {
+            objc2::msg_send![
+                super(this),
+                initWithContentRect: content,
+                styleMask: style,
+                backing: NSBackingStoreType::Buffered,
+                defer: false,
+            ]
+        };
+        Retained::into_super(window)
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -264,17 +318,7 @@ impl PaneWindow {
         if !native_titlebar {
             style |= NSWindowStyleMask::FullSizeContentView;
         }
-        // SAFETY: standard initializer; `defer: false` so the window backing
-        // exists immediately (the Metal layer needs a real backing scale).
-        let ns = unsafe {
-            NSWindow::initWithContentRect_styleMask_backing_defer(
-                mtm.alloc(),
-                content,
-                style,
-                NSBackingStoreType::Buffered,
-                false,
-            )
-        };
+        let ns = PanesNSWindow::new_ns_window(mtm, content, style);
         // SAFETY: `true` (the default for titled windows) would free the
         // ObjC object under our `Retained` on close.
         unsafe { ns.setReleasedWhenClosed(false) };

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -96,6 +96,9 @@ define_class!(
                 && let Some(view) = self.contentView()
             {
                 view.keyUp(event);
+                // No super on purpose: AppKit's key-equivalent path would
+                // swallow this keyUp anyway, and the view is its only
+                // intended consumer.
                 return;
             }
             let _: () = unsafe { objc2::msg_send![super(self), sendEvent: event] };

--- a/packages/vm/panes/protocol/src/lib.rs
+++ b/packages/vm/panes/protocol/src/lib.rs
@@ -270,8 +270,18 @@ pub enum ToGuest {
     },
 }
 
-/// [`ToGuest::KeyRepeat`] timing as `wl_keyboard.repeat_info` arguments:
-/// `(rate, delay)` = (repeats per second, ms before the first repeat).
+/// `wl_keyboard.repeat_info` arguments derived from [`ToGuest::KeyRepeat`]
+/// by [`wl_repeat_info`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RepeatInfo {
+    /// Repeats per second; 0 disables client-side repeat (`wl_keyboard`'s
+    /// own convention).
+    pub rate: i32,
+    /// Delay before the first repeat, ms.
+    pub delay: i32,
+}
+
+/// [`ToGuest::KeyRepeat`] timing as `wl_keyboard.repeat_info` arguments.
 ///
 /// Lives next to the wire type because it pins down what the fields mean to
 /// a consumer, and the protocol crate is the one crate both sides (and both
@@ -282,15 +292,19 @@ pub enum ToGuest {
 /// 1/s). A zero interval is nonsense from the wire and also maps to
 /// disabled rather than an unbounded rate.
 #[must_use]
-pub fn wl_repeat_info(delay_ms: u32, interval_ms: u32) -> (i32, i32) {
+pub fn wl_repeat_info(delay_ms: u32, interval_ms: u32) -> RepeatInfo {
     let rate = match interval_ms {
         0 => 0,
         interval => clamp_to_i32((1000 + interval / 2) / interval),
     };
-    (rate, clamp_to_i32(delay_ms))
+    RepeatInfo { rate, delay: clamp_to_i32(delay_ms) }
 }
 
 /// Saturate into `wl_keyboard.repeat_info`'s i32 arguments.
+// Clamping is the contract: a value past i32::MAX (only reachable from a
+// degenerate or hostile peer) pins to the maximum instead of failing the
+// connection over repeat timing.
+#[allow(clippy::fallible_int_fallback)]
 fn clamp_to_i32(value: u32) -> i32 {
     i32::try_from(value).unwrap_or(i32::MAX)
 }
@@ -430,27 +444,27 @@ mod tests {
     #[test]
     fn repeat_info_matches_macos_defaults() {
         // Factory settings: InitialKeyRepeat=25 (375ms), KeyRepeat=6 (90ms).
-        assert_eq!(wl_repeat_info(375, 90), (11, 375));
+        assert_eq!(wl_repeat_info(375, 90), RepeatInfo { rate: 11, delay: 375 });
         // Fastest sliders: InitialKeyRepeat=15 (225ms), KeyRepeat=2 (30ms).
-        assert_eq!(wl_repeat_info(225, 30), (33, 225));
+        assert_eq!(wl_repeat_info(225, 30), RepeatInfo { rate: 33, delay: 225 });
     }
 
     #[test]
     fn repeat_info_rounds_to_nearest_rate() {
-        assert_eq!(wl_repeat_info(600, 150).0, 7); // 6.67/s, not a truncated 6
-        assert_eq!(wl_repeat_info(600, 1800).0, 1); // slowest slider stop
+        assert_eq!(wl_repeat_info(600, 150).rate, 7); // 6.67/s, not a truncated 6
+        assert_eq!(wl_repeat_info(600, 1800).rate, 1); // slowest slider stop
     }
 
     #[test]
     fn repeat_info_disables_for_off_and_degenerate_intervals() {
         // macOS "Key Repeat: Off" reports a minutes-long interval.
-        assert_eq!(wl_repeat_info(375, 4_500_000).0, 0);
-        assert_eq!(wl_repeat_info(375, 0).0, 0);
+        assert_eq!(wl_repeat_info(375, 4_500_000).rate, 0);
+        assert_eq!(wl_repeat_info(375, 0).rate, 0);
     }
 
     #[test]
     fn repeat_info_saturates_into_i32() {
-        assert_eq!(wl_repeat_info(u32::MAX, 90), (11, i32::MAX));
+        assert_eq!(wl_repeat_info(u32::MAX, 90), RepeatInfo { rate: 11, delay: i32::MAX });
     }
 
     #[test]

--- a/packages/vm/panes/protocol/src/lib.rs
+++ b/packages/vm/panes/protocol/src/lib.rs
@@ -277,7 +277,7 @@ pub enum ToGuest {
 /// a consumer, and the protocol crate is the one crate both sides (and both
 /// platforms' tests) share. Rate rounds to the nearest integer per second.
 /// A rate that rounds to 0 (interval >= 2s) disables client repeat, which
-/// is what wl_keyboard defines rate 0 to mean and is only reachable by
+/// is what `wl_keyboard` defines rate 0 to mean and is only reachable by
 /// macOS "Key Repeat: Off" (the slowest slider stop, 1.8s, still rounds to
 /// 1/s). A zero interval is nonsense from the wire and also maps to
 /// disabled rather than an unbounded rate.

--- a/packages/vm/panes/protocol/src/lib.rs
+++ b/packages/vm/panes/protocol/src/lib.rs
@@ -32,10 +32,13 @@ use serde::{Deserialize, Serialize};
 /// postcard encodes the variant index, so inserting one mid-enum renumbers
 /// everything after it.
 pub const VERSION_MAJOR: u16 = 1;
-pub const VERSION_MINOR: u16 = 1;
+pub const VERSION_MINOR: u16 = 2;
 
 /// Minor that introduced [`ToHost::PointerLock`] / [`ToGuest::PointerRelative`].
 pub const MINOR_POINTER_LOCK: u16 = 1;
+
+/// Minor that introduced [`ToGuest::KeyRepeat`].
+pub const MINOR_KEY_REPEAT: u16 = 2;
 
 /// Guest vsock port the compositor listens on.
 pub const VSOCK_PORT: u32 = 7100;
@@ -249,6 +252,47 @@ pub enum ToGuest {
         dx: f64,
         dy: f64,
     },
+    /// The host user's key auto-repeat timing (macOS System Settings, read
+    /// via `NSEvent` `keyRepeatDelay`/`keyRepeatInterval`), sent once after
+    /// the guest's Hello. The compositor re-advertises it as
+    /// `wl_keyboard.repeat_info` (see [`wl_repeat_info`]) so client-side
+    /// auto-repeat matches the host exactly; the host never forwards OS
+    /// repeats (`isARepeat` keyDowns are dropped), making this the one
+    /// repeat authority. Since minor 2 ([`MINOR_KEY_REPEAT`]); only sent
+    /// once the guest's Hello advertised it.
+    KeyRepeat {
+        /// Delay before the first repeat, ms.
+        delay_ms: u32,
+        /// Interval between repeats, ms. macOS reports "Key Repeat: Off" as
+        /// a minutes-long interval, which [`wl_repeat_info`] turns into a
+        /// disabled repeat (rate 0).
+        interval_ms: u32,
+    },
+}
+
+/// [`ToGuest::KeyRepeat`] timing as `wl_keyboard.repeat_info` arguments:
+/// `(rate, delay)` = (repeats per second, ms before the first repeat).
+///
+/// Lives next to the wire type because it pins down what the fields mean to
+/// a consumer, and the protocol crate is the one crate both sides (and both
+/// platforms' tests) share. Rate rounds to the nearest integer per second.
+/// A rate that rounds to 0 (interval >= 2s) disables client repeat, which
+/// is what wl_keyboard defines rate 0 to mean and is only reachable by
+/// macOS "Key Repeat: Off" (the slowest slider stop, 1.8s, still rounds to
+/// 1/s). A zero interval is nonsense from the wire and also maps to
+/// disabled rather than an unbounded rate.
+#[must_use]
+pub fn wl_repeat_info(delay_ms: u32, interval_ms: u32) -> (i32, i32) {
+    let rate = match interval_ms {
+        0 => 0,
+        interval => clamp_to_i32((1000 + interval / 2) / interval),
+    };
+    (rate, clamp_to_i32(delay_ms))
+}
+
+/// Saturate into `wl_keyboard.repeat_info`'s i32 arguments.
+fn clamp_to_i32(value: u32) -> i32 {
+    i32::try_from(value).unwrap_or(i32::MAX)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -373,6 +417,40 @@ mod tests {
             panic!("wrong variant");
         };
         assert!((dx - -1.5).abs() < f64::EPSILON && (dy - 2.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn key_repeat_roundtrips() {
+        let mut buf = Vec::new();
+        write_msg(&mut buf, &ToGuest::KeyRepeat { delay_ms: 375, interval_ms: 90 }).unwrap();
+        let back: ToGuest = read_msg(&mut buf.as_slice()).unwrap();
+        assert!(matches!(back, ToGuest::KeyRepeat { delay_ms: 375, interval_ms: 90 }));
+    }
+
+    #[test]
+    fn repeat_info_matches_macos_defaults() {
+        // Factory settings: InitialKeyRepeat=25 (375ms), KeyRepeat=6 (90ms).
+        assert_eq!(wl_repeat_info(375, 90), (11, 375));
+        // Fastest sliders: InitialKeyRepeat=15 (225ms), KeyRepeat=2 (30ms).
+        assert_eq!(wl_repeat_info(225, 30), (33, 225));
+    }
+
+    #[test]
+    fn repeat_info_rounds_to_nearest_rate() {
+        assert_eq!(wl_repeat_info(600, 150).0, 7); // 6.67/s, not a truncated 6
+        assert_eq!(wl_repeat_info(600, 1800).0, 1); // slowest slider stop
+    }
+
+    #[test]
+    fn repeat_info_disables_for_off_and_degenerate_intervals() {
+        // macOS "Key Repeat: Off" reports a minutes-long interval.
+        assert_eq!(wl_repeat_info(375, 4_500_000).0, 0);
+        assert_eq!(wl_repeat_info(375, 0).0, 0);
+    }
+
+    #[test]
+    fn repeat_info_saturates_into_i32() {
+        assert_eq!(wl_repeat_info(u32::MAX, 90), (11, i32::MAX));
     }
 
     #[test]


### PR DESCRIPTION
Holding a key (or tapping cmd-backspace) in a panes guest repeated absurdly fast and ignored macOS keyboard settings (report via #1686 follow-up, after #1778).

Three root causes, all fixed here:

- **Compositor hardcoded `repeat_info(delay=400ms, rate=30/s)`** — every Wayland client (foot, GLFW/Minecraft) auto-repeats from that advertisement, ~3x the macOS default and unrelated to System Settings. Now: protocol 1.2 adds `ToGuest::KeyRepeat` carrying `NSEvent.keyRepeatDelay/keyRepeatInterval` (sent once per connection, gated on the guest's Hello minor per the postcard append-only convention); the compositor converts it via the unit-tested `wl_repeat_info` and applies `change_repeat_info`. One repeat authority: the Mac's settings. Old guest (minor <2): message never sent. Old host: compositor now falls back to macOS factory defaults (375ms, 11/s) instead of 30/s.
- **AppKit swallows `keyUp` while Cmd is held** — cmd-backspace forwarded the press but never the release, so the guest saw backspace held forever and clients repeated it "like an animation" until focus loss. New `NSWindow` subclass reroutes Cmd keyUps to the view. The host also tracks forwarded presses and releases them on focus loss (same fix `flagsChanged` modifiers already had), and keyUps for presses the guest never saw (host-consumed Cmd-W/Q) are dropped.
- **macOS unhides the hidden cursor on right-mouse-down** (menu preparation; same family as glfw#2648/#2656) — holding right-click in pointer-locked Minecraft showed the host cursor. While captured, button events re-check `CGCursorIsVisible` and re-hide (immediately + once from the back of the main queue), keeping hide/unhide balanced since each re-hide matches one OS-initiated unhide.

Notes:
- Host `isARepeat` keyDowns were already dropped on main; no double-forwarding existed. cmd-backspace reaches the guest as super+backspace exactly once (super via flagsChanged, backspace via keyDown); chord translation (cmd→ctrl etc.) is deliberately not in scope.
- A mid-session System Settings change applies on the next connection.

Validation:
- `panes-host --mock`: `panes-host: key repeat: KeyRepeat { delay_ms: 167, interval_ms: 33 }` → `mock: key repeat: delay 167 ms, interval 33 ms` (real System Settings values, 1.2 negotiation).
- darwin: `.#packages.aarch64-darwin.panes-host.passthru.tests.clippy` + `panes-host-all` green; repo lint green.
- linux: `cargo test -p panes-protocol` 15/15 and `cargo clippy -p panes-compositor` clean on vin-compute-1 (the aarch64 local builder is down; note panes-compositor is still validated nowhere in CI — see the panes-audio package.nix comment — possible follow-up to add x86_64-linux there too).
- Live guest swap (not done here; the running session was left untouched): `nix build .#panes-host` and restart the host process only — the compositor side is guest-image-pinned, so full effect (repeat_info from the Mac) needs a guest image rebuild + reboot; until then the host-side fixes (stuck Cmd keys, cursor re-hide) apply immediately and the guest keeps the 400ms/30s advertisement.

Written by Claude with human direction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stuck Cmd-key repeats and cursor flash in pointer lock, and match guest key repeat to macOS defaults
> - Bumps the wire protocol to 1.2 and adds a `ToGuest::KeyRepeat` message so the host sends the user's macOS key repeat delay/interval to the guest compositor once per connection.
> - The compositor now advertises `wl_keyboard.repeat_info` using macOS factory defaults (~11/s, 375ms delay) instead of the previous 30/s, 400ms values, and updates at runtime when `KeyRepeat` is received.
> - Introduces a `PanesNSWindow` subclass that reroutes `KeyUp` events while Cmd is held to the content view, preventing the guest from seeing keys stuck down after shortcuts.
> - On focus loss, all held keys (not just modifiers) are released guest-side via `release_held_keys`, stopping runaway auto-repeat.
> - Fixes pointer-lock cursor flash: right-mouse-down no longer leaves the cursor visible; a deferred `reassert_capture_cursor` re-hides it and also loops up to 16 times on capture release to ensure the cursor is truly visible when unlocking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee6bf81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->