### PR TITLE
feat(mcp): track redundant file reads and emit mcp_read_stats

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -5418,6 +5418,35 @@
       mkdir -p "$out"
     '';
 
+  # Redundant-read tracking (packages/mcp/tests/test_readstats.py, index#1924):
+  # the per-session tracker's core contract (same-content re-read is redundant,
+  # changed content is not, a different path is not, counters are per-session) and
+  # the exact `mcp_read_stats` journald line the ix fleet pipeline parses. Only
+  # imports `ix_notebook_mcp.readstats` (pure stdlib), so it reuses the typecheck
+  # interpreter, which already carries pytest.
+  readStatsTestSource = builtins.path {
+    name = "ix-mcp-readstats-test";
+    path = ./tests/test_readstats.py;
+  };
+  readStatsTests =
+    pkgs.runCommand "ix-mcp-readstats-tests"
+    {
+      nativeBuildInputs = [typecheckTestPython];
+      strictDeps = true;
+    }
+    ''
+      export HOME=$TMPDIR/home
+      mkdir -p "$HOME"
+      cp ${readStatsTestSource} "$TMPDIR/test_readstats.py"
+      ${lib.getExe typecheckTestPython} -m pytest "$TMPDIR/test_readstats.py" -q -p no:cacheprovider >stdout 2>stderr || {
+        echo "ix-mcp readstats tests failed:" >&2
+        cat stdout stderr >&2
+        exit 1
+      }
+      cat stdout
+      mkdir -p "$out"
+    '';
+
   # The Claude Code channel + interactive resource actions
   # (packages/mcp/tests/test_channel.py): the store outbox/events queues, the
   # kernel's notify() + action dispatch, the transport pump emitting
@@ -5861,6 +5890,7 @@ in
               inputsTests
               channelTests
               taskErrorsTests
+              readStatsTests
               inputBrowserSmoke
               svelteBundled
               svelteTests

