### PR TITLE
system-prompt: drop the second-consumer threshold for shared homes

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -469,9 +469,7 @@ let
           reusable owner the next consumer imports, in the repo's lib from day
           one even with a single consumer today: its shape is fixed by the
           format it owns, so extraction costs nothing and first use is the
-          extraction point. This is the exception, not license to hoist every
-          helper: a domain abstraction still waits for a real second consumer
-          before it earns a shared home.
+          extraction point.
         '';
         reason = ''
           Inline serialized forms (a socat `"TCP:''${host}:''${toString


### PR DESCRIPTION
Removes "a domain abstraction still waits for a real second consumer before it earns a shared home" from typedSerialization. User call after #1910: reuse-first; the caution read as a contradiction of the cross-repo import rule and gated extraction that costs nothing under the repo's structure. Rendered and reread via nix eval.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove second-consumer threshold guidance from agent system prompt
> Drops three sentences from [system-prompt.nix](https://github.com/indexable-inc/index/pull/1913/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that advised waiting for a second consumer before sharing a domain abstraction. The prompt now ends at 'extraction point.' without the additional hoisting caution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9484c4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->