### PR TITLE
feat(symphony): daily insights cron workflow posting its digest to Slack

### DIFF
--- a/packages/agent/symphony/.env.example
+++ b/packages/agent/symphony/.env.example
@@ -37,9 +37,9 @@ SYMPHONY_SLACK_NOTIFY_CRON_FAILURES=
 # Comma-separated workflow names whose successful cron runs also post, e.g.
 # "digest,quality". Use "*" to post every cron success (expect high-frequency
 # dispatchers like babysit-dispatch too). Defaults to none, so cron successes
-# stay quiet. Allowlisted runs also post their sink nodes' reserved
-# "summary" output as message content (see IR.RunNotifier); the bundled
-# indexable pack's daily digest is wired with
+# stay quiet. Notifying runs also post their sink nodes' reserved
+# "slack_summary" output as message content (see IR.RunNotifier); the
+# bundled indexable pack's daily digest is wired with
 # SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS=insights and
 # SYMPHONY_SLACK_NOTIFY_CHANNEL=C0A4TD9G7HR (#general).
 SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS=

--- a/packages/agent/symphony/.env.example
+++ b/packages/agent/symphony/.env.example
@@ -37,7 +37,11 @@ SYMPHONY_SLACK_NOTIFY_CRON_FAILURES=
 # Comma-separated workflow names whose successful cron runs also post, e.g.
 # "digest,quality". Use "*" to post every cron success (expect high-frequency
 # dispatchers like babysit-dispatch too). Defaults to none, so cron successes
-# stay quiet.
+# stay quiet. Allowlisted runs also post their sink nodes' reserved
+# "summary" output as message content (see IR.RunNotifier); the bundled
+# indexable pack's daily digest is wired with
+# SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS=insights and
+# SYMPHONY_SLACK_NOTIFY_CHANNEL=C0A4TD9G7HR (#general).
 SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS=
 
 # --- Dashboard / links ------------------------------------------------------

--- a/packages/agent/symphony/default.nix
+++ b/packages/agent/symphony/default.nix
@@ -118,6 +118,9 @@ in
       erlang
       pkgs.gh
       pkgs.git
+      # The bundled indexable pack's exec scripts build their structured
+      # {"slack_summary": ...} output with jq, so the runtime carries it.
+      pkgs.jq
       pkgs.openssh
     ];
     text = ''

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/config.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/config.ex
@@ -101,7 +101,7 @@ defmodule SymphonyElixir.Config do
       SYMPHONY_SLACK_POLL_MS  defaults to 60000
       SYMPHONY_SLACK_NOTIFY_CHANNEL optional; set empty to disable post-run notifications
       SYMPHONY_SLACK_NOTIFY_CRON_FAILURES post failed cron runs to Slack; defaults to true
-      SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS comma-separated workflow names whose cron successes also post, or "*" for every cron success; defaults to none. Allowlisted runs also post their sink nodes' reserved "summary" output as content (IR.RunNotifier)
+      SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS comma-separated workflow names whose cron successes also post, or "*" for every cron success; defaults to none. Notifying runs also post their sink nodes' reserved "slack_summary" output as content (IR.RunNotifier)
       SYMPHONY_ROOM_REGISTRY_URL central room.ix.dev a run's room-server registers with; also the Slack run-detail link base
       SYMPHONY_ROOM_REGISTRY_TOKEN optional bearer token for room backend registration writes
       SYMPHONY_ROOM_ADVERTISE_HOST optional; address a provisioned room-server binds/advertises so room.ix.dev can reach it

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/config.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/config.ex
@@ -101,7 +101,7 @@ defmodule SymphonyElixir.Config do
       SYMPHONY_SLACK_POLL_MS  defaults to 60000
       SYMPHONY_SLACK_NOTIFY_CHANNEL optional; set empty to disable post-run notifications
       SYMPHONY_SLACK_NOTIFY_CRON_FAILURES post failed cron runs to Slack; defaults to true
-      SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS comma-separated workflow names whose cron successes also post, or "*" for every cron success; defaults to none
+      SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS comma-separated workflow names whose cron successes also post, or "*" for every cron success; defaults to none. Allowlisted runs also post their sink nodes' reserved "summary" output as content (IR.RunNotifier)
       SYMPHONY_ROOM_REGISTRY_URL central room.ix.dev a run's room-server registers with; also the Slack run-detail link base
       SYMPHONY_ROOM_REGISTRY_TOKEN optional bearer token for room backend registration writes
       SYMPHONY_ROOM_ADVERTISE_HOST optional; address a provisioned room-server binds/advertises so room.ix.dev can reach it

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/run_notifier.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/run_notifier.ex
@@ -23,11 +23,13 @@ defmodule SymphonyElixir.IR.RunNotifier do
 
   Content sections: a succeeded run's message also carries the output of
   its sink nodes (nodes no other node depends on) when that output is a map
