### PR TITLE
docs: drop stale fff module references (kernel search is bare grep/find now)

### DIFF
--- a/packages/agent/subagents.nix
+++ b/packages/agent/subagents.nix
@@ -30,7 +30,7 @@
         that none of that crosses back. Only your final message reaches the parent.
 
         You have your own `index` MCP: a fresh Python kernel (`python_exec`) with the
-        bundled helpers (`browser`, `view`, `fff`, `sh`, image `Read`, ...). Drive the
+        bundled helpers (`browser`, `view`, `grep`, `find`, `sh`, image `Read`, ...). Drive the
         task to its outcome there, in this context, and return a small result.
 
         ## You are the executor, not a planner

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -701,7 +701,7 @@ let
       indexKernel = {
         text = ''
           Work through the index Python kernel (`python_exec`) and reuse its namespace.
-          Search with `fff.grep` and `fff.find`; run `api()` for helpers. Do not shell
+          Search with the kernel `grep` and `find` builtins; run `api()` for helpers. Do not shell
           out to `rg` or `fd` inside the kernel. Run independent non-mutating commands
           concurrently with `asyncio.gather` or `asyncio.TaskGroup`. If the kernel
           wedges, restart it or report the blocker. Set a dashboard topic before
@@ -719,7 +719,7 @@ let
       structuredPrimitives = {
         text = ''
           Prefer structured primitives over text munging: `view.ls`, `view.tree`,
-          `view.cat`, `fff.grep`, `fff.find`, and `nu` pipelines. For command output
+          `view.cat`, `grep`, `find`, and `nu` pipelines. For command output
           you plan to filter or parse, use `nu` first so the result arrives as a Polars
           DataFrame; use `sh().json()`, `.jsonl()`, or `.df()` only when `sh` is the
           right tool. Return tables as Polars DataFrames.

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -14,8 +14,8 @@ namespace has:
 Concurrency model (validated): each execution runs as an asyncio task on the
 kernel's own event loop, so many run at once and none blocks the others. Per-job
 stdout/stderr is captured by routing writes through a ``ContextVar`` set inside
-each task, so interleaved prints land in the right job. A blocking call (fff,
-numpy, a subprocess) stays non-blocking by going through ``asyncio.to_thread``
+each task, so interleaved prints land in the right job. A blocking call (numpy,
+a subprocess) stays non-blocking by going through ``asyncio.to_thread``
 (its GIL-releasing native work then runs off the loop).
 
 Every job also writes itself to the SQLite store at ``IX_MCP_STORE`` (start, a
@@ -842,7 +842,7 @@ class Result:
             return _result_from_values(list(value), llm_result=llm_result)
         frame = _frame_view(value)
         if frame is not None:
-            # A rich result type (fff GrepResult/SearchResult) that exposes a
+            # A rich result type (anything with ``_ix_to_frame_``) that exposes a
             # polars frame: render that frame the same as a bare DataFrame -- a
             # styled table for the human, compact NUON for the model -- so the
             # model reads the real rows, not a one-line summary repr.
@@ -1643,7 +1643,7 @@ def _parse_github_time(value: Any) -> datetime.datetime | None:
     if not isinstance(value, str) or not value or value.startswith("0001-"):
         return None
     try:
-        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return datetime.datetime.fromisoformat(value)
     except ValueError:
         return None
 
@@ -2601,8 +2601,8 @@ def _is_polars_df(value: Any) -> bool:
 
 def _frame_view(value: Any) -> Any:
     """A non-DataFrame value that opts into the table protocol by exposing
-    ``_ix_to_frame_()`` returning a polars DataFrame (e.g. an fff ``GrepResult``
-    or ``SearchResult``). Returns that frame, else None. Lets a rich result type
+    ``_ix_to_frame_()`` returning a polars DataFrame. Returns that frame, else
+    None. Lets a rich result type
     render as the styled table for the human and compact NUON for the model,
     instead of falling back to its one-line summary repr."""
     hook = getattr(value, "_ix_to_frame_", None)
@@ -3142,7 +3142,7 @@ def _type_error_hint(exc: TypeError) -> str:
       - ``grep() missing 1 required keyword-only argument: 'mode'``
 
     Looks the callable up in the user namespace (and a set of well-known module
-    prefixes like ``fff.``) so the hint shows the live signature. Returns an
+    prefixes like ``view.``) so the hint shows the live signature. Returns an
     empty string on any failure so callers can unconditionally append it.
     """
     try:
@@ -4155,7 +4155,7 @@ def install(user_ns: dict | None = None) -> None:
     # for asyncio (ensure_future / sleep), json (every CLI's --json output), and
     # pl within its first cells, and a NameError on `asyncio` in an async kernel
     # is pure friction (observed twice in one 2026-06-10 session). Bound like
-    # sh/fff/view; an explicit import returns the same module.
+    # sh/view; an explicit import returns the same module.
     target["asyncio"] = asyncio
     target["json"] = json
     with contextlib.suppress(Exception):  # polars may be absent; skip binding pl
@@ -4174,7 +4174,7 @@ def install(user_ns: dict | None = None) -> None:
     global _baseline_names, _lazy_module_names
     _baseline_names = frozenset(target)
     # Bind every other bundled module behind a lazy proxy, so `await maps.nearby(...)`
-    # works with no `import maps` just like fff/view -- but deferring the import to
+    # works with no `import maps` just like sh/view -- but deferring the import to
     # first use, so framework-heavy modules (maps pulls in MapKit + CoreLocation,
     # ~120ms) and platform-absent ones cost nothing at startup. Bound AFTER the
     # baseline snapshot on purpose: these names must NOT count as runtime surface,

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -562,6 +562,7 @@ async def pr_watch(
         str,
         Field(description="Repository worktree where gh should run."),
     ],
+    *,
     auto_merge: Annotated[
         bool,
         Field(description="Enable gh auto merge for this PR before watching."),

--- a/packages/mcp/src/browser/browser/__init__.py
+++ b/packages/mcp/src/browser/browser/__init__.py
@@ -1,6 +1,6 @@
 """Drive a running browser over the Chrome DevTools Protocol (CDP) with Playwright.
 
-Bundled like ``view``/``fff``/``sh``, and Playwright itself is bundled in the
+Bundled like ``view``/``search``/``sh``, and Playwright itself is bundled in the
 interpreter, so a session can ``import browser`` and drive a real browser with no
 ``pip``/``uv install`` and no ``playwright install`` step.
 

--- a/packages/mcp/src/fleet/fleet/__init__.py
+++ b/packages/mcp/src/fleet/fleet/__init__.py
@@ -1,6 +1,6 @@
 """Polars-returning SSH fan-out source for the ix-mcp kernel.
 
-Bundled like ``view``/``fff``/``search`` so every session can ``import fleet``
+Bundled like ``view``/``sh``/``search`` so every session can ``import fleet``
 with no setup. The point: a ``python_exec`` cell often wants the same file or the
 same command's output from *many* fleet hosts at once (every node's journald
 tail, every host's disk usage, a config that should be identical everywhere),

--- a/packages/mcp/src/mcp_client/mcp_client/__init__.py
+++ b/packages/mcp/src/mcp_client/mcp_client/__init__.py
@@ -1,6 +1,6 @@
 """Call any Model Context Protocol (MCP) server's tools from the kernel.
 
-Bundled like ``view``/``fff``/``sh`` so every session can ``import mcp_client``
+Bundled like ``view``/``search``/``sh`` so every session can ``import mcp_client``
 with no setup. The point: an MCP server is a bag of tools (and resources and
 prompts) behind a small JSON-RPC protocol -- a Todoist server, a GitHub server,
 a local stdio server you wrote -- and this module lets you connect to one and

--- a/packages/mcp/src/nix/nix/__init__.py
+++ b/packages/mcp/src/nix/nix/__init__.py
@@ -1,6 +1,6 @@
 """Parse a ``nix --log-format internal-json`` stream into polars + a live DAG.
 
-Bundled like ``view``/``fff``/``search`` so every session can ``import nix`` with
+Bundled like ``view``/``sh``/``search`` so every session can ``import nix`` with
 no setup. Nix's ``internal-json`` logger emits one ``@nix {...}`` line per event
 (an activity starting/stopping, a progress tick, a build-log line, an error).
 Reading that by hand is miserable; this turns it into the two things an agent and

--- a/packages/mcp/src/sh/sh/__init__.py
+++ b/packages/mcp/src/sh/sh/__init__.py
@@ -1,6 +1,6 @@
 """Run a shell command on the kernel's async loop and render it two ways.
 
-Bundled like ``view``/``fff``/``fleet`` so every session can ``import sh`` with no
+Bundled like ``view``/``search``/``fleet`` so every session can ``import sh`` with no
 setup. The point: when you genuinely need to shell out (a ``gh``/``git``/``nix``
 invocation with no Python binding), do it without blocking the one shared event
 loop and without leaking terminal escape codes into your own context.

--- a/packages/mcp/src/tasks/tasks/__init__.py
+++ b/packages/mcp/src/tasks/tasks/__init__.py
@@ -1,6 +1,6 @@
 """Example task-dependency graphs, generated in Python and stored in SQLite.
 
-Bundled like ``view``/``sh``/``fff`` so every session can ``import tasks`` with no
+Bundled like ``view``/``sh``/``search`` so every session can ``import tasks`` with no
 setup. It is the single source of truth for the task-graph demo site
 (``packages/mcp/task-graph``): Python generates a ~100-node dependency DAG and
 writes it to a SQLite file, and the website reads that very file (via sql.js) and

--- a/packages/tui/tui-py/python/tui/harness.py
+++ b/packages/tui/tui-py/python/tui/harness.py
@@ -517,7 +517,7 @@ class Codex(Agent):
         out: list[str] = []
         for line in lines[starts[-1]:]:
             stripped = line.strip()
-            if out and (stripped.startswith("›") or " · " in stripped and "gpt-" in stripped):
+            if out and (stripped.startswith("›") or (" · " in stripped and "gpt-" in stripped)):
                 break
             out.append(line.lstrip("• ").rstrip())
         return "\n".join(out).strip()


### PR DESCRIPTION
The `fff` kernel module was replaced by the fsearch-backed bare `grep`/`find` builtins, but the agent system prompt still told agents to call `fff.grep`/`fff.find` (observed burning two failed type-checked cells in a live session), and several bundled-module docstrings still cited `fff` as a live example.

- point `system-prompt.nix` and `subagents.nix` at the real builtins
- swap `fff` docstring examples in the bundled mcp modules for modules that exist
- clear the three pre-existing whole-tree ruff failures (FURB162, FBT002, RUF021) that block any commit via the shared lint hook

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop stale `fff` module references from docs and update kernel search guidance to use `grep`/`find`
> - Replaces all references to `fff`, `fff.grep`, and `fff.find` in module docstrings and agent prompts with `search`, `grep`, `find`, and `sh` across multiple packages.
> - Updates [system-prompt.nix](https://github.com/indexable-inc/index/pull/1871/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to guide use of kernel builtins `grep` and `find` and prefer `view.ls`, `view.tree`, `view.cat`, and `nu` pipelines over text munging.
> - Fixes ISO 8601 parsing in [runtime.py](https://github.com/indexable-inc/index/pull/1871/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) to pass values directly to `datetime.fromisoformat` instead of replacing trailing `Z`.
> - Makes `auto_merge`, `interval`, and `timeout` keyword-only in `tools.pr_watch` by inserting `*` before `auto_merge` in [tools.py](https://github.com/indexable-inc/index/pull/1871/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6).
> - Risk: datetime strings ending in `Z` in `_parse_github_time` now raise `ValueError` and return `None` instead of being parsed as UTC.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86971b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->