### PR TITLE
lib: expose mkForkChecks + forkDagCheckSrc; parameterize rebase-patches/upstream-pr by --mapping

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -79,6 +79,17 @@
   # rebase-patches), so it joins the registry-discovered `.#update` DAG. See
   # lib/fork-updater.nix.
   mkForkUpdater = import ./fork-updater.nix;
+  # Build the de-forked-package flake checks (`patched-src-<name>` +
+  # `patch-dag-<name>`) for a repo's fork list. The single owner of those check
+  # derivations, reused by `lib/per-system.nix` for index's own forks and by a
+  # downstream consumer (ix) for its forks via `inputs.index.lib.mkForkChecks`.
+  # See lib/mk-fork-checks.nix.
+  mkForkChecks = args: import ./mk-fork-checks.nix ({inherit lib;} // args);
+  # The directory holding the shared DAG driver + verifier (`dag-check.nu` +
+  # `dag-lib.nu`) that `mkForkChecks` stages into each `patch-dag-<name>` build.
+  # Exposed so a downstream consumer passes it straight through to `mkForkChecks`
+  # rather than reaching into index's package layout by path.
+  forkDagCheckSrc = paths.packagesRoot + "/rebase-patches";
   secretRefs = import ./util/secret-refs.nix {inherit lib;};
   selfVersionFor = self: import ./util/self-version.nix {inherit lib self;};
   checks = import ./checks.nix {inherit lib;};
@@ -480,6 +491,7 @@
       claudePlugin
       deepMerge
       forkPackages
+      forkDagCheckSrc
       goUnit
       hermes
       languages
@@ -487,6 +499,7 @@
       mcp
       minecraft
       mkBenchSuite
+      mkForkChecks
       mkForkUpdater
       mkMinecraftLoader
       mkMinecraftNbtFormat

--- a/lib/mk-fork-checks.nix
+++ b/lib/mk-fork-checks.nix
@@ -1,0 +1,91 @@
+# Build the de-forked-package flake checks (`patched-src-<name>` and
+# `patch-dag-<name>`) for a repo's fork list. Factored out of lib/per-system.nix
+# so the SAME builder serves both this repo (index) and a downstream consumer
+# (e.g. ix) that keeps its own fork mapping + patches but reuses index's
+# machinery via `inputs.index.lib.mkForkChecks`. One owner for the check
+# derivations means the two repos can never drift on how a series is validated.
+#
+# All repo-specific data is an argument; nothing about index's own forks is baked
+# in here:
+#   pkgs         : the target-system package set (for applyPatches / runCommand).
+#   patchedSrcFor: the `lib.patchedSrcFor pkgs` binding (see lib/util/patched-src.nix).
+#   forkPackages : the repo's fork mapping list (name / input / url / patchDir).
+#   forkSrcInputs: `name -> raw upstream src` (the `flake = false` inputs), keyed
+#                  by `fork.name`, so the check consumes the exact tree the build
+#                  patches.
+#   patchesRoot  : repo root the `fork.patchDir` (repo-relative) resolves against.
+#   flakeLock    : the repo's parsed `flake.lock` (for the pinned base rev per
+#                  input, validated against the committed dag.json base).
+#   dagCheckSrc  : a directory holding `dag-check.nu` + `dag-lib.nu` (index's
+#                  `packages/rebase-patches`), the shared DAG driver + verifier.
+{
+  lib,
+  pkgs,
+  patchedSrcFor,
+  forkPackages,
+  forkSrcInputs,
+  patchesRoot,
+  flakeLock,
+  dagCheckSrc,
+}: let
+  # `patched-src-<name>`: the seconds-fast "does the series still apply" gate.
+  # Built from the same `patchedSrcFor` the packages consume against the same raw
+  # upstream inputs, so the check can never drift from the real build: green here
+  # means the build gets an identical patched tree.
+  patchedSrcChecks = lib.genAttrs' forkPackages (
+    fork:
+      lib.nameValuePair "patched-src-${fork.name}" (
+        patchedSrcFor {
+          inherit (fork) name;
+          src = forkSrcInputs.${fork.name};
+          patchDir = patchesRoot + "/${fork.patchDir}";
+        }
+      )
+  );
+
+  # `patch-dag-<name>`: the fast textual sibling of `patched-src-<name>`. Where
+  # `patched-src` proves the linear series still applies, this proves the
+  # committed `dag.json` is honest and in sync (declared ancestors sufficient,
+  # independent patches commute byte-for-byte, NNNN is a topological order, and
+  # regenerating reproduces the committed bytes). Pure text work on the fetched
+  # src tree in the sandbox, so it stays seconds-fast. The derivation and
+  # verification logic is owned by `dagCheckSrc` (dag-{lib,check}.nu); the check
+  # just wires the src, patch dir, and pinned rev into that driver.
+  patchDagChecks = lib.genAttrs' forkPackages (
+    fork: let
+      expectedBase = flakeLock.nodes.${fork.input}.locked.rev;
+      # Import the committed patch series + dag.json into the store so the sandbox
+      # can read them (the raw repo path is not a sandbox input).
+      patchDirStore = builtins.path {
+        name = "${fork.name}-patches";
+        path = patchesRoot + "/${fork.patchDir}";
+      };
+    in
+      lib.nameValuePair "patch-dag-${fork.name}" (
+        pkgs.runCommand "patch-dag-${fork.name}-check"
+        {
+          nativeBuildInputs = [
+            pkgs.nushell
+            pkgs.git
+            # `chmod` (external) to make the read-only store src writable before
+            # the apply-tests, since git must write files during `am`.
+            pkgs.coreutils
+          ];
+        }
+        ''
+          # nushell's `use` resolves modules relative to the script file, so run
+          # the driver from a dir holding both it and dag-lib.nu.
+          workdir=$(mktemp -d)
+          cp ${dagCheckSrc}/dag-check.nu ${dagCheckSrc}/dag-lib.nu "$workdir/"
+          # git needs an identity even for the throwaway base commit.
+          export HOME="$workdir"
+          nu "$workdir/dag-check.nu" \
+            ${lib.escapeShellArg (toString forkSrcInputs.${fork.name})} \
+            ${patchDirStore} \
+            ${lib.escapeShellArg expectedBase}
+          touch "$out"
+        ''
+      )
+  );
+in
+  patchedSrcChecks // patchDagChecks

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -576,85 +576,33 @@
   repoPackages = ix.packageSetFor pkgs;
   inherit (repoPackages) site;
 