-  with a string under the reserved `"summary"` key. That is how a workflow
-  publishes real content (a digest, a report) through the notifier instead
-  of handing packs a Slack token: an exec script opts in by writing
-  `{"summary": ...}` to `SYMPHONY_OUTPUT_FILE` (see `Runtime.ExecRunner`).
-  Failed runs keep the compact failure summary only.
+  with a string under the reserved `"slack_summary"` key. That is how a
+  workflow publishes real content (a digest, a report) through the notifier
+  instead of handing packs a Slack token: an exec script opts in by writing
+  `{"slack_summary": ...}` to `SYMPHONY_OUTPUT_FILE` (see
+  `Runtime.ExecRunner`). The key names its destination so an ordinary
+  `"summary"` output field never publishes by accident. Failed runs keep
+  the compact failure summary only.
   """
 
   alias SymphonyElixir.Codex.Provision
@@ -155,11 +157,19 @@ defmodule SymphonyElixir.IR.RunNotifier do
   # Slack caps a section block's text at 3000 characters.
   @section_char_limit 3000
 
-  # The run's publishable content: each sink node's reserved "summary"
+  # The run's publishable content: each sink node's reserved "slack_summary"
   # output, one mrkdwn section per node (see moduledoc). Succeeded runs
   # only; a failed run's partial content would read as a delivered digest.
+  # Agent-authored text is untrusted: verbatim mrkdwn keeps *bold*/`code`
+  # rendering but disables <!channel>/<@user> mention parsing, so planted
+  # repo text cannot broadcast-ping the channel through the digest.
   defp content_sections(%RunGraph{status: :succeeded} = graph) do
-    for text <- sink_summaries(graph), do: section(truncate(text, @section_char_limit))
+    for text <- sink_summaries(graph) do
+      %{
+        "type" => "section",
+        "text" => %{"type" => "mrkdwn", "text" => truncate(text, @section_char_limit), "verbatim" => true}
+      }
+    end
   end
 
   defp content_sections(_graph), do: []
@@ -172,11 +182,18 @@ defmodule SymphonyElixir.IR.RunNotifier do
 
     for {id, node} <- Enum.sort_by(nodes, &elem(&1, 0)),
         not MapSet.member?(depended_on, id),
-        is_map(node.output) and not is_struct(node.output),
-        is_binary(node.output["summary"]),
-        node.output["summary"] != "",
-        do: node.output["summary"]
+        payload = structured_payload(node.output),
+        is_binary(payload["slack_summary"]),
+        payload["slack_summary"] != "",
+        do: payload["slack_summary"]
   end
+
+  # An exec node's decoded SYMPHONY_OUTPUT_FILE document is nested under
+  # :output in the runner's result wrapper (ExecRunner.apply_structured_output
+  # wraps it as %{kind: :exec, exit_code: 0, output: decoded, log: tail});
+  # a script that wrote no structured output leaves a binary there.
+  defp structured_payload(%{kind: :exec, output: payload}) when is_map(payload), do: payload
+  defp structured_payload(_output), do: nil
 
   defp node_breakdown(%RunGraph{nodes: nodes}) do
     nodes
@@ -340,11 +357,15 @@ defmodule SymphonyElixir.IR.RunNotifier do
 
   defp code(text), do: "`" <> to_string(text) <> "`"
 
-  # The limits are Slack's hard caps, so the ellipsis must fit inside them:
-  # slice to limit - 3 so the "..." never pushes the text over.
-  defp truncate(text, limit) when byte_size(text) <= limit, do: text
-
+  # The limits are Slack's hard caps in CHARACTERS ("must be less than 3001
+  # characters"), so both the guard and the slice count graphemes, and the
+  # ellipsis fits inside the cap: slice to limit - 3. A byte-based guard
+  # would spuriously truncate multibyte text far under the cap.
   defp truncate(text, limit) do
-    text |> String.slice(0, limit - 3) |> String.trim() |> Kernel.<>("...")
+    if String.length(text) <= limit do
+      text
+    else
+      text |> String.slice(0, limit - 3) |> String.trim() |> Kernel.<>("...")
+    end
   end
 end

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/run_notifier.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/run_notifier.ex
@@ -20,6 +20,14 @@ defmodule SymphonyElixir.IR.RunNotifier do
   specific names to surface only a few. The policy reads workflow names from
   config, never a literal in source, so `elixir/lib/` stays pack-agnostic.
   Non-cron terminal runs always notify.
+
+  Content sections: a succeeded run's message also carries the output of
+  its sink nodes (nodes no other node depends on) when that output is a map
+  with a string under the reserved `"summary"` key. That is how a workflow
+  publishes real content (a digest, a report) through the notifier instead
+  of handing packs a Slack token: an exec script opts in by writing
+  `{"summary": ...}` to `SYMPHONY_OUTPUT_FILE` (see `Runtime.ExecRunner`).
+  Failed runs keep the compact failure summary only.
   """
 
   alias SymphonyElixir.Codex.Provision
@@ -99,12 +107,15 @@ defmodule SymphonyElixir.IR.RunNotifier do
     header_text = "#{status_icon(status)} #{workflow} #{status_word(status)}"
 
     blocks =
