### PR TITLE
fix(ray): allow AF_NETLINK in both units (libzmq getifaddrs SIGABRT)

### DIFF
--- a/modules/services/ray/default.nix
+++ b/modules/services/ray/default.nix
@@ -450,6 +450,17 @@ in {
           # user namespace would block that, so both are disabled here.
           PrivateDevices = false;
           PrivateUsers = false;
+          # getifaddrs needs an AF_NETLINK route socket. libzmq's ip_resolver
+          # calls it and ABORTS the whole process (SIGABRT) on EAFNOSUPPORT,
+          # which killed the notebook kernel on hosts with certain interface
+          # sets; ray's own psutil/grpc interface enumeration walks the same
+          # path. Extend the hardening default (AF_INET/AF_INET6/AF_UNIX).
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+            "AF_NETLINK"
+          ];
         };
     };
 
@@ -476,6 +487,16 @@ in {
           # the object store, so it cannot run under a private /dev or userns.
           PrivateDevices = false;
           PrivateUsers = false;
+          # Same AF_NETLINK reasoning as the ray unit: the engine's Jupyter
+          # kernel dies by libzmq SIGABRT when getifaddrs cannot open a netlink
+          # socket (observed live: ip_resolver.cpp:542 EAFNOSUPPORT on
+          # vin-compute-1/hil-compute-1; A/B-verified fix).
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+            "AF_NETLINK"
+          ];
         };
     };
   };


### PR DESCRIPTION
Fourth and hopefully final layer of the ix prod ray stack (#1848, #1849): with ray + client server healthy, `ix-ray-notebook` still crash-loops on vin-compute-1 and hil-compute-1 — the embedded Jupyter kernel dies by **SIGABRT from libzmq** (`ip_resolver.cpp:542: Address family not supported by protocol`, coredumps every ~7s). `getifaddrs` needs an **AF_NETLINK** route socket and the hardening's `RestrictAddressFamilies` only allows `AF_INET/AF_INET6/AF_UNIX`.

A/B-verified live on vin-compute-1 via `systemd-run`: with `RestrictAddressFamilies="AF_INET AF_INET6 AF_UNIX"` the failure reproduces exactly; adding `AF_NETLINK` the engine comes up healthy (data API bound, kernel ready). Extended on both units since ray's psutil/grpc interface enumeration uses the same getifaddrs path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow AF_NETLINK in Ray systemd units to fix SIGABRT in libzmq getifaddrs
> Adds `RestrictAddressFamilies = AF_INET AF_INET6 AF_UNIX AF_NETLINK` to the hardening blocks of both the `ray.service` and `engine.service` units in [modules/services/ray/default.nix](https://github.com/indexable-inc/index/pull/1850/files#diff-fcb55115d0f76c61bd91044049504b687d342d6087ea0e2046702ed9a5133333). Without `AF_NETLINK`, calls to `getifaddrs` from libzmq, psutil, and gRPC fail with `EAFNOSUPPORT`, causing a `SIGABRT`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85487c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->