--- a/packages/mcp/ix_notebook_mcp/readstats.py
+++ b/packages/mcp/ix_notebook_mcp/readstats.py
@@ -1,0 +1,160 @@
+"""Per-session tracking of redundant file reads.
+
+Every kernel path that reads a real file *into the agent's context* (the ``read``
+MCP tool's file branch, ``view.cat``/``head``/``tail``, and any kernel read
+helper) records the read here. A read is REDUNDANT when the same
+``(absolute path, content bytes)`` pair was already read earlier in the same
+kernel session: with perfect memory the agent would not have needed it again.
+The KPI (indexable-inc/ix#6440) is ``redundant / total < 1%``.
+
+The counters are CUMULATIVE per session (never per-window deltas): each emitted
+``mcp_read_stats`` line reports the running totals since the session started, and
+the ix fleet pipeline (indexable-inc/ix#6453) differences them itself. ``window_s``
+is the fixed emit cadence, not a measurement window.
+
+Memory is bounded by construction: only the 16-byte content digests are kept, never
+the file bytes. The digest is over ``(absolute path, content)`` so the same bytes at
+two paths count as two distinct reads (a genuine second read), while the same path
+re-read unchanged is redundant.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import os
+import pathlib
+import sys
+
+# The emit cadence in seconds, and the exact ``window_s`` value in every
+# ``mcp_read_stats`` line. The ix fleet pipeline keys on this literal.
+EMIT_WINDOW_S = 300
+
+# The session key used when a read has no MCP session id (the shared namespace,
+# e.g. reads driven through `/api/exec` in the daemon `notebook` shape). A stable
+# string keeps the emitted `session` field non-empty and groupable.
+_SHARED_SESSION = "shared"
+
+
+def _digest(path: pathlib.Path, content: str | bytes) -> bytes:
+    """A 16-byte blake2b digest of ``(absolute path, content)``.
+
+    ``content`` is whatever the read already produced in memory -- the decoded
+    text for the text-read paths, raw bytes for a bytes read -- so hashing never
+    triggers a second disk read. Binding the path in means the same bytes read
+    from two files are two reads, not a false redundancy; the path is absolutized
+    first so ``foo.py`` and ``./foo.py`` collapse to one identity.
+    """
+    h = hashlib.blake2b(digest_size=16)
+    h.update(os.fspath(path.resolve()).encode("utf-8"))
+    h.update(b"\x00")
+    h.update(content if isinstance(content, bytes) else content.encode("utf-8", "surrogatepass"))
+    return h.digest()
+
+
+@dataclasses.dataclass
+class _SessionStats:
+    """The cumulative read counters and seen-digest set for one session."""
+
+    total_reads: int = 0
+    redundant_reads: int = 0
+    seen: set[bytes] = dataclasses.field(default_factory=set)
+    # The counts as of the last emitted line, so the periodic emitter only speaks
+    # when something changed (the issue's "IF counts changed").
+    emitted_total: int = -1
+    emitted_redundant: int = -1
+
+
+class ReadStatsTracker:
+    """Per-session redundant-read counters for one kernel process.
+
+    One instance lives for the kernel's lifetime and holds a small map of session
+    id -> :class:`_SessionStats`. It is driven entirely on the kernel's single
+    event loop, so it needs no lock.
+    """
+
+    def __init__(self) -> None:
+        self._by_session: dict[str, _SessionStats] = {}
+
+    def _stats(self, session: str | None) -> _SessionStats:
+        key = session or _SHARED_SESSION
+        stats = self._by_session.get(key)
+        if stats is None:
+            stats = _SessionStats()
+            self._by_session[key] = stats
+        return stats
+
+    def record(self, session: str | None, path: pathlib.Path, content: str | bytes) -> bool:
+        """Record one file read; return whether it was redundant.
+
+        ``content`` is the text (or bytes) already in memory from the read that
+        just happened -- this never touches the disk again. A caller that could
+        not read the file has no ``content`` to pass and never reaches here: an
+        unreadable path is that read's own error path, not a swallow.
+        """
+        stats = self._stats(session)
+        digest = _digest(path, content)
+        redundant = digest in stats.seen
+        stats.total_reads += 1
+        if redundant:
+            stats.redundant_reads += 1
+        else:
+            stats.seen.add(digest)
+        return redundant
+
+    def snapshot(self, session: str | None) -> dict[str, int]:
+        """The live cumulative counters for ``session`` (for the agent to read its
+        own redundancy rate). A session with no reads yet reports zeros."""
+        stats = self._by_session.get(session or _SHARED_SESSION)
+        if stats is None:
+            return {"total_reads": 0, "redundant_reads": 0}
+        return {"total_reads": stats.total_reads, "redundant_reads": stats.redundant_reads}
+
+    def _line(self, session_key: str, stats: _SessionStats) -> str:
+        """The exact one-line JSON contract parsed by the ix fleet pipeline.
+
+        Built by hand (not ``json.dumps``) so the field order and spacing match
+        the frozen contract in indexable-inc/ix#6453 byte-for-byte.
+        """
+        return (
+            f'{{"event":"mcp_read_stats","session":"{session_key}",'
+            f'"total_reads":{stats.total_reads},"redundant_reads":{stats.redundant_reads},'
+            f'"window_s":{EMIT_WINDOW_S}}}'
+        )
+
+    def _emit(self, session_key: str, stats: _SessionStats) -> None:
+        """Write one stats line to the kernel's stderr (which reaches journald in
+        the deployed service) and mark the counts as emitted. Stderr, not stdout:
+        in the stdio transport the real stdout carries the JSON-RPC stream, so a
+        stray write there would corrupt the protocol; stderr always reaches the
+        journal in both the stdio and daemon `notebook` shapes."""
+        print(self._line(session_key, stats), file=sys.__stderr__, flush=True)
+        stats.emitted_total = stats.total_reads
+        stats.emitted_redundant = stats.redundant_reads
+
+    def emit_changed(self) -> None:
+        """Emit one line per session whose counts changed since its last emit.
+
+        Called on the periodic (every ``EMIT_WINDOW_S``) tick.
+        """
+        for key, stats in self._by_session.items():
+            if stats.total_reads != stats.emitted_total or stats.redundant_reads != stats.emitted_redundant:
+                self._emit(key, stats)
+
+    def emit_final(self) -> None:
+        """Emit every session's final counts on clean shutdown, whether or not
+        they changed since the last periodic emit, so the last window is never
+        lost."""
+        for key, stats in self._by_session.items():
+            if stats.total_reads:
+                self._emit(key, stats)
+
+
+# The one tracker for this kernel process. Module-level so every read path shares
+# it and the periodic emitter and shutdown hook reach the same counters.
+_tracker = ReadStatsTracker()
+
+
+def tracker() -> ReadStatsTracker:
+    """The kernel's single :class:`ReadStatsTracker`."""
+    return _tracker

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -302,6 +302,12 @@ BUILTINS: tuple[Builtin, ...] = (
     ),
     Builtin("api", "the live catalog of every helper, as a polars frame (`api('grep')` to filter)"),
     Builtin(
+        "read_stats",
+        "this session's cumulative file-read counters ({total_reads, redundant_reads}); a "
+        "redundant read is a file re-read with byte-identical content -- check your own "
+        "redundancy rate (KPI: redundant/total < 1%)",
+    ),
+    Builtin(
         "grep",
         "content search backed by ripgrep (process-isolated + timeout, so it can't wedge the "
         "kernel): `await grep(pattern)` -> a polars frame, one row per match "

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import atexit
 import base64
 import binascii
 import collections
@@ -53,7 +54,7 @@ import uuid
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, overload
 
-from . import registry, typecheck
+from . import readstats, registry, typecheck
 
 _ix_current: contextvars.ContextVar = contextvars.ContextVar("ix_current_job", default=None)
 
@@ -74,6 +75,10 @@ task_errors: collections.deque[str] = collections.deque(maxlen=50)
 # The namespace-install flusher task (see _install), module-held so it cannot
 # be garbage-collected mid-flight.
 _flusher_task: asyncio.Task | None = None
+
+# Whether the redundant-read stats final-emit atexit hook has been registered, so
+# a re-install (tests re-run install() on one interpreter) does not double-register.
+_readstats_atexit_registered = False
 
 # Grace period between a task finishing with an exception and the failure being
 # reported: a parent that promptly retrieves it (`await task`, `gather`,
@@ -294,11 +299,16 @@ class Job:
         budget: float = 15.0,
         kind: str = "cell",
         topic: str = "",
+        session: str | None = None,
     ) -> None:
         self.id = uuid.uuid4().hex[:8]
         self.code = code
         self.name = name or self.id
         self.topic = topic
