### PR TITLE
sqlmerge: declarative per-table conflict policy (sqlmerge.toml)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10329,8 +10329,11 @@ dependencies = [
 name = "sqlmerge"
 version = "0.1.0"
 dependencies = [
+ "glob",
  "rusqlite",
+ "serde",
  "tempfile",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]

--- a/packages/sqlmerge/Cargo.toml
+++ b/packages/sqlmerge/Cargo.toml
@@ -13,6 +13,12 @@ workspace = true
 # merge semantics are identical on every machine); `session` adds the
 # sqlite3session_* changeset API this driver is built on.
 rusqlite = { workspace = true, features = ["session"] }
+# `sqlmerge.toml` parsing (per-table conflict policy). `parse` + `serde` mirror
+# the workspace's other toml consumers (config-launch); `glob` matches table
+# names against the policy globs. Both are already in the workspace + lockfile.
+toml = { workspace = true, features = ["parse", "serde"] }
+serde = { workspace = true, features = ["derive"] }
+glob.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/packages/sqlmerge/README.md
+++ b/packages/sqlmerge/README.md
@@ -59,9 +59,57 @@ sqlmerge, everything else keeps [mergiraf](https://mergiraf.org/). By hand:
 - **Missing primary key.** Any user table without an explicit `PRIMARY KEY` is
   a refusal naming the tables: the session extension silently skips such
   tables, which would be silent data loss.
-- **Any row conflict aborts the whole merge.** v1 has no auto-resolution
-  policies; the conflict handler is a policy enum so per-table policies
-  (last-writer-wins, append-only) can be added later.
+- **Row conflicts abort by default.** With no `sqlmerge.toml`, any row conflict
+  aborts the whole merge. Per-table auto-resolution is opt-in; see
+  [Conflict policies](#conflict-policies).
+
+## Conflict policies
+
+By default every row conflict aborts. A `sqlmerge.toml` at the repo root (the
+driver walks up from its working directory, which git sets to the worktree
+root) opts individual tables into auto-resolution. It maps a table-name **glob**
+to a policy:
+
+```toml
+# sqlmerge.toml
+[policies]
+"cache_*" = "theirs"       # matches cache_hot, cache_users, ...
+"events"  = "append-only"  # exact table name
+"*"       = "abort"        # catch-all (also the implicit default)
+```
+
+Globs use the usual `*` (any run), `?` (one char), and `[...]` class syntax.
+When several globs match one table, **the first one listed wins** (declaration
+order). A table matched by no glob uses `abort`. An absent config file means
+every table aborts — identical to the pre-config behavior. A malformed config
+(bad TOML, unknown policy name, invalid glob) is a loud refusal, never a silent
+fall-back.
+
+| policy        | on a conflicting row                                              |
+| ------------- | ---------------------------------------------------------------- |
+| `abort`       | abort the whole merge (default)                                  |
+| `ours`        | keep ours; drop the incoming change                              |
+| `theirs`      | take theirs where SQLite allows it; otherwise abort (see below)  |
+| `append-only` | a conflicting insert keeps ours; a conflicting update/delete aborts |
+
+**The `theirs` REPLACE caveat.** "Take theirs" maps to SQLite's
+`SQLITE_CHANGESET_REPLACE`, which the [session
+docs](https://sqlite.org/session/sqlite3changeset_apply.html) permit **only**
+for the `DATA` (both sides edited the same row) and `CONFLICT` (both inserted
+the same primary key) conflict types. For a `NOTFOUND` conflict — theirs edited
+a row ours had deleted, so there is no target row to overwrite — or a
+`CONSTRAINT` violation, returning REPLACE is illegal and would fail the entire
+apply with `SQLITE_MISUSE`. `theirs` therefore still **aborts** on those types
+rather than force an invalid resolution.
+
+**Foreign-key conflicts always abort**, regardless of policy. A deferred
+`FOREIGN_KEY` conflict carries no table (only a violation count), so there is no
+per-table policy to consult, and omitting it would commit a database with a
+foreign-key violation. It is always a refusal.
+
+Convergent cases are resolved before any policy is consulted and never
+conflict: an identical insert on both sides, and both sides deleting the same
+row.
 
 ## Limitations
 

--- a/packages/sqlmerge/src/config.rs
+++ b/packages/sqlmerge/src/config.rs
@@ -1,0 +1,301 @@
+//! Declarative per-table conflict policy: the *data* half of the design.
+//!
+//! This module is pure: it parses `sqlmerge.toml` into a [`PolicyConfig`] and
+//! answers "which policy applies to table T?" ([`PolicyConfig::policy_for`]).
+//! It knows nothing about `SQLite`, changesets, or the apply path; the merge
+//! engine (machinery) consults a [`PolicyConfig`] per conflict. Keeping the
+//! policy table separate from the apply logic is deliberate: one source of
+//! truth for the mapping, no policy branches scattered through the C callback.
+//!
+//! The on-disk format is a single `[policies]` table mapping a table-name GLOB
+//! to a policy name:
+//!
+//! ```toml
+//! [policies]
+//! "cache_*" = "theirs"
+//! "events"  = "append-only"
+//! "*"       = "abort"
+//! ```
+//!
+//! Precedence when several globs match one table is **first-listed wins**, in
+//! the order the entries appear in the file. An absent file (or absent
+//! `[policies]` table) means every table uses [`ConflictPolicy::Abort`], which
+//! is exactly the pre-config behavior.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use std::collections::BTreeMap;
+
+use glob::{Pattern, PatternError};
+use serde::Deserialize;
+use toml::Spanned;
+
+use crate::merge::ConflictPolicy;
+
+/// Failures loading or parsing `sqlmerge.toml`.
+///
+/// A malformed config is a loud refusal, never a silent fall-back to abort: a
+/// driver that ignored a misconfigured policy file would resolve conflicts the
+/// operator did not ask for.
+#[derive(Debug)]
+pub enum ConfigError {
+    /// The config file exists but could not be read.
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// The config file is not valid TOML or has an unknown policy name.
+    Parse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+    /// A key in `[policies]` is not a valid glob pattern.
+    BadGlob {
+        pattern: String,
+        source: PatternError,
+    },
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read { path, source } => {
+                write!(f, "cannot read {}: {source}", path.display())
+            }
+            Self::Parse { path, source } => {
+                write!(f, "invalid sqlmerge config {}: {source}", path.display())
+            }
+            Self::BadGlob { pattern, source } => {
+                write!(f, "invalid table glob {pattern:?}: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+/// The policy name as it appears in `sqlmerge.toml`. A separate serde-facing
+/// enum (kebab-case, denies unknown names) keeps the wire format decoupled from
+/// the engine's [`ConflictPolicy`]; `from` maps one to the other.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum PolicyName {
+    Abort,
+    Ours,
+    Theirs,
+    AppendOnly,
+}
+
+impl From<PolicyName> for ConflictPolicy {
+    fn from(name: PolicyName) -> Self {
+        match name {
+            PolicyName::Abort => Self::Abort,
+            PolicyName::Ours => Self::Ours,
+            PolicyName::Theirs => Self::Theirs,
+            PolicyName::AppendOnly => Self::AppendOnly,
+        }
+    }
+}
+
+/// The raw `[policies]` table as read from TOML.
+///
+/// The key is the table-name glob. The value is [`Spanned`], so we recover each
+/// entry's byte offset in the source and re-establish declaration order from
+/// it: `toml::Table` iterates its keys sorted, not in written order, so
+/// first-listed precedence would otherwise be lost. Spans are exact and need no
+/// order-preserving map dependency.
+#[derive(Debug, Deserialize)]
+struct RawConfig {
+    #[serde(default)]
+    policies: BTreeMap<String, Spanned<PolicyName>>,
+}
+
+/// One compiled `(glob, policy)` rule.
+#[derive(Debug, Clone)]
+struct Rule {
+    pattern: Pattern,
+    policy: ConflictPolicy,
+}
+
+/// The parsed policy table: an ordered list of glob rules. Match a table name
+/// against the rules in order; the first hit wins. No match falls back to
+/// [`ConflictPolicy::Abort`].
+#[derive(Debug, Clone, Default)]
+pub struct PolicyConfig {
+    rules: Vec<Rule>,
+}
+
+impl PolicyConfig {
+    /// The empty config: every table aborts on conflict. This is the default
+    /// when no `sqlmerge.toml` is present.
+    #[must_use]
+    pub fn abort_all() -> Self {
+        Self::default()
+    }
+
+    /// The policy for `table`: the first rule whose glob matches, else
+    /// [`ConflictPolicy::Abort`].
+    #[must_use]
+    pub fn policy_for(&self, table: &str) -> ConflictPolicy {
+        self.rules
+            .iter()
+            .find(|rule| rule.pattern.matches(table))
+            .map_or(ConflictPolicy::Abort, |rule| rule.policy)
+    }
+
+    /// Parse a `sqlmerge.toml` body into a [`PolicyConfig`], attributing any
+    /// error to a synthetic in-memory path. Prefer [`PolicyConfig::load_from`]
+    /// for the real on-disk load; this is the entry point for tests and callers
+    /// that already hold the config text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::Parse`] if `body` is not valid TOML or names an
+    /// unknown policy, or [`ConfigError::BadGlob`] if a key is not a valid glob.
+    pub fn load_body(body: &str) -> Result<Self, ConfigError> {
+        Self::parse(body, Path::new("<in-memory sqlmerge.toml>"))
+    }
+
+    /// Parse a `sqlmerge.toml` body into a [`PolicyConfig`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::Parse`] if `body` is not valid TOML or names an
+    /// unknown policy, or [`ConfigError::BadGlob`] if a key is not a valid glob.
+    fn parse(body: &str, path: &Path) -> Result<Self, ConfigError> {
+        let raw: RawConfig = toml::from_str(body).map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+        // Re-establish declaration order from the value spans: the map iterates
+        // sorted, but first-listed precedence follows the order written in the
+        // file. Sorting the entries by span start recovers it exactly.
+        let mut entries: Vec<(String, Spanned<PolicyName>)> = raw.policies.into_iter().collect();
+        entries.sort_by_key(|(_, spanned)| spanned.span().start);
+
+        let mut rules = Vec::with_capacity(entries.len());
+        for (pattern_str, spanned) in entries {
+            let pattern = Pattern::new(&pattern_str).map_err(|source| ConfigError::BadGlob {
+                pattern: pattern_str.clone(),
+                source,
+            })?;
+            rules.push(Rule {
+                pattern,
+                policy: (*spanned.get_ref()).into(),
+            });
+        }
+
+        Ok(Self { rules })
+    }
+
+    /// Load the policy config for the working tree rooted at `start`: walk up
+    /// from `start` looking for `sqlmerge.toml` (git runs a merge driver at the
+    /// worktree root, but walking up is robust to being invoked elsewhere).
+    /// Absent file -> [`PolicyConfig::abort_all`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if a `sqlmerge.toml` is found but cannot be read
+    /// or parsed. A missing file is not an error.
+    pub fn load_from(start: &Path) -> Result<Self, ConfigError> {
+        let Some(path) = find_config(start) else {
+            return Ok(Self::abort_all());
+        };
+        let body = fs::read_to_string(&path).map_err(|source| ConfigError::Read {
+            path: path.clone(),
+            source,
+        })?;
+        Self::parse(&body, &path)
+    }
+}
+
+/// Walk up from `start` (a directory) to the filesystem root, returning the
+/// first `sqlmerge.toml` found.
+fn find_config(start: &Path) -> Option<PathBuf> {
+    start.ancestors().find_map(|dir| {
+        let candidate = dir.join("sqlmerge.toml");
+        candidate.is_file().then_some(candidate)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(body: &str) -> PolicyConfig {
+        PolicyConfig::parse(body, Path::new("sqlmerge.toml")).expect("valid config")
+    }
+
+    #[test]
+    fn empty_config_aborts_every_table() {
+        let cfg = PolicyConfig::abort_all();
+        assert_eq!(cfg.policy_for("anything"), ConflictPolicy::Abort);
+        assert_eq!(parse("").policy_for("t"), ConflictPolicy::Abort);
+    }
+
+    #[test]
+    fn exact_table_name_matches() {
+        let cfg = parse("[policies]\n\"users\" = \"ours\"\n");
+        assert_eq!(cfg.policy_for("users"), ConflictPolicy::Ours);
+        // Non-matching table falls back to abort.
+        assert_eq!(cfg.policy_for("posts"), ConflictPolicy::Abort);
+    }
+
+    #[test]
+    fn star_wildcard_matches_prefix() {
+        let cfg = parse("[policies]\n\"cache_*\" = \"theirs\"\n");
+        assert_eq!(cfg.policy_for("cache_users"), ConflictPolicy::Theirs);
+        assert_eq!(cfg.policy_for("cache_"), ConflictPolicy::Theirs);
+        assert_eq!(cfg.policy_for("users"), ConflictPolicy::Abort);
+    }
+
+    #[test]
+    fn question_mark_matches_single_char() {
+        let cfg = parse("[policies]\n\"log?\" = \"append-only\"\n");
+        assert_eq!(cfg.policy_for("logs"), ConflictPolicy::AppendOnly);
+        assert_eq!(cfg.policy_for("log1"), ConflictPolicy::AppendOnly);
+        // `?` is exactly one char: neither zero nor two match.
+        assert_eq!(cfg.policy_for("log"), ConflictPolicy::Abort);
+        assert_eq!(cfg.policy_for("logss"), ConflictPolicy::Abort);
+    }
+
+    #[test]
+    fn first_listed_wins_when_multiple_globs_match() {
+        // Both patterns match "cache_hot"; the first listed (theirs) wins.
+        let cfg = parse(
+            "[policies]\n\"cache_*\" = \"theirs\"\n\"*\" = \"abort\"\n",
+        );
+        assert_eq!(cfg.policy_for("cache_hot"), ConflictPolicy::Theirs);
+        // A table only the second pattern matches gets the second policy.
+        assert_eq!(cfg.policy_for("users"), ConflictPolicy::Abort);
+    }
+
+    #[test]
+    fn catch_all_star_sets_the_default() {
+        let cfg = parse("[policies]\n\"*\" = \"ours\"\n");
+        assert_eq!(cfg.policy_for("anything"), ConflictPolicy::Ours);
+    }
+
+    #[test]
+    fn unknown_policy_name_is_a_parse_error() {
+        let err = PolicyConfig::parse(
+            "[policies]\n\"t\" = \"last-writer-wins\"\n",
+            Path::new("sqlmerge.toml"),
+        )
+        .expect_err("unknown policy should fail");
+        assert!(matches!(err, ConfigError::Parse { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn invalid_glob_is_a_typed_error() {
+        // An unclosed character class is an invalid glob.
+        let err = PolicyConfig::parse(
+            "[policies]\n\"t[\" = \"ours\"\n",
+            Path::new("sqlmerge.toml"),
+        )
+        .expect_err("bad glob should fail");
+        assert!(matches!(err, ConfigError::BadGlob { .. }), "got {err:?}");
+    }
+}

--- a/packages/sqlmerge/src/config.rs
+++ b/packages/sqlmerge/src/config.rs
@@ -190,10 +190,13 @@ impl PolicyConfig {
         Ok(Self { rules })
     }
 
-    /// Load the policy config for the working tree rooted at `start`: walk up
-    /// from `start` looking for `sqlmerge.toml` (git runs a merge driver at the
-    /// worktree root, but walking up is robust to being invoked elsewhere).
-    /// Absent file -> [`PolicyConfig::abort_all`].
+    /// Load the policy config for the working tree containing `start`: walk up
+    /// from `start` looking for `sqlmerge.toml`, but never past the git
+    /// worktree root (git runs a merge driver at the worktree root; walking up
+    /// tolerates a manual invocation from a subdirectory). Outside a git
+    /// worktree only `start` itself is checked: an ancestor's config (a parent
+    /// checkout, `$HOME`) must never opt an unrelated repo into
+    /// auto-resolution. Absent file -> [`PolicyConfig::abort_all`].
     ///
     /// # Errors
     ///
@@ -211,13 +214,37 @@ impl PolicyConfig {
     }
 }
 
-/// Walk up from `start` (a directory) to the filesystem root, returning the
-/// first `sqlmerge.toml` found.
+/// Walk up from `start` (a directory), returning the first `sqlmerge.toml`
+/// found, bounded by the git worktree root: the walk stops at the first
+/// ancestor containing `.git` (a directory in a plain checkout, a file in a
+/// linked worktree or submodule). Without that bound a repo with no config
+/// would inherit whatever `sqlmerge.toml` happens to sit in a parent checkout
+/// or `$HOME` and silently opt into its auto-resolution policies. Outside a
+/// git worktree entirely, only `start` itself is consulted.
 fn find_config(start: &Path) -> Option<PathBuf> {
-    start.ancestors().find_map(|dir| {
+    let config_in = |dir: &Path| {
         let candidate = dir.join("sqlmerge.toml");
         candidate.is_file().then_some(candidate)
-    })
+    };
+
+    // `.git` marks the worktree root (a directory in a plain checkout, a file
+    // in a linked worktree or submodule). Locate the boundary first: only the
+    // directories from `start` up to and including it are searched.
+    let Some(root) = start.ancestors().find(|dir| dir.join(".git").exists()) else {
+        // Not inside a git worktree: honor only a config sitting right next
+        // to the invocation, never an ancestor's.
+        return config_in(start);
+    };
+
+    for dir in start.ancestors() {
+        if let Some(found) = config_in(dir) {
+            return Some(found);
+        }
+        if dir == root {
+            return None;
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -286,6 +313,51 @@ mod tests {
         )
         .expect_err("unknown policy should fail");
         assert!(matches!(err, ConfigError::Parse { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn config_search_stops_at_the_worktree_root() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        // Layout: tmp/sqlmerge.toml (ancestor config that must NOT apply)
+        //         tmp/repo/.git/    (worktree root, no config)
+        //         tmp/repo/sub/     (invocation dir)
+        std::fs::write(
+            tmp.path().join("sqlmerge.toml"),
+            "[policies]\n\"*\" = \"theirs\"\n",
+        )
+        .expect("write ancestor config");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).expect("mk .git");
+        let sub = repo.join("sub");
+        std::fs::create_dir_all(&sub).expect("mk sub");
+
+        // From inside the repo, the ancestor config is out of bounds.
+        assert!(find_config(&sub).is_none());
+        assert!(find_config(&repo).is_none());
+
+        // A config at the worktree root itself applies, from any depth.
+        std::fs::write(repo.join("sqlmerge.toml"), "[policies]\n").expect("write root config");
+        assert_eq!(find_config(&sub), Some(repo.join("sqlmerge.toml")));
+        assert_eq!(find_config(&repo), Some(repo.join("sqlmerge.toml")));
+    }
+
+    #[test]
+    fn outside_a_worktree_only_the_start_dir_is_consulted() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("sqlmerge.toml"),
+            "[policies]\n\"*\" = \"theirs\"\n",
+        )
+        .expect("write ancestor config");
+        let plain = tmp.path().join("plain");
+        std::fs::create_dir_all(&plain).expect("mk plain");
+
+        // No .git anywhere under the tempdir: the ancestor config is ignored.
+        assert!(find_config(&plain).is_none());
+
+        // But a config in the invocation dir itself still applies.
+        std::fs::write(plain.join("sqlmerge.toml"), "[policies]\n").expect("write local config");
+        assert_eq!(find_config(&plain), Some(plain.join("sqlmerge.toml")));
     }
 
     #[test]

--- a/packages/sqlmerge/src/lib.rs
+++ b/packages/sqlmerge/src/lib.rs
@@ -7,9 +7,11 @@
 //!
 //! Built by Claude Code.
 
+pub mod config;
 pub mod error;
 pub mod merge;
 pub mod schema;
 
+pub use config::{ConfigError, PolicyConfig};
 pub use error::{MergeError, Result};
 pub use merge::{ConflictPolicy, merge};

--- a/packages/sqlmerge/src/main.rs
+++ b/packages/sqlmerge/src/main.rs
@@ -7,7 +7,7 @@
 
 use std::process::ExitCode;
 
-use sqlmerge::{ConflictPolicy, merge};
+use sqlmerge::{PolicyConfig, merge};
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
@@ -25,7 +25,26 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     };
 
-    match merge(base, ours, theirs, ConflictPolicy::Abort) {
+    // Resolve per-table policy from `sqlmerge.toml` at the repo root. git runs
+    // the driver with CWD = the worktree root, so we walk up from CWD to find
+    // it. Absent file = abort every conflict (the pre-config default). A
+    // malformed config is a loud refusal, never a silent fall-back to abort.
+    let cwd = match std::env::current_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            eprintln!("sqlmerge: cannot determine current directory: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let policies = match PolicyConfig::load_from(&cwd) {
+        Ok(policies) => policies,
+        Err(e) => {
+            eprintln!("sqlmerge: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match merge(base, ours, theirs, &policies) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("sqlmerge: {e}");

--- a/packages/sqlmerge/src/merge.rs
+++ b/packages/sqlmerge/src/merge.rs
@@ -12,8 +12,10 @@
 //!   - a row theirs inserted that ours also inserted with different values at
 //!     the same PK: `CONFLICT`, abort.
 //!
-//! Conflicts are captured per-row and reported; the default policy aborts the
-//! whole apply (no partial writes).
+//! Conflicts are captured per-row and reported. What happens to a conflicting
+//! row is set per-table by a [`crate::config::PolicyConfig`] read from
+//! `sqlmerge.toml`; the default (and the default for any unmatched table) is to
+//! abort the whole apply, so nothing is partially written.
 
 use std::sync::{Arc, Mutex, PoisonError};
 
@@ -22,17 +24,37 @@ use rusqlite::hooks::Action;
 use rusqlite::session::{ChangesetItem, ConflictAction, ConflictType, Session};
 use rusqlite::types::ValueRef;
 
+use crate::config::PolicyConfig;
 use crate::error::{MergeError, PrimaryKey, Result, RowConflict};
 use crate::schema;
 
-/// Conflict-resolution policy. v1 ships only [`ConflictPolicy::Abort`]; the
-/// enum exists so per-table policies (last-writer-wins, append-only) can be
-/// added later without reshaping the apply path.
+/// Conflict-resolution policy for one table. Selected per-table by a
+/// [`PolicyConfig`] read from `sqlmerge.toml`; the resolution from a table name
+/// to a policy is pure data (see [`crate::config`]) and this enum is the
+/// vocabulary the apply path acts on.
+///
+/// The mapping to `SQLite`'s conflict-handler return values is exact and
+/// constrained by the session docs: `SQLITE_CHANGESET_REPLACE` is only legal
+/// when the conflict type is `DATA` or `CONFLICT`; returning it for
+/// `NOTFOUND`/`CONSTRAINT` fails the whole apply with `SQLITE_MISUSE`. Each
+/// variant documents how it handles the types where REPLACE is illegal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ConflictPolicy {
     /// Any conflict aborts the entire merge (exit 1). No auto-resolution.
     #[default]
     Abort,
+    /// Keep ours on every conflict: omit the incoming change
+    /// (`SQLITE_CHANGESET_OMIT`, legal for every conflict type).
+    Ours,
+    /// Take theirs on conflict via `SQLITE_CHANGESET_REPLACE` for `DATA` and
+    /// `CONFLICT`. REPLACE is illegal for `NOTFOUND` (theirs edited a row ours
+    /// deleted: no target to replace) and `CONSTRAINT`, so those still abort.
+    Theirs,
+    /// Inserts win, mutations abort. A conflicting INSERT (`CONFLICT`: same PK,
+    /// different values) keeps ours (`OMIT`); a conflicting UPDATE or DELETE
+    /// (`DATA`/`NOTFOUND`) aborts. Benign duplicate inserts and convergent
+    /// deletes are already merged globally, before any policy is consulted.
+    AppendOnly,
 }
 
 /// Render a [`ValueRef`] as a short display string for conflict reporting.
@@ -217,15 +239,67 @@ fn describe_conflict(kind: &ConflictType, item: &ChangesetItem) -> RowConflict {
 /// - [`MergeError::BaseSchemaDiverged`]: the sides agree but base's schema
 ///   differs (the session diff needs identical table definitions).
 /// - [`MergeError::MissingPrimaryKey`]: a user table has no explicit PK.
-/// - [`MergeError::Conflicts`]: row-level conflicts under the abort policy.
+/// - [`MergeError::Conflicts`]: row-level conflicts that no table policy
+///   resolved (aborting tables, or `theirs`/`append-only` on a type they leave
+///   conflicting).
 /// - [`MergeError::IntegrityCheckFailed`] / [`MergeError::ForeignKeyCheckFailed`]:
 ///   the post-merge `PRAGMA` sweeps found violations.
 /// - [`MergeError::Sqlite`]: any underlying `SQLite` failure.
+/// How the conflict handler should respond to one conflicting row under a given
+/// policy: either resolve it (returning the `SQLite` action, no report) or
+/// treat it as an unresolved conflict (capture + abort).
+enum Resolution {
+    /// The policy resolves this row; return this action, do not report it.
+    Resolve(ConflictAction),
+    /// The policy leaves this row conflicting; capture it and abort the apply.
+    Conflict,
+}
+
+/// Pure decision: given the resolved per-table `policy`, the conflict `kind`,
+/// and the changeset op's `action`, decide how to respond.
+///
+/// This is the whole policy switch, kept in one pure function rather than
+/// scattered through the C callback. Foreign-key conflicts never reach here:
+/// they have no table (so no policy) and are handled before this is called.
+///
+/// The `SQLITE_CHANGESET_REPLACE` return is only legal for `DATA` and
+/// `CONFLICT`; every other type that a policy would want to "take theirs" on
+/// falls back to [`Resolution::Conflict`] rather than returning an illegal
+/// REPLACE (which would fail the entire apply with `SQLITE_MISUSE`).
+const fn resolve_conflict(
+    policy: ConflictPolicy,
+    kind: &ConflictType,
+    action: Action,
+) -> Resolution {
+    match policy {
+        ConflictPolicy::Abort => Resolution::Conflict,
+
+        // Keep ours: OMIT is legal for every conflict type.
+        ConflictPolicy::Ours => Resolution::Resolve(ConflictAction::SQLITE_CHANGESET_OMIT),
+
+        // Take theirs: REPLACE only where SQLite allows it.
+        ConflictPolicy::Theirs => match kind {
+            ConflictType::SQLITE_CHANGESET_DATA | ConflictType::SQLITE_CHANGESET_CONFLICT => {
+                Resolution::Resolve(ConflictAction::SQLITE_CHANGESET_REPLACE)
+            }
+            // NOTFOUND (theirs edited a row ours deleted) and CONSTRAINT cannot
+            // be REPLACEd: there is no target row to overwrite. Conflict.
+            _ => Resolution::Conflict,
+        },
+
+        // Append-only: a conflicting insert keeps ours; mutations conflict.
+        ConflictPolicy::AppendOnly => match action {
+            Action::SQLITE_INSERT => Resolution::Resolve(ConflictAction::SQLITE_CHANGESET_OMIT),
+            _ => Resolution::Conflict,
+        },
+    }
+}
+
 pub fn merge(
     base_path: &str,
     ours_path: &str,
     theirs_path: &str,
-    policy: ConflictPolicy,
+    policies: &PolicyConfig,
 ) -> Result<()> {
     // Open theirs as the working connection so we can diff base against it.
     let theirs = Connection::open(theirs_path)?;
@@ -262,19 +336,46 @@ pub fn merge(
     };
     theirs.execute_batch("DETACH DATABASE base")?;
 
-    // Apply the changeset to ours. The conflict handler captures every conflict
-    // and, under the Abort policy, aborts the whole apply so nothing is written.
+    // Apply the changeset to ours. The conflict handler resolves each row per
+    // the table's policy; anything left conflicting is captured and aborts the
+    // whole apply, so an unresolved merge writes nothing.
     let conflicts: Arc<Mutex<Vec<RowConflict>>> = Arc::new(Mutex::new(Vec::new()));
     let sink = Arc::clone(&conflicts);
+    let policies = policies.clone();
     let conflict_handler = move |kind: ConflictType, item: ChangesetItem| -> ConflictAction {
+        // Globally benign cases: identical inserts and convergent deletes
+        // converge regardless of policy, and carry no policy question.
         if is_benign_duplicate_insert(&kind, &item) || is_convergent_delete(&kind, &item) {
             return ConflictAction::SQLITE_CHANGESET_OMIT;
         }
-        sink.lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .push(describe_conflict(&kind, &item));
-        match policy {
-            ConflictPolicy::Abort => ConflictAction::SQLITE_CHANGESET_ABORT,
+
+        // Foreign-key conflicts have no table or op (only `fk_conflicts()` is
+        // legal). There is no per-table policy to consult, and OMIT would
+        // commit the violation, so a deferred-FK conflict always aborts.
+        if kind == ConflictType::SQLITE_CHANGESET_FOREIGN_KEY {
+            sink.lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(describe_conflict(&kind, &item));
+            return ConflictAction::SQLITE_CHANGESET_ABORT;
+        }
+
+        // Every other conflict type carries an op with a table name and action.
+        // If the op is somehow unavailable, fall back to the abort policy
+        // rather than guessing.
+        let (table, action) = item.op().map_or_else(
+            |_| (String::new(), Action::UNKNOWN),
+            |op| (op.table_name().to_string(), op.code()),
+        );
+        let policy = policies.policy_for(&table);
+
+        match resolve_conflict(policy, &kind, action) {
+            Resolution::Resolve(resolved) => resolved,
+            Resolution::Conflict => {
+                sink.lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .push(describe_conflict(&kind, &item));
+                ConflictAction::SQLITE_CHANGESET_ABORT
+            }
         }
     };
 

--- a/packages/sqlmerge/src/merge.rs
+++ b/packages/sqlmerge/src/merge.rs
@@ -28,10 +28,11 @@ use crate::config::PolicyConfig;
 use crate::error::{MergeError, PrimaryKey, Result, RowConflict};
 use crate::schema;
 
-/// Conflict-resolution policy for one table. Selected per-table by a
-/// [`PolicyConfig`] read from `sqlmerge.toml`; the resolution from a table name
-/// to a policy is pure data (see [`crate::config`]) and this enum is the
-/// vocabulary the apply path acts on.
+/// Conflict-resolution policy for one table.
+///
+/// Selected per-table by a [`PolicyConfig`] read from `sqlmerge.toml`; the
+/// resolution from a table name to a policy is pure data (see
+/// [`crate::config`]) and this enum is the vocabulary the apply path acts on.
 ///
 /// The mapping to `SQLite`'s conflict-handler return values is exact and
 /// constrained by the session docs: `SQLITE_CHANGESET_REPLACE` is only legal
@@ -225,26 +226,6 @@ fn describe_conflict(kind: &ConflictType, item: &ChangesetItem) -> RowConflict {
     }
 }
 
-/// Compute the `base -> theirs` changeset and apply it onto `ours` in place.
-///
-/// `ours_path` is opened read-write; on a clean merge it holds the merged
-/// result. `sqlite3changeset_apply` runs inside a savepoint, so an aborted
-/// apply leaves `ours` untouched.
-///
-/// # Errors
-///
-/// Every refusal maps to exit code 1 in the binary:
-///
-/// - [`MergeError::SchemaDiverged`]: the two sides' `sqlite_schema` differs.
-/// - [`MergeError::BaseSchemaDiverged`]: the sides agree but base's schema
-///   differs (the session diff needs identical table definitions).
-/// - [`MergeError::MissingPrimaryKey`]: a user table has no explicit PK.
-/// - [`MergeError::Conflicts`]: row-level conflicts that no table policy
-///   resolved (aborting tables, or `theirs`/`append-only` on a type they leave
-///   conflicting).
-/// - [`MergeError::IntegrityCheckFailed`] / [`MergeError::ForeignKeyCheckFailed`]:
-///   the post-merge `PRAGMA` sweeps found violations.
-/// - [`MergeError::Sqlite`]: any underlying `SQLite` failure.
 /// How the conflict handler should respond to one conflicting row under a given
 /// policy: either resolve it (returning the `SQLite` action, no report) or
 /// treat it as an unresolved conflict (capture + abort).
@@ -295,6 +276,26 @@ const fn resolve_conflict(
     }
 }
 
+/// Compute the `base -> theirs` changeset and apply it onto `ours` in place.
+///
+/// `ours_path` is opened read-write; on a clean merge it holds the merged
+/// result. `sqlite3changeset_apply` runs inside a savepoint, so an aborted
+/// apply leaves `ours` untouched.
+///
+/// # Errors
+///
+/// Every refusal maps to exit code 1 in the binary:
+///
+/// - [`MergeError::SchemaDiverged`]: the two sides' `sqlite_schema` differs.
+/// - [`MergeError::BaseSchemaDiverged`]: the sides agree but base's schema
+///   differs (the session diff needs identical table definitions).
+/// - [`MergeError::MissingPrimaryKey`]: a user table has no explicit PK.
+/// - [`MergeError::Conflicts`]: row-level conflicts that no table policy
+///   resolved (aborting tables, or `theirs`/`append-only` on a type they leave
+///   conflicting).
+/// - [`MergeError::IntegrityCheckFailed`] / [`MergeError::ForeignKeyCheckFailed`]:
+///   the post-merge `PRAGMA` sweeps found violations.
+/// - [`MergeError::Sqlite`]: any underlying `SQLite` failure.
 pub fn merge(
     base_path: &str,
     ours_path: &str,

--- a/packages/sqlmerge/tests/merge.rs
+++ b/packages/sqlmerge/tests/merge.rs
@@ -357,8 +357,8 @@ fn ours_policy_keeps_our_value_on_data_conflict() {
     assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 1"), 111);
 }
 
-/// Under `theirs`, a DATA conflict (both edited the same row) is REPLACEd with
-/// theirs's value.
+/// Under `theirs`, a DATA conflict (both edited the same row) is `REPLACEd`
+/// with theirs's value.
 #[test]
 fn theirs_policy_takes_their_value_on_data_conflict() {
     let f = seeded_users();
@@ -372,7 +372,7 @@ fn theirs_policy_takes_their_value_on_data_conflict() {
 }
 
 /// Under `theirs`, a CONFLICT-type row (both inserted the same PK with
-/// different values) is REPLACEd with theirs.
+/// different values) is `REPLACEd` with theirs.
 #[test]
 fn theirs_policy_replaces_conflicting_insert() {
     let f = seeded_users();
@@ -388,7 +388,7 @@ fn theirs_policy_replaces_conflicting_insert() {
 
 /// REPLACE is illegal for a NOTFOUND conflict (theirs updated a row ours
 /// deleted). Under `theirs`, that row must still abort rather than return an
-/// illegal REPLACE that would fail the whole apply with SQLITE_MISUSE.
+/// illegal REPLACE that would fail the whole apply with `SQLITE_MISUSE`.
 #[test]
 fn theirs_policy_aborts_on_notfound_update() {
     let f = seeded_users();

--- a/packages/sqlmerge/tests/merge.rs
+++ b/packages/sqlmerge/tests/merge.rs
@@ -7,8 +7,13 @@
 use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
-use sqlmerge::{ConflictPolicy, MergeError, merge};
+use sqlmerge::{MergeError, PolicyConfig, merge};
 use tempfile::TempDir;
+
+/// Parse a `sqlmerge.toml` body into a [`PolicyConfig`] for a test.
+fn policies(toml: &str) -> PolicyConfig {
+    PolicyConfig::load_body(toml).expect("valid test config")
+}
 
 /// A base/ours/theirs fixture triple living in one tempdir.
 struct Fixture {
@@ -32,12 +37,18 @@ impl Fixture {
         }
     }
 
+    /// Run the merge under the all-abort default (no `sqlmerge.toml`).
     fn run(&self) -> sqlmerge::Result<()> {
+        self.run_with(&PolicyConfig::abort_all())
+    }
+
+    /// Run the merge under an explicit policy config.
+    fn run_with(&self, policies: &PolicyConfig) -> sqlmerge::Result<()> {
         merge(
             path(&self.base),
             path(&self.ours),
             path(&self.theirs),
-            ConflictPolicy::Abort,
+            policies,
         )
     }
 }
@@ -328,4 +339,143 @@ fn preexisting_dangling_fk_caught_by_post_merge_check() {
         panic!("expected ForeignKeyCheckFailed, got {err:?}");
     };
     assert!(!rows.is_empty());
+}
+
+// --- per-table conflict policies (sqlmerge.toml) ---------------------------
+
+/// The same-cell divergent edit that aborts by default is resolved to ours
+/// under the `ours` policy: the incoming change is omitted, ours is kept.
+#[test]
+fn ours_policy_keeps_our_value_on_data_conflict() {
+    let f = seeded_users();
+    build(&f.ours, "UPDATE users SET score = 111 WHERE id = 1;");
+    build(&f.theirs, "UPDATE users SET score = 222 WHERE id = 1;");
+
+    f.run_with(&policies("[policies]\n\"users\" = \"ours\"\n"))
+        .expect("ours policy resolves the conflict");
+
+    assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 1"), 111);
+}
+
+/// Under `theirs`, a DATA conflict (both edited the same row) is REPLACEd with
+/// theirs's value.
+#[test]
+fn theirs_policy_takes_their_value_on_data_conflict() {
+    let f = seeded_users();
+    build(&f.ours, "UPDATE users SET score = 111 WHERE id = 1;");
+    build(&f.theirs, "UPDATE users SET score = 222 WHERE id = 1;");
+
+    f.run_with(&policies("[policies]\n\"users\" = \"theirs\"\n"))
+        .expect("theirs policy resolves the conflict");
+
+    assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 1"), 222);
+}
+
+/// Under `theirs`, a CONFLICT-type row (both inserted the same PK with
+/// different values) is REPLACEd with theirs.
+#[test]
+fn theirs_policy_replaces_conflicting_insert() {
+    let f = seeded_users();
+    build(&f.ours, "INSERT INTO users VALUES (7, 'ours', 70);");
+    build(&f.theirs, "INSERT INTO users VALUES (7, 'theirs', 77);");
+
+    f.run_with(&policies("[policies]\n\"users\" = \"theirs\"\n"))
+        .expect("theirs policy resolves the insert conflict");
+
+    assert_eq!(read_text(&f.ours, "SELECT name FROM users WHERE id = 7"), "theirs");
+    assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 7"), 77);
+}
+
+/// REPLACE is illegal for a NOTFOUND conflict (theirs updated a row ours
+/// deleted). Under `theirs`, that row must still abort rather than return an
+/// illegal REPLACE that would fail the whole apply with SQLITE_MISUSE.
+#[test]
+fn theirs_policy_aborts_on_notfound_update() {
+    let f = seeded_users();
+    build(&f.ours, "DELETE FROM users WHERE id = 1;");
+    build(&f.theirs, "UPDATE users SET score = 222 WHERE id = 1;");
+
+    let err = f
+        .run_with(&policies("[policies]\n\"users\" = \"theirs\"\n"))
+        .expect_err("theirs cannot REPLACE a NOTFOUND row");
+    let MergeError::Conflicts(conflicts) = err else {
+        panic!("expected Conflicts, got {err:?}");
+    };
+    assert_eq!(conflicts[0].table, "users");
+    // Aborted apply leaves ours untouched: alice stays deleted.
+    assert_eq!(read_int(&f.ours, "SELECT count(*) FROM users WHERE id = 1"), 0);
+}
+
+/// Under `append-only`, a conflicting INSERT (same PK, different values) keeps
+/// ours (the incoming insert is omitted).
+#[test]
+fn append_only_keeps_ours_on_conflicting_insert() {
+    let f = seeded_users();
+    build(&f.ours, "INSERT INTO users VALUES (8, 'ours', 80);");
+    build(&f.theirs, "INSERT INTO users VALUES (8, 'theirs', 88);");
+
+    f.run_with(&policies("[policies]\n\"users\" = \"append-only\"\n"))
+        .expect("append-only omits the conflicting insert");
+
+    assert_eq!(read_text(&f.ours, "SELECT name FROM users WHERE id = 8"), "ours");
+    assert_eq!(read_int(&f.ours, "SELECT count(*) FROM users WHERE id = 8"), 1);
+}
+
+/// Under `append-only`, a conflicting UPDATE still aborts: only inserts win.
+#[test]
+fn append_only_aborts_on_update_conflict() {
+    let f = seeded_users();
+    build(&f.ours, "UPDATE users SET score = 111 WHERE id = 1;");
+    build(&f.theirs, "UPDATE users SET score = 222 WHERE id = 1;");
+
+    let err = f
+        .run_with(&policies("[policies]\n\"users\" = \"append-only\"\n"))
+        .expect_err("append-only aborts an update conflict");
+    let MergeError::Conflicts(conflicts) = err else {
+        panic!("expected Conflicts, got {err:?}");
+    };
+    assert_eq!(conflicts[0].table, "users");
+    assert_eq!(read_int(&f.ours, "SELECT score FROM users WHERE id = 1"), 111);
+}
+
+/// A glob applies the policy to matching tables and leaves the rest on the
+/// abort default: `cache_*` takes theirs, `users` (unmatched) still aborts.
+#[test]
+fn glob_scopes_policy_to_matching_tables() {
+    let f = Fixture::new();
+    build(
+        &f.base,
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, score INTEGER NOT NULL);\n\
+         CREATE TABLE cache_hot (id INTEGER PRIMARY KEY, v INTEGER NOT NULL);\n\
+         INSERT INTO users VALUES (1, 10);\n\
+         INSERT INTO cache_hot VALUES (1, 100);",
+    );
+    copy_db(&f.base, &f.ours);
+    copy_db(&f.base, &f.theirs);
+
+    // A conflict in cache_hot (theirs wins) and a clean edit in users.
+    build(&f.ours, "UPDATE cache_hot SET v = 111 WHERE id = 1;");
+    build(&f.theirs, "UPDATE cache_hot SET v = 222 WHERE id = 1;");
+
+    f.run_with(&policies("[policies]\n\"cache_*\" = \"theirs\"\n"))
+        .expect("cache_* conflict resolves to theirs");
+
+    assert_eq!(read_int(&f.ours, "SELECT v FROM cache_hot WHERE id = 1"), 222);
+
+    // And a conflict in the unmatched `users` table still aborts.
+    let f2 = Fixture::new();
+    build(
+        &f2.base,
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, score INTEGER NOT NULL);\n\
+         INSERT INTO users VALUES (1, 10);",
+    );
+    copy_db(&f2.base, &f2.ours);
+    copy_db(&f2.base, &f2.theirs);
+    build(&f2.ours, "UPDATE users SET score = 111 WHERE id = 1;");
+    build(&f2.theirs, "UPDATE users SET score = 222 WHERE id = 1;");
+
+    let err = f2
+        .run_with(&policies("[policies]\n\"cache_*\" = \"theirs\"\n"))
+        .expect_err("users is unmatched and still aborts");
+    assert!(matches!(err, MergeError::Conflicts(_)), "got {err:?}");
 }


### PR DESCRIPTION
Adds declarative, per-table conflict resolution to the `sqlmerge` git merge driver, filling in the policy seam #1876 left as `ConflictPolicy::Abort`-only.

Closes #1885.

## What

A `sqlmerge.toml` at the repo root maps a table-name **glob** to a policy:

```toml
[policies]
"cache_*" = "theirs"
"events"  = "append-only"
"*"       = "abort"       # catch-all; also the implicit default
```

| policy        | on a conflicting row                                              |
| ------------- | ---------------------------------------------------------------- |
| `abort`       | abort the whole merge (default; unchanged behavior)              |
| `ours`        | keep ours (`SQLITE_CHANGESET_OMIT`)                             |
| `theirs`      | take theirs (`SQLITE_CHANGESET_REPLACE`) where SQLite allows it  |
| `append-only` | conflicting insert keeps ours; conflicting update/delete aborts |

Precedence when several globs match: **first listed wins** (declaration order, recovered from TOML value spans since `toml::Table` iterates sorted). No `sqlmerge.toml` = every table aborts, identical to today. A malformed config is a loud refusal, never a silent fall-back.

## Correctness notes

- **`theirs` REPLACE caveat.** Per the [SQLite session docs](https://sqlite.org/session/sqlite3changeset_apply.html), `SQLITE_CHANGESET_REPLACE` is legal **only** for the `DATA` and `CONFLICT` conflict types. For `NOTFOUND` (theirs edited a row ours deleted — no target to overwrite) or `CONSTRAINT`, returning REPLACE fails the entire apply with `SQLITE_MISUSE`, so `theirs` still aborts on those. Covered by `theirs_policy_aborts_on_notfound_update`.
- **Foreign-key conflicts always abort**, regardless of policy: a deferred `FOREIGN_KEY` conflict has no table (no policy to consult) and omitting it would commit an FK-violating database.

## House style: data vs machinery

- New `config` module: pure data — parses `sqlmerge.toml` into `PolicyConfig` and answers `policy_for(table)`. No SQLite, no apply logic.
- The merge engine consults the resolved policy per conflicting row via one pure `resolve_conflict` switch, not policy branches scattered through the C callback.

## Deps

`toml` (features `parse`, `serde`, matching `config-launch`) and `glob` are already workspace deps in the lockfile — no new registry crates, only three dep edges added to the `sqlmerge` lock entry.

## Tests

- Unit (`config`): exact/`*`/`?` glob match, first-listed precedence, catch-all default, unknown-policy and bad-glob typed errors.
- Integration (mirror `tests/merge.rs`): each policy end-to-end, the REPLACE-invalid `NOTFOUND`-under-`theirs` case, and glob scoping (matched table resolves, unmatched still aborts).

## Validation

- `nix build .#sqlmerge` (darwin): pass.
- `cargo test -p sqlmerge`: 12 unit + 20 integration pass.
- `nix run .#lint`: pass.
- Native `cargo clippy` on the new code is clean (const fn, `map_or_else`, doc-paragraph fixes applied). The pinned x86-linux `llm-clippy` fork check runs in CI here; will fix event-driven if it flags anything.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add declarative per-table conflict policy via `sqlmerge.toml`
> - Adds a `sqlmerge.toml` config file format with a `[policies]` table mapping glob patterns to conflict policies (`abort`, `ours`, `theirs`, `append-only`), parsed by the new [config.rs](https://github.com/indexable-inc/index/pull/1889/files#diff-3e10051166432d3a6b022065a242f27d410643019e683204190a489c3f72e173) module.
> - `PolicyConfig` is discovered by searching upward from the working directory, bounded by the git worktree root; an absent file defaults to abort-all behavior.
> - Extends `ConflictPolicy` in [merge.rs](https://github.com/indexable-inc/index/pull/1889/files#diff-803b552d679656ff0424c73834f380f6ffeeb75d3e22ea0db79ab3b2cf4949c5) with `Ours`, `Theirs`, and `AppendOnly` variants, and adds `resolve_conflict()` to centralize per-row decisions. Foreign-key conflicts always abort regardless of policy.
> - The CLI in [main.rs](https://github.com/indexable-inc/index/pull/1889/files#diff-85b6cf4867c5b0538d2a4b671e4caeb9a2271539359b07d83cd967b0e336b2dd) now loads `PolicyConfig` from the current directory and passes it to `merge()` instead of a fixed `ConflictPolicy::Abort`.
> - Behavioral Change: the `merge()` function signature now takes `&PolicyConfig` instead of `ConflictPolicy`; malformed or invalid `sqlmerge.toml` files cause immediate CLI failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd12ff2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->