### PR TITLE
test(image): assert the baked nix DB registers the pinned nixpkgs as valid

### DIFF
--- a/lib/image/oci-layer.nix
+++ b/lib/image/oci-layer.nix
@@ -82,10 +82,17 @@
         maxLayers = 67;
         contents = [systemRoot];
         config.Entrypoint = ["${toplevel}/init"];
-        # Include the nix database so store validity can be verified inside the image.
-        # This enables fast path validation without requiring a network lookup to the
-        # nixpkgs source. ix#6043: OCI image was missing this, causing VMs to timeout
-        # on first nix command.
+        # Bake `/nix/var/nix/db/db.sqlite` registering the whole closure as
+        # valid. Without it the guest boots with an empty store DB, so the
+        # nixpkgs source the registry pins (present in the image, valid nowhere)
+        # reads as invalid; nix's `narHash` short-circuit only skips re-ingest
+        # for a VALID path, so the first `nix run`/`nix eval` in a fresh VM
+        # re-copies the ~45k-file tree through VCFS: measured 5m40s first eval,
+        # ~1s once registered (2026-07-03). dockerTools runs closureInfo +
+        # `nix-store --load-db` at build time into the customisation layer,
+        # which oci-image-builder copies verbatim. ix#6043, index #1748/#1749/#1815.
+        # The `base-image-nix-db` check asserts the baked DB actually registers
+        # the nixpkgs source as valid (a bare db.sqlite is not enough).
         includeNixDB = true;
       };
 
@@ -121,17 +128,6 @@
       }
       ''
         oci-image-builder ${lib.escapeShellArgs (efficiencyArgs ++ ["${stream.passthru.conf}"])} "$out"
-
-        # Validate that the archive includes the nix database.
-        # This ensures VMs can verify store paths immediately without network roundtrips.
-        echo "Validating nix database inclusion..."
-        if tar -tf "$out" | grep -q 'db\.sqlite'; then
-          echo "✓ Database validation passed: db.sqlite found in OCI archive"
-        else
-          echo "ERROR: db.sqlite not found in OCI archive"
-          echo "This may indicate includeNixDB is not working correctly"
-          exit 1
-        fi
       '';
   };
 }

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -967,6 +967,11 @@
           # pre-run at build time so the VM never needs the network; see
           # tests/minecraft-blocks-vm.nix.
           minecraft-blocks-vm = tests.minecraftBlocksVm;
+          # Builds the base OCI archive and asserts its baked nix store DB
+          # registers the pinned nixpkgs source as valid, so a fresh VM's first
+          # `nix` command does not re-copy the tree through VCFS (ix
+          # #1748/#1749/#1815). Its own check because it builds an image.
+          base-image-nix-db = tests.baseImageNixDb;
           # Skills and subagents are rendered live by the SessionStart hook.
           # This gate forces both materialized directories to build.
           agent-skills = pkgs.runCommand "agent-skills-check" {} ''

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2163,6 +2163,60 @@
     cfg = config.ix.profiles.base;
   };
 
