### PR TITLE
clone-detect: fix overlap-mode LSH banding recall + duplicate-heavy estimate pruning

### DIFF
--- a/doc/clone-detect/overview.md
+++ b/doc/clone-detect/overview.md
@@ -92,7 +92,8 @@ skipping symlinks/non-UTF-8/`ignore-file` files, and collecting
   configured `type3_metric` (`jaccard.rs`): `jaccard` (default,
   `|A∩B| / |A∪B|`) or `overlap` (containment, `|A∩B| / min(|A|,|B|)`), which
   catches copy-then-insert clones Jaccard misses but also nets structural
-  boilerplate, so pair it with a higher threshold (`>= 0.8`).
+  boilerplate, so pair it with a higher threshold (`>= 0.9` for repo-scale
+  sweeps; lower only on small targeted trees).
   `rayon`-parallel across kinds.
 - **Sequence** (`--sequences`, `sequences.rs`): sliding window of statements.
 - `dedup_subsumed` drops groups whose fragments are byte-range contained in a

--- a/packages/code/clone-detect/cli/src/main.rs
+++ b/packages/code/clone-detect/cli/src/main.rs
@@ -46,7 +46,7 @@ struct Args {
 
     /// Type-3 confirmation metric: `jaccard` (symmetric, precise; default) or
     /// `overlap` (containment: catches copy-then-insert clones but also nets
-    /// boilerplate, so pair it with a higher threshold).
+    /// boilerplate, so pair it with a higher threshold, >= 0.9 at repo scale).
     #[arg(long, value_enum)]
     type3_metric: Option<MetricArg>,
 

--- a/packages/code/clone-detect/detect/src/lsh.rs
+++ b/packages/code/clone-detect/detect/src/lsh.rs
@@ -255,7 +255,7 @@ pub fn estimated_jaccard(sig_a: &[u64; NUM_HASHES], sig_b: &[u64; NUM_HASHES]) -
 }
 
 /// Estimate the overlap coefficient (containment) from `MinHash` signatures
-/// plus the exact feature counts, in O(`NUM_HASHES`).
+/// plus the exact *distinct* (set) feature counts, in O(`NUM_HASHES`).
 ///
 /// `MinHash` only estimates Jaccard `J = I/U`, but with the exact sizes and
 /// `U = |A| + |B| - I` the intersection follows: `I = J(|A| + |B|)/(1 + J)`,
@@ -264,9 +264,12 @@ pub fn estimated_jaccard(sig_a: &[u64; NUM_HASHES], sig_b: &[u64; NUM_HASHES]) -
 /// every LSH candidate pays the exact O(n+m) merge — measured as a >500x
 /// slowdown over this whole repo versus the pruned Jaccard path.
 ///
-/// The signature estimates *set* Jaccard while the sizes count multisets, so
-/// the result is biased for duplicate-heavy features; callers prune with a
-/// slack margin, never confirm.
+/// The signature estimates *set* Jaccard, so `len_a`/`len_b` MUST be distinct
+/// counts to keep the estimate internally consistent; feeding multiset lengths
+/// under-estimates duplicate-heavy fragments and wrongly prunes them. The
+/// confirmed metric is still multiset overlap, whose residual divergence from
+/// the set estimate is absorbed by the caller's slack margin (estimates only
+/// prune, never confirm).
 #[must_use]
 #[expect(
     clippy::cast_precision_loss,
@@ -529,6 +532,41 @@ mod tests {
             b.len(),
         );
         assert!(est < 0.3, "disjoint sets must estimate low overlap: {est}");
