### PR TITLE
ix-windows: native macOS overlay look (real transparency, rounded blur, hover-revealed close)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5123,6 +5123,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-quartz-core",
  "objc2-web-kit",
  "serde_json",
  "tao",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,6 +320,9 @@ tui = { path = "packages/tui/tui" }
 url = { version = "2.5.8", default-features = false }
 uuid = "1"
 webpki-roots = "1"
-wry = "0.55"
+# `transparent` is a non-default feature: without it `with_transparent(true)`
+# is a silent no-op and the webview paints an opaque canvas, hiding the
+# ix-windows blur behind a flat card.
+wry = { version = "0.55", features = ["transparent"] }
 x509-parser = "0.18"
 xxhash-rust = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,7 @@ numpy = "0.28"
 objc2 = "0.6"
 objc2-app-kit = "0.3"
 objc2-foundation = "0.3"
+objc2-quartz-core = "0.3"
 objc2-web-kit = "0.3"
 object_store = { version = "0.14", features = ["aws"] }
 panes-protocol = { path = "packages/vm/panes/protocol" }

--- a/doc/ix-windows/overview.md
+++ b/doc/ix-windows/overview.md
@@ -136,11 +136,12 @@ Public surface:
   the page background transparent (see `register_resource`'s styling guidance).
 - **Hover-revealed close.** The card paints a macOS traffic-light red dot at the
   top-left, visible only while the pointer is over the window (glyph on direct
-  hover, `pointer-events: none` while hidden). CSS `:hover` on the card cannot
-  drive the reveal (hover inside the sandboxed iframe does not set `:hover` on
-  the parent), so `OUTER_JS` toggles `html.ix-hover` from its own enter/leave
-  events plus an `ixhover` relay `INNER_JS` posts, debounced so an
-  iframe-to-chrome crossing does not flicker.
+  hover, `pointer-events: none` while hidden). The reveal is driven from Rust:
+  `main.rs` maps the OS `CursorEntered`/`CursorLeft` window events to
+  `WindowManager::set_hovered`, which toggles `html.ix-hover` via
+  `evaluate_script`. Page-side tracking cannot work here: CSS `:hover` and mouse
+  events do not cross the sandboxed iframe, and a fast pointer exit can skip the
+  page's final `mouseleave`, sticking the control visible.
 - **Native typography.** The inner document defaults to the system font
   (`-apple-system`, SF on macOS) with grayscale antialiasing forced
   (`-webkit-font-smoothing`), since WebKit disables subpixel smoothing on

--- a/doc/ix-windows/overview.md
+++ b/doc/ix-windows/overview.md
@@ -128,8 +128,24 @@ Public surface:
   joins all spaces and floats over fullscreen apps (`NSWindowCollectionBehavior`).
 - **Blur behind.** `install_blur` (macOS) inserts an `NSVisualEffectView`
   (`HUDWindow` material, `BehindWindow` blending) as the content view's first
-  subview, beneath the transparent webview, with a rounded, shadowed layer. The
-  rendered HTML paints on top of it.
+  subview, beneath the transparent webview, with a shadowed layer rounded at 12pt
+  with the continuous system corner curve (`kCACornerCurveContinuous`). The
+  rendered HTML paints on top of it, clipped to the same radius by the CSS
+  `#ix-root` `border-radius`, so blur and content share one rounded silhouette.
+  Resource HTML that paints its own opaque page background covers the blur; leave
+  the page background transparent (see `register_resource`'s styling guidance).
+- **Hover-revealed close.** The card paints a macOS traffic-light red dot at the
+  top-left, visible only while the pointer is over the window (glyph on direct
+  hover, `pointer-events: none` while hidden). CSS `:hover` on the card cannot
+  drive the reveal (hover inside the sandboxed iframe does not set `:hover` on
+  the parent), so `OUTER_JS` toggles `html.ix-hover` from its own enter/leave
+  events plus an `ixhover` relay `INNER_JS` posts, debounced so an
+  iframe-to-chrome crossing does not flicker.
+- **Native typography.** The inner document defaults to the system font
+  (`-apple-system`, SF on macOS) with grayscale antialiasing forced
+  (`-webkit-font-smoothing`), since WebKit disables subpixel smoothing on
+  transparent webviews and un-hinted text looks fuzzy on the blur; `code`/`pre`
+  opt back into `ui-monospace`.
 - **Sandboxed shell.** `shell(title, body)` builds a fully transparent trusted
   outer document whose `#ix-root` panel (the `STYLE` constant) shrink-wraps a
   single child: a `sandbox="allow-scripts"` (no `allow-same-origin`) `<iframe>`

--- a/packages/ix-windows/Cargo.toml
+++ b/packages/ix-windows/Cargo.toml
@@ -35,4 +35,6 @@ wry.workspace = true
 objc2 = { workspace = true }
 objc2-app-kit = { workspace = true }
 objc2-foundation = { workspace = true }
+# CALayer corner rounding (continuous curve) on the blur view.
+objc2-quartz-core = { workspace = true }
 objc2-web-kit = { workspace = true }

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -336,8 +336,8 @@ impl WindowManager {
         // It stays movable: `OUTER_JS` starts a window drag on mousedown over the
         // card chrome (`UserEvent::Drag` -> `drag_window`), since a borderless,
         // non-resizable window has no native title bar to grab.
-        // The overlay is a square card: a borderless window has square corners by
-        // default and `install_blur` adds no layer rounding.
+        // The card is rounded like a native macOS panel: `install_blur` rounds
+        // the blur layer and the CSS `#ix-root` radius clips the HTML to match.
         let builder = tao::window::WindowBuilder::new()
             .with_title(&pane.title)
             .with_decorations(false)
@@ -603,8 +603,10 @@ html, body { margin: 0; padding: 0; background: transparent; }
      mostly-transparent, click-intercepting always-on-top window. */
   min-width: 120px;
   min-height: 80px;
-  /* Square card (no border-radius). `overflow:hidden` still clips producer
-     content to the card bounds. */
+  /* Native macOS card rounding; matches the CALayer cornerRadius on the blur
+     view (`install_blur`), so the HTML clip and the blur clip coincide.
+     `overflow:hidden` clips producer content to the rounded card bounds. */
+  border-radius: 12px;
   overflow: hidden;
 }
 #ix-frame {
@@ -614,40 +616,45 @@ html, body { margin: 0; padding: 0; background: transparent; }
   width: 120px;
   height: 80px;
 }
