### PR TITLE
fix(ray,spark): scope firewall opens to the tailscale interface only

### DIFF
--- a/examples/ray/cluster/cluster-node.nix
+++ b/examples/ray/cluster/cluster-node.nix
@@ -144,7 +144,11 @@ in
   };
 
   # The worker port range is opened at the firewall directly: `expose` covers a
-  # single named listener, not a range.
+  # single named listener, not a range. Unlike the fleet module
+  # (modules/services/ray), this open is NOT scoped to a tailscale interface:
+  # these are ix guest VMs with no tailscale and no public interface at all
+  # (east-west only, no internet egress), so the guest-global firewall is
+  # already bounded by the east-west group's reachability.
   networking.firewall.allowedTCPPortRanges = [
     {
       from = ports.workerLow;

--- a/modules/services/ray/default.nix
+++ b/modules/services/ray/default.nix
@@ -205,7 +205,10 @@ in
       description = ''
         This node's role in the single cluster. Exactly one node must be `head`
         (it runs the GCS); every other node is a `worker` and must set
-        {option}`services.ix-ray.headAddress`.
+        {option}`services.ix-ray.headAddress`. The GCS is not HA (no external
+        Redis), so a head restart resets cluster state: in-flight tasks and
+        object refs are lost, and every raylet re-registers on its
+        `Restart=on-failure` -- a reset, not an orphaned cluster.
       '';
     };
 
@@ -353,9 +356,11 @@ in
       description = ''
         Open the inter-node Ray ports (node/object manager, worker range), the
         exec port, the mesh discovery port (when the notebook engine runs),
-        and on the head the GCS + client-server ports. Usually
-        unnecessary on a tailnet where peers reach each other directly, but
-        required if a firewall guards the tailscale interface.
+        and on the head the GCS + client-server ports -- on the tailscale
+        interface ONLY, never the global firewall (Ray has no per-call auth,
+        so these ports must stay unreachable from any public interface).
+        Usually unnecessary on a tailnet where peers reach each other
+        directly, but required if a firewall guards the tailscale interface.
       '';
     };
   };
@@ -376,7 +381,15 @@ in
       }
     ];
 
