### PR TITLE
Use Indexable Codex fork for MCP channel notifications

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,6 +45,23 @@
         "type": "github"
       }
     },
+    "codex-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783282574,
+        "narHash": "sha256-st9kcagTH5YDBmWDx1MzOPqel+MFtCQNe1W9R0wl8cU=",
+        "owner": "indexable-inc",
+        "repo": "codex",
+        "rev": "7d08748d54f3be979371e1d7b8659ab134d4189a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "indexable-inc",
+        "ref": "indexable/mcp-channel-notifications",
+        "repo": "codex",
+        "type": "github"
+      }
+    },
     "drgn-src": {
       "flake": false,
       "locked": {
@@ -375,6 +392,7 @@
         "bench-filesystem": "bench-filesystem",
         "btop-src": "btop-src",
         "clippy-fork": "clippy-fork",
+        "codex-src": "codex-src",
         "drgn-src": "drgn-src",
         "examples": "examples",
         "fff-src": "fff-src",

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,11 @@
       flake = false;
     };
 
+    codex-src = {
+      url = "github:indexable-inc/codex?ref=indexable/mcp-channel-notifications";
+      flake = false;
+    };
+
     btop-src = {
       url = "github:indexable-inc/btop/711f4a128b1b7009ee9cf0fa179a586c82586613";
       flake = false;
@@ -187,6 +192,7 @@
     launchk-src,
     snix-src,
     clippy-fork,
+    codex-src,
     ghostty,
     skills,
     examples,
@@ -268,6 +274,7 @@
         launchk-src
         snix-src
         clippy-fork
+        codex-src
         ghostty
         ;
     };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,6 +14,7 @@
   launchk-src,
   snix-src,
   clippy-fork,
+  codex-src,
   ghostty,
   # Flake source revision, stamped into builds that want to report it (see
   # `sharedHelpers.rev`). Defaulted so a direct `import ./lib` still evaluates.
@@ -487,6 +488,7 @@
       writeRustApplication
       ;
     btopSrc = btop-src;
+    codexSrc = codex-src;
     drgnSrc = drgn-src;
     perftestSrc = perftest-src;
     fffSrc = fff-src;

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -25,6 +25,7 @@
   # sibling is out of scope, so the wrapper bakes no MCP server there (the same
   # fallback the claude-code wrapper uses).
   repoPackages ? {},
+  codexSrc ? ix.codexSrc,
   # Rule names dropped from the default house prompt. Only affects the computed
   # `systemPrompt` default below; ignored when `systemPrompt` is passed
   # explicitly.
@@ -108,7 +109,7 @@
         (forcedSettings.features or {}) // (sharedPermissions.codex.forcedSettings.features or {});
     };
   specValue = {
-    target = lib.getExe codex;
+    target = lib.getExe codexWithNotifications;
     config_dir_env = "CODEX_HOME";
     config_dir_default = "~/.codex";
     config_file = "config.toml";
@@ -150,6 +151,34 @@
           ;
       }).codex;
   };
+  codexWithNotifications = codex.overrideAttrs (finalAttrs: previousAttrs: {
+    version = "0.0.0";
+    src = codexSrc;
+    sourceRoot = "source/codex-rs";
+    cargoHash = "sha256-mLpfLi5Wu/t/D8il/5xkDqCTHIeaJZ2OYMZmMIsg7E0=";
+    # buildRustPackage carries cargoDeps through overrideAttrs, so retarget the
+    # nested fixed-output staging derivation when swapping the upstream source.
+    cargoDeps = previousAttrs.cargoDeps.overrideAttrs (_: previousCargoAttrs: {
+      vendorStaging = previousCargoAttrs.vendorStaging.overrideAttrs (_: {
+        inherit (finalAttrs) src sourceRoot;
+        outputHash = finalAttrs.cargoHash;
+      });
+    });
+    postPatch = ''
+      # shell
+      substituteInPlace $cargoDepsCopy/*/webrtc-sys-*/build.rs \
+        --replace-fail "cargo:rustc-link-lib=static=webrtc" "cargo:rustc-link-lib=dylib=webrtc"
+      substituteInPlace Cargo.toml \
+        --replace-fail 'lto = "thin"' "" \
+        --replace-fail 'codegen-units = 4' ""
+    '';
+    meta =
+      previousAttrs.meta
+      // {
+        homepage = "https://github.com/indexable-inc/codex";
+        changelog = "https://github.com/indexable-inc/codex/commits/indexable/mcp-channel-notifications";
+      };
+  });
 in
   # These baked defaults also reach the Codex GUI app's remote-SSH sessions, not
   # just terminal use. The desktop app does NOT ship its own binary to the remote
@@ -162,8 +191,8 @@ in
   # uses `$SHELL -lc`, which skips ~/.bashrc/~/.zshrc), and a stale already-running
   # `codex app-server` is reused without re-injecting, so kill it once after a bump.
   symlinkJoin {
-    name = "codex-${codex.version}";
-    paths = [codex];
+    name = "codex-${codexWithNotifications.version}";
+    paths = [codexWithNotifications];
     # symlinkJoin links the whole codex output (libexec, completions, ...); we only
     # replace the entrypoint with our wrapper so the baked defaults ride every
     # invocation while everything else stays pristine.
@@ -183,9 +212,9 @@ in
       permissions = sharedPermissions.codex;
     };
     meta =
-      codex.meta
+      codexWithNotifications.meta
       // {
-        description = "${codex.meta.description or "OpenAI Codex CLI"} (index wrapper with baked defaults)";
+        description = "${codexWithNotifications.meta.description or "OpenAI Codex CLI"} (index wrapper with baked defaults)";
         mainProgram = binName;
       };
   }


### PR DESCRIPTION
## Summary
- points `packages/agent/codex` at the public `indexable-inc/codex` fork branch with MCP channel notification support
- exposes the fork source as `codex-src` and retargets the wrapped Codex package to it
- keeps the Codex wrapper launch spec pointed at the forked binary

## Validation
- `cargo test -p codex-rmcp-client --no-run` in the Codex fork
- `cargo test -p codex-mcp channel_notification_sender` in the Codex fork
- `cargo test -p codex-core channel_notification` in the Codex fork
- `nix eval --json --impure --expr <codex package metadata>`
- `nix build .#codex --no-link --print-out-paths` passed before the lint-only `# shell` comment and inherit rewrite
- `nix run .#lint`

Fixes #1857

(sent by Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch Codex package to Indexable fork for MCP channel notifications
> - Adds a new Nix flake input `codex-src` pointing to the `indexable/mcp-channel-notifications` branch of the `indexable-inc/codex` fork.
> - Introduces a `codexWithNotifications` derivation in [packages/agent/codex/default.nix](https://github.com/indexable-inc/index/pull/1872/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5) that builds from the fork's `codex-rs` subdirectory with an updated `cargoHash`.
> - Switches the installed wrapper from the upstream `codex` binary to `codexWithNotifications`, changing the reported version, metadata, and homepage to point to the fork.
> - Risk: the fork patches `Cargo.toml` to use dynamic (`dylib`) linking for `webrtc` and removes `lto`/`codegen-units` settings, which may affect runtime performance and requires the `webrtc` dylib to be present at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 910debe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->