### PR TITLE
de-fork nix: pin upstream 2.34.7 + in-repo patch series

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -106,7 +106,7 @@ jobs:
           body: |
             Automated fork-sync: bump each auto-updatable de-forked package's upstream base and regenerate its in-repo patch series through a real `git rebase`.
 
-            Driven by `lib/fork-packages.nix` (`autoUpdate = true`): currently **codex** (`openai/codex`) and **btop** (`aristocratos/btop`). **clippy is excluded** (`autoUpdate = false`): it is nightly-toolchain-coupled and rev-pinned, bumped by hand alongside the rust toolchain via `nix run .#rebase-patches -- clippy`.
+            Driven by `lib/fork-packages.nix` (`autoUpdate = true`): currently **codex** (`openai/codex`) and **btop** (`aristocratos/btop`). Excluded (`autoUpdate = false`, bumped by hand via `nix run .#rebase-patches -- <name>`): **clippy** is nightly-toolchain-coupled and rev-pinned, bumped alongside the rust toolchain; **nix** is our daemon toolchain, pinned at the rev the fleet daemon runs, bumped only when we deliberately move the daemon version.
 
             Each `patched-src-<name>` check was built against the freshly bumped base in this job, so the series still applies. The PR's `flake-check` CI rebuilds the full packages.
 

--- a/flake.lock
+++ b/flake.lock
@@ -228,6 +228,23 @@
         "url": "https://gitlab.freedesktop.org/mesa/mesa"
       }
     },
+    "nix-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777915353,
+        "narHash": "sha256-uj5KNW8Vdm60FCUxD2KsrCVH/WwoemvczWmmrb3Gvlo=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "2c6d06e9387cf58167cb5a7ab91cee7333d8d17c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "2c6d06e9387cf58167cb5a7ab91cee7333d8d17c",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780749050,
@@ -418,6 +435,7 @@
         "home-manager": "home-manager",
         "launchk-src": "launchk-src",
         "mesa-src": "mesa-src",
+        "nix-src": "nix-src",
         "nixpkgs": "nixpkgs",
         "nu-jupyter-kernel-src": "nu-jupyter-kernel-src",
         "perftest-src": "perftest-src",

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,20 @@
       flake = false;
     };
 
+    # Upstream NixOS/nix, patched in-repo (packages/nix/nix/patches). Pinned BY
+    # REV at tag 2.34.7, the version the hydra daemon runs (`nix store info` ->
+    # `Version: 2.34.7`): nix is our daemon toolchain, so the patched package
+    # must stay a protocol-compatible drop-in for the running daemon. The base
+    # moves DELIBERATELY, never under a routine `nix flake update`
+    # (fork-packages.nix marks it `autoUpdate = false`, so the scheduled
+    # fork-sync leaves it alone): bump this rev only when we intend to move the
+    # daemon version too, then `nix run .#rebase-patches -- nix` to regenerate
+    # the series on the new base.
+    nix-src = {
+      url = "github:NixOS/nix/2c6d06e9387cf58167cb5a7ab91cee7333d8d17c";
+      flake = false;
+    };
+
     # Upstream aristocratos/btop, patched in-repo (packages/terminal/btop/patches).
     # Tracks upstream main (autoUpdate = true in lib/fork-packages.nix): the base
     # free-floats under the scheduled fork-sync, which runs `nix flake update
@@ -235,6 +249,7 @@
     snix-src,
     clippy-src,
     codex-src,
+    nix-src,
     ghostty,
     mesa-src,
     skills,
@@ -318,6 +333,7 @@
         snix-src
         clippy-src
         codex-src
+        nix-src
         ghostty
         mesa-src
         ;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -15,6 +15,7 @@
   snix-src,
   clippy-src,
   codex-src,
+  nix-src,
   ghostty,
   mesa-src,
   # Flake source revision, stamped into builds that want to report it (see