-  # De-forked patched sources exposed as `checks.<system>.patched-src-<name>`
-  # (the seconds-fast "does the series still apply" gate). Built from the same
-  # `ix.patchedSrc` the packages consume, against the same raw upstream inputs,
-  # so the check can never drift from the real build: green here means the build
-  # gets an identical patched tree. Driven by the one fork-package list so a new
-  # entry there joins this set with no change here. Each raw input is exposed on
-  # the `ix` handle as `<name>Src` (see lib/default.nix sharedHelpers).
-  patchedSrcFor' = ix.patchedSrcFor pkgs;
-  forkSrcInputs = {
-    codex = ix.codexSrc;
-    btop = ix.btopSrc;
-    clippy = ix.clippySrc;
-    mesa = ix.mesaSrc;
-    nix = ix.nixSrc;
+  # De-forked patched sources + patch-DAG invariants exposed as
+  # `checks.<system>.{patched-src,patch-dag}-<name>`. `patched-src-<name>` is the
+  # seconds-fast "does the series still apply" gate, built from the same
+  # `patchedSrc` the packages consume against the same raw upstream inputs, so it
+  # can never drift from the real build. `patch-dag-<name>` is its textual
+  # sibling, validating the committed `dag.json` against the pinned base. Both are
+  # built by the shared `ix.mkForkChecks` (lib/mk-fork-checks.nix) — the one owner
+  # of these check derivations, reused verbatim by ix for its own forks — driven
+  # by index's fork-package list so a new entry there joins this set with no
+  # change here. Each raw input is exposed on the `ix` handle as `<name>Src` (see
+  # lib/default.nix sharedHelpers). Merged on every system, so
+  # `nix build .#checks.aarch64-darwin.patch-dag-clippy` validates natively.
+  forkChecks = ix.mkForkChecks {
+    inherit pkgs;
+    patchedSrcFor = ix.patchedSrcFor pkgs;
+    inherit (ix) forkPackages;
+    dagCheckSrc = ix.forkDagCheckSrc;
+    forkSrcInputs = {
+      codex = ix.codexSrc;
+      btop = ix.btopSrc;
+      clippy = ix.clippySrc;
+      mesa = ix.mesaSrc;
+      nix = ix.nixSrc;
+    };
+    patchesRoot = paths.root;
+    flakeLock = lib.importJSON (paths.root + "/flake.lock");
   };
-  patchedSrcChecks = lib.genAttrs' (import ./fork-packages.nix).forkPackages (
-    fork:
-      lib.nameValuePair "patched-src-${fork.name}" (
-        patchedSrcFor' {
-          inherit (fork) name;
-          src = forkSrcInputs.${fork.name};
-          patchDir = paths.root + "/${fork.patchDir}";
-        }
-      )
-  );
-
-  # Patch-dependency DAG invariant checks, one per fork package
-  # (`checks.<system>.patch-dag-<name>`), the fast textual sibling of
-  # `patched-src-<name>`. Where `patched-src` proves the linear series still
-  # applies, this proves the committed `dag.json` is honest and in sync: every
-  # patch applies given only its declared ancestors (no undeclared deps), every
-  # pair of DAG-independent patches commutes byte-for-byte (no silent overwrite),
-  # the NNNN order topologically sorts the DAG, and regenerating the DAG
-  # reproduces the committed bytes. Pure text work on the fetched src tree in the
-  # sandbox (no network, no build), so it stays seconds-fast. The derivation and
-  # verification logic is owned by packages/rebase-patches/dag-{lib,check}.nu; the
-  # check just wires the src, patch dir, and pinned rev into that driver. Merged
-  # on every system like patched-src, so `nix build .#checks.aarch64-darwin.
-  # patch-dag-clippy` validates the graph natively.
-  forkLock = lib.importJSON (paths.root + "/flake.lock");
-  # The nushell driver plus its shared lib, staged together so the driver's
-  # sibling `use dag-lib.nu` resolves at runtime.
-  dagCheckSrc = paths.packagesRoot + "/rebase-patches";
-  patchDagChecks = lib.genAttrs' (import ./fork-packages.nix).forkPackages (
-    fork: let
-      expectedBase = forkLock.nodes.${fork.input}.locked.rev;
-      # Import the committed patch series + dag.json into the store so the
-      # sandbox can read them (the raw repo path is not a sandbox input).
-      patchDirStore = builtins.path {
-        name = "${fork.name}-patches";
-        path = paths.root + "/${fork.patchDir}";
-      };
-    in
-      lib.nameValuePair "patch-dag-${fork.name}" (
-        pkgs.runCommand "patch-dag-${fork.name}-check"
-        {
-          nativeBuildInputs = [
-            pkgs.nushell
-            pkgs.git
-            # `chmod` (external) to make the read-only store src writable before
-            # the apply-tests, since git must write files during `am`.
-            pkgs.coreutils
-          ];
-        }
-        ''
-          # nushell's `use` resolves modules relative to the script file, so run
-          # the driver from a dir holding both it and dag-lib.nu.
-          workdir=$(mktemp -d)
-          cp ${dagCheckSrc}/dag-check.nu ${dagCheckSrc}/dag-lib.nu "$workdir/"
-          # git needs an identity even for the throwaway base commit.
-          export HOME="$workdir"
-          nu "$workdir/dag-check.nu" \
-            ${lib.escapeShellArg (toString forkSrcInputs.${fork.name})} \
-            ${patchDirStore} \
-            ${lib.escapeShellArg expectedBase}
-          touch "$out"
-        ''
-      )
-  );
 
   # One general updater for every content source in the repo, run in parallel
   # via dag-runner (the same engine `lint` uses). The Minecraft catalog and
