### PR TITLE
feat(agent): answer the question behind the question, verdict-first

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -799,6 +799,35 @@ let
       };
     }
     {
+      answerIntent = {
+        text = ''
+          Answer the question behind the question. Before answering, infer why
+          the user is asking (the decision they face, the project it serves)
+          and aim the answer there; a literally-correct answer to the wrong
+          question is a miss. For information and advice questions, open with
+          your verdict or intuition in a sentence or two, then only the facts
+          that earn it; keep the rest for follow-ups. Default to terse prose
+          over surveys: an exhaustive list, comparison table, or option
+          catalog only when the user asks for one or the decision genuinely
+          turns on seeing every option. When intent is ambiguous and the
+          readings diverge, answer the most likely reading and name the
+          assumption in one line.
+        '';
+        reason = ''
+          A research thread (SQLite/Dolt merge tooling) drew three corrections
+          in a row: each answer surveyed every tool with per-item feature
+          bullets while the user actually wanted a verdict for the unstated
+          use case (a git merge driver for DB files in their repo). The
+          user's own words: "think about why I asked this question", "this is
+          really verbose ... useful information first", and "I don't
+          necessarily need a list, I need your intuition first and then maybe
+          a list if I ask". Sibling of noMetaNarration, which owns leading
+          with the result for task status; this rule owns aiming at intent
+          and verdict-first shape for Q&A.
+        '';
+      };
+    }
+    {
       noMetaNarration = {
         text = ''
           Lead with the result. Skip process narration, deliberation, and rule

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -823,7 +823,9 @@ let
           necessarily need a list, I need your intuition first and then maybe
           a list if I ask". Sibling of noMetaNarration, which owns leading
           with the result for task status; this rule owns aiming at intent
-          and verdict-first shape for Q&A.
+          and verdict-first shape for Q&A. Distinct from decisiveness's "no
+          option menus", which governs choosing an action; this governs how
+          an answer is shaped.
         '';
       };
     }


### PR DESCRIPTION
Adds the `answerIntent` system-prompt rule, placed next to `noMetaNarration` (which owns result-first task status; this owns Q&A shape):

- infer why the user is asking and aim the answer at that intent
- open with the verdict or intuition, then only the facts that earn it
- terse prose by default; exhaustive lists/comparisons only when asked for or decisive
- ambiguous intent: answer the most likely reading, name the assumption

Rendered output verified with `nix eval --raw --impure`.

Closes #1865

(opened by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add verdict-first, intent-inferring response guideline to agent system prompt
> Adds an `answerIntent` rule to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1866/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) directing the agent to infer the question behind the question and lead responses with a brief verdict followed by only the most relevant supporting facts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5736032.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->