### PR TITLE
review-gate: attribute edits to the main session, defer while background work runs

### DIFF
--- a/packages/agent/claude-hooks/src/review.rs
+++ b/packages/agent/claude-hooks/src/review.rs
@@ -34,6 +34,20 @@ fn marker_path(session: &str) -> PathBuf {
     state_dir().join(format!("{session}.changed"))
 }
 
+/// True when this hook payload fired inside a subagent (Task tool) rather than
+/// the main thread. Claude Code populates `agent_id` ONLY inside a subagent call
+/// (`PostToolUse` carries it; the docs call it the way to "distinguish subagent
+/// hook calls from main-thread calls"), so its presence is the authoritative
+/// author signal. A subagent's `PostToolUse` reuses the PARENT `session_id`, so
+/// without this check its work-in-progress lands in the parent's marker and the
+/// Stop gate blames the main session for edits it never made.
+fn is_subagent(payload: &Value) -> bool {
+    payload
+        .get("agent_id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.is_empty())
+}
+
 /// `PostToolUse(Write|Edit|MultiEdit|NotebookEdit)`: record the edited path.
 /// Side effect only, never blocks.
 pub fn review_log_edit() {
@@ -43,6 +57,14 @@ pub fn review_log_edit() {
     let Ok(payload) = serde_json::from_str::<Value>(&input) else {
         return;
     };
+    // Attribute edits to the MAIN session only. A subagent's edits carry the
+    // parent's `session_id` but also an `agent_id`; the subagent owns and reviews
+    // its own diff, and a still-running background subagent's WIP must not arm the
+    // parent's gate. Drop subagent-authored edits here so the gate counts only the
+    // main session's own tool calls.
+    if is_subagent(&payload) {
+        return;
+    }
     let Some(session) = safe_session(&payload) else {
         return;
     };
@@ -75,6 +97,53 @@ struct StopBlock {
     reason: String,
 }
 
+/// True when the turn ended with background work still running. `background_tasks`
+/// (Stop/SubagentStop input, v2.1.145+) lists the bash commands and subagents
+/// still in flight; the element shape is version-dependent, so presence of any
+/// entry is the only signal relied on. A missing or non-array field reads as idle.
+fn background_active(payload: &Value) -> bool {
+    payload
+        .get("background_tasks")
+        .and_then(Value::as_array)
+        .is_some_and(|tasks| !tasks.is_empty())
+}
+
+/// What the Stop gate should do this turn, decided from the payload alone (no I/O).
+#[derive(Debug, PartialEq, Eq)]
+enum GateAction {
+    /// Allow the Stop and clear the marker (loop guard: forced continuation).
+    ClearAndAllow,
+    /// Allow the Stop but PRESERVE the marker, so the review still fires on a
+    /// later Stop. Used while the session's own background work is still running.
+    AllowKeepMarker,
+    /// Read the marker and, if there are unreviewed edits, consume it and block.
+    Evaluate,
+}
+
+/// Pure gate policy over the Stop payload. Keeps the two false-positive fixes
+/// (loop guard, background-work suppression) testable without stdin/stdout or
+/// filesystem state.
+fn gate_action(payload: &Value) -> GateAction {
+    // Loop guard: this Stop is already a forced continuation from a prior block.
+    // Clear the marker and allow, so the next genuine change-set can trigger again.
+    if payload
+        .get("stop_hook_active")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return GateAction::ClearAndAllow;
+    }
+    // Don't gate while the main session's own background work is still in flight:
+    // a non-empty `background_tasks` means a builder or scaffold subagent is
+    // mid-edit. Firing now would blame the parent for work-in-progress and re-fire
+    // on every Stop until the builder drains. Allow WITHOUT consuming the marker,
+    // so the review still fires on the next genuine Stop once nothing is running.
+    if background_active(payload) {
+        return GateAction::AllowKeepMarker;
+    }
+    GateAction::Evaluate
+}
+
 /// Stop: block once per change-set if there are unreviewed edits.
 pub fn review_gate() {
     let Some(input) = crate::read_stdin() else {
@@ -88,15 +157,13 @@ pub fn review_gate() {
     };
     let marker = marker_path(&session);
 
-    // Loop guard: this Stop is already a forced continuation from a prior block.
-    // Clear the marker and allow, so the next genuine change-set can trigger again.
-    if payload
-        .get("stop_hook_active")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-    {
-        let _ = std::fs::remove_file(&marker);
-        return;
+    match gate_action(&payload) {
+        GateAction::ClearAndAllow => {
+            let _ = std::fs::remove_file(&marker);
+            return;
+        }
+        GateAction::AllowKeepMarker => return,
+        GateAction::Evaluate => {}
     }
 
     let Ok(contents) = std::fs::read_to_string(&marker) else {
@@ -153,7 +220,7 @@ pub fn review_gate() {
 
 #[cfg(test)]
 mod tests {
-    use super::safe_session;
+    use super::{GateAction, gate_action, is_subagent, safe_session};
     use serde_json::json;
 
     #[test]
@@ -164,5 +231,84 @@ mod tests {
         assert!(safe_session(&json!({"session_id": "."})).is_none());
         assert!(safe_session(&json!({"session_id": ""})).is_none());
         assert!(safe_session(&json!({})).is_none());
+    }
+
+    // Attribution: a subagent's PostToolUse reuses the parent `session_id` but
+    // carries an `agent_id`. That marks it NOT the main session's own edit, so
+    // the logger must drop it and never arm the parent's gate.
+    #[test]
+    fn subagent_edit_is_attributed_to_subagent() {
+        // Main-thread edit: no agent_id.
+        assert!(!is_subagent(&json!({
+            "session_id": "s1",
+            "tool_input": {"file_path": "/repo/src/a.rs"},
+        })));
+        // Subagent edit: agent_id present (parent session_id reused).
+        assert!(is_subagent(&json!({
+            "session_id": "s1",
+            "agent_id": "agent-xyz",
+            "agent_type": "general-purpose",
+            "tool_input": {"file_path": "/repo/src/scaffold.rs"},
+        })));
+        // Empty agent_id is treated as main-thread (defensive).
+        assert!(!is_subagent(&json!({"session_id": "s1", "agent_id": ""})));
+    }
+
+    #[test]
+    fn gate_evaluates_a_plain_main_session_stop() {
+        assert_eq!(gate_action(&json!({"session_id": "s1"})), GateAction::Evaluate);
+    }
+
+    #[test]
+    fn gate_clears_and_allows_on_forced_continuation() {
+        // Loop guard: a Stop that is itself a forced continuation clears the marker.
+        assert_eq!(
+            gate_action(&json!({"session_id": "s1", "stop_hook_active": true})),
+            GateAction::ClearAndAllow,
+        );
+    }
+
+    // Regression: a background subagent (e.g. an in-progress scaffold across many
+    // files) is still running when the main turn ends. The gate must NOT fire and
+    // must PRESERVE the marker so the review still runs once the builder drains.
+    #[test]
+    fn gate_defers_while_background_work_runs() {
+        assert_eq!(
+            gate_action(&json!({
+                "session_id": "s1",
+                "background_tasks": [
+                    {"type": "subagent", "agent_type": "general-purpose", "status": "running"},
+                ],
+            })),
+            GateAction::AllowKeepMarker,
+        );
+    }
+
+    #[test]
+    fn gate_evaluates_when_background_tasks_drained() {
+        // Empty or absent background_tasks reads as idle -> normal evaluation.
+        assert_eq!(
+            gate_action(&json!({"session_id": "s1", "background_tasks": []})),
+            GateAction::Evaluate,
+        );
+        assert_eq!(
+            gate_action(&json!({"session_id": "s1", "background_tasks": "notanarray"})),
+            GateAction::Evaluate,
+        );
+    }
+
+    // The loop guard outranks the background-work check: a forced continuation
+    // must always clear the marker even if a background task is still listed, so
+    // the gate can never wedge into a permanent block.
+    #[test]
+    fn loop_guard_outranks_background_work() {
+        assert_eq!(
+            gate_action(&json!({
+                "session_id": "s1",
+                "stop_hook_active": true,
+                "background_tasks": [{"type": "bash", "status": "running"}],
+            })),
+            GateAction::ClearAndAllow,
+        );
     }
 }


### PR DESCRIPTION
## The bug

The Stop review gate (`claude-hooks review-gate`) repeatedly blocked a main session with "Unreviewed edits to N file(s) this session" for files being edited by that session's own **background subagents** mid-flight (e.g. an in-progress scaffold across ~12 files, and auto-memory `.md` edits). The main agent had to hand-wave a deferral a dozen times in one conversation.

The gate's intent (review finished work before declaring done) is right. Two things were wrong:

1. **Wrong attribution.** `review-log-edit` (PostToolUse) logged *every* edit regardless of author. A subagent's tool call reuses the **parent's** `session_id`, so a scaffold subagent editing a dozen files armed the *parent's* marker.
2. **Re-fires while a builder runs.** `review-gate` (Stop) blocked whenever the marker was non-empty, with no awareness that a background subagent was still mid-edit, so it fired on every Stop until the builder drained.

## The fix

Use signals the harness already exposes (Claude Code 2.1.145+), at the layer that owns the problem, no path skip-list:

- **Attribution** — drop subagent-authored edits in `review-log-edit`. `agent_id` is present *only* inside a subagent call (per the [hooks docs](https://code.claude.com/docs/en/hooks.md): "use this to distinguish subagent hook calls from main-thread calls"), so its presence means the edit is not the main session's own. Only the main thread's edits arm the gate. This also dissolves the auto-memory false positive for subagent-written memory.
- **Deferral** — while `background_tasks` (Stop input) is non-empty, a builder/scaffold subagent is still running. Allow the Stop **without consuming the marker**, so the review still fires once the background work drains. Presence of any entry is the only signal relied on (element shape is version-dependent).

Gate policy is extracted into a pure `gate_action()` + `is_subagent()` so both false positives are covered by unit tests.

## Tests

Added unit tests reproducing both false positives (subagent attribution, background-work deferral) plus the loop-guard-outranks-background precedence. `cargo test -p claude-hooks`: 26 pass.

## Live verification

Built the package and ran the compiled binary end-to-end against crafted payloads:

- A background subagent's 12-file scaffold WIP (agent_id + parent session_id) **does not** arm the parent marker.
- The gate stays **silent** while the subagent is still in `background_tasks`.
- Once the background work drains, the gate **fires for exactly the one main-session edit** (not the subagent's files), marker preserved until then so no review is lost.
- Regression: the classic path (main edits, no background) still blocks and consumes the marker; the `stop_hook_active` loop guard still clears and allows.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Attribute edits to the main session and defer stop gate while background tasks run
> - Edit logging in `review_log_edit` now ignores events with a non-empty `agent_id`, so edits made by subagents are not recorded in the parent session marker.
> - Stop gating in `review_gate` is refactored around a new `gate_action` policy function with three outcomes: clear-and-allow (loop guard), allow-keep-marker (background active), and evaluate (normal path).
> - When `payload.background_tasks` is a non-empty array, the gate defers without consuming the marker, preserving it for when background work completes.
> - New tests cover subagent attribution, each `GateAction` variant, and loop-guard precedence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 187a584.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->