### PR TITLE
feat(agent): gate native-tool disables on baked MCP servers, one policy table

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -236,8 +236,15 @@
       ;
   };
 
-  # Claude-native permission deny list rendered from shared agent policy.
-  sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {};
+  # Claude-native permission deny list rendered from shared agent policy. The
+  # gates fold in the native tools each baked MCP server supersedes: with the
+  # `index` kernel present the stock shell/file/search tools are denied, and
+  # the overlay build (no kernel) keeps them.
+  sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
+    inherit lib;
+    indexKernelBaked = mcpServers ? index;
+    exaSearchBaked = mcpServers ? exa;
+  };
 
   # Caller's extraSettings first, then the computed defaults recursively merged
   # ON TOP, so the keys below always win a conflict while the caller's other

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -114,7 +114,14 @@
     })
     flat;
 
-  sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {};
+  # Gates fold in the native tools each baked MCP server supersedes: with the
+  # `index` kernel present the codex shell is force-disabled, and the overlay
+  # build (no kernel baked) keeps its shell rather than losing every tool.
+  sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
+    inherit lib;
+    indexKernelBaked = mcpServers ? index;
+    exaSearchBaked = mcpServers ? exa;
+  };
   effectiveForcedSettings =
     forcedSettings
     // sharedPermissions.codex.forcedSettings

