### PR TITLE
Group dashboard resources by topic

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -640,9 +640,9 @@ let
           Search with `fff.grep` and `fff.find`; run `api()` for helpers. Do not shell
           out to `rg` or `fd` inside the kernel. Run independent non-mutating commands
           concurrently with `asyncio.gather` or `asyncio.TaskGroup`. If the kernel
-          wedges, restart it or report the blocker. Set a dashboard theme before
+          wedges, restart it or report the blocker. Set a dashboard topic before
           clusters of related kernel work and change it at phase boundaries; keep
-          several related tool calls under one theme so completed phases can fold
+          several related tool calls under one topic so completed phases can fold
           away as one group.
         '';
         reason = ''

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -679,6 +679,9 @@ let
           lands on `origin/main`. Prefer a PR; push directly to `main` only if it is
           genuinely unprotected. Own PRs through merge: push, watch CI, fix failures,
           resolve review, rebase, and re-queue until landed or truly blocked.
+          When the MCP `pr_watch` tool is available, use it for PR CI ownership:
+          it creates a live PR resource, shows check durations, enables auto
+          merge by default, and notifies the CLI on merge, failure, or timeout.
         '';
         reason = ''
           Tasks were reported done at an open PR that never landed; done means merged

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -527,14 +527,18 @@ let
     {
       shellCwd = {
         text = ''
-          The kernel `sh()` has no persistent cwd or shell state. Pass `cwd=<abs path>`
+          Prefer `nu` for shell-shaped work whose output you will filter, reshape, or
+          parse; it preserves structure and returns Polars DataFrames. Use `sh()` for
+          raw logs, writes, or external commands whose text must stay verbatim. The
+          kernel `sh()` has no persistent cwd or shell state. Pass `cwd=<abs path>`
           on every call, or use `git -C <worktree>`. Use argv-list form for commands
           containing backticks or `$(...)`: `sh([...])`. Before commit or branch work,
           verify the repo root and branch match the assigned worktree.
         '';
         reason = ''
           Kernel shells carry no cwd between calls; commit and branch work landed in
-          the wrong repo or branch.
+          the wrong repo or branch. DataFrame-shaped command results are easier to
+          inspect in the dashboard than dicts or scraped text.
         '';
       };
     }
@@ -549,7 +553,7 @@ let
           strength to task difficulty: strongest for hard reasoning, planning, and
           high-stakes decisions; cheaper tiers for mechanical edits, search, and
           settled execution. For simple delegated questions, use the MCP subagent
-          tool to spawn Codex with low reasoning.
+          tool to spawn Codex on `gpt-5.5` with low reasoning.
         '';
         reason = ''
           Serial main-thread editing wasted wall clock on independent work and bloated
@@ -636,7 +640,10 @@ let
           Search with `fff.grep` and `fff.find`; run `api()` for helpers. Do not shell
           out to `rg` or `fd` inside the kernel. Run independent non-mutating commands
           concurrently with `asyncio.gather` or `asyncio.TaskGroup`. If the kernel
-          wedges, restart it or report the blocker.
+          wedges, restart it or report the blocker. Set a dashboard theme before
+          clusters of related kernel work and change it at phase boundaries; keep
+          several related tool calls under one theme so completed phases can fold
+          away as one group.
         '';
         reason = ''
           Shelling out to `rg`/`fd` or sync subprocesses froze the kernel's single
