### PR TITLE
panes: fix clients stuck at 1x — ratchet output scale from per-window Configure; Hello scale = max over screens

### DIFF
--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -419,6 +419,26 @@ impl App {
         });
     }
 
+    /// Ratchet the advertised output scale up to `scale` and re-advertise per
+    /// surface. The host's Hello scale is read once at its startup from the
+    /// then-main screen, so it can undershoot the screen a window actually
+    /// lands on (host launched while a 1x display was frontmost); the
+    /// per-window Configure scale is live truth from that window's own
+    /// `NSWindow`, so a higher value corrects the global advertisement.
+    /// Monotonic within a connection (a window dragged to a 1x display must
+    /// not flip every other client back to 1x); a fresh Hello resets it.
+    fn raise_output_scale(&self, scale: u32) {
+        let scale = clamp_i32(scale.max(1));
+        if scale <= self.output.current_scale().integer_scale() {
+            return;
+        }
+        info!(scale, "output scale raised by per-window configure");
+        self.output.change_current_state(None, None, Some(Scale::Integer(scale)), None);
+        for pane in &self.panes {
+            self.send_preferred_scale(pane.toplevel.wl_surface());
+        }
+    }
+
     /// Try to move one frame onto the wire for `panes[idx]`, announcing the
     /// window first if this connection has not seen it. When there is
     /// nothing to send, release the window's frame callbacks instead: no