+    }
+
+    /// Duplicate-heavy regression (review finding on #1936): the estimate must
+    /// use *distinct* counts, because the signature only sees sets. Small = 30
+    /// tokens each repeated 10x (multiset 300, set 30); large = the same plus
+    /// 15 fresh tokens x2 (multiset 330, set 45). Exact multiset overlap is
+    /// 1.0. Feeding multiset lengths deflates the estimate to ~0.84 (a 0.95
+    /// threshold would wrongly prune); distinct counts keep it ~1.0.
+    #[test]
+    fn estimated_overlap_duplicate_heavy_containment() {
+        let mut small = Vec::new();
+        for token in 1..=30u64 {
+            small.extend(std::iter::repeat_n(token, 10));
+        }
+        let mut large = small.clone();
+        for token in 31..=45u64 {
+            large.extend(std::iter::repeat_n(token, 2));
+        }
+        small.sort_unstable();
+        large.sort_unstable();
+
+        let sig_small = minhash_signature(&small);
+        let sig_large = minhash_signature(&large);
+
+        let set_based = estimated_overlap(&sig_small, &sig_large, 30, 45);
+        let multiset_based =
+            estimated_overlap(&sig_small, &sig_large, small.len(), large.len());
+        assert!(
+            set_based > 0.9,
+            "set-consistent estimate must keep duplicate-heavy containment, got {set_based}"
+        );
+        assert!(
+            set_based > multiset_based,
+            "multiset lengths deflate the estimate: set {set_based} vs multiset {multiset_based}"
+        );
     }
 
     #[test]

--- a/packages/code/clone-detect/detect/src/type3.rs
+++ b/packages/code/clone-detect/detect/src/type3.rs
@@ -44,7 +44,7 @@ pub fn find(scan: &Output, threshold: f64, metric: Type3Metric) -> Vec<CloneGrou
     // Banding derived once from the threshold: shared by every kind group so the
     // LSH S-curve matches the configured similarity floor (see
     // `banding_for_threshold`).
-    let banding = banding_for_threshold(threshold);
+    let banding = banding_for_threshold(banding_threshold(threshold, metric));
 
     let mut by_kind: FxHashMap<&str, Vec<IndexedNode<'_>>> = FxHashMap::default();
 
@@ -71,6 +71,7 @@ pub fn find(scan: &Output, threshold: f64, metric: Type3Metric) -> Vec<CloneGrou
             // are already caught as Type-2 instances. Only send one representative
             // per unique normalized_hash into LSH to shrink bucket sizes.
             let mut seen_normalized: FxHashMap<u64, usize> = FxHashMap::default();
+            let mut lens: FxHashMap<NodeLocation, FeatureLens> = FxHashMap::default();
             let entries: Vec<LshEntry> = nodes
                 .iter()
                 .filter(|indexed| !indexed.node.subtree_features.is_empty())
@@ -82,12 +83,22 @@ pub fn find(scan: &Output, threshold: f64, metric: Type3Metric) -> Vec<CloneGrou
                     // Keep only the first occurrence of each normalized_hash
                     *count == 1
                 })
