### PR TITLE
fix(mcp): flush read stats daemon-side, hash returned payload, off-loop hash

### DIFF
--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -628,6 +628,9 @@ async def _run(cfg: Config) -> None:
         if mesh_runner is not None:
             await mesh_runner.cleanup()
         await runner.cleanup()
+        # Flush the final redundant-read stats while the kernel is still alive:
+        # shutdown() kills it with SIGKILL, past which no in-kernel code runs.
+        await kernel.emit_read_stats_final()
         await kernel.shutdown()
 
 

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -276,6 +276,15 @@ class Kernel:
         with contextlib.suppress(Exception):  # shutdown must proceed; periodic checkpoint plus replay guarantee a correct reopen
             await self._execute("await __ix_snapshot()", timeout=60.0)
 
+    async def emit_read_stats_final(self) -> None:
+        """Flush the final ``mcp_read_stats`` line per session at shutdown, so the
+        counts since the last periodic (~300s) emit reach the journal. Must run
+        BEFORE ``shutdown()`` (which kills the kernel with SIGKILL, past which no
+        in-kernel or atexit code runs). Best-effort: a flush failure must not block
+        shutdown, and the periodic emit already covered every prior window."""
+        with contextlib.suppress(Exception):  # shutdown must proceed even if the final flush fails
+            await self._execute("__ix_emit_read_stats_final()", timeout=30.0)
+
     async def restart(self) -> None:
         if self._km is not None:
             await self._km.restart_kernel(now=True)

--- a/packages/mcp/ix_notebook_mcp/readstats.py
+++ b/packages/mcp/ix_notebook_mcp/readstats.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import json
 import os
 import pathlib
 import sys
@@ -36,14 +37,17 @@ EMIT_WINDOW_S = 300
 _SHARED_SESSION = "shared"
 
 
-def _digest(path: pathlib.Path, content: str | bytes) -> bytes:
+def digest(path: pathlib.Path, content: str | bytes) -> bytes:
     """A 16-byte blake2b digest of ``(absolute path, content)``.
 
-    ``content`` is whatever the read already produced in memory -- the decoded
-    text for the text-read paths, raw bytes for a bytes read -- so hashing never
-    triggers a second disk read. Binding the path in means the same bytes read
-    from two files are two reads, not a false redundancy; the path is absolutized
-    first so ``foo.py`` and ``./foo.py`` collapse to one identity.
+    ``content`` is the exact payload the read RETURNED to the agent (the decoded
+    text, a line slice for a ranged read, or raw bytes) -- so hashing never
+    triggers a second disk read, and two reads that hand the agent different
+    content (e.g. lines 1-100 then 101-200 of one file) hash differently and are
+    both novel. Binding the path in means the same bytes read from two files are
+    two reads, not a false redundancy; the path is absolutized first so ``foo.py``
+    and ``./foo.py`` collapse to one identity. Pure and CPU-bound: safe to run off
+    the event loop for a large read (see the ``read`` MCP tool path).
     """
     h = hashlib.blake2b(digest_size=16)
     h.update(os.fspath(path.resolve()).encode("utf-8"))
@@ -84,23 +88,31 @@ class ReadStatsTracker:
             self._by_session[key] = stats
         return stats
 
