### PR TITLE
Publish sh and nu calls as job resources

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -3191,7 +3191,35 @@ async def _sweep_resources() -> None:
             # close() also tears down an interactive resource's action channel
             # and dispatcher, so a dead pane cannot keep accepting ix.act posts.
             res.close()
+            try:
+                # Very short-lived resources can open and close between flush
+                # ticks. Render one terminal snapshot before closing so they
+                # still appear under the job that created them.
+                if res.kind == "data":
+                    spec = await asyncio.wait_for(res.render_view(), timeout=2.0)
+                    res.html = json.dumps(spec, default=_safe_repr)
+                else:
+                    res.html = await asyncio.wait_for(res.render_html(), timeout=2.0)
+                res.error = None
+            except Exception as exc:
+                res.error = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+                res.html = (
+                    '<pre style="color:#f7768e;margin:0">resource render failed:\n'
+                    + _escape_html(res.error)
+                    + "</pre>"
+                )
             with contextlib.suppress(Exception):  # best-effort: store write must not kill the loop
+                _store.upsert_resource(
+                    _store_conn,
+                    id=res.id,
+                    title=res.title,
+                    kind=res.kind,
+                    html=res.html,
+                    status="closed",
+                    created_at=res.created,
+                    updated_at=now,
+                    execution_id=res.execution_id,
+                )
                 _store.close_resource(_store_conn, id=res.id, updated_at=now)
             resources.pop(res.id, None)
             continue

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -117,6 +117,7 @@ try:
     from ix_notebook_mcp.runtime import Result as _ResultBase
     from ix_notebook_mcp.runtime import _ANSI, _ansi_to_html, _ix_current, _strip_ansi
     from ix_notebook_mcp.runtime import _rename_current_job
+    from ix_notebook_mcp.runtime import register_resource as _register_resource
 
     _HAS_RESULT = True
 except Exception:  # pragma: no cover - exercised only outside the kernel
@@ -126,6 +127,7 @@ except Exception:  # pragma: no cover - exercised only outside the kernel
     _ResultBase = object
     _HAS_RESULT = False
     _ix_current = None
+    _register_resource = None
     _rename_current_job = None  # type: ignore[assignment]
     # SGR color only; the full escape grammar is the runtime's to own.
     _ANSI = re.compile(r"\x1b\[[0-9;]*m")
@@ -149,6 +151,8 @@ _COLOR_ENV = {
 }
 
 _MONO = "ui-monospace,SFMono-Regular,Menlo,monospace"
+_RESOURCE_TAIL_CHARS = 160_000
+_resource_counts: dict[str, int] = {}
 
 
 # Local file listing / reading / searching has a bundled, polars-first owner.
@@ -563,6 +567,87 @@ def _in_kernel_job() -> bool:
     return _ix_current is not None and _ix_current.get() is not None
 
 
