### PR TITLE
feat(agent): session-retro skill + retro-gate Stop hook (#1952)

### DIFF
--- a/packages/agent/claude-hooks/src/main.rs
+++ b/packages/agent/claude-hooks/src/main.rs
@@ -12,6 +12,7 @@
 
 mod friction;
 mod guards;
+mod retro;
 mod review;
 mod session_banner;
 
@@ -79,6 +80,7 @@ fn main() -> ExitCode {
         Some("session-banner") => session_banner::session_banner(),
         Some("review-log-edit") => review::review_log_edit(),
         Some("review-gate") => review::review_gate(),
+        Some("retro-gate") => retro::retro_gate(),
         Some("cargo-guard") => guards::cargo_guard(),
         Some("bash-habits-guard") => guards::bash_habits_guard(),
         Some("search-guard") => guards::search_guard(),

--- a/packages/agent/claude-hooks/src/retro.rs
+++ b/packages/agent/claude-hooks/src/retro.rs
@@ -1,0 +1,301 @@
+//! Always-on session-retrospective trigger, a sibling of the `review-gate` Stop
+//! hook (`review.rs`). On Stop of a substantive session it blocks ONCE with a
+//! nudge to run the `session-retro` skill, which walks the finished session and
+//! files GitHub issues for everything improvable. A per-session marker makes it
+//! fire at most once per session, mirroring how `review-gate` tracks its state.
+//!
+//! Substantive-session heuristic: a session that made enough tool calls is worth
+//! retrospecting; a trivial one-question session is not. The count comes from the
+//! Stop payload's `transcript_path` (both the Claude and codex JSONL dialects
+//! carry `tool_use` / `function_call` entries), gated by [`RETRO_MIN_TOOL_CALLS`].
+//!
+//! Like every hook in this crate it fails OPEN and SILENT: any missing input,
+//! parse error, or bad session id exits quietly and never blocks Stop. It shares
+//! the loop-guard and background-work suppression policy with `review-gate` so a
+//! forced continuation can never wedge it into a permanent block.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// Below this many tool calls a session is a trivial one-question interaction not
+/// worth a retro. Overridable for tests and tuning.
+const DEFAULT_MIN_TOOL_CALLS: usize = 8;
+
+/// Per-session marker dir; overridable so the hook can be tested against a temp
+/// dir, matching the `review-gate` `CLAUDE_REVIEW_STATE_DIR` convention.
+fn state_dir() -> PathBuf {
+    std::env::var_os("CLAUDE_RETRO_STATE_DIR")
+        .filter(|v| !v.is_empty())
+        .map_or_else(|| crate::home().join(".claude/.retro-state"), PathBuf::from)
+}
+
+fn min_tool_calls() -> usize {
+    std::env::var("CLAUDE_RETRO_MIN_TOOL_CALLS")
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(DEFAULT_MIN_TOOL_CALLS)
+}
+
+/// `session_id` is interpolated into a file path; accept only a plain filename
+/// component so a crafted value cannot escape the state dir. Same contract as
+/// `review::safe_session`.
+fn safe_session(payload: &Value) -> Option<String> {
+    let session = payload.get("session_id").and_then(Value::as_str)?;
+    if session.is_empty() || session == "." || session == ".." || session.contains('/') {
+        return None;
+    }
+    Some(session.to_owned())
+}
+
+/// One `<session>.retro-done` marker per session: its presence means the retro
+/// gate already fired, so a later Stop must not fire again.
+fn marker_path(session: &str) -> PathBuf {
+    state_dir().join(format!("{session}.retro-done"))
+}
+
+/// What the Stop gate should do this turn, decided from the payload alone (no
+/// transcript I/O). Mirrors `review::GateAction`.
+#[derive(Debug, PartialEq, Eq)]
+enum GateAction {
+    /// This Stop is a forced continuation from a prior block: allow so the loop
+    /// can never wedge.
+    Allow,
+    /// The main session's own background work is still running: allow now so the
+    /// retro fires on a later Stop once nothing is in flight.
+    Defer,
+    /// Read the transcript, and if substantive and not already done, fire.
+    Evaluate,
+}
+
+/// True when the turn ended with the session's own background work still
+/// running. Same `background_tasks` signal `review-gate` uses.
+fn background_active(payload: &Value) -> bool {
+    payload
+        .get("background_tasks")
+        .and_then(Value::as_array)
+        .is_some_and(|tasks| !tasks.is_empty())
+}
+
+/// Pure gate policy over the Stop payload.
+fn gate_action(payload: &Value) -> GateAction {
+    if payload
+        .get("stop_hook_active")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return GateAction::Allow;
+    }
+    if background_active(payload) {
+        return GateAction::Defer;
+    }
+    GateAction::Evaluate
+}
+
+/// Count tool calls in a session transcript, across both dialects. Claude JSONL
+/// carries `{"type":"tool_use",...}` content items on assistant messages; the
+/// codex rollout carries `{"type":"function_call",...}` payload items. Counting
+/// any occurrence of either type token is a cheap, dialect-agnostic proxy: a
+/// deliberate over-count of a nested field is still bounded by transcript size
+/// and only nudges the substantive threshold, never blocks Stop.
+fn count_tool_calls(transcript: &str) -> usize {
+    transcript
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .map(|v| count_tool_calls_in_value(&v))
+        .sum()
+}
+
+/// Recursively count objects whose `type` is a tool-call marker.
+fn count_tool_calls_in_value(v: &Value) -> usize {
+    match v {
+        Value::Object(map) => {
+            let here = usize::from(
+                map.get("type")
+                    .and_then(Value::as_str)
+                    .is_some_and(|t| t == "tool_use" || t == "function_call"),
+            );
+            here + map.values().map(count_tool_calls_in_value).sum::<usize>()
+        }
+        Value::Array(items) => items.iter().map(count_tool_calls_in_value).sum(),
+        _ => 0,
+    }
+}
+
+/// A session is substantive when it made at least the threshold of tool calls.
+const fn is_substantive(tool_calls: usize, threshold: usize) -> bool {
+    tool_calls >= threshold
+}
+
+#[derive(Serialize)]
+struct StopBlock {
+    decision: &'static str,
+    reason: String,
+}
+
+/// Stop: block once per substantive session with a nudge to run `session-retro`.
+pub fn retro_gate() {
+    if crate::flag_set("CLAUDE_CODE_DISABLE_RETRO_GATE") {
+        return;
+    }
+    let Some(input) = crate::read_stdin() else {
+        return;
+    };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    let Some(session) = safe_session(&payload) else {
+        return;
+    };
+
+    match gate_action(&payload) {
+        // A forced continuation still marks the retro done, so a later plain Stop
+        // does not re-fire after the skill (or a decline) has run.
+        GateAction::Allow => {
+            let dir = state_dir();
+            if std::fs::create_dir_all(&dir).is_ok() {
+                let _ = std::fs::write(marker_path(&session), b"");
+            }
+            return;
+        }
+        GateAction::Defer => return,
+        GateAction::Evaluate => {}
+    }
+
+    let marker = marker_path(&session);
+    if marker.exists() {
+        return;
+    }
+
+    let Some(transcript) = payload.get("transcript_path").and_then(Value::as_str) else {
+        return;
+    };
+    if transcript.is_empty() || !Path::new(transcript).is_file() {
+        return;
+    }
+    let Ok(contents) = std::fs::read_to_string(transcript) else {
+        return;
+    };
+    if !is_substantive(count_tool_calls(&contents), min_tool_calls()) {
+        return;
+    }
+
+    // Mark done BEFORE blocking: the block forces a continuation whose Stop must
+    // not fire the gate again. Losing the block to a write failure beats a wedge.
+    let dir = state_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    if std::fs::write(&marker, b"").is_err() {
+        return;
+    }
+
+    let reason = "Before finishing, run the `session-retro` skill: walk this \
+         session for everything improvable (corrected mistakes, denied or guarded \
+         tool calls, workarounds, missing structured interfaces, hook noise, \
+         stalled watches, anything repeated), route each to the owning repo, \
+         dedupe against open issues, and file concise GitHub issues per the \
+         `issues` skill with AI attribution. Bias to filing; skip only real \
+         duplicates. If this turn was a question to the user rather than finished \
+         work, restate that question after you dispatch the retro."
+        .to_owned();
+
+    // Stop hook contract: top-level {"decision":"block","reason":...}.
+    if let Ok(s) = serde_json::to_string(&StopBlock {
+        decision: "block",
+        reason,
+    }) {
+        println!("{s}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        GateAction, count_tool_calls, gate_action, is_substantive, safe_session,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn session_rejects_path_escapes() {
+        assert_eq!(
+            safe_session(&json!({"session_id": "abc-123"})).as_deref(),
+            Some("abc-123")
+        );
+        assert!(safe_session(&json!({"session_id": "../escape"})).is_none());
+        assert!(safe_session(&json!({"session_id": "a/b"})).is_none());
+        assert!(safe_session(&json!({"session_id": "."})).is_none());
+        assert!(safe_session(&json!({"session_id": ""})).is_none());
+        assert!(safe_session(&json!({})).is_none());
+    }
+
+    #[test]
+    fn gate_evaluates_a_plain_main_session_stop() {
+        assert_eq!(
+            gate_action(&json!({"session_id": "s1"})),
+            GateAction::Evaluate
+        );
+    }
+
+    #[test]
+    fn gate_allows_on_forced_continuation() {
+        // Loop guard: a forced continuation must always allow so the gate can
+        // never wedge into a permanent block.
+        assert_eq!(
+            gate_action(&json!({"session_id": "s1", "stop_hook_active": true})),
+            GateAction::Allow,
+        );
+    }
+
+    #[test]
+    fn gate_defers_while_background_work_runs() {
+        assert_eq!(
+            gate_action(&json!({
+                "session_id": "s1",
+                "background_tasks": [{"type": "subagent", "status": "running"}],
+            })),
+            GateAction::Defer,
+        );
+    }
+
+    #[test]
+    fn loop_guard_outranks_background_work() {
+        assert_eq!(
+            gate_action(&json!({
+                "session_id": "s1",
+                "stop_hook_active": true,
+                "background_tasks": [{"type": "bash", "status": "running"}],
+            })),
+            GateAction::Allow,
+        );
+    }
+
+    #[test]
+    fn counts_tool_calls_across_dialects() {
+        // Claude dialect: tool_use content items on assistant messages.
+        let claude = [
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"ok"},{"type":"tool_use","name":"Bash"}]}}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read"}]}}"#,
+            // user message with no tool call
+            r#"{"type":"user","message":{"role":"user","content":"hi"}}"#,
+        ]
+        .join("\n");
+        assert_eq!(count_tool_calls(&claude), 2);
+
+        // Codex dialect: function_call payload items.
+        let codex = [
+            r#"{"payload":{"type":"function_call","name":"shell"}}"#,
+            r#"{"payload":{"type":"function_call","name":"apply_patch"}}"#,
+        ]
+        .join("\n");
+        assert_eq!(count_tool_calls(&codex), 2);
+    }
+
+    #[test]
+    fn substantive_threshold() {
+        assert!(!is_substantive(7, 8));
+        assert!(is_substantive(8, 8));
+        assert!(is_substantive(20, 8));
+    }
+}

