### PR TITLE
nix: add build-status-dir observability patch series

### DIFF
--- a/packages/nix/nix/default.nix
+++ b/packages/nix/nix/default.nix
@@ -10,18 +10,20 @@
 # De-forking replacement for a standalone `indexable-inc/nix` fork checkout:
 # instead of tracking a whole fork branch, the delta lives as an ordered
 # `patches/` series applied on top of the exact upstream rev the daemon runs.
-# The current series carries two patches: the GC-roots client-interrupt
-# daemon crash fix (extracted from the fork's
-# `fix-gc-roots-client-interrupt-crash` branch, complete and clean against
-# 2.34.7), and an eval fix treating inaccessible default lookup-path entries
-# as absent (found while validating this build: the macOS sandbox denies the
-# host's root-channels dir with EPERM, which aborted the C API unit tests and
-# the recursive-nix functional test on any darwin host with root channels;
-# clean CI builders lack the path, which is why caches carry the stock drvs
-# green). The fork's
+# The current series carries the GC-roots client-interrupt daemon crash fix
+# (extracted from the fork's `fix-gc-roots-client-interrupt-crash` branch,
+# complete and clean against 2.34.7), an eval fix treating inaccessible
+# default lookup-path entries as absent (found while validating this build:
+# the macOS sandbox denies the host's root-channels dir with EPERM, which
+# aborted the C API unit tests and the recursive-nix functional test on any
+# darwin host with root channels; clean CI builders lack the path, which is
+# why caches carry the stock drvs green), and the `build-status-dir` global
+# build-observability series (patches 0003..0009): behind an experimental
+# feature of that name, every active build/substitution goal writes a JSON
+# status file under `<nixStateDir>/status/`, readable daemonlessly via the
+# new `nix store builds [--json]` command. The fork's
 # `codex/flake-check-eval-cache` branch (draft PR indexable-inc/nix#1) is
 # deliberately excluded: it is self-declared WIP, untested, and incomplete.
-# A parallel change lands a global build-observability series into this folder.
 let
   # Read `pkgs` from `ix` rather than a `pkgs` callPackage formal: a `src`/`pkgs`
   # formal is fragile against `callPackage` auto-binding, and the rest of the

