### PR TITLE
tests: pin allowSubstitutes = true on the aggregate cargo vendor dir

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4530,6 +4530,15 @@ let
         message = "cargo-unit policy checks should be disableable for generated workspaces";
       }
       {
+        # A Darwin consumer forces the (x86_64-linux) vendor dir at eval
+        # through the cross lane's IFD and can only ever satisfy it by
+        # substitution; linkFarm's `allowSubstitutes = false` default made
+        # that impossible (#1711). Pin the override so a vendor-dir refactor
+        # cannot silently regress Darwin eval of cross packages.
+        assertion = cargoUnitWorkspace.vendorDir.allowSubstitutes or false;
+        message = "the aggregate cargo vendor dir must set allowSubstitutes = true; Darwin cross consumers can only substitute it (#1711)";
+      }
+      {
         assertion = cargoUnitScope.base.alpha.drvPath != cargoUnitScope.alphaChanged.alpha.drvPath;
         message = "cargo-unit should rebuild the changed workspace crate";
       }


### PR DESCRIPTION
Follow-up to #1806 from its adversarial review (M1, confirmed): no test defended the vendor-dir `allowSubstitutes = true` override, so a revert to linkFarm's default would pass CI and silently regress #1711. Adds one eval assertion to the cargo-unit group pinning `cargoUnitWorkspace.vendorDir.allowSubstitutes or false`, with the #1711 rationale in a comment. The `or false` shape means a renamed/removed attr also fails loud instead of vacuously passing.

Refs #1711.

(authored by Claude Code on Andrew's behalf)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Assert `cargoUnitWorkspace.vendorDir.allowSubstitutes` is true in tests
> Adds a test assertion in [tests/default.nix](https://github.com/indexable-inc/index/pull/1807/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that `cargoUnitWorkspace.vendorDir.allowSubstitutes` evaluates to `true`. The assertion message notes that the aggregate cargo vendor dir must set `allowSubstitutes = true` for Darwin cross consumers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47be7f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->