@@ -516,6 +517,7 @@
     btopSrc = btop-src;
     codexSrc = codex-src;
     clippySrc = clippy-src;
+    nixSrc = nix-src;
     drgnSrc = drgn-src;
     perftestSrc = perftest-src;
     fffSrc = fff-src;

--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -64,5 +64,19 @@
       patchDir = "packages/vm/panes/guest-image/mesa/patches";
       autoUpdate = false;
     }
+    {
+      # nix is our daemon toolchain: the base is the exact rev the hydra daemon
+      # runs (tag 2.34.7), so the patched package is a protocol-compatible
+      # drop-in for the running daemon. The base moves DELIBERATELY, in the same
+      # change that moves the daemon version, never under a routine
+      # `nix flake update` or the scheduled fork-sync -- hence `autoUpdate =
+      # false`, which pins `nix-src` by rev and keeps it out of the cron. Bump the
+      # `nix-src` rev, then `nix run .#rebase-patches -- nix`.
+      name = "nix";
+      input = "nix-src";
+      url = "https://github.com/NixOS/nix.git";
+      patchDir = "packages/nix/nix/patches";
+      autoUpdate = false;
+    }
   ];
 }

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -589,6 +589,7 @@
     btop = ix.btopSrc;
     clippy = ix.clippySrc;
     mesa = ix.mesaSrc;
+    nix = ix.nixSrc;
   };
   patchedSrcChecks = lib.genAttrs' (import ./fork-packages.nix).forkPackages (
     fork:

