### PR TITLE
cache-push: fix the two chronically failing roots (snix, jupyter) and make root failures loud

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -140,11 +140,21 @@ jobs:
           echo "::notice::cache-push probe: $(wc -l < "$drvs") of $(wc -l < "$roots") roots need realising"
 
           # -n1, not one batch: a batched realise prints no paths at all if any
-          # single drv fails, which would publish nothing.
+          # single drv fails, which would publish nothing. The per-drv wrapper
+          # additionally records WHICH root failed (bare xargs only reports
+          # "something failed" via its exit status): nix does not cache
+          # failures, so a broken root re-realises and re-fails on every
+          # merge, and two such roots once taxed every run ~16 min while
+          # staying warning-level invisible (indexable-inc/index#1863). The
+          # error annotation below names them so a chronic failure is loud.
+          failed_roots="$workdir/failed-roots.txt"
+          : > "$failed_roots"
           realise_t=$SECONDS
-          "$xargs" -a "$drvs" -r -P16 -n1 nix-store --realise --keep-going > "$outs" 2>"$workdir/realise.err" \
+          # shellcheck disable=SC2016  # $1/$2 expand in the child bash, not here
+          "$xargs" -a "$drvs" -r -P16 -n1 bash -c \
+              'nix-store --realise --keep-going "$2" || { printf "%s\n" "$2" >> "$1"; exit 1; }' _ "$failed_roots" \
+            > "$outs" 2>"$workdir/realise.err" \
             || {
-              echo "::warning::some derivations failed to realise; publishing the rest"
               # Match any error line (nix phrases failures several ways); pure
               # bash because the runner PATH has no grep/sed.
               while IFS= read -r line; do
@@ -154,6 +164,17 @@ jobs:
               done < "$workdir/realise.err" | sort -u | head -n 20
             }
           phase realise "$realise_t"
+
+          if [ -s "$failed_roots" ]; then
+            # /nix/store/<hash>-<name>.drv -> <name>, joined on one line.
+            names=""
+            while IFS= read -r drv; do
+              name="${drv##*/}"
+              name="${name#*-}"
+              names="$names ${name%.drv}"
+            done < "$failed_roots"
+            echo "::error::cache-push: $(wc -l < "$failed_roots") root(s) failed to realise (rebuilt and re-failed on every merge until fixed):$names"
+          fi
 
           # `fallback = true` engages silently: nix rebuilds a failed
           # substitute from source with no distinct log line, so a degraded

--- a/packages/nix/snix/default.nix
+++ b/packages/nix/snix/default.nix
@@ -1,11 +1,13 @@
 {
   lib,
   ix,
+  stdenv,
   protobuf,
   pkg-config,
   cmake,
   perl,
   makeWrapper,
+  pkgsStatic,
   runCommand,
 }:
 # snix is the Rust reimplementation of Nix (TVL depot `git.snix.dev/snix/snix`).
@@ -62,6 +64,20 @@ let
       # at the whole snix checkout (the repo root that contains `snix/`).
       PROTO_ROOT = "${ix.snixSrc}";
     };
+
+    # snix-build resolves its sandbox shell at rustc time:
+    # `const SANDBOX_SHELL: &str = env!("SNIX_BUILD_SANDBOX_SHELL")` in
+    # build/src/buildservice/{bwrap,oci}.rs, so the crate does not compile
+    # without it and every merge re-built the whole dependency graph up to this
+    # unit only to fail (indexable-inc/index#1863). Mirror upstream's crate
+    # override (snix/utils.nix): a static busybox `sh` on Linux (copied into
+    # the build sandbox, so it must not carry runtime deps), the system shell
+    # on darwin. Scoped to the one package so the busybox store path does not
+    # perturb every other unit's identity.
+    packageBuildEnv.snix-build.SNIX_BUILD_SANDBOX_SHELL =
+      if stdenv.hostPlatform.isLinux
+      then "${pkgsStatic.busybox}/bin/sh"
+      else "/bin/sh";
 
     # Git dependencies pinned in snix's Cargo.lock, keyed by the exact lock
     # source string. Refresh with `nix flake update snix-src` then rebuild and

