### PR TITLE
feat(ci): fast-forward a cache-ready ref after Cache push succeeds

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -187,3 +187,62 @@ jobs:
           else
             echo "::notice::every root already cached in ix-public; nothing to realise or push"
           fi
+
+  # Consumers pinning `github:indexable-inc/index/main` can `nix flake update`
+  # inside the 15-25 min window between a merge and the push above finishing,
+  # locking a rev whose darwin cross closure is not yet on cache.ix.dev; the
+  # substitute-only darwin packages (RFC 0009) then fail with "Required
+  # system: 'x86_64-linux'" (indexable-inc/index#1862). Fast-forwarding
+  # `cache-ready` only after a successful push gives consumers a pin target
+  # whose closure is always published. Downstream of `push`, so a failure
+  # here never gates the cache publish itself.
+  advance-cache-ready:
+    needs: push
+    # workflow_dispatch can target any ref; only main commits may move the
+    # consumer pin.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Fast-forward cache-ready to the pushed commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Stderr stays on the job log: a 404 here is the expected first-run
+          # path, anything else explains itself in the log.
+          if ! current="$(gh api "repos/$REPOSITORY/git/ref/heads/cache-ready" --jq .object.sha)"; then
+            gh api -X POST "repos/$REPOSITORY/git/refs" \
+              -f ref=refs/heads/cache-ready -f "sha=$SHA" > /dev/null
+            echo "::notice::created cache-ready at $SHA"
+            exit 0
+          fi
+
+          if [ "$current" = "$SHA" ]; then
+            echo "::notice::cache-ready already at $SHA"
+            exit 0
+          fi
+
+          # force=false makes the update fast-forward-only: the API rejects
+          # any non-ancestor move, so a re-run of an older commit's workflow
+          # (or a full-pass dispatch racing a newer merge) can never drag the
+          # ref backwards past closures already published.
+          if gh api -X PATCH "repos/$REPOSITORY/git/refs/heads/cache-ready" \
+               -f "sha=$SHA" -F force=false > /dev/null; then
+            echo "::notice::cache-ready advanced: $current -> $SHA"
+            exit 0
+          fi
+
+          # Distinguish the expected rejection (this run's commit is already
+          # behind the ref) from a real failure that strands consumers.
+          status="$(gh api "repos/$REPOSITORY/compare/$SHA...cache-ready" --jq .status || echo unknown)"
+          if [ "$status" = "ahead" ] || [ "$status" = "identical" ]; then
+            echo "::notice::cache-ready ($current) is already at or past $SHA; not moving it backwards"
+          else
+            echo "::error::could not fast-forward cache-ready to $SHA (compare status: $status); darwin consumers tracking cache-ready stay pinned at $current (indexable-inc/index#1862)"
+            exit 1
+          fi

--- a/packages/site/src/lib/rfcs/0009-cross-compiled-darwin-packages.svx
+++ b/packages/site/src/lib/rfcs/0009-cross-compiled-darwin-packages.svx
@@ -153,6 +153,8 @@ The merge covers both Darwin systems, but with the Apple-silicon-only default th
 
 The `cache-push` workflow realises `.#cachePushRoots.x86_64-linux` and pushes closures to the public `ix-public` atticd cache at `cache.ix.dev` on every merge to main. The triple-suffixed cross outputs are part of that roots set. Because the Darwin aliases *are* those derivations, a Mac's `nix build .#dag-runner` resolves to a store path CI already pushed: substitution, not compilation. The cross unit graph is input-addressed (unlike the native workspace's floating content-addressed default), so every cross output path is known at eval and the Mac substitutes it via a plain narinfo lookup — the cache serves no `/realisations` build trace, which a floating content-addressed output would need to map its derivation to an output path (#1755).
 
+That push takes 15-25 minutes, so `main` briefly points at revs whose cross closure is not yet on the cache; a Mac that pins main inside that window hits the substitute-or-nothing wall (#1862). After the push succeeds, the workflow fast-forwards the `cache-ready` branch to the pushed commit. Consumers should pin `github:indexable-inc/index/cache-ready` instead of `main`: the ref trails main by one cache-push run, moves only forward along main history, and only ever points at revs whose darwin closure is already published.
+
 ### Proved in CI, on every push
 
 A green build does not prove the toolchain emitted a Darwin object; the smoke checks do. They run on the Linux CI host and read the Mach-O header:


### PR DESCRIPTION
Closes #1862.

`Cache push` takes 15-25 min per main commit, so a consumer that runs `nix flake update index` right after a merge pins a rev whose darwin cross closure (RFC 0009, substitute-only) is not yet on cache.ix.dev and fails with `Required system: 'x86_64-linux'`. Hit 2026-07-03 and 2026-07-05.

- New `advance-cache-ready` job in `cache-push.yml`: after the push job succeeds for a main commit, fast-forward the `cache-ready` branch to that rev via the git refs API with `force=false`, so the ref can only ever move forward along main history (re-runs of older commits and racing full-pass dispatches are rejected as non-fast-forward and logged as a notice, not an error). Genuine failures emit an `::error::` annotation. The job is downstream of `push`, so it never gates the cache publish itself.
- Job-level `permissions: contents: write` on the new ubuntu-latest job only; the workflow default stays `contents: read` and the self-hosted push job is untouched. The `main` ruleset covers only `refs/heads/main`, so a plain `GITHUB_TOKEN` branch push works (this is a ref update, not a PR creation).
- RFC 0009 gains a paragraph documenting `github:indexable-inc/index/cache-ready` as the consumer-facing pin target.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fast-forward `cache-ready` branch after successful cache push on main
> - Adds a new `advance-cache-ready` job to [cache-push.yml](.github/workflows/cache-push.yml) that runs after a successful push on `main`, using GitHub's refs API via `gh` to fast-forward (or create) the `cache-ready` branch to the pushed commit SHA.
> - The job no-ops if the ref is already at or ahead of the target SHA, and fails if a fast-forward is not possible.
> - Documents in the RFC that consumers should pin `github:indexable-inc/index/cache-ready` instead of `main` to avoid pulling caches before they are ready.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45c672f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->