### PR TITLE
feat(nix-web-monitor): provenance trails, user attribution, and live logs in the machine builds panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5470,6 +5479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6316,10 +6331,12 @@ dependencies = [
  "axum",
  "build-version",
  "bytes",
+ "bzip2",
  "clap",
  "ignore",
  "nix-web-monitor-parser",
  "rmp-serde",
+ "serde",
  "serde_json",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,9 @@ axum = "0.8"
 base64 = "0.22"
 build-version = { path = "packages/build-version" }
 bytes = "1"
+# Pure-Rust bzip2 (the 0.6 default backend is libbz2-rs-sys), used to read
+# Nix's build logs, which are bzip2-compressed on disk while being written.
+bzip2 = "0.6"
 chrono = { version = "0.4", default-features = false }
 clap = "4"
 source-atuin = { path = "packages/search/source/atuin" }

--- a/doc/nix-web-monitor/internals.md
+++ b/doc/nix-web-monitor/internals.md
@@ -109,3 +109,29 @@ string the panel shows and the loop retries after `RETRY_INTERVAL` (5s); the
 probe never returns an error (`:41`). `OpClass::classify`
 (`parser/src/daemon.rs:37`) groups syscalls so the panel shows work kind
 (Link/Rename dominate store optimisation, Write/Fsync dominate writing a path).
+
+## Machine-wide build view (`server/src/global.rs`)
+
+Everything above watches *one* nix invocation; `run_global_probe` watches the
+whole machine. It polls the patched-nix `nix store builds --json` subcommand
+(the `build-status-dir` experimental feature: every active build/substitution
+goal writes a status file under `<nixStateDir>/status/`), whose entries carry
+the derivation, worker pid, start time, requesting client user/uid, on-disk log
+path, and a why-chain walked up the goal's waiters to the root goal the client
+asked for. Detection is by result: if no invocation variant parses as a JSON
+build array (stock nix prints an "unknown command" error), the view is marked
+undetected and the panel hides; the probe re-probes every 30s so a mid-session
+nix upgrade is picked up. The parser side (`parser/src/global.rs`) owns the
+tolerant wire types: unknown fields are ignored, missing optionals become
+`None`, and an unknown goal kind folds to `Other`, so C++-side schema drift
+degrades one field rather than the probe.
+
+The panel groups rows by requesting user and renders each goal's why-chain as a
+provenance trail ("for <root> via <hop> → <hop>"), so any leaf build is
+attributable to the top-level thing that wanted it. Each build row can expand a
+live log tail served by `/api/global-log?drv=<drvPath>`: the server resolves the
+drv against the *current* machine view (never a caller-supplied path), then
+reads and bzip2-decompresses the log itself. Nix compresses build logs while
+writing them, so a live log is a truncated stream `nix log` refuses;
+`decompress_prefix` keeps everything decoded before the truncation point and
+`tail_lines` bounds the response to the newest 64 KiB at a line boundary.

--- a/packages/nix/nix-web-monitor/parser/src/global.rs
+++ b/packages/nix/nix-web-monitor/parser/src/global.rs
@@ -144,6 +144,37 @@ pub fn parse_builds(json: &str) -> Result<Vec<GlobalBuild>, serde_json::Error> {
 mod tests {
     use super::*;
 
+    /// A goal the client asked for directly: the writer records
+    /// `cause: "requested"` and a why-chain containing only the goal itself
+    /// (`isTopGoal` in the C++ writer). The UI keys "requested directly" off
+    /// this shape, so it must parse with the root equal to the leaf.
+    #[test]
+    fn parses_requested_root_whose_chain_is_itself() {
+        let json = r#"[
+            {
+                "drvPath": "/nix/store/aaa-app.drv",
+                "storePath": null,
+                "outputs": ["out"],
+                "type": "build",
+                "pid": 77,
+                "startTime": 1720200000,
+                "user": "alice",
+                "uid": 1000,
+                "logFile": "/nix/var/log/nix/drvs/aa/a-app.drv.bz2",
+                "why": {
+                    "rootDrvPath": "/nix/store/aaa-app.drv",
+                    "chain": ["/nix/store/aaa-app.drv"],
+                    "cause": "requested"
+                }
+            }
+        ]"#;
+        let builds = parse_builds(json).expect("requested root parses");
+        let build = &builds[0];
+        assert_eq!(build.why.cause.as_deref(), Some("requested"));
+        assert_eq!(build.why.chain, vec!["/nix/store/aaa-app.drv".to_owned()]);
+        assert_eq!(build.why.root_drv_path, build.drv_path);
+    }
+
     #[test]
     fn parses_full_build_with_why_chain() {
         let json = r#"[

--- a/packages/nix/nix-web-monitor/server/Cargo.toml
+++ b/packages/nix/nix-web-monitor/server/Cargo.toml
@@ -13,10 +13,12 @@ anyhow.workspace = true
 axum = { workspace = true, features = ["ws"] }
 build-version.workspace = true
 bytes.workspace = true
+bzip2.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 ignore.workspace = true
 nix-web-monitor-parser.workspace = true
 rmp-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-std", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync"] }
 tower-http = { workspace = true, features = ["fs"] }

--- a/packages/nix/nix-web-monitor/server/site/src/components/GlobalLogView.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/GlobalLogView.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  /// Inline tail of one machine build's on-disk log, fetched from the server's
+  /// `/api/global-log` endpoint (which decompresses the live `.drv.bz2` file).
+  /// Polls while mounted: the panel mounts one of these per *expanded* row, so
+  /// a collapsed log costs nothing.
+
+  type Props = {
+    /// Derivation whose log to tail. The server resolves it to the on-disk log
+    /// path recorded in the machine-wide build view.
+    drvPath: string;
+  };
+
+  const { drvPath }: Props = $props();
+
+  /// Refetch cadence while open; matches the global probe's two-second poll,
+  /// so the tail is as live as the row it belongs to.
+  const POLL_MS = 2000;
+
+  let text = $state('');
+  let note = $state<string | null>('loading log…');
+  let stream = $state<HTMLPreElement | null>(null);
+
+  async function fetchTail(target: string): Promise<void> {
+    try {
+      const response = await fetch(`/api/global-log?drv=${encodeURIComponent(target)}`);
+      if (!response.ok) {
+        // Keep showing a stale tail over a placeholder: a 404 mid-build just
+        // means the builder has not flushed (or the entry blinked); the next
+        // poll usually recovers.
+        if (text.length === 0) {
+          note = response.status === 404 ? 'no log output yet' : 'log unavailable';
+        }
+        return;
+      }
+      const body = await response.text();
+      if (body.length === 0) {
+        if (text.length === 0) note = 'no log output yet';
+        return;
+      }
+      text = body;
+      note = null;
+    } catch {
+      if (text.length === 0) note = 'log unavailable';
+    }
+  }
+
+  $effect(() => {
+    // Fetch on mount / re-target, then poll. The interval dies with the
+    // component, so collapsing the row stops the traffic.
+    void fetchTail(drvPath);
+    const timer = setInterval(() => void fetchTail(drvPath), POLL_MS);
+    return () => {
+      clearInterval(timer);
+    };
+  });
+
+  $effect(() => {
+    // Pin to the newest lines on every update: this is a tail view, not a
+    // scrollback browser (the full log stays available via `nix log` later).
+    void text;
+    if (stream !== null) stream.scrollTop = stream.scrollHeight;
+  });
+</script>
+
+{#if note !== null}
+  <div class="global-log-note">{note}</div>
+{:else}
+  <pre class="global-log-view" bind:this={stream}>{text}</pre>
+{/if}

--- a/packages/nix/nix-web-monitor/server/site/src/components/GlobalPanel.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/GlobalPanel.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import GlobalLogView from '$components/GlobalLogView.svelte';
   import PanelHeader from '$lib/PanelHeader.svelte';
   import { formatDuration, splitDerivation } from '$lib/format';
   import { useNow } from '$lib/now.svelte';
-  import type { GlobalBuild, GlobalBuilds } from '$lib/types';
+  import type { GlobalBuild, GlobalBuildKind, GlobalBuilds } from '$lib/types';
 
   type Props = {
     global: GlobalBuilds;
@@ -12,6 +13,14 @@
 
   const now = useNow();
 
+  /// Short badge per goal kind. The Rust side already folds unknown kinds into
+  /// `other`, so this record is total.
+  const BADGE: Record<GlobalBuildKind, string> = {
+    build: 'build',
+    substitution: 'sub',
+    other: 'other'
+  };
+
   /// The store path a row identifies: the drv for a build, the store path for a
   /// substitution. Either can be null on a drifted entry, so fall back to the
   /// other and finally to a placeholder rather than rendering `null`.
@@ -19,12 +28,62 @@
     return build.drvPath ?? build.storePath ?? '(unknown)';
   }
 
-  /// Short 'build' / 'sub' badge for the goal kind. Anything the C++ side adds
-  /// beyond the two known kinds is shown verbatim rather than dropped.
-  function badge(type: string): string {
-    if (type === 'build') return 'build';
-    if (type === 'substitution') return 'sub';
-    return type;
+  /// Stable row key. The status directory keys entries by `<path>-<pid>`: the
+  /// same derivation can appear once per daemon worker, so the path alone would
+  /// collide.
+  function rowKey(build: GlobalBuild): string {
+    return `${pathOf(build)}:${String(build.pid ?? 0)}`;
+  }
+
+  /// Builds grouped by the client user that requested them, so the panel
+  /// answers "who started this" before "what is it". Null users pool under one
+  /// unattributed group (a local store without a daemon records no client).
+  type UserGroup = Readonly<{
+    user: string | null;
+    label: string;
+    builds: readonly GlobalBuild[];
+  }>;
+
+  const groups = $derived(groupByUser(global.builds));
+
+  /// Group headers only earn their row when they attribute something: several
+  /// users, or one *known* user. A single anonymous group would just say
+  /// "unattributed" above every row.
+  const showGroups = $derived(groups.length > 1 || groups.some((group) => group.user !== null));
+
+  const meta = $derived(countsLabel(global.builds));
+
+  function groupByUser(builds: readonly GlobalBuild[]): UserGroup[] {
+    const buckets: { user: string | null; label: string; builds: GlobalBuild[] }[] = [];
+    for (const build of builds) {
+      const bucket = buckets.find((candidate) => candidate.user === build.user);
+      if (bucket === undefined) {
+        buckets.push({ user: build.user, label: build.user ?? 'unattributed', builds: [build] });
+      } else {
+        bucket.builds.push(build);
+      }
+    }
+    for (const bucket of buckets) {
+      // Oldest first within a group: long-running work floats to the top, and
+      // rows keep a stable order across the two-second re-polls.
+      bucket.builds.sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0));
+    }
+    return buckets.sort(
+      (a, b) => b.builds.length - a.builds.length || a.label.localeCompare(b.label)
+    );
+  }
+
+  /// Header meta splitting builds from substitutions, so the mix is readable
+  /// without scanning badges ("3 building · 2 fetching").
+  function countsLabel(builds: readonly GlobalBuild[]): string {
+    const building = builds.filter((build) => build.type === 'build').length;
+    const fetching = builds.filter((build) => build.type === 'substitution').length;
+    const other = builds.length - building - fetching;
+    const parts: string[] = [];
+    if (building > 0) parts.push(`${String(building)} building`);
+    if (fetching > 0) parts.push(`${String(fetching)} fetching`);
+    if (other > 0) parts.push(`${String(other)} other`);
+    return parts.length === 0 ? 'idle' : parts.join(' · ');
   }
 
   /// Live elapsed label from the goal's start. `startTime` is unix *seconds*
@@ -35,51 +94,129 @@
     return formatDuration(now.value - startTimeSec * 1000);
   }
 
