### PR TITLE
feat(mcp): official Blender Lab MCP as a second opt-in registry entry

### DIFF
--- a/lib/util/mcp/servers.nix
+++ b/lib/util/mcp/servers.nix
@@ -39,24 +39,41 @@ let
       };
     };
 
+  # Both Blender bridges share one shape: a stdio server the client spawns
+  # plus an addon socket inside a Blender GUI session, so each is emitted only
+  # when the consumer passes its binary. Command strings rather than packages
+  # because this registry is pure lib, out of `pkgs` scope.
   optionalServers =
     {
-      # Path to the packaged `blender-mcp` binary (`lib.getExe` of the
-      # `packages/blender-mcp` build). A command string rather than the package
-      # itself because this registry is pure lib, out of `pkgs` scope.
-      blenderMcp,
+      # `lib.getExe` of the `packages/blender-mcp` build (community bridge,
+      # ahujasid): broad automation surface (objects, materials, Poly Haven,
+      # code execution). Its addon owns localhost:9876.
+      blenderMcp ? null,
+      # `lib.getExe` of the `packages/blender-lab-mcp` build (official Blender
+      # Lab): docs/analysis surface (blendfile summaries, API + manual lookup,
+      # screenshots, code execution).
+      blenderLabMcp ? null,
     }:
-    {
-      # Stdio MCP server that bridges to the BlenderMCP addon socket on
-      # localhost:9876. Only useful on a host where a Blender GUI session has
-      # the matching addon (the package's `passthru.addon`) loaded, which is
-      # why it never enters `defaultServers`.
+    lib.optionalAttrs (blenderMcp != null) {
       blender = {
         transport = "stdio";
         command = blenderMcp;
         env = {
           # telemetry.py opt-out; the default phones home per tool call.
           DISABLE_TELEMETRY = "true";
+        };
+      };
+    }
+    // lib.optionalAttrs (blenderLabMcp != null) {
+      blender-lab = {
+        transport = "stdio";
+        command = blenderLabMcp;
+        env = {
+          # One up from the community addon's 9876 so both bridges can run in
+          # the same Blender. This value is the source of truth for the port:
+          # consumers configure the Lab addon's port preference FROM this env
+          # (read it back off this definition) rather than restating 9877.
+          BLENDER_MCP_PORT = "9877";
         };
       };
     };
@@ -78,8 +95,15 @@ in
     Opt-in servers that depend on machine-local state (a running GUI app, a
     local daemon) and so never enter the default set: baking them into every
     wrapper would hand fleet and CI agents a dead tool surface. Consumers merge
-    what applies, e.g.
-    `defaultServers { ... } // optionalServers { blenderMcp = lib.getExe blender-mcp; }`.
+    what applies (packages come from the flake package set / `packageSetFor`,
+    not the overlay), e.g.
+    `defaultServers { ... } // optionalServers { blenderMcp = lib.getExe repoPackages.blender-mcp; }`.
+
+    Caution: both Blender servers expose arbitrary-code-execution tools, and
+    `toCodexEntries` stamps `default_tools_approval_mode = "approve"` on every
+    rendered server. A consumer wiring these into an agent accepts
+    auto-approved code execution against its local Blender; keep that opt-in
+    per machine, never fleet policy.
   */
   inherit optionalServers;
 

--- a/packages/blender-lab-mcp/default.nix
+++ b/packages/blender-lab-mcp/default.nix
@@ -1,0 +1,89 @@
+# The OFFICIAL Blender Lab MCP (projects.blender.org/lab/blender_mcp), the
+# docs-oriented counterpart to the community bridge in packages/blender-mcp:
+# blendfile summaries, Python API / manual lookup, screenshots, plus code
+# execution. Same two-half shape (stdio server + in-Blender addon), and the
+# same one-pinned-rev rule keeps them version-matched (`passthru.addon`).
+#
+# Fetched from the bpype/blender_mcp GitHub mirror because the canonical
+# projects.blender.org gitea 403s nix's fetcher (curl passes); the pinned
+# commit SHA is identical on both remotes, and a git commit hash covers its
+# whole tree, so the mirror bytes are provably the upstream bytes.
+{
+  fetchzip,
+  ix,
+  lib,
+  nix,
+  python3,
+  # Writer for `passthru.updateScript` (flake-package path only; the package
+  # is not registered in the overlay). Same nullable-writer pattern as
+  # blender-mcp / vector-bin.
+  updateScriptWriter ? null,
+}:
+let
+  # Rev + SRI hash live in the sibling pins.json, never inline here (repo
+  # policy: no `hash = "sha256-..."` literals in tracked .nix). Bump the
+  # rev/url in pins.json, then `nix run .#update` re-pins the hash.
+  pin = ix.pins.loadPin ./pins.json "blender-lab-mcp";
+  updateScript =
+    if updateScriptWriter == null then
+      null
+    else
+      ix.pins.mkUpdater {
+        writeNushellApplication = updateScriptWriter;
+        inherit nix;
+        pname = "blender-lab-mcp";
+        relPath = "packages/blender-lab-mcp/pins.json";
+      };
+
+  src = fetchzip { inherit (pin) url hash; };
+in
+(python3.pkgs.buildPythonApplication {
+  pname = "blender-lab-mcp";
+  inherit (pin) version;
+  inherit src;
+  # The server is the repo's `mcp/` subproject (`blmcp` package); `addon/` and
+  # `chat_client/` are separate non-installable pieces.
+  sourceRoot = "${src.name}/mcp";
+  pyproject = true;
+
+  build-system = [ python3.pkgs.setuptools ];
+  # Upstream deps (mcp/pyproject.toml): docutils, mcp[cli], pyyaml. No lock
+  # file upstream, so versions pin through nixpkgs rather than a wheelhouse.
+  dependencies = [
+    python3.pkgs.docutils
+    python3.pkgs.mcp
+    python3.pkgs.pyyaml
+  ];
+
+  # Upstream names its console script `blender-mcp`, colliding with the
+  # community package's binary in a merged profile; the flake id is the
+  # unambiguous name.
+  postInstall = ''
+    # shell
+    mv "$out/bin/blender-mcp" "$out/bin/blender-lab-mcp"
+  '';
+
+  # Catches a missing transitive dep at build time (there is no upstream lock
+  # to trust); upstream's own tests need a running Blender, so skip them.
+  pythonImportsCheck = [ "blmcp" ];
+  doCheck = false;
+
+  meta = {
+    description = "Official Blender Lab MCP server for scene analysis, docs lookup, and code execution";
+    homepage = "https://projects.blender.org/lab/blender_mcp";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "blender-lab-mcp";
+  };
+}).overrideAttrs
+  (old: {
+    passthru =
+      (old.passthru or { })
+      // {
+        # The in-Blender half, from the SAME pinned rev as the server: a proper
+        # addon package (`blender_mcp_addon/`) consumers link into Blender's
+        # scripts/addons and enable. Its TCP port preference must match the
+        # registry entry's BLENDER_MCP_PORT (see ix.mcp.optionalServers).
+        addon = "${src}/addon/blender_mcp_addon";
+      }
+      // lib.optionalAttrs (updateScript != null) { inherit updateScript; };
+  })

