### PR TITLE
feat(mcp): nix-managed blender-mcp package + opt-in registry entry

### DIFF
--- a/lib/util/mcp/servers.nix
+++ b/lib/util/mcp/servers.nix
@@ -38,6 +38,28 @@ let
         url = "https://mcp.exa.ai/mcp";
       };
     };
+
+  optionalServers =
+    {
+      # Path to the packaged `blender-mcp` binary (`lib.getExe` of the
+      # `packages/blender-mcp` build). A command string rather than the package
+      # itself because this registry is pure lib, out of `pkgs` scope.
+      blenderMcp,
+    }:
+    {
+      # Stdio MCP server that bridges to the BlenderMCP addon socket on
+      # localhost:9876. Only useful on a host where a Blender GUI session has
+      # the matching addon (the package's `passthru.addon`) loaded, which is
+      # why it never enters `defaultServers`.
+      blender = {
+        transport = "stdio";
+        command = blenderMcp;
+        env = {
+          # telemetry.py opt-out; the default phones home per tool call.
+          DISABLE_TELEMETRY = "true";
+        };
+      };
+    };
 in
 {
   /**
@@ -51,6 +73,15 @@ in
       the keyless `exa` server is returned.
   */
   inherit defaultServers;
+
+  /**
+    Opt-in servers that depend on machine-local state (a running GUI app, a
+    local daemon) and so never enter the default set: baking them into every
+    wrapper would hand fleet and CI agents a dead tool surface. Consumers merge
+    what applies, e.g.
+    `defaultServers { ... } // optionalServers { blenderMcp = lib.getExe blender-mcp; }`.
+  */
+  inherit optionalServers;
 
   /**
     Compatibility name for consumers pinned to the original MCP registry API.

--- a/packages/blender-mcp/default.nix
+++ b/packages/blender-mcp/default.nix
@@ -1,0 +1,68 @@
+# ahujasid/blender-mcp, built from the pinned GitHub source (not `uvx` from
+# PyPI at runtime): the same rev carries both halves of the bridge — the stdio
+# MCP server (this package's `blender-mcp` binary) and the in-Blender addon
+# (`passthru.addon`) — so pinning one source keeps them version-matched and the
+# whole closure nix-managed. Chosen over Blender Lab's official MCP because
+# that project ships as a manual release bundle with no pinnable source
+# install; revisit when it grows one.
+{
+  ix,
+  lib,
+  pkgs,
+  # Writer for `passthru.updateScript` (flake-package path only); null on the
+  # overlay path so `pkgs.*` carries no updater. Same nullable-writer pattern
+  # as vector-bin / wasm-bindgen-cli.
+  updateScriptWriter ? null,
+}:
+let
+  # Rev + SRI hash live in the sibling pins.json, never inline here (repo
+  # policy: no `hash = "sha256-..."` literals in tracked .nix). Bump the
+  # rev/url in pins.json, then `nix run .#update` re-pins the hash.
+  pin = ix.pins.loadPin ./pins.json "blender-mcp";
+  updateScript =
+    if updateScriptWriter == null then
+      null
+    else
+      ix.pins.mkUpdater {
+        writeNushellApplication = updateScriptWriter;
+        inherit (pkgs) nix;
+        pname = "blender-mcp";
+        relPath = "packages/blender-mcp/pins.json";
+      };
+
+  src = pkgs.fetchzip { inherit (pin) url hash; };
+
+  # Upstream builds with setuptools, not uv's backend, so build isolation
+  # would try to fetch setuptools from an index the sandbox cannot reach;
+  # provide the backend on the interpreter and build unisolated instead.
+  python = pkgs.python3.withPackages (ps: [
+    ps.setuptools
+    ps.wheel
+  ]);
+in
+(ix.buildUvApplication pkgs {
+  pname = "blender-mcp";
+  inherit (pin) version;
+  inherit src python;
+  buildFlags = [ "--no-build-isolation" ];
+  # Third-party source: upstream is untyped, so the repo's strict
+  # zuban/ruff-ANN gates (meant for repo-owned Python) cannot pass here.
+  check = false;
+  meta = {
+    description = "MCP server bridging agents to a running Blender via its companion addon";
+    homepage = "https://github.com/ahujasid/blender-mcp";
+    license = lib.licenses.mit;
+    mainProgram = "blender-mcp";
+  };
+}).overrideAttrs
+  (old: {
+    passthru =
+      (old.passthru or { })
+      // {
+        # The in-Blender half of the bridge, from the SAME pinned rev as the
+        # server. Consumers load it into Blender (e.g. a scripts/startup hook)
+        # so the socket protocol on :9876 cannot drift from the server.
+        addon = "${src}/addon.py";
+      }
+      // lib.optionalAttrs (updateScript != null) { inherit updateScript; };
+  })

--- a/packages/blender-mcp/package.nix
+++ b/packages/blender-mcp/package.nix
@@ -1,0 +1,20 @@
+{
+  id = "blender-mcp";
+  packageSet = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+  flake = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+  updateScript = true;
+}

--- a/packages/blender-mcp/pins.json
+++ b/packages/blender-mcp/pins.json
@@ -1,0 +1,9 @@
+{
+  "blender-mcp": {
+    "version": "1.6.0",
+    "rev": "6e99eb5a442b83766a5796975ec7bb5bfc791341",
+    "url": "https://github.com/ahujasid/blender-mcp/archive/6e99eb5a442b83766a5796975ec7bb5bfc791341.tar.gz",
+    "prefetch": "unpack",
+    "hash": "sha256-X2kztoD64VBdZtUAVGRhD9+p9KZk8u1y2P6C+wxPz7A="
+  }
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2609,6 +2609,12 @@ let
         ) sampleCodexMcpEntries;
         message = "Codex MCP entries should be limited to index and Exa when index MCP is available";
       }
+      {
+        assertion =
+          (ix.mcp.toClaudeJson (ix.mcp.optionalServers { blenderMcp = "/bin/blender-mcp"; })).blender.command
+          == "/bin/blender-mcp";
+        message = "Opt-in Blender MCP server should render for Claude with the consumer's binary";
+      }
     ];
 
     provider-prompts = [


### PR DESCRIPTION
Adds a fully nix-managed Blender MCP path:

- `packages/blender-mcp`: builds ahujasid/blender-mcp from a pinned GitHub rev (`pins.json` + `updateScript`, `nix run .#update`), no `uvx`/PyPI at runtime. `passthru.addon` exposes the in-Blender `addon.py` from the same rev so server and addon cannot drift.
- `ix.mcp.optionalServers`: opt-in `blender` registry entry (stdio, `DISABLE_TELEMETRY=1`). Stays out of `defaultServers`: it needs a local Blender GUI session with the addon loaded, so baking it fleet-wide would be a dead tool surface.

Validated: package builds on aarch64-darwin; the store binary connected to a live Blender 5.1.2 addon socket on :9876.

Closes #1796

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Nix-managed `blender-mcp` package and opt-in MCP registry entry
> - Adds a new [`blender-mcp` package](https://github.com/indexable-inc/index/pull/1797/files#diff-622db493d3d5a81451f79a222641a998463b59c70d4b1edd0daa0d9ebbd56773) built from a pinned GitHub source via `buildUvApplication`, exposing the `blender-mcp` binary and a `passthru.addon` path for the companion Blender addon.
> - Adds an `optionalServers` function in [`lib/util/mcp/servers.nix`](https://github.com/indexable-inc/index/pull/1797/files#diff-a74190c62a3086f0b0e05489808b80559c743c45cb2f5d09e9734aa712b7604b) that returns an opt-in `blender` MCP server definition using stdio transport with `DISABLE_TELEMETRY=true`, given a `blenderMcp` command path.
> - Exports `optionalServers` from the top-level MCP module alongside `defaultServers`.
> - Adds a test asserting that `optionalServers` produces the correct `blender.command` in Claude JSON output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be91b2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->