### PR TITLE
de-fork mesa: gitlab upstream pin + in-repo venus patch series

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,6 +210,24 @@
         "type": "github"
       }
     },
+    "mesa-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780475834,
+        "narHash": "sha256-IkfRd98uHODgnISpaxnEZi83IPis62cacJEierMiAvU=",
+        "ref": "refs/tags/mesa-26.1.2",
+        "rev": "b3d356db66d92ff99ad5b3274569761290232899",
+        "shallow": true,
+        "type": "git",
+        "url": "https://gitlab.freedesktop.org/mesa/mesa"
+      },
+      "original": {
+        "ref": "refs/tags/mesa-26.1.2",
+        "shallow": true,
+        "type": "git",
+        "url": "https://gitlab.freedesktop.org/mesa/mesa"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780749050,
@@ -399,6 +417,7 @@
         "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
         "launchk-src": "launchk-src",
+        "mesa-src": "mesa-src",
         "nixpkgs": "nixpkgs",
         "nu-jupyter-kernel-src": "nu-jupyter-kernel-src",
         "perftest-src": "perftest-src",

--- a/flake.nix
+++ b/flake.nix
@@ -196,6 +196,27 @@
       url = "github:ghostty-org/ghostty/fd49716ea2084108aa098db390931c007495a1ab";
       flake = false;
     };
