### PR TITLE
system-prompt: add noHandWrittenSerializations rule

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -447,6 +447,28 @@ let
       };
     }
     {
+      noHandWrittenSerializations = {
+        text = ''
+          Never hand-write a serialized form a tool will parse (argv option strings,
+          connection URLs, query fragments, embedded mini-languages). Keep each fact
+          in a named, typed binding, and give the format one renderer that serializes
+          structured values (attrsets, lists) at the boundary; a renderer that accepts
+          pre-joined string fragments is the same bug moved down a level. Two call
+          sites assembling the same string shape means the renderer is missing. This
+          applies to: socat addresses, systemd units, Docker Compose files, Nix
+          expressions built as strings, shell argv, SQL queries, config file
+          fragments, API payloads, and any other format a downstream parser consumes.
+        '';
+        reason = ''
+          Hand-written socat addresses (kind + options as separate strings) drifted
+          across call sites until a unified renderer consolidated facts into structured
+          attrsets and produced byte-identical output. The same pattern appeared in
+          systemd units, query parameters, and shell argv scattered across the codebase
+          instead of rendered from one place.
+        '';
+      };
+    }
+    {
       fixAtSource = {
         text = ''
           Fix problems at their source. Choose the best long-term solution and prefer


### PR DESCRIPTION
Never hand-write serialized forms that downstream tools parse (argv, URLs, mini-languages). Keep facts in structured bindings and render them through one place.

Consolidates the socat address pattern that reduced fact drifting across call sites via unified renderer. The same principle applies to systemd units, query parameters, shell argv, config fragments, and any embedded serialization.

Proven by byte-identical output of rendered socat argv in config(0ccbc593).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `noHandWrittenSerializations` rule to system prompt
> Adds a new `noHandWrittenSerializations` rule to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1861/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that discourages hand-writing serialized forms for downstream parsers. The rule cites prior drift in hand-written addresses, units, and queries as motivation, and prescribes using centralized renderers for structured data instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized faf7b62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->