### PR TITLE
Remove duplicated domain-abstraction rule from typedSerialization

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -469,9 +469,7 @@ let
           reusable owner the next consumer imports, in the repo's lib from day
           one even with a single consumer today: its shape is fixed by the
           format it owns, so extraction costs nothing and first use is the
-          extraction point. This is the exception, not license to hoist every
-          helper: a domain abstraction still waits for a real second consumer
-          before it earns a shared home.
+          extraction point.
         '';
         reason = ''
           Inline serialized forms (a socat `"TCP:''${host}:''${toString


### PR DESCRIPTION
The rule about waiting for a second consumer before hoisting is already stated in oneImplementation. This sentence in typedSerialization was meant to clarify but became the confusion point itself. Removing it per user request.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicated domain-abstraction rule from the agent system prompt
> Removes three sentences after 'extraction point.' in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1914/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that duplicated guidance about not hoisting helpers prematurely and waiting for a second consumer before sharing a domain abstraction, producing a shorter prompt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 052c801.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->