### PR TITLE
fix(ray): valid spill flag + writable notebook HOME

### DIFF
--- a/modules/services/ray/default.nix
+++ b/modules/services/ray/default.nix
@@ -57,12 +57,11 @@
 
   # Spill target lives on real disk (the StateDirectory), NOT under the tmpfs
   # `/run/ray` temp-dir -- otherwise "spill to disk under memory pressure" would
-  # just consume RAM. directory_path is created by Ray under the StateDirectory.
+  # just consume RAM. Ray creates the directory itself. Passed via
+  # `--object-spilling-directory`: the JSON `--object-spilling-config` flag does
+  # not exist on `ray start` in ray 2.55 (the daemon rejects it and the unit
+  # crash-loops fleet-wide, ix deploy 2026-07-04).
   spillDir = "/var/lib/ray/spill";
-  spillConfig = builtins.toJSON {
-    type = "filesystem";
-    params.directory_path = spillDir;
-  };
 
   ray = lib.getExe' cfg.package "ray";
 
@@ -100,8 +99,8 @@
       (toString cfg.workerPortHigh)
       "--temp-dir"
       "/run/ray"
-      "--object-spilling-config"
-      spillConfig
+      "--object-spilling-directory"
+      spillDir
     ]
     ++ optionals (cfg.objectStoreMemory != null) [
       "--object-store-memory"
@@ -184,6 +183,12 @@
       IX_MCP_DASHBOARD_PORT = toString cfg.execPort;
       IX_FLEET_EXEC_PORT = toString cfg.execPort;
       IX_MCP_MESH_PORT = toString cfg.meshPort;
+      # The unit runs as root under systemdHardening's ProtectHome=true, which
+      # masks /root. Without an explicit HOME both the nushell launcher (plugin
+      # cache under $HOME/.config/nushell) and the engine ($HOME/.mgrep) resolve
+      # root's passwd home and die on EACCES. Point HOME at the unit's own
+      # writable StateDirectory, mirroring the ray unit's HOME=/run/ray.
+      HOME = "/var/lib/ix-ray-notebook";
     }
     // optionalAttrs cfg.execTrustNetwork {
       IX_MCP_EXEC_TRUST_NETWORK = "1";


### PR DESCRIPTION
Fixes the fleet-wide `ix-ray` / `ix-ray-notebook` crash-loops that have kept ix prod deploys red since 2026-07-03 (ix run 28715239103).

**Bug 1 — `ix-ray` (every compute node, head + workers):** the launcher passes `--object-spilling-config <json>`, but `ray start` in ray 2.55.1 has no such option; the daemon exits 2 (`Error: No such option: --object-spilling-config (Possible options: ..., --object-spilling-directory)`) and the unit crash-loops into start-limit-hit. Replaced with `--object-spilling-directory /var/lib/ray/spill` — the supported flag with identical filesystem-spill semantics. Verified against the exact deployed store path binary on hil-compute-3: CLI parsing now passes (proceeds to GCS connect).

**Bug 2 — `ix-ray-notebook`:** the unit runs as root under `systemdHardening`'s `ProtectHome=true` with no `HOME` override, so $HOME resolves to the masked `/root` and both the nushell launcher (`/root/.config/nushell/plugin.msgpackz`, hil-compute-2) and the engine (`/root/.mgrep/token.json` stat, hil-compute-3) die on EACCES. Set `HOME=/var/lib/ix-ray-notebook` (its StateDirectory), mirroring the ray unit's `HOME=/run/ray`.

After merge: bump the `index` pin in ix's flake.lock to redeploy.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Ray spill flag and writable HOME for notebook service
> - Replaces `--object-spilling-config` (JSON) with `--object-spilling-directory` in the Ray service startup args in [default.nix](https://github.com/indexable-inc/index/pull/1848/files#diff-fcb55115d0f76c61bd91044049504b687d342d6087ea0e2046702ed9a5133333), passing `/var/lib/ray/spill` directly as a supported flag.
> - Sets `HOME=/var/lib/ix-ray-notebook` in the `ix-ray-notebook` service environment to provide a writable home directory when running under `ProtectHome=true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9cce81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->