-    def record(self, session: str | None, path: pathlib.Path, content: str | bytes) -> bool:
-        """Record one file read; return whether it was redundant.
-
-        ``content`` is the text (or bytes) already in memory from the read that
-        just happened -- this never touches the disk again. A caller that could
-        not read the file has no ``content`` to pass and never reaches here: an
-        unreadable path is that read's own error path, not a swallow.
+    def record_digest(self, session: str | None, digest_bytes: bytes) -> bool:
+        """Record one read from its precomputed ``(path, content)`` digest; return
+        whether it was redundant. This is the fast, loop-only half: a set lookup
+        and three integer updates, no hashing -- the hashing (:func:`digest`) is
+        CPU-bound and can be run off the event loop first for a large read.
         """
         stats = self._stats(session)
-        digest = _digest(path, content)
-        redundant = digest in stats.seen
+        redundant = digest_bytes in stats.seen
         stats.total_reads += 1
         if redundant:
             stats.redundant_reads += 1
         else:
-            stats.seen.add(digest)
+            stats.seen.add(digest_bytes)
         return redundant
+
+    def record(self, session: str | None, path: pathlib.Path, content: str | bytes) -> bool:
+        """Record one file read (hash + count) in one call; return whether it was
+        redundant. ``content`` is the exact payload the read returned to the agent,
+        already in memory -- this never touches the disk again. A caller that could
+        not read the file has no ``content`` to pass and never reaches here: an
+        unreadable path is that read's own error path, not a swallow. Use this from
+        a synchronous read path (``view.cat``); an async path that may face a large
+        file should hash off-loop with :func:`digest` then call :meth:`record_digest`.
+        """
+        return self.record_digest(session, digest(path, content))
 
     def snapshot(self, session: str | None) -> dict[str, int]:
         """The live cumulative counters for ``session`` (for the agent to read its
@@ -113,11 +125,15 @@ class ReadStatsTracker:
     def _line(self, session_key: str, stats: _SessionStats) -> str:
         """The exact one-line JSON contract parsed by the ix fleet pipeline.
 
-        Built by hand (not ``json.dumps``) so the field order and spacing match
-        the frozen contract in indexable-inc/ix#6453 byte-for-byte.
+        Field order and spacing match the frozen contract in indexable-inc/ix#6453
+        byte-for-byte. The session id is the one free-form field, so it goes through
+        ``json.dumps`` (quotes included) -- a weird id (a quote, a backslash) can
+        then never emit a line the pipeline cannot parse. The integers and fixed
+        keys are formatted directly.
         """
+        session_json = json.dumps(session_key)
         return (
-            f'{{"event":"mcp_read_stats","session":"{session_key}",'
+            f'{{"event":"mcp_read_stats","session":{session_json},'
             f'"total_reads":{stats.total_reads},"redundant_reads":{stats.redundant_reads},'
             f'"window_s":{EMIT_WINDOW_S}}}'
         )
@@ -142,9 +158,16 @@ class ReadStatsTracker:
                 self._emit(key, stats)
 
     def emit_final(self) -> None:
-        """Emit every session's final counts on clean shutdown, whether or not
-        they changed since the last periodic emit, so the last window is never
-        lost."""
+        """Emit every session's final counts, whether or not they changed since the
+        last periodic emit, so the counts accrued since it (up to one ~300s window)
+        are not lost.
+
+        This must be driven explicitly at shutdown, NOT via ``atexit``: the daemon
+        stops the kernel with ``shutdown_kernel(now=True)``, which the bundled
+        jupyter_client turns into a SIGKILL of the kernel process -- atexit hooks
+        never run under SIGKILL. The server calls this in-kernel (through
+        ``__ix_emit_read_stats_final``) in its shutdown ``finally`` block, before it
+        kills the kernel (see cli._serve / kernel.emit_read_stats_final)."""
         for key, stats in self._by_session.items():
             if stats.total_reads:
                 self._emit(key, stats)

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import ast
 import asyncio
-import atexit
 import base64
 import binascii
 import collections
@@ -75,10 +74,6 @@ task_errors: collections.deque[str] = collections.deque(maxlen=50)
 # The namespace-install flusher task (see _install), module-held so it cannot
 # be garbage-collected mid-flight.
 _flusher_task: asyncio.Task | None = None
-
-# Whether the redundant-read stats final-emit atexit hook has been registered, so
-# a re-install (tests re-run install() on one interpreter) does not double-register.
-_readstats_atexit_registered = False
 
 # Grace period between a task finishing with an exception and the failure being
 # reported: a parent that promptly retrieves it (`await task`, `gather`,
@@ -3832,6 +3827,14 @@ async def __ix_exec(
     _emit(job)
 
 
+def __ix_emit_read_stats_final() -> None:
+    """Emit every session's final ``mcp_read_stats`` line. The server calls this
+    in-kernel from its shutdown ``finally`` block, BEFORE it kills the kernel with
+    ``shutdown_kernel(now=True)`` (a SIGKILL, which no atexit hook survives), so
+    the counts accrued since the last periodic emit are flushed to the journal."""
+    readstats.tracker().emit_final()
+
+
 def _existing_file(value: Any) -> pathlib.Path | None:
     """``value`` as a :class:`pathlib.Path` when it is a string naming an
     existing file, else None. The one rule `__ix_read` applies to both the raw
@@ -3920,9 +3923,6 @@ async def __ix_read(target: Any, start: int | None = None, end: int | None = Non
         # Off the loop: a large file read is blocking I/O, the one thing that
         # freezes every other job on the shared event loop.
         full = await asyncio.to_thread(path.read_text, errors="replace")
-        # Track this read for the redundant-read KPI (hash of path+content, on the
-        # bytes already in memory -- never a second disk read). See readstats.
-        readstats.tracker().record(session, path, full)
         label = _tilde(path)
         lang = _read_lang(path)
     else:
@@ -3947,6 +3947,15 @@ async def __ix_read(target: Any, start: int | None = None, end: int | None = Non
         selected = lines
         body = full
         first, last = 1, total
+    if path is not None:
+        # Track this read for the redundant-read KPI. Hash the payload the agent
+        # actually RECEIVED (`body`, i.e. the line slice for a ranged read), not
+        # the whole file -- so reading lines 1-100 then 101-200 is two novel reads,
+        # not a false redundancy. Hashing is CPU-bound and `body` can be large, so
+        # it runs off the event loop (like the read itself); only the fast set
+        # lookup + counter update lands back on the loop. Never a second disk read.
+        _digest = await asyncio.to_thread(readstats.digest, path, body)
+        readstats.tracker().record_digest(session, _digest)
     # Display context: the whole file when it fits, else the slice, else a
     # line-clipped head of the slice. `start`/`end`/`total`/`chars` always
     # describe what the model received; `text`+`context_start` describe display,
@@ -4174,6 +4183,7 @@ def install(user_ns: dict | None = None) -> None:
     target["__ix_run"] = __ix_run
     target["__ix_exec"] = __ix_exec
     target["__ix_read"] = __ix_read
+    target["__ix_emit_read_stats_final"] = __ix_emit_read_stats_final
     target["__ix_snapshot"] = __ix_snapshot
     target["__ix_restore"] = __ix_restore
     target["DASHBOARD_URL"] = os.environ.get("IX_MCP_DASHBOARD_URL", "")
@@ -4245,15 +4255,6 @@ def install(user_ns: dict | None = None) -> None:
     # A fresh session starts with no recorded references (the namespace is empty of
     # user names; refs accumulate as runs touch them).
     _name_refs.clear()
-
-    # Emit each session's final redundant-read counts when the kernel process
-    # exits cleanly (jupyter's graceful shutdown runs the interpreter's atexit
-    # hooks), so the last window since the periodic emit is never lost. Guarded so
-    # a re-install (tests) does not double-register.
-    global _readstats_atexit_registered
-    if not _readstats_atexit_registered:
-        atexit.register(readstats.tracker().emit_final)
-        _readstats_atexit_registered = True
 
     with contextlib.suppress(RuntimeError):  # no event loop yet (sync context): flusher and task watch are optional
         loop = asyncio.get_event_loop()

--- a/packages/mcp/tests/test_readstats.py
+++ b/packages/mcp/tests/test_readstats.py
@@ -136,3 +136,48 @@ def test_emit_final_reports_every_nonempty_session(tmp_path: pathlib.Path, capfd
     out = capfd.readouterr().err.strip()
     assert '"session":"s1"' in out
     assert '"total_reads":2' in out
+
+
+def test_ranged_reads_of_one_file_are_each_novel(tmp_path: pathlib.Path) -> None:
+    # The runtime hashes the payload the agent RECEIVED, not the whole file, so
+    # two disjoint ranges of one file are two distinct (path, content) pairs. This
+    # mirrors that by recording the two slices' content.
+    p = tmp_path / "a.py"
+    tracker = readstats.ReadStatsTracker()
+
+    assert tracker.record("s1", p, "lines 1-100 body") is False
+    assert tracker.record("s1", p, "lines 101-200 body") is False  # new page, not redundant
+    assert tracker.snapshot("s1") == {"total_reads": 2, "redundant_reads": 0}
+    # Re-reading the same range IS redundant.
+    assert tracker.record("s1", p, "lines 1-100 body") is True
+
+
+def test_record_digest_matches_record(tmp_path: pathlib.Path) -> None:
+    # The async read path hashes off-loop with digest() then calls record_digest();
+    # it must agree with the synchronous record() used by view.cat.
+    p = tmp_path / "a.py"
+    text = "x = 1\n"
+    a = readstats.ReadStatsTracker()
+    b = readstats.ReadStatsTracker()
+
+    a.record("s1", p, text)
+    b.record_digest("s1", readstats.digest(p, text))
+    assert a.snapshot("s1") == b.snapshot("s1")
+    # And a second read via each stays consistent (redundant both ways).
+    assert a.record("s1", p, text) is True
+    assert b.record_digest("s1", readstats.digest(p, text)) is True
+
+
+def test_weird_session_id_stays_valid_json(tmp_path: pathlib.Path, capfd) -> None:  # noqa: ANN001 -- pytest fixture
+    # A session id with a quote/backslash must not produce an unparseable line.
+    p = tmp_path / "a.py"
+    weird = 'ab"c\\d'
+    tracker = readstats.ReadStatsTracker()
+    tracker.record(weird, p, "x = 1\n")
+
+    tracker.emit_changed()
+    line = capfd.readouterr().err.strip()
+
+    parsed = json.loads(line)  # must not raise
+    assert parsed["session"] == weird
+    assert parsed["event"] == "mcp_read_stats"


### PR DESCRIPTION
Follow-up to #1928 (redundant file-read tracking), addressing adversarial-review blockers.

## [C1] Final emit was dead code under the real shutdown path
`shutdown_kernel(now=True)` becomes a SIGKILL of the kernel subprocess (bundled jupyter_client local_provisioner), so the kernel-side `atexit` hook never ran — every clean daemon stop lost the final partial window plus up to ~300s of counts. Now flushed **daemon-side**: new `Kernel.emit_read_stats_final()` runs `__ix_emit_read_stats_final()` in-kernel from `cli._serve`'s `finally` block, **before** `kernel.shutdown()` kills it (alongside `snapshot_session()`). The atexit hook is removed and the guarantee is corrected in the docstring.

## [C2] Ranged reads inflated the KPI
`__ix_read` hashed the whole file regardless of `start`/`end`, so reading lines 1-100 then 101-200 counted the second as redundant despite new content. Now hashes the **payload the agent received** (`body` — the slice), so disjoint ranges are each novel and a re-read of the same range is redundant. (A whole-file read after range reads counts as fresh; acceptable v1, documented.)

## [P1] blake2b ran on the event loop
The hash ran on the loop while the read itself was offloaded, so a ~100MB read blocked the loop ~50-100ms. Split `record()` into an off-loop `digest()` + on-loop `record_digest()`; `__ix_read` now hashes `body` via `asyncio.to_thread` too, leaving only the set lookup + counter update on the loop. `view.cat` keeps the one-call synchronous `record()`.

## [M1] Harden the emitted line
The session id is the one free-form field, so it now goes through `json.dumps` — a weird id (quote, backslash) can no longer emit an unparseable line. Fixed keys and integers stay formatted directly, so the contract is byte-identical for normal ids.

## Tests
Extended `tests/test_readstats.py`: disjoint ranges each novel + same-range re-read redundant, `digest()`+`record_digest()` agree with `record()`, and a quote/backslash session id still parses as JSON.

Validated locally (aarch64-darwin): `readStatsTests`, `strictTypecheck`, `runtimeSmoke`, `viewSmoke`, `engineBundled`, and repo `lint` all green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix read stats tracking to hash returned payload, escape session IDs, and flush before kernel shutdown
> - Redundant-read tracking in `__ix_read` now hashes only the returned body (respecting line ranges) off the event loop via `asyncio.to_thread`, so disjoint ranged reads of the same file count as distinct reads.
> - Adds `emit_read_stats_final()` to `Kernel` and `__ix_emit_read_stats_final()` in the runtime namespace, replacing the previous `atexit` hook with an explicit flush call before `kernel.shutdown()` sends SIGKILL.
> - Fixes JSON-escaping of the session field in emitted `mcp_read_stats` lines using `json.dumps`.
> - Behavioral Change: final stats emission is no longer triggered via `atexit`; it must be driven explicitly by the server before kernel termination.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c4fca3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->