### PR TITLE
Route simple subagent questions to Codex low mode

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -548,11 +548,13 @@ let
           orchestration, quick replies, and trivial one-step work. Match subagent model
           strength to task difficulty: strongest for hard reasoning, planning, and
           high-stakes decisions; cheaper tiers for mechanical edits, search, and
-          settled execution.
+          settled execution. For simple delegated questions, use the MCP subagent
+          tool to spawn Codex with low reasoning.
         '';
         reason = ''
           Serial main-thread editing wasted wall clock on independent work and bloated
-          the orchestrating context.
+          the orchestrating context. Simple lookup questions do not need expensive
+          reasoning, but still benefit from separate context.
         '';
       };
     }


### PR DESCRIPTION
## Summary
- Update `packages/agent/system-prompt.nix` so simple delegated questions use the MCP subagent tool to spawn Codex with low reasoning.
- Record why simple lookup questions should use cheaper reasoning while keeping separate context.

## Validation
- `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; agentName = "Codex"; }'`
- normalized rendered prompt contains the new instruction
- `nix run .#lint`

Fixes #1853

(sent by Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route simple subagent questions to Codex low reasoning mode in the agent system prompt
> Updates [system-prompt.nix](https://github.com/indexable-inc/index/pull/1854/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to instruct the agent to use the MCP subagent tool with low reasoning when delegating simple lookup questions. The rationale added is that simple questions don't need expensive reasoning but still benefit from a separate context window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2d082d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->