--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -1,36 +1,95 @@
-_: let
-  protectedMergeToolPatterns = [
-    "Bash(gh pr merge*--admin*)"
-    "Bash(gh pr merge*--force*)"
+# Shared agent permission policy: one agent-neutral fact per row, rendered per
+# agent CLI. The tool vocabularies differ (Claude Code denies tool names via
+# settings `permissions.deny`; codex disables `features.*` leaves via the
+# forced `-c` layer), so each capability row carries both handles and the
+# renderers at the bottom fold in the rows a wrapper's baked MCP servers make
+# redundant.
+{
+  lib,
+  # True when the wrapper bakes the `index` MCP server (the ix kernel,
+  # packages/mcp). The kernel owns shell, file IO, and code search
+  # (python_exec/nu, read, grep/find), so the stock native tools are disabled
+  # wherever it is present. A wrapper without the kernel (the overlay package
+  # set) keeps them: denying them there would leave the agent with no hands.
+  indexKernelBaked ? false,
+  # True when the wrapper bakes the `exa` MCP server, which supersedes the
+  # stock web search/fetch surface.
+  exaSearchBaked ? false,
+}: let
+  # One list of protected-merge command globs; the Claude render wraps them in
+  # Bash(...) deny patterns, the codex render ships them verbatim for hook use.
+  protectedMergeCommandPatterns = [
+    "gh pr merge*--admin*"
+    "gh pr merge*--force*"
   ];
 
-  supersededBuiltinTools = [
-    "WebSearch"
-    "WebFetch"
-  ];
-
-  codexForcedSettings = {
-    features = {
-      browser_use = false;
-      browser_use_external = false;
-      computer_use = false;
-      image_generation = false;
-      in_app_browser = false;
-      shell_tool = false;
-      standalone_web_search = false;
-      unified_exec = false;
+  # Native capabilities the index kernel supersedes. `claudeTools` are Claude
+  # Code tool names for `permissions.deny`; `codexFeatures` are codex
+  # `features.*` leaves for the forced `-c` layer. The file IO and search rows
+  # carry no codex handle: codex reads, writes, and searches through its shell
+  # (covered by the `shell` row), and its `apply_patch` tool is enabled
+  # per-model upstream with no config toggle to reach it.
+  kernelSuperseded = {
+    shell = {
+      claudeTools = ["Bash"];
+      codexFeatures = {
+        shell_tool = false;
+        unified_exec = false;
+      };
     };
+    fileRead = {
+      claudeTools = ["Read"];
+      codexFeatures = {};
+    };
+    fileWrite = {
+      claudeTools = ["Write" "NotebookEdit"];
+      codexFeatures = {};
+    };
+    fileEdit = {
+      claudeTools = ["Edit"];
+      codexFeatures = {};
+    };
+    fileSearch = {
+      claudeTools = ["Glob" "Grep"];
+      codexFeatures = {};
+    };
+  };
+  kernelClaudeTools = lib.concatMap (row: row.claudeTools) (lib.attrValues kernelSuperseded);
+  kernelCodexFeatures = lib.mergeAttrsList (
+    map (row: row.codexFeatures) (lib.attrValues kernelSuperseded)
+  );
+
+  # Web search/fetch superseded by the exa server.
+  exaSuperseded = {
+    claudeTools = [
+      "WebSearch"
+      "WebFetch"
+    ];
+    codexFeatures.standalone_web_search = false;
+  };
+
+  # Unconditional house policy: no browser/computer/media surfaces in baked
+  # wrappers, independent of which MCP servers ride along.
+  codexHouseFeatures = {
+    browser_use = false;
+    browser_use_external = false;
+    computer_use = false;
+    image_generation = false;
+    in_app_browser = false;
   };
 in {
   claude = {
-    deniedToolPatterns = protectedMergeToolPatterns ++ supersededBuiltinTools;
+    deniedToolPatterns =
+      map (pattern: "Bash(${pattern})") protectedMergeCommandPatterns
+      ++ lib.optionals exaSearchBaked exaSuperseded.claudeTools
+      ++ lib.optionals indexKernelBaked kernelClaudeTools;
   };
 
   codex = {
-    forcedSettings = codexForcedSettings;
-    protectedMergeCommandPatterns = [
-      "gh pr merge*--admin*"
-      "gh pr merge*--force*"
-    ];
+    forcedSettings.features =
+      codexHouseFeatures
+      // lib.optionalAttrs exaSearchBaked exaSuperseded.codexFeatures
+      // lib.optionalAttrs indexKernelBaked kernelCodexFeatures;
+    inherit protectedMergeCommandPatterns;
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3701,27 +3701,39 @@
       }
       {
         assertion = let
-          policy = import (paths.packagesRoot + "/agent/policy/permissions.nix") {};
+          policy = gates:
+            import (paths.packagesRoot + "/agent/policy/permissions.nix") ({inherit lib;} // gates);
+          bare = policy {};
+          baked = policy {
+            indexKernelBaked = true;
+            exaSearchBaked = true;
+          };
         in
-          policy.claude.deniedToolPatterns
+          # Without baked MCP servers only the merge protections remain: the
+          # stock tools are the agent's whole surface there.
+          bare.claude.deniedToolPatterns
           == [
             "Bash(gh pr merge*--admin*)"
             "Bash(gh pr merge*--force*)"
+          ]
+          && !(bare.codex.forcedSettings.features ? shell_tool)
+          # With the index kernel + exa baked, every superseded native tool is
+          # folded in, in each agent's own vocabulary.
+          && builtins.all (tool: builtins.elem tool baked.claude.deniedToolPatterns) [
+            "Bash"
+            "Read"
+            "Write"
+            "Edit"
+            "NotebookEdit"
+            "Glob"
+            "Grep"
             "WebSearch"
             "WebFetch"
           ]
-          && policy.codex.forcedSettings.features
-          == {
-            browser_use = false;
-            browser_use_external = false;
-            computer_use = false;
-            image_generation = false;
-            in_app_browser = false;
-            shell_tool = false;
-            standalone_web_search = false;
-            unified_exec = false;
-          };
-        message = "agent policy should deny only protected merges and built-in web search tools";
+          && baked.codex.forcedSettings.features.shell_tool == false
+          && baked.codex.forcedSettings.features.unified_exec == false
+          && baked.codex.forcedSettings.features.standalone_web_search == false;
+        message = "agent policy should gate kernel/exa-superseded native tools on the baked MCP servers";
       }
       {
         assertion = let


### PR DESCRIPTION
`packages/agent/policy/permissions.nix` becomes an agent-neutral capability table: each row names a native capability the index kernel supersedes (shell, file read/write/edit, search) with both agents' handles for it — Claude Code `permissions.deny` tool names (`Bash`, `Read`, `Write`, `Edit`, `NotebookEdit`, `Glob`, `Grep`) and codex forced `features.*` leaves (`shell_tool`, `unified_exec`) — applied only when the wrapper actually bakes the `index` MCP server. Web search/fetch disables now gate on the `exa` server the same way instead of being unconditional.

The file IO and search rows carry no codex handle by design: codex reads/writes/searches through its shell (covered by the `shell` row), and its `apply_patch` tool is enabled per-model upstream with no config toggle (checked at codex-src `be33f80b`: `spec_plan.rs` gates it on `model_info.apply_patch_tool_type`).

Also fixes a latent overlay hole: the overlay codex build bakes no MCP kernel but still force-disabled `shell_tool`/`unified_exec`, leaving that agent with no execution surface at all. The gate now keeps the shell wherever the kernel is absent (same for Claude's stock tools in the overlay build).

Behavior note for reviewers: with the kernel baked, the deny list applies to subagents too (they share the settings layer), so repo subagents declaring `Read`/`Bash`/`Grep` operate kernel-only. Intentional: the kernel is the superseding surface everywhere it exists.

Validated:
- rendered both gate combinations (deny list / forced features exactly as above; bare build keeps stock tools + merge protections only)
- `nix build .#claude-code .#codex` green on aarch64-darwin incl. install-check argv/hook regression net
- `nix run .#lint` 7/7 ok
- `checks.x86_64-linux.eval` green on vin-compute-1 (pinned policy assertion rewritten to the gated contract)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate native-tool disables in agent permissions on baked MCP servers
> - Refactors [permissions.nix](https://github.com/indexable-inc/index/pull/1917/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) from a flat policy table into a conditional model with two boolean gates: `indexKernelBaked` and `exaSearchBaked`.
> - When `indexKernelBaked` is true, Claude's `deniedToolPatterns` includes Bash/Read/Write/Edit/Glob/Grep tools and codex disables `shell_tool`/`unified_exec`; when `exaSearchBaked` is true, WebSearch/WebFetch are denied and `standalone_web_search` is disabled.
> - Without either gate, only protected merge command patterns and house policy features (browser/computer/image) are enforced.
> - Both [claude-code/default.nix](https://github.com/indexable-inc/index/pull/1917/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) and [codex/default.nix](https://github.com/indexable-inc/index/pull/1917/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5) now derive the gate booleans from the `mcpServers` attrset and pass them to the shared permissions module.
> - Behavioral Change: wrappers that previously always denied native shell/file/search tools will no longer do so unless the corresponding MCP server is baked in.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c9a212.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->