### PR TITLE
feat(nix-web-monitor): headless NDJSON build-view emitter

### DIFF
--- a/doc/nix-web-monitor/overview.md
+++ b/doc/nix-web-monitor/overview.md
@@ -33,8 +33,20 @@ own origin, so off-host access (LAN/Tailscale) needs no certificate.
 ```
 nix-web-monitor [--host H] [--port N] [--exit-when-done]
                 [--terminal-output summary|logs|quiet] [--nix-verbose]
+                [--emit ndjson]
                 -- <nix args...>
 ```
+
+- `--emit ndjson` (`server/src/emit.rs`): run headless. Instead of serving the
+  web UI, spawn the nix command, feed the parser, and stream a compact
+  [`BuildView`](../../packages/nix/nix-web-monitor/parser/src/build_view.rs) as
+  one JSON object per line on stdout (throttled to ~2 Hz, plus a final
+  authoritative snapshot after nix exits). This is the machine-readable
+  counterpart to the browser feed, consumed by the kernel `nix` module's live
+  build pane; it keeps the parser the single owner of internal-json rather than
+  re-deriving the render model in Python. Only the passthrough `nix …` command
+  has a headless form (a switch is a UI-only orchestration); the process exits
+  with nix's status.
 
 - `--host` (default `0.0.0.0`, `:49`) / `--port` (default `7532`, `:53`): the UI,
   the `/api/state` JSON snapshot, and the `/ws` delta feed all share this port.

