### PR TITLE
search-py: expose BM25 (file-search) bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9557,6 +9557,7 @@ dependencies = [
 name = "search-py"
 version = "0.1.0"
 dependencies = [
+ "file-search",
  "mixedbread",
  "pyo3",
  "pyo3-async-runtimes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ clone-pragma = { path = "packages/code/clone-detect/pragma" }
 clone-scanner = { path = "packages/code/clone-detect/scanner" }
 code-highlight = { path = "packages/code/code-highlight" }
 code-tokenizer = { path = "packages/search/code-tokenizer" }
+file-search = { path = "packages/search/file-search" }
 github-avatar = { path = "packages/github-avatar" }
 google-auth = { path = "packages/google/auth" }
 google-calendar = { path = "packages/google/calendar" }

--- a/packages/search/search-py/Cargo.toml
+++ b/packages/search/search-py/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib"]
 workspace = true
 
 [dependencies]
+file-search.workspace = true
 mixedbread.workspace = true
 pyo3 = { workspace = true, features = ["extension-module"] }
 pyo3-async-runtimes.workspace = true

--- a/packages/search/search-py/README.md
+++ b/packages/search/search-py/README.md
@@ -85,6 +85,39 @@ df = await search.recent(source=["shell"], since="6h")
 df.select("timestamp", "text")
 ```
 
+## BM25 (`file-search`)
+
+Three synchronous verbs run the local Tantivy BM25 engine
+([`file-search`](../file-search)) instead of the corpus store. They do no
+network I/O, so — unlike the three above — they are plain functions returning
+lists/dicts (no `await`, no DataFrame). All route through `file-search`'s own
+constructors, so they inherit the shared
+[`code-tokenizer`](../code-tokenizer) (camelCase / snake_case / kebab-case /
+whitespace splitting plus stemming): `"widget factory"` matches both
+`makeWidgetFactory` and `make_widget_factory`.
+
+```python
+# rerank a batch of texts in memory
+hits = search.bm25_rerank("retry backoff", candidate_texts, limit=5)
+# [{"index": 3, "score": 4.2, "text": "..."}, ...]
+
+# build an on-disk index, then search it
+search.bm25_index("/path/to/repo", index_dir="/tmp/idx")
+hits = search.bm25_search("async runtime", index_dir="/tmp/idx", limit=10)
+# [{"path": "...", "score": 2.1, "snippet": "...", "chunk_offset": 0}, ...]
+```
+
+- `bm25_rerank(query, texts, limit=None)`: rank in-memory strings; `limit`
+  defaults to the whole batch. Texts that match nothing are omitted. Each hit
+  is `{index, score, text}` where `index` is the position in the input list.
+- `bm25_index(path, index_dir, no_gitignore=False)`: walk `path` and index
+  text files into `index_dir`, creating it if absent. Honors `.gitignore`
+  unless `no_gitignore=True`. Returns `{files_indexed, files_skipped, errors}`.
+- `bm25_search(query, index_dir, limit=10, filter=None)`: search the index
+  (read-only, so it can run alongside indexing) in Tantivy query syntax;
+  `filter` restricts to files under a directory. Each hit is
+  `{path, score, snippet, chunk_offset}`.
+
 ## Scope selectors
 
 All optional; with none set the whole corpus is searched. List selectors accept

--- a/packages/search/search-py/python/search/__init__.py
+++ b/packages/search/search-py/python/search/__init__.py
@@ -50,6 +50,23 @@ per-query price, and may return fewer than ``top_k`` hits.
 
 Authentication mirrors the ``search`` CLI: ``MXBAI_API_KEY``, or the token
 written by ``mgrep login``.
+
+Three BM25 verbs, backed by the local ``file-search`` (Tantivy) engine, sit
+alongside the corpus queries. They do no network I/O, so unlike the three
+above they are plain synchronous functions returning lists/dicts (no
+``await``, no DataFrame):
+
+* ``bm25_rerank(query, texts, limit=None)`` reranks a batch of in-memory
+  strings, returning dicts ``{index, score, text}``.
+* ``bm25_index(path, index_dir)`` builds/updates an on-disk index.
+* ``bm25_search(query, index_dir, limit=10, filter=None)`` searches it,
+  returning dicts ``{path, score, snippet, chunk_offset}``.
+
+All three inherit the shared ``code-tokenizer`` (camelCase / snake_case /
+kebab-case / whitespace splitting plus stemming), so ``"widget factory"``
+matches both ``makeWidgetFactory`` and ``make_widget_factory``::
+
+    hits = search.bm25_rerank("retry backoff", candidate_texts, limit=5)
 """
 
 from __future__ import annotations
@@ -58,6 +75,7 @@ import functools
 from typing import TYPE_CHECKING
 
 from ._search import __version__
+from ._search import bm25_index, bm25_rerank, bm25_search
 from ._search import grep as _grep
 from ._search import recent as _recent
 from ._search import semantic as _semantic
@@ -77,7 +95,15 @@ if TYPE_CHECKING:
     _Raw = Callable[..., Awaitable[list[Hit]]]
     _Framed = Callable[..., Awaitable[pl.DataFrame]]
 
-__all__ = ["__version__", "grep", "recent", "semantic"]
+__all__ = [
+    "__version__",
+    "bm25_index",
+    "bm25_rerank",
+    "bm25_search",
+    "grep",
+    "recent",
+    "semantic",
+]
 
 # The stable column set, in display order: the six fields every hit carries,
 # then the provenance fields a record may or may not carry. Enforced on every

--- a/packages/search/search-py/python/search/_search.pyi
+++ b/packages/search/search-py/python/search/_search.pyi
@@ -39,6 +39,30 @@ class Hit(TypedDict, total=False):
     repo: str
     project: str
 
+class RerankHit(TypedDict):
+    """One reranked text from ``bm25_rerank``: its position in the input batch,
+    BM25 score, and body."""
+
+    index: int
+    score: float
+    text: str
+
+class FileHit(TypedDict):
+    """One hit from ``bm25_search`` over an on-disk index."""
+
+    path: str
+    score: float
+    snippet: str
+    chunk_offset: int
+
+class IndexStats(TypedDict):
+    """The outcome of a ``bm25_index`` run. ``errors`` pairs each skipped file
+    with the reason it could not be indexed."""
+
+    files_indexed: int
+    files_skipped: int
+    errors: list[list[str]]
+
 def semantic(
     query: str,
     top_k: int = ...,
@@ -88,3 +112,22 @@ def recent(
     until: int | str | None = ...,
     compact: bool = ...,
 ) -> Awaitable[list[Hit]]: ...
+
+# The BM25 (`file-search`) bindings are synchronous: no network I/O, so they
+# return their results directly rather than an awaitable.
+def bm25_rerank(
+    query: str,
+    texts: list[str],
+    limit: int | None = ...,
+) -> list[RerankHit]: ...
+def bm25_index(
+    path: str,
+    index_dir: str,
+    no_gitignore: bool = ...,
+) -> IndexStats: ...
+def bm25_search(
+    query: str,
+    index_dir: str,
+    limit: int = ...,
+    filter: str | None = ...,
+) -> list[FileHit]: ...

--- a/packages/search/search-py/src/lib.rs
+++ b/packages/search/search-py/src/lib.rs
@@ -15,6 +15,7 @@
 //! The returned awaitable is a native asyncio coroutine bridged through
 //! pyo3-async-runtimes, so callers `await` it on their own event loop.
 
+use file_search::{EphemeralSearch, SearchIndex, SearchIndexReader};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -490,11 +491,179 @@ fn hit_to_dict<'py>(py: Python<'py>, hit: &DisplayHit) -> PyResult<Bound<'py, Py
     Ok(dict)
 }
 
+/// Rerank a batch of texts against a query by BM25, in memory.
+///
+/// Builds a one-shot Tantivy index over `texts` and scores them against
+/// `query`, returning up to `limit` hits (default: every text) ranked best
+/// first. Each hit is a dict with `index` (the position in the input list),
+/// `score` (BM25), and `text` (the matched string). Texts that match nothing
+/// are omitted. Unlike [`semantic`]/[`grep`]/[`recent`], this does no network
+/// I/O and reads no corpus, so it is a plain synchronous function: it returns
+/// the list directly, not an awaitable.
+///
+/// Tokenization is inherited from `file_search` (the shared `code-tokenizer`
+/// stemmed tokenizer), so identifiers split on camelCase, snake_case,
+/// kebab-case, and whitespace before stemming: `"widget factory"` matches both
+/// `makeWidgetFactory` and `make_widget_factory`.
+///
+///     hits = search.bm25_rerank("retry backoff", candidate_texts, limit=5)
+#[pyfunction]
+#[pyo3(signature = (query, texts, limit = None))]
+fn bm25_rerank(
+    py: Python<'_>,
+    query: &str,
+    texts: Vec<String>,
+    limit: Option<usize>,
+) -> PyResult<Py<PyAny>> {
+    // Default to ranking the whole batch; the search never returns more hits
+    // than documents, so an oversized limit is harmless.
+    let limit = limit.unwrap_or(texts.len());
+    let ranked = rerank(query, texts, limit).map_err(|error| PyRuntimeError::new_err(error))?;
+
+    let out = pyo3::types::PyList::empty(py);
+    for hit in ranked {
+        let dict = PyDict::new(py);
+        dict.set_item("index", hit.index)?;
+        dict.set_item("score", hit.score)?;
+        dict.set_item("text", hit.text)?;
+        out.append(dict)?;
+    }
+    Ok(out.unbind().into_any())
+}
+
+/// Build (or update) an on-disk BM25 index over the files under `path`.
+///
+/// Walks `path` and indexes every text-shaped file into the Tantivy index at
+/// `index_dir`, creating it if absent — the same pipeline as the `file-search
+/// index` CLI subcommand, so it inherits the shared `code-tokenizer`. Honors
+/// `.gitignore` unless `no_gitignore=True`. Synchronous (local disk work, no
+/// network). Returns a dict with `files_indexed`, `files_skipped`, and
+/// `errors` (a list of `[path, message]` pairs for files that could not be
+/// read or parsed; these do not abort the walk).
+#[pyfunction]
+#[pyo3(signature = (path, index_dir, no_gitignore = false))]
+fn bm25_index(py: Python<'_>, path: &str, index_dir: &str, no_gitignore: bool) -> PyResult<Py<PyAny>> {
+    let mut index =
+        SearchIndex::open_or_create(index_dir).map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+    let stats = index
+        .index_directory(std::path::Path::new(path), !no_gitignore)
+        .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+
+    let dict = PyDict::new(py);
+    dict.set_item("files_indexed", stats.files_indexed)?;
+    dict.set_item("files_skipped", stats.files_skipped)?;
+    let errors = pyo3::types::PyList::empty(py);
+    for (path, message) in &stats.errors {
+        let pair = pyo3::types::PyList::empty(py);
+        pair.append(path.to_string_lossy())?;
+        pair.append(message)?;
+        errors.append(pair)?;
+    }
+    dict.set_item("errors", errors)?;
+    Ok(dict.unbind().into_any())
+}
+
+/// Search an on-disk BM25 index built by [`bm25_index`].
+///
+/// Opens the index at `index_dir` read-only (no writer lock, so it can run
+/// alongside an indexing pass) and returns up to `limit` hits matching `query`
+/// in Tantivy query syntax, ranked best first — the `file-search search`
+/// subcommand. When `filter` is set, only files under that directory match.
+/// Synchronous. Each hit is a dict with `path`, `score`, `snippet`, and
+/// `chunk_offset`.
+#[pyfunction]
+#[pyo3(signature = (query, index_dir, limit = 10, filter = None))]
+fn bm25_search(
+    py: Python<'_>,
+    query: &str,
+    index_dir: &str,
+    limit: usize,
+    filter: Option<&str>,
+) -> PyResult<Py<PyAny>> {
+    let reader =
+        SearchIndexReader::open(index_dir).map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+    let hits = reader
+        .search(query, limit, filter.map(std::path::Path::new))
+        .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+
+    let out = pyo3::types::PyList::empty(py);
+    for hit in hits {
+        let dict = PyDict::new(py);
+        dict.set_item("path", hit.path)?;
+        dict.set_item("score", hit.score)?;
+        dict.set_item("snippet", hit.snippet)?;
+        dict.set_item("chunk_offset", hit.chunk_offset)?;
+        out.append(dict)?;
+    }
+    Ok(out.unbind().into_any())
+}
+
+/// One reranked text: its position in the input batch, BM25 score, and body.
+struct Reranked {
+    index: usize,
+    score: f32,
+    text: String,
+}
+
+/// Rank `texts` against `query` through `file_search`'s [`EphemeralSearch`],
+/// which registers the shared `code-tokenizer` on its in-memory index. Kept
+/// free of `pyo3` types so `#[cfg(test)]` can exercise the tokenizer
+/// inheritance without a Python interpreter.
+fn rerank(query: &str, texts: Vec<String>, limit: usize) -> Result<Vec<Reranked>, String> {
+    let search = EphemeralSearch::from_texts(texts.iter().cloned()).map_err(|e| e.to_string())?;
+    let ranked = search.search(query, limit).map_err(|e| e.to_string())?;
+    Ok(ranked
+        .into_iter()
+        .map(|hit| Reranked {
+            index: hit.id,
+            score: hit.score,
+            // `hit.id` indexes back into the batch we just built the index from.
+            text: texts[hit.id].clone(),
+        })
+        .collect())
+}
+
 #[pymodule]
 fn _search(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(semantic, module)?)?;
     module.add_function(wrap_pyfunction!(grep, module)?)?;
     module.add_function(wrap_pyfunction!(recent, module)?)?;
+    module.add_function(wrap_pyfunction!(bm25_rerank, module)?)?;
+    module.add_function(wrap_pyfunction!(bm25_index, module)?)?;
+    module.add_function(wrap_pyfunction!(bm25_search, module)?)?;
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rerank;
+
+    /// The binding routes through `file_search::EphemeralSearch`, so it inherits
+    /// the shared `code-tokenizer`: a query of two plain words matches an
+    /// identifier written in camelCase and one in snake_case. If a future change
+    /// bypassed `file_search` and built a raw Tantivy schema with the default
+    /// tokenizer, neither identifier would split and this would return no hits.
+    #[test]
+    fn rerank_inherits_code_tokenizer() {
+        let texts = vec![
+            "fn makeWidgetFactory() {}".to_owned(),
+            "def make_widget_factory(): pass".to_owned(),
+            "the quick brown fox".to_owned(),
+        ];
+        let hits = rerank("widget factory", texts, 10).expect("rerank succeeds");
+        let matched: Vec<usize> = hits.iter().map(|h| h.index).collect();
+        assert!(
+            matched.contains(&0),
+            "camelCase makeWidgetFactory should match; got {matched:?}"
+        );
+        assert!(
+            matched.contains(&1),
+            "snake_case make_widget_factory should match; got {matched:?}"
+        );
+        assert!(
+            !matched.contains(&2),
+            "unrelated text should not match; got {matched:?}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #1878.

The MCP kernel imports `search` and could only reach the network semantic corpus. This adds three synchronous BM25 verbs backed by the local `file-search` (Tantivy) engine:

- `bm25_rerank(query, texts, limit=None)` — in-memory rerank of a batch of strings via `EphemeralSearch`; returns `{index, score, text}`.
- `bm25_index(path, index_dir, no_gitignore=False)` — build/update an on-disk index (the CLI `index` subcommand).
- `bm25_search(query, index_dir, limit=10, filter=None)` — search it (the `search` subcommand); returns `{path, score, snippet, chunk_offset}`.

No network I/O, so they are plain sync functions (no awaitable, no DataFrame), unlike semantic/grep/recent.

All three route through `file_search`'s own constructors, so they inherit the shared `code-tokenizer` (`CODE_STEMMED_TOKENIZER`: camelCase/snake_case/kebab-case/whitespace splitting + stemming) rather than a raw Tantivy schema. A `#[cfg(test)]` locks this in: `makeWidgetFactory` and `make_widget_factory` both rank for query "widget factory", while unrelated text does not.

Surface added to the `.pyi` stub, `__init__` re-exports, and README.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose BM25 file-search bindings (`bm25_index`, `bm25_search`, `bm25_rerank`) in search-py
> - Adds three new synchronous Python functions backed by the `file-search` (Tantivy) crate: `bm25_index` builds/updates an on-disk index, `bm25_search` queries it, and `bm25_rerank` scores an in-memory list of strings.
> - The Rust implementations in [`src/lib.rs`](https://github.com/indexable-inc/index/pull/1879/files#diff-8b2791c01370b8e518eebab401620520a6f6417a4d5fff715501869c363166f8) use `SearchIndex`, `SearchIndexReader`, and `EphemeralSearch` from the `file-search` workspace crate, with an internal `rerank` helper kept free of PyO3 types for unit testability.
> - All three functions are exported from [`python/search/__init__.py`](https://github.com/indexable-inc/index/pull/1879/files#diff-6428de7019c4a353ffe0219aa2d76d01e60b96b4e1cd2f118a24064bdb909cf0) and documented in the README.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 980ea3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->