-                .map(|indexed| LshEntry {
-                    location: NodeLocation {
+                .map(|indexed| {
+                    let location = NodeLocation {
                         file_id: indexed.file_id,
                         node_idx: indexed.node_idx,
-                    },
-                    signature: minhash_signature(&indexed.node.subtree_features),
+                    };
+                    lens.insert(
+                        location,
+                        FeatureLens {
+                            multiset: indexed.node.subtree_features.len(),
+                            set: distinct_count(&indexed.node.subtree_features),
+                        },
+                    );
+                    LshEntry {
+                        location,
+                        signature: minhash_signature(&indexed.node.subtree_features),
+                    }
                 })
                 .collect();
 
@@ -109,19 +120,25 @@ pub fn find(scan: &Output, threshold: f64, metric: Type3Metric) -> Vec<CloneGrou
                 // (containment), so pruning overlap candidates on a Jaccard
                 // estimate would silently drop the very insert/delete clones
                 // overlap exists to catch; `estimated_overlap` reconstructs
-                // containment from the Jaccard estimate plus exact sizes.
+                // containment from the Jaccard estimate plus exact sizes. The
+                // MinHash signature sees a set, so the estimate uses distinct
+                // counts; the size floor guards the exact (multiset) metric
+                // domain, so it uses multiset counts.
                 if let (Some(sig_a), Some(sig_b)) =
                     (index.signature(&pair.first), index.signature(&pair.second))
                 {
                     let estimate = match metric {
                         Type3Metric::Jaccard => estimated_jaccard(sig_a, sig_b),
                         Type3Metric::Overlap => {
-                            let len_a = feature_len(scan, &pair.first);
-                            let len_b = feature_len(scan, &pair.second);
-                            if !size_compatible(len_a, len_b) {
+                            let (Some(lens_a), Some(lens_b)) =
+                                (lens.get(&pair.first), lens.get(&pair.second))
+                            else {
+                                continue;
+                            };
+                            if !size_compatible(lens_a.multiset, lens_b.multiset) {
                                 continue;
                             }
-                            estimated_overlap(sig_a, sig_b, len_a, len_b)
+                            estimated_overlap(sig_a, sig_b, lens_a.set, lens_b.set)
                         }
                     };
                     if estimate < threshold - ESTIMATION_MARGIN {
@@ -148,14 +165,49 @@ pub fn find(scan: &Output, threshold: f64, metric: Type3Metric) -> Vec<CloneGrou
         .collect()
 }
 
-/// Feature-multiset size of the node at `loc`, `0` when the location is stale.
-/// LSH entries are built only from nodes with non-empty features, so a `0` here
-/// makes the overlap estimate `0.0` and the pair is pruned rather than panicking.
-fn feature_len(scan: &Output, loc: &NodeLocation) -> usize {
-    scan.files
-        .get(loc.file_id)
-        .and_then(|file| file.nodes.get(loc.node_idx))
-        .map_or(0, |node| node.subtree_features.len())
+/// The Jaccard level the LSH banding must be tuned to for a given metric.
+///
+/// LSH candidate generation is MinHash-based, so its S-curve lives in Jaccard
+/// space regardless of the confirmation metric. For Jaccard that is the
+/// threshold itself. For overlap, a pair can clear the overlap threshold `t`
+/// while its Jaccard is as low as the fully-contained, maximally size-gapped
+/// case: `I = t·min` and `max = min / r` (with `r` the size floor) give
+/// `J = t·min / (min + min/r - t·min) = t / (1 + 1/r - t)`. Banding on `t`
+/// directly puts the inflection far above that floor and silently drops the
+/// very size-gapped clones the overlap mode exists for (e.g. at `t = 0.8`,
+/// `r = 0.4`: J can be 0.296 while the t-derived inflection sits at 0.77).
+fn banding_threshold(threshold: f64, metric: Type3Metric) -> f64 {
+    match metric {
+        Type3Metric::Jaccard => threshold,
+        Type3Metric::Overlap => {
+            threshold / (1.0 + 1.0 / OVERLAP_SIZE_RATIO_FLOOR - threshold)
+        }
+    }
+}
+
+/// Multiset and distinct feature counts for one node, precomputed per LSH entry
+/// so the per-candidate estimate stays O(1).
+#[derive(Clone, Copy)]
+struct FeatureLens {
+    /// Total feature count with multiplicity (the exact metrics' domain).
+    multiset: usize,
+    /// Distinct feature count (the `MinHash` estimate's domain: signatures see
+    /// sets, so the overlap estimate must use set sizes or duplicate-heavy
+    /// fragments get under-estimated and wrongly pruned).
+    set: usize,
+}
+
+/// Count distinct values in a sorted slice (one linear pass over runs).
+fn distinct_count(sorted: &[u64]) -> usize {
+    let mut count = usize::from(!sorted.is_empty());
+    for window in sorted.windows(2) {
+        if let [a, b] = window
+            && a != b
+        {
+            count += 1;
+        }
+    }
+    count
 }
 
 /// Enforce [`OVERLAP_SIZE_RATIO_FLOOR`] on a pair of feature counts.
@@ -257,4 +309,38 @@ pub fn compute_similarity_with(a: &NodeInfo, b: &NodeInfo, metric: Type3Metric) 
     }
 
     min / max
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Jaccard mode bands on the configured threshold itself.
+    #[test]
+    fn banding_threshold_jaccard_is_identity() {
+        let t = banding_threshold(0.7, Type3Metric::Jaccard);
+        assert!((t - 0.7).abs() < 1e-9);
+    }
+
+    /// Overlap mode must band on the worst-case implied Jaccard, not the raw
+    /// threshold: a true overlap-0.8 pair at the maximum allowed size gap has
+    /// Jaccard `0.8 / (1 + 1/0.4 - 0.8) ~ 0.296`. Banding on 0.8 directly puts
+    /// the LSH inflection at ~0.77 and silently drops such pairs before the
+    /// exact check (the size-gapped clones this mode exists for).
+    #[test]
+    fn banding_threshold_overlap_uses_implied_jaccard_floor() {
+        let t = banding_threshold(0.8, Type3Metric::Overlap);
+        let expected = 0.8 / (1.0 + 1.0 / OVERLAP_SIZE_RATIO_FLOOR - 0.8);
+        assert!((t - expected).abs() < 1e-9);
+        assert!(t < 0.35, "implied floor must sit far below the raw threshold");
+    }
+
+    /// Distinct counting over sorted runs.
+    #[test]
+    fn distinct_count_over_runs() {
+        assert_eq!(distinct_count(&[]), 0);
+        assert_eq!(distinct_count(&[7]), 1);
+        assert_eq!(distinct_count(&[1, 1, 1]), 1);
+        assert_eq!(distinct_count(&[1, 1, 2, 3, 3]), 3);
+    }
 }

--- a/packages/code/clone-detect/detect/src/types.rs
+++ b/packages/code/clone-detect/detect/src/types.rs
@@ -17,8 +17,9 @@ use serde::{Deserialize, Serialize};
 ///   2019). The flip side: generic structural boilerplate contains easily, so
 ///   at the same threshold overlap reports far more groups (measured 40x on
 ///   this repo at 0.7). Use it for recall-oriented sweeps, preferably with a
-///   higher threshold (>= 0.8); pure insert/delete clones score near 1.0 under
-///   it, so a high threshold costs little recall on the cases it exists for.
+///   higher threshold (>= 0.9 at repo scale); pure insert/delete clones score
+///   near 1.0 under it, so a high threshold costs little recall on the cases
+///   it exists for.
 ///
 /// Jaccard is the default deliberately: it keeps default output precise (and
 /// byte-compatible with the tool's history), while overlap is the opt-in


### PR DESCRIPTION
Fixes the two review findings on #1936 — both were real recall bugs in the opt-in overlap metric. Refs #1929, #1935.

## P1: band overlap LSH on the implied Jaccard floor

LSH candidate generation is MinHash/Jaccard-space regardless of the confirmation metric. A valid overlap-`t` pair at the maximum allowed size gap (`OVERLAP_SIZE_RATIO_FLOOR` r = 0.4) has Jaccard only `t/(1 + 1/r - t)` (~0.30 at t = 0.8), while banding on the raw threshold put the S-curve inflection at ~0.77 — the size-gapped clones the mode exists for almost never surfaced. Overlap mode now bands on the implied floor (unit-tested).

## P2: set-consistent overlap estimate

`estimated_overlap` fed multiset lengths into a set-based MinHash identity, deflating duplicate-heavy fragments below the prune bar (regression-tested: a fully-contained duplicate-heavy pair estimated ~0.84 under multiset lengths vs ~1.0 set-consistent). Distinct feature counts are precomputed per LSH entry (one linear pass over the already-sorted features).

## Measured impact (packages/, this repo)

Honest recall makes overlap heavier — the old numbers were flattered by the P1 bug:

| overlap threshold | before (recall bug) | after (correct) |
|---|---|---|
| 0.8 | 14,089 groups / 1.3s | 121,239 / 33s |
| 0.9 | 4,504 / 0.6s | 14,040 / 1.5s |

Jaccard (default) unchanged: 2,328 / 0.6s. Docs now steer repo-scale overlap sweeps to `>= 0.9`; IDF down-weighting (#1935) is the precision path to make lower thresholds usable.

Validation: `cargo test` green (detect 61 + 9, cli 19 + 4), `nix run .#lint` green, clippy preflight clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix LSH banding recall and duplicate-heavy estimate pruning in overlap-mode Type-3 clone detection
> - LSH banding in overlap mode now uses the implied worst-case Jaccard floor (via new `banding_threshold`) instead of the raw overlap threshold, retaining size-gapped true positives that previously fell below the LSH inflection point.
> - Overlap estimation during candidate pruning now uses distinct (set) feature counts from a precomputed `FeatureLens` cache, avoiding incorrect pruning of duplicate-heavy containment cases.
> - Size compatibility pre-checks still use multiset lengths, keeping the existing size-floor filter intact.
> - Documentation and CLI help text for `--type3-metric overlap` updated to recommend thresholds >= 0.9 at repo scale.
> - Behavioral Change: overlap-mode detection now produces more candidate pairs and retains previously missed true positives; pruning behavior changes for duplicate-heavy token sequences.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37d9962.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->