### PR TITLE
push-cache: durable local binary cache for aarch64 builds

### DIFF
--- a/packages/nix/push-cache/default.nix
+++ b/packages/nix/push-cache/default.nix
@@ -1,0 +1,83 @@
+# `nix run .#push-cache -- <installable>...`: archive the full build closure of
+# one or more installables into a durable local file:// binary cache directory
+# (`$IX_PUSH_CACHE_DIR`, default `~/.cache/ix-push-cache`).
+#
+# Why a local cache and not cache.ix.dev: nothing aarch64-linux is ever
+# published there. cache-push.yml realises `cachePushRoots.x86_64-linux` on the
+# self-hosted CI host and pushes through that host's loopback attic shim — a
+# ghostunnel mTLS tunnel authenticated by the node's cas-fabric leaf cert, plus
+# a push JWT delivered by the fleet secret store (atticd signs narinfos
+# server-side, so there is no exportable signing key; the push path is fleet
+# surface, not a copyable credential). A developer Mac has neither, so an
+# aarch64 build that took hours (guest kernel, mesa fork, toolchains for
+# `packages.aarch64-linux.panes-guest-image`) evaporates on the next store GC
+# and rebuilds from source. This tool keeps those closures in a plain binary
+# cache directory outside any store, which the machine's aarch64 builder VM
+# (and optionally the host) lists as a `file://` substituter. The durable fix
+# is a native aarch64 CI builder pushing to ix-public like x86_64 does.
+#
+# The cache is unsigned (nix copy to file:// writes no narinfo signatures), so
+# a consumer must either sit inside the producing machine's trust domain (the
+# builder VM sets `require-sigs = false`; its disks are host-owned anyway) or
+# sign the paths separately before trusting them elsewhere.
+{writeNushellApplication}:
+writeNushellApplication {
+  name = "push-cache";
+  meta = {
+    description = "Archive an installable's full build closure into a local file:// binary cache";
+    mainProgram = "push-cache";
+  };
+  # No pinned nix in runtimeInputs: the client must speak the host daemon's
+  # protocol/experimental-feature set (ca-derivations on hydra), so use the
+  # ambient nix that just ran this app, same as chrome-vm and the updaters.
+  text = ''
+    # nu
+    def main [...installables: string] {
+      if ($installables | is-empty) {
+        error make {
+          msg: "usage: push-cache <installable>... e.g. push-cache .#packages.aarch64-linux.panes-guest-image"
+        }
+      }
+      let cache_dir = (
+        $env.IX_PUSH_CACHE_DIR?
+        | default (
+          ($env.XDG_CACHE_HOME? | default ($env.HOME | path join ".cache"))
+          | path join "ix-push-cache"
+        )
+      )
+      mkdir $cache_dir
+      # zstd over the xz default: this cache lives on local disk where write
+      # time, not size, is the constraint, and multi-GiB image closures under
+      # xz would dominate the whole run.
+      let cache_url = $"file://($cache_dir)?compression=zstd"
+
+      for installable in $installables {
+        print $"push-cache: building ($installable)"
+        ^nix build --no-link $installable
+
+        # The BUILD closure, not the runtime closure: requisites of the
+        # derivation plus every already-realised output (--include-outputs
+        # lists only outputs that exist, so nothing here forces extra builds).
+        # That is what keeps kernel/mesa/toolchain intermediates warm across a
+        # closure shift. The .drv files themselves are dropped: substitution
+        # serves outputs, and drvs re-instantiate for free from the flake.
+        let paths = (
+          ^nix path-info --derivation $installable
+          | lines
+          | each {|drv| ^nix-store --query --requisites --include-outputs $drv | lines }
+          | flatten
+          | uniq
+          | where {|p| not ($p | str ends-with ".drv") }
+        )
+
+        # --stdin instead of argv: an image build closure is thousands of
+        # paths, past the execve argument limit. nix skips paths whose narinfo
+        # is already in the cache, so re-runs are incremental.
+        print $"push-cache: copying ($paths | length) store paths to ($cache_dir)"
+        $paths | to text | ^nix copy --to $cache_url --stdin
+      }
+
+      print $"push-cache: done; substituter file://($cache_dir) is unsigned, so consumers need require-sigs = false or a separate signature"
+    }
+  '';
+}

--- a/packages/nix/push-cache/package.nix
+++ b/packages/nix/push-cache/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "push-cache";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+}


### PR DESCRIPTION
Building `packages.aarch64-linux.panes-guest-image` for the first time (#1686 bring-up) cost hours and tripped nine infra defects on the way. The repeat cost has one root cause: nothing aarch64-linux is ever cached. cache-push.yml realises `cachePushRoots.x86_64-linux` only, so kernel/mesa/toolchain closures rebuild from source whenever the closure shifts, and aarch64 images have zero CI coverage (the ncurses-6.6 initrd regression shipped invisibly).

**What this adds**: `nix run .#push-cache -- <installable>...` archives the full *build* closure (not just runtime) into a durable local `file://` binary cache (`~/.cache/ix-push-cache`, override with `IX_PUSH_CACHE_DIR`), zstd NARs, incremental re-runs. On hydra the builder VM now shares that dir over virtiofs and lists it as its first substituter (machine config, andrewgazelka/nix@6c095aad, along with the 8 vCPU / 16 GiB bump, declarative cache.ix.dev + ix-workspace key, download-stall timeouts, and require-sigs=false for host root-to-root pushes over local vmnet), so store GC on either side no longer re-pays the build.

**Why not push to cache.ix.dev**: the push path is fleet surface, not a copyable credential. atticd signs narinfos server-side (there is no exportable signing key at all), the push rides a ghostunnel mTLS tunnel authenticated by the CI node's cas-fabric leaf cert plus a secret-store JWT, and cache.ix.dev's public vhost is GET/HEAD-only. The durable fix is a native aarch64 CI builder pushing to ix-public the way x86_64 does; until then this keeps paid-for closures warm locally.

Validated: repo lint green; end-to-end run archives `.#jq^bin`'s build closure and `nix path-info --store file://...` serves it back.

Incident list this addresses (2026-07-02/03): builder VM pinned to 4 vCPU / 8 GiB on a many-core Mac; VM trusted only cache.nixos.org so cache.ix.dev + its key + require-sigs + timeouts were bind-mount-hacked in at runtime; plus ENOSPC mid-build, a GC-vs-build race, and the Mullvad/vmnet DHCP blackhole (tracked in machine memory).

Written by Claude (Fable 5) with Andrew.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `push-cache` CLI to archive aarch64 build closures into a local binary cache
> - Adds a new `push-cache` Nushell CLI defined in [default.nix](https://github.com/indexable-inc/index/pull/1834/files#diff-943dbeabf0eb03a992321447c40e372a43c423910ca5c76018cd522f722b1506) that builds specified Nix installables and copies their full closures into a local `file://` binary cache with zstd compression.
> - The cache directory defaults to `$XDG_CACHE_HOME/ix-push-cache` (or `$HOME/.cache/ix-push-cache`) but can be overridden via `$IX_PUSH_CACHE_DIR`.
> - Closure paths are gathered via `nix path-info --derivation` and `nix-store --query --requisites`, deduplicated, and streamed to `nix copy --stdin` to avoid argument-length limits.
> - Risk: the resulting substituter is unsigned, requiring `require-sigs = false` or separate signature management on consuming machines.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd5147d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->