--- a/packages/nix/nix/default.nix
+++ b/packages/nix/nix/default.nix
@@ -1,0 +1,121 @@
+{
+  ix,
+  lib,
+}:
+# Upstream NixOS/nix pinned at tag 2.34.7 (the `nix-src` input, surfaced as
+# `ix.nixSrc`) with the in-repo patch series (./patches) applied, built through
+# nixpkgs' own modular nix packaging so the result is a protocol-compatible
+# drop-in for the daemon the fleet runs.
+#
+# De-forking replacement for a standalone `indexable-inc/nix` fork checkout:
+# instead of tracking a whole fork branch, the delta lives as an ordered
+# `patches/` series applied on top of the exact upstream rev the daemon runs.
+# The current series carries two patches: the GC-roots client-interrupt
+# daemon crash fix (extracted from the fork's
+# `fix-gc-roots-client-interrupt-crash` branch, complete and clean against
+# 2.34.7), and an eval fix treating inaccessible default lookup-path entries
+# as absent (found while validating this build: the macOS sandbox denies the
+# host's root-channels dir with EPERM, which aborted the C API unit tests and
+# the recursive-nix functional test on any darwin host with root channels;
+# clean CI builders lack the path, which is why caches carry the stock drvs
+# green). The fork's
+# `codex/flake-check-eval-cache` branch (draft PR indexable-inc/nix#1) is
+# deliberately excluded: it is self-declared WIP, untested, and incomplete.
+# A parallel change lands a global build-observability series into this folder.
+let
+  # Read `pkgs` from `ix` rather than a `pkgs` callPackage formal: a `src`/`pkgs`
+  # formal is fragile against `callPackage` auto-binding, and the rest of the
+  # nix/* packages read `pkgs` off their argument the same way.
+  inherit (ix) pkgs;
+
+  # The patched upstream tree: the ./patches series applied 0001..NNNN on top of
+  # the pinned 2.34.7 source, via the shared de-fork util. This doubles as the
+  # `checks.<system>.patched-src-nix` conflict gate (per-system wiring), so a
+  # patch that stops applying fails there in seconds.
+  patchedSrc = ix.patchedSrc {
+    name = "nix";
+    src = ix.nixSrc;
+    patchDir = ./patches;
+  };
+
+  # nixpkgs builds `nixVersions.nix_2_34` as
+  # `(nixComponents_2_34.overrideSource fetchedSrc).appendPatches patches_common`
+  # then takes `.nix-everything` (pkgs/tools/package-management/nix/default.nix).
+  # The pinned rev IS the tag 2.34.7 nixpkgs itself fetches (byte-identical
+  # narHash), so swapping the fetched source for our patched tree via the same
+  # modular `overrideSource` handle rebuilds every component from the patched
+  # tree while keeping nixpkgs' interdependency scope and build wiring intact.
+  base = pkgs.nixVersions.nixComponents_2_34;
+
+  # nixpkgs' own whole-source patches for this version: currently just the
+  # aarch64-darwin flaky-test skip (empty on every other system). `overrideSource`
+  # resets the scope's `patches` to `[]`, so re-apply them here to match a stock
+  # `nix_2_34` build; our own delta rides in `patchedSrc`, not here.
+  patchesCommon = lib.optional pkgs.stdenv.hostPlatform.isDarwin (
+    pkgs.path + "/pkgs/tools/package-management/nix/patches/skip-flaky-darwin-tests.patch"
+  );
+
+  # Identify a patched daemon by version: `nix --version` (and
+  # `builtins.nixVersion`) report the version each *component* was compiled
+  # with -- the modular build's preConfigure writes the component derivation's
+  # `version` into the tree's `.version` on every build, so a `.version` source
+  # patch in our series would be clobbered and a version override on the
+  # `nix-everything` aggregate would only rename the store path. Set it through
+  # `overrideAllMesonComponents`, the last layer in the component builder
+  # stack, which also wins over the sourceLayer's `+<patch-count>` suffix.
+  # The marker is semver build metadata (`+ix`, like nixpkgs' own `+1`), not
+  # `-ix`: meson feeds the version to darwin ld's -current_version, which
+  # rejects a `-` suffix as a "malformed 32-bit x.y.z version number" but
+  # tolerates `+`.
+  patchedComponents =
+    ((base.overrideSource patchedSrc).appendPatches patchesCommon).overrideAllMesonComponents
+    (_: _: {version = "2.34.7+ix";});
+
+  # The aggregate `nix` package (daemon + client + libs), the same attribute
+  # `nixVersions.nix_2_34` exposes.
+  nixEverything = patchedComponents.nix-everything;
+
+  package = nixEverything.overrideAttrs (old: {
+    version = "2.34.7+ix";
+    meta =
+      (old.meta or {})
+      // {
+        description = "NixOS/nix 2.34.7 with the index in-repo patch series (GC-roots daemon-crash fix, lookup-path EPERM eval fix)";
+        mainProgram = "nix";
+      };
+  });
+
+  # The override's real risk is that the whole modular C++ tree still links and
+  # the patched daemon still runs, so the smoke test executes the binary and
+  # asserts the `+ix` marker. `--version` exits 0 without touching a store or
+  # daemon (absent in the sandbox), so it is safe as a build-time check.
+  smoke =
+    pkgs.runCommand "nix-ix-smoke"
+    {
+      nativeBuildInputs = [package];
+      strictDeps = true;
+    }
+    ''
+      version=$(nix --version)
+      case "$version" in
+        *"2.34.7+ix"*) ;;
+        *)
+          echo "nix --version did not report the patched 2.34.7+ix build" >&2
+          printf '%s\n' "$version" >&2
+          exit 1
+          ;;
+      esac
+      mkdir -p "$out"
+    '';
+in
+  package.overrideAttrs (old: {
+    passthru =
+      (old.passthru or {})
+      // {
+        tests =
+          (old.passthru.tests or old.tests or {})
+          // {
+            inherit smoke;
+          };
+      };
+  })

