### PR TITLE
panes: defer dmabuf readback to send time; band-parallel diff+lz4 (fixes the 60/30 acks cap)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7652,6 +7652,7 @@ dependencies = [
  "clap",
  "lz4_flex 0.13.1",
  "panes-protocol",
+ "rayon",
  "smithay",
  "tracing",
  "tracing-subscriber",

--- a/packages/vm/panes/compositor/Cargo.toml
+++ b/packages/vm/panes/compositor/Cargo.toml
@@ -23,6 +23,10 @@ lz4_flex = { version = "0.13", default-features = false, features = [
   "safe-decode",
 ] }
 panes-protocol.workspace = true
+# Band-parallel damage diff + LZ4 (src/frame.rs): the encode runs on the
+# event-loop thread inside the per-frame ack budget, and banding was designed
+# for this fan-out.
+rayon.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/packages/vm/panes/compositor/src/compositor/gpu.rs
+++ b/packages/vm/panes/compositor/src/compositor/gpu.rs
@@ -130,7 +130,6 @@ impl Gpu {
             )
             .context("copy texture")?;
         let bytes = self.renderer.map_texture(&mapping).context("map texture")?;
-        let mut bgra = bytes.to_vec();
         // Everything downstream (row repack, force-opaque, FrameStore::commit)
         // assumes tightly packed width*height*4; commit's debug_assert is
         // stripped in release, so this is the only guard between a padded or
@@ -138,21 +137,23 @@ impl Gpu {
         let stride = usize::try_from(width).context("texture width exceeds usize")? * 4;
         let expected = stride * usize::try_from(height).context("texture height exceeds usize")?;
         anyhow::ensure!(
-            stride > 0 && bgra.len() == expected,
+            stride > 0 && bytes.len() == expected,
             "readback of {} bytes is not tightly packed {width}x{height}x4",
-            bgra.len()
+            bytes.len()
         );
         // GLES readback is bottom-up (smithay's `GlesMapping::flipped()` is
         // unconditionally true) while the wire is top-down; ship it as-is and
-        // every dmabuf window renders upside down on the host. Repack rows in
-        // reverse, keyed on `flipped()` so a future non-flipped mapping stays
-        // correct.
+        // every dmabuf window renders upside down on the host. Build the
+        // owned copy directly in wire order (one pass over the mapping, no
+        // intermediate to_vec: this runs once per wire frame on the loop
+        // thread, and a 2x fullscreen frame is tens of MB).
+        let mut bgra = Vec::with_capacity(expected);
         if mapping.flipped() {
-            let mut top_down = Vec::with_capacity(bgra.len());
-            for row in bgra.rchunks_exact(stride) {
-                top_down.extend_from_slice(row);
+            for row in bytes.rchunks_exact(stride) {
+                bgra.extend_from_slice(row);
             }
-            bgra = top_down;
+        } else {
+            bgra.extend_from_slice(bytes);
         }
         // The copy above is Argb8888, but an alpha-less source format leaves
         // the A byte undefined (commonly 0). The wire is premultiplied BGRA,

--- a/packages/vm/panes/compositor/src/compositor/handlers.rs
+++ b/packages/vm/panes/compositor/src/compositor/handlers.rs
@@ -177,10 +177,13 @@ impl App {
         }
     }
 
-    /// Take the newly attached buffer (if any) out of the surface state,
-    /// copy its pixels into the pane's `FrameStore`, and release it back to
-    /// the client immediately (we hold a copy, so the client may reuse it;
-    /// this is the classic shm-copy compositor contract).
+    /// Take the newly attached buffer (if any) out of the surface state.
+    /// shm pixels are copied into the pane's `FrameStore` and the buffer is
+    /// released immediately (the classic shm-copy compositor contract). A
+    /// dmabuf is only HELD: its GPU readback is deferred until pacing allows
+    /// a send (`App::absorb_pending_gpu`), because a mailbox client commits
+    /// far faster than the wire drains and a per-commit readback saturates
+    /// the event loop (see `Pane::pending_gpu`).
     // significant_drop_tightening misfires here, same as sync_min_max: the
     // guard already spans only the buffer take + scale read.
     #[allow(clippy::significant_drop_tightening)]
@@ -196,9 +199,27 @@ impl App {
         });
         match intake.assignment {
             Some(BufferAssignment::NewBuffer(buffer)) => {
+                let scale = u32::try_from(intake.scale.max(1)).expect("clamped positive");
+                #[cfg(feature = "gpu")]
+                if self.gpu.is_some()
+                    && let Ok(dmabuf) = smithay::wayland::dmabuf::get_dmabuf(&buffer)
+                {
+                    let dmabuf = dmabuf.clone();
+                    let pane = &mut self.panes[idx];
+                    if let Some(old) = pane.pending_gpu.take()
+                        && old.buffer != buffer
+                    {
+                        // Superseded before it was read: hand it back
+                        // untouched. That frame is skipped, never shown late
+                        // (mailbox semantics).
+                        old.buffer.release();
+                    }
+                    pane.pending_gpu = Some(super::HeldGpuBuffer { buffer, dmabuf, scale });
+                    return;
+                }
                 if let Some(frame) = self.copy_buffer(&buffer) {
                     let pane = &mut self.panes[idx];
-                    pane.scale = u32::try_from(intake.scale.max(1)).expect("clamped positive");
+                    pane.scale = scale;
                     pane.store.commit(frame.bgra, frame.width, frame.height);
                 }
                 buffer.release();
@@ -209,6 +230,10 @@ impl App {
                 // so the pane resets to the never-announced state (a remap
                 // reuses the id; the host sees it as a brand-new window).
                 let pane = &mut self.panes[idx];
+                #[cfg(feature = "gpu")]
+                if let Some(held) = pane.pending_gpu.take() {
+                    held.buffer.release();
+                }
                 if pane.announced
                     && let Some(host) = &self.host
                 {

--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -115,6 +115,28 @@ struct Pane {
     /// 1x-screen window's coordinates by a global scale of 2 halves its
     /// cursor position (the index#1686 mixed-scale skew).
     configured_scale: Option<u32>,
+    /// Latest committed dmabuf, not yet read back. GPU readback is deferred
+    /// to send time (see [`App::absorb_pending_gpu`]): a mailbox client
+    /// (mesa's Wayland WSI commits once per `vkQueuePresentKHR`) can commit
+    /// hundreds of frames a second, and a per-commit readback of a 2x buffer
+    /// saturates the event-loop thread -- measured live with Minecraft
+    /// (index#1686): internal render at ~347fps, wire cadence collapsed to a
+    /// tick-quantized ~30 acks/s. Held unreleased so the client cannot write
+    /// into it while a readback may still happen; a superseding commit
+    /// releases it untouched (that frame is simply never sent, which is
+    /// mailbox semantics).
+    #[cfg(feature = "gpu")]
+    pending_gpu: Option<HeldGpuBuffer>,
+}
+
+/// A committed-but-not-yet-read-back dmabuf (see [`Pane::pending_gpu`]).
+#[cfg(feature = "gpu")]
+struct HeldGpuBuffer {
+    buffer: smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer,
+    dmabuf: smithay::backend::allocator::dmabuf::Dmabuf,
+    /// The commit's buffer scale; applied to [`Pane::scale`] when absorbed,
+    /// so the scale always describes the pixels actually on the wire.
+    scale: u32,
 }
 
 impl Pane {
@@ -135,6 +157,8 @@ impl Pane {
             scale: 1,
             announced_scale: 1,
             configured_scale: None,
+            #[cfg(feature = "gpu")]
+            pending_gpu: None,
         }
     }
 }
@@ -475,6 +499,39 @@ impl App {
         });
     }
 
+    /// One readback per WIRE frame: take the newest held dmabuf (see
+    /// [`Pane::pending_gpu`]) into the frame store, releasing the buffer to
+    /// its client. Called only when pacing allows a send, so however many
+    /// commits piled up while a frame was in flight, exactly the newest one
+    /// pays for a GPU readback.
+    #[cfg(feature = "gpu")]
+    fn absorb_pending_gpu(&mut self, idx: usize) {
+        let Some(held) = self.panes[idx].pending_gpu.take() else {
+            return;
+        };
+        let frame = self.gpu.as_mut().and_then(|gpu| match gpu.readback(&held.dmabuf) {
+            Ok(frame) => Some(frame),
+            Err(err) => {
+                warn!(%err, "dmabuf readback failed; skipping frame");
+                None
+            }
+        });
+        // Released only now: the client was not allowed to write into the
+        // buffer while a readback could still sample it.
+        held.buffer.release();
+        if let Some(frame) = frame {
+            let pane = &mut self.panes[idx];
+            pane.scale = held.scale;
+            pane.store.commit(frame.bgra, frame.width, frame.height);
+        }
+        // The absorbed commit may carry a new buffer scale; re-announce the
+        // wire unit before the frame this pump is about to send.
+        self.sync_window_scale(idx);
+    }
+
+    #[cfg(not(feature = "gpu"))]
+    fn absorb_pending_gpu(&mut self, _idx: usize) {}
+
     /// Try to move one frame onto the wire for `panes[idx]`, announcing the
     /// window first if this connection has not seen it. When there is
     /// nothing to send, release the window's frame callbacks instead: no
@@ -483,10 +540,21 @@ impl App {
     /// (that is the throttle; the ack or its watchdog releases them).
     fn pump(&mut self, idx: usize) {
         let now = self.now_ms();
+        if self.host.as_ref().is_none_or(|h| !h.ready) {
+            // No ready host: the 10Hz fallback tick paces this pane.
+            return;
+        }
+        if self.panes[idx].inflight.is_some() {
+            // A frame is pacing the wire. Any held dmabuf stays held (and
+            // keeps being superseded by newer commits) so the readback below
+            // captures the newest content once the ack lands.
+            return;
+        }
+        // Pacing allows a send: absorb the newest held dmabuf now.
+        self.absorb_pending_gpu(idx);
         let Self { host, panes, .. } = self;
         let pane = &mut panes[idx];
         let Some(host) = host.as_ref().filter(|h| h.ready) else {
-            // No ready host: the 10Hz fallback tick paces this pane.
             return;
         };
         if !pane.store.has_content() {
@@ -496,13 +564,10 @@ impl App {
             fire_frame_callbacks(pane.toplevel.wl_surface(), now);
             return;
         }
-        if pane.inflight.is_some() {
-            return;
-        }
         if !pane.announced {
             // This connection's WindowNew scale is the unit every later
-            // WindowMinMax for this window is converted at (the host divides
-            // by it; there is no per-window scale update message).
+            // WindowMinMax for this window is converted at, until a
+            // WindowScale re-announces it (1.3+; see sync_window_scale).
             pane.announced_scale = pane.scale;
             host.send(ToHost::WindowNew {
                 id: pane.id,

--- a/packages/vm/panes/compositor/src/frame.rs
+++ b/packages/vm/panes/compositor/src/frame.rs
@@ -7,6 +7,7 @@
 //! [`Tile`]s covering just the rows that changed, updating the mirror.
 
 use panes_protocol::{Encoding, Rect, Tile};
+use rayon::prelude::*;
 
 /// Tiles never exceed this many rows: banding bounds a tile's payload (a
 /// 3840-wide band is ~3.9 MB raw) so per-tile LZ4 can fan out across cores
@@ -104,8 +105,14 @@ impl FrameStore {
         if rects.is_empty() {
             return None;
         }
+        // Bands encode in parallel: this runs on the compositor's event-loop
+        // thread once per wire frame, and LZ4 over a 2x fullscreen frame is
+        // multiple milliseconds serial -- at a 120Hz ack budget of 8.3ms per
+        // frame that alone halves the achievable rate. Banding exists for
+        // exactly this fan-out (see BAND_ROWS); indexed par_iter keeps tile
+        // order.
         let tiles: Vec<Tile> = rects
-            .iter()
+            .par_iter()
             .map(|rect| encode_tile(&current.data, current.width, *rect, allow_lz4))
             .collect();
         // Update the mirror. The full path clones; the incremental path only
@@ -152,38 +159,39 @@ fn full_bands(width: u32, height: u32) -> Vec<Rect> {
 /// Compare two equally sized packed frames band by band; a changed band is
 /// tightened to its first..=last changed rows. Unchanged interior rows within
 /// a changed span are re-sent (row-granular tracking is not worth the
-/// bookkeeping at <=256-row bands).
+/// bookkeeping at <=256-row bands). Bands scan in parallel (same budget
+/// argument as the tile encode in `take_frame`: a full-motion 2x frame reads
+/// both copies end to end); the indexed collect keeps band order.
 fn diff_bands(prev: &[u8], next: &[u8], width: u32, height: u32) -> Vec<Rect> {
     let row_len = width as usize * BYTES_PER_PIXEL;
     let row_changed = |row: u32| {
         let start = row as usize * row_len;
         prev[start..start + row_len] != next[start..start + row_len]
     };
-    let mut rects = Vec::new();
-    let mut band = 0;
-    while band < height {
-        let end = (band + BAND_ROWS).min(height);
-        let mut first = None;
-        let mut last = 0;
-        for row in band..end {
-            if row_changed(row) {
-                if first.is_none() {
-                    first = Some(row);
+    let bands = height.div_ceil(BAND_ROWS);
+    (0..bands)
+        .into_par_iter()
+        .filter_map(|index| {
+            let band = index * BAND_ROWS;
+            let end = (band + BAND_ROWS).min(height);
+            let mut first = None;
+            let mut last = 0;
+            for row in band..end {
+                if row_changed(row) {
+                    if first.is_none() {
+                        first = Some(row);
+                    }
+                    last = row;
                 }
-                last = row;
             }
-        }
-        if let Some(first) = first {
-            rects.push(Rect {
+            first.map(|first| Rect {
                 x: 0,
                 y: first,
                 w: width,
                 h: last - first + 1,
-            });
-        }
-        band = end;
-    }
-    rects
+            })
+        })
+        .collect()
 }
 
 /// Encode one damage rect from a packed frame. LZ4 is only kept when it saves


### PR DESCRIPTION
Fixes the fresh 60-cap differential isolated after the #1844 host swap: real-guest MC paced at a rock-steady 58.8-60.0 acks/s (later 29.8-29.9) while `--mock` on the same host+display holds 120 and MC renders ~347fps internally (mailbox).

## Root cause: per-commit GPU readback, quantized by the genlock

There is no 60Hz constant anywhere (wl_output advertises the Hello refresh, 120000 mHz, verified live). The observed rates are `120/n` tick quantization of the one-frame-in-flight pacing: 60 = every 2nd display-link tick, 29.9 = every 4th. The guest's ack-to-frame turnaround crossed one 8.3ms tick period, then three.

What made it slow: mesa's Wayland WSI commits once per `vkQueuePresentKHR`, so a mailbox client commits hundreds of times a second, and `intake_buffer` did a **full synchronous GPU readback + repack on the event-loop thread for every commit** (`gpu.readback`: import, `copy_texture`, map, `to_vec`, flip repack, opaque pass). At the 2x buffer sizes #1843 restored that is 4x the pixels of the old 1x-stuck image -- the loop saturates, turnaround blows the tick budget, and the wire collapses to 120/n. The old image's 111-115 acks/s was the same code hiding behind 4x-smaller (wrongly 1x) MC buffers.

## Fix (guest-side only, no protocol change)

- **Defer dmabuf readback to send time**: a committed dmabuf is now held (unreleased, so the client cannot write into it) instead of read back; a superseding commit releases the old one untouched -- that frame is skipped, which is exactly mailbox semantics. The readback runs in `pump`, once per WIRE frame, ack-paced: commit rate no longer multiplies readback cost.
- **One-pass readback repack**: build the top-down copy straight from the mapped texture (drops the intermediate `to_vec`, one full-buffer pass saved).
- **Band-parallel diff + LZ4** (rayon, already a workspace dep): serial encode of a 2x frame alone eats most of the 8.3ms/frame budget at 120Hz; banding (`BAND_ROWS`) was designed for this fan-out and indexed rayon collect preserves tile order.

shm intake is unchanged: pool semantics require the copy at commit, and shm clients are frame-callback paced anyway.

## Validation

- `cargo check -p panes-compositor --all-targets` clean on x86_64-linux (vin-compute-1).
- Compositor tests 9/9 (incl. the frame.rs damage/tile-order tests that pin the parallel diff/encode ordering), protocol tests 16/16.
- `nix run .#lint` green.
- End-to-end acks/s validation rides the guest-image rebuild from main (coordinated separately; the builder closure is cached).

index#1686

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer dmabuf readback to send time and parallelize diff and LZ4 encoding across bands
> - dmabuf commits are now held in `Pane::pending_gpu` without immediate readback; `absorb_pending_gpu` performs exactly one GPU readback per wire frame just before send, implementing mailbox semantics and fixing the 60/30 ACKs throughput cap.
> - Band-level damage detection (`diff_bands`) and tile encoding (`FrameStore::take_frame`) now run in parallel using `rayon`, reducing per-frame CPU time on multi-core systems while preserving output order.
> - Superseded held dmabufs (i.e. a new commit arrives before the previous one is read back) are released immediately without readback.
> - Behavioral Change: GPU buffer scale is now applied at readback time rather than at commit time, so `Pane::scale` updates are deferred until the frame is actually sent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4105fa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->