### PR TITLE
nwm: machine-wide builds pane via `nix store builds --json`

### DIFF
--- a/packages/nix/nix-web-monitor/parser/src/global.rs
+++ b/packages/nix/nix-web-monitor/parser/src/global.rs
@@ -1,0 +1,275 @@
+//! Machine-wide build view (all active `nix` builds on the host).
+//!
+//! The rest of the monitor watches one `nix` invocation: its own build tree and
+//! the daemon syscalls that invocation drives. But a machine can be building for
+//! many reasons at once (a CI job, an editor's `nix develop`, another operator's
+//! switch), and none of that shows up in a single invocation's tree. This module
+//! owns the wire types for a *global* view fed by a patched-nix subcommand,
+//! `nix store builds --json`, which reads a daemon-independent status directory
+//! and lists every active build/substitution goal on the host, with the
+//! why-chain (root derivation -> ... -> this goal) and the cause that forced it.
+//!
+//! The subcommand is only present on a patched nix, so the whole view degrades
+//! gracefully: on stock nix the probe cannot parse a build list, marks the view
+//! undetected, and the UI hides the panel. The server owns polling the
+//! subcommand; this module owns the (pure, testable) wire types and the
+//! defensive JSON parse, so a minor schema drift on the C++ side yields `None`
+//! for the affected optional rather than crashing the probe.
+
+use serde::{Deserialize, Serialize};
+
+/// Why one build is happening.
+///
+/// The chain from the root derivation the operator asked for down to this goal,
+/// plus the cause that forced it. Every field is optional so a schema that omits
+/// one (or an entry with no known root) still deserializes; the UI renders
+/// whatever is present.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct GlobalWhy {
+    /// The derivation at the top of the want-chain: what was originally
+    /// requested (a `nix build .#app`), which this goal is a dependency of.
+    /// `None` when the source could not attribute a root.
+    pub root_drv_path: Option<String>,
+    /// Ordered chain of derivation paths from the root down to this goal, so the
+    /// UI can render `app -> ... -> foo`. May be empty.
+    pub chain: Vec<String>,
+    /// Why nix scheduled this goal: `requested`, `outputsMissing`,
+    /// `substitutionFailed`, `outputInvalid`, ... Left as a free string so a new
+    /// cause from the C++ side is surfaced verbatim rather than dropped.
+    pub cause: Option<String>,
+}
+
+/// The kind of goal: a local build or a substitution (fetch from a cache).
+///
+/// `#[serde(other)]` on [`Other`](GlobalBuildKind::Other) keeps an unknown kind
+/// from failing the whole parse; the UI shows it as a neutral badge.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GlobalBuildKind {
+    /// A derivation being built locally.
+    #[default]
+    Build,
+    /// A path being substituted (downloaded) from a binary cache.
+    Substitution,
+    /// A kind this build of the monitor does not know; surfaced, not dropped.
+    #[serde(other)]
+    Other,
+}
+
+/// One active build or substitution goal on the machine.
+///
+/// As reported by `nix store builds --json`.
+/// Fields are optional/defaulted because the exact schema is finalized on the
+/// C++ side in parallel: a substitution has no `drvPath` (it sets `storePath`),
+/// entries may omit `user`/`uid`/`logFile`, and `outputs` may be empty. Parsing
+/// stays lenient (unknown JSON fields ignored, missing optionals -> `None`) so a
+/// minor drift does not crash the probe.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct GlobalBuild {
+    /// The derivation being built. `None` for a substitution, which names a
+    /// `store_path` instead.
+    pub drv_path: Option<String>,
+    /// The store path being substituted. `None` for a local build.
+    pub store_path: Option<String>,
+    /// Wanted outputs (`out`, `dev`, ...). May be empty.
+    pub outputs: Vec<String>,
+    /// Build or substitution.
+    #[serde(rename = "type")]
+    pub kind: GlobalBuildKind,
+    /// The worker/builder pid, when the source reported one.
+    pub pid: Option<i64>,
+    /// Unix epoch *seconds* the goal started, for a live elapsed readout. `None`
+    /// when unknown. (Seconds, unlike the rest of the monitor's millisecond
+    /// timestamps -- the UI multiplies by 1000 before diffing against its clock.)
+    pub start_time: Option<i64>,
+    /// The client user that requested the build, when attributable.
+    pub user: Option<String>,
+    /// The client uid, when attributable.
+    pub uid: Option<i64>,
+    /// The build log file for this goal (a `.drv.bz2` under the nix log dir),
+    /// when the source recorded one. The server may stream it on request.
+    pub log_file: Option<String>,
+    /// The want-chain and cause that scheduled this goal.
+    pub why: GlobalWhy,
+}
+
+/// Wire-friendly snapshot of the machine-wide build view.
+///
+/// Mirrors [`DaemonInfo`](crate::DaemonInfo): `detected` is the analog of
+/// `tracing` (false when the subcommand is unavailable, i.e. stock nix), and
+/// `status` is the human line the UI shows ("not available (stock nix)",
+/// "12 active", or an error). The default is the undetected state, so a fresh
+/// `MonitorState` carries an empty view the UI hides until the probe flips it on.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GlobalBuilds {
+    /// Whether `nix store builds --json` is available and produced a build list.
+    /// False on stock nix (no such subcommand); the UI hides the panel.
+    pub detected: bool,
+    /// Active build/substitution goals on the machine, as last polled.
+    pub builds: Vec<GlobalBuild>,
+    /// Human state line, like [`DaemonInfo.status`](crate::DaemonInfo::status):
+    /// the availability note, the active count, or an error.
+    pub status: String,
+}
+
+impl Default for GlobalBuilds {
+    fn default() -> Self {
+        Self {
+            detected: false,
+            builds: Vec::new(),
+            status: "not available (stock nix)".to_owned(),
+        }
+    }
+}
+
+/// Parse the JSON array `nix store builds --json` prints into a list of goals.
+///
+/// Tolerant on purpose: unknown fields are ignored and missing optionals become
+/// `None` (see the `#[serde(default)]` on the row types), so a schema drift on
+/// the C++ side degrades one field rather than failing the whole probe.
+///
+/// # Errors
+///
+/// Returns a [`serde_json::Error`] when the payload is not a JSON array of the
+/// expected shape. The server treats that as "not detected": stock nix prints an
+/// "unknown command" error, not a build array, on the first poll.
+pub fn parse_builds(json: &str) -> Result<Vec<GlobalBuild>, serde_json::Error> {
+    serde_json::from_str(json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_full_build_with_why_chain() {
+        let json = r#"[
+            {
+                "drvPath": "/nix/store/aaa-foo.drv",
+                "storePath": null,
+                "outputs": ["out", "dev"],
+                "type": "build",
+                "pid": 12345,
+                "startTime": 1720200000,
+                "user": "alice",
+                "uid": 1000,
+                "logFile": "/nix/var/log/nix/drvs/ab/cdfoo.drv.bz2",
+                "why": {
+                    "rootDrvPath": "/nix/store/root-app.drv",
+                    "chain": ["/nix/store/root-app.drv", "/nix/store/aaa-foo.drv"],
+                    "cause": "outputsMissing"
+                }
+            }
+        ]"#;
+        let builds = parse_builds(json).expect("valid array parses");
+        assert_eq!(builds.len(), 1);
+        let build = &builds[0];
+        assert_eq!(build.drv_path.as_deref(), Some("/nix/store/aaa-foo.drv"));
+        assert_eq!(build.store_path, None);
+        assert_eq!(build.outputs, vec!["out".to_owned(), "dev".to_owned()]);
+        assert_eq!(build.kind, GlobalBuildKind::Build);
+        assert_eq!(build.pid, Some(12345));
+        assert_eq!(build.start_time, Some(1_720_200_000));
+        assert_eq!(build.user.as_deref(), Some("alice"));
+        assert_eq!(build.uid, Some(1000));
+        assert_eq!(
+            build.log_file.as_deref(),
+            Some("/nix/var/log/nix/drvs/ab/cdfoo.drv.bz2")
+        );
+        assert_eq!(
+            build.why.root_drv_path.as_deref(),
+            Some("/nix/store/root-app.drv")
+        );
+        assert_eq!(build.why.chain.len(), 2);
+        assert_eq!(build.why.cause.as_deref(), Some("outputsMissing"));
+    }
+
+    #[test]
+    fn parses_substitution_with_null_drv_path() {
+        let json = r#"[
+            {
+                "drvPath": null,
+                "storePath": "/nix/store/bbb-bar",
+                "outputs": [],
+                "type": "substitution",
+                "pid": 999,
+                "startTime": 1720200100,
+                "user": null,
+                "uid": null,
+                "logFile": null,
+                "why": {
+                    "rootDrvPath": null,
+                    "chain": [],
+                    "cause": "outputInvalid"
+                }
+            }
+        ]"#;
+        let builds = parse_builds(json).expect("valid array parses");
+        assert_eq!(builds.len(), 1);
+        let build = &builds[0];
+        assert_eq!(build.drv_path, None);
+        assert_eq!(build.store_path.as_deref(), Some("/nix/store/bbb-bar"));
+        assert!(build.outputs.is_empty());
+        assert_eq!(build.kind, GlobalBuildKind::Substitution);
+        assert_eq!(build.user, None);
+        assert_eq!(build.uid, None);
+        assert_eq!(build.log_file, None);
+        assert_eq!(build.why.root_drv_path, None);
+        assert!(build.why.chain.is_empty());
+        assert_eq!(build.why.cause.as_deref(), Some("outputInvalid"));
+    }
+
+    #[test]
+    fn parses_entry_missing_optional_fields() {
+        // A minimal entry: only the kind is present. Everything else defaults,
+        // proving the parse tolerates a source that omits fields entirely
+        // (rather than emitting explicit nulls).
+        let json = r#"[ { "type": "build" } ]"#;
+        let builds = parse_builds(json).expect("minimal entry parses");
+        assert_eq!(builds.len(), 1);
+        let build = &builds[0];
+        assert_eq!(build.kind, GlobalBuildKind::Build);
+        assert_eq!(build.drv_path, None);
+        assert_eq!(build.store_path, None);
+        assert!(build.outputs.is_empty());
+        assert_eq!(build.pid, None);
+        assert_eq!(build.start_time, None);
+        assert_eq!(build.why, GlobalWhy::default());
+    }
+
+    #[test]
+    fn unknown_kind_and_extra_fields_do_not_fail() {
+        // A future kind and an unknown top-level field must not break the parse:
+        // the kind falls back to `Other`, the extra field is ignored.
+        let json = r#"[
+            { "type": "coordinator", "someFutureField": 42, "outputs": ["out"] }
+        ]"#;
+        let builds = parse_builds(json).expect("tolerant of drift");
+        assert_eq!(builds.len(), 1);
+        assert_eq!(builds[0].kind, GlobalBuildKind::Other);
+        assert_eq!(builds[0].outputs, vec!["out".to_owned()]);
+    }
+
+    #[test]
+    fn empty_array_is_no_builds() {
+        assert!(parse_builds("[]").expect("empty array parses").is_empty());
+    }
+
+    #[test]
+    fn non_array_payload_errors() {
+        // Stock nix's "unknown subcommand" text is not a JSON array; the server
+        // relies on this being an error to mark the view undetected.
+        assert!(parse_builds("error: unknown flag").is_err());
+    }
+
+    #[test]
+    fn default_is_undetected() {
+        let default = GlobalBuilds::default();
+        assert!(!default.detected);
+        assert!(default.builds.is_empty());
+        assert!(!default.status.is_empty());
+    }
+}