@@ -1463,11 +1411,11 @@ in {
   # Flat keying: one derivation per `checks.<system>.<name>`, as the flake schema
   # and `nix flake check` require. The `.#check` gate and blast-radius consume
   # the sharded `ciChecks` instead, so this output is not what CI enumerates.
-  # `patchedSrcChecks` is merged on EVERY system (not just x86_64-linux like the
+  # `forkChecks` is merged on EVERY system (not just x86_64-linux like the
   # rest of `catalogFor`): the patched sources are cheap, platform-relevant
   # derivations, so `nix build .#checks.aarch64-darwin.patched-src-clippy`
   # validates the series against a local Darwin build right after a flake update.
-  checks = catalogFor rustPackageTestSets.flat // patchedSrcChecks // patchDagChecks;
+  checks = catalogFor rustPackageTestSets.flat // forkChecks;
   # Sharded keying for the memory-bounded CI evaluator (nix-fast-build /
   # nix-eval-jobs / blast-radius): each package's per-#[test] checks sit under one
   # `recurseForDerivations` group, so the evaluator lists cheap per-package names
@@ -1475,7 +1423,7 @@ in {
   # (ENG-2201). Not a `checks.<system>.<name>` output, because a non-derivation
   # there fails the flake schema. The patched-src checks are plain derivations,
   # so they key identically in both views.
-  ciChecks = catalogFor rustPackageTestSets.sharded // patchedSrcChecks // patchDagChecks;
+  ciChecks = catalogFor rustPackageTestSets.sharded // forkChecks;
 
   formatter = pkgs.alejandra;
 

--- a/packages/rebase-patches/default.nix
+++ b/packages/rebase-patches/default.nix
@@ -25,7 +25,11 @@
 #
 # The fork-package mapping (input name, upstream URL, patch dir) is data from
 # lib/fork-packages.nix, rendered to JSON and baked in as a store path, so the
-# script body hardcodes no per-package coordinates.
+# script body hardcodes no per-package coordinates. A downstream repo (e.g. ix)
+# that keeps its own fork mapping + patches reuses this one tool by pointing it
+# at its list: `nix run <index>#rebase-patches -- --mapping <its-fork.json>
+# [<name>]`, run from its repo root so `patchDir` and `flake.lock` resolve
+# there. One tool, parameterized by data, never copied per repo.
 {
   ix,
   formats,
@@ -242,9 +246,10 @@ in
       # `dag` subcommand: regenerate dag.json for one or all fork packages against
       # the currently-pinned base (working-tree flake.lock), without a rebase.
       def "main dag" [
-        name?: string # one fork package (codex | btop | clippy); all if omitted
+        name?: string  # one fork package (codex | btop | clippy); all if omitted
+        --mapping: string # fork-package JSON to drive (default: index's baked-in list)
       ] {
-        let forks = (fork select $name)
+        let forks = (fork select $name $mapping)
         let new_lock = (open --raw flake.lock | from json)
         for fork in $forks {
           let base = ($new_lock.nodes | get $fork.input | get locked | get rev)
@@ -252,9 +257,17 @@ in
         }
       }
 
-      # Resolve the selected fork records from an optional name.
-      def "fork select" [name?: string]: nothing -> list<record> {
-        let forks = (open $fork_data)
+      # The fork-package mapping to drive: the caller-supplied `--mapping` path
+      # (a downstream repo pointing this one tool at its own fork list, run from
+      # its repo root so `patchDir`/`flake.lock` resolve there) else index's own
+      # baked-in list. One tool, parameterized by data, never copied.
+      def "mapping path" [override?: string]: nothing -> string {
+        if $override == null { $fork_data } else { $override }
+      }
+
+      # Resolve the selected fork records from an optional name against `mapping`.
+      def "fork select" [name?: string, mapping?: string]: nothing -> list<record> {
+        let forks = (open (mapping path $mapping))
         if $name == null { return $forks }
         let hit = ($forks | where name == $name)
         if ($hit | is-empty) {
@@ -264,9 +277,10 @@ in
       }
 
       def main [
-        name?: string # one fork package (codex | btop | clippy | mesa); all changed if omitted
+        name?: string  # one fork package (codex | btop | clippy | mesa); all changed if omitted
+        --mapping: string # fork-package JSON to drive (default: index's baked-in list)
       ] {
-        let selected = (fork select $name)
+        let selected = (fork select $name $mapping)
 
         # Old base from the committed flake.lock, new base from the working
         # tree. `flake.lock` has no nushell-recognized extension, so parse JSON

--- a/packages/upstream-pr/default.nix
+++ b/packages/upstream-pr/default.nix
@@ -29,7 +29,9 @@
 #
 # The fork-package mapping (upstream URL, patch dir) is data from
 # lib/fork-packages.nix; the dependency closure is data from each series'
-# dag.json. Both are read, not hardcoded.
+# dag.json. Both are read, not hardcoded. A downstream repo (e.g. ix) reuses this
+# one tool for its own forks via `--mapping <its-fork.json>` (run from its repo
+# root); the baked-in list is index's default. One tool, parameterized by data.
 {
   ix,
   formats,
@@ -62,9 +64,16 @@ in
       const fork_data = "${forkData}"
       const org = "indexable-inc"
 
-      # Resolve a fork record by name, erroring with the known set otherwise.
-      def "fork by-name" [name: string]: nothing -> record {
-        let forks = (open $fork_data)
+      # The fork-package mapping to drive: the caller-supplied `--mapping` path (a
+      # downstream repo pointing this one tool at its own fork list) else index's
+      # baked-in list. One tool, parameterized by data, never copied.
+      def "mapping path" [override?: string]: nothing -> string {
+        if $override == null { $fork_data } else { $override }
+      }
+
+      # Resolve a fork record by name against `mapping`, erroring with the known set.
+      def "fork by-name" [name: string, mapping?: string]: nothing -> record {
+        let forks = (open (mapping path $mapping))
         let hit = ($forks | where name == $name)
         if ($hit | is-empty) {
           error make { msg: $"upstream-pr: no fork package named ($name); known: (($forks | get name) | str join ', ')" }
@@ -96,8 +105,9 @@ in
         patch: string  # patch file name (or its NNNN prefix / unique substring)
         --open         # also open a DRAFT PR upstream (outward act; default: prepare only)
         --dry-run      # run the whole flow but skip push + PR (validate content)
+        --mapping: string # fork-package JSON to drive (default: index's baked-in list)
       ] {
-        let fork = (fork by-name $pkg)
+        let fork = (fork by-name $pkg $mapping)
         let patch_dir = ($fork.patchDir | path expand)
         let dag_file = ($patch_dir | path join "dag.json")
         if not ($dag_file | path exists) {


### PR DESCRIPTION
Expose the de-fork machinery as reusable `lib` seams so a downstream repo (ix, #6409) consumes it instead of re-forking the code. No behavior change to index's own forks.

## What

- **`lib.mkForkChecks`** (new, `lib/mk-fork-checks.nix`) — the single owner of the `patched-src-<name>` + `patch-dag-<name>` check derivations, factored out of `lib/per-system.nix`. Takes all repo-specific data as arguments (`pkgs`, `patchedSrcFor`, `forkPackages`, `forkSrcInputs`, `patchesRoot`, `flakeLock`, `dagCheckSrc`); nothing about index's own forks is baked in. `per-system.nix` now calls it for index's forks; ix calls it for colmena/ghostty.
- **`lib.forkDagCheckSrc`** (new) — the directory holding the shared DAG driver + verifier (`dag-check.nu` + `dag-lib.nu`), so a consumer passes it straight through to `mkForkChecks` rather than reaching into index's package layout by path.
- **`rebase-patches --mapping <path>`** and **`upstream-pr --mapping <path>`** — one tool, parameterized by data. A downstream repo drives the same tool against its own fork-package JSON (run from its repo root so `patchDir`/`flake.lock` resolve there) instead of copying the tool. index's baked-in list stays the default.
- `lib.patchedSrcFor` was already exported; no change.

## Why

ix (#6409) is de-forking colmena/garage/ghostty with the same recipe. The one-implementation rule (index#1910) says the machinery must live in one repo, imported, not duplicated. These are the narrow seams ix needs: a check builder that takes a repo-local fork list, a shared DAG-driver handle, and the two CLIs made mapping-parameterized. ix keeps only its data (fork mapping entries + `patches/` + upstream pins) and imports everything else from `inputs.index.lib`.

## Eval cost

The `lib` output is a lazy attrset, so a consumer touching `inputs.index.lib.{patchedSrcFor,mkForkChecks,forkDagCheckSrc}` forces only those thunks, not index's package surface (verified: `nix eval` of `lib.patchedSrcFor` returns a lambda without forcing the catalog; the wall time is one-time source materialization paid at lock, not per-eval).

## Validation

- `nix run .#lint` clean.
- `.#checks.aarch64-darwin.{patched-src,patch-dag}-*` still eval and build through the refactored `mkForkChecks` (built `patched-src-btop` and `patch-dag-btop` — identical result to before).
- `rebase-patches --mapping <json>` and the default both verified: the default resolves index's baked-in fork list (`codex, btop, ...`), `--mapping` resolves the supplied list instead.

(driven by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `mkForkChecks` and `forkDagCheckSrc` from lib and add `--mapping` flag to rebase-patches/upstream-pr
> - Exports `mkForkChecks` and `forkDagCheckSrc` from [lib/default.nix](https://github.com/indexable-inc/index/pull/1912/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) so consumers can build fork check derivations without referencing internal paths.
> - Adds [lib/mk-fork-checks.nix](https://github.com/indexable-inc/index/pull/1912/files#diff-16a93a826a8ca129a1f7276d99d6a404b925348c985aa0543c090be2e8262c36), a reusable builder that emits `patched-src-<name>` and `patch-dag-<name>` flake check derivations for a given list of forks.
> - Refactors [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1912/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) to call `ix.mkForkChecks` instead of constructing `patchedSrcChecks` and `patchDagChecks` inline.
> - Adds an optional `--mapping` flag to both [packages/rebase-patches/default.nix](https://github.com/indexable-inc/index/pull/1912/files#diff-dd450ae43106772c7bb417e4f0f4b3d25042f7302914086c517c3c1c46e7726b) and [packages/upstream-pr/default.nix](https://github.com/indexable-inc/index/pull/1912/files#diff-4dc0016b78bc87c3e77368dbcd98833c239a0a714d4a8509a70d0cd4abb5e3fe) so the `dag`, `main`, and `prepare` commands can operate against a caller-supplied fork mapping JSON instead of the baked-in default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01c2387.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->