-      [
-        header(header_text),
-        section(summary),
-        context(context_text(graph)),
-        actions(graph, room_base_url)
-      ]
+      ([
+         header(header_text),
+         section(summary)
+       ] ++
+         content_sections(graph) ++
+         [
+           context(context_text(graph)),
+           actions(graph, room_base_url)
+         ])
       |> Enum.reject(&is_nil/1)
 
     %{
@@ -139,6 +150,32 @@ defmodule SymphonyElixir.IR.RunNotifier do
 
   defp failed_node_ids(%RunGraph{nodes: nodes}) do
     for {id, node} <- nodes, node.state == :failed, do: id
+  end
+
+  # Slack caps a section block's text at 3000 characters.
+  @section_char_limit 3000
+
+  # The run's publishable content: each sink node's reserved "summary"
+  # output, one mrkdwn section per node (see moduledoc). Succeeded runs
+  # only; a failed run's partial content would read as a delivered digest.
+  defp content_sections(%RunGraph{status: :succeeded} = graph) do
+    for text <- sink_summaries(graph), do: section(truncate(text, @section_char_limit))
+  end
+
+  defp content_sections(_graph), do: []
+
+  # Sink nodes (no other node depends on them) are the run's results by
+  # construction; interior node outputs are plumbing. Sorted by id so
+  # multi-sink runs render deterministically.
+  defp sink_summaries(%RunGraph{nodes: nodes}) do
+    depended_on = nodes |> Map.values() |> Enum.flat_map(& &1.deps) |> MapSet.new()
+
+    for {id, node} <- Enum.sort_by(nodes, &elem(&1, 0)),
+        not MapSet.member?(depended_on, id),
+        is_map(node.output) and not is_struct(node.output),
+        is_binary(node.output["summary"]),
+        node.output["summary"] != "",
+        do: node.output["summary"]
   end
 
   defp node_breakdown(%RunGraph{nodes: nodes}) do
@@ -303,9 +340,11 @@ defmodule SymphonyElixir.IR.RunNotifier do
 
   defp code(text), do: "`" <> to_string(text) <> "`"
 
+  # The limits are Slack's hard caps, so the ellipsis must fit inside them:
+  # slice to limit - 3 so the "..." never pushes the text over.
   defp truncate(text, limit) when byte_size(text) <= limit, do: text
 
   defp truncate(text, limit) do
-    text |> String.slice(0, limit - 1) |> String.trim() |> Kernel.<>("...")
+    text |> String.slice(0, limit - 3) |> String.trim() |> Kernel.<>("...")
   end
 end

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/run_notifier.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/run_notifier.ex
@@ -157,6 +157,11 @@ defmodule SymphonyElixir.IR.RunNotifier do
   # Slack caps a section block's text at 3000 characters.
   @section_char_limit 3000
 
+  # Slack rejects messages over 50 blocks; up to 4 are structural (header,
+  # summary, context, actions), so cap content sections well inside that. A
+  # wide fan-out truncating its digest list beats the whole post failing.
+  @max_content_sections 40
+
   # The run's publishable content: each sink node's reserved "slack_summary"
   # output, one mrkdwn section per node (see moduledoc). Succeeded runs
   # only; a failed run's partial content would read as a delivered digest.
@@ -164,7 +169,7 @@ defmodule SymphonyElixir.IR.RunNotifier do
   # rendering but disables <!channel>/<@user> mention parsing, so planted
   # repo text cannot broadcast-ping the channel through the digest.
   defp content_sections(%RunGraph{status: :succeeded} = graph) do
-    for text <- sink_summaries(graph) do
+    for text <- graph |> sink_summaries() |> Enum.take(@max_content_sections) do
       %{
         "type" => "section",
         "text" => %{"type" => "mrkdwn", "text" => truncate(text, @section_char_limit), "verbatim" => true}

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
@@ -23,7 +23,10 @@ defmodule SymphonyElixir.Runtime.ExecRunner do
   ${node.output.field}` gating and `map ${node.output.items}` fan-out work
   over exec nodes. A script that writes nothing keeps today's behavior (the
   combined stdout/stderr tail as `output`); a non-empty file that is not
-  valid JSON fails the node loudly rather than guessing.
+  valid JSON fails the node loudly rather than guessing. The `"summary"`
+  key is reserved: on a sink node, `IR.RunNotifier` posts its string value
+  as message content, which is how a pack publishes a digest to Slack
+  without ever holding the bot token.
 
   The return shape matches `Runtime.EngineClient.run_node/2`
   (`{:ok, output, thread_id}` / `{:error, reason, thread_id}`) so the

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
@@ -23,10 +23,10 @@ defmodule SymphonyElixir.Runtime.ExecRunner do
   ${node.output.field}` gating and `map ${node.output.items}` fan-out work
   over exec nodes. A script that writes nothing keeps today's behavior (the
   combined stdout/stderr tail as `output`); a non-empty file that is not
-  valid JSON fails the node loudly rather than guessing. The `"summary"`
-  key is reserved: on a sink node, `IR.RunNotifier` posts its string value
-  as message content, which is how a pack publishes a digest to Slack
-  without ever holding the bot token.
+  valid JSON fails the node loudly rather than guessing. The
+  `"slack_summary"` key is reserved: on a sink node, `IR.RunNotifier` posts
+  its string value as message content, which is how a pack publishes a
+  digest to Slack without ever holding the bot token.
 
   The return shape matches `Runtime.EngineClient.run_node/2`
   (`{:ok, output, thread_id}` / `{:error, reason, thread_id}`) so the

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/triggers/cron.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/triggers/cron.ex
@@ -83,6 +83,11 @@ defmodule SymphonyElixir.Triggers.Cron do
 
   require Logger
 
+  @doc """
+  `opts` may carry `:run_opts`, forwarded to `Ingress.start_by_trigger/2`
+  (`:engine`, `:store_opts`), so a test drives a full tick against a fake
+  engine and an isolated store. Production passes nothing.
+  """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -98,35 +103,35 @@ defmodule SymphonyElixir.Triggers.Cron do
   end
 
   @impl true
-  def init(_opts) do
+  def init(opts) do
     poll_ms = Config.get().cron_poll_ms
     schedule_tick(poll_ms)
-    {:ok, %{poll_ms: poll_ms}}
+    {:ok, %{poll_ms: poll_ms, run_opts: Keyword.get(opts, :run_opts, [])}}
   end
 
   @impl true
   def handle_info(:tick, state) do
-    tick_once()
+    tick_once(state.run_opts)
     schedule_tick(state.poll_ms)
     {:noreply, state}
   end
 
   @impl true
   def handle_call(:poll_now, _from, state) do
-    tick_once()
+    tick_once(state.run_opts)
     {:reply, :ok, state}
   end
 
   defp schedule_tick(ms), do: Process.send_after(self(), :tick, ms)
 
-  defp tick_once do
+  defp tick_once(run_opts) do
     now = DateTime.utc_now()
 
     WorkflowCatalog.for_trigger_kind(:cron)
-    |> Enum.each(fn entry -> evaluate_workflow(entry, now) end)
+    |> Enum.each(fn entry -> evaluate_workflow(entry, now, run_opts) end)
   end
 
-  defp evaluate_workflow(entry, now) do
+  defp evaluate_workflow(entry, now, run_opts) do
     case CronExpression.parse(entry.trigger.schedule) do
       {:ok, parsed} ->
         case CronState.get_last_fired(entry.name) do
@@ -147,7 +152,7 @@ defmodule SymphonyElixir.Triggers.Cron do
   defp maybe_fire_due(entry, parsed, last_fired, now) do
     case next_due(parsed, last_fired, now, entry.trigger.timezone) do
       {:fire, scheduled_for} ->
-        fire(entry, scheduled_for, now)
+        fire(entry, scheduled_for, now, run_opts)
 
       :not_due ->
         :ok
@@ -199,7 +204,7 @@ defmodule SymphonyElixir.Triggers.Cron do
     end
   end
 
-  defp fire(entry, %DateTime{} = scheduled_for, %DateTime{} = now) do
+  defp fire(entry, %DateTime{} = scheduled_for, %DateTime{} = now, run_opts) do
     trigger = %{
       kind: :cron,
       schedule: entry.trigger.schedule,
@@ -209,7 +214,7 @@ defmodule SymphonyElixir.Triggers.Cron do
       input: entry.trigger.input
     }
 
-    case Ingress.start_by_trigger(trigger) do
+    case Ingress.start_by_trigger(trigger, run_opts) do
       {:ok, started} ->
         :ok = CronState.record_fire(entry.name, now)
 

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/triggers/cron.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/triggers/cron.ex
@@ -141,7 +141,7 @@ defmodule SymphonyElixir.Triggers.Cron do
             :ok = CronState.seed_if_unset(entry.name, now)
 
           %DateTime{} = last_fired ->
-            maybe_fire_due(entry, parsed, last_fired, now)
+            maybe_fire_due(entry, parsed, last_fired, now, run_opts)
         end
 
       {:error, reason} ->
@@ -149,7 +149,7 @@ defmodule SymphonyElixir.Triggers.Cron do
     end
   end
 
-  defp maybe_fire_due(entry, parsed, last_fired, now) do
+  defp maybe_fire_due(entry, parsed, last_fired, now, run_opts) do
     case next_due(parsed, last_fired, now, entry.trigger.timezone) do
       {:fire, scheduled_for} ->
         fire(entry, scheduled_for, now, run_opts)

--- a/packages/agent/symphony/elixir/test/catalog_assets_test.exs
+++ b/packages/agent/symphony/elixir/test/catalog_assets_test.exs
@@ -37,9 +37,9 @@ defmodule SymphonyElixir.CatalogAssetsTest do
     assert {:ok, workflow} = Parser.parse(source, file: "insights.sym")
 
     assert workflow.name == "insights"
-    # 16:00 UTC = 9am Pacific; the notifier posts its summary via the
-    # SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS allowlist.
-    assert workflow.trigger == %{kind: :cron, schedule: "0 16 * * *", timezone: "UTC", input: %{}}
+    # The cron kind is the load-bearing contract: it is what Triggers.Cron
+    # selects on, and what makes this pack scheduled rather than manual.
+    assert %{kind: :cron, schedule: "0 16" <> _} = workflow.trigger
 
     binds = for {:bind, name, _expr} <- workflow.statements, do: name
     assert binds == ["insights"]

--- a/packages/agent/symphony/elixir/test/catalog_assets_test.exs
+++ b/packages/agent/symphony/elixir/test/catalog_assets_test.exs
@@ -32,6 +32,19 @@ defmodule SymphonyElixir.CatalogAssetsTest do
            |> Enum.all?(&match?({:ok, %Skill{}}, &1))
   end
 
+  test "indexable pack insights workflow fires daily via cron" do
+    source = File.read!(Path.join([@root, "workflows", "indexable", "workflows", "insights.sym"]))
+    assert {:ok, workflow} = Parser.parse(source, file: "insights.sym")
+
+    assert workflow.name == "insights"
+    # 16:00 UTC = 9am Pacific; the notifier posts its summary via the
+    # SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS allowlist.
+    assert workflow.trigger == %{kind: :cron, schedule: "0 16 * * *", timezone: "UTC", input: %{}}
+
+    binds = for {:bind, name, _expr} <- workflow.statements, do: name
+    assert binds == ["insights"]
+  end
+
   test "example workflow pack is safe and manual-only" do
     source = File.read!(Path.join(@example_workflows_dir, "inspect.sym"))
     assert {:ok, workflow} = Parser.parse(source, file: "inspect.sym")

--- a/packages/agent/symphony/elixir/test/catalog_assets_test.exs
+++ b/packages/agent/symphony/elixir/test/catalog_assets_test.exs
@@ -37,9 +37,9 @@ defmodule SymphonyElixir.CatalogAssetsTest do
     assert {:ok, workflow} = Parser.parse(source, file: "insights.sym")
 
     assert workflow.name == "insights"
-    # The cron kind is the load-bearing contract: it is what Triggers.Cron
-    # selects on, and what makes this pack scheduled rather than manual.
-    assert %{kind: :cron, schedule: "0 16" <> _} = workflow.trigger
+    # The cron kind and zone are the load-bearing contract: Triggers.Cron
+    # selects on them, and the zone keeps 9am Pacific across DST.
+    assert %{kind: :cron, schedule: "0 9" <> _, timezone: "America/Los_Angeles"} = workflow.trigger
 
     binds = for {:bind, name, _expr} <- workflow.statements, do: name
     assert binds == ["insights"]

--- a/packages/agent/symphony/elixir/test/symphony_elixir/ir/run_notifier_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/ir/run_notifier_test.exs
@@ -245,6 +245,23 @@ defmodule SymphonyElixir.IR.RunNotifierTest do
       assert String.ends_with?(content, "...")
     end
 
+    test "content sections are capped inside Slack's 50-block message limit" do
+      # 60 independent sinks (no deps between them); the message must stay
+      # under 50 blocks total, so content is capped rather than the whole
+      # post failing.
+      nodes =
+        for i <- 1..60, into: %{} do
+          id = "sink-#{String.pad_leading(Integer.to_string(i), 2, "0")}"
+          {id, exec_node(id, %{"slack_summary" => "digest #{i}"})}
+        end
+
+      payload = RunNotifier.build_payload(graph(status: :succeeded, trigger: %{kind: :cron}, nodes: nodes), nil)
+
+      assert length(payload["blocks"]) <= 50
+      # 1 run summary + the capped content sections.
+      assert length(section_texts(payload)) == 41
+    end
+
     test "a failed run posts no content even when a sink carries a summary" do
       payload =
         RunNotifier.build_payload(

--- a/packages/agent/symphony/elixir/test/symphony_elixir/ir/run_notifier_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/ir/run_notifier_test.exs
@@ -23,6 +23,20 @@ defmodule SymphonyElixir.IR.RunNotifierTest do
     }
   end
 
+  # An exec node whose (possibly structured) output the content sections
+  # read; `deps` is hand-set so a test can shape sink vs interior directly.
+  defp exec_node(id, output, deps \\ []) do
+    %Node{
+      id: id,
+      ast_origin: {:exec, id},
+      kind: :exec,
+      inputs: [],
+      deps: deps,
+      state: :succeeded,
+      output: output
+    }
+  end
+
   # The notifier only reads the two cron-policy fields; default to the
   # production defaults (failures on, no success allowlist) unless overridden.
   defp config(attrs \\ %{}) do
@@ -143,6 +157,65 @@ defmodule SymphonyElixir.IR.RunNotifierTest do
       # No room url was given, so there is no run-details button.
       assert is_nil(button_with_text(payload, "Run details"))
     end
+  end
+
+  describe "content sections" do
+    test "posts a sink node's reserved summary output as message content" do
+      payload =
+        RunNotifier.build_payload(
+          graph(
+            status: :succeeded,
+            trigger: %{kind: :cron},
+            nodes: %{
+              "gather" => exec_node("gather", %{"summary" => "interior digest"}),
+              "digest" => exec_node("digest", %{"summary" => "*hello* from the digest"}, ["gather"])
+            }
+          ),
+          nil
+        )
+
+      texts = section_texts(payload)
+      assert "*hello* from the digest" in texts
+      # Interior node output is plumbing, not publishable content.
+      refute "interior digest" in texts
+    end
+
+    test "a sink without a string summary adds no content" do
+      base = graph(status: :succeeded, trigger: %{kind: :cron})
+
+      for output <- [nil, "raw tail", %{"summary" => 42}, %{"report" => "x"}, %{"summary" => ""}] do
+        payload = RunNotifier.build_payload(%{base | nodes: %{"n" => exec_node("n", output)}}, nil)
+        assert length(section_texts(payload)) == 1, "unexpected content for output #{inspect(output)}"
+      end
+    end
+
+    test "content is truncated to Slack's 3000-char section cap" do
+      long = String.duplicate("a", 4_000)
+
+      payload =
+        RunNotifier.build_payload(
+          graph(status: :succeeded, trigger: %{kind: :cron}, nodes: %{"n" => exec_node("n", %{"summary" => long})}),
+          nil
+        )
+
+      [_summary, content] = section_texts(payload)
+      assert byte_size(content) <= 3_000
+      assert String.ends_with?(content, "...")
+    end
+
+    test "a failed run posts no content even when a sink carries a summary" do
+      payload =
+        RunNotifier.build_payload(
+          graph(status: :failed, trigger: %{kind: :cron}, nodes: %{"n" => exec_node("n", %{"summary" => "partial"})}),
+          nil
+        )
+
+      refute "partial" in section_texts(payload)
+    end
+  end
+
+  defp section_texts(payload) do
+    for %{"type" => "section", "text" => %{"text" => text}} <- payload["blocks"], do: text
   end
 
   defp button_with_text(payload, text) do

--- a/packages/agent/symphony/elixir/test/symphony_elixir/ir/run_notifier_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/ir/run_notifier_test.exs
@@ -23,9 +23,11 @@ defmodule SymphonyElixir.IR.RunNotifierTest do
     }
   end
 
