### PR TITLE
clone: budget gates (global + diff), wire clone stage into .#lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,6 +1665,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",

--- a/clone.toml
+++ b/clone.toml
@@ -15,3 +15,16 @@ ignore = [
     "*/fixtures/*",
     "*/snapshots/*",
 ]
+
+# Duplication budget consumed by `nix run .#clone` and enforced by the `clone`
+# lint stage. `global_pct` is the ceiling on whole-scan `duplication_pct`
+# (measured over the gated code, i.e. after the ignore globs above are applied).
+#
+# This is a RATCHET: the measured baseline is 0.729%, and this ceiling sits just
+# above it. Lower it as duplication is removed (re-measure with `nix run .#clone
+# -- . | jq .stats.duplication_pct`). Do NOT raise it without a written reason:
+# raising it silently admits new duplication.
+[budget]
+global_pct = 0.8
+diff_pct = 0.0
+diff_base = "origin/main"

--- a/doc/clone-detect/overview.md
+++ b/doc/clone-detect/overview.md
@@ -5,9 +5,11 @@ recognized file with tree-sitter, extracts significant subtrees, hashes them
 two ways (exact and identifier/literal-normalized), and reports clone groups:
 Type-1 (identical), Type-2 (identical modulo renaming), Type-3 (near-miss,
 structurally similar above a threshold), and statement Sequences. The `clone`
-binary emits JSON and a duplication percentage and exits non-zero when any clone
-survives, so it can gate CI; a repo-level [`clone.toml`](../../clone.toml)
-tunes thresholds and ignore globs (`nix run .#clone`).
+binary emits JSON and a duplication percentage and gates on **budgets**: it
+exits non-zero when an enabled gate's metric exceeds its ceiling (see
+[Gates](#gates)), so it can gate CI without failing on every pre-existing clone.
+A repo-level [`clone.toml`](../../clone.toml) tunes thresholds, ignore globs, and
+the `[budget]` ceilings (`nix run .#clone`).
 
 ## Member crates
 
@@ -28,17 +30,18 @@ All five are Rust workspace members; only `cli` is the flake/packageSet output
 ## Pipeline (`cli/src/main.rs:157-199`)
 
 ```
-find_config(path)            walk up for clone.toml (cli/src/main.rs:201-225)
-resolve_config              CLI flags > clone.toml > defaults (main.rs:232-269)
+find_config(path)            walk up for clone.toml (cli/src/main.rs)
+resolve_config              CLI flags > clone.toml > defaults (main.rs)
 Scanner::directory(path)    parse + index every file (scanner)
 instances(scan, config)     Type-1/2/3 + sequences (detect)
 filter::by_patterns         drop --ignore / clone.toml globs (cli/src/filter.rs)
-output_json                 DetectionResult as JSON (pretty optional)
+evaluate_gates              global + (optional) diff budgets (cli/src/gate.rs)
+output_json                 DetectionResult + gate object as JSON (pretty optional)
 badge::write (optional)     SVG duplication badge (cli/src/badge.rs)
 ```
 
-`run` returns "has clones", which `main` maps to exit `FAILURE`/`SUCCESS`
-(`main.rs:139-155`).
+`run` returns "any enabled gate failed", which `main` maps to exit
+`FAILURE`/`SUCCESS`.
 
 ## hash (`clone-hash`)
 
@@ -96,10 +99,72 @@ types are `serde`-serializable (the JSON output schema).
 
 ## cli (`clone`) config and flags
 
-Flags (`cli/src/main.rs:14-49`): `[PATH]` (default `.`), `--type3`,
-`--threshold`, `--min-lines`, `--min-nodes`, `--sequences`, `--window-size`,
-`--ignore` (repeatable glob), `--pretty`, `--badge PATH`. `clone.toml` mirrors
-these keys (`FileConfig`, `main.rs:52-63`); CLI flags win, booleans OR, ignore
-lists concatenate (`resolve_config`). The repo's [`clone.toml`](../../clone.toml)
-sets `min_lines = 8`, `min_nodes = 15`, and ignore globs for vendored/generated/
-test trees.
+Flags (`cli/src/main.rs`): `[PATH]` (default `.`), `--type3`, `--threshold`,
+`--min-lines`, `--min-nodes`, `--sequences`, `--window-size`, `--ignore`
+(repeatable glob), `--pretty`, `--badge PATH`, plus the gate flags
+`--max-global-pct`, `--max-diff-pct`, and `--diff [BASE]` (see [Gates](#gates)).
+`clone.toml` mirrors these keys (`FileConfig`) and adds a `[budget]` table; CLI
+flags win, booleans OR, ignore lists concatenate (`resolve_config`). The repo's
+[`clone.toml`](../../clone.toml) sets `min_lines = 8`, `min_nodes = 15`, ignore
+globs for vendored/generated/test trees, and `[budget] global_pct` as the
+duplication ratchet.
+
+## Gates
+
+Two independent budget gates decide the exit code (`cli/src/gate.rs`). Each is
+"metric must be `<=` its ceiling"; a metric exactly equal to the ceiling passes.
+The run exits `FAILURE` iff any enabled gate fails (or on error).
+
+- **global** (always evaluated): `stats.duplication_pct` over the whole scan vs
+  `global_pct`. Its ceiling is `--max-global-pct` > `[budget] global_pct` >
+  `0.0`. The `0.0` default reproduces the legacy behavior (any surviving clone
+  fails), so a repo with no `[budget]` and no gate flags gates exactly as before.
+- **diff** (opt-in, `--diff`): duplication concentrated on lines changed since a
+  git base rev. Changed lines are the added/modified new-side lines of
+  `git diff <merge-base(base, HEAD)>` taken against the working tree, so
+  uncommitted edits count (`cli/src/diff.rs`). A changed line is "duplicated"
+  when a surviving clone fragment in that file covers it;
+  `diff_pct = 100 * duplicated / changed` (`0` when nothing changed). The base is
+  the `--diff` argument > `[budget] diff_base` > `origin/main`; the ceiling is
+  `--max-diff-pct` > `[budget] diff_pct` > `0.0`. If git is missing or the base
+  rev is unknown, the run fails loudly rather than skipping the gate.
+
+The diff gate shells out to `git` with user/system config and external diff
+drivers disabled, so a custom `~/.gitconfig` pager or `diff.external` cannot
+corrupt the unified-diff parse. It never runs in the CI lint derivation (that
+copy has no `.git`); CI gates only on `global`.
+
+### `[budget]` config
+
+```toml
+[budget]
+global_pct = 1.1        # whole-scan duplication_pct ceiling
+diff_pct = 0.0          # changed-line duplication ceiling (used with --diff)
+diff_base = "origin/main"
+```
+
+### `gate` JSON
+
+`output_json` merges a `gate` object into the existing `{ instances, stats }`
+schema. A gate key is present only when the gate is enabled:
+
+```json
+{
+  "instances": [ ... ],
+  "stats": { ... },
+  "gate": {
+    "global": { "duplication_pct": 1.05, "budget_pct": 1.1, "pass": true },
+    "diff": {
+      "diff_pct": 0.0,
+      "budget_pct": 0.0,
+      "pass": true,
+      "base": "origin/main",
+      "base_sha": "aa24dc0b...",
+      "changed_lines": 12,
+      "duplicated_changed_lines": 0
+    }
+  }
+}
+```
+
+Each gate also logs a one-line PASS/FAIL summary to stderr via `tracing`.

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -36,7 +36,7 @@
   # up in the `lint` derivation build, not at `nix run` time.
   lintStage = ix.writeNushellApplication pkgs {
     name = "lint-stage";
-    meta.description = "One lint stage (alejandra | statix | deadnix | astlog | astlog-rust | astlog-elixir | ruff); driven by `lint`";
+    meta.description = "One lint stage (alejandra | statix | deadnix | astlog | astlog-rust | astlog-elixir | ruff | clone); driven by `lint`";
     runtimeInputs = [
       pkgs.alejandra
       pkgs.deadnix
@@ -44,6 +44,7 @@
       pkgs.ruff
       pkgs.statix
       repoPackages.astlog
+      repoPackages.clone
     ];
     text = ''
       # nu
@@ -137,8 +138,20 @@
           ruff check ${ix.ruffAnnArgs} ...$py_files
         }
       }
+      # Code clone detection over the whole tree (packages/code/clone-detect).
+      # `clone .` walks up for the repo `clone.toml`, whose `[budget]
+      # global_pct` is the ceiling on whole-scan `duplication_pct`; the binary
+      # exits nonzero when the global gate fails, so this gate ratchets
+      # duplication down without failing on every pre-existing clone. Only the
+      # global gate runs here: the diff gate needs a `.git` directory, and the
+      # CI lint derivation copies a `.git`-less source tree. `clone` prints the
+      # DetectionResult JSON to stdout; redirect it to null so a failing stage's
+      # log shows the tracing gate summary (stderr), not the full JSON blob.
+      def "main clone" [] {
+        clone . out> /dev/null
+      }
       def main [] {
-        error make { msg: "specify a stage: alejandra | statix | deadnix | astlog | astlog-rust | astlog-elixir | ruff" }
+        error make { msg: "specify a stage: alejandra | statix | deadnix | astlog | astlog-rust | astlog-elixir | ruff | clone" }
       }
     '';
   };
@@ -154,6 +167,7 @@
     "astlog-rust"
     "astlog-elixir"
     "ruff"
+    "clone"
   ];
 
   lintSpec = (pkgs.formats.json {}).generate "lint-dag.json" {

--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -272,6 +272,10 @@
           # ix-vt's tests dlopen the libghostty-vt dylib at runtime; make its lib
           # dir available so the loader resolves `@rpath`/`-l ghostty-vt`.
           ix-vt = [libghosttyVt];
+          # clone-cli's diff-gate integration tests build temp git repos and run
+          # `git` (directly and via the `clone` binary's diff gate). The test
+          # sandbox has no git otherwise, so the tests panic spawning it.
+          clone-cli = [workspacePkgs.git];
         };
         # `rodio` (packages/minecraft/minecraft/sound) pulls `cpal`/`alsa-sys`, whose build
         # script needs ALSA's pkg-config metadata to link `libasound` on Linux.

