### PR TITLE
push-cache: direct store-path mode (no realization)

### DIFF
--- a/packages/nix/push-cache/default.nix
+++ b/packages/nix/push-cache/default.nix
@@ -1,5 +1,5 @@
-# `nix run .#push-cache -- <installable>...`: archive the full build closure of
-# one or more installables into a durable local file:// binary cache directory
+# `nix run .#push-cache -- <installable|/nix/store/path>...`: archive store
+# closures into a durable local file:// binary cache directory
 # (`$IX_PUSH_CACHE_DIR`, default `~/.cache/ix-push-cache`).
 #
 # Why a local cache and not cache.ix.dev: nothing aarch64-linux is ever
@@ -24,7 +24,7 @@
 writeNushellApplication {
   name = "push-cache";
   meta = {
-    description = "Archive an installable's full build closure into a local file:// binary cache";
+    description = "Archive store closures into a local file:// binary cache";
     mainProgram = "push-cache";
   };
   # No pinned nix in runtimeInputs: the client must speak the host daemon's
@@ -32,12 +32,39 @@ writeNushellApplication {
   # ambient nix that just ran this app, same as chrome-vm and the updaters.
   text = ''
     # nu
-    def main [...installables: string] {
-      if ($installables | is-empty) {
+    # Two modes, split by argument shape:
+    #  - a /nix/store/... argument (or --paths-from FILE) is archived as-is:
+    #    `nix copy` closes over runtime references itself, with no evaluation
+    #    and no realisation. This is the only mode that works for paths built
+    #    REMOTELY and pulled back (e.g. aarch64-linux outputs from the builder
+    #    VM via `nix copy --from ssh-ng://root@vm`): the host store records no
+    #    deriver for them, so a drv-closure walk finds nothing, and building
+    #    the flake installable host-side dies on the platform mismatch.
+    #  - a flake installable is built locally and archived with its full BUILD
+    #    closure (all build-time deps' outputs, not just the runtime closure),
+    #    which is what keeps kernel/mesa/toolchain intermediates warm across a
+    #    closure shift.
+    def main [
+      --paths-from: string # file of already-valid store paths, one per line, archived as-is
+      ...installables: string
+    ] {
+      let listed = if $paths_from != null {
+        open --raw $paths_from | lines | str trim | where {|p| $p | is-not-empty }
+      } else {
+        []
+      }
+      let direct = (
+        $installables
+        | where {|i| $i | str starts-with "/nix/store/" }
+        | append $listed
+      )
+      let flakes = ($installables | where {|i| not ($i | str starts-with "/nix/store/") })
+      if ($direct | is-empty) and ($flakes | is-empty) {
         error make {
-          msg: "usage: push-cache <installable>... e.g. push-cache .#packages.aarch64-linux.panes-guest-image"
+          msg: "usage: push-cache <installable|/nix/store/path>... [--paths-from FILE]  e.g. push-cache .#packages.aarch64-linux.panes-guest-image"
         }
       }
+
       let cache_dir = (
         $env.IX_PUSH_CACHE_DIR?
         | default (
@@ -51,16 +78,20 @@ writeNushellApplication {
       # xz would dominate the whole run.
       let cache_url = $"file://($cache_dir)?compression=zstd"
 
-      for installable in $installables {
+      if ($direct | is-not-empty) {
+        print $"push-cache: copying ($direct | length) store paths + runtime closure to ($cache_dir)"
+        $direct | to text | ^nix copy --to $cache_url --stdin
+      }
+
+      for installable in $flakes {
         print $"push-cache: building ($installable)"
         ^nix build --no-link $installable
 
-        # The BUILD closure, not the runtime closure: requisites of the
-        # derivation plus every already-realised output (--include-outputs
-        # lists only outputs that exist, so nothing here forces extra builds).
-        # That is what keeps kernel/mesa/toolchain intermediates warm across a
-        # closure shift. The .drv files themselves are dropped: substitution
-        # serves outputs, and drvs re-instantiate for free from the flake.
+        # The BUILD closure: requisites of the derivation plus every
+        # already-realised output (--include-outputs lists only outputs that
+        # exist, so nothing here forces extra builds). The .drv files
+        # themselves are dropped: substitution serves outputs, and drvs
+        # re-instantiate for free from the flake.
         let paths = (
           ^nix path-info --derivation $installable
           | lines


### PR DESCRIPTION
Follow-up to #1834 from live use on hydra: push-cache couldn't archive an aarch64-linux closure. Remotely-built outputs pulled back from the builder VM (`nix copy --from ssh-ng://root@vm`) have no deriver in the host DB, so the drv-closure walk copied 0 paths; passing the flake installable instead tried to realize host-side and died on the platform mismatch.

Fix: arguments starting with `/nix/store/` (and a new `--paths-from FILE`, one path per line) skip evaluation and realization entirely and go straight to `nix copy --to file://... --stdin`, which closes over runtime references itself. Flake installables keep the build-closure mode from #1834.

Validated: repo lint green; direct-path, `--paths-from` (with blank-line filtering), and flake modes each archive and serve back `.#jq^bin` via `nix path-info --store file://...`; direct mode runs no build.

Written by Claude (Fable 5) with Andrew.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add direct store-path mode to `push-cache` CLI
> - Adds a `--paths-from` flag and support for raw `/nix/store/` paths as arguments to [`push-cache`](https://github.com/indexable-inc/index/pull/1839/files#diff-943dbeabf0eb03a992321447c40e372a43c423910ca5c76018cd522f722b1506)
> - Direct store paths (from args or `--paths-from`) are copied with their runtime closures to the cache via `nix copy --stdin`, skipping evaluation entirely
> - Flake installable arguments are still built with `nix build --no-link` before their BUILD closures are archived, as before
> - Behavioral Change: the CLI now requires at least one direct path or flake installable; the usage check and output messages reflect the new dual-mode behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1193266.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->