### PR TITLE
docs+test(agent): verified deny semantics + real overlay gate combination

### DIFF
--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -4,13 +4,25 @@
 # forced `-c` layer), so each capability row carries both handles and the
 # renderers at the bottom fold in the rows a wrapper's baked MCP servers make
 # redundant.
+#
+# Claude runtime semantics, verified empirically on the pinned CLI (2.1.197,
+# headless `claude -p --settings` probes): `permissions.deny` is a hard block
+# even under the wrapper's default `--dangerously-skip-permissions` posture
+# (bypass skips prompts, not deny rules), and a SUBAGENT whose definition
+# declares an explicit `tools:` allowlist re-grants a settings-denied tool.
+# So gating the stock tools here sends the MAIN agent kernel-first while the
+# repo subagents (subagents.nix, explicit tool lists) keep their declared
+# tools.
 {
   lib,
   # True when the wrapper bakes the `index` MCP server (the ix kernel,
   # packages/mcp). The kernel owns shell, file IO, and code search
-  # (python_exec/nu, read, grep/find), so the stock native tools are disabled
-  # wherever it is present. A wrapper without the kernel (the overlay package
-  # set) keeps them: denying them there would leave the agent with no hands.
+  # (python_exec/nu, read, grep/find), so the stock native tools this table
+  # maps are disabled wherever it is present. A wrapper without the kernel
+  # (the overlay package set) keeps the kernel-superseded tools: denying them
+  # there would leave the agent with no hands. (The exa-gated web pair below
+  # is a separate gate and is still denied in the overlay build, since exa is
+  # baked unconditionally by the default server set.)
   indexKernelBaked ? false,
   # True when the wrapper bakes the `exa` MCP server, which supersedes the
   # stock web search/fetch surface.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3703,20 +3703,27 @@
         assertion = let
           policy = gates:
             import (paths.packagesRoot + "/agent/policy/permissions.nix") ({inherit lib;} // gates);
-          bare = policy {};
+          # The overlay build's real gate combination: exa is baked
+          # unconditionally by the default server set, the kernel is not
+          # (repoPackages.mcp is out of scope there).
+          overlay = policy {exaSearchBaked = true;};
           baked = policy {
             indexKernelBaked = true;
             exaSearchBaked = true;
           };
         in
-          # Without baked MCP servers only the merge protections remain: the
-          # stock tools are the agent's whole surface there.
-          bare.claude.deniedToolPatterns
+          # Without the kernel only the merge protections and the
+          # exa-superseded web pair remain: the stock shell/file/search tools
+          # are that agent's whole surface.
+          overlay.claude.deniedToolPatterns
           == [
             "Bash(gh pr merge*--admin*)"
             "Bash(gh pr merge*--force*)"
+            "WebSearch"
+            "WebFetch"
           ]
-          && !(bare.codex.forcedSettings.features ? shell_tool)
+          && !(overlay.codex.forcedSettings.features ? shell_tool)
+          && overlay.codex.forcedSettings.features.standalone_web_search == false
           # With the index kernel + exa baked, every superseded native tool is
           # folded in, in each agent's own vocabulary.
           && builtins.all (tool: builtins.elem tool baked.claude.deniedToolPatterns) [


### PR DESCRIPTION
Review follow-ups to #1917 (M1/M2 plus the review's verification ask):

- **Verified the two load-bearing runtime behaviors** on the pinned CLI (2.1.197) with headless `claude -p --settings` probes: `permissions.deny` **is** enforced under the wrapper's default `--dangerously-skip-permissions` posture (main agent's `Bash` hard-blocked), and a subagent with an explicit `tools:` allowlist **re-grants** a denied tool (probe agent ran `Bash` under the same settings). Recorded in the permissions.nix header: main agent goes kernel-first, repo subagents keep their declared tools. No code change needed.
- M1: the `indexKernelBaked` comment no longer claims the overlay build keeps *all* native tools (the exa-gated web pair is denied there too, exa being unconditional in the default server set).
- M2: the eval test's ungated leg now models the real overlay combination (`exaSearchBaked = true`, no kernel) instead of a shape no wrapper produces.

Validated: policy render for the overlay combination matches the assertion; `nix run .#lint` 0 failures.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify deny semantics and add overlay gate test for exa-baked agent policy
> - Adds explanatory comments to [permissions.nix](https://github.com/indexable-inc/index/pull/1919/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) documenting observed Claude runtime semantics for `permissions.deny`, subagent tool allowlists, and the overlay gating strategy.
> - Updates [tests/default.nix](https://github.com/indexable-inc/index/pull/1919/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to replace the `bare` policy fixture with an `overlay` fixture using `exaSearchBaked = true`, better reflecting the real overlay build where exa is baked but the kernel is not.
> - Expands expected `deniedToolPatterns` for the overlay case to include `WebSearch` and `WebFetch`, and adds an assertion that `overlay.codex.forcedSettings.features.standalone_web_search == false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f73133e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->