### PR TITLE
feat(image): bake the index flake into the base image (registry pin + valid source)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -252,6 +252,7 @@
 
     ix = import ./lib {
       inherit
+        self
         rev
         revEpoch
         nixpkgs

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -23,6 +23,12 @@
   # revision. The `build-version` crate renders it. `0` when unknown. Defaulted
   # so a direct `import ./lib` still evaluates.
   revEpoch ? 0,
+  # The flake's own source (`self`), carrying `.outPath` (a `-source` store
+  # path with string context, so it roots into a closure like `nixpkgs`) and
+  # `.narHash`. Only the flake scope sees these, so they are plumbed down to
+  # `lib/image` for the guest `index` registry pin. Defaulted `null` so a bare
+  # `import ./lib` (no flake) still evaluates; `lib/image` guards on it.
+  self ? null,
 }: let
   inherit (nixpkgs) lib;
 
@@ -504,6 +510,7 @@
   inherit
     (import ./image {
       inherit
+        self
         lib
         nixpkgs
         paths

--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -9,6 +9,10 @@
   moduleList,
   writeNushellApplication,
   packageSetFor,
+  # The index flake's own `self`, for the guest `index` registry pin (see the
+  # `nix.registry.index` module below). `null` when `lib` is imported without a
+  # flake; the pin is then omitted.
+  self ? null,
 }: let
   /**
   One nixpkgs instance shared by every image evaluation. `lib.nixosSystem`
@@ -83,6 +87,28 @@
               inherit (nixpkgs) narHash;
             };
           }
+        ]
+        ++ lib.optional (self != null) {
+          # Same treatment for the `index` flake itself, so an in-guest
+          # `nix run index#<pkg>` (and any flake declaring `index` as an input
+          # at this locked rev) resolves against the source baked in the image
+          # instead of fetching it from GitHub. The base image's nix store DB
+          # (`includeNixDB`, oci-layer.nix) registers this `-source` path as
+          # valid — nix then treats the locked, narHash-matched reference as
+          # already present and never re-fetches or re-ingests it, the same
+          # property nixpkgs got in ix#6043/#1748/#1749/#1815.
+          #
+          # `self.outPath` is the ORIGINAL `-source` path and carries string
+          # context, so it roots into the image closure once (no duplicate
+          # copy — the #1748 trap). `self.narHash` locks the pin. Only this
+          # flake scope sees `self`, so it is plumbed down from `flake.nix`.
+          nix.registry.index.to = {
+            type = "path";
+            path = self.outPath;
+            inherit (self) narHash;
+          };
+        }
+        ++ [
           ./platform.nix
           ./oci-layer.nix
           # Home Manager as a NixOS module. Per-tool XDG config (Nushell,

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2166,7 +2166,7 @@
   # Regression fence for the guest-nix-slowness bug family. Do NOT delete as
   # redundant with the registry-pin assertion: this is the THIRD regression in
   # the same family, each of which passed the prior guard yet still left a fresh
-  # VM re-ingesting the ~45k-file nixpkgs tree through VCFS on first `nix`:
+  # VM re-ingesting a ~45k-file source tree through VCFS on first `nix`:
   #   1. missing narHash  — unlocked path: pin, re-hashed every eval (#1748/#1749)
   #   2. missing validity — narHash added, but narHash only short-circuits a path
   #      nix already considers VALID (#1815)
@@ -2174,12 +2174,26 @@
   #      all, so the pinned source (present in the image) was never valid; fixed
   #      by `includeNixDB = true` in oci-layer.nix
   # The boundary this defends: the built base OCI archive must ship a populated
-  # /nix/var/nix/db/db.sqlite whose ValidPaths includes the nixpkgs -source path.
-  # A bare db.sqlite, or the registry pin alone, is not enough. This check builds
-  # the real base archive and asserts exactly that, so it also proves the DB
-  # survives oci-image-builder's re-streaming. It builds an OCI image, so it is
-  # its own check (not the pure-eval `eval` aggregate) and runs on Linux.
-  baseImageNixDb =
+  # /nix/var/nix/db/db.sqlite whose ValidPaths includes EVERY path the image's
+  # flake registry pins (nixpkgs and, once baked, index) — otherwise the first
+  # in-guest `nix run nixpkgs#...`/`index#...` re-ingests that source. A bare
+  # db.sqlite, or the registry pin alone, is not enough. Deriving the required
+  # paths from the image's own `nix.registry.*.to.path` means a future pin is
+  # covered automatically and this can never silently drift from what ships.
+  # This check builds the real base archive and asserts exactly that, so it also
+  # proves the DB survives oci-image-builder's re-streaming. It builds an OCI
+  # image, so it is its own check (not the pure-eval `eval` aggregate) and runs
+  # on Linux.
+  baseImageNixDb = let
+    # Every `path`-type registry pin the image ships. Guard on the type so a
+    # non-path entry (e.g. a default indirect/github registry row) can't break
+    # the projection; those don't bake a source and aren't what this defends.
+    registryPaths = lib.pipe base.imageConfig.nix.registry [
+      builtins.attrValues
+      (builtins.filter (entry: (entry.to.type or null) == "path" && entry.to ? path))
+      (map (entry: entry.to.path))
+    ];
+  in
     pkgs.runCommand "ix-test-base-image-nix-db" {
       nativeBuildInputs = [
         pkgs.gnutar
@@ -2188,7 +2202,7 @@
         pkgs.coreutils
       ];
       archive = base.imageConfig.ix.build.ociImage;
-      nixpkgsSource = nixpkgs.outPath;
+      requiredPaths = registryPaths;
     } ''
       mkdir extract db
       # oci-image-builder writes uncompressed tar layers as blobs/sha256/<digest>.
@@ -2208,16 +2222,18 @@
         exit 1
       fi
       dbfile=db/nix/var/nix/db/db.sqlite
-      # The pinned nixpkgs source must be a VALID path in the shipped DB, or the
-      # guest re-ingests it on first eval.
-      count=$(sqlite3 "$dbfile" \
-        "SELECT count(*) FROM ValidPaths WHERE path = '$nixpkgsSource';")
-      if [ "$count" != "1" ]; then
-        echo "error: nixpkgs source $nixpkgsSource is not registered valid in the image nix DB (found $count rows)" >&2
-        echo "ValidPaths sample:" >&2
-        sqlite3 "$dbfile" "SELECT path FROM ValidPaths LIMIT 20;" >&2
-        exit 1
-      fi
+      # Every registry-pinned source must be a VALID path in the shipped DB, or
+      # the guest re-ingests it on first eval.
+      for src in $requiredPaths; do
+        count=$(sqlite3 "$dbfile" \
+          "SELECT count(*) FROM ValidPaths WHERE path = '$src';")
+        if [ "$count" != "1" ]; then
+          echo "error: registry-pinned source $src is not registered valid in the image nix DB (found $count rows)" >&2
+          echo "ValidPaths sample:" >&2
+          sqlite3 "$dbfile" "SELECT path FROM ValidPaths LIMIT 20;" >&2
+          exit 1
+        fi
+      done
       mkdir -p "$out"
     '';
 


### PR DESCRIPTION
## Goal

Give the `index` flake the same in-guest property nixpkgs got in #1816/#1817: a fresh VM's `nix run index#<pkg>` (and any flake declaring `index` as an input at the image's locked rev) resolves against the index source **baked in the image**, with zero GitHub fetch and zero VCFS re-ingest on first eval.

## How (item 1 — the dominant win)

Pin `nix.registry.index.to = { type = "path"; path = self.outPath; inherit (self) narHash; }`, exactly mirroring the nixpkgs pin at `lib/image/default.nix`. **The flake-input property:** a locked github/tarball input resolves locally when the store holds a valid path whose narHash matches the lock; the base image's `includeNixDB` store DB registers this `-source` path as valid, so nix short-circuits the reference and never fetches.

- Plumbs the flake's `self` (the only scope that sees `.outPath` + `.narHash`, per the #1749 note) from `flake.nix` → `lib/default.nix` → `lib/image/default.nix`. Guarded (`self ? null`, `lib.optional (self != null)`) so a bare `import ./lib` without a flake still evaluates.
- `self.outPath` is the ORIGINAL `-source` path and carries string context (verified: `getContext` → `{...-source: {path: true}}`), so it roots into the image closure **once** — no duplicate copy, the #1748 trap.
- Verified at eval: `base.imageConfig.nix.registry` now renders both `index` and `nixpkgs` as `path`-type pins with `-source` paths + narHashes.

## Regression fence

Generalized `checks.x86_64-linux.base-image-nix-db` to assert the shipped `db.sqlite` ValidPaths contains **every** `path`-type registry pin, derived from the image's own `nix.registry` — so it now covers `index` as well as `nixpkgs`, and any future pin is covered automatically without editing the check.

## Scope decision on item 2 (baking index's *other* locked inputs)

Enumerated from `flake.lock`, not guessed:
- **`nixpkgs`** — already baked + valid (same rev the image is built from). Free.
- **`path:` sub-inputs** (`examples`, `site`, `skills`, `tests`, `bench-filesystem`) — resolve inside the index source tree, so baking `self` already covers them. Free.
- **`flake=true` github inputs** — `rust-overlay` (19 MiB), `home-manager` (7 MiB), `hermes-agent` (**67 MiB**). These are forced only by specific package builds (e.g. a Rust package pulls rust-overlay), **not** by a typical `nix run index#<plain pkg>` eval. I deliberately did **not** bake them: baking all three (esp. hermes-agent's 67 MiB) is a large, permanent image-size cost for a source most invocations never touch, and the exact eval-forced set is package-specific. Recommendation: run the fresh-VM timing against the intended target; if it still fetches a specific source, bake exactly that one then.
- **`flake=false` `-src` inputs** (btop, drgn, fff, snix, …) — per-package build sources, never on a `nix run` eval path. Out of scope.

## Image size delta

The index source is a single **32 MiB** `-source` path with no closure deps (it's a source tree). That is required payload, not layer waste, and well within the OCI efficiency budget.

## Validation

- `nix run .#lint` green (alejandra + astlog + statix + deadnix + ruff).
- Eval-level proof on darwin: both registry pins render with the correct `-source` paths and narHashes. The base image itself builds only on Linux (image eval hits a darwin IFD), so the `base-image-nix-db` fence — now asserting the index path too — **relies on this PR's Linux CI**.

## Sequencing

Index-only change; no ix code change. After merge, the ix `index` pin bump (same path as #6187) delivers it to the base image build, then republish + fresh-VM `nix run index#<something small>` timing (owned by the delivery driver).

Refs ix#6043, index #1748/#1749/#1815.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bake a pinned `nix.registry.index` entry into the base NixOS image
> - Threads the flake's `self` through [flake.nix](https://github.com/indexable-inc/index/pull/1819/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) → [lib/default.nix](https://github.com/indexable-inc/index/pull/1819/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) → [lib/image/default.nix](https://github.com/indexable-inc/index/pull/1819/files#diff-3883253618b080892e770f4ceb96188ed814f4f588df529f7a82d338874c14bd) so the image build has access to `self.outPath` and `self.narHash`.
> - When `self` is provided, adds a `nix.registry.index` entry of `type=path` pointing to the baked source, so guests resolve `index` without refetching or reingesting the flake.
> - Updates the `baseImageNixDb` test in [tests/default.nix](https://github.com/indexable-inc/index/pull/1819/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to validate all path-type registry pins (not just nixpkgs) are present as valid paths in the image's Nix DB.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acb73b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->