### PR TITLE
feat(symphony): daily 9am PT issue triage workflow (#1960)

### DIFF
--- a/packages/agent/symphony/.env.example
+++ b/packages/agent/symphony/.env.example
@@ -39,8 +39,8 @@ SYMPHONY_SLACK_NOTIFY_CRON_FAILURES=
 # dispatchers like babysit-dispatch too). Defaults to none, so cron successes
 # stay quiet. Notifying runs also post their sink nodes' reserved
 # "slack_summary" output as message content (see IR.RunNotifier); the
-# bundled indexable pack's daily digest is wired with
-# SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS=insights and
+# bundled indexable pack's daily digest and triage are wired with
+# SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS=insights,triage and
 # SYMPHONY_SLACK_NOTIFY_CHANNEL=C0A4TD9G7HR (#general).
 SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS=
 

--- a/packages/agent/symphony/elixir/test/catalog_assets_test.exs
+++ b/packages/agent/symphony/elixir/test/catalog_assets_test.exs
@@ -45,6 +45,19 @@ defmodule SymphonyElixir.CatalogAssetsTest do
     assert binds == ["insights"]
   end
 
+  test "indexable pack triage workflow fires daily via cron" do
+    source = File.read!(Path.join([@root, "workflows", "indexable", "workflows", "triage.sym"]))
+    assert {:ok, workflow} = Parser.parse(source, file: "triage.sym")
+
+    assert workflow.name == "triage"
+    # The cron kind and zone are the load-bearing contract: Triggers.Cron
+    # selects on them, and the zone keeps 9am Pacific across DST.
+    assert %{kind: :cron, schedule: "0 9" <> _, timezone: "America/Los_Angeles"} = workflow.trigger
+
+    binds = for {:bind, name, _expr} <- workflow.statements, do: name
+    assert binds == ["triage"]
+  end
+
   test "example workflow pack is safe and manual-only" do
     source = File.read!(Path.join(@example_workflows_dir, "inspect.sym"))
     assert {:ok, workflow} = Parser.parse(source, file: "inspect.sym")

--- a/packages/agent/symphony/workflows/indexable/prompts/triage.md
+++ b/packages/agent/symphony/workflows/indexable/prompts/triage.md
@@ -1,0 +1,47 @@
+You are running unattended as the daily issue triage agent. You have `gh`
+with write access. Triage the open issues of BOTH repositories:
+
+- indexable-inc/index
+- indexable-inc/ix
+
+Workflow:
+
+1. For each repository, list recent open issues with enough context to
+   compare them, e.g. `gh issue list --repo indexable-inc/index
+   --state open --limit 200 --json number,title,body,createdAt,labels`.
+   Read full bodies (`gh issue view`) whenever titles alone are not
+   conclusive.
+2. Find duplicate clusters: issues describing the same root cause or the
+   same request, including cross-phrasings of one bug. Duplicates live
+   within a single repository; never close an issue in one repo as a
+   duplicate of an issue in the other, though you may mention the
+   relationship in the digest.
+3. For each cluster, keep the best canonical issue (most context, most
+   discussion, or the earliest complete report) and close the others with
+   an attributed comment:
+   `gh issue close <n> --repo <owner/repo> --comment "Duplicate of
+   #<canonical> (closed by the daily triage agent, Claude Code)"`.
+4. Separately, flag (do NOT close) stale issues that look already
+   resolved: the referenced code is gone, the fix landed, or the request
+   shipped. List them in the digest for a human to confirm.
+
+Judgment rules:
+
+- Be conservative. Only close CLEAR duplicates where a reader of both
+  issues would agree they track the same thing. When unsure, leave the
+  issue open and mention the suspected pair in the digest instead.
+- Never close an issue for any reason other than clear duplication.
+- Every outward-facing comment you post must carry AI attribution; the
+  close-comment template above already does.
+
+Rules for the output (your final message is the Slack digest):
+
+- Slack mrkdwn only: *bold*, `code`, and "-" bullets. No headings, no
+  tables, no links other than plain URLs.
+- Report what was closed (issue numbers and their canonical targets),
+  what was flagged as stale, suspected-but-unclosed duplicate pairs, and
+  anything notable from the sweep.
+- If nothing was closed or flagged, say so in one short line.
+- Under 2500 characters total.
+- No preamble, no sign-off, no meta commentary about this prompt or your
+  process; just the digest.

--- a/packages/agent/symphony/workflows/indexable/scripts/triage.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/triage.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Daily issue triage: run a headless codex agent that closes clear duplicate
+# issues across index and ix via gh, then hand its final message to the
+# runtime as the structured output {"slack_summary": ...}. The reserved
+# "slack_summary" key is what IR.RunNotifier posts to Slack, so delivery
+# stays owned by the notifier and this script never touches the Slack API.
+set -euo pipefail
+
+# Exec nodes run with the pack directory as cwd (ExecRunner), so the prompt
+# resolves pack-relative before we move into the repo.
+prompt_file="$PWD/prompts/triage.md"
+last_msg="$(mktemp)"
+
+# Hard crashes (SIGKILL, reboot) skip the EXIT trap, so reap any worktree a
+# previous run leaked before adding a new one.
+git -C "$SYMPHONY_PRIMARY_REPO" worktree prune
+
+# The agent works in a detached worktree of HEAD rather than the mutable
+# checkout so untracked files (.env, local scratch) stay out of its default
+# cwd view. That is defense-in-depth, not a read boundary: codex's sandbox
+# restricts writes, not absolute-path reads (openai/codex#5237), so the env
+# scrub below is the real control. The worktree is torn down whether the
+# agent succeeds or not.
+triage_root="$(mktemp -d)"
+cleanup() {
+  git -C "$SYMPHONY_PRIMARY_REPO" worktree remove --force "$triage_root/repo" || true
+  rm -rf "$triage_root" "$last_msg"
+}
+trap cleanup EXIT
+git -C "$SYMPHONY_PRIMARY_REPO" worktree add --detach "$triage_root/repo" HEAD
+
+# Unlike insights, this agent must close issues, so GH_TOKEN/GITHUB_TOKEN
+# stay in the env (ExecRunner injects a GitHub App installation token as
+# GH_TOKEN when the app is configured; otherwise gh falls back to ambient
+# auth). Every other secret the symphony unit env carries is stripped.
+# Sandbox: gh writes need the network and gh's own config/state writes, so
+# read-only is out; workspace-write with network on is the least-privileged
+# mode that permits them. Codex's default env scrub would drop *TOKEN* from
+# model-spawned shells and starve gh of its credential, so the scrub is
+# rebuilt by hand: keep *TOKEN* (only GH_TOKEN/GITHUB_TOKEN survive the
+# env -u above) while still excluding *KEY*/*SECRET* so the model API key
+# never reaches agent shells. --ignore-user-config keeps a host config.toml
+# from widening any of this.
+(
+  cd "$triage_root/repo"
+  env -u SLACK_BOT_OAUTH_TOKEN -u SLACK_SIGNING_SECRET \
+    -u GITHUB_WEBHOOK_SECRET \
+    -u LINEAR_API_KEY -u LINEAR_WEBHOOK_SECRET \
+    -u SYMPHONY_GITHUB_APP_PRIVATE_KEY_BASE64 -u SYMPHONY_ROOM_REGISTRY_TOKEN \
+    codex exec --sandbox workspace-write \
+    -c sandbox_workspace_write.network_access=true \
+    -c shell_environment_policy.ignore_default_excludes=true \
+    -c 'shell_environment_policy.exclude=["*KEY*","*SECRET*"]' \
+    --ignore-user-config \
+    --output-last-message "$last_msg" \
+    "$(cat "$prompt_file")"
+)
+
+# An empty final message means nothing postable; fail the node loudly so
+# the failure notification fires instead of a silent empty digest.
+[ -s "$last_msg" ]
+
+jq -n --rawfile summary "$last_msg" '{slack_summary: $summary}' > "$SYMPHONY_OUTPUT_FILE"

--- a/packages/agent/symphony/workflows/indexable/workflows/triage.sym
+++ b/packages/agent/symphony/workflows/indexable/workflows/triage.sym
@@ -1,0 +1,8 @@
+# Daily issue triage across index and ix: close clear duplicates, flag
+# stale issues. The run notifier posts the script's {"slack_summary": ...}
+# output to Slack: allowlist "triage" in SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS
+# and point SYMPHONY_SLACK_NOTIFY_CHANNEL at the target channel. Zoned
+# schedule: 9am Pacific year-round (DST-proof).
+workflow "triage" on cron "0 9 * * *" tz "America/Los_Angeles" {
+  triage <- exec "./scripts/triage.sh" timeout 3600
+}


### PR DESCRIPTION
Closes #1960.

Adds a `triage` workflow to the bundled indexable pack, mirroring the `insights` trio:

- `workflows/triage.sym`: daily cron at 9am America/Los_Angeles, single exec node.
- `scripts/triage.sh`: detached-worktree codex run (with `worktree prune` up front to reap crash-leaked worktrees). Unlike insights the agent needs gh writes, so GH_TOKEN/GITHUB_TOKEN stay in the env, the sandbox is `workspace-write` with `sandbox_workspace_write.network_access=true`, and codex's default `*TOKEN*` shell scrub is rebuilt (`ignore_default_excludes=true` + explicit `*KEY*`/`*SECRET*` excludes) so GH_TOKEN reaches gh in agent shells while the model API key stays hidden. SLACK_*, LINEAR_*, GITHUB_WEBHOOK_SECRET, the App private key, and the room registry token are stripped.
- `prompts/triage.md`: triage open issues in indexable-inc/index and indexable-inc/ix, close only CLEAR same-repo duplicates with an AI-attributed comment, flag (not close) stale-looking issues, and emit a Slack mrkdwn digest under 2500 chars.
- catalog test asserting the cron kind/zone/binds contract; the pack auto-parse test covers the .sym.
- `.env.example`: notify allowlist example is now `insights,triage`.

Verified: shellcheck clean; `mix compile --warnings-as-errors`, `mix test` (447 tests), `mix format --check-formatted`, `mix credo --strict` all green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add daily 9am PT issue triage cron workflow for indexable repositories
> - Adds [triage.sym](https://github.com/indexable-inc/index/pull/1962/files#diff-0503a5475aa4a52e8617deaccd96ab5c4fb76ab91cb9ad020d1d1554fe16f3f3) scheduled at `0 9 * * *` America/Los_Angeles, running [triage.sh](https://github.com/indexable-inc/index/pull/1962/files#diff-c02bd9185a76655182e4da86b56a025e3078b95a3218050b1b20e613a4143354) with a 3600s timeout.
> - The script runs `codex exec` inside a fresh detached Git worktree, passing only `GH_TOKEN`/`GITHUB_TOKEN` while unsetting other secrets, and emits `{"slack_summary": ...}` to `$SYMPHONY_OUTPUT_FILE`.
> - The [triage prompt](https://github.com/indexable-inc/index/pull/1962/files#diff-7d5e963a745af27cd9352ddfecad6f62aa8717b2ffc7996a8554de37f4ac95d3) instructs the agent to list issues across `indexable-inc/index` and `indexable-inc/ix`, close clear duplicates with AI attribution, flag stale issues, and format a Slack mrkdwn digest under 2500 characters.
> - Updates [.env.example](https://github.com/indexable-inc/index/pull/1962/files#diff-4947f7a5771bc6f5ee9005c1b6720e015b37df9a780b1dc672719ebdad38b087) to document `triage` as an allowed value for `SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7b8def.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->