### PR TITLE
fix(cache-push): fall back to source builds when a substitute is poisoned

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -24,11 +24,19 @@ concurrency:
 
 env:
   # Shared with check.yml; restricted settings are daemon-owned and ignored here.
+  # `fallback` is push-only (not in check.yml): a poisoned substitute -- a
+  # truncated HTTP 200 NAR from a cache incident (ix#6139) -- otherwise aborts
+  # realising a push root, and that root silently never publishes. Run
+  # 28657772825 lost the cross-IFD `cargo-vendor-dir` root exactly this way,
+  # leaving Darwin consumers unable to eval cross packages (#1711). Falling
+  # back to a source build keeps every root publishable regardless of cache
+  # health.
   NIX_CONFIG: |-
     experimental-features = nix-command flakes ca-derivations
     accept-flake-config = true
     max-jobs = auto
     cores = 1
+    fallback = true
 
 jobs:
   push:


### PR DESCRIPTION
Darwin consumers of cross rust packages still cannot eval (#1711) even though #1751 added the eval-time IFD outputs to `cachePushRoots`: the cache-push run itself substitutes deps from the poisoned attic cache (truncated HTTP 200 NARs, ix#6139), and without `fallback` a single bad substitute aborts `nix-store --realise` for the whole root. Run 28657772825 lost the cross-IFD `cargo-vendor-dir` root exactly this way (`unable to download .../nar/5s913...nar: HTTP error 200 (Transferred a partial file)` -> `some references of path .../cargo-vendor-dir could not be realised`).

One-line fix: `fallback = true` in the workflow's `NIX_CONFIG` (same mitigation as ix#6140's push-status-images), so a poisoned substitute is rebuilt from source and every root still publishes.

Note: the currently-served truncated NARs for already-pushed paths (e.g. `6md2...-cargo-units.nix`, NarSize 11068376 but 22943 bytes served) heal on the ix#6139 garage metadata recovery, not by re-pushing (attic dedups against existing chunk rows). This PR only makes the pusher itself immune.

Refs #1711.

(authored by Claude Code on Andrew's behalf)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to source builds when a substitute is poisoned in cache-push workflow
> Adds `fallback = true` to `NIX_CONFIG` in [cache-push.yml](.github/workflows/cache-push.yml) so that Nix falls back to building from source instead of failing when a cache substitute is unavailable or invalid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 297d462.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->