### PR TITLE
skills: silence merge-pr watcher between state changes; review-changes Workflow fallback

### DIFF
--- a/packages/agent/skills/merge-pr/SKILL.md
+++ b/packages/agent/skills/merge-pr/SKILL.md
@@ -24,7 +24,7 @@ Keep all CI watching inside the fork, and even there make it event-driven (see b
 
 > You own PR #<N> in <owner/repo> from now until it is merged or you are genuinely stuck. Loop:
 >
-> 1. **Watch CI fail-fast.** Run `gh pr checks <N> --watch --fail-fast --interval 20` so you wake the instant ANY check fails (not after all finish). Do NOT block a foreground Bash slot on it: launch it with `run_in_background: true` and wait on it with the `Monitor` tool / an `until` condition, so the watch returns the moment a check fails or all pass. `--fail-fast` needs gh ≥ 2.42; if it is rejected, drop the flag and parse `gh pr checks <N> --json name,state,bucket` on each wake instead.
+> 1. **Watch CI fail-fast, silently.** Arm exactly ONE event-driven watch and let it be the only thing that wakes you. It must complete only on a terminal or changed state — a check result (any fail / all pass), a new head sha, a merge or close event, or your own deadline — never on a timer tick that re-reports "pending". Run `gh pr checks <N> --watch --fail-fast --interval 20` with `run_in_background: true` (never a foreground Bash slot) so it returns the instant ANY check fails or all pass. `--fail-fast` needs gh ≥ 2.42; if it is rejected, drop the flag and run a background `until` loop over `gh pr checks <N> --json name,state,bucket` that exits only when the aggregate state differs from when you armed it.
 > 2. **If all checks pass → merge.** Use the repo's merge norm: for `indexable-inc/index` and `indexable-inc/ix`, admin force-merge immediately (`gh pr merge <N> --admin --squash`; merge queue is on, so do NOT pass `--delete-branch`). For other repos, enable auto-merge (`gh pr merge <N> --auto --squash`) unless the user said force-merge. Then report "merged" with the squash commit sha and stop.
 > 3. **If a check failed → diagnose and fix.**
 >    - Pull the failing logs: `gh pr checks <N>` to find the failed check, then `gh run view <run-id> --log-failed` (or `--log` for the failing job) to read the actual error. Read the real error, do not guess.
@@ -37,6 +37,8 @@ Keep all CI watching inside the fork, and even there make it event-driven (see b
 > **Escalate, do not guess, when:** the fix needs a product decision, the failure is in code you did not touch and the right fix is ambiguous, a required check needs human approval, or merging is blocked by a review the user must give. Report the specific blocker.
 >
 > **Watch the clock.** If a single CI round runs far longer than that repo's checks normally take, investigate the long-pole step rather than waiting it out (in index/ix, treat any check over ~1 min as a problem to look at, not wait on).
+>
+> **Report only on state change.** Every turn-end message you write lands as a task notification in the parent session, so a "still pending, waiting" update is pure noise. Never emit a no-change status report; if you wake and nothing changed, re-arm and yield silently. Batch progress into state-change reports only (a check failed, you pushed a fix, merged, stuck, blocked). Yielding silently never means stopping: keep a live watch armed whenever the outcome is pending, and re-arm it BEFORE ending the turn.
 >
 > Report concisely when done: final state (merged + sha / stopped-stuck / blocked), and for anything you fixed, one line per fix.
 

--- a/packages/agent/skills/review-changes/SKILL.md
+++ b/packages/agent/skills/review-changes/SKILL.md
@@ -31,15 +31,26 @@ value with no logic). Say so in one line and stop.
 
    ```
    Workflow({
-     scriptPath: "/Users/andrewgazelka/.config/nix/claude/global/skills/review-changes/review.workflow.js",
+     scriptPath: "~/.claude/skills/review-changes/review.workflow.js",
      args: { cwd: "<repo root>" }
    })
    ```
 
+   The script ships next to this skill; expand `~` to the absolute home path.
    The workflow runs in the background and notifies on completion. It fans out
    one `code-reviewer` finder per dimension over the diff, pipelines each finding
    through an independent skeptic that tries to refute it, and returns the
    surviving findings ranked, with Correctness and Security marked as blockers.
+
+   **Fallback — Workflow tool unavailable.** Not every harness/session exposes
+   a `Workflow` tool. If the call fails because the tool does not exist, do not
+   stall or improvise a different review: run the same shape manually. Spawn one
+   `code-reviewer` agent per dimension — correctness, security, performance,
+   maintainability — over the same diff (`git diff` + `git diff --staged`,
+   falling back to `git show HEAD`), all in a single message so they run
+   concurrently, each restricted to its one dimension. Then adversarially verify
+   each finding yourself (try to refute it against the actual code) before
+   reporting, and keep the same ranking: Correctness and Security are blockers.
 
 3. When it completes, report the verdict to the user, blockers first. Fix the
    confirmed Correctness/Security findings in the same turn, or state plainly why


### PR DESCRIPTION
Fixes background merge-watcher notification spam at the source: during one PR's CI run the fork emitted ~10 'Still pending. Waiting.' task notifications with no state change.

- **merge-pr**: charter step 1 now requires exactly one event-driven watch that completes only on a terminal or changed state (check fail/all-pass, new head sha, merge/close, deadline), never a timer tick. New charter paragraph: "Never emit a no-change status report; if you wake and nothing changed, re-arm and yield silently", with the re-arm-before-yield rule so silence never means stopping.
- **review-changes**: adds the documented fallback when the `Workflow` tool is not exposed (spawn one `code-reviewer` per dimension over the same diff, verify, same blocker ranking), and fixes the stale `scriptPath` pointing at the pre-index skills location.

Authored with Claude

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Silence merge-pr watcher between state changes and add review-changes Workflow fallback
> - Updates [merge-pr SKILL.md](https://github.com/indexable-inc/index/pull/1883/files#diff-608606067a31924f83acc16eac2b7e17158344e0e9065f833a53816cbb55ed36) to require a single, background, event-driven CI watcher that only reports on terminal or changed states, suppressing no-change status messages.
> - Updates [review-changes SKILL.md](https://github.com/indexable-inc/index/pull/1883/files#diff-130d0688ea9769c3b7447821469f2a8b68c491eb78a09b65beb72460bdb3336c) to use a home-relative `~/.claude/skills/review-changes/review.workflow.js` path (expanded to absolute at runtime) instead of a hardcoded user path.
> - Adds a fallback for environments without the Workflow tool: run parallel agents per review dimension (correctness, security, performance, maintainability), verify findings adversarially, and preserve blocker ranking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29b9cb8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->