### PR TITLE
clone-detect: Type-3 overlap metric + threshold-derived LSH banding

### DIFF
--- a/doc/clone-detect/overview.md
+++ b/doc/clone-detect/overview.md
@@ -85,23 +85,30 @@ skipping symlinks/non-UTF-8/`ignore-file` files, and collecting
   fully covered by Type-1 (`detector.rs:38-62`).
 - **Type-3** (`--type3`, `detect/src/type3.rs`): per node-kind, dedup by
   normalized hash, build a MinHash signature over `subtree_features`, bucket
-  with LSH (`lsh.rs`), pre-filter candidate pairs by estimated Jaccard, then
-  confirm with multiset Jaccard against `type3_threshold` (default `0.7`).
+  with LSH (`lsh.rs`; bands x rows are derived from the threshold so the
+  S-curve inflection sits just below it — a fixed banding silently drops every
+  pair under its inflection), pre-filter candidate pairs by the estimated
+  metric, then confirm against `type3_threshold` (default `0.7`) with the
+  configured `type3_metric` (`jaccard.rs`): `jaccard` (default,
+  `|A∩B| / |A∪B|`) or `overlap` (containment, `|A∩B| / min(|A|,|B|)`), which
+  catches copy-then-insert clones Jaccard misses but also nets structural
+  boilerplate, so pair it with a higher threshold (`>= 0.8`).
   `rayon`-parallel across kinds.
 - **Sequence** (`--sequences`, `sequences.rs`): sliding window of statements.
 - `dedup_subsumed` drops groups whose fragments are byte-range contained in a
   larger group (e.g. a function and its block, `detector.rs:139-202`).
 
-`DetectionResult` (`types.rs:65-84`) is `{ instances: Vec<CloneGroup>, stats }`;
-`Kind` is `Type1 | Type2 | Type3 { similarity } | Sequence { statements }`;
+`DetectionResult` (`types.rs`) is `{ instances: Vec<CloneGroup>, stats }`;
+`Kind` is `Type1 | Type2 | Type3 { similarity, metric } | Sequence
+{ statements }` (`metric` labels which similarity the score means);
 `stats.duplication_pct` is deduplicated duplicated lines over total lines. All
 types are `serde`-serializable (the JSON output schema).
 
 ## cli (`clone`) config and flags
 
