### PR TITLE
system-prompt: runtime-scoped sections + claude-code nix build observability note

### DIFF
--- a/packages/agent/prompt.nix
+++ b/packages/agent/prompt.nix
@@ -8,6 +8,12 @@
     claude = "Claude Code";
     codex = "Codex";
   };
+  # Runtime token each provider renders as, consumed by ./system-prompt.nix to
+  # filter runtime-scoped sections (a section's `runtimes` list holds these).
+  providerRuntimes = {
+    claude = "claude-code";
+    codex = "codex";
+  };
   extraSystemPrompts = {
     claude = ''
       You are Claude Code. When naming the coding-agent runtime or disclosing AI
@@ -23,6 +29,7 @@
       (import ./system-prompt.nix {
         inherit lib omitRules;
         agentName = providerNames.${provider};
+        runtime = providerRuntimes.${provider};
       })
       extraSystemPrompts.${provider}
     ];

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -1,6 +1,11 @@
 {
   lib,
   agentName ? "Claude Code",
+  # Target agent runtime for this render. Sections may narrow themselves to a
+  # subset of runtimes (see the optional `runtimes` field on a rule); this
+  # argument selects which. Tokens are the provider names ./prompt.nix maps:
+  # "claude-code", "codex".
+  runtime ? "claude-code",
   # Rule names to drop from this build's prompt, e.g.
   # `claude-code.override { omitRules = [ "reportToPlaybook" ]; }`.
   omitRules ? [],
@@ -9,11 +14,21 @@
 # Keep safety-critical rules explicit. Eval and rollouts are opt-in because prior
 # prompt edits caused live `claude -p ... --dangerously-skip-permissions` runs to
 # create real production side effects.
+#
+# Render and reread the claude-code prompt (the default runtime) with:
+#   nix eval --raw --impure --expr \
+#     'import ./packages/agent/system-prompt.nix { lib = (import <nixpkgs> {}).lib; }'
+# Pass `runtime = "codex";` in that attrset to render the Codex variant.
 let
   singletonRule = rule: let
     names = builtins.attrNames rule;
     name = builtins.head names;
     value = builtins.getAttr name rule;
+    valueNames = builtins.attrNames value;
+    # `runtimes` is optional; a section absent it applies to every runtime.
+    # attrNames is lexicographically sorted, so the two legal shapes are:
+    #   ["reason" "text"]  (all runtimes) and
+    #   ["reason" "runtimes" "text"]  (scoped to the listed runtimes).
   in
     assert lib.assertMsg (
       builtins.length names == 1
@@ -21,16 +36,16 @@ let
     # `reason` records the concrete failure mode or incident that motivated the
     # rule. It is provenance data for auditing and pruning, not prompt text:
     # rendering it would spend context tokens on metadiscussion.
-    # attrNames returns lexicographically sorted names, so `reason` precedes `text`.
     assert lib.assertMsg (
-      builtins.attrNames value
-      == [
-        "reason"
-        "text"
-      ]
-    ) "system-prompt.nix: rule `${name}` must have exactly `reason` and `text` fields"; {
+      valueNames
+      == ["reason" "text"]
+      || valueNames == ["reason" "runtimes" "text"]
+    ) "system-prompt.nix: rule `${name}` must have `reason` and `text` (and an optional `runtimes` list)"; {
       inherit name;
       inherit (value) text reason;
+      # Absent `runtimes` means every runtime; `null` marks that here so the
+      # filter below can treat "unset" and "listed" uniformly.
+      runtimes = value.runtimes or null;
     };
 
   # `order` is the source of truth: each key is the omitRules name and prompt order.
@@ -199,6 +214,25 @@ let
         reason = ''
           Questions about hosts and services were answered from stale docs while
           read-only SSH had the ground truth.
+        '';
+      };
+    }
+    {
+      machineBuildObservability = {
+        runtimes = ["claude-code"];
+        text = ''
+          When debugging a build or wondering what the nix daemon is doing, list
+          every in-flight daemon build machine-wide with `nix store builds --json`
+          (patched nix, experimental `build-status-dir`): each entry carries the
+          drv, client user, pid, log path, and the why-chain (the requested root
+          that pulled it in, and the cause). nwm renders this as the MACHINE BUILDS
+          pane (`nix run .#dashboard`, :7532). The subcommand is absent on stock
+          nix, so confirm it exists before relying on it (`nix store builds --help`).
+        '';
+        reason = ''
+          Machine-wide build observability shipped (nix 2.34.7+ix); agents
+          debugging builds guessed at daemon state instead of reading it. Scoped to
+          claude-code because it names claude-only tooling (nwm dashboard).
         '';
       };
     }