--- a/packages/nix/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix/nix-web-monitor/parser/src/lib.rs
@@ -10,9 +10,11 @@ use snafu::Snafu;
 pub mod activation;
 pub mod build_view;
 pub mod daemon;
+pub mod global;
 pub use activation::{Activation, ActivationStatus, ActivationStep};
 pub use build_view::{ActivityRow, BuildCounts, BuildRow, BuildView};
 pub use daemon::{DaemonInfo, DaemonOps, OpClass};
+pub use global::{GlobalBuild, GlobalBuildKind, GlobalBuilds, GlobalWhy};
 
 const NIX_JSON_PREFIX: &str = "@nix ";
 
@@ -268,6 +270,10 @@ pub enum Delta {
     OptimiseSet { optimise: OptimiseStats },
     /// The live nix-daemon syscall view changed (new counts, path, or status).
     DaemonSet { daemon: DaemonInfo },
+    /// The machine-wide build view changed: the set of active builds/substitutions
+    /// on the host, or the detection/status line, moved. Carries the whole view,
+    /// like [`DaemonSet`](Delta::DaemonSet): the build list is small and polled.
+    GlobalSet { global: GlobalBuilds },
     /// The activation phase (a `switch`'s `activate` run) changed: a step opened
     /// or closed, a line landed, or the phase status moved. Carries the whole
     /// subtree, like [`DaemonSet`](Delta::DaemonSet): the step list is small.
@@ -305,6 +311,9 @@ pub struct MonitorState {
     pub optimise: OptimiseStats,
     /// Live nix-daemon syscall view, fed out-of-band by the server's tracer.
     pub daemon: DaemonInfo,
+    /// Machine-wide build view, fed out-of-band by the server's global probe.
+    /// `detected: false` on stock nix (the subcommand is unavailable).
+    pub global: GlobalBuilds,
     /// Live activation view, fed out-of-band by the server's switch orchestrator.
     /// Empty (`active: false`) on a plain `nix build`.
     pub activation: Activation,
@@ -394,6 +403,7 @@ impl MonitorState {
             progress: self.progress,
             optimise: self.optimise,
             daemon: self.daemon.clone(),
+            global: self.global.clone(),
             activation: self.activation.clone(),
             diff: self.diff.clone(),
             expected: self.expected.clone(),
@@ -487,6 +497,22 @@ impl MonitorState {
         self.daemon = daemon;
         self.emit(Delta::DaemonSet {
             daemon: self.daemon.clone(),
+        });
+    }
+
+    /// Replace the machine-wide build view and broadcast the change.
+    ///
+    /// Called by the server's global probe on its poll timer. Skips the broadcast
+    /// when nothing changed so an idle machine (or a stock nix that stays
+    /// undetected) does not put a frame on the wire every poll; the snapshot
+    /// still carries the latest value for a freshly-connected client.
+    pub fn set_global(&mut self, global: GlobalBuilds) {
+        if self.global == global {
+            return;
+        }
+        self.global = global;
+        self.emit(Delta::GlobalSet {
+            global: self.global.clone(),
         });
     }
 
@@ -1136,6 +1162,9 @@ pub struct MonitorSnapshot {
     pub optimise: OptimiseStats,
     /// Live nix-daemon syscall view, fed out-of-band by the server's tracer.
     pub daemon: DaemonInfo,
+    /// Machine-wide build view, fed out-of-band by the server's global probe.
+    /// `detected: false` on stock nix (the subcommand is unavailable).
+    pub global: GlobalBuilds,
     /// Live activation view, fed out-of-band by the server's switch orchestrator.
     pub activation: Activation,
     /// Generation diff text (`nvd diff`), set once at the end of a switch.

--- a/packages/nix/nix-web-monitor/server/site/src/App.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/App.svelte
@@ -6,6 +6,7 @@
   import DaemonPanel from '$components/DaemonPanel.svelte';
   import DiffPanel from '$components/DiffPanel.svelte';
   import ErrorPanel from '$components/ErrorPanel.svelte';
+  import GlobalPanel from '$components/GlobalPanel.svelte';
   import LogPanel from '$components/LogPanel.svelte';
   import SummaryBar from '$components/SummaryBar.svelte';
   import Splitter from '$lib/Splitter.svelte';
@@ -225,6 +226,7 @@
           <ActivationPanel activation={snapshot.activation} />
         {/if}
         <DiffPanel diff={snapshot.diff} />
+        <GlobalPanel global={snapshot.global} />
         <DaemonPanel daemon={snapshot.daemon} />
         <ActivityGraph activities={snapshot.activities} builds={snapshot.builds} />
       </aside>

--- a/packages/nix/nix-web-monitor/server/site/src/components/GlobalPanel.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/GlobalPanel.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import PanelHeader from '$lib/PanelHeader.svelte';
+  import { formatDuration, splitDerivation } from '$lib/format';
+  import { useNow } from '$lib/now.svelte';
+  import type { GlobalBuild, GlobalBuilds } from '$lib/types';
+
+  type Props = {
+    global: GlobalBuilds;
+  };
+
+  const { global }: Props = $props();
+
+  const now = useNow();
+
+  /// The store path a row identifies: the drv for a build, the store path for a
+  /// substitution. Either can be null on a drifted entry, so fall back to the
+  /// other and finally to a placeholder rather than rendering `null`.
+  function pathOf(build: GlobalBuild): string {
+    return build.drvPath ?? build.storePath ?? '(unknown)';
+  }
+
+  /// Short 'build' / 'sub' badge for the goal kind. Anything the C++ side adds
+  /// beyond the two known kinds is shown verbatim rather than dropped.
+  function badge(type: string): string {
+    if (type === 'build') return 'build';
+    if (type === 'substitution') return 'sub';
+    return type;
+  }
+
+  /// Live elapsed label from the goal's start. `startTime` is unix *seconds*
+  /// (unlike the rest of the monitor's ms timestamps), so scale to ms before
+  /// diffing against the reactive clock. Empty when the source gave no start.
+  function elapsed(startTimeSec: number | null): string {
+    if (startTimeSec === null) return '';
+    return formatDuration(now.value - startTimeSec * 1000);
+  }
+
+  /// Compact why-chain: the derivation names from the requested root down to this
+  /// goal, joined by arrows (`app → foo`). Falls back to the root alone, then to
+  /// the cause, so a row always explains itself even on a sparse entry.
+  function whyChain(build: GlobalBuild): string {
+    const chain = build.why.chain;
+    if (chain.length > 0) {
+      return chain.map((path) => splitDerivation(path).name).join(' → ');
+    }
+    if (build.why.rootDrvPath !== null) {
+      return splitDerivation(build.why.rootDrvPath).name;
+    }
+    return build.why.cause ?? '';
+  }
+</script>
+
+{#if global.detected}
+  <section class="panel global-panel">
+    <PanelHeader title="machine builds">
+      <span class="panel-meta">{global.builds.length}</span>
+    </PanelHeader>
+
+    <div class="global-body">
+      {#if global.builds.length === 0}
+        <div class="global-status">no machine builds right now</div>
+      {:else}
+        {#each global.builds as build (pathOf(build))}
+          {@const parts = splitDerivation(pathOf(build))}
+          <div class="global-row" title={pathOf(build)}>
+            <div class="global-row-head">
+              <span class="global-badge global-badge-{build.type}">{badge(build.type)}</span>
+              <span class="global-name">{parts.name || pathOf(build)}</span>
+              {#if parts.version}<span class="global-version">{parts.version}</span>{/if}
+              <span class="global-elapsed">{elapsed(build.startTime)}</span>
+            </div>
+            <div class="global-row-meta">
+              {#if build.user !== null}<span class="global-user">{build.user}</span>{/if}
+              {#if build.why.cause !== null}<span class="global-cause">{build.why.cause}</span>{/if}
+            </div>
+            {#if whyChain(build)}
+              <div class="global-why" title={build.why.rootDrvPath ?? ''}>{whyChain(build)}</div>
+            {/if}
+            {#if build.logFile !== null}
+              <div class="global-log" title={build.logFile}>{build.logFile}</div>
+            {/if}
+          </div>
+        {/each}
+      {/if}
+    </div>
+  </section>
+{/if}

--- a/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
@@ -39,6 +39,7 @@ type Working = {
   progress: MonitorSnapshot['progress'];
   optimise: MonitorSnapshot['optimise'];
   daemon: MonitorSnapshot['daemon'];
+  global: MonitorSnapshot['global'];
   activation: MonitorSnapshot['activation'];
   diff: MonitorSnapshot['diff'];
   expected: Record<string, number>;
@@ -67,6 +68,7 @@ function createWorking(): Working {
       currentPath: null,
       hotPaths: []
     },
+    global: { detected: false, builds: [], status: '' },
     activation: { active: false, command: '', steps: [], status: '' },
     diff: null,
     expected: {},
@@ -107,6 +109,9 @@ export function applyDelta(working: Working, delta: Delta): Working {
     case 'daemonSet':
       working.daemon = delta.daemon;
       return working;
+    case 'globalSet':
+      working.global = delta.global;
+      return working;
     case 'activationSet':
       working.activation = delta.activation;
       return working;
@@ -146,6 +151,7 @@ function fromSnapshot(snapshot: MonitorSnapshot): Working {
     progress: snapshot.progress,
     optimise: snapshot.optimise,
     daemon: snapshot.daemon,
+    global: snapshot.global,
     activation: snapshot.activation,
     diff: snapshot.diff,
     expected: { ...snapshot.expected },
@@ -187,6 +193,7 @@ export function projectSnapshot(working: Working): MonitorSnapshot {
     progress: working.progress,
     optimise: working.optimise,
     daemon: working.daemon,
+    global: working.global,
     activation: working.activation,
     diff: working.diff,
     expected: { ...working.expected },

--- a/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
@@ -73,6 +73,43 @@ export const daemonInfoSchema = v.object({
   hotPaths: v.array(daemonHotPathSchema)
 });
 
+/// Why one machine-wide build is happening: the chain from the requested root
+/// derivation down to this goal, plus the cause that forced it. Mirrors the Rust
+/// `GlobalWhy`; every field is optional so a source that omits one still parses.
+export const globalWhySchema = v.object({
+  rootDrvPath: v.nullable(v.string()),
+  chain: v.array(v.string()),
+  cause: v.nullable(v.string())
+});
+
+/// One active build or substitution goal on the machine, from the patched-nix
+/// `nix store builds --json` subcommand. Mirrors the Rust `GlobalBuild`; a
+/// substitution has a null `drvPath` and sets `storePath`. `startTime` is unix
+/// *seconds* (the rest of the monitor uses milliseconds), so the panel multiplies
+/// by 1000 before diffing against its clock. `kind` is a free string ('build' /
+/// 'substitution' / an unknown future kind), so a schema drift is surfaced.
+export const globalBuildSchema = v.object({
+  drvPath: v.nullable(v.string()),
+  storePath: v.nullable(v.string()),
+  outputs: v.array(v.string()),
+  type: v.string(),
+  pid: v.nullable(v.number()),
+  startTime: v.nullable(v.number()),
+  user: v.nullable(v.string()),
+  uid: v.nullable(v.number()),
+  logFile: v.nullable(v.string()),
+  why: globalWhySchema
+});
+
+/// Machine-wide build view. `detected` is false on stock nix (the subcommand is
+/// unavailable), in which case the panel hides and `status` explains why. Mirrors
+/// the Rust `GlobalBuilds`.
+export const globalBuildsSchema = v.object({
+  detected: v.boolean(),
+  builds: v.array(globalBuildSchema),
+  status: v.string()
+});
+
 /// One activation step (a `home`/`os` switch's `activate` run): a named unit of
 /// work plus the output lines it printed. Mirrors the Rust `ActivationStep`.
 export const activationStepSchema = v.object({
@@ -151,6 +188,8 @@ export const snapshotSchema = v.object({
   progress: v.nullable(activityProgressSchema),
   optimise: optimiseStatsSchema,
   daemon: daemonInfoSchema,
+  /// Machine-wide build view; `detected: false` on stock nix (panel hidden).
+  global: globalBuildsSchema,
   /// Live activation view during a `home`/`os` switch; `active: false` otherwise.
   activation: activationSchema,
   /// Generation diff text (`nvd diff`), set once at the end of a switch.
@@ -182,6 +221,7 @@ export const deltaSchema = v.variant('type', [
   v.object({ type: v.literal('progressSet'), progress: activityProgressSchema }),
   v.object({ type: v.literal('optimiseSet'), optimise: optimiseStatsSchema }),
   v.object({ type: v.literal('daemonSet'), daemon: daemonInfoSchema }),
+  v.object({ type: v.literal('globalSet'), global: globalBuildsSchema }),
   v.object({ type: v.literal('activationSet'), activation: activationSchema }),
   v.object({ type: v.literal('diffSet'), diff: v.string() }),
   v.object({ type: v.literal('expectedSet'), name: v.string(), value: v.number() }),
@@ -200,6 +240,9 @@ export type OptimiseStats = v.InferOutput<typeof optimiseStatsSchema>;
 export type DaemonOps = v.InferOutput<typeof daemonOpsSchema>;
 export type DaemonHotPath = v.InferOutput<typeof daemonHotPathSchema>;
 export type DaemonInfo = v.InferOutput<typeof daemonInfoSchema>;
+export type GlobalWhy = v.InferOutput<typeof globalWhySchema>;
+export type GlobalBuild = v.InferOutput<typeof globalBuildSchema>;
+export type GlobalBuilds = v.InferOutput<typeof globalBuildsSchema>;
 export type ActivationStep = v.InferOutput<typeof activationStepSchema>;
 export type Activation = v.InferOutput<typeof activationSchema>;
 export type ActivityNode = v.InferOutput<typeof activityNodeSchema>;
@@ -240,6 +283,7 @@ export const EMPTY_SNAPSHOT: MonitorSnapshot = Object.freeze({
       currentPath: null,
       hotPaths: []
     },
+  global: { detected: false, builds: [], status: '' },
   activation: { active: false, command: '', steps: [], status: '' },
   diff: null,
   expected: {},

--- a/packages/nix/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix/nix-web-monitor/server/site/src/style.css
@@ -619,6 +619,113 @@ main.dragging-v .splitter-v::after {
   color: var(--faint);
 }
 
+/* ---------- machine builds panel (patched nix only) ---------- */
+
+/* Sits above the daemon panel in the side pane; caps its height so the daemon
+ * panel and activity graph below stay visible. Self-hides on stock nix (the
+ * component renders nothing when `detected` is false). */
+.side-pane > .global-panel {
+  flex: 0 0 auto;
+  max-height: 40%;
+  border-bottom: 1px solid var(--line);
+}
+
+.global-body {
+  min-height: 0;
+  overflow: auto;
+  padding: 0.4rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.global-status {
+  color: var(--muted);
+}
+
+.global-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.global-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+/* badge | name | version | elapsed, name flexes and truncates. */
+.global-row-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.global-badge {
+  flex: 0 0 auto;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0 0.3rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--muted);
+}
+
+.global-badge-substitution {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+}
+
+.global-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: var(--ink);
+}
+
+.global-version {
+  flex: 0 0 auto;
+  color: var(--faint);
+}
+
+.global-elapsed {
+  flex: 0 0 auto;
+  color: var(--muted);
+}
+
+.global-row-meta {
+  display: flex;
+  gap: 0.5rem;
+  color: var(--faint);
+  font-size: 0.85rem;
+}
+
+.global-cause {
+  color: var(--muted);
+}
+
+/* The why-chain: root -> ... -> this goal, one truncated line. */
+.global-why {
+  color: var(--faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.global-log {
+  color: var(--faint);
+  font-size: 0.8rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* ---------- activation + diff panels (switch only) ---------- */
 
 /* Both ride at the top of the side pane during a switch and cap their height so

--- a/packages/nix/nix-web-monitor/server/src/global.rs
+++ b/packages/nix/nix-web-monitor/server/src/global.rs
@@ -1,0 +1,192 @@
+//! Machine-wide build probe (best-effort, patched-nix only).
+//!
+//! Polls a patched-nix subcommand, `nix store builds --json`, which reads a
+//! daemon-independent status directory and prints every active build/substitution
+//! goal on the host, with the why-chain (root derivation -> ... -> this goal)
+//! that scheduled it. The rest of the monitor only ever sees one invocation's
+//! tree; this is the one view of *everything* the machine is building right now,
+//! and why.
+//!
+//! The subcommand exists only on a patched nix, so the probe auto-detects: it
+//! runs the command and, if the output does not parse as a JSON build array
+//! (stock nix prints an "unknown command" error instead), marks the view
+//! undetected and the UI hides the panel. Like the daemon tracer, it never
+//! returns and never panics: every failure becomes a status string, and the
+//! loop backs off and retries so a mid-session nix upgrade is eventually picked
+//! up.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use nix_web_monitor_parser::{GlobalBuilds, MonitorState};
+use nix_web_monitor_parser::global::parse_builds;
+use tokio::process::Command;
+use tokio::sync::{RwLock, broadcast};
+
+use crate::broadcast_deltas;
+
+/// How often the machine-wide build view is re-polled once detected. Slower than
+/// the daemon tracer's one-second sample: this shells out to `nix` each tick, so
+/// a couple of seconds keeps the panel live without a constant subprocess churn.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Back-off before re-probing after the subcommand comes back undetected (stock
+/// nix). No point hammering a stock nix that will never grow the subcommand
+/// mid-run, but re-probe occasionally so a nix upgrade during a long-lived UI
+/// session is picked up.
+const RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Run the machine-wide build probe until the task is aborted.
+///
+/// Never returns: like [`run_daemon_probe`](crate::daemon::run_daemon_probe),
+/// the global view is a best-effort overlay, so any failure becomes a status the
+/// panel shows (or a hidden panel) and the loop retries.
+pub async fn run_global_probe(monitor: Arc<RwLock<MonitorState>>, deltas: broadcast::Sender<Bytes>) {
+    loop {
+        let Some(builds) = poll_builds().await else {
+            // Undetected: publish the undetected view once (its `Default` carries
+            // the "not available" status) so a later detection can flip the panel
+            // on, then back off before re-probing.
+            publish(&monitor, &deltas, GlobalBuilds::default()).await;
+            tokio::time::sleep(RETRY_INTERVAL).await;
+            continue;
+        };
+        let status = format!("{} active", builds.len());
+        let global = GlobalBuilds {
+            detected: true,
+            builds,
+            status,
+        };
+        publish(&monitor, &deltas, global).await;
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Run `nix store builds --json` and parse its output into a build list, or
+/// `None` when the subcommand is unavailable (stock nix) or errored.
+///
+/// Detection is by *result*, not by exit-code text-matching: whatever variant of
+/// the invocation yields a parseable JSON array wins. A stock nix prints an
+/// "unknown command" / "unrecognised flag" error to stderr (not a JSON array),
+/// so every variant fails to parse and this returns `None` -> undetected.
+async fn poll_builds() -> Option<Vec<nix_web_monitor_parser::GlobalBuild>> {
+    // The patched command may be gated behind an experimental feature, but an
+    // *unknown* experimental feature is itself an error on stock nix. So try the
+    // plain form first (works if the command is ungated) and, only if that does
+    // not parse, the feature-gated form. Whichever yields a JSON array is used;
+    // if neither does, the subcommand is not available.
+    const ATTEMPTS: [&[&str]; 2] = [
+        &["store", "builds", "--json", "--extra-experimental-features", "nix-command"],
+        &[
+            "store",
+            "builds",
+            "--json",
+            "--extra-experimental-features",
+            "nix-command build-status-dir",
+        ],
+    ];
+    for args in ATTEMPTS {
+        if let Some(builds) = try_builds(args).await {
+            return Some(builds);
+        }
+    }
+    None
+}
+
+/// Run one `nix` argument variant and return the parsed builds if its stdout is
+/// a JSON build array. Any spawn failure, or output that is not a build array,
+/// yields `None` so the caller falls through to the next variant / undetected.
+async fn try_builds(args: &[&str]) -> Option<Vec<nix_web_monitor_parser::GlobalBuild>> {
+    let output = Command::new("nix").args(args).output().await.ok()?;
+    // Parse stdout regardless of exit status: a patched nix might print the array
+    // and still exit nonzero on some warning, and a stock nix prints its error to
+    // stderr with empty stdout, so the parse is the real detector.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_builds(stdout.trim()).ok()
+}
+
+/// Push a machine-wide build view to the monitor and broadcast the change.
+/// Mirrors the daemon probe's `publish_status`: `set_global` skips a no-op, so an
+/// unchanged view puts no frame on the wire.
+async fn publish(
+    monitor: &Arc<RwLock<MonitorState>>,
+    deltas: &broadcast::Sender<Bytes>,
+    global: GlobalBuilds,
+) {
+    monitor.write().await.set_global(global);
+    let _ = broadcast_deltas(monitor, deltas).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use nix_web_monitor_parser::{GlobalBuildKind, MonitorState};
+
+    use super::*;
+
+    /// End-to-end of the parse-into-state path the probe drives: a sample
+    /// `nix store builds --json` payload folds into a `GlobalBuilds` with the
+    /// right rows and why-chain, and `set_global` broadcasts a `GlobalSet` delta.
+    #[test]
+    fn sample_payload_folds_into_state_with_why_chain() {
+        let json = r#"[
+            {
+                "drvPath": "/nix/store/aaa-foo.drv",
+                "outputs": ["out"],
+                "type": "build",
+                "pid": 4242,
+                "startTime": 1720200000,
+                "user": "alice",
+                "uid": 1000,
+                "logFile": "/nix/var/log/nix/drvs/ab/cdfoo.drv.bz2",
+                "why": {
+                    "rootDrvPath": "/nix/store/root-app.drv",
+                    "chain": ["/nix/store/root-app.drv", "/nix/store/aaa-foo.drv"],
+                    "cause": "outputsMissing"
+                }
+            },
+            {
+                "storePath": "/nix/store/bbb-bar",
+                "type": "substitution",
+                "why": { "cause": "outputInvalid" }
+            }
+        ]"#;
+        let builds = parse_builds(json).expect("sample payload parses");
+        let global = GlobalBuilds {
+            detected: true,
+            status: format!("{} active", builds.len()),
+            builds,
+        };
+
+        assert_eq!(global.builds.len(), 2);
+        assert_eq!(global.status, "2 active");
+        assert_eq!(global.builds[0].kind, GlobalBuildKind::Build);
+        assert_eq!(global.builds[0].user.as_deref(), Some("alice"));
+        assert_eq!(
+            global.builds[0].why.root_drv_path.as_deref(),
+            Some("/nix/store/root-app.drv")
+        );
+        assert_eq!(global.builds[0].why.chain.len(), 2);
+        assert_eq!(global.builds[1].kind, GlobalBuildKind::Substitution);
+        assert_eq!(
+            global.builds[1].store_path.as_deref(),
+            Some("/nix/store/bbb-bar")
+        );
+
+        // Folding into state emits exactly one GlobalSet delta.
+        let mut state = MonitorState::default();
+        state.set_global(global.clone());
+        let deltas = state.drain_deltas();
+        assert_eq!(deltas.len(), 1);
+        assert!(matches!(
+            deltas.first(),
+            Some(nix_web_monitor_parser::Delta::GlobalSet { .. })
+        ));
+        assert!(state.snapshot().global.detected);
+        assert_eq!(state.snapshot().global.builds.len(), 2);
+
+        // Re-setting the identical view is a no-op (no redundant frame).
+        state.set_global(global);
+        assert!(state.drain_deltas().is_empty());
+    }
+}

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -28,9 +28,11 @@ use tower_http::services::ServeDir;
 mod daemon;
 mod dependencies;
 mod emit;
+mod global;
 mod reasons;
 use daemon::run_daemon_probe;
 use dependencies::resolve_dependencies;
+use global::run_global_probe;
 
 /// Bound on the delta broadcast ring. A client that falls this far behind gets
 /// resynced with a fresh `Reset` rather than the dropped frames.
@@ -221,6 +223,12 @@ async fn main() -> Result<()> {
     // life of the UI. Best-effort, so its handle is just aborted at shutdown.
     let daemon_probe = tokio::spawn(run_daemon_probe(Arc::clone(&monitor), deltas.clone()));
 
+    // Poll the machine-wide build view (all active builds on the host, and why),
+    // when the patched-nix `nix store builds --json` subcommand is present. Like
+    // the daemon probe, it lives for the whole UI and self-hides on stock nix; a
+    // best-effort overlay whose handle is just aborted at shutdown.
+    let global_probe = tokio::spawn(run_global_probe(Arc::clone(&monitor), deltas.clone()));
+
     let build = tokio::spawn(run_job(
         job,
         args.terminal_output,
@@ -241,6 +249,7 @@ async fn main() -> Result<()> {
             .context("waiting for Ctrl-C")?;
     }
     daemon_probe.abort();
+    global_probe.abort();
     http_server.abort();
     // Propagate Nix's exit status either way; otherwise the wrapper masks
     // build failures from shells and CI.


### PR DESCRIPTION
Part of #1897 (global build observability). This is the nwm half; the patched-nix half is a 7-patch series onto NixOS/nix 2.34.7 awaiting the `nix` fork-package scaffold.

## What

A **global mode** for nix-web-monitor: a MACHINE BUILDS pane showing everything the machine is building right now and why, not just the wrapped invocation.

- Server probe polls `nix store builds --json` (the patched nix's daemon-independent build status directory) every 2s and broadcasts a `GlobalSet` delta, mirroring the daemon syscall view (`DaemonSet`) end to end.
- Each row: build/sub badge, derivation name, client user, live elapsed, cause, the **why-chain** (root goal → this build), and the drv log path.
- **Auto-detected, graceful on stock nix**: detection is by result (a run of `nix store builds --json` that parses as a JSON array ⇒ supported; plain and feature-gated variants tried). On stock nix the pane is hidden entirely and nothing else changes; re-probes every 30s so a mid-session nix upgrade is picked up.
- Deserialization is tolerant (all fields optional, unknown fields ignored) so schema drift degrades a field, not the probe.

## Validation

- cargo test: 63 passed (7 new parser tests: why-chain, substitution, missing-optionals, unknown-kind tolerance); clippy clean; svelte-check 0 errors 0 warnings; eslint clean.
- Stock nix (Playwright, headless chromium): zero `.global-panel` nodes, all existing panes render a live build — no regression.
- Patched nix end-to-end: with a 60s sleeper building against a private store, `/api/state` carried `global: {detected: true, builds: [...]}` and the DOM rendered:
  ```
  MACHINE BUILDS 1
  BUILD obs-demo-sleeper 25s
  outputsMissing
  obs-demo-top → obs-demo-sleeper
  /private/tmp/.../log/drvs/w6/...-obs-demo-sleeper-60.drv.bz2
  ```
  i.e. the machine-wide entry with its why-chain, rendered from the status dir with no daemon connection anywhere in the path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add machine-wide builds pane to nix-web-monitor via `nix store builds --json`
> - Adds a background probe ([global.rs](https://github.com/indexable-inc/index/pull/1906/files#diff-4820d587d4c1c1d078b1a44dc5322acedb592ec373035bd38ff4634e02411c8e)) that polls `nix store builds --json` (trying two experimental-feature flag variants) and publishes a `GlobalBuilds` snapshot to connected clients via a new `globalSet` delta.
> - Adds parser types (`GlobalBuild`, `GlobalBuilds`, `GlobalWhy`, `GlobalBuildKind`) in [parser/src/global.rs](https://github.com/indexable-inc/index/pull/1906/files#diff-a8aef52744a31d4a9a38106f9fae9b6fc0cbf10a6842b15bce0d8b5fb81c8085) with tolerant serde deserialization and a catch-all `Other` kind variant.
> - Adds a [GlobalPanel.svelte](https://github.com/indexable-inc/index/pull/1906/files#diff-63da9d7b5d9bdbad3545513615466f2adc45a723a375562faf1fd67c98d7586d) UI component that shows active machine-wide builds and substitutions with live elapsed times and why-chains; self-hides when `detected` is false (stock nix).
> - Extends the client-side transport and Zod schemas in [types.ts](https://github.com/indexable-inc/index/pull/1906/files#diff-ac494b4407fb098b0f3ee2833d616bbc824652bdfbed7da3f6340cb23617b2a9) and [monitor-transport.ts](https://github.com/indexable-inc/index/pull/1906/files#diff-dba85d54e0925fb7633af5cb6058f2ece6c381b7d502cdd4457e7f5a682b84e5) to handle `globalSet` deltas and include `global` in snapshots.
> - Risk: the probe tolerates non-zero exit codes and determines availability purely by JSON parse success, so a patched nix binary emitting non-array JSON would silently appear as undetected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 169fcb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->