### PR TITLE
panes: per-window scale (protocol 1.3), mixed-scale cursor fix, screen-change recompute

### DIFF
--- a/packages/vm/panes/compositor/src/compositor/handlers.rs
+++ b/packages/vm/panes/compositor/src/compositor/handlers.rs
@@ -120,6 +120,10 @@ impl CompositorHandler for App {
             self.intake_buffer(idx);
         }
 
+        // Unit re-announcement must precede the min/max that may follow in
+        // this same commit: a 1.3 host interprets WindowMinMax in the most
+        // recently announced scale.
+        self.sync_window_scale(idx);
         self.sync_min_max(idx, &root);
 
         // Send now if pacing allows, or release the frame callbacks if there

--- a/packages/vm/panes/compositor/src/compositor/input.rs
+++ b/packages/vm/panes/compositor/src/compositor/input.rs
@@ -44,9 +44,9 @@ fn pointer_motion(app: &mut App, id: panes_protocol::WindowId, x: f64, y: f64) {
     app.pointer_focus = Some(id);
     let time = app.now_ms();
     // Wire coords are drawable pixels (panes-protocol convention); smithay's
-    // pointer space is logical, so divide by the host scale, mirroring the
-    // xdg configure division in `on_configure`.
-    let scale = host_scale(app);
+    // pointer space is logical, so divide by the window's scale, mirroring
+    // the xdg configure division in `on_configure`.
+    let scale = wire_scale(app, id);
     // Focus is handed over explicitly (second tuple element = the surface's
     // origin in "global" space, which for us is always 0,0), so smithay
     // emits enter/leave pairs as the host moves between windows.
@@ -75,7 +75,7 @@ fn pointer_relative(app: &mut App, id: panes_protocol::WindowId, dx: f64, dy: f6
     };
     // Wire deltas are buffer pixels (same convention as PointerMotion), so
     // the same pixel->logical division applies.
-    let scale = host_scale(app);
+    let scale = wire_scale(app, id);
     let delta = Point::from((dx / scale, dy / scale));
     let utime = app.now_us();
     pointer.relative_motion(
@@ -93,12 +93,21 @@ fn pointer_relative(app: &mut App, id: panes_protocol::WindowId, dx: f64, dy: f6
     pointer.frame(app);
 }
 
-/// The host's global `backingScaleFactor` from Hello, as the divisor that
-/// takes wire pixel coordinates to logical surface coordinates. Input only
-/// flows after Hello, so a missing host (1) is a startup-race fallback, not a
-/// silent unit change.
-fn host_scale(app: &App) -> f64 {
-    f64::from(app.host.as_ref().map_or(1, |host| host.scale.max(1)))
+/// The divisor that takes one window's wire pixel coordinates to logical
+/// surface coordinates: that window's own backing scale from the host's last
+/// `Configure`. Per window because displays mix scales -- dividing a
+/// 1x-screen window's coordinates by a global scale of 2 puts its cursor at
+/// half the true position (the index#1686 mixed-scale skew). Falls back to
+/// the global Hello scale for a window the host has not configured yet, and
+/// to 1 before Hello (a startup race, not a silent unit change: input only
+/// flows after Hello).
+fn wire_scale(app: &App, id: panes_protocol::WindowId) -> f64 {
+    let scale = app
+        .pane_index(id)
+        .and_then(|idx| app.panes[idx].configured_scale)
+        .or_else(|| app.host.as_ref().map(|host| host.scale))
+        .unwrap_or(1);
+    f64::from(scale.max(1))
 }
 
 fn pointer_button(
@@ -152,7 +161,7 @@ fn pointer_axis(
     let (horizontal, vertical) = if source == WireAxisSource::Wheel {
         (horizontal, vertical)
     } else {
-        let scale = host_scale(app);
+        let scale = wire_scale(app, id);
         (horizontal / scale, vertical / scale)
     };
     let source = match source {

--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -18,8 +18,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
 use panes_protocol::{
-    Encoding, MINOR_POINTER_LOCK, ToGuest, ToHost, VERSION_MAJOR, VERSION_MINOR, WindowId,
-    wl_repeat_info,
+    Encoding, MINOR_POINTER_LOCK, MINOR_WINDOW_SCALE, ToGuest, ToHost, VERSION_MAJOR,
+    VERSION_MINOR, WindowId, wl_repeat_info,
 };
 use smithay::input::{Seat, SeatState};
 use smithay::output::{Mode, Output, PhysicalProperties, Scale, Subpixel};
@@ -101,12 +101,20 @@ struct Pane {
     max: Option<(u32, u32)>,
     /// Buffer scale of the last commit (forwarded in `WindowNew`).
     scale: u32,
-    /// The scale `WindowNew` carried on the current connection: the fixed
-    /// unit for this window's wire min/max (protocol contract). Kept apart
-    /// from `scale` because a client may change buffer scale mid-connection
-    /// (e.g. re-render 2x after the host's Hello raised the output scale)
-    /// and the wire has no per-window scale update to tell the host.
+    /// The unit this window's wire min/max are in: seeded by its `WindowNew`
+    /// and re-announced by `ToHost::WindowScale` whenever `scale` changes
+    /// afterwards (1.3+ host). Against a pre-1.3 host it stays frozen at the
+    /// `WindowNew` value for the connection (the protocol's old contract),
+    /// which is why it is kept apart from `scale`.
     announced_scale: u32,
+    /// This window's `NSWindow` `backingScaleFactor` from the host's last
+    /// `Configure`: the live per-window unit of every wire pixel coordinate
+    /// the host sends for it (pointer motion/deltas, sizes). `None` until
+    /// the first Configure; input mapping then falls back to the global
+    /// Hello scale. Kept per window because displays mix scales: dividing a
+    /// 1x-screen window's coordinates by a global scale of 2 halves its
+    /// cursor position (the index#1686 mixed-scale skew).
+    configured_scale: Option<u32>,
 }
 
 impl Pane {
@@ -126,6 +134,7 @@ impl Pane {
             max: None,
             scale: 1,
             announced_scale: 1,
+            configured_scale: None,
         }
     }
 }
@@ -439,6 +448,33 @@ impl App {
         }
     }
 
+    /// Re-announce `panes[idx]`'s wire unit when its buffer scale drifted
+    /// from the last announcement (the client re-rendered at a new scale,
+    /// e.g. adopting a raised output scale). A 1.3+ host takes
+    /// `ToHost::WindowScale` and re-interprets later `WindowMinMax` sizes in
+    /// the new unit; against an older host nothing is sent and
+    /// `announced_scale` stays frozen at the `WindowNew` value, the old
+    /// protocol contract.
+    fn sync_window_scale(&mut self, idx: usize) {
+        let pane = &mut self.panes[idx];
+        if !pane.announced || pane.scale == pane.announced_scale {
+            return;
+        }
+        let Some(host) = self
+            .host
+            .as_ref()
+            .filter(|h| h.ready && h.minor >= MINOR_WINDOW_SCALE)
+        else {
+            return;
+        };
+        pane.announced_scale = pane.scale;
+        info!(id = pane.id, scale = pane.scale, "window scale re-announced");
+        host.send(ToHost::WindowScale {
+            id: pane.id,
+            scale: pane.scale,
+        });
+    }
+
     /// Try to move one frame onto the wire for `panes[idx]`, announcing the
     /// window first if this connection has not seen it. When there is
     /// nothing to send, release the window's frame callbacks instead: no
@@ -542,6 +578,10 @@ impl App {
                         // old one says nothing about it.
                         pane.watchdog_ticks = INFLIGHT_WATCHDOG_TICKS;
                         pane.announced = false;
+                        // The next host's Configures speak for its own
+                        // NSWindows; a scale from the dead connection must
+                        // not map its input.
+                        pane.configured_scale = None;
                         pane.store.invalidate();
                     }
                     info!("host disconnected; windows re-announce on reconnect");
@@ -722,6 +762,9 @@ impl App {
         // factors are 1 or 2, and wp_fractional_scale would buy softness at
         // readback bandwidth the vsock budget cannot spare.
         let scale = scale.max(1);
+        // Live per-window unit for the host's pixel coordinates (input
+        // mapping divides by it; see `Pane::configured_scale`).
+        self.panes[idx].configured_scale = Some(scale);
         self.raise_output_scale(scale);
         let size_valid = width > 0 && height > 0;
         self.panes[idx].toplevel.with_pending_state(|state| {

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -10,7 +10,8 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::process::ExitCode;
-use std::sync::mpsc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, mpsc};
 use std::time::{Duration, Instant};
 
 use objc2::rc::Retained;
@@ -27,7 +28,7 @@ use objc2_metal::MTLDrawable as _;
 use objc2_quartz_core::CAMetalDisplayLinkUpdate;
 use panes_protocol::{MINOR_KEY_REPEAT, MINOR_POINTER_LOCK, ToGuest, ToHost, WindowId};
 
-use crate::conn::{self, Event, HostInfo, Target};
+use crate::conn::{self, Event, Target};
 use crate::render::Renderer;
 use crate::window::{PaneWindow, WindowParams};
 
@@ -56,6 +57,10 @@ struct App {
     /// whole engage/release mechanism: dropping the old value restores the
     /// cursor (see [`CursorCapture`]).
     capture: Option<CursorCapture>,
+    /// Shared with the connection supervisor, which reads it for each
+    /// (re)connect's Hello; rewritten by [`screens_changed`] so the facts
+    /// track the live screen table.
+    host_info: Arc<conn::HostInfo>,
 }
 
 /// An engaged pointer capture: cursor hidden and dissociated from mouse
@@ -153,25 +158,12 @@ pub fn run(target: Target, title_prefix: String, native_titlebar: bool) -> ExitC
     // presence and Cmd-Tab participation.
     ns_app.setActivationPolicy(NSApplicationActivationPolicy::Regular);
 
-    let screen = NSScreen::mainScreen(mtm);
-    let max_fps = screen.as_ref().map_or(60, |screen| screen.maximumFramesPerSecond());
-    // Hello advertises the HIGHEST backing scale of any attached display, not
-    // the startup main screen's: this read happens once per process, and a
-    // host launched while a 1x display was frontmost would otherwise say
-    // scale=1 for the whole session, pinning every guest client to 1x buffers
-    // stretched over Retina drawables (seen live with GLFW/Minecraft,
-    // index#1686). Windows that land on a lower-scale screen are still
-    // handled per window: their Configure carries that screen's real backing
-    // scale. Fallback 2.0 (headless/no screens) errs toward sharp.
-    let backing = NSScreen::screens(mtm)
-        .iter()
-        .map(|screen| screen.backingScaleFactor())
-        .fold(0.0_f64, f64::max);
-    let backing = if backing > 0.0 { backing } else { 2.0 };
-    eprintln!(
-        "panes-host: max screen backingScaleFactor={backing}, main screen \
-         maximumFramesPerSecond={max_fps}"
-    );
+    log_screens(mtm);
+    let facts = read_screen_facts(mtm);
+    let host_info = Arc::new(conn::HostInfo {
+        refresh_mhz: AtomicU32::new(facts.refresh_mhz),
+        scale: AtomicU32::new(facts.scale),
+    });
 
     let renderer = match Renderer::new() {
         Ok(renderer) => renderer,
@@ -192,27 +184,118 @@ pub fn run(target: Target, title_prefix: String, native_titlebar: bool) -> ExitC
             ack_stats: HashMap::new(),
             peer_minor: 0,
             capture: None,
+            host_info: host_info.clone(),
         });
     });
 
     // App activation delegate: a deactivated app must never hold the user's
     // cursor hostage, so capture is released on resign-active and re-engaged
-    // (if the guest still wants it) on reactivation.
+    // (if the guest still wants it) on reactivation. Also the screen-change
+    // hook (see `screens_changed`).
     let delegate = AppDelegate::new(mtm);
     ns_app.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
 
+    conn::spawn(target, host_info);
+
+    ns_app.run();
+    ExitCode::SUCCESS
+}
+
+/// One line per attached screen with the facts presentation depends on
+/// (backing scale, max refresh, frame, which one is main); logged at startup
+/// and again on every screen-parameters change. Replaces a one-shot startup
+/// summary that kept being read as current truth hours later: a live 1x/60Hz
+/// incident was misdiagnosed as a bad `NSScreen` read when the host had
+/// simply been launched while a 1x external display was the main screen
+/// (index#1686).
+fn log_screens(mtm: MainThreadMarker) {
+    // Frame equality marks the main screen: screens never overlap exactly,
+    // and it avoids leaning on NSScreen instance identity across the two
+    // accessors.
+    let main_frame = NSScreen::mainScreen(mtm).map(|screen| screen.frame());
+    for screen in NSScreen::screens(mtm) {
+        let frame = screen.frame();
+        eprintln!(
+            "panes-host: screen {}x{} at ({}, {}): backingScaleFactor={} \
+             maximumFramesPerSecond={}{}",
+            frame.size.width,
+            frame.size.height,
+            frame.origin.x,
+            frame.origin.y,
+            screen.backingScaleFactor(),
+            screen.maximumFramesPerSecond(),
+            if main_frame == Some(frame) { " (main)" } else { "" },
+        );
+    }
+}
+
+/// Snapshot of the screen-derived facts [`ToGuest::Hello`] advertises.
+struct ScreenFacts {
+    refresh_mhz: u32,
+    scale: u32,
+}
+
+/// Facts [`ToGuest::Hello`] advertises, from the current screen table:
+/// refresh from the main screen, scale = the HIGHEST `backingScaleFactor` of
+/// any attached display, not the main screen's. A host launched (or
+/// reconnecting) while a 1x display is frontmost must not pin every guest
+/// client to 1x buffers stretched over Retina drawables (seen live with
+/// GLFW/Minecraft, index#1686); windows that land on a lower-scale screen
+/// are corrected per window by their Configure. Fallback 2.0 (headless / no
+/// screens) errs toward sharp.
+fn read_screen_facts(mtm: MainThreadMarker) -> ScreenFacts {
+    let max_fps =
+        NSScreen::mainScreen(mtm).map_or(60, |screen| screen.maximumFramesPerSecond());
+    let backing = NSScreen::screens(mtm)
+        .iter()
+        .map(|screen| screen.backingScaleFactor())
+        .fold(0.0_f64, f64::max);
+    let backing = if backing > 0.0 { backing } else { 2.0 };
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let host = HostInfo {
+    ScreenFacts {
         // Clamped into u32 range explicitly: no real panel exceeds 1000Hz,
         // and the clamp makes the (impossible) fallback a visible policy
         // rather than a silent unwrap_or.
         refresh_mhz: u32::try_from(max_fps.clamp(1, 1000)).expect("clamped to 1..=1000") * 1000,
         scale: (backing.round().max(1.0)) as u32,
-    };
-    conn::spawn(target, host);
+    }
+}
 
-    ns_app.run();
-    ExitCode::SUCCESS
+/// `applicationDidChangeScreenParameters:`: displays attach, detach, or
+/// change mode/scale in place, with no reliable per-window signal
+/// (`windowDidChangeScreen:` only fires when a window lands on a different
+/// screen object; an in-place mode switch fires nothing window-level). Seen
+/// live (index#1686): a window left on the built-in panel after a 1x/60Hz
+/// external detached kept ticking at ~60 acks/s. Re-derive everything
+/// screen-dependent: refresh the Hello facts for future reconnects, re-pin
+/// every window's stream rate, and re-sync layer geometry so the guest gets
+/// a Configure with the window's current backing scale.
+fn screens_changed() {
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    log_screens(mtm);
+    let facts = read_screen_facts(mtm);
+    with_app(|app| {
+        // Relaxed matches the reader (conn.rs): independent u32 facts.
+        app.host_info.refresh_mhz.store(facts.refresh_mhz, Ordering::Relaxed);
+        app.host_info.scale.store(facts.scale, Ordering::Relaxed);
+        for (id, window) in &mut app.windows {
+            window.refresh_stream_rate(mtm);
+            let size = window.sync_layer_geometry();
+            window.mark_dirty();
+            let activated = window.ns.isKeyWindow();
+            if let Some(out) = &app.out {
+                let _ = out.send(ToGuest::Configure {
+                    id: *id,
+                    width: size.width,
+                    height: size.height,
+                    scale: size.scale,
+                    activated,
+                });
+            }
+        }
+    });
 }
 
 /// Entry point for supervisor events, always on the main queue.
@@ -343,6 +426,12 @@ fn handle_msg(app: &mut App, msg: ToHost, recv: f64) -> Deferred {
                 eprintln!("panes-host: pointer lock for unknown window {id}");
             }
             sync_capture(app);
+            Deferred::default()
+        }
+        ToHost::WindowScale { id, scale } => {
+            if let Some(window) = app.windows.get_mut(&id) {
+                window.set_guest_scale(scale);
+            }
             Deferred::default()
         }
     }
