### PR TITLE
fix(ray): put bash on the launcher PATH (client server worker exec)

### DIFF
--- a/modules/services/ray/default.nix
+++ b/modules/services/ray/default.nix
@@ -118,6 +118,13 @@
     runtimeInputs = [
       pkgs.tailscale
       cfg.package
+      # Ray execs its runtime-env worker wrappers via `os.execvp("bash", ...)`
+      # (ray._private.runtime_env.context.exec_worker) -- the head's Ray Client
+      # server spawns its default worker through that path on startup, and any
+      # runtime_env task does the same on workers. The hardened unit gets only
+      # this PATH, so without bash the subprocess dies with FileNotFoundError,
+      # `--block` sees it exit, and the daemon flaps (~70s cycle on the head).
+      pkgs.bash
     ];
     text = ''
       # nu


### PR DESCRIPTION
Third and final layer of the ix prod ray crash-loop (after #1848): with the `ray[client]` grpc deps present, the head's Ray Client server actually starts — and dies immediately, because ray spawns its server default worker via `os.execvp("bash", ...)` (`ray._private.runtime_env.context.exec_worker`) and the hardened systemd unit's PATH has no `bash` (`FileNotFoundError` in `ray_client_server.err`). `ray start --block` monitors subprocesses, sees the death, exits 1 → the head flaps on a ~70s cycle (observed live on hil-compute-1), and every worker notebook kernel that starts during a down-window dies with 'Kernel died before replying to kernel_info'.

Any `runtime_env` task exec on workers goes through the same `bash -c` wrapper, so the dependency belongs on all roles: add `pkgs.bash` to the ray launcher's runtimeInputs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `bash` to Ray service `runtimeInputs` to fix worker subprocess failures
> Ray invokes worker wrappers via `execvp("bash", ...)`, but `bash` was absent from the hardened systemd unit's PATH, causing a `FileNotFoundError` and daemon flapping. Adding `pkgs.bash` to `runtimeInputs` in [default.nix](https://github.com/indexable-inc/index/pull/1849/files#diff-fcb55115d0f76c61bd91044049504b687d342d6087ea0e2046702ed9a5133333) puts `bash` on the unit's PATH so worker subprocesses can start.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ea5d6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->