-  # An exec node whose (possibly structured) output the content sections
-  # read; `deps` is hand-set so a test can shape sink vs interior directly.
-  defp exec_node(id, output, deps \\ []) do
+  # An exec node carrying the runner's real result wrapper: the decoded
+  # SYMPHONY_OUTPUT_FILE document (or the raw stream tail) nests under
+  # :output, exactly as ExecRunner.apply_structured_output stores it.
+  # `deps` is hand-set so a test can shape sink vs interior directly.
+  defp exec_node(id, payload, deps \\ []) do
     %Node{
       id: id,
       ast_origin: {:exec, id},
@@ -33,7 +35,7 @@ defmodule SymphonyElixir.IR.RunNotifierTest do
       inputs: [],
       deps: deps,
       state: :succeeded,
-      output: output
+      output: %{kind: :exec, exit_code: 0, output: payload, log: "stream tail"}
     }
   end
 
@@ -167,8 +169,8 @@ defmodule SymphonyElixir.IR.RunNotifierTest do
             status: :succeeded,
             trigger: %{kind: :cron},
             nodes: %{
-              "gather" => exec_node("gather", %{"summary" => "interior digest"}),
-              "digest" => exec_node("digest", %{"summary" => "*hello* from the digest"}, ["gather"])
+              "gather" => exec_node("gather", %{"slack_summary" => "interior digest"}),
+              "digest" => exec_node("digest", %{"slack_summary" => "*hello* from the digest"}, ["gather"])
             }
           ),
           nil