@@ -648,9 +655,16 @@ let
       structuredPrimitives = {
         text = ''
           Prefer structured primitives over text munging: `view.ls`, `view.tree`,
-          `view.cat`, `fff.grep`, and `fff.find`. Parse `sh` output with `.json()`,
-          `.jsonl()`, or `.df()`. Run one command per `sh()` call and combine results in
-          Python. Return tables as polars DataFrames.
+          `view.cat`, `fff.grep`, `fff.find`, and `nu` pipelines. For command output
+          you plan to filter or parse, use `nu` first so the result arrives as a Polars
+          DataFrame; use `sh().json()`, `.jsonl()`, or `.df()` only when `sh` is the
+          right tool. Return tables as Polars DataFrames.
+
+
+          For reusable Python, write explicit annotations at function and data
+          boundaries. For package Python edits, run the repo's type-checking
+          entry point when one exists; do not treat an untyped compile-only
+          check as equivalent.
         '';
         reason = ''
           Ad hoc text munging of command output was fragile, and combining commands in

--- a/packages/dashboard/dashboard-core/site/src/components/CodeBlock.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/CodeBlock.svelte
@@ -1,22 +1,40 @@
 <script lang="ts">
-  import { highlight } from '$lib/highlight';
+  import { highlightLines } from '$lib/highlight';
 
   // A code block, syntax-highlighted by shiki when possible. While the highlighter
   // loads (or for an unknown language / offline CDN) it shows the raw text, so the
   // code is always legible immediately and highlighting upgrades it in place.
-  let { code, lang = 'text' }: { code: string; lang?: string } = $props();
+  let {
+    code,
+    lang = 'text',
+    line = null,
+    errorLine = null,
+  }: { code: string; lang?: string; line?: number | null; errorLine?: number | null } = $props();
 
   let html = $state<string | null>(null);
+  const rawLines = $derived(code.split('\n'));
+
+  function markLines(lines: string[], live: number | null, error: number | null): string {
+    return lines
+      .map((part, index) => {
+        const n = index + 1;
+        const cls = n === error ? 'cb-line cb-error' : n === live ? 'cb-line cb-live' : 'cb-line';
+        return `<span class="${cls}" data-line="${n}">${part || ' '}</span>`;
+      })
+      .join('\n');
+  }
 
   $effect(() => {
     // Track the inputs; a value-equal source (the live tail re-emits the same
     // string each frame) is `===` and does not re-run this.
     const c = code;
     const l = lang;
+    const live = line;
+    const err = errorLine;
     let alive = true;
     html = null;
-    void highlight(c, l).then((out) => {
-      if (alive) html = out;
+    void highlightLines(c, l).then((out) => {
+      if (alive) html = out ? markLines(out, live, err) : null;
     });
     return () => {
       alive = false;
@@ -29,5 +47,24 @@
   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
   {@html html}
 {:else}
-  <pre class="cb-raw">{code}</pre>
+  <pre class="cb-raw">{#each rawLines as rawLine, index}<span class="cb-line" class:cb-live={line === index + 1} class:cb-error={errorLine === index + 1} data-line={index + 1}>{rawLine || ' '}</span>{/each}</pre>
 {/if}
+
+<style>
+  :global(.cb-line) {
+    display: block;
+    padding: 0 0.6rem;
+    margin: 0 -0.6rem;
+    border-left: 2px solid transparent;
+  }
+
+  :global(.cb-live) {
+    background: color-mix(in srgb, #7bd88f 14%, transparent);
+    border-left-color: #7bd88f;
+  }
+
+  :global(.cb-error) {
+    background: color-mix(in srgb, #fc618d 16%, transparent);
+    border-left-color: #fc618d;
+  }
+</style>

--- a/packages/dashboard/dashboard-core/site/src/components/RunDetail.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/RunDetail.svelte
@@ -138,7 +138,7 @@
               <span class="caret"></span><span class="panel-label">code</span>
               <span class="panel-hint">{pane.lang || 'source'}</span>
             </summary>
-            <div class="panel-body"><CodeBlock code={pane.source ?? ''} lang={pane.lang ?? 'text'} /></div>
+            <div class="panel-body"><CodeBlock code={pane.source ?? ''} lang={pane.lang ?? 'text'} line={pane.line ?? null} errorLine={pane.error_line ?? null} /></div>
           </details>
         {/if}
         {#if hasStreamOut || resultIsPrimary || running}

--- a/packages/dashboard/dashboard-core/site/src/components/Sidebar.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   // The unified left sidebar: the ix logotype + live dot, a filter box, then three
-  // foldable sections — SESSIONS (each session foldable, its runs nested
+  // foldable sections: SESSIONS (each session foldable, its runs nested
   // oldest-first, a log growing downward), RESOURCES, and RECORDINGS. It owns the center-stage selection
   // and the vim keyboard nav; fold state is persisted in ui. Folding is driven by
   // ui.folds (not native <details>) so the flattened keyboard walk matches exactly
@@ -32,34 +32,74 @@
   let filterEl: HTMLInputElement | undefined;
   const q = $derived(query.trim().toLowerCase());
 
-  function runMatches(r: typeof model.sessions[number]['runs'][number]): boolean {
+  function paneMatches(r: typeof model.resources[number]): boolean {
     if (!q) return true;
     return [r.pane.title, r.pane.subtitle, r.pane.lang, paneId(r.key)].some((v) =>
       (v ?? '').toLowerCase().includes(q),
     );
   }
-  // A session's visible runs under the filter: all if the session label matches,
-  // else only the matching runs.
-  function visibleRuns(label: string, runs: typeof model.sessions[number]['runs']) {
-    if (!q || label.toLowerCase().includes(q)) return runs;
-    return runs.filter(runMatches);
+  function themeMatches(t: typeof model.sessions[number]['themes'][number]): boolean {
+    return !q || t.label.toLowerCase().includes(q);
+  }
+  // A session's visible children under the filter: all if the session label
+  // matches, else only matching resources and runs.
+  function visibleSession(s: typeof model.sessions[number]) {
+    if (!q || s.label.toLowerCase().includes(q)) return s;
+    const themes = s.themes
+      .map((t) => {
+        if (themeMatches(t)) return t;
+        const runs = t.runs
+          .map((r) => {
+            if (paneMatches(r)) return r;
+            const resources = r.resources.filter(paneMatches);
+            return resources.length > 0 ? { ...r, resources } : null;
+          })
+          .filter((r) => r !== null);
+        return { ...t, runs };
+      })
+      .filter((t) => t.runs.length > 0);
+    return {
+      ...s,
+      resources: s.resources.filter(paneMatches),
+      themes,
+      runs: themes.flatMap((t) => t.runs),
+    };
   }
 
   const sessions = $derived(
     model.sessions
-      .map((s) => ({ ...s, runs: visibleRuns(s.label, s.runs) }))
-      .filter((s) => s.runs.length > 0),
+      .map(visibleSession)
+      .filter((s) => s.resources.length > 0 || s.runs.length > 0),
   );
   const resources = $derived(
-    model.resources.filter(runMatches),
+    model.resources.filter(paneMatches),
   );
   const recordings = $derived(
     model.recordings.filter((rec) => !q || rec.id.toLowerCase().includes(q)),
   );
 
-  // The filtered model the keyboard walks. Fold checks read ui via isOpen.
+  function themeFoldKey(s: typeof sessions[number], t: typeof s.themes[number]): string {
+    return 'theme:' + s.scope + ':' + t.key;
+  }
+  const themeDefaults = $derived(
+    new Map(
+      sessions.flatMap((s) => {
+        const newest = s.themes.reduce<typeof s.themes[number] | null>(
+          (best, t) => (best && (best.lastActivity ?? 0) >= (t.lastActivity ?? 0) ? best : t),
+          null,
+        );
+        return s.themes.map((t) => [themeFoldKey(s, t), t.key === newest?.key] as const);
+      }),
+    ),
+  );
+  function openFold(foldKey: string): boolean {
+    return ui.folds[foldKey] ?? themeDefaults.get(foldKey) ?? isOpen(foldKey);
+  }
+
+  // The filtered model the keyboard walks. Theme folds default to opening only
+  // the newest theme in each session, so completed earlier phases stay tucked away.
   const filteredModel = $derived({ ...model, sessions, resources, recordings });
-  const flat = $derived(flattenVisible(filteredModel, isOpen));
+  const flat = $derived(flattenVisible(filteredModel, openFold));
 
   // ----- selection -------------------------------------------------------
   function onSelect(sel: Selection): void {
@@ -121,11 +161,21 @@
     selectIndex((i < 0 ? 0 : i) + delta);
   }
 
-  // The fold key of the selection's owning session (runs live under one), for
-  // h/za to act on the enclosing session.
-  function sessionFoldKeyOf(sel: Selection | null): string | null {
-    if (!sel || sel.kind !== 'run') return null;
-    for (const s of sessions) if (s.runs.some((r) => r.key === sel.key)) return 'sess:' + s.scope;
+  // The fold key of the selection's closest owner. Resources live under the
+  // session, while runs live under the theme inside that session.
+  function ownerFoldKeyOf(sel: Selection | null): string | null {
+    if (!sel || (sel.kind !== 'run' && sel.kind !== 'resource')) return null;
+    for (const s of sessions) {
+      if (s.resources.some((r) => r.key === sel.key)) {
+        return 'sess:' + s.scope;
+      }
+      for (const t of s.themes) {
+        if (t.runs.some((r) => r.key === sel.key)) return themeFoldKey(s, t);
+        if (t.runs.some((r) => r.resources.some((resource) => resource.key === sel.key))) {
+          return themeFoldKey(s, t);
+        }
+      }
+    }
     return null;
   }
 
@@ -144,13 +194,19 @@
   }
   // `h`: fold the enclosing session (if a run is selected), else fold the section.
   function back(): void {
-    const foldKey = sessionFoldKeyOf(ui.selection);
+    const foldKey = ownerFoldKeyOf(ui.selection);
     if (foldKey) setFold(foldKey, false);
   }
   // `za`: toggle the enclosing session's fold.
   function fold(): void {
-    const foldKey = sessionFoldKeyOf(ui.selection);
+    const foldKey = ownerFoldKeyOf(ui.selection);
     if (foldKey) toggleFold(foldKey);
+  }
+
+  function durationHeat(ms: number | undefined): string {
+    if (!ms) return '';
+    const pct = Math.min(24, Math.max(4, Math.round(Math.log10(ms + 1) * 5)));
+    return `--dur-heat: ${pct}%`;
   }
 
   onMount(() => {
@@ -210,19 +266,63 @@
             <span class="session-age">{age ? `active ${age}` : ''}</span>
           </button>
           {#if isOpen(foldKey)}
-            {#each s.runs as r (r.key)}
-              {@const running = r.led === 'running'}
+            {#each s.resources as r (r.key)}
               <button
-                class="run-row"
-                class:selected={ui.selection?.kind === 'run' && ui.selection.key === r.key}
+                class="res-row in-session"
+                class:selected={ui.selection?.kind === 'resource' && ui.selection.key === r.key}
                 data-nav={r.key}
-                onclick={() => onSelect({ kind: 'run', key: r.key })}
-                title={runTooltip(running, r.pane.duration_ms, r.pane.created_at, refMs) || r.pane.title || ''}
+                onclick={() => onSelect({ kind: 'resource', key: r.key })}
+                title={r.pane.title || ''}
               >
+                <span class="res-icon">{kindOf(r.pane) === 'terminal' ? '▮' : '▤'}</span>
+                <span class="res-name">{r.pane.title || '(resource)'}</span>
                 <span class="led led-{r.led}"></span>
-                <span class="run-intent">{r.pane.title || '(run)'}</span>
-                <span class="run-time">{humanTime(r.pane.created_at, refMs)}</span>
+                <span class="res-meta">{resourceMeta(r.pane)}</span>
               </button>
+            {/each}
+            {#each s.themes as t (t.key)}
+              {@const themeKey = themeFoldKey(s, t)}
+              <button
+                class="theme-head"
+                onclick={() => toggleFold(themeKey)}
+                aria-expanded={openFold(themeKey)}
+                title={t.label}
+              >
+                <span class="caret" class:open={openFold(themeKey)}></span>
+                <span class="theme-name">{t.label}</span>
+                <span class="theme-count">{t.runs.length}</span>
+              </button>
+              {#if openFold(themeKey)}
+                {#each t.runs as r (r.key)}
+                  {@const running = r.led === 'running'}
+                  <button
+                    class="run-row"
+                    class:selected={ui.selection?.kind === 'run' && ui.selection.key === r.key}
+                    data-nav={r.key}
+                    onclick={() => onSelect({ kind: 'run', key: r.key })}
+                    style={durationHeat(r.pane.duration_ms)}
+                    title={runTooltip(running, r.pane.duration_ms, r.pane.created_at, refMs) || r.pane.title || ''}
+                  >
+                    <span class="led led-{r.led}"></span>
+                    <span class="run-intent">{r.pane.title || '(run)'}</span>
+                    <span class="run-time">{humanTime(r.pane.created_at, refMs)}</span>
+                  </button>
+                  {#each r.resources as child (child.key)}
+                    <button
+                      class="res-row in-run"
+                      class:selected={ui.selection?.kind === 'resource' && ui.selection.key === child.key}
+                      data-nav={child.key}
+                      onclick={() => onSelect({ kind: 'resource', key: child.key })}
+                      title={child.pane.title || ''}
+                    >
+                      <span class="res-icon">{kindOf(child.pane) === 'terminal' ? '▮' : '▤'}</span>
+                      <span class="res-name">{child.pane.title || '(resource)'}</span>
+                      <span class="led led-{child.led}"></span>
+                      <span class="res-meta">{resourceMeta(child.pane)}</span>
+                    </button>
+                  {/each}
+                {/each}
+              {/if}
             {/each}
           {/if}
         {/each}
@@ -457,14 +557,46 @@
     font-variant-numeric: tabular-nums;
   }
 
+  .theme-head {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px 5px 28px;
+    font: inherit;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-faint);
+    background: none;
+    border: 0;
+    cursor: pointer;
+    text-align: left;
+  }
+  .theme-head:hover {
+    background: var(--elev, var(--panel));
+  }
+  .theme-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .theme-count {
+    flex: none;
+    font-size: 10px;
+    color: var(--ink-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
   .run-row {
     width: 100%;
     display: flex;
     align-items: center;
     gap: 7px;
-    padding: 5px 10px 5px 34px;
+    padding: 5px 10px 5px 42px;
     font: inherit;
-    background: none;
+    background: color-mix(in srgb, var(--accent) var(--dur-heat, 0%), transparent);
     border: 0;
     border-left: 2px solid transparent;
     cursor: pointer;
@@ -520,6 +652,12 @@
   .rec-row.selected {
     background: var(--accent-soft);
     border-left-color: var(--accent);
+  }
+  .res-row.in-session {
+    padding-left: 28px;
+  }
+  .res-row.in-run {
+    padding-left: 54px;
   }
   .res-icon {
     flex: none;

--- a/packages/dashboard/dashboard-core/site/src/components/Sidebar.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/Sidebar.svelte
@@ -38,16 +38,16 @@
       (v ?? '').toLowerCase().includes(q),
     );
   }
-  function themeMatches(t: typeof model.sessions[number]['themes'][number]): boolean {
+  function topicMatches(t: typeof model.sessions[number]['topics'][number]): boolean {
     return !q || t.label.toLowerCase().includes(q);
   }
   // A session's visible children under the filter: all if the session label
   // matches, else only matching resources and runs.
   function visibleSession(s: typeof model.sessions[number]) {
     if (!q || s.label.toLowerCase().includes(q)) return s;
-    const themes = s.themes
+    const topics = s.topics
       .map((t) => {
-        if (themeMatches(t)) return t;
+        if (topicMatches(t)) return t;
         const runs = t.runs
           .map((r) => {
             if (paneMatches(r)) return r;
@@ -61,8 +61,8 @@
     return {
       ...s,
       resources: s.resources.filter(paneMatches),
-      themes,
-      runs: themes.flatMap((t) => t.runs),
+      topics,
+      runs: topics.flatMap((t) => t.runs),
     };
   }
 
@@ -78,26 +78,26 @@
     model.recordings.filter((rec) => !q || rec.id.toLowerCase().includes(q)),
   );
 
-  function themeFoldKey(s: typeof sessions[number], t: typeof s.themes[number]): string {
-    return 'theme:' + s.scope + ':' + t.key;
+  function topicFoldKey(s: typeof sessions[number], t: typeof s.topics[number]): string {
+    return 'topic:' + s.scope + ':' + t.key;
   }
-  const themeDefaults = $derived(
+  const topicDefaults = $derived(
     new Map(
       sessions.flatMap((s) => {
-        const newest = s.themes.reduce<typeof s.themes[number] | null>(
+        const newest = s.topics.reduce<typeof s.topics[number] | null>(
           (best, t) => (best && (best.lastActivity ?? 0) >= (t.lastActivity ?? 0) ? best : t),
           null,
         );
-        return s.themes.map((t) => [themeFoldKey(s, t), t.key === newest?.key] as const);
+        return s.topics.map((t) => [topicFoldKey(s, t), t.key === newest?.key] as const);
       }),
     ),
   );
   function openFold(foldKey: string): boolean {
-    return ui.folds[foldKey] ?? themeDefaults.get(foldKey) ?? isOpen(foldKey);
+    return ui.folds[foldKey] ?? topicDefaults.get(foldKey) ?? isOpen(foldKey);
   }
 
-  // The filtered model the keyboard walks. Theme folds default to opening only
-  // the newest theme in each session, so completed earlier phases stay tucked away.
+  // The filtered model the keyboard walks. Topic folds default to opening only
+  // the newest topic in each session, so completed earlier phases stay tucked away.
   const filteredModel = $derived({ ...model, sessions, resources, recordings });
   const flat = $derived(flattenVisible(filteredModel, openFold));
 
@@ -162,17 +162,17 @@
   }
 
   // The fold key of the selection's closest owner. Resources live under the
-  // session, while runs live under the theme inside that session.
+  // session, while runs live under the topic inside that session.
   function ownerFoldKeyOf(sel: Selection | null): string | null {
     if (!sel || (sel.kind !== 'run' && sel.kind !== 'resource')) return null;
     for (const s of sessions) {
       if (s.resources.some((r) => r.key === sel.key)) {
         return 'sess:' + s.scope;
       }
-      for (const t of s.themes) {
-        if (t.runs.some((r) => r.key === sel.key)) return themeFoldKey(s, t);
+      for (const t of s.topics) {
+        if (t.runs.some((r) => r.key === sel.key)) return topicFoldKey(s, t);
         if (t.runs.some((r) => r.resources.some((resource) => resource.key === sel.key))) {
-          return themeFoldKey(s, t);
+          return topicFoldKey(s, t);
         }
       }
     }
@@ -280,19 +280,19 @@
                 <span class="res-meta">{resourceMeta(r.pane)}</span>
               </button>
             {/each}
-            {#each s.themes as t (t.key)}
-              {@const themeKey = themeFoldKey(s, t)}
+            {#each s.topics as t (t.key)}
+              {@const topicKey = topicFoldKey(s, t)}
               <button
-                class="theme-head"
-                onclick={() => toggleFold(themeKey)}
-                aria-expanded={openFold(themeKey)}
+                class="topic-head"
+                onclick={() => toggleFold(topicKey)}
+                aria-expanded={openFold(topicKey)}
                 title={t.label}
               >
-                <span class="caret" class:open={openFold(themeKey)}></span>
-                <span class="theme-name">{t.label}</span>
-                <span class="theme-count">{t.runs.length}</span>
+                <span class="caret" class:open={openFold(topicKey)}></span>
+                <span class="topic-name">{t.label}</span>
+                <span class="topic-count">{t.runs.length}</span>
               </button>
-              {#if openFold(themeKey)}
+              {#if openFold(topicKey)}
                 {#each t.runs as r (r.key)}
                   {@const running = r.led === 'running'}
                   <button
@@ -557,7 +557,7 @@
     font-variant-numeric: tabular-nums;
   }
 
-  .theme-head {
+  .topic-head {
     width: 100%;
     display: flex;
     align-items: center;
@@ -572,17 +572,17 @@
     cursor: pointer;
     text-align: left;
   }
-  .theme-head:hover {
+  .topic-head:hover {
     background: var(--elev, var(--panel));
   }
-  .theme-name {
+  .topic-name {
     flex: 1 1 auto;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .theme-count {
+  .topic-count {
     flex: none;
     font-size: 10px;
     color: var(--ink-faint);

--- a/packages/dashboard/dashboard-core/site/src/components/TermBody.svelte
+++ b/packages/dashboard/dashboard-core/site/src/components/TermBody.svelte
@@ -4,7 +4,8 @@
   import { metrics } from '$lib/metrics.svelte';
   import type { Pane } from '$lib/types';
 
-  // The terminal renderer: the pane's `body` is the ANSI-SGR screen. Repaint
+  // The terminal renderer: `scrollback` is plain text and `body` is the ANSI-SGR
+  // viewport. Repaint
   // imperatively (spans are built in JS) and track only the primitives that
   // should trigger a repaint, so per-frame object churn does not thrash a full
   // replaceChildren on unchanged cards.
@@ -13,10 +14,13 @@
 
   const alive = $derived(pane.alive !== false);
   const screen = $derived(pane.body ?? '');
-  const output = $derived(hasOutput(screen));
+  const scrollback = $derived(pane.scrollback ?? '');
+  const scrollbackRows = $derived(scrollback ? scrollback.split('\n').length : 0);
+  const fullScreen = $derived(scrollback ? `${scrollback}\n${screen}` : screen);
+  const output = $derived(hasOutput(fullScreen));
   const cursor = $derived<Cursor | null>(
     alive && output && pane.cursor_visible !== false && typeof pane.cursor_row === 'number'
-      ? { row: pane.cursor_row, col: pane.cursor_col ?? 0, shape: pane.cursor_shape ?? 'block' }
+      ? { row: pane.cursor_row + scrollbackRows, col: pane.cursor_col ?? 0, shape: pane.cursor_shape ?? 'block' }
       : null,
   );
   // A stable string key for the cursor: `cursor` is a fresh object each frame, so
@@ -25,6 +29,7 @@
 
   $effect(() => {
     void screen;
+    void scrollback;
     void cursorKey;
     void output;
     void alive;
@@ -34,7 +39,7 @@
     if (!el) return;
     untrack(() => {
       if (output) {
-        renderInto(el, screen, cursor);
+        renderInto(el, fullScreen, cursor);
       } else {
         const ph = document.createElement('span');
         ph.className = 'placeholder';

--- a/packages/dashboard/dashboard-core/site/src/lib/sidebar.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/sidebar.ts
@@ -39,7 +39,7 @@ export interface ResourceNode {
   parent?: string;
 }
 
-export interface ThemeNode {
+export interface TopicNode {
   key: string;
   label: string;
   runs: RunNode[];
@@ -53,7 +53,7 @@ export interface SessionNode {
   // sidebar sorts sessions by it (newest first).
   lastActivity?: number;
   resources: ResourceNode[];
-  themes: ThemeNode[];
+  topics: TopicNode[];
   runs: RunNode[];
 }
 
@@ -85,26 +85,26 @@ function lastRunActivity(runs: RunNode[]): number | undefined {
   return runs.length ? runs[runs.length - 1].pane.created_at : undefined;
 }
 
-function themeLabel(run: RunNode): string {
-  const raw = run.pane.theme?.trim();
-  return raw || 'unthemed';
+function topicLabel(run: RunNode): string {
+  const raw = run.pane.topic?.trim();
+  return raw || 'unfiled';
 }
 
-function groupRunsByTheme(runs: RunNode[]): ThemeNode[] {
-  const themes: ThemeNode[] = [];
-  const byKey = new Map<string, ThemeNode>();
+function groupRunsByTopic(runs: RunNode[]): TopicNode[] {
+  const topics: TopicNode[] = [];
+  const byKey = new Map<string, TopicNode>();
   for (const run of runs) {
-    const label = themeLabel(run);
-    let theme = byKey.get(label);
-    if (!theme) {
-      theme = { key: label, label, runs: [], lastActivity: undefined };
-      byKey.set(label, theme);
-      themes.push(theme);
+    const label = topicLabel(run);
+    let topic = byKey.get(label);
+    if (!topic) {
+      topic = { key: label, label, runs: [], lastActivity: undefined };
+      byKey.set(label, topic);
+      topics.push(topic);
     }
-    theme.runs.push(run);
-    theme.lastActivity = run.pane.created_at;
+    topic.runs.push(run);
+    topic.lastActivity = run.pane.created_at;
   }
-  return themes;
+  return topics;
 }
 
 // Newest-activity first (a session whose last run is more recent sorts above one
@@ -164,7 +164,7 @@ export function buildSidebar(
         label: s.label,
         lastActivity: lastRunActivity(runs),
         resources,
-        themes: groupRunsByTheme(runs),
+        topics: groupRunsByTopic(runs),
         runs,
       };
     })
@@ -214,8 +214,8 @@ export function flattenVisible(
     for (const s of model.sessions) {
       if (!open('sess:' + s.scope)) continue;
       for (const r of s.resources) out.push({ selection: { kind: 'resource', key: r.key } });
-      for (const t of s.themes) {
-        if (!open('theme:' + s.scope + ':' + t.key)) continue;
+      for (const t of s.topics) {
+        if (!open('topic:' + s.scope + ':' + t.key)) continue;
         for (const r of t.runs) {
           out.push({ selection: { kind: 'run', key: r.key } });
           for (const resource of r.resources) out.push({ selection: { kind: 'resource', key: resource.key } });

--- a/packages/dashboard/dashboard-core/site/src/lib/sidebar.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/sidebar.ts
@@ -1,10 +1,11 @@
-// The unified sidebar's data model: sessions (each holding its runs), resources,
-// and recordings, grouped under foldable sections. Building the tree once — and
-// reading it for both rendering and keyboard navigation — guarantees that what
+// The unified sidebar's data model: sessions (each holding resources and runs),
+// global resources, and recordings, grouped under foldable sections. Building
+// the tree once and reading it for both rendering and keyboard navigation
+// guarantees that what
 // `j`/`k` walk is exactly what the eye sees, honouring every fold.
 import { paneScope, compareCreatedAt } from './scope.ts';
 import { feedSessions, shortScope, type FeedSession } from './feed-sessions.ts';
-import { isRun, isResource, ledOf, kindOf, withKey, type Led } from './run.ts';
+import { isRun, isResource, ledOf, kindOf, paneId, withKey, type Led } from './run.ts';
 import type { Pane, PaneRecord } from './types.ts';
 import type { RecordingInfo } from './stream.svelte.ts';
 
@@ -28,6 +29,21 @@ export interface RunNode {
   key: string;
   pane: Pane;
   led: Led;
+  resources: ResourceNode[];
+}
+
+export interface ResourceNode {
+  key: string;
+  pane: Pane;
+  led: Led;
+  parent?: string;
+}
+
+export interface ThemeNode {
+  key: string;
+  label: string;
+  runs: RunNode[];
+  lastActivity?: number;
 }
 
 export interface SessionNode {
@@ -36,13 +52,9 @@ export interface SessionNode {
   // The session's newest run's created_at; the card renders it as an age and the
   // sidebar sorts sessions by it (newest first).
   lastActivity?: number;
+  resources: ResourceNode[];
+  themes: ThemeNode[];
   runs: RunNode[];
-}
-
-export interface ResourceNode {
-  key: string;
-  pane: Pane;
-  led: Led;
 }
 
 export interface SidebarModel {
@@ -73,6 +85,28 @@ function lastRunActivity(runs: RunNode[]): number | undefined {
   return runs.length ? runs[runs.length - 1].pane.created_at : undefined;
 }
 
+function themeLabel(run: RunNode): string {
+  const raw = run.pane.theme?.trim();
+  return raw || 'unthemed';
+}
+
+function groupRunsByTheme(runs: RunNode[]): ThemeNode[] {
+  const themes: ThemeNode[] = [];
+  const byKey = new Map<string, ThemeNode>();
+  for (const run of runs) {
+    const label = themeLabel(run);
+    let theme = byKey.get(label);
+    if (!theme) {
+      theme = { key: label, label, runs: [], lastActivity: undefined };
+      byKey.set(label, theme);
+      themes.push(theme);
+    }
+    theme.runs.push(run);
+    theme.lastActivity = run.pane.created_at;
+  }
+  return themes;
+}
+
 // Newest-activity first (a session whose last run is more recent sorts above one
 // whose last run is older), scope as the stable tie-break. A session with no
 // timed run sorts last.
@@ -96,11 +130,17 @@ export function buildSidebar(
   // ordering (by last run activity), so it is taken here, not there.
   const sessionOrder: FeedSession[] = feedSessions(panes);
   const runsByScope = new Map<string, RunNode[]>();
+  const resourcesByScope = new Map<string, ResourceNode[]>();
   for (const { key, pane } of all) {
-    if (!isRun(key, pane)) continue;
-    const rows = runsByScope.get(pane.scope) ?? [];
-    rows.push({ key, pane, led: ledOf(pane) });
-    runsByScope.set(pane.scope, rows);
+    if (isRun(key, pane)) {
+      const rows = runsByScope.get(pane.scope) ?? [];
+      rows.push({ key, pane, led: ledOf(pane), resources: [] });
+      runsByScope.set(pane.scope, rows);
+    } else if (isResource(key, pane)) {
+      const rows = resourcesByScope.get(pane.scope) ?? [];
+      rows.push({ key, pane, led: ledOf(pane), parent: pane.parent });
+      resourcesByScope.set(pane.scope, rows);
+    }
   }
 
   // Keep only scopes that hold runs (a pure-resource scope isn't a session),
@@ -109,10 +149,22 @@ export function buildSidebar(
   const sessions: SessionNode[] = sessionOrder
     .map((s) => {
       const runs = (runsByScope.get(s.scope) ?? []).sort(compareRunsOldestFirst);
+      const allResources = (resourcesByScope.get(s.scope) ?? []).sort(
+        (a, b) =>
+          compareCreatedAt(a.pane.created_at, b.pane.created_at) || a.key.localeCompare(b.key),
+      );
+      const runsByPaneId = new Map(runs.map((run) => [paneId(run.key), run]));
+      for (const resource of allResources) {
+        const parent = resource.parent ? runsByPaneId.get(resource.parent) : undefined;
+        if (parent) parent.resources.push(resource);
+      }
+      const resources = allResources.filter((resource) => !resource.parent || !runsByPaneId.has(resource.parent));
       return {
         scope: s.scope,
         label: s.label,
         lastActivity: lastRunActivity(runs),
+        resources,
+        themes: groupRunsByTheme(runs),
         runs,
       };
     })
@@ -121,7 +173,7 @@ export function buildSidebar(
 
   const resources: ResourceNode[] = all
     .filter(({ key, pane }) => isResource(key, pane))
-    .map(({ key, pane }) => ({ key, pane, led: ledOf(pane) }))
+    .map(({ key, pane }) => ({ key, pane, led: ledOf(pane), parent: pane.parent }))
     .sort(
       (a, b) =>
         compareCreatedAt(a.pane.created_at, b.pane.created_at) || a.key.localeCompare(b.key),
@@ -143,7 +195,7 @@ export function resourceMeta(p: Pane): string {
   return p.subtitle || p.kind || 'html';
 }
 
-// One flattened, currently-visible selectable row, in render order — exactly what
+// One flattened, currently-visible selectable row in render order, exactly what
 // `j`/`k` step through. Session headers and section headers are not selectable
 // targets (folding them is a separate motion), so only runs, resources, and
 // recordings appear here.
@@ -161,7 +213,14 @@ export function flattenVisible(
   if (open('sessions')) {
     for (const s of model.sessions) {
       if (!open('sess:' + s.scope)) continue;
-      for (const r of s.runs) out.push({ selection: { kind: 'run', key: r.key } });
+      for (const r of s.resources) out.push({ selection: { kind: 'resource', key: r.key } });
+      for (const t of s.themes) {
+        if (!open('theme:' + s.scope + ':' + t.key)) continue;
+        for (const r of t.runs) {
+          out.push({ selection: { kind: 'run', key: r.key } });
+          for (const resource of r.resources) out.push({ selection: { kind: 'resource', key: resource.key } });
+        }
+      }
     }
   }
   if (open('resources')) {

--- a/packages/dashboard/dashboard-core/site/src/lib/types.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/types.ts
@@ -39,7 +39,7 @@ export interface PaneRecord {
   // feed shows this instead of an age so a row reads as "how long it took".
   duration_ms?: number;
   // exec-only: fold group inside the session.
-  theme?: string;
+  topic?: string;
   // exec-only: 1-based source line currently executing or where an error raised.
   line?: number;
   error_line?: number;

--- a/packages/dashboard/dashboard-core/site/src/lib/types.ts
+++ b/packages/dashboard/dashboard-core/site/src/lib/types.ts
@@ -8,11 +8,16 @@ export interface PaneRecord {
   kind?: string;
   title?: string;
   subtitle?: string;
+  // Optional parent pane id within the same producer, used to nest resources
+  // under the run that created them.
+  parent?: string;
   // Milliseconds since the epoch, stamped once when the pane first appears. Every
   // pane has it; the card renders it as a human age.
   created_at?: number;
   // The one large mutable field for terminal/html/data, interpreted by `kind`.
   body?: string;
+  // terminal-only: plain scrollback above the styled viewport in `body`.
+  scrollback?: string;
   // terminal-only geometry, cursor, and exit state
   rows?: number;
   cols?: number;
@@ -33,6 +38,11 @@ export interface PaneRecord {
   // exec-only: wall-clock the run took, in milliseconds, set when it finishes. The
   // feed shows this instead of an age so a row reads as "how long it took".
   duration_ms?: number;
+  // exec-only: fold group inside the session.
+  theme?: string;
+  // exec-only: 1-based source line currently executing or where an error raised.
+  line?: number;
+  error_line?: number;
   // Inline-trace execution: a JSON-encoded array of `{line, text}` (the hub stores
   // it as canonical text like the data body, so the frontend parses it). Each
   // entry pairs a captured stdout chunk with the 1-based source line that emitted

--- a/packages/dashboard/dashboard-core/src/dashboard/hub.rs
+++ b/packages/dashboard/dashboard-core/src/dashboard/hub.rs
@@ -109,7 +109,7 @@ fn view_scalars(view: &View) -> Vec<ScalarField> {
             field("lang", Scalar::Str(e.lang.clone())),
             field("running", Scalar::Bool(e.running)),
             field("ok", e.ok.map_or(Scalar::Absent, Scalar::Bool)),
-            field("theme", e.theme.clone().map_or(Scalar::Absent, Scalar::Str)),
+            field("topic", e.topic.clone().map_or(Scalar::Absent, Scalar::Str)),
             field(
                 "duration_ms",
                 e.duration_ms.map_or(Scalar::Absent, |ms| {
@@ -698,7 +698,7 @@ mod tests {
                     running: false,
                     ok: Some(true),
                     duration_ms: Some(9),
-                    theme: Some("test".to_owned()),
+                    topic: Some("test".to_owned()),
                     line: None,
                     error_line: None,
                     trace: Vec::new(),
@@ -743,7 +743,7 @@ mod tests {
                 running: true,
                 ok: None,
                 duration_ms: None,
-                theme: None,
+                topic: None,
                 line: None,
                 error_line: None,
                 trace: Vec::new(),
@@ -765,7 +765,7 @@ mod tests {
                 running: false,
                 ok: Some(true),
                 duration_ms: Some(4),
-                theme: Some("test".to_owned()),
+                topic: Some("test".to_owned()),
                 line: None,
                 error_line: None,
                 trace: vec![ExecTraceLine {

--- a/packages/dashboard/dashboard-core/src/dashboard/hub.rs
+++ b/packages/dashboard/dashboard-core/src/dashboard/hub.rs
@@ -109,11 +109,22 @@ fn view_scalars(view: &View) -> Vec<ScalarField> {
             field("lang", Scalar::Str(e.lang.clone())),
             field("running", Scalar::Bool(e.running)),
             field("ok", e.ok.map_or(Scalar::Absent, Scalar::Bool)),
+            field("theme", e.theme.clone().map_or(Scalar::Absent, Scalar::Str)),
             field(
                 "duration_ms",
                 e.duration_ms.map_or(Scalar::Absent, |ms| {
                     Scalar::Int(i64::try_from(ms).unwrap_or(i64::MAX))
                 }),
+            ),
+            field(
+                "line",
+                e.line
+                    .map_or(Scalar::Absent, |line| Scalar::Int(i64::from(line))),
+            ),
+            field(
+                "error_line",
+                e.error_line
+                    .map_or(Scalar::Absent, |line| Scalar::Int(i64::from(line))),
             ),
         ],
         View::Data(d) => vec![field("renderer", Scalar::Str(d.renderer.clone()))],
@@ -136,7 +147,10 @@ struct TextField {
 fn view_texts(view: &View) -> Vec<TextField> {
     let field = |name, value| TextField { name, value };
     match view {
-        View::Terminal(t) => vec![field("body", t.screen.clone())],
+        View::Terminal(t) => vec![
+            field("body", t.screen.clone()),
+            field("scrollback", t.scrollback.clone()),
+        ],
         View::Html(h) => vec![field("body", h.html.clone())],
         View::Exec(e) => vec![
             field("source", e.source.clone()),
@@ -215,6 +229,7 @@ struct Slot {
     kind: &'static str,
     title: String,
     subtitle: String,
+    parent: Option<String>,
     /// Cached scalar meta, keyed by field name. Absent from the map until first
     /// written, so the first apply writes every field the view declares.
     scalars: HashMap<&'static str, Scalar>,
@@ -329,6 +344,7 @@ impl DocState {
                 // when the real value is empty.
                 title: sentinel(),
                 subtitle: sentinel(),
+                parent: None,
                 scalars: HashMap::new(),
                 texts,
             },
@@ -352,6 +368,16 @@ impl DocState {
                 .map_err(loro_err)?;
             slot.subtitle.clone_from(&pane.subtitle);
         }
+        if slot.parent != pane.parent {
+            match &pane.parent {
+                Some(parent) => slot
+                    .meta
+                    .insert("parent", parent.as_str())
+                    .map_err(loro_err)?,
+                None => slot.meta.delete("parent").map_err(loro_err)?,
+            }
+            slot.parent.clone_from(&pane.parent);
+        }
         for field in view_scalars(&pane.view) {
             if slot.scalars.get(field.name) != Some(&field.value) {
                 write_scalar(&slot.meta, field.name, &field.value)?;
@@ -372,21 +398,16 @@ impl DocState {
         Ok(())
     }
 
-    /// Drop every pane under `scope` (its producer disconnected). Returns the
-    /// delta when the scope held anything.
+    /// Keep panes under `scope` when its producer disconnects.
+    ///
+    /// A terminal/resource pane is still useful after the process or producer
+    /// dies: it is the final state a human wants to inspect. The next live
+    /// snapshot from the same scope still reconciles normally through
+    /// [`apply_scope`](Self::apply_scope), including deleting panes that are no
+    /// longer reported by that producer.
     fn remove_scope(&mut self, scope: &str) -> Result<Option<Vec<u8>>> {
-        let prefix = format!("{scope}{SCOPE_SEP}");
-        let dead: Vec<String> = self
-            .panes
-            .keys()
-            .filter(|key| key.starts_with(&prefix))
-            .cloned()
-            .collect();
-        if dead.is_empty() {
-            return Ok(None);
-        }
-        self.drop_keys(&dead)?;
-        self.commit_delta()
+        let _ = scope;
+        Ok(None)
     }
 
     fn drop_keys(&mut self, keys: &[String]) -> Result<()> {
@@ -538,6 +559,7 @@ mod tests {
                 cols: 80,
                 alive: true,
                 screen: screen.to_owned(),
+                scrollback: String::new(),
                 cursor_row: 0,
                 cursor_col: 0,
                 cursor_visible: true,
@@ -555,7 +577,7 @@ mod tests {
     }
 
     /// The core multi-producer invariant: one producer's reconcile never touches
-    /// another's panes, and dropping a producer removes only its own.
+    /// another's panes, and dropping a producer keeps the final snapshot.
     #[test]
     fn scopes_do_not_clobber_each_other() {
         let mut state = DocState::new();
@@ -571,10 +593,11 @@ mod tests {
         assert_eq!(state.panes.len(), 2);
         assert!(state.panes.keys().any(|key| key.starts_with("b\u{1f}")));
 
-        // Disconnecting producer a removes only a's panes.
+        // Disconnecting producer a keeps the last visible state.
         state.remove_scope("a").unwrap();
-        assert_eq!(state.panes.len(), 1);
-        assert!(state.panes.keys().all(|key| key.starts_with("b\u{1f}")));
+        assert_eq!(state.panes.len(), 2);
+        assert!(state.panes.keys().any(|key| key.starts_with("a\u{1f}")));
+        assert!(state.panes.keys().any(|key| key.starts_with("b\u{1f}")));
     }
 
     /// A tick that changes nothing produces no delta, so idle producers do not
@@ -645,6 +668,16 @@ mod tests {
         assert!(state.remove_scope("ghost").unwrap().is_none());
     }
 
+    #[test]
+    fn removing_scope_retains_last_panes() {
+        let mut state = DocState::new();
+        state.apply_scope("a", &[terminal("1", "last")]).unwrap();
+        let key = doc_key("a", "1");
+        assert!(state.panes.contains_key(&key));
+        assert!(state.remove_scope("a").unwrap().is_none());
+        assert_eq!(state.panes[&key].text("body"), "last");
+    }
+
     /// Heterogeneous panes coexist under one scope: a terminal, an HTML pane, an
     /// exec pane, and a data pane all land with the right `kind` and text fields,
     /// and an unchanged re-apply of the mixed set yields no delta.
@@ -665,6 +698,9 @@ mod tests {
                     running: false,
                     ok: Some(true),
                     duration_ms: Some(9),
+                    theme: Some("test".to_owned()),
+                    line: None,
+                    error_line: None,
                     trace: Vec::new(),
                 },
             ),
@@ -707,6 +743,9 @@ mod tests {
                 running: true,
                 ok: None,
                 duration_ms: None,
+                theme: None,
+                line: None,
+                error_line: None,
                 trace: Vec::new(),
             },
         );
@@ -726,6 +765,9 @@ mod tests {
                 running: false,
                 ok: Some(true),
                 duration_ms: Some(4),
+                theme: Some("test".to_owned()),
+                line: None,
+                error_line: None,
                 trace: vec![ExecTraceLine {
                     line: 1,
                     text: "hi\n".to_owned(),

--- a/packages/dashboard/dashboard-core/src/pane.rs
+++ b/packages/dashboard/dashboard-core/src/pane.rs
@@ -40,6 +40,10 @@ pub struct Pane {
     /// Optional one-line subtitle (args, a status, a URL). Empty hides it.
     #[serde(default)]
     pub subtitle: String,
+    /// Optional parent pane id within the same producer, used to nest resources
+    /// under the run that created them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
     /// The pane body, tagged by `kind` on the wire.
     pub view: View,
 }
@@ -54,6 +58,7 @@ impl Pane {
             id: id.into(),
             title,
             subtitle,
+            parent: None,
             view: View::Terminal(view),
         }
     }
@@ -65,6 +70,7 @@ impl Pane {
             id: id.into(),
             title: title.into(),
             subtitle: String::new(),
+            parent: None,
             view: View::Html(HtmlView { html: html.into() }),
         }
     }
@@ -80,6 +86,7 @@ impl Pane {
             id: id.into(),
             title,
             subtitle: String::new(),
+            parent: None,
             view: View::Exec(view),
         }
     }
@@ -97,6 +104,7 @@ impl Pane {
             id: id.into(),
             title: title.into(),
             subtitle: String::new(),
+            parent: None,
             view: View::Data(DataView {
                 renderer: renderer.into(),
                 data,
@@ -153,6 +161,9 @@ pub struct TerminalView {
     /// encoding per-cell color and attributes. The dashboard parses the SGR
     /// back into styled spans; a plain reader still sees the text.
     pub screen: String,
+    /// Plain scrollback lines that have moved above the visible viewport.
+    #[serde(default)]
+    pub scrollback: String,
     // These fields were added after the first wire shape. `#[serde(default)]`
     // keeps a mixed-version dashboard working: a producer built before this
     // change streams views without them, and the aggregator drops a snapshot
@@ -225,6 +236,15 @@ pub struct ExecView {
     /// shows it instead of an age so a row reads as "how long it took".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<u64>,
+    /// Fold group label inside the producer session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<String>,
+    /// 1-based source line currently executing while running.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    /// 1-based source line where a failed run raised, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_line: Option<u32>,
     /// Inline-trace execution: each chunk of captured stdout paired with the
     /// 1-based `source` line that emitted it, in emission order, so the view can
     /// render output beside the line that produced it. This is the "inline
@@ -330,6 +350,7 @@ mod tests {
             cols: 80,
             alive: true,
             screen: screen.to_owned(),
+            scrollback: String::new(),
             cursor_row: 0,
             cursor_col: 0,
             cursor_visible: true,
@@ -378,6 +399,9 @@ mod tests {
                         running: false,
                         ok: Some(true),
                         duration_ms: Some(12),
+                        theme: Some("test".to_owned()),
+                        line: None,
+                        error_line: None,
                         trace: Vec::new(),
                     },
                 ),
@@ -409,6 +433,9 @@ mod tests {
                 running: true,
                 ok: None,
                 duration_ms: None,
+                theme: None,
+                line: None,
+                error_line: None,
                 trace: Vec::new(),
             },
         );

--- a/packages/dashboard/dashboard-core/src/pane.rs
+++ b/packages/dashboard/dashboard-core/src/pane.rs
@@ -238,7 +238,7 @@ pub struct ExecView {
     pub duration_ms: Option<u64>,
     /// Fold group label inside the producer session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub theme: Option<String>,
+    pub topic: Option<String>,
     /// 1-based source line currently executing while running.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line: Option<u32>,
@@ -399,7 +399,7 @@ mod tests {
                         running: false,
                         ok: Some(true),
                         duration_ms: Some(12),
-                        theme: Some("test".to_owned()),
+                        topic: Some("test".to_owned()),
                         line: None,
                         error_line: None,
                         trace: Vec::new(),
@@ -433,7 +433,7 @@ mod tests {
                 running: true,
                 ok: None,
                 duration_ms: None,
-                theme: None,
+                topic: None,
                 line: None,
                 error_line: None,
                 trace: Vec::new(),

--- a/packages/dashboard/dashboard-core/tests/pipeline.rs
+++ b/packages/dashboard/dashboard-core/tests/pipeline.rs
@@ -26,6 +26,9 @@ fn exec_pane() -> Pane {
             running: false,
             ok: Some(true),
             duration_ms: Some(7),
+            theme: Some("test".to_owned()),
+            line: None,
+            error_line: None,
             trace: Vec::new(),
         },
     )

--- a/packages/dashboard/dashboard-core/tests/pipeline.rs
+++ b/packages/dashboard/dashboard-core/tests/pipeline.rs
@@ -26,7 +26,7 @@ fn exec_pane() -> Pane {
             running: false,
             ok: Some(true),
             duration_ms: Some(7),
-            theme: Some("test".to_owned()),
+            topic: Some("test".to_owned()),
             line: None,
             error_line: None,
             trace: Vec::new(),

--- a/packages/dashboard/dashboard/src/main.rs
+++ b/packages/dashboard/dashboard/src/main.rs
@@ -257,7 +257,7 @@ fn demo_panes(tick: u64) -> Vec<Pane> {
             running,
             ok: if running { None } else { Some(true) },
             duration_ms: if running { None } else { Some(420) },
-            theme: Some("demo".to_owned()),
+            topic: Some("demo".to_owned()),
             line: if running { Some(2) } else { None },
             error_line: None,
             // The loop's prints all come from the second source line.

--- a/packages/dashboard/dashboard/src/main.rs
+++ b/packages/dashboard/dashboard/src/main.rs
@@ -211,6 +211,7 @@ fn demo_panes(tick: u64) -> Vec<Pane> {
             alive: true,
             // A green "tick" line, exercising the SGR renderer.
             screen: format!("\x1b[32mtick {tick}\x1b[0m\n{bar}\nany resource is a pane"),
+            scrollback: format!("previous tick {}", tick.saturating_sub(1)),
             cursor_row: 0,
             cursor_col: 0,
             cursor_visible: false,
@@ -256,6 +257,9 @@ fn demo_panes(tick: u64) -> Vec<Pane> {
             running,
             ok: if running { None } else { Some(true) },
             duration_ms: if running { None } else { Some(420) },
+            theme: Some("demo".to_owned()),
+            line: if running { Some(2) } else { None },
+            error_line: None,
             // The loop's prints all come from the second source line.
             trace: if running {
                 Vec::new()

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1900,7 +1900,7 @@
     # session_set_name joined the surface in #1615 but this expected set was
     # not updated with it; the stale drv kept passing from cache on main until
     # this package's inputs changed and forced a rebuild.
-    + "expected = {'python_exec','read','kernel_trace','tui_act','session_set_name','theme_set','reply'}; "
+    + "expected = {'python_exec','read','kernel_trace','tui_act','session_set_name','topic_set','reply'}; "
     + "assert set(names) == expected, ('tool surface drifted: %r' % (names,)); "
     + "from ix_notebook_mcp import registry; instr = mcp._mcp_server.instructions; "
     + "assert 'root=' not in instr, 'a parameter/signature leaked into the instructions'; "
@@ -3158,8 +3158,8 @@
 
             named = await tools.session_set_name("wedge smoke")
             assert "wedge smoke" in " ".join(getattr(c, "text", "") or "" for c in named), named
-            themed = await tools.theme_set("wedge validation")
-            assert "wedge validation" in " ".join(getattr(c, "text", "") or "" for c in themed), themed
+            topic = await tools.topic_set("wedge validation")
+            assert "wedge validation" in " ".join(getattr(c, "text", "") or "" for c in topic), topic
 
             started = loop.time()
             clamped = await tools.python_exec(

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1900,7 +1900,7 @@
     # session_set_name joined the surface in #1615 but this expected set was
     # not updated with it; the stale drv kept passing from cache on main until
     # this package's inputs changed and forced a rebuild.
-    + "expected = {'python_exec','read','kernel_trace','tui_act','session_set_name','topic_set','reply'}; "
+    + "expected = {'python_exec','pr_watch','read','kernel_trace','tui_act','session_set_name','topic_set','reply'}; "
     + "assert set(names) == expected, ('tool surface drifted: %r' % (names,)); "
     + "from ix_notebook_mcp import registry; instr = mcp._mcp_server.instructions; "
     + "assert 'root=' not in instr, 'a parameter/signature leaked into the instructions'; "

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1900,7 +1900,7 @@
     # session_set_name joined the surface in #1615 but this expected set was
     # not updated with it; the stale drv kept passing from cache on main until
     # this package's inputs changed and forced a rebuild.
-    + "expected = {'python_exec','read','kernel_trace','tui_act','session_set_name','reply'}; "
+    + "expected = {'python_exec','read','kernel_trace','tui_act','session_set_name','theme_set','reply'}; "
     + "assert set(names) == expected, ('tool surface drifted: %r' % (names,)); "
     + "from ix_notebook_mcp import registry; instr = mcp._mcp_server.instructions; "
     + "assert 'root=' not in instr, 'a parameter/signature leaked into the instructions'; "
@@ -3158,6 +3158,8 @@
 
             named = await tools.session_set_name("wedge smoke")
             assert "wedge smoke" in " ".join(getattr(c, "text", "") or "" for c in named), named
+            themed = await tools.theme_set("wedge validation")
+            assert "wedge validation" in " ".join(getattr(c, "text", "") or "" for c in themed), themed
 
             started = loop.time()
             clamped = await tools.python_exec(

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -139,6 +139,13 @@ SESSION = (
     "the intent titles the run's card, so the board reads as a list of intents, not raw code."
 )
 
+PR_WATCH = (
+    "For pull requests, use `pr_watch` instead of a hand-written polling loop. It creates a "
+    "live PR resource under the current task, shows each required check or action with elapsed "
+    "time, enables auto merge by default, and notifies the CLI when the PR merges, fails, or "
+    "times out."
+)
+
 DISCOVER = (
     "`api()` is your reference (always in the namespace, no import): it lists every helper — the "
     "kernel builtins and each bundled module's public surface — with its live signature and a "

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -104,14 +104,19 @@ BLOCKING = (
 RESULT_CONTRACT = (
     "Cells behave like a notebook: the last expression is the result, whatever its type (`2+2` "
     "returns 4, `df` returns the styled table with compact CSV to you, a string returns "
-    "verbatim, a dict/list renders as a table), and anything the cell printed comes back with "
+    "verbatim, a dict/list renders as a table). Prefer returning a Polars DataFrame for "
+    "structured facts you expect to inspect, sort, filter, or show on the dashboard. Anything "
+    "the cell printed comes back with "
     "it. A cell whose last statement is None (an assignment, a side-effecting call) returns its "
     "stdout, or a quiet ok. `yield` streams: each yielded value reaches both the human and you "
     "the moment it is produced, so yield as you go to report progress and partial results. "
     "`Result` is the opt-in for splitting the two views, `Result(user_html=..., llm_result=..., "
     "llm_images=...)`, when the human should see something rich that you should not pay tokens "
     "for (note: an explicit Result suppresses the automatic stdout echo; page "
-    "jobs['<id>'].output instead)."
+    "jobs['<id>'].output instead). For reusable Python in the kernel, write explicit "
+    "annotations at function and data boundaries. For package Python edits, run the repo's "
+    "type-checking entry point when one exists, and do not treat an untyped compile-only "
+    "check as equivalent."
 )
 
 # --- kernel guide only ---
@@ -126,9 +131,12 @@ SESSION = (
     "you make is grouped under this session on the live dashboard, and a human may "
     "be watching several agents at once; a clear name is how they tell yours apart. "
     "It defaults to the connecting client and working directory (e.g. `claude-code · index`), "
-    "which is ambiguous once agents share a repo, so name it. Also pass a one-line "
-    "`intent` on every `python_exec` (it is required): the intent titles the run's "
-    "card, so the board reads as a list of intents, not raw code."
+    "which is ambiguous once agents share a repo, so name it. Then call `theme_set` "
+    "before the first `python_exec` call and whenever you switch phases. A theme "
+    "groups a handful of related runs under one fold in the dashboard, so use labels "
+    "like `inspect diff`, `patch sidebar`, or `validate build`, not one theme per "
+    "call. Also pass a one-line `intent` on every `python_exec` (it is required): "
+    "the intent titles the run's card, so the board reads as a list of intents, not raw code."
 )
 
 DISCOVER = (
@@ -156,15 +164,18 @@ NO_SHELL = (
 )
 
 NU = (
-    "For everything else a shell would do — running a command and shaping its output, a "
-    "pipeline, listing/filtering/transforming, reaching into files or the web — reach for `nu` "
+    "For everything else a shell would do: running a command and shaping its output, a "
+    "pipeline, listing/filtering/transforming, reaching into files or the web, reach for `nu` "
     "FIRST, before `sh`. `await nu(\"ls | where size > 1kb | sort-by size\")` runs a real "
-    "nushell pipeline and every result comes back as a polars DataFrame, structured end to end "
+    "nushell pipeline and every result comes back as a Polars DataFrame, structured end to end "
     "(`ls`, `ps`, `sys`, `open Cargo.toml`, `from csv`, `http get`, `where`, `group-by`, "
     "`select`) — no jq/awk/sed/cut text munging and no scraping columns out of a text dump. A "
     "record is one row, a scalar a one-cell `value` column; dates and durations arrive as real "
     "Datetime/Duration columns and filesize as bytes, so you filter and sort on typed values, "
-    "not strings. The engine is embedded and PERSISTENT, a REPL: a `let`, a `def`, or a `cd` in "
+    "not strings. For `gh ... --json`, clear color forcing before `from json`: "
+    "`with-env {NO_COLOR: \"1\" CLICOLOR: \"0\" CLICOLOR_FORCE: \"0\" FORCE_COLOR: \"0\"} "
+    "{ gh pr view 1 --json state | complete | get stdout | from json }`. "
+    "The engine is embedded and PERSISTENT, a REPL: a `let`, a `def`, or a `cd` in "
     "one call is visible to the next, so bind an expensive fetch once (`let data = http get "
     "...`) and query it across calls; `nu.reset()` clears that state. Pipe a polars frame you "
     "already have THROUGH a pipeline with `await nu(\"where a > 1 | sort-by a\", input=df)`. Use "
@@ -251,7 +262,7 @@ OUTPUT_HTML = (
 )
 
 POLARS = (
-    "Prefer polars for any tabular data: return a DataFrame (or `Result.of(df)`) and the human "
+    "Prefer Polars for any tabular data: return a DataFrame (or `Result.of(df)`) and the human "
     "gets the styled HTML table for free while you get the frame as compact, untruncated CSV — so "
     "you never hand-build a table and a wide/long-stringed frame is never clipped to you. Use "
     "`pl`; pandas is not bundled. Even key/value data — environment variables, a config dict, "

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -131,10 +131,10 @@ SESSION = (
     "you make is grouped under this session on the live dashboard, and a human may "
     "be watching several agents at once; a clear name is how they tell yours apart. "
     "It defaults to the connecting client and working directory (e.g. `claude-code · index`), "
-    "which is ambiguous once agents share a repo, so name it. Then call `theme_set` "
-    "before the first `python_exec` call and whenever you switch phases. A theme "
+    "which is ambiguous once agents share a repo, so name it. Then call `topic_set` "
+    "before the first `python_exec` call and whenever you switch phases. A topic "
     "groups a handful of related runs under one fold in the dashboard, so use labels "
-    "like `inspect diff`, `patch sidebar`, or `validate build`, not one theme per "
+    "like `inspect diff`, `patch sidebar`, or `validate build`, not one topic per "
     "call. Also pass a one-line `intent` on every `python_exec` (it is required): "
     "the intent titles the run's card, so the board reads as a list of intents, not raw code."
 )

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -189,7 +189,12 @@ class Kernel:
             return outputs, summary
 
     async def python_exec(
-        self, code: str, budget: float, name: str | None = None, session: str | None = None
+        self,
+        code: str,
+        budget: float,
+        name: str | None = None,
+        session: str | None = None,
+        theme: str | None = None,
     ) -> tuple[list[dict], dict | None]:
         """Run user ``code`` with a foreground budget; return (outputs, summary).
 
@@ -206,9 +211,10 @@ class Kernel:
         """
         name_arg = "None" if name is None else repr(name)
         session_arg = "None" if session is None else repr(session)
+        theme_arg = "None" if theme is None else repr(theme)
         wrapper = (
             f"await __ix_exec({code!r}, budget={float(budget)!r}, "
-            f"name={name_arg}, session={session_arg})"
+            f"name={name_arg}, session={session_arg}, theme={theme_arg})"
         )
         grace = self._config.wedge_grace
         deadline = float(budget) + grace
@@ -233,6 +239,10 @@ class Kernel:
         shell channel instead of ``__ix_exec``.
         """
         await self._execute(f"session.name = {name!r}\nsession._sync()", timeout=10.0)
+
+    async def set_theme(self, theme: str) -> None:
+        """Set the dashboard theme without creating an execution card."""
+        await self._execute(f"session.theme = {theme!r}", timeout=10.0)
 
     async def _interrupt(self) -> bool:
         """Break a synchronous call wedging the kernel's event loop. ipykernel's

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -194,7 +194,7 @@ class Kernel:
         budget: float,
         name: str | None = None,
         session: str | None = None,
-        theme: str | None = None,
+        topic: str | None = None,
     ) -> tuple[list[dict], dict | None]:
         """Run user ``code`` with a foreground budget; return (outputs, summary).
 
@@ -211,10 +211,10 @@ class Kernel:
         """
         name_arg = "None" if name is None else repr(name)
         session_arg = "None" if session is None else repr(session)
-        theme_arg = "None" if theme is None else repr(theme)
+        topic_arg = "None" if topic is None else repr(topic)
         wrapper = (
             f"await __ix_exec({code!r}, budget={float(budget)!r}, "
-            f"name={name_arg}, session={session_arg}, theme={theme_arg})"
+            f"name={name_arg}, session={session_arg}, topic={topic_arg})"
         )
         grace = self._config.wedge_grace
         deadline = float(budget) + grace
@@ -240,9 +240,9 @@ class Kernel:
         """
         await self._execute(f"session.name = {name!r}\nsession._sync()", timeout=10.0)
 
-    async def set_theme(self, theme: str) -> None:
-        """Set the dashboard theme without creating an execution card."""
-        await self._execute(f"session.theme = {theme!r}", timeout=10.0)
+    async def set_topic(self, topic: str) -> None:
+        """Set the dashboard topic without creating an execution card."""
+        await self._execute(f"session.topic = {topic!r}", timeout=10.0)
 
     async def _interrupt(self) -> bool:
         """Break a synchronous call wedging the kernel's event loop. ipykernel's

--- a/packages/mcp/ix_notebook_mcp/pane_bridge.py
+++ b/packages/mcp/ix_notebook_mcp/pane_bridge.py
@@ -111,15 +111,18 @@ def _resource_pane(res: dict) -> dict:
     pane_id = f"resource/{res['id']}"
     title = res.get("title") or res["id"]
     kind = res.get("kind") or ""
+    status = res.get("status") or "live"
+    subtitle = f"{kind} · {status}" if kind else status
     body = res.get("html") or ""
+    parent = res.get("execution_id") or None
     if kind == "data":
         try:
             spec = json.loads(body)
         except (json.JSONDecodeError, TypeError):
             spec = None
         if isinstance(spec, dict) and isinstance(spec.get("renderer"), str) and "data" in spec:
-            return data_pane(pane_id, title, spec["renderer"], spec["data"], subtitle=kind)
-    return html_pane(pane_id, title, body, subtitle=kind)
+            return data_pane(pane_id, title, spec["renderer"], spec["data"], subtitle=subtitle, parent=parent)
+    return html_pane(pane_id, title, body, subtitle=subtitle, parent=parent)
 
 
 def _panes(conn: sqlite3.Connection) -> list[dict]:
@@ -161,6 +164,9 @@ def _panes(conn: sqlite3.Connection) -> list[dict]:
                 result=row.get("result") or "",
                 ok=_ok(status),
                 duration_ms=duration_ms,
+                theme=row.get("theme"),
+                line=row.get("line"),
+                error_line=row.get("error_line"),
                 title=intent,
             )
         )
@@ -180,12 +186,11 @@ def _panes(conn: sqlite3.Connection) -> list[dict]:
                     spec["renderer"],
                     spec["data"],
                     subtitle="output",
+                    parent=row["id"],
                 )
             )
         elif any(_is_rich(out) for out in outputs) and (rendered := _render_outputs(outputs)):
-            panes.append(
-                html_pane(f"{row['id']}/out", intent or "output", rendered, subtitle="output")
-            )
+            panes.append(html_pane(f"{row['id']}/out", intent or "output", rendered, subtitle="output", parent=row["id"]))
     # The agent's curated presentation cells (the highlight reel the old UI's
     # cells pane showed), each rendered as an html pane in position order.
     for cell in store.cells(conn):

--- a/packages/mcp/ix_notebook_mcp/pane_bridge.py
+++ b/packages/mcp/ix_notebook_mcp/pane_bridge.py
@@ -164,7 +164,7 @@ def _panes(conn: sqlite3.Connection) -> list[dict]:
                 result=row.get("result") or "",
                 ok=_ok(status),
                 duration_ms=duration_ms,
-                theme=row.get("theme"),
+                topic=row.get("topic"),
                 line=row.get("line"),
                 error_line=row.get("error_line"),
                 title=intent,

--- a/packages/mcp/ix_notebook_mcp/produce.py
+++ b/packages/mcp/ix_notebook_mcp/produce.py
@@ -72,7 +72,7 @@ def exec_pane(
     ok: bool | None = None,
     lang: str = "python",
     duration_ms: int | None = None,
-    theme: str | None = None,
+    topic: str | None = None,
     line: int | None = None,
     error_line: int | None = None,
     trace: list[dict] | None = None,
@@ -95,8 +95,8 @@ def exec_pane(
         view["ok"] = ok
     if duration_ms is not None:
         view["duration_ms"] = duration_ms
-    if theme:
-        view["theme"] = theme
+    if topic:
+        view["topic"] = topic
     if line is not None:
         view["line"] = line
     if error_line is not None:

--- a/packages/mcp/ix_notebook_mcp/produce.py
+++ b/packages/mcp/ix_notebook_mcp/produce.py
@@ -72,6 +72,9 @@ def exec_pane(
     ok: bool | None = None,
     lang: str = "python",
     duration_ms: int | None = None,
+    theme: str | None = None,
+    line: int | None = None,
+    error_line: int | None = None,
     trace: list[dict] | None = None,
     title: str | None = None,
     subtitle: str = "",
@@ -92,6 +95,12 @@ def exec_pane(
         view["ok"] = ok
     if duration_ms is not None:
         view["duration_ms"] = duration_ms
+    if theme:
+        view["theme"] = theme
+    if line is not None:
+        view["line"] = line
+    if error_line is not None:
+        view["error_line"] = error_line
     if trace:
         view["trace"] = trace
     return {
@@ -102,25 +111,44 @@ def exec_pane(
     }
 
 
-def data_pane(pane_id: str, title: str, renderer: str, data: object, subtitle: str = "") -> dict:
+def data_pane(
+    pane_id: str,
+    title: str,
+    renderer: str,
+    data: object,
+    subtitle: str = "",
+    parent: str | None = None,
+) -> dict:
     """A ``data`` pane: structured JSON rendered by the named frontend ``renderer``
     (an unknown name falls back to the generic JSON tree)."""
-    return {
+    pane = {
         "id": pane_id,
         "title": title,
         "subtitle": subtitle,
         "view": {"kind": "data", "renderer": renderer, "data": data},
     }
+    if parent:
+        pane["parent"] = parent
+    return pane
 
 
-def html_pane(pane_id: str, title: str, html: str, subtitle: str = "") -> dict:
+def html_pane(
+    pane_id: str,
+    title: str,
+    html: str,
+    subtitle: str = "",
+    parent: str | None = None,
+) -> dict:
     """An ``html`` pane: the producer ships its own UI, mounted in a sandboxed frame."""
-    return {
+    pane = {
         "id": pane_id,
         "title": title,
         "subtitle": subtitle,
         "view": {"kind": "html", "html": html},
     }
+    if parent:
+        pane["parent"] = parent
+    return pane
 
 
 class PaneProducer:

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -295,6 +295,11 @@ BUILTINS: tuple[Builtin, ...] = (
         "enabled drops it silently",
     ),
     Builtin(
+        "watch_pr",
+        "watch a GitHub PR as a live resource, show required checks with elapsed time, enable "
+        "auto merge by default, and notify when it merges, fails, or times out",
+    ),
+    Builtin(
         "sh",
         "run an external binary (git/nix/gh/cargo writes, long commands, raw logs) off the loop "
         "-- the escape hatch when `nu` won't do; use sh([...]) for argv-list/no shell parsing and "

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -35,7 +35,9 @@ import binascii
 import collections
 import contextlib
 import contextvars
+import datetime
 import dataclasses
+import html as html_lib
 import inspect
 import json
 import os
@@ -1635,6 +1637,190 @@ async def notify(content: str, **meta: Any) -> None:
         content=str(content),
         meta=json.dumps({key: str(value) for key, value in meta.items()}),
     )
+
+
+def _parse_github_time(value: Any) -> datetime.datetime | None:
+    if not isinstance(value, str) or not value or value.startswith("0001-"):
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _format_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return ""
+    seconds = max(0, int(seconds))
+    minutes, sec = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {sec}s"
+    return f"{sec}s"
+
+
+def _pr_check_duration(check: Mapping[str, Any], now: datetime.datetime) -> str:
+    started = _parse_github_time(check.get("startedAt"))
+    if started is None:
+        return ""
+    completed = _parse_github_time(check.get("completedAt"))
+    end = completed or now
+    return _format_duration((end - started).total_seconds())
+
+
+def _pr_resource_html(state: Mapping[str, Any]) -> str:
+    pr = html_lib.escape(str(state.get("pr") or ""))
+    title = html_lib.escape(str(state.get("title") or "PR"))
+    url = html_lib.escape(str(state.get("url") or "#"))
+    status = html_lib.escape(str(state.get("status") or "starting"))
+    merge = html_lib.escape(str(state.get("merge_state") or ""))
+    elapsed = html_lib.escape(str(state.get("elapsed") or ""))
+    auto = html_lib.escape(str(state.get("auto_merge") or ""))
+    error = state.get("error")
+    now = datetime.datetime.now(datetime.UTC)
+    rows = []
+    for check in state.get("checks") or []:
+        name = html_lib.escape(str(check.get("name") or check.get("workflowName") or "check"))
+        raw_state = str(check.get("conclusion") or check.get("status") or "pending")
+        css_state = re.sub(r"[^a-z0-9_-]+", "-", raw_state.lower())
+        shown_state = html_lib.escape(raw_state.lower())
+        duration = html_lib.escape(_pr_check_duration(check, now))
+        rows.append(
+            "<tr>"
+            f"<td>{name}</td>"
+            f"<td><span class=\"state {css_state}\">{shown_state}</span></td>"
+            f"<td>{duration}</td>"
+            "</tr>"
+        )
+    if not rows:
+        rows.append('<tr><td colspan="3" class="empty">waiting for checks</td></tr>')
+    error_html = ""
+    if error:
+        error_html = f'<div class="error">{html_lib.escape(str(error))}</div>'
+    return (
+        "<style>"
+        "body{margin:0;font:13px ui-sans-serif,system-ui;color:#e5e7eb;background:#111827}"
+        ".card{padding:14px;min-width:360px}.top{display:flex;gap:10px;align-items:baseline}"
+        "a{color:#93c5fd;text-decoration:none}.title{font-weight:650}.meta{color:#9ca3af;margin:8px 0 12px}"
+        "table{border-collapse:collapse;width:100%}td,th{padding:6px 8px;border-top:1px solid #374151;text-align:left}"
+        "th{font-size:11px;color:#9ca3af;text-transform:uppercase;letter-spacing:.04em}.state{border-radius:999px;padding:2px 7px;background:#374151}"
+        ".completed,.success{background:#064e3b;color:#a7f3d0}.in_progress,.queued,.pending{background:#78350f;color:#fde68a}"
+        ".failure,.cancelled,.timed_out,.action_required{background:#7f1d1d;color:#fecaca}.empty{color:#9ca3af;text-align:center}"
+        ".error{margin-top:10px;color:#fecaca;background:#7f1d1d;padding:8px;border-radius:6px;white-space:pre-wrap}"
+        "</style>"
+        "<div class=\"card\">"
+        f"<div class=\"top\"><a href=\"{url}\" target=\"_blank\">PR {pr}</a><span class=\"title\">{title}</span></div>"
+        f"<div class=\"meta\">{status} {merge} {elapsed} {auto}</div>"
+        "<table><thead><tr><th>required action</th><th>state</th><th>time</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table>{error_html}</div>"
+    )
+
+
+async def watch_pr(
+    pr: str | int,
+    *,
+    cwd: str | None = None,
+    auto_merge: bool = True,
+    merge_method: str = "squash",
+    delete_branch: bool = True,
+    interval: float = 15.0,
+    timeout: float = 3600.0,
+) -> dict[str, Any]:
+    """Watch a GitHub PR, mirror required checks as a resource, and optionally enable auto merge."""
+    clean_pr = str(pr).strip()
+    if not clean_pr:
+        raise ValueError("pr must be a number, URL, or branch understood by gh")
+    if merge_method not in {"merge", "squash", "rebase"}:
+        raise ValueError("merge_method must be merge, squash, or rebase")
+    safe_id = re.sub(r"[^A-Za-z0-9._-]+", "-", clean_pr).strip("-") or uuid.uuid4().hex[:8]
+    state: dict[str, Any] = {
+        "pr": clean_pr,
+        "title": "",
+        "url": "",
+        "status": "starting",
+        "merge_state": "",
+        "checks": [],
+        "auto_merge": "",
+        "error": "",
+        "elapsed": "",
+    }
+    started = time.time()
+    resource = register_resource(
+        render=lambda: _pr_resource_html(state),
+        id=f"pr-{safe_id}",
+        title=f"PR {clean_pr}",
+        kind="pr",
+        alive=lambda: state.get("status") not in {"merged", "closed", "failed", "timed out"},
+    )
+    import nu as nu_call
+
+    async def run_nu(code: str) -> Any:
+        return await nu_call(
+            code,
+            cwd=cwd,
+            env={"PR": clean_pr},
+            timeout=60,
+        )
+
+    async def refresh() -> dict[str, Any]:
+        out = await run_nu(
+            'with-env {NO_COLOR: "1" CLICOLOR: "0" CLICOLOR_FORCE: "0" FORCE_COLOR: "0"} '
+            '{ gh pr view $env.PR --json number,title,state,mergeStateStatus,statusCheckRollup,'
+            'url,autoMergeRequest,isDraft,reviewDecision | complete | get stdout | from json }'
+        )
+        row = out.to_dicts()[0]
+        checks = row.get("statusCheckRollup") or []
+        title = row.get("title") or f"PR {row.get('number') or clean_pr}"
+        state.update(
+            {
+                "pr": row.get("number") or clean_pr,
+                "title": title,
+                "url": row.get("url") or "",
+                "status": str(row.get("state") or "").lower(),
+                "merge_state": row.get("mergeStateStatus") or "",
+                "checks": checks,
+                "auto_merge": "auto merge on" if row.get("autoMergeRequest") else "auto merge off",
+                "elapsed": _format_duration(time.time() - started),
+                "error": "",
+            }
+        )
+        return row
+
+    if auto_merge:
+        flag = f"--{merge_method}"
+        delete = "--delete-branch" if delete_branch else ""
+        merge = await run_nu(f"gh pr merge $env.PR --auto {flag} {delete} | complete")
+        if int(merge["exit_code"][0]) != 0:
+            state["error"] = str(merge["stderr"][0] or merge["stdout"][0])
+
+    last: dict[str, Any] = {}
+    while True:
+        last = await refresh()
+        checks = last.get("statusCheckRollup") or []
+        failures = [
+            check
+            for check in checks
+            if check.get("conclusion") in {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}
+        ]
+        if last.get("state") != "OPEN":
+            state["status"] = "merged" if last.get("state") == "MERGED" else "closed"
+            resource.close()
+            await notify(f"PR {clean_pr} finished with state {last.get('state')}", resource=resource.id, pr=clean_pr)
+            return {"state": last.get("state"), "url": last.get("url"), "checks": len(checks)}
+        if failures:
+            state["status"] = "failed"
+            state["error"] = "One or more required actions failed."
+            resource.close()
+            await notify(f"PR {clean_pr} has failing checks", resource=resource.id, pr=clean_pr)
+            return {"state": "failed", "url": last.get("url"), "failures": failures}
+        if time.time() - started > timeout:
+            state["status"] = "timed out"
+            resource.close()
+            await notify(f"PR {clean_pr} watch timed out", resource=resource.id, pr=clean_pr)
+            return {"state": "timed out", "url": last.get("url"), "checks": len(checks)}
+        await asyncio.sleep(interval)
 
 
 @dataclasses.dataclass
@@ -3902,6 +4088,7 @@ def install(user_ns: dict | None = None) -> None:
     target["Input"] = Input
     target["ask"] = ask
     target["notify"] = notify
+    target["watch_pr"] = watch_pr
     target["input_channels"] = input_channels
     target["__ix_run"] = __ix_run
     target["__ix_exec"] = __ix_exec

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -291,12 +291,12 @@ class Job:
         name: str | None = None,
         budget: float = 15.0,
         kind: str = "cell",
-        theme: str = "",
+        topic: str = "",
     ) -> None:
         self.id = uuid.uuid4().hex[:8]
         self.code = code
         self.name = name or self.id
-        self.theme = theme
+        self.topic = topic
         # 'cell' for a normal execution; 'replay' for a re-run performed while
         # reopening a session file. Replays never feed future replays
         # (store.replayable filters on this), so a session cannot double-run
@@ -1485,7 +1485,7 @@ def _ask_form_html(
     submit_label: str,
 ) -> str:
     """The self-contained form HTML :func:`ask` renders: a prompt, the inputs, and
-    a wiring script that gathers the values and calls ``ixSubmit``. Themed for the
+    a wiring script that gathers the values and calls ``ixSubmit``. Arranged for the
     dashboard's light/dark surface; every agent-supplied string is escaped."""
     if choices is not None:
         body = "".join(
@@ -1792,7 +1792,7 @@ class Session:
         self._name = ""  # explicit, user-set via `session.name = ...`
         self._client = ""  # the connecting MCP client's reported identity
         self._workdir = ""  # this kernel's cwd basename, for the default label
-        self._theme = ""  # current fold group for runs in this session
+        self._topic = ""  # current fold group for runs in this session
         self._rev = 0
         self._synced = -1
 
@@ -1810,13 +1810,13 @@ class Session:
         self._rev += 1
 
     @property
-    def theme(self) -> str:
+    def topic(self) -> str:
         """The current dashboard fold group for future runs."""
-        return self._theme or "unfiled"
+        return self._topic or "unfiled"
 
-    @theme.setter
-    def theme(self, value: str) -> None:
-        self._theme = " ".join((value or "").split())
+    @topic.setter
+    def topic(self, value: str) -> None:
+        self._topic = " ".join((value or "").split())
         self._rev += 1
 
     @property
@@ -1834,8 +1834,8 @@ class Session:
 
     def __repr__(self) -> str:
         tail = f" · {self._client}" if self._client and self._client != self.name else ""
-        theme = f" theme={self.theme!r}" if self._theme else ""
-        return f"<Session {self.name!r}{tail}{theme}>"
+        topic = f" topic={self.topic!r}" if self._topic else ""
+        return f"<Session {self.name!r}{tail}{topic}>"
 
     def _sync(self) -> None:
         """Mirror the session label to the store when it has changed, so the
@@ -2118,7 +2118,7 @@ async def _runner(job: Job, ns: dict) -> None:
                 started_at=job.started,
                 budget=job.budget,
                 kind=job.kind,
-                theme=job.theme,
+                topic=job.topic,
             )
     try:
         # Static type check BEFORE running (default on; IX_MCP_TYPECHECK=0 or the
@@ -2249,7 +2249,7 @@ async def _runner(job: Job, ns: dict) -> None:
                     job_id=job.id,
                     job_name=job.name,
                     status=job.status,
-                    theme=job.theme,
+                    topic=job.topic,
                 )
 
 
@@ -3455,13 +3455,13 @@ async def __ix_run(
     name: str | None = None,
     kind: str = "cell",
     session: str | None = None,
-    theme: str | None = None,
+    topic: str | None = None,
 ) -> Job:
     """Run ``code`` as a task; wait up to ``budget`` for it; return the Job either
     way (done, or still running in the background). ``session`` selects the
     namespace the code runs in (see :func:`_session_ns`)."""
     ns = _session_ns(session)
-    job = Job(code, name, budget=budget, kind=kind, theme=theme or globals()["session"].theme)
+    job = Job(code, name, budget=budget, kind=kind, topic=topic or globals()["session"].topic)
     job._ns = ns
     jobs[job.id] = job
     job.task = asyncio.ensure_future(_runner(job, ns))
@@ -3500,7 +3500,7 @@ def _job_summary(job: Job) -> dict:
     return {
         "id": job.id,
         "name": job.name,
-        "theme": job.theme,
+        "topic": job.topic,
         "status": job.status,
         "running": job.running(),
         "output": job.tail(_SUMMARY_CHARS),
@@ -3559,12 +3559,12 @@ async def __ix_exec(
     budget: float = 15.0,
     name: str | None = None,
     session: str | None = None,
-    theme: str | None = None,
+    topic: str | None = None,
 ) -> None:
     """The MCP server's per-call entrypoint: run with a budget, emit the summary.
     ``session`` is the caller's MCP session id (per-session namespace; None for
     the shared one)."""
-    job = await __ix_run(code, budget=budget, name=name, session=session, theme=theme)
+    job = await __ix_run(code, budget=budget, name=name, session=session, topic=topic)
     _emit(job)
 
 

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -285,10 +285,18 @@ class Job:
     """A single ``python_exec`` execution: an awaitable handle over the asyncio
     task running the code, with its captured output, result, and status."""
 
-    def __init__(self, code: str, name: str | None = None, budget: float = 15.0, kind: str = "cell") -> None:
+    def __init__(
+        self,
+        code: str,
+        name: str | None = None,
+        budget: float = 15.0,
+        kind: str = "cell",
+        theme: str = "",
+    ) -> None:
         self.id = uuid.uuid4().hex[:8]
         self.code = code
         self.name = name or self.id
+        self.theme = theme
         # 'cell' for a normal execution; 'replay' for a re-run performed while
         # reopening a session file. Replays never feed future replays
         # (store.replayable filters on this), so a session cannot double-run
@@ -336,6 +344,9 @@ class Job:
         # a per-session namespace -- see _session_ns). Set by __ix_run so the
         # bindings snapshot reads the namespace the cell actually wrote to.
         self._ns: dict | None = None
+        # Set once __ix_run returns before the task finishes. When such a job
+        # reaches a terminal state later, notify the agent session.
+        self.backgrounded = False
 
     def _append(self, s: str) -> None:
         """Append output, trimming to the most recent _MAX_OUTPUT_CHARS so a
@@ -1006,8 +1017,9 @@ class Resource:
     widget, anything with a current HTML representation. Register one with
     :func:`register_resource`; while it stays alive the runtime mirrors its
     latest HTML to the store every flush tick and the dashboard sidebar shows
-    all live resources updating in place. The resource closes itself (leaves the
-    sidebar) when its ``alive`` predicate reports the source is gone.
+    all resources updating in place. The resource closes itself (switches to a
+    closed indicator while keeping its final pane) when its ``alive`` predicate
+    reports the source is gone.
 
     Pass ``actions={"name": handler}`` to make the resource interactive: its HTML
     gets ``ix.act(name, payload)`` and ``ix.events(fn)`` injected (see
@@ -1024,10 +1036,12 @@ class Resource:
         render: Any,
         alive: Any = None,
         actions: Mapping[str, Any] | None = None,
+        execution_id: str = "",
     ) -> None:
         self.id = id
         self.title = title
         self.kind = kind
+        self.execution_id = execution_id
         self._render = render
         self._alive = alive
         self.status = "live"
@@ -1044,9 +1058,7 @@ class Resource:
         return self.status == "closed"
 
     def close(self) -> Resource:
-        """Close the resource so the sidebar drops it on the next tick (and tear
-        down its action channel/dispatcher, so a stale page can no longer queue
-        work for it)."""
+        """Close the resource and tear down any action channel/dispatcher."""
         self.status = "closed"
         if self._dispatcher is not None:
             self._dispatcher.cancel()
@@ -1223,7 +1235,7 @@ def register_resource(
       updating one view), instead of spawning a new pane each call. Omitted -> a
       random id, i.e. a new resource every time.
     - ``alive``: optional predicate; when it returns False the resource closes
-      itself and leaves the sidebar. Else call ``.close()`` on the returned handle.
+      itself but keeps its final pane. Else call ``.close()`` on the returned handle.
 
     Viewing it as a native overlay window (macOS): besides the web dashboard, the
     ``ix-windows`` consumer renders each live resource as its own floating, blurred,
@@ -1317,7 +1329,9 @@ def register_resource(
     old = resources.get(rid)
     if old is not None:
         old.close()
-    res = Resource(rid, str(title), kind, render, alive, actions=actions)
+    current = _ix_current.get()
+    execution_id = getattr(current, "id", "") if current is not None else ""
+    res = Resource(rid, str(title), kind, render, alive, actions=actions, execution_id=execution_id)
     resources[rid] = res
     return res
 
@@ -1778,6 +1792,7 @@ class Session:
         self._name = ""  # explicit, user-set via `session.name = ...`
         self._client = ""  # the connecting MCP client's reported identity
         self._workdir = ""  # this kernel's cwd basename, for the default label
+        self._theme = ""  # current fold group for runs in this session
         self._rev = 0
         self._synced = -1
 
@@ -1795,6 +1810,16 @@ class Session:
         self._rev += 1
 
     @property
+    def theme(self) -> str:
+        """The current dashboard fold group for future runs."""
+        return self._theme or "unfiled"
+
+    @theme.setter
+    def theme(self, value: str) -> None:
+        self._theme = " ".join((value or "").split())
+        self._rev += 1
+
+    @property
     def client(self) -> str:
         """The connecting MCP client's reported identity (read-only)."""
         return self._client
@@ -1809,7 +1834,8 @@ class Session:
 
     def __repr__(self) -> str:
         tail = f" · {self._client}" if self._client and self._client != self.name else ""
-        return f"<Session {self.name!r}{tail}>"
+        theme = f" theme={self.theme!r}" if self._theme else ""
+        return f"<Session {self.name!r}{tail}{theme}>"
 
     def _sync(self) -> None:
         """Mirror the session label to the store when it has changed, so the
@@ -2092,6 +2118,7 @@ async def _runner(job: Job, ns: dict) -> None:
                 started_at=job.started,
                 budget=job.budget,
                 kind=job.kind,
+                theme=job.theme,
             )
     try:
         # Static type check BEFORE running (default on; IX_MCP_TYPECHECK=0 or the
@@ -2215,6 +2242,15 @@ async def _runner(job: Job, ns: dict) -> None:
         _ix_current.reset(token)
         _persist_final(job)
         _mark_snapshot_dirty()
+        if job.backgrounded and job.kind != "replay":
+            with contextlib.suppress(Exception):
+                await notify(
+                    f"Background job {job.name} finished with status {job.status}.",
+                    job_id=job.id,
+                    job_name=job.name,
+                    status=job.status,
+                    theme=job.theme,
+                )
 
 
 def _persist_final(job: Job) -> None:
@@ -3003,6 +3039,7 @@ async def _sweep_resources() -> None:
                 status=status,
                 created_at=res.created,
                 updated_at=now,
+                execution_id=res.execution_id,
             )
 
 
@@ -3418,16 +3455,19 @@ async def __ix_run(
     name: str | None = None,
     kind: str = "cell",
     session: str | None = None,
+    theme: str | None = None,
 ) -> Job:
     """Run ``code`` as a task; wait up to ``budget`` for it; return the Job either
     way (done, or still running in the background). ``session`` selects the
     namespace the code runs in (see :func:`_session_ns`)."""
     ns = _session_ns(session)
-    job = Job(code, name, budget=budget, kind=kind)
+    job = Job(code, name, budget=budget, kind=kind, theme=theme or globals()["session"].theme)
     job._ns = ns
     jobs[job.id] = job
     job.task = asyncio.ensure_future(_runner(job, ns))
     await asyncio.wait({job.task}, timeout=budget)
+    if not job.task.done():
+        job.backgrounded = True
     return job
 
 
@@ -3460,6 +3500,7 @@ def _job_summary(job: Job) -> dict:
     return {
         "id": job.id,
         "name": job.name,
+        "theme": job.theme,
         "status": job.status,
         "running": job.running(),
         "output": job.tail(_SUMMARY_CHARS),
@@ -3514,12 +3555,16 @@ def _emit(job: Job) -> None:
 
 
 async def __ix_exec(
-    code: str, budget: float = 15.0, name: str | None = None, session: str | None = None
+    code: str,
+    budget: float = 15.0,
+    name: str | None = None,
+    session: str | None = None,
+    theme: str | None = None,
 ) -> None:
     """The MCP server's per-call entrypoint: run with a budget, emit the summary.
     ``session`` is the caller's MCP session id (per-session namespace; None for
     the shared one)."""
-    job = await __ix_run(code, budget=budget, name=name, session=session)
+    job = await __ix_run(code, budget=budget, name=name, session=session, theme=theme)
     _emit(job)
 
 

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS executions (
     bindings    TEXT NOT NULL DEFAULT '{}',
     kind        TEXT NOT NULL DEFAULT 'cell',
     namespace   TEXT NOT NULL DEFAULT '[]',
-    theme       TEXT NOT NULL DEFAULT ''
+    topic       TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS executions_started ON executions (started_at);
 
@@ -193,9 +193,9 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if "namespace" not in have:
         with contextlib.suppress(sqlite3.OperationalError):
             conn.execute("ALTER TABLE executions ADD COLUMN namespace TEXT NOT NULL DEFAULT '[]'")
-    if "theme" not in have:
+    if "topic" not in have:
         with contextlib.suppress(sqlite3.OperationalError):
-            conn.execute("ALTER TABLE executions ADD COLUMN theme TEXT NOT NULL DEFAULT ''")
+            conn.execute("ALTER TABLE executions ADD COLUMN topic TEXT NOT NULL DEFAULT ''")
     resource_have = {row[1] for row in conn.execute("PRAGMA table_info(resources)")}
     if "execution_id" not in resource_have:
         with contextlib.suppress(sqlite3.OperationalError):
@@ -211,12 +211,12 @@ def start(
     started_at: float,
     budget: float = 15.0,
     kind: str = "cell",
-    theme: str = "",
+    topic: str = "",
 ) -> None:
     conn.execute(
-        "INSERT OR REPLACE INTO executions (id, name, code, status, started_at, budget, output, kind, theme) "
+        "INSERT OR REPLACE INTO executions (id, name, code, status, started_at, budget, output, kind, topic) "
         "VALUES (?, ?, ?, 'running', ?, ?, '', ?, ?)",
-        (id, name, code, started_at, budget, kind, theme),
+        (id, name, code, started_at, budget, kind, topic),
     )
 
 
@@ -289,7 +289,7 @@ def finish(
 # `get` return the identical shape (the embed contract in feed.py depends on it).
 _EXEC_COLUMNS = (
     "id, name, code, status, started_at, ended_at, budget, output, result, error, "
-    "line, error_line, outputs, bindings, kind, theme"
+    "line, error_line, outputs, bindings, kind, topic"
 )
 
 

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -39,7 +39,8 @@ CREATE TABLE IF NOT EXISTS executions (
     outputs     TEXT NOT NULL DEFAULT '[]',
     bindings    TEXT NOT NULL DEFAULT '{}',
     kind        TEXT NOT NULL DEFAULT 'cell',
-    namespace   TEXT NOT NULL DEFAULT '[]'
+    namespace   TEXT NOT NULL DEFAULT '[]',
+    theme       TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS executions_started ON executions (started_at);
 
@@ -69,6 +70,7 @@ CREATE TABLE IF NOT EXISTS resources (
     kind        TEXT NOT NULL DEFAULT 'html',
     html        TEXT NOT NULL DEFAULT '',
     status      TEXT NOT NULL DEFAULT 'live',
+    execution_id TEXT NOT NULL DEFAULT '',
     created_at  REAL NOT NULL,
     updated_at  REAL NOT NULL
 );
@@ -191,6 +193,13 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if "namespace" not in have:
         with contextlib.suppress(sqlite3.OperationalError):
             conn.execute("ALTER TABLE executions ADD COLUMN namespace TEXT NOT NULL DEFAULT '[]'")
+    if "theme" not in have:
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute("ALTER TABLE executions ADD COLUMN theme TEXT NOT NULL DEFAULT ''")
+    resource_have = {row[1] for row in conn.execute("PRAGMA table_info(resources)")}
+    if "execution_id" not in resource_have:
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute("ALTER TABLE resources ADD COLUMN execution_id TEXT NOT NULL DEFAULT ''")
 
 
 def start(
@@ -202,11 +211,12 @@ def start(
     started_at: float,
     budget: float = 15.0,
     kind: str = "cell",
+    theme: str = "",
 ) -> None:
     conn.execute(
-        "INSERT OR REPLACE INTO executions (id, name, code, status, started_at, budget, output, kind) "
-        "VALUES (?, ?, ?, 'running', ?, ?, '', ?)",
-        (id, name, code, started_at, budget, kind),
+        "INSERT OR REPLACE INTO executions (id, name, code, status, started_at, budget, output, kind, theme) "
+        "VALUES (?, ?, ?, 'running', ?, ?, '', ?, ?)",
+        (id, name, code, started_at, budget, kind, theme),
     )
 
 
@@ -279,7 +289,7 @@ def finish(
 # `get` return the identical shape (the embed contract in feed.py depends on it).
 _EXEC_COLUMNS = (
     "id, name, code, status, started_at, ended_at, budget, output, result, error, "
-    "line, error_line, outputs, bindings, kind"
+    "line, error_line, outputs, bindings, kind, theme"
 )
 
 
@@ -434,20 +444,21 @@ def upsert_resource(
     status: str,
     created_at: float,
     updated_at: float,
+    execution_id: str = "",
 ) -> None:
     """Insert a resource or refresh its rendered HTML/status in place."""
     conn.execute(
-        "INSERT INTO resources (id, title, kind, html, status, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?) "
+        "INSERT INTO resources (id, title, kind, html, status, execution_id, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
         "ON CONFLICT(id) DO UPDATE SET "
         "title = excluded.title, kind = excluded.kind, html = excluded.html, "
-        "status = excluded.status, updated_at = excluded.updated_at",
-        (id, title, kind, html, status, created_at, updated_at),
+        "status = excluded.status, execution_id = excluded.execution_id, updated_at = excluded.updated_at",
+        (id, title, kind, html, status, execution_id, created_at, updated_at),
     )
 
 
 def close_resource(conn: sqlite3.Connection, *, id: str, updated_at: float) -> None:
-    """Mark a resource closed so the sidebar drops it (the row stays for history)."""
+    """Mark a resource closed while keeping its final pane visible."""
     conn.execute(
         "UPDATE resources SET status = 'closed', updated_at = ? WHERE id = ?",
         (updated_at, id),
@@ -710,10 +721,10 @@ def replayable(conn: sqlite3.Connection, since: float | None) -> list[dict]:
 
 
 def live_resources(conn: sqlite3.Connection) -> list[dict]:
-    """Every resource not yet closed, oldest first, as plain dicts for the sidebar."""
+    """Every resource, oldest first, as plain dicts for the sidebar."""
     conn.row_factory = sqlite3.Row
     rows = conn.execute(
-        "SELECT id, title, kind, html, status, created_at, updated_at "
-        "FROM resources WHERE status != 'closed' ORDER BY created_at ASC"
+        "SELECT id, title, kind, html, status, execution_id, created_at, updated_at "
+        "FROM resources ORDER BY created_at ASC"
     ).fetchall()
     return [dict(r) for r in rows]

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -147,7 +147,9 @@ _dashboard_started = False
 # (index#1789 review). The one stdio/embedder client has no session object to
 # key on; its label lives in `_solo_session_name` and dies with the process.
 _session_labels: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+_session_themes: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 _solo_session_name: str | None = None
+_solo_theme: str | None = None
 
 
 def _session_label(ctx: Context | None) -> str | None:
@@ -166,6 +168,51 @@ def _set_session_label(ctx: Context | None, name: str) -> None:
     else:
         _session_labels[session] = name
 
+
+
+
+def _session_theme(ctx: Context | None) -> str | None:
+    """The current fold theme this call's session chose."""
+    session = _http_session(ctx)
+    if session is None:
+        return _solo_theme
+    return _session_themes.get(session)
+
+
+def _set_session_theme(ctx: Context | None, theme: str) -> None:
+    global _solo_theme
+    session = _http_session(ctx)
+    if session is None:
+        _solo_theme = theme
+    else:
+        _session_themes[session] = theme
+
+
+def _theme_required() -> bool:
+    """Whether python_exec requires an explicit theme first."""
+    return os.environ.get("IX_MCP_REQUIRE_THEME", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+async def _require_theme(ctx: Context | None, *, intent: str | None = None) -> None:
+    """Fail fast until this MCP session has named the current dashboard theme."""
+    if not _theme_required() or _session_theme(ctx) is not None:
+        return
+    suggestion = f" Suggested theme from this call: {intent!r}." if intent else ""
+    raise McpError(
+        ErrorData(
+            code=types.INVALID_REQUEST,
+            message=(
+                "Set a dashboard theme first: call theme_set with a short label for "
+                "the current cluster of related tool calls."
+                f"{suggestion}"
+            ),
+        )
+    )
 
 def session_names() -> list[str]:
     """The labels live MCP sessions gave themselves, for the mesh endpoint.
@@ -360,6 +407,42 @@ async def session_set_name(
     return [outputs.text(f"dashboard session named: {clean}")]
 
 
+@mcp.tool(
+    structured_output=False,
+    description=(
+        "Set the current dashboard theme for this MCP connection. Call this before "
+        "a related cluster of python_exec calls, and change it when the work moves "
+        "to a new phase; runs fold under the theme inside the session."
+    ),
+)
+async def theme_set(
+    theme: Annotated[
+        str,
+        Field(
+            description=(
+                "Short label for the current cluster of related tool calls, 3 to "
+                "80 characters, with no code or secrets"
+            )
+        ),
+    ],
+    ctx: Context | None = None,
+) -> Content:
+    await _start_dashboard_once()
+    await _identify_client_once(ctx)
+    await _require_session_name(ctx, intent=theme)
+    clean = " ".join((theme or "").split())
+    if not 3 <= len(clean) <= 80:
+        raise McpError(
+            ErrorData(
+                code=types.INVALID_PARAMS,
+                message="Theme must be 3 to 80 non-whitespace characters.",
+            )
+        )
+    await current_kernel().set_theme(clean)
+    _set_session_theme(ctx, clean)
+    return [outputs.text(f"dashboard theme set: {clean}")]
+
+
 # Every tool sets structured_output=False: FastMCP otherwise derives an output
 # schema from the return annotation and DUPLICATES the entire reply as
 # `structuredContent` JSON, so each image block went to the client twice (once
@@ -386,6 +469,7 @@ async def python_exec(
     await _start_dashboard_once()
     await _identify_client_once(ctx)
     await _require_session_name(ctx, intent=intent)
+    await _require_theme(ctx, intent=intent)
     # A foreground budget is how long the run holds the one shared shell channel
     # before it backgrounds, so cap it: a giant budget (a 15-minute `await
     # jobs[...]`) would block every other call behind it. The clamp is surfaced
@@ -395,7 +479,7 @@ async def python_exec(
     # `intent` is the run's human label (the dashboard feed's title); it flows to
     # the kernel as the job name and lands in the store's `name` column.
     cell_outputs, summary = await current_kernel().python_exec(
-        code, effective_budget, intent, session=_session_id(ctx)
+        code, effective_budget, intent, session=_session_id(ctx), theme=_session_theme(ctx)
     )
     rendered = outputs.to_mcp(cell_outputs)
     if summary is None:

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -147,9 +147,9 @@ _dashboard_started = False
 # (index#1789 review). The one stdio/embedder client has no session object to
 # key on; its label lives in `_solo_session_name` and dies with the process.
 _session_labels: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
-_session_themes: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+_session_topics: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 _solo_session_name: str | None = None
-_solo_theme: str | None = None
+_solo_topic: str | None = None
 
 
 def _session_label(ctx: Context | None) -> str | None:
@@ -171,26 +171,26 @@ def _set_session_label(ctx: Context | None, name: str) -> None:
 
 
 
-def _session_theme(ctx: Context | None) -> str | None:
-    """The current fold theme this call's session chose."""
+def _session_topic(ctx: Context | None) -> str | None:
+    """The current fold topic this call's session chose."""
     session = _http_session(ctx)
     if session is None:
-        return _solo_theme
-    return _session_themes.get(session)
+        return _solo_topic
+    return _session_topics.get(session)
 
 
-def _set_session_theme(ctx: Context | None, theme: str) -> None:
-    global _solo_theme
+def _set_session_topic(ctx: Context | None, topic: str) -> None:
+    global _solo_topic
     session = _http_session(ctx)
     if session is None:
-        _solo_theme = theme
+        _solo_topic = topic
     else:
-        _session_themes[session] = theme
+        _session_topics[session] = topic
 
 
-def _theme_required() -> bool:
-    """Whether python_exec requires an explicit theme first."""
-    return os.environ.get("IX_MCP_REQUIRE_THEME", "1").strip().lower() not in (
+def _topic_required() -> bool:
+    """Whether python_exec requires an explicit topic first."""
+    return os.environ.get("IX_MCP_REQUIRE_TOPIC", "1").strip().lower() not in (
         "0",
         "false",
         "no",
@@ -198,16 +198,16 @@ def _theme_required() -> bool:
     )
 
 
-async def _require_theme(ctx: Context | None, *, intent: str | None = None) -> None:
-    """Fail fast until this MCP session has named the current dashboard theme."""
-    if not _theme_required() or _session_theme(ctx) is not None:
+async def _require_topic(ctx: Context | None, *, intent: str | None = None) -> None:
+    """Fail fast until this MCP session has named the current dashboard topic."""
+    if not _topic_required() or _session_topic(ctx) is not None:
         return
-    suggestion = f" Suggested theme from this call: {intent!r}." if intent else ""
+    suggestion = f" Suggested topic from this call: {intent!r}." if intent else ""
     raise McpError(
         ErrorData(
             code=types.INVALID_REQUEST,
             message=(
-                "Set a dashboard theme first: call theme_set with a short label for "
+                "Set a dashboard topic first: call topic_set with a short label for "
                 "the current cluster of related tool calls."
                 f"{suggestion}"
             ),
@@ -410,13 +410,13 @@ async def session_set_name(
 @mcp.tool(
     structured_output=False,
     description=(
-        "Set the current dashboard theme for this MCP connection. Call this before "
+        "Set the current dashboard topic for this MCP connection. Call this before "
         "a related cluster of python_exec calls, and change it when the work moves "
-        "to a new phase; runs fold under the theme inside the session."
+        "to a new phase; runs fold under the topic inside the session."
     ),
 )
-async def theme_set(
-    theme: Annotated[
+async def topic_set(
+    topic: Annotated[
         str,
         Field(
             description=(
@@ -429,18 +429,18 @@ async def theme_set(
 ) -> Content:
     await _start_dashboard_once()
     await _identify_client_once(ctx)
-    await _require_session_name(ctx, intent=theme)
-    clean = " ".join((theme or "").split())
+    await _require_session_name(ctx, intent=topic)
+    clean = " ".join((topic or "").split())
     if not 3 <= len(clean) <= 80:
         raise McpError(
             ErrorData(
                 code=types.INVALID_PARAMS,
-                message="Theme must be 3 to 80 non-whitespace characters.",
+                message="Topic must be 3 to 80 non-whitespace characters.",
             )
         )
-    await current_kernel().set_theme(clean)
-    _set_session_theme(ctx, clean)
-    return [outputs.text(f"dashboard theme set: {clean}")]
+    await current_kernel().set_topic(clean)
+    _set_session_topic(ctx, clean)
+    return [outputs.text(f"dashboard topic set: {clean}")]
 
 
 # Every tool sets structured_output=False: FastMCP otherwise derives an output
@@ -469,7 +469,7 @@ async def python_exec(
     await _start_dashboard_once()
     await _identify_client_once(ctx)
     await _require_session_name(ctx, intent=intent)
-    await _require_theme(ctx, intent=intent)
+    await _require_topic(ctx, intent=intent)
     # A foreground budget is how long the run holds the one shared shell channel
     # before it backgrounds, so cap it: a giant budget (a 15-minute `await
     # jobs[...]`) would block every other call behind it. The clamp is surfaced
@@ -479,7 +479,7 @@ async def python_exec(
     # `intent` is the run's human label (the dashboard feed's title); it flows to
     # the kernel as the job name and lands in the store's `name` column.
     cell_outputs, summary = await current_kernel().python_exec(
-        code, effective_budget, intent, session=_session_id(ctx), theme=_session_theme(ctx)
+        code, effective_budget, intent, session=_session_id(ctx), topic=_session_topic(ctx)
     )
     rendered = outputs.to_mcp(cell_outputs)
     if summary is None:

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -457,6 +457,7 @@ async def topic_set(
         guide.NAMESPACE,
         guide.BLOCKING,
         guide.RESULT_CONTRACT,
+        guide.PR_WATCH,
         guide.SEE_INSTRUCTIONS,
     ),
 )
@@ -541,6 +542,71 @@ async def python_exec(
             )
         )
     return parts
+
+
+@mcp.tool(
+    structured_output=False,
+    description=(
+        "Watch a GitHub pull request in the dashboard. Creates a live PR resource "
+        "nested under this task, lists required checks and actions with elapsed "
+        "time, enables auto merge by default, and notifies the CLI when the PR "
+        "merges, fails, or times out. Use this instead of hand-written PR polling."
+    ),
+)
+async def pr_watch(
+    pr: Annotated[
+        str,
+        Field(description="PR number, URL, or branch understood by gh, for example 1856."),
+    ],
+    cwd: Annotated[
+        str,
+        Field(description="Repository worktree where gh should run."),
+    ],
+    auto_merge: Annotated[
+        bool,
+        Field(description="Enable gh auto merge for this PR before watching."),
+    ] = True,
+    interval: Annotated[
+        float,
+        Field(description="Seconds between GitHub status refreshes."),
+    ] = 15.0,
+    timeout: Annotated[
+        float,
+        Field(description="Seconds to watch before the resource closes as timed out."),
+    ] = 3600.0,
+    ctx: Context | None = None,
+) -> Content:
+    await _start_dashboard_once()
+    await _identify_client_once(ctx)
+    await _require_session_name(ctx, intent=f"watch PR {pr}")
+    await _require_topic(ctx, intent=f"watch PR {pr}")
+    code = (
+        "await watch_pr("
+        f"{pr!r}, cwd={cwd!r}, auto_merge={auto_merge!r}, "
+        f"interval={interval!r}, timeout={timeout!r}"
+        ")"
+    )
+    cell_outputs, summary = await current_kernel().python_exec(
+        code,
+        min(5.0, config().max_budget),
+        f"watch PR {pr}",
+        session=_session_id(ctx),
+        topic=_session_topic(ctx),
+    )
+    rendered = outputs.to_mcp(cell_outputs)
+    resource = f"pr-{re.sub(r'[^A-Za-z0-9._-]+', '-', str(pr)).strip('-')}"
+    header = outputs.text(
+        json.dumps(
+            {
+                "job": summary.get("id") if summary else None,
+                "status": summary.get("status") if summary else None,
+                "running": summary.get("running") if summary else None,
+                "elapsed_s": summary.get("elapsed_s") if summary else None,
+                "resource": resource,
+            }
+        )
+    )
+    return [header, *(item for item in rendered if getattr(item, "text", None) != "(no output)")]
 
 
 @mcp.tool(structured_output=False, description=guide.READ)

--- a/packages/tui/tui-py/python/tui/harness.py
+++ b/packages/tui/tui-py/python/tui/harness.py
@@ -259,6 +259,8 @@ class Agent:
         then presses Enter, and presses it once more if the turn has not started.
         Grounded against Claude Code, which drops the occasional fast Enter.
         """
+        if not self._started:
+            await self.start()
         await self.keyboard.type(text)
         # The box may wrap/scroll the text; submit anyway if it times out.
         with contextlib.suppress(WaitTimeout):
@@ -279,6 +281,14 @@ class Agent:
         await self.wait_for_idle(timeout=timeout, settle=settle)
         delta = _tail_delta(before, await self._lines())
         return self.parse_reply(delta)
+
+    async def ask(self, text: str, *, timeout: float = 180.0, settle: float = 0.6) -> str:
+        """Submit one question and return the parsed reply.
+
+        `ask` is the high-level name for simple delegation; it keeps the visible
+        resource open, unlike a headless one-shot command.
+        """
+        return await self.run(text, timeout=timeout, settle=settle)
 
     # -- waiting (Playwright-style) -----------------------------------------
 
@@ -439,6 +449,41 @@ class Codex(Agent):
     binary = "codex"
     ready = re.compile(r"[›❯>]\s*$", re.MULTILINE)
     busy_marker = None
+
+    def __init__(
+        self,
+        *args: str,
+        model: str = "gpt-5.5",
+        reasoning_effort: str = "low",
+        approval: str = "never",
+        sandbox: str = "danger-full-access",
+        **kwargs: object,
+    ) -> None:
+        defaults = (
+            "-c",
+            f"model_reasoning_effort={reasoning_effort!r}",
+            "--model",
+            model,
+            "--ask-for-approval",
+            approval,
+            "--sandbox",
+            sandbox,
+        )
+        super().__init__(*defaults, *args, **kwargs)  # type: ignore[arg-type]
+
+    def parse_reply(self, transcript: str) -> str:
+        """Keep the final Codex answer block from a TUI transcript."""
+        lines = transcript.splitlines()
+        starts = [i for i, line in enumerate(lines) if line.lstrip().startswith("•")]
+        if not starts:
+            return transcript.strip()
+        out: list[str] = []
+        for line in lines[starts[-1]:]:
+            stripped = line.strip()
+            if out and (stripped.startswith("›") or " · " in stripped and "gpt-" in stripped):
+                break
+            out.append(line.lstrip("• ").rstrip())
+        return "\n".join(out).strip()
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/tui/tui-py/python/tui/harness.py
+++ b/packages/tui/tui-py/python/tui/harness.py
@@ -30,7 +30,7 @@ Quick start, exactly the shape of a Playwright test:
     # or the one-liner: submit, wait for the turn to finish, return the reply
     answer = await agent.run("summarize CONTRIBUTING.md", timeout=180)
 
-    # or fan out across mixed agents through the shared AgentLike interface
+    # or fan out across mixed agents through the shared Agent interface
     claude, codex = await Claude.launch(cwd="/repo"), await Codex.launch(cwd="/repo")
     replies = await asyncio.gather(
         claude.run_to_completion("find one risk"),
@@ -70,51 +70,19 @@ import hashlib
 import re
 from collections.abc import Awaitable, Callable, Sequence
 from types import TracebackType
-from typing import ClassVar, Protocol, Self
+from typing import ClassVar, Self
 
 from . import Key, Pattern, Snapshot, Tui, WaitTimeout
 
 __all__ = [
     "Agent",
     "AgentAssertions",
-    "AgentLike",
     "Claude",
     "Codex",
     "Gate",
     "Keyboard",
     "expect",
 ]
-
-
-class AgentLike(Protocol):
-    """Shared async interface implemented by `Agent`, `Claude`, and `Codex`.
-
-    Use this for orchestration code that should not care which coding agent is
-    behind the PTY:
-
-        agents: list[AgentLike] = [
-            await Claude.launch(cwd="/repo"),
-            await Codex.launch(cwd="/repo"),
-        ]
-        replies = await asyncio.gather(
-            *(agent.run_to_completion("summarize this repo") for agent in agents)
-        )
-
-    The concrete classes expose more Playwright-style controls, but these are
-    the stable high-level operations for mixed-agent fan-out.
-    """
-
-    async def send_message(self, text: str) -> None:
-        """Submit a message without waiting for the turn to finish."""
-
-    async def run_to_completion(
-        self,
-        text: str,
-        *,
-        timeout: float = 180.0,
-        settle: float = 0.6,
-    ) -> str:
-        """Submit a message, wait for idle, and return the parsed reply."""
 
 
 class Gate:

--- a/packages/tui/tui-py/python/tui/harness.py
+++ b/packages/tui/tui-py/python/tui/harness.py
@@ -30,6 +30,13 @@ Quick start, exactly the shape of a Playwright test:
     # or the one-liner: submit, wait for the turn to finish, return the reply
     answer = await agent.run("summarize CONTRIBUTING.md", timeout=180)
 
+    # or fan out across mixed agents through the shared AgentLike interface
+    claude, codex = await Claude.launch(cwd="/repo"), await Codex.launch(cwd="/repo")
+    replies = await asyncio.gather(
+        claude.run_to_completion("find one risk"),
+        codex.run_to_completion("find one risk"),
+    )
+
 Why drive the real TUI instead of `claude -p`? A headless `-p` run is invisible
 and uninterruptible. A harness drives the actual TUI in a PTY, so the session
 shows up live on the `tui` web dashboard (`nix run .#tui-dashboard`) just like a
@@ -63,11 +70,51 @@ import hashlib
 import re
 from collections.abc import Awaitable, Callable, Sequence
 from types import TracebackType
-from typing import ClassVar, Self
+from typing import ClassVar, Protocol, Self
 
 from . import Key, Pattern, Snapshot, Tui, WaitTimeout
 
-__all__ = ["Agent", "AgentAssertions", "Claude", "Codex", "Gate", "Keyboard", "expect"]
+__all__ = [
+    "Agent",
+    "AgentAssertions",
+    "AgentLike",
+    "Claude",
+    "Codex",
+    "Gate",
+    "Keyboard",
+    "expect",
+]
+
+
+class AgentLike(Protocol):
+    """Shared async interface implemented by `Agent`, `Claude`, and `Codex`.
+
+    Use this for orchestration code that should not care which coding agent is
+    behind the PTY:
+
+        agents: list[AgentLike] = [
+            await Claude.launch(cwd="/repo"),
+            await Codex.launch(cwd="/repo"),
+        ]
+        replies = await asyncio.gather(
+            *(agent.run_to_completion("summarize this repo") for agent in agents)
+        )
+
+    The concrete classes expose more Playwright-style controls, but these are
+    the stable high-level operations for mixed-agent fan-out.
+    """
+
+    async def send_message(self, text: str) -> None:
+        """Submit a message without waiting for the turn to finish."""
+
+    async def run_to_completion(
+        self,
+        text: str,
+        *,
+        timeout: float = 180.0,
+        settle: float = 0.6,
+    ) -> str:
+        """Submit a message, wait for idle, and return the parsed reply."""
 
 
 class Gate:
@@ -269,6 +316,14 @@ class Agent:
         if not await self._turn_started():
             await self.keyboard.press(Key.ENTER)
 
+    async def send_message(self, text: str) -> None:
+        """Submit `text` without waiting for the agent to finish the turn.
+
+        High-level interface alias for `prompt`, shared by `Claude` and `Codex`
+        so orchestrators can type against `AgentLike`.
+        """
+        await self.prompt(text)
+
     async def run(self, text: str, *, timeout: float = 180.0, settle: float = 0.6) -> str:
         """Submit `text`, wait for the turn to finish, return the agent's reply.
 
@@ -282,13 +337,27 @@ class Agent:
         delta = _tail_delta(before, await self._lines())
         return self.parse_reply(delta)
 
+    async def run_to_completion(
+        self,
+        text: str,
+        *,
+        timeout: float = 180.0,
+        settle: float = 0.6,
+    ) -> str:
+        """Submit `text`, wait for idle, and return the parsed reply.
+
+        This is the agent-interface name for `run`, meant for mixed fan-out:
+        `await asyncio.gather(claude.run_to_completion(q), codex.run_to_completion(q))`.
+        """
+        return await self.run(text, timeout=timeout, settle=settle)
+
     async def ask(self, text: str, *, timeout: float = 180.0, settle: float = 0.6) -> str:
         """Submit one question and return the parsed reply.
 
         `ask` is the high-level name for simple delegation; it keeps the visible
         resource open, unlike a headless one-shot command.
         """
-        return await self.run(text, timeout=timeout, settle=settle)
+        return await self.run_to_completion(text, timeout=timeout, settle=settle)
 
     # -- waiting (Playwright-style) -----------------------------------------
 

--- a/packages/tui/tui/src/frame/mod.rs
+++ b/packages/tui/tui/src/frame/mod.rs
@@ -26,6 +26,11 @@ pub async fn collect_panes(manager: &crate::TuiManager) -> Vec<Pane> {
         let Ok(cells) = instance.read_styled_cells_async().await else {
             continue;
         };
+        let scrollback = instance
+            .read_scrollback_async()
+            .await
+            .map(|lines| lines.join("\n"))
+            .unwrap_or_default();
         // Cursor and exit are best-effort: a failed cursor read defaults to the
         // top-left, never dropping the whole pane.
         let cursor = instance
@@ -48,6 +53,7 @@ pub async fn collect_panes(manager: &crate::TuiManager) -> Vec<Pane> {
                 cols: instance.cols(),
                 alive: instance.is_alive(),
                 screen: sgr::encode(&rows),
+                scrollback,
                 cursor_row: cursor.row,
                 cursor_col: cursor.col,
                 cursor_visible: cursor.visible,

--- a/packages/tui/tui/src/slice/core.rs
+++ b/packages/tui/tui/src/slice/core.rs
@@ -3,7 +3,7 @@ use crate::{Error, Result};
 /// A resolved 1-indexed inclusive range, with optional endpoints filled in from
 /// the available extent.
 #[derive(Debug, Clone, Copy)]
-struct Bounds {
+pub(super) struct Bounds {
     /// First selected index (1-indexed, inclusive).
     from: usize,
     /// Last selected index (1-indexed, inclusive).


### PR DESCRIPTION
## Summary
* Adds dashboard topics for kernel work, with older completed topics folded by default.
* Nests resources under the task that produced them and keeps final resource panes visible after producers close.
* Adds code line highlighting, duration heat, terminal scrollback, Codex helper defaults, a high-level ask helper, shared `Agent` methods for Claude and Codex with `send_message` and `run_to_completion`, nu guidance, Polars DataFrame guidance, explicit Python typing guidance, background job completion notifications, and `pr_watch` for live PR CI resources with auto merge.

## Validation
* python -m py_compile packages/mcp/ix_notebook_mcp/*.py packages/tui/tui-py/python/tui/harness.py
* nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; agentName = "Codex"; }'
* git diff --check
* npm run check
* npm run build
* cargo check -p dashboard-core -p dashboard -p tui
* cargo test -p dashboard-core
* Review passes: correctness, security, performance, maintainability found no confirmed blockers.

Note: nix run .#lint was attempted, but failed while building a tree-sitter-kotlin-ng dependency before project lint diagnostics ran. The focused checks above passed.

Fixes #1855

(sent by Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group dashboard sidebar runs under collapsible topics with live PR watch support
> - The dashboard sidebar now organizes runs into collapsible topic groups within sessions; session-level and run-level resources nest under their respective owners, with duration-based background heat on run rows.
> - Adds a `topic_set` MCP tool and `watch_pr` MCP tool; `topic_set` labels subsequent executions, and `watch_pr` polls a GitHub PR via `gh`, renders a live HTML resource with check statuses, and optionally enables auto-merge.
> - `python_exec` now requires a topic to be set (configurable via `IX_MCP_REQUIRE_TOPIC`) and forwards the topic into the kernel execution wrapper and store.
> - Pane structs gain `parent`, `topic`, `line`, `error_line`, and `scrollback` fields; the `CodeBlock` component highlights the current executing line and error line; terminals render scrollback above the viewport.
> - Behavioral Change: `live_resources` now returns all resources including closed ones; `remove_scope` no longer deletes panes, preserving the final snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 792a362.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->