### PR TITLE
base profile: ship ugrep in the default image

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -566,6 +566,10 @@ in {
           ripgrep
           strace
           tcpdump
+          # Complements ripgrep with what it lacks: boolean queries
+          # (-%), fuzzy match (-Z), and searching inside archives and
+          # compressed files (-z).
+          ugrep
           # Pane and tab multiplexer for one session. Connection survival
           # across SSH drops is handled by ix itself (AGENTS.md "VM
           # assumptions"), so zellij is shipped for splits, not reattach.


### PR DESCRIPTION
Adds `ugrep` to the base profile's `environment.systemPackages` so every ix VM image carries it alongside ripgrep. ugrep covers what ripgrep lacks: boolean queries (`-%`), fuzzy match (`-Z`), and searching inside archives/compressed files (`-z`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ugrep` to the base profile default packages
> Adds `ugrep` to the packages list in [default.nix](https://github.com/indexable-inc/index/pull/1877/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) alongside `ripgrep`. `ugrep` complements `ripgrep` with boolean queries (`-%`), fuzzy matching (`-Z`), and searching inside archives and compressed files (`-z`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 927d588.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->