-/* Borderless windows have no native close control, so the card paints its own.
-   It floats over the top-right corner at a faint base opacity, brightening on
-   hover. A faint *always-on* base (not reveal-on-card-hover) is deliberate: the
-   content fills the card via a sandboxed iframe, and hovering inside that opaque-
-   origin iframe does not set `:hover` on the parent card, so a pure
-   `#ix-root:hover` reveal would only ever show while the cursor sat on the button
-   itself -- undiscoverable.
-   `position: fixed` (not absolute) pins it to the webview viewport's top-right:
+/* Borderless windows have no native close control, so the card paints its own:
+   a macOS traffic-light red dot at the top-LEFT (where native windows put it),
+   revealed only while the pointer is over the window. CSS `:hover` on the card
+   cannot drive the reveal (hovering inside the sandboxed opaque-origin iframe
+   does not set `:hover` on the parent), so `OUTER_JS` toggles `html.ix-hover`
+   from its own enter/leave events plus an `ixhover` relay the iframe posts.
+   While hidden it is also `pointer-events: none`, so it never intercepts a
+   click meant for content.
+   The `\u{00d7}` glyph rides in the markup but is transparent until the dot
+   itself is hovered, matching the native traffic-light behavior.
+   `position: fixed` (not absolute) pins it to the webview viewport's corner:
    when a resource is wider/taller than the monitor clamp the window shows scroll-
    bars over the oversized `#ix-root`, and an absolutely-positioned control would
    sit at the off-screen content edge. `#ix-root` sets no transform/filter, so the
    fixed control also escapes its `overflow:hidden` clip. */
 #ix-close {
   position: fixed;
-  top: 4px;
-  right: 4px;
+  top: 6px;
+  left: 6px;
   z-index: 2;
-  width: 16px;
-  height: 16px;
+  width: 12px;
+  height: 12px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font: 13px/1 ui-monospace, 'SF Mono', Menlo, monospace;
-  color: #cdd6f4;
-  background: rgba(40, 40, 60, 0.55);
+  font: 700 9px/1 -apple-system, system-ui, sans-serif;
+  color: transparent;
+  background: #ff5f57;
+  box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.2);
   border-radius: 50%;
-  cursor: pointer;
-  opacity: 0.4;
-  transition: opacity 0.12s ease, background 0.12s ease;
+  cursor: default;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
   -webkit-user-select: none;
   user-select: none;
 }
-#ix-root:hover #ix-close { opacity: 0.75; }
-#ix-close:hover { background: rgba(220, 80, 90, 0.9); opacity: 1; }
+html.ix-hover #ix-close { opacity: 1; pointer-events: auto; }
+#ix-close:hover { color: rgba(77, 0, 0, 0.8); }
 ";
 
 /// Inner (sandboxed) document styling: transparent so the outer card tint shows;
@@ -662,9 +669,15 @@ const INNER_STYLE: &str = "\
 :root { color-scheme: dark; }
 html, body { margin: 0; padding: 0; background: transparent; }
 body {
-  color: #cdd6f4;
-  font: 14px/1.5 ui-monospace, 'SF Mono', Menlo, monospace;
+  color: rgba(255, 255, 255, 0.92);
+  /* Native default: the system font (SF on macOS), antialiased. WebKit turns
+     off subpixel smoothing on transparent webviews, which leaves un-hinted
+     text looking fuzzy; forcing grayscale antialiasing keeps it crisp on the
+     blur. Code content opts back into mono below. */
+  font: 13px/1.45 -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  -webkit-font-smoothing: antialiased;
 }
+code, pre, kbd, samp { font-family: ui-monospace, 'SF Mono', Menlo, monospace; }
 #ix-content {
   display: inline-block;
   width: max-content;
@@ -689,6 +702,26 @@ const OUTER_JS: &str = "\
   var close = document.getElementById('ix-close');
   if (!frame || !root) return;
   function ipc(msg) { if (window.ipc && window.ipc.postMessage) window.ipc.postMessage(msg); }
