### PR TITLE
feat(symphony): home-manager module composing portable-services (#1956)

### DIFF
--- a/doc/symphony/operations/overview.md
+++ b/doc/symphony/operations/overview.md
@@ -187,6 +187,46 @@ services.symphony = {
 };
 ```
 
+## home-manager module (`packages/agent/symphony/home-module.nix`)
+
+`homeModules.symphony` runs the runtime as a user service: one declarative
+instance renders a native launchd agent on macOS and a native systemd user unit
+on Linux by composing `homeModules.portable-services`. It mirrors the NixOS
+module's vocabulary (`package`, `stateDir`, `httpPort`, `primaryRepo`,
+`repoRoot`, `workflowPack`/`packDir`, `extraEnvironment`, `environmentFile`,
+`secretsCommand`) minus the system-level pieces (no `user`, tmpfiles, or
+polkit); `bin/run-nix` creates the state dirs itself and defaults `stateDir` to
+`~/.local/state/symphony`. `packDir` is the hot-reload surface: point it at a
+mutable checkout and the runtime picks up edited `.sym` workflows and skills
+without a restart. Two knobs are home-specific: `extraPath` prepends packages
+to the service PATH (this is where deployers add their host-owned `codex`,
+plus `jq`/`gh` for workflows), and because launchd has no `EnvironmentFile`,
+secrets are loaded by a rendered launch wrapper that sources `environmentFile`
+and execs under `secretsCommand`. The unit is `restart = "always"` with no
+interval: the BEAM is the scheduler, cron triggers live inside it.
+
+```nix
+# home.nix on a workstation (e.g. hydra)
+{
+  imports = [index.homeModules.symphony];
+
+  services.symphony = {
+    enable = true;
+    primaryRepo = "/Users/andrewgazelka/Projects/indexable-inc/index";
+    packDir = "/Users/andrewgazelka/Projects/indexable-inc/symphony-pack";
+    environmentFile = "/Users/andrewgazelka/.config/symphony/secrets.env";
+    extraPath = [
+      pkgs.codex
+      pkgs.jq
+      pkgs.gh
+    ];
+  };
+}
+```
+
+Eval coverage (rendered plist, user unit, wrapper) lives in
+`tests/symphony-home-module.nix`, bundled into the `eval` flake check.
+
 ## Quality gates
 
 The required lane (compile `--warnings-as-errors`, `mix format --check-formatted`,

--- a/flake.nix
+++ b/flake.nix
@@ -439,6 +439,16 @@
         indexPackages = system: packages.${system};
         portableServicesModule = ix.portableServices.homeModule;
       };
+      # Workstation-facing module: run the Symphony BEAM runtime as a user
+      # service (native launchd agent on macOS, systemd user unit on Linux)
+      # by composing portable-services. Mirrors the NixOS module's option
+      # vocabulary; point `packDir` at a mutable checkout for hot-reloaded
+      # workflows and skills. See packages/agent/symphony/home-module.nix.
+      symphony = import ./packages/agent/symphony/home-module.nix {
+        indexPackages = system: packages.${system};
+        portableServicesModule = ix.portableServices.homeModule;
+        inherit ix;
+      };
     };
     overlays.default = ix.overlay;
     templates = {};

--- a/packages/agent/symphony/home-module.nix
+++ b/packages/agent/symphony/home-module.nix
@@ -1,0 +1,224 @@
+# home-manager module exposing `services.symphony`: run the Symphony BEAM
+# runtime as a user service, composing the portable-services layer so one
+# spec renders a native launchd agent on macOS and a native systemd user
+# unit on Linux. Option vocabulary mirrors the NixOS module
+# (modules/services/symphony/default.nix); only the concepts that make
+# sense in a user session are kept (no user/tmpfiles/polkit).
+#
+# Hot reload: point `packDir` at a mutable checkout (a plain working tree,
+# not a store path); the runtime re-reads `.sym` workflows and skills from
+# it live, so a `git pull` in the pack updates behavior without a restart.
+#
+# Secrets never land in the Nix store: `extraEnvironment` is rendered into
+# the world-readable agent/unit, so real credentials go through
+# `environmentFile` (sourced by the launch wrapper at start; launchd has no
+# EnvironmentFile equivalent) or `secretsCommand` (a `bws run --`-style
+# injector that wraps the exec).
+{
+  indexPackages,
+  portableServicesModule,
+  ix,
+}: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit
+    (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    optionalAttrs
+    optionalString
+    types
+    ;
+
+  cfg = config.services.symphony;
+
+  defaultPackage = (indexPackages pkgs.stdenv.hostPlatform.system).symphony;
+
+  # The repo's checked-bash writer (lib/util/writers.nix): the launcher is an
+  # exec-style wrapper (POSIX `.` sourcing of the secrets file, `exec` handoff
+  # to the optional secrets injector), which is the sanctioned bash escape
+  # hatch. `runtimeInputs` prepends `extraPath` to PATH, which is how the
+  # host-owned `codex` (deliberately not a runtime input of the symphony
+  # package) reaches the service.
+  inherit (ix) writeBashApplication;
+
+  launcher = writeBashApplication pkgs {
+    name = "symphony-launch";
+    runtimeInputs = cfg.extraPath;
+    text =
+      optionalString (cfg.environmentFile != null) ''
+        # launchd has no EnvironmentFile, so the wrapper sources the secrets
+        # file itself: KEY=VALUE lines, a shell-sourceable superset of the
+        # systemd EnvironmentFile format. set -a exports everything it sets.
+        set -a
+        . ${lib.escapeShellArg (toString cfg.environmentFile)}
+        set +a
+      ''
+      + ''
+        exec ${
+          optionalString (cfg.secretsCommand != null) (lib.escapeShellArgs cfg.secretsCommand + " ")
+        }${lib.getExe cfg.package} "$@"
+      '';
+  };
+in {
+  imports = [portableServicesModule];
+
+  options.services.symphony = {
+    enable = mkEnableOption "the Symphony runtime as a user service";
+
+    package = mkOption {
+      type = types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "index.packages.\${system}.symphony";
+      description = "Symphony package to run (this flake's launcher around bin/run-nix).";
+    };
+
+    stateDir = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Directory for runs, workspaces, logs, and the staged runtime copy
+        (SYMPHONY_STATE_DIR). Null leaves it to the launcher, which resolves
+        `$HOME/.local/state/symphony` at start; an eval-time default would
+        have to bake one machine's home path into the unit.
+      '';
+    };
+
+    httpPort = mkOption {
+      type = types.port;
+      default = 4040;
+      description = "Phoenix HTTP listener port (SYMPHONY_HTTP_PORT).";
+    };
+
+    primaryRepo = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Absolute path to the primary repository checkout (SYMPHONY_PRIMARY_REPO).";
+    };
+
+    repoRoot = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Optional parent directory of sibling repository checkouts (SYMPHONY_REPO_ROOT). Defaults to the parent of primaryRepo.";
+    };
+
+    workflowPack = mkOption {
+      type = types.str;
+      default = "example";
+      description = "Built-in workflow pack name; ignored when packDir is set.";
+    };
+
+    packDir = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Absolute path to an external workflow pack (SYMPHONY_PACK_DIR).
+        Takes precedence over workflowPack. This is the hot-reload surface:
+        point it at a mutable checkout (as a string path, never a `./`
+        literal, which would copy an immutable snapshot into the store) and
+        the runtime picks up edited `.sym` workflows and skills without a
+        restart.
+      '';
+    };
+
+    extraEnvironment = mkOption {
+      type = types.attrsOf types.str;
+      default = {};
+      description = ''
+        Additional environment variables exported to the service. Use for
+        non-secret config (SYMPHONY_BOT_USERNAME, LINEAR_WORKSPACE_SLUG,
+        ...); values are rendered into the world-readable Nix store, so put
+        secrets in environmentFile or behind secretsCommand instead.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Path to a KEY=VALUE secrets file (LINEAR_API_KEY, GITHUB_TOKEN,
+        SLACK_BOT_OAUTH_TOKEN, ...) sourced by the launch wrapper at start,
+        since launchd has no systemd EnvironmentFile. Point it at a runtime
+        path owned by your secret manager; leave null if secretsCommand
+        injects everything.
+      '';
+    };
+
+    secretsCommand = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      example = [
+        "bws"
+        "run"
+        "--"
+      ];
+      description = ''
+        Optional command that wraps the exec and injects secrets into the
+        environment (Bitwarden `bws run -- ...` or any compatible CLI that
+        execs its trailing arguments). Put the injector binary on PATH via
+        extraPath, and any token it needs (BWS_ACCESS_TOKEN) in
+        environmentFile.
+      '';
+    };
+
+    extraPath = mkOption {
+      type = types.listOf types.package;
+      default = [];
+      example = lib.literalExpression "[ pkgs.jq pkgs.gh ]";
+      description = ''
+        Extra packages prepended to the service PATH. bin/run-nix refuses to
+        start without an authenticated `codex` on PATH (intentionally not a
+        runtime input of the symphony package, so the binary and its
+        credentials stay host-owned); deployers add their codex package here,
+        plus anything workflows shell out to.
+      '';
+    };
+
+    launcher = mkOption {
+      type = types.package;
+      readOnly = true;
+      description = ''
+        The rendered launch wrapper: sources environmentFile, prepends
+        extraPath to PATH, and execs the package under secretsCommand.
+        Read-only; exposed so tests can inspect it and operators can run the
+        exact service command by hand.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.symphony.launcher = launcher;
+
+    services.portable.symphony = {
+      description = "Symphony runtime";
+      command = [(lib.getExe launcher)];
+      environment =
+        {
+          SYMPHONY_HTTP_PORT = toString cfg.httpPort;
+          SYMPHONY_WORKFLOW_PACK = cfg.workflowPack;
+        }
+        // optionalAttrs (cfg.stateDir != null) {
+          SYMPHONY_STATE_DIR = toString cfg.stateDir;
+        }
+        // optionalAttrs (cfg.primaryRepo != null) {
+          SYMPHONY_PRIMARY_REPO = toString cfg.primaryRepo;
+        }
+        // optionalAttrs (cfg.repoRoot != null) {
+          SYMPHONY_REPO_ROOT = toString cfg.repoRoot;
+        }
+        // optionalAttrs (cfg.packDir != null) {
+          SYMPHONY_PACK_DIR = toString cfg.packDir;
+        }
+        // cfg.extraEnvironment;
+      # The BEAM is the scheduler: cron triggers live inside the runtime, so
+      # the unit's whole job is to keep it up from login onward. No interval;
+      # a poller here would fight the long-running daemon.
+      restart = "always";
+      runAtLoad = true;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -15,6 +15,14 @@
   # (repo policy: no hash literals in tracked .nix).
   pins = ix.pins.loadPins ./pins.json;
   portableServicesTest = import ./portable-services.nix {inherit lib pkgs ix;};
+  symphonyHomeModuleTest = import ./symphony-home-module.nix {
+    inherit
+      lib
+      pkgs
+      ix
+      paths
+      ;
+  };
   # VM boot smoke test for the minecraft-blocks Paper plugin (ENG-2186). Not
   # part of the `eval` aggregate: it boots a qemu VM, so it is its own check
   # (`checks.<system>.minecraft-blocks-vm`).
@@ -5611,6 +5619,7 @@ in {
   # Strict type + annotation gate over the public ix-sdk Python sources.
   sdkPythonStrict = sdkPython.strictCheck;
   portableServices = portableServicesTest;
+  symphonyHomeModule = symphonyHomeModuleTest;
   minecraftBlocksVm = minecraftBlocksVmTest;
   inherit baseImageNixDb;
 
@@ -5622,6 +5631,7 @@ in {
       fleetTest
       helperTest
       portableServicesTest
+      symphonyHomeModuleTest
       cargoUnitPrebuiltTest
     ]
   );

--- a/tests/symphony-home-module.nix
+++ b/tests/symphony-home-module.nix
@@ -1,0 +1,175 @@
+# Eval tests for the symphony home-manager module. Evaluates
+# `services.symphony` through the real module with a stub portable-services
+# declaration (options only, no platform dispatch), then renders the
+# resulting `services.portable.symphony` spec through the pure launchd and
+# systemd transforms. The platform dispatch itself is already covered by
+# tests/portable-services.nix, so asserting on the transforms keeps this
+# test host-independent: both the plist and the user unit are checked on
+# every CI platform.
+{
+  lib,
+  pkgs,
+  ix,
+  paths,
+}: let
+  ps = ix.portableServices;
+
+  # Same `services.portable` declaration the real home module provides,
+  # minus its launchd/systemd config, so evalModules needs no home-manager
+  # option stubs.
+  portableDecl = {
+    options.services.portable = lib.mkOption {
+      type = lib.types.attrsOf ps.serviceSubmodule;
+      default = {};
+    };
+  };
+
+  # Eval-only stand-in for the symphony package: lib.getExe only constructs
+  # the /bin path string, so the stub is instantiated but never built.
+  symphonyStub = pkgs.runCommand "symphony" {meta.mainProgram = "symphony";} ''
+    mkdir -p "$out/bin"
+  '';
+
+  homeModule = import (paths.root + "/packages/agent/symphony/home-module.nix") {
+    indexPackages = _system: {symphony = symphonyStub;};
+    portableServicesModule = portableDecl;
+    inherit ix;
+  };
+
+  evalSymphony = settings:
+    (lib.evalModules {
+      modules = [
+        # Inject `pkgs` the way home-manager does (a module arg), not via
+        # specialArgs.
+        {_module.args.pkgs = pkgs;}
+        homeModule
+        {services.symphony = settings;}
+      ];
+    }).config;
+
+  # Full configuration: every knob that changes the rendered units.
+  full = evalSymphony {
+    enable = true;
+    httpPort = 4141;
+    stateDir = "/home/dev/.local/state/symphony";
+    primaryRepo = "/home/dev/src/index";
+    packDir = "/home/dev/src/symphony-pack";
+    extraEnvironment.SYMPHONY_BOT_USERNAME = "symphony-bot";
+    environmentFile = "/home/dev/.config/symphony/secrets.env";
+    secretsCommand = [
+      "bws"
+      "run"
+      "--"
+    ];
+    extraPath = [pkgs.jq];
+  };
+
+  # Defaults: only enable set, so the launcher owns state-dir and pack
+  # resolution and the wrapper is a bare exec.
+  minimal = evalSymphony {enable = true;};
+
+  fullSpec = full.services.portable.symphony;
+  fullLaunchd = ps.toLaunchdConfig fullSpec;
+  fullSystemd = ps.toSystemdUnits fullSpec;
+  fullLauncher = full.services.symphony.launcher;
+
+  minimalSpec = minimal.services.portable.symphony;
+  minimalLauncher = minimal.services.symphony.launcher;
+
+  # lib.hasInfix compiles the needle into a regex, and Nix refuses a regex
+  # string that carries store-path context; the needles below interpolate
+  # derivations (jq, the symphony stub), so drop the context. Assertion-only:
+  # nothing built depends on the discarded context.
+  hasDrvInfix = needle: lib.hasInfix (builtins.unsafeDiscardStringContext needle);
+
+  assertions = [
+    # --- command: one argv element, the rendered launch wrapper ---
+    {
+      assertion =
+        lib.length fullSpec.command == 1 && lib.hasSuffix "/bin/symphony-launch" (lib.head fullSpec.command);
+      message = "command should be exactly the launch wrapper";
+    }
+
+    # --- environment: typed options land in both renders ---
+    {
+      assertion = fullLaunchd.EnvironmentVariables.SYMPHONY_HTTP_PORT == "4141";
+      message = "httpPort should render into the launchd plist environment";
+    }
+    {
+      assertion = fullLaunchd.EnvironmentVariables.SYMPHONY_PACK_DIR == "/home/dev/src/symphony-pack";
+      message = "packDir should render as SYMPHONY_PACK_DIR (the hot-reload surface)";
+    }
+    {
+      assertion = fullLaunchd.EnvironmentVariables.SYMPHONY_STATE_DIR == "/home/dev/.local/state/symphony";
+      message = "stateDir should render as SYMPHONY_STATE_DIR when set";
+    }
+    {
+      assertion = fullLaunchd.EnvironmentVariables.SYMPHONY_BOT_USERNAME == "symphony-bot";
+      message = "extraEnvironment should merge into the launchd environment";
+    }
+    {
+      assertion =
+        lib.elem "SYMPHONY_PRIMARY_REPO=/home/dev/src/index" fullSystemd.service.Service.Environment
+        && lib.elem "SYMPHONY_BOT_USERNAME=symphony-bot" fullSystemd.service.Service.Environment;
+      message = "typed options and extraEnvironment should land in the systemd Environment list";
+    }
+
+    # --- restart policy: the BEAM is the scheduler, keep it up ---
+    {
+      assertion = fullLaunchd.KeepAlive == true && fullLaunchd.RunAtLoad == true;
+      message = "launchd agent should KeepAlive and RunAtLoad (restart=always daemon)";
+    }
+    {
+      assertion = !(fullLaunchd ? StartInterval);
+      message = "no interval: cron lives inside the runtime, not the unit";
+    }
+    {
+      assertion = fullSystemd.service.Service.Restart == "always";
+      message = "systemd unit should Restart=always";
+    }
+    {
+      assertion = fullSystemd.service.Install.WantedBy == ["default.target"] && fullSystemd.timer == null;
+      message = "systemd unit should be session-wanted with no timer";
+    }
+
+    # --- launch wrapper: PATH, secrets file, secretsCommand ---
+    {
+      assertion = hasDrvInfix "${pkgs.jq}/bin" fullLauncher.text;
+      message = "extraPath entries should be prepended to PATH in the wrapper";
+    }
+    {
+      # escapeShellArg leaves safe paths unquoted, so match the bare form.
+      assertion = lib.hasInfix ". /home/dev/.config/symphony/secrets.env" fullLauncher.text;
+      message = "environmentFile should be sourced by the wrapper";
+    }
+    {
+      assertion = hasDrvInfix "exec bws run -- ${symphonyStub}/bin/symphony" fullLauncher.text;
+      message = "secretsCommand should wrap the exec of the package launcher";
+    }
+
+    # --- defaults: launcher-owned state dir, bare exec wrapper ---
+    {
+      assertion =
+        minimalSpec.environment
+        == {
+          SYMPHONY_HTTP_PORT = "4040";
+          SYMPHONY_WORKFLOW_PACK = "example";
+        };
+      message = "defaults should export only port and built-in pack (launcher owns SYMPHONY_STATE_DIR)";
+    }
+    {
+      assertion =
+        hasDrvInfix "exec ${symphonyStub}/bin/symphony \"$@\"" minimalLauncher.text
+        && !(lib.hasInfix "set -a" minimalLauncher.text);
+      message = "without environmentFile/secretsCommand the wrapper should be a bare exec";
+    }
+  ];
+
+  failures = map (a: a.message) (lib.filter (a: !a.assertion) assertions);
+in
+  assert lib.assertMsg (failures == []) (
+    "symphony-home-module:\n  " + lib.concatStringsSep "\n  " failures
+  );
+    pkgs.runCommand "ix-test-symphony-home-module" {__structuredAttrs = true;} ''
+      mkdir -p "$out"
+    ''


### PR DESCRIPTION
Closes #1956.

**What**: `homeModules.symphony` (`packages/agent/symphony/home-module.nix`): one declarative `services.symphony` instance renders a native launchd agent on macOS and a native systemd user unit on Linux by composing `homeModules.portable-services` (no duplicated unit rendering).

**Options** mirror the NixOS module (`modules/services/symphony`) where they make sense in a user session: `package`, `stateDir` (null = launcher's `~/.local/state/symphony`), `httpPort`, `primaryRepo`, `repoRoot`, `workflowPack`, `packDir` (the hot-reload surface: point at a mutable checkout, symphony hot-reloads `.sym` and skills), `extraEnvironment`, `environmentFile`, `secretsCommand`. Home-specific: `extraPath` (packages prepended to service PATH: the host-owned `codex`, `jq`/`gh`).

**Secrets**: launchd has no `EnvironmentFile`, so a `writeBashApplication` launch wrapper sources `environmentFile` (`set -a`), prepends `extraPath`, and execs the package under `secretsCommand` (e.g. `bws run --`). The wrapper is exposed read-only as `services.symphony.launcher`. Unit is `restart = "always"`, `runAtLoad`, no interval: the BEAM is the scheduler.

**Tests**: `tests/symphony-home-module.nix` (16 asserts, bundled into the `eval` flake check) evaluates the real module and asserts the rendered plist + user unit + wrapper: command path, env propagation (typed options and `extraEnvironment` in both renders), restart policy, PATH containing `extraPath` entries, `secretsCommand` wrapping, and the defaults case. Validated purely on darwin (full `eval` check IFDs linux cargo-unit graphs).

**Docs**: home-manager section in `doc/symphony/operations/overview.md` with a workstation usage snippet.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add home-manager module for running Symphony as a user service
> - Adds [home-module.nix](https://github.com/indexable-inc/index/pull/1957/files#diff-0b5afdb67fffaefb032bf05aadaaef8312dc2037c837d885503184d758fa064f) defining `services.symphony` options for home-manager, mirroring the NixOS module semantics at user scope (port, repos, pack hot-reload, environment, secrets).
> - Exports the module as `homeModules.symphony` from [flake.nix](https://github.com/indexable-inc/index/pull/1957/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0), enabling macOS (launchd) and Linux (systemd user) deployments.
> - Generates a `symphony-launch` bash wrapper that sources an optional `environmentFile`, optionally wraps exec with a `secretsCommand`, and prepends `extraPath` to `PATH`.
> - Wires an eval test in [tests/symphony-home-module.nix](https://github.com/indexable-inc/index/pull/1957/files#diff-ffbb12dccc6856c13d7f465476313995da7914bab7dc64fba2410a1847580954) that validates launchd and systemd output for both full and minimal configurations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88ed6de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->