--- a/packages/nix/nix/patches/0003-libutil-add-build-status-dir-experimental-feature.patch
+++ b/packages/nix/nix/patches/0003-libutil-add-build-status-dir-experimental-feature.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 5 Jul 2026 20:12:08 -0700
+Subject: [PATCH 1/7] libutil: add build-status-dir experimental feature
+
+Introduces the `build-status-dir` experimental feature. It gates the
+daemon-independent build status directory: when enabled, build and
+substitution goals write JSON status files under `<store-state-dir>/status/`,
+and the `nix store builds` command reads them.
+
+This commit only adds the feature flag; the producer and consumer are
+wired up in following commits.
+
+diff --git a/src/libutil/experimental-features.cc b/src/libutil/experimental-features.cc
+index 5ce1183..e4f8b30 100644
+--- a/src/libutil/experimental-features.cc
++++ b/src/libutil/experimental-features.cc
+@@ -25,7 +25,7 @@ struct ExperimentalFeatureDetails
+  * feature, we either have no issue at all if few features are not added
+  * at the end of the list, or a proper merge conflict if they are.
+  */
+-constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::BLAKE3Hashes);
++constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::BuildStatusDir);
+ 
+ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails = {{
+     {
+@@ -279,6 +279,20 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
+         )",
+         .trackingUrl = "https://github.com/NixOS/nix/milestone/60",
+     },
++    {
++        .tag = Xp::BuildStatusDir,
++        .name = "build-status-dir",
++        .description = R"(
++            Makes each build and substitution goal write a JSON status file
++            to `<store-state-dir>/status/` (e.g. `/nix/var/nix/status/`) while
++            it is doing real work, and removes it on completion. This gives
++            global, daemon-independent observability into what a Nix daemon is
++            building and why: the [`nix store builds`](@docroot@/command-ref/new-cli/nix3-store-builds.md)
++            command reads that directory directly, without connecting to the
++            daemon.
++        )",
++        .trackingUrl = "https://github.com/NixOS/nix/milestone/60",
++    },
+ }};
+ 
+ static_assert(
+diff --git a/src/libutil/include/nix/util/experimental-features.hh b/src/libutil/include/nix/util/experimental-features.hh
+index 1a97f26..4a245d2 100644
+--- a/src/libutil/include/nix/util/experimental-features.hh
++++ b/src/libutil/include/nix/util/experimental-features.hh
+@@ -38,6 +38,7 @@ enum struct ExperimentalFeature {
+     PipeOperators,
+     ExternalBuilders,
+     BLAKE3Hashes,
++    BuildStatusDir,
+ };
+ 
+ /**

--- a/packages/nix/nix/patches/0004-libstore-add-build-status-directory-writer.patch
+++ b/packages/nix/nix/patches/0004-libstore-add-build-status-directory-writer.patch
@@ -1,0 +1,390 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 5 Jul 2026 20:12:16 -0700
+Subject: [PATCH 2/7] libstore: add build status directory writer
+
+Adds a `BuildStatus` RAII writer that records what a goal is doing to a JSON
+file under `<store-state-dir>/status/` (e.g. `/nix/var/nix/status/`). The
+constructor writes the file atomically (write-to-temp + rename); the
+destructor removes it. Since the daemon forks one worker per client, this
+shared filesystem state is how a build becomes globally observable.
+
+Each file records the derivation/store path, wanted outputs, worker pid,
+start time, the requesting client's uid/user (see the following daemon
+commit), the on-disk log file, and a why-chain walked up through the goal's
+`waiters` to the root goal the client requested.
+
+Also factors out `logFileFor()`, mirroring the build log path formula so the
+status file's `logFile` field points at the real log, and a per-process
+`setBuildStatusClientInfo()` for the daemon to record client identity.
+
+Writing is a no-op unless the `build-status-dir` experimental feature is
+enabled.
+
+diff --git a/src/libstore/build/build-status.cc b/src/libstore/build/build-status.cc
+new file mode 100644
+index 0000000..329a9c9
+--- /dev/null
++++ b/src/libstore/build/build-status.cc
+@@ -0,0 +1,230 @@
++#include "nix/store/build/build-status.hh"
++#include "nix/store/build/derivation-building-goal.hh"
++#include "nix/store/build/derivation-goal.hh"
++#include "nix/store/build/derivation-trampoline-goal.hh"
++#include "nix/store/build/substitution-goal.hh"
++#include "nix/store/build/worker.hh"
++#include "nix/store/local-fs-store.hh"
++#include "nix/store/local-store.hh"
++#include "nix/store/globals.hh"
++#include "nix/util/experimental-features.hh"
++#include "nix/util/file-system.hh"
++#include "nix/util/logging.hh"
++
++#include <nlohmann/json.hpp>
++
++#include <filesystem>
++#include <set>
++#include <unistd.h>
++
++namespace nix {
++
++/**
++ * Per-process client identity, set once per daemon connection in the forked
++ * worker. Each worker is its own process, so a process-global is the natural
++ * fit (and mirrors how the daemon already stuffs the client pid into argv[1]).
++ */
++static BuildStatusClientInfo currentClientInfo;
++
++void setBuildStatusClientInfo(BuildStatusClientInfo info)
++{
++    currentClientInfo = std::move(info);
++}
++
++std::filesystem::path buildStatusDir()
++{
++    return settings.nixStateDir / "status";
++}
++
++std::optional<std::filesystem::path> logFileFor(Store & store, const StorePath & drvPath, bool compress)
++{
++    /* Mirror the formula used by `LogFile` in derivation-building-goal.cc so
++       the status file points at the real log. */
++    auto baseName = std::string(baseNameOf(store.printStorePath(drvPath)));
++
++    std::filesystem::path logDir;
++    if (auto * localStore = dynamic_cast<LocalStore *>(&store))
++        logDir = localStore->config->logDir.get();
++    else if (dynamic_cast<LocalFSStore *>(&store))
++        logDir = settings.getLogFileSettings().nixLogDir;
++    else
++        return std::nullopt;
++
++    auto dir = logDir / LocalFSStore::drvsLogDir / baseName.substr(0, 2);
++    return dir / (baseName.substr(2) + (compress ? ".bz2" : ""));
++}
++
++namespace {
++
++/**
++ * The store path a goal is working on, for display in the why-chain.
++ */
++std::optional<StorePath> goalPath(const Goal & goal)
++{
++    if (auto * g = dynamic_cast<const DerivationBuildingGoal *>(&goal))
++        return g->getDrvPath();
++    if (auto * g = dynamic_cast<const DerivationGoal *>(&goal))
++        return g->drvPath;
++    if (auto * g = dynamic_cast<const DerivationTrampolineGoal *>(&goal))
++        return g->drvReq->getBaseStorePath();
++    if (auto * g = dynamic_cast<const PathSubstitutionGoal *>(&goal))
++        return g->storePath;
++    return std::nullopt;
++}
++
++/**
++ * Walk `waiters` transitively from @p goal until we reach a root goal (one
++ * with no waiters, i.e. the top goal the client asked for). The chain is
++ * returned root-first: `chain.front()` is the root, `chain.back()` is @p goal.
++ *
++ * `waiters` are goals waiting *on* this one, so following any waiter ascends
++ * towards a root; a goal that nothing waits on is itself a root.
++ */
++std::vector<StorePath> whyChain(Goal & goal)
++{
++    std::vector<StorePath> chainLeafFirst;
++    std::set<const Goal *> visited;
++
++    Goal * cur = &goal;
++    while (cur && !visited.contains(cur)) {
++        visited.insert(cur);
++
++        /* Consecutive goals often share a path (the same derivation's
++           trampoline, per-output, and building goals all stack up); collapse
++           them so the chain reads as one hop per derivation. */
++        if (auto p = goalPath(*cur))
++            if (chainLeafFirst.empty() || chainLeafFirst.back() != *p)
++                chainLeafFirst.push_back(*p);
++
++        /* Ascend to a waiter (a goal waiting on this one). Any waiter leads to
++           a root, so following one is enough for the why-chain. A goal with no
++           live waiters is a root; stop there. */
++        Goal * next = nullptr;
++        for (auto & weak : cur->waiters)
++            if (auto w = weak.lock()) {
++                next = w.get();
++                break;
++            }
++        cur = next;
++    }
++
++    std::reverse(chainLeafFirst.begin(), chainLeafFirst.end());
++    return chainLeafFirst;
++}
++
++nlohmann::json whyJSON(Goal & goal, Store & store, std::string_view cause)
++{
++    auto chain = whyChain(goal);
++
++    nlohmann::json chainJSON = nlohmann::json::array();
++    for (auto & p : chain)
++        chainJSON.push_back(store.printStorePath(p));
++
++    nlohmann::json why;
++    why["rootDrvPath"] = chain.empty() ? nlohmann::json(nullptr) : nlohmann::json(store.printStorePath(chain.front()));
++    why["chain"] = std::move(chainJSON);
++    why["cause"] = cause;
++    return why;
++}
++
++/**
++ * Is @p goal a root goal the client asked for directly? A root is a goal that
++ * nothing else is waiting on.
++ */
++bool isTopGoal(Goal & goal)
++{
++    for (auto & weak : goal.waiters)
++        if (weak.lock())
++            return false;
++    return true;
++}
++
++} // namespace
++
++std::unique_ptr<BuildStatus> BuildStatus::forBuild(
++    Goal & goal,
++    Store & store,
++    const StorePath & drvPath,
++    std::vector<std::string> outputs,
++    std::optional<std::filesystem::path> logFile)
++{
++    if (!experimentalFeatureSettings.isEnabled(Xp::BuildStatusDir))
++        return nullptr;
++
++    auto self = std::unique_ptr<BuildStatus>(new BuildStatus());
++    try {
++        nlohmann::json j;
++        j["drvPath"] = store.printStorePath(drvPath);
++        j["storePath"] = nullptr;
++        j["outputs"] = outputs;
++        j["type"] = "build";
++        j["pid"] = getpid();
++        j["startTime"] = time(nullptr);
++        j["user"] = currentClientInfo.user ? nlohmann::json(*currentClientInfo.user) : nlohmann::json(nullptr);
++        j["uid"] = currentClientInfo.uid ? nlohmann::json(*currentClientInfo.uid) : nlohmann::json(nullptr);
++        j["logFile"] = logFile ? nlohmann::json(logFile->string()) : nlohmann::json(nullptr);
++        j["why"] = whyJSON(goal, store, isTopGoal(goal) ? "requested" : "outputsMissing");
++
++        self->path = buildStatusDir() / (std::string(drvPath.to_string()) + "-" + std::to_string(getpid()) + ".json");
++        self->write(j.dump());
++    } catch (...) {
++        /* Observability must never break a build. */
++        ignoreExceptionExceptInterrupt();
++        return nullptr;
++    }
++    return self;
++}
++
++std::unique_ptr<BuildStatus> BuildStatus::forSubstitution(Goal & goal, Store & store, const StorePath & storePath)
++{
++    if (!experimentalFeatureSettings.isEnabled(Xp::BuildStatusDir))
++        return nullptr;
++
++    auto self = std::unique_ptr<BuildStatus>(new BuildStatus());
++    try {
++        nlohmann::json j;
++        j["drvPath"] = nullptr;
++        j["storePath"] = store.printStorePath(storePath);
++        j["outputs"] = nlohmann::json::array();
++        j["type"] = "substitution";
++        j["pid"] = getpid();
++        j["startTime"] = time(nullptr);
++        j["user"] = currentClientInfo.user ? nlohmann::json(*currentClientInfo.user) : nlohmann::json(nullptr);
++        j["uid"] = currentClientInfo.uid ? nlohmann::json(*currentClientInfo.uid) : nlohmann::json(nullptr);
++        j["logFile"] = nullptr;
++        j["why"] = whyJSON(goal, store, isTopGoal(goal) ? "requested" : "outputInvalid");
++
++        self->path =
++            buildStatusDir() / (std::string(storePath.to_string()) + "-" + std::to_string(getpid()) + ".json");
++        self->write(j.dump());
++    } catch (...) {
++        ignoreExceptionExceptInterrupt();
++        return nullptr;
++    }
++    return self;
++}
++
++void BuildStatus::write(std::string_view json)
++{
++    createDirs(buildStatusDir());
++    /* Write to a temp file and rename so a reader never sees a half-written
++       file. */
++    auto tmp = path;
++    tmp += ".tmp";
++    writeFile(tmp, json);
++    std::filesystem::rename(tmp, path);
++    active = true;
++}
++
++BuildStatus::~BuildStatus()
++{
++    if (!active)
++        return;
++    try {
++        std::filesystem::remove(path);
++    } catch (...) {
++        ignoreExceptionInDestructor();
++    }
++}
++
++} // namespace nix
+diff --git a/src/libstore/include/nix/store/build/build-status.hh b/src/libstore/include/nix/store/build/build-status.hh
+new file mode 100644
+index 0000000..a1855ed
+--- /dev/null
++++ b/src/libstore/include/nix/store/build/build-status.hh
+@@ -0,0 +1,101 @@
++#pragma once
++///@file
++
++#include "nix/store/path.hh"
++#include "nix/store/build/goal.hh"
++
++#include <optional>
++#include <string>
++#include <vector>
++
++namespace nix {
++
++class Store;
++
++/**
++ * Identity of the client that requested the work a goal is doing.
++ *
++ * The daemon forks one worker process per client connection, so this is
++ * recorded once per connection as a process-global (see @ref
++ * setBuildStatusClientInfo) and read back by every goal running in that
++ * worker.
++ */
++struct BuildStatusClientInfo
++{
++    std::optional<uid_t> uid;
++    std::optional<std::string> user;
++};
++
++/**
++ * Record the identity of the client for the current process. Called once per
++ * connection in the forked daemon worker. Safe to leave unset (e.g. for a
++ * local store with no daemon), in which case the recorded uid/user are null.
++ */
++void setBuildStatusClientInfo(BuildStatusClientInfo info);
++
++/**
++ * The directory into which status files are written, i.e.
++ * `<store-state-dir>/status`. Derived from `settings.nixStateDir`, so it
++ * honors `NIX_STATE_DIR`.
++ */
++std::filesystem::path buildStatusDir();
++
++/**
++ * Compute the path of the build log file for @p drvPath, using the exact same
++ * formula as the build log writer (see `LogFile` in
++ * derivation-building-goal.cc). Returns `std::nullopt` if build logs are not
++ * being kept.
++ */
++std::optional<std::filesystem::path> logFileFor(Store & store, const StorePath & drvPath, bool compress);
++
++/**
++ * RAII writer for a single goal's status file under @ref buildStatusDir.
++ *
++ * The constructor writes one JSON file atomically (write-to-temp + rename)
++ * describing the goal that is now doing real work; the destructor removes it.
++ * Instantiate a `BuildStatus` at the point a goal starts a build or
++ * substitution, and store it as a goal member so RAII removes the file when
++ * the goal finishes or is destroyed.
++ *
++ * Writing is gated behind the `build-status-dir` experimental feature: if the
++ * feature is disabled the writer is a no-op.
++ */
++class BuildStatus
++{
++    std::filesystem::path path;
++    bool active = false;
++
++public:
++    /**
++     * Write the status file for a build goal.
++     *
++     * @param goal The goal doing the work; its `waiters` are walked to
++     * compute the why-chain up to the root goal the client requested.
++     * @param drvPath The derivation being built.
++     * @param outputs The wanted output names.
++     * @param logFile The on-disk build log path, if any.
++     */
++    static std::unique_ptr<BuildStatus> forBuild(
++        Goal & goal,
++        Store & store,
++        const StorePath & drvPath,
++        std::vector<std::string> outputs,
++        std::optional<std::filesystem::path> logFile);
++
++    /**
++     * Write the status file for a substitution goal.
++     */
++    static std::unique_ptr<BuildStatus> forSubstitution(Goal & goal, Store & store, const StorePath & storePath);
++
++    BuildStatus(const BuildStatus &) = delete;
++    BuildStatus & operator=(const BuildStatus &) = delete;
++
++    ~BuildStatus();
++
++private:
++    BuildStatus() = default;
++
++    void write(std::string_view json);
++};
++
++} // namespace nix
+diff --git a/src/libstore/include/nix/store/meson.build b/src/libstore/include/nix/store/meson.build
+index 93be592..f49b322 100644
+--- a/src/libstore/include/nix/store/meson.build
++++ b/src/libstore/include/nix/store/meson.build
+@@ -14,6 +14,7 @@ headers = [ config_pub_h ] + files(
+   'binary-cache-store.hh',
+   'build-result.hh',
+   'build/build-log.hh',
++  'build/build-status.hh',
+   'build/derivation-builder.hh',
+   'build/derivation-building-goal.hh',
+   'build/derivation-building-misc.hh',
+diff --git a/src/libstore/meson.build b/src/libstore/meson.build
+index edc476a..1439fc1 100644
+--- a/src/libstore/meson.build
++++ b/src/libstore/meson.build
+@@ -276,6 +276,7 @@ sources = files(
+   'binary-cache-store.cc',
+   'build-result.cc',
+   'build/build-log.cc',
++  'build/build-status.cc',
+   'build/derivation-builder.cc',
+   'build/derivation-building-goal.cc',
+   'build/derivation-check.cc',

--- a/packages/nix/nix/patches/0005-libstore-write-status-files-from-build-and-substitut.patch
+++ b/packages/nix/nix/patches/0005-libstore-write-status-files-from-build-and-substitut.patch
@@ -1,0 +1,174 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 5 Jul 2026 20:12:30 -0700
+Subject: [PATCH 3/7] libstore: write status files from build and substitution
+ goals
+
+Instantiate a `BuildStatus` at the point each goal starts doing real work:
+both `mcRunningBuilds` sites in DerivationBuildingGoal (build hook / remote,
+and local build) and the `runningSubstitutions` site in PathSubstitutionGoal.
+
+The writer is held as a goal member, so RAII removes the status file when the
+goal completes; the file is also reset explicitly on the goal's done/cleanup
+paths so it is gone before the worker process can be reused.
+
+DerivationBuildingGoal gains a `getDrvPath()` accessor so the why-chain walker
+can identify a build goal's path.
+
+diff --git a/src/libstore/build/derivation-building-goal.cc b/src/libstore/build/derivation-building-goal.cc
+index 60ca549..fea6e05 100644
+--- a/src/libstore/build/derivation-building-goal.cc
++++ b/src/libstore/build/derivation-building-goal.cc
+@@ -9,6 +9,7 @@
+ #include "nix/util/environment-variables.hh"
+ #include "nix/util/config-global.hh"
+ #include "nix/store/build/worker.hh"
++#include "nix/store/build/build-status.hh"
+ #include "nix/util/util.hh"
+ #include "nix/util/compression.hh"
+ #include "nix/store/common-protocol.hh"
+@@ -50,6 +51,18 @@ std::string DerivationBuildingGoal::key()
+     return "dd$" + std::string(drvPath.name()) + "$" + worker.store.printStorePath(drvPath);
+ }
+ 
++/**
++ * The names of the outputs a build goal is producing, for the status file.
++ */
++static std::vector<std::string> wantedOutputNames(const std::map<std::string, InitialOutput> & initialOutputs)
++{
++    std::vector<std::string> names;
++    names.reserve(initialOutputs.size());
++    for (auto & [name, _] : initialOutputs)
++        names.push_back(name);
++    return names;
++}
++
+ std::string showKnownOutputs(const StoreDirConfig & store, const Derivation & drv)
+ {
+     std::string msg;
+@@ -641,6 +654,12 @@ Goal::Co DerivationBuildingGoal::buildWithHook(
+             msg,
+             Logger::Fields{worker.store.printStorePath(drvPath), hook->machineName, 1, 1}));
+     mcRunningBuilds = std::make_unique<MaintainCount<uint64_t>>(worker.runningBuilds);
++    buildStatus = BuildStatus::forBuild(
++        *this,
++        worker.store,
++        drvPath,
++        wantedOutputNames(initialOutputs),
++        logFileFor(worker.store, drvPath, settings.getLogFileSettings().compressLog));
+     worker.updateProgress();
+ 
+     std::string currentHookLine;
+@@ -807,6 +826,12 @@ Goal::Co DerivationBuildingGoal::buildLocally(
+             std::make_unique<Activity>(
+                 *logger, lvlInfo, actBuild, msg, Logger::Fields{worker.store.printStorePath(drvPath), "", 1, 1}));
+         mcRunningBuilds = std::make_unique<MaintainCount<uint64_t>>(worker.runningBuilds);
++        buildStatus = BuildStatus::forBuild(
++            *this,
++            worker.store,
++            drvPath,
++            wantedOutputNames(initialOutputs),
++            logFileFor(worker.store, drvPath, settings.getLogFileSettings().compressLog));
+         worker.updateProgress();
+     };
+ 
+@@ -1322,6 +1347,7 @@ DerivationBuildingGoal::checkPathValidity(std::map<std::string, InitialOutput> &
+ Goal::Done DerivationBuildingGoal::doneSuccess(BuildResult::Success::Status status, SingleDrvOutputs builtOutputs)
+ {
+     mcRunningBuilds.reset();
++    buildStatus.reset();
+ 
+     if (status == BuildResult::Success::Built)
+         worker.doneBuilds++;
+@@ -1338,6 +1364,7 @@ Goal::Done DerivationBuildingGoal::doneSuccess(BuildResult::Success::Status stat
+ Goal::Done DerivationBuildingGoal::doneFailure(BuildError ex)
+ {
+     mcRunningBuilds.reset();
++    buildStatus.reset();
+ 
+     worker.exitStatusFlags.updateFromStatus(ex.status);
+     if (ex.status != BuildResult::Failure::DependencyFailed)
+diff --git a/src/libstore/build/substitution-goal.cc b/src/libstore/build/substitution-goal.cc
+index d58bec8..7d7d194 100644
+--- a/src/libstore/build/substitution-goal.cc
++++ b/src/libstore/build/substitution-goal.cc
+@@ -202,6 +202,7 @@ Goal::Co PathSubstitutionGoal::tryToRun(
+     }
+ 
+     auto maintainRunningSubstitutions = std::make_unique<MaintainCount<uint64_t>>(worker.runningSubstitutions);
++    buildStatus = BuildStatus::forSubstitution(*this, worker.store, storePath);
+     worker.updateProgress();
+ 
+ #ifndef _WIN32
+@@ -309,6 +310,8 @@ Goal::Co PathSubstitutionGoal::tryToRun(
+ void PathSubstitutionGoal::cleanup()
+ {
+     try {
++        buildStatus.reset();
++
+         if (thr.joinable()) {
+             // FIXME: signal worker thread to quit.
+             thr.join();
+diff --git a/src/libstore/include/nix/store/build/derivation-building-goal.hh b/src/libstore/include/nix/store/build/derivation-building-goal.hh
+index 826cf2c..9295066 100644
+--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
++++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
+@@ -10,6 +10,7 @@
+ #include "nix/store/pathlocks.hh"
+ #include "nix/store/build/goal.hh"
+ #include "nix/store/build/build-log.hh"
++#include "nix/store/build/build-status.hh"
+ 
+ namespace nix {
+ 
+@@ -44,6 +45,12 @@ struct DerivationBuildingGoal : public Goal
+         const StorePath & drvPath, const Derivation & drv, Worker & worker, BuildMode buildMode, bool storeDerivation);
+     ~DerivationBuildingGoal();
+ 
++    /** The path of the derivation being built. */
++    const StorePath & getDrvPath() const
++    {
++        return drvPath;
++    }
++
+ private:
+ 
+     /** The path of the derivation. */
+@@ -62,6 +69,12 @@ private:
+ 
+     std::unique_ptr<MaintainCount<uint64_t>> mcRunningBuilds;
+ 
++    /**
++     * Daemon-independent status file for this build, present while the build
++     * is actually running (see the `build-status-dir` experimental feature).
++     */
++    std::unique_ptr<BuildStatus> buildStatus;
++
+     std::string key() override;
+ 
+     struct LocalBuildCapability
+diff --git a/src/libstore/include/nix/store/build/substitution-goal.hh b/src/libstore/include/nix/store/build/substitution-goal.hh
+index 7ce28d1..52144c2 100644
+--- a/src/libstore/include/nix/store/build/substitution-goal.hh
++++ b/src/libstore/include/nix/store/build/substitution-goal.hh
+@@ -4,6 +4,7 @@
+ #include "nix/store/build/worker.hh"
+ #include "nix/store/store-api.hh"
+ #include "nix/store/build/goal.hh"
++#include "nix/store/build/build-status.hh"
+ #include "nix/util/muxable-pipe.hh"
+ #include <coroutine>
+ #include <future>
+@@ -36,6 +37,12 @@ struct PathSubstitutionGoal : public Goal
+     std::unique_ptr<MaintainCount<uint64_t>> maintainExpectedSubstitutions, maintainRunningSubstitutions,
+         maintainExpectedNar, maintainExpectedDownload;
+ 
++    /**
++     * Daemon-independent status file for this substitution, present while it
++     * is actually running (see the `build-status-dir` experimental feature).
++     */
++    std::unique_ptr<BuildStatus> buildStatus;
++
+     /**
+      * Content address for recomputing store path
+      */

--- a/packages/nix/nix/patches/0006-libstore-daemon-record-client-uid-and-user-for-build.patch
+++ b/packages/nix/nix/patches/0006-libstore-daemon-record-client-uid-and-user-for-build.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 5 Jul 2026 20:12:38 -0700
+Subject: [PATCH 4/7] libstore/daemon: record client uid and user for build
+ status
+
+Thread the connecting client's uid and user name from the daemon's
+`authPeer`/fork path into the per-process `setBuildStatusClientInfo()`, so
+each build and substitution status file is attributed to the client that
+requested the work. Each daemon worker is its own process, so a process-global
+set once per connection is the natural place for this (mirroring how the
+daemon already stuffs the client pid into argv[1]).
+
+When no daemon is involved (e.g. a local store), the recorded uid/user are
+null.
+
+diff --git a/src/nix/unix/daemon.cc b/src/nix/unix/daemon.cc
+index 5b41d42..a5e1023 100644
+--- a/src/nix/unix/daemon.cc
++++ b/src/nix/unix/daemon.cc
+@@ -17,6 +17,7 @@
+ #include "nix/cmd/legacy.hh"
+ #include "nix/cmd/unix-socket-server.hh"
+ #include "nix/store/daemon.hh"
++#include "nix/store/build/build-status.hh"
+ #include "man-pages.hh"
+ 
+ #include <algorithm>
+@@ -348,6 +349,10 @@ static void daemonLoop(ref<const StoreConfig> storeConfig, std::optional<Trusted
+                             strncpy(savedArgv[1], processName.c_str(), strlen(savedArgv[1]));
+                         }
+ 
++                        // Record the client identity so build/substitution
++                        // goals can attribute their status files to it.
++                        setBuildStatusClientInfo({.uid = peer.uid, .user = userName});
++
+                         // Handle the connection.
+                         auto store = storeConfig->openStore();
+                         store->init();

--- a/packages/nix/nix/patches/0007-nix-add-nix-store-builds-command.patch
+++ b/packages/nix/nix/patches/0007-nix-add-nix-store-builds-command.patch
@@ -1,0 +1,250 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 5 Jul 2026 20:12:45 -0700
+Subject: [PATCH 5/7] nix: add 'nix store builds' command
+
+Adds `nix store builds`, which reports the builds and substitutions currently
+in progress by reading the status directory directly, *without* connecting to
+a Nix daemon. It derives the directory from `settings.nixStateDir`, so it
+honors `NIX_STATE_DIR` exactly like the writer.
+
+For each `*.json` file it parses the entry and checks that the recorded worker
+pid is still alive (via `kill(pid, 0)`); stale files left by a crashed worker
+are skipped and removed. Output is a human-readable summary, or a JSON array
+with `--json`.
+
+Gated behind the `build-status-dir` experimental feature.
+
+diff --git a/src/nix/meson.build b/src/nix/meson.build
+index 039b202..69fdb6c 100644
+--- a/src/nix/meson.build
++++ b/src/nix/meson.build
+@@ -99,6 +99,7 @@ nix_sources = [ config_priv_h ] + files(
+   'search.cc',
+   'self-exe.cc',
+   'sigs.cc',
++  'store-builds.cc',
+   'store-copy-log.cc',
+   'store-delete.cc',
+   'store-gc.cc',
+diff --git a/src/nix/store-builds.cc b/src/nix/store-builds.cc
+new file mode 100644
+index 0000000..c509e41
+--- /dev/null
++++ b/src/nix/store-builds.cc
+@@ -0,0 +1,132 @@
++#include "nix/cmd/command.hh"
++#include "nix/main/common-args.hh"
++#include "nix/store/globals.hh"
++#include "nix/util/experimental-features.hh"
++#include "nix/util/file-system.hh"
++#include "nix/util/logging.hh"
++
++#include <nlohmann/json.hpp>
++
++#include <csignal>
++
++using namespace nix;
++
++/**
++ * The status directory, i.e. `<store-state-dir>/status`. Kept in sync with
++ * `buildStatusDir()` in libstore, but computed here from `settings.nixStateDir`
++ * so this command never has to link against or open a store: it honors
++ * `NIX_STATE_DIR` just like the writer.
++ */
++static std::filesystem::path statusDir()
++{
++    return settings.nixStateDir / "status";
++}
++
++/**
++ * Is the process @p pid still alive? A status file whose writer has died
++ * (e.g. after a crash) is stale and should be ignored/removed.
++ */
++static bool pidAlive(pid_t pid)
++{
++    if (pid <= 0)
++        return false;
++    if (::kill(pid, 0) == 0)
++        return true;
++    return errno != ESRCH;
++}
++
++struct CmdStoreBuilds : Command, MixJSON
++{
++    std::string description() override
++    {
++        return "show the builds and substitutions currently in progress";
++    }
++
++    std::string doc() override
++    {
++        return
++#include "store-builds.md"
++            ;
++    }
++
++    Category category() override
++    {
++        return catUtility;
++    }
++
++    std::optional<ExperimentalFeature> experimentalFeature() override
++    {
++        return Xp::BuildStatusDir;
++    }
++
++    void run() override
++    {
++        /* The `experimentalFeature()` override advertises the gate (e.g. in
++           `nix __dump-cli`), but the multi-command dispatcher does not enforce
++           a subcommand's feature automatically, so require it here too. */
++        experimentalFeatureSettings.require(Xp::BuildStatusDir);
++
++        auto dir = statusDir();
++
++        std::vector<nlohmann::json> entries;
++
++        if (std::filesystem::exists(dir)) {
++            for (auto & entry : std::filesystem::directory_iterator{dir}) {
++                auto & p = entry.path();
++                if (p.extension() != ".json")
++                    continue;
++
++                nlohmann::json j;
++                try {
++                    j = nlohmann::json::parse(readFile(p.string()));
++                } catch (...) {
++                    /* A half-written or corrupt file; skip it. */
++                    continue;
++                }
++
++                /* Drop entries whose writer is no longer alive. */
++                auto pidIt = j.find("pid");
++                if (pidIt != j.end() && pidIt->is_number()) {
++                    if (!pidAlive(pidIt->get<pid_t>())) {
++                        try {
++                            std::filesystem::remove(p);
++                        } catch (...) {
++                        }
++                        continue;
++                    }
++                }
++
++                entries.push_back(std::move(j));
++            }
++        }
++
++        if (json) {
++            printJSON(nlohmann::json(entries));
++            return;
++        }
++
++        if (entries.empty()) {
++            notice("No builds or substitutions are currently in progress.");
++            return;
++        }
++
++        for (auto & j : entries) {
++            auto type = j.value("type", "?");
++            auto pid = j.value("pid", 0);
++            auto user = j.contains("user") && !j["user"].is_null() ? j["user"].get<std::string>() : "<unknown>";
++            if (type == "substitution")
++                logger->cout("%s  substituting %s  (pid %d, user %s)", type, j.value("storePath", "?"), pid, user);
++            else
++                logger->cout("%s  building %s  (pid %d, user %s)", type, j.value("drvPath", "?"), pid, user);
++            if (j.contains("why") && j["why"].contains("chain")) {
++                auto & chain = j["why"]["chain"];
++                if (chain.is_array() && !chain.empty())
++                    logger->cout("    because %s wants it (%s)",
++                        chain.front().get<std::string>(),
++                        j["why"].value("cause", "?"));
++            }
++        }
++    }
++};
++
++static auto rCmdStoreBuilds = registerCommand2<CmdStoreBuilds>({"store", "builds"});
+diff --git a/src/nix/store-builds.md b/src/nix/store-builds.md
+new file mode 100644
+index 0000000..62eaba0
+--- /dev/null
++++ b/src/nix/store-builds.md
+@@ -0,0 +1,77 @@
++R""(
++
++# Examples
++
++* Show what the local Nix daemon is currently building or substituting:
++
++  ```console
++  # nix store builds
++  build  building /nix/store/…-hello-2.12.drv  (pid 12345, user alice)
++      because /nix/store/…-app.drv wants it (outputsMissing)
++  ```
++
++* Get the same information as JSON, for consumption by another program:
++
++  ```console
++  # nix store builds --json
++  [
++    {
++      "drvPath": "/nix/store/…-hello-2.12.drv",
++      "storePath": null,
++      "outputs": ["out"],
++      "type": "build",
++      "pid": 12345,
++      "startTime": 1720200000,
++      "user": "alice",
++      "uid": 1000,
++      "logFile": "/nix/var/log/nix/drvs/ab/cdef….drv.bz2",
++      "why": {
++        "rootDrvPath": "/nix/store/…-app.drv",
++        "chain": ["/nix/store/…-app.drv", "/nix/store/…-hello-2.12.drv"],
++        "cause": "outputsMissing"
++      }
++    }
++  ]
++  ```
++
++# Description
++
++This command reports the builds and substitutions that are *currently in
++progress*, giving global, daemon-independent observability into what Nix is
++doing and *why*.
++
++Unlike most `nix store` subcommands, `nix store builds` does **not** connect to
++a Nix daemon. Instead it reads the *status directory*
++`<store-state-dir>/status` (e.g. `/nix/var/nix/status`), where each active
++build or substitution goal writes one JSON file while it is doing real work and
++removes it on completion. The directory location is derived from the Nix state
++directory, so it honors the `NIX_STATE_DIR` environment variable.
++
++Because each daemon worker is a separate process, a status file can be left
++behind if its writer crashes. `nix store builds` treats a file whose recorded
++`pid` is no longer alive as stale: it ignores such files and removes them.
++
++Each status file, and each element of the `--json` array, has the following
++fields:
++
++- `drvPath`: the derivation being built, or `null` for a substitution.
++- `storePath`: the store path being substituted, or `null` for a build.
++- `outputs`: the wanted output names (builds only).
++- `type`: `"build"` or `"substitution"`.
++- `pid`: the daemon worker process building/substituting this path.
++- `startTime`: when the work began, in seconds since the Unix epoch.
++- `user` / `uid`: the client that requested the work, if known (otherwise
++  `null`, e.g. for a local store used without a daemon).
++- `logFile`: the on-disk build log path (builds only), if build logs are kept.
++- `why`: the chain of goals leading to this one:
++  - `rootDrvPath`: the top-level goal the client asked for.
++  - `chain`: the goals from the root down to this one, root first.
++  - `cause`: a best-effort reason this goal exists (e.g. `"requested"`,
++    `"outputsMissing"`, `"outputInvalid"`).
++
++This command is only available with the
++[`build-status-dir`](@docroot@/development/experimental-features.md#xp-feature-build-status-dir)
++experimental feature enabled. That same feature gates the writing of status
++files, so both the producer and this consumer must have it enabled.
++
++)""

--- a/packages/nix/nix/patches/0008-tests-functional-test-build-status-directory.patch
+++ b/packages/nix/nix/patches/0008-tests-functional-test-build-status-directory.patch
@@ -1,0 +1,122 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 5 Jul 2026 20:21:14 -0700
+Subject: [PATCH 6/7] tests/functional: test build status directory
+
+Adds `build-status.sh`: with the `build-status-dir` feature enabled it starts
+a sleeping build, polls `nix store builds --json` until the build's status
+file appears, and asserts the entry's type, drvPath, non-empty why-chain and
+live pid. After killing the build it asserts the status directory drains back
+to empty. The test uses the direct (non-daemon) store, so it also confirms the
+command honors `NIX_STATE_DIR`.
+
+diff --git a/tests/functional/build-status.nix b/tests/functional/build-status.nix
+new file mode 100644
+index 0000000..bfce0df
+--- /dev/null
++++ b/tests/functional/build-status.nix
+@@ -0,0 +1,11 @@
++with import ./config.nix;
++
++# A derivation whose builder sleeps, so the build stays "running" long enough
++# for `nix store builds` to observe its status file.
++mkDerivation {
++  name = "build-status-sleeper";
++  buildCommand = ''
++    sleep 30
++    echo hi > $out
++  '';
++}
+diff --git a/tests/functional/build-status.sh b/tests/functional/build-status.sh
+new file mode 100644
+index 0000000..2001ab0
+--- /dev/null
++++ b/tests/functional/build-status.sh
+@@ -0,0 +1,75 @@
++#!/usr/bin/env bash
++
++source common.sh
++
++# The build status directory is daemon-independent shared state on the
++# filesystem, so this test exercises the direct (non-daemon) store: it starts a
++# sleeping build and checks that `nix store builds` sees it without connecting
++# to a daemon.
++TODO_NixOS
++
++enableFeatures "build-status-dir"
++
++clearStore
++
++nixExpr=build-status.nix
++
++drvPath=$(nix-instantiate "$nixExpr")
++echo "derivation is $drvPath"
++
++# Start the (sleeping) build in the background.
++nix build --file "$nixExpr" --no-link &
++buildPid=$!
++
++cleanup() {
++    kill "$buildPid" 2> /dev/null || true
++    wait "$buildPid" 2> /dev/null || true
++}
++trap cleanup EXIT
++
++# The status file is written exactly when the build starts doing real work, so
++# poll `nix store builds` until our build shows up (or time out).
++found=
++for _ in $(seq 1 100); do
++    if nix store builds --json | jq -e --arg drv "$drvPath" \
++        'any(.[]; .type == "build" and (.drvPath | endswith("build-status-sleeper.drv")))' > /dev/null; then
++        found=1
++        break
++    fi
++    sleep 0.2
++done
++[[ -n $found ]]
++
++# Grab the entry and assert its shape.
++entry=$(nix store builds --json | jq --arg drv "$drvPath" \
++    'map(select(.drvPath | endswith("build-status-sleeper.drv"))) | .[0]')
++echo "$entry" | jq .
++
++[[ $(echo "$entry" | jq -r '.type') == build ]]
++[[ $(echo "$entry" | jq -r '.storePath') == null ]]
++[[ $(echo "$entry" | jq -r '.drvPath') == *build-status-sleeper.drv ]]
++# The why-chain must be non-empty and end at this derivation.
++[[ $(echo "$entry" | jq '.why.chain | length') -ge 1 ]]
++[[ $(echo "$entry" | jq -r '.why.chain | last') == *build-status-sleeper.drv ]]
++# The pid must be set and refer to a live process.
++pid=$(echo "$entry" | jq -r '.pid')
++[[ -n $pid && $pid != null ]]
++kill -0 "$pid"
++
++# Stop the build; the status directory must drain.
++cleanup
++trap - EXIT
++
++# The worker removes its status file on exit, so the directory should now be
++# empty (`nix store builds` also prunes any stale files as it reads).
++empty=
++for _ in $(seq 1 100); do
++    if [[ $(nix store builds --json | jq 'length') == 0 ]]; then
++        empty=1
++        break
++    fi
++    sleep 0.2
++done
++[[ -n $empty ]]
++
++echo "build-status.sh: OK"
+diff --git a/tests/functional/meson.build b/tests/functional/meson.build
+index bc4d264..08e346e 100644
+--- a/tests/functional/meson.build
++++ b/tests/functional/meson.build
+@@ -152,6 +152,7 @@ suites = [
+       'placeholders.sh',
+       'ssh-relay.sh',
+       'build.sh',
++      'build-status.sh',
+       'build-cores.sh',
+       'build-delete.sh',
+       'output-normalization.sh',

--- a/packages/nix/nix/patches/0009-doc-release-note-for-build-status-directory-and-nix-.patch
+++ b/packages/nix/nix/patches/0009-doc-release-note-for-build-status-directory-and-nix-.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 5 Jul 2026 20:21:19 -0700
+Subject: [PATCH 7/7] doc: release note for build status directory and 'nix
+ store builds'
+
+
+diff --git a/doc/manual/rl-next/build-status-dir.md b/doc/manual/rl-next/build-status-dir.md
+new file mode 100644
+index 0000000..de97280
+--- /dev/null
++++ b/doc/manual/rl-next/build-status-dir.md
+@@ -0,0 +1,21 @@
++---
++synopsis: "New experimental `build-status-dir` feature and `nix store builds` command"
++prs: []
++---
++
++Nix can now expose what a daemon is building or substituting, and *why*,
++without connecting to the daemon.
++
++With the `build-status-dir` [experimental feature](@docroot@/development/experimental-features.md)
++enabled, each active build or substitution goal writes a JSON status file to
++`<store-state-dir>/status/` (e.g. `/nix/var/nix/status/`) while it is doing
++real work, and removes it on completion. Each file records the derivation or
++store path, the wanted outputs, the worker pid, the requesting client's
++uid/user, the on-disk build log, and the chain of goals leading up to the
++root that the client requested.
++
++The new `nix store builds` command reads that directory directly — it does
++*not* connect to a daemon — and reports the builds and substitutions currently
++in progress, as a human-readable summary or, with `--json`, as a JSON array.
++Stale files left behind by a crashed worker (identified by a dead pid) are
++ignored and cleaned up.

--- a/packages/nix/nix/patches/dag.json
+++ b/packages/nix/nix/patches/dag.json
@@ -9,6 +9,34 @@
     {
       "patch": "0002-fix-libexpr-treat-inaccessible-default-lookup-path-e.patch",
       "deps": []
+    },
+    {
+      "patch": "0003-libutil-add-build-status-dir-experimental-feature.patch",
+      "deps": []
+    },
+    {
+      "patch": "0004-libstore-add-build-status-directory-writer.patch",
+      "deps": []
+    },
+    {
+      "patch": "0005-libstore-write-status-files-from-build-and-substitut.patch",
+      "deps": []
+    },
+    {
+      "patch": "0006-libstore-daemon-record-client-uid-and-user-for-build.patch",
+      "deps": []
+    },
+    {
+      "patch": "0007-nix-add-nix-store-builds-command.patch",
+      "deps": []
+    },
+    {
+      "patch": "0008-tests-functional-test-build-status-directory.patch",
+      "deps": []
+    },
+    {
+      "patch": "0009-doc-release-note-for-build-status-directory-and-nix-.patch",
+      "deps": []
     }
   ]
 }


### PR DESCRIPTION
Lands the global build-observability series from #1897 into the `packages/nix/nix` fork package as patches 0003..0009 on NixOS/nix 2.34.7.

**What the series adds**
- `build-status-dir` experimental feature: each active build/substitution goal writes `<nixStateDir>/status/<drv>-<pid>.json` (atomic tmp+rename, RAII removal, pid-liveness stale pruning) with drvPath, outputs, pid, startTime, client uid/user, logFile, and a why-chain up to the root goal.
- New daemonless `nix store builds [--json]` command that reads that directory.
- Functional test (`tests/functional/build-status.sh`) and release note.
- `dag.json` regenerated via `nix run .#rebase-patches -- dag nix` (9 nodes, same base `2c6d06e`).

**Validation**
- `checks.aarch64-darwin.patched-src-nix` and `checks.aarch64-darwin.patch-dag-nix`: built clean (series applies conflict-free).
- Full `nix-ix` + `nix-ix.tests.smoke`: built on aarch64-darwin (hydra) and x86_64-linux (vin-compute-1); both report `nix (Nix) 2.34.7+ix`.
- Live behavior check on vin-compute-1 against a throwaway chroot store: during a running build the status file exists and `nix store builds --json` emits the full record; after completion the array is empty and the file is gone.

The consumer side (nwm `nix store builds --json` probe + GlobalPanel) already merged as #1906. Fleet rollout (daemon actually running `nix-ix` with the feature enabled) is a config-repo change, tracked on #1897.

Refs #1897

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `build-status-dir` patch series and `nix store builds` command to Nix derivation
> - Adds seven new patches (0003–0009) to the Nix package in [packages/nix/nix/](https://github.com/indexable-inc/index/pull/1916/files#diff-1dc641ea25d906b4a438eb78edb33fbee040a6e7939d65d68f231dc60d7903d0) that implement a `build-status-dir` experimental feature.
> - During builds and substitutions, a RAII `BuildStatus` writer emits per-goal JSON status files to a configurable status directory; the Unix daemon attributes these files to the requesting client's uid/username.
> - Adds a `nix store builds` CLI command that reads the status directory and renders active builds in JSON or human-readable form without contacting the daemon.
> - Includes functional tests and a release note patch.
> - Updates [patches/dag.json](https://github.com/indexable-inc/index/pull/1916/files#diff-bb8cabe3c8aca5a21a04124e99377308810f2ffd5701104ed528dd747207dc2d) to wire all seven patches into the build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a883675.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->