-    networking.firewall = mkIf cfg.openFirewall {
+    # Scoped to the tailscale interface, never the global firewall: Ray's GCS
+    # and Client server carry NO authentication (any peer that can reach them
+    # runs arbitrary code), and a fleet host can also have a PUBLIC interface.
+    # A global `allowedTCPPorts` would have exposed `ray://<public-ip>:10001`
+    # to the internet (index#1800 review). The daemons bind the tailscale IPv4,
+    # and the tailnet is the module's stated trust boundary, so the tailscale
+    # interface is exactly where these ports may open. `tailscale0` is
+    # tailscaled's default (and the fleet's) interface name.
+    networking.firewall.interfaces."tailscale0" = mkIf cfg.openFirewall {
       allowedTCPPorts = [
         cfg.execPort
         cfg.nodeManagerPort

--- a/modules/services/spark/default.nix
+++ b/modules/services/spark/default.nix
@@ -359,7 +359,13 @@ in
     };
     users.groups.spark = { };
 
-    networking.firewall = mkIf cfg.openFirewall {
+    # Scoped to the tailscale interface, never the global firewall: Spark's
+    # master RPC and Connect server carry no authentication (submitting a job
+    # is code execution), and a fleet host can also have a PUBLIC interface --
+    # a global `allowedTCPPorts` would have exposed them to the internet
+    # (index#1800 review, same class as ix-ray). The daemons bind the
+    # tailscale IPv4, so that interface is exactly where these ports may open.
+    networking.firewall.interfaces."tailscale0" = mkIf cfg.openFirewall {
       allowedTCPPorts =
         # Pinned inter-node data-plane ports (driver + block managers), opened on
         # every node so executors and the driver reach each other over the tailnet.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2657,24 +2657,48 @@ let
       }
       {
         # The head opens the GCS (workers join), the Ray Client server
-        # (off-cluster `ray://` drivers), exec, and pinned inter-node ports.
+        # (off-cluster `ray://` drivers), exec, and pinned inter-node ports --
+        # on the tailscale interface only.
         assertion =
           let
-            ports = ixRayHead.networking.firewall.allowedTCPPorts;
+            ports = ixRayHead.networking.firewall.interfaces."tailscale0".allowedTCPPorts;
           in
           builtins.elem 6379 ports
           && builtins.elem 10001 ports
           && builtins.elem 8799 ports
           && builtins.elem 6380 ports
           && builtins.elem 6381 ports;
-        message = "ix-ray head should open the GCS, client-server, exec, and inter-node manager ports";
+        message = "ix-ray head should open the GCS, client-server, exec, and inter-node manager ports on tailscale0";
+      }
+      {
+        # Ray's GCS and Client server are unauthenticated (reaching them is
+        # arbitrary code execution), so NOTHING may open them on the global
+        # firewall: a fleet host can also face the internet, and a global
+        # `allowedTCPPorts` would have published `ray://<public-ip>:10001`
+        # (index#1800 review).
+        assertion =
+          let
+            globalPorts = ixRayHead.networking.firewall.allowedTCPPorts;
+            globalRanges = ixRayHead.networking.firewall.allowedTCPPortRanges;
+            rayPorts = [
+              6379
+              6380
+              6381
+              8798
+              8799
+              10001
+            ];
+          in
+          builtins.all (p: !(builtins.elem p globalPorts)) rayPorts
+          && builtins.all (r: !(r.from == 10002 && r.to == 10031)) globalRanges;
+        message = "ix-ray must never open its ports on the global firewall, only on tailscale0";
       }
       {
         # A worker opens its inter-node + exec ports, but neither the GCS nor the
         # client-server port (only the head serves those).
         assertion =
           let
-            ports = ixRayWorker.networking.firewall.allowedTCPPorts;
+            ports = ixRayWorker.networking.firewall.interfaces."tailscale0".allowedTCPPorts;
           in
           builtins.elem 8799 ports
           && builtins.elem 6380 ports
@@ -2765,20 +2789,38 @@ let
         message = "ix-spark master should run master + worker + connect daemons";
       }
       {
-        # Connect (15002) and master RPC (7077) are opened on the master.
+        # Connect (15002) and master RPC (7077) are opened on the master, on
+        # the tailscale interface only.
         assertion =
           let
-            ports = ixSparkMaster.networking.firewall.allowedTCPPorts;
+            ports = ixSparkMaster.networking.firewall.interfaces."tailscale0".allowedTCPPorts;
           in
           builtins.elem 15002 ports && builtins.elem 7077 ports;
-        message = "ix-spark master should open the Connect (15002) and master (7077) ports";
+        message = "ix-spark master should open the Connect (15002) and master (7077) ports on tailscale0";
+      }
+      {
+        # Spark's master RPC and Connect server are unauthenticated (a job
+        # submission is code execution), so nothing may open them on the GLOBAL
+        # firewall -- same exposure class as ix-ray (index#1800 review).
+        assertion =
+          let
+            globalPorts = ixSparkMaster.networking.firewall.allowedTCPPorts;
+          in
+          builtins.all (p: !(builtins.elem p globalPorts)) [
+            7077
+            7078
+            7079
+            7080
+            15002
+          ];
+        message = "ix-spark must never open its ports on the global firewall, only on tailscale0";
       }
       {
         # A worker only runs a worker joining the remote master: no master, no
         # connect, and it must not open the master's ports.
         assertion =
           let
-            ports = ixSparkWorker.networking.firewall.allowedTCPPorts;
+            ports = ixSparkWorker.networking.firewall.interfaces."tailscale0".allowedTCPPorts;
           in
           (ixSparkWorker.systemd.services ? spark-worker)
           && !(ixSparkWorker.systemd.services ? spark-master)


### PR DESCRIPTION
Ray's GCS + Client server and Spark's master RPC + Connect server are unauthenticated (reaching them is arbitrary code execution). `openFirewall = true` opened them on the GLOBAL firewall, i.e. every interface, and fleet hosts face the internet, so it would have published `ray://<public-ip>:10001` (index#1800 review, S1).

- Firewall opens move to `networking.firewall.interfaces."tailscale0"` (exec/mesh included, defense in depth); the daemons already bind the tailscale IPv4 and the tailnet is the stated trust boundary.
- Eval tests now assert the ray/spark ports are ABSENT from the global firewall, so this cannot regress.
- Documents the non-HA GCS (head restart = cluster reset, raylets re-register via Restart=on-failure).
- `examples/ray/cluster` keeps its guest-global worker range with a comment why: those ix guest VMs have no tailscale and no public interface (east-west only), so tailscale0 scoping cannot apply there.

Validated by evaluating the ix fleet consumer against this branch (override-input): head global firewall = [53,80,443,8444] (no Ray ports), tailscale0 = [6379,6380,6381,8798,8799,10001] + worker range; workers expose no 6379/10001 anywhere.

Refs index#1800.

_Authored by Claude (Opus 4.8) on behalf of @andrewgazelka._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope Ray and Spark firewall rules to the `tailscale0` interface only
> - Changes `openFirewall` in both [services/ray](https://github.com/indexable-inc/index/pull/1802/files#diff-fcb55115d0f76c61bd91044049504b687d342d6087ea0e2046702ed9a5133333) and [services/spark](https://github.com/indexable-inc/index/pull/1802/files#diff-a2b1947d38332db6feae0231345dbceec287e5e298dc0b952aff12feb14c70f4) to open ports under `networking.firewall.interfaces."tailscale0"` instead of the global firewall, since neither Ray nor Spark has per-call authentication.
> - Updates tests to assert ports appear on `tailscale0` and are absent from the global firewall.
> - The Ray cluster node example in [cluster-node.nix](https://github.com/indexable-inc/index/pull/1802/files#diff-4c4822f84dc715e2feab4d0c118d89414d2e274c2b952439e23fe4443c6af07e) retains a global firewall opening with an updated comment explaining it runs in guest VMs with no public interface and no Tailscale.
> - Behavioral Change: any deployment relying on `openFirewall = true` to expose Ray or Spark ports on all interfaces will now only have those ports reachable via `tailscale0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ded4f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->