--- a/packages/nix/nix/package.nix
+++ b/packages/nix/nix/package.nix
@@ -1,0 +1,21 @@
+{
+  # Upstream NixOS/nix (nix-src input) with the in-repo patch series
+  # (./patches) applied, built through nixpkgs' modular nix packaging so it is
+  # a drop-in for the daemon version the fleet runs (2.34.7). Surfaced as
+  # `pkgs.nix-ix` in the repo package set and as the `nix-ix` flake output.
+  #
+  # Deliberately NOT in the nixpkgs overlay: the derivation reads
+  # `pkgs.nixVersions.nixComponents_2_34` as its base, so injecting this package
+  # under the bare `nix` name would make it its own base (infinite recursion),
+  # exactly as nix-eval-jobs / nix-output-monitor document for their overrides.
+  #
+  # `autoUpdate = false` in lib/fork-packages.nix keeps the base pinned by rev
+  # and out of the scheduled fork-sync, so it is not wired to the routine
+  # `nix run .#update` DAG (like clippy, and unlike codex/btop): the daemon
+  # version moves only under a deliberate change. Hence no `updateScript` flag.
+  id = "nix-ix";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  passthruTests = true;
+}

--- a/packages/nix/nix/patches/0001-fix-libstore-don-t-crash-the-daemon-when-a-GC-roots-.patch
+++ b/packages/nix/nix/patches/0001-fix-libstore-don-t-crash-the-daemon-when-a-GC-roots-.patch
@@ -1,0 +1,51 @@
+From 365d8c7d194cbd3eba674c18c19242c9e2dfa45f Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 5 Jul 2026 19:54:54 -0700
+Subject: [PATCH] fix(libstore): don't crash the daemon when a GC roots client
+ thread is interrupted
+
+The GC roots server in LocalStore::collectGarbage handles each connected
+client in a std::thread whose read loop is guarded only by `catch (Error & e)`.
+FdSource::readLine() -> checkInterrupt() throws Interrupted, which derives from
+BaseError, not Error, so it escapes the catch. An exception escaping a
+std::thread's top-level body calls std::terminate() and aborts the whole
+nix-daemon (SIGABRT). The interrupt flag is process-global, so any client
+disconnecting mid-operation while a collectGarbage() runs crashes the daemon --
+frequent on a busy multi-client daemon (CI cancelling/timing-out builds).
+
+Broaden the catch to `catch (...)` and swallow via ignoreExceptionInDestructor(),
+mirroring the auto-GC worker thread in the same file.
+
+Origin: indexable-inc/nix branch fix-gc-roots-client-interrupt-crash (commit
+4a2e137b3), rebased onto the 2.34.7 base.
+---
+ src/libstore/gc.cc | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/libstore/gc.cc b/src/libstore/gc.cc
+index 16b81ab..3e959c8 100644
+--- a/src/libstore/gc.cc
++++ b/src/libstore/gc.cc
+@@ -495,6 +495,19 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
+                         } catch (Error & e) {
+                             debug("reading GC root from client: %s", e.msg());
+                             break;
++                        } catch (...) {
++                            /* This is the top-level body of a std::thread, so any
++                               exception that escapes it calls std::terminate() and
++                               aborts the whole daemon (true whether the thread is
++                               later joined or detached). readLine() throws
++                               Interrupted, which derives from BaseError, not Error,
++                               when the interrupt flag is set -- e.g. when another
++                               client disconnects mid-operation while this GC runs
++                               -- so the catch above does not catch it. Swallow it
++                               and drop this connection instead of crashing,
++                               mirroring the auto-GC worker thread below. */
++                            ignoreExceptionInDestructor();
++                            break;
+                         }
+                     }
+                 });
+-- 
+2.54.0
+