@@ -178,35 +180,75 @@ defmodule SymphonyElixir.IR.RunNotifierTest do
       assert "*hello* from the digest" in texts
       # Interior node output is plumbing, not publishable content.
       refute "interior digest" in texts
+
+      # Agent-authored content is untrusted; verbatim mrkdwn disables
+      # <!channel>/<@user> mention parsing so it cannot broadcast-ping.
+      [content_block] = for %{"text" => %{"text" => "*hello*" <> _} = text} <- payload["blocks"], do: text
+      assert content_block["verbatim"] == true
     end
 
     test "a sink without a string summary adds no content" do
       base = graph(status: :succeeded, trigger: %{kind: :cron})
 
-      for output <- [nil, "raw tail", %{"summary" => 42}, %{"report" => "x"}, %{"summary" => ""}] do
-        payload = RunNotifier.build_payload(%{base | nodes: %{"n" => exec_node("n", output)}}, nil)
-        assert length(section_texts(payload)) == 1, "unexpected content for output #{inspect(output)}"
+      # "raw tail" is the no-structured-output case: the runner leaves the
+      # stream tail (a binary) under :output when the script wrote no JSON.
+      for payload <- ["raw tail", %{"slack_summary" => 42}, %{"report" => "x"}, %{"slack_summary" => ""}] do
+        message = RunNotifier.build_payload(%{base | nodes: %{"n" => exec_node("n", payload)}}, nil)
+        assert length(section_texts(message)) == 1, "unexpected content for payload #{inspect(payload)}"
       end
+
+      # A node that never produced any output at all.
+      bare = %Node{id: "n", ast_origin: {:exec, "n"}, kind: :exec, inputs: [], deps: [], state: :succeeded}
+      message = RunNotifier.build_payload(%{base | nodes: %{"n" => bare}}, nil)
+      assert length(section_texts(message)) == 1
     end
 
-    test "content is truncated to Slack's 3000-char section cap" do
+    test "content is truncated to Slack's 3000-character section cap" do
       long = String.duplicate("a", 4_000)
 
       payload =
         RunNotifier.build_payload(
-          graph(status: :succeeded, trigger: %{kind: :cron}, nodes: %{"n" => exec_node("n", %{"summary" => long})}),
+          graph(status: :succeeded, trigger: %{kind: :cron}, nodes: %{"n" => exec_node("n", %{"slack_summary" => long})}),
           nil
         )
 
       [_summary, content] = section_texts(payload)
-      assert byte_size(content) <= 3_000
+      assert String.length(content) <= 3_000
+      assert String.ends_with?(content, "...")
+    end
+
+    test "multibyte content under the character cap is not truncated" do
+      # 1200 CJK chars = 3600 bytes: over a byte-measured cap, well under
+      # Slack's 3000-character one. It must pass through untouched.
+      cjk = String.duplicate("語", 1_200)
+
+      payload =
+        RunNotifier.build_payload(
+          graph(status: :succeeded, trigger: %{kind: :cron}, nodes: %{"n" => exec_node("n", %{"slack_summary" => cjk})}),
+          nil
+        )
+
+      assert cjk in section_texts(payload)
+    end
+
+    test "multibyte content over the character cap truncates by characters" do
+      long = String.duplicate("語", 3_500)
+
+      payload =
+        RunNotifier.build_payload(
+          graph(status: :succeeded, trigger: %{kind: :cron}, nodes: %{"n" => exec_node("n", %{"slack_summary" => long})}),
+          nil
+        )
+
+      [_summary, content] = section_texts(payload)
+      assert String.length(content) <= 3_000
       assert String.ends_with?(content, "...")
     end
 
     test "a failed run posts no content even when a sink carries a summary" do
       payload =
         RunNotifier.build_payload(
-          graph(status: :failed, trigger: %{kind: :cron}, nodes: %{"n" => exec_node("n", %{"summary" => "partial"})}),
+          graph(status: :failed, trigger: %{kind: :cron}, nodes: %{"n" => exec_node("n", %{"slack_summary" => "partial"})}),
           nil
         )
 

--- a/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
@@ -134,4 +134,139 @@ defmodule SymphonyElixir.Triggers.CronTest do
       assert Process.alive?(cron)
     end
   end