+        # The MCP session id this run belongs to (None = the shared namespace).
+        # Carried so a read helper running inside the cell can attribute its read
+        # to the right session's redundant-read counters (see readstats).
+        self.session = session
         # 'cell' for a normal execution; 'replay' for a re-run performed while
         # reopening a session file. Replays never feed future replays
         # (store.replayable filters on this), so a session cannot double-run
@@ -3145,6 +3155,18 @@ def api(filter: str | None = None) -> Any:
         return "\n".join(f'{r["where"]:>6}  {r["sig"]:<{width}}  {r["summary"]}' for r in rows)
 
 
+def read_stats() -> dict[str, int]:
+    """This session's cumulative file-read counters: ``total_reads`` and
+    ``redundant_reads`` (a redundant read is the same file with byte-identical
+    content read earlier in this session -- with perfect memory you would not
+    have needed it again). Use it to check your own redundancy rate; the KPI is
+    ``redundant_reads / total_reads < 1%`` (indexable-inc/ix#6440). The same
+    counters are emitted to the service journal as ``mcp_read_stats`` lines."""
+    job = _ix_current.get()
+    session = job.session if job is not None else None
+    return readstats.tracker().snapshot(session)
+
+
 _TYPEERROR_CALL_RE = re.compile(
     r"^(\w+)\(\) (got an unexpected keyword argument|missing \d+ required (keyword-only argument|positional argument))"
 )