@@ -690,14 +710,19 @@ impl App {
         // the window's scale or a Retina client that honors the advertised
         // output scale renders a buffer scale^2 the drawable. div_ceil keeps a
         // stray pixel row covered rather than letterboxed.
-        // Scale advertisement stays global (wl_output + preferred_buffer_scale
-        // both derive from Hello): a per-window Configure scale that differs
-        // (window dragged to a non-Retina external display) is not re-echoed
-        // per surface, so that window's content is host-rescaled until it
+        // Scale advertisement stays global (wl_output + preferred_buffer_scale),
+        // seeded by Hello and ratcheted UP by any higher per-window Configure
+        // scale (raise_output_scale): a stale Hello scale=1 with Retina
+        // Configures at scale=2 otherwise pins every client to buffer scale 1,
+        // rendering half the drawable forever (measured live with
+        // GLFW/Minecraft, index#1686). A LOWER per-window scale (window
+        // dragged to a non-Retina external display) is not re-echoed per
+        // surface, so that window's content is host-rescaled until it
         // returns. Fractional scale is out of scope by design: macOS backing
         // factors are 1 or 2, and wp_fractional_scale would buy softness at
         // readback bandwidth the vsock budget cannot spare.
         let scale = scale.max(1);
+        self.raise_output_scale(scale);
         let size_valid = width > 0 && height > 0;
         self.panes[idx].toplevel.with_pending_state(|state| {
             if size_valid {

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -155,9 +155,22 @@ pub fn run(target: Target, title_prefix: String, native_titlebar: bool) -> ExitC
 
     let screen = NSScreen::mainScreen(mtm);
     let max_fps = screen.as_ref().map_or(60, |screen| screen.maximumFramesPerSecond());
-    let backing = screen.as_ref().map_or(2.0, |screen| screen.backingScaleFactor());
+    // Hello advertises the HIGHEST backing scale of any attached display, not
+    // the startup main screen's: this read happens once per process, and a
+    // host launched while a 1x display was frontmost would otherwise say
+    // scale=1 for the whole session, pinning every guest client to 1x buffers
+    // stretched over Retina drawables (seen live with GLFW/Minecraft,
+    // index#1686). Windows that land on a lower-scale screen are still
+    // handled per window: their Configure carries that screen's real backing
+    // scale. Fallback 2.0 (headless/no screens) errs toward sharp.
+    let backing = NSScreen::screens(mtm)
+        .iter()
+        .map(|screen| screen.backingScaleFactor())
+        .fold(0.0_f64, f64::max);
+    let backing = if backing > 0.0 { backing } else { 2.0 };
     eprintln!(
-        "panes-host: main screen maximumFramesPerSecond={max_fps} backingScaleFactor={backing}"
+        "panes-host: max screen backingScaleFactor={backing}, main screen \
+         maximumFramesPerSecond={max_fps}"
     );
 
     let renderer = match Renderer::new() {


### PR DESCRIPTION
Fixes the live "Minecraft never adopts 2x buffer scale" incident (index#1686 follow-up): every MC window mapped `854x480@1` and the host looped `presenting 2056x1290 frames scaled onto the 4112x2580 drawable`.

## Root cause (verified; not the GLFW client)

GLFW's Wayland scale path is fine: against this compositor, a probe linked to the exact Maven LWJGL 3.4.1 `libglfw.so` adopts `set_buffer_scale(2)` in every ordering (output-before-window, scale flip after map, MC's hidden-then-shown flow), and a replica guest booted from the live image (MC 26.2 on venus Vulkan) maps `WindowNew 1708x960 SCALE=2` when the host says scale 2. MC never sets `GLFW_SCALE_FRAMEBUFFER` (scanned the unobfuscated 26.2 jar for `0x2200D`/`0x23001`: absent), so default framebuffer scaling is active.

The incident is a host/compositor scale disagreement:

- panes-host reads `NSScreen::mainScreen().backingScaleFactor()` **once at startup** for `Hello.scale`. Launched while a 1x display is frontmost, it says `Hello scale=1` for the whole session.
- Its Retina windows still send `Configure` in drawable pixels at `scale=2`. The compositor divides by that scale for the logical size but **never corrects the advertised output scale**, which comes only from Hello.
- Net effect: every client is told "scale 1, logical size = drawable/2" and renders exactly half the drawable, forever. Reproduced bit-for-bit on a rig (compositor + scripted host, `Hello scale=1` + `Configure 1708x960@2`): GLFW stays at fb 854x480 pre-fix.

## Fix

- **Compositor**: `raise_output_scale` -- a higher per-window Configure scale ratchets the global `wl_output` + `preferred_buffer_scale` advertisement up (monotonic within a connection so a window dragged to a 1x display does not flip everyone back; a fresh Hello still resets).
- **Host**: `Hello.scale` = max `backingScaleFactor` across **all** attached screens instead of the startup main screen.

## Validation

- x86 rig (vin-compute-1), exact LWJGL 3.4.1 glfw: incident wire pre-fix stuck at `fb 854x480@1`; post-fix flips to `fb 1708x960@2` one frame after the Configure.
- aarch64: fixed compositor `nix copy`-swapped into a live-image replica guest (real MC 26.2, venus). Incident wire: MC maps `854x480@1`, converges to 1708x960 frames by seq 5.
- `panes-host` clippy + test suite green; `panes-compositor` builds for aarch64-linux and x86_64-linux. (Its x86 clippy gate carries 4 pre-existing failures on main -- the crate is aarch64-only so CI never lints it; this diff adds none.)

## Follow-up

`WindowNew.scale` stays frozen per connection (mapped-before-Hello windows announce @1 then re-render 2x; visuals converge since frames match the drawable, but `WindowMinMax` stays in the stale unit until reconnect). A per-window scale update message is a protocol-minor follow-up.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clients stuck at 1x scale by ratcheting output scale from per-window Configure and deriving Hello scale from max across screens
> - Adds `raise_output_scale` in [mod.rs](https://github.com/indexable-inc/index/pull/1843/files#diff-20a94c4c7d7f1b2cdb580548a7a8c9bc9903230bd99a9f4ab0fcfa2988918aa4) that only increases the compositor's integer output scale, re-sending `preferred_buffer_scale` to all surfaces when a higher scale is observed — lower per-window scales are ignored.
> - The `on_configure` XDG toplevel handler now calls `raise_output_scale` after each Configure event, so any window reporting a higher scale upgrades the global output scale for all clients.
> - Changes the Hello scale seed in [app.rs](https://github.com/indexable-inc/index/pull/1843/files#diff-930d602aa44ba1ddc9ad1786eb57eaf20fff7bf180adbef33351879c9c9354da) from the main screen's `backingScaleFactor` to the maximum across all attached screens, with a fallback to 2.0 when no screens are found or the result is non-positive.
> - Behavioral Change: clients that previously received no `preferred_buffer_scale` advertisement (or a stale 1x value) will now receive an updated scale if any window or screen reports a higher value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6bb48c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->