+
+  describe "tick firing (full stack, fake engine)" do
+    defmodule FakeEngine do
+      @behaviour SymphonyElixir.Runtime.EngineClient
+
+      @impl true
+      def run_node(%SymphonyElixir.IR.Node{id: id}, _opts), do: {:ok, %{ran: id}, "thread-#{id}"}
+
+      @impl true
+      def status(_thread_id), do: :unknown
+    end
+
+    setup %{tmp_dir: base} do
+      start_supervised!({Registry, keys: :unique, name: SymphonyElixir.Runtime.Registry})
+      start_supervised!({Task.Supervisor, name: SymphonyElixir.TaskSupervisor})
+      start_supervised!(SymphonyElixir.Runtime.Supervisor)
+      start_supervised!(SymphonyElixir.CronState)
+
+      store = Path.join(base, "store")
+      workflows = Path.join(base, "workflows")
+      File.mkdir_p!(store)
+      File.mkdir_p!(workflows)
+      start_supervised!({WorkflowCatalog, workflows_dir: workflows, poll_ms: 60_000})
+
+      store_opts = [dir: store]
+      start_supervised!({Cron, run_opts: [engine: FakeEngine, store_opts: store_opts]})
+
+      {:ok, store_opts: store_opts, workflows_dir: workflows}
+    end
+
+    # Workflow names are unique per test because CronState persists to the
+    # shared test-root cron_state.json across this file's tests.
+    defp unique_name(prefix), do: "#{prefix}-#{System.unique_integer([:positive])}"
+
+    defp write_cron_sym!(dir, name, header_rest) do
+      source = ~s|workflow "#{name}" on cron #{header_rest} { a <- agent { engine: codex, model: "m", prompt: inline "go" } }|
+      File.write!(Path.join(dir, "#{name}.sym"), source)
+      WorkflowCatalog.scan(dir)
+    end
+
+    # Only stable snapshots: the store writes temp-then-rename, so a raw
+    # File.ls! can catch a transient <run_id>.json.tmp mid-persist.
+    defp run_files(store_opts) do
+      store_opts
+      |> Keyword.fetch!(:dir)
+      |> Path.join("*.json")
+      |> Path.wildcard()
+      |> Enum.map(&Path.basename/1)
+    end
+
+    # Same tolerance as IngressTest: start_link returns before the :advance
+    # continuation writes the first snapshot.
+    defp wait_terminal(run_id, store_opts, attempts \\ 60) do
+      case SymphonyElixir.IR.Store.load(run_id, store_opts) do
+        {:ok, %{status: status} = graph} when status in [:succeeded, :failed, :cancelled] ->
+          graph
+
+        _ when attempts == 0 ->
+          flunk("run #{run_id} never terminal")
+
+        _ ->
+          Process.sleep(20)
+          wait_terminal(run_id, store_opts, attempts - 1)
+      end
+    end
+
+    defp wait_run_count(store_opts, expected, attempts \\ 60) do
+      files = run_files(store_opts)
+
+      cond do
+        length(files) == expected ->
+          files
+
+        attempts == 0 ->
+          flunk("expected #{expected} run files, have #{inspect(files)}")
+
+        true ->
+          Process.sleep(20)
+          wait_run_count(store_opts, expected, attempts - 1)
+      end
+    end
+
+    @tag :tmp_dir
+    test "first observation seeds the watermark without firing", %{store_opts: store_opts, workflows_dir: dir} do
+      name = unique_name("seed")
+      write_cron_sym!(dir, name, ~s|"* * * * *"|)
+
+      assert :ok = Cron.poll_now()
+
+      assert %DateTime{} = SymphonyElixir.CronState.get_last_fired(name)
+      assert run_files(store_opts) == []
+    end
+
+    @tag :tmp_dir
+    test "fires exactly one zoned catch-up run and stamps the cron trigger", %{store_opts: store_opts, workflows_dir: dir} do
+      name = unique_name("daily")
+      write_cron_sym!(dir, name, ~s|"0 9 * * *" tz "America/Los_Angeles"|)
+
+      # A watermark two days back has a passed 9am-LA match, so the next
+      # tick owes exactly one catch-up fire.
+      :ok = SymphonyElixir.CronState.seed_if_unset(name, DateTime.add(DateTime.utc_now(), -2, :day))
+
+      assert :ok = Cron.poll_now()
+      [run_file] = wait_run_count(store_opts, 1)
+
+      # Let the run finish before the second tick so no snapshot persist
+      # races the file-count assertions below.
+      run_id = Path.rootname(run_file)
+      graph = wait_terminal(run_id, store_opts)
+      assert %{kind: :cron, schedule: "0 9 * * *", timezone: "America/Los_Angeles"} = graph.trigger
+
+      # The fire advanced the watermark to now, so an immediate second tick
+      # owes nothing: the watermark is untouched (record_fire is the only
+      # writer) and no second run appears.
+      watermark = SymphonyElixir.CronState.get_last_fired(name)
+      assert :ok = Cron.poll_now()
+      assert SymphonyElixir.CronState.get_last_fired(name) == watermark
+      assert run_files(store_opts) == [run_file]
+    end
+
+    @tag :tmp_dir
+    test "an unparseable schedule is logged and skipped without poisoning the tick", %{workflows_dir: dir} do
+      bad = unique_name("bad")
+      good = unique_name("good")
+      write_cron_sym!(dir, bad, ~s|"not a cron"|)
+      write_cron_sym!(dir, good, ~s|"* * * * *"|)
+
+      assert :ok = Cron.poll_now()
+
+      # The bad schedule cannot seed (it never parses), the good one still
+      # did: the tick walked past the failure instead of crashing.
+      assert is_nil(SymphonyElixir.CronState.get_last_fired(bad))
+      assert %DateTime{} = SymphonyElixir.CronState.get_last_fired(good)
+    end
+  end
 end

--- a/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
@@ -6,7 +6,8 @@ defmodule SymphonyElixir.Triggers.CronTest do
 
   import ExUnit.CaptureLog
 
-  alias SymphonyElixir.{CronExpression, WorkflowCatalog}
+  alias SymphonyElixir.{CronExpression, CronState, WorkflowCatalog}
+  alias SymphonyElixir.IR.{Node, Store}
   alias SymphonyElixir.Triggers.Cron
 
   # US DST in 2026: spring forward Sun Mar 8 (02:00 PST -> 03:00 PDT),
@@ -114,7 +115,7 @@ defmodule SymphonyElixir.Triggers.CronTest do
       )
 
       start_supervised!({WorkflowCatalog, workflows_dir: dir, poll_ms: 60_000})
-      start_supervised!(SymphonyElixir.CronState)
+      start_supervised!(CronState)
       cron = start_supervised!({Cron, []})
 
       # The catalog's boot scan is an async message; scan synchronously so
@@ -140,7 +141,7 @@ defmodule SymphonyElixir.Triggers.CronTest do
       @behaviour SymphonyElixir.Runtime.EngineClient
 
       @impl true
-      def run_node(%SymphonyElixir.IR.Node{id: id}, _opts), do: {:ok, %{ran: id}, "thread-#{id}"}
+      def run_node(%Node{id: id}, _opts), do: {:ok, %{ran: id}, "thread-#{id}"}
 
       @impl true
       def status(_thread_id), do: :unknown
@@ -150,7 +151,7 @@ defmodule SymphonyElixir.Triggers.CronTest do
       start_supervised!({Registry, keys: :unique, name: SymphonyElixir.Runtime.Registry})
       start_supervised!({Task.Supervisor, name: SymphonyElixir.TaskSupervisor})
       start_supervised!(SymphonyElixir.Runtime.Supervisor)
-      start_supervised!(SymphonyElixir.CronState)
+      start_supervised!(CronState)
 
       store = Path.join(base, "store")
       workflows = Path.join(base, "workflows")
@@ -187,7 +188,7 @@ defmodule SymphonyElixir.Triggers.CronTest do
     # Same tolerance as IngressTest: start_link returns before the :advance
     # continuation writes the first snapshot.
     defp wait_terminal(run_id, store_opts, attempts \\ 60) do
-      case SymphonyElixir.IR.Store.load(run_id, store_opts) do
+      case Store.load(run_id, store_opts) do
         {:ok, %{status: status} = graph} when status in [:succeeded, :failed, :cancelled] ->
           graph
 
@@ -223,7 +224,7 @@ defmodule SymphonyElixir.Triggers.CronTest do
 
       assert :ok = Cron.poll_now()
 
-      assert %DateTime{} = SymphonyElixir.CronState.get_last_fired(name)
+      assert %DateTime{} = CronState.get_last_fired(name)
       assert run_files(store_opts) == []
     end
 
@@ -234,7 +235,7 @@ defmodule SymphonyElixir.Triggers.CronTest do
 
       # A watermark two days back has a passed 9am-LA match, so the next
       # tick owes exactly one catch-up fire.
-      :ok = SymphonyElixir.CronState.seed_if_unset(name, DateTime.add(DateTime.utc_now(), -2, :day))
+      :ok = CronState.seed_if_unset(name, DateTime.add(DateTime.utc_now(), -2, :day))
 
       assert :ok = Cron.poll_now()
       [run_file] = wait_run_count(store_opts, 1)
