### PR TITLE
Remove landing sound instruction

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -10,7 +10,6 @@
   procps,
   ripgrep,
   git,
-  minecraft-sound,
   bubblewrap,
   socat,
   nix,
@@ -268,14 +267,12 @@
   };
 
   # Dirs prepended to PATH at launch (the old `--prefix PATH :`): ps for process
-  # checks, the pinned ripgrep, the house minecraft-sound chime, and the Linux
-  # sandbox helpers. Passed to the launcher as `path_prepend` (it joins them
-  # ahead of the caller's PATH).
+  # checks, the pinned ripgrep, and the Linux sandbox helpers. Passed to the
+  # launcher as `path_prepend` (it joins them ahead of the caller's PATH).
   pathPrepend = map (p: "${lib.getBin p}/bin") (
     [
       procps
       ripgrep
-      minecraft-sound
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       bubblewrap

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -819,11 +819,10 @@ let
           or `🌸 PR merged: [<title or number>](<url>) in <duration>`.
           For merged PRs, include queue split when applicable:
           `<total> (<before-queue> before queue, <in-queue> in queue)`.
-          Also play `minecraft-sound play block/amethyst/resonate1`.
         '';
         reason = ''
-          Landings were easy to miss in long sessions; one uniform line plus a sound
-          makes them auditable at a glance.
+          Landings were easy to miss in long sessions; one uniform line makes them
+          auditable at a glance.
         '';
       };
     }


### PR DESCRIPTION
## Summary
- Remove the system prompt requirement to play `minecraft-sound` after landings.
- Stop adding `minecraft-sound` to the Claude Code wrapper PATH now that the prompt no longer needs it.

## Validation
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'`
- `nix-instantiate --parse packages/agent/claude-code/default.nix`
- `nix build .#claude-code --no-link`
- `nix run .#lint`

(sent by Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove landing sound instruction from agent system prompt
> Removes the `minecraft-sound play block/amethyst/resonate1` instruction from the PR landing notifications block in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1821/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df). Also removes `minecraft-sound` from the inputs and PATH prepend in [default.nix](https://github.com/indexable-inc/index/pull/1821/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c1905e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->