--- a/packages/nix/nix-web-monitor/parser/src/build_view.rs
+++ b/packages/nix/nix-web-monitor/parser/src/build_view.rs
@@ -1,0 +1,293 @@
+//! The compact build-tree render model.
+//!
+//! [`MonitorSnapshot`](crate::MonitorSnapshot) is the full state the web UI
+//! consumes over its delta protocol: every activity, a 500-line log tail, the
+//! dependency DAG, daemon syscalls, the switch activation subtree. That is far
+//! more than a small "what is this build doing right now" pane needs, and its
+//! log tail changes every line -- pathological for a dashboard body that is
+//! diffed wholesale on each tick.
+//!
+//! [`BuildView`] is the projection of that state a build-tree pane actually
+//! renders: the derivations (with status and phase), a few in-flight non-build
+//! activities (fetches, copies) with their progress, the aggregate counters,
+//! and a capped error list. It is owned here, alongside the parser, so the
+//! kernel's headless emitter and the dashboard's `nix-build` renderer share one
+//! definition of the model instead of each re-deriving it. Bounded by
+//! construction (`ERROR_LIMIT`, `ACTIVITY_LIMIT`), so the serialized body stays
+//! small no matter how verbose the build.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ActivityStatus, BuildStatus, MonitorState};
+
+/// Most recent errors carried in a view. A build usually fails on one root
+/// error; the cap bounds a warning-heavy eval without dropping the failure.
+const ERROR_LIMIT: usize = 20;
+
+/// In-flight non-build activities carried in a view (fetches, copies,
+/// substitutions). The build rows carry the bulk of the tree; this is the
+/// "what else is happening" strip, so a handful is plenty and keeps the body
+/// bounded when hundreds of paths are fetched at once.
+const ACTIVITY_LIMIT: usize = 24;
+
+/// One derivation row in a [`BuildView`]: the pane renders these as the tree.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildRow {
+    /// The `.drv` store path, the row's stable identity.
+    pub derivation: String,
+    /// The human name pulled from the store path (`<hash>-<name>.drv` -> `name`),
+    /// so the pane can show `ripgrep-14.1.0` rather than the full hashed path.
+    pub name: String,
+    pub status: BuildStatus,
+    /// The build's current phase (`unpackPhase`, `buildPhase`, ...) when Nix has
+    /// reported one, else `None`.
+    pub phase: Option<String>,
+    /// The remote builder host, when the build ran off-machine.
+    pub host: Option<String>,
+    /// How many build-log lines this derivation has emitted; a rough liveness
+    /// signal for a build with no phase reporting.
+    pub log_count: usize,
+    /// Whether Nix resolved this derivation before building it (content
+    /// addressed), so the pane can badge the folded row rather than let it look
+    /// like a stray.
+    pub content_addressed: bool,
+}
+
+/// One in-flight non-build activity (a fetch, a copy, a substitution). Kept
+/// separate from [`BuildRow`] because these have progress bars, not phases.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityRow {
+    /// The activity kind name (`copy_path`, `substitute`, `file_transfer`, ...).
+    pub kind: String,
+    /// The activity's own text (`copying '/nix/store/...'`), trimmed of ANSI.
+    pub text: String,
+    /// Work done so far, when the activity reports byte/item progress.
+    pub done: i64,
+    /// Total work expected, when known (`0` when the activity is unsized).
+    pub expected: i64,
+    /// Bytes the server measured for a "copying … to the store" activity Nix
+    /// reports without progress; `None` on every other activity.
+    pub size_bytes: Option<i64>,
+}
+
+/// The compact render model for a build-tree pane: everything the pane draws,
+/// and nothing it does not. Produced by [`MonitorState::build_view`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildView {
+    /// The Nix invocation label (`nix build .#ix`), the tree's root.
+    pub command: String,
+    /// Derivation rows: planned, running, and settled, in first-seen order.
+    pub builds: Vec<BuildRow>,
+    /// In-flight non-build activities (fetches, copies), newest first, capped at
+    /// [`ACTIVITY_LIMIT`].
+    pub activities: Vec<ActivityRow>,
+    /// Count of build rows in each status, so the pane's summary bar needs no
+    /// second pass over `builds`.
+    pub counts: BuildCounts,
+    /// The most recent error-level messages, capped at [`ERROR_LIMIT`].
+    pub errors: Vec<String>,
+    /// Whether the wrapped Nix process has exited.
+    pub finished: bool,
+    /// The wrapped process's exit status once it has exited (`None` while
+    /// running, or when Nix reported no code).
+    pub exit_code: Option<i32>,
+}
+
+/// Build-row counts by status, for the pane's summary bar.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildCounts {
+    pub planned: usize,
+    pub running: usize,
+    pub stopped: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+}
+
+impl MonitorState {
+    /// Project the current state into the compact [`BuildView`] a build-tree
+    /// pane renders. Bounded by construction, unlike [`snapshot`](Self::snapshot):
+    /// the log tail, dependency DAG, and daemon view are dropped, and errors and
+    /// non-build activities are capped, so the serialized body stays small on the
+    /// dashboard's wholesale-diffed pane path regardless of build verbosity.
+    #[must_use]
+    pub fn build_view(&self) -> BuildView {
+        let mut counts = BuildCounts::default();
+        let builds: Vec<BuildRow> = self
+            .builds
+            .values()
+            .map(|build| {
+                match build.status {
+                    BuildStatus::Planned => counts.planned += 1,
+                    BuildStatus::Running => counts.running += 1,
+                    BuildStatus::Stopped => counts.stopped += 1,
+                    BuildStatus::Succeeded => counts.succeeded += 1,
+                    BuildStatus::Failed => counts.failed += 1,
+                }
+                BuildRow {
+                    name: derivation_name(&build.derivation),
+                    derivation: build.derivation.clone(),
+                    status: build.status,
+                    phase: build.phase.clone(),
+                    host: build.host.clone(),
+                    log_count: build.log_count,
+                    content_addressed: build.content_addressed,
+                }
+            })
+            .collect();
+
+        // Running non-build activities that carry their own progress: fetches,
+        // copies, substitutions. A build's own activity is represented by its
+        // build row, so skip anything already attached to a build. Newest first
+        // so the strip shows what just started, capped so a fan-out of hundreds
+        // of fetches cannot unbound the body.
+        let mut activities: Vec<ActivityRow> = self
+            .activities
+            .values()
+            .filter(|activity| {
+                activity.status == ActivityStatus::Running
+                    && activity.build.is_none()
+                    && activity.activity_type.name != "build"
+                    && !activity.text.is_empty()
+            })
+            .map(|activity| {
+                let progress = activity.progress.unwrap_or_default();
+                ActivityRow {
+                    kind: activity.activity_type.name.clone(),
+                    text: activity.text.clone(),
+                    done: progress.done,
+                    expected: progress.expected,
+                    size_bytes: activity.size_bytes,
+                }
+            })
+            .collect();
+        // `activities` is a BTreeMap keyed by ascending id, so later ids are
+        // more recent; reverse for newest-first, then cap.
+        activities.reverse();
+        activities.truncate(ACTIVITY_LIMIT);
+
+        let errors = self
+            .errors
+            .iter()
+            .rev()
+            .take(ERROR_LIMIT)
+            .rev()
+            .cloned()
+            .collect();
+
+        BuildView {
+            command: self.command_label().to_owned(),
+            builds,
+            activities,
+            counts,
+            errors,
+            finished: self.finished,
+            exit_code: self.exit_code,
+        }
+    }
+}
+
+/// The human name in a `<hash>-<name>.drv` store path (`ripgrep-14.1.0`), or the
+/// whole path when it does not match that shape. Splits once on the first `-`
+/// after the `/nix/store/<hash>` prefix and strips the `.drv` suffix, matching
+/// how Nix itself names a derivation in its output.
+fn derivation_name(derivation: &str) -> String {
+    let base = derivation
+        .rsplit('/')
+        .next()
+        .unwrap_or(derivation)
+        .strip_suffix(".drv")
+        .unwrap_or(derivation);
+    // `<hash>-<name>`: the hash has no `-`, so the first `-` splits it off.
+    base.split_once('-')
+        .map_or_else(|| base.to_owned(), |(_hash, name)| name.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_start(id: u64, drv: &str) -> String {
+        format!(
+            r#"@nix {{"action":"start","fields":["{drv}","local",1,1],"id":{id},"level":3,"text":"building '{drv}'","type":105}}"#
+        )
+    }
+
+    #[test]
+    fn build_view_projects_rows_counts_and_name() {
+        let drv = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ripgrep-14.1.0.drv";
+        let mut state = MonitorState::new("nix build .#ripgrep".to_owned());
+        state.apply_line(&build_start(7, drv));
+        state.apply_line(r#"@nix {"action":"result","fields":["buildPhase"],"id":7,"type":104}"#);
+
+        let view = state.build_view();
+        assert_eq!(view.command, "nix build .#ripgrep");
+        assert_eq!(view.builds.len(), 1);
+        assert_eq!(view.builds[0].name, "ripgrep-14.1.0");
+        assert_eq!(view.builds[0].status, BuildStatus::Running);
+        assert_eq!(view.builds[0].phase.as_deref(), Some("buildPhase"));
+        assert_eq!(view.counts.running, 1);
+        assert!(!view.finished);
+    }
+
+    #[test]
+    fn build_view_reports_finish_and_exit_code() {
+        let drv = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-demo.drv";
+        let mut state = MonitorState::default();
+        state.apply_line(&build_start(7, drv));
+        state.apply_line(r#"@nix {"action":"stop","id":7}"#);
+        state.finish(Some(0));
+
+        let view = state.build_view();
+        assert!(view.finished);
+        assert_eq!(view.exit_code, Some(0));
+        assert_eq!(view.counts.succeeded, 1);
+        assert_eq!(view.builds[0].status, BuildStatus::Succeeded);
+    }
+
+    #[test]
+    fn build_view_caps_errors_to_the_most_recent() {
+        let mut state = MonitorState::default();
+        for i in 0..(ERROR_LIMIT + 5) {
+            state.apply_line(&format!(
+                r#"@nix {{"action":"msg","level":0,"msg":"error number {i}"}}"#
+            ));
+        }
+        let view = state.build_view();
+        assert_eq!(view.errors.len(), ERROR_LIMIT);
+        // The tail is kept: the last error pushed is the last one shown.
+        assert_eq!(
+            view.errors.last().map(String::as_str),
+            Some(&format!("error number {}", ERROR_LIMIT + 4)[..])
+        );
+    }
+
+    #[test]
+    fn build_view_excludes_build_activities_from_the_activity_strip() {
+        let drv = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-demo.drv";
+        let mut state = MonitorState::default();
+        state.apply_line(&build_start(7, drv));
+        // A fetch activity: no build attached, carries text.
+        state.apply_line(
+            r#"@nix {"action":"start","fields":[],"id":8,"level":3,"text":"downloading 'https://example/x'","type":101}"#,
+        );
+
+        let view = state.build_view();
+        assert_eq!(view.builds.len(), 1, "the build is a build row");
+        assert_eq!(view.activities.len(), 1, "only the fetch is an activity row");
+        assert_eq!(view.activities[0].kind, "file_transfer");
+    }
+
+    #[test]
+    fn derivation_name_strips_hash_and_suffix() {
+        assert_eq!(
+            derivation_name("/nix/store/abcdef0123456789abcdef0123456789-ripgrep-14.1.0.drv"),
+            "ripgrep-14.1.0"
+        );
+        // A path that does not match the shape is returned as-is.
+        assert_eq!(derivation_name("weird"), "weird");
+    }
+}

--- a/packages/nix/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix/nix-web-monitor/parser/src/lib.rs
@@ -8,8 +8,10 @@ use serde_json::Value;
 use snafu::Snafu;
 
 pub mod activation;
+pub mod build_view;
 pub mod daemon;
 pub use activation::{Activation, ActivationStatus, ActivationStep};
+pub use build_view::{ActivityRow, BuildCounts, BuildRow, BuildView};
 pub use daemon::{DaemonInfo, DaemonOps, OpClass};
 
 const NIX_JSON_PREFIX: &str = "@nix ";
@@ -370,6 +372,13 @@ impl MonitorState {
             command,
             ..Self::default()
         }
+    }
+
+    /// The Nix invocation label this monitor was constructed with (`nix build
+    /// .#ix`), shown as the build tree's root. Read by [`build_view`](Self::build_view).
+    #[must_use]
+    pub fn command_label(&self) -> &str {
+        &self.command
     }
 
     #[must_use]

--- a/packages/nix/nix-web-monitor/server/src/emit.rs
+++ b/packages/nix/nix-web-monitor/server/src/emit.rs
@@ -1,0 +1,149 @@
+//! Headless NDJSON emitter: the machine-readable counterpart to the web UI.
+//!
+//! The web server streams msgpack deltas to a browser. A programmatic consumer
+//! (the kernel `nix` module's live-pane path) wants the same parser as the
+//! single owner of internal-json, but as plain lines on stdout, not a socket.
+//! [`run`] spawns the nix command exactly as the server does
+//! (`--log-format internal-json`), feeds each stderr line through
+//! [`MonitorState`], and prints the compact [`BuildView`](nix_web_monitor_parser::BuildView)
+//! as one JSON object per line, throttled so a chatty build cannot flood the
+//! consumer. Our stdout is reserved for that NDJSON, so nix's own stdout (its
+//! command output) is redirected to our stderr rather than mixed in, and the
+//! emitter exits with nix's status.
+//!
+//! No HTTP server, no broadcast channel, no daemon probe: the emitter is the
+//! thin, dependency-light path, and the render model it emits is owned by the
+//! parser crate so the dashboard renderer and this emitter never drift.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use nix_web_monitor_parser::MonitorState;
+use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::time::{Instant, MissedTickBehavior, interval};
+
+/// Minimum wall-clock between emitted snapshots. Nix emits a line per activity
+/// event; at ~2 Hz the consumer sees prompt progress without a line per event
+/// (which would defeat the point of a compact projection and hammer the
+/// dashboard's wholesale-diffed pane). A change that lands between ticks rides
+/// the next tick; the final snapshot after exit is always emitted.
+const EMIT_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Run `nix <args>` under the parser and emit throttled `BuildView` NDJSON on
+/// stdout, returning nix's exit code (`None` if it reported none).
+///
+/// `nix_verbose` passes `-v` to nix for richer activity events, matching the
+/// server's `--nix-verbose`.
+pub async fn run(nix_args: Vec<String>, nix_verbose: bool) -> Result<Option<i32>> {
+    let command_label = format!("nix {}", nix_args.join(" "));
+    let mut state = MonitorState::new(command_label);
+
+    let mut command = Command::new("nix");
+    if nix_verbose {
+        command.arg("-v");
+    }
+    command
+        .arg("--log-format")
+        .arg("internal-json")
+        .args(&nix_args)
+        // stdout is nix's real output (e.g. `nix eval --raw`); forward it to our
+        // own stdout is wrong here because we emit NDJSON there, so drain it to
+        // stderr instead, keeping stdout a clean NDJSON channel. The events we
+        // parse ride stderr.
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = command.spawn().context("spawning nix")?;
+    let child_stdout = child.stdout.take().context("nix stdout was not captured")?;
+    let child_stderr = child.stderr.take().context("nix stderr was not captured")?;
+
+    // Forward nix's stdout to our stderr so it is visible for debugging without
+    // corrupting the NDJSON channel on our stdout.
+    let stdout_task = tokio::spawn(async move {
+        let mut reader = child_stdout;
+        let _ = io::copy(&mut reader, &mut io::stderr()).await;
+    });
+
+    let mut lines = BufReader::new(child_stderr);
+    let mut buf: Vec<u8> = Vec::new();
+    let mut ticker = interval(EMIT_INTERVAL);
+    // The first tick fires immediately; skip a missed tick rather than burst to
+    // catch up, so a slow consumer never gets a backlog of snapshots at once.
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    // Whether state changed since the last emit, so an idle interval (a long
+    // silent build phase) does not re-emit an identical snapshot every tick.
+    let mut dirty = false;
+    // The last tick we actually emitted on, so a burst of events between ticks
+    // still emits at most once per interval.
+    let mut last_emit = Instant::now();
+
+    loop {
+        buf.clear();
+        tokio::select! {
+            read = lines.read_until(b'\n', &mut buf) => {
+                let read = read.context("reading nix stderr")?;
+                if read == 0 {
+                    break;
+                }
+                trim_eol(&mut buf);
+                // Lossy decode so a builder's non-UTF-8 byte never stalls the
+                // pipe (and then blocks the child on a full stderr), matching
+                // the server's stderr reader.
+                let line = String::from_utf8_lossy(&buf);
+                state.apply_line(&line);
+                dirty = true;
+                // Coalesce: emit at most once per interval even under a burst.
+                if last_emit.elapsed() >= EMIT_INTERVAL {
+                    emit(&state).await?;
+                    dirty = false;
+                    last_emit = Instant::now();
+                }
+            }
+            _ = ticker.tick() => {
+                if dirty {
+                    emit(&state).await?;
+                    dirty = false;
+                    last_emit = Instant::now();
+                }
+            }
+        }
+    }
+
+    let status = child.wait().await.context("waiting for nix")?;
+    let exit_code = status.code();
+    // Settle still-running/stopped builds against the real exit code (Nix never
+    // marks a build succeeded; a clean exit promotes them), then emit the final
+    // snapshot so the consumer's last line is authoritative.
+    state.finish(exit_code);
+    emit(&state).await?;
+
+    // The stdout drain ends when the child's stdout closes; join so a late line
+    // is flushed before we exit.
+    let _ = stdout_task.await;
+    Ok(exit_code)
+}
+
+/// Serialize the current build view and write it as one NDJSON line on stdout,
+/// flushing so the consumer sees it promptly (a buffered pipe would otherwise
+/// hold it until the buffer filled or the process exited).
+async fn emit(state: &MonitorState) -> Result<()> {
+    let mut line = serde_json::to_vec(&state.build_view()).context("serializing build view")?;
+    line.push(b'\n');
+    let mut stdout = io::stdout();
+    stdout.write_all(&line).await.context("writing NDJSON")?;
+    stdout.flush().await.context("flushing NDJSON")?;
+    Ok(())
+}
+
+/// Drop a trailing `\n` and any preceding `\r` from a read line.
+fn trim_eol(buf: &mut Vec<u8>) {
+    if buf.last() == Some(&b'\n') {
+        buf.pop();
+    }
+    if buf.last() == Some(&b'\r') {
+        buf.pop();
+    }
+}

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -27,6 +27,7 @@ use tower_http::services::ServeDir;
 
 mod daemon;
 mod dependencies;
+mod emit;
 mod reasons;
 use daemon::run_daemon_probe;
 use dependencies::resolve_dependencies;
@@ -59,8 +60,10 @@ struct Args {
     /// Static UI directory. The Nix package wrapper fills this in. Always comes
     /// from the env the wrapper sets, so it is never passed after a subcommand
     /// and need not be `global` (which clap forbids on a required argument).
+    /// Optional so the headless `--emit` path (which serves no UI) runs without
+    /// it; the web-UI path validates it is present in [`validate_site_dir`].
     #[arg(long, env = "NIX_WEB_MONITOR_SITE_DIR")]
-    site_dir: PathBuf,
+    site_dir: Option<PathBuf>,
 
     /// Exit when the Nix command finishes instead of keeping the web UI alive.
     #[arg(long, global = true)]
@@ -74,8 +77,23 @@ struct Args {
     #[arg(long, global = true)]
     nix_verbose: bool,
 
+    /// Run headless: emit the build tree as NDJSON on stdout instead of serving
+    /// the web UI. One compact JSON `BuildView` per line, throttled, for a
+    /// programmatic consumer (the kernel `nix` module's live pane). Only the
+    /// passthrough `nix …` subcommand is supported; a switch has no headless
+    /// form. Exits with nix's status.
+    #[arg(long, value_enum, global = true)]
+    emit: Option<EmitFormat>,
+
     #[command(subcommand)]
     command: NwmCommand,
+}
+
+/// Machine-readable output format for the headless emitter (`--emit`).
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum EmitFormat {
+    /// One JSON `BuildView` object per line (newline-delimited JSON).
+    Ndjson,
 }
 
 /// What `nwm` runs under the monitor. The named subcommands wrap the
@@ -157,14 +175,29 @@ async fn main() -> Result<()> {
         .version(build_version::version_static(env!("CARGO_PKG_VERSION")))
         .get_matches();
     let args = Args::from_arg_matches(&matches).unwrap_or_else(|error| error.exit());
-    validate_site_dir(&args.site_dir)?;
+
+    // Headless emitter: no UI, no daemon probe -- spawn nix, stream the build
+    // tree as NDJSON, exit with nix's status. Only the passthrough `nix …`
+    // subcommand has a headless form; a switch is a UI-only orchestration.
+    if args.emit.is_some() {
+        let NwmCommand::Nix(nix_args) = args.command else {
+            bail!("--emit supports only the passthrough `nix …` command, not a switch");
+        };
+        let exit_code = emit::run(nix_args, args.nix_verbose).await?;
+        std::process::exit(exit_code.unwrap_or(1));
+    }
+
+    let site_dir = args
+        .site_dir
+        .context("--site-dir (or NIX_WEB_MONITOR_SITE_DIR) is required to serve the web UI")?;
+    validate_site_dir(&site_dir)?;
 
     // Record startup before any build runs: the "what changed" reason baseline
     // uses it to exclude outputs registered during this run (see `reasons`).
     reasons::record_start_time();
 
     let index_html =
-        Bytes::from(std::fs::read(args.site_dir.join("index.html")).context("reading index.html")?);
+        Bytes::from(std::fs::read(site_dir.join("index.html")).context("reading index.html")?);
 
     let job = build_job(args.command).await.context("planning job")?;
     let monitor = Arc::new(RwLock::new(MonitorState::new(job.command_label.clone())));
@@ -179,7 +212,7 @@ async fn main() -> Result<()> {
         deltas: deltas.clone(),
         index_html,
     };
-    let http_server = serve(http_addr, args.site_dir, state).await?;
+    let http_server = serve(http_addr, site_dir, state).await?;
 
     eprintln!("nix-web-monitor: http://{http_addr}");
 


### PR DESCRIPTION
Adds the machine-readable half of `nix-web-monitor`: a compact `BuildView` render model owned by the `parser` crate (the single owner of Nix internal-json), plus a `--emit ndjson` headless mode on the server binary that spawns nix, feeds the state machine, and streams throttled `BuildView` NDJSON on stdout (one JSON object per line, ~2 Hz, plus a final authoritative snapshot after nix exits). Exits with nix's status.

This is the foundation for the kernel `nix()` live build pane (issue #1832): the pane consumes this NDJSON instead of Python re-deriving the render model. The follow-up PR adds the kernel helper + `nix-build` Svelte renderer.

- `parser/src/build_view.rs`: `BuildView` (builds, in-flight activities, counts, capped errors) + `MonitorState::build_view()`, bounded by construction so the dashboard's wholesale-diffed pane body stays small.
- `server/src/emit.rs`: the headless emitter. Reuses the parser; no HTTP, no daemon probe.
- `server/src/main.rs`: wires `--emit`; `site_dir` is now optional (validated only on the web-UI path).

Validation (x86_64-linux, vin-compute-1): parser + server clippy clean (nursery/pedantic), 5 new `build_view` unit tests pass, and an end-to-end emitter run against a real `nix build` produced correct progress + final snapshots (`succeeded`, `finished:true`, `exitCode:0`).

Reviewed with the code-reviewer agent: no correctness/security blockers; fixed one misleading doc comment it flagged.

Part of #1832. AI-authored (Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--emit ndjson` headless mode to nix-web-monitor to stream BuildView snapshots
> - Adds a new `--emit ndjson` CLI flag to `nix-web-monitor` that runs headlessly without starting the HTTP server, spawning `nix` and streaming compact `BuildView` snapshots as NDJSON to stdout at ~2 Hz.
> - Introduces `BuildView`, `BuildRow`, `ActivityRow`, and `BuildCounts` structs in the parser crate, serialized with camelCase field names, representing a bounded snapshot of current build state.
> - Implements `MonitorState::build_view()` in [build_view.rs](https://github.com/indexable-inc/index/pull/1833/files#diff-42951a1393b45abc70f07ade5dfe0ed3f49fb409526f5e335a0cf103c2f1d0e6) to project monitor state into `BuildView`, capping errors and activities to avoid unbounded output.
> - The headless emitter in [emit.rs](https://github.com/indexable-inc/index/pull/1833/files#diff-f400679dcdde3f2a040f72041bd1e44e0e772b7fd31bb8776d22f76e0779008b) relays nix's stdout to stderr and exits with nix's exit code.
> - `--site-dir` is no longer required when `--emit` is set; it is only validated in UI-serving mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44f7e3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->