### PR TITLE
refactor(symphony): move attempt bookkeeping into IR.Graph (#1939)

### DIFF
--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/graph.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/graph.ex
@@ -17,10 +17,13 @@ defmodule SymphonyElixir.IR.Graph do
     is left alone; the runtime reconciles those through the task path.
 
   `ready_nodes/1` is the scheduler's input, `apply_output/3` is the
-  scheduler's commit step, and `reset_node/2` is the retry path.
+  scheduler's commit step, and `reset_node/2` is the retry path. The
+  attempt bookkeeping (`mark_running/3`, `record_finished_attempt/4`,
+  `mark_attempt_stranded/2`, ...) lives here too: how a node's attempt
+  history evolves is graph algebra, even though the runtime decides when.
   """
 
-  alias SymphonyElixir.IR.{Node, RunGraph}
+  alias SymphonyElixir.IR.{Attempt, Node, RunGraph}
 
   @doc """
   Nodes that may start now: state `:pending`, `:ready`, or `:retrying`,
@@ -165,6 +168,151 @@ defmodule SymphonyElixir.IR.Graph do
         graph
     end
   end
+
+  # --- attempt bookkeeping --------------------------------------------
+
+  @doc """
+  Mark a node `:running` and open attempt `attempt_n` on it. The attempt
+  records what will execute it (engine for agent turns, executor kind
+  otherwise), so the run record is honest even before the attempt ends.
+  """
+  @spec mark_running(RunGraph.t(), Node.t(), pos_integer()) :: RunGraph.t()
+  def mark_running(%RunGraph{} = graph, %Node{} = node, attempt_n) do
+    attempt = Attempt.start(attempt_n, attempt_engine(node))
+    updated = %{node | state: :running, attempts: node.attempts ++ [attempt], updated_at: DateTime.utc_now()}
+    %{graph | nodes: Map.put(graph.nodes, node.id, updated), updated_at: DateTime.utc_now()}
+  end
+
+  @doc """
+  Close the node's current attempt with `result` and stamp the attempt's
+  reattach handle to `thread_id`. A node with no open attempt (its
+  `:running` mark never persisted before the result arrived) gets one
+  synthesized so the run record still explains the outcome. An unknown
+  node id is a no-op.
+  """
+  @spec record_finished_attempt(RunGraph.t(), String.t(), {:ok, term()} | {:error, term()}, String.t() | nil) ::
+          RunGraph.t()
+  def record_finished_attempt(%RunGraph{} = graph, node_id, result, thread_id) do
+    case Map.fetch(graph.nodes, node_id) do
+      {:ok, %Node{attempts: []} = node} ->
+        attempt =
+          attempt_n_seed()
+          |> Attempt.start(attempt_engine(node), thread_id)
+          |> Attempt.finish(attempt_state_for(result), outcome_for(result), cost_for(result))
+
+        put_node(graph, %{node | attempts: [attempt]})
+
+      {:ok, node} ->
+        attempts = finish_current_attempt(node.attempts, result, thread_id)
+        put_node(graph, %{node | attempts: attempts})
+
+      :error ->
+        graph
+    end
+  end
+
+  @doc """
+  Stamp the current attempt's reattach handle mid-flight (an executor
+  reports its engine thread or child run id as soon as it opens one, so a
+  crash before the result still leaves a handle to reconcile against).
+  Only a `:running` node with an open attempt is stamped; anything else is
+  a no-op because the terminal path already recorded the handle.
+  """
+  @spec record_attempt_thread_id(RunGraph.t(), String.t(), String.t()) :: RunGraph.t()
+  def record_attempt_thread_id(%RunGraph{} = graph, node_id, thread_id) do
+    case Map.fetch(graph.nodes, node_id) do
+      {:ok, %Node{attempts: []}} ->
+        graph
+
+      {:ok, %Node{state: :running, attempts: attempts} = node} ->
+        current = Enum.max_by(attempts, & &1.n)
+        updated = Enum.map(attempts, fn a -> if a.n == current.n, do: %{a | thread_id: thread_id}, else: a end)
+        put_node(graph, %{node | attempts: updated})
+
+      {:ok, _node} ->
+        graph
+
+      :error ->
+        graph
+    end
+  end
+
+  @doc """
+  Close the node's current attempt as `:stranded`: its owning task died
+  without reporting a result, so the attempt may or may not have acted. A
+  node with no recorded attempt gets one synthesized so the run record
+  still explains the strand. Routing (retry vs human review) is the
+  caller's policy; this only records the fact.
+  """
+  @spec mark_attempt_stranded(RunGraph.t(), Node.t()) :: RunGraph.t()
+  def mark_attempt_stranded(%RunGraph{} = graph, %Node{attempts: []} = node) do
+    attempt = Attempt.start(1, attempt_engine(node)) |> Attempt.finish(:stranded, :stranded)
+    put_node(graph, %{node | attempts: [attempt]})
+  end
+
+  def mark_attempt_stranded(%RunGraph{} = graph, %Node{attempts: attempts} = node) do
+    current = Enum.max_by(attempts, & &1.n)
+    finished = Attempt.finish(current, :stranded, :stranded)
+    updated = Enum.map(attempts, fn a -> if a.n == current.n, do: finished, else: a end)
+    put_node(graph, %{node | attempts: updated})
+  end
+
+  @doc """
+  Set a node's state without touching its output or attempts. The bare
+  transition the runtime uses for states no result carries (`:cancelled`,
+  `:upstream_failed`, `:retrying`, `:stranded`). An unknown node id is a
+  no-op.
+  """
+  @spec transition(RunGraph.t(), String.t(), Node.state()) :: RunGraph.t()
+  def transition(%RunGraph{} = graph, node_id, state) do
+    case Map.fetch(graph.nodes, node_id) do
+      {:ok, node} -> put_node(graph, %{node | state: state})
+      :error -> graph
+    end
+  end
+
+  defp put_node(%RunGraph{} = graph, %Node{} = node) do
+    updated = %{node | updated_at: DateTime.utc_now()}
+    %{graph | nodes: Map.put(graph.nodes, node.id, updated), updated_at: DateTime.utc_now()}
+  end
+
+  defp finish_current_attempt(attempts, result, thread_id) do
+    current = Enum.max_by(attempts, & &1.n)
+    finished = %{Attempt.finish(current, attempt_state_for(result), outcome_for(result), cost_for(result)) | thread_id: thread_id}
+    Enum.map(attempts, fn a -> if a.n == current.n, do: finished, else: a end)
+  end
+
+  defp attempt_n_seed, do: 1
+
+  # An attempt records what executed it. Agent attempts carry the engine;
+  # exec/subrun carry the executor kind so the run record is honest about a
+  # node that never touched an engine.
+  defp attempt_engine(%Node{kind: :agent, envelope: %{engine: engine}}) when engine in [:codex, :claude, :pi],
+    do: engine
+
+  defp attempt_engine(%Node{kind: :exec}), do: :exec
+  defp attempt_engine(%Node{kind: :subrun}), do: :subrun
+  defp attempt_engine(_node), do: :codex
+
+  defp attempt_state_for({:ok, _}), do: :succeeded
+  defp attempt_state_for({:error, _}), do: :failed
+
+  defp outcome_for({:ok, _}), do: :ok
+  defp outcome_for({:error, reason}), do: {:error, reason}
+
+  # Per-turn cost rides on the successful result's output map (the engine
+  # client lowers the room-server `usage` totals to the `Attempt.cost`
+  # shape there). A failure carries only the error reason on the
+  # synchronous path, so its cost is unknown (nil), and an exec/subrun
+  # output without a cost key is also nil.
+  defp cost_for({:ok, output}) when is_map(output) do
+    case Map.get(output, :cost) do
+      cost when is_map(cost) -> cost
+      _ -> nil
+    end
+  end
+
+  defp cost_for(_), do: nil
 
   @doc "Nodes currently `:running`. The runtime owns the live task for each of these."
   @spec running_nodes(RunGraph.t()) :: [Node.t()]

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime.ex
@@ -47,7 +47,7 @@ defmodule SymphonyElixir.Runtime do
   use GenServer, restart: :transient
 
   alias SymphonyElixir.GithubApp
-  alias SymphonyElixir.IR.{Attempt, Graph, Materializer, Node, RunGraph, RunNotifier, Store}
+  alias SymphonyElixir.IR.{Graph, Materializer, Node, RunGraph, RunNotifier, Store}
   alias SymphonyElixir.Runtime.{Events, ExecRunner, Placement, Recovery, SubrunRunner}
 
   require Logger
@@ -95,9 +95,7 @@ defmodule SymphonyElixir.Runtime do
 
   @doc "Read the current graph snapshot. Used by tests and the operator surface."
   @spec graph(pid() | String.t()) :: RunGraph.t()
-  @spec graph(pid()) :: RunGraph.t()
   def graph(pid) when is_pid(pid), do: GenServer.call(pid, :graph)
-  @spec graph(binary()) :: RunGraph.t()
   def graph(run_id) when is_binary(run_id), do: GenServer.call(via(run_id), :graph)
 
   @typedoc "Who requested an operator action, recorded in the audit log."
@@ -215,7 +213,7 @@ defmodule SymphonyElixir.Runtime do
 
     cancelled =
       Enum.reduce(state.graph.nodes, state.graph, fn {id, node}, acc ->
-        if Node.terminal?(node), do: acc, else: transition(acc, id, :cancelled)
+        if Node.terminal?(node), do: acc, else: Graph.transition(acc, id, :cancelled)
       end)
 
     finished =
@@ -269,7 +267,7 @@ defmodule SymphonyElixir.Runtime do
   @impl true
   def handle_info({:node_done, node_id, result, thread_id}, state) do
     state = drop_task_for(state, node_id)
-    graph = record_finished_attempt(state.graph, node_id, result, thread_id)
+    graph = Graph.record_finished_attempt(state.graph, node_id, result, thread_id)
     graph = Graph.apply_output(graph, node_id, result)
     # A succeeded node may unlock a gate or fan-out: its output is now in
     # known_outputs, so re-expand the AST to emit any newly-justified
@@ -303,7 +301,7 @@ defmodule SymphonyElixir.Runtime do
 
   @impl true
   def handle_info({:attempt_thread_id, node_id, thread_id}, state) do
-    graph = record_attempt_thread_id(state.graph, node_id, thread_id)
+    graph = Graph.record_attempt_thread_id(state.graph, node_id, thread_id)
     persist(graph, state)
     {:noreply, %{state | graph: graph}}
   end
@@ -343,7 +341,7 @@ defmodule SymphonyElixir.Runtime do
 
     failed =
       Enum.reduce(graph.nodes, graph, fn {id, node}, acc ->
-        if Node.terminal?(node), do: acc, else: transition(acc, id, :upstream_failed)
+        if Node.terminal?(node), do: acc, else: Graph.transition(acc, id, :upstream_failed)
       end)
 
     failed = %{failed | status: :failed}
@@ -430,7 +428,7 @@ defmodule SymphonyElixir.Runtime do
     # Mark + persist the attempt as running before provisioning so the node
     # is observable during a slow placement acquire. The turn task is only
     # spawned after placement resolves (it reads the per-run base_url).
-    graph = mark_running(state.graph, node, attempt_n)
+    graph = Graph.mark_running(state.graph, node, attempt_n)
     persist(graph, state)
     state = ensure_placement(%{state | graph: graph}, node)
     graph = state.graph
@@ -631,61 +629,15 @@ defmodule SymphonyElixir.Runtime do
 
   defp dig(_value, _path), do: nil
 
-  # --- graph transitions ----------------------------------------------
+  # --- crash routing ----------------------------------------------------
 
-  defp mark_running(%RunGraph{} = graph, %Node{} = node, attempt_n) do
-    attempt = Attempt.start(attempt_n, attempt_engine(node))
-    updated = %{node | state: :running, attempts: node.attempts ++ [attempt], updated_at: DateTime.utc_now()}
-    %{graph | nodes: Map.put(graph.nodes, node.id, updated), updated_at: DateTime.utc_now()}
-  end
-
-  defp record_finished_attempt(%RunGraph{} = graph, node_id, result, thread_id) do
-    case Map.fetch(graph.nodes, node_id) do
-      {:ok, %Node{attempts: []} = node} ->
-        attempt =
-          attempt_n_seed()
-          |> Attempt.start(attempt_engine(node), thread_id)
-          |> Attempt.finish(attempt_state_for(result), outcome_for(result), cost_for(result))
-
-        put_node(graph, %{node | attempts: [attempt]})
-
-      {:ok, node} ->
-        attempts = finish_current_attempt(node.attempts, result, thread_id)
-        put_node(graph, %{node | attempts: attempts})
-
-      :error ->
-        graph
-    end
-  end
-
-  defp record_attempt_thread_id(%RunGraph{} = graph, node_id, thread_id) do
-    case Map.fetch(graph.nodes, node_id) do
-      {:ok, %Node{attempts: []}} ->
-        graph
-
-      {:ok, %Node{state: :running, attempts: attempts} = node} ->
-        current = Enum.max_by(attempts, & &1.n)
-        updated = Enum.map(attempts, fn a -> if a.n == current.n, do: %{a | thread_id: thread_id}, else: a end)
-        put_node(graph, %{node | attempts: updated})
-
-      {:ok, _node} ->
-        graph
-
-      :error ->
-        graph
-    end
-  end
-
-  defp finish_current_attempt(attempts, result, thread_id) do
-    current = Enum.max_by(attempts, & &1.n)
-    finished = %{Attempt.finish(current, attempt_state_for(result), outcome_for(result), cost_for(result)) | thread_id: thread_id}
-    Enum.map(attempts, fn a -> if a.n == current.n, do: finished, else: a end)
-  end
-
+  # Record the strand on the attempt (via Graph), then route by the
+  # non-idempotent retry policy: this is the decision the GenServer owns,
+  # so it stays here rather than in the pure graph algebra.
   defp strand_node(%RunGraph{} = graph, node_id) do
     case Map.fetch(graph.nodes, node_id) do
       {:ok, node} ->
-        graph = mark_attempt_stranded(graph, node)
+        graph = Graph.mark_attempt_stranded(graph, node)
         node = graph.nodes[node_id]
 
         if Recovery.auto_retryable?(node) do
@@ -693,38 +645,14 @@ defmodule SymphonyElixir.Runtime do
           # (`Graph.ready_nodes/1` treats :retrying as schedulable). The
           # attempt history, including the stranded attempt just recorded,
           # is preserved so the retry budget and audit trail survive.
-          transition(graph, node_id, :retrying)
+          Graph.transition(graph, node_id, :retrying)
         else
-          transition(graph, node_id, :stranded)
+          Graph.transition(graph, node_id, :stranded)
         end
 
       :error ->
         graph
     end
-  end
-
-  defp mark_attempt_stranded(%RunGraph{} = graph, %Node{attempts: []} = node) do
-    attempt = Attempt.start(1, attempt_engine(node)) |> Attempt.finish(:stranded, :stranded)
-    put_node(graph, %{node | attempts: [attempt]})
-  end
-
-  defp mark_attempt_stranded(%RunGraph{} = graph, %Node{attempts: attempts} = node) do
-    current = Enum.max_by(attempts, & &1.n)
-    finished = Attempt.finish(current, :stranded, :stranded)
-    updated = Enum.map(attempts, fn a -> if a.n == current.n, do: finished, else: a end)
-    put_node(graph, %{node | attempts: updated})
-  end
-
-  defp transition(%RunGraph{} = graph, node_id, state) do
-    case Map.fetch(graph.nodes, node_id) do
-      {:ok, node} -> put_node(graph, %{node | state: state})
-      :error -> graph
-    end
-  end
-
-  defp put_node(%RunGraph{} = graph, %Node{} = node) do
-    updated = %{node | updated_at: DateTime.utc_now()}
-    %{graph | nodes: Map.put(graph.nodes, node.id, updated), updated_at: DateTime.utc_now()}
   end
 
   defp drop_task_for(state, node_id) do
@@ -814,8 +742,6 @@ defmodule SymphonyElixir.Runtime do
 
   # --- helpers --------------------------------------------------------
 
-  defp attempt_n_seed, do: 1
-
   # Dispatch one attempt by node kind. Only `:agent` nodes are engine
   # turns and go through the injected engine client; `:exec` runs a pack
   # script locally; `:subrun` launches a nested run through `SubrunRunner`
@@ -824,34 +750,4 @@ defmodule SymphonyElixir.Runtime do
   defp run_attempt(%Node{kind: :agent} = node, engine, run_opts), do: engine.run_node(node, run_opts)
   defp run_attempt(%Node{kind: :exec} = node, _engine, run_opts), do: ExecRunner.run(node, run_opts)
   defp run_attempt(%Node{kind: :subrun} = node, _engine, run_opts), do: SubrunRunner.run(node, run_opts)
-
-  # An attempt records what executed it. Agent attempts carry the engine;
-  # exec/subrun carry the executor kind so the run record is honest about a
-  # node that never touched an engine.
-  defp attempt_engine(%Node{kind: :agent, envelope: %{engine: engine}}) when engine in [:codex, :claude, :pi],
-    do: engine
-
-  defp attempt_engine(%Node{kind: :exec}), do: :exec
-  defp attempt_engine(%Node{kind: :subrun}), do: :subrun
-  defp attempt_engine(_node), do: :codex
-
-  defp attempt_state_for({:ok, _}), do: :succeeded
-  defp attempt_state_for({:error, _}), do: :failed
-
-  defp outcome_for({:ok, _}), do: :ok
-  defp outcome_for({:error, reason}), do: {:error, reason}
-
-  # Per-turn cost rides on the successful result's output map (the engine
-  # client lowers the room-server `usage` totals to the `Attempt.cost`
-  # shape there). A failure carries only the error reason on the
-  # synchronous path, so its cost is unknown (nil), and an exec/subrun
-  # output without a cost key is also nil.
-  defp cost_for({:ok, output}) when is_map(output) do
-    case Map.get(output, :cost) do
-      cost when is_map(cost) -> cost
-      _ -> nil
-    end
-  end
-
-  defp cost_for(_), do: nil
 end

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/ingress.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/ingress.ex
@@ -31,7 +31,6 @@ defmodule SymphonyElixir.Runtime.Ingress do
   @spec start_workflow(WorkflowCatalog.entry(), map() | nil, keyword()) :: {:ok, started()} | {:error, term()}
   def start_workflow(entry, trigger_context \\ nil, opts \\ [])
 
-  @spec start_workflow(WorkflowCatalog.entry(), map() | nil, keyword()) :: {:ok, started()} | {:error, term()}
   def start_workflow(%{ast: ast, hash: hash} = entry, trigger_context, opts) do
     run_id = Keyword.get_lazy(opts, :run_id, fn -> generate_run_id(entry) end)
     start_opts = Keyword.drop(opts, [:run_id])

--- a/packages/agent/symphony/elixir/test/symphony_elixir/ir/graph_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/ir/graph_test.exs
@@ -1,7 +1,7 @@
 defmodule SymphonyElixir.IR.GraphTest do
   use ExUnit.Case, async: true
 
-  alias SymphonyElixir.IR.{Graph, Node, RunGraph}
+  alias SymphonyElixir.IR.{Attempt, Graph, Node, RunGraph}
 
   defp node(id, opts) do
     Node.new(
@@ -111,6 +111,108 @@ defmodule SymphonyElixir.IR.GraphTest do
 
       assert g.nodes["a"].state == :pending
       assert g.nodes["a"].output == nil
+    end
+  end
+
+  describe "attempt bookkeeping" do
+    test "mark_running opens a running attempt recording the executor kind" do
+      g = graph([node("a", state: :pending)])
+
+      g = Graph.mark_running(g, g.nodes["a"], 1)
+
+      assert %Node{state: :running, attempts: [attempt]} = g.nodes["a"]
+      assert %Attempt{n: 1, engine: :exec, state: :running, outcome: nil} = attempt
+    end
+
+    test "running -> finished: the open attempt closes with outcome, cost, and thread id" do
+      cost = %{usd: 0.5, tokens_in: 10}
+      g = graph([node("a", state: :pending)])
+
+      g = Graph.mark_running(g, g.nodes["a"], 1)
+      g = Graph.record_finished_attempt(g, "a", {:ok, %{cost: cost}}, "thread-1")
+
+      assert [attempt] = g.nodes["a"].attempts
+      assert %Attempt{n: 1, state: :succeeded, outcome: :ok, cost: ^cost, thread_id: "thread-1"} = attempt
+      assert attempt.finished_at != nil
+    end
+
+    test "a failed result closes the attempt :failed with the error and no cost" do
+      g = graph([node("a", state: :pending)])
+
+      g = Graph.mark_running(g, g.nodes["a"], 1)
+      g = Graph.record_finished_attempt(g, "a", {:error, :boom}, nil)
+
+      assert [%Attempt{state: :failed, outcome: {:error, :boom}, cost: nil}] = g.nodes["a"].attempts
+    end
+
+    test "cost accumulates per attempt: a retry's cost lands on the new attempt only" do
+      g = graph([node("a", state: :pending)])
+
+      g = Graph.mark_running(g, g.nodes["a"], 1)
+      g = Graph.record_finished_attempt(g, "a", {:ok, %{cost: %{usd: 1.0}}}, "t1")
+      g = Graph.mark_running(g, g.nodes["a"], 2)
+      g = Graph.record_finished_attempt(g, "a", {:ok, %{cost: %{usd: 2.0}}}, "t2")
+
+      assert [%Attempt{n: 1, cost: %{usd: 1.0}}, %Attempt{n: 2, cost: %{usd: 2.0}}] =
+               Enum.sort_by(g.nodes["a"].attempts, & &1.n)
+    end
+
+    test "record_finished_attempt synthesizes an attempt when none was recorded" do
+      g = graph([node("a", state: :running)])
+
+      g = Graph.record_finished_attempt(g, "a", {:ok, %{}}, "thread-9")
+
+      assert [%Attempt{n: 1, state: :succeeded, thread_id: "thread-9"}] = g.nodes["a"].attempts
+    end
+
+    test "record_finished_attempt on an unknown node is a no-op" do
+      g = graph([node("a", state: :pending)])
+      assert Graph.record_finished_attempt(g, "nope", {:ok, %{}}, nil) == g
+    end
+
+    test "record_attempt_thread_id stamps only a running node's open attempt" do
+      g = graph([node("a", state: :pending)])
+      g = Graph.mark_running(g, g.nodes["a"], 1)
+
+      g = Graph.record_attempt_thread_id(g, "a", "mid-flight")
+      assert [%Attempt{thread_id: "mid-flight"}] = g.nodes["a"].attempts
+
+      # A node with no open attempt, a non-running node, and an unknown id
+      # are all no-ops: the terminal path already recorded the handle.
+      fresh = graph([node("b", state: :pending)])
+      assert Graph.record_attempt_thread_id(fresh, "b", "x") == fresh
+      assert Graph.record_attempt_thread_id(fresh, "nope", "x") == fresh
+    end
+
+    test "mark_attempt_stranded closes the current attempt as stranded" do
+      g = graph([node("a", state: :pending)])
+      g = Graph.mark_running(g, g.nodes["a"], 1)
+
+      g = Graph.mark_attempt_stranded(g, g.nodes["a"])
+
+      assert [%Attempt{n: 1, state: :stranded, outcome: :stranded}] = g.nodes["a"].attempts
+    end
+
+    test "mark_attempt_stranded synthesizes an attempt when none was recorded" do
+      g = graph([node("a", state: :running)])
+
+      g = Graph.mark_attempt_stranded(g, g.nodes["a"])
+
+      assert [%Attempt{n: 1, state: :stranded, outcome: :stranded}] = g.nodes["a"].attempts
+    end
+
+    test "transition sets the node state without touching output or attempts" do
+      g = graph([node("a", state: :pending)])
+      g = Graph.mark_running(g, g.nodes["a"], 1)
+
+      g = Graph.transition(g, "a", :stranded)
+
+      assert g.nodes["a"].state == :stranded
+      assert [%Attempt{state: :running}] = g.nodes["a"].attempts
+      assert g.nodes["a"].output == nil
+
+      # An unknown id is a no-op, matching the other bookkeeping entries.
+      assert Graph.transition(g, "nope", :cancelled) == g
     end
   end
 


### PR DESCRIPTION
Refactor slice 5 of #1939.

- **Pure moves**: `mark_running`, `record_finished_attempt`, `record_attempt_thread_id`, `mark_attempt_stranded`, `transition` (plus private helpers `put_node`, `finish_current_attempt`, `attempt_engine`, `attempt_state_for`, `outcome_for`, `cost_for`, `attempt_n_seed`) go from the `Runtime` GenServer into `IR.Graph`, which already owns `apply_output`/`reset_node`. Public with `@spec` where the runtime calls them; helpers stay private. No behavior changes.
- **Runtime keeps** scheduling, placement, and lifecycle; `strand_node` stays there because it routes by `Recovery` policy, now calling the Graph primitives.
- **Spec dedup**: drop the stuttered duplicate `@spec`s on `Runtime.graph/1` and `Ingress.start_workflow/3`.
- **Tests**: direct unit tests in `graph_test.exs` for the moved functions (running -> finished lifecycle, stranded marking, per-attempt cost, mid-flight thread-id stamping, transition). `runtime_test.exs` passes unchanged as the behavioral guard.

Verified with the pinned toolchain: `mix compile --warnings-as-errors`, `mix test` (435 tests, 0 failures), `mix format --check-formatted`, and `mix credo --strict` against the shared CI config (`lib/elixir/credo.exs`) all green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move attempt bookkeeping from `Runtime` into `IR.Graph`
> - Moves `mark_running/3`, `record_finished_attempt/4`, `record_attempt_thread_id/3`, `mark_attempt_stranded/2`, `transition/3`, and related helpers from [runtime.ex](https://github.com/indexable-inc/index/pull/1959/files#diff-29653b73216dd3c6b6dd30fcfe071b42e47d55066301de501f6bcfe37c7cfa5e) into [ir/graph.ex](https://github.com/indexable-inc/index/pull/1959/files#diff-a449c1e50db2d48a6d0574a71aca98f1f5511719a4c2e186ea83b24e43d12a3b), making `IR.Graph` the canonical owner of attempt state.
> - `Runtime` now delegates all attempt bookkeeping to `Graph.*` calls; local implementations are deleted.
> - New tests in [graph_test.exs](https://github.com/indexable-inc/index/pull/1959/files#diff-a9a53f500e9f5a8ac524bb096a7f8408b3fb7850d7564e9e7bd44b3067dc2118) cover the moved functions, including attempt synthesis, cost accumulation, thread id stamping, and no-op behavior on unknown nodes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65d9390.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->