### PR TITLE
fix(ray): exec `ray start`, not `ray --head` (crash-loop)

### DIFF
--- a/modules/services/ray/default.nix
+++ b/modules/services/ray/default.nix
@@ -108,7 +108,7 @@
       (toString cfg.objectStoreMemory)
     ];
 
-  startArgsNu = "[ ${lib.concatMapStringsSep " " builtins.toJSON (modeArgs ++ commonArgs)} ]";
+  startArgsNu = "[ ${lib.concatMapStringsSep " " builtins.toJSON (["start"] ++ modeArgs ++ commonArgs)} ]";
 
   # Resolve this node's tailscale IPv4 at runtime (it is host state, not a Nix
   # value), fail loudly if tailscale is not up, then exec `ray start` bound to

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2745,6 +2745,20 @@
         message = "ix-ray daemon should use /run/ray and leave the shared-memory object store mappable";
       }
       {
+        # Both roles must exec `ray start <flags>`: the launcher builds its arg
+        # list from `["start"] ++ modeArgs`, so the rendered script must carry
+        # the `start` subcommand ahead of the mode flag. Regressed once when the
+        # list began with `--head`/`--address` and Ray crash-looped on
+        # `No such option: --head` (index#1800 crash-loop).
+        assertion = let
+          headScript = builtins.readFile ixRayHead.systemd.services.ix-ray.serviceConfig.ExecStart;
+          workerScript = builtins.readFile ixRayWorker.systemd.services.ix-ray.serviceConfig.ExecStart;
+        in
+          lib.hasInfix "\"start\" \"--head\"" headScript
+          && lib.hasInfix "\"start\" \"--address\"" workerScript;
+        message = "ix-ray launcher must exec `ray start` (the `start` subcommand ahead of --head/--address), never `ray --head`";
+      }
+      {
         # A worker with no headAddress cannot know where to join: fail eval.
         assertion = let
           failures = failedAssertionsFor [


### PR DESCRIPTION
## Problem

`services.ix-ray` crash-loops on every node. The launcher built its exec arg list from `modeArgs ++ commonArgs`, which begins with `--head` (head) or `--address` (worker), so it ran:

```
ray --head --port 6379 ... --block
```

`ray` has no top-level `--head`, so every `ix-ray.service` died with `Error: No such option: --head` (exit 2) and `Restart=on-failure` spun it forever. Confirmed live on `hil-compute-1` (restart counter 300+) after the #1800 deploy. Affects both head and worker roles.

## Fix

Prepend the `start` subcommand to the shared arg list (`["start"] ++ modeArgs ++ commonArgs`), so both roles exec `ray start ...`. This matches the correct reference in `examples/ray/cluster/cluster-node.nix` (which already prepends `"start"`).

Checked the two sibling launchers for the same class of bug:
- `examples/ray/cluster/cluster-node.nix` — already correct (`start` is prepended).
- `modules/services/spark/default.nix` — not affected; Spark daemons launch via `spark-class <FQCN>` / `start-connect-server.sh`, no missing subcommand.

## Regression guard

Added an eval assertion in `tests/default.nix` that reads both rendered launcher scripts and requires `"start" "--head"` (head) and `"start" "--address"` (worker), so `ray --head` cannot come back.

Refs #1800

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Ray crash-loop by prepending `start` subcommand to `ExecStart` args
> The Ray NixOS module was generating commands like `ray --head` instead of `ray start --head`, causing Ray to error with "No such option: --head" and crash-loop. Fixes [default.nix](https://github.com/indexable-inc/index/pull/1820/files#diff-fcb55115d0f76c61bd91044049504b687d342d6087ea0e2046702ed9a5133333) to prepend `"start"` to the args list, and adds assertions in [tests/default.nix](https://github.com/indexable-inc/index/pull/1820/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) verifying the subcommand appears before the mode flag for both head and worker units.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab11771.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->