### PR TITLE
panes-host: un-swallow chorded keyUps, fix modifier latch, translate Cmd editing chords

### DIFF
--- a/packages/vm/panes/host/README.md
+++ b/packages/vm/panes/host/README.md
@@ -104,17 +104,31 @@ compositor).
   user's actual macOS repeat timing is shipped once per connection
   (`ToGuest::KeyRepeat`, from `NSEvent.keyRepeatDelay/Interval`; protocol
   1.2) so guest repeat matches System Settings exactly.
-  `flagsChanged` turns into modifier press/release by toggling a held-set
-  keyed on kVK; caps lock (one event per toggle) synthesizes press+release.
-  Forwarded key presses are tracked in a second held-set: keyUps only go
-  out for tracked keys, and on resign-key every held key and modifier is
-  released guest-side (AppKit stops delivering keyUp/flagsChanged to a
-  non-key window; a key stuck down guest-side would auto-repeat forever).
-  The `NSWindow` subclass reroutes Cmd keyUps to the view -- AppKit
-  swallows them as key-equivalent processing, which used to stick e.g.
-  Cmd-Backspace down forever guest-side.
+  `flagsChanged` turns into modifier press/release by checking the event's
+  device-independent class flag against a held-set keyed on kVK: a key we
+  saw press is releasing, an unseen key with its class down is pressing,
+  and an unseen key with its class up is the release of a press from
+  before this window had focus and is dropped (the old membership toggle
+  guessed "press" there, latching the modifier in the guest's xkb state so
+  text input went dead until the next focus loss). Caps lock (one event
+  per toggle) synthesizes press+release.
+  Forwarded key presses are tracked in a map recording exactly what went
+  on the wire: keyUps release precisely that, only for tracked keys, and
+  on resign-key everything held is released guest-side (AppKit stops
+  delivering keyUp/flagsChanged to a non-key window; a key stuck down
+  guest-side auto-repeats forever). `NSApplication.sendEvent` discards
+  keyUps while Cmd is held (key-equivalent processing, above the window),
+  so a local event monitor re-delivers them to the key window (GLFW's
+  workaround) whose `sendEvent` override hands them to the view; when Cmd
+  itself goes up, any key still marked as pressed-during-the-chord is
+  released defensively.
   Cmd+W (CloseRequest) and Cmd+Q (CloseRequest to all, then exit) stay
-  host-side; other Cmd chords are forwarded.
+  host-side. Other Cmd chords are translated to their Linux equivalents by
+  default (Cmd+A/C/V/X/Z -> Ctrl+same via one synthetic left-ctrl,
+  Cmd+Backspace -> Ctrl+Backspace, Cmd+Left/Right -> Home/End; Shift rides
+  along, unmapped Cmd chords are swallowed and Super never reaches the
+  guest). `--no-chord-translation` restores raw Super-chord forwarding for
+  Linux-native muscle memory.
 - **Pointer**: the view is flipped (top-left origin) and multiplies points
   by `backingScaleFactor`, so protocol coordinates are buffer pixels.
   Buttons map to evdev (`BTN_LEFT` 0x110, `BTN_RIGHT` 0x111, `BTN_MIDDLE`

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -19,7 +19,7 @@ use objc2::runtime::ProtocolObject;
 use objc2::{MainThreadMarker, MainThreadOnly, define_class};
 use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate, NSCursor, NSEvent,
-    NSScreen, NSWindow,
+    NSEventMask, NSEventModifierFlags, NSScreen, NSWindow,
 };
 use dispatch2::DispatchQueue;
 use objc2_core_graphics::{CGAssociateMouseAndMouseCursorPosition, CGError};
@@ -32,6 +32,18 @@ use crate::conn::{self, Event, Target};
 use crate::render::Renderer;
 use crate::window::{PaneWindow, WindowParams};
 
+/// Presentation and input policy from the CLI.
+pub struct RunOptions {
+    /// Prefix prepended to every window title.
+    pub title_prefix: String,
+    /// Stock macOS chrome instead of the default hidden-titlebar style (see
+    /// `window::apply_hidden_titlebar`).
+    pub native_titlebar: bool,
+    /// Translate macOS editing chords to Linux equivalents (default; see
+    /// `view::translate_chord`). `--no-chord-translation` clears it.
+    pub chord_translation: bool,
+}
+
 thread_local! {
     static APP: RefCell<Option<App>> = const { RefCell::new(None) };
 }
@@ -41,10 +53,7 @@ struct App {
     renderer: Renderer,
     windows: HashMap<WindowId, PaneWindow>,
     out: Option<mpsc::Sender<ToGuest>>,
-    title_prefix: String,
-    /// `--native-titlebar`: stock macOS chrome instead of the default
-    /// hidden-titlebar style (see `window::apply_hidden_titlebar`).
-    native_titlebar: bool,
+    options: RunOptions,
     quitting: bool,
     /// Per-window ack counters behind the periodic acks/s log: the real-path
     /// equivalent of mock's rate line, and the 120Hz-genlock evidence
@@ -148,7 +157,7 @@ impl Deferred {
     }
 }
 
