### PR TITLE
Commit root .gitattributes routing SQLite files to sqlmerge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# SQLite databases merge with the sqlmerge driver (packages/sqlmerge), not as
+# binary blobs. On an ix VM the base profile wires this globally; committing it
+# here also covers off-VM clones and documents the intent. The driver still
+# has to be configured (`[merge "sqlite"]`) — see packages/sqlmerge/README.md.
+*.db merge=sqlite
+*.sqlite merge=sqlite
+*.sqlite3 merge=sqlite


### PR DESCRIPTION
Adds a root `.gitattributes` routing `*.db` / `*.sqlite` / `*.sqlite3` to the sqlmerge driver.

`packages/sqlmerge` (#1876) wired the driver into `modules/profiles/base`, but `programs.git.attributes` there writes the operator's **global** gitattributes (`~/.config/git/attributes`), so routing only applies on an ix VM. Off-VM clones — and the repo's own committed `packages/mcp/task-graph/public/tasks.sqlite` — had no declarative routing.

Committing the three lines at the repo root makes the driver apply for anyone who has it configured (every ix operator, in this repo) and version-controls the intent. Kept minimal: mergiraf's global `* merge=mergiraf` stays VM-only so off-VM clones aren't forced onto it. Off-VM users still need the `[merge \"sqlite\"]` driver + `sqlmerge` binary, both in `packages/sqlmerge/README.md`.

Closes #1884

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `.gitattributes` to route SQLite files to the `sqlite` merge driver
> Adds a root-level [`.gitattributes`](.gitattributes) file that assigns the custom `sqlite` merge driver to `*.db`, `*.sqlite`, and `*.sqlite3` files. Comments in the file document where the driver configuration is expected to live.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8735b42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->