--- a/packages/nix/nix/patches/0002-fix-libexpr-treat-inaccessible-default-lookup-path-e.patch
+++ b/packages/nix/nix/patches/0002-fix-libexpr-treat-inaccessible-default-lookup-path-e.patch
@@ -1,0 +1,47 @@
+From 315554e6dcd5e281a855605c570935d52a9d0e67 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 5 Jul 2026 21:29:59 -0700
+Subject: [PATCH] fix(libexpr): treat inaccessible default lookup-path entries
+ as absent
+
+EvalSettings::getDefaultNixPath() probes its optional convenience entries
+(~/.nix-defexpr/channels, $NIX_STATE_DIR/profiles/per-user/root/channels)
+with the throwing std::filesystem::exists() overload. When the stat fails
+with something other than ENOENT -- e.g. EPERM from the macOS build sandbox
+denying the host's /nix/var while nix runs inside a derivation
+(recursive-nix, or the libflake C API unit tests on any darwin host that
+has root channels) -- the filesystem_error aborts every --impure eval, even
+one that never consults the lookup path.
+
+Switch to the non-throwing overload: an entry that cannot be stat'd is
+simply not offered as a default lookup path, matching how a missing entry
+already behaves.
+---
+ src/libexpr/eval-settings.cc | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/src/libexpr/eval-settings.cc b/src/libexpr/eval-settings.cc
+index 5cf0ae0..69c2494 100644
+--- a/src/libexpr/eval-settings.cc
++++ b/src/libexpr/eval-settings.cc
+@@ -82,7 +82,16 @@ Strings EvalSettings::getDefaultNixPath()
+ {
+     Strings res;
+     auto add = [&](const std::filesystem::path & p, const std::string & s = std::string()) {
+-        if (std::filesystem::exists(p)) {
++        /* Use the non-throwing exists() overload: these default lookup-path
++           entries are optional conveniences, so an inaccessible path must mean
++           "absent", not an eval abort. The throwing overload turns an EPERM
++           stat -- e.g. the macOS build sandbox denying access to the host's
++           /nix/var/nix/profiles/per-user/root/channels while nix runs inside a
++           derivation (recursive-nix, the C API unit tests) -- into a fatal
++           filesystem_error for any --impure eval, even one that never uses the
++           lookup path entry. */
++        std::error_code ec;
++        if (std::filesystem::exists(p, ec)) {
+             if (s.empty()) {
+                 res.push_back(p.string());
+             } else {
+-- 
+2.54.0
+


### PR DESCRIPTION
Closes #1896. Brings `nix` into the patches-on-upstream de-fork system from #1893.

## What

- **`nix-src` flake input** (`flake = false`) pinned at rev `2c6d06e9387cf58167cb5a7ab91cee7333d8d17c` (tag **2.34.7**) — the exact version the fleet daemon runs (`nix store info` -> `Version: 2.34.7`). The locked narHash is byte-identical to the source nixpkgs' own `nixVersions.nix_2_34` fetches, so this is a like-for-like base.
- **`nix` entry in `lib/fork-packages.nix`** with `autoUpdate = false`: nix is our daemon toolchain, so the base moves only under a deliberate change, never the scheduled fork-sync (same posture as clippy). The one fork list drives the `patched-src-nix` check and the `rebase-patches -- nix` arg automatically.
- **`packages/nix/nix/`** (`package.nix` + `default.nix`, id `nix-ix`): builds the aggregate nix through nixpkgs' modular packaging via `(nixComponents_2_34.overrideSource patchedSrc).appendPatches patchesCommon`, re-applying nixpkgs' own whole-source patches. `nix --version` is set to `2.34.7+ix` at the derivation level so a patched daemon is identifiable (the modular `preConfigure` clobbers the tree's `.version`, so a source patch would not stick), with a smoke test asserting the `+ix` marker.

## Patch series (two patches)

`0001`: the **GC-roots client-interrupt daemon-crash fix**, extracted from the fork's `fix-gc-roots-client-interrupt-crash` branch. `LocalStore::collectGarbage` handles each GC-roots client in a `std::thread` guarded only by `catch (Error &)`; `readLine()` throws `Interrupted` (derives from `BaseError`, not `Error`), which escapes the catch, escapes the thread body, and `std::terminate()`s the whole daemon. The fix broadens the catch, mirroring the auto-GC worker thread in the same file. Complete, root-cause, applies with zero fuzz against 2.34.7.

The fork's `codex/flake-check-eval-cache` branch (draft PR indexable-inc/nix#1, context in RFC #405) is **deliberately excluded**: it is self-declared WIP ("compile/behaviour validation in progress"), untested (its own design doc lists "add tests" as an outstanding pre-upstream follow-up), and incomplete. Not safe as a stable patch.

A parallel change lands a global build-observability series into `packages/nix/nix/patches/`; the folder is left ready for it.

## Validation

- `nix run .#lint` clean.
- `checks.aarch64-darwin.patched-src-nix` builds (series applies cleanly on 2.34.7).
- `packages.aarch64-darwin.nix-ix` builds; smoke test confirms `nix --version` reports `2.34.7+ix`.
- The `rebase-patches` mapping and the `patched-src-nix` per-system check are both driven by the single `lib/fork-packages.nix` entry — no other wiring, verified via `nix eval .#lib.forkPackages`.

Does **not** touch the running daemon or the `indexable-inc/nix` fork repo (which stays alive for the upstreaming workflow).

## Two non-obvious mechanics (found while validating)

- **Version marker**: `nix --version` reports the version each *component* was compiled with (the modular build's `preConfigure` writes the component derivation's `version` into the tree's `.version`, clobbering any source patch; an override on the `nix-everything` aggregate only renames the store path). The `+ix` suffix (build metadata, not `-ix`: meson feeds the version to darwin ld's `-current_version`, which rejects a `-` suffix as malformed but tolerates `+`, like nixpkgs' own `+1`) is therefore set via `overrideAllMesonComponents`, the last layer in the component builder stack, which also wins over the sourceLayer's `+<patch-count>` suffix.
- **Lookup-path EPERM (patch `0002`)**: `EvalSettings::getDefaultNixPath()` probes its optional root-channels entry with the throwing `std::filesystem::exists()`, so the macOS build sandbox's EPERM on any host that has root channels (any workstation, including the native darwin CI lane host) aborts the libflake C API unit tests and the recursive-nix functional test. Reproduced identically with the *stock* `nixVersions.nix_2_34` (`nix build --rebuild` of its `nix-flake-tests.tests.run` fails the same 3 tests on this host), so it is an upstream nix bug our patch fixes at the root: an inaccessible optional lookup-path entry is treated as absent, matching missing-entry behavior. Upstreamable.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin upstream Nix 2.34.7 with an in-repo patch series replacing the forked Nix
> - Adds a pinned `nix-src` flake input at NixOS/nix 2.34.7 and wires it through [flake.nix](https://github.com/indexable-inc/index/pull/1908/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0), [lib/default.nix](https://github.com/indexable-inc/index/pull/1908/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188), and [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1908/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683).
> - Builds a new `nix-ix` package in [packages/nix/nix/default.nix](https://github.com/indexable-inc/index/pull/1908/files#diff-4332ad9feb37626c0ac4a68155597b10c261c0e0460cfcbca84f88d3d6125c6e) based on nixpkgs' `nixComponents_2_34`, applying two in-repo patches and reporting version `2.34.7+ix`.
> - Patch [0001](https://github.com/indexable-inc/index/pull/1908/files#diff-2a703db65303f7f7d269ae802072e8f5e4a984d141b3ab175452f2051dd5d197) broadens exception handling in `LocalStore::collectGarbage` to prevent `std::terminate` when a GC roots client thread is interrupted.
> - Patch [0002](https://github.com/indexable-inc/index/pull/1908/files#diff-553bdf991d44939134c8fbd67b0844c7353e95a19ee8d0c53b727f16dcc07818) makes `EvalSettings::getDefaultNixPath()` tolerate EPERM on default lookup-path entries instead of throwing.
> - The `nix-src` input is excluded from auto-update in [lib/fork-packages.nix](https://github.com/indexable-inc/index/pull/1908/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4) and must be bumped manually to match the daemon revision.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b983519.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->