### PR TITLE
lib: expose mkPackageRegistry + mkPackageSet for downstream consumers

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -37,11 +37,22 @@
 
   system = "x86_64-linux";
 
-  packageRegistry = import (paths.packagesRoot + "/registry.nix") {
-    inherit lib;
-    root = paths.packagesRoot;
-    inherit (lists) findDuplicates;
-  };
+  # Registry-driven package discovery, exposed as a factory over any packages
+  # root so a downstream consumer (ix) discovers its own `packages/<name>/
+  # {package.nix,default.nix}` tree with index's `package.nix`-marker walker
+  # (`packages/registry.nix`) rather than re-forking it. index's own registry
+  # below is one call of this factory.
+  mkPackageRegistry = {root}:
+    import (paths.packagesRoot + "/registry.nix") {
+      inherit lib root;
+      inherit (lists) findDuplicates;
+    };
+  # The generic registry-driven assembly loop (callPackage each entry, place it
+  # at its `packageSet.attrPath`), the shared core `lib/packages.nix` uses for
+  # index and a consumer reuses for its own registry + context. See
+  # lib/mk-package-set.nix.
+  mkPackageSet = import ./mk-package-set.nix {inherit lib;};
+  packageRegistry = mkPackageRegistry {root = paths.packagesRoot;};
   packagePath = id: let
     entry = packageRegistry.byId.${id} or (throw "ix.lib: package registry has no `${id}` entry");
   in
@@ -616,6 +627,8 @@
         mkFleetFor
         mkImage
         mkNonNixImage
+        mkPackageRegistry
+        mkPackageSet
         nixosModules
         overlay
         overlays

--- a/lib/mk-package-set.nix
+++ b/lib/mk-package-set.nix
@@ -1,0 +1,34 @@
+# Generic registry-driven package-set assembly, shared by index's own
+# `lib/packages.nix` and by a downstream consumer (ix) that discovers its
+# packages with the same `package.nix`-marker registry (`packages/registry.nix`,
+# exposed as `ix.mkPackageRegistry`). The registry walk and the "callPackage each
+# entry, place it at its `packageSet.attrPath`" assembly are index-owned
+# machinery; the per-repo `context`/`ix` bundle threaded into each package is
+# not, so the caller supplies it through `autoArgsFor`.
+#
+# This is the one implementation of the assembly loop. index's `lib/packages.nix`
+# builds its index-specific `context` and calls straight through here; ix does
+# the same with its own context, so neither repo re-forks the loop.
+{lib}: let
+  inherit (import ./util/deep-merge.nix {inherit lib;}) strictList;
+in
+  {
+    # A `packages/registry.nix` result (from `mkPackageRegistry { root; }`).
+    packageRegistry,
+    # The package set the entries build against; also names the system the
+    # registry filters `packageSet` targets by.
+    pkgs,
+    # `entry -> repoPackages -> attrs`: the caller-owned argument bundle handed
+    # to `callPackageWith` for one entry. `repoPackages` is the assembled set
+    # itself (a lazy fix-point), so an entry can depend on a sibling by id.
+    # `entry` is the registry entry (id, path, packageSet, ...). The caller
+    # decides what `pkgs`/`ix`/context to merge in; this loop only wires the
+    # self-reference and placement.
+    autoArgsFor,
+  }: let
+    packageSystem = pkgs.stdenv.hostPlatform.system;
+    buildEntry = entry: lib.callPackageWith (autoArgsFor entry packageSet) entry.path {};
+    packageTreeFor = entry: lib.setAttrByPath entry.packageSet.attrPath (buildEntry entry);
+    packageSet = strictList (map packageTreeFor (packageRegistry.packageSetEntriesFor packageSystem));
+  in
+    packageSet

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -44,24 +44,19 @@
     # leaves it unset, which is the signal to omit the updater.
     updateScriptWriter = ixForPackages.writeNushellApplication pkgs;
   };
