### PR TITLE
ci(cache-push): warn loudly when realise falls back to source builds

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -30,7 +30,10 @@ env:
   # 28657772825 lost the cross-IFD `cargo-vendor-dir` root exactly this way,
   # leaving Darwin consumers unable to eval cross packages (#1711). Falling
   # back to a source build keeps every root publishable regardless of cache
-  # health.
+  # health. Remove once indexable-inc/ix#6139 closes with the cache serving
+  # verified-complete NARs (the migrate-guard root cause already landed in
+  # indexable-inc/ix#6149); the fallback-detection warning in the realise
+  # phase below goes with it.
   NIX_CONFIG: |-
     experimental-features = nix-command flakes ca-derivations
     accept-flake-config = true
@@ -151,6 +154,24 @@ jobs:
               done < "$workdir/realise.err" | sort -u | head -n 20
             }
           phase realise "$realise_t"
+
+          # `fallback = true` engages silently: nix rebuilds a failed
+          # substitute from source with no distinct log line, so a degraded
+          # cache would surface only as slower runs. Every substitution
+          # failure does leave a download-error line in realise.err even when
+          # the realise itself then succeeds; count those and warn loudly.
+          # Pure bash (no grep on the runner PATH), same as the error loop
+          # above.
+          fallback_hits=0
+          while IFS= read -r line; do
+            case $line in
+              *"Transferred a partial file"* | *"unable to download"* | *"some substitutes for the outputs"*)
+                fallback_hits=$(( fallback_hits + 1 )) ;;
+            esac
+          done < "$workdir/realise.err"
+          if [ "$fallback_hits" -gt 0 ]; then
+            echo "::warning::cache-push: $fallback_hits substitution-failure line(s) during realise; nix fell back to source builds (cache health degraded, see indexable-inc/ix#6139)"
+          fi
 
           if [ -s "$outs" ]; then
             push_t=$SECONDS


### PR DESCRIPTION
Follow-up to #1804 from its adversarial review (two confirmed non-blocking gaps):

- **H1 (loud fallback)**: `fallback = true` rebuilds a poisoned substitute silently; the only symptom is a slower run. Now the realise phase counts substitution-failure lines in `realise.err` (`unable to download` / `Transferred a partial file` / `some substitutes for the outputs`) and emits `::warning::cache-push: N substitution-failure line(s) ... fell back to source builds` when any are present. Pure bash, same style as the existing error loop (runner PATH has no grep).
- **H2 (debt removability)**: the comment now states when the mitigation can be removed: once indexable-inc/ix#6139 closes with the cache serving verified-complete NARs (migrate-guard root cause already landed in indexable-inc/ix#6149).

Refs #1711.

(authored by Claude Code on Andrew's behalf)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn when Nix substitution failures cause source builds in the cache-push workflow
> After the `phase realise` step in [cache-push.yml](.github/workflows/cache-push.yml), a new bash block scans `realise.err` for substitution failure indicators (e.g., `unable to download`, `Transferred a partial file`) and emits a GitHub Actions warning with the failure count when any are detected. Comments note this fallback behavior is temporary pending resolution of indexable-inc/ix#6139.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54a9611.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->