### PR TITLE
fix(dashboard): replay recordings off the main thread

### DIFF
--- a/packages/dashboard/dashboard-core/site/src/components/Sidebar.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/Sidebar.svelte
@@ -7,7 +7,7 @@
   // what is visible.
   import { onMount } from 'svelte';
   import { store, timeline, loadRecording } from '$lib/stream.svelte';
-  import { ui, isOpen, toggleFold, setFold, select, focusPane, humanTime, humanAge, humanClock, runTooltip } from '$lib/ui.svelte';
+  import { ui, isOpen, toggleFold, setFold, select, focusPane, humanTime, humanAge, humanClock, humanDate, recordingLabel, runTooltip } from '$lib/ui.svelte';
   import { setListNav } from '$lib/keys.svelte';
   import {
     buildSidebar,
@@ -65,14 +65,10 @@
   function onSelect(sel: Selection): void {
     select(sel);
     if (sel.kind === 'recording') {
-      // Mirror the status-bar picker: once the recording's panes are in, land on
-      // its first run so the center stage shows content, not the empty prompt.
-      // If the recording opens with no runs at its start, keep the recording
-      // selected — the prompt to scrub is then accurate.
-      void loadRecording(sel.id).then(() => {
-        const first = flat.find((f) => f.selection.kind !== 'recording');
-        if (first) select(first.selection);
-      });
+      // The recording replays in a worker; its panes arrive asynchronously. Once
+      // they land in `store.panes` the selection-repair effect below lands the
+      // center stage on the newest run, so there is nothing to chain here.
+      void loadRecording(sel.id);
     }
   }
 
@@ -270,7 +266,9 @@
       </button>
       {#if isOpen('recordings')}
         {#if recordings.length === 0}
-          <div class="section-empty">none</div>
+          <div class="section-empty">no saved sessions yet</div>
+        {:else}
+          <div class="section-note">saved session replays — click to scrub the timeline</div>
         {/if}
         {#each recordings as rec (rec.id)}
           <button
@@ -278,11 +276,10 @@
             class:selected={ui.selection?.kind === 'recording' && ui.selection.id === rec.id}
             data-nav={'rec:' + rec.id}
             onclick={() => onSelect({ kind: 'recording', id: rec.id })}
-            title={rec.id}
+            title={`replay session from ${humanDate(rec.started_ms, refMs)} ${humanClock(rec.started_ms)} · ${(rec.bytes / 1024 / 1024).toFixed(1)} MB`}
           >
-            <span class="res-icon">●</span>
-            <span class="res-name">{humanClock(rec.started_ms)}</span>
-            <span class="res-meta">{(rec.bytes / 1024).toFixed(0)}kb</span>
+            <span class="res-icon">▶</span>
+            <span class="res-name">{recordingLabel(rec.started_ms, rec.updated_ms, refMs)}</span>
           </button>
         {/each}
       {/if}
@@ -398,6 +395,15 @@
     font-size: 11px;
     color: var(--ink-faint);
     font-style: italic;
+  }
+  /* One-line explainer under the recordings header, so a first-time viewer knows
+     these rows are replayable session snapshots, not live resources. */
+  .section-note {
+    padding: 2px 12px 6px 26px;
+    font-family: var(--mono);
+    font-size: 10px;
+    line-height: 1.3;
+    color: var(--ink-faint);
   }
 
   /* A shared CSS chevron; rotates open. */

--- a/packages/dashboard/dashboard-core/site/src/components/Statusbar.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/Statusbar.svelte
@@ -16,7 +16,7 @@
     leaveRecording,
     shareUrl,
   } from '$lib/stream.svelte';
-  import { humanClock } from '$lib/ui.svelte';
+  import { humanClock, recordingLabel } from '$lib/ui.svelte';
 
   let { sessionCount, runCount }: { sessionCount: number; runCount: number } = $props();
 
@@ -66,8 +66,9 @@
     <button
       class="scrub-tag"
       class:live={following && isLive}
+      class:seeking={timeline.seeking}
       onclick={() => (controlsOpen = !controlsOpen)}
-      title="timeline controls"
+      title={timeline.seeking ? 'loading frame…' : 'timeline controls'}
     >{following ? (isLive ? 'LIVE' : 'END') : humanClock(value)}</button>
     <input
       class="scrubber"
@@ -96,10 +97,10 @@
           {/each}
         </span>
         {#if timeline.recordings.length}
-          <select class="tl-rec" onchange={onPick} value={timeline.source}>
+          <select class="tl-rec" onchange={onPick} value={timeline.source} title="replay a saved session">
             <option value="live">● live</option>
             {#each timeline.recordings as rec (rec.id)}
-              <option value={rec.id}>{humanClock(rec.started_ms)} · {(rec.bytes / 1024).toFixed(0)}kb</option>
+              <option value={rec.id}>{recordingLabel(rec.started_ms, rec.updated_ms, Date.now())}</option>
             {/each}
           </select>
         {/if}
@@ -193,6 +194,20 @@
   }
   .scrub-tag.live {
     color: var(--live);
+  }
+  .scrub-tag.seeking {
+    color: var(--accent);
+    animation: seek-pulse 1s ease-in-out infinite;
+  }
+  @keyframes seek-pulse {
+    50% {
+      opacity: 0.45;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .scrub-tag.seeking {
+      animation: none;
+    }
   }
   .scrub-tag:hover {
     color: var(--ink);

--- a/packages/dashboard/dashboard-core/site/src/lib/recording-worker.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/recording-worker.ts
@@ -1,0 +1,188 @@
+// The recording replay runs off the main thread.
+//
+// A saved recording is a full Loro oplog: replaying a past moment means checking
+// the document out to the frontier at that timestamp. That checkout is O(the
+// op-distance travelled), and a real session's oplog is large (a long-running
+// exec pane appends its stdout op by op), so a single far checkout can take many
+// seconds. Doing it on the UI thread froze the page on every scrub tick and
+// every playback frame. This worker owns the recording's `LoroDoc` and does all
+// the import and checkout work here, so the main thread only ever renders the
+// pane snapshots this worker posts back.
+//
+// loro-crdt is imported dynamically (not a static top-level import) on purpose:
+// the site is bundled to a single self-contained HTML with the CDN import marked
+// external, and an inlined worker chunk turns a *static* external import into an
+// undefined global. A dynamic `import()` survives that bundling as a real
+// runtime import, matching how the main thread loads loro.
+import type { LoroDoc, OpId } from 'https://esm.sh/loro-crdt@1';
+import type { PaneRecord } from './types';
+
+// One change reduced to what scrubbing needs: the id of its last op (the version
+// to check out to land exactly after it) and its timestamp. Mirrors the shape the
+// main thread used before this moved into the worker.
+interface Mark {
+  peer: string;
+  counter: number;
+  ts: number;
+  lamport: number;
+}
+
+// Messages the main thread sends in.
+export type RecordingRequest =
+  | { type: 'load'; id: string; bytes: ArrayBuffer }
+  | { type: 'seek'; ts: number };
+
+// Messages this worker posts back. `id` echoes the load request so a reply for a
+// superseded recording (the user switched fast) can be ignored.
+export type RecordingResponse =
+  | {
+      type: 'loaded';
+      id: string;
+      minTs: number;
+      maxTs: number;
+      changeCount: number;
+      startTs: number;
+      panes: Record<string, PaneRecord>;
+    }
+  | { type: 'frame'; id: string; ts: number; panes: Record<string, PaneRecord> }
+  | { type: 'error'; id: string; message: string };
+
+let LoroDocCtor: typeof LoroDoc | null = null;
+let doc: LoroDoc | null = null;
+let marks: Mark[] = [];
+let currentId = '';
+
+// A pending seek target coalesces to the newest: a drag fires many `input`
+// events, but each checkout is expensive, so we only ever compute the latest
+// requested position and drop the ones the user scrubbed past.
+let pendingTs: number | null = null;
+let seeking = false;
+
+async function loro(): Promise<typeof LoroDoc> {
+  if (!LoroDocCtor) {
+    const mod = await import('https://esm.sh/loro-crdt@1');
+    LoroDocCtor = mod.LoroDoc;
+  }
+  return LoroDocCtor;
+}
+
+// Rebuild the change index from the oplog. The aggregator is the sole editor, so
+// the marks sort cleanly by time then lamport and the last mark at or before a
+// timestamp fully describes the state at that moment.
+function rebuildIndex(d: LoroDoc): void {
+  const next: Mark[] = [];
+  for (const [peer, changes] of d.getAllChanges()) {
+    for (const c of changes) {
+      next.push({
+        peer: String(peer),
+        counter: c.counter + c.length - 1,
+        ts: c.timestamp,
+        lamport: c.lamport,
+      });
+    }
+  }
+  next.sort((a, b) => a.ts - b.ts || a.lamport - b.lamport);
+  marks = next;
+}
+
+// The version (frontier) at or before `ts`: the last mark at or before it.
+function frontierAt(ts: number): OpId[] {
+  let lo = 0;
+  let hi = marks.length - 1;
+  let best = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (marks[mid].ts <= ts) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  if (best < 0) best = 0;
+  const mark = marks[best];
+  return mark ? [{ peer: mark.peer, counter: mark.counter }] : [];
+}
+
+function panesAt(d: LoroDoc, ts: number): Record<string, PaneRecord> {
+  const frontier = frontierAt(ts);
+  if (frontier.length) d.checkout(frontier);
+  return (d.toJSON().panes ?? {}) as Record<string, PaneRecord>;
+}
+
+// Run the newest pending seek, then any seek that arrived while it ran, until the
+// queue drains. Serialising this way means an expensive checkout never stacks up
+// behind the many events a slider drag emits.
+function drainSeek(): void {
+  if (seeking || pendingTs === null || !doc) return;
+  seeking = true;
+  const d = doc;
+  const id = currentId;
+  // Let the message loop breathe between checkouts so a fresh, newer target can
+  // land and supersede a stale one before we spend seconds on it.
+  queueMicrotask(() => {
+    // A `load` may have arrived between scheduling and running this microtask; it
+    // sets `currentId` synchronously before its first await, so a changed id means
+    // `d` is a stale document we must not check out or reply for.
+    if (id !== currentId) {
+      seeking = false;
+      return;
+    }
+    const ts = pendingTs;
+    pendingTs = null;
+    if (ts === null) {
+      seeking = false;
+      return;
+    }
+    try {
+      const panes = panesAt(d, ts);
+      const reply: RecordingResponse = { type: 'frame', id, ts, panes };
+      self.postMessage(reply);
+    } catch (err) {
+      const reply: RecordingResponse = {
+        type: 'error',
+        id,
+        message: String(err),
+      };
+      self.postMessage(reply);
+    }
+    seeking = false;
+    drainSeek();
+  });
+}
+
+self.onmessage = async (event: MessageEvent<RecordingRequest>) => {
+  const msg = event.data;
+  if (msg.type === 'load') {
+    currentId = msg.id;
+    pendingTs = null;
+    seeking = false;
+    try {
+      const Ctor = await loro();
+      doc = new Ctor();
+      doc.import(new Uint8Array(msg.bytes));
+      rebuildIndex(doc);
+      const minTs = marks.length ? marks[0].ts : 0;
+      const maxTs = marks.length ? marks[marks.length - 1].ts : 0;
+      // Open the recording parked at its start, like the old main-thread path.
+      const panes = panesAt(doc, minTs);
+      const reply: RecordingResponse = {
+        type: 'loaded',
+        id: msg.id,
+        minTs,
+        maxTs,
+        changeCount: marks.length,
+        startTs: minTs,
+        panes,
+      };
+      self.postMessage(reply);
+    } catch (err) {
+      const reply: RecordingResponse = { type: 'error', id: msg.id, message: String(err) };
+      self.postMessage(reply);
+    }
+    return;
+  }
+  // seek
+  pendingTs = msg.ts;
+  drainSeek();
+};

--- a/packages/dashboard/dashboard-core/site/src/lib/stream.svelte.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/stream.svelte.ts
@@ -6,11 +6,20 @@
 // document is a full recording: we keep the whole oplog, list its changes, and
 // check the document out to any past version to replay it. `store` is the
 // rendered pane set at the current view; `timeline` is the scrubber state.
-// Switching to a saved recording swaps the document for one fetched over HTTP,
-// so live and replay share one rendering path.
-import { LoroDoc, type ChangeMeta, type OpId } from 'https://esm.sh/loro-crdt@1';
+//
+// Two rendering paths share one `store`. The LIVE stream imports small
+// incremental frames on the main thread and always shows the latest version —
+// cheap, so it stays here. A saved RECORDING is replayed in a Web Worker
+// (`recording-worker.ts`): checking a large oplog out to an arbitrary past
+// version is O(the op-distance travelled) and takes seconds, which froze the UI
+// when done per scrub tick on the main thread. The worker owns the recording's
+// document and posts back the pane snapshot at each requested moment, so the main
+// thread only renders.
+import { LoroDoc } from 'https://esm.sh/loro-crdt@1';
 import { paneScope, SCOPE_SEP } from './scope.ts';
 import type { PaneRecord } from './types';
+import RecordingWorker from './recording-worker.ts?worker&inline';
+import type { RecordingRequest, RecordingResponse } from './recording-worker.ts';
 
 export { SCOPE_SEP };
 
@@ -31,6 +40,8 @@ export interface RecordingInfo {
 // The replay timeline. `source` is `'live'` for the SSE stream or a recording id
 // for a loaded snapshot. `following` pins the view to the latest version (so a
 // live frame advances it); scrubbing or playing detaches it at `position`.
+// `seeking` is true while the worker is computing a replay frame, so the UI can
+// show that a scrub is in flight rather than looking frozen.
 export const timeline = $state({
   source: 'live' as string,
   following: true,
@@ -40,11 +51,12 @@ export const timeline = $state({
   maxTs: 0,
   position: 0,
   changeCount: 0,
+  seeking: false,
   recordings: [] as RecordingInfo[],
 });
 
-// One change reduced to what scrubbing needs: the id of its last op (the version
-// to check out to land exactly after it) and its timestamp.
+// One change reduced to what a pinned-live scrub needs: the id of its last op
+// (the version to check out to land just after it) and its timestamp.
 interface Mark {
   peer: string;
   counter: number;
@@ -53,39 +65,18 @@ interface Mark {
 }
 
 let doc = new LoroDoc();
-let marks: Mark[] = [];
+// The live doc's change index, rebuilt on each frame. Only the live path uses it;
+// a recording's index lives in the worker with its document.
+let liveMarks: Mark[] = [];
 let es: EventSource | null = null;
 let raf = 0;
 let lastTick = 0;
 // A `#t=` deep link to apply once the live history covers it.
 let pendingSeek: number | null = null;
 
-function b64ToBytes(b64: string): Uint8Array {
-  const bin = atob(b64);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-// Rebuild the change index from the oplog and refresh the timeline bounds. The
-// aggregator is the sole editor, so the marks sort cleanly by time then lamport.
-function rebuildIndex(): void {
-  const next: Mark[] = [];
-  for (const [peer, changes] of doc.getAllChanges()) {
-    for (const c of changes) {
-      next.push({ peer: String(peer), counter: c.counter + c.length - 1, ts: c.timestamp, lamport: c.lamport });
-    }
-  }
-  next.sort((a, b) => a.ts - b.ts || a.lamport - b.lamport);
-  marks = next;
-  timeline.changeCount = next.length;
-  timeline.minTs = next.length ? next[0].ts : 0;
-  timeline.maxTs = next.length ? next[next.length - 1].ts : 0;
-}
-
-// The version (frontier) at or before `ts`. Single-editor history means the last
-// mark at or before `ts` fully describes the state, so its op id is the frontier.
-function frontierAt(ts: number): OpId[] {
+// The version (frontier) at or before `ts`: the last mark at or before it. The
+// aggregator is the sole editor, so that mark fully describes the state there.
+function frontierAt(marks: Mark[], ts: number): { peer: string; counter: number }[] {
   let lo = 0;
   let hi = marks.length - 1;
   let best = -1;
@@ -103,10 +94,27 @@ function frontierAt(ts: number): OpId[] {
   return mark ? [{ peer: mark.peer, counter: mark.counter }] : [];
 }
 
-// Read the current document view into `store`. Called after every checkout, so
-// the same path renders the live latest and any scrubbed-to past version.
-function readPanes(): void {
-  const panes = (doc.toJSON().panes ?? {}) as Record<string, PaneRecord>;
+// The replay worker and the recording it currently holds. Created lazily on the
+// first recording load and reused across recordings.
+let worker: Worker | null = null;
+// The id whose frames we are currently rendering. A frame for any other id is a
+// stale reply (the user switched recordings) and is dropped.
+let activeRecordingId = '';
+// A `#t=` position to scrub to once the recording finishes loading (a deep link
+// opens the recording and then jumps to the shared moment).
+let recordingSeekOnLoad: number | null = null;
+
+function b64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+// Read a pane set into `store`, deriving the producer count and status line. The
+// live path and the worker's replay frames both funnel through here so they
+// render identically.
+function applyPanes(panes: Record<string, PaneRecord>): void {
   store.panes = panes;
   const scopes = new Set<string>();
   for (const key of Object.keys(panes)) {
@@ -121,20 +129,36 @@ function readPanes(): void {
     where;
 }
 
-// Render the document at the current timeline view: the latest version while
-// following, else the frontier at `position`.
-function render(): void {
-  if (timeline.following) {
-    // Keep position pinned to the live edge while following, so pressing Play
-    // restarts from the recording's start (position >= maxTs) rather than from
-    // a stale position (often 0 = the Unix epoch, which looks stuck).
-    timeline.position = timeline.maxTs;
-    doc.checkoutToLatest();
-  } else {
-    const frontier = frontierAt(timeline.position);
-    if (frontier.length) doc.checkout(frontier);
+// Render the LIVE document at the current view: the latest version while
+// following. A recording never enters here — its frames come from the worker.
+function renderLive(): void {
+  // Keep position pinned to the live edge while following, so pressing Play
+  // restarts from the recording's start (position >= maxTs) rather than from
+  // a stale position (often 0 = the Unix epoch, which looks stuck).
+  timeline.position = timeline.maxTs;
+  doc.checkoutToLatest();
+  applyPanes((doc.toJSON().panes ?? {}) as Record<string, PaneRecord>);
+}
+
+// Rebuild the live change index and timeline bounds from the oplog. The live doc
+// grows by small incremental frames, so this stays cheap on the main thread.
+function rebuildLiveBounds(): void {
+  const next: Mark[] = [];
+  for (const [peer, changes] of doc.getAllChanges()) {
+    for (const c of changes) {
+      next.push({
+        peer: String(peer),
+        counter: c.counter + c.length - 1,
+        ts: c.timestamp,
+        lamport: c.lamport,
+      });
+    }
   }
-  readPanes();
+  next.sort((a, b) => a.ts - b.ts || a.lamport - b.lamport);
+  liveMarks = next;
+  timeline.changeCount = next.length;
+  timeline.minTs = next.length ? next[0].ts : 0;
+  timeline.maxTs = next.length ? next[next.length - 1].ts : 0;
 }
 
 function onFrame(data: string): void {
@@ -146,7 +170,7 @@ function onFrame(data: string): void {
     console.warn('dashboard: dropped malformed frame', err);
     return;
   }
-  rebuildIndex();
+  rebuildLiveBounds();
   if (pendingSeek !== null && timeline.minTs <= pendingSeek && pendingSeek <= timeline.maxTs) {
     const target = pendingSeek;
     pendingSeek = null;
@@ -155,15 +179,16 @@ function onFrame(data: string): void {
   }
   // Following tracks live; a pinned (scrubbing) view stays put while the slider
   // max grows underneath it.
-  if (timeline.following) render();
+  if (timeline.following) renderLive();
 }
 
 export function connect(): void {
   if (es) return;
   timeline.source = 'live';
   timeline.following = true;
+  timeline.seeking = false;
   doc = new LoroDoc();
-  marks = [];
+  liveMarks = [];
   es = new EventSource('/events');
   es.addEventListener('open', () => {
     store.live = true;
@@ -197,18 +222,19 @@ function step(now: number): void {
   const dt = lastTick ? now - lastTick : 0;
   lastTick = now;
   timeline.position = Math.min(timeline.maxTs, timeline.position + dt * timeline.speed);
-  render();
   if (timeline.position >= timeline.maxTs) {
     // Reached the end: snap back to following the latest (live tail, or the
-    // recording's end).
+    // recording's end). goLive() renders maxTs itself, so don't render here too
+    // — a second seek to the same version would repeat the (costly) checkout.
     goLive();
     return;
   }
+  renderAt(timeline.position);
   raf = requestAnimationFrame(step);
 }
 
 export function play(): void {
-  if (!marks.length) return;
+  if (timeline.changeCount <= 1) return;
   // Restart from the beginning when parked at the end.
   if (timeline.position >= timeline.maxTs) timeline.position = timeline.minTs;
   timeline.following = false;
@@ -222,12 +248,44 @@ export function pause(): void {
   stopClock();
 }
 
+// Render the view at `ts`. Live checks out on the main thread (cheap); a
+// recording hands the timestamp to the worker, which coalesces rapid requests and
+// posts back the frame.
+function renderAt(ts: number): void {
+  if (timeline.source === 'live') {
+    if (timeline.following) {
+      renderLive();
+    } else {
+      // The live doc's history is small; a bounded checkout on the main thread is
+      // fine. Reuse the recording-free path by checking out directly.
+      checkoutLiveTo(ts);
+    }
+    return;
+  }
+  if (worker) {
+    // During playback frames flow continuously; only flag "seeking" for a manual
+    // scrub, so the indicator marks a deliberate jump rather than pulsing on
+    // every animation frame.
+    if (!timeline.playing) timeline.seeking = true;
+    const req: RecordingRequest = { type: 'seek', ts };
+    worker.postMessage(req);
+  }
+}
+
+// Check the live doc out to the frontier at `ts` and read it into the store.
+// Only used for a pinned live view; the live oplog is small so this is cheap.
+function checkoutLiveTo(ts: number): void {
+  const frontier = frontierAt(liveMarks, ts);
+  if (frontier.length) doc.checkout(frontier);
+  applyPanes((doc.toJSON().panes ?? {}) as Record<string, PaneRecord>);
+}
+
 export function scrubTo(ts: number): void {
   timeline.following = false;
   timeline.playing = false;
   stopClock();
   timeline.position = Math.max(timeline.minTs, Math.min(timeline.maxTs, ts));
-  render();
+  renderAt(timeline.position);
 }
 
 export function goLive(): void {
@@ -235,7 +293,7 @@ export function goLive(): void {
   timeline.playing = false;
   stopClock();
   timeline.position = timeline.maxTs;
-  render();
+  renderAt(timeline.position);
 }
 
 export function setSpeed(speed: number): void {
@@ -260,12 +318,47 @@ export async function refreshRecordings(): Promise<void> {
   }
 }
 
-export async function loadRecording(id: string): Promise<void> {
-  let bytes: Uint8Array;
+function ensureWorker(): Worker {
+  if (worker) return worker;
+  worker = new RecordingWorker();
+  worker.onmessage = (event: MessageEvent<RecordingResponse>) => {
+    const msg = event.data;
+    // Drop replies for a recording we have since left or switched away from.
+    if (msg.id !== activeRecordingId) return;
+    if (msg.type === 'loaded') {
+      timeline.minTs = msg.minTs;
+      timeline.maxTs = msg.maxTs;
+      timeline.changeCount = msg.changeCount;
+      timeline.position = msg.startTs;
+      timeline.seeking = false;
+      applyPanes(msg.panes);
+      // A deep link opened this recording to jump to a shared moment; now that
+      // the bounds are known, honour it.
+      if (recordingSeekOnLoad !== null) {
+        const at = recordingSeekOnLoad;
+        recordingSeekOnLoad = null;
+        scrubTo(at);
+      }
+    } else if (msg.type === 'frame') {
+      timeline.seeking = false;
+      applyPanes(msg.panes);
+    } else {
+      timeline.seeking = false;
+      console.warn('dashboard: recording replay failed', msg.message);
+    }
+  };
+  return worker;
+}
+
+// Load a recording into the replay worker. `seekTo`, when given, is the moment to
+// scrub to once the oplog has imported (used by a `#t=` deep link).
+export async function loadRecording(id: string, seekTo?: number): Promise<void> {
+  recordingSeekOnLoad = seekTo ?? null;
+  let bytes: ArrayBuffer;
   try {
     const resp = await fetch(`/recording/${encodeURIComponent(id)}`);
     if (!resp.ok) return;
-    bytes = new Uint8Array(await resp.arrayBuffer());
+    bytes = await resp.arrayBuffer();
   } catch {
     return;
   }
@@ -276,24 +369,23 @@ export async function loadRecording(id: string): Promise<void> {
   store.live = false;
   stopClock();
   timeline.source = id;
-  doc = new LoroDoc();
-  try {
-    doc.import(bytes);
-  } catch (err) {
-    console.warn('dashboard: failed to load recording', err);
-    return;
-  }
-  rebuildIndex();
-  // Open a recording parked at its start, paused, ready to play.
+  // Open a recording parked at its start, paused, ready to play. The worker
+  // reports the real bounds once it has imported the oplog.
   timeline.following = false;
   timeline.playing = false;
-  timeline.position = timeline.minTs;
-  render();
+  timeline.seeking = true;
+  activeRecordingId = id;
+  const w = ensureWorker();
+  const req: RecordingRequest = { type: 'load', id, bytes };
+  // Transfer the buffer so a large recording is not copied into the worker.
+  w.postMessage(req, [bytes]);
 }
 
 export function leaveRecording(): void {
   if (timeline.source === 'live') return;
   stopClock();
+  activeRecordingId = '';
+  timeline.seeking = false;
   // Drop any `#rec=`/`#t=` deep link first: `connect()` re-runs `applyHash`,
   // which would otherwise reload the very recording we are leaving.
   if (location.hash) history.replaceState(null, '', location.pathname + location.search);
@@ -316,9 +408,7 @@ function applyHash(): void {
   const rec = params.get('rec');
   const t = params.get('t');
   if (rec) {
-    void loadRecording(rec).then(() => {
-      if (t) scrubTo(Number(t));
-    });
+    void loadRecording(rec, t ? Number(t) : undefined);
   } else if (t) {
     // A live deep link: seek once the streamed history reaches that moment.
     pendingSeek = Number(t);

--- a/packages/dashboard/dashboard-core/site/src/lib/time.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/time.ts
@@ -74,3 +74,43 @@ export function humanClock(ms: number): string {
   if (!ms) return '—';
   return new Date(ms).toLocaleTimeString();
 }
+
+// A calendar-date label ("today", "yesterday", "Jun 30", "Jun 30 2025") for a
+// recording's start, so the recordings list reads as dated sessions rather than
+// bare ids. `refMs` is the current wall-clock (for the today/yesterday window).
+export function humanDate(ms: number, refMs: number): string {
+  if (!ms) return '';
+  const start = new Date(ms);
+  const now = new Date(refMs);
+  // Count whole calendar days between the two local dates. Project each local
+  // Y/M/D onto a UTC midnight so the subtraction is an exact multiple of 24h;
+  // subtracting local midnights directly would be off by an hour across a DST
+  // boundary (a spring-forward day is only 23h), which floors "yesterday" to
+  // "today".
+  const dayNumber = (d: Date) => Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()) / 86_400_000;
+  const days = dayNumber(now) - dayNumber(start);
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  const sameYear = start.getFullYear() === now.getFullYear();
+  return start.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    ...(sameYear ? {} : { year: 'numeric' }),
+  });
+}
+
+// The label for a saved recording: when it started and how long the session ran,
+// e.g. "today 14:32 · 47m" or "Jun 30 · 2m". Reads as a dated session replay
+// instead of an opaque id, so a user grasps what a recording is at a glance.
+export function recordingLabel(startedMs: number, updatedMs: number, refMs: number): string {
+  const clock = new Date(startedMs).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  const ran = Math.max(0, updatedMs - startedMs);
+  // Sub-second "durations" are just a single snapshot; show only the start then.
+  const span = ran >= 1000 ? humanDuration(ran) : '';
+  const when = `${humanDate(startedMs, refMs)} ${clock}`.trim();
+  return span ? `${when} · ${span}` : when;
+}

--- a/packages/dashboard/dashboard-core/site/src/lib/ui.svelte.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/ui.svelte.ts
@@ -6,7 +6,7 @@ import type { Selection } from './sidebar';
 
 // Re-export the pure time formatters so components keep one import site (`ui`)
 // for both the reactive clock and the labels it drives.
-export { humanAge, humanTime, humanDuration, runTooltip, humanClock } from './time';
+export { humanAge, humanTime, humanDuration, runTooltip, humanClock, humanDate, recordingLabel } from './time';
 
 // ----- fold state (persisted) --------------------------------------------
 // One boolean per fold key: a section id ('sessions'/'resources'/'recordings')

--- a/packages/dashboard/dashboard-core/site/src/worker.d.ts
+++ b/packages/dashboard/dashboard-core/site/src/worker.d.ts
@@ -1,0 +1,7 @@
+// Vite's `?worker&inline` import: the module default-exports a constructor that
+// spawns the worker (inlined as a blob, so the single-file build stays one HTML).
+// Declared here because the site does not pull in `vite/client`'s ambient types.
+declare module '*?worker&inline' {
+  const workerConstructor: new () => Worker;
+  export default workerConstructor;
+}

--- a/packages/dashboard/dashboard-core/site/tests/time.test.ts
+++ b/packages/dashboard/dashboard-core/site/tests/time.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { humanTime, humanDuration, runTooltip, humanAge } from '../src/lib/time.ts';
+import { humanTime, humanDuration, runTooltip, humanAge, humanDate, recordingLabel } from '../src/lib/time.ts';
 
 const MIN = 60_000;
 const HOUR = 60 * MIN;
@@ -68,6 +68,51 @@ describe('runTooltip', () => {
 
   it('is empty for a finished run with no duration', () => {
     assert.equal(runTooltip(false, undefined, ref, ref), '');
+  });
+});
+
+describe('humanDate', () => {
+  // Anchor the reference at a fixed local wall-clock so the today/yesterday
+  // windows are calendar-day based, not a rolling 24h.
+  const ref = new Date('2026-07-02T14:32:00').getTime();
+
+  it('labels the reference day "today" and the prior day "yesterday"', () => {
+    assert.equal(humanDate(new Date('2026-07-02T09:00:00').getTime(), ref), 'today');
+    assert.equal(humanDate(new Date('2026-07-01T23:00:00').getTime(), ref), 'yesterday');
+  });
+
+  it('shows a short date within the year and adds the year otherwise', () => {
+    assert.equal(humanDate(new Date('2026-06-20T10:00:00').getTime(), ref), 'Jun 20');
+    assert.match(humanDate(new Date('2025-06-20T10:00:00').getTime(), ref), /2025/);
+  });
+
+  it('is empty for a missing timestamp', () => {
+    assert.equal(humanDate(0, ref), '');
+  });
+
+  it('counts calendar days across a DST boundary (whole-day, not 24h math)', () => {
+    // US spring-forward 2026 is Mar 8; the day before is only 23h long, which a
+    // naive (midnight - midnight)/86_400_000 floor would count as 0 days and
+    // mislabel as "today". Anchor "now" on Mar 9 and the start on Mar 8.
+    const now = new Date('2026-03-09T10:00:00').getTime();
+    assert.equal(humanDate(new Date('2026-03-09T01:00:00').getTime(), now), 'today');
+    assert.equal(humanDate(new Date('2026-03-08T23:30:00').getTime(), now), 'yesterday');
+  });
+});
+
+describe('recordingLabel', () => {
+  const ref = new Date('2026-07-02T14:32:00').getTime();
+  const start = new Date('2026-07-02T11:53:00').getTime();
+
+  it('joins the start (date + clock) with the run duration', () => {
+    const out = recordingLabel(start, start + 47 * MIN + 12_000, ref);
+    assert.match(out, /^today \d{1,2}:\d{2} · 47m12s$/);
+  });
+
+  it('omits a sub-second span (a single-snapshot recording)', () => {
+    const out = recordingLabel(start, start + 200, ref);
+    assert.match(out, /^today \d{1,2}:\d{2}$/);
+    assert.doesNotMatch(out, /·/);
   });
 });
 


### PR DESCRIPTION
The dashboard's RECORDINGS replay froze the UI. Root cause: timeline scrub/playback called `doc.checkout()` synchronously on the main thread, and Loro checkout cost is O(op-distance) — on a real 33 MB recording a single far checkout took **6-17 s** (profile in #1828).

**Fix:** move the recording's `LoroDoc` + all import/checkout work into a Web Worker; the main thread only renders the frames it posts back. Seek requests coalesce to the newest target so a slider drag never stacks up checkouts. Live replay stays on the main thread (small incremental frames). The worker imports loro via a dynamic `import()` so the CDN import survives the single-file build as a real runtime import.

**Legibility:** recordings rows now read as dated session replays (`today 14:32 · 47m`) instead of a bare id, with a "saved session replays" note and a replay icon; the scrub tag pulses while a frame loads.

**Verified** in headless Chromium against the real 33 MB recording: a rapid scrub keeps the main-thread max stall at ~53 ms (was 6-17 s). svelte-check clean, 28/28 site tests pass, site build (incl. nix `buildSvelteSite`) passes.

**Review:** ran the multi-agent adversarial review (review-changes / code-reviewer, correctness + security) over the diff and fixed the confirmed findings — a DST day-count bug in `humanDate` (today/yesterday off by one across spring-forward), a redundant end-of-playback checkout, and hardened the worker against a `load` that supersedes an in-flight seek. No security blockers; the one flagged item (unpinned `esm.sh` CDN import, no CSP/SRI) is pre-existing — the main thread already imports the same URL — and is out of scope for this PR.

Closes #1828

_Authored with Claude Code._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move recording replay off the main thread using a Web Worker
> - Adds [recording-worker.ts](https://github.com/indexable-inc/index/pull/1831/files#diff-30fce75b041acfb585378ca599cc3445ecfee2cb6628e73177bdf3553612a6cd) to handle CRDT loading and seeking in a Web Worker, posting `loaded` and `frame` messages back to the main thread asynchronously.
> - Coalesces rapid seek requests in the worker so only the newest target is processed, reducing unnecessary CRDT checkouts.
> - Adds a `seeking` flag to timeline state, used by [Statusbar.svelte](https://github.com/indexable-inc/index/pull/1831/files#diff-26119c3660baaef89d9b6208575ba50590dcad11a8445ed59e7caadda0c1734d) to show a pulsing loading indicator on the scrub button during in-flight seeks.
> - Introduces `recordingLabel` and `humanDate` helpers in [time.ts](https://github.com/indexable-inc/index/pull/1831/files#diff-ee723251b434595018cd6057378216a11e21c426bfd780fdf304a11a68094039) to display session-oriented labels (date, time, duration) in the sidebar and status bar recording lists.
> - Behavioral Change: recording bounds and pane state are now delivered asynchronously; deep-link seeks into recordings are deferred until the worker posts `loaded`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a174939.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->