### PR TITLE
search-py: fix limit=0 panic across FFI, release GIL on BM25 work

### DIFF
--- a/packages/search/file-search/src/ephemeral.rs
+++ b/packages/search/file-search/src/ephemeral.rs
@@ -88,6 +88,13 @@ impl EphemeralSearch {
     ///
     /// Returns an error if the query cannot be parsed or the search fails.
     pub fn search(&self, query: &str, limit: usize) -> Result<Vec<RankResult>> {
+        // `TopDocs::with_limit` asserts `limit != 0` (tantivy 0.26.1), so a
+        // zero limit would panic. This also covers reranking an empty corpus,
+        // where the caller derives `limit` from the (empty) text batch.
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
         let parser = QueryParser::for_index(&self.index, vec![self.content_field]);
         let parsed = parser.parse_query(query).context(QueryParseSnafu)?;
 

--- a/packages/search/file-search/src/search.rs
+++ b/packages/search/file-search/src/search.rs
@@ -27,6 +27,12 @@ pub fn search(
     limit: usize,
     filter_directory: Option<&Path>,
 ) -> Result<Vec<SearchResult>> {
+    // `TopDocs::with_limit` asserts `limit != 0` (tantivy 0.26.1), so a zero
+    // limit would panic. Asking for zero hits is well-defined: return none.
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
     reader.reload().context(error::SearchSnafu)?;
     let searcher = reader.searcher();
 

--- a/packages/search/file-search/tests/roundtrip.rs
+++ b/packages/search/file-search/tests/roundtrip.rs
@@ -175,6 +175,44 @@ fn search_index_reader_opens_without_writer_lock() {
 }
 
 #[test]
+fn search_with_limit_zero_returns_empty() {
+    let workdir = TempDir::new().expect("workdir");
+    let index_dir = TempDir::new().expect("index dir");
+
+    fs::write(workdir.path().join("note.md"), "alpha bravo charlie").expect("write");
+
+    let mut index = SearchIndex::open_or_create(index_dir.path()).expect("open");
+    index.index_directory(workdir.path(), false).expect("index");
+
+    // `TopDocs::with_limit(0)` panics; a zero limit must return no hits, not
+    // abort. Regression for the PanicException surfaced through search-py.
+    let hits = index.search("alpha", 0, None).expect("limit=0 must not panic");
+    assert!(hits.is_empty(), "limit=0 should return no hits: {hits:?}");
+}
+
+#[test]
+fn ephemeral_search_with_limit_zero_returns_empty() {
+    let search = EphemeralSearch::from_texts([
+        "fibonacci runs in exponential time without memoization".to_string(),
+    ])
+    .expect("build ephemeral");
+
+    // Guards the empty-batch rerank path in search-py, where `limit` is derived
+    // from the (possibly empty) text batch and would reach `with_limit(0)`.
+    let results = search.search("fibonacci", 0).expect("limit=0 must not panic");
+    assert!(results.is_empty(), "limit=0 should return no hits: {results:?}");
+}
+
+#[test]
+fn ephemeral_from_empty_texts_ranks_empty() {
+    let search = EphemeralSearch::from_texts(std::iter::empty()).expect("build empty ephemeral");
+    // An empty corpus with a matching-limit derived from `texts.len() == 0`
+    // must not panic.
+    let results = search.search("anything", 0).expect("empty corpus must not panic");
+    assert!(results.is_empty(), "empty corpus should return no hits: {results:?}");
+}
+
+#[test]
 fn ephemeral_reranks_matching_text_higher() {
     let search = EphemeralSearch::from_texts([
         "totally unrelated content".to_string(),

--- a/packages/search/search-py/src/lib.rs
+++ b/packages/search/search-py/src/lib.rs
@@ -518,7 +518,12 @@ fn bm25_rerank(
     // Default to ranking the whole batch; the search never returns more hits
     // than documents, so an oversized limit is harmless.
     let limit = limit.unwrap_or(texts.len());
-    let ranked = rerank(query, texts, limit).map_err(|error| PyRuntimeError::new_err(error))?;
+    // Build and query the in-memory Tantivy index off the GIL; a large batch
+    // would otherwise freeze the caller's asyncio loop. `rerank` uses no pyo3
+    // types, so it runs cleanly detached; re-attach only to build the dicts.
+    let ranked = py
+        .detach(|| rerank(query, texts, limit))
+        .map_err(PyRuntimeError::new_err)?;
 
     let out = pyo3::types::PyList::empty(py);
     for hit in ranked {
@@ -543,10 +548,14 @@ fn bm25_rerank(
 #[pyfunction]
 #[pyo3(signature = (path, index_dir, no_gitignore = false))]
 fn bm25_index(py: Python<'_>, path: &str, index_dir: &str, no_gitignore: bool) -> PyResult<Py<PyAny>> {
-    let mut index =
-        SearchIndex::open_or_create(index_dir).map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
-    let stats = index
-        .index_directory(std::path::Path::new(path), !no_gitignore)
+    // Walking and indexing a directory is all disk/CPU work with no pyo3
+    // types; run it off the GIL so a large index does not freeze the caller's
+    // asyncio loop, then re-attach only to build the result dict.
+    let stats = py
+        .detach(|| {
+            let mut index = SearchIndex::open_or_create(index_dir)?;
+            index.index_directory(std::path::Path::new(path), !no_gitignore)
+        })
         .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
 
     let dict = PyDict::new(py);
@@ -580,10 +589,14 @@ fn bm25_search(
     limit: usize,
     filter: Option<&str>,
 ) -> PyResult<Py<PyAny>> {
-    let reader =
-        SearchIndexReader::open(index_dir).map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
-    let hits = reader
-        .search(query, limit, filter.map(std::path::Path::new))
+    // Opening the index and searching is all disk/CPU work with no pyo3 types;
+    // run it off the GIL so it does not freeze the caller's asyncio loop, then
+    // re-attach only to build the result dicts.
+    let hits = py
+        .detach(|| {
+            let reader = SearchIndexReader::open(index_dir)?;
+            reader.search(query, limit, filter.map(std::path::Path::new))
+        })
         .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
 
     let out = pyo3::types::PyList::empty(py);
@@ -665,5 +678,24 @@ mod tests {
             !matched.contains(&2),
             "unrelated text should not match; got {matched:?}"
         );
+    }
+
+    /// `bm25_rerank(query, [])` derives `limit = texts.len() = 0`, which used
+    /// to reach `TopDocs::with_limit(0)` and panic (re-raised as a pyo3
+    /// `PanicException` across the FFI boundary). An empty batch must rank to
+    /// an empty result.
+    #[test]
+    fn rerank_empty_batch_is_empty() {
+        let hits = rerank("anything", Vec::new(), 0).expect("empty batch must not panic");
+        assert!(hits.is_empty(), "empty batch should rank empty");
+    }
+
+    /// An explicit `limit == 0` on a non-empty batch must also return empty
+    /// rather than panic.
+    #[test]
+    fn rerank_limit_zero_is_empty() {
+        let texts = vec!["fn makeWidgetFactory() {}".to_owned()];
+        let hits = rerank("widget factory", texts, 0).expect("limit=0 must not panic");
+        assert!(hits.is_empty(), "limit=0 should rank empty");
     }
 }


### PR DESCRIPTION
Follow-up to #1879, found by post-merge adversarial review.

- **C1/C2 panic across FFI**: `TopDocs::with_limit(0)` asserts `limit != 0` (tantivy 0.26.1). Any `limit=0` search panicked, and `bm25_rerank(query, [])` hit it via `limit = texts.len() = 0`; pyo3 re-raised it as a `PanicException`. Fixed at the source: `file-search`'s `search()` and `EphemeralSearch::search()` early-return empty on `limit == 0`, which also fixes the CLI `--limit 0` and the empty-corpus rerank in one place.
- **P1 GIL hold**: the three sync BM25 fns did all Tantivy CPU/disk work holding the GIL, freezing the caller's asyncio loop. Now wrapped in `py.detach()`, re-attaching only to build the Python result objects.

Regression tests: `file-search` `search(query, 0)` / `EphemeralSearch::search(query, 0)` / empty-corpus rerank return empty; `search-py` `rerank(query, [], 0)` and `rerank(query, [text], 0)` return empty.

Closes #1880

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `limit=0` panic in BM25 search and release GIL during search operations
> - Adds early-return guards in `EphemeralSearch.search` and the `search` function in [ephemeral.rs](https://github.com/indexable-inc/index/pull/1881/files#diff-c1cf4206f8beb8e210ef59a40304cb8cc4cbe8a11d3a05b585d6063fb789d370) and [search.rs](https://github.com/indexable-inc/index/pull/1881/files#diff-524cabcf40adf55ef0199012ca6f869380139fee256ab69458a8e5ce2c58e40d) to return an empty result when `limit == 0`, preventing a panic from `TopDocs::with_limit(0)`.
> - Wraps CPU/disk-bound work in `bm25_rerank`, `bm25_index`, and `bm25_search` in `py.detach` so the Python GIL is released during BM25 computation in [lib.rs](https://github.com/indexable-inc/index/pull/1881/files#diff-8b2791c01370b8e518eebab401620520a6f6417a4d5fff715501869c363166f8).
> - Adds tests covering `limit=0` for both indexed and ephemeral search paths, and for empty input batches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3411097.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->