-Flags (`cli/src/main.rs`): `[PATH]` (default `.`), `--type3`, `--threshold`,
-`--min-lines`, `--min-nodes`, `--sequences`, `--window-size`, `--ignore`
-(repeatable glob), `--pretty`, `--badge PATH`, plus the gate flags
+Flags (`cli/src/main.rs`): `[PATH]` (default `.`), `--type3`, `--type3-metric`,
+`--threshold`, `--min-lines`, `--min-nodes`, `--sequences`, `--window-size`,
+`--ignore` (repeatable glob), `--pretty`, `--badge PATH`, plus the gate flags
 `--max-global-pct`, `--max-diff-pct`, and `--diff [BASE]` (see [Gates](#gates)).
 `clone.toml` mirrors these keys (`FileConfig`) and adds a `[budget]` table; CLI
 flags win, booleans OR, ignore lists concatenate (`resolve_config`). The repo's

--- a/packages/code/clone-detect/cli/src/main.rs
+++ b/packages/code/clone-detect/cli/src/main.rs
@@ -8,8 +8,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use clap::Parser;
-use clone_detect::{DetectConfig, DetectionResult, instances};
+use clap::{Parser, ValueEnum};
+use clone_detect::{DetectConfig, DetectionResult, Type3Metric, instances};
 use clone_scanner::{Config, Scanner};
 use gate::{DiffGate, GateReport, GlobalGate};
 use serde_json::Value;
@@ -17,6 +17,23 @@ use snafu::ResultExt as _;
 
 /// Config file name discovered by walking up from the scan target directory.
 const CONFIG_FILENAME: &str = "clone.toml";
+
+/// CLI/config spelling of the Type-3 metric, mapped to [`Type3Metric`].
+#[derive(Debug, Clone, Copy, ValueEnum, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum MetricArg {
+    Jaccard,
+    Overlap,
+}
+
+impl From<MetricArg> for Type3Metric {
+    fn from(m: MetricArg) -> Self {
+        match m {
+            MetricArg::Jaccard => Self::Jaccard,
+            MetricArg::Overlap => Self::Overlap,
+        }
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "clone", version, about)]
@@ -26,6 +43,12 @@ struct Args {
 
     #[arg(long)]
     type3: bool,
+
+    /// Type-3 confirmation metric: `jaccard` (symmetric, precise; default) or
+    /// `overlap` (containment: catches copy-then-insert clones but also nets
+    /// boilerplate, so pair it with a higher threshold).
+    #[arg(long, value_enum)]
+    type3_metric: Option<MetricArg>,
 
     #[arg(long)]
     threshold: Option<f64>,
@@ -86,6 +109,7 @@ struct FileConfig {
     min_nodes: Option<usize>,
     threshold: Option<f64>,
     type3: Option<bool>,
+    type3_metric: Option<MetricArg>,
     sequences: Option<bool>,
     window_size: Option<usize>,
     pretty: Option<bool>,
@@ -111,6 +135,7 @@ struct ResolvedConfig {
     min_nodes: usize,
     threshold: f64,
     type3: bool,
+    type3_metric: Type3Metric,
     sequences: bool,
     window_size: usize,
     pretty: bool,
@@ -236,6 +261,7 @@ fn run() -> Result<bool, RunError> {
     let detect_config = DetectConfig {
         enable_type3: config.type3,
         type3_threshold: config.threshold,
+        type3_metric: config.type3_metric,
         enable_sequences: config.sequences,
         sequence_window_size: config.window_size,
     };
@@ -379,6 +405,7 @@ fn resolve_config(args: &Args, file: Option<FileConfig>) -> ResolvedConfig {
         min_nodes: None,
         threshold: None,
         type3: None,
+        type3_metric: None,
         sequences: None,
         window_size: None,
         pretty: None,
@@ -425,6 +452,10 @@ fn resolve_config(args: &Args, file: Option<FileConfig>) -> ResolvedConfig {
             .or(file.threshold)
             .unwrap_or(DEFAULT_THRESHOLD),
         type3: args.type3 || file.type3.unwrap_or(false),
+        type3_metric: args
+            .type3_metric
+            .or(file.type3_metric)
+            .map_or_else(Type3Metric::default, Type3Metric::from),
         sequences: args.sequences || file.sequences.unwrap_or(false),
         window_size: args
             .window_size

--- a/packages/code/clone-detect/detect/src/detector.rs
+++ b/packages/code/clone-detect/detect/src/detector.rs
@@ -62,7 +62,7 @@ pub fn instances(scan: &Output, config: &DetectConfig) -> DetectionResult {
     }
 
     let type3_groups = if config.enable_type3 {
-        find(scan, config.type3_threshold)
+        find(scan, config.type3_threshold, config.type3_metric)
     } else {
         Vec::new()
     };
@@ -146,9 +146,35 @@ fn dedup_subsumed(groups: &mut Vec<CloneGroup>) {
     // are checked as potential containers before inner groups.
     groups.sort_by_key(|g| std::cmp::Reverse(total_byte_span(g)));
 
+    // Intern file paths to integer ids up front: the O(n^2) subsumption scan
+    // below compares fragment files pairwise, and `PathBuf` equality re-walks
+    // path components each time — profiling showed it dominating whole-repo
+    // runs once Type-3 group counts reach the thousands. With interned ids,
+    // each comparison is a single integer branch.
+    let keys: Vec<Vec<FragKey>> = {
+        let mut path_ids: FxHashMap<&PathBuf, usize> = FxHashMap::default();
+        groups
+            .iter()
+            .map(|group| {
+                group
+                    .fragments
+                    .iter()
+                    .map(|frag| {
+                        let next = path_ids.len();
+                        FragKey {
+                            file_id: *path_ids.entry(&frag.file).or_insert(next),
+                            start: frag.byte_range.start,
+                            end: frag.byte_range.end,
+                        }
+                    })
+                    .collect()
+            })
+            .collect()
+    };
+
     let mut subsumed = vec![false; n];
 
-    for i in 0..n {
+    for (i, outer) in keys.iter().enumerate() {
         let Some(&already) = subsumed.get(i) else {
             break;
         };
@@ -156,21 +182,13 @@ fn dedup_subsumed(groups: &mut Vec<CloneGroup>) {
             continue;
         }
 
-        let Some(outer) = groups.get(i) else {
-            break;
-        };
-
-        for j in (i + 1)..n {
+        for (j, inner) in keys.iter().enumerate().skip(i + 1) {
             let Some(&already_j) = subsumed.get(j) else {
                 break;
             };
             if already_j {
                 continue;
             }
-
-            let Some(inner) = groups.get(j) else {
-                break;
-            };
 
             if is_subsumed_by(inner, outer)
                 && let Some(flag) = subsumed.get_mut(j)
@@ -189,14 +207,23 @@ fn dedup_subsumed(groups: &mut Vec<CloneGroup>) {
     *groups = kept;
 }
 
+/// A fragment reduced to integers for the subsumption scan: interned file id
+/// plus byte range.
+#[derive(Clone, Copy)]
+struct FragKey {
+    file_id: usize,
+    start: usize,
+    end: usize,
+}
+
 /// Check if every fragment in `inner` is byte-range contained within
 /// some fragment of `outer` from the same file.
-fn is_subsumed_by(inner: &CloneGroup, outer: &CloneGroup) -> bool {
-    inner.fragments.iter().all(|inner_frag| {
-        outer.fragments.iter().any(|outer_frag| {
-            outer_frag.file == inner_frag.file
-                && outer_frag.byte_range.start <= inner_frag.byte_range.start
-                && outer_frag.byte_range.end >= inner_frag.byte_range.end
+fn is_subsumed_by(inner: &[FragKey], outer: &[FragKey]) -> bool {
+    inner.iter().all(|inner_frag| {
+        outer.iter().any(|outer_frag| {
+            outer_frag.file_id == inner_frag.file_id
+                && outer_frag.start <= inner_frag.start
+                && outer_frag.end >= inner_frag.end
         })
     })
 }

--- a/packages/code/clone-detect/detect/src/jaccard.rs
+++ b/packages/code/clone-detect/detect/src/jaccard.rs
@@ -4,17 +4,26 @@ struct Run {
     count: u32,
 }
 
-/// Compute exact multiset Jaccard similarity from pre-sorted feature slices.
-///
-/// Uses a two-pointer merge — zero allocation, cache-friendly O(n+m).
-#[must_use]
-pub fn multiset_sorted(a: &[u64], b: &[u64]) -> f64 {
-    debug_assert!(a.is_sorted(), "multiset_sorted: a must be sorted");
-    debug_assert!(b.is_sorted(), "multiset_sorted: b must be sorted");
+/// Multiset overlap counts from a two-pointer merge of two sorted slices.
+struct Overlap {
+    /// `|A ∩ B|` counted with multiplicity (`sum of min(count_a, count_b)`).
+    intersection: u32,
+    /// `|A ∪ B|` counted with multiplicity (`sum of max(count_a, count_b)`).
+    union: u32,
+    /// `|A|` = total element count of `a` (with multiplicity).
+    len_a: u32,
+    /// `|B|` = total element count of `b` (with multiplicity).
+    len_b: u32,
+}
 
-    if a.is_empty() && b.is_empty() {
-        return 0.0;
-    }
+/// Merge two pre-sorted multisets, accumulating intersection, union, and sizes
+/// in a single O(n+m) pass. Zero allocation, cache-friendly.
+///
+/// Every downstream similarity metric (Jaccard, overlap coefficient) is a ratio
+/// of these four counts, so we compute them once and let callers pick the ratio.
+fn merge_sorted(a: &[u64], b: &[u64]) -> Overlap {
+    debug_assert!(a.is_sorted(), "merge_sorted: a must be sorted");
+    debug_assert!(b.is_sorted(), "merge_sorted: b must be sorted");
 
     let mut intersection = 0u32;
     let mut union = 0u32;
@@ -43,7 +52,8 @@ pub fn multiset_sorted(a: &[u64], b: &[u64]) -> f64 {
         }
     }
 
-    // Remaining elements in whichever slice is not exhausted
+    // Remaining elements in whichever slice is not exhausted contribute only
+    // to the union (no counterpart to intersect with).
     while i < a.len() {
         let run = run_length(a, i);
         union += run.count;
@@ -55,17 +65,62 @@ pub fn multiset_sorted(a: &[u64], b: &[u64]) -> f64 {
         j += run.count as usize;
     }
 
-    if union == 0 {
+    // Widening to u32 is safe: AST feature counts are far below u32::MAX.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "AST feature counts are far below u32::MAX"
+    )]
+    Overlap {
+        intersection,
+        union,
+        len_a: a.len() as u32,
+        len_b: b.len() as u32,
+    }
+}
+
+/// Compute exact multiset **Jaccard** similarity from pre-sorted feature slices:
+/// `|A ∩ B| / |A ∪ B|`.
+#[must_use]
+pub fn multiset_sorted(a: &[u64], b: &[u64]) -> f64 {
+    if a.is_empty() && b.is_empty() {
         return 0.0;
     }
 
-    f64::from(intersection) / f64::from(union)
+    let o = merge_sorted(a, b);
+    if o.union == 0 {
+        return 0.0;
+    }
+    f64::from(o.intersection) / f64::from(o.union)
+}
+
+/// Compute the multiset **overlap coefficient** (containment) from pre-sorted
+/// feature slices: `|A ∩ B| / min(|A|, |B|)`.
+///
+/// Unlike Jaccard, this does not penalize size differences: if the smaller
+/// multiset is (nearly) contained in the larger one, similarity stays high.
+/// That is exactly the "copy-paste then insert/delete a few statements" case
+/// (moderately Type-3 in `BigCloneBench` terms), where symmetric Jaccard drops
+/// below threshold purely because the edited clone grew or shrank. Sherlock's
+/// N-overlap result (IEEE TC 2019) found overlap outperforms Jaccard for source
+/// similarity for this reason.
+#[must_use]
+pub fn overlap_sorted(a: &[u64], b: &[u64]) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+
+    let o = merge_sorted(a, b);
+    let min_len = o.len_a.min(o.len_b);
+    if min_len == 0 {
+        return 0.0;
+    }
+    f64::from(o.intersection) / f64::from(min_len)
 }
 
 /// Count consecutive equal elements starting at `start` in a sorted slice.
 ///
 /// Callers guarantee `start < slice.len()` (guarded by the `while i < a.len()`
-/// loop condition in `multiset_sorted`).
+/// loop condition in [`merge_sorted`]).
 #[inline]
 fn run_length(slice: &[u64], start: usize) -> Run {
     let Some(&value) = slice.get(start) else {
@@ -107,5 +162,47 @@ mod tests {
     fn empty() {
         assert!(multiset_sorted(&[], &[]).abs() < 0.001);
         assert!(multiset_sorted(&[1, 2], &[]).abs() < 0.001);
+    }
+
+    #[test]
+    fn overlap_identical() {
+        let sim = overlap_sorted(&[1, 2, 3], &[1, 2, 3]);
+        assert!((sim - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn overlap_disjoint() {
+        let sim = overlap_sorted(&[1, 2, 3], &[4, 5, 6]);
+        assert!(sim.abs() < 0.001);
+    }
+
+    #[test]
+    fn overlap_empty() {
+        assert!(overlap_sorted(&[], &[]).abs() < 0.001);
+        assert!(overlap_sorted(&[1, 2], &[]).abs() < 0.001);
+    }
+
+    /// The defining asymmetry: a small multiset fully contained in a larger one.
+    /// `A = {1,2,3}`, `B = {1,2,3,4,5,6}`. Intersection = 3.
+    /// Jaccard = 3/6 = 0.5 (penalizes the size gap); overlap = 3/min(3,6) = 1.0.
+    #[test]
+    fn overlap_beats_jaccard_on_containment() {
+        let a = [1, 2, 3];
+        let b = [1, 2, 3, 4, 5, 6];
+        let jac = multiset_sorted(&a, &b);
+        let ovl = overlap_sorted(&a, &b);
+        assert!((jac - 0.5).abs() < 0.001, "jaccard = {jac}");
+        assert!((ovl - 1.0).abs() < 0.001, "overlap = {ovl}");
+        assert!(ovl > jac, "overlap must exceed jaccard under containment");
+    }
+
+    /// Overlap is symmetric in its arguments (min is order-independent).
+    #[test]
+    fn overlap_symmetric() {
+        let a = [1, 2, 3];
+        let b = [1, 2, 3, 4, 5, 6];
+        let ab = overlap_sorted(&a, &b);
+        let ba = overlap_sorted(&b, &a);
+        assert!((ab - ba).abs() < 0.001);
     }
 }

--- a/packages/code/clone-detect/detect/src/lib.rs
+++ b/packages/code/clone-detect/detect/src/lib.rs
@@ -6,9 +6,10 @@ mod type3;
 mod types;
 
 pub use detector::instances;
-pub use type3::compute_similarity;
+pub use type3::{compute_similarity, compute_similarity_with};
 pub use types::{
-    ByteRange, CloneGroup, DetectConfig, DetectionResult, DetectionStats, Fragment, Kind, LineRange,
+    ByteRange, CloneGroup, DetectConfig, DetectionResult, DetectionStats, Fragment, Kind,
+    LineRange, Type3Metric,
 };
 
 #[cfg(test)]

--- a/packages/code/clone-detect/detect/src/lsh.rs
+++ b/packages/code/clone-detect/detect/src/lsh.rs
@@ -3,16 +3,88 @@ use std::hash::{Hash, Hasher};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet, FxHasher};
 
 /// Number of hash functions in the `MinHash` signature.
+///
+/// Highly composite (2^6) so [`banding_for_threshold`] has many `b*r = 64`
+/// factorizations to tune the LSH S-curve against a configured threshold.
 pub const NUM_HASHES: usize = 64;
-
-/// Number of bands for LSH banding.
-const NUM_BANDS: usize = 16;
-
-/// Rows per band = `NUM_HASHES` / `NUM_BANDS`.
-const ROWS_PER_BAND: usize = NUM_HASHES / NUM_BANDS;
 
 /// Maximum bucket size before we skip a bucket (too noisy to be useful).
 const MAX_BUCKET_SIZE: usize = 200;
+
+/// LSH banding parameters: `num_bands` bands of `rows_per_band` rows each,
+/// with `num_bands * rows_per_band == NUM_HASHES`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Banding {
+    pub num_bands: usize,
+    pub rows_per_band: usize,
+}
+
+/// Derive `(bands, rows)` from the configured similarity threshold.
+///
+/// With MinHash-LSH banding, a pair of similarity `s` becomes a candidate with
+/// probability `1 - (1 - s^r)^b`; the S-curve inflection ("LSH threshold") sits
+/// near `t ≈ (1/b)^(1/r)`. Pairs above `t` are almost always surfaced, pairs
+/// below it almost never. So `t` MUST sit at or just below the configured
+/// similarity threshold: if `t` is higher, every pair between the two is
+/// silently dropped before verification (pure recall loss); if `t` is far
+/// lower, we waste work verifying false candidates.
+///
+/// The previous hard-coded 16×4 banding pinned `t = (1/16)^(1/4) ≈ 0.5`, so any
+/// configured threshold below ~0.5 could never surface a candidate. We instead
+/// enumerate every `b*r = NUM_HASHES` factorization and pick the one whose `t`
+/// is the largest value not exceeding the target (falling back to the smallest
+/// `t` if the target is below all of them, i.e. very low thresholds), keeping
+/// the signature size constant.
+#[must_use]
+pub fn banding_for_threshold(threshold: f64) -> Banding {
+    // Clamp to a sane open interval; t is only defined for 0 < s < 1, and the
+    // caller's threshold is a similarity ratio.
+    let target = threshold.clamp(0.01, 0.99);
+
+    let mut best: Option<(Banding, f64)> = None;
+    let mut fallback: Option<(Banding, f64)> = None;
+
+    let mut rows_per_band = 1usize;
+    while rows_per_band <= NUM_HASHES {
+        if NUM_HASHES.is_multiple_of(rows_per_band) {
+            let num_bands = NUM_HASHES / rows_per_band;
+            let banding = Banding {
+                num_bands,
+                rows_per_band,
+            };
+            // t = (1/b)^(1/r)
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "num_bands <= NUM_HASHES = 64, exact in f64"
+            )]
+            let t = (1.0 / num_bands as f64).powf(1.0 / rows_per_band as f64);
+
+            // Track the smallest achievable t as a fallback for targets below
+            // every t (keeps recall high rather than dropping everything).
+            if fallback.is_none_or(|(_, ft)| t < ft) {
+                fallback = Some((banding, t));
+            }
+
+            // Prefer the largest t that stays at or below the target: closest
+            // fit from below minimizes false candidates without losing recall.
+            if t <= target && best.is_none_or(|(_, bt)| t > bt) {
+                best = Some((banding, t));
+            }
+        }
+        rows_per_band += 1;
+    }
+
+    best.or(fallback)
+        .map_or(
+            // NUM_HASHES >= 1 guarantees at least one factorization, so this is
+            // unreachable; keep a defined value rather than panic.
+            Banding {
+                num_bands: NUM_HASHES,
+                rows_per_band: 1,
+            },
+            |(banding, _)| banding,
+        )
+}
 
 /// Seed generation multiplier (`SplitMix64` gamma constant).
 const SEED_MUL: u64 = 0x517c_c1b7_2722_0a95;
@@ -96,14 +168,18 @@ pub struct NodePair {
 pub struct LshIndex {
     bands: Vec<FxHashMap<u64, Vec<NodeLocation>>>,
     signatures: FxHashMap<NodeLocation, [u64; NUM_HASHES]>,
+    banding: Banding,
 }
 
 impl LshIndex {
-    /// Build an LSH index from nodes with their `MinHash` signatures.
+    /// Build an LSH index from nodes with their `MinHash` signatures, banding
+    /// the signature per `banding` (derived from the configured threshold via
+    /// [`banding_for_threshold`]).
     #[must_use]
-    pub fn build(entries: &[LshEntry]) -> Self {
-        let mut bands: Vec<FxHashMap<u64, Vec<NodeLocation>>> = Vec::with_capacity(NUM_BANDS);
-        for _ in 0..NUM_BANDS {
+    pub fn build(entries: &[LshEntry], banding: Banding) -> Self {
+        let mut bands: Vec<FxHashMap<u64, Vec<NodeLocation>>> =
+            Vec::with_capacity(banding.num_bands);
+        for _ in 0..banding.num_bands {
             bands.push(FxHashMap::default());
         }
 
@@ -112,12 +188,22 @@ impl LshIndex {
         for entry in entries {
             signatures.insert(entry.location, entry.signature);
             for (band_idx, band_map) in bands.iter_mut().enumerate() {
-                let band_hash = hash_band(&entry.signature, band_idx);
+                let band_hash = hash_band(&entry.signature, band_idx, banding.rows_per_band);
                 band_map.entry(band_hash).or_default().push(entry.location);
             }
         }
 
-        Self { bands, signatures }
+        Self {
+            bands,
+            signatures,
+            banding,
+        }
+    }
+
+    /// The banding this index was built with.
+    #[must_use]
+    pub const fn banding(&self) -> Banding {
+        self.banding
     }
 
     /// Return all candidate pairs that hash to the same bucket in at least one band.
@@ -168,6 +254,39 @@ pub fn estimated_jaccard(sig_a: &[u64; NUM_HASHES], sig_b: &[u64; NUM_HASHES]) -
     matches as f64 / NUM_HASHES as f64
 }
 
+/// Estimate the overlap coefficient (containment) from `MinHash` signatures
+/// plus the exact feature counts, in O(`NUM_HASHES`).
+///
+/// `MinHash` only estimates Jaccard `J = I/U`, but with the exact sizes and
+/// `U = |A| + |B| - I` the intersection follows: `I = J(|A| + |B|)/(1 + J)`,
+/// hence `overlap = I / min(|A|, |B|)`. Without this, the overlap metric has no
+/// cheap candidate prune (a low-Jaccard pair can still be high-overlap), and
+/// every LSH candidate pays the exact O(n+m) merge — measured as a >500x
+/// slowdown over this whole repo versus the pruned Jaccard path.
+///
+/// The signature estimates *set* Jaccard while the sizes count multisets, so
+/// the result is biased for duplicate-heavy features; callers prune with a
+/// slack margin, never confirm.
+#[must_use]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "feature counts are far below f64 mantissa precision"
+)]
+pub fn estimated_overlap(
+    sig_a: &[u64; NUM_HASHES],
+    sig_b: &[u64; NUM_HASHES],
+    len_a: usize,
+    len_b: usize,
+) -> f64 {
+    let min_len = len_a.min(len_b);
+    if min_len == 0 {
+        return 0.0;
+    }
+    let j = estimated_jaccard(sig_a, sig_b);
+    let intersection = j * (len_a + len_b) as f64 / (1.0 + j);
+    (intersection / min_len as f64).min(1.0)
+}
+
 const fn canonical_pair(a: NodeLocation, b: NodeLocation) -> NodePair {
     if a.file_id < b.file_id || (a.file_id == b.file_id && a.node_idx <= b.node_idx) {
         NodePair {
@@ -182,10 +301,10 @@ const fn canonical_pair(a: NodeLocation, b: NodeLocation) -> NodePair {
     }
 }
 
-fn hash_band(signature: &[u64; NUM_HASHES], band_idx: usize) -> u64 {
-    let start = band_idx * ROWS_PER_BAND;
+fn hash_band(signature: &[u64; NUM_HASHES], band_idx: usize, rows_per_band: usize) -> u64 {
+    let start = band_idx * rows_per_band;
     let mut hasher = FxHasher::default();
-    for val in signature.iter().skip(start).take(ROWS_PER_BAND) {
+    for val in signature.iter().skip(start).take(rows_per_band) {
         val.hash(&mut hasher);
     }
     hasher.finish()
@@ -247,7 +366,7 @@ mod tests {
                 signature: sig_c,
             },
         ];
-        let index = LshIndex::build(&entries);
+        let index = LshIndex::build(&entries, banding_for_threshold(0.7));
         let pairs = index.candidate_pairs();
 
         let similar_pair = pairs.contains(&canonical_pair(loc_a, loc_b));
@@ -257,6 +376,111 @@ mod tests {
         assert!(
             !dissimilar_pair,
             "Dissimilar items A and C should not be candidates"
+        );
+    }
+
+    #[test]
+    fn banding_is_always_a_valid_factorization() {
+        for pct in 1..=99 {
+            let b = banding_for_threshold(f64::from(pct) / 100.0);
+            assert_eq!(
+                b.num_bands * b.rows_per_band,
+                NUM_HASHES,
+                "banding for {pct}% must factor NUM_HASHES"
+            );
+        }
+    }
+
+    /// A higher configured threshold demands a higher LSH S-curve threshold,
+    /// which means more rows per band (fewer bands). The banding must respond
+    /// monotonically so it neither over- nor under-generates candidates.
+    #[test]
+    fn banding_rows_grow_with_threshold() {
+        let low = banding_for_threshold(0.3);
+        let high = banding_for_threshold(0.9);
+        assert!(
+            high.rows_per_band >= low.rows_per_band,
+            "higher threshold should use >= rows per band: {low:?} vs {high:?}"
+        );
+    }
+
+    /// The threshold-derived banding for a low target must place its S-curve
+    /// inflection below that target, or pairs between the inflection and the
+    /// target are silently dropped. The old fixed 16x4 banding pinned the
+    /// inflection at 0.5, so threshold 0.4 was unreachable.
+    #[test]
+    fn low_threshold_lowers_lsh_inflection() {
+        let b = banding_for_threshold(0.4);
+        #[expect(clippy::cast_precision_loss, reason = "counts exact in f64")]
+        let t = (1.0 / b.num_bands as f64).powf(1.0 / b.rows_per_band as f64);
+        assert!(
+            t <= 0.4,
+            "derived inflection {t:.3} must sit at/below target 0.4; banding {b:?}"
+        );
+        // The old hard-coded banding could not: its inflection is exactly 0.5.
+        let old_t = (1.0f64 / 16.0).powf(1.0 / 4.0);
+        assert!(old_t > 0.4, "old 16x4 inflection {old_t:.3} exceeds 0.4");
+    }
+
+    /// Regression for the silent recall floor. Build many independent
+    /// ~0.45-similar pairs and count how many each banding surfaces. `MinHash`
+    /// collision is probabilistic per pair, so we assert on the aggregate: the
+    /// threshold-0.4 derived banding must surface nearly all of them, while the
+    /// old 16x4 banding (inflection 0.5, above 0.45) surfaces materially fewer.
+    /// Set Jaccard here is 11/(11+7+7)=0.44.
+    #[test]
+    fn low_threshold_surfaces_borderline_pairs() {
+        const PAIRS: usize = 40;
+        let shared_size = 11u64;
+        let unique_size = 7u64;
+
+        let mut entries = Vec::new();
+        let mut want = Vec::new();
+        for p in 0..PAIRS {
+            let base = (p as u64) * 1000;
+            let shared: Vec<u64> = (0..shared_size).map(|k| base + k).collect();
+            let mut fa = shared.clone();
+            fa.extend((0..unique_size).map(|k| base + 100 + k));
+            let mut fb = shared;
+            fb.extend((0..unique_size).map(|k| base + 200 + k));
+
+            let la = NodeLocation {
+                file_id: p * 2,
+                node_idx: 0,
+            };
+            let lb = NodeLocation {
+                file_id: p * 2 + 1,
+                node_idx: 0,
+            };
+            entries.push(LshEntry {
+                location: la,
+                signature: minhash_signature(&fa),
+            });
+            entries.push(LshEntry {
+                location: lb,
+                signature: minhash_signature(&fb),
+            });
+            want.push(canonical_pair(la, lb));
+        }
+
+        let count = |banding: Banding| {
+            let pairs = LshIndex::build(&entries, banding).candidate_pairs();
+            want.iter().filter(|w| pairs.contains(w)).count()
+        };
+
+        let derived = count(banding_for_threshold(0.4));
+        let old = count(Banding {
+            num_bands: 16,
+            rows_per_band: 4,
+        });
+
+        assert!(
+            derived >= PAIRS * 9 / 10,
+            "threshold-0.4 banding must surface >=90% of ~0.45-similar pairs, got {derived}/{PAIRS}"
+        );
+        assert!(
+            derived > old,
+            "derived banding must surface strictly more than old 16x4: {derived} vs {old}"
         );
     }
 
@@ -273,5 +497,43 @@ mod tests {
         let sig_b = minhash_signature(&[100, 200, 300]);
         let est = estimated_jaccard(&sig_a, &sig_b);
         assert!(est < 0.2, "Disjoint sets should have low estimated Jaccard");
+    }
+
+    /// Containment: A (10 features) fully inside B (30 features). True Jaccard
+    /// is 10/30 ~ 0.33 but true overlap is 1.0; the estimate must recover the
+    /// high overlap from the low Jaccard signal plus the sizes.
+    #[test]
+    fn estimated_overlap_recovers_containment() {
+        let a: Vec<u64> = (1..=10).collect();
+        let b: Vec<u64> = (1..=30).collect();
+        let sig_a = minhash_signature(&a);
+        let sig_b = minhash_signature(&b);
+
+        let jac = estimated_jaccard(&sig_a, &sig_b);
+        let ovl = estimated_overlap(&sig_a, &sig_b, a.len(), b.len());
+        assert!(jac < 0.6, "containment pair has low Jaccard, got {jac}");
+        assert!(
+            ovl > 0.75,
+            "estimated overlap must recover containment, got {ovl}"
+        );
+    }
+
+    #[test]
+    fn estimated_overlap_disjoint_stays_low() {
+        let a: Vec<u64> = (1..=20).collect();
+        let b: Vec<u64> = (1000..=1020).collect();
+        let est = estimated_overlap(
+            &minhash_signature(&a),
+            &minhash_signature(&b),
+            a.len(),
+            b.len(),
+        );
+        assert!(est < 0.3, "disjoint sets must estimate low overlap: {est}");
+    }
+
+    #[test]
+    fn estimated_overlap_empty_is_zero() {
+        let sig = minhash_signature(&[1, 2, 3]);
+        assert!(estimated_overlap(&sig, &sig, 0, 3).abs() < 0.001);
     }
 }

--- a/packages/code/clone-detect/detect/src/tests/serialization.rs
+++ b/packages/code/clone-detect/detect/src/tests/serialization.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use crate::{ByteRange, CloneGroup, DetectionResult, DetectionStats, Fragment, Kind, LineRange};
+use crate::{
+    ByteRange, CloneGroup, DetectionResult, DetectionStats, Fragment, Kind, LineRange, Type3Metric,
+};
 
 #[test]
 fn type_to_string() {
@@ -8,10 +10,15 @@ fn type_to_string() {
     let json = serde_json::to_string(&type1).unwrap();
     assert!(json.contains("type1"));
 
-    let type3 = Kind::Type3 { similarity: 0.85 };
+    let type3 = Kind::Type3 {
+        similarity: 0.85,
+        metric: Type3Metric::Overlap,
+    };
     let json = serde_json::to_string(&type3).unwrap();
     assert!(json.contains("type3"));
     assert!(json.contains("0.85"));
+    // The metric label must ride along so `similarity` is interpretable.
+    assert!(json.contains("overlap"), "metric must be serialized: {json}");
 }
 
 #[test]
@@ -22,8 +29,13 @@ fn type_from_string() {
     let type2: Kind = serde_json::from_str("\"type2\"").unwrap();
     assert_eq!(type2, Kind::Type2);
 
-    let type3: Kind = serde_json::from_str("{\"type3\":{\"similarity\":0.75}}").unwrap();
-    assert!(matches!(type3, Kind::Type3 { similarity } if (similarity - 0.75).abs() < 0.001));
+    let type3: Kind =
+        serde_json::from_str("{\"type3\":{\"similarity\":0.75,\"metric\":\"jaccard\"}}").unwrap();
+    assert!(matches!(
+        type3,
+        Kind::Type3 { similarity, metric }
+            if (similarity - 0.75).abs() < 0.001 && metric == Type3Metric::Jaccard
+    ));
 }
 
 #[test]

--- a/packages/code/clone-detect/detect/src/tests/similarity.rs
+++ b/packages/code/clone-detect/detect/src/tests/similarity.rs
@@ -1,4 +1,4 @@
-use crate::compute_similarity;
+use crate::{Type3Metric, compute_similarity_with};
 
 fn make_node_with_features(node_count: usize, features: Vec<u64>) -> clone_hash::NodeInfo {
     clone_hash::NodeInfo {
@@ -14,89 +14,104 @@ fn make_node_with_features(node_count: usize, features: Vec<u64>) -> clone_hash:
     }
 }
 
-/// Two nodes with identical feature multisets should have similarity 1.0
+fn jaccard(a: &clone_hash::NodeInfo, b: &clone_hash::NodeInfo) -> f64 {
+    compute_similarity_with(a, b, Type3Metric::Jaccard)
+}
+
+fn overlap(a: &clone_hash::NodeInfo, b: &clone_hash::NodeInfo) -> f64 {
+    compute_similarity_with(a, b, Type3Metric::Overlap)
+}
+
+/// Two nodes with identical feature multisets should have similarity 1.0 under
+/// either metric.
 #[test]
 fn identical_children() {
     let a = make_node_with_features(50, vec![100, 200, 300]);
     let b = make_node_with_features(50, vec![100, 200, 300]);
-    let sim = compute_similarity(&a, &b);
-    assert!(
-        (sim - 1.0).abs() < 0.001,
-        "Identical features should give similarity 1.0, got {sim}"
-    );
+    assert!((jaccard(&a, &b) - 1.0).abs() < 0.001);
+    assert!((overlap(&a, &b) - 1.0).abs() < 0.001);
 }
 
-/// Two nodes with completely different features should have similarity 0.0
+/// Two nodes with completely different features should have similarity 0.0.
 #[test]
 fn completely_different_children() {
     let a = make_node_with_features(50, vec![100, 200, 300]);
     let b = make_node_with_features(50, vec![400, 500, 600]);
-    let sim = compute_similarity(&a, &b);
-    assert!(
-        sim < 0.01,
-        "Completely different features should give similarity ~0.0, got {sim}"
-    );
+    assert!(jaccard(&a, &b) < 0.01);
+    assert!(overlap(&a, &b) < 0.01);
 }
 
-/// Partial overlap: 2 out of 3 features match
+/// Partial overlap: 2 of 3 features match. Jaccard = 2/4 = 0.5;
+/// overlap = 2/min(3,3) = 0.667.
 #[test]
 fn partial_overlap() {
     let a = make_node_with_features(50, vec![100, 200, 300]);
     let b = make_node_with_features(55, vec![100, 200, 400]);
-    let sim = compute_similarity(&a, &b);
-    // Jaccard of {100,200,300} and {100,200,400}: intersection=2, union=4 → 0.5
     assert!(
-        (sim - 0.5).abs() < 0.01,
-        "2/4 Jaccard overlap should give ~0.5, got {sim}"
+        (jaccard(&a, &b) - 0.5).abs() < 0.01,
+        "jaccard = {}",
+        jaccard(&a, &b)
+    );
+    assert!(
+        (overlap(&a, &b) - 2.0 / 3.0).abs() < 0.01,
+        "overlap = {}",
+        overlap(&a, &b)
     );
 }
 
-/// One node has an extra feature (superset): 3 matching, 1 extra
+/// One node is a superset (3 matching, 1 extra) — the containment case.
+/// Jaccard = 3/4 = 0.75 (penalizes the extra feature); overlap = 3/3 = 1.0.
+/// This asymmetry is what the overlap metric exists for.
 #[test]
 fn one_extra_child() {
     let a = make_node_with_features(50, vec![100, 200, 300]);
     let b = make_node_with_features(60, vec![100, 200, 300, 400]);
-    let sim = compute_similarity(&a, &b);
-    // Jaccard: intersection=3, union=4 → 0.75
     assert!(
-        (sim - 0.75).abs() < 0.01,
-        "3/4 Jaccard overlap should give ~0.75, got {sim}"
+        (jaccard(&a, &b) - 0.75).abs() < 0.01,
+        "jaccard = {}",
+        jaccard(&a, &b)
+    );
+    assert!(
+        (overlap(&a, &b) - 1.0).abs() < 0.01,
+        "containment should give overlap 1.0, got {}",
+        overlap(&a, &b)
     );
 }
 
-/// Both nodes have no features — fallback to node count ratio
+/// Both nodes have no features — fallback to node count ratio (min/max), which
+/// is metric-independent.
 #[test]
 fn no_children_fallback() {
     let a = make_node_with_features(50, vec![]);
     let b = make_node_with_features(60, vec![]);
-    let sim = compute_similarity(&a, &b);
-    // Fallback: min/max = 50/60 ≈ 0.833
-    assert!(
-        (sim - 0.833).abs() < 0.01,
-        "Empty features should fallback to node count ratio, got {sim}"
-    );
+    assert!((jaccard(&a, &b) - 0.833).abs() < 0.01);
+    assert!((overlap(&a, &b) - 0.833).abs() < 0.01);
 }
 
-/// Zero nodes in both — similarity 0.0
+/// Zero nodes in both — similarity 0.0.
 #[test]
 fn zero_nodes() {
     let a = make_node_with_features(0, vec![]);
     let b = make_node_with_features(0, vec![]);
-    let sim = compute_similarity(&a, &b);
-    assert!(sim.abs() < 0.001, "Zero nodes should give 0.0, got {sim}");
+    assert!(jaccard(&a, &b).abs() < 0.001);
+    assert!(overlap(&a, &b).abs() < 0.001);
 }
 
-/// Duplicate features should be treated as multiset (counted individually)
+/// Duplicate features are treated as a multiset. `{100,100,200}` vs
+/// `{100,200,200}`: intersection = min(2,1) + min(1,2) = 2. Jaccard = 2/4 = 0.5;
+/// overlap = 2/min(3,3) = 0.667.
 #[test]
 fn multiset_duplicates() {
     let a = make_node_with_features(50, vec![100, 100, 200]);
     let b = make_node_with_features(50, vec![100, 200, 200]);
-    let sim = compute_similarity(&a, &b);
-    // Multiset intersection: min(2,1) for 100 = 1, min(1,2) for 200 = 1 → 2
-    // Multiset union: max(2,1) for 100 = 2, max(1,2) for 200 = 2 → 4
-    // Jaccard: 2/4 = 0.5
     assert!(
-        (sim - 0.5).abs() < 0.01,
-        "Multiset Jaccard with duplicate features should be 0.5, got {sim}"
+        (jaccard(&a, &b) - 0.5).abs() < 0.01,
+        "jaccard = {}",
+        jaccard(&a, &b)
+    );
+    assert!(
+        (overlap(&a, &b) - 2.0 / 3.0).abs() < 0.01,
+        "overlap = {}",
+        overlap(&a, &b)
     );
 }

--- a/packages/code/clone-detect/detect/src/tests/type3.rs
+++ b/packages/code/clone-detect/detect/src/tests/type3.rs
@@ -1,7 +1,105 @@
 use tempfile::TempDir;
 
 use super::helpers::{create_temp_file, scan_and_run};
-use crate::DetectConfig;
+use crate::{DetectConfig, DetectionResult, Kind, Type3Metric};
+
+/// The original function for the moderately-Type-3 fixture.
+const MT3_ORIGINAL: &str = r"
+fn accumulate(values: &[i32]) -> i32 {
+    let mut total = 0;
+    for value in values {
+        if *value > 0 {
+            total += value;
+        }
+    }
+    total
+}
+";
+
+/// [`MT3_ORIGINAL`] copied and then edited: a running count, a running max, and
+/// a final log line inserted. Same skeleton, several inserted statements — the
+/// dominant real-world "copy-paste then edit" clone (moderately Type-3 in
+/// `BigCloneBench` terms). The inserts grow the feature multiset enough that
+/// symmetric Jaccard falls below 0.7 while the original stays nearly fully
+/// contained (overlap ~1.0).
+const MT3_EDITED: &str = r#"
+fn accumulate(values: &[i32]) -> i32 {
+    let mut total = 0;
+    let mut count = 0;
+    let mut maximum = i32::MIN;
+    for value in values {
+        if *value > 0 {
+            total += value;
+        }
+        count += 1;
+        if *value > maximum {
+            maximum = *value;
+        }
+    }
+    println!("count={} max={}", count, maximum);
+    total
+}
+"#;
+
+/// Does any Type-3 group pair up two whole `function_item` fragments?
+fn has_function_pair_group(result: &DetectionResult) -> bool {
+    result.instances.iter().any(|g| {
+        matches!(g.clone_type, Kind::Type3 { .. })
+            && g.fragments.len() >= 2
+            && g.fragments.iter().all(|f| f.kind == "function_item")
+    })
+}
+
+fn run_mt3(metric: Type3Metric) -> DetectionResult {
+    let dir = TempDir::new().unwrap();
+    create_temp_file(&dir, "orig.rs", MT3_ORIGINAL);
+    create_temp_file(&dir, "edited.rs", MT3_EDITED);
+    let config = DetectConfig {
+        enable_type3: true,
+        type3_threshold: 0.7,
+        type3_metric: metric,
+        ..DetectConfig::default()
+    };
+    scan_and_run(&dir, &config)
+}
+
+/// The asymmetry that motivates the overlap metric: at the default 0.7
+/// threshold, the copy-with-inserted-statements pair is caught by `overlap` and
+/// missed by `jaccard`. If this stops holding, either the fixture drifted or a
+/// metric changed semantics.
+#[test]
+fn overlap_catches_inserted_statement_clone_jaccard_misses() {
+    let jaccard = run_mt3(Type3Metric::Jaccard);
+    assert!(
+        !has_function_pair_group(&jaccard),
+        "jaccard at 0.7 should miss the insert-heavy clone (that is its documented weakness)"
+    );
+
+    let overlap = run_mt3(Type3Metric::Overlap);
+    assert!(
+        has_function_pair_group(&overlap),
+        "overlap at 0.7 must catch the insert-heavy clone"
+    );
+}
+
+/// Every reported Type-3 group must be labeled with the metric that produced
+/// its similarity score, so downstream consumers can interpret the number.
+#[test]
+fn type3_groups_carry_their_metric() {
+    let result = run_mt3(Type3Metric::Overlap);
+    for group in &result.instances {
+        if let Kind::Type3 { metric, .. } = group.clone_type {
+            assert_eq!(metric, Type3Metric::Overlap);
+        }
+    }
+    assert!(
+        result
+            .instances
+            .iter()
+            .any(|g| matches!(g.clone_type, Kind::Type3 { .. })),
+        "fixture must produce at least one Type-3 group under overlap"
+    );
+}
 
 #[test]
 fn disabled_by_default() {

--- a/packages/code/clone-detect/detect/src/type3.rs
+++ b/packages/code/clone-detect/detect/src/type3.rs
@@ -4,14 +4,34 @@ use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 
 use crate::{
-    jaccard::multiset_sorted,
-    lsh::{LshEntry, LshIndex, NodeLocation, estimated_jaccard, minhash_signature},
-    types::{CloneGroup, Fragment, Kind},
+    jaccard::{multiset_sorted, overlap_sorted},
+    lsh::{
+        LshEntry, LshIndex, NodeLocation, banding_for_threshold, estimated_jaccard,
+        estimated_overlap, minhash_signature,
+    },
+    types::{CloneGroup, Fragment, Kind, Type3Metric},
 };
 
-/// Margin for the `MinHash` estimate pre-check. The estimate approximates
-/// set Jaccard which can differ from multiset Jaccard, so we allow some slack.
+/// Margin for the `MinHash` estimate pre-check. The estimates approximate the
+/// set-based metric while confirmation is multiset-based, so we allow slack and
+/// only prune what is clearly below threshold.
 const ESTIMATION_MARGIN: f64 = 0.1;
+
+/// Size-compatibility floor for the overlap metric: `min(|A|, |B|) / max(|A|,
+/// |B|)` must be at least this (fragments within 2.5x of each other).
+///
+/// Overlap divides by the smaller multiset, so without a size bound a tiny
+/// generic fragment whose features happen to be swallowed by a much larger
+/// node scores 1.0 — a false positive — and, worse, defeats the `MinHash`
+/// pre-check: `estimated_overlap` scales the Jaccard estimate by
+/// `(|A|+|B|)/min`, so at high size skew a single noisy matching slot (1/64)
+/// saturates the estimate and every such pair pays the exact merge (measured
+/// as a timeout over this repo versus ~1s with the floor).
+///
+/// 0.4 admits an edited copy that grew up to 2.5x — well beyond the
+/// "insert a few statements" clones overlap targets (`BigCloneBench` MT3) —
+/// while excluding the degenerate containment pairs.
+const OVERLAP_SIZE_RATIO_FLOOR: f64 = 0.4;
 
 /// A scanned node with its position in the file list.
 struct IndexedNode<'a> {
@@ -20,7 +40,12 @@ struct IndexedNode<'a> {
     node: &'a NodeInfo,
 }
 
-pub fn find(scan: &Output, threshold: f64) -> Vec<CloneGroup> {
+pub fn find(scan: &Output, threshold: f64, metric: Type3Metric) -> Vec<CloneGroup> {
+    // Banding derived once from the threshold: shared by every kind group so the
+    // LSH S-curve matches the configured similarity floor (see
+    // `banding_for_threshold`).
+    let banding = banding_for_threshold(threshold);
+
     let mut by_kind: FxHashMap<&str, Vec<IndexedNode<'_>>> = FxHashMap::default();
 
     for (file_id, file) in scan.files.iter().enumerate() {
@@ -70,15 +95,35 @@ pub fn find(scan: &Output, threshold: f64) -> Vec<CloneGroup> {
                 return Vec::new();
             }
 
-            let index = LshIndex::build(&entries);
+            let index = LshIndex::build(&entries, banding);
             let mut groups = Vec::new();
 
             for pair in index.candidate_pairs() {
-                // Fast pre-check: estimate Jaccard from MinHash signatures
+                // Fast pre-check: estimate the confirmation metric from the
+                // MinHash signatures and prune clearly-too-dissimilar pairs
+                // before the exact O(n+m) merge. This prune carries the whole
+                // pipeline's performance: without it every LSH candidate pays
+                // the exact merge, which measured >500x slower over this repo.
+                //
+                // The estimate must match the metric. Overlap >= Jaccard
+                // (containment), so pruning overlap candidates on a Jaccard
+                // estimate would silently drop the very insert/delete clones
+                // overlap exists to catch; `estimated_overlap` reconstructs
+                // containment from the Jaccard estimate plus exact sizes.
                 if let (Some(sig_a), Some(sig_b)) =
                     (index.signature(&pair.first), index.signature(&pair.second))
                 {
-                    let estimate = estimated_jaccard(sig_a, sig_b);
+                    let estimate = match metric {
+                        Type3Metric::Jaccard => estimated_jaccard(sig_a, sig_b),
+                        Type3Metric::Overlap => {
+                            let len_a = feature_len(scan, &pair.first);
+                            let len_b = feature_len(scan, &pair.second);
+                            if !size_compatible(len_a, len_b) {
+                                continue;
+                            }
+                            estimated_overlap(sig_a, sig_b, len_a, len_b)
+                        }
+                    };
                     if estimate < threshold - ESTIMATION_MARGIN {
                         continue;
                     }
@@ -90,6 +135,7 @@ pub fn find(scan: &Output, threshold: f64) -> Vec<CloneGroup> {
                         loc_a: pair.first,
                         loc_b: pair.second,
                         threshold,
+                        metric,
                     },
                 ) else {
                     continue;
@@ -102,10 +148,32 @@ pub fn find(scan: &Output, threshold: f64) -> Vec<CloneGroup> {
         .collect()
 }
 
+/// Feature-multiset size of the node at `loc`, `0` when the location is stale.
+/// LSH entries are built only from nodes with non-empty features, so a `0` here
+/// makes the overlap estimate `0.0` and the pair is pruned rather than panicking.
+fn feature_len(scan: &Output, loc: &NodeLocation) -> usize {
+    scan.files
+        .get(loc.file_id)
+        .and_then(|file| file.nodes.get(loc.node_idx))
+        .map_or(0, |node| node.subtree_features.len())
+}
+
+/// Enforce [`OVERLAP_SIZE_RATIO_FLOOR`] on a pair of feature counts.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "feature counts are far below f64 mantissa precision"
+)]
+fn size_compatible(len_a: usize, len_b: usize) -> bool {
+    let min = len_a.min(len_b) as f64;
+    let max = len_a.max(len_b) as f64;
+    max > 0.0 && min / max >= OVERLAP_SIZE_RATIO_FLOOR
+}
+
 struct CandidatePair {
     loc_a: NodeLocation,
     loc_b: NodeLocation,
     threshold: f64,
+    metric: Type3Metric,
 }
 
 /// Try to build a Type-3 clone group from two node locations.
@@ -123,13 +191,27 @@ fn try_make_group(scan: &Output, pair: &CandidatePair) -> Option<CloneGroup> {
         return None;
     }
 
-    let similarity = compute_similarity(node_a, node_b);
+    // Ground-truth enforcement of the overlap size floor (the candidate loop
+    // also prunes on it, but only inside the estimate fast path).
+    if pair.metric == Type3Metric::Overlap
+        && !size_compatible(
+            node_a.subtree_features.len(),
+            node_b.subtree_features.len(),
+        )
+    {
+        return None;
+    }
+
+    let similarity = compute_similarity_with(node_a, node_b, pair.metric);
     if similarity < pair.threshold {
         return None;
     }
 
     Some(CloneGroup {
-        clone_type: Kind::Type3 { similarity },
+        clone_type: Kind::Type3 {
+            similarity,
+            metric: pair.metric,
+        },
         fragments: vec![
             Fragment::from_node(file_a, node_a),
             Fragment::from_node(file_b, node_b),
@@ -137,15 +219,31 @@ fn try_make_group(scan: &Output, pair: &CandidatePair) -> Option<CloneGroup> {
     })
 }
 
-/// Compute structural similarity between two AST nodes.
+/// Compute structural similarity between two AST nodes using the default
+/// (Jaccard) metric. Kept for external callers; new code should prefer
+/// [`compute_similarity_with`] to be explicit about the metric.
+#[must_use]
+pub fn compute_similarity(a: &NodeInfo, b: &NodeInfo) -> f64 {
+    compute_similarity_with(a, b, Type3Metric::default())
+}
+
+/// Compute structural similarity between two AST nodes under `metric`.
+///
+/// When both nodes carry subtree features, the score is the chosen multiset
+/// metric over those features. Otherwise (features unavailable) both metrics
+/// fall back to the node-count ratio `min/max` — a coarse structural bound,
+/// not a feature comparison, so there is nothing metric-specific to compute.
 #[must_use]
 #[expect(
     clippy::cast_precision_loss,
     reason = "AST node counts are far below f64 mantissa precision"
 )]
-pub fn compute_similarity(a: &NodeInfo, b: &NodeInfo) -> f64 {
+pub fn compute_similarity_with(a: &NodeInfo, b: &NodeInfo, metric: Type3Metric) -> f64 {
     if !a.subtree_features.is_empty() && !b.subtree_features.is_empty() {
-        return multiset_sorted(&a.subtree_features, &b.subtree_features);
+        return match metric {
+            Type3Metric::Jaccard => multiset_sorted(&a.subtree_features, &b.subtree_features),
+            Type3Metric::Overlap => overlap_sorted(&a.subtree_features, &b.subtree_features),
+        };
     }
 
     let count_a = a.node_count as f64;

--- a/packages/code/clone-detect/detect/src/types.rs
+++ b/packages/code/clone-detect/detect/src/types.rs
@@ -2,12 +2,45 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+/// Similarity metric used to confirm a Type-3 candidate pair.
+///
+/// Both operate on the same sorted multiset of structural subtree features; they
+/// differ only in the denominator, which changes what "similar" means:
+///
+/// - [`Jaccard`](Type3Metric::Jaccard): `|A ∩ B| / |A ∪ B|`. Symmetric, but
+///   penalizes size differences, so a clone with a few inserted/deleted
+///   statements drops below threshold even when one fragment is nearly a subset
+///   of the other.
+/// - [`Overlap`](Type3Metric::Overlap): `|A ∩ B| / min(|A|, |B|)` (overlap
+///   coefficient / containment). Does not penalize the size gap, so it catches
+///   the dominant "copy-paste then edit" case (Sherlock N-overlap, IEEE TC
+///   2019). The flip side: generic structural boilerplate contains easily, so
+///   at the same threshold overlap reports far more groups (measured 40x on
+///   this repo at 0.7). Use it for recall-oriented sweeps, preferably with a
+///   higher threshold (>= 0.8); pure insert/delete clones score near 1.0 under
+///   it, so a high threshold costs little recall on the cases it exists for.
+///
+/// Jaccard is the default deliberately: it keeps default output precise (and
+/// byte-compatible with the tool's history), while overlap is the opt-in
+/// wide-net mode. Each Type-3 group reports the metric that produced it
+/// ([`Kind::Type3`]), so `similarity` values are never ambiguous.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum Type3Metric {
+    #[default]
+    Jaccard,
+    Overlap,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum Kind {
     Type1,
     Type2,
-    Type3 { similarity: f64 },
+    /// A near-miss (gapped) clone. `similarity` is the score under `metric`, so
+    /// the two fields must be read together: a `0.8` under `overlap` and under
+    /// `jaccard` mean different things.
+    Type3 { similarity: f64, metric: Type3Metric },
     Sequence { statements: usize },
 }
 
@@ -87,11 +120,12 @@ pub struct DetectionStats {
 pub struct DetectConfig {
     pub enable_type3: bool,
     pub type3_threshold: f64,
+    pub type3_metric: Type3Metric,
     pub enable_sequences: bool,
     pub sequence_window_size: usize,
 }
 
-/// Default Jaccard similarity threshold for Type-3 clone detection.
+/// Default similarity threshold for Type-3 clone detection.
 const DEFAULT_TYPE3_THRESHOLD: f64 = 0.7;
 
 impl Default for DetectConfig {
@@ -99,6 +133,7 @@ impl Default for DetectConfig {
         Self {
             enable_type3: false,
             type3_threshold: DEFAULT_TYPE3_THRESHOLD,
+            type3_metric: Type3Metric::default(),
             enable_sequences: false,
             sequence_window_size: crate::sequences::DEFAULT_WINDOW_SIZE,
         }


### PR DESCRIPTION
Closes #1929. Follow-ups deferred to #1935.

## What

- **`type3_metric = "jaccard" | "overlap"`** (clone.toml key + `--type3-metric`): overlap coefficient `|A∩B|/min(|A|,|B|)` confirms the dominant "copy-paste then insert/delete statements" clone that symmetric Jaccard structurally misses (Sherlock N-overlap, IEEE TC 2019). Each Type-3 group's JSON now carries `metric`, so `similarity` is never ambiguous. The MT3 fixture test encodes the asymmetry directly: a function copied with 3 inserted statements scores jaccard 0.47 / overlap 0.99, caught by overlap at the 0.7 default threshold, missed by jaccard.
- **Threshold-derived LSH banding**: `lsh.rs` hard-coded 16 bands x 4 rows, pinning the S-curve inflection at `(1/16)^(1/4) ~ 0.5` — any configured threshold below ~0.5 could **never** surface a candidate (silent recall loss). Bands x rows are now chosen per detection run so the inflection sits just below the configured threshold (NIL-style r/b tuning, signature size unchanged). Regression-tested with an aggregate 40-pair recall assertion at threshold 0.4.
- **Containment-aware candidate prune**: overlap can exceed the MinHash Jaccard estimate, so pruning overlap candidates on estimated Jaccard would drop exactly the clones the metric exists for. `estimated_overlap` reconstructs containment from the Jaccard estimate plus exact multiset sizes in O(64), plus a size floor (fragments within 2.5x) that kills the degenerate tiny-fragment-in-huge-node matches. Without these the overlap run over `packages/` never completed.
- **`dedup_subsumed` path interning**: profiling showed whole-repo runs dominated by `PathBuf` component comparison inside the O(n^2) subsumption scan; file paths are interned to integer ids first.

## Default choice (deliberate)

`jaccard` stays the default. Measured over `packages/` in this repo:

| metric | threshold | Type-3 groups | wall |
|---|---|---|---|
| jaccard | 0.7 | 2,321 | 1.4s |
| overlap | 0.7 | 269,258 | 162s |
| overlap | 0.8 | 14,089 | 1.3s |
| overlap | 0.9 | 4,504 | 0.6s |

Overlap at the shared 0.7 default is a boilerplate firehose (generic blocks contain each other), so it ships opt-in with docs steering to `>= 0.8`; pure insert/delete clones score ~1.0 under overlap, so the higher threshold costs little recall on its target class. IDF down-weighting (#1935) is the path to making overlap default-able. NIL-style LCS verification was evaluated and deferred: `subtree_features` are sorted (order lost), so LCS needs a new preorder-ordered sequence — design in #1935.

## Validation

- `cargo test` green for detect (57 + 9 integration), hash (33), cli (19 + 4 gate/ignore integration) post-rebase over #1932.
- `nix run .#lint` green, including the new clone gate stage from #1932 (type3 is off in repo clone.toml, gate output unchanged).
- `nix build .#clone` succeeds; benchmark table above from the built binary.

Literature: NIL (ESEC/FSE 2021) verification + LSH tuning framing; Sherlock N-overlap (IEEE TC 2019) for overlap-beats-Jaccard on code similarity.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add overlap similarity metric and threshold-derived LSH banding to Type-3 clone detection
> - Adds a `Type3Metric` enum (`jaccard` | `overlap`) selectable via `--type3-metric` CLI flag or `type3_metric` in `clone.toml`, defaulting to Jaccard.
> - Implements `overlap_sorted` (containment coefficient) in [jaccard.rs](https://github.com/indexable-inc/index/pull/1936/files#diff-8ef4e92a336fe76cc2f51b7c2b72c5179194d00a8df567c4d5f6fbeded33c122) and `compute_similarity_with` in [type3.rs](https://github.com/indexable-inc/index/pull/1936/files#diff-3d11777295033abf6b8745fdcfa580481d5658bf2bdebec7fd7fc4d079bf544d) to dispatch per metric.
> - Replaces fixed LSH banding with `banding_for_threshold` in [lsh.rs](https://github.com/indexable-inc/index/pull/1936/files#diff-34d9ccb14f1bcd605976cf1832e9c5a8919c511fe0ef12b20de4acf258550cfe), which selects band/row counts so the S-curve inflection aligns with the configured threshold.
> - Adds a size-ratio floor (`min/max >= 0.4`) to prune extreme size-skew pairs when using the overlap metric.
> - Behavioral Change: `Kind::Type3` in JSON output now includes a `metric` field, changing the serialized schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f241a68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->