### PR TITLE
system-prompt: one-implementation rule extends across repo boundaries

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -395,10 +395,19 @@ let
           prompts, instructions, this prompt included), state each rule once at its
           owner and cross-reference instead of restating: duplicates drift and
           contradict.
+
+          This holds across repository boundaries: when a sibling repo needs
+          machinery another repo already owns, do not reimplement it. Expose a
+          narrow seam at the owner (a lib flake output, a tool parameterized over
+          the consumer's data) and consume it through a flake input; land the
+          exposure PR at the owner first. Each consumer keeps only its own data
+          (mappings, pins, patches), never a copy of the machinery.
         '';
         reason = ''
           Duplicated logic and restated rules drifted until copies contradicted each
-          other, including within instruction docs.
+          other, including within instruction docs. An agent reimplemented the
+          fork-patch machinery inside ix instead of importing it from index
+          (ix#6409 rework); the user rejected the duplicate.
         '';
       };
     }


### PR DESCRIPTION
Extends the oneImplementation section: machinery is exposed once at its owning repo (narrow lib output or a tool parameterized over consumer data) and consumed via flake inputs; consumers keep only data. Prompted by the ix#6409 rework where fork-patch machinery got reimplemented in ix instead of imported from index. Rendered and reread via nix eval.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend one-implementation rule in agent system prompt to cover cross-repo boundaries
> Updates [system-prompt.nix](https://github.com/indexable-inc/index/pull/1910/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to instruct agents not to reimplement machinery that already exists in a sibling repo. Instead, agents should expose a narrow seam at the owning repo (e.g., a `lib` flake output or parameterized tool) and consume it via a flake input, keeping only consumer-specific data locally. Adds a concrete example: an agent reimplementing fork-patch machinery inside `ix` instead of importing it from `index` was rejected (ix#6409 rework).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53dd9fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->