@@ -691,6 +780,11 @@ define_class!(
         #[unsafe(method(applicationDidBecomeActive:))]
         fn application_did_become_active(&self, _notification: &NSNotification) {
             with_app(sync_capture);
+        }
+
+        #[unsafe(method(applicationDidChangeScreenParameters:))]
+        fn application_did_change_screen_parameters(&self, _notification: &NSNotification) {
+            screens_changed();
         }
     }
 );

--- a/packages/vm/panes/host/src/conn.rs
+++ b/packages/vm/panes/host/src/conn.rs
@@ -7,7 +7,8 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
-use std::sync::mpsc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, mpsc};
 use std::time::Duration;
 
 use dispatch2::DispatchQueue;
@@ -34,17 +35,22 @@ pub enum Event {
     Disconnected,
 }
 
-/// Host facts advertised in [`ToGuest::Hello`], captured from `NSScreen` on
-/// the main thread before the supervisor starts.
+/// Host facts advertised in [`ToGuest::Hello`]. Read from `NSScreen` on the
+/// main thread, and re-written there on every screen-parameters change
+/// (displays attach/detach/change mode mid-session); the supervisor loads
+/// the current values at each (re)connect, so a Hello sent after a display
+/// change advertises the topology that exists, not the one from launch.
 pub struct HostInfo {
-    pub refresh_mhz: u32,
-    pub scale: u32,
+    /// Main-screen refresh in mHz (e.g. 120000 for `ProMotion`).
+    pub refresh_mhz: AtomicU32,
+    /// Highest `backingScaleFactor` of any attached display.
+    pub scale: AtomicU32,
 }
 
 const BACKOFF_START: Duration = Duration::from_millis(250);
 const BACKOFF_MAX: Duration = Duration::from_secs(5);
 
