### PR TITLE
base image: disable nix SQLite WAL (VCFS layer corrupts it)

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -42,6 +42,17 @@ in {
       "https://cache.ix.dev"
     ];
 
+    # The guest's writable layer (`/`, incl. `/nix/var/nix/db`) is a virtiofs
+    # FUSE mount with no DAX cache capability, so a memory-mapped file is served
+    # through FUSE writeback rather than a coherent shared window. SQLite's WAL
+    # mode needs exactly that: an mmap'd `*-shm` for cross-connection shared
+    # state plus strict WAL/main fsync ordering on checkpoint. Neither holds on
+    # this layer, so the nix DB's WAL silently corrupts and `nix` degrades to
+    # `database disk image is malformed`. Rollback-journal mode drops the `-shm`
+    # mmap dependency and keeps the DB intact. Mitigation for the VCFS layer bug
+    # tracked in indexable-inc/ix#6259; drop this once that layer honors mmap+fsync.
+    nix.settings.use-sqlite-wal = false;
+
     # Install terminfo for every common terminal emulator so ncurses tools
     # (`clear`, `tmux`, `vim`, ...) work no matter what `$TERM` an operator's
     # client propagates in. Without this, shelling in from Ghostty fails with


### PR DESCRIPTION
## What

Set `nix.settings.use-sqlite-wal = false` in the auto-enabled base profile, so every ix VM image renders its guest `nix.conf` with SQLite rollback-journal mode instead of WAL.

## Why

Fresh ix VMs were degrading to unusable: `nix run` cold took 57s re-substituting a single baked path, `ix new` took 235s to Connect, and eventually every `nix` command hard-failed with `database disk image is malformed`.

Root cause (diagnosed on live VM `upright-stag`, evidence in indexable-inc/ix#6259): the guest's writable layer — `/`, including `/nix/var/nix/db` — is a virtiofs FUSE mount with **no DAX cache capability** (`virtio_fs_setup_dax: No cache capability` in guest dmesg). SQLite's WAL mode needs an mmap'd `*-shm` file for shared state plus strict WAL/main fsync ordering on checkpoint; a FUSE-backed layer without DAX honors neither, so the WAL diverges and the b-tree silently corrupts. The baked DB is fine — a 96 MB never-checkpointed runtime WAL is what's corrupt.

Rollback-journal mode (`use-sqlite-wal = false`) drops the `-shm` mmap dependency entirely, so the DB stays intact on this layer.

## Scope / sanity check

Confirmed the guest's nix reads a genuinely **mutable** DB on the rw layer (in-VM `touch /nix/var/nix/db/.wtest` succeeds; WAL is runtime-written), so this setting lands exactly where the corruption happens — not on the baked read-only copy.

This is a **mitigation**, not the real fix. It only covers nix. The underlying VCFS/VMFS FUSE layer not honoring mmap+fsync (tracked in indexable-inc/ix#6259) makes SQLite in WAL mode unsound for *any* guest service, and the comment in the code points there. Drop this line once that layer is fixed.

## Validation

- `nix eval` through `evalImageConfig` (the path every image build and eval test uses): `use-sqlite-wal = false`, substituters unchanged (`["https://cache.ix.dev", "https://cache.nixos.org/"]`).
- `nix run .#lint` clean (7/7 tasks).

Ships with the next base publish and makes fresh VMs reliable without waiting for the VCFS fix.

(authored by an AI agent via Claude Code on behalf of andrewgazelka)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable Nix SQLite WAL mode to prevent VCFS layer corruption
> VirtioFS/FUSE has limitations with mmap and fsync ordering that corrupt the SQLite WAL (`-shm`) file used by Nix. Sets `nix.settings.use-sqlite-wal = false` in [profiles/base/default.nix](https://github.com/indexable-inc/index/pull/1847/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) to switch Nix to rollback-journal mode, which avoids mmap'd `-shm` files and the problematic WAL/main fsync ordering. Risk: rollback-journal mode has lower write concurrency than WAL mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e41410f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->