+  # Regression fence for the guest-nix-slowness bug family (ix #1748/#1749/#1815):
+  # the image must ship a nix store DB that registers the pinned nixpkgs source as
+  # VALID. #1749 locked the registry pin's narHash, but narHash only short-circuits
+  # re-ingest for a path nix already considers valid; the OCI image baked no store
+  # DB at all, so the pinned source (present in the image) read as invalid and the
+  # first in-VM `nix` command re-copied the ~45k-file tree through VCFS (5m40s).
+  # `includeNixDB = true` (oci-layer.nix) fixes it by baking db.sqlite via
+  # closureInfo + `nix-store --load-db` into the customisation layer, which
+  # oci-image-builder copies verbatim. This check builds the real base OCI archive
+  # and asserts db.sqlite registers the nixpkgs source as valid, so it also proves
+  # the DB survives oci-image-builder's re-streaming. It builds an OCI image, so it
+  # is its own check (not the pure-eval `eval` aggregate) and runs on Linux.
+  baseImageNixDb =
+    pkgs.runCommand "ix-test-base-image-nix-db" {
+      nativeBuildInputs = [
+        pkgs.gnutar
+        pkgs.sqlite
+        pkgs.gnugrep
+        pkgs.coreutils
+      ];
+      archive = base.imageConfig.ix.build.ociImage;
+      nixpkgsSource = nixpkgs.outPath;
+    } ''
+      mkdir extract db
+      # oci-image-builder writes uncompressed tar layers as blobs/sha256/<digest>.
+      # The nix store DB lives in the customisation layer; find whichever blob
+      # carries it and extract just that file.
+      tar -C extract -xf "$archive"
+      found=
+      for blob in extract/blobs/sha256/*; do
+        if tar -tf "$blob" 2>/dev/null | grep -qx './nix/var/nix/db/db.sqlite'; then
+          tar -C db -xf "$blob" ./nix/var/nix/db/db.sqlite
+          found=1
+          break
+        fi
+      done
+      if [ -z "$found" ]; then
+        echo "error: no OCI layer contains nix/var/nix/db/db.sqlite; the image ships no store DB (includeNixDB off?)" >&2
+        exit 1
+      fi
+      dbfile=db/nix/var/nix/db/db.sqlite
+      # The pinned nixpkgs source must be a VALID path in the shipped DB, or the
+      # guest re-ingests it on first eval.
+      count=$(sqlite3 "$dbfile" \
+        "SELECT count(*) FROM ValidPaths WHERE path = '$nixpkgsSource';")
+      if [ "$count" != "1" ]; then
+        echo "error: nixpkgs source $nixpkgsSource is not registered valid in the image nix DB (found $count rows)" >&2
+        echo "ValidPaths sample:" >&2
+        sqlite3 "$dbfile" "SELECT path FROM ValidPaths LIMIT 20;" >&2
+        exit 1
+      fi
+      mkdir -p "$out"
+    '';
+
   # --- Language helpers -----------------------------------------------------
 
   languages = {
@@ -5494,6 +5548,7 @@ in {
   sdkPythonStrict = sdkPython.strictCheck;
   portableServices = portableServicesTest;
   minecraftBlocksVm = minecraftBlocksVmTest;
+  inherit baseImageNixDb;
 
   # Aggregate. Pulls every group test into one derivation so
   # `nix flake check` covers the whole suite.


### PR DESCRIPTION
## Context: the fix already landed in parallel

While I was preparing the `includeNixDB` fix, **#1816** (same author, fixes ix#6043) merged the identical root-cause fix one minute before this PR opened. Rather than duplicate it, this PR keeps #1816's `includeNixDB = true` and **upgrades the regression fence**.

## Root cause (unchanged, for reference)

A fresh `ix new` VM's first flake command re-ingested the ~45k-file nixpkgs tree through VCFS (5m40s first eval, ~1s after). The registry-pinned nixpkgs source shipped in the image but read as **invalid** (`nix path-info` -> "path is not valid") because the OCI image baked no nix store DB (`streamLayeredImage`'s `includeNixDB` defaults false; the guest boot runs no `nix-store --load-db`). nix's narHash short-circuit only skips re-ingest for a VALID path. Refs: index #1748/#1749/#1815, ix#6043.

## What this PR changes (net vs main, after rebasing onto #1816)

- **Replaces #1816's inline archive check** with a proper durable check. #1816's check was `tar -tf "$out" | grep db.sqlite` on the final OCI tar — but that lists only the top-level tar members (`blobs/`, `index.json`), not files nested inside layer blobs, and it never verifies store-path *validity*. A db.sqlite that exists but doesn't register the nixpkgs path would pass it while the slow re-ingest persists.
- **Adds `checks.x86_64-linux.base-image-nix-db`**: builds the real base OCI archive, extracts `db.sqlite` from the layer blob that carries it, and asserts `ValidPaths` contains the pinned nixpkgs `-source` path. This fences the true invariant (validity, not mere presence) and also proves `oci-image-builder` preserves the baked DB through re-streaming.
- Tightens the `includeNixDB` comment to record the measured cost and why validity is the point.

## Validation

- `nix run .#lint` green; flake evals cleanly (no more duplicate-attribute error; the earlier CI failure was the pre-rebase duplicate `includeNixDB`).
- The `base-image-nix-db` check builds an OCI image, so it runs on Linux CI (darwin can't build it locally — image eval hits an IFD).

Closes #1815

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test asserting the baked Nix DB registers the pinned nixpkgs as a valid path
> - Introduces `tests.baseImageNixDb` in [tests/default.nix](https://github.com/indexable-inc/index/pull/1817/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a): unpacks the base OCI archive, finds the layer containing the Nix store DB, and queries `db.sqlite` via `sqlite3` to confirm the pinned nixpkgs source path is present in the `ValidPaths` table.
> - Moves the previously inline `db.sqlite` presence check out of the [lib/image/oci-layer.nix](https://github.com/indexable-inc/index/pull/1817/files#diff-2f593cc5e1a07acba76a950c1132a06b5d7646750989d806816be811310a32f4) build script and into this dedicated, more thorough test.
> - Registers the new test as `base-image-nix-db` in the `checks` set in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1817/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a2e32a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->