+  // Reveal the close control only while the pointer is over the window. Two
+  // sources feed the state because no single one covers the whole card: this
+  // document's own events fire over the chrome but not over the iframe (the
+  // iframe's document receives those), and the iframe relays its enter/leave
+  // as `ixhover` messages (handled below). The off side is debounced so an
+  // iframe->chrome crossing (leave then enter within one gesture) cannot
+  // flicker the control.
+  var hoverTimer = null;
+  function hoverOn() {
+    if (hoverTimer) { clearTimeout(hoverTimer); hoverTimer = null; }
+    document.documentElement.classList.add('ix-hover');
+  }
+  function hoverOff() {
+    if (hoverTimer) clearTimeout(hoverTimer);
+    hoverTimer = setTimeout(function () {
+      document.documentElement.classList.remove('ix-hover');
+    }, 120);
+  }
+  document.addEventListener('mouseover', hoverOn);
+  document.documentElement.addEventListener('mouseleave', hoverOff);
   // Drag the borderless window by any bare card chrome: a mousedown that reaches
   // this (outer, trusted) document landed outside the iframe (which captures its
   // own events). With zero padding the card shrink-wraps the content, so this
@@ -714,6 +747,9 @@ const OUTER_JS: &str = "\
     // The iframe relays a Cmd-press (or a press on its empty background) so the
     // window stays movable even though content fills the card edge to edge.
     if (data && data.t === 'ixdrag') { ipc('drag'); return; }
+    // The iframe's hover relay: the only signal that the pointer is over the
+    // content area (this document never sees those events).
+    if (data && data.t === 'ixhover') { if (data.on) hoverOn(); else hoverOff(); return; }
     if (!data || data.t !== 'ixsize') return;
     var w = Number(data.w), h = Number(data.h);
     // Reject only garbage and negatives. Zero is a valid report (an empty resource,
@@ -774,6 +810,16 @@ const INNER_JS: &str = "\
     if (bare && !event.metaKey) event.preventDefault();
     parent.postMessage({ t: 'ixdrag' }, '*');
   }, true);