@@ -248,9 +249,9 @@ defmodule SymphonyElixir.Triggers.CronTest do
       # The fire advanced the watermark to now, so an immediate second tick
       # owes nothing: the watermark is untouched (record_fire is the only
       # writer) and no second run appears.
-      watermark = SymphonyElixir.CronState.get_last_fired(name)
+      watermark = CronState.get_last_fired(name)
       assert :ok = Cron.poll_now()
-      assert SymphonyElixir.CronState.get_last_fired(name) == watermark
+      assert CronState.get_last_fired(name) == watermark
       assert run_files(store_opts) == [run_file]
     end
 
@@ -265,8 +266,8 @@ defmodule SymphonyElixir.Triggers.CronTest do
 
       # The bad schedule cannot seed (it never parses), the good one still
       # did: the tick walked past the failure instead of crashing.
-      assert is_nil(SymphonyElixir.CronState.get_last_fired(bad))
-      assert %DateTime{} = SymphonyElixir.CronState.get_last_fired(good)
+      assert is_nil(CronState.get_last_fired(bad))
+      assert %DateTime{} = CronState.get_last_fired(good)
     end
   end
 end

--- a/packages/agent/symphony/workflows/indexable/prompts/insights.md
+++ b/packages/agent/symphony/workflows/indexable/prompts/insights.md
@@ -1,0 +1,23 @@
+You are running unattended inside a read-only checkout of the primary
+repository. Produce today's insights digest; it will be posted verbatim to
+the engineering Slack channel.
+
+Explore the repository however you find productive: recent commit history,
+open TODO markers, dependency pins, CI configuration, module structure,
+docs that drifted from code. Then report 3 to 5 genuinely interesting,
+non-obvious, actionable insights. Good insights are things a maintainer
+would want to act on: quiet drift, growing duplication, a risky default,
+an abandoned half-migration, an opportunity to delete code.
+
+Rules for the output (your final message is the digest):
+
+- Slack mrkdwn only: *bold*, `code`, and "-" bullets. No headings, no
+  tables, no links other than plain URLs.
+- One bullet per insight; lead with a bold phrase, then one or two
+  sentences of evidence.
+- Cite at least one concrete file path per insight.
+- Under 2500 characters total.
+- No preamble, no sign-off, no meta commentary about this prompt or your
+  process; just the digest.
+- Prefer surprising findings over summaries of recent activity. Skip
+  anything a reader of the commit log would already know.

--- a/packages/agent/symphony/workflows/indexable/repositories.yaml
+++ b/packages/agent/symphony/workflows/indexable/repositories.yaml
@@ -1,0 +1,5 @@
+repositories:
+  - name: index
+    owner_repo: indexable-inc/index
+    default_branch: main
+    primary: true

--- a/packages/agent/symphony/workflows/indexable/scripts/insights.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/insights.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Daily insights digest: run a read-only headless codex agent over the
+# primary repository and hand its final message to the runtime as the
+# structured output {"summary": ...}. The reserved "summary" key is what
+# IR.RunNotifier posts to Slack, so delivery stays owned by the notifier
+# and this script never touches the Slack API.
+set -euo pipefail
+
+# Exec nodes run with the pack directory as cwd (ExecRunner), so the prompt
+# resolves pack-relative before we cd into the repo.
+prompt_file="$PWD/prompts/insights.md"
+last_msg="$(mktemp)"
+trap 'rm -f "$last_msg"' EXIT
+
+# Strip the Slack secret: the agent is open-ended, and posting is the
+# notifier's job, so it must not be able to speak as the bot.
+(
+  cd "$SYMPHONY_PRIMARY_REPO"
+  env -u SLACK_BOT_OAUTH_TOKEN \
+    codex exec --sandbox read-only --output-last-message "$last_msg" \
+    "$(cat "$prompt_file")"
+)
+
+# An empty final message means nothing postable; fail the node loudly so
+# the failure notification fires instead of a silent empty digest.
+[ -s "$last_msg" ]
+
+jq -n --rawfile summary "$last_msg" '{summary: $summary}' > "$SYMPHONY_OUTPUT_FILE"

--- a/packages/agent/symphony/workflows/indexable/scripts/insights.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/insights.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Daily insights digest: run a read-only headless codex agent over the
 # primary repository and hand its final message to the runtime as the
-# structured output {"summary": ...}. The reserved "summary" key is what
-# IR.RunNotifier posts to Slack, so delivery stays owned by the notifier
-# and this script never touches the Slack API.
+# structured output {"slack_summary": ...}. The reserved "slack_summary"
+# key is what IR.RunNotifier posts to Slack, so delivery stays owned by
+# the notifier and this script never touches the Slack API.
 set -euo pipefail
 
 # Exec nodes run with the pack directory as cwd (ExecRunner), so the prompt
@@ -12,12 +12,20 @@ prompt_file="$PWD/prompts/insights.md"
 last_msg="$(mktemp)"
 trap 'rm -f "$last_msg"' EXIT
 
-# Strip the Slack secret: the agent is open-ended, and posting is the
-# notifier's job, so it must not be able to speak as the bot.
+# The agent is open-ended and its output is published, so strip every
+# secret the symphony unit env carries (ExecRunner inherits the full BEAM
+# env and injects GH_TOKEN); codex only needs its own API key. Containment
+# beyond that relies on codex's read-only sandbox (network off) and its
+# default *KEY*/*SECRET*/*TOKEN* env scrub for model-spawned shells;
+# --ignore-user-config keeps a host config.toml from re-enabling network.
 (
   cd "$SYMPHONY_PRIMARY_REPO"
-  env -u SLACK_BOT_OAUTH_TOKEN \
-    codex exec --sandbox read-only --output-last-message "$last_msg" \
+  env -u SLACK_BOT_OAUTH_TOKEN -u SLACK_SIGNING_SECRET \
+    -u GH_TOKEN -u GITHUB_TOKEN -u GITHUB_WEBHOOK_SECRET \
+    -u LINEAR_API_KEY -u LINEAR_WEBHOOK_SECRET \
+    -u SYMPHONY_GITHUB_APP_PRIVATE_KEY_BASE64 -u SYMPHONY_ROOM_REGISTRY_TOKEN \
+    codex exec --sandbox read-only --ignore-user-config \
+    --output-last-message "$last_msg" \
     "$(cat "$prompt_file")"
 )
 
@@ -25,4 +33,4 @@ trap 'rm -f "$last_msg"' EXIT
 # the failure notification fires instead of a silent empty digest.
 [ -s "$last_msg" ]
 
-jq -n --rawfile summary "$last_msg" '{summary: $summary}' > "$SYMPHONY_OUTPUT_FILE"
+jq -n --rawfile summary "$last_msg" '{slack_summary: $summary}' > "$SYMPHONY_OUTPUT_FILE"

--- a/packages/agent/symphony/workflows/indexable/scripts/insights.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/insights.sh
@@ -7,19 +7,29 @@
 set -euo pipefail
 
 # Exec nodes run with the pack directory as cwd (ExecRunner), so the prompt
-# resolves pack-relative before we cd into the repo.
+# resolves pack-relative before we move into the repo.
 prompt_file="$PWD/prompts/insights.md"
 last_msg="$(mktemp)"
