### PR TITLE
system-prompt-eval: fail loudly on unknown expects ids

### DIFF
--- a/packages/agent/system-prompt-eval/default.nix
+++ b/packages/agent/system-prompt-eval/default.nix
@@ -61,9 +61,11 @@
     '';
 
   # Offline, deterministic: the scoring math is the CI-gating signal, unit-tested
-  # against the installed package with no network or key.
+  # against the installed package with no network or key. SYSTEM_PROMPT_EVAL_DATA_DIR
+  # points the dataset-integrity check (validate_expects over the committed JSONL)
+  # at the real datasets, the same way the wrapped `package` does at runtime.
   scoring = pkgs.runCommand "system-prompt-eval-scoring" {strictDeps = true;} ''
-    ${unwrapped}/venv/bin/python ${./tests/test_scoring.py}
+    SYSTEM_PROMPT_EVAL_DATA_DIR=${data} ${unwrapped}/venv/bin/python ${./tests/test_scoring.py}
     mkdir -p "$out"
   '';
 

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/behaviors_eval.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/behaviors_eval.py
@@ -22,6 +22,7 @@ NAME = "behaviors"
 def run(ctx: EvalContext, *, tasks_path: Path | None = None, behaviors_path: Path | None = None) -> EvalReport:
     behaviors = data.load_behaviors(behaviors_path)
     tasks = data.load_tasks(tasks_path)
+    data.validate_expects(tasks, behaviors)
     if ctx.limit is not None:
         tasks = tasks[: ctx.limit]
 

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/data.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/data.py
@@ -50,3 +50,21 @@ def load_tasks(override: Path | None = None) -> list[TaskCase]:
         )
         for row in _read_lines("tasks.jsonl", override)
     ]
+
+
+def validate_expects(tasks: list[TaskCase], behaviors: list[Behavior]) -> None:
+    """Fail loudly if a task's ``expects`` names a behavior id absent from the catalog.
+
+    A typo'd or stale id would otherwise be silently dropped where ``expects`` is
+    consumed (the runner scores only ids present in the catalog), masking dataset
+    drift as a quietly lower score instead of a load-time error.
+    """
+    known = {b.id for b in behaviors}
+    unknown = sorted(
+        {bid for task in tasks for bid in task.expects if bid not in known}
+    )
+    if unknown:
+        raise ValueError(
+            f"tasks.jsonl expects unknown behavior id(s) not in behaviors.jsonl: "
+            f"{', '.join(unknown)}"
+        )

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/runner.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/runner.py
@@ -35,7 +35,12 @@ def run_eval(
     max_workers: int = 4,
     progress: Progress = _noop,
 ) -> list[RolloutResult]:
-    """Run ``rollouts`` fresh agents per task, capture transcripts, then judge."""
+    """Run ``rollouts`` fresh agents per task, capture transcripts, then judge.
+
+    Assumes every task's ``expects`` id is present in ``behaviors``; callers load
+    both through :mod:`data` and validate with ``data.validate_expects`` first, so
+    an unknown id here is a bug in the caller, not dataset drift to swallow.
+    """
     by_id = {b.id: b for b in behaviors}
     jobs = _jobs(tasks, rollouts)
 
@@ -65,7 +70,7 @@ def run_eval(
     for result in captured:
         if result.error is not None:
             continue
-        expected = [by_id[bid] for bid in expects_by_id[result.case_id] if bid in by_id]
+        expected = [by_id[bid] for bid in expects_by_id[result.case_id]]
         progress(f"judge {result.case_id}#{result.rollout}")
         try:
             result.verdicts = judge.grade(

--- a/packages/agent/system-prompt-eval/tests/test_scoring.py
+++ b/packages/agent/system-prompt-eval/tests/test_scoring.py
@@ -8,7 +8,8 @@ turns judge verdicts into the committed score.
 
 from __future__ import annotations
 
-from system_prompt_eval.model import BehaviorVerdict, RolloutResult, TaskCase
+from system_prompt_eval.data import load_behaviors, load_tasks, validate_expects
+from system_prompt_eval.model import Behavior, BehaviorVerdict, RolloutResult, TaskCase
 from system_prompt_eval.report import (
     longest_streak_for,
     max_streak,
@@ -98,6 +99,29 @@ def test_max_streak_across_tasks() -> None:
         _result("t2", 1, {"a": True}),
     ]
     assert max_streak(results, tasks) == 2
+
+
+def test_validate_expects_accepts_known_ids() -> None:
+    behaviors = [Behavior(id="a", name="A", rubric="")]
+    tasks = [TaskCase(id="t", task="", expects=("a",))]
+    validate_expects(tasks, behaviors)  # must not raise
+
+
+def test_validate_expects_rejects_unknown_id() -> None:
+    behaviors = [Behavior(id="a", name="A", rubric="")]
+    tasks = [TaskCase(id="t", task="", expects=("a", "typo_id"))]
+    error: ValueError | None = None
+    try:
+        validate_expects(tasks, behaviors)
+    except ValueError as exc:
+        error = exc
+    assert error is not None, "expected ValueError for an unknown expects id"
+    assert "typo_id" in str(error)
+
+
+def test_committed_tasks_expect_only_cataloged_behaviors() -> None:
+    """Guards the actual datasets: a bad id here would silently score wrong."""
+    validate_expects(load_tasks(), load_behaviors())  # must not raise
 
 
 def _main() -> None:


### PR DESCRIPTION
Fixes silent dataset drift in the system-prompt-eval behaviors eval: a typo'd or stale id in a task's `expects` was quietly dropped by `runner.py`'s `if bid in by_id` filter instead of failing, so a bad id just meant a lower score, not an error.

- Adds `data.validate_expects(tasks, behaviors)`, called once by `behaviors_eval.run` right after loading both datasets, raising `ValueError` listing any unknown id(s).
- Removes the now-dead silent filter in `runner.py` (`by_id[bid]` direct lookup, since validation already guarantees the id exists).
- Covers it in `tests/test_scoring.py`: unit tests for `validate_expects` (accept/reject), plus a test that runs it against the actual committed `datasets/tasks.jsonl` + `datasets/behaviors.jsonl`, wired into the offline `scoring` passthru test (no network, no API key).

Closes #1811

*Filed and implemented by Claude (agent issue-1811-expects-integrity) via Claude Code.*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail loudly on unknown behavior ids in system-prompt-eval expects
> - Adds `validate_expects()` in [data.py](https://github.com/indexable-inc/index/pull/1812/files#diff-08dd07f94a9a8337e1c9e3f76d28936eac57cca4dc1319ab337a86a43307de32) that raises a `ValueError` listing any behavior ids referenced by tasks but absent from the loaded catalog.
> - Calls `validate_expects()` in the `run()` entrypoint before evaluation begins, replacing the previous silent drop of unknown ids.
> - Removes the `if bid in by_id` guard in [runner.py](https://github.com/indexable-inc/index/pull/1812/files#diff-45f223b688d66c39a78507c1fc374b217011eaaaabc7a826b92cfa089787b3a9) so unknown ids now surface as a `KeyError` rather than being silently ignored.
> - Adds unit and integration tests, including a dataset-integrity check that validates committed tasks reference only cataloged behaviors.
> - Behavioral Change: tasks with unknown expects ids now raise a `ValueError` at load time instead of being silently skipped during evaluation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cea6264.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->