### PR TITLE
refactor(symphony): extract WebhookAuth and TriggerResponse, add missing webhook signature tests (#1939)

### DIFF
--- a/packages/agent/symphony/elixir/lib/symphony_elixir/dsl/parser.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/dsl/parser.ex
@@ -63,6 +63,7 @@ defmodule SymphonyElixir.DSL.Parser do
 
   alias SymphonyElixir.DSL.AST
   alias SymphonyElixir.DSL.Parser.Lexer
+  alias SymphonyElixir.Runtime.Trigger
 
   @type diagnostic :: %{
           message: String.t(),
@@ -165,7 +166,7 @@ defmodule SymphonyElixir.DSL.Parser do
 
   defp parse_trigger_kind("linear", state) do
     with {:ok, label, s1} <- labeled_string(state, "label") do
-      {:ok, %{kind: :linear, label: normalize_label(label)}, s1}
+      {:ok, %{kind: :linear, label: Trigger.normalize_label(label)}, s1}
     end
   end
 
@@ -184,7 +185,7 @@ defmodule SymphonyElixir.DSL.Parser do
   defp parse_trigger_kind("github_pr_label", state) do
     with {:ok, repo, s1} <- labeled_string(state, "repo"),
          {:ok, label, s2} <- labeled_string(s1, "label") do
-      {:ok, %{kind: :github_pr_label, repo: String.trim(repo), label: normalize_label(label)}, s2}
+      {:ok, %{kind: :github_pr_label, repo: String.trim(repo), label: Trigger.normalize_label(label)}, s2}
     end
   end
 
@@ -248,8 +249,6 @@ defmodule SymphonyElixir.DSL.Parser do
       other -> error(state, "expected a string for #{what}", token_value(other))
     end
   end
-
-  defp normalize_label(label), do: label |> String.trim() |> String.downcase()
 
   defp parse_statements(state, acc) do
     case peek(state) do

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/trigger.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/trigger.ex
@@ -80,6 +80,19 @@ defmodule SymphonyElixir.Runtime.Trigger do
   @spec matches?(declared(), event()) :: boolean()
   def matches?(_declared, _event), do: false
 
+  @doc """
+  Normalize a label to this matcher's vocabulary: trimmed and lowercased.
+
+  Both sides of a label comparison route through here (the DSL parser for
+  a workflow's declared `label`, the webhook controllers for an inbound
+  event's labels), so `"Bug "` and `"bug"` select the same workflows. A
+  non-string (a malformed event payload) normalizes to `""`, which
+  matches no declared label.
+  """
+  @spec normalize_label(term()) :: String.t()
+  def normalize_label(label) when is_binary(label), do: label |> String.trim() |> String.downcase()
+  def normalize_label(_label), do: ""
+
   # A Slack producer resolves the declared channel name (`#general`) to an
   # id once and stamps both `channel` and `channel_id` on the event, so the
   # declared name compares equal to either. Comparing against both keeps

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/github_webhook_controller.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/github_webhook_controller.ex
@@ -5,19 +5,20 @@ defmodule SymphonyElixirWeb.GithubWebhookController do
   Only pull_request.labeled events are actionable. Matching is driven by
   `.sym` workflows declaring trigger.kind = github_pr_label with a
   trigger.repo and trigger.label that match the incoming event, resolved
-  through the shared `Runtime.Trigger` matcher.
+  through the shared `Runtime.Trigger` matcher. Requests are authenticated
+  by `SymphonyElixirWeb.WebhookAuth` against `GITHUB_WEBHOOK_SECRET`.
   """
 
   use Phoenix.Controller, formats: [:json]
 
-  alias SymphonyElixir.Config
-  alias SymphonyElixir.Runtime.Ingress
+  alias SymphonyElixir.Runtime.{Ingress, Trigger}
+  alias SymphonyElixirWeb.{TriggerResponse, WebhookAuth}
 
   require Logger
 
   @spec accept(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def accept(conn, params) do
-    with :ok <- verify_signature(conn),
+    with :ok <- WebhookAuth.verify(conn, :github),
          :ok <- verify_event(conn) do
       json(conn, handle_event(params))
     else
@@ -28,44 +29,6 @@ defmodule SymphonyElixirWeb.GithubWebhookController do
         |> put_status(status)
         |> json(%{error: reason})
     end
-  end
-
-  defp verify_signature(conn) do
-    cond do
-      is_nil(Config.get().github_webhook_secret) ->
-        {:error, :unauthorized, "github webhook secret not configured"}
-
-      is_nil(conn.assigns[:raw_body]) ->
-        {:error, :bad_request, "missing raw body"}
-
-      true ->
-        provided =
-          conn
-          |> Plug.Conn.get_req_header("x-hub-signature-256")
-          |> List.first()
-
-        expected = expected_signature(conn.assigns.raw_body)
-
-        cond do
-          is_nil(provided) ->
-            {:error, :unauthorized, "missing X-Hub-Signature-256 header"}
-
-          byte_size(provided) != byte_size(expected) ->
-            {:error, :unauthorized, "signature mismatch"}
-
-          not Plug.Crypto.secure_compare(provided, expected) ->
-            {:error, :unauthorized, "signature mismatch"}
-
-          true ->
-            :ok
-        end
-    end
-  end
-
-  defp expected_signature(raw_body) do
-    secret = Config.get().github_webhook_secret
-    digest = :crypto.mac(:hmac, :sha256, secret, raw_body) |> Base.encode16(case: :lower)
-    "sha256=" <> digest
   end
 
   defp verify_event(conn) do
@@ -79,21 +42,22 @@ defmodule SymphonyElixirWeb.GithubWebhookController do
   defp handle_event(%{"action" => "labeled", "pull_request" => pr, "repository" => repo, "label" => label})
        when is_map(pr) and is_map(repo) and is_map(label) do
     repo_name = Map.get(repo, "full_name")
-    label_name = label |> Map.get("name", "") |> normalize_label()
+    label_name = label |> Map.get("name", "") |> Trigger.normalize_label()
     pr_number = Map.get(pr, "number")
 
     cond do
       Map.get(pr, "state") != "open" ->
-        %{ok: true, results: [format_result({:ignored, "PR is not open"})]}
+        %{ok: true, results: [TriggerResponse.format_result({:ignored, "PR is not open"})]}
 
       not is_integer(pr_number) ->
-        %{ok: true, results: [format_result({:ignored, "PR number missing"})]}
+        %{ok: true, results: [TriggerResponse.format_result({:ignored, "PR number missing"})]}
 
       active_run_exists?(repo_name, pr_number) ->
-        %{ok: true, results: [format_result({:deduped, pr_number})]}
+        %{ok: true, results: [TriggerResponse.format_result({:deduped, %{pr_number: pr_number}})]}
 
       true ->
-        start_label(build_trigger(repo_name, label_name, pr_number, pr), repo_name, pr_number)
+        trigger = build_trigger(repo_name, label_name, pr_number, pr)
+        TriggerResponse.start_by_trigger(trigger, "#{repo_name}##{pr_number} via github label")
     end
   end
 
@@ -113,18 +77,6 @@ defmodule SymphonyElixirWeb.GithubWebhookController do
     }
   end
 
-  defp start_label(trigger, repo_name, pr_number) do
-    case Ingress.start_by_trigger(trigger) do
-      {:ok, started} ->
-        Logger.info("Started runs=#{Enum.map_join(started, ",", & &1.run_id)} for #{repo_name}##{pr_number} via github label")
-        %{ok: true, enqueued: length(started), results: Enum.map(started, &format_result({:enqueued, &1.run_id}))}
-
-      {:error, reason} ->
-        Logger.warning("Failed to start github label run for #{repo_name}##{pr_number}: #{inspect(reason)}")
-        %{ok: true, results: [format_result({:error, inspect(reason)})]}
-    end
-  end
-
   defp active_run_exists?(repo, pr_number) do
     Ingress.seen_trigger?(fn
       {status, %{kind: :github_pr_label, repo: r, pr_number: n}} ->
@@ -134,12 +86,4 @@ defmodule SymphonyElixirWeb.GithubWebhookController do
         false
     end)
   end
-
-  defp normalize_label(name) when is_binary(name), do: name |> String.trim() |> String.downcase()
-  defp normalize_label(_), do: ""
-
-  defp format_result({:enqueued, run_id}), do: %{status: "enqueued", run_id: run_id}
-  defp format_result({:deduped, pr_number}), do: %{status: "deduped", pr_number: pr_number}
-  defp format_result({:ignored, reason}), do: %{status: "ignored", reason: reason}
-  defp format_result({:error, reason}), do: %{status: "error", reason: reason}
 end

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/linear_webhook_controller.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/linear_webhook_controller.ex
@@ -15,16 +15,9 @@ defmodule SymphonyElixirWeb.LinearWebhookController do
   - Copy the signing secret into `LINEAR_WEBHOOK_SECRET` on the
     symphony host
 
-  Security:
-
-  - Every request must carry a `Linear-Signature` header that is
-    `hex(hmac_sha256(secret, raw_body))`. Mismatched signatures get
-    `401`. The raw body is preserved by
-    `SymphonyElixirWeb.RawBodyReader` so HMAC is over the exact bytes
-    Linear signed.
-  - Absent secret -> we refuse to authenticate any request and return
-    `401`; this fail-closed default keeps an empty-secret deployment
-    from silently accepting unsigned traffic.
+  Security: every request must carry a `Linear-Signature` header that is
+  `hex(hmac_sha256(secret, raw_body))`, verified fail-closed by
+  `SymphonyElixirWeb.WebhookAuth` over the exact bytes Linear signed.
 
   Dedupe: an issue with an active run (status `:pending` or
   `:running`) is skipped, matching the previous poller's contract.
@@ -32,14 +25,14 @@ defmodule SymphonyElixirWeb.LinearWebhookController do
 
   use Phoenix.Controller, formats: [:json]
 
-  alias SymphonyElixir.Config
-  alias SymphonyElixir.Runtime.Ingress
+  alias SymphonyElixir.Runtime.{Ingress, Trigger}
+  alias SymphonyElixirWeb.WebhookAuth
 
   require Logger
 
   @spec accept(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def accept(conn, params) do
-    case verify_signature(conn) do
+    case WebhookAuth.verify(conn, :linear) do
       :ok ->
         handle_event(params)
         json(conn, %{ok: true})
@@ -51,41 +44,6 @@ defmodule SymphonyElixirWeb.LinearWebhookController do
         |> put_status(status)
         |> json(%{error: reason})
     end
-  end
-
-  defp verify_signature(conn) do
-    cond do
-      is_nil(Config.get().linear_webhook_secret) ->
-        {:error, :unauthorized, "linear webhook secret not configured"}
-
-      is_nil(conn.assigns[:raw_body]) ->
-        {:error, :bad_request, "missing raw body"}
-
-      true ->
-        provided =
-          conn
-          |> Plug.Conn.get_req_header("linear-signature")
-          |> List.first()
-
-        cond do
-          is_nil(provided) ->
-            {:error, :unauthorized, "missing Linear-Signature header"}
-
-          not Plug.Crypto.secure_compare(provided, expected_signature(conn.assigns.raw_body)) ->
-            {:error, :unauthorized, "signature mismatch"}
-
-          true ->
-            :ok
-        end
-    end
-  end
-
-  defp expected_signature(raw_body) do
-    secret = Config.get().linear_webhook_secret
-
-    :hmac
-    |> :crypto.mac(:sha256, secret, raw_body)
-    |> Base.encode16(case: :lower)
   end
 
   defp handle_event(%{"type" => "Issue", "action" => action} = event)
@@ -101,7 +59,7 @@ defmodule SymphonyElixirWeb.LinearWebhookController do
   defp extract_labels(%{"labels" => labels}) when is_list(labels) do
     labels
     |> Enum.map(fn
-      %{"name" => name} when is_binary(name) -> String.downcase(String.trim(name))
+      %{"name" => name} when is_binary(name) -> Trigger.normalize_label(name)
       _ -> nil
     end)
     |> Enum.reject(&is_nil/1)

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/slack_events_controller.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/slack_events_controller.ex
@@ -1,16 +1,21 @@
 defmodule SymphonyElixirWeb.SlackEventsController do
-  @moduledoc "Receives Slack Events API callbacks and starts app-mention IR runs."
+  @moduledoc """
+  Receives Slack Events API callbacks and starts app-mention IR runs.
+  Requests are authenticated by `SymphonyElixirWeb.WebhookAuth` against
+  `SLACK_SIGNING_SECRET`.
+  """
 
   use Phoenix.Controller, formats: [:json]
 
-  alias SymphonyElixir.{Config, Slack, WorkflowCatalog}
   alias SymphonyElixir.Runtime.Ingress
+  alias SymphonyElixir.{Slack, WorkflowCatalog}
+  alias SymphonyElixirWeb.{TriggerResponse, WebhookAuth}
 
   require Logger
 
   @spec accept(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def accept(conn, %{"type" => "url_verification", "challenge" => challenge}) do
-    case verify_signature(conn) do
+    case WebhookAuth.verify(conn, :slack) do
       :ok ->
         json(conn, %{challenge: challenge})
 
@@ -21,7 +26,7 @@ defmodule SymphonyElixirWeb.SlackEventsController do
 
   @spec accept(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def accept(conn, %{"event" => %{"type" => "app_mention"} = event}) do
-    case verify_signature(conn) do
+    case WebhookAuth.verify(conn, :slack) do
       :ok ->
         json(conn, handle_app_mention(event))
 
@@ -33,7 +38,7 @@ defmodule SymphonyElixirWeb.SlackEventsController do
 
   @spec accept(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def accept(conn, _params) do
-    case verify_signature(conn) do
+    case WebhookAuth.verify(conn, :slack) do
       :ok ->
         json(conn, %{ok: true, ignored: true})
 
@@ -49,10 +54,10 @@ defmodule SymphonyElixirWeb.SlackEventsController do
 
     cond do
       not is_binary(channel) or not is_binary(ts) ->
-        %{ok: true, results: [format_result({:ignored, "missing channel or ts"})]}
+        %{ok: true, results: [TriggerResponse.format_result({:ignored, "missing channel or ts"})]}
 
       active_run_exists?(channel, ts) ->
-        %{ok: true, results: [format_result({:deduped, ts})]}
+        %{ok: true, results: [TriggerResponse.format_result({:deduped, %{message_ts: ts}})]}
 
       true ->
         # Stamp both the raw channel id the event carries and any declared
@@ -68,17 +73,7 @@ defmodule SymphonyElixirWeb.SlackEventsController do
           text: Map.get(event, "text", "")
         }
 
-        start_mention(trigger)
-    end
-  end
-
-  defp start_mention(trigger) do
-    case Ingress.start_by_trigger(trigger) do
-      {:ok, started} ->
-        %{ok: true, enqueued: length(started), results: Enum.map(started, &format_result({:enqueued, &1.run_id}))}
-
-      {:error, reason} ->
-        %{ok: true, results: [format_result({:error, inspect(reason)})]}
+        TriggerResponse.start_by_trigger(trigger, "#{channel}@#{ts} via slack app mention")
     end
   end
 
@@ -111,46 +106,4 @@ defmodule SymphonyElixirWeb.SlackEventsController do
         false
     end)
   end
-
-  defp verify_signature(conn) do
-    secret = Config.get().slack_signing_secret
-
-    cond do
-      is_nil(secret) ->
-        {:error, :unauthorized, "slack signing secret not configured"}
-
-      is_nil(conn.assigns[:raw_body]) ->
-        {:error, :bad_request, "missing raw body"}
-
-      true ->
-        timestamp = conn |> Plug.Conn.get_req_header("x-slack-request-timestamp") |> List.first()
-        provided = conn |> Plug.Conn.get_req_header("x-slack-signature") |> List.first()
-        expected = expected_signature(secret, timestamp, conn.assigns.raw_body)
-
-        cond do
-          is_nil(timestamp) or is_nil(provided) ->
-            {:error, :unauthorized, "missing Slack signature headers"}
-
-          byte_size(provided) != byte_size(expected) ->
-            {:error, :unauthorized, "signature mismatch"}
-
-          not Plug.Crypto.secure_compare(provided, expected) ->
-            {:error, :unauthorized, "signature mismatch"}
-
-          true ->
-            :ok
-        end
-    end
-  end
-
-  defp expected_signature(secret, timestamp, body) do
-    base = "v0:" <> to_string(timestamp) <> ":" <> body
-    digest = :crypto.mac(:hmac, :sha256, secret, base) |> Base.encode16(case: :lower)
-    "v0=" <> digest
-  end
-
-  defp format_result({:enqueued, run_id}), do: %{status: "enqueued", run_id: run_id}
-  defp format_result({:deduped, ts}), do: %{status: "deduped", message_ts: ts}
-  defp format_result({:ignored, reason}), do: %{status: "ignored", reason: reason}
-  defp format_result({:error, reason}), do: %{status: "error", reason: reason}
 end

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/trigger_response.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/trigger_response.ex
@@ -1,0 +1,50 @@
+defmodule SymphonyElixirWeb.TriggerResponse do
+  @moduledoc """
+  The webhook controllers' shared response vocabulary: one formatter for
+  the per-run `results` entries and one start-log-respond step over
+  `Runtime.Ingress`, so the github and slack controllers cannot drift
+  apart on response field names or start/failure logging.
+  """
+
+  alias SymphonyElixir.Runtime.Ingress
+
+  require Logger
+
+  @typedoc "One per-run entry in a trigger response's `results` list."
+  @type result ::
+          {:enqueued, String.t()}
+          | {:deduped, map()}
+          | {:ignored, String.t()}
+          | {:error, String.t()}
+
+  @doc """
+  Start every workflow matching `trigger` and shape the JSON body the
+  controller answers with. `subject` names the event in the log line
+  (e.g. `"acme/widgets#7 via github label"`). A failed start still
+  answers `ok: true`: the webhook was authenticated and handled, so the
+  failure is symphony's to log, not the provider's to retry.
+  """
+  @spec start_by_trigger(map(), String.t()) :: map()
+  def start_by_trigger(trigger, subject) do
+    case Ingress.start_by_trigger(trigger) do
+      {:ok, started} ->
+        Logger.info("Started runs=#{Enum.map_join(started, ",", & &1.run_id)} for #{subject}")
+        %{ok: true, enqueued: length(started), results: Enum.map(started, &format_result({:enqueued, &1.run_id}))}
+
+      {:error, reason} ->
+        Logger.warning("Failed to start run for #{subject}: #{inspect(reason)}")
+        %{ok: true, results: [format_result({:error, inspect(reason)})]}
+    end
+  end
+
+  @doc """
+  One `results` entry. `:deduped` carries a map because each provider
+  dedups on its own key (`pr_number`, `message_ts`); the map is merged
+  into the entry beside the status.
+  """
+  @spec format_result(result()) :: map()
+  def format_result({:enqueued, run_id}), do: %{status: "enqueued", run_id: run_id}
+  def format_result({:deduped, extra}) when is_map(extra), do: Map.put(extra, :status, "deduped")
+  def format_result({:ignored, reason}), do: %{status: "ignored", reason: reason}
+  def format_result({:error, reason}), do: %{status: "error", reason: reason}
+end

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/webhook_auth.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/webhook_auth.ex
@@ -1,0 +1,97 @@
+defmodule SymphonyElixirWeb.WebhookAuth do
+  @moduledoc """
+  Shared HMAC signature verification for the webhook trigger controllers.
+
+  Each provider signs the raw request bytes (preserved by
+  `SymphonyElixirWeb.RawBodyReader`) with a shared secret; a controller
+  calls `verify/2` before trusting any parsed field. Keeping the check here
+  pins the semantics every provider must share: an unconfigured secret
+  fails closed with 401 (an empty-secret deployment must not silently
+  accept unsigned traffic), a missing raw body is a 400 (the request never
+  went through the body reader), and every comparison is a length-guarded
+  `Plug.Crypto.secure_compare`.
+
+  Only the signature scheme differs per provider:
+
+  - `:github` signs the raw body; `X-Hub-Signature-256` carries
+    `"sha256=" <> hex`.
+  - `:slack` signs `"v0:" <> timestamp <> ":" <> body` where the timestamp
+    rides in `X-Slack-Request-Timestamp`; `X-Slack-Signature` carries
+    `"v0=" <> hex`.
+  - `:linear` signs the raw body; `Linear-Signature` carries the bare hex
+    digest.
+  """
+
+  alias SymphonyElixir.Config
+
+  @typedoc "A webhook provider with a configured signing secret."
+  @type provider :: :github | :slack | :linear
+
+  @doc """
+  Verify the request's HMAC signature against `provider`'s configured
+  secret. Returns `:ok` or `{:error, status, message}` for the controller
+  to render.
+  """
+  @spec verify(Plug.Conn.t(), provider()) :: :ok | {:error, :unauthorized | :bad_request, String.t()}
+  def verify(conn, :github) do
+    with {:ok, secret} <- secret(Config.get().github_webhook_secret, "github webhook secret not configured"),
+         {:ok, body} <- raw_body(conn),
+         {:ok, provided} <- header(conn, "x-hub-signature-256", "missing X-Hub-Signature-256 header") do
+      compare(provided, "sha256=" <> hex_hmac(secret, body))
+    end
+  end
+
+  def verify(conn, :slack) do
+    with {:ok, secret} <- secret(Config.get().slack_signing_secret, "slack signing secret not configured"),
+         {:ok, body} <- raw_body(conn),
+         {:ok, timestamp} <- header(conn, "x-slack-request-timestamp", "missing Slack signature headers"),
+         {:ok, provided} <- header(conn, "x-slack-signature", "missing Slack signature headers") do
+      compare(provided, "v0=" <> hex_hmac(secret, "v0:" <> timestamp <> ":" <> body))
+    end
+  end
+
+  def verify(conn, :linear) do
+    with {:ok, secret} <- secret(Config.get().linear_webhook_secret, "linear webhook secret not configured"),
+         {:ok, body} <- raw_body(conn),
+         {:ok, provided} <- header(conn, "linear-signature", "missing Linear-Signature header") do
+      compare(provided, hex_hmac(secret, body))
+    end
+  end
+
+  # An absent secret refuses every request rather than skipping the check,
+  # so a deployment missing the env var cannot accept unsigned traffic.
+  defp secret(nil, message), do: {:error, :unauthorized, message}
+  defp secret(secret, _message), do: {:ok, secret}
+
+  # Verification needs the exact bytes the provider signed; only requests
+  # routed through RawBodyReader (the /api/v1/triggers/ paths) carry them.
+  defp raw_body(conn) do
+    case conn.assigns[:raw_body] do
+      nil -> {:error, :bad_request, "missing raw body"}
+      body -> {:ok, body}
+    end
+  end
+
+  defp header(conn, name, message) do
+    case conn |> Plug.Conn.get_req_header(name) |> List.first() do
+      nil -> {:error, :unauthorized, message}
+      value -> {:ok, value}
+    end
+  end
+
+  defp hex_hmac(secret, payload) do
+    :hmac
+    |> :crypto.mac(:sha256, secret, payload)
+    |> Base.encode16(case: :lower)
+  end
+
+  # secure_compare is only constant-time over equal-length inputs, so guard
+  # the length first; unequal lengths can never match anyway.
+  defp compare(provided, expected) do
+    if byte_size(provided) == byte_size(expected) and Plug.Crypto.secure_compare(provided, expected) do
+      :ok
+    else
+      {:error, :unauthorized, "signature mismatch"}
+    end
+  end
+end

--- a/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
@@ -8,7 +8,10 @@ defmodule SymphonyElixir.Runtime.ExecRunnerTest do
     pack = Path.join(System.tmp_dir!(), "exec_runner_#{System.unique_integer([:positive])}")
     File.mkdir_p!(Path.join(pack, "scripts"))
     on_exit(fn -> File.rm_rf(pack) end)
-    {:ok, pack: pack}
+    # The port's cd resolves symlinks (macOS /tmp is a symlink to
+    # /private/tmp), so hand tests the physical path a script's pwd reports.
+    {physical, 0} = System.cmd("pwd", [], cd: pack)
+    {:ok, pack: String.trim(physical)}
   end
 
   defp write_script!(pack, rel, body, mode \\ 0o755) do

--- a/packages/agent/symphony/elixir/test/symphony_elixir_web/github_webhook_controller_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir_web/github_webhook_controller_test.exs
@@ -1,0 +1,47 @@
+defmodule SymphonyElixirWeb.GithubWebhookControllerTest do
+  # Swaps the shared Config snapshot in ETS to configure the webhook
+  # secret, so this module cannot run concurrently with tests reading the
+  # same snapshot.
+  use ExUnit.Case, async: false
+
+  import Plug.{Conn, Test}
+
+  @opts SymphonyElixirWeb.Endpoint.init([])
+  @secret "gh-controller-secret"
+
+  setup do
+    snapshot = SymphonyElixir.Config.get()
+    :ets.insert(:symphony_config, {:snapshot, %{snapshot | github_webhook_secret: @secret}})
+    on_exit(fn -> :ets.insert(:symphony_config, {:snapshot, snapshot}) end)
+  end
+
+  # A closed PR exercises the full endpoint pipeline (RawBodyReader,
+  # WebhookAuth over the exact wire bytes, event handling) and answers
+  # before touching the IR store or the run supervisor.
+  test "accepts a correctly signed pull_request event" do
+    body =
+      Jason.encode!(%{
+        action: "labeled",
+        pull_request: %{number: 7, state: "closed"},
+        repository: %{full_name: "acme/widgets"},
+        label: %{name: "Deploy"}
+      })
+
+    signature = "sha256=" <> Base.encode16(:crypto.mac(:hmac, :sha256, @secret, body), case: :lower)
+
+    conn =
+      :post
+      |> conn("/api/v1/triggers/github", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("x-hub-signature-256", signature)
+      |> put_req_header("x-github-event", "pull_request")
+      |> SymphonyElixirWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+
+    assert Jason.decode!(conn.resp_body) == %{
+             "ok" => true,
+             "results" => [%{"status" => "ignored", "reason" => "PR is not open"}]
+           }
+  end
+end

--- a/packages/agent/symphony/elixir/test/symphony_elixir_web/linear_webhook_controller_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir_web/linear_webhook_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule SymphonyElixirWeb.LinearWebhookControllerTest do
+  # Swaps the shared Config snapshot in ETS to configure the webhook
+  # secret, so this module cannot run concurrently with tests reading the
+  # same snapshot.
+  use ExUnit.Case, async: false
+
+  import Plug.{Conn, Test}
+
+  @opts SymphonyElixirWeb.Endpoint.init([])
+  @secret "linear-controller-secret"
+
+  setup do
+    snapshot = SymphonyElixir.Config.get()
+    :ets.insert(:symphony_config, {:snapshot, %{snapshot | linear_webhook_secret: @secret}})
+    on_exit(fn -> :ets.insert(:symphony_config, {:snapshot, snapshot}) end)
+  end
+
+  # A non-Issue event exercises the full endpoint pipeline (RawBodyReader,
+  # WebhookAuth over the exact wire bytes, event dispatch) and answers
+  # before touching the IR store or the run supervisor.
+  test "accepts a correctly signed event" do
+    body = Jason.encode!(%{type: "Comment", action: "create"})
+    signature = Base.encode16(:crypto.mac(:hmac, :sha256, @secret, body), case: :lower)
+
+    conn =
+      :post
+      |> conn("/api/v1/triggers/linear", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("linear-signature", signature)
+      |> SymphonyElixirWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    assert Jason.decode!(conn.resp_body) == %{"ok" => true}
+  end
+end

--- a/packages/agent/symphony/elixir/test/symphony_elixir_web/webhook_auth_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir_web/webhook_auth_test.exs
@@ -1,0 +1,166 @@
+defmodule SymphonyElixirWeb.WebhookAuthTest do
+  # Each test swaps the shared Config snapshot in ETS (the pattern
+  # runtime_test.exs established), so this module cannot run concurrently
+  # with tests reading the same snapshot.
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+
+  alias SymphonyElixirWeb.WebhookAuth
+
+  @body ~s({"hello":"webhook"})
+
+  defp with_secret(key, value) do
+    snapshot = SymphonyElixir.Config.get()
+    :ets.insert(:symphony_config, {:snapshot, Map.put(snapshot, key, value)})
+    on_exit(fn -> :ets.insert(:symphony_config, {:snapshot, snapshot}) end)
+  end
+
+  # Build a conn the way the endpoint hands it to a trigger controller:
+  # parsed params are irrelevant here, but the raw body must be assigned
+  # exactly as RawBodyReader retains it.
+  defp signed_conn(headers, body \\ @body) do
+    conn = :post |> conn("/api/v1/triggers/test", body) |> Plug.Conn.assign(:raw_body, body)
+    Enum.reduce(headers, conn, fn {name, value}, acc -> Plug.Conn.put_req_header(acc, name, value) end)
+  end
+
+  defp hex_hmac(secret, payload) do
+    :hmac |> :crypto.mac(:sha256, secret, payload) |> Base.encode16(case: :lower)
+  end
+
+  describe "verify/2 for :github" do
+    test "accepts a correctly signed body" do
+      with_secret(:github_webhook_secret, "gh-secret")
+      signature = "sha256=" <> hex_hmac("gh-secret", @body)
+
+      assert WebhookAuth.verify(signed_conn([{"x-hub-signature-256", signature}]), :github) == :ok
+    end
+
+    test "rejects a signature computed with the wrong secret" do
+      with_secret(:github_webhook_secret, "gh-secret")
+      signature = "sha256=" <> hex_hmac("not-the-secret", @body)
+
+      assert WebhookAuth.verify(signed_conn([{"x-hub-signature-256", signature}]), :github) ==
+               {:error, :unauthorized, "signature mismatch"}
+    end
+
+    test "rejects a truncated signature without raising on the length mismatch" do
+      with_secret(:github_webhook_secret, "gh-secret")
+      signature = "sha256=" <> String.slice(hex_hmac("gh-secret", @body), 0..-2//1)
+
+      assert WebhookAuth.verify(signed_conn([{"x-hub-signature-256", signature}]), :github) ==
+               {:error, :unauthorized, "signature mismatch"}
+    end
+
+    test "rejects when the signature header is missing" do
+      with_secret(:github_webhook_secret, "gh-secret")
+
+      assert WebhookAuth.verify(signed_conn([]), :github) ==
+               {:error, :unauthorized, "missing X-Hub-Signature-256 header"}
+    end
+
+    test "rejects when the secret is not configured" do
+      with_secret(:github_webhook_secret, nil)
+      signature = "sha256=" <> hex_hmac("gh-secret", @body)
+
+      assert WebhookAuth.verify(signed_conn([{"x-hub-signature-256", signature}]), :github) ==
+               {:error, :unauthorized, "github webhook secret not configured"}
+    end
+
+    test "rejects when the raw body was not retained" do
+      with_secret(:github_webhook_secret, "gh-secret")
+      signature = "sha256=" <> hex_hmac("gh-secret", @body)
+
+      conn =
+        :post
+        |> conn("/api/v1/triggers/test", @body)
+        |> Plug.Conn.put_req_header("x-hub-signature-256", signature)
+
+      assert WebhookAuth.verify(conn, :github) == {:error, :bad_request, "missing raw body"}
+    end
+  end
+
+  describe "verify/2 for :slack" do
+    @timestamp "1531420618"
+
+    test "accepts a correctly signed body" do
+      with_secret(:slack_signing_secret, "slack-secret")
+      signature = "v0=" <> hex_hmac("slack-secret", "v0:" <> @timestamp <> ":" <> @body)
+
+      conn = signed_conn([{"x-slack-request-timestamp", @timestamp}, {"x-slack-signature", signature}])
+      assert WebhookAuth.verify(conn, :slack) == :ok
+    end
+
+    test "rejects when the timestamp differs from the signed one" do
+      with_secret(:slack_signing_secret, "slack-secret")
+      signature = "v0=" <> hex_hmac("slack-secret", "v0:" <> @timestamp <> ":" <> @body)
+
+      conn = signed_conn([{"x-slack-request-timestamp", "1531420619"}, {"x-slack-signature", signature}])
+      assert WebhookAuth.verify(conn, :slack) == {:error, :unauthorized, "signature mismatch"}
+    end
+
+    test "rejects when either signature header is missing" do
+      with_secret(:slack_signing_secret, "slack-secret")
+      signature = "v0=" <> hex_hmac("slack-secret", "v0:" <> @timestamp <> ":" <> @body)
+
+      only_signature = signed_conn([{"x-slack-signature", signature}])
+      only_timestamp = signed_conn([{"x-slack-request-timestamp", @timestamp}])
+
+      assert WebhookAuth.verify(only_signature, :slack) ==
+               {:error, :unauthorized, "missing Slack signature headers"}
+
+      assert WebhookAuth.verify(only_timestamp, :slack) ==
+               {:error, :unauthorized, "missing Slack signature headers"}
+    end
+
+    test "rejects when the secret is not configured" do
+      with_secret(:slack_signing_secret, nil)
+      signature = "v0=" <> hex_hmac("slack-secret", "v0:" <> @timestamp <> ":" <> @body)
+
+      conn = signed_conn([{"x-slack-request-timestamp", @timestamp}, {"x-slack-signature", signature}])
+
+      assert WebhookAuth.verify(conn, :slack) ==
+               {:error, :unauthorized, "slack signing secret not configured"}
+    end
+  end
+
+  describe "verify/2 for :linear" do
+    test "accepts a correctly signed body (bare hex digest)" do
+      with_secret(:linear_webhook_secret, "linear-secret")
+      signature = hex_hmac("linear-secret", @body)
+
+      assert WebhookAuth.verify(signed_conn([{"linear-signature", signature}]), :linear) == :ok
+    end
+
+    test "rejects a signature over a different body" do
+      with_secret(:linear_webhook_secret, "linear-secret")
+      signature = hex_hmac("linear-secret", @body <> "tampered")
+
+      assert WebhookAuth.verify(signed_conn([{"linear-signature", signature}]), :linear) ==
+               {:error, :unauthorized, "signature mismatch"}
+    end
+
+    test "rejects a wrong-length signature (the guard the old controller skipped)" do
+      with_secret(:linear_webhook_secret, "linear-secret")
+      signature = String.slice(hex_hmac("linear-secret", @body), 0..-2//1)
+
+      assert WebhookAuth.verify(signed_conn([{"linear-signature", signature}]), :linear) ==
+               {:error, :unauthorized, "signature mismatch"}
+    end
+
+    test "rejects when the signature header is missing" do
+      with_secret(:linear_webhook_secret, "linear-secret")
+
+      assert WebhookAuth.verify(signed_conn([]), :linear) ==
+               {:error, :unauthorized, "missing Linear-Signature header"}
+    end
+
+    test "rejects when the secret is not configured" do
+      with_secret(:linear_webhook_secret, nil)
+      signature = hex_hmac("linear-secret", @body)
+
+      assert WebhookAuth.verify(signed_conn([{"linear-signature", signature}]), :linear) ==
+               {:error, :unauthorized, "linear webhook secret not configured"}
+    end
+  end
+end


### PR DESCRIPTION
Slices 1 and 4 of #1939 (PR2 of the plan).

- **WebhookAuth**: one module owns HMAC verification for the github/slack/linear trigger controllers. Shared semantics pinned in one place: missing secret fails closed with 401, missing raw body is 400, every comparison is a length-guarded `Plug.Crypto.secure_compare` (the linear controller previously skipped the length guard the other two had). The three controllers' duplicated `verify_signature`/`expected_signature` privates are deleted.
- **TriggerResponse**: dedupes the identical `format_result/1` clauses and the Ingress start-log-respond block the github and slack controllers mirrored. No per-provider adapter behaviour; kept minimal.
- **normalize_label/1** moves into `Runtime.Trigger` (the matcher owns the label vocabulary); the DSL parser, the github controller, and the linear controller's inline copy all route through it.
- **Tests**: new `webhook_auth_test.exs` with real computed HMACs per provider (accept, reject, wrong length, missing header, missing secret, missing raw body), plus happy-path endpoint tests for the github and linear webhooks (only slack had one).
- **exec_runner_test** now compares against the physical pack path so `make all` passes on macOS, where `/tmp` resolves to `/private/tmp` through the port's cd.

Validated with `make all` (compile -Werror, format check, credo --strict against the shared config, 417 tests green).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract `WebhookAuth` and `TriggerResponse` modules and add webhook signature tests in Symphony
> - Introduces [`WebhookAuth`](https://github.com/indexable-inc/index/pull/1948/files#diff-222d1e54c9810a0cc52d6baeb6aecf81e258533e5626e2700c14ca5fc2e10876) with a `verify/2` function that centralizes HMAC signature verification for GitHub, Slack, and Linear webhooks, replacing duplicated local helpers in each controller.
> - Introduces [`TriggerResponse`](https://github.com/indexable-inc/index/pull/1948/files#diff-214aef83506f413f1dfc5ebd5ab5497b52d1205da6840517eb22ba733aa72191) with `start_by_trigger/2` and `format_result/1`, centralizing run-start logic and response shaping previously duplicated across controllers.
> - Moves `normalize_label/1` into [`SymphonyElixir.Runtime.Trigger`](https://github.com/indexable-inc/index/pull/1948/files#diff-4cfd3c9064567775943a822030cabc1806a2bce5153af136e5bc2c48357c95a6) as a public utility, removing duplicates in the parser and controllers.
> - Adds signature verification tests for all three webhook providers in [`webhook_auth_test.exs`](https://github.com/indexable-inc/index/pull/1948/files#diff-2cb2087f03001fed6022eca3f452fe7ecc6d6059a2f29b682a9f7ab85c54d6c4), covering correct signatures, wrong secrets, truncated signatures, missing headers, and missing raw bodies.
> - `WebhookAuth.verify/2` is fail-closed: missing secrets, headers, or raw body all return `{:error, :unauthorized}` rather than raising.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39a2495.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->