-trap 'rm -f "$last_msg"' EXIT
 
-# The agent is open-ended and its output is published, so strip every
-# secret the symphony unit env carries (ExecRunner inherits the full BEAM
-# env and injects GH_TOKEN); codex only needs its own API key. Containment
-# beyond that relies on codex's read-only sandbox (network off) and its
-# default *KEY*/*SECRET*/*TOKEN* env scrub for model-spawned shells;
+# The agent reads a detached worktree of HEAD, not the mutable checkout:
+# untracked files (.env, local scratch) in the operator's tree must never
+# be readable by a prompt whose output is posted to Slack. Tracked content
+# only, and the worktree is torn down whether the agent succeeds or not.
+digest_root="$(mktemp -d)"
+cleanup() {
+  git -C "$SYMPHONY_PRIMARY_REPO" worktree remove --force "$digest_root/repo" || true
+  rm -rf "$digest_root" "$last_msg"
+}
+trap cleanup EXIT
+git -C "$SYMPHONY_PRIMARY_REPO" worktree add --detach "$digest_root/repo" HEAD
+
+# Strip every secret the symphony unit env carries (ExecRunner inherits the
+# full BEAM env and injects GH_TOKEN); codex only needs its own API key.
+# Containment beyond that relies on codex's read-only sandbox (network off)
+# and its default *KEY*/*SECRET*/*TOKEN* env scrub for model-spawned shells;
 # --ignore-user-config keeps a host config.toml from re-enabling network.
 (
-  cd "$SYMPHONY_PRIMARY_REPO"
+  cd "$digest_root/repo"
   env -u SLACK_BOT_OAUTH_TOKEN -u SLACK_SIGNING_SECRET \
     -u GH_TOKEN -u GITHUB_TOKEN -u GITHUB_WEBHOOK_SECRET \
     -u LINEAR_API_KEY -u LINEAR_WEBHOOK_SECRET \

--- a/packages/agent/symphony/workflows/indexable/workflows/insights.sym
+++ b/packages/agent/symphony/workflows/indexable/workflows/insights.sym
@@ -1,7 +1,7 @@
 # Daily open-ended repo insights. The run notifier posts the script's
 # {"slack_summary": ...} output to Slack: allowlist "insights" in
 # SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS and point SYMPHONY_SLACK_NOTIFY_CHANNEL
-# at the target channel. 16:00 UTC = 9am Pacific (cron schedules are UTC-only).
-workflow "insights" on cron "0 16 * * *" {
+# at the target channel. Zoned schedule: 9am Pacific year-round (DST-proof).
+workflow "insights" on cron "0 9 * * *" tz "America/Los_Angeles" {
   insights <- exec "./scripts/insights.sh" timeout 3600
 }

--- a/packages/agent/symphony/workflows/indexable/workflows/insights.sym
+++ b/packages/agent/symphony/workflows/indexable/workflows/insights.sym
@@ -1,0 +1,7 @@
+# Daily open-ended repo insights. The run notifier posts the script's
+# {"summary": ...} output to Slack: allowlist "insights" in
+# SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS and point SYMPHONY_SLACK_NOTIFY_CHANNEL
+# at the target channel. 16:00 UTC = 9am Pacific (cron schedules are UTC-only).
+workflow "insights" on cron "0 16 * * *" {
+  insights <- exec "./scripts/insights.sh" timeout 3600
+}

--- a/packages/agent/symphony/workflows/indexable/workflows/insights.sym
+++ b/packages/agent/symphony/workflows/indexable/workflows/insights.sym
@@ -1,5 +1,5 @@
 # Daily open-ended repo insights. The run notifier posts the script's
-# {"summary": ...} output to Slack: allowlist "insights" in
+# {"slack_summary": ...} output to Slack: allowlist "insights" in
 # SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS and point SYMPHONY_SLACK_NOTIFY_CHANNEL
 # at the target channel. 16:00 UTC = 9am Pacific (cron schedules are UTC-only).
 workflow "insights" on cron "0 16 * * *" {


### PR DESCRIPTION
Closes #1938.

- New `workflows/indexable` pack: `insights.sym` fires `on cron "0 16 * * *"` (9am PT), running a read-only headless `codex exec` over `SYMPHONY_PRIMARY_REPO`; the script writes `{"summary": ...}` to `SYMPHONY_OUTPUT_FILE`.
- `IR.RunNotifier` posts sink-node `"summary"` output as message content on succeeded runs (Slack 3000-char section cap), so an allowlisted cron digest carries its actual insights; packs never hold the bot token. Failed runs keep the compact failure summary.
- `Triggers.Cron` gains `:run_opts` injection and a pure `next_due/3`, giving the tick its first tests (seed-no-fire, single catch-up, unparseable schedule skipped).
- Fix: shared `truncate/2` overshot Slack's hard caps by 2 chars (the 150-char header cap was already affected).

Deployment wiring (out of repo, documented in `.env.example`): `workflowPack = "indexable"` or `SYMPHONY_PACK_DIR`, `SYMPHONY_SLACK_NOTIFY_CHANNEL=C0A4TD9G7HR` (#general), `SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS=insights`, `codex` + `jq` on the unit path.

Follow-up: ix#6485 (`lastAgentMessage` on the engine wire contract) converts this to a true `agent` node.

Validation: full `mix test` (411 tests; sole failure is the pre-existing darwin `/private/tmp` artifact, fails on base too), format, credo, shellcheck on the pack script, cron tests run 5x for flake stability.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add daily insights cron workflow that posts a Slack digest via `slack_summary` sink output
> - Adds an [`insights.sym`](https://github.com/indexable-inc/index/pull/1947/files#diff-c02d63373792813511029aead26b169e56db3fb7b75120f2d23a82cea1916098) cron workflow (9am PT daily) that runs [`insights.sh`](https://github.com/indexable-inc/index/pull/1947/files#diff-364a554c8d8c5f993ce44303d0a5507cc5c8755ead4b9e983b2e789d0d05929f), which invokes `codex exec` against the primary repo and writes `{"slack_summary": ...}` to `$SYMPHONY_OUTPUT_FILE`.
> - Extends [`IR.RunNotifier`](https://github.com/indexable-inc/index/pull/1947/files#diff-72c9a0a909792e6ac863bef9bcd9fe87a77d3cc588e77c406cadd2537fb4cfe6) to append sink nodes' `"slack_summary"` output as Slack section blocks on succeeded runs, capped at 40 sections and 3000 chars each.
> - Propagates `run_opts` through the cron trigger stack so cron-fired runs can carry notify configuration into [`Ingress.start_by_trigger/2`](https://github.com/indexable-inc/index/pull/1947/files#diff-c2c70653322a20575e59b51c3970a843166eeab10e2f76fe2f12996951b5bc9c).
> - Adds `jq` to the symphony runtime environment for use in exec scripts that produce structured JSON output.
> - Fixes `truncate/2` in `RunNotifier` to count characters instead of bytes, preventing over-truncation of multibyte content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d62c4c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->