+  // Relay pointer presence so the outer document can reveal its close control:
+  // mouse events over the content land in this document only, so without this
+  // relay the outer document would never learn the window is hovered. postMessage
+  // is sandbox-permitted; the payload carries no content data.
+  document.documentElement.addEventListener('mouseenter', function () {
+    parent.postMessage({ t: 'ixhover', on: true }, '*');
+  });
+  document.documentElement.addEventListener('mouseleave', function () {
+    parent.postMessage({ t: 'ixhover', on: false }, '*');
+  });
   var lastW = -1, lastH = -1, pending = false;
   function report() {
     pending = false;
@@ -814,7 +860,12 @@ fn install_blur(window: &Window) {
         NSVisualEffectState, NSVisualEffectView, NSWindow, NSWindowCollectionBehavior,
         NSWindowOrderingMode,
     };
+    use objc2_quartz_core::kCACornerCurveContinuous;
     use tao::platform::macos::WindowExtMacOS;
+
+    /// Card corner radius in points; must match the CSS `#ix-root` border-radius
+    /// so the HTML clip and the blur clip coincide.
+    const CORNER_RADIUS: f64 = 12.0;
 
     let Some(mtm) = MainThreadMarker::new() else {
         return;
@@ -847,10 +898,20 @@ fn install_blur(window: &Window) {
         effect.setAutoresizingMask(
             NSAutoresizingMaskOptions::ViewWidthSizable | NSAutoresizingMaskOptions::ViewHeightSizable,
         );
+        // Round the blur like a native macOS panel (continuous "squircle" curve,
+        // the post-Big-Sur system corner). The webview's HTML is clipped to the
+        // same radius by the CSS `#ix-root` border-radius, so blur and content
+        // share one rounded silhouette and the window shadow follows it.
+        effect.setWantsLayer(true);
+        if let Some(layer) = effect.layer() {
+            layer.setCornerRadius(CORNER_RADIUS);
+            layer.setMasksToBounds(true);
+            // SAFETY: reading a CoreAnimation constant (an extern NSString), valid
+            // for the process lifetime.
+            layer.setCornerCurve(unsafe { kCACornerCurveContinuous });
+        }
         // Place the blur beneath the webview (added as the content view's first
-        // subview), so the rendered HTML paints on top of it. A borderless window
-        // is square by default, and we keep it square: no layer cornerRadius on
-        // the blur or the content view.
+        // subview), so the rendered HTML paints on top of it.
         content.addSubview_positioned_relativeTo(&effect, NSWindowOrderingMode::Below, None);
 
         ns_window.setHasShadow(true);

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -898,10 +898,18 @@ fn install_blur(window: &Window) {
         effect.setAutoresizingMask(
             NSAutoresizingMaskOptions::ViewWidthSizable | NSAutoresizingMaskOptions::ViewHeightSizable,
         );
+        // Place the blur beneath the webview (added as the content view's first
+        // subview), so the rendered HTML paints on top of it.
+        content.addSubview_positioned_relativeTo(&effect, NSWindowOrderingMode::Below, None);
+
         // Round the blur like a native macOS panel (continuous "squircle" curve,
         // the post-Big-Sur system corner). The webview's HTML is clipped to the
         // same radius by the CSS `#ix-root` border-radius, so blur and content
-        // share one rounded silhouette and the window shadow follows it.
+        // share one rounded silhouette and the window shadow follows it. Runs
+        // after addSubview: AppKit creates the backing layer lazily, and before
+        // insertion into the (layer-backed) window hierarchy `layer()` can be
+        // nil. Loud on failure -- a missing layer means square corners, and a
+        // silent skip here cost a debugging round.
         effect.setWantsLayer(true);
         if let Some(layer) = effect.layer() {
             layer.setCornerRadius(CORNER_RADIUS);
@@ -909,10 +917,9 @@ fn install_blur(window: &Window) {
             // SAFETY: reading a CoreAnimation constant (an extern NSString), valid
             // for the process lifetime.
             layer.setCornerCurve(unsafe { kCACornerCurveContinuous });
+        } else {
+            eprintln!("ix-windows: no backing layer on the blur view; corners stay square");
         }
-        // Place the blur beneath the webview (added as the content view's first
-        // subview), so the rendered HTML paints on top of it.
-        content.addSubview_positioned_relativeTo(&effect, NSWindowOrderingMode::Below, None);
 
         ns_window.setHasShadow(true);
         ns_window.invalidateShadow();

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -591,7 +591,11 @@ fn escape_attr(text: &str) -> String {
 /// transparent and chrome-less; the outer script sizes it to the content size the
 /// inner document reports, so `#ix-root` shrink-wraps it.
 const STYLE: &str = "\
-:root { color-scheme: dark; }
+/* No `color-scheme: dark` here or in INNER_STYLE: WKWebView paints an opaque
+   canvas when the document opts into dark color-scheme, even with
+   `drawsBackground` off (the tauri/wry transparent-window gotcha), which would
+   hide the NSVisualEffectView blur entirely. Dark styling is done with explicit
+   colors instead. */
 html, body { margin: 0; padding: 0; background: transparent; }
 #ix-root {
   position: relative;
@@ -666,7 +670,8 @@ html.ix-hover #ix-close { opacity: 1; pointer-events: auto; }
 /// the true intrinsic width; `max-width` caps runaway width (the OS window resize
 /// is clamped to the monitor on top of that).
 const INNER_STYLE: &str = "\
-:root { color-scheme: dark; }
+/* No `color-scheme: dark`: it would opaque the canvas and hide the window blur
+   (see STYLE). */
 html, body { margin: 0; padding: 0; background: transparent; }
 body {
   color: rgba(255, 255, 255, 0.92);

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -299,6 +299,23 @@ impl WindowManager {
         }
     }
 
+    /// Show or hide a window's close control. Driven by the OS cursor
+    /// enter/leave events (`main.rs`), not page script: the sandboxed iframe
+    /// swallows pointer events over content, and a fast exit can skip the page's
+    /// final `mouseleave` entirely, leaving a JS-tracked reveal stuck on. The
+    /// class toggle is idempotent, so repeated or crossed events are harmless.
+    pub fn set_hovered(&self, window: WindowId, hovered: bool) {
+        let Some(key) = self.by_window.get(&window) else {
+            return;
+        };
+        if let Some(open) = self.windows.get(key) {
+            let js = format!(
+                "document.documentElement.classList.toggle('ix-hover', {hovered});"
+            );
+            let _ = open.webview.evaluate_script(&js);
+        }
+    }
+
     /// Begin an interactive move of the window whose chrome the user pressed.
     /// `OUTER_JS` posts `"drag"` on mousedown over the card chrome; `drag_window`
     /// hands the rest of the gesture to the OS so the overlay tracks the cursor.
@@ -624,8 +641,8 @@ html, body { margin: 0; padding: 0; background: transparent; }
    a macOS traffic-light red dot at the top-LEFT (where native windows put it),
    revealed only while the pointer is over the window. CSS `:hover` on the card
    cannot drive the reveal (hovering inside the sandboxed opaque-origin iframe
-   does not set `:hover` on the parent), so `OUTER_JS` toggles `html.ix-hover`
-   from its own enter/leave events plus an `ixhover` relay the iframe posts.
+   does not set `:hover` on the parent), so Rust toggles `html.ix-hover` from
+   the OS cursor enter/leave events (`WindowManager::set_hovered`).
    While hidden it is also `pointer-events: none`, so it never intercepts a
    click meant for content.
    The `\u{00d7}` glyph rides in the markup but is transparent until the dot
@@ -707,26 +724,9 @@ const OUTER_JS: &str = "\
   var close = document.getElementById('ix-close');
   if (!frame || !root) return;
   function ipc(msg) { if (window.ipc && window.ipc.postMessage) window.ipc.postMessage(msg); }
-  // Reveal the close control only while the pointer is over the window. Two
-  // sources feed the state because no single one covers the whole card: this
-  // document's own events fire over the chrome but not over the iframe (the
-  // iframe's document receives those), and the iframe relays its enter/leave
-  // as `ixhover` messages (handled below). The off side is debounced so an
-  // iframe->chrome crossing (leave then enter within one gesture) cannot
-  // flicker the control.
-  var hoverTimer = null;
-  function hoverOn() {
-    if (hoverTimer) { clearTimeout(hoverTimer); hoverTimer = null; }
-    document.documentElement.classList.add('ix-hover');
-  }
-  function hoverOff() {
-    if (hoverTimer) clearTimeout(hoverTimer);
-    hoverTimer = setTimeout(function () {
-      document.documentElement.classList.remove('ix-hover');
-    }, 120);
-  }
-  document.addEventListener('mouseover', hoverOn);
-  document.documentElement.addEventListener('mouseleave', hoverOff);
+  // The close control's reveal (`html.ix-hover`) is toggled from Rust off the
+  // OS cursor enter/leave events, not tracked here: page-side tracking cannot
+  // see pointer events over the sandboxed iframe and misses fast window exits.
   // Drag the borderless window by any bare card chrome: a mousedown that reaches
   // this (outer, trusted) document landed outside the iframe (which captures its
   // own events). With zero padding the card shrink-wraps the content, so this
@@ -752,9 +752,6 @@ const OUTER_JS: &str = "\
     // The iframe relays a Cmd-press (or a press on its empty background) so the
     // window stays movable even though content fills the card edge to edge.
     if (data && data.t === 'ixdrag') { ipc('drag'); return; }
-    // The iframe's hover relay: the only signal that the pointer is over the
-    // content area (this document never sees those events).
-    if (data && data.t === 'ixhover') { if (data.on) hoverOn(); else hoverOff(); return; }
     if (!data || data.t !== 'ixsize') return;
     var w = Number(data.w), h = Number(data.h);
     // Reject only garbage and negatives. Zero is a valid report (an empty resource,
@@ -815,16 +812,6 @@ const INNER_JS: &str = "\
     if (bare && !event.metaKey) event.preventDefault();
     parent.postMessage({ t: 'ixdrag' }, '*');
   }, true);
-  // Relay pointer presence so the outer document can reveal its close control:
-  // mouse events over the content land in this document only, so without this
-  // relay the outer document would never learn the window is hovered. postMessage
-  // is sandbox-permitted; the payload carries no content data.
-  document.documentElement.addEventListener('mouseenter', function () {
-    parent.postMessage({ t: 'ixhover', on: true }, '*');
-  });
-  document.documentElement.addEventListener('mouseleave', function () {
-    parent.postMessage({ t: 'ixhover', on: false }, '*');
-  });
   var lastW = -1, lastH = -1, pending = false;
   function report() {
     pending = false;
@@ -900,10 +887,6 @@ fn install_blur(window: &Window) {
             // Loud: a silent None here leaves a light-gray card under white text.
             None => eprintln!("ix-windows: darkAqua appearance unavailable; card stays light"),
         }
-        eprintln!(
-            "ix-windows: window effectiveAppearance = {:?}",
-            ns_window.effectiveAppearance().name()
-        );
 
         let Some(content) = ns_window.contentView() else {
             return;

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -69,6 +69,14 @@ pub enum UserEvent {
     /// `×` and posts `"close"`, which the loop routes to
     /// [`WindowManager::window_closed`].
     Close { window: WindowId },
+    /// The page saw pointer activity; reveal this window's close control. Only
+    /// the ON edge comes from the page: these always-on-top windows of a
+    /// never-activated background app get no AppKit tracking-area events, so
+    /// tao's `CursorEntered`/`CursorLeft` never fire, and the page's own
+    /// `mouseleave` misses fast exits. The OFF edge is Rust polling the cursor
+    /// against the window frame ([`WindowManager::sweep_hover`]) while anything
+    /// is hovered.
+    Hover { window: WindowId },
 }
 
 /// A pane's global identity across producers: `(producer id, pane id)`. A pane id
@@ -139,6 +147,10 @@ pub struct WindowManager {
     /// How many windows have been opened, used to cascade each new overlay so
     /// they do not stack exactly on top of each other.
     opened: u32,
+    /// Windows whose close control is currently revealed. Fed by page-reported
+    /// hover ([`UserEvent::Hover`]), cleared by [`sweep_hover`](Self::sweep_hover)
+    /// when the OS cursor is measured outside the window frame.
+    hovered: HashSet<WindowId>,
 }
 
 impl WindowManager {
@@ -153,6 +165,7 @@ impl WindowManager {
             failed: HashSet::new(),
             dismissed_keys,
             opened: 0,
+            hovered: HashSet::new(),
         }
     }
 
@@ -228,6 +241,7 @@ impl WindowManager {
         let Some(key) = self.by_window.remove(&window) else {
             return false;
         };
+        self.hovered.remove(&window);
         // Persist on first sighting of this key; the file is an append-only log, so
         // a no-op insert must not append a duplicate line.
         if self.dismissed_keys.insert(key.clone()) {
@@ -299,20 +313,80 @@ impl WindowManager {
         }
     }
 
-    /// Show or hide a window's close control. Driven by the OS cursor
-    /// enter/leave events (`main.rs`), not page script: the sandboxed iframe
-    /// swallows pointer events over content, and a fast exit can skip the page's
-    /// final `mouseleave` entirely, leaving a JS-tracked reveal stuck on. The
-    /// class toggle is idempotent, so repeated or crossed events are harmless.
-    pub fn set_hovered(&self, window: WindowId, hovered: bool) {
-        let Some(key) = self.by_window.get(&window) else {
+    /// Show or hide a window's close control (idempotent; only a state change
+    /// touches the page). See [`UserEvent::Hover`] for why the ON edge comes
+    /// from the page and the OFF edge from [`sweep_hover`](Self::sweep_hover).
+    pub fn set_hovered(&mut self, window: WindowId, hovered: bool) {
+        if !self.by_window.contains_key(&window) {
+            return;
+        }
+        let changed = if hovered {
+            self.hovered.insert(window)
+        } else {
+            self.hovered.remove(&window)
+        };
+        if !changed {
+            return;
+        }
+        let Some(open) = self.by_window.get(&window).and_then(|key| self.windows.get(key)) else {
             return;
         };
-        if let Some(open) = self.windows.get(key) {
-            let js = format!(
-                "document.documentElement.classList.toggle('ix-hover', {hovered});"
-            );
-            let _ = open.webview.evaluate_script(&js);
+        let js = format!("document.documentElement.classList.toggle('ix-hover', {hovered});");
+        let _ = open.webview.evaluate_script(&js);
+    }
+
+    /// Whether any window's close control is revealed; while true the event loop
+    /// wakes on a short timer to run [`sweep_hover`](Self::sweep_hover), so a
+    /// missed leave event can never stick a control on.
+    #[must_use]
+    pub fn any_hovered(&self) -> bool {
+        !self.hovered.is_empty()
+    }
+
+    /// Hide the close control of every hovered window the cursor is no longer
+    /// over, by measuring the global cursor against each window's frame. This is
+    /// the only reliable OFF edge on macOS: the page can miss its final
+    /// `mouseleave` on a fast exit, and no tracking-area events reach a
+    /// never-key background window. Both `NSEvent::mouseLocation` and
+    /// `NSWindow::frame` are in the same bottom-left global coordinate space, so
+    /// containment is a plain rect test. Non-macOS builds clear all (no blur
+    /// styling there either; the overlay is currently a Darwin-only output).
+    pub fn sweep_hover(&mut self) {
+        #[cfg(target_os = "macos")]
+        {
+            use objc2_app_kit::{NSEvent, NSWindow};
+            use tao::platform::macos::WindowExtMacOS;
+
+            let cursor = NSEvent::mouseLocation();
+            let stale: Vec<WindowId> = self
+                .hovered
+                .iter()
+                .copied()
+                .filter(|id| {
+                    let Some(open) = self.by_window.get(id).and_then(|key| self.windows.get(key))
+                    else {
+                        return true; // window is gone; drop its hover state
+                    };
+                    // SAFETY: on the main thread `tao` hands back a live NSWindow
+                    // pointer; we only read its frame, without retaining.
+                    let frame =
+                        unsafe { (*open.window.ns_window().cast::<NSWindow>()).frame() };
+                    !(cursor.x >= frame.origin.x
+                        && cursor.x <= frame.origin.x + frame.size.width
+                        && cursor.y >= frame.origin.y
+                        && cursor.y <= frame.origin.y + frame.size.height)
+                })
+                .collect();
+            for id in stale {
+                self.set_hovered(id, false);
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let all: Vec<WindowId> = self.hovered.iter().copied().collect();
+            for id in all {
+                self.set_hovered(id, false);
+            }
         }
     }
 
@@ -397,6 +471,11 @@ impl WindowManager {
                 let body = request.body().as_str();
                 if body == "drag" {
                     let _ = proxy.send_event(UserEvent::Drag { window: id });
+                } else if body == "hover" {
+                    // Unforgeable-ness doesn't matter here (worst case producer
+                    // script reveals a close control the user can ignore), so no
+                    // token, unlike `close`.
+                    let _ = proxy.send_event(UserEvent::Hover { window: id });
                 } else if body == close_msg {
                     let _ = proxy.send_event(UserEvent::Close { window: id });
                 } else if let Some((w, h)) = parse_size(body) {
@@ -441,10 +520,11 @@ impl WindowManager {
         );
     }
 
-    /// Close one window and clear both indexes.
+    /// Close one window and clear every index holding it.
     fn close(&mut self, key: &PaneKey) {
         if let Some(open) = self.windows.remove(key) {
             self.by_window.remove(&open.window.id());
+            self.hovered.remove(&open.window.id());
             // `open` drops here, closing the OS window.
         }
     }
@@ -724,9 +804,19 @@ const OUTER_JS: &str = "\
   var close = document.getElementById('ix-close');
   if (!frame || !root) return;
   function ipc(msg) { if (window.ipc && window.ipc.postMessage) window.ipc.postMessage(msg); }
-  // The close control's reveal (`html.ix-hover`) is toggled from Rust off the
-  // OS cursor enter/leave events, not tracked here: page-side tracking cannot
-  // see pointer events over the sandboxed iframe and misses fast window exits.
+  // Hover ON edge: report pointer activity to Rust (throttled; Rust reveals the
+  // close control). The OFF edge is NOT tracked here -- Rust polls the cursor
+  // against the window frame -- because this document never sees events over
+  // the sandboxed iframe and a fast window exit can skip the final mouseleave.
+  var lastHover = 0;
+  function hover() {
+    var now = Date.now();
+    if (now - lastHover < 150) return;
+    lastHover = now;
+    ipc('hover');
+  }
+  document.addEventListener('mousemove', hover, true);
+  document.addEventListener('mouseover', hover, true);
   // Drag the borderless window by any bare card chrome: a mousedown that reaches
   // this (outer, trusted) document landed outside the iframe (which captures its
   // own events). With zero padding the card shrink-wraps the content, so this
@@ -752,6 +842,8 @@ const OUTER_JS: &str = "\
     // The iframe relays a Cmd-press (or a press on its empty background) so the
     // window stays movable even though content fills the card edge to edge.
     if (data && data.t === 'ixdrag') { ipc('drag'); return; }
+    // Pointer activity inside the iframe (this document never sees it directly).
+    if (data && data.t === 'ixhover') { hover(); return; }
     if (!data || data.t !== 'ixsize') return;
     var w = Number(data.w), h = Number(data.h);
     // Reject only garbage and negatives. Zero is a valid report (an empty resource,
@@ -812,6 +904,18 @@ const INNER_JS: &str = "\
     if (bare && !event.metaKey) event.preventDefault();
     parent.postMessage({ t: 'ixdrag' }, '*');
   }, true);
+  // Hover ON edge over content: relay pointer activity out (throttled). Capture
+  // phase so producer content calling stopPropagation cannot starve it. The
+  // sandbox permits postMessage; the payload carries no content data.
+  var lastHover = 0;
+  function hover() {
+    var now = Date.now();
+    if (now - lastHover < 150) return;
+    lastHover = now;
+    parent.postMessage({ t: 'ixhover' }, '*');
+  }
+  document.addEventListener('mousemove', hover, true);
+  document.addEventListener('mouseover', hover, true);
   var lastW = -1, lastH = -1, pending = false;
   function report() {
     pending = false;

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -861,6 +861,7 @@ fn install_blur(window: &Window) {
     use objc2::MainThreadMarker;
     use objc2::rc::Retained;
     use objc2_app_kit::{
+        NSAppearance, NSAppearanceCustomization as _, NSAppearanceNameDarkAqua,
         NSAutoresizingMaskOptions, NSVisualEffectBlendingMode, NSVisualEffectMaterial,
         NSVisualEffectState, NSVisualEffectView, NSWindow, NSWindowCollectionBehavior,
         NSWindowOrderingMode,
@@ -886,6 +887,17 @@ fn install_blur(window: &Window) {
     // thread/ownership requirements in the types), so no `unsafe` is needed; only
     // the raw `Retained::retain` above is.
     {
+        // Pin the window to dark appearance: the card's palette is dark (white
+        // text on the HUD material), and without this the NSVisualEffectView
+        // follows the system appearance, rendering a milky light-gray card in
+        // light mode under white text. The CSS deliberately does not set
+        // `color-scheme: dark` (it would opaque the canvas, see `STYLE`), so the
+        // appearance must be pinned here at the window level.
+        // SAFETY: reading an AppKit appearance-name constant (an extern
+        // NSString), valid for the process lifetime.
+        let dark = NSAppearance::appearanceNamed(unsafe { NSAppearanceNameDarkAqua });
+        ns_window.setAppearance(dark.as_deref());
+
         let Some(content) = ns_window.contentView() else {
             return;
         };

--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -895,8 +895,15 @@ fn install_blur(window: &Window) {
         // appearance must be pinned here at the window level.
         // SAFETY: reading an AppKit appearance-name constant (an extern
         // NSString), valid for the process lifetime.
-        let dark = NSAppearance::appearanceNamed(unsafe { NSAppearanceNameDarkAqua });
-        ns_window.setAppearance(dark.as_deref());
+        match NSAppearance::appearanceNamed(unsafe { NSAppearanceNameDarkAqua }) {
+            Some(dark) => ns_window.setAppearance(Some(&dark)),
+            // Loud: a silent None here leaves a light-gray card under white text.
+            None => eprintln!("ix-windows: darkAqua appearance unavailable; card stays light"),
+        }
+        eprintln!(
+            "ix-windows: window effectiveAppearance = {:?}",
+            ns_window.effectiveAppearance().name()
+        );
 
         let Some(content) = ns_window.contentView() else {
             return;

--- a/packages/ix-windows/src/main.rs
+++ b/packages/ix-windows/src/main.rs
@@ -105,6 +105,7 @@ fn main() {
                 event: WindowEvent::CursorEntered { .. },
                 ..
             } => {
+                eprintln!("ix-windows: cursor entered {window_id:?}");
                 manager.set_hovered(window_id, true);
             }
             Event::WindowEvent {
@@ -112,6 +113,7 @@ fn main() {
                 event: WindowEvent::CursorLeft { .. },
                 ..
             } => {
+                eprintln!("ix-windows: cursor left {window_id:?}");
                 manager.set_hovered(window_id, false);
             }
             _ => {}

--- a/packages/ix-windows/src/main.rs
+++ b/packages/ix-windows/src/main.rs
@@ -10,7 +10,7 @@
 
 use std::path::PathBuf;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use clap::Parser;
 use dashboard_core::{ProducerEvent, discovery_dir, subscribe};
@@ -33,6 +33,11 @@ struct Cli {
     #[arg(long, default_value_t = 500)]
     rescan_ms: u64,
 }
+
+/// How often to re-check the cursor against hovered windows' frames
+/// ([`WindowManager::sweep_hover`]). Only ticks while a close control is
+/// revealed; the loop is otherwise fully event-driven.
+const HOVER_SWEEP: Duration = Duration::from_millis(200);
 
 fn main() {
     let cli = Cli::parse();
@@ -95,28 +100,25 @@ fn main() {
             } => {
                 manager.window_closed(window_id);
             }
-            // Hover state for the close control comes from the OS, not the page:
-            // AppKit tracking areas deliver enter/leave reliably even when the
-            // pointer flicks out of the window so fast the page never sees a
-            // final mouseleave (which left the control stuck visible when this
-            // was JS-tracked).
-            Event::WindowEvent {
-                window_id,
-                event: WindowEvent::CursorEntered { .. },
-                ..
-            } => {
-                eprintln!("ix-windows: cursor entered {window_id:?}");
-                manager.set_hovered(window_id, true);
-            }
-            Event::WindowEvent {
-                window_id,
-                event: WindowEvent::CursorLeft { .. },
-                ..
-            } => {
-                eprintln!("ix-windows: cursor left {window_id:?}");
-                manager.set_hovered(window_id, false);
+            // The page saw pointer activity: reveal the close control. The OFF
+            // edge is the sweep below, not a page event (see `UserEvent::Hover`;
+            // tao's CursorEntered/CursorLeft never fire for these never-key
+            // background windows, verified empirically).
+            Event::UserEvent(UserEvent::Hover { window }) => {
+                manager.set_hovered(window, true);
             }
             _ => {}
         }
+        // While any close control is revealed, wake on a short timer and clear
+        // the ones the cursor has left; otherwise idle indefinitely. Every wake
+        // (timer or event) sweeps, so a stale reveal survives at most one tick.
+        if manager.any_hovered() {
+            manager.sweep_hover();
+        }
+        *control_flow = if manager.any_hovered() {
+            ControlFlow::WaitUntil(Instant::now() + HOVER_SWEEP)
+        } else {
+            ControlFlow::Wait
+        };
     });
 }

--- a/packages/ix-windows/src/main.rs
+++ b/packages/ix-windows/src/main.rs
@@ -95,6 +95,25 @@ fn main() {
             } => {
                 manager.window_closed(window_id);
             }
+            // Hover state for the close control comes from the OS, not the page:
+            // AppKit tracking areas deliver enter/leave reliably even when the
+            // pointer flicks out of the window so fast the page never sees a
+            // final mouseleave (which left the control stuck visible when this
+            // was JS-tracked).
+            Event::WindowEvent {
+                window_id,
+                event: WindowEvent::CursorEntered { .. },
+                ..
+            } => {
+                manager.set_hovered(window_id, true);
+            }
+            Event::WindowEvent {
+                window_id,
+                event: WindowEvent::CursorLeft { .. },
+                ..
+            } => {
+                manager.set_hovered(window_id, false);
+            }
             _ => {}
         }
     });

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1249,6 +1249,22 @@ def register_resource(
     close. Move one by dragging its card chrome (the padding around the content);
     it is not resizable (size follows the content).
 
+    STYLING: write content, not a page. The host (dashboard pane and overlay
+    window alike) already provides the card: a translucent, rounded surface that
+    on macOS blurs whatever is behind the window, plus the close control and the
+    system font (SF via ``-apple-system``, antialiased; ``code``/``pre`` are
+    monospace). For a native look:
+
+    - Do NOT set a background on ``html``/``body`` or paint a full-bleed
+      wrapper: an opaque background covers the blur and the card reads as a flat
+      rectangle. Leave the page transparent; tint only small elements
+      (badges, rows) and prefer translucent tints (``rgba``) over solid fills.
+    - Do NOT add your own card chrome: no page-level ``border-radius``,
+      ``box-shadow``, or outer border; the host draws those.
+    - Add your own padding (the host renders content edge to edge), size
+      intrinsically (the window auto-fits the content; avoid ``100vw``/fixed
+      page widths), and inherit the host font instead of restating one.
+
     Interactive (buttons/forms that run python): pass ``actions`` -- a dict of
     name -> handler (sync or async, called with the submitted payload). The HTML
     is served with ``ix.act(name, payload)`` and ``ix.events(fn)`` pre-wired.


### PR DESCRIPTION
Makes the resource overlays look like native macOS panels. Verified live on hydra with screenshots at each step.

- **Root cause of the long-standing flat cards**: wry's `transparent` cargo feature is non-default, so `with_transparent(true)` was a silent no-op and the WKWebView painted an opaque canvas over the NSVisualEffectView. The blur never showed. Feature now enabled.
- Second transparency killer removed: CSS `color-scheme: dark` makes WKWebView paint an opaque canvas even with `drawsBackground` off; dark styling is now explicit colors plus a `darkAqua` appearance pin on the window (so the HUD material stays dark in system light mode).
- Continuous 12pt corner rounding on the blur layer (objc2-quartz-core, already in wry's dep graph), matched by the CSS clip; set after `addSubview` since the backing layer is created lazily, loud if missing.
- Close control is now a macOS traffic-light red dot, top-left, revealed only while the pointer is over the window. ON edge: page-reported pointer activity (throttled, capture-phase, relayed from the sandboxed iframe). OFF edge: a 200ms Rust sweep of `NSEvent mouseLocation` against hovered window frames, because tao's `CursorEntered/CursorLeft` never fire for these never-key background windows and the page misses fast exits (verified: zero events across the window).
- Default typography goes native: `-apple-system` + forced grayscale antialiasing (WebKit drops subpixel smoothing on transparent webviews); `code`/`pre` stay mono.
- `register_resource` docstring gains styling guidance: content-not-a-page, transparent body (an opaque page background is what hides the blur), no own card chrome, add your own padding.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native macOS transparency, rounded blur corners, and hover-revealed close button to ix-windows overlays
> - Enables wry's `transparent` feature so `with_transparent(true)` produces a truly transparent webview instead of an opaque canvas.
> - Updates `install_blur` to pin the `NSVisualEffectView` to `DarkAqua` appearance and apply a 12pt continuous corner radius via CoreAnimation, matching the macOS HUD silhouette.
> - Adds a `Hover` user event and `WindowManager::set_hovered` that toggles an `ix-hover` CSS class on the overlay's `documentElement` via `evaluate_script`, driven by IPC messages posted from both the outer document and inner iframe.
> - Adds `sweep_hover` (polled every 200 ms via `WaitUntil` when any window is hovered) to clear hover state when the cursor leaves a window frame using `NSEvent::mouseLocation` / `NSWindow::frame`, catching cases where page leave-events are missed.
> - Behavioral Change: the event loop switches from fully event-driven (`Wait`) to a 200 ms periodic wake (`WaitUntil`) whenever any overlay is hovered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d22f226.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->