### PR TITLE
feat(agent): default branch-off side tasks to a background subagent

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -611,11 +611,18 @@ let
           high-stakes decisions; cheaper tiers for mechanical edits, search, and
           settled execution. For simple delegated questions, use the MCP subagent
           tool to spawn Codex on `gpt-5.5` with low reasoning.
+          When a request branches off the current conversation (a side task,
+          fix, or change that is not the thread's main line), dispatch it to a
+          named background subagent by default and keep the main thread
+          conversational; do the work inline only when it is the conversation's
+          actual subject or trivially quick.
         '';
         reason = ''
           Serial main-thread editing wasted wall clock on independent work and bloated
           the orchestrating context. Simple lookup questions do not need expensive
-          reasoning, but still benefit from separate context.
+          reasoning, but still benefit from separate context. Doing a mid-conversation
+          side task inline blocks the user's follow-ups; a background subagent keeps the
+          live conversation fluid.
         '';
       };
     }


### PR DESCRIPTION
Extends the existing `backgroundSubagents` rule so a mid-conversation request that branches off the thread's main line (a side task, fix, or change) is dispatched to a named background subagent by default, keeping the live conversation fluid. Inline only when the task is the conversation's actual subject or trivially quick.

Motivated by a real incident: during a research conversation, a side system-prompt change was done inline (worktree/edit/PR), interrupting the conversation flow.

Closes #1867

_Authored by Claude on behalf of Andrew._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default branch-off side tasks to a background subagent in the system prompt
> Updates [system-prompt.nix](https://github.com/indexable-inc/index/pull/1868/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to instruct the model to dispatch side tasks (requests that branch from the main conversation) to named background subagents by default, keeping the main thread conversational. Inline mid-conversation side tasks are now only handled directly when they are the primary subject or trivially quick.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f963ef4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->