### PR TITLE
fix(mcp): import re in tools.py so pr_watch works

### DIFF
--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -34,6 +34,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import sqlite3
 import uuid
 import weakref

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -403,3 +403,46 @@ def test_reply_tool_appends_event_for_live_resource(tmp_path: Path, monkeypatch:
         assert [(r["kind"], json.loads(r["body"])["text"]) for r in rows] == [("reply", "deployed ✓")]
 
     asyncio.run(run())
+
+
+def test_pr_watch_tool_returns_header_with_slugged_resource(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pr_watch's happy path up to the header (regression: NameError on `re`, #1900)."""
+
+    async def run() -> None:
+        from ix_notebook_mcp import tools
+
+        cfg = Config(workdir=tmp_path, store_path=tmp_path / "w.db")
+        monkeypatch.setattr("ix_notebook_mcp.tools.config", lambda: cfg)
+
+        async def gate(*_args: object, **_kwargs: object) -> None:
+            return None
+
+        monkeypatch.setattr(tools, "_start_dashboard_once", gate)
+        monkeypatch.setattr(tools, "_identify_client_once", gate)
+        monkeypatch.setattr(tools, "_require_session_name", gate)
+        monkeypatch.setattr(tools, "_require_topic", gate)
+
+        class FakeKernel:
+            async def python_exec(
+                self,
+                code: str,
+                budget: float,
+                intent: str,
+                *,
+                session: str | None = None,
+                topic: str | None = None,
+            ) -> tuple[list, dict]:
+                assert "watch_pr" in code
+                return [], {"id": "ab12", "status": "running", "running": True, "elapsed_s": 0.1}
+
+        monkeypatch.setattr(tools, "current_kernel", FakeKernel)
+
+        out = await tools.pr_watch("https://github.com/o/r/pull/1856", cwd=str(tmp_path))
+        header = json.loads(out[0].text)
+        # The URL is slugged into a resource id safe for the dashboard route.
+        assert header["resource"] == "pr-https-github.com-o-r-pull-1856"
+        assert header["job"] == "ab12"
+
+    asyncio.run(run())


### PR DESCRIPTION
`pr_watch` slugs its PR argument into a dashboard resource id with `re.sub` (tools.py:598), but the module never imported `re`, so every call died immediately with `name 're' is not defined`.

- Add the missing `import re` to `packages/mcp/ix_notebook_mcp/tools.py`.
- Add a regression test in `packages/mcp/tests/test_channel.py` (already wired as the `channelTests` nix check) that drives `pr_watch`'s happy path through the slugging line with a faked kernel and gates.

Validated: all 17 channel tests pass with the mcp interpreter; the one local `nix build .#mcp.tests.channelTests` failure (`test_sse_streams_new_events_only`, socket bind PermissionError) is a pre-existing darwin-sandbox limitation, reproduced on an unmodified tree. `nix run .#lint -- --json` is fully green.

Closes #1900

(authored by Claude Code, Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing `re` import in `tools.py` so `pr_watch` works
> Adds the missing `import re` statement to [`tools.py`](https://github.com/indexable-inc/index/pull/1901/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6), which caused a `NameError` at runtime when `pr_watch` was called. Also adds a regression test in [`test_channel.py`](https://github.com/indexable-inc/index/pull/1901/files#diff-f1684e518bfcf4f7df252a5c209b046a82ed7c2db27ff168d3e422b623323bbd) that invokes `pr_watch` with a GitHub PR URL and asserts the returned header contains a slugged `resource` and expected `job` id.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 239b8be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->