### PR TITLE
sqlmerge: git merge driver for SQLite databases + base-profile git wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,6 +5547,7 @@ version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
+ "bindgen",
  "cc",
  "pkg-config",
  "vcpkg",
@@ -10320,6 +10321,14 @@ dependencies = [
  "js-sys",
  "rsqlite-vfs",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sqlmerge"
+version = "0.1.0"
+dependencies = [
+ "rusqlite",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ members = [
   "packages/search/source/parquet",
   "packages/search/search-py",
   "packages/skill-lint",
+  "packages/sqlmerge",
   "packages/search/source/slack",
   "packages/search/sink/mixedbread",
   "packages/search/sink/parquet",

--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -285,6 +285,29 @@
         nativeBuildInputs =
           lib.optional targetIsLinux workspacePkgs.pkg-config
           ++ lib.optionals (appleToolchain != null) appleToolchain.runtimeInputs;
+        # rusqlite's `session` feature (pulled in by `sqlmerge`, and unified
+        # across the workspace by cargo's feature resolution) switches
+        # libsqlite3-sys to `buildtime_bindgen`: the pregenerated bundled
+        # bindings do not cover the sqlite3session_* API, so its build script
+        # runs bindgen, which dlopens libclang at runtime and parses the
+        # bundled sqlite3 headers. macOS's relaxed sandbox lets clang-sys find
+        # a system libclang, but the Linux sandbox has none, so hand it
+        # nixpkgs' libclang plus clang's builtin and libc include dirs.
+        # Scoped per-package so the env does not invalidate every other unit
+        # in the dependency closure (see cargo-unit's buildWorkspace docs).
+        packageBuildEnv = lib.optionalAttrs targetIsLinux {
+          libsqlite3-sys = {
+            LIBCLANG_PATH = "${workspacePkgs.llvmPackages.libclang.lib}/lib";
+            BINDGEN_EXTRA_CLANG_ARGS = lib.concatStringsSep " " [
+              "-isystem"
+              "${workspacePkgs.llvmPackages.libclang.lib}/lib/clang/${
+                lib.versions.major workspacePkgs.llvmPackages.libclang.version
+              }/include"
+              "-isystem"
+              "${workspacePkgs.stdenv.cc.libc.dev}/include"
+            ];
+          };
+        };
         env =
           {
             # ix-vt-sys's build script reads this to emit the libghostty-vt link

--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -323,6 +323,16 @@ in {
         # baked into every image.
         git = {
           enable = true;
+          # Route SQLite database files to the sqlmerge driver instead of
+          # mergiraf's global `* merge=mergiraf`. gitattributes resolves each
+          # attribute by the LAST matching line, and the mergiraf HM module
+          # contributes its wildcard line at default order, so pin these after
+          # it with mkAfter or the wildcard would win for .db files too.
+          attributes = lib.mkAfter [
+            "*.db merge=sqlite"
+            "*.sqlite merge=sqlite"
+            "*.sqlite3 merge=sqlite"
+          ];
           settings = {
             alias = {
               # Compact log: subject + short hash, one per line.
@@ -332,7 +342,29 @@ in {
               # Delete local branches whose remote-tracking branch is gone.
               cleanup = "!git fetch --prune && git branch -vv | grep \": gone]\" | grep -v \"\\\\*\" | awk \"{print \\$1}\" | xargs -r git branch -d";
             };
-            init.defaultBranch = "main";
+            init = {
+              defaultBranch = "main";
+              # Git 3.0 flips new repos to SHA-256 objects; adopt ahead of the
+              # default flip. GitHub started hosting sha256 repos in mid-2026
+              # (actions/checkout and gh already handle them). The object
+              # format is per-repo and fixed at init, so existing SHA-1 clones
+              # are untouched.
+              defaultObjectFormat = "sha256";
+              # reftable (also the Git 3.0 direction) replaces the loose-file
+              # + packed-refs backend: atomic multi-ref transactions and no
+              # D/F or case-sensitivity ref-name collisions, which matters on
+              # VMs that script branch churn. Per-repo and fixed at init,
+              # like the object format.
+              defaultRefFormat = "reftable";
+            };
+            # Refuse to operate on a bare repository unless it is named
+            # explicitly (--git-dir / GIT_DIR). A cloned repo can embed a
+            # bare repo with a malicious config in a subdirectory; without
+            # this, any git command that walks into it executes that config's
+            # hooks and aliases (the attack safe.bareRepository was added
+            # for). Agents cd through untrusted checkouts constantly, so the
+            # hardening default is worth the rare explicit --git-dir.
+            safe.bareRepository = "explicit";
             pull.rebase = true;
             push = {
               autoSetupRemote = true;
@@ -360,6 +392,15 @@ in {
               # three-way merge output; we set ff/renormalize alongside.
               ff = "only";
               renormalize = true;
+              # Three-way merge for SQLite database files (repo crate
+              # `packages/sqlmerge`, via the session extension). Without a
+              # driver a .db file is binary to git and every concurrent edit
+              # is a full-file conflict. The `attributes` lines above route
+              # *.db/*.sqlite/*.sqlite3 here; mergiraf keeps everything else.
+              sqlite = {
+                name = "SQLite three-way merge (sqlmerge)";
+                driver = "${lib.getExe pkgs.sqlmerge} %O %A %B";
+              };
             };
             diff = {
               algorithm = "histogram";

--- a/packages/sqlmerge/Cargo.toml
+++ b/packages/sqlmerge/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sqlmerge"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "git merge driver for SQLite databases: three-way merge via the session extension"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The workspace entry pins `bundled` (SQLite compiled into the binary, so the
+# merge semantics are identical on every machine); `session` adds the
+# sqlite3session_* changeset API this driver is built on.
+rusqlite = { workspace = true, features = ["session"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/packages/sqlmerge/README.md
+++ b/packages/sqlmerge/README.md
@@ -1,0 +1,72 @@
+# sqlmerge
+
+A git merge driver for SQLite database files: a real three-way merge of row
+data via the [SQLite session extension](https://sqlite.org/sessionintro.html),
+instead of git's default "binary files conflict".
+
+Built by Claude Code.
+
+## How it works
+
+git hands the driver three files: the common ancestor (`%O`), our version
+(`%A`), and their version (`%B`). sqlmerge computes the changeset
+`base -> theirs` with the session extension and applies it onto `ours` (in
+place, as git expects), keyed by primary key:
+
+- a row only one side changed merges cleanly;
+- both sides making the same change (same edit, identical insert, or both
+  deleting the row) is not a conflict;
+- both sides changing the same row differently is a conflict, and so is a
+  delete on one side against an edit on the other: the driver prints a
+  per-row report (table, primary key, ours vs theirs values) to stderr and
+  exits 1, so git marks the file conflicted;
+- after a clean apply, `PRAGMA integrity_check` and `PRAGMA foreign_key_check`
+  must pass, or the merge is refused.
+
+## git wiring
+
+In the ix base profile this is wired for every VM by home-manager
+(`modules/profiles/base`): `*.db` / `*.sqlite` / `*.sqlite3` files merge with
+sqlmerge, everything else keeps [mergiraf](https://mergiraf.org/). By hand:
+
+```gitattributes
+# .gitattributes
+*.db merge=sqlite
+```
+
+```ini
+# git config
+[merge "sqlite"]
+    name = SQLite three-way merge (sqlmerge)
+    driver = sqlmerge %O %A %B
+```
+
+## Exit codes
+
+| code | meaning                                                            |
+| ---- | ------------------------------------------------------------------ |
+| 0    | merged clean; `%A` now holds the merged database                   |
+| 1    | conflict or refusal (details on stderr); git marks the file conflicted |
+
+## Refusals (by design, no fallbacks)
+
+- **Schema divergence.** If `sqlite_schema` differs between ours and theirs
+  (ignoring whitespace outside quoted literals), the driver refuses and lists
+  the differing objects. Changesets are data-only; sqlmerge never pretends to
+  merge DDL. The merge base must share the schema too: even when both sides
+  applied the same migration, the session diff cannot span a schema change,
+  so that case is a (typed) refusal as well.
+- **Missing primary key.** Any user table without an explicit `PRIMARY KEY` is
+  a refusal naming the tables: the session extension silently skips such
+  tables, which would be silent data loss.
+- **Any row conflict aborts the whole merge.** v1 has no auto-resolution
+  policies; the conflict handler is a policy enum so per-table policies
+  (last-writer-wins, append-only) can be added later.
+
+## Limitations
+
+- No DDL merge: all three versions (base, ours, theirs) must share the schema.
+- Every user table needs an explicit `PRIMARY KEY`.
+- The database is treated as data at rest: WAL sidecar files are not
+  considered (git never versions a live database anyway; checkpoint before
+  committing).

--- a/packages/sqlmerge/default.nix
+++ b/packages/sqlmerge/default.nix
@@ -1,0 +1,13 @@
+{
+  ix,
+  lib,
+  ...
+}:
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "sqlmerge";
+  meta = {
+    description = "git merge driver for SQLite databases: three-way merge via the session extension";
+    license = lib.licenses.mit;
+    mainProgram = "sqlmerge";
+  };
+}

--- a/packages/sqlmerge/package.nix
+++ b/packages/sqlmerge/package.nix
@@ -1,0 +1,11 @@
+{
+  id = "sqlmerge";
+  packageSet = true;
+  flake = true;
+  # The base profile wires sqlmerge into git as the merge driver for SQLite
+  # files, so thread it into the nixpkgs overlay for modules to take as
+  # `pkgs.sqlmerge`.
+  overlay = true;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/sqlmerge/src/error.rs
+++ b/packages/sqlmerge/src/error.rs
@@ -1,0 +1,170 @@
+//! Typed errors for the merge driver.
+//!
+//! Every variant maps to a loud, human-readable stderr message and exit code 1.
+//! There is no catch-all string error: a merge driver that fails silently or
+//! ambiguously is a data-loss hazard, so each refusal names exactly what went
+//! wrong.
+
+use std::fmt;
+
+/// A row's primary key rendered for display (one column per element).
+#[derive(Debug, Clone)]
+pub struct PrimaryKey(pub Vec<String>);
+
+impl fmt::Display for PrimaryKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "({})", self.0.join(", "))
+    }
+}
+
+/// One row-level conflict surfaced by the changeset-apply conflict handler.
+#[derive(Debug, Clone)]
+pub struct RowConflict {
+    pub table: String,
+    pub kind: String,
+    pub primary_key: PrimaryKey,
+    /// Column-by-column "ours" value at the point of conflict, when available.
+    pub ours: Vec<String>,
+    /// Column-by-column incoming "theirs" value, when available.
+    pub theirs: Vec<String>,
+}
+
+impl fmt::Display for RowConflict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ours = self.ours.join(", ");
+        let theirs = self.theirs.join(", ");
+        write!(
+            f,
+            "table {} pk {} [{}]: ours=[{ours}] theirs=[{theirs}]",
+            self.table, self.primary_key, self.kind
+        )
+    }
+}
+
+/// A single schema object whose SQL diverges between ours and theirs.
+#[derive(Debug, Clone)]
+pub struct SchemaDivergence {
+    pub object: String,
+    pub ours: Option<String>,
+    pub theirs: Option<String>,
+}
+
+/// Everything that can make a merge refuse (all map to exit code 1).
+#[derive(Debug)]
+pub enum MergeError {
+    /// A database file could not be opened or read.
+    Sqlite(rusqlite::Error),
+    /// `sqlite_schema` diverges between ours and theirs; DDL is never merged.
+    SchemaDiverged(Vec<SchemaDivergence>),
+    /// Ours and theirs agree, but the merge base's schema differs (e.g. both
+    /// sides applied the same DDL migration). `sqlite3session_diff` needs
+    /// identical table definitions on both ends, so this cannot be merged.
+    BaseSchemaDiverged(Vec<String>),
+    /// One or more user tables lack an explicit `PRIMARY KEY`. The session
+    /// extension silently skips such tables, which would be silent data loss.
+    MissingPrimaryKey(Vec<String>),
+    /// The changeset apply hit row conflicts; the default policy aborts.
+    Conflicts(Vec<RowConflict>),
+    /// `PRAGMA integrity_check` reported corruption after a clean apply.
+    IntegrityCheckFailed(Vec<String>),
+    /// `PRAGMA foreign_key_check` reported violations after a clean apply.
+    ForeignKeyCheckFailed(Vec<String>),
+}
+
+impl From<rusqlite::Error> for MergeError {
+    fn from(e: rusqlite::Error) -> Self {
+        Self::Sqlite(e)
+    }
+}
+
+impl std::error::Error for MergeError {}
+
+impl fmt::Display for MergeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sqlite(e) => write!(f, "sqlite error: {e}"),
+            Self::SchemaDiverged(objs) => {
+                writeln!(
+                    f,
+                    "refusing to merge: schema (sqlite_schema) diverges between the two sides."
+                )?;
+                writeln!(
+                    f,
+                    "sqlmerge merges data (rows), never DDL. Resolve the schema by hand first."
+                )?;
+                writeln!(f, "diverging objects:")?;
+                for o in objs {
+                    let ours = o.ours.as_deref().unwrap_or("<absent>");
+                    let theirs = o.theirs.as_deref().unwrap_or("<absent>");
+                    writeln!(
+                        f,
+                        "  - {}\n      ours:   {ours}\n      theirs: {theirs}",
+                        o.object
+                    )?;
+                }
+                Ok(())
+            }
+            Self::BaseSchemaDiverged(objects) => {
+                writeln!(
+                    f,
+                    "refusing to merge: the merge base's schema differs from the two sides \
+                     (did both sides apply the same DDL migration?)."
+                )?;
+                writeln!(
+                    f,
+                    "sqlmerge merges data (rows), never DDL; the session diff needs all three \
+                     versions to share a schema."
+                )?;
+                writeln!(f, "objects that changed since base:")?;
+                for o in objects {
+                    writeln!(f, "  - {o}")?;
+                }
+                Ok(())
+            }
+            Self::MissingPrimaryKey(tables) => {
+                writeln!(
+                    f,
+                    "refusing to merge: {} table(s) lack an explicit PRIMARY KEY.",
+                    tables.len()
+                )?;
+                writeln!(
+                    f,
+                    "the SQLite session extension silently skips PK-less tables, \
+                     which would be silent data loss."
+                )?;
+                writeln!(f, "tables:")?;
+                for t in tables {
+                    writeln!(f, "  - {t}")?;
+                }
+                Ok(())
+            }
+            Self::Conflicts(conflicts) => {
+                writeln!(
+                    f,
+                    "merge conflict: {} row(s) could not be merged automatically.",
+                    conflicts.len()
+                )?;
+                for c in conflicts {
+                    writeln!(f, "  - {c}")?;
+                }
+                Ok(())
+            }
+            Self::IntegrityCheckFailed(rows) => {
+                writeln!(f, "post-merge PRAGMA integrity_check failed:")?;
+                for r in rows {
+                    writeln!(f, "  - {r}")?;
+                }
+                Ok(())
+            }
+            Self::ForeignKeyCheckFailed(rows) => {
+                writeln!(f, "post-merge PRAGMA foreign_key_check found violations:")?;
+                for r in rows {
+                    writeln!(f, "  - {r}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, MergeError>;

--- a/packages/sqlmerge/src/lib.rs
+++ b/packages/sqlmerge/src/lib.rs
@@ -1,0 +1,15 @@
+//! sqlmerge: a git merge driver for SQLite database files.
+//!
+//! Three-way merge via the SQLite session extension. The public surface is
+//! [`merge::merge`] plus the typed [`error::MergeError`]; the `sqlmerge` binary
+//! is a thin argv wrapper over it. See the crate README for git wiring and
+//! semantics.
+//!
+//! Built by Claude Code.
+
+pub mod error;
+pub mod merge;
+pub mod schema;
+
+pub use error::{MergeError, Result};
+pub use merge::{ConflictPolicy, merge};

--- a/packages/sqlmerge/src/lib.rs
+++ b/packages/sqlmerge/src/lib.rs
@@ -1,6 +1,6 @@
-//! sqlmerge: a git merge driver for SQLite database files.
+//! sqlmerge: a git merge driver for `SQLite` database files.
 //!
-//! Three-way merge via the SQLite session extension. The public surface is
+//! Three-way merge via the `SQLite` session extension. The public surface is
 //! [`merge::merge`] plus the typed [`error::MergeError`]; the `sqlmerge` binary
 //! is a thin argv wrapper over it. See the crate README for git wiring and
 //! semantics.

--- a/packages/sqlmerge/src/main.rs
+++ b/packages/sqlmerge/src/main.rs
@@ -1,4 +1,4 @@
-//! `sqlmerge <base> <ours> <theirs>`: a git merge driver for SQLite files.
+//! `sqlmerge <base> <ours> <theirs>`: a git merge driver for `SQLite` files.
 //!
 //! git invokes this as the `%O %A %B` triple: `%O` is the common ancestor
 //! (base), `%A` is our version (rewritten in place with the merge result), and

--- a/packages/sqlmerge/src/main.rs
+++ b/packages/sqlmerge/src/main.rs
@@ -1,0 +1,35 @@
+//! `sqlmerge <base> <ours> <theirs>`: a git merge driver for SQLite files.
+//!
+//! git invokes this as the `%O %A %B` triple: `%O` is the common ancestor
+//! (base), `%A` is our version (rewritten in place with the merge result), and
+//! `%B` is their version. Exit 0 means a clean merge was written to `<ours>`;
+//! exit 1 means conflict or refusal, and git then marks the file conflicted.
+
+use std::process::ExitCode;
+
+use sqlmerge::{ConflictPolicy, merge};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    let [_, base, ours, theirs] = args.as_slice() else {
+        eprintln!(
+            "usage: sqlmerge <base> <ours> <theirs>\n\
+             \n\
+             git merge driver for SQLite databases. Wire it up with:\n\
+             \n\
+             .gitattributes:    *.db merge=sqlite\n\
+             git config:        [merge \"sqlite\"]\n\
+             \x20                    name = SQLite three-way merge\n\
+             \x20                    driver = sqlmerge %O %A %B"
+        );
+        return ExitCode::FAILURE;
+    };
+
+    match merge(base, ours, theirs, ConflictPolicy::Abort) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("sqlmerge: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/packages/sqlmerge/src/merge.rs
+++ b/packages/sqlmerge/src/merge.rs
@@ -1,0 +1,347 @@
+//! The three-way merge engine.
+//!
+//! Strategy: the SQLite session extension can compute a *changeset* describing
+//! how one database differs from another (`sqlite3session_diff`, exposed as
+//! `Session::diff`). We compute the changeset `base -> theirs` and apply it to
+//! `ours`. The result is `ours` with theirs's changes layered on top, which is
+//! exactly a three-way merge keyed by primary key:
+//!
+//!   - a row theirs changed but ours didn't: applies cleanly;
+//!   - a row both sides changed to the same value: applies cleanly;
+//!   - a row both sides changed differently: `DATA` conflict, abort;
+//!   - a row theirs inserted that ours also inserted with different values at
+//!     the same PK: `CONFLICT`, abort.
+//!
+//! Conflicts are captured per-row and reported; the default policy aborts the
+//! whole apply (no partial writes).
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use rusqlite::Connection;
+use rusqlite::hooks::Action;
+use rusqlite::session::{ChangesetItem, ConflictAction, ConflictType, Session};
+use rusqlite::types::ValueRef;
+
+use crate::error::{MergeError, PrimaryKey, Result, RowConflict};
+use crate::schema;
+
+/// Conflict-resolution policy. v1 ships only [`ConflictPolicy::Abort`]; the
+/// enum exists so per-table policies (last-writer-wins, append-only) can be
+/// added later without reshaping the apply path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ConflictPolicy {
+    /// Any conflict aborts the entire merge (exit 1). No auto-resolution.
+    #[default]
+    Abort,
+}
+
+/// Render a [`ValueRef`] as a short display string for conflict reporting.
+fn render_value(v: ValueRef<'_>) -> String {
+    match v {
+        ValueRef::Null => "NULL".to_string(),
+        ValueRef::Integer(i) => i.to_string(),
+        ValueRef::Real(f) => f.to_string(),
+        ValueRef::Text(bytes) => match std::str::from_utf8(bytes) {
+            Ok(s) => format!("'{s}'"),
+            Err(_) => format!("<{} bytes text>", bytes.len()),
+        },
+        ValueRef::Blob(bytes) => format!("<blob {} bytes>", bytes.len()),
+    }
+}
+
+/// SQLite-value equality for conflict resolution: same type, same payload.
+/// `Real` compares bitwise via `to_bits` so NaN-vs-NaN and -0.0 are handled
+/// deterministically; two rows written identically compare equal.
+fn values_equal(a: ValueRef<'_>, b: ValueRef<'_>) -> bool {
+    match (a, b) {
+        (ValueRef::Null, ValueRef::Null) => true,
+        (ValueRef::Integer(x), ValueRef::Integer(y)) => x == y,
+        (ValueRef::Real(x), ValueRef::Real(y)) => x.to_bits() == y.to_bits(),
+        (ValueRef::Text(x), ValueRef::Text(y)) | (ValueRef::Blob(x), ValueRef::Blob(y)) => x == y,
+        _ => false,
+    }
+}
+
+/// True for a `NOTFOUND` DELETE: the changeset deletes a row that ours already
+/// deleted. Both sides want the row gone and it is gone, so omitting the change
+/// converges. A `NOTFOUND` on an UPDATE stays a real conflict: theirs edited a
+/// row ours deleted, and there is no obviously right answer.
+fn is_convergent_delete(kind: &ConflictType, item: &ChangesetItem) -> bool {
+    *kind == ConflictType::SQLITE_CHANGESET_NOTFOUND
+        && item
+            .op()
+            .is_ok_and(|op| matches!(op.code(), Action::SQLITE_DELETE))
+}
+
+/// True if a `CONFLICT`-type item (a required INSERT that hit an existing row)
+/// is a benign duplicate: ours (the existing row, via `conflict`) equals theirs
+/// (the incoming row, via `new_value`) in every column. The session extension
+/// reports every insert-over-existing as a conflict without comparing values,
+/// so "both sides inserted the same row" surfaces here and must not abort.
+fn is_benign_duplicate_insert(kind: &ConflictType, item: &ChangesetItem) -> bool {
+    if *kind != ConflictType::SQLITE_CHANGESET_CONFLICT {
+        return false;
+    }
+    let Ok(op) = item.op() else {
+        return false;
+    };
+    let Ok(ncols) = usize::try_from(op.number_of_columns()) else {
+        return false;
+    };
+    if ncols == 0 {
+        return false;
+    }
+
+    for col in 0..ncols {
+        let (Ok(ours), Ok(theirs)) = (item.conflict(col), item.new_value(col)) else {
+            return false;
+        };
+        if !values_equal(ours, theirs) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Pull the primary-key column values out of a conflicting item for reporting.
+///
+/// `pk()` returns a per-column mask of which columns form the PK. For those
+/// columns we read the value: on an UPDATE/DELETE the PK lives in `old`, on an
+/// INSERT it lives in `new`. We try old first, then new, and fall back to a
+/// placeholder so reporting never fails the merge on its own.
+fn extract_primary_key(item: &ChangesetItem, action: &Action, ncols: usize) -> PrimaryKey {
+    let mask = item.pk().map(<[u8]>::to_vec).unwrap_or_default();
+    let mut parts = Vec::new();
+    for col in 0..ncols {
+        let is_pk = mask.get(col).copied().unwrap_or(0) != 0;
+        if !is_pk {
+            continue;
+        }
+        let value = match action {
+            Action::SQLITE_INSERT => item.new_value(col).ok(),
+            _ => item
+                .old_value(col)
+                .ok()
+                .or_else(|| item.new_value(col).ok()),
+        };
+        parts.push(value.map_or_else(|| "?".to_string(), render_value));
+    }
+    PrimaryKey(parts)
+}
+
+/// Ours-vs-theirs column values for a `DATA`/`CONFLICT` conflict row.
+struct ConflictValues {
+    /// The row currently in ours, via `ChangesetItem::conflict`.
+    ours: Vec<String>,
+    /// The incoming row from theirs, via `ChangesetItem::new_value`.
+    theirs: Vec<String>,
+}
+
+fn conflict_values(item: &ChangesetItem, ncols: usize) -> ConflictValues {
+    let mut ours = Vec::new();
+    let mut theirs = Vec::new();
+    for col in 0..ncols {
+        if let Ok(v) = item.conflict(col) {
+            ours.push(render_value(v));
+        }
+        if let Ok(v) = item.new_value(col) {
+            theirs.push(render_value(v));
+        }
+    }
+    ConflictValues { ours, theirs }
+}
+
+/// Build the per-row conflict report for a conflict-handler callback.
+///
+/// The set of valid [`ChangesetItem`] accessors depends on the conflict type
+/// (SQLite session docs). `FOREIGN_KEY` has no current row or operation; only
+/// `fk_conflicts()` is legal, and calling `op()`/`pk()`/value accessors on it
+/// dereferences a null pointer and crashes. `conflict()` values exist only for
+/// `DATA` and `CONFLICT`.
+fn describe_conflict(kind: &ConflictType, item: &ChangesetItem) -> RowConflict {
+    if *kind == ConflictType::SQLITE_CHANGESET_FOREIGN_KEY {
+        let n = item.fk_conflicts().unwrap_or(0);
+        return RowConflict {
+            table: "<deferred foreign key>".to_string(),
+            kind: format!("{kind:?}"),
+            primary_key: PrimaryKey(Vec::new()),
+            ours: Vec::new(),
+            theirs: vec![format!("{n} deferred FK violation(s)")],
+        };
+    }
+
+    let (table, action, ncols) = match item.op() {
+        Ok(o) => {
+            // A negative column count cannot occur (it is a length from
+            // SQLite); treat an impossible value as zero columns rather than
+            // panicking inside the C callback, where unwinding would abort.
+            let ncols = match usize::try_from(o.number_of_columns()) {
+                Ok(n) => n,
+                Err(_) => 0,
+            };
+            (o.table_name().to_string(), o.code(), ncols)
+        }
+        Err(_) => ("<unknown>".to_string(), Action::UNKNOWN, 0),
+    };
+
+    let primary_key = extract_primary_key(item, &action, ncols);
+    let values = match kind {
+        ConflictType::SQLITE_CHANGESET_DATA | ConflictType::SQLITE_CHANGESET_CONFLICT => {
+            conflict_values(item, ncols)
+        }
+        _ => ConflictValues {
+            ours: Vec::new(),
+            theirs: Vec::new(),
+        },
+    };
+
+    RowConflict {
+        table,
+        kind: format!("{kind:?}"),
+        primary_key,
+        ours: values.ours,
+        theirs: values.theirs,
+    }
+}
+
+/// Compute the `base -> theirs` changeset and apply it onto `ours` in place.
+///
+/// `ours_path` is opened read-write; on a clean merge it holds the merged
+/// result. `sqlite3changeset_apply` runs inside a savepoint, so an aborted
+/// apply leaves `ours` untouched.
+///
+/// # Errors
+///
+/// Every refusal maps to exit code 1 in the binary:
+///
+/// - [`MergeError::SchemaDiverged`]: the two sides' `sqlite_schema` differs.
+/// - [`MergeError::BaseSchemaDiverged`]: the sides agree but base's schema
+///   differs (the session diff needs identical table definitions).
+/// - [`MergeError::MissingPrimaryKey`]: a user table has no explicit PK.
+/// - [`MergeError::Conflicts`]: row-level conflicts under the abort policy.
+/// - [`MergeError::IntegrityCheckFailed`] / [`MergeError::ForeignKeyCheckFailed`]:
+///   the post-merge `PRAGMA` sweeps found violations.
+/// - [`MergeError::Sqlite`]: any underlying SQLite failure.
+pub fn merge(
+    base_path: &str,
+    ours_path: &str,
+    theirs_path: &str,
+    policy: ConflictPolicy,
+) -> Result<()> {
+    // Open theirs as the working connection so we can diff base against it.
+    let theirs = Connection::open(theirs_path)?;
+    let ours = Connection::open(ours_path)?;
+
+    // Gate 1: schema must match (ignoring whitespace). Changesets are data-only.
+    // The base must share the schema too, or the session diff below would fail
+    // with a raw SQLITE_SCHEMA error instead of a typed refusal.
+    schema::assert_schema_matches(&ours, &theirs)?;
+    {
+        let base = Connection::open(base_path)?;
+        schema::assert_base_schema_matches(&base, &theirs)?;
+    }
+
+    // Gate 2: every user table needs an explicit PRIMARY KEY, else the session
+    // extension silently skips it (silent data loss).
+    schema::assert_all_tables_have_primary_key(&ours)?;
+    schema::assert_all_tables_have_primary_key(&theirs)?;
+
+    // Compute changeset base -> theirs, one table at a time. `Session::diff`
+    // records the delta that turns the ATTACHed `base` schema into the
+    // session's own connection (theirs).
+    theirs.execute_batch(&format!(
+        "ATTACH DATABASE {} AS base",
+        quote_string_literal(base_path)
+    ))?;
+    let changeset = {
+        let mut session = Session::new(&theirs)?;
+        for table in schema::user_tables(&theirs)? {
+            // `diff` has an unused generic `D` that cannot be inferred; pin it.
+            session.diff::<&str, &str>("base", &table)?;
+        }
+        session.changeset()?
+    };
+    theirs.execute_batch("DETACH DATABASE base")?;
+
+    // Apply the changeset to ours. The conflict handler captures every conflict
+    // and, under the Abort policy, aborts the whole apply so nothing is written.
+    let conflicts: Arc<Mutex<Vec<RowConflict>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&conflicts);
+    let conflict_handler = move |kind: ConflictType, item: ChangesetItem| -> ConflictAction {
+        if is_benign_duplicate_insert(&kind, &item) || is_convergent_delete(&kind, &item) {
+            return ConflictAction::SQLITE_CHANGESET_OMIT;
+        }
+        sink.lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(describe_conflict(&kind, &item));
+        match policy {
+            ConflictPolicy::Abort => ConflictAction::SQLITE_CHANGESET_ABORT,
+        }
+    };
+
+    let filter: Option<fn(&str) -> bool> = None;
+    let apply_result = ours.apply(&changeset, filter, conflict_handler);
+
+    // Surface captured conflicts as a typed error. An aborted apply also
+    // returns an Err from `apply`; the per-row report is the richer signal.
+    let captured = conflicts
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clone();
+    if !captured.is_empty() {
+        return Err(MergeError::Conflicts(captured));
+    }
+    apply_result?;
+
+    // Post-merge: fail loudly on any corruption or FK violation. No fallbacks.
+    assert_integrity(&ours)?;
+    assert_foreign_keys(&ours)?;
+
+    Ok(())
+}
+
+/// `PRAGMA integrity_check` returns a single row "ok" on success, else one row
+/// per problem.
+fn assert_integrity(conn: &Connection) -> Result<()> {
+    let mut stmt = conn.prepare("PRAGMA integrity_check")?;
+    let rows: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<_, _>>()?;
+
+    if rows == ["ok"] {
+        Ok(())
+    } else {
+        Err(MergeError::IntegrityCheckFailed(rows))
+    }
+}
+
+/// `PRAGMA foreign_key_check` returns zero rows when clean, else one row per
+/// violation (table, rowid, referenced table, FK index).
+fn assert_foreign_keys(conn: &Connection) -> Result<()> {
+    let mut stmt = conn.prepare("PRAGMA foreign_key_check")?;
+    let rows: Vec<String> = stmt
+        .query_map([], |row| {
+            let table: String = row.get(0)?;
+            let rowid: Option<i64> = row.get(1)?;
+            let parent: String = row.get(2)?;
+            let fkid: i64 = row.get(3)?;
+            let rowid_text = rowid.map_or_else(|| "?".to_string(), |r| r.to_string());
+            Ok(format!(
+                "table {table} rowid {rowid_text} violates FK #{fkid} -> {parent}"
+            ))
+        })?
+        .collect::<std::result::Result<_, _>>()?;
+
+    if rows.is_empty() {
+        Ok(())
+    } else {
+        Err(MergeError::ForeignKeyCheckFailed(rows))
+    }
+}
+
+/// Quote a path as a SQL string literal (single quotes doubled) for use in an
+/// `ATTACH` statement. Paths from git are trusted, but quoting keeps us correct
+/// for paths containing quotes.
+fn quote_string_literal(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}

--- a/packages/sqlmerge/src/merge.rs
+++ b/packages/sqlmerge/src/merge.rs
@@ -1,6 +1,6 @@
 //! The three-way merge engine.
 //!
-//! Strategy: the SQLite session extension can compute a *changeset* describing
+//! Strategy: the `SQLite` session extension can compute a *changeset* describing
 //! how one database differs from another (`sqlite3session_diff`, exposed as
 //! `Session::diff`). We compute the changeset `base -> theirs` and apply it to
 //! `ours`. The result is `ours` with theirs's changes layered on top, which is
@@ -41,15 +41,15 @@ fn render_value(v: ValueRef<'_>) -> String {
         ValueRef::Null => "NULL".to_string(),
         ValueRef::Integer(i) => i.to_string(),
         ValueRef::Real(f) => f.to_string(),
-        ValueRef::Text(bytes) => match std::str::from_utf8(bytes) {
-            Ok(s) => format!("'{s}'"),
-            Err(_) => format!("<{} bytes text>", bytes.len()),
-        },
+        ValueRef::Text(bytes) => std::str::from_utf8(bytes).map_or_else(
+            |_| format!("<{} bytes text>", bytes.len()),
+            |s| format!("'{s}'"),
+        ),
         ValueRef::Blob(bytes) => format!("<blob {} bytes>", bytes.len()),
     }
 }
 
-/// SQLite-value equality for conflict resolution: same type, same payload.
+/// `SQLite`-value equality for conflict resolution: same type, same payload.
 /// `Real` compares bitwise via `to_bits` so NaN-vs-NaN and -0.0 are handled
 /// deterministically; two rows written identically compare equal.
 fn values_equal(a: ValueRef<'_>, b: ValueRef<'_>) -> bool {
@@ -109,7 +109,7 @@ fn is_benign_duplicate_insert(kind: &ConflictType, item: &ChangesetItem) -> bool
 /// columns we read the value: on an UPDATE/DELETE the PK lives in `old`, on an
 /// INSERT it lives in `new`. We try old first, then new, and fall back to a
 /// placeholder so reporting never fails the merge on its own.
-fn extract_primary_key(item: &ChangesetItem, action: &Action, ncols: usize) -> PrimaryKey {
+fn extract_primary_key(item: &ChangesetItem, action: Action, ncols: usize) -> PrimaryKey {
     let mask = item.pk().map(<[u8]>::to_vec).unwrap_or_default();
     let mut parts = Vec::new();
     for col in 0..ncols {
@@ -154,7 +154,7 @@ fn conflict_values(item: &ChangesetItem, ncols: usize) -> ConflictValues {
 /// Build the per-row conflict report for a conflict-handler callback.
 ///
 /// The set of valid [`ChangesetItem`] accessors depends on the conflict type
-/// (SQLite session docs). `FOREIGN_KEY` has no current row or operation; only
+/// (`SQLite` session docs). `FOREIGN_KEY` has no current row or operation; only
 /// `fk_conflicts()` is legal, and calling `op()`/`pk()`/value accessors on it
 /// dereferences a null pointer and crashes. `conflict()` values exist only for
 /// `DATA` and `CONFLICT`.
@@ -170,21 +170,20 @@ fn describe_conflict(kind: &ConflictType, item: &ChangesetItem) -> RowConflict {
         };
     }
 
-    let (table, action, ncols) = match item.op() {
-        Ok(o) => {
-            // A negative column count cannot occur (it is a length from
-            // SQLite); treat an impossible value as zero columns rather than
-            // panicking inside the C callback, where unwinding would abort.
-            let ncols = match usize::try_from(o.number_of_columns()) {
-                Ok(n) => n,
-                Err(_) => 0,
-            };
-            (o.table_name().to_string(), o.code(), ncols)
-        }
-        Err(_) => ("<unknown>".to_string(), Action::UNKNOWN, 0),
-    };
+    // A negative column count cannot occur (it is a length from SQLite); fold
+    // that impossible case into the op-unavailable fallback rather than
+    // panicking inside the C callback, where unwinding would abort.
+    let (table, action, ncols) = item
+        .op()
+        .ok()
+        .and_then(|o| {
+            usize::try_from(o.number_of_columns())
+                .ok()
+                .map(|ncols| (o.table_name().to_string(), o.code(), ncols))
+        })
+        .unwrap_or_else(|| ("<unknown>".to_string(), Action::UNKNOWN, 0));
 
-    let primary_key = extract_primary_key(item, &action, ncols);
+    let primary_key = extract_primary_key(item, action, ncols);
     let values = match kind {
         ConflictType::SQLITE_CHANGESET_DATA | ConflictType::SQLITE_CHANGESET_CONFLICT => {
             conflict_values(item, ncols)
@@ -221,7 +220,7 @@ fn describe_conflict(kind: &ConflictType, item: &ChangesetItem) -> RowConflict {
 /// - [`MergeError::Conflicts`]: row-level conflicts under the abort policy.
 /// - [`MergeError::IntegrityCheckFailed`] / [`MergeError::ForeignKeyCheckFailed`]:
 ///   the post-merge `PRAGMA` sweeps found violations.
-/// - [`MergeError::Sqlite`]: any underlying SQLite failure.
+/// - [`MergeError::Sqlite`]: any underlying `SQLite` failure.
 pub fn merge(
     base_path: &str,
     ours_path: &str,

--- a/packages/sqlmerge/src/schema.rs
+++ b/packages/sqlmerge/src/schema.rs
@@ -11,7 +11,7 @@
 //!   2. The merge base must share that schema too: `sqlite3session_diff`
 //!      requires identical table definitions on both ends of the diff, so a
 //!      base behind a DDL migration (even one both sides applied identically)
-//!      is a typed refusal, not a raw SQLite error.
+//!      is a typed refusal, not a raw `SQLite` error.
 //!   3. The session extension silently skips any table without an explicit
 //!      `PRIMARY KEY`. Merging such a table would drop changes with no error,
 //!      so we refuse loudly instead.
@@ -92,7 +92,7 @@ fn normalize_sql(sql: &str) -> String {
 ///
 /// We read from `sqlite_schema` (aka `sqlite_master`). Rows with NULL `sql`
 /// (auto-created indexes for `PRIMARY KEY` / `UNIQUE`) are excluded: they are
-/// derived from the table definitions we already compare, and SQLite does not
+/// derived from the table definitions we already compare, and `SQLite` does not
 /// store SQL for them.
 fn schema_objects(conn: &Connection) -> Result<BTreeMap<String, String>> {
     let mut stmt = conn.prepare(
@@ -151,10 +151,11 @@ pub fn assert_schema_matches(ours: &Connection, theirs: &Connection) -> Result<(
     }
 }
 
-/// Refuse if the merge base's schema differs from the (already matching)
-/// sides. `sqlite3session_diff` requires the same table definition on both
-/// ends, so without this gate a schema-migrated base surfaces as a raw
-/// `SQLITE_SCHEMA` error mid-diff instead of a typed refusal.
+/// Refuse if the merge base's schema differs from the (matching) sides.
+///
+/// `sqlite3session_diff` requires the same table definition on both ends, so
+/// without this gate a schema-migrated base surfaces as a raw `SQLITE_SCHEMA`
+/// error mid-diff instead of a typed refusal.
 ///
 /// # Errors
 ///

--- a/packages/sqlmerge/src/schema.rs
+++ b/packages/sqlmerge/src/schema.rs
@@ -1,0 +1,261 @@
+//! Schema gate and primary-key gate.
+//!
+//! Changesets produced by the session extension are data-only: they carry row
+//! inserts/updates/deletes keyed by primary key, and nothing about the table
+//! definitions. Three consequences drive this module:
+//!
+//!   1. If the schema diverges between the merged sides, applying a data
+//!      changeset across that boundary is meaningless (or corrupting), so we
+//!      refuse. We compare the SQL text of every schema object,
+//!      whitespace-insensitively (outside quoted literals).
+//!   2. The merge base must share that schema too: `sqlite3session_diff`
+//!      requires identical table definitions on both ends of the diff, so a
+//!      base behind a DDL migration (even one both sides applied identically)
+//!      is a typed refusal, not a raw SQLite error.
+//!   3. The session extension silently skips any table without an explicit
+//!      `PRIMARY KEY`. Merging such a table would drop changes with no error,
+//!      so we refuse loudly instead.
+
+use std::collections::BTreeMap;
+
+use rusqlite::Connection;
+
+use crate::error::{MergeError, Result, SchemaDivergence};
+
+/// Normalize schema SQL for whitespace-insensitive comparison: outside quoted
+/// regions, collapse runs of whitespace to a single space and drop spaces
+/// adjacent to structural punctuation (`(`, `)`, `,`). This makes
+/// `CREATE TABLE t (id ...)` and `CREATE TABLE t( id ... )` compare equal,
+/// since pure reformatting is not a schema change, while any token difference
+/// (an added column, a changed type) still shows up.
+///
+/// Quoted regions are copied verbatim: `'...'` string literals (a changed
+/// `DEFAULT 'a, b'` is a real schema change), `"..."`/`` `...` `` quoted
+/// identifiers, and `[...]` bracket identifiers. Doubled closing quotes
+/// (`''`, `""`) are the SQL escape and stay inside the region.
+fn normalize_sql(sql: &str) -> String {
+    let mut out = String::with_capacity(sql.len());
+    let mut chars = sql.chars().peekable();
+    let mut closing_quote: Option<char> = None;
+
+    while let Some(ch) = chars.next() {
+        if let Some(q) = closing_quote {
+            out.push(ch);
+            if ch == q {
+                if chars.peek() == Some(&q) {
+                    // Doubled quote: the escape for a literal quote character.
+                    // Copy it and stay inside the quoted region.
+                    if let Some(escaped) = chars.next() {
+                        out.push(escaped);
+                    }
+                } else {
+                    closing_quote = None;
+                }
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => {
+                closing_quote = Some(ch);
+                out.push(ch);
+            }
+            '[' => {
+                closing_quote = Some(']');
+                out.push(ch);
+            }
+            c if c.is_whitespace() => {
+                // Collapse to one space; suppress it entirely at the start or
+                // after an opening paren / comma.
+                if !out.is_empty() && !out.ends_with([' ', '(', ',']) {
+                    out.push(' ');
+                }
+            }
+            '(' | ')' | ',' => {
+                // Drop the space before structural punctuation.
+                if out.ends_with(' ') {
+                    out.pop();
+                }
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+
+    if out.ends_with(' ') {
+        out.pop();
+    }
+    out
+}
+
+/// Map of schema object name to its (normalized) defining SQL.
+///
+/// We read from `sqlite_schema` (aka `sqlite_master`). Rows with NULL `sql`
+/// (auto-created indexes for `PRIMARY KEY` / `UNIQUE`) are excluded: they are
+/// derived from the table definitions we already compare, and SQLite does not
+/// store SQL for them.
+fn schema_objects(conn: &Connection) -> Result<BTreeMap<String, String>> {
+    let mut stmt = conn.prepare(
+        "SELECT name, sql FROM sqlite_schema \
+         WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' \
+         ORDER BY name",
+    )?;
+    let map = stmt
+        .query_map([], |row| {
+            let name: String = row.get(0)?;
+            let sql: String = row.get(1)?;
+            Ok((name, normalize_sql(&sql)))
+        })?
+        .collect::<std::result::Result<BTreeMap<_, _>, _>>()?;
+    Ok(map)
+}
+
+/// Every schema object whose (normalized) SQL differs between `a` and `b`,
+/// including objects present on only one side.
+fn diverging_objects(a: &Connection, b: &Connection) -> Result<Vec<SchemaDivergence>> {
+    let a = schema_objects(a)?;
+    let b = schema_objects(b)?;
+
+    let mut names: Vec<&String> = a.keys().chain(b.keys()).collect();
+    names.sort_unstable();
+    names.dedup();
+
+    let mut divergences = Vec::new();
+    for name in names {
+        let a_sql = a.get(name);
+        let b_sql = b.get(name);
+        if a_sql != b_sql {
+            divergences.push(SchemaDivergence {
+                object: name.clone(),
+                ours: a_sql.cloned(),
+                theirs: b_sql.cloned(),
+            });
+        }
+    }
+    Ok(divergences)
+}
+
+/// Refuse if the schema of `ours` and `theirs` diverges (whitespace-insensitive).
+///
+/// # Errors
+///
+/// Returns [`MergeError::SchemaDiverged`] listing every object whose SQL
+/// differs (or exists on only one side), or [`MergeError::Sqlite`] if either
+/// schema cannot be read.
+pub fn assert_schema_matches(ours: &Connection, theirs: &Connection) -> Result<()> {
+    let divergences = diverging_objects(ours, theirs)?;
+    if divergences.is_empty() {
+        Ok(())
+    } else {
+        Err(MergeError::SchemaDiverged(divergences))
+    }
+}
+
+/// Refuse if the merge base's schema differs from the (already matching)
+/// sides. `sqlite3session_diff` requires the same table definition on both
+/// ends, so without this gate a schema-migrated base surfaces as a raw
+/// `SQLITE_SCHEMA` error mid-diff instead of a typed refusal.
+///
+/// # Errors
+///
+/// Returns [`MergeError::BaseSchemaDiverged`] naming the objects whose schema
+/// changed relative to base, or [`MergeError::Sqlite`] if either schema
+/// cannot be read.
+pub fn assert_base_schema_matches(base: &Connection, side: &Connection) -> Result<()> {
+    let divergences = diverging_objects(base, side)?;
+    if divergences.is_empty() {
+        Ok(())
+    } else {
+        let objects = divergences.into_iter().map(|d| d.object).collect();
+        Err(MergeError::BaseSchemaDiverged(objects))
+    }
+}
+
+/// Names of user tables (excludes `sqlite_%` internal tables and views).
+///
+/// # Errors
+///
+/// Returns [`MergeError::Sqlite`] if the schema cannot be read.
+pub fn user_tables(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT name FROM sqlite_schema \
+         WHERE type = 'table' AND name NOT LIKE 'sqlite_%' \
+         ORDER BY name",
+    )?;
+    let tables = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(tables)
+}
+
+/// Return true if `table` has at least one column flagged as part of the
+/// primary key. `PRAGMA table_info` sets `pk` > 0 for PK columns.
+///
+/// A `rowid` alias declared `INTEGER PRIMARY KEY` reports `pk = 1`, which is
+/// exactly the case the session extension handles, so it correctly counts as
+/// having a PK. A `WITHOUT ROWID` table always has a PK by definition. Only a
+/// plain table with no `PRIMARY KEY` clause (rows keyed by the implicit rowid,
+/// which the session extension cannot address) reports no `pk` column.
+fn table_has_primary_key(conn: &Connection, table: &str) -> Result<bool> {
+    let mut stmt = conn.prepare("SELECT COUNT(*) FROM pragma_table_info(?1) WHERE pk > 0")?;
+    let count: i64 = stmt.query_row([table], |row| row.get(0))?;
+    Ok(count > 0)
+}
+
+/// Refuse if any user table lacks an explicit `PRIMARY KEY`.
+///
+/// # Errors
+///
+/// Returns [`MergeError::MissingPrimaryKey`] naming every PK-less table, or
+/// [`MergeError::Sqlite`] if the schema cannot be read.
+pub fn assert_all_tables_have_primary_key(conn: &Connection) -> Result<()> {
+    let mut missing = Vec::new();
+    for table in user_tables(conn)? {
+        if !table_has_primary_key(conn, &table)? {
+            missing.push(table);
+        }
+    }
+
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(MergeError::MissingPrimaryKey(missing))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_sql;
+
+    #[test]
+    fn collapses_whitespace_outside_quotes() {
+        assert_eq!(
+            normalize_sql("CREATE TABLE t (\n  id  INTEGER  PRIMARY KEY ,\n  v TEXT\n)"),
+            normalize_sql("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)"),
+        );
+    }
+
+    #[test]
+    fn preserves_whitespace_inside_string_literals() {
+        let spaced = normalize_sql("CREATE TABLE t (v TEXT DEFAULT 'a, b')");
+        let tight = normalize_sql("CREATE TABLE t (v TEXT DEFAULT 'a,b')");
+        assert_ne!(spaced, tight);
+        assert!(spaced.contains("'a, b'"));
+    }
+
+    #[test]
+    fn doubled_quote_escape_stays_inside_literal() {
+        // 'it''s  x' contains an escaped quote; the run of spaces after it is
+        // still inside the literal and must survive.
+        let sql = "CREATE TABLE t (v TEXT DEFAULT 'it''s  x')";
+        assert!(normalize_sql(sql).contains("'it''s  x'"));
+    }
+
+    #[test]
+    fn preserves_quoted_identifiers() {
+        let quoted = normalize_sql("CREATE TABLE \"my  table\" (id INTEGER PRIMARY KEY)");
+        assert!(quoted.contains("\"my  table\""));
+        let bracket = normalize_sql("CREATE TABLE [my  table] (id INTEGER PRIMARY KEY)");
+        assert!(bracket.contains("[my  table]"));
+    }
+}

--- a/packages/sqlmerge/tests/merge.rs
+++ b/packages/sqlmerge/tests/merge.rs
@@ -1,0 +1,331 @@
+//! Integration tests for the merge engine.
+//!
+//! Each test builds base/ours/theirs SQLite fixtures in a tempdir, runs the
+//! merge, and asserts either a clean merge (with the expected row state) or a
+//! specific typed refusal.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use sqlmerge::{ConflictPolicy, MergeError, merge};
+use tempfile::TempDir;
+
+/// A base/ours/theirs fixture triple living in one tempdir.
+struct Fixture {
+    _dir: TempDir,
+    base: PathBuf,
+    ours: PathBuf,
+    theirs: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let base = dir.path().join("base.db");
+        let ours = dir.path().join("ours.db");
+        let theirs = dir.path().join("theirs.db");
+        Fixture {
+            _dir: dir,
+            base,
+            ours,
+            theirs,
+        }
+    }
+
+    fn run(&self) -> sqlmerge::Result<()> {
+        merge(
+            path(&self.base),
+            path(&self.ours),
+            path(&self.theirs),
+            ConflictPolicy::Abort,
+        )
+    }
+}
+
+fn path(p: &Path) -> &str {
+    p.to_str().expect("utf8 path")
+}
+
+/// Open a db, run a batch of SQL, close it.
+fn build(db: &Path, sql: &str) {
+    let conn = Connection::open(db).expect("open");
+    conn.execute_batch(sql).expect("exec batch");
+}
+
+/// Copy `from` to `to` as an independent byte-copy of the base database.
+/// `build` opens each fixture with its own connection and closes it before we
+/// copy, so a plain filesystem copy is safe (no open WAL to reconcile).
+fn copy_db(from: &Path, to: &Path) {
+    std::fs::copy(from, to).expect("copy db");
+}
+
+/// Read a single integer cell.
+fn read_int(db: &Path, sql: &str) -> i64 {
+    let conn = Connection::open(db).expect("open");
+    conn.query_row(sql, [], |r| r.get(0)).expect("query")
+}
+
+/// Read a single text cell.
+fn read_text(db: &Path, sql: &str) -> String {
+    let conn = Connection::open(db).expect("open");
+    conn.query_row(sql, [], |r| r.get(0)).expect("query")
+}
+
+const USERS_SCHEMA: &str =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, score INTEGER NOT NULL);";
+
+/// A standard base with three users; ours and theirs start as copies.
+fn seeded_users() -> Fixture {
+    let f = Fixture::new();
+    build(
+        &f.base,
+        &format!(
+            "{USERS_SCHEMA}\n\
+             INSERT INTO users VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'carol', 30);"
+        ),
+    );
+    copy_db(&f.base, &f.ours);
+    copy_db(&f.base, &f.theirs);
+    f
+}
+
+#[test]
+fn non_overlapping_row_edits_merge_clean() {
+    let f = seeded_users();
+    // ours edits alice; theirs edits bob. Disjoint rows.
+    build(&f.ours, "UPDATE users SET score = 11 WHERE id = 1;");
+    build(&f.theirs, "UPDATE users SET score = 22 WHERE id = 2;");
+
+    f.run().expect("clean merge");
+
+    // ours keeps its alice edit and gains theirs's bob edit.
+    assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 1"), 11);
+    assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 2"), 22);
+    assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 3"), 30);
+}
+
+#[test]
+fn same_cell_divergent_edit_conflicts() {
+    let f = seeded_users();
+    // Both edit alice's score to different values.
+    build(&f.ours, "UPDATE users SET score = 111 WHERE id = 1;");
+    build(&f.theirs, "UPDATE users SET score = 222 WHERE id = 1;");
+
+    let err = f.run().expect_err("should conflict");
+    let MergeError::Conflicts(conflicts) = err else {
+        panic!("expected Conflicts, got {err:?}");
+    };
+    assert_eq!(conflicts.len(), 1);
+    assert_eq!(conflicts[0].table, "users");
+
+    // ours must be left unchanged (aborted apply, no partial write).
+    assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 1"), 111);
+}
+
+#[test]
+fn inserts_with_different_pks_merge() {
+    let f = seeded_users();
+    build(&f.ours, "INSERT INTO users VALUES (4, 'dave', 40);");
+    build(&f.theirs, "INSERT INTO users VALUES (5, 'erin', 50);");
+
+    f.run().expect("clean merge");
+
+    assert_eq!(read_int(&f.ours, "SELECT count(*) FROM users"), 5);
+    assert_eq!(read_text(&f.ours, "SELECT name FROM users WHERE id = 4"), "dave");
+    assert_eq!(read_text(&f.ours, "SELECT name FROM users WHERE id = 5"), "erin");
+}
+
+#[test]
+fn identical_insert_both_sides_is_not_a_conflict() {
+    let f = seeded_users();
+    // Same PK, same values, on both sides.
+    build(&f.ours, "INSERT INTO users VALUES (6, 'frank', 60);");
+    build(&f.theirs, "INSERT INTO users VALUES (6, 'frank', 60);");
+
+    f.run().expect("identical insert should merge clean");
+
+    assert_eq!(read_int(&f.ours, "SELECT count(*) FROM users WHERE id = 6"), 1);
+    assert_eq!(read_text(&f.ours, "SELECT name FROM users WHERE id = 6"), "frank");
+}
+
+#[test]
+fn convergent_delete_merges_clean() {
+    let f = seeded_users();
+    // Both sides delete carol. The changeset's DELETE finds the row already
+    // gone (NOTFOUND) and the end state matches on both sides: not a conflict.
+    build(&f.ours, "DELETE FROM users WHERE id = 3;");
+    build(&f.theirs, "DELETE FROM users WHERE id = 3;");
+
+    f.run().expect("convergent delete should merge clean");
+
+    assert_eq!(read_int(&f.ours, "SELECT count(*) FROM users WHERE id = 3"), 0);
+    assert_eq!(read_int(&f.ours, "SELECT count(*) FROM users"), 2);
+}
+
+#[test]
+fn delete_vs_update_conflicts() {
+    let f = seeded_users();
+    // theirs deletes alice; ours edited her. The changeset DELETE finds a row
+    // whose values differ from base (DATA conflict): a real conflict.
+    build(&f.ours, "UPDATE users SET score = 111 WHERE id = 1;");
+    build(&f.theirs, "DELETE FROM users WHERE id = 1;");
+
+    let err = f.run().expect_err("delete-vs-update should conflict");
+    let MergeError::Conflicts(conflicts) = err else {
+        panic!("expected Conflicts, got {err:?}");
+    };
+    assert_eq!(conflicts[0].table, "users");
+
+    // ours untouched by the aborted apply.
+    assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 1"), 111);
+}
+
+#[test]
+fn update_vs_delete_conflicts() {
+    let f = seeded_users();
+    // theirs edits alice; ours deleted her. The changeset UPDATE finds no row
+    // (NOTFOUND on update): a real conflict, unlike the convergent delete.
+    build(&f.ours, "DELETE FROM users WHERE id = 1;");
+    build(&f.theirs, "UPDATE users SET score = 222 WHERE id = 1;");
+
+    let err = f.run().expect_err("update-vs-delete should conflict");
+    let MergeError::Conflicts(conflicts) = err else {
+        panic!("expected Conflicts, got {err:?}");
+    };
+    assert_eq!(conflicts[0].table, "users");
+
+    // ours untouched by the aborted apply: alice stays deleted.
+    assert_eq!(read_int(&f.ours, "SELECT count(*) FROM users WHERE id = 1"), 0);
+}
+
+#[test]
+fn base_schema_divergence_refused() {
+    let f = seeded_users();
+    // Both sides apply the SAME migration, so ours == theirs, but base is
+    // behind. The session diff cannot span a schema change; refuse typed.
+    build(&f.ours, "ALTER TABLE users ADD COLUMN email TEXT;");
+    build(&f.theirs, "ALTER TABLE users ADD COLUMN email TEXT;");
+
+    let err = f.run().expect_err("should refuse");
+    let MergeError::BaseSchemaDiverged(objects) = err else {
+        panic!("expected BaseSchemaDiverged, got {err:?}");
+    };
+    assert_eq!(objects, vec!["users".to_string()]);
+}
+
+#[test]
+fn missing_primary_key_table_refused() {
+    let f = Fixture::new();
+    // `logs` has no PRIMARY KEY, so the session extension would silently skip it.
+    build(
+        &f.base,
+        "CREATE TABLE logs (msg TEXT NOT NULL, at INTEGER NOT NULL);",
+    );
+    copy_db(&f.base, &f.ours);
+    copy_db(&f.base, &f.theirs);
+    build(&f.theirs, "INSERT INTO logs VALUES ('hi', 1);");
+
+    let err = f.run().expect_err("should refuse");
+    let MergeError::MissingPrimaryKey(tables) = err else {
+        panic!("expected MissingPrimaryKey, got {err:?}");
+    };
+    assert_eq!(tables, vec!["logs".to_string()]);
+}
+
+#[test]
+fn schema_divergence_refused() {
+    let f = Fixture::new();
+    build(&f.base, USERS_SCHEMA);
+    copy_db(&f.base, &f.ours);
+    copy_db(&f.base, &f.theirs);
+    // theirs adds a column: DDL divergence.
+    build(&f.theirs, "ALTER TABLE users ADD COLUMN email TEXT;");
+
+    let err = f.run().expect_err("should refuse");
+    let MergeError::SchemaDiverged(objs) = err else {
+        panic!("expected SchemaDiverged, got {err:?}");
+    };
+    assert!(objs.iter().any(|o| o.object == "users"));
+}
+
+#[test]
+fn schema_whitespace_difference_is_not_divergence() {
+    let f = Fixture::new();
+    build(
+        &f.base,
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER NOT NULL);\n\
+         INSERT INTO t VALUES (1, 1);",
+    );
+    copy_db(&f.base, &f.ours);
+    // Rebuild theirs from scratch with reformatted (but equivalent) DDL.
+    build(
+        &f.theirs,
+        "CREATE TABLE t (\n  id  INTEGER  PRIMARY KEY,\n  v   INTEGER  NOT NULL\n);\n\
+         INSERT INTO t VALUES (1, 1);",
+    );
+    build(&f.theirs, "UPDATE t SET v = 2 WHERE id = 1;");
+
+    f.run().expect("whitespace-only schema difference should merge");
+    assert_eq!(read_int(&f.ours, "SELECT v FROM t WHERE id = 1"), 2);
+}
+
+const FK_SCHEMA: &str = "CREATE TABLE parent (id INTEGER PRIMARY KEY);\n\
+     CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL \
+     REFERENCES parent(id));";
+
+#[test]
+fn foreign_key_violation_from_merge_caught() {
+    let f = Fixture::new();
+    build(
+        &f.base,
+        &format!("{FK_SCHEMA}\nINSERT INTO parent VALUES (1);\nINSERT INTO child VALUES (10, 1);"),
+    );
+    copy_db(&f.base, &f.ours);
+    copy_db(&f.base, &f.theirs);
+
+    // ours deletes the parent that theirs's new child will reference.
+    build(&f.ours, "PRAGMA foreign_keys=OFF; DELETE FROM parent WHERE id = 1;");
+    // theirs adds a child pointing at parent 1 (still present in theirs).
+    build(&f.theirs, "INSERT INTO child VALUES (11, 1);");
+
+    // Applying theirs's new child (parent_id=1) onto ours (parent 1 gone) is an
+    // FK violation. It must be caught and refused (exit 1). SQLite's changeset
+    // apply raises this as a FOREIGN_KEY conflict; either that or the
+    // post-merge PRAGMA foreign_key_check is an acceptable catch, as long as we
+    // refuse.
+    let err = f.run().expect_err("should catch FK violation");
+    assert!(
+        matches!(
+            err,
+            MergeError::Conflicts(_) | MergeError::ForeignKeyCheckFailed(_)
+        ),
+        "expected an FK-related refusal, got {err:?}"
+    );
+}
+
+#[test]
+fn preexisting_dangling_fk_caught_by_post_merge_check() {
+    let f = Fixture::new();
+    build(
+        &f.base,
+        &format!("{FK_SCHEMA}\nINSERT INTO parent VALUES (1);\nINSERT INTO child VALUES (10, 1);"),
+    );
+    copy_db(&f.base, &f.ours);
+    copy_db(&f.base, &f.theirs);
+
+    // ours already holds a dangling child (parent 2 never existed), created
+    // with FK enforcement off. The base->theirs changeset only touches parent,
+    // so the apply does not re-check this row; the post-merge
+    // foreign_key_check must.
+    build(
+        &f.ours,
+        "PRAGMA foreign_keys=OFF; INSERT INTO child VALUES (99, 2);",
+    );
+    build(&f.theirs, "INSERT INTO parent VALUES (3);");
+
+    let err = f.run().expect_err("should catch pre-existing dangling FK");
+    let MergeError::ForeignKeyCheckFailed(rows) = err else {
+        panic!("expected ForeignKeyCheckFailed, got {err:?}");
+    };
+    assert!(!rows.is_empty());
+}

--- a/packages/sqlmerge/tests/merge.rs
+++ b/packages/sqlmerge/tests/merge.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the merge engine.
 //!
-//! Each test builds base/ours/theirs SQLite fixtures in a tempdir, runs the
+//! Each test builds base/ours/theirs `SQLite` fixtures in a tempdir, runs the
 //! merge, and asserts either a clean merge (with the expected row state) or a
 //! specific typed refusal.
 
@@ -24,7 +24,7 @@ impl Fixture {
         let base = dir.path().join("base.db");
         let ours = dir.path().join("ours.db");
         let theirs = dir.path().join("theirs.db");
-        Fixture {
+        Self {
             _dir: dir,
             base,
             ours,


### PR DESCRIPTION
Adds `packages/sqlmerge`, a git merge driver for SQLite database files: three-way merge of row data via the SQLite session extension (rusqlite `bundled`+`session`).

- **Semantics:** changeset `base -> theirs` applied onto `ours`. Disjoint edits, identical edits/inserts, and convergent deletes merge clean; same-cell divergence, delete-vs-edit, and NOTFOUND-on-update conflict with a per-row stderr report and exit 1 (git marks the file conflicted). Schema gate (ours vs theirs AND vs base, whitespace-insensitive outside quoted literals), explicit-PK gate (session extension silently skips PK-less tables), post-merge `integrity_check` + `foreign_key_check`. No DDL merge, no auto-resolution in v1 (policy enum for later).
- **profiles/base:** wires `*.db`/`*.sqlite`/`*.sqlite3` to the driver via home-manager (mergiraf keeps everything else; attributes pinned with `mkAfter` so the specific rule outlasts mergiraf's `* merge=mergiraf` wildcard), plus git 3.0-era defaults: `init.defaultObjectFormat=sha256`, `init.defaultRefFormat=reftable`, `safe.bareRepository=explicit`.
- **Validated:** 13 integration + 4 unit tests green; real `git merge` E2E (clean + conflict paths) against the nix-built binary; `nix build .#sqlmerge` green on darwin; repo lint green.

Built by Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `sqlmerge` Git merge driver for SQLite databases with base-profile wiring
> - Introduces a new `sqlmerge` binary crate that performs three-way merges of SQLite databases using SQLite's session changeset API: computes a changeset from base→theirs and applies it onto ours, keyed by primary key.
> - Refuses to merge when schemas diverge between inputs, tables lack explicit primary keys, row-level conflicts occur, or post-merge integrity/foreign key checks fail; leaves `ours` unchanged on any failure.
> - Wires the driver into the base home-manager Git config via [modules/profiles/base/default.nix](https://github.com/indexable-inc/index/pull/1876/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e): `*.db`, `*.sqlite`, and `*.sqlite3` files are routed to the `sqlite` merge driver using `pkgs.sqlmerge`.
> - Also adds `init.defaultObjectFormat=sha256`, `init.defaultRefFormat=reftable`, and `safe.bareRepository=explicit` to the base Git config, affecting all new repositories initialized in user environments.
> - Risk: `init.defaultObjectFormat=sha256` and `reftable` apply globally to new repos and are incompatible with SHA-1 remotes; `safe.bareRepository=explicit` will cause Git to refuse to operate on implicitly bare repos.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac77a1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->