-  inherit (import ./util/deep-merge.nix {inherit lib;}) strictList;
-  buildEntry = entry: let
-    # `repoPackages` is the package set itself (a lazy fix-point), so an
-    # entry can depend on a sibling by id (e.g. packages/agent/claude-code reads
-    # `repoPackages.mcp`). Threaded under one name rather than merged flat
-    # into autoArgs: a flat merge would let ids that shadow nixpkgs attrs
-    # (`btop`, `kitty`, ...) hijack other packages' arguments, and a
-    # same-named nixpkgs override would resolve to itself.
-    autoArgs =
+  mkPackageSet = import ./mk-package-set.nix {inherit lib;};
+in
+  # index's own package set, assembled through the shared registry-driven loop
+  # (`lib/mk-package-set.nix`). The only index-specific part is `autoArgsFor`:
+  # `repoPackages` is threaded under one name (not merged flat) so ids that
+  # shadow nixpkgs attrs (`btop`, `kitty`, ...) cannot hijack another package's
+  # arguments and a same-named nixpkgs override does not resolve to itself.
+  mkPackageSet {
+    inherit packageRegistry pkgs;
+    autoArgsFor = entry: repoPackages:
       pkgs
       // context
       // {
-        inherit entry;
-        repoPackages = packageSet;
+        inherit entry repoPackages;
       };
-  in
-    lib.callPackageWith autoArgs entry.path {};
-  packageTreeFor = entry: lib.setAttrByPath entry.packageSet.attrPath (buildEntry entry);
-  packageSet = strictList (map packageTreeFor (packageRegistry.packageSetEntriesFor packageSystem));
-in
-  packageSet
+  }


### PR DESCRIPTION
Exposes index's package-registry machinery as narrow `lib` outputs so a downstream consumer (ix, [#6425](https://github.com/indexable-inc/ix/issues/6425)) can adopt the same `packages/<name>/{package.nix,default.nix}` auto-discovery layout without re-forking the loop — the cross-repo one-implementation rule (#1910), same pattern as `mkForkChecks` (#1912).

## What

- **`lib/mk-package-set.nix`** — the generic registry-driven assembly loop (callPackage each entry, place it at its `packageSet.attrPath`), extracted from `lib/packages.nix`. Parameterized over a caller-supplied `autoArgsFor entry repoPackages` so the per-repo `ix`/context bundle stays with the consumer; the walk + placement + self-reference fix-point are the shared part. `lib/packages.nix` (index's own set) is now one call of it.
- **`ix.mkPackageRegistry { root; }`** — the `package.nix`-marker walker over any packages root. `packages/registry.nix` was already pure over `{ root; }`; this just binds `findDuplicates` and surfaces it. index's own `packageRegistry` is one call of this factory.
- **`ix.mkPackageSet`** — the shared loop, exposed for a consumer to drive with its own registry + context.

## Why

ix's package set is currently 34 hand-wired `import (nixRoot + "/packages/X.nix")` calls in one 1000-line outputs file. To mirror index's registry auto-discovery it must consume index's walker + assembly rather than copy them. Extracting the loop here means one implementation across both repos.

## Faithful (byte-identical) refactor

- `packages.aarch64-darwin.dag-runner` outPath unchanged (`fq9lbmhql51fnl0chy78afbz9b5a7nni-dag-runner-0.1.0`).
- The full `builtins.attrNames packages.aarch64-darwin` set is identical to main (diff clean).

## Validation

- `nix run .#lint -- --json`: all stages green (alejandra, statix, deadnix, astlog, astlog-rust, astlog-elixir, ruff).
- Package attr-name parity + `dag-runner` outPath parity above.

(driven by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `mkPackageRegistry` and `mkPackageSet` factories from `lib` for downstream consumers
> - Extracts package registry and package-set assembly into reusable factory functions so downstream consumers can build their own registries and package sets.
> - `mkPackageRegistry` in [lib/default.nix](https://github.com/indexable-inc/index/pull/1915/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) wraps the import of `packages/registry.nix` and accepts a `{root}` argument, replacing the previous direct import.
> - `mkPackageSet` is extracted into [lib/mk-package-set.nix](https://github.com/indexable-inc/index/pull/1915/files#diff-72b8f195657ca837ee0d6650ef036d1458ed7159015bc81b6817e66a787215ed), implementing a registry-driven assembly loop that resolves packages per target system and threads a self-referential `repoPackages` via `autoArgsFor`.
> - [lib/packages.nix](https://github.com/indexable-inc/index/pull/1915/files#diff-f353132c25d1c6d3f15551dba2d12c8c65c630f707c44f44e14229726bad009c) is refactored to delegate to `mkPackageSet`, removing its local `buildEntry`/`packageTreeFor` implementations.
> - Both `mkPackageRegistry` and `mkPackageSet` are added to the `lib` export surface.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce3859a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->