### PR TITLE
dashboard: newest-first sessions + session age instead of run count

### DIFF
--- a/packages/dashboard/dashboard-core/site/src/components/Sidebar.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/Sidebar.svelte
@@ -7,7 +7,7 @@
   // what is visible.
   import { onMount } from 'svelte';
   import { store, timeline, loadRecording } from '$lib/stream.svelte';
-  import { ui, isOpen, toggleFold, setFold, select, focusPane, humanTime, humanClock, runTooltip } from '$lib/ui.svelte';
+  import { ui, isOpen, toggleFold, setFold, select, focusPane, humanTime, humanAge, humanClock, runTooltip } from '$lib/ui.svelte';
   import { setListNav } from '$lib/keys.svelte';
   import {
     buildSidebar,
@@ -88,8 +88,9 @@
       return;
     }
     if (!flat.some((f) => selectionEq(f.selection, ui.selection))) {
-      // Newest by timestamp, not render order: sessions are ordered by first
-      // appearance, so an older session can hold the most recent run.
+      // Newest by timestamp, not render order: runs are oldest-first within a
+      // session, and a filter/fold can hide the globally newest run, so the
+      // first visible row isn't necessarily the most recent one.
       const runs = flat.filter((f) => f.selection.kind === 'run');
       const newest = runs.reduce<(typeof runs)[number] | null>((best, f) => {
         const key = (f.selection as { key: string }).key;
@@ -201,10 +202,16 @@
         {/if}
         {#each sessions as s (s.scope)}
           {@const foldKey = 'sess:' + s.scope}
-          <button class="session-head" onclick={() => toggleFold(foldKey)} aria-expanded={isOpen(foldKey)} title={s.label}>
+          {@const age = humanAge(s.lastActivity, refMs)}
+          <button
+            class="session-head"
+            onclick={() => toggleFold(foldKey)}
+            aria-expanded={isOpen(foldKey)}
+            title={s.label}
+          >
             <span class="caret" class:open={isOpen(foldKey)}></span>
             <span class="session-name">{s.label}</span>
-            <span class="count">{s.runs.length}</span>
+            <span class="session-age">{age ? `active ${age}` : ''}</span>
           </button>
           {#if isOpen(foldKey)}
             {#each s.runs as r (r.key)}
@@ -435,6 +442,13 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  .session-age {
+    flex: none;
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--ink-faint);
+    font-variant-numeric: tabular-nums;
   }
 
   .run-row {

--- a/packages/dashboard/dashboard-core/site/src/lib/feed-sessions.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/feed-sessions.ts
@@ -1,38 +1,26 @@
-import { compareCreatedAt, paneScope } from './scope.ts';
+import { paneScope } from './scope.ts';
 import type { PaneRecord } from './types.ts';
 
 export interface FeedSession {
   scope: string;
   label: string;
-  createdAt?: number;
 }
 
 export function shortScope(scope: string): string {
   return scope ? scope.slice(0, 8) : 'local';
 }
 
-function noteCreated(created: Map<string, number>, scope: string, pane: PaneRecord): void {
-  const value = pane.created_at;
-  if (value === undefined) return;
-  const previous = created.get(scope);
-  if (previous === undefined || value < previous) created.set(scope, value);
-}
-
-function compareFeedSessions(a: FeedSession, b: FeedSession): number {
-  const byCreated = compareCreatedAt(a.createdAt, b.createdAt);
-  if (byCreated !== 0) return byCreated;
-  return a.scope.localeCompare(b.scope);
-}
-
+// Group panes into sessions by scope and resolve each session's label from its
+// reserved `renderer:'session'` pane. Ordering is left to the caller (the
+// sidebar sorts by last run activity); the scope sort here is only a stable,
+// deterministic default so the set is reproducible.
 export function feedSessions(panes: Record<string, PaneRecord>): FeedSession[] {
   const labels = new Map<string, string>();
-  const created = new Map<string, number>();
   const scopes = new Set<string>();
 
   for (const [key, pane] of Object.entries(panes)) {
     const scope = paneScope(key);
     scopes.add(scope);
-    noteCreated(created, scope, pane);
     if ((pane.kind ?? 'data') === 'data' && pane.renderer === 'session') {
       labels.set(scope, pane.title || 'session');
     }
@@ -42,7 +30,6 @@ export function feedSessions(panes: Record<string, PaneRecord>): FeedSession[] {
     .map((scope) => ({
       scope,
       label: labels.get(scope) || shortScope(scope),
-      createdAt: created.get(scope),
     }))
-    .sort(compareFeedSessions);
+    .sort((a, b) => a.scope.localeCompare(b.scope));
 }

--- a/packages/dashboard/dashboard-core/site/src/lib/sidebar.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/sidebar.ts
@@ -33,6 +33,9 @@ export interface RunNode {
 export interface SessionNode {
   scope: string;
   label: string;
+  // The session's newest run's created_at; the card renders it as an age and the
+  // sidebar sorts sessions by it (newest first).
+  lastActivity?: number;
   runs: RunNode[];
 }
 
@@ -62,6 +65,26 @@ function compareRunsOldestFirst(a: RunNode, b: RunNode): number {
   return a.key.localeCompare(b.key);
 }
 
+// A session's recency: the newest run it holds (max created_at over runs, not
+// resource/namespace/output panes), so a session sorts and reads by when its
+// last tool call ran. Runs are the isRun-filtered set, already sorted
+// oldest-first, so the last one is the newest.
+function lastRunActivity(runs: RunNode[]): number | undefined {
+  return runs.length ? runs[runs.length - 1].pane.created_at : undefined;
+}
+
+// Newest-activity first (a session whose last run is more recent sorts above one
+// whose last run is older), scope as the stable tie-break. A session with no
+// timed run sorts last.
+function compareSessionsNewestFirst(a: SessionNode, b: SessionNode): number {
+  const at = a.lastActivity;
+  const bt = b.lastActivity;
+  if (at !== undefined && bt !== undefined && at !== bt) return bt - at;
+  if (at !== undefined && bt === undefined) return -1;
+  if (at === undefined && bt !== undefined) return 1;
+  return a.scope.localeCompare(b.scope);
+}
+
 // Build the whole sidebar model from the live pane set plus the recordings list.
 export function buildSidebar(
   panes: Record<string, PaneRecord>,
@@ -69,7 +92,8 @@ export function buildSidebar(
 ): SidebarModel {
   const all = paneList(panes);
 
-  // Sessions in first-appearance order (feedSessions is the shared grouping).
+  // feedSessions groups every scope and resolves its label; the sidebar owns the
+  // ordering (by last run activity), so it is taken here, not there.
   const sessionOrder: FeedSession[] = feedSessions(panes);
   const runsByScope = new Map<string, RunNode[]>();
   for (const { key, pane } of all) {
@@ -79,15 +103,21 @@ export function buildSidebar(
     runsByScope.set(pane.scope, rows);
   }
 
-  // feedSessions lists every scope that has any pane; keep only those holding
-  // runs, so a pure-resource scope doesn't show as an empty session.
+  // Keep only scopes that hold runs (a pure-resource scope isn't a session),
+  // then order sessions newest-run-first so the one you're actively using floats
+  // to the top. Runs within a session stay oldest-first (a log growing downward).
   const sessions: SessionNode[] = sessionOrder
-    .map((s) => ({
-      scope: s.scope,
-      label: s.label,
-      runs: (runsByScope.get(s.scope) ?? []).sort(compareRunsOldestFirst),
-    }))
-    .filter((s) => s.runs.length > 0);
+    .map((s) => {
+      const runs = (runsByScope.get(s.scope) ?? []).sort(compareRunsOldestFirst);
+      return {
+        scope: s.scope,
+        label: s.label,
+        lastActivity: lastRunActivity(runs),
+        runs,
+      };
+    })
+    .filter((s) => s.runs.length > 0)
+    .sort(compareSessionsNewestFirst);
 
   const resources: ResourceNode[] = all
     .filter(({ key, pane }) => isResource(key, pane))

--- a/packages/dashboard/dashboard-core/site/tests/feed-sessions.test.ts
+++ b/packages/dashboard/dashboard-core/site/tests/feed-sessions.test.ts
@@ -15,28 +15,30 @@ function sessionPane(title: string, created_at: number): PaneRecord {
 }
 
 describe('feedSessions', () => {
-  it('sorts sessions by creation time', () => {
+  it('groups every scope and resolves its session label', () => {
     const panes: Record<string, PaneRecord> = {
-      [`late${SCOPE_SEP}session`]: sessionPane('A label sorts first', 300),
-      [`early${SCOPE_SEP}session`]: sessionPane('Z label sorts last', 100),
-      [`middle${SCOPE_SEP}run`]: { kind: 'exec', title: 'run', created_at: 200 },
+      [`alpha${SCOPE_SEP}session`]: sessionPane('Alpha', 100),
+      [`alpha${SCOPE_SEP}r1`]: { kind: 'exec', title: 'run', created_at: 200 },
+      // A scope with no session-label pane falls back to a short scope.
+      [`bravo${SCOPE_SEP}r1`]: { kind: 'exec', title: 'run', created_at: 150 },
     };
 
-    assert.deepEqual(
-      feedSessions(panes).map((s) => s.scope),
-      ['early', 'middle', 'late'],
-    );
+    assert.deepEqual(feedSessions(panes), [
+      { scope: 'alpha', label: 'Alpha' },
+      { scope: 'bravo', label: 'bravo' },
+    ]);
   });
 
-  it('uses scope as the stable tie-break', () => {
+  it('orders by scope (a stable default; the sidebar re-orders by activity)', () => {
     const panes: Record<string, PaneRecord> = {
-      [`bravo${SCOPE_SEP}session`]: sessionPane('Bravo', 100),
-      [`alpha${SCOPE_SEP}session`]: sessionPane('Alpha', 100),
+      [`charlie${SCOPE_SEP}session`]: sessionPane('C', 300),
+      [`alpha${SCOPE_SEP}session`]: sessionPane('A', 100),
+      [`bravo${SCOPE_SEP}session`]: sessionPane('B', 200),
     };
 
     assert.deepEqual(
       feedSessions(panes).map((s) => s.scope),
-      ['alpha', 'bravo'],
+      ['alpha', 'bravo', 'charlie'],
     );
   });
 });

--- a/packages/dashboard/dashboard-core/site/tests/sidebar.test.ts
+++ b/packages/dashboard/dashboard-core/site/tests/sidebar.test.ts
@@ -60,6 +60,20 @@ describe('buildSidebar', () => {
     assert.equal(model.runCount, 3);
     assert.equal(model.sessions.length, 2);
   });
+
+  it('orders sessions by newest run, newest first', () => {
+    // Session B's newest run (210) beats A's newest run (130), so B sorts first.
+    assert.deepEqual(
+      model.sessions.map((s) => s.scope),
+      [T, S],
+    );
+  });
+
+  it('sets lastActivity to the newest run, not an output attachment', () => {
+    const a = model.sessions.find((s) => s.scope === S);
+    // A's newest *run* is r2 at 130 — the r2/out attachment at 131 does not count.
+    assert.equal(a?.lastActivity, 130);
+  });
 });
 
 describe('flattenVisible', () => {
@@ -70,10 +84,11 @@ describe('flattenVisible', () => {
 
   it('walks runs, resources, then recordings in render order', () => {
     const rows = flattenVisible(model, allOpen);
+    // Session B (newest activity) comes before A; runs stay oldest-first within.
     assert.deepEqual(rows.map((r) => r.selection), [
+      { kind: 'run', key: `${T}${SCOPE_SEP}r1` },
       { kind: 'run', key: `${S}${SCOPE_SEP}r1` },
       { kind: 'run', key: `${S}${SCOPE_SEP}r2` },
-      { kind: 'run', key: `${T}${SCOPE_SEP}r1` },
       { kind: 'resource', key: `${S}${SCOPE_SEP}resource/term` },
       { kind: 'recording', id: 'rec1' },
     ]);


### PR DESCRIPTION
The dashboard sidebar was hard to navigate: sessions were ordered oldest-first, so the one you just used sank to the bottom, and each session card showed a run count that told you nothing about recency.

- **Newest-first ordering:** sessions now sort by the recency of their newest run (their last tool call), so the session you're actively using floats to the top. An older session that just got a fresh run outranks a newer idle one.
- **Session age instead of run count:** each session card shows a live "active 2m ago" where the run count used to be — time since the last run, which is also the sort key. Driven by the existing once-a-second clock. Runs within a session stay oldest-first (the deliberate "log growing downward" order).
- Recency is computed over runs only (the `isRun`-filtered set), so a background resource or output attachment doesn't float an idle session to the top.

Ran the multi-agent `review-changes` adversarial pass over the diff: no correctness or security blockers; applied its maintainability notes (scoped recency to runs, refreshed the stale ordering comments).

Tests updated for the new ordering; `svelte-check` (0 errors) and `vite build` both pass locally.

Closes #1824

🤖 Authored with Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort dashboard sessions newest-first and show relative activity age instead of run count
> - `buildSidebar` in [sidebar.ts](https://github.com/indexable-inc/index/pull/1825/files#diff-7ada3bd293595da5f58b035183f625acd48cad78bd426ff844c9d86e67e64e2a) now orders sessions by most recent run activity descending, using a new `compareSessionsNewestFirst` comparator; scopes with zero runs are filtered out.
> - Each `SessionNode` gains a `lastActivity` field (the newest run's `created_at`), which [Sidebar.svelte](https://github.com/indexable-inc/index/pull/1825/files#diff-b46f1aac085e106c4c36eae26631b69816e81fefa81cda7b7ad08e94023a4d82) uses to display a relative `active {age}` label in place of the run count.
> - `feedSessions` in [feed-sessions.ts](https://github.com/indexable-inc/index/pull/1825/files#diff-cbf9bd49d8a778478efe2ed97c15dd8b6291c71c1b93ac4060ae119b02c2833e) drops `createdAt` tracking and now returns sessions ordered by scope name as a stable default.
> - Behavioral Change: session order in the sidebar changes from creation-time to most-recent-activity order; the run count display is replaced by a faint monospace age string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 692ff69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->