### PR TITLE
examples: add fleet/hello multi-node starter

### DIFF
--- a/examples/fleet/hello/README.md
+++ b/examples/fleet/hello/README.md
@@ -1,0 +1,43 @@
+# Fleet hello
+
+The smallest multi-node fleet: one `web` node and three `worker` replicas,
+the ix analog of a Kubernetes Service plus a 3-replica Deployment.
+
+`web` serves a static page over HTTP and exposes it to the fleet's east-west
+group. Each worker resolves the listener by name with
+`ix.endpointOf nodes.web "http"` and proves reachability through its health
+check, so the generated up wrapper only reports healthy once every worker can
+reach the web node.
+
+## Run
+
+```sh
+# From the index repo root.
+nix run .#fleet-hello-up
+```
+
+## Shape
+
+- [`ix.nix`](ix.nix) defines the fleet: one `web` node and a `worker` node
+  with `replicas = 3`, all in one east-west group, with `dependsOn` so the
+  web node boots first.
+- [`web.nix`](web.nix) runs nginx and declares `ix.networking.expose.http`,
+  which opens the firewall, registers the port claim, and names the endpoint
+  workers resolve.
+- [`worker.nix`](worker.nix) resolves that endpoint and curls it as its
+  health check.
+
+## Verify
+
+```sh
+ix shell worker-0 -- curl --fail http://web:8080/
+```
+
+Replicas are numbered `worker-0` through `worker-2`; each reaches `web` by
+its node name over the east-west network.
+
+## Scale
+
+Worker count is one line: raise `worker.replicas` in [`ix.nix`](ix.nix).
+Nothing else changes; new replicas join the group and pick up the same
+health check.

--- a/examples/fleet/hello/flake.nix
+++ b/examples/fleet/hello/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "ix example: fleet-hello";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    index = {
+      url = "github:indexable-inc/index";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {index, ...}: let
+    fleet = import ./ix.nix {inherit index;};
+  in {
+    ix.fleets.default = fleet;
+    inherit (fleet) nixosConfigurations;
+  };
+}

--- a/examples/fleet/hello/ix.nix
+++ b/examples/fleet/hello/ix.nix
@@ -1,0 +1,18 @@
+{index}: let
+  eastWestGroup = "fleet-hello";
+in
+  index.lib.mkFleet {
+    nodes = {
+      web = {
+        groups = [eastWestGroup];
+        modules = [./web.nix];
+      };
+
+      worker = {
+        replicas = 3;
+        dependsOn = ["web"];
+        groups = [eastWestGroup];
+        modules = [./worker.nix];
+      };
+    };
+  }

--- a/examples/fleet/hello/web.nix
+++ b/examples/fleet/hello/web.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  httpPort = 8080;
+in {
+  services.nginx = {
+    enable = true;
+    virtualHosts."fleet-hello" = {
+      default = true;
+      listen = [
+        {
+          addr = "0.0.0.0";
+          port = httpPort;
+        }
+      ];
+      locations."/".return = "200 'hello from the fleet\n'";
+    };
+  };
+
+  # One declaration opens the firewall, registers the port claim, and lets
+  # workers resolve this listener with `ix.endpointOf nodes.web "http"`.
+  ix.networking.expose.http = {
+    port = httpPort;
+    description = "hello HTTP service for the fleet's workers";
+  };
+
+  ix.healthChecks = {
+    nginx.unit = "nginx";
+
+    http-loopback = {
+      description = "hello HTTP service answers locally";
+      command = [
+        (lib.getExe pkgs.curl)
+        "--fail"
+        "--silent"
+        "--show-error"
+        "http://127.0.0.1:${toString httpPort}/"
+      ];
+    };
+  };
+}

--- a/examples/fleet/hello/worker.nix
+++ b/examples/fleet/hello/worker.nix
@@ -1,0 +1,23 @@
+{
+  ix,
+  lib,
+  nodes,
+  pkgs,
+  ...
+}: let
+  # Resolve the web node's listener by the name it exposes it under.
+  web = ix.endpointOf nodes.web "http";
+in {
+  environment.systemPackages = [pkgs.curl];
+
+  ix.healthChecks.web-reachable = {
+    description = "web service is reachable from this worker";
+    command = [
+      (lib.getExe pkgs.curl)
+      "--fail"
+      "--silent"
+      "--show-error"
+      "http://${web}/"
+    ];
+  };
+}


### PR DESCRIPTION
The smallest multi-node fleet example: one `web` node plus `worker` with `replicas = 3` in one east-west group, discovery via `ix.endpointOf nodes.web "http"`, `dependsOn`, and per-worker reachability health checks. The k8s Service + Deployment hello-world analog; the existing multi-node examples (ray/cluster, multi-client/file-sharing, east-west/firewall) all bury the fleet mechanics under a domain.

Validated locally: mkFleet eval yields `web`, `worker-0..2`; `worker-0`'s health check resolves to `http://web:8080/`; discovery exposes `fleet-hello-{up,health,replace,switch,diff}`; `nix run .#lint` clean.

Closes #1898

(authored by Claude Code, Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fleet/hello multi-node starter example with web and worker nodes
> - Adds a minimal fleet example in [examples/fleet/hello/](https://github.com/indexable-inc/index/pull/1899/files#diff-59ed5c7b9e076e20a977b5efbda22650da49046cfeae90a832cf1fd7cdfe5b96) using `index.lib.mkFleet`, with one `web` node and three `worker` replicas in a shared east-west group.
> - [web.nix](https://github.com/indexable-inc/index/pull/1899/files#diff-73037e03477dfc8c1e09d77fa5df75d525b4184c3db544d85d0f64dda64795eb) configures nginx on port 8080 serving a static response, exposes an HTTP endpoint via `ix.networking.expose.http`, and defines health checks for the nginx unit and HTTP endpoint.
> - [worker.nix](https://github.com/indexable-inc/index/pull/1899/files#diff-9de09eaa7e4a30ab8ced288cc964942e3959f8b47ec84047cd69c0e3dece0b69) defines a health check that resolves the web node's HTTP endpoint via `ix.endpointOf` and verifies reachability with curl.
> - [flake.nix](https://github.com/indexable-inc/index/pull/1899/files#diff-657b1bcb01bea9dc36f22385ddd7fe19b9b6433052ffda121643f4c5fbb03589) wires up `ix.fleets.default` and re-exports `nixosConfigurations` so the fleet can be built directly from flake outputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3a67c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->