--- a/packages/agent/policy/hooks.nix
+++ b/packages/agent/policy/hooks.nix
@@ -22,6 +22,7 @@
     subagentCacheLookup = hookRunnerSubcommand "subagent-cache-lookup";
     reviewEditLogger = hookRunnerSubcommand "review-log-edit";
     stopReviewGate = hookRunnerSubcommand "review-gate";
+    stopRetroGate = hookRunnerSubcommand "retro-gate";
     frictionIssueReporter = hookRunnerSubcommand "friction-report";
     subagentCachePopulate = hookRunnerSubcommand "subagent-cache-populate";
   };
@@ -97,6 +98,12 @@
     Stop = [
       {
         command = hookCommands.stopReviewGate;
+        agents = ["claude"];
+      }
+      # Retrospect a substantive session and file GitHub issues for what was
+      # improvable, once per session (own marker), like the review gate above.
+      {
+        command = hookCommands.stopRetroGate;
         agents = ["claude"];
       }
       {

--- a/packages/agent/skills/session-retro/SKILL.md
+++ b/packages/agent/skills/session-retro/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: session-retro
+description: "Retrospect the current session at its end and file a GitHub issue for everything improvable. Use when the Stop retro gate asks for it, or when asked to run a session retro, retro the session, mine this session for friction, or file issues for what went wrong this session. Walks what happened (corrected mistakes, denied or guarded tool calls, workarounds, retries, missing structured interfaces, hook noise, stalled watches, anything repeated), routes each to the owning repo, dedupes against open issues, and files concise issues per the issues skill with AI attribution."
+---
+
+# session-retro
+
+Turn the session you just finished into GitHub issues. Friction that repeats is
+friction that was never captured; capturing it at session end, in the repo that
+owns the fix, is how the tooling improves instead of every session relearning
+the same lesson. Bias to filing: many small precise issues beat none, and the
+user explicitly wants volume. The one hard limit is duplicates: never two issues
+for the same root cause.
+
+This is the agent-driven GitHub side of retrospection. The `friction-report`
+Stop hook files coarse items to Linear automatically; this skill produces the
+higher-quality, deduped, repo-routed GitHub issues.
+
+## Walk the session
+
+Scan this session's own transcript and your memory of it for every moment it
+fell short of fully agentic work. Look for:
+
+- **Corrected mistakes**: a wrong assumption you had to walk back, a wrong file
+  or command, something the user had to re-explain or correct.
+- **Denied or guarded tool calls**: a hook or permission that blocked you, a
+  guard message you had to route around.
+- **Workarounds**: a `sed`/manual edit reached for because a proper interface
+  was missing, a retry loop, a fallback you disliked.
+- **Missing structured interfaces**: a tool with no `--json`, output you had to
+  scrape, a flag or helper that should exist but does not.
+- **Missing context**: a fact that should have been ambient (a doc, a memory, a
+  CLAUDE.md line) and cost time to rediscover.
+- **Hook noise / stalled watches**: a hook that misfired or over-fired, a
+  monitor that never fired, a background watch that stalled.
+- **Anything repeated**: the same step, question, or error that recurred within
+  the session or across sessions.
+
+Routine iteration, a new user requirement, and stylistic preference are not
+friction. Every item must name the specific tool, file, flag, or missing fact;
+generic complaints are worthless.
+
+## Route and dedupe
+
+For each candidate:
+
+1. **Decide the owning repo**: the repo that owns the fix, not where the symptom
+   showed up. A weak flag on a repo tool, a misleading system-prompt rule, a
+   missing memory: each has a clear owner (`indexable-inc/index`,
+   `indexable-inc/ix`, or another org repo).
+2. **Search open issues first**: `gh search issues --repo <owner>/<repo>
+   "<keywords>" --state open` (or `gh issue list --repo <o>/<r> --search
+   "<keywords>"`). If a real duplicate exists, do NOT re-file. When you have new
+   evidence, comment on the existing issue instead (`gh issue comment`).
+
+## File
+
+File each survivor per the `issues` skill: short body (problem, evidence,
+proposed fix), one concrete observation per issue, labels at filing time
+(`bug`, `enhancement`, `documentation`, `ai-capable`, ...). Pass the body
+through `--body-file -` or a temp file, never an escaped `--body` string.
+
+Every issue must include:
+
+- **Evidence**: the decisive moment, quoted or with a concrete handle (a
+  command that was denied, the exact error, the tool and flag that was missing).
+  A repro command or step list when it is a bug.
+- **Proposed fix**: the smallest concrete change that would have prevented it.
+- **AI attribution**: note it was filed by an AI agent via a session retro (see
+  the `issues` and system-prompt AI-disclosure conventions).
+
+Do not open a second issue for a root cause already tracked or already filed
+earlier in this same retro.


### PR DESCRIPTION
Adds the agent-driven half of the always-on session retrospective (#1952):
a `session-retro` skill and a `retro-gate` Stop hook.

## What

- **`session-retro` skill** (`packages/agent/skills/session-retro`): walks the
  finished session for everything improvable (corrected mistakes, denied/guarded
  tool calls, workarounds, missing structured interfaces, hook noise, stalled
  watches, anything repeated), routes each to the owning repo, searches open
  issues to skip real duplicates (comments when there is new evidence), and files
  concise GitHub issues per the `issues` skill with AI attribution. Auto-discovered
  by `lib/skills.nix`.
- **`retro-gate` Stop hook** (`packages/agent/claude-hooks/src/retro.rs`): mirrors
  `review-gate`. On Stop of a substantive session it blocks once with a short nudge
  to run the skill. Substantive = tool-call count in the transcript (Claude and
  codex dialects) over a threshold, so trivial one-question sessions are skipped.
  A per-session `.retro-done` marker makes it fire at most once. Shares the
  loop-guard and background-work suppression with the review gate; fails open and
  silent. Wired into the Stop event in `packages/agent/policy/hooks.nix`.

This is the GitHub side; the existing `friction-report` hook remains the automatic
Linear side.

## Validation

- `nix run .#run -- cargo test -p claude-hooks`: 33 passed (6 new retro tests
  covering session-id escapes, loop guard, background-work defer, cross-dialect
  tool-call counting, substantive threshold).
- `nix build .#claude-hooks`: green.
- `nix run .#skill-lint -- packages/agent/skills/session-retro/SKILL.md`: 0 errors,
  0 warnings.
- `nix run .#lint`: green.
- Rendered `hooks.nix`: claude Stop event now runs review-gate, retro-gate,
  friction-report in that order.

The system-prompt rule (part 1 of #1952) lands in a separate PR after the
in-flight system-prompt PR #1949 merges, to avoid racing it.

---
_Authored by an AI agent via Claude Code._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `session-retro` skill and `retro-gate` Stop hook to claude-hooks
> - Adds a new `retro-gate` subcommand to the [claude-hooks binary](https://github.com/indexable-inc/index/pull/1953/files#diff-2d219c1873e0f6f8db7cbd30aeabac405d384c224e26f89100fa1eafed6c62eb) that runs as a Stop hook for Claude agents, blocking once per substantive session to prompt a retrospective.
> - The gate parses the Stop payload, counts `tool_use`/`function_call` entries in the JSONL transcript, and blocks with a `decision=block` JSON response when the session exceeds a configurable threshold (default: 8 tool calls, overridable via `CLAUDE_RETRO_MIN_TOOL_CALLS`).
> - A per-session marker file in `~/.claude/.retro-state` (overridable via `CLAUDE_RETRO_STATE_DIR`) prevents the gate from firing more than once per session.
> - The gate fails open and silent on any error (missing stdin, bad JSON, unsafe session ID, unreadable transcript), and defers when background tasks are active.
> - Adds the [session-retro skill](https://github.com/indexable-inc/index/pull/1953/files#diff-15ff72dcae872fcc77e1ab26a288af08dd2a88ee8a62d17f31187c58ff5d2071) and wires the hook into the [policy hooks config](https://github.com/indexable-inc/index/pull/1953/files#diff-24259d26867d29930c34306344c2664467b358d809c32c92ee35e26d811e7c32).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bd02de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->