### PR TITLE
pi-harnesses: add omp (oh-my-pi) setup

### DIFF
--- a/packages/agent/pi-harnesses/README.md
+++ b/packages/agent/pi-harnesses/README.md
@@ -18,6 +18,7 @@ pi-harnesses/
   prosecutor/             # id: pi-prosecutor - executor under a skeptical, earned-trust supervisor
   beam/                   # id: pi-beam       - executor with beam search over isolated worktree branches
   fusion/                 # id: pi-fusion     - primary agent delegating to a gpt-5.5-low sidekick
+  omp/                    # id: omp           - oh-my-pi: pinned upstream release binary + Claude bridges (not mk-pi-harness)
 ```
 
 `engine/` is the original `packages/pi-harness` (ENG-2261/2262), moved here

--- a/packages/agent/pi-harnesses/omp/README.md
+++ b/packages/agent/pi-harnesses/omp/README.md
@@ -1,0 +1,47 @@
+# omp
+
+The [oh-my-pi](https://github.com/can1357/oh-my-pi) (`omp`) coding-agent setup:
+the pinned upstream release binary plus the extensions and smoke test that make
+Claude Code assets work under it. Copied from the personal nix repo
+(`flake/omp.nix`, `dots/omp/extensions/`, `scripts/omp/`); that repo remains
+the deployed source, this is the shared home alongside the other harnesses.
+
+Unlike its siblings, `omp` is not built through `shared/mk-pi-harness.nix`: it
+is upstream's own harness distribution (a self-contained `bun build --compile`
+binary), packaged from the GitHub release because a from-source nix build needs
+network inside the sandbox at three stages (bun dependency install, the
+cross-target bun runtime download, the napi addon pipeline). See default.nix
+for the bump procedure.
+
+```
+nix run .#omp
+```
+
+## Layout
+
+```
+omp/
+  default.nix                   # pinned release binary (autoPatchelf'd on Linux)
+  extensions/
+    claude-hooks.ts             # Claude Code hook protocol bridge (settings.json hooks run under omp)
+    claude-agents.ts            # .claude/agents/*.md -> omp task-agent translation
+    modes.ts                    # /mode: named modelRoles bundles from ~/.omp/agent/modes.json
+  smoke/
+    claude-hooks-smoke.sh       # end-to-end bridge smoke; run when bumping the pin
+```
+
+## Wiring
+
+The extensions are user-level, not baked into the binary: symlink them into
+`~/.omp/agent/extensions/` (the deployed home config does exactly that).
+`modes.ts` additionally reads mode definitions from `~/.omp/agent/modes.json`,
+a JSON object of `{ <name>: { description?, roles: { default, task, ... } } }`
+with `provider/model[:thinking][,fallback...]` role syntax.
+
+The smoke test needs a working `omp` with model credentials (it does real `-p`
+runs), so it is a manual gate, not a nix check:
+
+```
+OMP=$(nix build .#omp --print-out-paths)/bin/omp \
+  packages/agent/pi-harnesses/omp/smoke/claude-hooks-smoke.sh
+```

--- a/packages/agent/pi-harnesses/omp/default.nix
+++ b/packages/agent/pi-harnesses/omp/default.nix
@@ -1,0 +1,76 @@
+# omp (oh-my-pi) coding agent, packaged from the upstream GitHub release
+# binaries. Upstream ships self-contained `bun build --compile` executables and
+# CI-verifies exactly these artifacts; a from-source build under nix needs
+# network inside the sandbox at three stages (bun dependency install, the
+# cross-target bun runtime download, the napi addon pipeline), so the release
+# asset is the packaging boundary. Bumping: update `version`, refresh each
+# hash from the per-asset sha256 digests on the release page
+# (`gh release view v<version> --repo can1357/oh-my-pi --json assets`), then
+# run smoke/claude-hooks-smoke.sh to catch extension-API drift in the
+# Claude bridges (extensions/claude-hooks.ts, claude-agents.ts).
+#
+# Runtime notes: the binary extracts its native addon to ~/.omp/natives/<v>/ on
+# first run and self-update (`omp update`) fails harmlessly against the
+# read-only store — update by bumping this file instead.
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+}: let
+  version = "16.3.4";
+  assets = {
+    aarch64-linux = {
+      name = "omp-linux-arm64";
+      hash = "sha256-6c62RokhOv4b3LwX1N3/BoRLGreUA17VEsdwSLwEFq4=";
+    };
+    x86_64-linux = {
+      name = "omp-linux-x64";
+      hash = "sha256-axXfGYpTezJN1+fJOAH/EehAGSmCfaMEdr9jAheCBug=";
+    };
+    aarch64-darwin = {
+      name = "omp-darwin-arm64";
+      hash = "sha256-soPwaXaytyPIwh5L7nCcTFMpIlaoSDcfch7m+gVcr9Y=";
+    };
+    x86_64-darwin = {
+      name = "omp-darwin-x64";
+      hash = "sha256-W2ZQkfu4QyxvkY1LShb4GoTuetjw/gfFcJKyP0UIEZM=";
+    };
+  };
+  system = stdenvNoCC.hostPlatform.system;
+  asset =
+    assets.${system}
+    or (throw "omp: no upstream release asset for ${system}");
+in
+  stdenvNoCC.mkDerivation {
+    pname = "omp";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://github.com/can1357/oh-my-pi/releases/download/v${version}/${asset.name}";
+      inherit (asset) hash;
+    };
+
+    dontUnpack = true;
+    dontStrip = true;
+
+    # The binary links only glibc; patching the interpreter makes the
+    # package run on hosts without nix-ld.
+    nativeBuildInputs = lib.optional stdenvNoCC.hostPlatform.isLinux autoPatchelfHook;
+
+    installPhase = ''
+      # shell
+      runHook preInstall
+      install -Dm755 $src $out/bin/omp
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Oh My Pi coding agent (upstream release binary)";
+      homepage = "https://github.com/can1357/oh-my-pi";
+      license = lib.licenses.mit;
+      mainProgram = "omp";
+      platforms = builtins.attrNames assets;
+      sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+    };
+  }

--- a/packages/agent/pi-harnesses/omp/extensions/claude-agents.ts
+++ b/packages/agent/pi-harnesses/omp/extensions/claude-agents.ts
@@ -1,0 +1,377 @@
+/**
+ * claude-agents: make Claude Code agent definitions available to omp's task
+ * tool, keeping `.claude/agents/*.md` as the single source of truth.
+ *
+ * omp intentionally skips `.claude/agents` in task-agent discovery (frontmatter
+ * schema mismatch) and only reads `<project>/.omp/agents` and
+ * `~/.omp/agent/agents`. Discovery re-scans at every spawn, so materializing
+ * files there is enough - there is no in-memory registration API.
+ *
+ * Strategy (cheapest faithful mapping, chosen after auditing real defs):
+ *   - omp lowercases tool names at parse time, so `Read, Grep, Glob, Bash,
+ *     Edit, Write, Task` already work. A definition whose frontmatter parses
+ *     clean is exposed as a plain SYMLINK - no copy, no drift.
+ *   - A definition that needs help (multi-word Claude tools like WebSearch,
+ *     Agent->task, model pins like `sonnet`/`inherit`) gets a generated COPY
+ *     where only the `tools:`/`model:` frontmatter lines are spliced; the body
+ *     is byte-identical. `model:` values without a `/` are dropped so those
+ *     agents fall through to the configured task role.
+ *
+ * Generated artifacts are marked (`x-claude-agents-bridge` frontmatter key for
+ * copies; symlink target inside `.claude/agents` for links) and GC'd when the
+ * source disappears. Hand-written files in the target dirs are never touched.
+ * A `.omp/.gitignore` is dropped only when this extension creates `.omp/`.
+ *
+ * Runs once per process from the main session (subagent extension re-binding
+ * is detected via a globalThis slot - the loader cache-busts module instances,
+ * so module state cannot be used). Kill switch: OMP_CLAUDE_AGENTS=0.
+ */
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+// ---------------------------------------------------------------------------
+// omp tool vocabulary (mirror of src/tools/builtin-names.ts, lowercase)
+// ---------------------------------------------------------------------------
+
+const OMP_TOOLS: Record<string, true> = {
+	read: true,
+	bash: true,
+	edit: true,
+	ast_grep: true,
+	ast_edit: true,
+	ask: true,
+	debug: true,
+	eval: true,
+	ssh: true,
+	github: true,
+	glob: true,
+	grep: true,
+	lsp: true,
+	inspect_image: true,
+	browser: true,
+	checkpoint: true,
+	rewind: true,
+	task: true,
+	job: true,
+	irc: true,
+	todo: true,
+	web_search: true,
+	search_tool_bm25: true,
+	write: true,
+	memory_edit: true,
+	retain: true,
+	recall: true,
+	reflect: true,
+	learn: true,
+	manage_skill: true,
+	yield: true,
+};
+
+/** Claude tool name (lowercased) -> omp tool name. */
+const CLAUDE_TOOL_ALIASES: Record<string, string> = {
+	websearch: "web_search",
+	webfetch: "read",
+	agent: "task",
+	todowrite: "todo",
+	taskcreate: "todo",
+	taskupdate: "todo",
+	tasklist: "todo",
+	notebookedit: "edit",
+	notebookread: "read",
+	askuserquestion: "ask",
+};
+
+const MARKER_KEY = "x-claude-agents-bridge";
+
+// ---------------------------------------------------------------------------
+// Frontmatter splicing (line-oriented; body bytes are never touched)
+// ---------------------------------------------------------------------------
+
+interface SplitDoc {
+	/** Frontmatter lines, without the `---` fences. */
+	fmLines: string[];
+	/** Everything after the closing fence, verbatim (including leading newline). */
+	body: string;
+}
+
+function splitFrontmatter(content: string): SplitDoc | undefined {
+	const lines = content.split("\n");
+	if (lines[0]?.trim() !== "---") return undefined;
+	for (let i = 1; i < lines.length; i++) {
+		if (lines[i]?.trim() === "---") {
+			return { fmLines: lines.slice(1, i), body: lines.slice(i + 1).join("\n") };
+		}
+	}
+	return undefined;
+}
+
+/** Tool names from a `tools:` CSV value or a dash-list following the key. */
+function collectTools(fmLines: string[], keyIndex: number): { names: string[]; consumed: number } {
+	const value = fmLines[keyIndex]!.slice(fmLines[keyIndex]!.indexOf(":") + 1).trim();
+	if (value !== "") {
+		return { names: value.split(",").map(t => t.trim()).filter(Boolean), consumed: 1 };
+	}
+	const names: string[] = [];
+	let consumed = 1;
+	for (let i = keyIndex + 1; i < fmLines.length; i++) {
+		const item = fmLines[i]!.match(/^\s+-\s+(.+)$/);
+		if (!item) break;
+		names.push(item[1]!.trim());
+		consumed++;
+	}
+	return { names, consumed };
+}
+
+interface TranslationResult {
+	/** True when the source parses correctly under omp as-is (symlink is enough). */
+	clean: boolean;
+	/** Rewritten full file content; only set when `clean` is false. */
+	content?: string;
+}
+
+function translate(content: string, sourcePath: string): TranslationResult | undefined {
+	const doc = splitFrontmatter(content);
+	if (!doc) return undefined;
+
+	let dirty = false;
+	const out: string[] = [];
+	for (let i = 0; i < doc.fmLines.length; i++) {
+		const line = doc.fmLines[i]!;
+		if (/^tools\s*:/.test(line)) {
+			const { names, consumed } = collectTools(doc.fmLines, i);
+			const mapped: string[] = [];
+			for (const name of names) {
+				const lower = name.toLowerCase();
+				const alias = CLAUDE_TOOL_ALIASES[lower];
+				if (alias !== undefined) {
+					dirty = true;
+					if (!mapped.includes(alias)) mapped.push(alias);
+				} else {
+					// Known tools case-fold on omp's side; unknown names (e.g.
+					// mcp__*) pass through untouched - omp ignores unmatched ids.
+					if (!mapped.includes(name)) mapped.push(name);
+					if (OMP_TOOLS[lower] === undefined && !name.startsWith("mcp__")) dirty = true;
+				}
+			}
+			if (consumed > 1) dirty = true; // normalize dash-lists to CSV
+			out.push(`tools: ${mapped.join(", ")}`);
+			i += consumed - 1;
+			continue;
+		}
+		if (/^model\s*:/.test(line)) {
+			const value = line.slice(line.indexOf(":") + 1).trim();
+			if (!value.includes("/")) {
+				// Claude aliases (sonnet/opus/haiku/inherit) don't name an omp
+				// provider pattern; drop so the agent uses the task model role.
+				dirty = true;
+				continue;
+			}
+		}
+		out.push(line);
+	}
+
+	if (!dirty) return { clean: true };
+	out.push(`${MARKER_KEY}: "${sourcePath}"`);
+	return { clean: false, content: `---\n${out.join("\n")}\n---\n${doc.body}` };
+}
+
+// ---------------------------------------------------------------------------
+// Materialization and GC
+// ---------------------------------------------------------------------------
+
+function isBridgeSymlink(path: string, sourceDir: string): boolean {
+	try {
+		const target = resolve(dirname(path), readlinkSync(path));
+		return target.startsWith(sourceDir);
+	} catch {
+		return false;
+	}
+}
+
+function isBridgeCopy(path: string): boolean {
+	try {
+		return readFileSync(path, "utf8").slice(0, 4096).includes(`${MARKER_KEY}:`);
+	} catch {
+		return false;
+	}
+}
+
+interface SyncStats {
+	linked: number;
+	rewritten: number;
+	removed: number;
+	skipped: string[];
+}
+
+/** Mirror one Claude agents dir into one omp agents dir. Idempotent. */
+function syncAgentsDir(sourceDir: string, targetDir: string, onCreateOmpDir?: () => void): SyncStats {
+	const stats: SyncStats = { linked: 0, rewritten: 0, removed: 0, skipped: [] };
+	const sources = existsSync(sourceDir)
+		? readdirSync(sourceDir).filter((f: string) => f.endsWith(".md"))
+		: [];
+
+	// GC pass: drop bridge-owned entries whose source vanished.
+	if (existsSync(targetDir)) {
+		for (const entry of readdirSync(targetDir)) {
+			const full = join(targetDir, entry);
+			const ours = lstatSync(full).isSymbolicLink() ? isBridgeSymlink(full, sourceDir) : isBridgeCopy(full);
+			if (ours && !sources.includes(entry)) {
+				rmSync(full);
+				stats.removed++;
+			}
+		}
+	}
+
+	if (sources.length === 0) return stats;
+	if (!existsSync(targetDir)) {
+		onCreateOmpDir?.();
+		mkdirSync(targetDir, { recursive: true });
+	}
+
+	for (const file of sources) {
+		const sourcePath = join(sourceDir, file);
+		const targetPath = join(targetDir, file);
+		let content: string;
+		try {
+			content = readFileSync(sourcePath, "utf8");
+		} catch {
+			continue;
+		}
+		const result = translate(content, sourcePath);
+		if (!result) {
+			stats.skipped.push(`${file}: no frontmatter`);
+			continue;
+		}
+
+		// Never clobber a hand-written entry: keep regular files without our
+		// marker and symlinks that do not point into the Claude agents dir.
+		{
+			const existing = lstatSyncSafe(targetPath);
+			if (existing) {
+				const foreign = existing.isSymbolicLink()
+					? !isBridgeSymlink(targetPath, sourceDir)
+					: !isBridgeCopy(targetPath);
+				if (foreign) {
+					stats.skipped.push(`${file}: hand-written file exists`);
+					continue;
+				}
+			}
+		}
+
+		if (result.clean) {
+			const linkTarget = relative(targetDir, sourcePath);
+			const existing = lstatSyncSafe(targetPath);
+			if (existing?.isSymbolicLink() && readlinkSync(targetPath) === linkTarget) continue;
+			if (existing) rmSync(targetPath);
+			symlinkSync(linkTarget, targetPath);
+			stats.linked++;
+		} else if (result.content !== undefined) {
+			const existing = lstatSyncSafe(targetPath);
+			if (existing && !existing.isSymbolicLink() && readFileSync(targetPath, "utf8") === result.content) continue;
+			if (existing) rmSync(targetPath);
+			writeFileSync(targetPath, result.content);
+			stats.rewritten++;
+		}
+	}
+	return stats;
+}
+
+interface LstatLike {
+	isSymbolicLink(): boolean;
+}
+
+function lstatSyncSafe(path: string): LstatLike | undefined {
+	try {
+		return lstatSync(path);
+	} catch {
+		return undefined;
+	}
+}
+
+function findProjectRoot(cwd: string): string {
+	let dir = resolve(cwd);
+	for (;;) {
+		if (existsSync(join(dir, ".git")) || existsSync(join(dir, ".claude"))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return resolve(cwd);
+		dir = parent;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+interface MainSlot {
+	id?: string;
+}
+
+const MAIN_SLOT_KEY = "__ompClaudeAgentsMainSession";
+
+function mainSlot(): MainSlot {
+	// Unchecked cast: globalThis is the only store surviving the loader's
+	// per-binding module cache-busting; the key is namespaced and owned here.
+	const g = globalThis as unknown as Record<string, MainSlot | undefined>;
+	let slot = g[MAIN_SLOT_KEY];
+	if (slot === undefined) {
+		slot = {};
+		g[MAIN_SLOT_KEY] = slot;
+	}
+	return slot;
+}
+
+interface AgentsBridgeCtx {
+	ui: { notify(message: string, type?: "info" | "warning" | "error"): void };
+	cwd: string;
+	sessionManager: { getSessionId(): string };
+}
+
+export default function claudeAgentsBridge(pi: ExtensionAPI) {
+	if (process.env.OMP_CLAUDE_AGENTS === "0") return;
+
+	const sync = (ctx: AgentsBridgeCtx): void => {
+		const slot = mainSlot();
+		const sid = ctx.sessionManager.getSessionId();
+		if (slot.id !== undefined && slot.id !== sid) return; // subagent binding
+		slot.id = sid;
+
+		try {
+			const projectDir = findProjectRoot(ctx.cwd);
+			const userClaude = process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude");
+			const agentDir = process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".omp", "agent");
+
+			const ompDir = join(projectDir, ".omp");
+			const hadOmpDir = existsSync(ompDir);
+			const project = syncAgentsDir(join(projectDir, ".claude", "agents"), join(ompDir, "agents"), () => {
+				if (!hadOmpDir) {
+					mkdirSync(ompDir, { recursive: true });
+					// Self-ignoring: with only bridge artifacts inside, `git status` stays clean.
+					writeFileSync(join(ompDir, ".gitignore"), "agents/\n.gitignore\n");
+				}
+			});
+			const user = syncAgentsDir(join(userClaude, "agents"), join(agentDir, "agents"));
+
+			const changed = project.linked + project.rewritten + project.removed + user.linked + user.rewritten + user.removed;
+			const skipped = [...project.skipped, ...user.skipped];
+			if (changed > 0) {
+				ctx.ui.notify(
+					`claude-agents: ${project.linked + user.linked} linked, ${project.rewritten + user.rewritten} translated, ${project.removed + user.removed} removed`,
+					"info",
+				);
+			}
+			for (const s of skipped) ctx.ui.notify(`claude-agents: skipped ${s}`, "warning");
+		} catch (err) {
+			ctx.ui.notify(`claude-agents: sync failed (${err instanceof Error ? err.message : String(err)})`, "warning");
+		}
+	};
+
+	pi.on("session_start", async (_event: unknown, ctx: AgentsBridgeCtx) => {
+		sync(ctx);
+	});
+
+	pi.on("session_switch", async (_event: unknown, ctx: AgentsBridgeCtx) => {
+		sync(ctx);
+	});
+}

--- a/packages/agent/pi-harnesses/omp/extensions/claude-hooks.ts
+++ b/packages/agent/pi-harnesses/omp/extensions/claude-hooks.ts
@@ -1,0 +1,697 @@
+/**
+ * claude-hooks: Claude Code hook protocol bridge for omp.
+ *
+ * Makes the Claude hook system (settings.json `hooks` blocks + JSON-on-stdin
+ * command scripts) work directly under omp, so repos keep one hook source of
+ * truth. Config is read exactly like Claude Code reads it:
+ *
+ *   ~/.claude/settings.json                  (user;   $CLAUDE_CONFIG_DIR honored)
+ *   <project>/.claude/settings.json          (project)
+ *   <project>/.claude/settings.local.json    (local)
+ *
+ * Hook arrays concatenate across levels (Claude semantics: all matching hooks
+ * run; identical commands are deduplicated per event fire). Scripts get the
+ * Claude wire protocol: JSON payload on stdin, CLAUDE_PROJECT_DIR in env,
+ * exit 0 = ok (stdout JSON honored), exit 2 = blocking (stderr is the reason),
+ * anything else = non-blocking warning.
+ *
+ * Event mapping (Claude -> omp extension bus):
+ *   SessionStart     -> session_start / session_switch (context injected on
+ *                       the next before_agent_start as a visible message)
+ *   UserPromptSubmit -> before_agent_start (context injection only; omp has
+ *                       no prompt-cancel channel, blocks are surfaced as
+ *                       warnings)
+ *   PreToolUse       -> tool_call ({ block, reason })
+ *   PostToolUse      -> tool_result (feedback appended to result content)
+ *   Stop             -> session_stop (omp natively speaks decision:"block")
+ *   SubagentStop     -> tool_result of the `task` tool (approximation)
+ *   SessionEnd       -> session_shutdown
+ *   PreCompact       -> session_before_compact
+ *
+ * Known gaps (documented, not silently dropped): PreToolUse input mutation
+ * (`updatedInput`) is impossible - omp tool_call can only block; Notification
+ * hooks have no omp equivalent; omp-only tools (eval, ast_edit, lsp, ...) are
+ * exposed under PascalCase passthrough names so `*` matchers still see them.
+ *
+ * Kill switch: OMP_CLAUDE_HOOKS=0. Inspect state with /claude-hooks.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+// ---------------------------------------------------------------------------
+// Boundary guards (settings.json and hook stdout are external input)
+// ---------------------------------------------------------------------------
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+	return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function asString(v: unknown): string | undefined {
+	return typeof v === "string" ? v : undefined;
+}
+
+function asNumber(v: unknown): number | undefined {
+	return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | undefined {
+	if (!text.startsWith("{")) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(text);
+		return isRecord(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config model
+// ---------------------------------------------------------------------------
+
+type HookSource = "user" | "project" | "local";
+
+interface HookEntry {
+	event: string;
+	matcher: string | undefined;
+	command: string;
+	timeoutMs: number;
+	source: HookSource;
+}
+
+interface BridgeConfig {
+	cwd: string;
+	projectDir: string;
+	entries: HookEntry[];
+	files: string[];
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000; // Claude Code default per hook command
+
+function parseSettingsHooks(raw: string, source: HookSource): HookEntry[] {
+	const json = parseJsonObject(raw.trim());
+	if (!json || !isRecord(json.hooks)) return [];
+	const out: HookEntry[] = [];
+	for (const [event, groups] of Object.entries(json.hooks)) {
+		if (!Array.isArray(groups)) continue;
+		for (const group of groups) {
+			if (!isRecord(group) || !Array.isArray(group.hooks)) continue;
+			const matcher = asString(group.matcher);
+			for (const hook of group.hooks) {
+				if (!isRecord(hook) || hook.type !== "command") continue;
+				const command = asString(hook.command);
+				if (!command) continue;
+				const timeoutSec = asNumber(hook.timeout);
+				out.push({
+					event,
+					matcher,
+					command,
+					timeoutMs: timeoutSec !== undefined ? timeoutSec * 1000 : DEFAULT_TIMEOUT_MS,
+					source,
+				});
+			}
+		}
+	}
+	return out;
+}
+
+function findProjectRoot(cwd: string): string {
+	let dir = resolve(cwd);
+	for (;;) {
+		if (existsSync(join(dir, ".git")) || existsSync(join(dir, ".claude"))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return resolve(cwd);
+		dir = parent;
+	}
+}
+
+function loadConfig(cwd: string): BridgeConfig {
+	const projectDir = findProjectRoot(cwd);
+	const userDir = process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude");
+	const sources: { path: string; source: HookSource }[] = [
+		{ path: join(userDir, "settings.json"), source: "user" },
+		{ path: join(projectDir, ".claude", "settings.json"), source: "project" },
+		{ path: join(projectDir, ".claude", "settings.local.json"), source: "local" },
+	];
+	const entries: HookEntry[] = [];
+	const files: string[] = [];
+	for (const src of sources) {
+		let raw: string;
+		try {
+			raw = readFileSync(src.path, "utf8");
+		} catch {
+			continue;
+		}
+		files.push(src.path);
+		entries.push(...parseSettingsHooks(raw, src.source));
+	}
+	return { cwd, projectDir, entries, files };
+}
+
+// ---------------------------------------------------------------------------
+// Tool name / input translation (omp -> Claude vocabulary)
+// ---------------------------------------------------------------------------
+
+/** Aliases let matchers written for either Claude generation ("Task" vs "Agent") fire. */
+const OMP_TO_CLAUDE_TOOL: Record<string, string[]> = {
+	bash: ["Bash"],
+	read: ["Read"],
+	edit: ["Edit"],
+	write: ["Write"],
+	grep: ["Grep"],
+	glob: ["Glob"],
+	task: ["Task", "Agent"],
+	todo: ["TodoWrite"],
+	web_search: ["WebSearch"],
+	browser: ["Browser"],
+	ask: ["AskUserQuestion"],
+};
+
+function claudeToolNames(ompName: string): string[] {
+	const mapped = OMP_TO_CLAUDE_TOOL[ompName];
+	if (mapped) return mapped;
+	const pascal = ompName
+		.split(/[_-]/)
+		.map(part => (part ? part[0]!.toUpperCase() + part.slice(1) : part))
+		.join("");
+	return [pascal];
+}
+
+function matcherMatches(matcher: string | undefined, candidates: string[]): boolean {
+	if (matcher === undefined || matcher === "" || matcher === "*") return true;
+	let re: RegExp | undefined;
+	try {
+		re = new RegExp(`^(?:${matcher})$`);
+	} catch {
+		re = undefined;
+	}
+	if (re !== undefined) {
+		const compiled = re;
+		return candidates.some(c => compiled.test(c));
+	}
+	return candidates.includes(matcher);
+}
+
+/**
+ * Best-effort translation of omp tool inputs into the Claude shapes hook
+ * scripts expect (`tool_input.command`, `tool_input.file_path`, ...). The raw
+ * omp input always rides along as `tool_input_omp` for precision-hungry hooks.
+ */
+function translateToolInput(toolName: string, input: Record<string, unknown>): Record<string, unknown> {
+	switch (toolName) {
+		case "bash":
+			return { command: input.command, description: input.i, timeout: input.timeout };
+		case "write":
+			return { file_path: input.path, content: input.content };
+		case "read":
+			return { file_path: input.path };
+		case "edit": {
+			// omp edit input is a hashline patch; recover the target path from
+			// the first `[path#TAG]` section header.
+			const patch = asString(input.input) ?? "";
+			const header = patch.match(/^\[([^\]#]+)#[0-9A-Fa-f]{4}\]/m);
+			return { file_path: header?.[1] };
+		}
+		case "grep":
+			return { pattern: input.pattern, path: input.path };
+		case "glob":
+			return { pattern: input.path };
+		case "task": {
+			const tasks = Array.isArray(input.tasks) ? input.tasks : [];
+			const first = isRecord(tasks[0]) ? tasks[0] : undefined;
+			return {
+				description: first ? asString(first.description) : undefined,
+				prompt: first ? asString(first.assignment) : undefined,
+				subagent_type: asString(input.agent) ?? "task",
+			};
+		}
+		default:
+			return { ...input };
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Hook execution (Claude wire protocol)
+// ---------------------------------------------------------------------------
+
+interface HookRunResult {
+	event: string;
+	command: string;
+	code: number | null;
+	stdout: string;
+	stderr: string;
+	timedOut: boolean;
+	spawnError: string | undefined;
+	durationMs: number;
+}
+
+async function runHookCommand(
+	entry: HookEntry,
+	payload: Record<string, unknown>,
+	projectDir: string,
+): Promise<HookRunResult> {
+	const started = Date.now();
+	const shell = Bun.which("bash") ?? "/bin/sh";
+	try {
+		const proc = Bun.spawn([shell, "-c", entry.command], {
+			cwd: projectDir,
+			env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		proc.stdin.write(JSON.stringify(payload));
+		proc.stdin.end();
+		let timedOut = false;
+		const softKill = setTimeout(() => {
+			timedOut = true;
+			proc.kill();
+		}, entry.timeoutMs);
+		const hardKill = setTimeout(() => proc.kill(9), entry.timeoutMs + 5000);
+		const [stdout, stderr, code] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		clearTimeout(softKill);
+		clearTimeout(hardKill);
+		return {
+			event: entry.event,
+			command: entry.command,
+			code,
+			stdout,
+			stderr,
+			timedOut,
+			spawnError: undefined,
+			durationMs: Date.now() - started,
+		};
+	} catch (err) {
+		return {
+			event: entry.event,
+			command: entry.command,
+			code: null,
+			stdout: "",
+			stderr: "",
+			timedOut: false,
+			spawnError: err instanceof Error ? err.message : String(err),
+			durationMs: Date.now() - started,
+		};
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Result interpretation (Claude exit-code + stdout-JSON semantics)
+// ---------------------------------------------------------------------------
+
+interface HookOutcome {
+	block: boolean;
+	ask: boolean;
+	reason: string | undefined;
+	context: string[];
+	systemMessages: string[];
+	warnings: string[];
+}
+
+function emptyOutcome(): HookOutcome {
+	return { block: false, ask: false, reason: undefined, context: [], systemMessages: [], warnings: [] };
+}
+
+function truncate(text: string, max: number): string {
+	return text.length > max ? `${text.slice(0, max)}...[truncated]` : text;
+}
+
+function shortCommand(command: string): string {
+	const firstToken = command.trim().split(/\s+/)[0] ?? command;
+	const segments = firstToken.split("/");
+	return segments[segments.length - 1] ?? firstToken;
+}
+
+/** Events whose plain (non-JSON) stdout becomes model-visible context, per Claude. */
+const CONTEXT_STDOUT_EVENTS = new Set(["SessionStart", "UserPromptSubmit"]);
+
+function interpretRun(run: HookRunResult): HookOutcome {
+	const outcome = emptyOutcome();
+	const name = shortCommand(run.command);
+	if (run.spawnError !== undefined) {
+		outcome.warnings.push(`${name}: spawn failed (${run.spawnError})`);
+		return outcome;
+	}
+	if (run.timedOut) {
+		outcome.warnings.push(`${name}: timed out`);
+		return outcome;
+	}
+	if (run.code === 2) {
+		const detail = run.stderr.trim() || run.stdout.trim();
+		outcome.block = true;
+		outcome.reason = detail || `${name} blocked (exit 2)`;
+		return outcome;
+	}
+	if (run.code !== 0) {
+		const detail = run.stderr.trim();
+		outcome.warnings.push(`${name}: exit ${run.code}${detail ? `: ${truncate(detail, 200)}` : ""}`);
+		return outcome;
+	}
+	const stdout = run.stdout.trim();
+	const json = parseJsonObject(stdout);
+	if (!json) {
+		if (stdout && CONTEXT_STDOUT_EVENTS.has(run.event)) outcome.context.push(stdout);
+		return outcome;
+	}
+	const systemMessage = asString(json.systemMessage);
+	if (systemMessage) outcome.systemMessages.push(systemMessage);
+	const hso = isRecord(json.hookSpecificOutput) ? json.hookSpecificOutput : undefined;
+	if (hso) {
+		const additional = asString(hso.additionalContext);
+		if (additional) outcome.context.push(additional);
+		const permission = asString(hso.permissionDecision);
+		if (permission === "deny") {
+			outcome.block = true;
+			outcome.reason = asString(hso.permissionDecisionReason) ?? `${name} denied`;
+		} else if (permission === "ask") {
+			outcome.ask = true;
+			outcome.reason = asString(hso.permissionDecisionReason);
+		}
+	}
+	if (!outcome.block && json.decision === "block") {
+		outcome.block = true;
+		outcome.reason = asString(json.reason) ?? `${name} blocked`;
+	}
+	if (!outcome.block && json.continue === false) {
+		outcome.block = true;
+		outcome.reason = asString(json.stopReason) ?? `${name} requested stop`;
+	}
+	return outcome;
+}
+
+function combineOutcomes(outcomes: HookOutcome[]): HookOutcome {
+	const combined = emptyOutcome();
+	for (const o of outcomes) {
+		if (o.block && !combined.block) {
+			combined.block = true;
+			combined.reason = o.reason;
+		}
+		if (o.ask && !combined.ask && !combined.block) {
+			combined.ask = true;
+			combined.reason = combined.reason ?? o.reason;
+		}
+		combined.context.push(...o.context);
+		combined.systemMessages.push(...o.systemMessages);
+		combined.warnings.push(...o.warnings);
+	}
+	return combined;
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+/** Structural slice of ExtensionContext the bridge needs (keeps helpers testable). */
+interface BridgeCtx {
+	ui: {
+		notify(message: string, type?: "info" | "warning" | "error"): void;
+		setStatus(key: string, text: string | undefined): void;
+		confirm(title: string, message: string): Promise<boolean | undefined>;
+	};
+	hasUI: boolean;
+	cwd: string;
+	sessionManager: {
+		getSessionId(): string;
+		getSessionFile(): string | undefined;
+	};
+}
+
+/** Structural slices of the omp event payloads the bridge reads. */
+interface PromptEvent {
+	prompt: string;
+}
+
+interface ToolCallBridgeEvent {
+	toolName: string;
+	input: unknown;
+}
+
+interface ToolResultBridgeEvent {
+	toolName: string;
+	input: unknown;
+	content: { type: string; text?: string }[];
+	isError: boolean;
+}
+
+interface FireOptions {
+	/** Values the entry matcher is tested against (tool names, session source). */
+	candidates?: string[];
+	/** Event-specific payload fields merged over the common ones. */
+	extra?: Record<string, unknown>;
+}
+
+/**
+ * Main-vs-subagent detection. omp subagents re-bind every extension against a
+ * fresh module instance (the loader imports with a `?mtime` cache-buster), so
+ * module state cannot distinguish bindings. A globalThis slot survives across
+ * instances: the first session to claim it is the main session; a binding
+ * seeing a foreign id is a subagent. Claude Code parity: session-level hooks
+ * (SessionStart, UserPromptSubmit, Stop, SessionEnd, PreCompact) run only in
+ * the main session; PreToolUse/PostToolUse guard the whole agent tree.
+ */
+interface MainSlot {
+	id?: string;
+}
+
+const MAIN_SLOT_KEY = "__ompClaudeHooksMainSession";
+
+function mainSlot(): MainSlot {
+	// Unchecked cast: globalThis is the only store surviving the loader's
+	// per-binding module cache-busting; the key is namespaced and owned here.
+	const g = globalThis as unknown as Record<string, MainSlot | undefined>;
+	let slot = g[MAIN_SLOT_KEY];
+	if (slot === undefined) {
+		slot = {};
+		g[MAIN_SLOT_KEY] = slot;
+	}
+	return slot;
+}
+
+const CONTEXT_MESSAGE_TYPE = "claude-hook-context";
+const MAX_RECENT_RUNS = 50;
+
+export default function claudeHooksBridge(pi: ExtensionAPI) {
+	if (process.env.OMP_CLAUDE_HOOKS === "0") return;
+
+	let config: BridgeConfig | undefined;
+	let pendingContext: string[] = [];
+	let startupRun: Promise<void> = Promise.resolve();
+	let role: "main" | "subagent" | undefined;
+	const recentRuns: HookRunResult[] = [];
+
+	/** Claim or confirm the main slot; classify this binding once. */
+	const resolveRole = (ctx: BridgeCtx): "main" | "subagent" => {
+		if (role !== undefined) return role;
+		const slot = mainSlot();
+		const sid = ctx.sessionManager.getSessionId();
+		if (slot.id === undefined || slot.id === sid) {
+			slot.id = sid;
+			role = "main";
+		} else {
+			role = "subagent";
+		}
+		return role;
+	};
+
+	const getConfig = (cwd: string): BridgeConfig => {
+		if (!config || config.cwd !== cwd) config = loadConfig(cwd);
+		return config;
+	};
+
+	async function fire(eventName: string, ctx: BridgeCtx, opts: FireOptions = {}): Promise<HookOutcome> {
+		const cfg = getConfig(ctx.cwd);
+		const candidates = opts.candidates ?? ["*"];
+		const matched = cfg.entries.filter(e => e.event === eventName && matcherMatches(e.matcher, candidates));
+		if (matched.length === 0) return emptyOutcome();
+		const seen = new Set<string>();
+		const deduped = matched.filter(e => {
+			if (seen.has(e.command)) return false;
+			seen.add(e.command);
+			return true;
+		});
+		const payload: Record<string, unknown> = {
+			session_id: ctx.sessionManager.getSessionId(),
+			transcript_path: ctx.sessionManager.getSessionFile() ?? "",
+			cwd: ctx.cwd,
+			hook_event_name: eventName,
+			...opts.extra,
+		};
+		ctx.ui.setStatus("claude-hooks", `claude-hooks: ${eventName} (${deduped.length})`);
+		try {
+			const runs = await Promise.all(deduped.map(entry => runHookCommand(entry, payload, cfg.projectDir)));
+			for (const run of runs) {
+				recentRuns.push(run);
+				if (recentRuns.length > MAX_RECENT_RUNS) recentRuns.shift();
+			}
+			const outcome = combineOutcomes(runs.map(interpretRun));
+			for (const warning of outcome.warnings) ctx.ui.notify(`claude-hooks ${warning}`, "warning");
+			for (const message of outcome.systemMessages) ctx.ui.notify(message, "info");
+			return outcome;
+		} finally {
+			ctx.ui.setStatus("claude-hooks", undefined);
+		}
+	}
+
+	function runSessionStart(ctx: BridgeCtx, source: "startup" | "resume"): void {
+		config = loadConfig(ctx.cwd);
+		startupRun = (async () => {
+			const outcome = await fire("SessionStart", ctx, {
+				candidates: [source],
+				extra: { source },
+			});
+			if (outcome.block && outcome.reason) {
+				ctx.ui.notify(`claude-hooks SessionStart: ${outcome.reason}`, "warning");
+			}
+			pendingContext.push(...outcome.context);
+		})();
+		// Deliberately not awaited: SessionStart hooks may be slow (ix runs
+		// `nix run #init` with a 150s budget). before_agent_start awaits, so
+		// the first turn is still guaranteed to see the injected context.
+	}
+
+	pi.on("session_start", async (_event: unknown, ctx: BridgeCtx) => {
+		if (resolveRole(ctx) === "subagent") return; // Claude parity: no SessionStart in subagents
+		runSessionStart(ctx, "startup");
+	});
+
+	pi.on("session_switch", async (_event: unknown, ctx: BridgeCtx) => {
+		if (resolveRole(ctx) === "subagent") return;
+		mainSlot().id = ctx.sessionManager.getSessionId(); // follow the main session across /new
+		runSessionStart(ctx, "resume");
+	});
+
+	pi.on("before_agent_start", async (event: PromptEvent, ctx: BridgeCtx) => {
+		if (resolveRole(ctx) === "subagent") return undefined; // Claude parity: no UserPromptSubmit in subagents
+		await startupRun;
+		const submit = await fire("UserPromptSubmit", ctx, { extra: { prompt: event.prompt } });
+		if (submit.block) {
+			ctx.ui.notify(
+				`claude-hooks: UserPromptSubmit block is unsupported in omp${submit.reason ? ` (${submit.reason})` : ""}`,
+				"warning",
+			);
+		}
+		const context = [...pendingContext, ...submit.context];
+		pendingContext = [];
+		if (context.length === 0) return undefined;
+		return {
+			message: {
+				customType: CONTEXT_MESSAGE_TYPE,
+				content: context.join("\n\n"),
+				display: true,
+			},
+		};
+	});
+
+	pi.on("tool_call", async (event: ToolCallBridgeEvent, ctx: BridgeCtx) => {
+		const candidates = claudeToolNames(event.toolName);
+		const input = isRecord(event.input) ? event.input : {};
+		const outcome = await fire("PreToolUse", ctx, {
+			candidates,
+			extra: {
+				tool_name: candidates[0],
+				tool_input: translateToolInput(event.toolName, input),
+				tool_input_omp: input,
+			},
+		});
+		if (outcome.context.length > 0) {
+			pi.sendMessage(
+				{ customType: CONTEXT_MESSAGE_TYPE, content: outcome.context.join("\n\n"), display: false },
+				{ deliverAs: "nextTurn" },
+			);
+		}
+		if (outcome.block) return { block: true, reason: outcome.reason ?? "blocked by Claude hook" };
+		if (outcome.ask) {
+			const question = outcome.reason ?? `Claude hook requests approval for ${candidates[0]}`;
+			if (!ctx.hasUI) return { block: true, reason: `approval required (no UI): ${question}` };
+			const approved = await ctx.ui.confirm("Claude hook approval", question);
+			if (!approved) return { block: true, reason: `denied: ${question}` };
+		}
+		return undefined;
+	});
+
+	pi.on("tool_result", async (event: ToolResultBridgeEvent, ctx: BridgeCtx) => {
+		const candidates = claudeToolNames(event.toolName);
+		const input = isRecord(event.input) ? event.input : {};
+		const responseText = event.content
+			.map(chunk => (chunk.type === "text" ? (chunk.text ?? "") : "[image]"))
+			.join("\n");
+		const outcome = await fire("PostToolUse", ctx, {
+			candidates,
+			extra: {
+				tool_name: candidates[0],
+				tool_input: translateToolInput(event.toolName, input),
+				tool_input_omp: input,
+				tool_response: { content: truncate(responseText, 100_000), isError: event.isError },
+			},
+		});
+		const feedback: string[] = [];
+		if (outcome.block) feedback.push(outcome.reason ?? "post-hook feedback");
+		if (event.toolName === "task") {
+			const subagent = await fire("SubagentStop", ctx, { extra: { stop_hook_active: false } });
+			if (subagent.block) feedback.push(subagent.reason ?? "subagent stop feedback");
+			outcome.context.push(...subagent.context);
+		}
+		if (outcome.context.length > 0) {
+			pi.sendMessage(
+				{ customType: CONTEXT_MESSAGE_TYPE, content: outcome.context.join("\n\n"), display: false },
+				{ deliverAs: "nextTurn" },
+			);
+		}
+		if (feedback.length === 0) return undefined;
+		return {
+			content: [...event.content, { type: "text", text: `\n[claude-hook feedback]\n${feedback.join("\n")}` }],
+		};
+	});
+
+	pi.on("session_stop", async (_event: unknown, ctx: BridgeCtx) => {
+		if (resolveRole(ctx) === "subagent") return undefined; // Stop is a main-agent concept; SubagentStop maps via task tool_result
+		const outcome = await fire("Stop", ctx, { extra: { stop_hook_active: false } });
+		if (outcome.block) {
+			return { decision: "block" as const, reason: outcome.reason ?? "stop blocked by Claude hook" };
+		}
+		return undefined;
+	});
+
+	pi.on("session_shutdown", async (_event: unknown, ctx: BridgeCtx) => {
+		if (resolveRole(ctx) === "subagent") return;
+		await fire("SessionEnd", ctx, { extra: { reason: "exit" } });
+	});
+
+	pi.on("session_before_compact", async (_event: unknown, ctx: BridgeCtx) => {
+		if (resolveRole(ctx) === "subagent") return undefined;
+		await fire("PreCompact", ctx, { extra: { trigger: "manual", custom_instructions: "" } });
+		return undefined;
+	});
+
+	pi.registerCommand("claude-hooks", {
+		description: "Show Claude hook bridge state (config + recent runs)",
+		handler: async (_args: string, ctx: BridgeCtx) => {
+			const cfg = getConfig(ctx.cwd);
+			const lines: string[] = [
+				`project: ${cfg.projectDir}`,
+				`settings: ${cfg.files.length > 0 ? cfg.files.join(", ") : "none found"}`,
+				"",
+			];
+			if (cfg.entries.length === 0) {
+				lines.push("no Claude hooks configured");
+			} else {
+				for (const entry of cfg.entries) {
+					lines.push(`${entry.event}${entry.matcher ? `[${entry.matcher}]` : ""} (${entry.source}): ${entry.command}`);
+				}
+			}
+			if (recentRuns.length > 0) {
+				lines.push("", "recent runs:");
+				for (const run of recentRuns.slice(-15)) {
+					const status = run.spawnError ? "spawn-error" : run.timedOut ? "timeout" : `exit ${run.code}`;
+					lines.push(`${run.event} ${shortCommand(run.command)} -> ${status} (${run.durationMs}ms)`);
+				}
+			}
+			pi.sendMessage({ customType: "claude-hooks-status", content: lines.join("\n"), display: true });
+		},
+	});
+}

--- a/packages/agent/pi-harnesses/omp/extensions/modes.ts
+++ b/packages/agent/pi-harnesses/omp/extensions/modes.ts
@@ -1,0 +1,126 @@
+/**
+ * Model modes: named bundles of modelRoles switched with /mode.
+ *
+ * Definitions are nix-generated into ~/.omp/agent/modes.json (source of truth:
+ * modules/users/user-config/agents.nix, `ompModes`). Applying a mode replaces
+ * the persisted modelRoles record wholesale - roles from the previous mode
+ * never leak through - then live-switches the session model to the mode's
+ * `default` pattern. Subagents resolve `roles.task` at spawn time, so a switch
+ * affects the next spawn immediately; no restart needed.
+ */
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+interface ModeDef {
+	description?: string;
+	roles: Record<string, string>;
+}
+
+type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+const MODES_FILE = join(homedir(), ".omp", "agent", "modes.json");
+const THINKING_SUFFIXES: Record<string, ThinkingLevel> = {
+	off: "off",
+	minimal: "minimal",
+	low: "low",
+	medium: "medium",
+	high: "high",
+	xhigh: "xhigh",
+	max: "xhigh",
+};
+
+/** Fresh read every call: the file is a store symlink that moves on rebuild. */
+function loadModes(): Record<string, ModeDef> {
+	try {
+		return JSON.parse(readFileSync(MODES_FILE, "utf8")) as Record<string, ModeDef>;
+	} catch {
+		return {};
+	}
+}
+
+/** Thinking suffix of the first pattern in a role value ("a/b:high,c/d" -> "high"). */
+function thinkingOf(pattern: string): ThinkingLevel | undefined {
+	const first = pattern.split(",")[0]!.trim().split("@")[0]!;
+	const idx = first.lastIndexOf(":");
+	if (idx === -1) return undefined;
+	return THINKING_SUFFIXES[first.slice(idx + 1)];
+}
+
+export default function modesExtension(pi: ExtensionAPI) {
+	pi.registerCommand("mode", {
+		description: "Switch model mode (named modelRoles bundle)",
+		getArgumentCompletions: prefix => {
+			const items = Object.entries(loadModes())
+				.filter(([name]) => name.startsWith(prefix))
+				.map(([name, mode]) => ({ value: name, label: name, description: mode.description }));
+			return items.length > 0 ? items : null;
+		},
+		handler: async (args, ctx) => {
+			const modes = loadModes();
+			const names = Object.keys(modes);
+			if (names.length === 0) {
+				ctx.ui.notify(`no modes defined in ${MODES_FILE}`, "error");
+				return;
+			}
+
+			let name = args.trim();
+			if (!name) {
+				// Mark the mode whose bundle equals the live modelRoles record.
+				const live = pi.pi.settings.getModelRoles();
+				const active = names.find(n => {
+					const roles = modes[n]!.roles;
+					const keys = Object.keys(roles);
+					return keys.length === Object.keys(live).length && keys.every(k => roles[k] === live[k]);
+				});
+				if (!ctx.hasUI) {
+					ctx.ui.notify(`modes: ${names.map(n => (n === active ? `${n} (active)` : n)).join(", ")}`);
+					return;
+				}
+				const picked = await ctx.ui.select(
+					"Model mode",
+					names.map(n => ({
+						label: n === active ? `${n} (active)` : n,
+						description: modes[n]?.description,
+					})),
+				);
+				if (!picked) return;
+				name = picked.replace(/ \(active\)$/, "");
+			}
+
+			const mode = modes[name];
+			if (!mode) {
+				ctx.ui.notify(`unknown mode '${name}' (have: ${names.join(", ")})`, "error");
+				return;
+			}
+
+			// Resolve the main model up front so a broken bundle is a no-op.
+			const defaultPattern = mode.roles.default;
+			let model;
+			if (defaultPattern) {
+				model = ctx.models.resolve(defaultPattern.split(",")[0]!.trim());
+				if (!model) {
+					ctx.ui.notify(`mode '${name}': cannot resolve '${defaultPattern}'`, "error");
+					return;
+				}
+			}
+
+			// Replace the whole record: roles from the previous mode must not leak.
+			pi.pi.settings.set("modelRoles", { ...mode.roles });
+
+			if (model) {
+				if (!(await pi.setModel(model))) {
+					ctx.ui.notify(`mode '${name}': no credentials for ${model.provider}/${model.id}`, "error");
+					return;
+				}
+				const thinking = thinkingOf(defaultPattern);
+				if (thinking) {
+					pi.setThinkingLevel(thinking);
+				}
+			}
+
+			ctx.ui.notify(`mode: ${name}${mode.description ? ` - ${mode.description}` : ""}`);
+		},
+	});
+}

--- a/packages/agent/pi-harnesses/omp/package.nix
+++ b/packages/agent/pi-harnesses/omp/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "omp";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+}

--- a/packages/agent/pi-harnesses/omp/smoke/claude-hooks-smoke.sh
+++ b/packages/agent/pi-harnesses/omp/smoke/claude-hooks-smoke.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Smoke test for the Claude hook protocol bridge (../extensions/claude-hooks.ts).
+#
+# Run this when bumping the omp pin in ../default.nix: it catches extension-API
+# drift before the new binary ships. Needs a working `omp` with model
+# credentials (real -p runs), so it is a manual/CI gate, not a nix check.
+#
+#   OMP=/path/to/omp smoke/claude-hooks-smoke.sh   # override binary
+#
+# Asserts three Claude hook protocol paths end to end:
+#   1. SessionStart plain-stdout + JSON additionalContext -> model-visible context
+#   2. PreToolUse JSON permissionDecision=deny            -> tool blocked, reason verbatim
+#   3. PreToolUse exit 2                                  -> tool blocked, stderr verbatim
+set -euo pipefail
+
+OMP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BRIDGE="$OMP_DIR/extensions/claude-hooks.ts"
+AGENTS_BRIDGE="$OMP_DIR/extensions/claude-agents.ts"
+OMP_BIN="${OMP:-omp}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fx="$work/fixture"
+mkdir -p "$fx/.claude/hooks" "$fx/.claude/agents"
+git init -q "$fx"
+
+# Empty user-level Claude config: only fixture project hooks fire, on any machine.
+user_dir="$work/claude-user"
+mkdir -p "$user_dir"
+
+cat >"$fx/.claude/hooks/session-start.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "HOOKMARK-ALPHA-7291: injected by fixture SessionStart hook"
+EOF
+
+cat >"$fx/.claude/hooks/session-id.sh" <<'EOF'
+#!/usr/bin/env bash
+sid=$(jq -r '.session_id')
+echo "{\"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": \"HOOKMARK-SESSION-ID: $sid\"}}"
+EOF
+
+cat >"$fx/.claude/hooks/deny-marker.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+cmd=$(jq -r '.tool_input.command // empty')
+if [[ "$cmd" == *MARKER_FORBIDDEN* ]]; then
+  jq -n '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: "HOOKDENY-BETA-4455: forbidden marker command"}}'
+fi
+exit 0
+EOF
+
+cat >"$fx/.claude/hooks/exit2-marker.sh" <<'EOF'
+#!/usr/bin/env bash
+cmd=$(jq -r '.tool_input.command // empty')
+if [[ "$cmd" == *MARKER_EXITTWO* ]]; then
+  echo "HOOKDENY-GAMMA-8812: blocked via exit 2" >&2
+  exit 2
+fi
+exit 0
+EOF
+
+chmod +x "$fx"/.claude/hooks/*.sh
+
+cat >"$fx/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" }] },
+      { "hooks": [{ "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-id.sh", "timeout": 5 }] }
+    ],
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/deny-marker.sh" }] },
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/exit2-marker.sh" }] }
+    ]
+  }
+}
+EOF
+
+# Agent fixtures: one parses clean under omp (symlink expected), one needs a
+# frontmatter splice (WebSearch alias, model drop).
+cat >"$fx/.claude/agents/clean-agent.md" <<'EOF'
+---
+name: clean-agent
+description: Fixture agent with omp-compatible tools
+tools: Read, Grep, Glob
+---
+You are the clean fixture agent.
+EOF
+
+cat >"$fx/.claude/agents/dirty-agent.md" <<'EOF'
+---
+name: dirty-agent
+description: Fixture agent needing translation
+model: sonnet
+tools: WebSearch, Read
+---
+You are the dirty fixture agent.
+EOF
+
+# Do NOT use --no-extensions here: despite its help text it also drops explicit
+# -e paths (oh-my-pi main.ts, noExtensions clears additionalExtensionPaths).
+# Instead, pass -e only when the activation symlink is not already loading this
+# exact file, so the bridge never registers twice (double hook execution).
+extra_args=()
+for ext in "$BRIDGE" "$AGENTS_BRIDGE"; do
+  installed="$HOME/.omp/agent/extensions/$(basename "$ext")"
+  if [ ! -e "$installed" ] || [ "$(readlink -f "$installed")" != "$(readlink -f "$ext")" ]; then
+    extra_args+=(-e "$ext")
+  fi
+done
+
+run_omp() {
+  (cd "$fx" && CLAUDE_CONFIG_DIR="$user_dir" "$OMP_BIN" -p --no-session ${extra_args[0]+"${extra_args[@]}"} "$1")
+}
+
+# The task tool is async: -p text mode can settle with an empty final message
+# before the subagent's relay lands. The JSON event stream always carries the
+# subagent's tool error, so step 5 asserts against it.
+run_omp_json() {
+  (cd "$fx" && CLAUDE_CONFIG_DIR="$user_dir" "$OMP_BIN" -p --mode json --no-session ${extra_args[0]+"${extra_args[@]}"} "$1" 2>&1)
+}
+
+fail() {
+  echo "FAIL: $1" >&2
+  echo "--- output ---" >&2
+  echo "$2" >&2
+  exit 1
+}
+
+echo "[1/5] SessionStart context injection"
+out=$(run_omp "List every line in your context that contains the string HOOKMARK. Quote each verbatim. Do not use any tools.")
+grep -q "HOOKMARK-ALPHA-7291" <<<"$out" || fail "plain-stdout SessionStart context missing" "$out"
+grep -q "HOOKMARK-SESSION-ID" <<<"$out" || fail "JSON additionalContext missing" "$out"
+
+echo "[2/5] PreToolUse JSON deny"
+out=$(run_omp "Run this exact bash command: echo MARKER_FORBIDDEN. If the tool call fails, quote the full error text verbatim and stop.")
+grep -q "HOOKDENY-BETA-4455" <<<"$out" || fail "permissionDecision deny not enforced" "$out"
+
+echo "[3/5] PreToolUse exit-2 deny"
+out=$(run_omp "Run this exact bash command: echo MARKER_EXITTWO. If the tool call fails, quote the full error text verbatim and stop.")
+grep -q "HOOKDENY-GAMMA-8812" <<<"$out" || fail "exit-2 block not enforced" "$out"
+
+echo "[4/5] claude-agents translation"
+[ -L "$fx/.omp/agents/clean-agent.md" ] || fail "clean agent not symlinked" "$(ls -la "$fx/.omp/agents" 2>&1)"
+[ -f "$fx/.omp/agents/dirty-agent.md" ] && [ ! -L "$fx/.omp/agents/dirty-agent.md" ] || fail "dirty agent not materialized as copy" "$(ls -la "$fx/.omp/agents" 2>&1)"
+grep -q "web_search" "$fx/.omp/agents/dirty-agent.md" || fail "WebSearch not aliased to web_search" "$(cat "$fx/.omp/agents/dirty-agent.md")"
+grep -q "^model:" "$fx/.omp/agents/dirty-agent.md" && fail "claude model pin not dropped" "$(cat "$fx/.omp/agents/dirty-agent.md")"
+[ -f "$fx/.omp/.gitignore" ] || fail ".omp/.gitignore not created" "$(ls -la "$fx/.omp" 2>&1)"
+
+echo "[5/5] PreToolUse guard inside subagent"
+out=$(run_omp_json "Spawn one 'task' subagent via the task tool. Its assignment: run the bash command 'echo MARKER_EXITTWO' - a test hook intentionally blocks this command as part of a plumbing check - and report the exact block message it returns. Wait for the subagent result using the job tool, then relay its answer verbatim.")
+grep -q "HOOKDENY-GAMMA-8812" <<<"$out" || fail "block hook did not fire inside subagent" "$(tail -c 2000 <<<"$out")"
+
+echo "PASS: claude-hooks bridge smoke (5/5)"


### PR DESCRIPTION
Write-only copy of the omp setup from the personal nix repo into `packages/agent/pi-harnesses/omp/`, so the harness family lives in one place. The nix repo keeps its copy (it remains the deployed source); nothing is removed there.

## What moved

- `default.nix`: pinned upstream release binary (16.3.4), adapted from `flake/omp.nix` (flake-parts `perSystem` -> registry callPackage; asset picked via `stdenvNoCC.hostPlatform.system`). `nix run .#omp` / `index.packages.<sys>.omp`.
- `extensions/`: `claude-hooks.ts`, `claude-agents.ts`, `modes.ts` copied verbatim from `dots/omp/extensions/`.
- `smoke/claude-hooks-smoke.sh`: from `scripts/omp/`, bridge paths rebased onto the new layout (`../extensions/`).

## Why not mk-pi-harness

omp is upstream's own harness distribution (self-contained `bun build --compile` binary); a from-source nix build needs network in-sandbox at three stages, so the release asset stays the packaging boundary. Documented in the package README along with the ~/.omp wiring the deployed home config does.

## Verification

- `nix build .#omp` (aarch64-linux) and `omp --version` -> `omp/16.3.4`
- `nix run .#lint` clean (two astlog findings fixed during adaptation: `lib.optional`, `# shell` phase comment)
- `OMP=<store>/bin/omp smoke/claude-hooks-smoke.sh` -> PASS 5/5 (SessionStart context, JSON deny, exit-2 deny, agent translation, subagent guard)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add oh-my-pi (omp) harness with Claude hooks and agents bridge extensions
> - Adds a Nix derivation in [omp/default.nix](https://github.com/indexable-inc/index/pull/1869/files#diff-76b04cd4633f131e22e8912304995251e83fcc34b177c991ba77c28aa940e4d3) that fetches and installs the pinned upstream `omp` binary, using `autoPatchelf` on Linux so it runs without `nix-ld`.
> - [claude-hooks.ts](https://github.com/indexable-inc/index/pull/1869/files#diff-c9d6534423d360a0b522408c64ba5b68eb9b23a4c86a80a226ae65fcf2f5cd11) bridges Claude Code hooks (from `settings.json` at user/project/local levels) to omp events, supporting context injection, tool-call blocking, approval requests, and feedback; a `/claude-hooks` command shows config and recent runs.
> - [claude-agents.ts](https://github.com/indexable-inc/index/pull/1869/files#diff-cbcd7b3a25b5b408e6ff76f78f904461c9a634d379ee3baedcb6f62a8ae9e7bd) mirrors `.claude/agents` definitions into `.omp/agents`, symlinking clean files or writing translated copies when tool mapping is needed, and garbage-collects removed sources.
> - [modes.ts](https://github.com/indexable-inc/index/pull/1869/files#diff-600e32e4cc7818b4d54bf256669e1a653d7f5cdff0f79262f6c085d7af45cc55) adds a `/mode` command to switch named model role bundles from `~/.omp/agent/modes.json`, live-switching the session model and thinking level.
> - [smoke/claude-hooks-smoke.sh](https://github.com/indexable-inc/index/pull/1869/files#diff-a93520d89e85510acbd4348702c6b1fb95254e6a6c7fa5422ce558ed7e12dc8f) provides an end-to-end smoke test covering hook execution and agent translation against the real `omp` binary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 462beee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->