### PR TITLE
feat(image): bake index rust-overlay source into base image

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -513,6 +513,7 @@
         self
         lib
         nixpkgs
+        rust-overlay
         paths
         system
         home-manager

--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   nixpkgs,
+  rust-overlay,
   paths,
   system,
   home-manager,
@@ -50,6 +51,33 @@
   };
 
   /**
+  Locked flake-input sources baked into the base image but NOT reachable
+  through a `nix.registry.*` pin, so `system.extraDependencies` roots them
+  into the system closure (and `includeNixDB` in oci-layer.nix registers
+  everything in that closure as valid). Single source of truth: the module
+  below sets `system.extraDependencies` to this list, and the
+  `base-image-nix-db` check (tests/default.nix) reads it back off the
+  evaluated `system.extraDependencies` to assert each path ships valid — the
+  registry-derived projection there cannot catch these, precisely because
+  they are not registry pins.
+
+  Measurement-driven exception to the "don't bake the flake inputs" hold
+  (index #1748/#1815): on the current base image the FIRST `nix run index#jq`
+  in a fresh ix VM took 2m44.8s, its log showing `unpacking
+  'github:oxalica/rust-overlay/107c334f...' into the Git cache` — evaluating
+  index's flake under `nix run` forces the `rust-overlay` input source, which
+  the image does not ship, so nix fetches and unpacks it through VCFS. Baking
+  it drops that to the warm ~2.6s. rust-overlay is ~19M; home-manager and
+  hermes-agent stay unbaked until a measurement justifies each.
+
+  `.outPath` is the ORIGINAL `-source` store path with string context, so it
+  roots into the closure once (no duplicate copy — the #1748 trap); the path
+  must be the LOCKED input so it matches what index's `flake.lock` narHash
+  resolves to during in-guest eval.
+  */
+  extraBakedSources = [rust-overlay.outPath];
+
+  /**
   Run the platform config, OCI packaging, base profile, the full module
   registry, and the caller's `modules` through `lib.nixosSystem`, then
   return the evaluated `config`. This is the evaluation path every
@@ -86,6 +114,13 @@
               path = nixpkgs.outPath;
               inherit (nixpkgs) narHash;
             };
+          }
+          {
+            # Root the extra baked sources (see `extraBakedSources` above) into
+            # the system closure so `includeNixDB` registers them as valid and
+            # an in-guest `nix run index#...` finds rust-overlay already present
+            # instead of unpacking it through VCFS (measured 2m44.8s -> ~2.6s).
+            system.extraDependencies = extraBakedSources;
           }
         ]
         ++ lib.optional (self != null) {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2174,16 +2174,23 @@
   #      all, so the pinned source (present in the image) was never valid; fixed
   #      by `includeNixDB = true` in oci-layer.nix
   # The boundary this defends: the built base OCI archive must ship a populated
-  # /nix/var/nix/db/db.sqlite whose ValidPaths includes EVERY path the image's
-  # flake registry pins (nixpkgs and, once baked, index) — otherwise the first
-  # in-guest `nix run nixpkgs#...`/`index#...` re-ingests that source. A bare
-  # db.sqlite, or the registry pin alone, is not enough. Deriving the required
-  # paths from the image's own `nix.registry.*.to.path` means a future pin is
-  # covered automatically and this can never silently drift from what ships.
-  # This check builds the real base archive and asserts exactly that, so it also
-  # proves the DB survives oci-image-builder's re-streaming. It builds an OCI
-  # image, so it is its own check (not the pure-eval `eval` aggregate) and runs
-  # on Linux.
+  # /nix/var/nix/db/db.sqlite whose ValidPaths includes EVERY source the image
+  # bakes for in-guest eval — otherwise the first in-guest `nix` re-ingests it.
+  # Two classes of baked source, both covered here:
+  #   - flake registry pins (nixpkgs and, once baked, index), read off
+  #     `nix.registry.*.to.path`; and
+  #   - sources baked WITHOUT a registry pin via `system.extraDependencies`
+  #     (rust-overlay — forced when index's flake evaluates under `nix run`,
+  #     but reached through no registry row), read off that option. The
+  #     registry-derived projection cannot catch these, precisely because they
+  #     are not registry pins, so they need their own list.
+  # A bare db.sqlite, or the registry pin alone, is not enough. Deriving the
+  # required paths from the image's OWN config (the registry and
+  # `system.extraDependencies`) means a future pin or baked source is covered
+  # automatically and this can never silently drift from what ships. This check
+  # builds the real base archive and asserts exactly that, so it also proves the
+  # DB survives oci-image-builder's re-streaming. It builds an OCI image, so it
+  # is its own check (not the pure-eval `eval` aggregate) and runs on Linux.
   baseImageNixDb = let
     # Every `path`-type registry pin the image ships. Guard on the type so a
     # non-path entry (e.g. a default indirect/github registry row) can't break
@@ -2193,6 +2200,10 @@
       (builtins.filter (entry: (entry.to.type or null) == "path" && entry.to ? path))
       (map (entry: entry.to.path))
     ];
+    # Sources baked into the system closure without a registry pin (the
+    # `extraBakedSources` list in lib/image/default.nix). `toString` so a path
+    # value renders as its store path for the sqlite lookup below.
+    extraBakedPaths = map toString base.imageConfig.system.extraDependencies;
   in
     pkgs.runCommand "ix-test-base-image-nix-db" {
       nativeBuildInputs = [
@@ -2202,7 +2213,7 @@
         pkgs.coreutils
       ];
       archive = base.imageConfig.ix.build.ociImage;
-      requiredPaths = registryPaths;
+      requiredPaths = registryPaths ++ extraBakedPaths;
     } ''
       mkdir extract db
       # oci-image-builder writes uncompressed tar layers as blobs/sha256/<digest>.


### PR DESCRIPTION
## What

Bake index's **locked** `rust-overlay` source into the base VM image so an in-guest `nix run index#<pkg>` no longer fetches and unpacks it through VCFS on first use.

## Why (measured)

On the current base image, in a fresh `ix` VM:

- **First** `nix run index#jq`: **2m44.8s**, log line `unpacking 'github:oxalica/rust-overlay/107c334f...' into the Git cache...`
- Warm run: **2.6s**

Evaluating index's flake under `nix run` forces the `rust-overlay` input source. It is not baked into the image, so nix fetches + unpacks it through the guest's VCFS store. This is the same failure family as the nixpkgs/index source not shipping valid (index #1748 / #1815 / ix#6043), now for a third input that eval forces.

This is the **measurement-driven exception** to the "don't bake the flake inputs" hold: `rust-overlay` is ~19M and eval demonstrably forces it. `home-manager` and `hermes-agent` stay unbaked until a measurement justifies each.

## How

- `lib/image/default.nix`: `system.extraDependencies = [rust-overlay.outPath]` roots the locked source into the system closure. `includeNixDB` (oci-layer.nix) then registers everything in the closure as valid, so the guest's narHash-matched reference resolves to a present path and never re-fetches — the property nixpkgs/`self` already have. `rust-overlay` is plumbed down from `flake.nix` the same way `nixpkgs`/`self` reach this scope; `.outPath` (original `-source`, string context) roots once without a duplicate copy (#1748 trap).
- `tests/default.nix`: extend `base-image-nix-db` to also assert the `system.extraDependencies` paths are ValidPaths in the shipped DB. The registry-derived projection there cannot catch a non-registry pin, so an explicit extra-baked-sources list (read back off `system.extraDependencies`, one source of truth with the module) covers it.

## Validation

Built the real fence on x86_64-linux (vin-compute-1) — it builds the actual base OCI archive, extracts the shipped `db.sqlite`, and asserts every required source (nixpkgs, index, **and now `xgx5jkx...-source` = the locked rust-overlay**) is a ValidPath:

```
/nix/store/jq7x2q8wmdrljgahj01yxvskdmiivwnv-ix-test-base-image-nix-db
```

Confirmed the baked path equals `rust-overlay.outPath` at rev `107c334f` / narHash `sha256-hBdiQYd40xRtBWBiXHUxuQYWmJBiK19YO1FiYgrmEo0=`, matching index's `flake.lock`.

After merge: ix pin bump + base image republish (handled separately).

Refs ix#6217.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bake rust-overlay source into the base image closure via `system.extraDependencies`
> - Adds `rust-overlay.outPath` to a new `extraBakedSources` list in [lib/image/default.nix](https://github.com/indexable-inc/index/pull/1837/files#diff-3883253618b080892e770f4ceb96188ed814f4f588df529f7a82d338874c14bd) and roots it in the system closure via `system.extraDependencies`, so `includeNixDB` registers it as a valid path without a registry pin.
> - Expands the `baseImageNixDb` test in [tests/default.nix](https://github.com/indexable-inc/index/pull/1837/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to assert that both registry-pinned paths and paths from `system.extraDependencies` are present in the base image's Nix DB.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cf56fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->