### PR TITLE
prompt: issue-first workflow with GitHub sub-issues, open master issue in browser

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -333,10 +333,23 @@ let
           Tie real work to a GitHub or Linear issue before starting. Find one, or create
           one with the repro and desired outcome. Reference it in the branch, PR, and
           relevant comments; keep reproduce-before-fix and root-cause notes there.
+
+          For real multi-part work, make the first task creating a GitHub master issue
+          plus one sub-issue per modular piece. GitHub has native parent/child
+          sub-issues (no `gh` subcommand yet): create each child with `gh issue create`,
+          read its database id with
+          `gh api repos/<o>/<r>/issues/<n> --jq .id`, then attach it with
+          `gh api --method POST repos/<o>/<r>/issues/<parent>/sub_issues -F sub_issue_id=<db id>`.
+          Pass the database id, not the issue number. Cross-repo within the org works.
+
+          Then open the master issue in the browser (`open <url>` on macOS) so the human
+          sees the plan immediately.
         '';
         reason = ''
           Repro steps and root-cause notes were lost with the session when work had no
-          durable issue trail.
+          durable issue trail. Multi-part work without a master issue and sub-issues had
+          no shared plan to track pieces against; opening it surfaces the plan to the
+          human up front instead of after the work is done.
         '';
       };
     }


### PR DESCRIPTION
Extends the `tieToIssue` rule in `packages/agent/system-prompt.nix` (in place, no duplicate section):

- For real multi-part work, first create a GitHub master issue plus one sub-issue per modular piece, using the native REST sub-issues API (create child with `gh issue create`, get its database id via `gh api .../issues/<n> --jq .id`, attach with `POST .../issues/<parent>/sub_issues -F sub_issue_id=<db id>`). Cross-repo within the org works.
- Then `open` the master issue in the browser so the human sees the plan immediately.

Validated the file renders with `nix eval --raw --impure`.

Closes #1922

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add issue-first workflow with GitHub master issue and sub-issues to system prompt
> Updates [system-prompt.nix](https://github.com/indexable-inc/index/pull/1923/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to instruct the agent to create a GitHub master issue with linked sub-issues using `gh` CLI and `gh api` commands, then open the master issue in the browser so the plan is visible up front. The reason text is expanded to explain the value of this approach for multi-part work.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b834ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->