### PR TITLE
fix(rust): allow substituting the aggregate cargo vendor dir

### DIFF
--- a/lib/rust/vendor.nix
+++ b/lib/rust/vendor.nix
@@ -312,7 +312,16 @@ let
           Cargo.lock contains multiple git dependencies with the same name-version: ${join ", " duplicateNameVersions}
           cargo-unit cannot generate an aggregate vendor dir for this lock without losing source identity.
         '';
-        pkgs.linkFarm "cargo-vendor-dir" vendorEntries;
+        (pkgs.linkFarm "cargo-vendor-dir" vendorEntries).overrideAttrs (_old: {
+          # linkFarm hardcodes `allowSubstitutes = false` (a symlink farm is
+          # cheaper to rebuild than to fetch). That default is wrong here: a
+          # Darwin consumer forces this x86_64-linux drv at eval time through
+          # the cross lane's IFD (`import unitsNix` reaches the vendor dir),
+          # cannot build it, and with substitution disallowed cannot use the
+          # pushed cache output either -- eval dies with `platform mismatch`
+          # no matter how healthy cache.ix.dev is (#1711).
+          allowSubstitutes = true;
+        });
     in
     {
       inherit vendorSources vendorDir;


### PR DESCRIPTION
Third (and root-cause) layer of #1711. With the cache fully healed (ix#6139 recovery) and the IFD closure pushed (#1751, #1804, #1805), Darwin eval of `packages.aarch64-darwin.nix-web-monitor` STILL fails:

```
error: Cannot build '/nix/store/94w40yj...-cargo-vendor-dir.drv'.
       Reason: platform mismatch
```

Verified against a fresh chroot store: nix substituted all 1169 references of the vendor dir, the cached NAR is intact (decompresses to exactly NarSize), and nix still refused to substitute the vendor dir itself. The drv env shows why: `allowSubstitutes = ""` -- `linkFarm` hardcodes `allowSubstitutes = false` ("cheaper to rebuild than fetch"), which is exactly wrong for a drv that Darwin consumers can only ever satisfy by substitution.

One-line fix via `overrideAttrs`: `allowSubstitutes = true` on the aggregate vendor dir. Note this rotates the vendor-dir drv hash -> unit graphs re-render -> first cache-push run after merge republishes the new IFD closure (now durable per #1804/#1805).

Validation plan (from an aarch64-darwin host with no local copies): `nix eval --store <fresh> --raw github:indexable-inc/index/<merged rev>#packages.aarch64-darwin.nix-web-monitor.outPath` after the post-merge cache-push completes.

Refs #1711.

(authored by Claude Code on Andrew's behalf)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow binary cache substitution for the aggregate cargo vendor directory
> The `vendorDir` derivation in [vendor.nix](https://github.com/indexable-inc/index/pull/1806/files#diff-a68ba2f291e368b8545afebfed95122fe35b497c0e4e6be7aae8ca53864a61b7) now sets `allowSubstitutes = true` via `overrideAttrs`. By default, Nix sets `allowSubstitutes = false` for `linkFarm` derivations, which forces a local build even when a cached result is available. This fix lets Nix fetch the vendor directory from binary caches instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f54bda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->