--- a/packages/code/clone-detect/cli/Cargo.toml
+++ b/packages/code/clone-detect/cli/Cargo.toml
@@ -21,5 +21,8 @@ toml = { workspace = true, features = ["parse", "serde"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/packages/code/clone-detect/cli/src/diff.rs
+++ b/packages/code/clone-detect/cli/src/diff.rs
@@ -1,0 +1,293 @@
+//! Git-backed changed-line discovery for the diff gate.
+//!
+//! The diff gate asks: of the lines this change touched, how many landed on
+//! duplicated code? "Touched" means added or modified lines on the new side of
+//! `git diff <merge-base(base, HEAD)>`, taken against the working tree so
+//! uncommitted edits count. This module owns the process concerns (invoking
+//! `git`, resolving the merge base) and the pure unified-diff hunk parser; the
+//! gate math lives in [`crate::gate`].
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use snafu::{OptionExt as _, ResultExt as _, ensure};
+
+/// Added/modified line numbers per file, 1-indexed on the new (working-tree)
+/// side. A file with only deletions contributes no lines.
+///
+/// Keys from [`changed_lines`] are absolute paths (repo root joined with git's
+/// repo-relative path, canonicalized where possible) so they can be matched
+/// against clone-fragment paths regardless of how the scan target was spelled.
+/// [`parse_unified_diff`] on its own returns git's repo-relative paths; the
+/// absolutization happens in [`changed_lines`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ChangedLines(pub BTreeMap<PathBuf, BTreeSet<usize>>);
+
+#[derive(Debug, snafu::Snafu)]
+pub enum DiffError {
+    #[snafu(display("failed to run `git {args}`: is git installed and on PATH?"))]
+    Spawn {
+        args: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display(
+        "`git {args}` failed (exit {code}): {stderr}",
+        code = code.map_or_else(|| "signal".to_owned(), |c| c.to_string()),
+    ))]
+    Command {
+        args: String,
+        code: Option<i32>,
+        stderr: String,
+    },
+
+    #[snafu(display("`git {args}` printed non-UTF-8 output"))]
+    NonUtf8 {
+        args: String,
+        source: std::string::FromUtf8Error,
+    },
+
+    #[snafu(display(
+        "could not find a merge base between {base:?} and HEAD; \
+         is {base:?} a known revision? (fetch it, or pass a different --diff base)"
+    ))]
+    NoMergeBase { base: String },
+
+    #[snafu(display("malformed diff hunk header: {line:?}"))]
+    BadHunkHeader { line: String },
+}
+
+/// A `git` invocation neutralized against the caller's environment: user/system
+/// config, pager, and external diff drivers are all disabled so output is a
+/// stable, machine-parseable unified diff regardless of the caller's
+/// `~/.gitconfig` (a columnar `diff.external`, a pager, or color codes would all
+/// corrupt the parse). `dir` anchors the command in the scanned repository, not
+/// the process's own working directory.
+fn git_command(dir: &Path) -> Command {
+    let mut command = Command::new("git");
+    command
+        .current_dir(dir)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_PAGER", "cat")
+        .env("GIT_OPTIONAL_LOCKS", "0");
+    command
+}
+
+/// Run `git` in `dir`, returning stdout on a zero exit or a precise error
+/// otherwise (never a silent fallback: the diff gate must fail loudly when git
+/// cannot answer).
+fn git(dir: &Path, args: &[&str]) -> Result<String, DiffError> {
+    let display = args.join(" ");
+    let output = git_command(dir)
+        .args(args)
+        .output()
+        .context(SpawnSnafu { args: &display })?;
+
+    ensure!(
+        output.status.success(),
+        CommandSnafu {
+            args: &display,
+            code: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+        }
+    );
+
+    String::from_utf8(output.stdout).context(NonUtf8Snafu { args: &display })
+}
+
+/// Resolve the merge base of `base` and `HEAD` in the repository at `dir`. Fails
+/// loudly when `base` is unknown or the two revisions share no history.
+pub fn merge_base(dir: &Path, base: &str) -> Result<String, DiffError> {
+    // `git merge-base` exits 1 with empty output when there is no common
+    // ancestor and nonzero with a message when `base` is not a valid revision;
+    // distinguish the "no ancestor" case for a clearer error.
+    let display = format!("merge-base {base} HEAD");
+    let output = git_command(dir)
+        .args(["merge-base", base, "HEAD"])
+        .output()
+        .context(SpawnSnafu { args: &display })?;
+
+    if output.status.success() {
+        let sha = String::from_utf8(output.stdout)
+            .context(NonUtf8Snafu { args: &display })?
+            .trim()
+            .to_owned();
+        // Success with empty output means the revisions share no common
+        // ancestor; treat it as the same failure as an unknown base.
+        ensure!(!sha.is_empty(), NoMergeBaseSnafu { base });
+        return Ok(sha);
+    }
+
+    // A nonzero exit with no diagnostic is git's "not a valid object" for the
+    // base rev; surface the actionable message rather than an opaque exit code.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    ensure!(!stderr.trim().is_empty(), NoMergeBaseSnafu { base });
+    CommandSnafu {
+        args: &display,
+        code: output.status.code(),
+        stderr: stderr.trim().to_owned(),
+    }
+    .fail()
+}
+
+/// Changed lines relative to the merge base of `base` and `HEAD`, resolved in
+/// the repository at `dir` and including uncommitted working-tree edits. Diffing
+/// `<merge-base>` (a single tree argument, no `--cached`) against the working
+/// tree is what folds committed and uncommitted changes into one set.
+///
+/// Line numbers are the git-native 1-indexed new-side lines; the gate converts
+/// tree-sitter's 0-indexed fragment lines to match (see [`crate::gate`]).
+pub fn changed_lines(dir: &Path, base: &str) -> Result<(String, ChangedLines), DiffError> {
+    let base_sha = merge_base(dir, base)?;
+    // `--unified=0` so every hunk header's new-side range is exactly the
+    // added/modified lines; `--no-ext-diff`/`--no-textconv` keep the payload a
+    // literal unified diff. This covers tracked edits (committed since the base
+    // and uncommitted), but git omits untracked files from `diff`.
+    let raw = git(
+        dir,
+        &[
+            "diff",
+            "--no-color",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--unified=0",
+            &base_sha,
+        ],
+    )?;
+    let relative = parse_unified_diff(&raw)?;
+
+    // Resolve git's repo-relative paths against the repository root so they can
+    // be compared to clone-fragment paths (which reflect the scan target, not
+    // the repo root).
+    let root = repo_root(dir)?;
+    let mut changed = ChangedLines(
+        relative
+            .0
+            .into_iter()
+            .map(|(rel, lines)| (absolutize(&root, &rel), lines))
+            .collect(),
+    );
+
+    // A brand-new (untracked, non-ignored) file is an uncommitted change whose
+    // every line is added, but `git diff` never reports it. List those files and
+    // count all their lines so a duplicated new file cannot slip past the gate.
+    add_untracked(dir, &root, &mut changed)?;
+
+    Ok((base_sha, changed))
+}
+
+/// The repository's top-level directory (canonicalized), the anchor for git's
+/// repo-relative diff paths.
+fn repo_root(dir: &Path) -> Result<PathBuf, DiffError> {
+    let out = git(dir, &["rev-parse", "--show-toplevel"])?;
+    Ok(PathBuf::from(out.trim()))
+}
+
+/// Join a repo-relative path onto the repo root and canonicalize it. Falls back
+/// to the plain join if canonicalization fails (e.g. the file was since
+/// deleted), which still matches a fragment path canonicalized the same way.
+fn absolutize(root: &Path, rel: &Path) -> PathBuf {
+    let joined = root.join(rel);
+    std::fs::canonicalize(&joined).unwrap_or(joined)
+}
+
+/// Add every line of each untracked, non-`.gitignore`d file to `changed`. Each
+/// such file is wholly new, so its changed lines are `1..=line_count`. Paths are
+/// keyed absolutely (against `root`) to match [`changed_lines`].
+fn add_untracked(dir: &Path, root: &Path, changed: &mut ChangedLines) -> Result<(), DiffError> {
+    // `-z` gives NUL-separated paths so filenames with spaces/newlines survive;
+    // `--exclude-standard` honors .gitignore/.git/info/exclude so ignored build
+    // output is not counted as a change.
+    let listing = git(dir, &["ls-files", "--others", "--exclude-standard", "-z"])?;
+
+    for rel in listing.split('\0').filter(|s| !s.is_empty()) {
+        let rel = Path::new(rel);
+        let path = absolutize(root, rel);
+        // A file listed by git but unreadable (a race, or a broken symlink) is
+        // skipped rather than failing the whole gate: it contributes no lines.
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let line_count = contents.lines().count();
+        if line_count == 0 {
+            continue;
+        }
+        let entry = changed.0.entry(path).or_default();
+        entry.extend(1..=line_count);
+    }
+
+    Ok(())
+}
+
+/// Parse a `--unified=0 --no-color` diff into the set of added/modified new-side
+/// line numbers per file. Pure: driven only by the text, so it is unit-tested
+/// against fixed diff fixtures.
+///
+/// The two lines that matter:
+/// - `+++ b/<path>` names the current file (`+++ /dev/null` on a deletion).
+/// - `@@ -old[,n] +new[,m] @@` gives the new-side start `new` and length `m`
+///   (`m` defaults to 1). Those `m` lines, `new..new+m`, are the changed lines.
+pub fn parse_unified_diff(diff: &str) -> Result<ChangedLines, DiffError> {
+    let mut out: BTreeMap<PathBuf, BTreeSet<usize>> = BTreeMap::new();
+    let mut current: Option<PathBuf> = None;
+
+    for line in diff.lines() {
+        if let Some(rest) = line.strip_prefix("+++ ") {
+            current = new_side_path(rest);
+        } else if line.starts_with("@@ ") {
+            // A hunk with no `+++` before it, or one against /dev/null
+            // (deletion), has no new-side file to attribute lines to.
+            let Some(path) = current.clone() else {
+                continue;
+            };
+            let (start, count) = parse_hunk_new_range(line)?;
+            let entry = out.entry(path).or_default();
+            for offset in 0..count {
+                entry.insert(start + offset);
+            }
+        }
+    }
+
+    Ok(ChangedLines(out))
+}
+
+/// Extract the new-side path from a `+++ ` header body, stripping the `b/`
+/// prefix git adds. `/dev/null` (a deletion) yields `None`.
+fn new_side_path(rest: &str) -> Option<PathBuf> {
+    // Strip a trailing tab-delimited timestamp if present (git omits it, but
+    // some diff producers add one).
+    let path = rest.split('\t').next().unwrap_or(rest);
+    if path == "/dev/null" {
+        return None;
+    }
+    let stripped = path.strip_prefix("b/").unwrap_or(path);
+    Some(PathBuf::from(stripped))
+}
+
+/// Parse the new-side `+new[,count]` range from a hunk header
+/// `@@ -old[,n] +new[,m] @@ ...`. A `count` of 0 (pure deletion at that point)
+/// yields an empty range.
+fn parse_hunk_new_range(line: &str) -> Result<(usize, usize), DiffError> {
+    let new_field = line
+        .split_whitespace()
+        .find_map(|token| token.strip_prefix('+'))
+        .context(BadHunkHeaderSnafu { line })?;
+
+    let mut parts = new_field.splitn(2, ',');
+    let start: usize = parts
+        .next()
+        .and_then(|s| s.parse().ok())
+        .context(BadHunkHeaderSnafu { line })?;
+    let count: usize = match parts.next() {
+        Some(c) => c.parse().ok().context(BadHunkHeaderSnafu { line })?,
+        None => 1,
+    };
+    Ok((start, count))
+}
+
+#[cfg(test)]
+mod tests;