@@ -3307,12 +3329,19 @@ def _drain_inputs() -> None:
             channel._deliver(payload)
 
 
+# When the flusher last emitted the redundant-read stats, so it fires on the
+# readstats.EMIT_WINDOW_S cadence rather than every flusher tick.
+_last_readstats_emit = 0.0
+
+
 async def _flusher() -> None:
     """Throttled background loop: persist every running job's output tail and
     re-render every live resource to the store so the dashboard shows both live.
     One loop for all jobs and resources (cheap)."""
     if _store is None or _store_conn is None:
         return
+    global _last_readstats_emit
+    _last_readstats_emit = time.time()
     while True:
         await asyncio.sleep(0.5)
         for job in list(jobs.values()):
@@ -3326,6 +3355,11 @@ async def _flusher() -> None:
         _drain_inputs()
         cells._sync()
         session._sync()
+        now = time.time()
+        if now - _last_readstats_emit >= readstats.EMIT_WINDOW_S:
+            _last_readstats_emit = now
+            with contextlib.suppress(Exception):  # best-effort: a stats emit must not kill the loop
+                readstats.tracker().emit_changed()
         if _SESSION and _snapshot_dirty and not _snapshot_busy and not _restoring:
             # Fire-and-forget so a multi-second dump of a big namespace never
             # stalls the live-output mirroring this loop exists for.
