### PR TITLE
fix(symphony): insights script: prune leaked worktrees, accurate isolation comment

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/insights.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/insights.sh
@@ -11,10 +11,14 @@ set -euo pipefail
 prompt_file="$PWD/prompts/insights.md"
 last_msg="$(mktemp)"
 
-# The agent reads a detached worktree of HEAD, not the mutable checkout:
-# untracked files (.env, local scratch) in the operator's tree must never
-# be readable by a prompt whose output is posted to Slack. Tracked content
-# only, and the worktree is torn down whether the agent succeeds or not.
+# The agent reads a detached worktree of HEAD, not the mutable checkout,
+# so untracked files (.env, local scratch) in the operator's tree are out
+# of the default view. Defense-in-depth only: codex's read-only sandbox
+# restricts writes, not absolute-path reads (openai/codex#5237), so the
+# env scrub below is the actual secret control. The worktree is torn down
+# whether the agent succeeds or not; the prune reaps predecessors leaked
+# by hard crashes (SIGKILL/reboot skip the EXIT trap).
+git -C "$SYMPHONY_PRIMARY_REPO" worktree prune
 digest_root="$(mktemp -d)"
 cleanup() {
   git -C "$SYMPHONY_PRIMARY_REPO" worktree remove --force "$digest_root/repo" || true


### PR DESCRIPTION
Post-merge review follow-up to #1947 (see #1938). Adds `git worktree prune` before each run's `worktree add` (EXIT traps don't fire on SIGKILL/reboot, so orphans accumulated) and corrects the isolation comment: codex's read-only sandbox blocks writes, not absolute-path reads (openai/codex#5237), so the worktree is defense-in-depth and the env scrub is the real secret control.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prune stale Git worktrees at startup in the insights script
> Adds a `git worktree prune` call against `$SYMPHONY_PRIMARY_REPO` at the start of [insights.sh](https://github.com/indexable-inc/index/pull/1961/files#diff-364a554c8d8c5f993ce44303d0a5507cc5c8755ead4b9e983b2e789d0d05929f), before the temporary digest directory is created. This cleans up stale worktrees left by previous hard crashes. The surrounding comment block is also revised to clarify sandbox isolation behavior and the prune rationale.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 037a807.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->