### PR TITLE
feat(mcp/nix): live nix build-tree pane via the nix-web-monitor emitter

### DIFF
--- a/packages/dashboard/dashboard-core/site/src/components/NixBuildBody.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/NixBuildBody.svelte
@@ -1,0 +1,347 @@
+<script lang="ts">
+  // The `nix-build` data renderer: a live Nix build tree. The pane's `body` is a
+  // JSON `BuildView` (owned by the Rust nix-web-monitor parser crate and streamed
+  // by its `--emit ndjson` mode; see packages/nix/nix-web-monitor). This draws it
+  // compactly and still — a summary bar of status counts, the derivation rows with
+  // phase and a status dot, an in-flight-activity strip with progress bars, and any
+  // errors highlighted. Colors are theme variables, so it follows the dashboard's
+  // light/dark scheme with no per-mode markup.
+  import type { Pane } from '$lib/types';
+
+  let { pane }: { pane: Pane } = $props();
+
+  type BuildStatus = 'planned' | 'running' | 'stopped' | 'succeeded' | 'failed';
+
+  interface BuildRow {
+    derivation: string;
+    name: string;
+    status: BuildStatus;
+    phase?: string | null;
+    host?: string | null;
+    logCount: number;
+    contentAddressed: boolean;
+  }
+
+  interface ActivityRow {
+    kind: string;
+    text: string;
+    done: number;
+    expected: number;
+    sizeBytes?: number | null;
+  }
+
+  interface Counts {
+    planned: number;
+    running: number;
+    stopped: number;
+    succeeded: number;
+    failed: number;
+  }
+
+  interface BuildView {
+    command: string;
+    builds: BuildRow[];
+    activities: ActivityRow[];
+    counts: Counts;
+    errors: string[];
+    finished: boolean;
+    exitCode?: number | null;
+  }
+
+  const view = $derived.by<BuildView | null>(() => {
+    try {
+      const parsed: unknown = JSON.parse(pane.body ?? '');
+      return parsed && typeof parsed === 'object' ? (parsed as BuildView) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  const counts = $derived(
+    view?.counts ?? { planned: 0, running: 0, stopped: 0, succeeded: 0, failed: 0 },
+  );
+  // Sort rows so the eye lands on what matters: failures first, then running,
+  // then the rest in first-seen order. A stable index keeps equal-rank rows put.
+  const rank: Record<BuildStatus, number> = {
+    failed: 0,
+    running: 1,
+    stopped: 2,
+    planned: 3,
+    succeeded: 4,
+  };
+  const builds = $derived.by(() =>
+    (view?.builds ?? [])
+      .map((b, i) => ({ b, i }))
+      .sort((x, y) => rank[x.b.status] - rank[y.b.status] || x.i - y.i)
+      .map(({ b }) => b),
+  );
+  const activities = $derived(view?.activities ?? []);
+  const errors = $derived(view?.errors ?? []);
+
+  // The status chips shown in the summary bar, in a fixed order; zero-count ones
+  // are dropped so the bar stays quiet on a small build.
+  const chips = $derived(
+    (
+      [
+        ['failed', counts.failed],
+        ['running', counts.running],
+        ['succeeded', counts.succeeded],
+        ['planned', counts.planned],
+        ['stopped', counts.stopped],
+      ] as [BuildStatus, number][]
+    ).filter(([, n]) => n > 0),
+  );
+
+  const statusMark: Record<BuildStatus, string> = {
+    planned: '○',
+    running: '▶',
+    stopped: '◼',
+    succeeded: '✓',
+    failed: '✗',
+  };
+
+  const state = $derived(
+    view?.finished ? (errors.length || view.exitCode ? 'failed' : 'done') : 'building',
+  );
+
+  function pct(done: number, expected: number): number | null {
+    if (!expected || expected <= 0) return null;
+    return Math.max(0, Math.min(100, Math.round((done / expected) * 100)));
+  }
+
+  function fmtBytes(n: number | null | undefined): string {
+    if (n == null || n <= 0) return '';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let v = n;
+    let u = 0;
+    while (v >= 1024 && u < units.length - 1) {
+      v /= 1024;
+      u += 1;
+    }
+    return `${v < 10 && u > 0 ? v.toFixed(1) : Math.round(v)} ${units[u]}`;
+  }
+</script>
+
+<div class="nb">
+  {#if !view}
+    <div class="nb-empty">starting…</div>
+  {:else}
+    <header class="nb-head">
+      <span class="nb-dot nb-{state}"></span>
+      <span class="nb-cmd" title={view.command}>{view.command}</span>
+      <span class="nb-chips">
+        {#each chips as [status, n] (status)}
+          <span class="nb-chip nb-{status}">{statusMark[status]} {n}</span>
+        {/each}
+      </span>
+    </header>
+
+    {#if errors.length}
+      <div class="nb-errors">
+        {#each errors as err, i (i)}
+          <pre class="nb-err">{err}</pre>
+        {/each}
+      </div>
+    {/if}
+
+    {#if builds.length}
+      <ul class="nb-list">
+        {#each builds as b (b.derivation)}
+          <li class="nb-row">
+            <span class="nb-mark nb-{b.status}">{statusMark[b.status]}</span>
+            <span class="nb-name">{b.name}</span>
+            {#if b.phase}<span class="nb-phase">{b.phase}</span>{/if}
+            {#if b.contentAddressed}<span class="nb-tag">ca</span>{/if}
+            {#if b.host}<span class="nb-host">{b.host}</span>{/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+
+    {#if activities.length}
+      <ul class="nb-acts">
+        {#each activities as a, i (i)}
+          {@const p = pct(a.done, a.expected)}
+          <li class="nb-act">
+            <span class="nb-akind">{a.kind}</span>
+            <span class="nb-atext" title={a.text}>{a.text}</span>
+            {#if p !== null}
+              <span class="nb-bar"><span class="nb-fill" style="width:{p}%"></span></span>
+            {:else if a.sizeBytes}
+              <span class="nb-size">{fmtBytes(a.sizeBytes)}</span>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+
+    {#if !builds.length && !activities.length && !errors.length}
+      <div class="nb-empty">no derivations yet</div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .nb {
+    font-family: var(--mono);
+    font-size: 12px;
+    padding: 6px 0 8px;
+    color: var(--ink);
+  }
+  .nb-empty {
+    padding: 10px 14px;
+    color: var(--ink-faint);
+    font-style: italic;
+  }
+  .nb-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px 8px;
+    border-bottom: 1px solid var(--edge);
+  }
+  .nb-cmd {
+    color: var(--ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+  .nb-chips {
+    display: flex;
+    gap: 6px;
+    flex: none;
+  }
+  .nb-chip {
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink-dim);
+  }
+  /* A small status dot for the whole run, and per-status colors reused by the
+     row marks and chips. Semantic colors are hard-coded (they carry meaning that
+     must survive both themes); everything else is a theme variable. */
+  .nb-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex: none;
+    background: var(--ink-faint);
+  }
+  .nb-dot.nb-building {
+    background: #4b8bf5;
+  }
+  .nb-dot.nb-done {
+    background: #3fb950;
+  }
+  .nb-dot.nb-failed {
+    background: #e5534b;
+  }
+  .nb-failed {
+    color: #e5534b;
+  }
+  .nb-running {
+    color: #4b8bf5;
+  }
+  .nb-succeeded {
+    color: #3fb950;
+  }
+  .nb-planned,
+  .nb-stopped {
+    color: var(--ink-faint);
+  }
+  .nb-errors {
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--edge);
+  }
+  .nb-err {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: #e5534b;
+    font-size: 11.5px;
+    line-height: 1.4;
+  }
+  .nb-list,
+  .nb-acts {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+  }
+  .nb-acts {
+    border-top: 1px solid var(--edge);
+  }
+  .nb-row,
+  .nb-act {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 2px 12px;
+    line-height: 1.5;
+  }
+  .nb-mark {
+    flex: none;
+    width: 1ch;
+    text-align: center;
+  }
+  .nb-name {
+    color: var(--ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+  .nb-phase {
+    flex: none;
+    color: var(--ink-dim);
+    font-size: 11px;
+  }
+  .nb-tag {
+    flex: none;
+    font-size: 10px;
+    color: var(--ink-faint);
+    border: 1px solid var(--edge);
+    border-radius: 3px;
+    padding: 0 3px;
+  }
+  .nb-host {
+    flex: none;
+    margin-left: auto;
+    color: var(--ink-faint);
+    font-size: 11px;
+  }
+  .nb-akind {
+    flex: none;
+    color: var(--ink-dim);
+    font-size: 11px;
+    min-width: 7ch;
+  }
+  .nb-atext {
+    color: var(--ink-faint);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+    flex: 1 1 auto;
+    font-size: 11px;
+  }
+  .nb-bar {
+    flex: none;
+    width: 60px;
+    height: 5px;
+    border-radius: 3px;
+    background: var(--edge);
+    overflow: hidden;
+  }
+  .nb-fill {
+    display: block;
+    height: 100%;
+    background: #4b8bf5;
+  }
+  .nb-size {
+    flex: none;
+    color: var(--ink-faint);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/packages/dashboard/dashboard-core/site/src/lib/renderers.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/renderers.ts
@@ -12,6 +12,7 @@ import ExecBody from '$components/ExecBody.svelte';
 import FileViewBody from '$components/FileViewBody.svelte';
 import HtmlBody from '$components/HtmlBody.svelte';
 import NamespaceBody from '$components/NamespaceBody.svelte';
+import NixBuildBody from '$components/NixBuildBody.svelte';
 import TermBody from '$components/TermBody.svelte';
 import type { Pane } from './types';
 
@@ -31,6 +32,9 @@ const dataRenderers: Record<string, Component<{ pane: Pane }>> = {
   namespace: NamespaceBody,
   // A read's highlighted file card (the kernel's `read` tool / `view.cat`).
   'file-view': FileViewBody,
+  // A live Nix build tree (the kernel's `nix.run`/`nix.build`), streamed from the
+  // nix-web-monitor emitter's BuildView.
+  'nix-build': NixBuildBody,
 };
 
 export const fallback: Component<{ pane: Pane }> = DataBody;

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2,6 +2,14 @@
   ix,
   lib,
 }: let
+  # The headless Nix build-tree emitter. The `nix` module's live-pane path spawns
+  # it (`nix-web-monitor --emit ndjson`) so the parser stays the single owner of
+  # internal-json; baked onto the wrapper env (IX_NIX_WEB_MONITOR_BIN) rather than
+  # resolved from PATH. It rides the ix overlay (`overlay = true` in its
+  # package.nix), so it is on the overlaid `pkgs` under its id -- read it there,
+  # not via a `repoPackages` formal, because mcp is also called through
+  # callPackage paths (e.g. pi-harness) that do not bind one.
+  nixWebMonitorBin = pkgs.nix-web-monitor;
   # Read the package set from `ix` rather than a `pkgs` callPackage formal (which
   # `override` can't reach). `ix.pkgs` is the caller's set, the same value
   # callPackage would have auto-bound to a `pkgs` arg in the flake package set.
@@ -1333,6 +1341,7 @@
         --set SCIPQL_SOUFFLE ${lib.escapeShellArg (lib.getExe' pkgs.souffle "souffle")} \
         --set IX_MCP_TY_BIN ${lib.escapeShellArg tyBin} \
         --set IX_MCP_TY_PYTHON ${lib.escapeShellArg mcpPython.interpreter} \
+        --set IX_NIX_WEB_MONITOR_BIN ${lib.escapeShellArg (lib.getExe nixWebMonitorBin)} \
         --prefix PATH : ${
         lib.makeBinPath [
           pkgs.ripgrep
@@ -1353,6 +1362,7 @@
         --set SCIPQL_SOUFFLE ${lib.escapeShellArg (lib.getExe' pkgs.souffle "souffle")} \
         --set IX_MCP_TY_BIN ${lib.escapeShellArg tyBin} \
         --set IX_MCP_TY_PYTHON ${lib.escapeShellArg mcpPython.interpreter} \
+        --set IX_NIX_WEB_MONITOR_BIN ${lib.escapeShellArg (lib.getExe nixWebMonitorBin)} \
         --prefix PATH : ${
         lib.makeBinPath [
           pkgs.ripgrep

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -177,15 +177,16 @@ NU = (
 )
 
 SH = (
-    "`sh` is the escape hatch for what `nu` should not do: running a real external binary "
-    "(`git`/`nix`/`gh`/`cargo` and other writes and side effects), a long-running command, or "
-    "one whose raw text/log you want verbatim. It runs the child off the loop in its own "
+    "`sh` is the escape hatch for what `nu` (and `nix`) should not do: running a real external "
+    "binary (`git`/`gh`/`cargo` and other writes and side effects; for `nix` use the `nix` module "
+    "above, not `sh(['nix', ...])`), a long-running command, or one whose raw text/log you want "
+    "verbatim. It runs the child off the loop in its own "
     "session, streams into the job's pageable output, enforces a timeout with a process-group "
     "kill (so it can't hang in `running` after the command finished but a child held the pipe "
     "open — the exact failure a raw async subprocess gives you), and preserves clean color. To "
     "run elsewhere pass `cwd=`, never a `cd X && ...` prefix; one command per call, never "
     "`cmd1; echo ===; cmd2` chains scraped apart with string splitting. Prefer DATA over text "
-    "even here: when the CLI speaks JSON (`gh --json`, `cargo metadata`, `nix --json`) use it "
+    "even here: when the CLI speaks JSON (`gh --json`, `cargo metadata`, `kubectl -o json`) use it "
     "and parse the Output with `.json()` / `.jsonl()` / `.df()` (a polars frame ready to filter "
     "and render). `sh` takes a shell string (`await sh('git status --short')`) or an argv list "
     "(`await sh(['git', 'commit', '-m', msg])`) that bypasses shell parsing; `await sh.zsh(...)` "
@@ -195,6 +196,20 @@ SH = (
     "into the message), and a repr'd multi-line string loses its newlines — for any prose "
     "argument (a commit message, a PR body) use the argv-list form so it bypasses shell parsing, "
     "or write it to a temp file and `git commit -F <file>`."
+)
+
+NIX = (
+    "For any `nix` command, use the bundled `nix` module — NEVER `sh(['nix', ...])` or "
+    "`nu('nix ...')`. `await nix.run(['build', '.#foo'])` (or the shorthand `await "
+    "nix.build('.#foo')`) runs the build through the nix-web-monitor emitter and, for free, "
+    "publishes a LIVE build-tree pane to the dashboard — every derivation with its phase and "
+    "status, in-flight fetches with progress bars, failures highlighted — that updates as the "
+    "build runs and self-closes when it finishes. The returned handle exposes `.ok`, `.errors`, "
+    "and `.builds` (a polars frame), so branch on the outcome the same way as `sh().ok`. `await "
+    "nix.eval('.#x', apply='...')` returns a native Python value without hand-quoting a Nix "
+    "function through the shell, and `await nix.attrs('.')` catalogs a flake's buildable outputs "
+    "as a frame. Run a long build as a background job and sample the handle between turns. Drop to "
+    "`sh` for nix ONLY when you need its raw stdout verbatim (e.g. `nix eval --raw`)."
 )
 
 VERIFY = (

--- a/packages/mcp/ix_notebook_mcp/pane_bridge.py
+++ b/packages/mcp/ix_notebook_mcp/pane_bridge.py
@@ -101,6 +101,27 @@ def _is_rich(out: dict) -> bool:
     )
 
 
+def _resource_pane(res: dict) -> dict:
+    """One live resource as a pane. A ``data`` resource carries a JSON
+    ``{"renderer", "data"}`` spec in its ``html`` field (see runtime._sweep_resources)
+    and becomes a native `data` pane routed through the frontend renderer registry;
+    every other resource is an html pane in a sandboxed frame. A `data` resource
+    whose spec fails to decode (e.g. a render error stored the HTML error string in
+    the same field) falls back to an html pane so the error is still shown."""
+    pane_id = f"resource/{res['id']}"
+    title = res.get("title") or res["id"]
+    kind = res.get("kind") or ""
+    body = res.get("html") or ""
+    if kind == "data":
+        try:
+            spec = json.loads(body)
+        except (json.JSONDecodeError, TypeError):
+            spec = None
+        if isinstance(spec, dict) and isinstance(spec.get("renderer"), str) and "data" in spec:
+            return data_pane(pane_id, title, spec["renderer"], spec["data"], subtitle=kind)
+    return html_pane(pane_id, title, body, subtitle=kind)
+
+
 def _panes(conn: sqlite3.Connection) -> list[dict]:
     """The MCP's current pane set, mapped from the store."""
     panes: list[dict] = []
@@ -173,15 +194,8 @@ def _panes(conn: sqlite3.Connection) -> list[dict]:
             panes.append(
                 html_pane(f"cell/{cell['id']}", cell.get("title") or "cell", rendered, subtitle="cell")
             )
-    panes.extend(
-        html_pane(
-            f"resource/{res['id']}",
-            res.get("title") or res["id"],
-            res.get("html") or "",
-            subtitle=res.get("kind") or "",
-        )
-        for res in store.live_resources(conn)
-    )
+    for res in store.live_resources(conn):
+        panes.append(_resource_pane(res))
     rows = store.latest_namespace(conn)
     if rows:
         panes.append(data_pane("namespace", "Namespace", "namespace", rows))

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -78,8 +78,10 @@ MODULES: tuple[Module, ...] = (
     ),
     Module(
         "nix",
-        "run a nix build and get its internals as polars (`.events` / `.activities`) plus a live "
-        "build DAG; `nix.attrs()` catalogs the flake's buildable attrs",
+        "run a nix build with a live dashboard build-tree pane; the returned BuildRun exposes "
+        "`.ok` / `.errors` / `.builds` (a polars frame). `nix.eval()` returns a flake value and "
+        "`nix.attrs()` catalogs the flake's buildable attrs; `nix.parse()` folds a captured "
+        "internal-json log into polars frames",
     ),
     Module("fleet", "async polars SSH fan-out across hosts (`read_ndjson` / `scan`)"),
     Module(

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1067,16 +1067,39 @@ class Resource:
             # A source whose liveness check raises is treated as gone.
             return False
 
+    async def _render_out(self) -> Any:
+        """Invoke the render, awaiting it if it is a coroutine. The raw output,
+        before any HTML coercion: an html resource stringifies it, a `data`
+        resource keeps the structure (a ``{"renderer", "data"}`` spec)."""
+        out = self._render() if callable(self._render) else self._render
+        if inspect.iscoroutine(out):
+            out = await out
+        return out
+
     async def render_html(self) -> str:
         """The current HTML for this resource (awaits the render if it is async).
         An interactive resource gets its wiring script prepended, so the page's
         markup can call ``ix.act``/``ix.events`` without including anything."""
-        out = self._render() if callable(self._render) else self._render
-        if inspect.iscoroutine(out):
-            out = await out
+        out = await self._render_out()
         html = out if isinstance(out, str) else str(out)
         script = self.script
         return script + html if script else html
+
+    async def render_view(self) -> dict:
+        """The current structured view for a ``kind="data"`` resource: a
+        ``{"renderer": name, "data": <json>}`` spec the dashboard renders with a
+        native component (via the frontend renderer registry) instead of a
+        sandboxed HTML frame. The counterpart to :meth:`render_html`, for a live,
+        self-updating pane that wants a real renderer rather than baked markup
+        (e.g. the `nix` module's live build tree). The render must return that
+        dict; anything else is an error the sweep surfaces on the pane."""
+        out = await self._render_out()
+        if not (isinstance(out, dict) and isinstance(out.get("renderer"), str) and "data" in out):
+            raise TypeError(
+                "a data resource's render must return {'renderer': str, 'data': ...}; "
+                f"got {type(out).__name__}"
+            )
+        return out
 
     @property
     def script(self) -> str:
@@ -2953,7 +2976,14 @@ async def _sweep_resources() -> None:
         status = "live"
         try:
             # Bound each render so one wedged source cannot stall the whole loop.
-            res.html = await asyncio.wait_for(res.render_html(), timeout=2.0)
+            # A `data` resource renders a structured {renderer, data} spec, stored
+            # as JSON in the same `html` column (the pane bridge decodes it into a
+            # native `data` pane); an html resource renders markup as before.
+            if res.kind == "data":
+                spec = await asyncio.wait_for(res.render_view(), timeout=2.0)
+                res.html = json.dumps(spec, default=_safe_repr)
+            else:
+                res.html = await asyncio.wait_for(res.render_html(), timeout=2.0)
             res.error = None
         except Exception as exc:
             status = "error"

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -66,6 +66,7 @@ _KERNEL_GUIDE = guide.compose(
     guide.DISCOVER,
     guide.NO_SHELL,
     guide.NU,
+    guide.NIX,
     guide.SH,
     guide.POLARS,
     guide.RESULT_CONTRACT,

--- a/packages/mcp/src/nix/nix/__init__.py
+++ b/packages/mcp/src/nix/nix/__init__.py
@@ -21,25 +21,29 @@ derived from it.
 Two ways in:
 
 * :func:`parse` -- pure, synchronous, over text or an iterable of lines. No
-  subprocess, so it is trivially testable and works on a captured log.
-* :func:`run` / :func:`build` -- async: spawn ``nix`` with ``--log-format
-  internal-json`` on the shared event loop, feed a :class:`NixLog` line by line,
-  and (in a kernel session) register it as a live dashboard **Resource** so the
-  human watches the DAG grow and self-close when the build finishes. The model
-  gets the finished :class:`NixLog` back -- ``log.activities`` / ``log.events``
-  are polars frames, ``log.tree()`` is the rendered DAG.
+  subprocess, so it is trivially testable and works on a captured log. Returns a
+  :class:`NixLog` (``.events`` / ``.activities`` polars frames, ``.tree()``).
+* :func:`run` / :func:`build` -- async: the *live* path. Rather than re-parsing
+  internal-json in Python, they spawn the Rust ``nix-web-monitor`` emitter
+  (``--emit ndjson``), the single owner of that parsing, which folds the stream
+  into a build tree and streams a compact ``BuildView`` per state change. Each
+  line updates a :class:`BuildRun`, and (in a kernel session) a live dashboard
+  pane rendered by the native ``nix-build`` renderer shows the tree grow and
+  self-close when the build finishes. The model gets the :class:`BuildRun` back
+  (``.builds`` is a polars frame, ``.ok`` / ``.errors`` / ``.tree()``).
 
 Run it as a background job (``await nix.build(".#foo")`` runs past the budget and
-backgrounds); next turn ``await jobs['..']`` yields the finished :class:`NixLog`
-(``log.activities`` / ``log.events`` / ``log.tree()``), while the dashboard
-Resource shows the DAG growing live as it builds.
+backgrounds); next turn ``await jobs['..']`` yields the finished :class:`BuildRun`,
+while the dashboard pane shows the tree growing live as it builds.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import html as _html
 import json as _json
+import os
 import re
 import time
 from collections.abc import Iterable
@@ -50,7 +54,17 @@ import polars as pl
 if TYPE_CHECKING:
     from ix_notebook_mcp.runtime import Resource
 
-__all__ = ["ACTIVITY_TYPES", "RESULT_TYPES", "NixLog", "attrs", "build", "eval", "parse", "run"]
+__all__ = [
+    "ACTIVITY_TYPES",
+    "RESULT_TYPES",
+    "BuildRun",
+    "NixLog",
+    "attrs",
+    "build",
+    "eval",
+    "parse",
+    "run",
+]
 
 __version__ = "0.1.0"
 
@@ -343,21 +357,164 @@ def parse(source: str | Iterable[str]) -> NixLog:
     return log
 
 
-def _register_live(log: NixLog) -> Resource | None:
-    """Register ``log`` as a live dashboard Resource, if running in a kernel.
+# The BuildView renderer registered in the dashboard frontend (see
+# packages/dashboard/dashboard-core/site/src/lib/renderers.ts). A live `data`
+# resource with this renderer draws the build tree natively.
+_NIX_BUILD_RENDERER = "nix-build"
 
-    Decoupled on purpose: outside the kernel (a test, a plain interpreter) the
-    runtime is absent and this is a silent no-op, so the parser stays pure.
+
+def _nix_web_monitor_bin() -> str:
+    """The `nix-web-monitor` binary the emitter runs. The mcp wrapper bakes its
+    path onto the env (``IX_NIX_WEB_MONITOR_BIN``); outside that wrapper (a bare
+    interpreter, a test) fall back to the name on PATH, so a dev shell with the
+    package installed still works."""
+    return os.environ.get("IX_NIX_WEB_MONITOR_BIN") or "nix-web-monitor"
+
+
+class BuildRun:
+    """A live record of one ``nix`` invocation, driven by the Rust
+    ``nix-web-monitor`` emitter (the single owner of internal-json parsing).
+
+    Where :class:`NixLog` parses a *captured* stream in Python, a ``BuildRun`` is
+    the *live* path: :func:`run` spawns ``nix-web-monitor --emit ndjson``, which
+    streams a compact ``BuildView`` (one JSON object per line) as the build
+    progresses, and each line replaces :attr:`view` here. A handle to it is a
+    live view of the in-flight build; in a kernel it also shows up as a
+    self-closing dashboard pane rendered by the native ``nix-build`` renderer.
     """
+
+    def __init__(self, *, label: str | None = None) -> None:
+        self.label = label
+        # The latest BuildView the emitter sent (its camelCase JSON shape, owned
+        # by the parser crate). None until the first line lands.
+        self.view: dict[str, Any] | None = None
+        self.done = False
+        self.returncode: int | None = None
+        self.started = time.time()
+        # Set when the emitter binary could not be spawned at all (so there is no
+        # process and no BuildView), surfaced through :attr:`error`.
+        self._spawn_error: str | None = None
+
+    def feed(self, line: str) -> None:
+        """Consume one NDJSON line from the emitter, replacing :attr:`view`.
+
+        A blank line (or one that is not a JSON object with the BuildView shape)
+        is ignored, so a stray diagnostic on the channel never corrupts state.
+        """
+        line = line.strip()
+        if not line:
+            return
+        try:
+            obj = _json.loads(line)
+        except _json.JSONDecodeError:
+            return
+        if isinstance(obj, dict) and "builds" in obj and "counts" in obj:
+            self.view = obj
+
+    @property
+    def error(self) -> str | None:
+        """The build's first error message, or a synthetic one for a non-zero
+        exit that reported none. Mirrors :attr:`NixLog.error`."""
+        if self._spawn_error is not None:
+            return self._spawn_error
+        errors: list[Any] = (self.view or {}).get("errors") or []
+        if errors:
+            return str(errors[0])
+        if self.done and self.returncode not in (0, None):
+            return f"nix exited with code {self.returncode}"
+        return None
+
+    @property
+    def ok(self) -> bool:
+        """True once the build finished successfully (done, exit 0, no error),
+        matching :attr:`NixLog.ok` and ``sh()``'s ``Output.ok`` so callers can
+        branch on success the same way across all three."""
+        return self.done and self.returncode == 0 and not (self.view or {}).get("errors")
+
+    @property
+    def builds(self) -> pl.DataFrame:
+        """One row per derivation (name, status, phase, log count), from the
+        latest ``BuildView``. A well-typed empty frame before the first line."""
+        rows: list[dict[str, Any]] = (self.view or {}).get("builds") or []
+        schema = {
+            "derivation": pl.Utf8,
+            "name": pl.Utf8,
+            "status": pl.Utf8,
+            "phase": pl.Utf8,
+            "host": pl.Utf8,
+            "logCount": pl.Int64,
+            "contentAddressed": pl.Boolean,
+        }
+        return pl.DataFrame([{k: r.get(k) for k in schema} for r in rows], schema=schema)
+
+    @property
+    def errors(self) -> list[str]:
+        """The error messages in the latest ``BuildView`` (capped by the emitter)."""
+        return [str(e) for e in ((self.view or {}).get("errors") or [])]
+
+    def resource_view(self) -> dict[str, Any]:
+        """The structured view for a live ``data`` dashboard resource: the
+        ``nix-build`` renderer plus the latest ``BuildView`` as its data. Before
+        the first line lands, a minimal placeholder so the pane renders at once."""
+        data = self.view or {
+            "command": f"nix {self.label}" if self.label else "nix",
+            "builds": [],
+            "activities": [],
+            "counts": {"planned": 0, "running": 0, "stopped": 0, "succeeded": 0, "failed": 0},
+            "errors": [],
+            "finished": self.done,
+            "exitCode": self.returncode,
+        }
+        return {"renderer": _NIX_BUILD_RENDERER, "data": data}
+
+    def tree(self) -> str:
+        """A compact text summary of the build (rows and status counts), for a
+        model-facing repr away from the dashboard."""
+        view = self.view or {}
+        counts: dict[str, int] = view.get("counts") or {}
+        head = " · ".join(
+            f"{n} {label}"
+            for label, key in (
+                ("running", "running"),
+                ("done", "succeeded"),
+                ("failed", "failed"),
+                ("planned", "planned"),
+            )
+            if (n := counts.get(key))
+        )
+        lines = [head or "(starting…)"]
+        for build in view.get("builds") or []:
+            mark = {"succeeded": "✓", "failed": "✗", "running": "▶"}.get(build.get("status"), "·")
+            phase = f" [{build['phase']}]" if build.get("phase") else ""
+            lines.append(f"  {mark} {build.get('name', '?')}{phase}")
+        return "\n".join(lines)
+
+    def _repr_html_(self) -> str:
+        state = "error" if self.error else "done" if self.done else "building…"
+        return (
+            "<pre style='font:12px ui-monospace,monospace;margin:0'>"
+            f"{_html.escape(state)}\n{_html.escape(self.tree())}</pre>"
+        )
+
+    def __repr__(self) -> str:
+        counts: dict[str, int] = (self.view or {}).get("counts") or {}
+        state = "error" if self.error else "done" if self.done else "building…"
+        return f"<BuildRun {self.label or ''} [{state}] {counts.get('succeeded', 0)} built>"
+
+
+def _register_live(run_state: BuildRun) -> Resource | None:
+    """Register ``run_state`` as a live ``data`` dashboard resource, if running in
+    a kernel. Decoupled on purpose: outside the kernel (a test, a plain
+    interpreter) the runtime is absent and this is a silent no-op."""
     try:
         from ix_notebook_mcp.runtime import register_resource
     except Exception:
         return None
     return register_resource(
-        render=log.resource_html,
-        title=f"nix {log.label}" if log.label else "nix",
-        kind="html",
-        alive=lambda: not log.done,
+        render=run_state.resource_view,
+        title=f"nix {run_state.label}" if run_state.label else "nix",
+        kind="data",
+        alive=lambda: not run_state.done,
     )
 
 
@@ -367,36 +524,56 @@ async def run(
     cwd: str | None = None,
     live: bool = True,
     label: str | None = None,
-) -> NixLog:
-    """Run ``nix <args>`` with ``internal-json`` logging, returning a NixLog.
+) -> BuildRun:
+    """Run ``nix <args>`` under the ``nix-web-monitor`` emitter, returning a
+    :class:`BuildRun`.
 
     Streams onto the shared event loop (never blocks it). ``args`` is everything
-    after ``nix`` (e.g. ``["build", ".#mcp"]``); ``--log-format internal-json`` is
-    appended. With ``live`` (the default) the in-flight log shows up as a
-    self-closing dashboard Resource. Run it as a background job for a long build
-    and sample the returned NixLog between turns.
+    after ``nix`` (e.g. ``["build", ".#mcp"]``). The emitter (the single owner of
+    internal-json parsing) spawns nix, folds the event stream into a build tree,
+    and streams a compact ``BuildView`` per state change; each line updates the
+    returned :class:`BuildRun`. With ``live`` (the default) the in-flight build
+    shows up as a self-closing dashboard pane drawn by the native ``nix-build``
+    renderer. Run it as a background job for a long build and sample the returned
+    handle between turns.
 
     ``cwd`` defaults to the kernel process's working directory; pass ``cwd=`` to
     resolve a flake ref (``.#foo``) against a specific worktree.
     """
-    log = NixLog(label=label or (args[1] if len(args) > 1 else args[0] if args else "nix"))
+    run_state = BuildRun(label=label or (args[1] if len(args) > 1 else args[0] if args else "nix"))
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            _nix_web_monitor_bin(),
+            "--emit",
+            "ndjson",
+            "--",
+            *args,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            # The emitter routes nix's own stdout to its stderr; keep it out of our
+            # NDJSON parse by draining it to the parent's stderr (not merged into
+            # stdout, which carries the BuildView lines).
+            stderr=None,
+        )
+    except OSError as exc:
+        # The emitter binary is missing or not executable (e.g. a bare interpreter
+        # with IX_NIX_WEB_MONITOR_BIN unset and nothing on PATH). Settle the run so
+        # a caller sees the failure and, critically, so a live resource registered
+        # below would self-close -- but register only AFTER a successful spawn, so
+        # a failed spawn leaks no forever-alive pane.
+        run_state.done = True
+        run_state.returncode = None
+        run_state._spawn_error = f"could not run {_nix_web_monitor_bin()}: {exc}"
+        return run_state
+    # Register the live pane only now that the process exists: a spawn failure
+    # above returns early, so `alive` (keyed off `done`) can never pin a pane open.
     if live:
-        _register_live(log)
-    proc = await asyncio.create_subprocess_exec(
-        "nix",
-        *args,
-        "--log-format",
-        "internal-json",
-        cwd=cwd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-    )
+        _register_live(run_state)
     assert proc.stdout is not None
-    # Read raw chunks and split on newlines ourselves: a single `buildLogLine`
-    # (a compiler/test/minified line) can exceed asyncio's default 64 KiB
-    # StreamReader limit, which would make `async for`/`readline` raise and
-    # abort mid-stream. `finally` guarantees the process is reaped and the live
-    # Resource self-closes (`alive` keys off `log.done`) on every exit path.
+    # Read raw chunks and split on newlines ourselves: a build-log line folded
+    # into a BuildView can exceed asyncio's default 64 KiB StreamReader limit,
+    # which would make `readline` raise and abort mid-stream. `finally` reaps the
+    # process and lets the live resource self-close (`alive` keys off `done`).
     buf = b""
     try:
         while True:
@@ -406,18 +583,23 @@ async def run(
             buf += chunk
             *complete, buf = buf.split(b"\n")
             for line in complete:
-                log.feed(line.decode(errors="replace"))
+                run_state.feed(line.decode(errors="replace"))
         if buf:
-            log.feed(buf.decode(errors="replace"))
+            run_state.feed(buf.decode(errors="replace"))
     finally:
-        log.returncode = await proc.wait()
-        log.done = True
-        if log.returncode and not log.error:
-            log.error = f"nix exited with code {log.returncode}"
-    return log
+        # On cancellation (or any early exit) the child must be signaled, not just
+        # awaited: a bare `await proc.wait()` would let a cancelled build keep
+        # running to completion while this coroutine parks in the finally. Kill it
+        # if it has not already exited, then reap.
+        if proc.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.terminate()
+        run_state.returncode = await proc.wait()
+        run_state.done = True
+    return run_state
 
 
-async def build(attr: str, *flags: str, cwd: str | None = None, live: bool = True) -> NixLog:
+async def build(attr: str, *flags: str, cwd: str | None = None, live: bool = True) -> BuildRun:
     """Convenience for :func:`run` of ``nix build <attr> [flags]``."""
     return await run(["build", attr, *flags], cwd=cwd, live=live, label=attr)
 

--- a/packages/mcp/src/worktree/worktree/__init__.py
+++ b/packages/mcp/src/worktree/worktree/__init__.py
@@ -132,12 +132,12 @@ class Worktree:
             await _sh(["git", "-C", str(self.path), "add", "-A"], check=True, cwd=str(self.path))
         return await _sh(["git", "-C", str(self.path), "commit", "-m", message], cwd=str(self.path))
 
-    async def build(self, attr: str, *flags: str, add: bool = True, **kwargs: Any) -> _nix_mod.NixLog:  # noqa: ANN401 -- forwarded to nix.build()
+    async def build(self, attr: str, *flags: str, add: bool = True, **kwargs: Any) -> _nix_mod.BuildRun:  # noqa: ANN401 -- forwarded to nix.build()
         """``nix build`` this worktree's flake (bundled ``nix``, ``cwd`` threaded).
 
         With ``add`` (the default) ``git add -A`` runs first, because a flake only
         sees files git tracks -- an unstaged new file would be invisible and the
-        build would silently use the old tree. Returns the :class:`nix.NixLog`.
+        build would silently use the old tree. Returns the :class:`nix.BuildRun`.
         """
         import nix as _nix
 


### PR DESCRIPTION
Wires the kernel `nix()` helper to the live build-tree dashboard pane, reusing the `nix-web-monitor` parser (merged in #1833) as the single owner of internal-json — no render model re-derived in Python.

- `nix.run`/`build` now spawn `nix-web-monitor --emit ndjson`, consume its `BuildView` NDJSON into a new `BuildRun`, and publish a live `data` pane with renderer `nix-build` that self-closes when the build finishes. `BuildRun` exposes `.ok` / `.errors` / `.builds` (a polars frame). `NixLog`/`parse` stay for offline captured-log parsing.
- Dashboard `Resource` gains `kind="data"` support (render returns a `{renderer, data}` spec, stored as JSON in the resource `html` column); the pane bridge emits a native `data` pane for it, falling back to html on decode failure.
- `NixBuildBody.svelte` (new) + `renderers.ts`: the `nix-build` renderer — a compact, still, dark-mode-aware build tree with status dots, phases, progress bars, and highlighted failures.
- A `NIX` guidance fragment recommends `nix()` for nix commands; `IX_NIX_WEB_MONITOR_BIN` is baked onto the mcp wrapper.

Validation (x86_64-linux, vin-compute-1): `rust-mcp-strictTypecheck`, `rust-mcp-nixSmoke`, `rust-mcp-worktreeSmoke`, `rust-mcp-apiSmoke`, and `rust-dashboard-site` (svelte-check + build + site tests) all pass; the `ix-mcp` wrapper builds with the emitter env baked in; and an end-to-end run of the real bundled `nix` module driving the real emitter against a live `nix build` produced correct live state (a fresh build settled `succeeded`, counts `{succeeded: 1}`, `resource_view` = `nix-build` spec). The emitter-spawn-failure path was also verified (clean error, no leaked pane).

Reviewed with the code-reviewer agent: fixed the two blockers it found — a live-resource leak when the emitter binary can't be spawned, and cancellation not killing the child nix process — plus a stale registry summary.

Closes #1832. AI-authored (Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live Nix build-tree pane via nix-web-monitor emitter
> - Replaces the `NixLog`-based approach with a new `BuildRun` class in [nix/__init__.py](https://github.com/indexable-inc/index/pull/1838/files#diff-b4bb27410b6cb969e2cdc750a71d049b0c52a3faecc2ca9709a4278184a20890) that drives builds via `nix-web-monitor --emit ndjson`, parsing structured `BuildView` JSON as output streams in.
> - Adds a `NixBuildBody` Svelte component in [NixBuildBody.svelte](https://github.com/indexable-inc/index/pull/1838/files#diff-132d707d8087ee182df6e35e8a35780ede6f7bd42a49312b9cdcac3ef2bd0a7f) that renders a live build tree with progress bars, status chips, activity list, and error display.
> - Live resources of kind `data` are now stored as JSON specs (`{renderer, data}`) in [runtime.py](https://github.com/indexable-inc/index/pull/1838/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) and decoded into native data panes by [pane_bridge.py](https://github.com/indexable-inc/index/pull/1838/files#diff-15ac91e2bd934cd2d162cb306e416451de225725389c3a9cc51bb6ad2bd5c908), replacing the previous HTML-only path.
> - `nix.build` and `worktree.Worktree.build` now return `BuildRun` instead of `NixLog`; `IX_NIX_WEB_MONITOR_BIN` is injected into the MCP wrapper env via [default.nix](https://github.com/indexable-inc/index/pull/1838/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db).
> - Behavioral Change: `nix.run` and `nix.build` return `BuildRun` (not `NixLog`), breaking any callers that relied on `NixLog`-specific properties.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa878f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->