@@ -1035,7 +1069,12 @@ let
     name: builtins.length (builtins.filter (other: other == name) ruleNames) > 1
   ) (lib.unique ruleNames);
   unknownOmits = builtins.filter (name: !(builtins.any (rule: rule.name == name) order)) omitRules;
-  kept = builtins.filter (rule: !(builtins.elem rule.name omitRules)) order;
+  appliesToRuntime = rule: rule.runtimes == null || builtins.elem runtime rule.runtimes;
+  kept =
+    builtins.filter (
+      rule: !(builtins.elem rule.name omitRules) && appliesToRuntime rule
+    )
+    order;
 in
   assert lib.assertMsg (
     duplicateNames == []


### PR DESCRIPTION
Closes #1950.

## Mechanism (generic)
Sections in `system-prompt.nix` can now declare which agent runtimes they apply to via an optional `runtimes = [ "claude-code" ];` field (absent = all runtimes). The renderer takes a `runtime` argument (default `"claude-code"`) and filters. One source of truth: the same `order` list renders per-runtime.

- `prompt.nix` maps each provider to its runtime token (`claude` -> `claude-code`, `codex` -> `codex`) and threads it through `systemPromptFor`.
- `singletonRule` assert extended to allow the optional field: legal shapes are `[reason text]` or `[reason runtimes text]`. Verified the assert still rejects a malformed rule.
- `system-prompt-eval` imports the file directly with no `runtime` and gets the claude-code render, which is correct (eval targets claude).

## Content (claude-code only)
New `machineBuildObservability` section (runtimes = claude-code): `nix store builds --json` (patched nix, experimental `build-status-dir`) lists every in-flight daemon build machine-wide with drv, client user, pid, log path, and the why-chain; nwm renders it as the MACHINE BUILDS pane (`nix run .#dashboard`, :7532). Degrades to absent on stock nix, so probe by checking the subcommand exists. Placed right after `liveSystemEvidence` (answer machine/service state from the machine).

## Validation
- `nix run .#lint` clean (also runs as pre-commit hook).
- Rendered both runtimes; the only diff between claude-code and codex is exactly this one section (present for claude-code, absent for codex).
- Header eval snippet kept accurate and verified verbatim.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add runtime-scoped rule filtering to system-prompt with a `claude-code`-only build observability rule
> - [system-prompt.nix](https://github.com/indexable-inc/index/pull/1951/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) gains an optional `runtime` parameter (default `"claude-code"`) used to filter rules by their declared `runtimes` list; rules without a `runtimes` field apply to all runtimes.
> - [prompt.nix](https://github.com/indexable-inc/index/pull/1951/files#diff-5559a2a80a64417c055fd920fda60b94b9e4c5b6db3e14aaaf33c17cac3ba1eb) defines a `providerRuntimes` map (`claude → "claude-code"`, `codex → "codex"`) and passes the resolved token as `runtime` when importing the system prompt.
> - Adds a new `machineBuildObservability` rule scoped to `["claude-code"]` that instructs use of `nix store builds --json` and references a dashboard.
> - Behavioral Change: the rendered system prompt now varies by provider; rules with a `runtimes` field are excluded when the runtime does not match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized accf586.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->