### PR TITLE
agent: scope MEMORY.md index edits to the touched line

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -101,8 +101,13 @@ let
           derivable from code or git history, with relative dates converted to
           absolute dates; and `reference` for external resources.
 
-          After writing or updating a memory, keep `MEMORY.md` as a one-line index:
-          `- [Title](file.md): hook`. Do not put full memory content there.
+          After writing or updating a memory, add or fix only its own line in
+          `MEMORY.md`, the index: one line per file, `- file.md: <hook>`, where the
+          hook is a short trigger phrase (a handful of words), not the memory's full
+          description. Edit that single line in place; never regenerate the whole
+          index, reformat lines you did not touch, or paste each file's frontmatter
+          description into it. The index must stay compact enough to load whole, so
+          keep total size small even as files grow into the hundreds.
           Before saving, update an existing memory instead of duplicating it, and
           delete memories that turn out to be wrong. Do not save what the repo
           already records or what only matters to the current conversation. Recalled
@@ -113,7 +118,12 @@ let
           Sessions relearned the same gotchas and duplicated or contradicted stored
           notes; the schema plus index keeps recall cheap and stale entries deletable.
           Saves deferred to session end were forgotten, so cross-session facts went
-          unwritten; writing at the moment of learning is the fix.
+          unwritten; writing at the moment of learning is the fix. The old wording
+          ("keep MEMORY.md as a one-line index") led agents to regenerate the whole
+          index from scratch, title-casing each filename and pasting its full
+          frontmatter description, which at hundreds of files ballooned past the
+          context cap and destroyed the curated file; scoping edits to the one
+          touched line with a short hook keeps it bounded.
         '';
       };
     }


### PR DESCRIPTION
## Problem

`packages/agent/system-prompt.nix` told the agent to *"keep `MEMORY.md` as a one-line index: `- [Title](file.md): hook`"* with no size bound and no "preserve the curated file" directive. A weak/fast model reads this as license to regenerate the whole index from scratch, deriving `Title` by title-casing the filename and pasting each file's full frontmatter `description` as the hook. At 400+ memory files that produced a ~76KB flat alphabetical index each time, destroying the hand-curated compact version (~17KB).

`MEMORY.md` loads into every session via additionalContext, which is byte-capped; content past the cap is silently dropped at load, so the bloat is also functionally truncated (the tail never reaches context).

There is no code generator to fix: confirmed the pinned claude-code binary has no MEMORY.md writer in this format (only the unrelated `memory_scan`). The owner is this system-prompt instruction.

## Fix

Scope the rule to the one entry the agent just touched: edit only that line, use `- file.md: <short hook>` (drop the mechanical title-cased display text since the filename link is already the handle), cap the hook at a short trigger phrase rather than the full description, and forbid regenerating the whole index or reformatting untouched lines. The block's `reason` records why.

## Validation

- `nix-instantiate --parse` and full `prompt.nix` render both succeed; reread the rendered memory section (no dashes, reads cleanly).
- `nix run .#lint -- --json`: all checks `ok` (astlog warnings are pre-existing, in unrelated files).

Fixes #1835

Filed and fixed by an AI agent (Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope MEMORY.md index edits to a single hook line per touched file
> Updates the agent system prompt in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1836/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to instruct agents to add or update only the single `- file.md: <hook>` line for the memory being changed, rather than regenerating the entire index. The prompt now explicitly forbids reformatting untouched lines, pasting frontmatter descriptions, or expanding entries with full titles — keeping the index compact as the file count grows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7229a26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->