@@ -3691,7 +3725,7 @@ async def __ix_run(
     way (done, or still running in the background). ``session`` selects the
     namespace the code runs in (see :func:`_session_ns`)."""
     ns = _session_ns(session)
-    job = Job(code, name, budget=budget, kind=kind, topic=topic or globals()["session"].topic)
+    job = Job(code, name, budget=budget, kind=kind, topic=topic or globals()["session"].topic, session=session)
     job._ns = ns
     jobs[job.id] = job
     job.task = asyncio.ensure_future(_runner(job, ns))
@@ -3886,6 +3920,9 @@ async def __ix_read(target: Any, start: int | None = None, end: int | None = Non
         # Off the loop: a large file read is blocking I/O, the one thing that
         # freezes every other job on the shared event loop.
         full = await asyncio.to_thread(path.read_text, errors="replace")
+        # Track this read for the redundant-read KPI (hash of path+content, on the
+        # bytes already in memory -- never a second disk read). See readstats.
+        readstats.tracker().record(session, path, full)
         label = _tilde(path)
         lang = _read_lang(path)
     else:
@@ -4181,6 +4218,7 @@ def install(user_ns: dict | None = None) -> None:
 
         target["pl"] = _polars_mod
     target["api"] = api
+    target["read_stats"] = read_stats
     # Failures of fire-and-forget tasks, newest last (see the deque's comment).
     # A report also lands in the spawning job's output, tagged `[task_errors]`,
     # which is how the name advertises itself.
@@ -4207,6 +4245,15 @@ def install(user_ns: dict | None = None) -> None:
     # A fresh session starts with no recorded references (the namespace is empty of
     # user names; refs accumulate as runs touch them).
     _name_refs.clear()
+
+    # Emit each session's final redundant-read counts when the kernel process
+    # exits cleanly (jupyter's graceful shutdown runs the interpreter's atexit
+    # hooks), so the last window since the periodic emit is never lost. Guarded so
+    # a re-install (tests) does not double-register.
+    global _readstats_atexit_registered
+    if not _readstats_atexit_registered:
+        atexit.register(readstats.tracker().emit_final)
+        _readstats_atexit_registered = True
 
     with contextlib.suppress(RuntimeError):  # no event loop yet (sync context): flusher and task watch are optional
         loop = asyncio.get_event_loop()

--- a/packages/mcp/src/view/view/__init__.py
+++ b/packages/mcp/src/view/view/__init__.py
@@ -734,6 +734,24 @@ def tree(
 # --------------------------------------------------------------------------- #
 
 
+def _record_read(path: pathlib.Path, text: str) -> None:
+    """Attribute a file read to the current session's redundant-read counters.
+
+    Reaches into the kernel runtime lazily (as ``sh`` does) so ``view`` stays
+    usable standalone: outside the bundled interpreter the import fails and the
+    read simply is not tracked. Hashing runs on the ``text`` already in memory,
+    never a second disk read. Best-effort: tracking must never break a read.
+    """
+    try:
+        from ix_notebook_mcp import readstats
+        from ix_notebook_mcp.runtime import _ix_current
+    except Exception:
+        return
+    job = _ix_current.get()
+    session = job.session if job is not None else None
+    readstats.tracker().record(session, path, text)
+
+
 def cat(
     path: str | os.PathLike[str],
     lines: tuple[int, int] | None = None,
@@ -746,6 +764,7 @@ def cat(
     """
     p = pathlib.Path(path)
     text = p.read_text(errors="replace")
+    _record_read(p, text)
     start = 1
     if lines is not None:
         a, b = lines
@@ -764,14 +783,18 @@ def read(*args: Any, **kwargs: Any) -> Code:  # noqa: ANN401 -- forwarded verbat
 def head(path: str | os.PathLike[str], n: int = 20, *, lang: str | None = None) -> Code:
     """The first ``n`` lines of a file as a :class:`Code` view."""
     p = pathlib.Path(path)
-    sliced = p.read_text(errors="replace").splitlines()[:n]
+    text = p.read_text(errors="replace")
+    _record_read(p, text)
+    sliced = text.splitlines()[:n]
     return Code("\n".join(sliced), lang or _lang_for(p), title=str(p), start_line=1)
 
 
 def tail(path: str | os.PathLike[str], n: int = 20, *, lang: str | None = None) -> Code:
     """The last ``n`` lines of a file as a :class:`Code` view."""
     p = pathlib.Path(path)
-    all_lines = p.read_text(errors="replace").splitlines()
+    text = p.read_text(errors="replace")
+    _record_read(p, text)
+    all_lines = text.splitlines()
     start = max(1, len(all_lines) - n + 1)
     return Code(
         "\n".join(all_lines[-n:]), lang or _lang_for(p), title=str(p), start_line=start

--- a/packages/mcp/tests/test_readstats.py
+++ b/packages/mcp/tests/test_readstats.py
@@ -1,0 +1,138 @@
+"""Redundant-read tracking (index#1924).
+
+Every kernel path that reads a real file into agent context records the read; a
+read is redundant when the same (path, content) pair was seen earlier in the same
+session. These tests pin the tracker's core contract -- same-content re-read
+counts as redundant, changed content does not, a different path does not -- plus
+the exact ``mcp_read_stats`` journald line the ix fleet pipeline parses.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from ix_notebook_mcp import readstats
+
+
+def test_same_content_reread_is_redundant(tmp_path: pathlib.Path) -> None:
+    p = tmp_path / "a.py"
+    text = "x = 1\n"
+    tracker = readstats.ReadStatsTracker()
+
+    assert tracker.record("s1", p, text) is False  # first read: novel
+    assert tracker.record("s1", p, text) is True  # byte-identical re-read: redundant
+
+    snap = tracker.snapshot("s1")
+    assert snap == {"total_reads": 2, "redundant_reads": 1}
+
+
+def test_changed_content_is_not_redundant(tmp_path: pathlib.Path) -> None:
+    p = tmp_path / "a.py"
+    tracker = readstats.ReadStatsTracker()
+
+    assert tracker.record("s1", p, "x = 1\n") is False
+    assert tracker.record("s1", p, "x = 2\n") is False  # same path, new bytes
+
+    assert tracker.snapshot("s1") == {"total_reads": 2, "redundant_reads": 0}
+
+
+def test_same_content_different_path_is_not_redundant(tmp_path: pathlib.Path) -> None:
+    text = "shared\n"
+    a = tmp_path / "a.py"
+    b = tmp_path / "b.py"
+    tracker = readstats.ReadStatsTracker()
+
+    assert tracker.record("s1", a, text) is False
+    assert tracker.record("s1", b, text) is False  # same bytes, different file
+
+    assert tracker.snapshot("s1") == {"total_reads": 2, "redundant_reads": 0}
+
+
+def test_counters_are_per_session(tmp_path: pathlib.Path) -> None:
+    p = tmp_path / "a.py"
+    text = "x = 1\n"
+    tracker = readstats.ReadStatsTracker()
+
+    tracker.record("s1", p, text)
+    # A re-read in a DIFFERENT session is novel there: each session tracks its own
+    # seen-set, so this is not redundant.
+    assert tracker.record("s2", p, text) is False
+    assert tracker.snapshot("s1") == {"total_reads": 1, "redundant_reads": 0}
+    assert tracker.snapshot("s2") == {"total_reads": 1, "redundant_reads": 0}
+
+
+def test_none_session_maps_to_shared_key(tmp_path: pathlib.Path) -> None:
+    p = tmp_path / "a.py"
+    text = "x = 1\n"
+    tracker = readstats.ReadStatsTracker()
+
+    tracker.record(None, p, text)
+    assert tracker.record(None, p, text) is True  # shared session tracks redundancy
+    assert tracker.snapshot(None) == {"total_reads": 2, "redundant_reads": 1}
+
+
+def test_bytes_and_text_hash_identically(tmp_path: pathlib.Path) -> None:
+    p = tmp_path / "a.py"
+    tracker = readstats.ReadStatsTracker()
+
+    assert tracker.record("s1", p, "café\n") is False
+    # The bytes form of the same content is the same read (UTF-8), so redundant.
+    assert tracker.record("s1", p, "café\n".encode()) is True
+
+
+def test_emit_line_matches_contract(tmp_path: pathlib.Path, capfd) -> None:  # noqa: ANN001 -- pytest fixture
+    p = tmp_path / "a.py"
+    text = "x = 1\n"
+    tracker = readstats.ReadStatsTracker()
+    tracker.record("sess-42", p, text)
+    tracker.record("sess-42", p, text)
+
+    tracker.emit_changed()
+    line = capfd.readouterr().err.strip()
+
+    # Exact key order and shape the ix fleet pipeline (ix#6453) parses.
+    assert line == (
+        '{"event":"mcp_read_stats","session":"sess-42",'
+        '"total_reads":2,"redundant_reads":1,"window_s":300}'
+    )
+    # ...and it is valid JSON with the documented fields.
+    assert json.loads(line) == {
+        "event": "mcp_read_stats",
+        "session": "sess-42",
+        "total_reads": 2,
+        "redundant_reads": 1,
+        "window_s": 300,
+    }
+
+
+def test_emit_changed_only_speaks_when_counts_change(tmp_path: pathlib.Path, capfd) -> None:  # noqa: ANN001 -- pytest fixture
+    p = tmp_path / "a.py"
+    tracker = readstats.ReadStatsTracker()
+    tracker.record("s1", p, "x = 1\n")
+
+    tracker.emit_changed()
+    assert capfd.readouterr().err.strip() != ""  # first emit speaks
+
+    tracker.emit_changed()  # nothing changed since
+    assert capfd.readouterr().err.strip() == ""
+
+    tracker.record("s1", p, "x = 2\n")
+    tracker.emit_changed()  # a new read: speaks again
+    assert '"total_reads":2' in capfd.readouterr().err
+
+
+def test_emit_final_reports_every_nonempty_session(tmp_path: pathlib.Path, capfd) -> None:  # noqa: ANN001 -- pytest fixture
+    p = tmp_path / "a.py"
+    tracker = readstats.ReadStatsTracker()
+    tracker.record("s1", p, "x = 1\n")
+    tracker.record("s1", p, "x = 1\n")  # emit periodically, then shut down
+    tracker.emit_changed()
+    capfd.readouterr()
+
+    # A clean-shutdown emit reports the final counts even if unchanged since the
+    # last periodic emit, so the last window is never lost.
+    tracker.emit_final()
+    out = capfd.readouterr().err.strip()
+    assert '"session":"s1"' in out
+    assert '"total_reads":2' in out


### PR DESCRIPTION
Closes #1924

Instruments every kernel path that reads a real file into agent context and tracks redundant reads, emitting aggregated stats to the service journal on the contract the ix fleet pipeline (indexable-inc/ix#6453) parses.

## What

- **New `ix_notebook_mcp/readstats.py`**: a per-kernel-session `ReadStatsTracker`. On each real-file read it hashes `(absolute path, content)` with blake2b (16-byte digest); a read is **redundant** when that `(path, hash)` pair was seen earlier in the same session. Memory-bounded: only digests are stored, never file bytes, and the hash runs on bytes already in memory (never a second disk read).
- **Instrumented read paths**: the `read` MCP tool's file branch (`runtime.__ix_read`) and `view.cat`/`head`/`tail`. `view` resolves the current session lazily from the running job (as `sh` reaches into the runtime), so it stays usable standalone.
- **Emit**: the kernel flusher emits one line per session whose counts changed every 300s, and an `atexit` hook emits final counts on clean shutdown, exactly:
  ```
  {"event":"mcp_read_stats","session":"<id>","total_reads":N,"redundant_reads":M,"window_s":300}
  ```
  Written to stderr (never the stdio JSON-RPC channel); reaches journald in the deployed `ix-ray-notebook` service. Counters are **cumulative per session** (documented in the module) — the fleet pipeline differences them.
- **Agent-facing**: a `read_stats()` builtin (in `api()`) returns this session's live `{total_reads, redundant_reads}` so a session can check its own redundancy rate (KPI target redundant/total < 1%, indexable-inc/ix#6440).

## Tests

New `tests/test_readstats.py` (wired as the `readStatsTests` nix check): same-content re-read counts as redundant, changed content does not, same bytes at a different path does not, counters are per-session, bytes/text hash identically, and the emitted line matches the frozen JSON contract byte-for-byte.

Validated locally (aarch64-darwin): `strictTypecheck`, `readStatsTests`, `runtimeSmoke`, `viewSmoke`, `engineBundled`, and repo `lint` all green. (`apiSmoke` fails only from a darwin-sandbox socket-bind restriction, unrelated to this change.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track redundant file reads per session and emit `mcp_read_stats` JSON lines to stderr
> - Adds [readstats.py](https://github.com/indexable-inc/index/pull/1928/files#diff-5e76173bb81e6d731a1ebf289f1a5c266a39026499a66c8e9c30828b5d6f56d7) with a `ReadStatsTracker` that records per-session `total_reads` and `redundant_reads`, using a blake2b digest over path+content to detect redundant reads.
> - Integrates tracking into [runtime.py](https://github.com/indexable-inc/index/pull/1928/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) (`__ix_read`) and [view/__init__.py](https://github.com/indexable-inc/index/pull/1928/files#diff-3fb883791c4d496cf7370e61715a007772f0dca222406e20e8c8944f7ef1a2ab) (`cat`, `head`, `tail`) so all file read paths are covered.
> - The flusher in [runtime.py](https://github.com/indexable-inc/index/pull/1928/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) emits `mcp_read_stats` JSON lines to stderr every 300s when counts change; final counts are emitted at process exit via `atexit`.
> - Exposes a `read_stats()` builtin in the runtime namespace returning `{total_reads, redundant_reads}` for the current session.
> - Behavioral Change: each file read now computes a blake2b digest and performs a set lookup, adding minor per-read overhead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e424e49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->