### PR TITLE
system-prompt: file friction at discovery (#1952)

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -407,6 +407,32 @@ let
       };
     }
     {
+      fileFrictionAtDiscovery = {
+        text = ''
+          Whenever you catch yourself being dumb, file a GitHub issue at that
+          moment, not at session end. The triggers: a wrong assumption you had
+          to correct, a workaround you reached for, wasted time from a missing
+          tool, flag, or doc, a guard or hook that misfired, an instruction
+          (this prompt, a skill, a memory) that misled you. File in the repo
+          that owns the fix, with the concrete evidence: the exact command,
+          error, denied call, or missing interface, and the smallest change
+          that would have prevented it. Deduplicate against open issues first
+          and skip real duplicates. This is the interface-friction case of
+          machineReadableInterfaces generalized to every kind of self-inflicted
+          friction, filed through tieToIssue and owned through agentPerIssue.
+        '';
+        reason = ''
+          Friction was captured only when the user asked at the end of a
+          session: this session filed six such issues (#1941 through #1946)
+          in one batch at the user's prompt, by which point the concrete
+          evidence had to be reconstructed from memory. Filing at the moment of
+          discovery, while the command, error, and context are live, is the
+          fix; the session-retro skill and its Stop gate then sweep for
+          anything missed.
+        '';
+      };
+    }
+    {
       preV1 = {
         text = ''
           This codebase is pre-v1. Prefer the correct API over compatibility. Migrate
@@ -626,8 +652,8 @@ let
           When a tool we control lacks one, fix the
           interface upstream (a `--json` flag, structured output) rather than parsing
           prose. Treat any interface friction the same way (a missing flag, output, or
-          helper): improve it or file an issue or PR instead of silently working
-          around it.
+          helper): improve it or file an issue or PR (see fileFrictionAtDiscovery)
+          instead of silently working around it.
         '';
         reason = ''
           Scraping human-oriented output broke on format changes when a structured


### PR DESCRIPTION
Adds a `fileFrictionAtDiscovery` rule to the agent system prompt, placed in the issue-filing cluster (right after `tieToIssue` and `agentPerIssue`).

## What it says
File a GitHub issue the moment you catch friction, not at session end. Triggers: a wrong assumption you had to correct, a workaround you reached for, wasted time from a missing tool/flag/doc, a guard or hook that misfired, or an instruction (prompt, skill, memory) that misled you. File in the repo that owns the fix, with concrete evidence (exact command, error, denied call, missing interface) and the smallest preventing change. Deduplicate against open issues first. It is the interface-friction case of `machineReadableInterfaces` generalized to every kind of self-inflicted friction, filed through `tieToIssue` and owned through `agentPerIssue`.

## Why
Friction was captured only when the user asked at the end of a session. This session filed six such issues (#1941 through #1946) in one batch at the user's prompt, by which point the concrete evidence had to be reconstructed from memory. Filing at the moment of discovery, while the command, error, and context are live, is the fix; the session-retro skill and its Stop gate then sweep for anything missed.

The `machineReadableInterfaces` rule's interface-friction sentence now cross-references this rule, so the friction rule is stated once at its owner (per `oneImplementation`). The new rule has no `runtimes` field, so it applies to every runtime (verified: renders under both the default and codex variants).

Tracking issue #1952.

Authored by an AI agent via Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `fileFrictionAtDiscovery` directive to system prompt to file issues at point of discovery
> Adds a new `fileFrictionAtDiscovery` entry to [system-prompt.nix](https://github.com/indexable-inc/index/pull/1955/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) that instructs the agent to file a GitHub issue immediately upon encountering self-inflicted friction (wrong assumptions, missing tools/flags/docs, misfired hooks, misleading instructions) rather than batching at end of session. Also adds a cross-reference to `fileFrictionAtDiscovery` within the existing interface-friction guidance that previously advised filing issues or PRs instead of working around problems silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f22c9c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->