### PR TITLE
system-prompt: clarify DRY-across-repos and second-consumer rule

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -395,10 +395,19 @@ let
           prompts, instructions, this prompt included), state each rule once at its
           owner and cross-reference instead of restating: duplicates drift and
           contradict.
+
+          This holds across repository boundaries: when a sibling repo needs
+          machinery another repo already owns, do not reimplement it. Expose a
+          narrow seam at the owner (a lib flake output, a tool parameterized over
+          the consumer's data) and consume it through a flake input; land the
+          exposure PR at the owner first. Each consumer keeps only its own data
+          (mappings, pins, patches), never a copy of the machinery.
         '';
         reason = ''
           Duplicated logic and restated rules drifted until copies contradicted each
-          other, including within instruction docs.
+          other, including within instruction docs. An agent reimplemented the
+          fork-patch machinery inside ix instead of importing it from index
+          (ix#6409 rework); the user rejected the duplicate.
         '';
       };
     }

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -397,11 +397,13 @@ let
           contradict.
 
           This holds across repository boundaries: when a sibling repo needs
-          machinery another repo already owns, do not reimplement it. Expose a
-          narrow seam at the owner (a lib flake output, a tool parameterized over
-          the consumer's data) and consume it through a flake input; land the
-          exposure PR at the owner first. Each consumer keeps only its own data
-          (mappings, pins, patches), never a copy of the machinery.
+          machinery another repo already owns, do not reimplement it. The
+          sibling's need is the real second consumer that earns a shared home,
+          so expose a narrow seam at the owner (a lib flake output, a tool
+          parameterized over the consumer's data) and consume it through a
+          flake input; land the exposure PR at the owner first. Each consumer
+          keeps only its own data (mappings, pins, patches), never a copy of
+          the machinery.
         '';
         reason = ''
           Duplicated logic and restated rules drifted until copies contradicted each


### PR DESCRIPTION
Clarify and expand the system prompt's one-implementation rule to explicitly cover sibling repository machinery reuse.

**Changes:**
- System prompt now requires importing machinery across repos via flake seams instead of reimplementing
- Consumers keep only their own data (patches, pins, mappings); machinery lives at the owner
- Reinforces that a shared home is earned on the second consumer (not predicted)

**Context:** 
This prompted by ix#6409 rework where fork-patch machinery was duplicated into ix instead of imported from index.lib. The user rejected the duplicate, so the system prompt is being updated to make this rule explicit for future agents.

The index fork-packages machinery is the authority; ix should import patchedSrcFor from index.lib rather than maintaining a local patched-src.nix copy.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify DRY-across-repos and second-consumer rules in the agent system prompt
> Updates the rule text in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1911/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to explicitly address cross-repository duplication. The rule now instructs consumers to expose a narrow seam at the owner repository (e.g., a lib flake output or parameterized tool) and consume it via a flake input, keeping only consumer-specific data locally. The `reason` string is extended with a concrete example: an agent that reimplemented fork-patch machinery in `ix` instead of importing from `index`, referencing the `ix#6409` rework and its user rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc4fe7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->