### PR TITLE
cache-push: fix darwin lane ENOSPC (scope roots, serialise realise, free disk)

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -233,6 +233,12 @@ jobs:
     # darwin runner. 3 cores / 7 GiB, so eval workers and realise parallelism
     # stay small.
     runs-on: macos-14
+    # The darwin roots' dependency closures overlap the linux lane (shared
+    # nixpkgs paths, and any x86_64-linux path a wrapper references):
+    # realising here substitutes them from cache.ix.dev, which only serves
+    # them after the linux push lands. Running after `push` turns those into
+    # downloads instead of doomed platform-mismatch builds.
+    needs: push
     # A cold codex (full codex-rs workspace rustc build) is 40-80 min on this
     # runner; warm runs are probe + substitution only.
     timeout-minutes: 240
@@ -251,6 +257,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Free scratch disk
+        # arm64 hosted macs ship ~14 GB free and a cold codex realise needs
+        # more than that in target-dir scratch alone: the first lane run died
+        # ENOSPC at 43 MB free (run 28762717645). The preinstalled Xcode
+        # bundles and simulator runtimes are dead weight here (nix brings its
+        # own SDK); reclaiming them buys tens of GB. Best-effort: a layout
+        # change in the runner image must not fail the lane.
+        run: |
+          df -h / | tail -n 1
+          sudo rm -rf /Applications/Xcode_*.app ~/Library/Developer/CoreSimulator || true
+          df -h / | tail -n 1
 
       - name: Install nix
         uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
@@ -350,8 +368,14 @@ jobs:
           : > "$outs"
           realise_t=$SECONDS
           if [ -s "$drvs" ]; then
+            # -P 1, not -P 3: the runner's scratch disk is the binding
+            # constraint, not cores. Three concurrent rust/npm builds each
+            # keep a full target dir on disk at once and the first lane run
+            # died ENOSPC with 43 MB free (run 28762717645); serial roots cap
+            # peak scratch at one build while `max-jobs`/`cores` still use
+            # every core inside it.
             # shellcheck disable=SC2016  # $1/$2 expand in the child bash, not here
-            xargs -P 3 -n 1 bash -c \
+            xargs -P 1 -n 1 bash -c \
                 'nix-store --realise --keep-going "$2" || { printf "%s\n" "$2" >> "$1"; exit 1; }' _ "$failed_roots" \
               < "$drvs" > "$outs" 2>"$workdir/realise.err" \
               || {

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1404,7 +1404,15 @@ in {
       native-ifd-vendor-dir = crossWorkspace.units.vendorDir;
     };
   in
-    imagesAsClosures // exampleNodeToplevels // crossIfdRoots // nativeIfdRoots;
+    # Fleet node toplevels are NixOS closures: on Darwin they can only
+    # eval-error (every `<fleet>-<node>` row in the first darwin lane run was
+    # an eval failure, run 28762717645), so they stay a linux-lane concern.
+    # Alias-shadowed natives (dag-runner, nix-web-monitor) need no exclusion
+    # here: the flake grafts `linuxDarwinAliases` over this set, so the darwin
+    # lane sees the cross drvs and its system filter drops them.
+    if pkgs.stdenv.hostPlatform.isDarwin
+    then imagesAsClosures // nativeIfdRoots
+    else imagesAsClosures // exampleNodeToplevels // crossIfdRoots;
 
   inherit darwinPackageAliases;
 


### PR DESCRIPTION
First darwin lane run ([28762717645](https://github.com/indexable-inc/index/actions/runs/28762717645)) died ENOSPC at 43 MB free, taking blender-lab-mcp/npm fixups down with it (truncated writes read as invalid object files).

- `cachePushRoots` on darwin drops the fleet node toplevels: NixOS closures, every one an eval error on the mac. Alias-shadowed natives need no extra handling; the flake's `linuxDarwinAliases` graft plus the workflow's system filter already exclude them.
- `darwin-build` now `needs: push`: overlapping dep closures substitute from cache.ix.dev instead of racing the linux lane into platform-mismatch build attempts.
- Roots realise serially (`-P 1`): the ~14 GB scratch disk is the binding constraint, not the 3 cores; a single build still saturates them.
- Reclaim preinstalled Xcode/simulator bundles up front (best-effort) for the cold-codex headroom.

Part of #1890.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ENOSPC errors on Darwin cache-push by scoping roots, serialising realise, and freeing disk
> - On Darwin, [per-system.nix](https://github.com/indexable-inc/index/pull/1920/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) now returns only `imagesAsClosures // nativeIfdRoots`, dropping `exampleNodeToplevels` and `crossIfdRoots` which are excluded to non-Darwin hosts.
> - The `darwin-realise` step in [cache-push.yml](https://github.com/indexable-inc/index/pull/1920/files#diff-56c6f531ecd11b28cb14d6aa2ec8abf63b2cb701d82ce2f772c5a324c3bbbfb8) now runs `xargs -P 1` (serial) instead of `xargs -P 3` (parallel) to reduce peak disk pressure.
> - A new "Free scratch disk" step removes Xcode bundles and CoreSimulator runtimes (`/Applications/Xcode_*.app` and `~/Library/Developer/CoreSimulator`) before realisation.
> - The `darwin-build` job now depends on the `push` job completing first to enforce sequencing.
> - Behavioral Change: Darwin runners now build a smaller set of roots and no longer parallelise realisation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad95acf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->