--- a/packages/blender-lab-mcp/package.nix
+++ b/packages/blender-lab-mcp/package.nix
@@ -1,0 +1,20 @@
+{
+  id = "blender-lab-mcp";
+  packageSet = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+  flake = {
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+  updateScript = true;
+}

--- a/packages/blender-lab-mcp/pins.json
+++ b/packages/blender-lab-mcp/pins.json
@@ -1,0 +1,9 @@
+{
+  "blender-lab-mcp": {
+    "version": "1.0.0",
+    "rev": "98b0e49d98321d321c7e631389200f513f765d59",
+    "url": "https://github.com/bpype/blender_mcp/archive/98b0e49d98321d321c7e631389200f513f765d59.tar.gz",
+    "prefetch": "unpack",
+    "hash": "sha256-rzP12jkdE1cmg0G35mKupdl2IAHIl5MS3dE0jwlrKzA="
+  }
+}

--- a/packages/blender-mcp/default.nix
+++ b/packages/blender-mcp/default.nix
@@ -9,9 +9,9 @@
   ix,
   lib,
   pkgs,
-  # Writer for `passthru.updateScript` (flake-package path only); null on the
-  # overlay path so `pkgs.*` carries no updater. Same nullable-writer pattern
-  # as vector-bin / wasm-bindgen-cli.
+  # Writer for `passthru.updateScript` (flake-package path only; the package
+  # is not registered in the overlay). Same nullable-writer pattern as
+  # vector-bin / wasm-bindgen-cli.
   updateScriptWriter ? null,
 }:
 let

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2615,6 +2615,15 @@ let
           == "/bin/blender-mcp";
         message = "Opt-in Blender MCP server should render for Claude with the consumer's binary";
       }
+      {
+        assertion =
+          let
+            servers = ix.mcp.optionalServers { blenderLabMcp = "/bin/blender-lab-mcp"; };
+          in
+          builtins.attrNames servers == [ "blender-lab" ]
+          && servers.blender-lab.env.BLENDER_MCP_PORT == "9877";
+        message = "Opt-in Blender Lab server should render alone with its non-default port";
+      }
     ];
 
     provider-prompts = [


### PR DESCRIPTION
Adds the official Blender Lab MCP (projects.blender.org/lab/blender_mcp) beside the community bridge, so machines choose either or both:

- `packages/blender-lab-mcp`: pinned rev via pins.json + updateScript (GitHub mirror; same commit SHA as the canonical gitea, whose archive endpoint 403s nix). `buildPythonApplication` with nixpkgs deps (upstream has no lock); binary renamed to `blender-lab-mcp` to avoid colliding with the community `blender-mcp`; `passthru.addon` ships the matching addon package.
- `ix.mcp.optionalServers`: params now nullable; new `blender-lab` entry pinned to `BLENDER_MCP_PORT=9877` (community addon owns 9876) so both run in one Blender session.
- Review follow-ups from #1797: overlay-path comment corrections + approval-mode caution on optionalServers.

Validated: builds on aarch64-darwin (`pythonImportsCheck` on `blmcp`), registry renders for both Claude and Codex, lint green.

Closes #1799

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `blender-lab-mcp` as an opt-in MCP registry entry with Blender addon passthru
> - Adds a new [`packages/blender-lab-mcp`](https://github.com/indexable-inc/index/pull/1801/files#diff-18576d3fa4aa4fc3d5ac266f0cb2f647b9a2094c8bcc4fca7dedb187ef6d0ba7) Nix package that builds the official Blender Lab MCP from a pinned source tarball, renames the upstream `blender-mcp` console script to `blender-lab-mcp` to avoid collision, and exposes `passthru.addon` pointing at the bundled Blender addon directory.
> - Extends [`ix.mcp.optionalServers`](https://github.com/indexable-inc/index/pull/1801/files#diff-a74190c62a3086f0b0e05489808b80559c743c45cb2f5d09e9734aa712b7604b) to accept a `blenderLabMcp` argument and conditionally emit a `blender-lab` stdio server entry with `BLENDER_MCP_PORT` fixed to `9877`.
> - Adds a test assertion in [`tests/default.nix`](https://github.com/indexable-inc/index/pull/1801/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) verifying the `blender-lab` server entry and its port env var.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3abde6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->