-pub fn run(target: Target, title_prefix: String, native_titlebar: bool) -> ExitCode {
+pub fn run(target: Target, options: RunOptions) -> ExitCode {
     let Some(mtm) = MainThreadMarker::new() else {
         eprintln!("panes-host: must start on the main thread");
         return ExitCode::FAILURE;
@@ -178,8 +187,7 @@ pub fn run(target: Target, title_prefix: String, native_titlebar: bool) -> ExitC
             renderer,
             windows: HashMap::new(),
             out: None,
-            title_prefix,
-            native_titlebar,
+            options,
             quitting: false,
             ack_stats: HashMap::new(),
             peer_minor: 0,
@@ -194,6 +202,8 @@ pub fn run(target: Target, title_prefix: String, native_titlebar: bool) -> ExitC
     // hook (see `screens_changed`).
     let delegate = AppDelegate::new(mtm);
     ns_app.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+
+    install_key_up_monitor(mtm);
 
     conn::spawn(target, host_info);
 
@@ -298,6 +308,39 @@ fn screens_changed() {
     });
 }
 
+/// Un-swallow Cmd keyUps. `NSApplication.sendEvent` routes a keyUp with Cmd
+/// held into key-equivalent processing and never delivers it to the key
+/// window -- above `NSWindow`, so a window-level `sendEvent` override alone
+/// never sees it -- leaving the guest with the chorded key stuck down and
+/// auto-repeating forever (one Cmd-Backspace deleted "like an animation"
+/// until the next focus change). A local event monitor observes every event
+/// before that dispatch: re-deliver Cmd keyUps to the key window ourselves,
+/// exactly GLFW's workaround (`cocoa_init.m` `keyUpMonitor`). The window's
+/// `sendEvent` override routes them on to the view, and the view's held-key
+/// map dedupes if `AppKit` ever delivers the original too.
+fn install_key_up_monitor(mtm: MainThreadMarker) {
+    let block = block2::RcBlock::new(
+        move |event: core::ptr::NonNull<NSEvent>| -> *mut NSEvent {
+            // SAFETY: AppKit passes a valid event; local monitors run on the
+            // main thread.
+            let ev = unsafe { event.as_ref() };
+            if ev.modifierFlags().contains(NSEventModifierFlags::Command)
+                && let Some(window) = NSApplication::sharedApplication(mtm).keyWindow()
+            {
+                window.sendEvent(ev);
+            }
+            // Hand the event back so normal dispatch continues unchanged.
+            event.as_ptr()
+        },
+    );
+    // SAFETY: the block returns the pointer it was handed (valid, non-null).
+    let monitor =
+        unsafe { NSEvent::addLocalMonitorForEventsMatchingMask_handler(NSEventMask::KeyUp, &block) };
+    // Intentionally never removed: the monitor must live as long as the app,
+    // and dropping the token would not uninstall it anyway.
+    std::mem::forget(monitor);
+}
+
 /// Entry point for supervisor events, always on the main queue.
 pub fn on_event(event: Event) {
     let Some(mtm) = MainThreadMarker::new() else {
@@ -347,15 +390,14 @@ fn handle_msg(app: &mut App, msg: ToHost, recv: f64) -> Deferred {
                 app.mtm,
                 &app.renderer,
                 &params,
-                &app.title_prefix,
-                app.native_titlebar,
+                &app.options,
             );
             app.windows.insert(id, window);
             Deferred::default()
         }
         ToHost::WindowTitle { id, title } => {
             if let Some(window) = app.windows.get(&id) {
-                window.set_title(&app.title_prefix, &title);
+                window.set_title(&app.options.title_prefix, &title);
             }
             Deferred::default()
         }

--- a/packages/vm/panes/host/src/audio.rs
+++ b/packages/vm/panes/host/src/audio.rs
@@ -168,7 +168,7 @@ fn build_output(
         .context("no default audio output device")?;
     let config = cpal::StreamConfig {
         channels,
-        // `cpal::SampleRate` is a plain u32 alias in 0.17.
+        // `cpal::SampleRate` is a plain u32 alias in 0.18.
         sample_rate: rate,
         // The device default (~10 ms on macOS): small enough for the latency
         // budget, and not fighting whatever quantum other apps negotiated.
@@ -176,7 +176,7 @@ fn build_output(
     };
     let stream = device
         .build_output_stream(
-            &config,
+            config,
             move |data: &mut [f32], _info: &cpal::OutputCallbackInfo| {
                 // Outcomes are counted inside the buffer; no logging here,
                 // this closure runs on the realtime render thread.

--- a/packages/vm/panes/host/src/main.rs
+++ b/packages/vm/panes/host/src/main.rs
@@ -72,6 +72,14 @@ struct Cli {
     #[arg(long)]
     native_titlebar: bool,
 
+    /// Forward Cmd chords to the guest as raw Super chords (Linux
+    /// semantics) instead of the default translation to Linux editing
+    /// equivalents (Cmd+A/C/V/X/Z -> Ctrl+same, Cmd+Backspace ->
+    /// Ctrl+Backspace, Cmd+Left/Right -> Home/End; unmapped Cmd chords are
+    /// swallowed like a native app without that shortcut).
+    #[arg(long)]
+    no_chord_translation: bool,
+
     /// Serve the built-in mock guest on a temp socket and connect to it:
     /// one animated test window, received input logged to stderr.
     #[arg(long, conflicts_with_all = ["connect", "tcp"])]
@@ -129,7 +137,14 @@ fn run_host(cli: Cli) -> ExitCode {
         audio::spawn(audio::Target::Tcp(addr));
     }
 
-    app::run(target, cli.title_prefix, cli.native_titlebar)
+    app::run(
+        target,
+        app::RunOptions {
+            title_prefix: cli.title_prefix,
+            native_titlebar: cli.native_titlebar,
+            chord_translation: !cli.no_chord_translation,
+        },
+    )
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/packages/vm/panes/host/src/view.rs
+++ b/packages/vm/panes/host/src/view.rs
@@ -460,6 +460,13 @@ impl PanesView {
     pub fn release_held_keys(&self) {
         let modifiers: Vec<u16> = self.ivars().held_modifiers.borrow_mut().drain().collect();
         for kvk in modifiers {
+            // Tracked for chord classification but never forwarded in
+            // translation mode (see flags_changed): releasing it here would
+            // hand the guest a Super release for a press it never saw.
+            if self.ivars().chord_translation && (kvk == KVK_COMMAND || kvk == KVK_RIGHT_COMMAND)
+            {
+                continue;
+            }
             self.send_key(kvk, ButtonState::Released);
         }
         let keys: Vec<u16> = self.ivars().held_keys.borrow().keys().copied().collect();

--- a/packages/vm/panes/host/src/view.rs
+++ b/packages/vm/panes/host/src/view.rs
@@ -10,7 +10,7 @@
 //! downward scroll, so both axes are negated on the way out.
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
@@ -36,24 +36,83 @@ const KVK_ANSI_Q: u16 = 0x0C;
 const KVK_ANSI_W: u16 = 0x0D;
 const KVK_CAPS_LOCK: u16 = 0x39;
 
+/// kVK codes for the Cmd editing chords translated to their Linux
+/// equivalents (`HIToolbox` Events.h), plus the modifier keys themselves.
+const KVK_ANSI_A: u16 = 0x00;
+const KVK_ANSI_Z: u16 = 0x06;
+const KVK_ANSI_X: u16 = 0x07;
+const KVK_ANSI_C: u16 = 0x08;
+const KVK_ANSI_V: u16 = 0x09;
+const KVK_DELETE: u16 = 0x33; // backspace
+const KVK_LEFT_ARROW: u16 = 0x7B;
+const KVK_RIGHT_ARROW: u16 = 0x7C;
+const KVK_SHIFT: u16 = 0x38;
+const KVK_RIGHT_SHIFT: u16 = 0x3C;
+const KVK_CONTROL: u16 = 0x3B;
+const KVK_RIGHT_CONTROL: u16 = 0x3E;
+const KVK_OPTION: u16 = 0x3A;
+const KVK_RIGHT_OPTION: u16 = 0x3D;
+const KVK_COMMAND: u16 = 0x37;
+const KVK_RIGHT_COMMAND: u16 = 0x36;
+const KVK_FUNCTION: u16 = 0x3F;
+
+/// evdev keycodes (input-event-codes.h) for translation targets that have no
+/// kVK on the Mac keyboard, plus the synthetic chord modifier.
+const KEY_LEFTCTRL: u32 = 29;
+const KEY_HOME: u32 = 102;
+const KEY_END: u32 = 107;
+
 /// One line per wheel click, in `wl_pointer` axis units. libinput's convention
 /// (15 units per detent) so guest toolkits scroll the expected distance.
 const WHEEL_AXIS_PER_LINE: f64 = 15.0;
 
+/// What actually went out on the wire for one key press, so its release
+/// mirrors the press exactly no matter which modifiers are down by then (a
+/// user may release Cmd before or after the chorded key, and a translated
+/// press must never be un-pressed as its untranslated self).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ForwardedKey {
+    /// evdev keycode sent in the press.
+    keycode: u32,
+    /// The press was wrapped in a synthetic left-ctrl (Cmd chord
+    /// translation); the release drops the ctrl once no other forwarded key
+    /// still needs it.
+    ctrl: bool,
+    /// Pressed while Cmd was down: released defensively when Cmd goes up
+    /// (`release_cmd_chords`), because `AppKit` swallows chorded keyUps at
+    /// the `NSApplication` layer and the un-swallow monitor
+    /// (`app::install_key_up_monitor`) is behavior we do not control.
+    chorded: bool,
+}
+
+/// How one Cmd chord is presented to the guest (see [`translate_chord`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Translation {
+    keycode: u32,
+    ctrl: bool,
+}
+
 pub struct ViewIvars {
     id: WindowId,
     tracking: RefCell<Option<Retained<NSTrackingArea>>>,
-    /// Modifier keys currently held, keyed by kVK. `flagsChanged` fires for
-    /// press and release alike; toggling membership tells them apart without
-    /// hardcoding Apple's device-dependent left/right flag bits.
+    /// Modifier keys currently held, keyed by kVK. Press vs release is
+    /// decided against the event's device-independent class flag (see
+    /// `flags_changed`); membership exists to catch the release of a key
+    /// whose class stays down (two Cmds held, one released) and to release
+    /// everything on focus loss.
     held_modifiers: RefCell<HashSet<u16>>,
-    /// Non-modifier keys whose press was forwarded, keyed by kVK. Two jobs:
-    /// releasing on focus loss (a keyUp after Cmd-Tab never reaches this
-    /// view, so a key held across it would stay pressed guest-side and
-    /// auto-repeat forever), and gating keyUp forwarding to keys the guest
-    /// actually saw pressed (the host-consumed Cmd-W/Q must not leak a
-    /// stray release).
-    held_keys: RefCell<HashSet<u16>>,
+    /// Non-modifier keys whose press was forwarded, keyed by kVK, with what
+    /// was forwarded. Jobs: releasing on focus loss (a keyUp after Cmd-Tab
+    /// never reaches this view, so a key held across it would stay pressed
+    /// guest-side and auto-repeat forever), gating keyUp forwarding to keys
+    /// the guest actually saw pressed (the host-consumed Cmd-W/Q must not
+    /// leak a stray release), and releasing exactly what the press sent
+    /// (chord translation).
+    held_keys: RefCell<HashMap<u16, ForwardedKey>>,
+    /// Translate macOS editing chords to their Linux equivalents
+    /// (`translate_chord`) instead of forwarding raw Super chords; from
+    /// `app::RunOptions` (`--no-chord-translation` clears it).
+    chord_translation: bool,
     /// Pointer capture engaged for this window (`app::sync_capture`): motion
     /// goes out as `PointerRelative` deltas, and the absolute re-anchor
     /// before buttons/scrolls is skipped (the frozen cursor position is
@@ -192,7 +251,8 @@ define_class!(
                 return;
             }
             let code = event.keyCode();
-            if event.modifierFlags().contains(NSEventModifierFlags::Command) {
+            let cmd = event.modifierFlags().contains(NSEventModifierFlags::Command);
+            if cmd {
                 // App-level shortcuts stay host-side, like any native app.
                 match code {
                     KVK_ANSI_W => {
@@ -206,19 +266,40 @@ define_class!(
                     _ => {}
                 }
             }
-            self.ivars().held_keys.borrow_mut().insert(code);
-            self.send_key(code, ButtonState::Pressed);
+            let forwarded = if cmd && self.ivars().chord_translation {
+                let Some(translation) = translate_chord(code) else {
+                    // An unmapped Cmd chord does nothing, like a native app
+                    // that lacks the shortcut; forwarding the bare key would
+                    // type a stray character instead (Super itself is not
+                    // forwarded in translation mode).
+                    return;
+                };
+                ForwardedKey { keycode: translation.keycode, ctrl: translation.ctrl, chorded: true }
+            } else {
+                let Some(keycode) = keymap::evdev_from_kvk(code) else {
+                    eprintln!("panes-host: no evdev mapping for kVK {code:#x}");
+                    return;
+                };
+                ForwardedKey { keycode, ctrl: false, chorded: cmd }
+            };
+            let mut held = self.ivars().held_keys.borrow_mut();
+            // One synthetic ctrl serves however many translated chords are
+            // down; engage it only for the first.
+            if forwarded.ctrl && !held.values().any(|key| key.ctrl) {
+                self.send_keycode(KEY_LEFTCTRL, ButtonState::Pressed);
+            }
+            held.insert(code, forwarded);
+            drop(held);
+            self.send_keycode(forwarded.keycode, ButtonState::Pressed);
         }
 
         #[unsafe(method(keyUp:))]
         fn key_up(&self, event: &NSEvent) {
-            let code = event.keyCode();
             // Only keys whose press was forwarded: a release for a key the
             // guest never saw pressed (host-consumed shortcut, focus gained
-            // mid-hold) would be noise.
-            if self.ivars().held_keys.borrow_mut().remove(&code) {
-                self.send_key(code, ButtonState::Released);
-            }
+            // mid-hold, chord already swept by release_cmd_chords) would be
+            // noise.
+            self.release_forwarded(event.keyCode());
         }
 
         #[unsafe(method(flagsChanged:))]
@@ -234,25 +315,123 @@ define_class!(
             }
             let state = {
                 let mut held = self.ivars().held_modifiers.borrow_mut();
-                if held.insert(code) {
-                    ButtonState::Pressed
-                } else {
-                    held.remove(&code);
-                    ButtonState::Released
+                let transition = modifier_class(code).map_or_else(
+                    // Unmapped modifier key: membership toggling is the only
+                    // signal left (no class flag to consult).
+                    || {
+                        Some(if held.contains(&code) {
+                            ButtonState::Released
+                        } else {
+                            ButtonState::Pressed
+                        })
+                    },
+                    |class| {
+                        modifier_transition(
+                            held.contains(&code),
+                            event.modifierFlags().contains(class),
+                        )
+                    },
+                );
+                // None: release of a key pressed before this window had key
+                // focus (Cmd-Tab back with the modifier still down); the
+                // guest never saw the press. The old membership toggle
+                // guessed "press" here, latching the modifier in the guest's
+                // xkb state so every letter became a dead chord and text
+                // input stopped until the next focus loss.
+                let Some(state) = transition else {
+                    eprintln!(
+                        "panes-host: ignoring release of modifier kVK {code:#x} pressed \
+                         before focus"
+                    );
+                    return;
+                };
+                match state {
+                    ButtonState::Pressed => {
+                        held.insert(code);
+                    }
+                    ButtonState::Released => {
+                        held.remove(&code);
+                    }
                 }
+                state
             };
+            let cmd_key = code == KVK_COMMAND || code == KVK_RIGHT_COMMAND;
+            // Cmd went fully up: defensively release everything pressed
+            // inside the chord (see release_cmd_chords).
+            if cmd_key && !event.modifierFlags().contains(NSEventModifierFlags::Command) {
+                self.release_cmd_chords();
+            }
+            // In translation mode Super never reaches the guest: chords are
+            // presented as their Linux equivalents, and a bare Super press
+            // would turn them back into Super chords.
+            if cmd_key && self.ivars().chord_translation {
+                return;
+            }
             self.send_key(code, state);
         }
     }
 );
 
+/// The device-independent `NSEventModifierFlags` class bit a modifier key
+/// contributes to (`HIToolbox` Events.h kVK codes).
+const fn modifier_class(kvk: u16) -> Option<NSEventModifierFlags> {
+    match kvk {
+        KVK_SHIFT | KVK_RIGHT_SHIFT => Some(NSEventModifierFlags::Shift),
+        KVK_CONTROL | KVK_RIGHT_CONTROL => Some(NSEventModifierFlags::Control),
+        KVK_OPTION | KVK_RIGHT_OPTION => Some(NSEventModifierFlags::Option),
+        KVK_COMMAND | KVK_RIGHT_COMMAND => Some(NSEventModifierFlags::Command),
+        KVK_FUNCTION => Some(NSEventModifierFlags::Function),
+        _ => None,
+    }
+}
+
+/// What a `flagsChanged` for one modifier key means, given whether we saw
+/// its press (`held`) and whether its modifier class is down after the event
+/// (`class_down`). `None` = forward nothing.
+///
+/// A key we saw press can only be releasing (a second press cannot arrive
+/// without an intervening release, even with its sibling holding the class
+/// flag down). A key we did not see press is a press when its class is down;
+/// when the class is up it is the release of a press this window never saw
+/// (modifier held across a focus change), which must be dropped, not
+/// toggle-guessed into a press.
+const fn modifier_transition(held: bool, class_down: bool) -> Option<ButtonState> {
+    match (held, class_down) {
+        (true, _) => Some(ButtonState::Released),
+        (false, true) => Some(ButtonState::Pressed),
+        (false, false) => None,
+    }
+}
+
+/// macOS editing chords -> what a Linux app expects, so guest apps respond
+/// to Mac muscle memory (on by default; `--no-chord-translation` restores
+/// raw Super chords): Cmd+A/C/V/X/Z -> Ctrl+same, Cmd+Backspace ->
+/// Ctrl+Backspace (delete word), Cmd+Left/Right -> Home/End. Shift rides
+/// along natively (Cmd+Shift+Z -> Ctrl+Shift+Z).
+fn translate_chord(kvk: u16) -> Option<Translation> {
+    match kvk {
+        KVK_ANSI_A | KVK_ANSI_C | KVK_ANSI_V | KVK_ANSI_X | KVK_ANSI_Z | KVK_DELETE => {
+            Some(Translation { keycode: keymap::evdev_from_kvk(kvk)?, ctrl: true })
+        }
+        KVK_LEFT_ARROW => Some(Translation { keycode: KEY_HOME, ctrl: false }),
+        KVK_RIGHT_ARROW => Some(Translation { keycode: KEY_END, ctrl: false }),
+        _ => None,
+    }
+}
+
 impl PanesView {
-    pub fn new(mtm: MainThreadMarker, id: WindowId, frame: NSRect) -> Retained<Self> {
+    pub fn new(
+        mtm: MainThreadMarker,
+        id: WindowId,
+        frame: NSRect,
+        chord_translation: bool,
+    ) -> Retained<Self> {
         let this = Self::alloc(mtm).set_ivars(ViewIvars {
             id,
             tracking: RefCell::new(None),
             held_modifiers: RefCell::new(HashSet::new()),
-            held_keys: RefCell::new(HashSet::new()),
+            held_keys: RefCell::new(HashMap::new()),
+            chord_translation,
             relative: Cell::new(false),
             last_relative: Cell::new((f64::NEG_INFINITY, 0)),
         });
@@ -270,18 +449,52 @@ impl PanesView {
     /// them. `AppKit` stops delivering `flagsChanged` and `keyUp` once the
     /// window resigns key, so anything held across a Cmd-Tab would otherwise
     /// stay pressed in the guest forever (a stuck regular key auto-repeats
-    /// forever via `wl_keyboard.repeat_info`; a stuck modifier also inverts
-    /// the `flagsChanged` toggle heuristic on its next use).
+    /// forever via `wl_keyboard.repeat_info`).
     pub fn release_held_keys(&self) {
-        let ivars = self.ivars();
-        let held: Vec<u16> = ivars
-            .held_modifiers
-            .borrow_mut()
-            .drain()
-            .chain(ivars.held_keys.borrow_mut().drain())
-            .collect();
-        for kvk in held {
+        let modifiers: Vec<u16> = self.ivars().held_modifiers.borrow_mut().drain().collect();
+        for kvk in modifiers {
             self.send_key(kvk, ButtonState::Released);
+        }
+        let keys: Vec<u16> = self.ivars().held_keys.borrow().keys().copied().collect();
+        for kvk in keys {
+            self.release_forwarded(kvk);
+        }
+    }
+
+    /// Release exactly what the press for `kvk` forwarded (see
+    /// [`ForwardedKey`]); a no-op for keys the guest never saw pressed.
+    fn release_forwarded(&self, kvk: u16) {
+        let (key, ctrl_still_needed) = {
+            let mut held = self.ivars().held_keys.borrow_mut();
+            let Some(key) = held.remove(&kvk) else {
+                return;
+            };
+            (key, held.values().any(|other| other.ctrl))
+        };
+        self.send_keycode(key.keycode, ButtonState::Released);
+        if key.ctrl && !ctrl_still_needed {
+            self.send_keycode(KEY_LEFTCTRL, ButtonState::Released);
+        }
+    }
+
+    /// Cmd went fully up: release every key that went down inside the chord.
+    /// Their real keyUps are normally re-delivered by the un-swallow monitor
+    /// (`app::install_key_up_monitor`), but that leans on `AppKit` dispatch
+    /// details; this sweep guarantees no chorded key outlives its chord (a
+    /// latched Backspace auto-repeats guest-side forever). A chord key still
+    /// physically held after Cmd-up stops repeating early, the safe side of
+    /// the trade.
+    fn release_cmd_chords(&self) {
+        let chorded: Vec<u16> = self
+            .ivars()
+            .held_keys
+            .borrow()
+            .iter()
+            .filter(|(_, key)| key.chorded)
+            .map(|(kvk, _)| *kvk)
+            .collect();
+        for kvk in chorded {
+            self.release_forwarded(kvk);
         }
     }
 
@@ -422,6 +635,72 @@ impl PanesView {
             eprintln!("panes-host: no evdev mapping for kVK {kvk:#x}");
             return;
         };
+        self.send_keycode(keycode, state);
+    }
+
+    fn send_keycode(&self, keycode: u32, state: ButtonState) {
         app::send(ToGuest::Key { id: self.ivars().id, keycode, state });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modifier_release_after_focus_gain_is_dropped() {
+        // The latch bug: modifier physically released after Cmd-Tab back,
+        // press never seen -> must forward nothing, not a phantom press.
+        assert_eq!(modifier_transition(false, false), None);
+    }
+
+    #[test]
+    fn modifier_press_and_release_round_trip() {
+        assert_eq!(modifier_transition(false, true), Some(ButtonState::Pressed));
+        assert_eq!(modifier_transition(true, false), Some(ButtonState::Released));
+    }
+
+    #[test]
+    fn modifier_sibling_release_keeps_class_down() {
+        // Left and right Cmd held, one releases: class flag still set, but a
+        // key we saw press can only be releasing.
+        assert_eq!(modifier_transition(true, true), Some(ButtonState::Released));
+    }
+
+    #[test]
+    fn modifier_classes_cover_both_sides() {
+        for (left, right, class) in [
+            (KVK_SHIFT, KVK_RIGHT_SHIFT, NSEventModifierFlags::Shift),
+            (KVK_CONTROL, KVK_RIGHT_CONTROL, NSEventModifierFlags::Control),
+            (KVK_OPTION, KVK_RIGHT_OPTION, NSEventModifierFlags::Option),
+            (KVK_COMMAND, KVK_RIGHT_COMMAND, NSEventModifierFlags::Command),
+        ] {
+            assert_eq!(modifier_class(left), Some(class));
+            assert_eq!(modifier_class(right), Some(class));
+        }
+        assert_eq!(modifier_class(KVK_FUNCTION), Some(NSEventModifierFlags::Function));
+        assert_eq!(modifier_class(KVK_ANSI_A), None);
+    }
+
+    #[test]
+    fn chord_translation_table() {
+        // Ctrl-wrapped: same physical key, synthetic ctrl.
+        for kvk in [KVK_ANSI_A, KVK_ANSI_C, KVK_ANSI_V, KVK_ANSI_X, KVK_ANSI_Z, KVK_DELETE] {
+            let translation = translate_chord(kvk).expect("mapped chord");
+            assert!(translation.ctrl);
+            assert_eq!(Some(translation.keycode), keymap::evdev_from_kvk(kvk));
+        }
+        // Line motion: different key, no ctrl.
+        assert_eq!(
+            translate_chord(KVK_LEFT_ARROW),
+            Some(Translation { keycode: KEY_HOME, ctrl: false })
+        );
+        assert_eq!(
+            translate_chord(KVK_RIGHT_ARROW),
+            Some(Translation { keycode: KEY_END, ctrl: false })
+        );
+        // Everything else is swallowed, never typed raw.
+        assert_eq!(translate_chord(KVK_ANSI_W), None);
+        assert_eq!(translate_chord(0x0F), None); // R
     }
 }

--- a/packages/vm/panes/host/src/view.rs
+++ b/packages/vm/panes/host/src/view.rs
@@ -373,6 +373,21 @@ define_class!(
             if cmd_key && self.ivars().chord_translation {
                 return;
             }
+            // A real LEFT ctrl pressed while the synthetic chord ctrl is
+            // down: both are evdev KEY_LEFTCTRL, so forwarding this press
+            // would double-press an already-down key, and the chord's
+            // release would then drop ctrl out from under the user's
+            // physical hold. Adopt instead: the key is already pressed
+            // guest-side, and this real key's release (tracked in
+            // held_modifiers above) now owns the eventual release. Right
+            // ctrl is a different evdev key (KEY_RIGHTCTRL) and coexists.
+            if state == ButtonState::Pressed
+                && code == KVK_CONTROL
+                && self.ivars().synthetic_ctrl.get()
+            {
+                self.ivars().synthetic_ctrl.set(false);
+                return;
+            }
             self.send_key(code, state);
         }
     }

--- a/packages/vm/panes/host/src/view.rs
+++ b/packages/vm/panes/host/src/view.rs
@@ -113,6 +113,11 @@ pub struct ViewIvars {
     /// (`translate_chord`) instead of forwarding raw Super chords; from
     /// `app::RunOptions` (`--no-chord-translation` clears it).
     chord_translation: bool,
+    /// The synthetic left-ctrl for translated chords is currently pressed
+    /// guest-side. Explicit state, not inferred from `held_keys`: the guard
+    /// against a physically-held ctrl (see `key_down`) means a ctrl-wrapped
+    /// entry does not always imply we pressed one.
+    synthetic_ctrl: Cell<bool>,
     /// Pointer capture engaged for this window (`app::sync_capture`): motion
     /// goes out as `PointerRelative` deltas, and the absolute re-anchor
     /// before buttons/scrolls is skipped (the frozen cursor position is
@@ -282,14 +287,15 @@ define_class!(
                 };
                 ForwardedKey { keycode, ctrl: false, chorded: cmd }
             };
-            let mut held = self.ivars().held_keys.borrow_mut();
             // One synthetic ctrl serves however many translated chords are
-            // down; engage it only for the first.
-            if forwarded.ctrl && !held.values().any(|key| key.ctrl) {
+            // down; engage it only for the first, and not at all while the
+            // user physically holds ctrl (same evdev keycode: a second press
+            // would later release ctrl out from under their real hold).
+            if forwarded.ctrl && !self.ivars().synthetic_ctrl.get() && !self.real_ctrl_held() {
+                self.ivars().synthetic_ctrl.set(true);
                 self.send_keycode(KEY_LEFTCTRL, ButtonState::Pressed);
             }
-            held.insert(code, forwarded);
-            drop(held);
+            self.ivars().held_keys.borrow_mut().insert(code, forwarded);
             self.send_keycode(forwarded.keycode, ButtonState::Pressed);
         }
 
@@ -432,6 +438,7 @@ impl PanesView {
             held_modifiers: RefCell::new(HashSet::new()),
             held_keys: RefCell::new(HashMap::new()),
             chord_translation,
+            synthetic_ctrl: Cell::new(false),
             relative: Cell::new(false),
             last_relative: Cell::new((f64::NEG_INFINITY, 0)),
         });
@@ -472,9 +479,19 @@ impl PanesView {
             (key, held.values().any(|other| other.ctrl))
         };
         self.send_keycode(key.keycode, ButtonState::Released);
-        if key.ctrl && !ctrl_still_needed {
+        // Only release a ctrl we pressed (`synthetic_ctrl`): a chord that
+        // rode a physically-held ctrl must leave that ctrl to the user's own
+        // `flagsChanged` release.
+        if key.ctrl && !ctrl_still_needed && self.ivars().synthetic_ctrl.get() {
+            self.ivars().synthetic_ctrl.set(false);
             self.send_keycode(KEY_LEFTCTRL, ButtonState::Released);
         }
+    }
+
+    /// A physical ctrl key's forwarded press is still outstanding.
+    fn real_ctrl_held(&self) -> bool {
+        let held = self.ivars().held_modifiers.borrow();
+        held.contains(&KVK_CONTROL) || held.contains(&KVK_RIGHT_CONTROL)
     }
 
     /// Cmd went fully up: release every key that went down inside the chord.

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -76,13 +76,13 @@ pub struct WindowParams {
 }
 
 define_class!(
-    // `NSWindow` subclass whose only job is un-swallowing Cmd keyUps: AppKit
-    // routes a keyUp with Command held into key-equivalent processing and
-    // never delivers it to the responder chain, so the guest would see the
-    // key stuck down and its clients would auto-repeat it until focus is
-    // lost (one Cmd-Backspace tap in a guest editor deleted forever). Hand
-    // those keyUps to the content view like any other key event; the view's
-    // held-key set drops the ones whose press the guest never saw.
+    // `NSWindow` subclass whose only job is routing Cmd keyUps to the view.
+    // AppKit discards those during key-equivalent processing in
+    // `NSApplication.sendEvent` -- ABOVE this window, so this override alone
+    // never fires on the normal path; `app::install_key_up_monitor`
+    // re-delivers the event to the key window and lands here. Hand it to the
+    // content view like any other key event; the view's held-key map drops
+    // the ones whose press the guest never saw.
     #[unsafe(super(NSWindow))]
     #[thread_kind = MainThreadOnly]
     #[name = "PanesWindow"]
@@ -298,9 +298,10 @@ impl PaneWindow {
         mtm: MainThreadMarker,
         renderer: &Renderer,
         params: &WindowParams,
-        title_prefix: &str,
-        native_titlebar: bool,
+        options: &crate::app::RunOptions,
     ) -> Self {
+        let title_prefix = &options.title_prefix;
+        let native_titlebar = options.native_titlebar;
         let scale = f64::from(params.scale.max(1));
         let content = NSRect::new(
             NSPoint::new(0.0, 0.0),
@@ -339,7 +340,7 @@ impl PaneWindow {
         ns.setAcceptsMouseMovedEvents(true);
         ns.center();
 
-        let view = PanesView::new(mtm, params.id, content);
+        let view = PanesView::new(mtm, params.id, content, options.chord_translation);
         let layer = CAMetalLayer::new();
         layer.setDevice(Some(&renderer.device));
         layer.setPixelFormat(objc2_metal::MTLPixelFormat::BGRA8Unorm);


### PR DESCRIPTION
Live regression after #1793 (user repro: cmd-backspace in a Minecraft text field deletes "like an animation" and stays latched; ctrl-backspace behaves).

Root cause (corrects a #1793 assumption): **`NSApplication.sendEvent` discards keyUps while Cmd is held** during key-equivalent processing — *above* `NSWindow`, so #1793's window-level `sendEvent` override never saw them. The chorded key stayed pressed guest-side and `wl_keyboard.repeat_info` repeat ran forever.

Fixes:
- **Local `NSEvent` monitor** re-delivers Cmd keyUps to the key window (GLFW's exact workaround, `cocoa_init.m` `keyUpMonitor`); the `PanesWindow` override hands them to the view. Belt-and-braces: when Cmd goes fully up, every key pressed during the chord is released defensively, so no chorded key can outlive its chord even if AppKit dispatch changes.
- **Modifier latch** (the earlier "can't type, Esc works" episode, recovered by modifier taps): `flagsChanged` used a membership toggle, so a modifier physically released after a focus gain (cmd-tab back while holding Cmd/Ctrl — Ctrl is the Minecraft sprint key) was misread as a *press* and latched in the guest xkb state, turning letters into dead chords. Press/release is now decided against the event's device-independent class flag; the release of a never-seen press is dropped. Unit-tested (`modifier_transition`, incl. the two-Cmds-one-released case).
- **Held keys are now a map of exactly what each press forwarded**, so a release always mirrors its press regardless of modifier state at release time.

Product addition (requested; was deferred in #1793): **macOS editing chords translate to Linux equivalents by default** — Cmd+A/C/V/X/Z → Ctrl+same (one synthetic left-ctrl, refcounted across overlapping chords), Cmd+Backspace → Ctrl+Backspace, Cmd+Left/Right → Home/End, Shift rides along (Cmd+Shift+Z → Ctrl+Shift+Z). Unmapped Cmd chords are swallowed like a native app without that shortcut, and Super never reaches the guest in this mode. `--no-chord-translation` restores raw Super forwarding.

Answering the review questions from triage: the reroute cannot double-release (the held map gate makes a second release a no-op) or leak across windows (each window's view has its own map, drained on resign-key); the compositor's `wl_keyboard.enter` modifiers come from smithay's xkb state, which only ever reflects what the host forwarded — the enter path was consistent, the host's phantom press was the bug. The user's tap-each-modifier workaround works on the running binary because a tap re-balances the toggle.

Validation: darwin clippy gate + `panes-host-all` (incl. new `modifier_transition`/`translate_chord` tests) green, repo lint green, `panes-host --mock` handshake/KeyRepeat unchanged, `--help` shows the flag. Host-only change — no protocol or compositor edits, deploys with a host process restart.

Adversarial review outcome (internal max-effort reviewer): C1 — a physical left-ctrl pressed *after* the synthetic chord ctrl engaged would double-press evdev 29 and later release it under the real hold — fixed by ownership handoff (`eb3d0557`: the real key's release adopts the already-pressed ctrl; right-ctrl is evdev 97 and coexists). M1 — phantom Super release on focus loss in translation mode — fixed in `2d433c0b`. M2 (extract the held-key/synthetic-ctrl bookkeeping into a pure, table-testable state machine) deferred as a follow-up; the pure decision functions are unit-tested today.

Written by Claude with human direction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix modifier latch and un-swallow chorded keyUps, translate Cmd editing chords to Linux equivalents in panes-host
> - Installs a local `NSEvent` monitor for Cmd keyUp events that re-delivers them to the key window via `sendEvent`, so chorded keys no longer stick in the guest.
> - Reworks `flags_changed` to use device-independent modifier class flags and a held-set keyed on `kVK`, dropping releases for modifiers whose press predates focus gain to prevent modifier latching.
> - On Cmd-up, defensively releases all keys pressed during the chord via the new `release_cmd_chords` helper.
> - By default, translates macOS Cmd editing chords to Linux equivalents (Cmd+A/C/V/X/Z/Delete → Ctrl+same; Cmd+Left/Right → Home/End) and swallows unmapped Cmd chords; add `--no-chord-translation` to forward raw Super chords instead.
> - Risk: chord translation is on by default and changes guest input behavior for all Cmd key presses unless `--no-chord-translation` is passed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef9b9f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->