-pub fn spawn(target: Target, host: HostInfo) {
+pub fn spawn(target: Target, host: Arc<HostInfo>) {
     std::thread::spawn(move || supervise(&target, &host));
 }
 
@@ -103,8 +109,10 @@ fn run_connection(stream: Stream, host: &HostInfo) {
     let hello = ToGuest::Hello {
         major: VERSION_MAJOR,
         minor: VERSION_MINOR,
-        refresh_mhz: host.refresh_mhz,
-        scale: host.scale,
+        // Relaxed: single u32 facts, no ordering relationship between them
+        // worth paying for (each is independently valid slightly stale).
+        refresh_mhz: host.refresh_mhz.load(Ordering::Relaxed),
+        scale: host.scale.load(Ordering::Relaxed),
         encodings: vec![Encoding::Raw, Encoding::Lz4],
     };
     if tx.send(hello).is_err() {

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -263,9 +263,10 @@ pub struct PaneWindow {
     _win_delegate: Retained<WinDelegate>,
     _link_delegate: Retained<LinkDelegate>,
     surface: Option<Surface>,
-    /// Scale from `WindowNew`: the fixed unit for this window's protocol
-    /// min/max sizes (protocol contract; the guest converts `WindowMinMax`
-    /// at the same announced scale even if the client rescales later).
+    /// The unit for this window's protocol min/max sizes: seeded by
+    /// `WindowNew`, re-announced by `WindowScale` when a 1.3 guest's client
+    /// re-renders at a new buffer scale (a 1.2 guest keeps it frozen for the
+    /// connection, the old contract).
     guest_scale: u32,
     pending_ack: Option<u64>,
     dirty: bool,
@@ -462,6 +463,12 @@ impl PaneWindow {
         if !self.native_titlebar {
             apply_hidden_titlebar(&self.ns);
         }
+    }
+
+    /// Adopt a `ToHost::WindowScale` re-announcement (protocol minor 3):
+    /// every later `WindowMinMax` for this window arrives in this unit.
+    pub fn set_guest_scale(&mut self, scale: u32) {
+        self.guest_scale = scale.max(1);
     }
 
     pub fn set_min_max(&self, min: Option<(u32, u32)>, max: Option<(u32, u32)>) {

--- a/packages/vm/panes/protocol/src/lib.rs
+++ b/packages/vm/panes/protocol/src/lib.rs
@@ -32,13 +32,16 @@ use serde::{Deserialize, Serialize};
 /// postcard encodes the variant index, so inserting one mid-enum renumbers
 /// everything after it.
 pub const VERSION_MAJOR: u16 = 1;
-pub const VERSION_MINOR: u16 = 2;
+pub const VERSION_MINOR: u16 = 3;
 
 /// Minor that introduced [`ToHost::PointerLock`] / [`ToGuest::PointerRelative`].
 pub const MINOR_POINTER_LOCK: u16 = 1;
 
 /// Minor that introduced [`ToGuest::KeyRepeat`].
 pub const MINOR_KEY_REPEAT: u16 = 2;
+
+/// Minor that introduced [`ToHost::WindowScale`].
+pub const MINOR_WINDOW_SCALE: u16 = 3;
 
 /// Guest vsock port the compositor listens on.
 pub const VSOCK_PORT: u32 = 7100;
@@ -91,19 +94,19 @@ pub enum ToHost {
         /// Buffer scale the guest renders at when this window was announced
         /// (the host `backingScaleFactor` echoed back through
         /// `ToGuest::Configure` when the client honors it, 1 for a
-        /// scale-blind client). Also the fixed unit for this window's
-        /// `WindowMinMax` sizes: a client that changes buffer scale
-        /// mid-connection changes only its frame dimensions, there is no
-        /// per-window scale update message.
+        /// scale-blind client). Also the unit for this window's
+        /// `WindowMinMax` sizes until a [`ToHost::WindowScale`] re-announces
+        /// it; on a pre-1.3 host the unit stays frozen at this value for the
+        /// connection (the guest never sends the update).
         scale: u32,
     },
     WindowTitle {
         id: WindowId,
         title: String,
     },
-    /// Sizes are buffer pixels at the scale this connection's `WindowNew`
-    /// carried (the host divides by that scale for `NSWindow`
-    /// `contentMin/MaxSize` points), NOT the current buffer scale.
+    /// Sizes are buffer pixels at the window's announced scale (its
+    /// `WindowNew`, updated by any later [`ToHost::WindowScale`]; the host
+    /// divides by that scale for `NSWindow` `contentMin/MaxSize` points).
     WindowMinMax {
         id: WindowId,
         min: Option<(u32, u32)>,
@@ -148,6 +151,18 @@ pub enum ToHost {
     PointerLock {
         id: WindowId,
         locked: bool,
+    },
+    /// The window's buffer scale changed after `WindowNew` (the client
+    /// re-rendered at a new scale, e.g. adopting the compositor's raised
+    /// output scale, or moving between 1x and 2x-backed content). Re-announces
+    /// the unit later `WindowMinMax` sizes for this window are in; ordered on
+    /// the same stream, so the host applies it before any `WindowMinMax` that
+    /// follows. Since minor 3 ([`MINOR_WINDOW_SCALE`]); only sent once the
+    /// host's Hello advertised it (a 1.2 host keeps the frozen-per-connection
+    /// `WindowNew` unit).
+    WindowScale {
+        id: WindowId,
+        scale: u32,
     },
 }
 
@@ -431,6 +446,14 @@ mod tests {
             panic!("wrong variant");
         };
         assert!((dx - -1.5).abs() < f64::EPSILON && (dy - 2.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn window_scale_roundtrips() {
+        let mut buf = Vec::new();
+        write_msg(&mut buf, &ToHost::WindowScale { id: 9, scale: 2 }).unwrap();
+        let back: ToHost = read_msg(&mut buf.as_slice()).unwrap();
+        assert!(matches!(back, ToHost::WindowScale { id: 9, scale: 2 }));
     }
 
     #[test]


### PR DESCRIPTION
Root-caused from last night's live incident (windows pacing ~60 acks/s with 1x drawables while MC rendered 347fps internally) and folds in the per-window-scale follow-up scoped in #1843's PR body.

## Root cause: the host read the display truthfully; the topology was not what it looked like

A probe binary (NSScreen + CGDisplayCopyDisplayMode at three lifecycle points: pre-NSApplication, post-sharedApplication, post-finishLaunching) run from the kernel, tmux, and plain contexts reads **identical, correct values in every context and at every lifecycle point** -- there is no query-context or launch-timing bug (hypothesis "NSScreen before app launch" is dead).

The WindowServer log has the real story:

| time (Jul 3) | event |
|---|---|
| 15:37:41 | external 7680x2160 display added, mode 83 = **1x @ 120Hz**, `marking main`; built-in shifted to (-2056,0) |
| 18:33, ~20:16 | bad host runs: `main screen maximumFramesPerSecond=120 backingScaleFactor=1` -- the truthful read of that main screen; windows presented onto 768x**2159** / 795x**1080** drawables (2160-tall 1x panel, not the 2658px-tall built-in) |
| 20:13:54 | external `removed`, built-in re-marked main |
| after | `system_profiler` shows exactly one display -- while the quoted log line was from a process started hours earlier |

The one-shot startup log line masquerading as current truth is what turned a plugged-in monitor into a "wrong display info" bug hunt. And after the unplug, the surviving window kept ticking at ~59.9 acks/s **on the 120Hz built-in**: an in-place topology change fires no `windowDidChangeScreen:`.

The mixed-scale session also reproduced the cursor skew that forced the live-host rollback from post-#1843 main: the host sends pointer coords multiplied by each window's **own** `backingScaleFactor`, but the compositor divided by the single **global** Hello scale -- with Hello=2 (max over screens) and a window on the 1x external, the guest saw the cursor at half its true position.

## Fix

- **protocol 1.3**: `ToHost::WindowScale { id, scale }` re-announces a window's wire unit when its buffer scale changes after `WindowNew` (the frozen-per-connection unit gap from #1843); later `WindowMinMax` sizes are in the latest announced unit. Gated on the host's Hello minor; a 1.2 host keeps the old frozen contract.
- **compositor**: pointer motion / relative deltas / finger-axis values divide by the window's own last-`Configure` scale (live per-window truth) instead of the global Hello scale; falls back to Hello before the first Configure. This kills the mixed-scale cursor skew.
- **host**: `applicationDidChangeScreenParameters:` re-logs the screen table, re-pins every window's `CAMetalDisplayLink` rate, re-syncs layer geometry (Configure with current backing scale), and refreshes the Hello facts so a reconnect advertises the topology that exists now, not launch-time's.
- **host**: startup logs one line per screen (scale, max fps, frame, main marker) instead of the one-shot summary that misled the diagnosis.

## Validation

- `panes-host` aarch64-darwin: clippy + full unit test suite + unusedCrateDependencies green (`nix build .#packages.aarch64-darwin.panes-host.passthru.tests.{panes-host-all,clippy,unusedCrateDependencies}`).
- `panes-protocol`: 16/16 tests pass on x86_64-linux (incl. the new `window_scale_roundtrips`).
- `panes-compositor`: `cargo check` clean on x86_64-linux (vin-compute-1); the aarch64-linux package build needs the linux builder VM (not up on hydra tonight) -- the crate is aarch64-only in CI as before.
- Old-peer compatibility: 1.3 host + 1.2 guest and 1.2 host + 1.3 guest both stay on the old semantics (WindowScale is emission-gated on the peer minor).

index#1686

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-window scale support (protocol 1.3) and fix mixed-scale cursor mapping
> - Bumps the wire protocol to minor version 3 and adds a `ToHost::WindowScale` message, allowing the compositor to re-announce a window's scale after `WindowNew` so subsequent `WindowMinMax` values are interpreted in the correct unit.
> - Adds `configured_scale` to `Pane` and introduces `wire_scale()` in [input.rs](https://github.com/indexable-inc/index/pull/1844/files#diff-22d607a34b9f6391315a0ba5c371bd88ecef007a2e374d5070465f6d298b678f), replacing the global `host_scale()` so pointer motion, relative motion, and continuous-axis deltas are divided by the window's own backing scale factor.
> - Adds a `screens_changed` handler (wired to `applicationDidChangeScreenParameters`) in [app.rs](https://github.com/indexable-inc/index/pull/1844/files#diff-930d602aa44ba1ddc9ad1786eb57eaf20fff7bf180adbef33351879c9c9354da) that re-reads screen facts, updates atomic `HostInfo` fields, refreshes stream rates, and re-sends `Configure` with the current window size and scale.
> - `HostInfo` fields `refresh_mhz` and `scale` are now `AtomicU32`, so each new connection's `Hello` reflects the current display state rather than static startup values.
> - Risk: Wire protocol minor bumped to 3; hosts and guests negotiating minor < 3 will not send `WindowScale`, so mixed-version deployments retain the old single-scale behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92d5374.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->