### PR TITLE
first-principles skill: default to interactive HTML explainers

### DIFF
--- a/packages/agent/skills/first-principles/SKILL.md
+++ b/packages/agent/skills/first-principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-principles
-description: Adopt a conversational, first-principles teaching tone when explaining any technical or STEM concept (math, physics, CS, EE, statistics, crypto, ML, networking, systems, algorithms, data structures, logic, or adjacent fields). Use whenever the user asks how something works, why something happens, what a term means, for an explanation of an algorithm/protocol/proof/mechanism, or uses phrasing like "explain", "help me understand", "walk me through", "ELI5", "what is", "how does X work". Also for short follow-ups on a technical topic already under discussion. Skip only when the user explicitly wants a quick one-liner, code only, or signals they already know the basics.
+description: Adopt a conversational, first-principles teaching tone when explaining any technical or STEM concept (math, physics, CS, EE, statistics, crypto, ML, networking, systems, algorithms, data structures, logic, or adjacent fields). Use whenever the user asks how something works, why something happens, what a term means, for an explanation of an algorithm/protocol/proof/mechanism, or uses phrasing like "explain", "help me understand", "walk me through", "ELI5", "what is", "how does X work". Also for short follow-ups on a technical topic already under discussion, and when the user asks for an interactive, visual, or explorable explainer. Skip only when the user explicitly wants a quick one-liner, code only, or signals they already know the basics.
 ---
 
 # First-Principles Teaching
@@ -80,6 +80,19 @@ Likewise, if you're uncertain about something or it's outside your expertise, sa
 The intensity dial should respond to context. A quick clarifying question deserves a quick clarifying answer; don't bulldoze through with a TED talk when someone just wanted a sanity check. But when the question is open-ended ("explain X to me," "I don't really understand Y") or when the topic has real depth waiting to be uncovered, lean fully into the teaching stance.
 
 If unsure which mode is wanted, you can briefly preview ("I can give you the quick version or walk through it from the ground up: which is more useful?") but usually it's better to just pick the right altitude based on the question and adjust if the person signals otherwise.
+
+## Ship an interactive explainer by default
+
+When the topic is substantial (an open-ended "how does X work", a mechanism with moving parts, anything where a picture or a knob teaches faster than a paragraph), don't stop at prose: build a self-contained interactive HTML explainer and keep the chat reply to a short tour of what's inside. This extends Calibration rather than overriding it: a quick clarification or follow-up still gets a quick prose answer, and the artifact is reserved for depth worth exploring.
+
+What makes the artifact earn its place:
+
+- **Manipulable, not decorative.** Every interactive element must let the reader test the mental model: a slider that changes an input and shows the effect, a toggle that compares with/without, a before/after comparison slider, a step-through diagram that walks a pipeline stage by stage. Motion and interactivity carry meaning; cut ornament-only animation.
+- **Self-contained.** One HTML file, zero external dependencies or network fetches. Draw visuals procedurally (canvas or SVG) so the page works offline and can be shared as a single file.
+- **Honest visuals.** Label stylized or simulated demos as illustrations of the concept, not real output. When the topic is empirical, research it first and link sources in a footer.
+- **Progressively structured.** Same layering as the prose stance: sections that build from the core intuition outward, misconceptions named explicitly, and a short self-check quiz standing in for the conversational check-in questions.
+
+Deliver it: write the file somewhere durable and sensible, open it in the browser when the session has a display (otherwise just give the path), then give the one-paragraph tour in chat. When you ship one, its prose follows "Artifacts are not conversations" below.
 
 ## Artifacts are not conversations
 

--- a/packages/mcp/ix_notebook_mcp/pane_bridge.py
+++ b/packages/mcp/ix_notebook_mcp/pane_bridge.py
@@ -194,8 +194,7 @@ def _panes(conn: sqlite3.Connection) -> list[dict]:
             panes.append(
                 html_pane(f"cell/{cell['id']}", cell.get("title") or "cell", rendered, subtitle="cell")
             )
-    for res in store.live_resources(conn):
-        panes.append(_resource_pane(res))
+    panes.extend(_resource_pane(res) for res in store.live_resources(conn))
     rows = store.latest_namespace(conn)
     if rows:
         panes.append(data_pane("namespace", "Namespace", "namespace", rows))


### PR DESCRIPTION
For substantial topics the skill now directs shipping a self-contained interactive HTML explainer (manipulable demos, procedural canvas/SVG visuals, labeled illustrations, sources footer, self-check quiz) by default, keeping chat prose for quick follow-ups per Calibration. Validated by a DLSS 5 explainer artifact built in this format.

Also carries a one-line ruff PERF401 fix in `packages/mcp/ix_notebook_mcp/pane_bridge.py`: #1838 left whole-tree lint red on main, which blocks every pre-commit in the repo.

Closes #1840

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default first-principles skill to produce interactive HTML explainers
> - Updates [SKILL.md](https://github.com/indexable-inc/index/pull/1842/files#diff-ff8b70c7c591bd8dbf6b68d31fb9f07bbeaa1b1ff52e71329d48ab550e2ea18b) to include shipping an interactive, visual, or explorable HTML explainer as a default output criterion for the first-principles skill.
> - Fixes `_panes` in [pane_bridge.py](https://github.com/indexable-inc/index/pull/1842/files#diff-15ac91e2bd934cd2d162cb306e416451de225725389c3a9cc51bb6ad2bd5c908) to use `extend` instead of `append` when adding live resource panes, so each element of the iterable is added individually rather than the whole iterable as a single item.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fd5ca9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->