+def _next_resource_id(kind: str) -> str | None:
+    if _ix_current is None:
+        return None
+    job = _ix_current.get()
+    job_id = getattr(job, "id", None) if job is not None else None
+    if not job_id:
+        return None
+    key = str(job_id)
+    count = _resource_counts.get(key, 0) + 1
+    _resource_counts[key] = count
+    return f"{kind}-{key}-{count}"
+
+
+def _command_title(kind: str, shown: str) -> str:
+    clean = re.sub(r"\s+", " ", _redact(shown)).strip()
+    if len(clean) > 72:
+        clean = clean[:69] + "..."
+    return f"{kind}: {clean or 'command'}"
+
+
+def _sh_resource_html(state: dict[str, object]) -> str:
+    now = asyncio.get_running_loop().time()
+    ended = state.get("ended")
+    end_time = ended if isinstance(ended, float) else now
+    started = state.get("started")
+    started_time = started if isinstance(started, float) else end_time
+    duration = max(0.0, end_time - started_time)
+    status = str(state.get("status") or "running")
+    code = state.get("code")
+    live_chunks = state.get("chunks")
+    if isinstance(live_chunks, list):
+        raw = "".join(str(chunk) for chunk in live_chunks)
+    else:
+        raw = str(state.get("raw") or "")
+    omitted = ""
+    if len(raw) > _RESOURCE_TAIL_CHARS:
+        omitted = f"... truncated to last {_RESOURCE_TAIL_CHARS:,} chars\n"
+        raw = raw[-_RESOURCE_TAIL_CHARS:]
+    body = _ansi_to_html(omitted + raw)
+    cmd = _html.escape(_redact(str(state.get("cmd") or "")))
+    cwd = state.get("cwd")
+    cwd_html = f'<span class="cwd">{_html.escape(os.fspath(cwd))}</span>' if cwd else ""
+    ok = status == "done" and code == 0
+    bad = status in {"failed", "timed out", "cancelled"} or (status == "done" and code != 0)
+    cls = "ok" if ok else "bad" if bad else "running"
+    code_html = "" if code is None else f'<span class="code">exit {code}</span>'
+    return (
+        "<style>"
+        "body{margin:0;background:#0f1117;color:#e5e7eb;font:12px ui-monospace,SFMono-Regular,Menlo,monospace}"
+        ".wrap{padding:10px}.meta{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:8px}"
+        ".pill{border-radius:999px;padding:2px 8px;background:#334155}.ok{background:#064e3b;color:#a7f3d0}"
+        ".bad{background:#7f1d1d;color:#fecaca}.running{background:#78350f;color:#fde68a}"
+        ".cmd{color:#93c5fd;white-space:pre-wrap;word-break:break-word;margin-bottom:6px}"
+        ".cwd{color:#9ca3af}.code{color:#9ca3af}pre{margin:0;white-space:pre-wrap;word-break:break-word}"
+        "</style>"
+        '<div class="wrap">'
+        '<div class="meta">'
+        f'<span class="pill {cls}">{_html.escape(status)}</span>'
+        f'<span>{duration:.2f}s</span>{code_html}{cwd_html}'
+        "</div>"
+        f'<div class="cmd">$ {cmd}</div>'
+        f"<pre>{body}</pre>"
+        "</div>"
+    )
+
+
+def _register_sh_resource(state: dict[str, object]) -> object | None:
+    if _register_resource is None or not _in_kernel_job():
+        return None
+    rid = _next_resource_id("sh")
+    if rid is None:
+        return None
+    return _register_resource(
+        render=lambda: _sh_resource_html(state),
+        id=rid,
+        title=_command_title("sh", str(state.get("cmd") or "")),
+        kind="sh",
+        alive=lambda: state.get("status") == "running",
+    )
+
+
 async def sh(
     cmd: str | list[str],
     *,
@@ -659,32 +744,55 @@ async def sh(
     if env:
         full_env.update(env)
 
-    if isinstance(cmd, (list, tuple)):
-        argv = [str(part) for part in cmd]
-        shown = shlex.join(argv)
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            cwd=cwd,
-            env=full_env,
-            start_new_session=True,
-        )
-    else:
-        shown = cmd
-        proc = await asyncio.create_subprocess_shell(
-            cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            cwd=cwd,
-            env=full_env,
-            start_new_session=True,
-        )
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    argv: list[str] | None = [str(part) for part in cmd] if isinstance(cmd, (list, tuple)) else None
+    shown = shlex.join(argv) if argv is not None else str(cmd)
+    state: dict[str, object] = {
+        "cmd": shown,
+        "cwd": os.fspath(cwd) if cwd is not None else None,
+        "status": "running",
+        "code": None,
+        "raw": "",
+        "started": started,
+        "ended": None,
+    }
+    resource = _register_sh_resource(state)
+
+    try:
+        if argv is not None:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=cwd,
+                env=full_env,
+                start_new_session=True,
+            )
+        else:
+            proc = await asyncio.create_subprocess_shell(
+                cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=cwd,
+                env=full_env,
+                start_new_session=True,
+            )
+    except Exception as exc:
+        state["status"] = "failed"
+        state["code"] = -1
+        state["raw"] = f"{type(exc).__name__}: {exc}\n"
+        state["ended"] = loop.time()
+        close = getattr(resource, "close", None)
+        if callable(close):
+            close()
+        raise
 
     do_echo = _in_kernel_job() if echo is None else echo
     decoder = codecs.getincrementaldecoder("utf-8")("replace")
     stripper = _EchoStripper()
     chunks: list[str] = []