--- a/packages/code/clone-detect/cli/src/diff.rs
+++ b/packages/code/clone-detect/cli/src/diff.rs
@@ -26,6 +26,13 @@ use snafu::{OptionExt as _, ResultExt as _, ensure};
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ChangedLines(pub BTreeMap<PathBuf, BTreeSet<usize>>);
 
+/// The resolved diff for the gate: the merge-base commit it was taken against
+/// and the changed lines on the working-tree side.
+pub struct RepoDiff {
+    pub base_sha: String,
+    pub changed: ChangedLines,
+}
+
 #[derive(Debug, snafu::Snafu)]
 pub enum DiffError {
     #[snafu(display("failed to run `git {args}`: is git installed and on PATH?"))]
@@ -141,7 +148,7 @@ pub fn merge_base(dir: &Path, base: &str) -> Result<String, DiffError> {
 ///
 /// Line numbers are the git-native 1-indexed new-side lines; the gate converts
 /// tree-sitter's 0-indexed fragment lines to match (see [`crate::gate`]).
-pub fn changed_lines(dir: &Path, base: &str) -> Result<(String, ChangedLines), DiffError> {
+pub fn changed_lines(dir: &Path, base: &str) -> Result<RepoDiff, DiffError> {
     let base_sha = merge_base(dir, base)?;
     // `--unified=0` so every hunk header's new-side range is exactly the
     // added/modified lines; `--no-ext-diff`/`--no-textconv` keep the payload a
@@ -177,7 +184,7 @@ pub fn changed_lines(dir: &Path, base: &str) -> Result<(String, ChangedLines), D
     // count all their lines so a duplicated new file cannot slip past the gate.
     add_untracked(dir, &root, &mut changed)?;
 
-    Ok((base_sha, changed))
+    Ok(RepoDiff { base_sha, changed })
 }
 
 /// The repository's top-level directory (canonicalized), the anchor for git's
@@ -244,10 +251,10 @@ pub fn parse_unified_diff(diff: &str) -> Result<ChangedLines, DiffError> {
             let Some(path) = current.clone() else {
                 continue;
             };
-            let (start, count) = parse_hunk_new_range(line)?;
+            let range = parse_hunk_new_range(line)?;
             let entry = out.entry(path).or_default();
-            for offset in 0..count {
-                entry.insert(start + offset);
+            for offset in 0..range.count {
+                entry.insert(range.start + offset);
             }
         }
     }
@@ -268,10 +275,17 @@ fn new_side_path(rest: &str) -> Option<PathBuf> {
     Some(PathBuf::from(stripped))
 }
 
+/// The new-side line range of a hunk header: `count` lines starting at 1-indexed
+/// `start`. A `count` of 0 is a pure deletion (no new-side lines).
+struct HunkRange {
+    start: usize,
+    count: usize,
+}
+
 /// Parse the new-side `+new[,count]` range from a hunk header
 /// `@@ -old[,n] +new[,m] @@ ...`. A `count` of 0 (pure deletion at that point)
 /// yields an empty range.
-fn parse_hunk_new_range(line: &str) -> Result<(usize, usize), DiffError> {
+fn parse_hunk_new_range(line: &str) -> Result<HunkRange, DiffError> {
     let new_field = line
         .split_whitespace()
         .find_map(|token| token.strip_prefix('+'))
@@ -286,7 +300,7 @@ fn parse_hunk_new_range(line: &str) -> Result<(usize, usize), DiffError> {
         Some(c) => c.parse().ok().context(BadHunkHeaderSnafu { line })?,
         None => 1,
     };
-    Ok((start, count))
+    Ok(HunkRange { start, count })
 }
 
 #[cfg(test)]

--- a/packages/code/clone-detect/cli/src/diff/tests.rs
+++ b/packages/code/clone-detect/cli/src/diff/tests.rs
@@ -1,0 +1,134 @@
+use std::path::PathBuf;
+
+use super::{ChangedLines, parse_unified_diff};
+
+/// Lines recorded for `path` in a parsed diff, as a sorted vec for assertions.
+fn lines_for(changed: &ChangedLines, path: &str) -> Vec<usize> {
+    changed
+        .0
+        .get(&PathBuf::from(path))
+        .map(|set| set.iter().copied().collect())
+        .unwrap_or_default()
+}
+
+#[test]
+fn single_modified_line() {
+    // `@@ -2 +2 @@` with no count means one new-side line at 2.
+    let diff = "\
+diff --git a/f.txt b/f.txt
+--- a/f.txt
++++ b/f.txt
+@@ -2 +2 @@ a
+-b
++B2
+";
+    let changed = parse_unified_diff(diff).unwrap();
+    assert_eq!(lines_for(&changed, "f.txt"), vec![2]);
+}
+
+#[test]
+fn added_block_uses_count() {
+    // `@@ -3,0 +4,2 @@` adds two lines starting at 4.
+    let diff = "\
++++ b/f.txt
+@@ -3,0 +4,2 @@ c
++X
++Y
+";
+    let changed = parse_unified_diff(diff).unwrap();
+    assert_eq!(lines_for(&changed, "f.txt"), vec![4, 5]);
+}
+
+#[test]
+fn pure_deletion_contributes_no_lines() {
+    // A deletion hunk has a new-side count of 0: `@@ -5,3 +4,0 @@`.
+    let diff = "\
++++ b/f.txt
+@@ -5,3 +4,0 @@ c
+-gone1
+-gone2
+-gone3
+";
+    let changed = parse_unified_diff(diff).unwrap();
+    assert!(lines_for(&changed, "f.txt").is_empty());
+}
+
+#[test]
+fn deleted_file_new_side_is_dev_null() {
+    // `+++ /dev/null` (whole-file deletion): no new-side path to attribute to,
+    // so the hunk is dropped rather than misattributed.
+    let diff = "\
+diff --git a/gone.txt b/gone.txt
+--- a/gone.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-a
+-b
+";
+    let changed = parse_unified_diff(diff).unwrap();
+    assert!(changed.0.is_empty());
+}
+
+#[test]
+fn multiple_files_and_hunks() {
+    let diff = "\
++++ b/a.rs
+@@ -10 +10 @@
+-old
++new
+@@ -20,0 +21,3 @@
++p
++q
++r
++++ b/b.rs
+@@ -1,0 +1,1 @@
++only
+";
+    let changed = parse_unified_diff(diff).unwrap();
+    assert_eq!(lines_for(&changed, "a.rs"), vec![10, 21, 22, 23]);
+    assert_eq!(lines_for(&changed, "b.rs"), vec![1]);
+}
+
+#[test]
+fn new_file_added() {
+    // A brand-new file: old side is /dev/null, new side names the file, and the
+    // whole body is added.
+    let diff = "\
+--- /dev/null
++++ b/new.rs
+@@ -0,0 +1,3 @@
++line1
++line2
++line3
+";
+    let changed = parse_unified_diff(diff).unwrap();
+    assert_eq!(lines_for(&changed, "new.rs"), vec![1, 2, 3]);
+}
+
+#[test]
+fn strips_b_prefix_only() {
+    // The `b/` prefix is git's convention; a path that itself starts with a
+    // literal `b/` segment after stripping is preserved.
+    let diff = "\
++++ b/crate/src/main.rs
+@@ -1 +1 @@
+-a
++b
+";
+    let changed = parse_unified_diff(diff).unwrap();
+    assert_eq!(lines_for(&changed, "crate/src/main.rs"), vec![1]);
+}
+
+#[test]
+fn empty_diff_is_empty() {
+    let changed = parse_unified_diff("").unwrap();
+    assert!(changed.0.is_empty());
+}
+
+#[test]
+fn hunk_before_any_file_header_is_ignored() {
+    // Defensive: a stray hunk with no preceding `+++` has nothing to attribute.
+    let diff = "@@ -1 +1 @@\n-a\n+b\n";
+    let changed = parse_unified_diff(diff).unwrap();
+    assert!(changed.0.is_empty());
+}

--- a/packages/code/clone-detect/cli/src/filter.rs
+++ b/packages/code/clone-detect/cli/src/filter.rs
@@ -1,34 +1,58 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
+
 use clone_detect::{DetectionResult, DetectionStats, Kind};
+use clone_scanner::Output;
 
 const MIN_FRAGMENTS: usize = 2;
+/// Multiplier turning a ratio into a percentage (mirrors `detect`).
+const PERCENT: f64 = 100.0;
 
+/// Drop fragments in ignored files, then **recompute** the duplication stats
+/// over what survives.
+///
+/// The detector computes `duplication_pct` over the whole scan; if we only
+/// dropped fragments and copied the pre-filter stats, the ignore globs would
+/// not move the number the gate keys on (the metric would be identical with and
+/// without ignores). So this recomputes:
+/// - `duplicated_lines` from the surviving groups only (same per-file,
+///   skip-the-original dedup as `detect::compute_duplicated_lines`), and
+/// - `total_lines` over the **gated** files only — files matching an ignore
+///   glob are removed from the denominator too, so the metric reads as
+///   "duplication among the code the gate actually covers", not diluted by
+///   vendored/generated lines that can never contribute clones.
+///
+/// `files_scanned` and `nodes_analyzed` still describe the raw scan (they are
+/// not gate inputs), so they are passed through unchanged.
 pub fn by_patterns(
     result: DetectionResult,
+    scan: &Output,
     patterns: &[glob::Pattern],
 ) -> Result<DetectionResult, crate::RunError> {
     if patterns.is_empty() {
         return Ok(result);
     }
 
-    let mut filtered_clones = Vec::new();
+    let matches_ignore = |path: &std::path::Path| -> Result<bool, crate::RunError> {
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| crate::RunError::NonUtf8Path {
+                path: path.to_path_buf(),
+            })?;
+        Ok(patterns.iter().any(|pattern| pattern.matches(path_str)))
+    };
 
+    let mut filtered_clones = Vec::new();
     for mut clone in result.instances {
         let mut fragments = Vec::with_capacity(clone.fragments.len());
-
         for fragment in clone.fragments {
-            let Some(path_str) = fragment.file.to_str() else {
-                return Err(crate::RunError::NonUtf8Path {
-                    path: fragment.file,
-                });
-            };
-
-            if !patterns.iter().any(|pattern| pattern.matches(path_str)) {
+            if !matches_ignore(&fragment.file)? {
                 fragments.push(fragment);
             }
         }
-
         clone.fragments = fragments;
-
         if clone.fragments.len() >= MIN_FRAGMENTS {
             filtered_clones.push(clone);
         }
@@ -38,7 +62,6 @@ pub fn by_patterns(
     let mut type2_groups = 0;
     let mut type3_groups = 0;
     let mut sequence_groups = 0;
-
     for clone in &filtered_clones {
         match clone.clone_type {
             Kind::Type1 => type1_groups += 1,
@@ -48,14 +71,25 @@ pub fn by_patterns(
         }
     }
 
+    // Denominator: lines of gated files only.
+    let mut total_lines = 0_usize;
+    for file in &scan.files {
+        if !matches_ignore(&file.path)? {
+            total_lines += file.source.lines().count();
+        }
+    }
+
+    let duplicated_lines = duplicated_lines(&filtered_clones);
+    let duplication_pct = ratio_pct(duplicated_lines, total_lines);
+
     Ok(DetectionResult {
         instances: filtered_clones,
         stats: DetectionStats {
             files_scanned: result.stats.files_scanned,
             nodes_analyzed: result.stats.nodes_analyzed,
-            total_lines: result.stats.total_lines,
-            duplicated_lines: result.stats.duplicated_lines,
-            duplication_pct: result.stats.duplication_pct,
+            total_lines,
+            duplicated_lines,
+            duplication_pct,
             type1_groups,
             type2_groups,
             type3_groups,
@@ -63,3 +97,35 @@ pub fn by_patterns(
         },
     })
 }
+
+/// Deduplicated duplicated-line count over the surviving groups. Mirrors
+/// `detect::compute_duplicated_lines`: per group skip the first fragment (the
+/// "original"), and dedup line numbers per file across all groups.
+fn duplicated_lines(instances: &[clone_detect::CloneGroup]) -> usize {
+    let mut per_file: BTreeMap<&PathBuf, BTreeSet<usize>> = BTreeMap::new();
+    for group in instances {
+        for frag in group.fragments.iter().skip(1) {
+            let lines = per_file.entry(&frag.file).or_default();
+            for line in frag.lines.start..=frag.lines.end {
+                lines.insert(line);
+            }
+        }
+    }
+    per_file.values().map(BTreeSet::len).sum()
+}
+
+/// `100 * numerator / denominator`, `0.0` when the denominator is zero.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "line counts stay far below f64 mantissa precision"
+)]
+fn ratio_pct(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        (numerator as f64 / denominator as f64) * PERCENT
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/packages/code/clone-detect/cli/src/filter/tests.rs
+++ b/packages/code/clone-detect/cli/src/filter/tests.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+use clone_detect::{ByteRange, CloneGroup, Fragment, Kind, LineRange};
+
+use super::{duplicated_lines, ratio_pct};
+
+fn fragment(file: &str, start: usize, end: usize) -> Fragment {
+    Fragment {
+        file: PathBuf::from(file),
+        byte_range: ByteRange { start: 0, end: 0 },
+        lines: LineRange { start, end },
+        kind: "function_item".to_owned(),
+    }
+}
+
+fn group(fragments: Vec<Fragment>) -> CloneGroup {
+    CloneGroup {
+        clone_type: Kind::Type1,
+        fragments,
+    }
+}
+
+#[test]
+fn duplicated_lines_skips_the_original_fragment() {
+    // Two fragments, one line each: the first is the "original", so only the
+    // second's line counts as duplicated.
+    let g = group(vec![fragment("a.rs", 0, 4), fragment("b.rs", 10, 14)]);
+    // b.rs rows 10..=14 => 5 lines.
+    assert_eq!(duplicated_lines(&[g]), 5);
+}
+
+#[test]
+fn duplicated_lines_dedups_overlapping_ranges_per_file() {
+    // Two groups whose duplicate fragments overlap in the same file: rows
+    // 10..=14 and 12..=16 in b.rs union to 10..=16 (7 distinct lines), not 10.
+    let g1 = group(vec![fragment("a.rs", 0, 4), fragment("b.rs", 10, 14)]);
+    let g2 = group(vec![fragment("a.rs", 20, 24), fragment("b.rs", 12, 16)]);
+    assert_eq!(duplicated_lines(&[g1, g2]), 7);
+}
+
+#[test]
+fn ratio_pct_zero_denominator_is_zero() {
+    assert_eq!(ratio_pct(5, 0), 0.0);
+    assert_eq!(ratio_pct(0, 0), 0.0);
+}
+
+#[test]
+fn ratio_pct_basic() {
+    assert!((ratio_pct(1, 4) - 25.0).abs() < 1e-9);
+    assert_eq!(ratio_pct(0, 100), 0.0);
+}

--- a/packages/code/clone-detect/cli/src/filter/tests.rs
+++ b/packages/code/clone-detect/cli/src/filter/tests.rs
@@ -39,12 +39,20 @@ fn duplicated_lines_dedups_overlapping_ranges_per_file() {
 }
 
 #[test]
+#[expect(
+    clippy::float_cmp,
+    reason = "0.0 is exactly representable and the guard returns it verbatim"
+)]
 fn ratio_pct_zero_denominator_is_zero() {
     assert_eq!(ratio_pct(5, 0), 0.0);
     assert_eq!(ratio_pct(0, 0), 0.0);
 }
 
 #[test]
+#[expect(
+    clippy::float_cmp,
+    reason = "0.0 is exactly representable and 0/100 yields it verbatim"
+)]
 fn ratio_pct_basic() {
     assert!((ratio_pct(1, 4) - 25.0).abs() < 1e-9);
     assert_eq!(ratio_pct(0, 100), 0.0);

--- a/packages/code/clone-detect/cli/src/gate.rs
+++ b/packages/code/clone-detect/cli/src/gate.rs
@@ -1,0 +1,168 @@
+//! Budget gates over a `DetectionResult`.
+//!
+//! Two independent gates, each "metric must be <= budget":
+//! - global: the whole-scan `duplication_pct`.
+//! - diff: duplication concentrated on the lines changed relative to a git base
+//!   rev (see [`crate::diff`] for how the changed-line set is produced).
+//!
+//! The math here is pure: it takes an already-computed changed-line set and the
+//! surviving clone fragments and reports pass/fail. All git/process work lives
+//! in [`crate::diff`] so this module stays testable without a repository.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
+
+use clone_detect::DetectionResult;
+use serde::Serialize;
+
+use crate::diff::ChangedLines;
+
+/// A gate metric is duplicated when it lies at or below its budget. Fail is the
+/// strict complement, so a metric exactly equal to the budget passes.
+fn passes(metric: f64, budget: f64) -> bool {
+    metric <= budget
+}
+
+/// Whole-scan duplication gate.
+#[derive(Debug, Clone, Serialize)]
+pub struct GlobalGate {
+    /// `stats.duplication_pct` from the detection result.
+    pub duplication_pct: f64,
+    /// The configured ceiling.
+    pub budget_pct: f64,
+    pub pass: bool,
+}
+
+impl GlobalGate {
+    #[must_use]
+    pub fn evaluate(result: &DetectionResult, budget_pct: f64) -> Self {
+        let duplication_pct = result.stats.duplication_pct;
+        Self {
+            duplication_pct,
+            budget_pct,
+            pass: passes(duplication_pct, budget_pct),
+        }
+    }
+}
+
+/// Duplication concentrated on changed lines.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiffGate {
+    /// `100 * duplicated_changed_lines / changed_lines`, or `0.0` when nothing
+    /// changed.
+    pub diff_pct: f64,
+    /// The configured ceiling.
+    pub budget_pct: f64,
+    pub pass: bool,
+    /// The base ref as requested (e.g. `origin/main`), before resolution.
+    pub base: String,
+    /// The merge-base commit the diff was taken against.
+    pub base_sha: String,
+    /// Total added/modified lines across all changed files.
+    pub changed_lines: usize,
+    /// Of those, how many a surviving clone fragment covers.
+    pub duplicated_changed_lines: usize,
+}
+
+impl DiffGate {
+    /// A changed line is "duplicated" when a surviving clone fragment in the
+    /// same file covers it. `diff_pct` is the ratio of such lines to all
+    /// changed lines; with no changed lines it is `0.0` (an empty diff cannot
+    /// regress duplication), so it always passes any non-negative budget.
+    #[must_use]
+    pub fn evaluate(
+        result: &DetectionResult,
+        changed: &ChangedLines,
+        budget_pct: f64,
+        base: String,
+        base_sha: String,
+    ) -> Self {
+        let covered = covered_lines(result);
+
+        let mut changed_total = 0_usize;
+        let mut duplicated = 0_usize;
+        for (file, lines) in &changed.0 {
+            changed_total += lines.len();
+            if let Some(covered_in_file) = covered.get(file) {
+                duplicated += lines.intersection(covered_in_file).count();
+            }
+        }
+
+        // Ratio in percent; guard the zero-changed-lines case so an empty diff
+        // reports 0% rather than NaN.
+        let diff_pct = if changed_total == 0 {
+            0.0
+        } else {
+            ratio_pct(duplicated, changed_total)
+        };
+
+        Self {
+            diff_pct,
+            budget_pct,
+            pass: passes(diff_pct, budget_pct),
+            base,
+            base_sha,
+            changed_lines: changed_total,
+            duplicated_changed_lines: duplicated,
+        }
+    }
+}
+
+/// `100 * numerator / denominator` computed in f64. Callers guarantee
+/// `denominator > 0`.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "line counts are far below f64's 2^53 exact-integer range"
+)]
+fn ratio_pct(numerator: usize, denominator: usize) -> f64 {
+    100.0 * numerator as f64 / denominator as f64
+}
+
+/// The set of source lines covered by any surviving clone fragment, keyed by
+/// file and in git's 1-indexed coordinate.
+///
+/// `Fragment::lines` comes from tree-sitter `Node::start_position().row`, which
+/// is 0-indexed; `ChangedLines` comes from `git diff`, which is 1-indexed. We
+/// convert the fragment ranges here (`+1`) so both sides compare in the same
+/// coordinate. Comparing raw would shift every fragment up by one line and
+/// mis-attribute duplication.
+fn covered_lines(result: &DetectionResult) -> BTreeMap<PathBuf, BTreeSet<usize>> {
+    let mut covered: BTreeMap<PathBuf, BTreeSet<usize>> = BTreeMap::new();
+    for group in &result.instances {
+        for fragment in &group.fragments {
+            // Canonicalize so fragment paths (spelled however the scan target
+            // was) match the absolute keys `ChangedLines` uses.
+            let key = std::fs::canonicalize(&fragment.file).unwrap_or_else(|_| fragment.file.clone());
+            let entry = covered.entry(key).or_default();
+            for row in fragment.lines.start..=fragment.lines.end {
+                entry.insert(row + 1);
+            }
+        }
+    }
+    covered
+}
+
+/// The overall gate outcome for the enabled gates, serialized under the `gate`
+/// key of the CLI's JSON output. A gate is `None` when it was not enabled.
+#[derive(Debug, Clone, Serialize)]
+pub struct GateReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub global: Option<GlobalGate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff: Option<DiffGate>,
+}
+
+impl GateReport {
+    /// True when every enabled gate passed. With no gate enabled there is
+    /// nothing to fail, so it passes (the caller decides whether that is legal;
+    /// legacy "any clone fails" is modeled as a global budget of `0.0`).
+    #[must_use]
+    pub fn passed(&self) -> bool {
+        self.global.as_ref().is_none_or(|g| g.pass) && self.diff.as_ref().is_none_or(|d| d.pass)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/packages/code/clone-detect/cli/src/gate/tests.rs
+++ b/packages/code/clone-detect/cli/src/gate/tests.rs
@@ -68,6 +68,10 @@ fn global_gate_passes_at_or_below_budget() {
 }
 
 #[test]
+#[expect(
+    clippy::float_cmp,
+    reason = "diff_pct is exactly 0.0 when there are no changed lines"
+)]
 fn diff_gate_zero_changed_lines_passes() {
     // No changed lines => diff_pct is 0, which passes even a 0.0 budget.
     let r = result(50.0, vec![group("a.rs", 1, 100)]);
@@ -79,6 +83,10 @@ fn diff_gate_zero_changed_lines_passes() {
 }
 
 #[test]
+#[expect(
+    clippy::float_cmp,
+    reason = "100.0 is exact when every changed line is duplicated"
+)]
 fn diff_gate_all_changed_lines_duplicated() {
     // A clone at rows 10..=20 covers 1-indexed lines 11..=21; the change touches
     // 12,13,14 — all inside it.
@@ -118,6 +126,10 @@ fn diff_gate_partial_overlap() {
 }
 
 #[test]
+#[expect(
+    clippy::float_cmp,
+    reason = "diff_pct is exactly 0.0 when no changed line is duplicated"
+)]
 fn diff_gate_ignores_clones_in_unchanged_files() {
     // The clone is in b.rs but the change touched a.rs: nothing duplicated.
     let r = result(0.0, vec![group("b.rs", 1, 100)]);

--- a/packages/code/clone-detect/cli/src/gate/tests.rs
+++ b/packages/code/clone-detect/cli/src/gate/tests.rs
@@ -1,0 +1,177 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
+
+use clone_detect::{
+    ByteRange, CloneGroup, DetectionResult, DetectionStats, Fragment, Kind, LineRange,
+};
+
+use super::{DiffGate, GateReport, GlobalGate};
+use crate::diff::ChangedLines;
+
+/// A detection result carrying `duplication_pct` and the given clone groups.
+/// The non-fragment stats fields are irrelevant to gate math, so they are
+/// zeroed except `duplication_pct`.
+fn result(duplication_pct: f64, groups: Vec<CloneGroup>) -> DetectionResult {
+    DetectionResult {
+        instances: groups,
+        stats: DetectionStats {
+            files_scanned: 0,
+            nodes_analyzed: 0,
+            total_lines: 0,
+            duplicated_lines: 0,
+            duplication_pct,
+            type1_groups: 0,
+            type2_groups: 0,
+            type3_groups: 0,
+            sequence_groups: 0,
+        },
+    }
+}
+
+/// A Type-1 clone group with one fragment covering `file` rows `start..=end`.
+/// Rows are tree-sitter's 0-indexed coordinate (as `Fragment::lines` carries);
+/// the gate converts them to git's 1-indexed lines when comparing, so a
+/// fragment at rows `start..=end` covers 1-indexed lines `start+1..=end+1`.
+/// A group needs 2+ fragments in production, but gate math only reads the
+/// covered line ranges, so a single fragment is enough to exercise coverage.
+fn group(file: &str, start: usize, end: usize) -> CloneGroup {
+    CloneGroup {
+        clone_type: Kind::Type1,
+        fragments: vec![Fragment {
+            file: PathBuf::from(file),
+            byte_range: ByteRange { start: 0, end: 0 },
+            lines: LineRange { start, end },
+            kind: "function_item".to_owned(),
+        }],
+    }
+}
+
+/// A `ChangedLines` from `(path, [lines])` pairs.
+fn changed(entries: &[(&str, &[usize])]) -> ChangedLines {
+    let mut map: BTreeMap<PathBuf, BTreeSet<usize>> = BTreeMap::new();
+    for (path, lines) in entries {
+        map.insert(PathBuf::from(*path), lines.iter().copied().collect());
+    }
+    ChangedLines(map)
+}
+
+#[test]
+fn global_gate_passes_at_or_below_budget() {
+    let r = result(1.05, vec![]);
+    assert!(GlobalGate::evaluate(&r, 1.1).pass);
+    // Exactly equal passes (metric <= budget).
+    assert!(GlobalGate::evaluate(&r, 1.05).pass);
+    // Above budget fails.
+    assert!(!GlobalGate::evaluate(&r, 1.0).pass);
+}
+
+#[test]
+fn diff_gate_zero_changed_lines_passes() {
+    // No changed lines => diff_pct is 0, which passes even a 0.0 budget.
+    let r = result(50.0, vec![group("a.rs", 1, 100)]);
+    let g = DiffGate::evaluate(&r, &changed(&[]), 0.0, "origin/main".into(), "sha".into());
+    assert_eq!(g.diff_pct, 0.0);
+    assert_eq!(g.changed_lines, 0);
+    assert_eq!(g.duplicated_changed_lines, 0);
+    assert!(g.pass);
+}
+
+#[test]
+fn diff_gate_all_changed_lines_duplicated() {
+    // A clone at rows 10..=20 covers 1-indexed lines 11..=21; the change touches
+    // 12,13,14 — all inside it.
+    let r = result(0.0, vec![group("a.rs", 10, 20)]);
+    let g = DiffGate::evaluate(
+        &r,
+        &changed(&[("a.rs", &[12, 13, 14])]),
+        50.0,
+        "b".into(),
+        "s".into(),
+    );
+    assert_eq!(g.changed_lines, 3);
+    assert_eq!(g.duplicated_changed_lines, 3);
+    assert_eq!(g.diff_pct, 100.0);
+    // 100% > 50% budget => fail.
+    assert!(!g.pass);
+}
+
+#[test]
+fn diff_gate_partial_overlap() {
+    // Clone at rows 10..=15 covers 1-indexed lines 11..=16. Changed lines are
+    // 11,12,16,17,30: 11, 12, and 16 fall inside the clone, so 3 of 5 changed
+    // lines are duplicated => 60%.
+    let r = result(0.0, vec![group("a.rs", 10, 15)]);
+    let g = DiffGate::evaluate(
+        &r,
+        &changed(&[("a.rs", &[11, 12, 16, 17, 30])]),
+        60.0,
+        "b".into(),
+        "s".into(),
+    );
+    assert_eq!(g.changed_lines, 5);
+    assert_eq!(g.duplicated_changed_lines, 3);
+    assert!((g.diff_pct - 60.0).abs() < 1e-9);
+    // Exactly at budget passes.
+    assert!(g.pass);
+}
+
+#[test]
+fn diff_gate_ignores_clones_in_unchanged_files() {
+    // The clone is in b.rs but the change touched a.rs: nothing duplicated.
+    let r = result(0.0, vec![group("b.rs", 1, 100)]);
+    let g = DiffGate::evaluate(
+        &r,
+        &changed(&[("a.rs", &[1, 2, 3])]),
+        0.0,
+        "b".into(),
+        "s".into(),
+    );
+    assert_eq!(g.duplicated_changed_lines, 0);
+    assert_eq!(g.diff_pct, 0.0);
+    assert!(g.pass);
+}
+
+#[test]
+fn report_passes_only_when_all_enabled_gates_pass() {
+    let passing_global = GlobalGate {
+        duplication_pct: 1.0,
+        budget_pct: 2.0,
+        pass: true,
+    };
+    let failing_diff = DiffGate {
+        diff_pct: 90.0,
+        budget_pct: 10.0,
+        pass: false,
+        base: "b".into(),
+        base_sha: "s".into(),
+        changed_lines: 10,
+        duplicated_changed_lines: 9,
+    };
+
+    // No gates: nothing to fail.
+    assert!(
+        GateReport {
+            global: None,
+            diff: None,
+        }
+        .passed()
+    );
+    // One gate passes.
+    assert!(
+        GateReport {
+            global: Some(passing_global.clone()),
+            diff: None,
+        }
+        .passed()
+    );
+    // A failing diff gate sinks the report even when global passes.
+    assert!(
+        !GateReport {
+            global: Some(passing_global),
+            diff: Some(failing_diff),
+        }
+        .passed()
+    );
+}

--- a/packages/code/clone-detect/cli/src/main.rs
+++ b/packages/code/clone-detect/cli/src/main.rs
@@ -1,11 +1,18 @@
 mod badge;
+mod diff;
 mod filter;
+mod gate;
 
-use std::{io::Write, path::PathBuf};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 use clap::Parser;
 use clone_detect::{DetectConfig, DetectionResult, instances};
 use clone_scanner::{Config, Scanner};
+use gate::{DiffGate, GateReport, GlobalGate};
+use serde_json::Value;
 use snafu::ResultExt as _;
 
 /// Config file name discovered by walking up from the scan target directory.
@@ -46,6 +53,22 @@ struct Args {
     /// Write an SVG duplication badge to this path
     #[arg(long)]
     badge: Option<PathBuf>,
+
+    /// Fail if whole-scan `duplication_pct` exceeds this percentage. Overrides
+    /// `[budget] global_pct`.
+    #[arg(long)]
+    max_global_pct: Option<f64>,
+
+    /// Enable the diff gate against a git base rev (default resolution:
+    /// `[budget] diff_base`, else `origin/main`). Fails if duplication over the
+    /// lines changed since the merge base exceeds `--max-diff-pct`.
+    #[arg(long, value_name = "BASE")]
+    diff: Option<Option<String>>,
+
+    /// Fail if duplication over changed lines exceeds this percentage.
+    /// Overrides `[budget] diff_pct`. Only meaningful with `--diff`.
+    #[arg(long)]
+    max_diff_pct: Option<f64>,
 }
 
 /// Project-level configuration loaded from `clone.toml`.
@@ -60,6 +83,19 @@ struct FileConfig {
     window_size: Option<usize>,
     pretty: Option<bool>,
     ignore: Option<Vec<String>>,
+    budget: Option<BudgetConfig>,
+}
+
+/// The `[budget]` table: duplication ceilings for the gates.
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BudgetConfig {
+    /// Ceiling for whole-scan `duplication_pct`.
+    global_pct: Option<f64>,
+    /// Ceiling for duplication over changed lines (diff gate).
+    diff_pct: Option<f64>,
+    /// Default base rev for the diff gate (e.g. `origin/main`).
+    diff_base: Option<String>,
 }
 
 /// Resolved configuration after merging CLI flags over file config over defaults.
@@ -72,12 +108,30 @@ struct ResolvedConfig {
     window_size: usize,
     pretty: bool,
     ignore: Vec<String>,
+    /// Whole-scan `duplication_pct` ceiling. Defaults to `0.0`, which reproduces
+    /// the legacy "any surviving clone fails" behavior when no budget is set.
+    global_pct: f64,
+    /// The resolved diff gate, or `None` when `--diff` was not passed.
+    diff: Option<DiffGateConfig>,
+}
+
+/// Diff gate parameters, present only when the gate is enabled.
+struct DiffGateConfig {
+    base: String,
+    budget_pct: f64,
 }
 
 const DEFAULT_MIN_LINES: usize = 5;
 const DEFAULT_MIN_NODES: usize = 10;
 const DEFAULT_THRESHOLD: f64 = 0.7;
 const DEFAULT_WINDOW_SIZE: usize = 3;
+/// Legacy behavior: with no budget configured, any surviving clone fails the
+/// global gate, i.e. a ceiling of zero duplication.
+const DEFAULT_GLOBAL_PCT: f64 = 0.0;
+/// Diff gate default ceiling: no duplication allowed on changed lines.
+const DEFAULT_DIFF_PCT: f64 = 0.0;
+/// Diff gate default base rev when neither the flag nor config specifies one.
+const DEFAULT_DIFF_BASE: &str = "origin/main";
 
 #[derive(Debug, snafu::Snafu)]
 enum RunError {
@@ -116,6 +170,9 @@ enum RunError {
 
     #[snafu(display("path is not valid UTF-8: {}", path.display()))]
     NonUtf8Path { path: PathBuf },
+
+    #[snafu(display("diff gate could not read git history"))]
+    Diff { source: diff::DiffError },
 }
 
 /// Install a tracing subscriber reading filter directives from `RUST_LOG`
@@ -140,8 +197,8 @@ fn main() -> std::process::ExitCode {
     init_tracing();
 
     match run() {
-        Ok(has_clones) => {
-            if has_clones {
+        Ok(gate_failed) => {
+            if gate_failed {
                 std::process::ExitCode::FAILURE
             } else {
                 std::process::ExitCode::SUCCESS
@@ -184,18 +241,94 @@ fn run() -> Result<bool, RunError> {
             .iter()
             .map(|p| glob::Pattern::new(p).context(BadGlobSnafu { pattern: p.clone() }))
             .collect::<Result<_, _>>()?;
-        result = filter::by_patterns(result, &patterns)?;
+        result = filter::by_patterns(result, &scan, &patterns)?;
     }
 
-    let has_clones = !result.instances.is_empty();
+    let report = evaluate_gates(&result, &config, &args.path)?;
 
-    output_json(&result, config.pretty)?;
+    output_json(&result, &report, config.pretty)?;
 
     if let Some(badge_path) = &args.badge {
         badge::write(badge_path, result.stats.duplication_pct)?;
     }
 
-    Ok(has_clones)
+    // The run "fails" (exit FAILURE) iff any enabled gate failed.
+    Ok(!report.passed())
+}
+
+/// Evaluate the enabled gates and emit a one-line human summary per gate to
+/// stderr via tracing.
+fn evaluate_gates(
+    result: &DetectionResult,
+    config: &ResolvedConfig,
+    scan_path: &std::path::Path,
+) -> Result<GateReport, RunError> {
+    let global = GlobalGate::evaluate(result, config.global_pct);
+    log_gate(
+        "global",
+        global.pass,
+        global.duplication_pct,
+        global.budget_pct,
+    );
+
+    // Git runs relative to the scanned tree: a file target anchors on its parent
+    // directory, a directory target on itself. This is what makes `--diff` work
+    // when the scan path is not the process's working directory.
+    let repo_dir: PathBuf = if scan_path.is_file() {
+        scan_path
+            .parent()
+            .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
+    } else {
+        scan_path.to_path_buf()
+    };
+
+    let diff = config
+        .diff
+        .as_ref()
+        .map(|cfg| {
+            let (base_sha, changed) =
+                diff::changed_lines(&repo_dir, &cfg.base).context(DiffSnafu)?;
+            let gate =
+                DiffGate::evaluate(result, &changed, cfg.budget_pct, cfg.base.clone(), base_sha);
+            log_diff_gate(&gate);
+            Ok(gate)
+        })
+        .transpose()?;
+
+    Ok(GateReport {
+        global: Some(global),
+        diff,
+    })
+}
+
+/// One-line pass/fail summary for a simple metric-vs-budget gate.
+fn log_gate(name: &str, pass: bool, metric: f64, budget: f64) {
+    let verdict = if pass { "PASS" } else { "FAIL" };
+    tracing::info!(gate = name, %verdict, metric_pct = metric, budget_pct = budget, "clone {name} gate {verdict}: {metric:.4}% <= {budget:.4}%? {pass}");
+}
+
+/// One-line summary for the diff gate, including the resolved base and changed-
+/// line counts.
+fn log_diff_gate(gate: &DiffGate) {
+    let verdict = if gate.pass { "PASS" } else { "FAIL" };
+    tracing::info!(
+        gate = "diff",
+        %verdict,
+        base = gate.base,
+        base_sha = gate.base_sha,
+        diff_pct = gate.diff_pct,
+        budget_pct = gate.budget_pct,
+        duplicated = gate.duplicated_changed_lines,
+        changed = gate.changed_lines,
+        "clone diff gate {verdict}: {dup}/{tot} changed lines duplicated = {pct:.4}% <= {budget:.4}%? {pass} (base {base}@{sha})",
+        dup = gate.duplicated_changed_lines,
+        tot = gate.changed_lines,
+        pct = gate.diff_pct,
+        budget = gate.budget_pct,
+        pass = gate.pass,
+        base = gate.base,
+        sha = &gate.base_sha,
+    );
 }
 
 /// Walk up from `start` looking for `clone.toml`. Returns `None` if not found.
@@ -239,10 +372,33 @@ fn resolve_config(args: &Args, file: Option<FileConfig>) -> ResolvedConfig {
         window_size: None,
         pretty: None,
         ignore: None,
+        budget: None,
     });
 
     let mut ignore = file.ignore.unwrap_or_default();
     ignore.extend(args.ignore.iter().cloned());
+
+    let budget = file.budget.unwrap_or_default();
+
+    // Global gate: CLI > `[budget] global_pct` > 0.0 (legacy any-clone-fails).
+    let global_pct = args
+        .max_global_pct
+        .or(budget.global_pct)
+        .unwrap_or(DEFAULT_GLOBAL_PCT);
+
+    // Diff gate is opt-in at invocation. When enabled, the base is the flag's
+    // argument, else `[budget] diff_base`, else `origin/main`; the budget is the
+    // flag, else `[budget] diff_pct`, else 0.0.
+    let diff = args.diff.as_ref().map(|flag_base| DiffGateConfig {
+        base: flag_base
+            .clone()
+            .or_else(|| budget.diff_base.clone())
+            .unwrap_or_else(|| DEFAULT_DIFF_BASE.to_owned()),
+        budget_pct: args
+            .max_diff_pct
+            .or(budget.diff_pct)
+            .unwrap_or(DEFAULT_DIFF_PCT),
+    });
 
     ResolvedConfig {
         min_lines: args
@@ -265,15 +421,39 @@ fn resolve_config(args: &Args, file: Option<FileConfig>) -> ResolvedConfig {
             .unwrap_or(DEFAULT_WINDOW_SIZE),
         pretty: args.pretty || file.pretty.unwrap_or(false),
         ignore,
+        global_pct,
+        diff,
     }
 }
 
-fn output_json(result: &DetectionResult, pretty: bool) -> Result<(), RunError> {
+/// Emit the detection result plus a `gate` object reporting each enabled gate.
+/// The result and report serialize independently, then merge into one object so
+/// the existing `instances`/`stats` schema is untouched and `gate` is additive.
+fn output_json(
+    result: &DetectionResult,
+    report: &GateReport,
+    pretty: bool,
+) -> Result<(), RunError> {
+    let value = serde_json::to_value(result).context(JsonWriteSnafu)?;
+    let gate = serde_json::to_value(report).context(JsonWriteSnafu)?;
+
+    // `DetectionResult` is a struct, so serde always yields a JSON object; a
+    // non-object would mean the type changed shape, hence the explicit expect.
+    let Value::Object(mut object) = value else {
+        return Err(RunError::JsonWrite {
+            source: <serde_json::Error as serde::ser::Error>::custom(
+                "detection result did not serialize to an object",
+            ),
+        });
+    };
+    object.insert("gate".to_owned(), gate);
+    let merged = Value::Object(object);
+
     let mut stdout = std::io::stdout().lock();
     if pretty {
-        serde_json::to_writer_pretty(&mut stdout, result).context(JsonWriteSnafu)?;
+        serde_json::to_writer_pretty(&mut stdout, &merged).context(JsonWriteSnafu)?;
     } else {
-        serde_json::to_writer(&mut stdout, result).context(JsonWriteSnafu)?;
+        serde_json::to_writer(&mut stdout, &merged).context(JsonWriteSnafu)?;
     }
     writeln!(stdout).context(StdoutWriteSnafu)?;
     Ok(())

--- a/packages/code/clone-detect/cli/src/main.rs
+++ b/packages/code/clone-detect/cli/src/main.rs
@@ -62,6 +62,13 @@ struct Args {
     /// Enable the diff gate against a git base rev (default resolution:
     /// `[budget] diff_base`, else `origin/main`). Fails if duplication over the
     /// lines changed since the merge base exceeds `--max-diff-pct`.
+    // `Option<Option<T>>` is clap's idiom for an optional flag with an optional
+    // value: outer `None` = flag absent (gate off), `Some(None)` = `--diff` with
+    // no base (resolve from config/default), `Some(Some(b))` = `--diff b`.
+    #[expect(
+        clippy::option_option,
+        reason = "clap encodes flag-present-vs-value-present as Option<Option<_>>"
+    )]
     #[arg(long, value_name = "BASE")]
     diff: Option<Option<String>>,
 
@@ -286,10 +293,14 @@ fn evaluate_gates(
         .diff
         .as_ref()
         .map(|cfg| {
-            let (base_sha, changed) =
-                diff::changed_lines(&repo_dir, &cfg.base).context(DiffSnafu)?;
-            let gate =
-                DiffGate::evaluate(result, &changed, cfg.budget_pct, cfg.base.clone(), base_sha);
+            let diff = diff::changed_lines(&repo_dir, &cfg.base).context(DiffSnafu)?;
+            let gate = DiffGate::evaluate(
+                result,
+                &diff.changed,
+                cfg.budget_pct,
+                cfg.base.clone(),
+                diff.base_sha,
+            );
             log_diff_gate(&gate);
             Ok(gate)
         })

--- a/packages/code/clone-detect/cli/tests/diff_gate.rs
+++ b/packages/code/clone-detect/cli/tests/diff_gate.rs
@@ -57,9 +57,15 @@ fn git(dir: &Path, args: &[&str]) -> Output {
     output
 }
 
+/// The parsed result of a `clone` invocation.
+struct CloneRun {
+    json: Value,
+    success: bool,
+}
+
 /// Run the `clone` binary in `dir` with the given args, returning parsed JSON
 /// stdout and the exit success flag.
-fn run_clone(dir: &Path, args: &[&str]) -> (Value, bool) {
+fn run_clone(dir: &Path, args: &[&str]) -> CloneRun {
     let output = Command::new(env!("CARGO_BIN_EXE_clone"))
         .current_dir(dir)
         .args(args)
@@ -68,7 +74,10 @@ fn run_clone(dir: &Path, args: &[&str]) -> (Value, bool) {
     let stdout = String::from_utf8(output.stdout).expect("clone stdout is UTF-8");
     let json: Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|e| panic!("clone stdout is not JSON ({e}): {stdout}"));
-    (json, output.status.success())
+    CloneRun {
+        json,
+        success: output.status.success(),
+    }
 }
 
 #[test]
@@ -97,7 +106,8 @@ fn diff_gate_fails_on_duplicated_change_while_global_passes() {
     // Global budget is permissive (100%), diff budget is 0%. Diff base is HEAD:
     // merge-base(HEAD, HEAD) == HEAD, so the diff is HEAD-tree vs the worktree,
     // i.e. the uncommitted duplicate.
-    let (json, success) = run_clone(dir, &["--diff", "HEAD", ".", "--pretty"]);
+    let run = run_clone(dir, &["--diff", "HEAD", ".", "--pretty"]);
+    let json = &run.json;
 
     let global = &json["gate"]["global"];
     assert_eq!(
@@ -120,7 +130,10 @@ fn diff_gate_fails_on_duplicated_change_while_global_passes() {
     );
 
     // Exit code follows the worst gate: a failing diff gate means failure.
-    assert!(!success, "clone should exit nonzero when the diff gate fails");
+    assert!(
+        !run.success,
+        "clone should exit nonzero when the diff gate fails"
+    );
 }
 
 #[test]
@@ -147,13 +160,14 @@ fn diff_gate_passes_when_change_is_not_duplicated() {
     )
     .unwrap();
 
-    let (json, success) = run_clone(dir, &["--diff", "HEAD", "."]);
+    let run = run_clone(dir, &["--diff", "HEAD", "."]);
+    let json = &run.json;
     assert_eq!(
         json["gate"]["diff"]["pass"],
         Value::Bool(true),
         "diff gate should pass when the change is not duplicated: {json:#}"
     );
-    assert!(success, "clone should exit zero when all gates pass");
+    assert!(run.success, "clone should exit zero when all gates pass");
 }
 
 #[test]

--- a/packages/code/clone-detect/cli/tests/diff_gate.rs
+++ b/packages/code/clone-detect/cli/tests/diff_gate.rs
@@ -1,0 +1,185 @@
+//! End-to-end diff gate: build a temp git repo, commit a base, add a function
+//! that duplicates an existing one, and assert the diff gate fails (the added
+//! lines are all duplicated) while a permissive global budget passes.
+
+use std::{
+    path::Path,
+    process::{Command, Output},
+};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// A Rust function large enough to clear the default `min_lines`/`min_nodes`
+/// clone thresholds.
+const ORIGINAL: &str = "\
+fn alpha(input: i64) -> i64 {
+    let mut total = 0;
+    for step in 0..input {
+        total += step * 2;
+        total -= 1;
+    }
+    total + 42
+}
+";
+
+/// A byte-for-byte-structural duplicate under a different name: a Type-2 clone
+/// of `ORIGINAL` (identical modulo the identifiers), so its lines land in a
+/// clone group.
+const DUPLICATE: &str = "\
+fn beta(value: i64) -> i64 {
+    let mut sum = 0;
+    for count in 0..value {
+        sum += count * 2;
+        sum -= 1;
+    }
+    sum + 42
+}
+";
+
+fn git(dir: &Path, args: &[&str]) -> Output {
+    let output = Command::new("git")
+        .current_dir(dir)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .args(args)
+        .output()
+        .expect("git should run");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+/// Run the `clone` binary in `dir` with the given args, returning parsed JSON
+/// stdout and the exit success flag.
+fn run_clone(dir: &Path, args: &[&str]) -> (Value, bool) {
+    let output = Command::new(env!("CARGO_BIN_EXE_clone"))
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("clone binary should run");
+    let stdout = String::from_utf8(output.stdout).expect("clone stdout is UTF-8");
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("clone stdout is not JSON ({e}): {stdout}"));
+    (json, output.status.success())
+}
+
+#[test]
+fn diff_gate_fails_on_duplicated_change_while_global_passes() {
+    let repo = TempDir::new().expect("tempdir");
+    let dir = repo.path();
+
+    // A clone.toml that lowers the thresholds enough for the small fixtures to
+    // register as clones, and does not ignore the source files.
+    std::fs::write(
+        dir.join("clone.toml"),
+        "min_lines = 3\nmin_nodes = 5\n[budget]\nglobal_pct = 100.0\ndiff_pct = 0.0\n",
+    )
+    .unwrap();
+
+    git(dir, &["init", "-q"]);
+    // Base commit: one function, no duplication yet.
+    std::fs::write(dir.join("original.rs"), ORIGINAL).unwrap();
+    git(dir, &["add", "-A"]);
+    git(dir, &["commit", "-qm", "base"]);
+
+    // The change under test: add a duplicate function in a new file. Its lines
+    // are all "changed" (added) and all part of a clone group.
+    std::fs::write(dir.join("duplicate.rs"), DUPLICATE).unwrap();
+
+    // Global budget is permissive (100%), diff budget is 0%. Diff base is HEAD:
+    // merge-base(HEAD, HEAD) == HEAD, so the diff is HEAD-tree vs the worktree,
+    // i.e. the uncommitted duplicate.
+    let (json, success) = run_clone(dir, &["--diff", "HEAD", ".", "--pretty"]);
+
+    let global = &json["gate"]["global"];
+    assert_eq!(
+        global["pass"], Value::Bool(true),
+        "global gate should pass under a 100% budget: {json:#}"
+    );
+
+    let diff = &json["gate"]["diff"];
+    assert_eq!(
+        diff["pass"], Value::Bool(false),
+        "diff gate should fail: the added function duplicates the base: {json:#}"
+    );
+    assert!(
+        diff["changed_lines"].as_u64().unwrap() > 0,
+        "the added file must contribute changed lines: {json:#}"
+    );
+    assert!(
+        diff["duplicated_changed_lines"].as_u64().unwrap() > 0,
+        "the added duplicate must cover some changed lines: {json:#}"
+    );
+
+    // Exit code follows the worst gate: a failing diff gate means failure.
+    assert!(!success, "clone should exit nonzero when the diff gate fails");
+}
+
+#[test]
+fn diff_gate_passes_when_change_is_not_duplicated() {
+    let repo = TempDir::new().expect("tempdir");
+    let dir = repo.path();
+
+    std::fs::write(
+        dir.join("clone.toml"),
+        "min_lines = 3\nmin_nodes = 5\n[budget]\nglobal_pct = 100.0\ndiff_pct = 0.0\n",
+    )
+    .unwrap();
+
+    git(dir, &["init", "-q"]);
+    std::fs::write(dir.join("original.rs"), ORIGINAL).unwrap();
+    git(dir, &["add", "-A"]);
+    git(dir, &["commit", "-qm", "base"]);
+
+    // Add a unique, non-duplicated function: its changed lines are not covered
+    // by any clone, so the diff gate passes even at a 0% budget.
+    std::fs::write(
+        dir.join("unique.rs"),
+        "fn gamma() -> &'static str {\n    \"a wholly unique body\"\n}\n",
+    )
+    .unwrap();
+
+    let (json, success) = run_clone(dir, &["--diff", "HEAD", "."]);
+    assert_eq!(
+        json["gate"]["diff"]["pass"],
+        Value::Bool(true),
+        "diff gate should pass when the change is not duplicated: {json:#}"
+    );
+    assert!(success, "clone should exit zero when all gates pass");
+}
+
+#[test]
+fn diff_gate_fails_loudly_on_unknown_base() {
+    let repo = TempDir::new().expect("tempdir");
+    let dir = repo.path();
+
+    std::fs::write(dir.join("clone.toml"), "min_lines = 3\nmin_nodes = 5\n").unwrap();
+    git(dir, &["init", "-q"]);
+    std::fs::write(dir.join("original.rs"), ORIGINAL).unwrap();
+    git(dir, &["add", "-A"]);
+    git(dir, &["commit", "-qm", "base"]);
+
+    // A base rev that does not exist must fail the run, never silently skip.
+    let output = Command::new(env!("CARGO_BIN_EXE_clone"))
+        .current_dir(dir)
+        .args(["--diff", "definitely-not-a-real-ref", "."])
+        .output()
+        .expect("clone binary should run");
+    assert!(
+        !output.status.success(),
+        "clone must exit nonzero when the diff base is unknown"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("merge base") || stderr.contains("definitely-not-a-real-ref"),
+        "error should name the missing base: {stderr}"
+    );
+}

--- a/packages/code/clone-detect/cli/tests/ignore_pct.rs
+++ b/packages/code/clone-detect/cli/tests/ignore_pct.rs
@@ -1,0 +1,67 @@
+//! An ignore glob must lower `duplication_pct`: the CLI recomputes stats over
+//! the surviving (gated) code after filtering, so ignoring a duplicated file
+//! removes both its duplicated lines and its lines from the denominator.
+
+use std::{path::Path, process::Command};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// A function body large enough to clear the default clone thresholds.
+fn func(name: &str) -> String {
+    format!(
+        "fn {name}(input: i64) -> i64 {{\n    let mut total = 0;\n    for step in 0..input {{\n        total += step * 2;\n        total -= 1;\n    }}\n    total + 42\n}}\n"
+    )
+}
+
+fn duplication_pct(dir: &Path, extra_args: &[&str]) -> f64 {
+    let mut args = vec!["--pretty", "."];
+    args.extend_from_slice(extra_args);
+    let output = Command::new(env!("CARGO_BIN_EXE_clone"))
+        .current_dir(dir)
+        .args(&args)
+        .output()
+        .expect("clone binary should run");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not JSON ({e}): {stdout}"));
+    json["stats"]["duplication_pct"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("no duplication_pct in {json:#}"))
+}
+
+#[test]
+fn ignore_glob_lowers_duplication_pct() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path();
+
+    // Three files: a.rs and b.rs are structural duplicates (a clone), c.rs is a
+    // duplicate pair too but lives under a `generated/` subtree we will ignore.
+    std::fs::write(path.join("a.rs"), func("alpha")).unwrap();
+    std::fs::write(path.join("b.rs"), func("beta")).unwrap();
+    std::fs::create_dir(path.join("generated")).unwrap();
+    std::fs::write(path.join("generated").join("g1.rs"), func("gen_one")).unwrap();
+    std::fs::write(path.join("generated").join("g2.rs"), func("gen_two")).unwrap();
+
+    // A permissive global budget so the run exits 0 and we can read the number.
+    std::fs::write(
+        path.join("clone.toml"),
+        "min_lines = 3\nmin_nodes = 5\n[budget]\nglobal_pct = 100.0\n",
+    )
+    .unwrap();
+
+    let without_ignore = duplication_pct(path, &[]);
+    // Ignoring the generated subtree drops those duplicated lines AND their
+    // lines from the denominator, so the metric must strictly decrease.
+    let with_ignore = duplication_pct(path, &["--ignore", "*/generated/*"]);
+
+    assert!(
+        without_ignore > 0.0,
+        "baseline should detect duplication: {without_ignore}"
+    );
+    assert!(
+        with_ignore < without_ignore,
+        "ignoring a duplicated subtree must lower duplication_pct: \
+         without={without_ignore} with={with_ignore}"
+    );
+}


### PR DESCRIPTION
Adds budget-based gating to the `clone` CLI so it can gate `.#lint` without failing on every pre-existing clone, and wires a `clone` stage into the lint DAG.

Fixes #1930

## Gates

Two independent gates (`packages/code/clone-detect/cli/src/gate.rs`), each "metric must be `<=` its ceiling"; equal passes; the run exits `FAILURE` iff any enabled gate fails.

- **global** (always on): whole-scan `duplication_pct` vs `--max-global-pct` > `[budget] global_pct` > `0.0`. The `0.0` default reproduces the legacy "any clone fails" behavior, so nothing changes for a repo with no `[budget]`.
- **diff** (opt-in, `--diff [BASE]`): duplication over lines changed since `merge-base(base, HEAD)`, taken against the working tree so uncommitted and untracked edits count (`cli/src/diff.rs`). `diff_pct = 100 * duplicated changed / total changed` (`0` when nothing changed). Base is `--diff` arg > `[budget] diff_base` > `origin/main`; ceiling is `--max-diff-pct` > `[budget] diff_pct` > `0.0`. Missing git or an unknown base fails loudly, never skips.

The JSON output gains a `gate` object (per gate: value, budget, pass; diff adds resolved base sha and changed-line counts). Each gate logs a one-line PASS/FAIL to stderr.

## Stats fix

`filter::by_patterns` previously copied pre-filter `duplication_pct` verbatim, so ignore globs did not move the number the gate keys on. It now recomputes duplicated lines from surviving groups and excludes ignored files from the denominator, so the metric reads as "duplication among gated code". This drops the measured baseline from 1.055% to **0.729%**.

## Lint wiring

`clone` is added to `lintStages` with a `def "main clone"` running the global gate (`clone .`). Only the global gate runs in lint: the CI lint derivation copies a `.git`-less source tree, so the diff gate cannot run there. `repoPackages.clone` is added to the lint-stage runtime inputs. The root `clone.toml` sets `[budget] global_pct = 0.8` as a ratchet (baseline 0.729 + headroom; lower as duplication is removed, do not raise without justification).

## Validation

- `nix run .#lint` green locally with the new clone stage (0.7s).
- `nix build .#checks.aarch64-darwin` lint derivation builds without `.git`.
- clone-cli unit + integration tests pass (diff hunk parsing, gate math edge cases, an end-to-end diff-gate repo, an ignore-glob-lowers-pct check).
- `clone .` exits 0 under the budget; `clone --diff origin/main .` reports 0/1441 changed lines duplicated.
- x86 clippy validated on a linux builder (darwin cannot build the Linux-only clippy gate natively).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add global and diff budget gates to clone-detect CLI and wire into lint stage
> - Adds a `gate` module with `GlobalGate` and `DiffGate` that evaluate duplication budgets; results are serialized under a new top-level `gate` key in the JSON output.
> - Adds `--max-global-pct`, `--diff [BASE]`, and `--max-diff-pct` CLI flags; budgets can also be set in a new `[budget]` section in [clone.toml](https://github.com/indexable-inc/index/pull/1932/files#diff-71d9798ec940a623c1ae0813b562b8a292318681adc4a729e6243e6be7e59385) with defined CLI > config precedence.
> - `DiffGate` computes changed lines via git (including untracked files) relative to a merge-base, implemented in the new [diff.rs](https://github.com/indexable-inc/index/pull/1932/files#diff-d42fbec6eb6ca0e600b5900c2b65bbd505562ec213078592634988ccf79dab36) module.
> - Fixes ignored-file accounting in `filter::by_patterns` so `duplication_pct` is recomputed over non-ignored files only.
> - Wires `clone` into the Nix lint stage in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/1932/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) so the stage fails when the global gate fails.
> - Behavioral Change: exit code semantics change from
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b2fa75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->