--- a/packages/nu-jupyter-kernel/default.nix
+++ b/packages/nu-jupyter-kernel/default.nix
@@ -1,7 +1,11 @@
 {
   ix,
   lib,
+  stdenv,
   rustPlatform,
+  pkg-config,
+  fontconfig,
+  freetype,
 }: let
   src = ix.nuJupyterKernelSrc;
 in
@@ -13,6 +17,18 @@ in
     strictDeps = true;
 
     cargoLock.lockFile = src + "/Cargo.lock";
+
+    # font-kit (pulled in through nu_plugin_plotters) compiles
+    # yeslogic-fontconfig-sys and freetype-sys on Linux only (macOS uses
+    # core-text instead). Their build scripts locate the system libraries via
+    # pkg-config; without these inputs the fontconfig probe fails and the
+    # package broke every x86_64-linux Cache push run
+    # (indexable-inc/index#1863).
+    nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux pkg-config;
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+      fontconfig
+      freetype
+    ];
 
     meta = {
       description = "A Jupyter raw kernel for Nushell";


### PR DESCRIPTION
Fixes #1863.

Every Cache push run rebuilt and re-failed the same two roots, setting a fixed ~16 min realise floor per merge with nothing published:

- **snix**: `snix-build` reads its sandbox shell via `env!("SNIX_BUILD_SANDBOX_SHELL")` at compile time, so the crate never compiled. Set it through `packageBuildEnv.snix-build` (scoped to the one package so it does not perturb the rest of the unit graph), mirroring upstream `snix/utils.nix`: static busybox `sh` on Linux, `/bin/sh` on darwin.
- **jupyter**: `nu-jupyter-kernel`'s font-kit dependency compiles `yeslogic-fontconfig-sys` + `freetype-sys` on Linux only; their build scripts probe via pkg-config. Added `pkg-config` (native) and `fontconfig`/`freetype` (build inputs), gated to Linux since macOS uses core-text.
- **cache-push guard** (issue's last paragraph): the realise phase now records which root drvs failed and emits an `::error::` annotation naming them, so a chronically failing root is loud instead of a silent per-merge tax.

Validated on vin-compute-1 (x86_64-linux):
- repro'd both failure fingerprints on main (`w4nrrn3qz2a2nbsn77a83p0f43ccmxmm-snix_build-0.1.0.drv`, `yeslogic-fontconfig-sys v6.0.0` pkg-config panic), then with the fixes:
- `nix build .#packages.x86_64-linux.snix` → `snix --version` works
- `nix build .#packages.x86_64-linux.jupyter` → exit 0, wrapper runs
- both packages still eval (`--dry-run`) on aarch64-darwin; `nix run .#lint` clean on the diff (the ruff failure in `packages/tui/tui-py` pre-exists on main); actionlint clean on the workflow.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix snix and nu-jupyter-kernel build failures and surface derivation errors in cache-push
> - Fixes `snix-build` compilation by setting `SNIX_BUILD_SANDBOX_SHELL` at build time: static busybox `sh` on Linux, `/bin/sh` on Darwin, in [default.nix](https://github.com/indexable-inc/index/pull/1870/files#diff-4972406d690949e0451425de2bd6ed9ce5e05d8f607724b70adbf130df65beb2)
> - Fixes `nu-jupyter-kernel` Linux build by adding `pkg-config`, `fontconfig`, and `freetype` as build inputs to satisfy `font-kit` dependencies, in [default.nix](https://github.com/indexable-inc/index/pull/1870/files#diff-872a3cb62a5da9d3bb49eb733a5bf8173278e3b7ad4cef81c1f40fb7de845d26)
> - Replaces the generic warning in [cache-push.yml](https://github.com/indexable-inc/index/pull/1870/files#diff-56c6f531ecd11b28cb14d6aa2ec8abf63b2cb701d82ce2f772c5a324c3bbbfb8) with per-derivation failure tracking that emits a `::error::` annotation listing the names of any failed roots after the realise phase
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b32a0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->