+    state["chunks"] = chunks
 
     def _keep(text: str) -> None:
         chunks.append(text)
@@ -704,8 +812,6 @@ async def sh(
             sys.stdout.write(stripper.flush())
         await proc.wait()
 
-    loop = asyncio.get_running_loop()
-    started = loop.time()
     try:
         if timeout is not None:
             await asyncio.wait_for(_drain(), timeout)
@@ -723,19 +829,38 @@ async def sh(
         # parses this to return the matches found so far) instead of discarding a
         # long scan's work. It is the same merged stdout+stderr text `.raw` holds.
         exc.partial_output = "".join(chunks)  # type: ignore[attr-defined]
+        state["status"] = "timed out"
+        state["raw"] = exc.partial_output
+        state["ended"] = loop.time()
+        close = getattr(resource, "close", None)
+        if callable(close):
+            close()
         raise exc from None
     except asyncio.CancelledError:
         # The awaiting task was cancelled (jobs['<id>'].cancel()): take the child
         # and its whole group down with it, so a cancelled cell never leaves an
         # orphan still running (and holding locks) in the background.
         _terminate(proc)
+        state["status"] = "cancelled"
+        state["ended"] = loop.time()
+        close = getattr(resource, "close", None)
+        if callable(close):
+            close()
         raise
 
     duration = loop.time() - started
+    code = proc.returncode if proc.returncode is not None else -1
+    state["status"] = "done" if code == 0 else "failed"
+    state["code"] = code
+    state["raw"] = "".join(chunks)
+    state["ended"] = loop.time()
+    close = getattr(resource, "close", None)
+    if callable(close):
+        close()
     out = Output(
         cmd=shown,
-        code=proc.returncode if proc.returncode is not None else -1,
-        raw="".join(chunks),
+        code=code,
+        raw=str(state["raw"]),
         duration=duration,
         hint=_structured_hint(cmd),
     )

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -102,6 +102,7 @@ import re
 import shlex
 import signal
 import sys
+import time
 from typing import Any
 
 __all__ = ["Output", "ShellError", "sh", "zsh"]
@@ -588,7 +589,7 @@ def _command_title(kind: str, shown: str) -> str:
 
 
 def _sh_resource_html(state: dict[str, object]) -> str:
-    now = asyncio.get_running_loop().time()
+    now = time.monotonic()
     ended = state.get("ended")
     end_time = ended if isinstance(ended, float) else now
     started = state.get("started")

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -163,6 +163,28 @@ def test_interactive_resource_id_must_be_script_safe(tmp_path: Path, monkeypatch
     asyncio.run(run())
 
 
+def test_closed_before_first_sweep_keeps_final_resource(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+        res = runtime.register_resource(render=lambda: "<p>terminal</p>", id="blink", title="blink")
+        res.close()
+
+        await runtime._sweep_resources()
+
+        row = conn.execute(
+            "SELECT title, html, status FROM resources WHERE id = ?",
+            ("blink",),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "blink"
+        assert row[1] == "<p>terminal</p>"
+        assert row[2] == "closed"
+        assert "blink" not in runtime.resources
+
+    asyncio.run(run())
+
+
 def test_action_dispatch_runs_handler_and_streams_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     async def run() -> None:
         conn = store.connect(tmp_path / "r.db")

--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -174,3 +174,48 @@ def test_reset_discards_state() -> None:
     nu.reset()
     with pytest.raises(nu.NuError):
         run(nu("$doomed"))
+
+
+def test_nu_registers_job_resource(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Job:
+        id = "job456"
+
+    class Current:
+        def get(self) -> Job:
+            return Job()
+
+    class Resource:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    calls: list[dict[str, object]] = []
+    resource = Resource()
+
+    def register_resource(**kwargs: object) -> Resource:
+        calls.append(kwargs)
+        return resource
+
+    monkeypatch.setattr(nu, "_ix_current", Current())
+    monkeypatch.setattr(nu, "_register_resource", register_resource)
+    monkeypatch.setattr(nu, "_resource_counts", {})
+
+    df = run(nu("1 + 1"))
+
+    assert df["value"].item() == 2
+    assert resource.closed
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["id"] == "nu-job456-1"
+    assert call["kind"] == "nu"
+    assert str(call["title"]).startswith("nu: ")
+    render = call["render"]
+    assert callable(render)
+    html = render()
+    assert "done" in html
+    assert "2" in html
+    alive = call["alive"]
+    assert callable(alive)
+    assert alive() is False

--- a/packages/mcp/tests/test_sh_module.py
+++ b/packages/mcp/tests/test_sh_module.py
@@ -155,3 +155,87 @@ def test_zsh_helper_uses_zsh_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: pat
         "cmd": ["zsh", "-lc", "print $ZSH_VERSION"],
         "kwargs": {"cwd": cwd, "timeout": 1},
     }
+
+
+def test_sh_registers_job_resource(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Job:
+        id = "job123"
+
+    class Current:
+        def get(self) -> Job:
+            return Job()
+
+    class Resource:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    calls: list[dict[str, object]] = []
+    resource = Resource()
+
+    def register_resource(**kwargs: object) -> Resource:
+        calls.append(kwargs)
+        return resource
+
+    monkeypatch.setattr(sh, "_ix_current", Current())
+    monkeypatch.setattr(sh, "_register_resource", register_resource)
+    monkeypatch.setattr(sh, "_resource_counts", {})
+
+    out = asyncio.run(sh.sh([sys.executable, "-c", "print('resource-ok')"], echo=False))
+
+    assert out.ok
+    assert resource.closed
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["id"] == "sh-job123-1"
+    assert call["kind"] == "sh"
+    assert str(call["title"]).startswith("sh: ")
+    assert callable(call["render"])
+    html = call["render"]()
+    assert "resource-ok" in html
+    assert "done" in html
+    alive = call["alive"]
+    assert callable(alive)
+    assert alive() is False
+
+
+def test_sh_startup_failure_registers_terminal_resource(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Job:
+        id = "job404"
+
+    class Current:
+        def get(self) -> Job:
+            return Job()
+
+    class Resource:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    calls: list[dict[str, object]] = []
+    resource = Resource()
+
+    def register_resource(**kwargs: object) -> Resource:
+        calls.append(kwargs)
+        return resource
+
+    monkeypatch.setattr(sh, "_ix_current", Current())
+    monkeypatch.setattr(sh, "_register_resource", register_resource)
+    monkeypatch.setattr(sh, "_resource_counts", {})
+
+    with pytest.raises(FileNotFoundError):
+        asyncio.run(sh.sh(["__ix_missing_executable_for_resource_test__"], echo=False))
+
+    assert resource.closed
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["id"] == "sh-job404-1"
+    render = call["render"]
+    assert callable(render)
+    html = render()
+    assert "FileNotFoundError" in html
+    assert "failed" in html

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -67,8 +67,11 @@ Contract:
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import html as _html
 import inspect as _inspect
 import os
+import re
 from typing import TYPE_CHECKING
 
 from ._nu import Engine, NuError
@@ -84,11 +87,15 @@ __version__ = "0.1.0"
 # the dashboard. Outside (plain `import nu` in a test), it is silently ignored.
 try:
     from ix_notebook_mcp.runtime import _ix_current, _rename_current_job
+    from ix_notebook_mcp.runtime import register_resource as _register_resource
 except Exception:  # pragma: no cover - exercised only outside the kernel
     _ix_current = None
+    _register_resource = None
     _rename_current_job = None
 
 _engine: Engine | None = None
+_RESOURCE_TAIL_CHARS = 120_000
+_resource_counts: dict[str, int] = {}
 
 # The per-session slot: engines live INSIDE the session's namespace dict, so
 # an engine's lifetime is exactly its session's and one agent's `let`/`cd`
@@ -104,6 +111,91 @@ def _session_slot() -> dict | None:
     job = _ix_current.get()
     ns = getattr(job, "_ns", None) if job is not None else None
     return ns if isinstance(ns, dict) else None
+
+
+def _in_kernel_job() -> bool:
+    return _ix_current is not None and _ix_current.get() is not None
+
+
+def _next_resource_id(kind: str) -> str | None:
+    if _ix_current is None:
+        return None
+    job = _ix_current.get()
+    job_id = getattr(job, "id", None) if job is not None else None
+    if not job_id:
+        return None
+    key = str(job_id)
+    count = _resource_counts.get(key, 0) + 1
+    _resource_counts[key] = count
+    return f"{kind}-{key}-{count}"
+
+
+def _title(code: str) -> str:
+    clean = re.sub(r"\s+", " ", code).strip()
+    if len(clean) > 72:
+        clean = clean[:69] + "..."
+    return f"nu: {clean or 'pipeline'}"
+
+
+def _short_repr(value: object) -> str:
+    rows = getattr(value, "to_dicts", None)
+    if callable(rows):
+        with contextlib.suppress(Exception):
+            return repr(rows())
+    text = repr(value)
+    if len(text) > _RESOURCE_TAIL_CHARS:
+        return "... truncated to tail\n" + text[-_RESOURCE_TAIL_CHARS:]
+    return text
+
+
+def _nu_resource_html(state: dict[str, object]) -> str:
+    now = asyncio.get_running_loop().time()
+    ended = state.get("ended")
+    end_time = ended if isinstance(ended, float) else now
+    started = state.get("started")
+    started_time = started if isinstance(started, float) else end_time
+    duration = max(0.0, end_time - started_time)
+    status = str(state.get("status") or "running")
+    bad = status in {"failed", "timed out", "cancelled"}
+    cls = "bad" if bad else "ok" if status == "done" else "running"
+    code = _html.escape(str(state.get("code") or ""))
+    cwd = state.get("cwd")
+    cwd_html = f'<span class="cwd">{_html.escape(os.fspath(cwd))}</span>' if cwd else ""
+    body_value = state.get("error") if bad else state.get("result")
+    body = _html.escape("" if body_value is None else _short_repr(body_value))
+    return (
+        "<style>"
+        "body{margin:0;background:#0f1117;color:#e5e7eb;font:12px ui-monospace,SFMono-Regular,Menlo,monospace}"
+        ".wrap{padding:10px}.meta{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:8px}"
+        ".pill{border-radius:999px;padding:2px 8px;background:#334155}.ok{background:#064e3b;color:#a7f3d0}"
+        ".bad{background:#7f1d1d;color:#fecaca}.running{background:#78350f;color:#fde68a}"
+        ".cmd{color:#93c5fd;white-space:pre-wrap;word-break:break-word;margin-bottom:6px}"
+        ".cwd{color:#9ca3af}pre{margin:0;white-space:pre-wrap;word-break:break-word}"
+        "</style>"
+        '<div class="wrap">'
+        '<div class="meta">'
+        f'<span class="pill {cls}">{_html.escape(status)}</span>'
+        f"<span>{duration:.2f}s</span>{cwd_html}"
+        "</div>"
+        f'<div class="cmd">nu&gt; {code}</div>'
+        f"<pre>{body}</pre>"
+        "</div>"
+    )
+
+
+def _register_nu_resource(state: dict[str, object]) -> object | None:
+    if _register_resource is None or not _in_kernel_job():
+        return None
+    rid = _next_resource_id("nu")
+    if rid is None:
+        return None
+    return _register_resource(
+        render=lambda: _nu_resource_html(state),
+        id=rid,
+        title=_title(str(state.get("code") or "")),
+        kind="nu",
+        alive=lambda: state.get("status") == "running",
+    )
 
 
 def _default_engine() -> Engine:
@@ -166,6 +258,17 @@ async def _run(
         _rename_current_job(name)
 
     engine = _default_engine()
+    loop = asyncio.get_running_loop()
+    state: dict[str, object] = {
+        "code": code,
+        "cwd": os.fspath(cwd) if cwd is not None else None,
+        "status": "running",
+        "result": None,
+        "error": None,
+        "started": loop.time(),
+        "ended": None,
+    }
+    resource = _register_nu_resource(state)
     coroutine, handle = engine.eval(
         code,
         input=_serialize_input(input) if input is not None else None,
@@ -173,7 +276,7 @@ async def _run(
         env=env,
     )
     try:
-        return await asyncio.wait_for(asyncio.ensure_future(coroutine), timeout)
+        decoded = await asyncio.wait_for(asyncio.ensure_future(coroutine), timeout)
     except TimeoutError:
         # The handle targets THIS eval only, so a timeout that fires while we
         # are still queued behind another pipeline can never interrupt it.
@@ -184,12 +287,39 @@ async def _run(
         # behind it. A fresh engine costs the persistent state (documented);
         # the abandoned one stops (and drops) whenever its element finishes.
         _discard_engine(engine)
+        state["status"] = "timed out"
+        state["error"] = f"nu pipeline timed out after {timeout}s (engine state discarded): {code}"
+        state["ended"] = loop.time()
+        close = getattr(resource, "close", None)
+        if callable(close):
+            close()
         raise TimeoutError(
             f"nu pipeline timed out after {timeout}s (engine state discarded): {code}"
         ) from None
     except asyncio.CancelledError:
         handle.interrupt()
+        state["status"] = "cancelled"
+        state["ended"] = loop.time()
+        close = getattr(resource, "close", None)
+        if callable(close):
+            close()
         raise
+    except Exception as exc:
+        state["status"] = "failed"
+        state["error"] = str(exc)
+        state["ended"] = loop.time()
+        close = getattr(resource, "close", None)
+        if callable(close):
+            close()
+        raise
+    else:
+        state["status"] = "done"
+        state["result"] = decoded
+        state["ended"] = loop.time()
+        close = getattr(resource, "close", None)
+        if callable(close):
+            close()
+        return decoded
 
 
 def _rows_frame(rows: list[dict]) -> pl.DataFrame:

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -72,6 +72,7 @@ import html as _html
 import inspect as _inspect
 import os
 import re
+import time
 from typing import TYPE_CHECKING
 
 from ._nu import Engine, NuError
@@ -149,7 +150,7 @@ def _short_repr(value: object) -> str:
 
 
 def _nu_resource_html(state: dict[str, object]) -> str:
-    now = asyncio.get_running_loop().time()
+    now = time.monotonic()
     ended = state.get("ended")
     end_time = ended if isinstance(ended, float) else now
     started = state.get("started")


### PR DESCRIPTION
## Summary
- publish each `sh` call as a persistent job resource, including startup failures
- publish each `nu` call as a persistent job resource with status, duration, cwd, result, or error
- persist a terminal resource snapshot when a resource closes before the first sweep sees it

## Validation
- `python -m py_compile` on changed Python sources and tests
- direct contract checks for `sh`, `sh` startup failure, `nu`, and closed-before-first-sweep persistence
- `git diff --check`
- read-only review agents reported no correctness blockers and no actionable findings

## Note
- Targeted Nix checks could not launch builders locally: the `nix build .#mcp.tests.typecheckSmoke .#mcp.tests.nuTests .#mcp.tests.channelTests` client stayed idle with no child builder and no output, so I stopped that validation job and used direct contract checks instead.

Closes #1858

(sent by Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish `sh` and `nu` calls as live job resources with HTML snapshots
> - When `sh()` or `nu()` runs inside a kernel job, it now registers a live resource that streams status and, on completion, stores an HTML snapshot with duration, exit code/status, and terminal output.
> - Resource IDs follow the pattern `{kind}-{job_id}-{n}` (e.g. `sh-job123-1`), tracked per-job via a `_resource_counts` dict in each module.
> - The sweep task in [runtime.py](https://github.com/indexable-inc/index/pull/1859/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now records a final rendered snapshot for dead resources before closing them, so resources closed between flush ticks are still persisted.
> - Errors (startup failure, timeout, cancellation) are captured into the resource's HTML, showing the error message and a `failed`/`timed out`/`cancelled` status pill.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8b3ca9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->