-  /// Compact why-chain: the derivation names from the requested root down to this
-  /// goal, joined by arrows (`app → foo`). Falls back to the root alone, then to
-  /// the cause, so a row always explains itself even on a sparse entry.
-  function whyChain(build: GlobalBuild): string {
+  /// One hop of the provenance trail: a derivation shown by name, full path
+  /// kept for the tooltip.
+  type TrailHop = Readonly<{ path: string; name: string }>;
+
+  /// The ancestors that wanted this goal: the requested root plus the
+  /// intermediate hops between it and this goal, in root -> leaf order. Null
+  /// when the goal *is* the root (nothing above it to attribute to).
+  type Trail = Readonly<{ root: TrailHop; via: readonly TrailHop[] }>;
+
+  function hop(path: string): TrailHop {
+    const name = splitDerivation(path).name;
+    return { path, name: name.length > 0 ? name : path };
+  }
+
+  function whyTrail(build: GlobalBuild): Trail | null {
+    // The why-chain is root-first and ends with the goal itself; drop that
+    // leaf so the trail is only the ancestors.
     const chain = build.why.chain;
-    if (chain.length > 0) {
-      return chain.map((path) => splitDerivation(path).name).join(' → ');
+    const ancestors =
+      chain.length > 0 && chain[chain.length - 1] === pathOf(build) ? chain.slice(0, -1) : chain;
+    const root = ancestors.length > 0 ? ancestors[0] : build.why.rootDrvPath;
+    if (root === null || root === pathOf(build)) return null;
+    return { root: hop(root), via: ancestors.slice(1).map(hop) };
+  }
+
+  /// Label when there is no ancestor trail. A top goal reads "requested
+  /// directly"; a sparse entry that still carries a cause shows it verbatim so
+  /// the row explains itself either way.
+  function noTrailLabel(build: GlobalBuild): string {
+    const cause = build.why.cause;
+    return cause === null || cause === 'requested' ? 'requested directly' : cause;
+  }
+
+  /// Row tooltip: the full store path plus the identity details (outputs,
+  /// worker pid, requesting user/uid, cause) that would crowd the row itself.
+  function rowTitle(build: GlobalBuild): string {
+    const lines = [pathOf(build)];
+    if (build.outputs.length > 0) lines.push(`outputs: ${build.outputs.join(', ')}`);
+    if (build.pid !== null) lines.push(`worker pid ${String(build.pid)}`);
+    if (build.user !== null) {
+      lines.push(
+        build.uid === null
+          ? `requested by ${build.user}`
+          : `requested by ${build.user} (uid ${String(build.uid)})`
+      );
     }
-    if (build.why.rootDrvPath !== null) {
-      return splitDerivation(build.why.rootDrvPath).name;
-    }
-    return build.why.cause ?? '';
+    if (build.why.cause !== null) lines.push(`cause: ${build.why.cause}`);
+    return lines.join('\n');
+  }
+
+  /// Trail tooltip: the full why-chain, one store path per line, root first.
+  function trailTitle(build: GlobalBuild): string {
+    if (build.why.chain.length > 0) return build.why.chain.join('\n→ ');
+    return build.why.rootDrvPath ?? '';
+  }
+
+  /// Which row's log drawer is open, by row key. One at a time keeps the panel
+  /// compact; clicking the open row's toggle closes it.
+  let openLog = $state<string | null>(null);
+
+  function toggleLog(key: string): void {
+    openLog = openLog === key ? null : key;
   }
 </script>
 
 {#if global.detected}
   <section class="panel global-panel">
     <PanelHeader title="machine builds">
-      <span class="panel-meta">{global.builds.length}</span>
+      <span class="panel-meta">{meta}</span>
     </PanelHeader>
 
     <div class="global-body">
       {#if global.builds.length === 0}
         <div class="global-status">no machine builds right now</div>
       {:else}
-        {#each global.builds as build (pathOf(build))}
-          {@const parts = splitDerivation(pathOf(build))}
-          <div class="global-row" title={pathOf(build)}>
-            <div class="global-row-head">
-              <span class="global-badge global-badge-{build.type}">{badge(build.type)}</span>
-              <span class="global-name">{parts.name || pathOf(build)}</span>
-              {#if parts.version}<span class="global-version">{parts.version}</span>{/if}
-              <span class="global-elapsed">{elapsed(build.startTime)}</span>
+        {#each groups as group (group.label)}
+          {#if showGroups}
+            <div class="global-group">
+              <span class="global-group-user">{group.label}</span>
+              <span class="global-group-count">{group.builds.length}</span>
             </div>
-            <div class="global-row-meta">
-              {#if build.user !== null}<span class="global-user">{build.user}</span>{/if}
-              {#if build.why.cause !== null}<span class="global-cause">{build.why.cause}</span>{/if}
+          {/if}
+          {#each group.builds as build (rowKey(build))}
+            {@const parts = splitDerivation(pathOf(build))}
+            {@const trail = whyTrail(build)}
+            <div class="global-row">
+              <div class="global-row-head" title={rowTitle(build)}>
+                <span class="global-badge global-badge-{build.type}">{BADGE[build.type]}</span>
+                <span class="global-name">{parts.name.length > 0 ? parts.name : pathOf(build)}</span>
+                {#if parts.version.length > 0}<span class="global-version">{parts.version}</span>{/if}
+                {#if build.drvPath !== null && build.logFile !== null}
+                  <button
+                    type="button"
+                    class="global-log-toggle"
+                    class:open={openLog === rowKey(build)}
+                    aria-expanded={openLog === rowKey(build)}
+                    onclick={() => {
+                      toggleLog(rowKey(build));
+                    }}
+                  >
+                    log
+                  </button>
+                {/if}
+                <span class="global-elapsed">{elapsed(build.startTime)}</span>
+              </div>
+              <div class="global-why" title={trailTitle(build)}>
+                {#if trail === null}
+                  <span class="global-requested">{noTrailLabel(build)}</span>
+                {:else}
+                  <span class="global-why-label">for</span>
+                  <span class="global-why-root" title={trail.root.path}>{trail.root.name}</span>
+                  {#if trail.via.length > 0}
+                    <span class="global-why-via"
+                      >via {trail.via.map((step) => step.name).join(' → ')}</span
+                    >
+                  {/if}
+                {/if}
+              </div>
+              {#if build.drvPath !== null && openLog === rowKey(build)}
+                <GlobalLogView drvPath={build.drvPath} />
+              {/if}
             </div>
-            {#if whyChain(build)}
-              <div class="global-why" title={build.why.rootDrvPath ?? ''}>{whyChain(build)}</div>
-            {/if}
-            {#if build.logFile !== null}
-              <div class="global-log" title={build.logFile}>{build.logFile}</div>
-            {/if}
-          </div>
+          {/each}
         {/each}
       {/if}
     </div>

--- a/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
@@ -82,17 +82,21 @@ export const globalWhySchema = v.object({
   cause: v.nullable(v.string())
 });
 
+/// The kind of machine-wide goal. Mirrors the Rust `GlobalBuildKind`, which
+/// already folds any unknown kind from the C++ side into `other` before it
+/// reaches the wire, so the wire value is a closed set.
+export const globalBuildKindSchema = v.picklist(['build', 'substitution', 'other']);
+
 /// One active build or substitution goal on the machine, from the patched-nix
 /// `nix store builds --json` subcommand. Mirrors the Rust `GlobalBuild`; a
 /// substitution has a null `drvPath` and sets `storePath`. `startTime` is unix
 /// *seconds* (the rest of the monitor uses milliseconds), so the panel multiplies
-/// by 1000 before diffing against its clock. `kind` is a free string ('build' /
-/// 'substitution' / an unknown future kind), so a schema drift is surfaced.
+/// by 1000 before diffing against its clock.
 export const globalBuildSchema = v.object({
   drvPath: v.nullable(v.string()),
   storePath: v.nullable(v.string()),
   outputs: v.array(v.string()),
-  type: v.string(),
+  type: globalBuildKindSchema,
   pid: v.nullable(v.number()),
   startTime: v.nullable(v.number()),
   user: v.nullable(v.string()),
@@ -241,6 +245,7 @@ export type DaemonOps = v.InferOutput<typeof daemonOpsSchema>;
 export type DaemonHotPath = v.InferOutput<typeof daemonHotPathSchema>;
 export type DaemonInfo = v.InferOutput<typeof daemonInfoSchema>;
 export type GlobalWhy = v.InferOutput<typeof globalWhySchema>;
+export type GlobalBuildKind = v.InferOutput<typeof globalBuildKindSchema>;
 export type GlobalBuild = v.InferOutput<typeof globalBuildSchema>;
 export type GlobalBuilds = v.InferOutput<typeof globalBuildsSchema>;
 export type ActivationStep = v.InferOutput<typeof activationStepSchema>;

--- a/packages/nix/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix/nix-web-monitor/server/site/src/style.css
@@ -643,6 +643,27 @@ main.dragging-v .splitter-v::after {
   color: var(--muted);
 }
 
+/* One requesting user's header: name left, build count right. Rendered only
+ * when attribution adds information (several users, or one known user). */
+.global-group {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-bottom: -0.3rem;
+}
+
+.global-group:not(:first-child) {
+  margin-top: 0.2rem;
+}
+
+.global-group-count {
+  color: var(--faint);
+}
+
 .global-row {
   display: flex;
   flex-direction: column;
@@ -656,7 +677,7 @@ main.dragging-v .splitter-v::after {
   padding-bottom: 0;
 }
 
-/* badge | name | version | elapsed, name flexes and truncates. */
+/* badge | name | version | log | elapsed, name flexes and truncates. */
 .global-row-head {
   display: flex;
   align-items: baseline;
@@ -699,31 +720,77 @@ main.dragging-v .splitter-v::after {
   color: var(--muted);
 }
 
-.global-row-meta {
-  display: flex;
-  gap: 0.5rem;
-  color: var(--faint);
-  font-size: 0.85rem;
-}
-
-.global-cause {
+/* Toggle for the row's inline log tail; styled as a quiet chip that fills with
+ * the accent while the drawer is open. */
+.global-log-toggle {
+  appearance: none;
+  flex: 0 0 auto;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 0 0.3rem;
+  font-family: inherit;
+  font-size: 0.72rem;
   color: var(--muted);
+  cursor: pointer;
 }
 
-/* The why-chain: root -> ... -> this goal, one truncated line. */
+.global-log-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.global-log-toggle.open {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--panel);
+}
+
+/* The provenance trail: "for <root> via <hop> → <hop>". Root-first so the
+ * attribution survives the end-of-line truncation. */
 .global-why {
   color: var(--faint);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 0.85rem;
 }
 
-.global-log {
+.global-why-label,
+.global-requested {
+  color: var(--faint);
+}
+
+/* The top-level thing that wanted this build: the answer to "why is my fan
+ * spinning", so it reads as ink rather than a dim afterthought. */
+.global-why-root {
+  color: var(--ink);
+}
+
+.global-why-via {
+  color: var(--faint);
+}
+
+/* Inline log tail under a row: a short fixed-height stream pinned to the
+ * newest lines, mirroring the main log drawer's look at panel scale. */
+.global-log-view {
+  margin: 0.15rem 0 0;
+  padding: 0.3rem 0.4rem;
+  max-height: 9rem;
+  overflow: auto;
+  background: var(--panel-soft);
+  border: 1px solid var(--line-soft);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.global-log-note {
+  margin-top: 0.15rem;
   color: var(--faint);
   font-size: 0.8rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 /* ---------- activation + diff panels (switch only) ---------- */

--- a/packages/nix/nix-web-monitor/server/src/global.rs
+++ b/packages/nix/nix-web-monitor/server/src/global.rs
@@ -163,13 +163,19 @@ pub async fn log_file_for(monitor: &Arc<RwLock<MonitorState>>, drv_path: &str) -
 pub async fn read_log_tail(path: PathBuf) -> std::io::Result<String> {
     tokio::task::spawn_blocking(move || {
         let bytes = std::fs::read(&path)?;
-        let (text, prefix_dropped) = if path.extension().is_some_and(|extension| extension == "bz2")
-        {
+        let decoded = if path.extension().is_some_and(|extension| extension == "bz2") {
             decompress_prefix(&bytes)
         } else {
-            (bytes, false)
+            DecodedTail {
+                bytes,
+                prefix_dropped: false,
+            }
         };
-        Ok(tail_lines(&text, LOG_TAIL_BYTES, prefix_dropped))
+        Ok(tail_lines(
+            &decoded.bytes,
+            LOG_TAIL_BYTES,
+            decoded.prefix_dropped,
+        ))
     })
     .await
     // The closure neither panics nor is cancelled; a join error here is a bug.
@@ -191,10 +197,15 @@ pub async fn read_log_tail(path: PathBuf) -> std::io::Result<String> {
 /// default 900 KB block size, meaning a quiet build's log decodes to nothing
 /// until its first 900 KB of output. That granularity is inherent to reading
 /// what nix wrote; the panel shows "no log output yet" until then.
-/// Returns the retained bytes plus whether earlier decoded bytes were dropped
-/// by the rolling cap, so the caller knows the buffer no longer starts at the
-/// log's true beginning (and must cut forward to a line boundary either way).
-fn decompress_prefix(bytes: &[u8]) -> (Vec<u8>, bool) {
+/// What the tolerant decode retained: the newest decoded bytes, plus whether
+/// the rolling cap discarded earlier bytes (so the buffer no longer starts at
+/// the log's true beginning and the caller must cut to a line boundary).
+struct DecodedTail {
+    bytes: Vec<u8>,
+    prefix_dropped: bool,
+}
+
+fn decompress_prefix(bytes: &[u8]) -> DecodedTail {
     let mut decoder = bzip2::read::BzDecoder::new(bytes);
     let mut out = Vec::new();
     let mut dropped = false;
@@ -213,7 +224,10 @@ fn decompress_prefix(bytes: &[u8]) -> (Vec<u8>, bool) {
             Err(_) => break,
         }
     }
-    (out, dropped)
+    DecodedTail {
+        bytes: out,
+        prefix_dropped: dropped,
+    }
 }
 
 /// The last `keep` bytes as text, cut forward to a line boundary so the tail
@@ -318,9 +332,9 @@ mod tests {
     #[test]
     fn bz2_log_round_trips_and_tails() {
         let text = "configuring\nbuilding\ninstalling\n";
-        let (decoded, dropped) = decompress_prefix(&compress_bzip2(text, 9));
-        assert_eq!(decoded, text.as_bytes());
-        assert!(!dropped, "a small log keeps its whole prefix");
+        let decoded = decompress_prefix(&compress_bzip2(text, 9));
+        assert_eq!(decoded.bytes, text.as_bytes());
+        assert!(!decoded.prefix_dropped, "a small log keeps its whole prefix");
         assert_eq!(tail_lines(text.as_bytes(), 1 << 20, false), text);
     }
 
@@ -339,11 +353,11 @@ mod tests {
         let compressed = compress_bzip2(&text, 1);
         let truncated = &compressed[..compressed.len() / 2];
 
-        let (decoded, _) = decompress_prefix(truncated);
-        assert!(!decoded.is_empty(), "completed blocks decode");
-        assert!(decoded.len() < text.len(), "but not the whole log");
+        let decoded = decompress_prefix(truncated);
+        assert!(!decoded.bytes.is_empty(), "completed blocks decode");
+        assert!(decoded.bytes.len() < text.len(), "but not the whole log");
         assert!(
-            String::from_utf8_lossy(&decoded).contains("incompressible entropy 8d1f4a2c"),
+            String::from_utf8_lossy(&decoded.bytes).contains("incompressible entropy 8d1f4a2c"),
             "decoded bytes are real log content"
         );
     }
@@ -355,13 +369,13 @@ mod tests {
     fn truncated_first_block_decodes_to_empty() {
         let compressed = compress_bzip2(&"short log\n".repeat(100), 9);
         let truncated = &compressed[..compressed.len() / 2];
-        assert!(decompress_prefix(truncated).0.is_empty());
+        assert!(decompress_prefix(truncated).bytes.is_empty());
     }
 
     /// Garbage that is not bzip2 at all decodes to nothing rather than failing.
     #[test]
     fn non_bzip2_bytes_decode_to_empty() {
-        assert!(decompress_prefix(b"error: not a log").0.is_empty());
+        assert!(decompress_prefix(b"error: not a log").bytes.is_empty());
     }
 
     /// The tail is bounded and opens on a line boundary, never mid-line.

--- a/packages/nix/nix-web-monitor/server/src/global.rs
+++ b/packages/nix/nix-web-monitor/server/src/global.rs
@@ -163,12 +163,13 @@ pub async fn log_file_for(monitor: &Arc<RwLock<MonitorState>>, drv_path: &str) -
 pub async fn read_log_tail(path: PathBuf) -> std::io::Result<String> {
     tokio::task::spawn_blocking(move || {
         let bytes = std::fs::read(&path)?;
-        let text = if path.extension().is_some_and(|extension| extension == "bz2") {
+        let (text, prefix_dropped) = if path.extension().is_some_and(|extension| extension == "bz2")
+        {
             decompress_prefix(&bytes)
         } else {
-            bytes
+            (bytes, false)
         };
-        Ok(tail_lines(&text, LOG_TAIL_BYTES))
+        Ok(tail_lines(&text, LOG_TAIL_BYTES, prefix_dropped))
     })
     .await
     // The closure neither panics nor is cancelled; a join error here is a bug.
@@ -184,9 +185,19 @@ pub async fn read_log_tail(path: PathBuf) -> std::io::Result<String> {
 /// so a decode error just ends the read: everything decoded so far *is* the
 /// live log. Only the last [`LOG_TAIL_BYTES`]-ish bytes are retained while
 /// decoding, so a huge log never balloons memory.
-fn decompress_prefix(bytes: &[u8]) -> Vec<u8> {
+///
+/// bzip2 is a block format (the BWT inverse needs the whole block), so the
+/// live tail advances one *completed* block at a time: nix compresses at the
+/// default 900 KB block size, meaning a quiet build's log decodes to nothing
+/// until its first 900 KB of output. That granularity is inherent to reading
+/// what nix wrote; the panel shows "no log output yet" until then.
+/// Returns the retained bytes plus whether earlier decoded bytes were dropped
+/// by the rolling cap, so the caller knows the buffer no longer starts at the
+/// log's true beginning (and must cut forward to a line boundary either way).
+fn decompress_prefix(bytes: &[u8]) -> (Vec<u8>, bool) {
     let mut decoder = bzip2::read::BzDecoder::new(bytes);
     let mut out = Vec::new();
+    let mut dropped = false;
     let mut chunk = vec![0_u8; 64 * 1024];
     loop {
         match decoder.read(&mut chunk) {
@@ -195,21 +206,25 @@ fn decompress_prefix(bytes: &[u8]) -> Vec<u8> {
                 out.extend_from_slice(&chunk[..read]);
                 if out.len() > LOG_TAIL_BYTES * 2 {
                     out.drain(..out.len() - LOG_TAIL_BYTES);
+                    dropped = true;
                 }
             }
             // A truncated live stream (or garbage): keep what decoded.
             Err(_) => break,
         }
     }
-    out
+    (out, dropped)
 }
 
 /// The last `keep` bytes as text, cut forward to a line boundary so the tail
-/// never opens mid-line. Lossy decode: build logs are not guaranteed UTF-8.
-fn tail_lines(bytes: &[u8], keep: usize) -> String {
+/// never opens mid-line. `prefix_dropped` marks a buffer whose head was already
+/// discarded upstream (the decoder's rolling cap cuts at an arbitrary byte), so
+/// the cut applies even when the buffer is under `keep`. Lossy decode: build
+/// logs are not guaranteed UTF-8.
+fn tail_lines(bytes: &[u8], keep: usize, prefix_dropped: bool) -> String {
     let start = bytes.len().saturating_sub(keep);
     let mut tail = &bytes[start..];
-    if start > 0
+    if (start > 0 || prefix_dropped)
         && let Some(newline) = tail.iter().position(|&byte| byte == b'\n')
     {
         tail = &tail[newline + 1..];
@@ -223,10 +238,12 @@ mod tests {
 
     use super::*;
 
-    /// Compress `text` the way Nix writes build logs, for fixture files.
-    fn compress_bzip2(text: &str) -> Vec<u8> {
+    /// Compress `text` as a bzip2 stream. `level` also sets the block size
+    /// (`level * 100 KB`): nix writes at the default level 9, but the
+    /// truncation test uses level 1 so a modest fixture spans several blocks.
+    fn compress_bzip2(text: &str, level: u32) -> Vec<u8> {
         use std::io::Write;
-        let mut encoder = bzip2::write::BzEncoder::new(Vec::new(), bzip2::Compression::default());
+        let mut encoder = bzip2::write::BzEncoder::new(Vec::new(), bzip2::Compression::new(level));
         encoder.write_all(text.as_bytes()).expect("compress log");
         encoder.finish().expect("finish bzip2 stream")
     }
@@ -301,45 +318,73 @@ mod tests {
     #[test]
     fn bz2_log_round_trips_and_tails() {
         let text = "configuring\nbuilding\ninstalling\n";
-        let compressed = compress_bzip2(text);
-        assert_eq!(decompress_prefix(&compressed), text.as_bytes());
-        assert_eq!(tail_lines(text.as_bytes(), 1 << 20), text);
+        let (decoded, dropped) = decompress_prefix(&compress_bzip2(text, 9));
+        assert_eq!(decoded, text.as_bytes());
+        assert!(!dropped, "a small log keeps its whole prefix");
+        assert_eq!(tail_lines(text.as_bytes(), 1 << 20, false), text);
     }
 
     /// A log truncated mid-stream (the live-write case: no bzip2 footer, last
-    /// block cut short) still yields every fully-decoded byte instead of an
+    /// block cut short) still yields every *completed* block instead of an
     /// error. This is the exact case `nix log` refuses and the reason the
-    /// server decompresses the file itself.
+    /// server decompresses the file itself. Level 1 (100 KB blocks) keeps the
+    /// fixture small while spanning several blocks; nix's level-9 stream
+    /// behaves identically at 900 KB granularity.
     #[test]
-    fn truncated_bz2_stream_yields_decoded_prefix() {
-        let line = "log line with enough text to span compressed blocks\n";
-        let text = line.repeat(4096);
-        let compressed = compress_bzip2(&text);
+    fn truncated_bz2_stream_yields_completed_blocks() {
+        let line = "log line with some incompressible entropy 8d1f4a2c\n";
+        // ~500 KB uncompressed -> ~5 level-1 blocks, and enough decoded output
+        // to exercise the rolling cap.
+        let text = line.repeat(10_000);
+        let compressed = compress_bzip2(&text, 1);
         let truncated = &compressed[..compressed.len() / 2];
 
-        let decoded = decompress_prefix(truncated);
-        assert!(!decoded.is_empty(), "half the stream decodes to something");
-        assert!(decoded.len() < text.len(), "but not to the whole log");
+        let (decoded, _) = decompress_prefix(truncated);
+        assert!(!decoded.is_empty(), "completed blocks decode");
+        assert!(decoded.len() < text.len(), "but not the whole log");
         assert!(
-            decoded.starts_with(line.as_bytes()),
-            "decoded prefix is the log's real prefix"
+            String::from_utf8_lossy(&decoded).contains("incompressible entropy 8d1f4a2c"),
+            "decoded bytes are real log content"
         );
+    }
+
+    /// A truncated stream whose first block never completed (a quiet build's
+    /// live log) decodes to nothing, and must not error: the panel shows
+    /// "no log output yet".
+    #[test]
+    fn truncated_first_block_decodes_to_empty() {
+        let compressed = compress_bzip2(&"short log\n".repeat(100), 9);
+        let truncated = &compressed[..compressed.len() / 2];
+        assert!(decompress_prefix(truncated).0.is_empty());
     }
 
     /// Garbage that is not bzip2 at all decodes to nothing rather than failing.
     #[test]
     fn non_bzip2_bytes_decode_to_empty() {
-        assert!(decompress_prefix(b"error: not a log").is_empty());
+        assert!(decompress_prefix(b"error: not a log").0.is_empty());
     }
 
     /// The tail is bounded and opens on a line boundary, never mid-line.
     #[test]
     fn tail_is_bounded_and_line_aligned() {
         let text: String = (0..1000).map(|i| format!("line {i}\n")).collect();
-        let tail = tail_lines(text.as_bytes(), 100);
+        let tail = tail_lines(text.as_bytes(), 100, false);
         assert!(tail.len() <= 100);
         assert!(tail.starts_with("line "), "tail begins at a line start");
         assert!(tail.ends_with("line 999\n"), "tail keeps the newest lines");
+    }
+
+    /// When the decoder already dropped the head (rolling cap), the cut to a
+    /// line boundary must happen even though the buffer is under the cap:
+    /// the buffer's first line is a fragment cut at an arbitrary byte.
+    #[test]
+    fn dropped_prefix_forces_line_boundary_cut() {
+        assert_eq!(tail_lines(b"ragment\nwhole line\n", 1 << 20, true), "whole line\n");
+        // Without the marker the same buffer is a complete log and keeps line 1.
+        assert_eq!(
+            tail_lines(b"ragment\nwhole line\n", 1 << 20, false),
+            "ragment\nwhole line\n"
+        );
     }
 
     /// `log_file_for` only resolves builds the status view currently lists:
@@ -378,7 +423,7 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("nwm-global-log-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("create scratch dir");
         let path = dir.join("test.drv.bz2");
-        std::fs::write(&path, compress_bzip2("hello from the builder\n"))
+        std::fs::write(&path, compress_bzip2("hello from the builder\n", 9))
             .expect("write fixture log");
 
         let tail = read_log_tail(path).await.expect("fixture log reads");

--- a/packages/nix/nix-web-monitor/server/src/global.rs
+++ b/packages/nix/nix-web-monitor/server/src/global.rs
@@ -212,16 +212,16 @@ fn decompress_prefix(bytes: &[u8]) -> DecodedTail {
     let mut chunk = vec![0_u8; 64 * 1024];
     loop {
         match decoder.read(&mut chunk) {
-            Ok(0) => break,
-            Ok(read) => {
+            Ok(read) if read > 0 => {
                 out.extend_from_slice(&chunk[..read]);
                 if out.len() > LOG_TAIL_BYTES * 2 {
                     out.drain(..out.len() - LOG_TAIL_BYTES);
                     dropped = true;
                 }
             }
-            // A truncated live stream (or garbage): keep what decoded.
-            Err(_) => break,
+            // Clean EOF, or a truncated live stream / garbage: either way,
+            // everything decoded so far is the readable log.
+            Ok(_) | Err(_) => break,
         }
     }
     DecodedTail {
@@ -381,7 +381,11 @@ mod tests {
     /// The tail is bounded and opens on a line boundary, never mid-line.
     #[test]
     fn tail_is_bounded_and_line_aligned() {
-        let text: String = (0..1000).map(|i| format!("line {i}\n")).collect();
+        use std::fmt::Write;
+        let text = (0..1000).fold(String::new(), |mut log, i| {
+            let _ = writeln!(log, "line {i}");
+            log
+        });
         let tail = tail_lines(text.as_bytes(), 100, false);
         assert!(tail.len() <= 100);
         assert!(tail.starts_with("line "), "tail begins at a line start");

--- a/packages/nix/nix-web-monitor/server/src/global.rs
+++ b/packages/nix/nix-web-monitor/server/src/global.rs
@@ -14,13 +14,20 @@
 //! returns and never panics: every failure becomes a status string, and the
 //! loop backs off and retries so a mid-session nix upgrade is eventually picked
 //! up.
+//!
+//! This module also owns reading a machine build's on-disk log for the panel's
+//! inline log drawer (see [`read_log_tail`]): the status entries carry the
+//! `/nix/var/log/nix/drvs/…` path each build is writing, and the UI fetches a
+//! tail of it through `/api/global-log`.
 
+use std::io::Read;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
-use nix_web_monitor_parser::{GlobalBuilds, MonitorState};
 use nix_web_monitor_parser::global::parse_builds;
+use nix_web_monitor_parser::{GlobalBuild, GlobalBuilds, MonitorState};
 use tokio::process::Command;
 use tokio::sync::{RwLock, broadcast};
 
@@ -36,6 +43,11 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 /// mid-run, but re-probe occasionally so a nix upgrade during a long-lived UI
 /// session is picked up.
 const RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Cap on the decompressed log tail `/api/global-log` returns. A build log can
+/// run to hundreds of megabytes; the panel's inline drawer only ever shows the
+/// live tail, so everything older is dropped at a line boundary.
+const LOG_TAIL_BYTES: usize = 64 * 1024;
 
 /// Run the machine-wide build probe until the task is aborted.
 ///
@@ -68,16 +80,16 @@ pub async fn run_global_probe(monitor: Arc<RwLock<MonitorState>>, deltas: broadc
 ///
 /// Detection is by *result*, not by exit-code text-matching: whatever variant of
 /// the invocation yields a parseable JSON array wins. A stock nix prints an
-/// "unknown command" / "unrecognised flag" error to stderr (not a JSON array),
-/// so every variant fails to parse and this returns `None` -> undetected.
-async fn poll_builds() -> Option<Vec<nix_web_monitor_parser::GlobalBuild>> {
-    // The patched command may be gated behind an experimental feature, but an
-    // *unknown* experimental feature is itself an error on stock nix. So try the
-    // plain form first (works if the command is ungated) and, only if that does
-    // not parse, the feature-gated form. Whichever yields a JSON array is used;
-    // if neither does, the subcommand is not available.
+/// "unknown command" / "unknown experimental feature" error to stderr (not a
+/// JSON array), so every variant fails to parse and this returns `None` ->
+/// undetected.
+async fn poll_builds() -> Option<Vec<GlobalBuild>> {
+    // The patched command is gated behind the `build-status-dir` experimental
+    // feature, so the feature-enabling form is the one that normally succeeds
+    // and goes first (one subprocess per tick on a patched nix). The plain form
+    // is the fallback for a nix that rejects the unknown feature name but has
+    // the command ungated or the feature enabled via nix.conf.
     const ATTEMPTS: [&[&str]; 2] = [
-        &["store", "builds", "--json", "--extra-experimental-features", "nix-command"],
         &[
             "store",
             "builds",
@@ -85,6 +97,7 @@ async fn poll_builds() -> Option<Vec<nix_web_monitor_parser::GlobalBuild>> {
             "--extra-experimental-features",
             "nix-command build-status-dir",
         ],
+        &["store", "builds", "--json", "--extra-experimental-features", "nix-command"],
     ];
     for args in ATTEMPTS {
         if let Some(builds) = try_builds(args).await {
@@ -97,7 +110,7 @@ async fn poll_builds() -> Option<Vec<nix_web_monitor_parser::GlobalBuild>> {
 /// Run one `nix` argument variant and return the parsed builds if its stdout is
 /// a JSON build array. Any spawn failure, or output that is not a build array,
 /// yields `None` so the caller falls through to the next variant / undetected.
-async fn try_builds(args: &[&str]) -> Option<Vec<nix_web_monitor_parser::GlobalBuild>> {
+async fn try_builds(args: &[&str]) -> Option<Vec<GlobalBuild>> {
     let output = Command::new("nix").args(args).output().await.ok()?;
     // Parse stdout regardless of exit status: a patched nix might print the array
     // and still exit nonzero on some warning, and a stock nix prints its error to
@@ -118,11 +131,105 @@ async fn publish(
     let _ = broadcast_deltas(monitor, deltas).await;
 }
 
+/// Resolve an active machine build's recorded log file by its derivation path.
+///
+/// This is the gate on `/api/global-log`: the server only ever opens paths the
+/// status directory itself advertised for a *currently active* build, so the
+/// endpoint cannot be steered at arbitrary files.
+pub async fn log_file_for(monitor: &Arc<RwLock<MonitorState>>, drv_path: &str) -> Option<PathBuf> {
+    monitor
+        .read()
+        .await
+        .global
+        .builds
+        .iter()
+        .find(|build| build.drv_path.as_deref() == Some(drv_path))
+        .and_then(|build| build.log_file.as_deref().map(PathBuf::from))
+}
+
+/// Read the tail of one build's on-disk log, decompressing when needed.
+///
+/// Nix compresses build logs *while writing them* (`.drv.bz2` under
+/// `/nix/var/log/nix/drvs`), so a live log is a truncated bzip2 stream. `nix
+/// log` refuses such a stream, which is why the server reads the file itself:
+/// [`decompress_prefix`] keeps everything decoded before the truncation point.
+/// The blocking read and decompression run off the async executor.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error when the file cannot be read (most
+/// commonly [`std::io::ErrorKind::NotFound`] before the builder's first output
+/// flush creates it).
+pub async fn read_log_tail(path: PathBuf) -> std::io::Result<String> {
+    tokio::task::spawn_blocking(move || {
+        let bytes = std::fs::read(&path)?;
+        let text = if path.extension().is_some_and(|extension| extension == "bz2") {
+            decompress_prefix(&bytes)
+        } else {
+            bytes
+        };
+        Ok(tail_lines(&text, LOG_TAIL_BYTES))
+    })
+    .await
+    // The closure neither panics nor is cancelled; a join error here is a bug.
+    .unwrap_or_else(|join_error| {
+        Err(std::io::Error::other(format!(
+            "log read task failed: {join_error}"
+        )))
+    })
+}
+
+/// Decompress as much of a bzip2 stream as is decodable, bounded to a rolling
+/// tail. A log being written is truncated mid-block and has no stream footer,
+/// so a decode error just ends the read: everything decoded so far *is* the
+/// live log. Only the last [`LOG_TAIL_BYTES`]-ish bytes are retained while
+/// decoding, so a huge log never balloons memory.
+fn decompress_prefix(bytes: &[u8]) -> Vec<u8> {
+    let mut decoder = bzip2::read::BzDecoder::new(bytes);
+    let mut out = Vec::new();
+    let mut chunk = vec![0_u8; 64 * 1024];
+    loop {
+        match decoder.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => {
+                out.extend_from_slice(&chunk[..read]);
+                if out.len() > LOG_TAIL_BYTES * 2 {
+                    out.drain(..out.len() - LOG_TAIL_BYTES);
+                }
+            }
+            // A truncated live stream (or garbage): keep what decoded.
+            Err(_) => break,
+        }
+    }
+    out
+}
+
+/// The last `keep` bytes as text, cut forward to a line boundary so the tail
+/// never opens mid-line. Lossy decode: build logs are not guaranteed UTF-8.
+fn tail_lines(bytes: &[u8], keep: usize) -> String {
+    let start = bytes.len().saturating_sub(keep);
+    let mut tail = &bytes[start..];
+    if start > 0
+        && let Some(newline) = tail.iter().position(|&byte| byte == b'\n')
+    {
+        tail = &tail[newline + 1..];
+    }
+    String::from_utf8_lossy(tail).into_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use nix_web_monitor_parser::{GlobalBuildKind, MonitorState};
 
     use super::*;
+
+    /// Compress `text` the way Nix writes build logs, for fixture files.
+    fn compress_bzip2(text: &str) -> Vec<u8> {
+        use std::io::Write;
+        let mut encoder = bzip2::write::BzEncoder::new(Vec::new(), bzip2::Compression::default());
+        encoder.write_all(text.as_bytes()).expect("compress log");
+        encoder.finish().expect("finish bzip2 stream")
+    }
 
     /// End-to-end of the parse-into-state path the probe drives: a sample
     /// `nix store builds --json` payload folds into a `GlobalBuilds` with the
@@ -188,5 +295,105 @@ mod tests {
         // Re-setting the identical view is a no-op (no redundant frame).
         state.set_global(global);
         assert!(state.drain_deltas().is_empty());
+    }
+
+    /// A complete `.bz2` log round-trips; the tail keeps the end of the log.
+    #[test]
+    fn bz2_log_round_trips_and_tails() {
+        let text = "configuring\nbuilding\ninstalling\n";
+        let compressed = compress_bzip2(text);
+        assert_eq!(decompress_prefix(&compressed), text.as_bytes());
+        assert_eq!(tail_lines(text.as_bytes(), 1 << 20), text);
+    }
+
+    /// A log truncated mid-stream (the live-write case: no bzip2 footer, last
+    /// block cut short) still yields every fully-decoded byte instead of an
+    /// error. This is the exact case `nix log` refuses and the reason the
+    /// server decompresses the file itself.
+    #[test]
+    fn truncated_bz2_stream_yields_decoded_prefix() {
+        let line = "log line with enough text to span compressed blocks\n";
+        let text = line.repeat(4096);
+        let compressed = compress_bzip2(&text);
+        let truncated = &compressed[..compressed.len() / 2];
+
+        let decoded = decompress_prefix(truncated);
+        assert!(!decoded.is_empty(), "half the stream decodes to something");
+        assert!(decoded.len() < text.len(), "but not to the whole log");
+        assert!(
+            decoded.starts_with(line.as_bytes()),
+            "decoded prefix is the log's real prefix"
+        );
+    }
+
+    /// Garbage that is not bzip2 at all decodes to nothing rather than failing.
+    #[test]
+    fn non_bzip2_bytes_decode_to_empty() {
+        assert!(decompress_prefix(b"error: not a log").is_empty());
+    }
+
+    /// The tail is bounded and opens on a line boundary, never mid-line.
+    #[test]
+    fn tail_is_bounded_and_line_aligned() {
+        let text: String = (0..1000).map(|i| format!("line {i}\n")).collect();
+        let tail = tail_lines(text.as_bytes(), 100);
+        assert!(tail.len() <= 100);
+        assert!(tail.starts_with("line "), "tail begins at a line start");
+        assert!(tail.ends_with("line 999\n"), "tail keeps the newest lines");
+    }
+
+    /// `log_file_for` only resolves builds the status view currently lists:
+    /// the drv must be active *and* carry a recorded log. This is the
+    /// arbitrary-file-read gate on `/api/global-log`.
+    #[tokio::test]
+    async fn log_file_for_resolves_only_active_builds() {
+        let with_log = GlobalBuild {
+            drv_path: Some("/nix/store/aaa-foo.drv".to_owned()),
+            log_file: Some("/nix/var/log/nix/drvs/ab/cdfoo.drv.bz2".to_owned()),
+            ..GlobalBuild::default()
+        };
+        let without_log = GlobalBuild {
+            drv_path: Some("/nix/store/bbb-bar.drv".to_owned()),
+            ..GlobalBuild::default()
+        };
+        let mut state = MonitorState::default();
+        state.set_global(GlobalBuilds {
+            detected: true,
+            builds: vec![with_log, without_log],
+            status: "2 active".to_owned(),
+        });
+        let monitor = Arc::new(RwLock::new(state));
+
+        assert_eq!(
+            log_file_for(&monitor, "/nix/store/aaa-foo.drv").await,
+            Some(PathBuf::from("/nix/var/log/nix/drvs/ab/cdfoo.drv.bz2"))
+        );
+        assert_eq!(log_file_for(&monitor, "/nix/store/bbb-bar.drv").await, None);
+        assert_eq!(log_file_for(&monitor, "/etc/passwd").await, None);
+    }
+
+    /// Reading a real compressed file end-to-end through the async entry point.
+    #[tokio::test]
+    async fn read_log_tail_reads_compressed_file() {
+        let dir = std::env::temp_dir().join(format!("nwm-global-log-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let path = dir.join("test.drv.bz2");
+        std::fs::write(&path, compress_bzip2("hello from the builder\n"))
+            .expect("write fixture log");
+
+        let tail = read_log_tail(path).await.expect("fixture log reads");
+        assert_eq!(tail, "hello from the builder\n");
+
+        std::fs::remove_dir_all(&dir).expect("clean scratch dir");
+    }
+
+    /// A missing log file (builder has not flushed yet) is a clean `NotFound`,
+    /// which the endpoint maps to 404 rather than an empty 200.
+    #[tokio::test]
+    async fn read_log_tail_missing_file_is_not_found() {
+        let error = read_log_tail(PathBuf::from("/nonexistent/nwm-test.drv.bz2"))
+            .await
+            .expect_err("missing file errors");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -8,9 +8,9 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use axum::Json;
 use axum::Router;
-use axum::extract::State;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::http::header;
+use axum::extract::{Query, State};
+use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use bytes::Bytes;
@@ -287,6 +287,7 @@ fn router(site_dir: &Path, state: AppState) -> Router {
     Router::new()
         .route("/", get(serve_index))
         .route("/api/state", get(state_snapshot))
+        .route("/api/global-log", get(global_log))
         .route("/ws", get(ws_handler))
         .fallback_service(static_files)
         .with_state(state)
@@ -313,6 +314,48 @@ async fn serve_index(State(state): State<AppState>) -> impl IntoResponse {
 /// WebSocket. Same payload the live stream seeds each client with.
 async fn state_snapshot(State(state): State<AppState>) -> Json<MonitorSnapshot> {
     Json(state.monitor.read().await.snapshot())
+}
+
+/// Which machine build's log `/api/global-log` should tail, by derivation path.
+#[derive(serde::Deserialize)]
+struct GlobalLogQuery {
+    drv: String,
+}
+
+/// Tail of one machine build's on-disk log, as plain text.
+///
+/// The derivation must be an *active* build in the machine-wide view with a
+/// recorded log file: the server only opens paths the status directory itself
+/// advertised, never a caller-supplied filesystem path. 404s cover both "not an
+/// active build" (it finished between poll and click) and "log not written yet"
+/// (the builder has produced no output), so the panel can show a quiet
+/// placeholder instead of an error.
+async fn global_log(
+    State(state): State<AppState>,
+    Query(query): Query<GlobalLogQuery>,
+) -> Response {
+    let Some(log_file) = global::log_file_for(&state.monitor, &query.drv).await else {
+        return (
+            StatusCode::NOT_FOUND,
+            "not an active machine build with a recorded log",
+        )
+            .into_response();
+    };
+    match global::read_log_tail(log_file).await {
+        Ok(text) => (
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            text,
+        )
+            .into_response(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            (StatusCode::NOT_FOUND, "log not written yet").into_response()
+        }
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("reading build log failed: {error}"),
+        )
+            .into_response(),
+    }
 }
 
 /// Upgrade the request to a WebSocket and stream deltas to it. The page is
@@ -1279,6 +1322,65 @@ mod tests {
             json.get("activities").is_some(),
             "snapshot exposes activities"
         );
+    }
+
+    /// `/api/global-log` serves the tail of an active machine build's log and
+    /// refuses anything the machine-wide view does not currently list. This is
+    /// the whole HTTP contract the panel's log drawer depends on: route, state
+    /// lookup, file read, and the not-found shapes.
+    #[tokio::test]
+    async fn global_log_serves_active_build_logs_only() {
+        let dir = std::env::temp_dir().join(format!("nwm-global-route-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let log_path = dir.join("fixture.drv");
+        std::fs::write(&log_path, b"builder says hi\n").expect("write fixture log");
+
+        let state = test_state();
+        state.monitor.write().await.set_global(
+            nix_web_monitor_parser::GlobalBuilds {
+                detected: true,
+                builds: vec![nix_web_monitor_parser::GlobalBuild {
+                    drv_path: Some("/nix/store/aaa-foo.drv".to_owned()),
+                    log_file: Some(log_path.to_string_lossy().into_owned()),
+                    ..nix_web_monitor_parser::GlobalBuild::default()
+                }],
+                status: "1 active".to_owned(),
+            },
+        );
+        let app = router(Path::new("/nonexistent-site"), state);
+
+        let found = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/global-log?drv=%2Fnix%2Fstore%2Faaa-foo.drv")
+                    .body(Body::empty())
+                    .expect("request builds"),
+            )
+            .await
+            .expect("router responds");
+        assert_eq!(found.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(found.into_body(), 1 << 20)
+            .await
+            .expect("body collects");
+        assert_eq!(&body[..], b"builder says hi\n");
+
+        let unknown = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/global-log?drv=%2Fetc%2Fpasswd")
+                    .body(Body::empty())
+                    .expect("request builds"),
+            )
+            .await
+            .expect("router responds");
+        assert_eq!(
+            unknown.status(),
+            StatusCode::NOT_FOUND,
+            "a drv the machine view does not list must not resolve to a file"
+        );
+
+        std::fs::remove_dir_all(&dir).expect("clean scratch dir");
     }
 
     /// `/ws` must be a wired route that performs the WebSocket upgrade: a plain


### PR DESCRIPTION
Part of #1897 (global build observability). Reworks the MACHINE BUILDS pane (#1906) so it answers *what* is building and *why* at a glance, now that the patched nix (#1916) is merged and feeding it.

## What

- **Why**: each goal's why-chain renders as a provenance trail, root first — `for darwin-system via python3` — so a random cc1plus-heavy build is immediately attributable to the top-level thing that wanted it. Top goals read `requested directly`; rows group by the requesting client user, so "who started this" is the first thing visible.
- **What**: package name + dimmed version up front; full store path, worker pid, outputs, uid, and cause live in the tooltip. Elapsed ticks live from `startTime`; builds vs substitutions keep distinct badges and the header meta splits `3 building · 1 fetching`.
- **Logs**: each build row expands to a live tail of its on-disk log via a new `GET /api/global-log?drv=…`. The server resolves the drv against the *current* machine view only (never a caller-supplied path) and decompresses the `.drv.bz2` itself: nix compresses build logs while writing them, so a live log is a truncated bzip2 stream that `nix log` refuses. Completed blocks decode; the response is bounded to the newest 64 KiB, cut at a line boundary.
- **Typed boundaries**: the goal kind is a closed picklist on the TS side (mirroring the Rust enum's `Other` fold); the probe tries the feature-gated invocation first so a patched nix costs one subprocess per tick.

## Before / after

| before | after | log expanded |
|---|---|---|
| ![before](https://gist.githubusercontent.com/andrewgazelka/98bb989a8e8fe66950dba29edbc12324/raw/821ad78be355b5a9f7dbd405a6489d31aa2dee92/before-panel.png) | ![after](https://gist.githubusercontent.com/andrewgazelka/98bb989a8e8fe66950dba29edbc12324/raw/821ad78be355b5a9f7dbd405a6489d31aa2dee92/panel-only.png) | ![log](https://gist.githubusercontent.com/andrewgazelka/98bb989a8e8fe66950dba29edbc12324/raw/821ad78be355b5a9f7dbd405a6489d31aa2dee92/panel-log-open.png) |

## Validation

- Parser/server unit tests against fixture JSON matching the patch-series schema, plus bzip2 truncation cases (multi-block mid-stream, un-completed first block, rolling-cap line-boundary cut — the last one was a real bug the e2e caught).
- End-to-end on a mac with the built `nix-ix` on PATH and a scratch `NIX_STATE_DIR` status dir: probe detected the subcommand, `/api/state` carried all four fixture goals, and Playwright verified the rendered DOM (groups `andrew`/`ci-runner`, trails `for darwin-system via python3`, live elapsed, decompressed live log tails for full, truncated, and uncompressed logs; 404 for non-listed drvs).
- `nix build .#nix-web-monitor` (aarch64-darwin) green; `nix run .#lint` clean; svelte-check + eslint clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provenance trails, user attribution, and live build logs to the machine builds panel
> - Groups builds in the machine builds panel by requesting user with per-group counts and a kind badge per row (`build`, `substitution`, `other`).
> - Adds provenance trail rendering showing the root dependency and intermediate hops; rows triggered directly show a 'requested directly' label.
> - Adds a per-row toggle button that opens an inline live log tail, polling `/api/global-log?drv=<drvPath>` every 2s and auto-scrolling to new content.
> - Adds the `/api/global-log` server endpoint ([server/src/main.rs](https://github.com/indexable-inc/index/pull/1921/files#diff-5f7a5a3bf017bab11020325a81b81855b5999b26a72220162e9d5873d7cd5d6d)) backed by `global::read_log_tail` ([server/src/global.rs](https://github.com/indexable-inc/index/pull/1921/files#diff-4820d587d4c1c1d078b1a44dc5322acedb592ec373035bd38ff4634e02411c8e)), which reads up to ~64 KiB from live `.bz2` logs using a tolerant bzip2 decoder that handles truncated streams.
> - Risk: `GlobalBuild.type` now validates strictly as `'build' | 'substitution' | 'other'`; payloads with any other value will fail client-side schema validation where they previously passed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6de5369.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->