### PR TITLE
mcp: bring ix_notebook_mcp/tools.py into the strict type-check gate

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1425,12 +1425,23 @@
     "worktree"
     "mesh"
   ];
+  # The `ix_notebook_mcp` server package is migrated file-by-file (the package
+  # as a whole is still ~200 errors from strict-clean, index#1902): each file
+  # here is a check target inside the copied `ix_notebook_mcp/` tree. zuban
+  # only reports errors in the named targets, so a listed file's imports of
+  # still-unmigrated siblings do not drag their errors in.
+  strictGreenServerFiles = [
+    "tools.py"
+  ];
   strictTypecheck = let
     # All src module package dirs go on MYPYPATH so first-party cross-imports
     # resolve; the green subset are the actual check targets.
     allSrcModules = builtins.attrNames (builtins.readDir ./src);
     mypypath = lib.concatMapStringsSep ":" (m: "src/${m}") allSrcModules;
-    targets = lib.concatMapStringsSep " " (m: "src/${m}/${m}") strictGreenModules;
+    targets = lib.concatStringsSep " " (
+      map (m: "src/${m}/${m}") strictGreenModules
+      ++ map (f: "ix_notebook_mcp/${f}") strictGreenServerFiles
+    );
   in
     pkgs.runCommand "ix-mcp-strict-typecheck"
     {
@@ -1449,14 +1460,14 @@
       chmod -R u+w ix_notebook_mcp src
 
       export MYPYPATH=${lib.escapeShellArg mypypath}:.
-      echo "zuban check --strict over: ${toString strictGreenModules}"
+      echo "zuban check --strict over: ${toString strictGreenModules} + ix_notebook_mcp: ${toString strictGreenServerFiles}"
       zuban check --strict \
         --config-file zuban.ini \
         --python-executable ${mcpPython.interpreter} \
         --python-version ${pkgs.python3.pythonVersion} \
         --platform linux \
         ${targets}
-      echo "ruff check (ANN + TID251 no-cast) over: ${toString strictGreenModules}"
+      echo "ruff check (ANN + TID251 no-cast) over: ${toString strictGreenModules} + ix_notebook_mcp: ${toString strictGreenServerFiles}"
       ruff check ${ix.ruffAnnArgs} ${targets}
 
       mkdir -p "$out"

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -92,7 +92,9 @@ mcp = FastMCP("ix-mcp")
 
 # One short id per live MCP session, keyed weakly by the session object so an id
 # is stable for a client's whole session and the map never pins a closed one.
-_session_ids: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+# Keys are typed `object`: the session is only ever used as an identity key here
+# (see `_http_session`), never through the ServerSession API.
+_session_ids: weakref.WeakKeyDictionary[object, str] = weakref.WeakKeyDictionary()
 
 
 def _http_session(ctx: Context | None) -> object | None:
@@ -147,8 +149,8 @@ _dashboard_started = False
 # session instead of a long-lived `serve --http` advertising it forever
 # (index#1789 review). The one stdio/embedder client has no session object to
 # key on; its label lives in `_solo_session_name` and dies with the process.
-_session_labels: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
-_session_topics: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+_session_labels: weakref.WeakKeyDictionary[object, str] = weakref.WeakKeyDictionary()
+_session_topics: weakref.WeakKeyDictionary[object, str] = weakref.WeakKeyDictionary()
 _solo_session_name: str | None = None
 _solo_topic: str | None = None
 
@@ -660,12 +662,16 @@ _reply_conn: sqlite3.Connection | None = None
 def _reply_store() -> sqlite3.Connection:
     global _reply_conn
     if _reply_conn is None:
+        # `store_path` is None outside `serve` (e.g. an embedder driving the
+        # tools directly), which needs the same error as having no config at all.
         try:
             path = config().store_path
-        except RuntimeError as exc:
+        except RuntimeError:
+            path = None
+        if path is None:
             raise McpError(
                 ErrorData(code=types.INTERNAL_ERROR, message="no store configured; reply needs `ix-mcp serve`")
-            ) from exc
+            )
         from . import store
 
         _reply_conn = store.connect(path)
@@ -783,9 +789,13 @@ async def _read_resource_handler(uri: AnyUrl) -> list[ReadResourceContents]:
 
 
 # Register on the wrapped low-level server (overriding FastMCP's, which the
-# handlers above delegate back to for static resources).
-mcp._mcp_server.list_resources()(_list_resources_handler)
-mcp._mcp_server.read_resource()(_read_resource_handler)
+# handlers above delegate back to for static resources). The mcp SDK defines
+# these decorator factories with no annotations at all, so each call trips
+# disallow-untyped-calls under --strict; the handlers themselves are fully
+# typed and the returned decorators annotate their `func` parameter, so the
+# registration is still checked.
+mcp._mcp_server.list_resources()(_list_resources_handler)  # type: ignore[no-untyped-call]
+mcp._mcp_server.read_resource()(_read_resource_handler)  # type: ignore[no-untyped-call]
 
 
 @mcp.tool(


### PR DESCRIPTION
The zuban `strictGreenModules` gate only covered `src/*` modules, so `ix_notebook_mcp/tools.py` (the module defining most MCP tools) had no gate against undefined names: #1900's `pr_watch` NameError on a missing `import re` shipped and only failed at tool-call time. #1901 fixed the instance; this closes the class.

- Add a `strictGreenServerFiles` list to the `strictTypecheck` derivation so `ix_notebook_mcp` migrates file-by-file (the whole package is still ~200 zuban errors from strict-clean, so listing the package wholesale would balloon the diff), starting with `tools.py`.
- Make `tools.py` strict-clean (7 errors on the pre-#1901 tree, 6 after): parameterize the three `WeakKeyDictionary` session maps; reject a None `config().store_path` in `_reply_store` with the same McpError as having no config instead of passing None to `store.connect`; two targeted `no-untyped-call` ignores with a why-comment on the low-level handler registrations (the mcp SDK's `list_resources()`/`read_resource()` decorator factories carry no annotations; a callee-side zuban.ini per-module relaxation was tried first and zuban does not honor it).

Validated: `nix build .#mcp.tests.strictTypecheck` green with the new target; all 17 channel tests pass with the pinned mcp interpreter (the sandboxed `channelTests` `test_sse_streams_new_events_only` socket-bind PermissionError reproduces on an unmodified main tree, pre-existing darwin sandbox limitation); `nix run .#lint -- --json` green.

The remaining `ix_notebook_mcp` modules stay out of the set for now; noted on #1902.

Closes #1902

(authored by Claude Code, Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bring `ix_notebook_mcp/tools.py` into the strict type-check gate
> - Adds `tools.py` to the strict mypy/ruff check targets in [default.nix](https://github.com/indexable-inc/index/pull/1904/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) so it is validated alongside other `src` module targets.
> - Annotates the three `WeakKeyDictionary` module variables with explicit `WeakKeyDictionary[object, str]` type parameters to satisfy strict checking.
> - Adds `# type: ignore[no-untyped-call]` to the `list_resources`/`read_resource` decorator registrations where the MCP library lacks type annotations.
> - Fixes `_reply_store` to catch `RuntimeError` from `config().store_path` and raise `McpError(INTERNAL_ERROR, "no store configured; reply needs \`ix-mcp serve\`")` instead of propagating a bare exception or continuing with a `None` path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a997246.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->