+
+    # Upstream mesa (gitlab.freedesktop.org), patched in-repo for the panes GPU
+    # guest (packages/vm/panes/guest-image/mesa/patches): the venus driver-side
+    # external-semaphore delta (index#1742). De-forking replacement for the old
+    # `indexable-inc/mesa` snapshot fork tarball; pinned by the `mesa-26.1.2`
+    # tag, so the patched tree is the upstream tag tree plus the venus commits.
+    #
+    # `shallow=1` is load-bearing (same reason as snix-src): mesa's git history
+    # is huge, and only the source tree at the pinned tag is ever used (through
+    # `ix.mesaSrc` -> patchedSrc), never history or revCount. Without it the
+    # lock records `revCount`, forcing a full-history clone on every cold
+    # `nix flake archive` / direnv load. `flake.lock` still records the rev, so
+    # `rebase-patches` can read the base rev; the URL is a real git remote so
+    # its scratch-clone fetch works. Pinned by rev (autoUpdate = false in
+    # lib/fork-packages.nix): a mesa bump must be rebased AND boot-validated on
+    # a linux GPU host (the venus patch is validated by running the guest, not
+    # by CI), so it moves only under a deliberate manual bump, never the cron.
+    mesa-src = {
+      url = "git+https://gitlab.freedesktop.org/mesa/mesa?ref=refs/tags/mesa-26.1.2&shallow=1";
+      flake = false;
+    };
   };
 
   outputs = {
@@ -215,6 +236,7 @@
     clippy-src,
     codex-src,
     ghostty,
+    mesa-src,
     skills,
     examples,
     tests,
@@ -297,6 +319,7 @@
         clippy-src
         codex-src
         ghostty
+        mesa-src
         ;
     };
     devSystems = [

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -16,6 +16,7 @@
   clippy-src,
   codex-src,
   ghostty,
+  mesa-src,
   # Flake source revision, stamped into builds that want to report it (see
   # `sharedHelpers.rev`). Defaulted so a direct `import ./lib` still evaluates.
   rev ? "dev",
@@ -521,6 +522,7 @@
     nuJupyterKernelSrc = nu-jupyter-kernel-src;
     launchkSrc = launchk-src;
     snixSrc = snix-src;
+    mesaSrc = mesa-src;
   };
 
   /**

--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -49,5 +49,20 @@
       patchDir = "packages/llm-clippy/patches";
       autoUpdate = false;
     }
+    {
+      # mesa is panes-GPU-coupled: its input is pinned by rev (upstream tag
+      # mesa-26.1.2) and must move only under a deliberate bump, never a blanket
+      # `nix flake update` or the scheduled fork-sync. The venus driver-side
+      # sync-fd patch (index#1742) is validated by BOOTING the panes guest on a
+      # linux GPU host and exercising the WSI acquire path, not by CI, so a base
+      # bump is a rebase-plus-boot event, not a routine cron. `url` is the
+      # gitlab git remote so `rebase-patches`' scratch-clone fetch works; the
+      # build consumes `ix.mesaSrc` (the shallow git input) through patchedSrc.
+      name = "mesa";
+      input = "mesa-src";
+      url = "https://gitlab.freedesktop.org/mesa/mesa.git";
+      patchDir = "packages/vm/panes/guest-image/mesa/patches";
+      autoUpdate = false;
+    }
   ];
 }

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -588,6 +588,7 @@
     codex = ix.codexSrc;
     btop = ix.btopSrc;
     clippy = ix.clippySrc;
+    mesa = ix.mesaSrc;
   };
   patchedSrcChecks = lib.genAttrs' (import ./fork-packages.nix).forkPackages (
     fork:

--- a/packages/rebase-patches/default.nix
+++ b/packages/rebase-patches/default.nix
@@ -114,7 +114,7 @@ in
       }
 
       def main [
-        name?: string # one fork package (codex | btop | clippy); all changed if omitted
+        name?: string # one fork package (codex | btop | clippy | mesa); all changed if omitted
       ] {
         let forks = (open $fork_data)
         let selected = if $name != null {

--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -166,9 +166,10 @@ in {
       VK_DRIVER_FILES = "${pkgs.mesa}/share/vulkan/icd.d/virtio_icd.aarch64.json";
       MESA_VK_DEVICE_SELECT = "1af4:1050!";
       # 26.2's Vulkan backend hard-requires VK_KHR_synchronization2. The
-      # guest mesa (indexable-inc/mesa fork, see ../guest-image/default.nix
-      # and index#1742) now exposes sync2 natively by handling temporary sync
-      # fd semaphore imports driver-side, so Khronos' emulation layer is a
+      # guest mesa (upstream mesa + the in-repo venus patch series, see
+      # ../guest-image/default.nix and index#1742/#1894) now exposes sync2
+      # natively by handling temporary sync fd semaphore imports driver-side,
+      # so Khronos' emulation layer is a
       # passthrough no-op here: with force_enable unset it self-retires when
       # the driver advertises the extension. It stays wired as the fallback
       # if the driver ever masks sync2 again (e.g. a mesa bump without the

--- a/packages/vm/panes/guest-image/default.nix
+++ b/packages/vm/panes/guest-image/default.nix
@@ -39,9 +39,11 @@
         nixpkgs.overlays = [
           (final: prev: {
             inherit (repoPackages) panes-compositor panes-audio;
-            # ./pins.json also carries the mesa src pin, so hand
-            # lwjgl-natives.nix only the lwjgl-* entries (it asserts one
-            # shared LWJGL version across its pins).
+            # ./pins.json carries only the lwjgl-* jar pins now (mesa is a
+            # de-forked patch series, not a pin; see the `mesa` override below
+            # and index#1894), but keep the prefix filter as a guard so an
+            # unrelated future pin cannot leak into lwjgl-natives.nix, which
+            # asserts one shared LWJGL version across its pins.
             lwjgl-natives-linux-arm64 = final.callPackage ./lwjgl-natives.nix {
               pins = lib.filterAttrs (name: _: lib.hasPrefix "lwjgl" name) (ix.pins.loadPins ./pins.json);
             };
@@ -49,30 +51,35 @@
             # `ix` is not in module scope; apps.nix uses it for the Minecraft
             # launch wrapper instead of the unchecked writeShellScript.
             writeBashApplication = ix.writeBashApplication final;
-            # Venus (virtio-gpu Vulkan) with the mesa fork's driver-side
-            # external-semaphore patch (index#1742): MoltenVK hosts never
-            # support SYNC_FD semaphore import, so stock mesa masks
-            # VK_KHR_synchronization2 (clamping the device to Vulkan 1.2) and
-            # VK_KHR_swapchain. Only `src` is swapped; the fork is upstream
-            # tag mesa-26.1.2 plus the patch commit, so nixpkgs' recipe and
-            # patches still apply. The fork branch is the single source of
-            # truth for the patch (rather than an in-tree .patch file): its
-            # history carries the upstreamable commit and the pinned tree is
-            # what upstream review sees. `hardware.graphics.enable` in
-            # ./nixos.nix consumes `pkgs.mesa`, so this override is what
-            # /run/opengl-driver (and the container ICDs) get.
-            mesa = let
-              pin = ix.pins.loadPin ./pins.json "mesa-src";
-            in
-              prev.mesa.overrideAttrs (old: {
-                # The version assert only catches upstream version bumps; a
-                # nixpkgs change to mesa's own patch set can also stop
-                # applying against the fork tree and force a rebase, and only
-                # the build failure catches that case.
-                src = assert lib.assertMsg (old.version == pin.version)
-                "panes-guest-image: mesa fork pin is ${pin.version} but nixpkgs mesa is ${old.version}; rebase indexable-inc/mesa branch ix/venus-driver-side-semaphore onto the new upstream tag and re-pin";
-                  final.fetchzip {inherit (pin) url hash;};
-              });
+            # Venus (virtio-gpu Vulkan) with the driver-side external-semaphore
+            # delta (index#1742): MoltenVK hosts never support SYNC_FD semaphore
+            # import, so stock mesa masks VK_KHR_synchronization2 (clamping the
+            # device to Vulkan 1.2) and VK_KHR_swapchain. Only `src` is swapped;
+            # the patched tree is upstream tag mesa-26.1.2 plus the venus
+            # commits, so nixpkgs' recipe and patches still apply.
+            #
+            # De-forked (index#1894): the delta is an in-repo patch series
+            # (./mesa/patches) applied to the upstream `mesa-src` input through
+            # `ix.patchedSrc`, replacing the old `indexable-inc/mesa` snapshot
+            # fork tarball. `packages/rebase-patches` regenerates the series on a
+            # base bump; `checks.<system>.patched-src-mesa` gates that it still
+            # applies. `hardware.graphics.enable` in ./nixos.nix consumes
+            # `pkgs.mesa`, so this override is what /run/opengl-driver (and the
+            # container ICDs) get.
+            mesa = prev.mesa.overrideAttrs (old: {
+              # The pinned base is upstream mesa-26.1.2, so the patched tree's
+              # version equals nixpkgs mesa only when both track 26.1.2. A
+              # nixpkgs mesa bump ahead of the pin can also stop the nixpkgs
+              # patch set applying against the pinned tree; the assert catches
+              # the version skew, the build failure catches the patch skew.
+              src = assert lib.assertMsg (old.version == "26.1.2")
+              "panes-guest-image: mesa patch series is pinned at 26.1.2 (mesa-src input) but nixpkgs mesa is ${old.version}; bump the mesa-src tag in flake.nix, run `nix run .#rebase-patches -- mesa`, and boot-validate the panes guest on a linux GPU host";
+                ix.patchedSrc {
+                  name = "mesa";
+                  src = ix.mesaSrc;
+                  patchDir = ./mesa/patches;
+                };
+            });
           })
         ];
         # The builder-chosen root login key (see the sshAuthorizedKey package

--- a/packages/vm/panes/guest-image/mesa/patches/0001-venus-handle-temporary-sync-fd-semaphore-imports-dri.patch
+++ b/packages/vm/panes/guest-image/mesa/patches/0001-venus-handle-temporary-sync-fd-semaphore-imports-dri.patch
@@ -1,0 +1,498 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Thu, 2 Jul 2026 17:34:18 -0700
+Subject: [PATCH 1/3] venus: handle temporary sync fd semaphore imports
+ driver-side
+
+When the renderer cannot import sync fd semaphores (no SYNC_FD import in
+the renderer-side vkGetPhysicalDeviceExternalSemaphoreProperties, e.g.
+MoltenVK hosts behind virglrenderer), venus used to mask
+VK_KHR_synchronization2 (clamping the device to Vulkan 1.2) and every
+WSI extension, because the temporary sync fd import performed by wsi
+acquire was resolved by fixing the renderer-side semaphore payload with
+vkImportSemaphoreResourceMESA, which the renderer services with the
+renderer-side VK_KHR_external_semaphore_fd.
+
+Handle the temporary payload purely on the driver side instead, as
+suggested by the existing comment in
+vn_physical_device_get_passthrough_extensions: at submission time the
+guest waits on the sync fd and the then-satisfied semaphore wait is
+elided from the renderer submission, reusing the temp batch storage that
+already exists for the feedback machinery.  Waiting the temporary
+payload restores the permanent payload, so the renderer-side semaphore
+state stays consistent with temporary import semantics.  The renderer
+path is kept when sync fd import is available.
+
+With the wsi wait semaphores taken care of either way:
+- expose VK_KHR_synchronization2 (and thus Vulkan 1.3) unconditionally
+- expose the WSI extensions without renderer sync fd import
+- only force-enable the renderer-side VK_KHR_external_semaphore_fd for
+  wsi when the renderer supports sync fd import (it is neither needed
+  nor necessarily available otherwise)
+
+Two supporting fixes for renderers without sync fd support:
+- stop advertising SYNC_FD external binary semaphore handles when the
+  renderer cannot service vn_GetSemaphoreFdKHR
+  (vkWait/ImportSemaphoreResourceMESA); common wsi keys its dma-buf
+  implicit out fence path off this query and must not be led into it
+- wait inside the wsi queue submit when common wsi cannot install the
+  implicit out fence, as previously done for vtest only
+
+Refs: indexable-inc/index#1686
+
+diff --git a/src/virtio/vulkan/vn_device.c b/src/virtio/vulkan/vn_device.c
+index f7a1f1cc6a0..01a850204d7 100644
+--- a/src/virtio/vulkan/vn_device.c
++++ b/src/virtio/vulkan/vn_device.c
+@@ -326,11 +326,16 @@ vn_device_fix_create_info(const struct vn_device *dev,
+       }
+    }
+ 
+-   /* see vn_queue_submission_count_batch_semaphores */
+-   if (!app_exts->KHR_external_semaphore_fd && has_wsi) {
+-      assert(physical_dev->renderer_sync_fd.semaphore_importable);
++   /* Needed by vn_queue_submission_fix_batch_semaphores to fix the
++    * renderer-side wsi acquire semaphore payload at submission time.  When
++    * the renderer lacks semaphore sync fd import (e.g. MoltenVK hosts), the
++    * wait is elided on the driver side instead
++    * (vn_queue_submission_scrub_batch_waits) and the renderer-side extension
++    * is neither needed nor necessarily available.
++    */
++   if (!app_exts->KHR_external_semaphore_fd && has_wsi &&
++       physical_dev->renderer_sync_fd.semaphore_importable)
+       extra_exts[extra_count++] = VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME;
+-   }
+ 
+    /* see vn_cmd_set_external_acquire_unmodified */
+    if (VN_PRESENT_SRC_INTERNAL_LAYOUT != VK_IMAGE_LAYOUT_PRESENT_SRC_KHR &&
+diff --git a/src/virtio/vulkan/vn_physical_device.c b/src/virtio/vulkan/vn_physical_device.c
+index 2d2e22b500e..e524fb155fa 100644
+--- a/src/virtio/vulkan/vn_physical_device.c
++++ b/src/virtio/vulkan/vn_physical_device.c
+@@ -1151,7 +1151,18 @@ vn_physical_device_init_external_semaphore_handles(
+    physical_dev->external_binary_semaphore_handles = 0;
+    physical_dev->external_timeline_semaphore_handles = 0;
+ 
+-   if (physical_dev->instance->renderer->info.has_external_sync) {
++   /* Sync fd export (vn_GetSemaphoreFdKHR) requires renderer-side semaphore
++    * sync fd export and import (vkWaitSemaphoreResourceMESA and
++    * vkImportSemaphoreResourceMESA are serviced with the renderer-side
++    * VK_KHR_external_semaphore_fd).  Do not advertise SYNC_FD handles
++    * without them: common wsi keys its dma-buf implicit out fence path off
++    * vkGetPhysicalDeviceExternalSemaphoreProperties, which must not lead it
++    * into vn_GetSemaphoreFdKHR on renderers that cannot service it (e.g.
++    * MoltenVK hosts).
++    */
++   if (physical_dev->instance->renderer->info.has_external_sync &&
++       physical_dev->renderer_sync_fd.semaphore_exportable &&
++       physical_dev->renderer_sync_fd.semaphore_importable) {
+ #if !DETECT_OS_WINDOWS
+       physical_dev->external_binary_semaphore_handles =
+          VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
+@@ -1216,20 +1227,24 @@ vn_physical_device_get_native_extensions(
+ #endif /* VK_USE_PLATFORM_ANDROID_KHR */
+ 
+ #ifdef VN_USE_WSI_PLATFORM
+-   if (physical_dev->renderer_sync_fd.semaphore_importable) {
+-      exts->KHR_incremental_present = true;
++   /* The wsi acquire semaphore and fence waits are handled either by fixing
++    * the renderer-side semaphore payload at submission time (renderer
++    * supports semaphore sync fd import) or purely on the driver side (see
++    * vn_queue_submission_scrub_batch_waits), so swapchain support no longer
++    * requires renderer sync fd import.
++    */
++   exts->KHR_incremental_present = true;
+ #ifndef VK_USE_PLATFORM_WIN32_KHR
+-      exts->KHR_present_id = true;
+-      exts->KHR_present_id2 = true;
+-      exts->KHR_present_wait = true;
+-      exts->KHR_present_wait2 = true;
++   exts->KHR_present_id = true;
++   exts->KHR_present_id2 = true;
++   exts->KHR_present_wait = true;
++   exts->KHR_present_wait2 = true;
+ #endif /* VK_USE_PLATFORM_WIN32_KHR */
+-      exts->KHR_swapchain = true;
+-      exts->KHR_swapchain_maintenance1 = true;
+-      exts->KHR_swapchain_mutable_format = true;
+-      exts->EXT_hdr_metadata = true;
+-      exts->EXT_swapchain_maintenance1 = true;
+-   }
++   exts->KHR_swapchain = true;
++   exts->KHR_swapchain_maintenance1 = true;
++   exts->KHR_swapchain_mutable_format = true;
++   exts->EXT_hdr_metadata = true;
++   exts->EXT_swapchain_maintenance1 = true;
+ 
+    /* VK_EXT_pci_bus_info is required by common wsi to decide whether native
+     * image or prime blit is used. Meanwhile, venus must stay on native image
+@@ -1266,16 +1281,17 @@ vn_physical_device_get_passthrough_extensions(
+ {
+    struct vn_renderer *renderer = physical_dev->instance->renderer;
+ 
+-#if defined(VK_USE_PLATFORM_ANDROID_KHR) || defined(VN_USE_WSI_PLATFORM)
+-   /* WSI support currently requires semaphore sync fd import for
+-    * VK_KHR_synchronization2 for code simplicity. This requirement can be
+-    * dropped by implementing external semaphore purely on the driver side
+-    * (aka no corresponding renderer side object).
++   /* WSI acquire creates temporary sync fd imports on the acquire semaphore
++    * and fence.  When the renderer supports semaphore sync fd import, the
++    * import is resolved by fixing the renderer-side semaphore payload at
++    * submission time.  Otherwise, the temporary payload is handled purely on
++    * the driver side: the guest waits on the sync fd and the semaphore wait
++    * is elided from the renderer submission (see
++    * vn_queue_submission_scrub_batch_waits).  Either way the wsi wait
++    * semaphores are taken care of, so sync2 no longer depends on renderer
++    * sync fd support.
+     */
+-   const bool can_sync2 = physical_dev->renderer_sync_fd.semaphore_importable;
+-#else
+    static const bool can_sync2 = true;
+-#endif
+ 
+    *exts = (struct vk_device_extension_table){
+       /* promoted to VK_VERSION_1_1 */
+diff --git a/src/virtio/vulkan/vn_queue.c b/src/virtio/vulkan/vn_queue.c
+index b22f2469ea4..61d4583a5d5 100644
+--- a/src/virtio/vulkan/vn_queue.c
++++ b/src/virtio/vulkan/vn_queue.c
+@@ -50,6 +50,16 @@ struct vn_queue_submission {
+    uint32_t pnext_count;
+    uint32_t dev_mask_count;
+    bool has_zink_sync_batch;
++   /* wait semaphores with temporary sync fd payloads that the renderer
++    * cannot import: the guest waits on the sync fd and the semaphore wait is
++    * elided from the renderer submission
++    */
++   bool has_elided_waits;
++   /* total (not just elided) wait semaphore count of the batches that have
++    * at least one elided wait: each such batch gets a full copy of its wait
++    * arrays in temp storage for compaction
++    */
++   uint32_t scrub_wait_count;
+    struct vn_sync_payload_external external_payload;
+ 
+    /* Temporary storage allocation for submission
+@@ -66,6 +76,9 @@ struct vn_queue_submission {
+     *    - a single cmd for query feedback (qfb)
+     *    - one cmd for each signal semaphore that has feedback (sfb)
+     *    - if last batch, a single cmd for ffb
++    * scrub
++    *  - for each batch with elided waits: compacted copies of the batch wait
++    *    semaphore arrays (see vn_queue_submission_scrub_batch_waits)
+     */
+    struct {
+       void *storage;
+@@ -82,6 +95,8 @@ struct vn_queue_submission {
+          VkCommandBufferSubmitInfo *cmd_infos;
+       };
+ 
++      void *scrub;
++
+       struct vn_submit_info_pnext_fix *pnexts;
+       uint32_t *dev_masks;
+    } temp;
+@@ -391,6 +406,7 @@ vn_queue_submission_fix_batch_semaphores(struct vn_queue_submission *submit,
+    VkDevice dev_handle = vk_device_to_handle(queue_vk->base.device);
+    struct vn_device *dev = vn_device_from_handle(dev_handle);
+ 
++   bool batch_has_elided_waits = false;
+    const uint32_t wait_count =
+       vn_get_wait_semaphore_count(submit, batch_index);
+    for (uint32_t i = 0; i < wait_count; i++) {
+@@ -401,6 +417,26 @@ vn_queue_submission_fix_batch_semaphores(struct vn_queue_submission *submit,
+       if (payload->type != VN_SYNC_TYPE_IMPORTED_SYNC_FD)
+          continue;
+ 
++      if (!dev->physical_device->renderer_sync_fd.semaphore_importable &&
++          submit->batch_type != VK_STRUCTURE_TYPE_BIND_SPARSE_INFO) {
++         /* The renderer cannot import sync fds (e.g. MoltenVK hosts), so the
++          * temporary payload lives purely on the driver side.  Defer the
++          * guest-side wait to vn_queue_submission_scrub_batch_waits, which
++          * waits on the sync fd and elides this semaphore wait from the
++          * renderer submission after the batches have been copied to temp
++          * storage.
++          *
++          * Sparse batches are excluded: they bypass the temp batch storage.
++          * No renderer lacking sync fd import is known to expose sparse
++          * binding (MoltenVK has none), so an imported payload should never
++          * reach a sparse queue; if one ever does, the pre-existing path
++          * below keeps the renderer-side payload fix, which fails loudly
++          * (assert / unserviceable renderer call) rather than hanging.
++          */
++         batch_has_elided_waits = true;
++         continue;
++      }
++
+       if (!vn_semaphore_wait_external(dev, sem))
+          return VK_ERROR_DEVICE_LOST;
+ 
+@@ -415,6 +451,22 @@ vn_queue_submission_fix_batch_semaphores(struct vn_queue_submission *submit,
+                                              &res_info);
+    }
+ 
++   if (batch_has_elided_waits) {
++      submit->has_elided_waits = true;
++      submit->scrub_wait_count += wait_count;
++
++      /* compacting the wait arrays requires fixed copies of the pnext
++       * structs that carry per-wait-semaphore arrays
++       */
++      if (submit->batch_type == VK_STRUCTURE_TYPE_SUBMIT_INFO) {
++         const VkSubmitInfo *batch = &submit->submit_batches[batch_index];
++         if (vk_find_struct_const(batch->pNext,
++                                  TIMELINE_SEMAPHORE_SUBMIT_INFO) ||
++             vk_find_struct_const(batch->pNext, DEVICE_GROUP_SUBMIT_INFO))
++            submit->pnext_count++;
++      }
++   }
++
+    return VK_SUCCESS;
+ }
+ 
+@@ -536,7 +588,7 @@ vn_queue_submission_alloc_storage(struct vn_queue_submission *submit)
+ {
+    struct vn_queue *queue = vn_queue_from_handle(submit->queue_handle);
+ 
+-   if (!submit->feedback_types)
++   if (!submit->feedback_types && !submit->has_elided_waits)
+       return VK_SUCCESS;
+ 
+    /* for original batches or a new batch to hold feedback fence cmd */
+@@ -545,23 +597,37 @@ vn_queue_submission_alloc_storage(struct vn_queue_submission *submit)
+    /* for fence, timeline semaphore and query feedback cmds */
+    const size_t total_cmd_size =
+       vn_get_cmd_size(submit) * MAX2(submit->cmd_count, 1);
++   /* for compacted copies of the wait semaphore arrays of batches with
++    * elided waits: wait infos for VkSubmitInfo2 batches, or semaphores plus
++    * timeline values, wait stages and device indices for VkSubmitInfo
++    * batches (each a multiple of 8 bytes, keeping the sections aligned)
++    */
++   const size_t total_scrub_size =
++      submit->batch_type == VK_STRUCTURE_TYPE_SUBMIT_INFO_2
++         ? submit->scrub_wait_count * sizeof(VkSemaphoreSubmitInfo)
++         : submit->scrub_wait_count *
++              (sizeof(VkSemaphore) + sizeof(uint64_t) +
++               sizeof(VkPipelineStageFlags) + sizeof(uint32_t));
+    /* for fixing command buffer counts in device group info, if it exists */
+    const size_t total_pnext_size =
+       submit->pnext_count * sizeof(struct vn_submit_info_pnext_fix);
+    const size_t total_dev_mask_size =
+       submit->dev_mask_count * sizeof(uint32_t);
+    submit->temp.storage = vn_cached_storage_get(
+-      &queue->storage, total_batch_size + total_cmd_size + total_pnext_size +
+-                          total_dev_mask_size);
++      &queue->storage, total_batch_size + total_cmd_size + total_scrub_size +
++                          total_pnext_size + total_dev_mask_size);
+    if (!submit->temp.storage)
+       return VK_ERROR_OUT_OF_HOST_MEMORY;
+ 
+    submit->temp.batches = submit->temp.storage;
+    submit->temp.cmds = submit->temp.storage + total_batch_size;
+-   submit->temp.pnexts =
++   submit->temp.scrub =
+       submit->temp.storage + total_batch_size + total_cmd_size;
++   submit->temp.pnexts = submit->temp.storage + total_batch_size +
++                         total_cmd_size + total_scrub_size;
+    submit->temp.dev_masks = submit->temp.storage + total_batch_size +
+-                            total_cmd_size + total_pnext_size;
++                            total_cmd_size + total_scrub_size +
++                            total_pnext_size;
+ 
+    return VK_SUCCESS;
+ }
+@@ -883,13 +949,153 @@ vn_queue_submission_setup_batch(struct vn_queue_submission *submit,
+    return VK_SUCCESS;
+ }
+ 
++/* Elide the waits on semaphores with driver-side-only temporary sync fd
++ * payloads from the renderer submission.
++ *
++ * When the renderer cannot import sync fds, a temporary sync fd import (e.g.
++ * from wsi acquire) has no renderer-side effect: the renderer-side semaphore
++ * has no pending signal operation for the wait to consume.  So the guest
++ * waits on the sync fd here instead, and the then-satisfied semaphore wait
++ * is dropped from the batch's wait array before encoding.  Waiting the
++ * temporary payload also restores the permanent payload, keeping the
++ * renderer-side semaphore state consistent with temporary import semantics.
++ */
++static VkResult
++vn_queue_submission_scrub_batch_waits(struct vn_queue_submission *submit,
++                                      uint32_t batch_index)
++{
++   struct vk_queue *queue_vk = vk_queue_from_handle(submit->queue_handle);
++   struct vn_device *dev = vn_device_from_vk(queue_vk->base.device);
++
++   const uint32_t wait_count =
++      vn_get_wait_semaphore_count(submit, batch_index);
++   bool batch_has_elided_waits = false;
++   for (uint32_t i = 0; i < wait_count; i++) {
++      struct vn_semaphore *sem = vn_semaphore_from_handle(
++         vn_get_wait_semaphore(submit, batch_index, i));
++      if (sem->payload->type == VN_SYNC_TYPE_IMPORTED_SYNC_FD) {
++         batch_has_elided_waits = true;
++         break;
++      }
++   }
++   if (!batch_has_elided_waits)
++      return VK_SUCCESS;
++
++   assert(!dev->physical_device->renderer_sync_fd.semaphore_importable);
++
++   if (submit->batch_type == VK_STRUCTURE_TYPE_SUBMIT_INFO_2) {
++      VkSubmitInfo2 *batch = &submit->temp.submit2_batches[batch_index];
++      VkSemaphoreSubmitInfo *infos = submit->temp.scrub;
++      submit->temp.scrub += wait_count * sizeof(*infos);
++
++      uint32_t count = 0;
++      for (uint32_t i = 0; i < wait_count; i++) {
++         struct vn_semaphore *sem = vn_semaphore_from_handle(
++            batch->pWaitSemaphoreInfos[i].semaphore);
++         if (sem->payload->type == VN_SYNC_TYPE_IMPORTED_SYNC_FD) {
++            if (!vn_semaphore_wait_external(dev, sem))
++               return VK_ERROR_DEVICE_LOST;
++            continue;
++         }
++         infos[count++] = batch->pWaitSemaphoreInfos[i];
++      }
++      batch->pWaitSemaphoreInfos = infos;
++      batch->waitSemaphoreInfoCount = count;
++      return VK_SUCCESS;
++   }
++
++   assert(submit->batch_type == VK_STRUCTURE_TYPE_SUBMIT_INFO);
++   VkSubmitInfo *batch = &submit->temp.submit_batches[batch_index];
++
++   const VkTimelineSemaphoreSubmitInfo *timeline =
++      vk_find_struct_const(batch->pNext, TIMELINE_SEMAPHORE_SUBMIT_INFO);
++   const VkDeviceGroupSubmitInfo *group =
++      vk_find_struct_const(batch->pNext, DEVICE_GROUP_SUBMIT_INFO);
++   const bool has_wait_values = timeline && timeline->waitSemaphoreValueCount;
++   const bool has_wait_dev_indices = group && group->waitSemaphoreCount;
++
++   VkSemaphore *sems = submit->temp.scrub;
++   uint64_t *values = (void *)&sems[wait_count];
++   VkPipelineStageFlags *stages = (void *)&values[wait_count];
++   uint32_t *dev_indices = (void *)&stages[wait_count];
++   submit->temp.scrub +=
++      wait_count * (sizeof(VkSemaphore) + sizeof(uint64_t) +
++                    sizeof(VkPipelineStageFlags) + sizeof(uint32_t));
++
++   uint32_t count = 0;
++   for (uint32_t i = 0; i < wait_count; i++) {
++      struct vn_semaphore *sem =
++         vn_semaphore_from_handle(batch->pWaitSemaphores[i]);
++      if (sem->payload->type == VN_SYNC_TYPE_IMPORTED_SYNC_FD) {
++         if (!vn_semaphore_wait_external(dev, sem))
++            return VK_ERROR_DEVICE_LOST;
++         continue;
++      }
++      sems[count] = batch->pWaitSemaphores[i];
++      stages[count] = batch->pWaitDstStageMask[i];
++      if (has_wait_values)
++         values[count] = timeline->pWaitSemaphoreValues[i];
++      if (has_wait_dev_indices)
++         dev_indices[count] = group->pWaitSemaphoreDeviceIndices[i];
++      count++;
++   }
++   batch->pWaitSemaphores = sems;
++   batch->pWaitDstStageMask = stages;
++   batch->waitSemaphoreCount = count;
++
++   if (!has_wait_values && !has_wait_dev_indices)
++      return VK_SUCCESS;
++
++   /* Rebuild the pnext chain with fixed copies of the structs that carry
++    * per-wait-semaphore arrays.  The chain may already point at fixed copies
++    * installed by vn_fix_device_group_cmd_count, so copy from the current
++    * chain rather than the original batch.
++    */
++   struct vn_submit_info_pnext_fix *pnext_fix = submit->temp.pnexts++;
++   VkBaseOutStructure *dst = (void *)batch;
++   vk_foreach_struct_const(src, batch->pNext) {
++      void *pnext = NULL;
++      switch (src->sType) {
++      case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO:
++         memcpy(&pnext_fix->group, src, sizeof(pnext_fix->group));
++         if (has_wait_dev_indices) {
++            pnext_fix->group.waitSemaphoreCount = count;
++            pnext_fix->group.pWaitSemaphoreDeviceIndices = dev_indices;
++         }
++         pnext = &pnext_fix->group;
++         break;
++      case VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO:
++         memcpy(&pnext_fix->protected, src, sizeof(pnext_fix->protected));
++         pnext = &pnext_fix->protected;
++         break;
++      case VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO:
++         memcpy(&pnext_fix->timeline, src, sizeof(pnext_fix->timeline));
++         if (has_wait_values) {
++            pnext_fix->timeline.waitSemaphoreValueCount = count;
++            pnext_fix->timeline.pWaitSemaphoreValues = values;
++         }
++         pnext = &pnext_fix->timeline;
++         break;
++      default:
++         break;
++      }
++
++      if (pnext) {
++         dst->pNext = pnext;
++         dst = pnext;
++      }
++   }
++
++   return VK_SUCCESS;
++}
++
+ static VkResult
+ vn_queue_submission_setup_batches(struct vn_queue_submission *submit)
+ {
+    assert(submit->batch_type == VK_STRUCTURE_TYPE_SUBMIT_INFO_2 ||
+           submit->batch_type == VK_STRUCTURE_TYPE_SUBMIT_INFO);
+ 
+-   if (!submit->feedback_types)
++   if (!submit->feedback_types && !submit->has_elided_waits)
+       return VK_SUCCESS;
+ 
+    /* For a submission that is:
+@@ -922,6 +1128,14 @@ vn_queue_submission_setup_batches(struct vn_queue_submission *submit)
+ 
+    submit->batches = submit->temp.batches;
+ 
++   if (submit->has_elided_waits) {
++      for (uint32_t i = 0; i < submit->batch_count; i++) {
++         VkResult result = vn_queue_submission_scrub_batch_waits(submit, i);
++         if (result != VK_SUCCESS)
++            return result;
++      }
++   }
++
+    return VK_SUCCESS;
+ }
+ 
+diff --git a/src/virtio/vulkan/vn_wsi.c b/src/virtio/vulkan/vn_wsi.c
+index f64cabae8d1..1efef235105 100644
+--- a/src/virtio/vulkan/vn_wsi.c
++++ b/src/virtio/vulkan/vn_wsi.c
+@@ -390,12 +390,15 @@ vn_wsi_validate_image_format_info(struct vn_physical_device *physical_dev,
+ VkResult
+ vn_wsi_fence_wait(struct vn_device *dev, struct vn_queue *queue)
+ {
+-   /* External sync is supported by virtgpu backend but not vtest backend. For
+-    * vtest, common wsi will skip the implicit out fence installation due to
+-    * the lack of external SYNC_FD semaphore support. So we'll detect async
+-    * present thread and properly wait inside the wsi queue submit.
++   /* Common wsi installs the implicit out fence via the dma-buf sync file
++    * export path only when the driver advertises SYNC_FD binary semaphore
++    * export (see wsi_signal_dma_buf_from_semaphore), which requires
++    * renderer-side sync fd support on top of the virtgpu backend.  When the
++    * out fence cannot be installed (vtest, or renderers without semaphore
++    * sync fd support such as MoltenVK hosts), detect the async present
++    * thread and properly wait inside the wsi queue submit.
+     */
+-   if (dev->renderer->info.has_external_sync ||
++   if (dev->physical_device->external_binary_semaphore_handles ||
+        dev->renderer->info.has_implicit_fencing)
+       return VK_SUCCESS;
+ 

--- a/packages/vm/panes/guest-image/mesa/patches/0002-README.ix-document-snapshot-fork-layout.patch
+++ b/packages/vm/panes/guest-image/mesa/patches/0002-README.ix-document-snapshot-fork-layout.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Thu, 2 Jul 2026 18:31:24 -0700
+Subject: [PATCH 2/3] README.ix: document snapshot fork layout
+
+Refs: indexable-inc/index#1686
+
+diff --git a/README.ix.md b/README.ix.md
+new file mode 100644
+index 00000000000..432a318d42f
+--- /dev/null
++++ b/README.ix.md
+@@ -0,0 +1,29 @@
++# indexable-inc/mesa
++
++Snapshot fork of [mesa](https://gitlab.freedesktop.org/mesa/mesa) carrying the
++venus (virtio-gpu Vulkan) driver-side external semaphore patch for the panes
++GPU guest (indexable-inc/index#1686, tracking issue indexable-inc/index#1742).
++
++## Layout
++
++- Branch `ix/venus-driver-side-semaphore`: the base snapshot plus the patch
++  commits.
++- The base commit is a **snapshot** of the upstream `mesa-26.1.2` tag
++  (`git archive` of gitlab.freedesktop.org/mesa/mesa @ mesa-26.1.2), not the
++  full upstream history: upstream history is ~2 GB and the fork only needs to
++  pin a patched source tree for a nix `fetchFromGitHub` src override. The
++  version must match the mesa recipe of the nixpkgs pin used by
++  indexable-inc/index (26.1.2).
++
++## Why
++
++On macOS hosts (vmkit/libkrun -> virglrenderer -> MoltenVK), MoltenVK never
++supports SYNC_FD semaphore import, so upstream venus masks
++VK_KHR_synchronization2 (clamping the guest device to Vulkan 1.2) and all WSI
++extensions. The patch implements mesa's own suggested fix: handle temporary
++sync fd semaphore imports purely on the driver side (guest-side wait plus
++eliding the semaphore wait from the renderer submission), so sync2, Vulkan
++1.3, and VK_KHR_swapchain no longer depend on renderer sync fd import.
++
++Intended to be upstreamed to mesa; this fork exists so the guest image can
++pin it meanwhile.

--- a/packages/vm/panes/guest-image/mesa/patches/0003-venus-fail-sparse-batches-waiting-on-driver-side-syn.patch
+++ b/packages/vm/panes/guest-image/mesa/patches/0003-venus-fail-sparse-batches-waiting-on-driver-side-syn.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Thu, 2 Jul 2026 20:12:59 -0700
+Subject: [PATCH 3/3] venus: fail sparse batches waiting on driver-side sync fd
+ imports
+
+The previous fallback relied on an assert that compiles out under NDEBUG (nixpkgs release builds), leaving a silent renderer hang on the (currently unreachable) sparse+imported+non-importable combination. Log and return VK_ERROR_DEVICE_LOST explicitly; keep the assert for debug builds. Review follow-up for indexable-inc/index#1763.
+
+diff --git a/src/virtio/vulkan/vn_queue.c b/src/virtio/vulkan/vn_queue.c
+index 61d4583a5d5..f9c03d58010 100644
+--- a/src/virtio/vulkan/vn_queue.c
++++ b/src/virtio/vulkan/vn_queue.c
+@@ -429,14 +429,28 @@ vn_queue_submission_fix_batch_semaphores(struct vn_queue_submission *submit,
+           * Sparse batches are excluded: they bypass the temp batch storage.
+           * No renderer lacking sync fd import is known to expose sparse
+           * binding (MoltenVK has none), so an imported payload should never
+-          * reach a sparse queue; if one ever does, the pre-existing path
+-          * below keeps the renderer-side payload fix, which fails loudly
+-          * (assert / unserviceable renderer call) rather than hanging.
++          * reach a sparse queue; if one ever does, the explicit check below
++          * returns VK_ERROR_DEVICE_LOST rather than handing the renderer an
++          * import it cannot service.
+           */
+          batch_has_elided_waits = true;
+          continue;
+       }
+ 
++      if (!dev->physical_device->renderer_sync_fd.semaphore_importable) {
++         /* Only reachable for sparse batches (non-sparse imported waits were
++          * elided above).  The renderer-side payload fix below would hand a
++          * vkImportSemaphoreResourceMESA to a renderer that cannot service
++          * it, which hangs in release builds where the assert compiles out;
++          * fail loudly instead.
++          */
++         vn_log(dev->instance,
++                "sparse batch waits on a temporarily imported sync fd "
++                "semaphore, but the renderer cannot import sync fds");
++         assert(!"sparse batch wait on driver-side sync fd import");
++         return VK_ERROR_DEVICE_LOST;
++      }
++
+       if (!vn_semaphore_wait_external(dev, sem))
+          return VK_ERROR_DEVICE_LOST;
+ 

--- a/packages/vm/panes/guest-image/pins.json
+++ b/packages/vm/panes/guest-image/pins.json
@@ -1,11 +1,4 @@
 {
-  "mesa-src": {
-    "version": "26.1.2",
-    "url": "https://github.com/indexable-inc/mesa/archive/41e040d437beca9c34994fe3d14b213c2bad59ea.tar.gz",
-    "branch": "ix/venus-driver-side-semaphore",
-    "hash": "sha256-c9oAynAK6kbCt2A6VYL/VEChIsYJvinzcXmDqILTeX8=",
-    "prefetch": "unpack"
-  },
   "lwjgl": {
     "version": "3.4.1",
     "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.4.1/lwjgl-3.4.1-natives-linux-arm64.jar",


### PR DESCRIPTION
Closes #1894. Follow-up to #1893 / #1903.

De-forks mesa: replaces the `indexable-inc/mesa` snapshot-fork tarball (pinned in `packages/vm/panes/guest-image/pins.json` at `41e040d4`) with an upstream `mesa-src` input plus the venus delta as an in-repo patch series, applied through `ix.patchedSrc` — the same pattern as codex/btop/clippy.

## What
- **`flake.nix`**: new `mesa-src` = `git+https://gitlab.freedesktop.org/mesa/mesa?ref=refs/tags/mesa-26.1.2&shallow=1` (`flake = false`). `shallow=1` is load-bearing (same reason as `snix-src`): mesa's git history is huge and only the tag tree is ever used; without it the lock records `revCount` and a cold `nix flake archive`/direnv load clones full history. The lock still records the rev, so `rebase-patches` can read the base.
- **`lib/fork-packages.nix`**: mesa entry, `autoUpdate = false`. mesa is panes-GPU-coupled: a base bump must be rebased **and boot-validated on a linux GPU host** (the venus patch is proven by running the guest, not CI), so it moves only under a deliberate manual `rebase-patches` run, never the scheduled fork-sync cron (which filters on `autoUpdate`). `url` is the gitlab git remote so `rebase-patches`' scratch-clone fetch works.
- **`lib/default.nix`** / **`lib/per-system.nix`**: expose `ix.mesaSrc`; add mesa to `forkSrcInputs` so `checks.<system>.patched-src-mesa` is generated on every system.
- **`packages/vm/panes/guest-image/{default,pins,apps}.nix`**: the guest mesa overlay now consumes `ix.patchedSrc { src = ix.mesaSrc; patchDir = ./mesa/patches; }`; the `mesa-src` pin is dropped from `pins.json` (which now carries only the lwjgl-* jars).
- **`packages/vm/panes/guest-image/mesa/patches/`**: the 3-patch series (venus driver-side sync-fd semaphores, `README.ix`, venus sparse-batch `VK_ERROR_DEVICE_LOST` fallback), exported `--zero-commit --no-signature --no-stat`.

## Delta provenance
The fork was an orphan snapshot: commit `ab3d243` (no parents) is a `git archive` of the `mesa-26.1.2` tag, and its tree is **bit-identical** to the upstream tag tree (`4f43e4da`). Upstream `mesa-26.1.2` = `b3d356db`. Applying the 3-commit delta (`ab3d243..41e040d`) onto `b3d356db` reproduces the fork's final tree (`118a6c45`) exactly.

## Faithful migration
Upstream `mesa-26.1.2` + the series → git tree `118a6c45`, **bit-identical to the old fork tree**. The built `patched-src` derivation differs from the old **GitHub archive tarball** only in `*.csv` line endings (LF vs CRLF): mesa's `.gitattributes` marks csv `eol=crlf`, which GitHub's archive applies on checkout but nix's git fetcher leaves as the raw LF blob. All 31 differing files are csv, each byte-identical after stripping CR, and `format_parser.py` strips per-line whitespace, so the build is unaffected.

## Validation
- `nix run .#lint` green.
- Built `checks.aarch64-darwin.patched-src-mesa` **and** `checks.x86_64-linux.patched-src-mesa` (on vin-compute-1) — the series applies on both.
- Byte-identity: `diff -r` of the patched tree vs the old `indexable-inc/mesa` tarball is CRLF-in-csv only (proof above).
- Guest-image overlay evaluates cleanly (version assert passes); darwin eval stops only at the unrelated x86-IFD platform mismatch, same boundary as #1893.
- **Boundary**: the full aarch64-linux mesa compile + panes-guest boot needs an aarch64 GPU host (no aarch64-linux builder is configured here), same as #1893's heavy builds. CI's `flake-check` builds `.#ciChecks.x86_64-linux`, which is exactly `patched-src-mesa` for this change (proven green), not the aarch64 image.

## After merge
Fork-only-branch sweep on `indexable-inc/mesa` (set-difference vs upstream branch names), then archive the repo — **unless** it holds an in-flight upstream GitLab MR branch (`venus-driver-side-sync-fd`), in which case report instead of archiving.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### De-fork Mesa by switching to upstream pin with an in-repo venus patch series
> - Replaces the `pins.json`-based Mesa snapshot tarball with a pinned upstream Mesa 26.1.2 flake input (`mesa-src`) and applies patches from [`packages/vm/panes/guest-image/mesa/patches/`](https://github.com/indexable-inc/index/pull/1907/files#diff-750cf57625bdd8071e67c0f7db7a35ca678b07056cd7fc60e3f2804a5c1a432d) via `ix.patchedSrc`.
> - Adds a venus patch that handles temporary sync fd semaphore imports on the driver side, exposing `VK_KHR_synchronization2` and WSI extensions even when the renderer lacks sync fd import support.
> - Adds a follow-up venus patch that returns `VK_ERROR_DEVICE_LOST` for sparse batches waiting on driver-side-only sync fd semaphores, preventing silent hangs.
> - Registers Mesa in the fork-package infrastructure ([`lib/fork-packages.nix`](https://github.com/indexable-inc/index/pull/1907/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4)) with `autoUpdate` disabled so it won't be bumped automatically.
> - Behavioral Change: Mesa build provenance changes from a pre-patched fork tarball to upstream source with patches applied at build time; runtime behavior reflects the new venus semaphore handling logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e4f440.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->