### PR TITLE
ix-windows: correct install_blur SAFETY comment

### DIFF
--- a/packages/ix-windows/src/lib.rs
+++ b/packages/ix-windows/src/lib.rs
@@ -967,8 +967,9 @@ fn install_blur(window: &Window) {
     let Some(mtm) = MainThreadMarker::new() else {
         return;
     };
-    // SAFETY: on the main thread `tao` hands back a live, retained `NSWindow`
-    // pointer; `Retained::retain` balances the +1 when this scope ends.
+    // SAFETY: on the main thread `tao` hands back a live *borrowed* (+0)
+    // `NSWindow` pointer; `Retained::retain` takes its own +1 and releases it
+    // when the `Retained` drops, so ownership stays balanced.
     let ns_window = unsafe { Retained::retain(window.ns_window().cast::<NSWindow>()) };
     let Some(ns_window): Option<Retained<NSWindow>> = ns_window else {
         return;


### PR DESCRIPTION
Follow-up to #1874's review: the SAFETY comment implied tao hands over a +1 retained `NSWindow` pointer that `Retained::retain` balances. tao lends a borrowed (+0) pointer; `retain` takes and releases its own +1. Comment-only change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `install_blur` SAFETY comment in ix-windows to clarify NSWindow ownership semantics
> Corrects the `unsafe` SAFETY comment in [lib.rs](https://github.com/indexable-inc/index/pull/1875/files#diff-1e1abdcf7151daee9cdb984d29eca28bda3ded2eaa1b78937674b8156ef55a43) to accurately describe that `tao` returns a borrowed (+0) `NSWindow` pointer and that `Retained::retain` takes its own +1 reference, releasing it on drop. No code logic is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6be0b37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->