### PR TITLE
Stop denying Claude Bash with index MCP

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -238,9 +238,7 @@
   };
 
   # Claude-native permission deny list rendered from shared agent policy.
-  sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
-    inherit lib mcpServers;
-  };
+  sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {};
 
   # Caller's extraSettings first, then the computed defaults recursively merged
   # ON TOP, so the keys below always win a conflict while the caller's other

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -99,9 +99,7 @@
     })
     flat;
 
-  sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
-    inherit lib mcpServers;
-  };
+  sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {};
   effectiveForcedSettings =
     forcedSettings
     // sharedPermissions.codex.forcedSettings

--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -1,18 +1,13 @@
-{
-  lib,
-  mcpServers ? {},
-}: let
+_: let
   protectedMergeToolPatterns = [
     "Bash(gh pr merge*--admin*)"
     "Bash(gh pr merge*--force*)"
   ];
 
-  supersededBuiltinTools =
-    [
-      "WebSearch"
-      "WebFetch"
-    ]
-    ++ lib.optional (mcpServers ? index) "Bash";
+  supersededBuiltinTools = [
+    "WebSearch"
+    "WebFetch"
+  ];
 
   codexForcedSettings = {
     features = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3602,10 +3602,7 @@
       }
       {
         assertion = let
-          policy = import (paths.packagesRoot + "/agent/policy/permissions.nix") {
-            inherit lib;
-            mcpServers = {};
-          };
+          policy = import (paths.packagesRoot + "/agent/policy/permissions.nix") {};
         in
           policy.claude.deniedToolPatterns
           == [
@@ -3625,7 +3622,7 @@
             standalone_web_search = false;
             unified_exec = false;
           };
-        message = "agent policy should always disable built-in web search tools";
+        message = "agent policy should deny only protected merges and built-in web search tools";
       }
       {
         assertion = let


### PR DESCRIPTION
Summary
- Removed the conditional Claude `Bash` deny when the index MCP server is configured.
- Simplified the shared agent permissions policy now that it no longer depends on MCP server presence.
- Updated the eval assertion to pin the exact Claude deny list.

Validation
- `nix eval --raw --impure --expr 'let policy = import ./packages/agent/policy/permissions.nix {}; in builtins.toJSON policy.claude.deniedToolPatterns'`
- `nix run .#lint`

Refs #1813

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop denying Bash when the index MCP server is configured
> Removes the conditional logic in [permissions.nix](https://github.com/indexable-inc/index/pull/1814/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) that added `"Bash"` to `supersededBuiltinTools` when an `index` MCP server was present. `supersededBuiltinTools` now always contains only `["WebSearch", "WebFetch"]`. The module signature is simplified to ignore all inputs, and call sites in `claude-code`, `codex`, and tests are updated to pass `{}`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f6f7b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->