### PR TITLE
fix(symphony): scan WorkflowCatalog synchronously at boot

### DIFF
--- a/packages/agent/symphony/elixir/lib/symphony_elixir/workflow_catalog.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/workflow_catalog.ex
@@ -109,7 +109,15 @@ defmodule SymphonyElixir.WorkflowCatalog do
       poll_ms: Keyword.get_lazy(opts, :poll_ms, fn -> Config.get().catalog_poll_ms end)
     }
 
-    schedule_scan(0)
+    # Scan synchronously before returning: start_link/start_supervised! must
+    # not hand back a catalog whose ETS tables can still be mutated by a
+    # scan racing the caller. An async boot scan let a caller's own
+    # scan/1 (called right after start_supervised! returns, as every test
+    # here does) interleave with this process's :scan handler on the same
+    # directory and tables, so whichever remove_missing/1 ran last could
+    # wipe entries the other had just inserted.
+    scan(state.workflows_dir)
+    schedule_scan(state.poll_ms)
     {:ok, state}
   end
 

--- a/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
@@ -121,8 +121,9 @@ defmodule SymphonyElixir.Triggers.CronTest do
       start_supervised!(CronState)
       cron = start_supervised!({Cron, []})
 
-      # The catalog's boot scan is an async message; scan synchronously so
-      # the first poll below deterministically sees the workflow.
+      # start_supervised!/1 already ran the catalog's synchronous boot scan,
+      # so this just re-scans; kept explicit so the workflow's presence
+      # before the first poll below isn't an implicit assumption.
       :ok = WorkflowCatalog.scan(dir)
 
       # First poll seeds the watermark; the second evaluates against it and


### PR DESCRIPTION
Fixes #1964.

## Root cause

`WorkflowCatalog.init/1` scheduled its first scan as an async `:scan`
message (`schedule_scan(0)`). `start_supervised!/1` returns as soon as
`init/1` completes, before that message is processed. Every test in
`workflow_catalog_test.exs` calls the synchronous, public
`WorkflowCatalog.scan(dir)` right after `start_supervised!` returns —
that call runs in the test process and isn't serialized through the
GenServer, so it could interleave with the GenServer's own pending
boot-scan handler on the same directory and ETS tables.

When both scans ran concurrently, whichever `remove_missing/1` finished
last could wipe entries the other scan had just inserted (its own
`seen` set didn't include files written after it started walking the
directory), logging "removed workflow (file deleted)" and failing the
test's very next assertion. This matched a build log from the flaky
run that showed exactly that log line during
`"parses .sym files and indexes them by name and trigger"`.

## Fix

Run the first scan synchronously inside `init/1` before returning,
then schedule only the recurring poll. This is the same fix shape the
cron tests already document as a workaround ("scan synchronously so
the first poll deterministically sees the workflow") — now it's true
by construction instead of a per-caller convention.

## Verification

- `mix test test/symphony_elixir/workflow_catalog_test.exs --repeat-until-failure 500 --max-failures 1`: 501 runs, 0 failures (pre-fix baseline: 60 fresh-process runs passed too, since the race window is narrow — the sandboxed nix-check environment surfaces it more readily than a local run).
- 100+ fresh-process `mix test` runs (varying `--seed`) across `workflow_catalog_test.exs`, `cron_test.exs`, and `ingress_test.exs`: 0 failures.
- `mix format --check-formatted`: clean.
- `mix credo --config-file ../../../../lib/elixir/credo.exs`: no issues.
- `MIX_ENV=test mix test`: 447 tests, 2 failures — both pre-existing and unrelated (`WorkspaceTest` failing on `git commit` due to a local 1Password git-signing agent error), reproduced identically on unmodified `main` before this change.
- Could not run the sandboxed `nix build .#checks.x86_64-linux.symphony-elixir` check locally via the vin-compute-1 remote builder: the local 1Password SSH-agent integration refused to sign non-interactively for this session, unrelated to this fix. CI will run the real sandboxed check.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scan `WorkflowCatalog` synchronously during GenServer init
> Previously, `WorkflowCatalog.init` scheduled an immediate async scan via `schedule_scan(0)`, meaning the catalog could be empty briefly after boot. It now calls `scan(state.workflows_dir)` synchronously before returning from `init`, then schedules the next poll after `poll_ms`. Behavioral Change: the first scan now blocks the GenServer init callback instead of running asynchronously after startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fcb2e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->