### PR TITLE
fix(cache-push): keep darwin store flat to survive the 14 GB hosted mac

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -362,10 +362,24 @@ jobs:
           # (#1863). Individual root failures warn without failing the job,
           # matching the linux lane's temperament; job-level failures (empty
           # eval, relay upload) are what block `cache-ready`.
+          #
+          # Each root is realised, copied into the relay cache, and then GC'd
+          # in the same child, so the Nix store never holds more than one
+          # root's closure at a time. The store grew monotonically before
+          # (realise all, copy all at the end): on the ~14 GB hosted mac the
+          # accumulated closures of ~100 roots plus a cold codex build's
+          # scratch overran the disk and every remaining root died ENOSPC
+          # (run 28770353669, 17 roots "failed" purely on `No space left`).
+          # The relay dir is a plain NAR directory, so once a root is copied
+          # there its store paths are redundant; `nix store gc` reclaims the
+          # closure (no GC roots are held), and any dependency a later root
+          # shares simply re-substitutes as a cheap download.
           failed_roots="$workdir/failed-roots.txt"
           : > "$failed_roots"
           outs="$workdir/outs.txt"
           : > "$outs"
+          relay_cache="file://$PWD/relay/cache?compression=zstd"
+          mkdir -p relay
           realise_t=$SECONDS
           if [ -s "$drvs" ]; then
             # -P 1, not -P 3: the runner's scratch disk is the binding
@@ -374,10 +388,25 @@ jobs:
             # died ENOSPC with 43 MB free (run 28762717645); serial roots cap
             # peak scratch at one build while `max-jobs`/`cores` still use
             # every core inside it.
-            # shellcheck disable=SC2016  # $1/$2 expand in the child bash, not here
-            xargs -P 1 -n 1 bash -c \
-                'nix-store --realise --keep-going "$2" || { printf "%s\n" "$2" >> "$1"; exit 1; }' _ "$failed_roots" \
-              < "$drvs" > "$outs" 2>"$workdir/realise.err" \
+            # shellcheck disable=SC2016  # positional args expand in the child
+            xargs -P 1 -n 1 bash -c '
+                failed="$1"; outs="$2"; relay="$3"; drv="$4"
+                # Realise, then immediately copy the closure into the relay
+                # and drop it from the store. A realise OR a relay-copy failure
+                # records the root as failed (the copy is what darwin-push
+                # relays, so a lost copy is as bad as a lost build).
+                if out="$(nix-store --realise --keep-going "$drv")" \
+                   && printf "%s\n" "$out" | xargs -r nix copy --to "$relay"; then
+                  printf "%s\n" "$out" >> "$outs"
+                  # gc keeps anything still referenced (later roots re-fetch
+                  # it), so reclaiming here never breaks a subsequent realise.
+                  nix store gc >/dev/null 2>&1 || true
+                else
+                  printf "%s\n" "$drv" >> "$failed"
+                  exit 1
+                fi
+              ' _ "$failed_roots" "$outs" "$relay_cache" \
+              < "$drvs" 2>"$workdir/realise.err" \
               || {
                 grep -F 'error:' "$workdir/realise.err" | sort -u | head -n 20 \
                   | while IFS= read -r line; do
@@ -406,15 +435,12 @@ jobs:
             echo "::warning::darwin-build: $fallback_hits substitution-failure line(s) during realise; nix fell back to source builds (cache health degraded, see indexable-inc/ix#6139)"
           fi
 
-          # Stage the relay: the realised closures as a zstd file:// binary
-          # cache plus the root list darwin-push feeds to attic. An empty
-          # roots.txt tells darwin-push there is nothing to relay.
-          mkdir -p relay
+          # Stage the relay: each realised root was already copied into the
+          # zstd file:// cache above (per-root, to keep the store flat), so
+          # here we only record the root list darwin-push feeds to attic. An
+          # empty roots.txt tells darwin-push there is nothing to relay.
           sort -u "$outs" > relay/roots.txt
           if [ -s relay/roots.txt ]; then
-            copy_t=$SECONDS
-            xargs -n 64 nix copy --to "file://$PWD/relay/cache?compression=zstd" < relay/roots.txt
-            phase copy "$copy_t"
             echo "::notice::relay cache size: $(du -sh relay | cut -f1)"
           else
             echo "::notice::every darwin root already cached; empty relay"


### PR DESCRIPTION
## Problem

The `darwin-build` lane in `cache-push.yml` has been red for 9+ hours, pinning `cache-ready` at 5679768720 (#1888) while `main` is dozens of commits ahead. Consumers pinning `github:indexable-inc/index/cache-ready` are starved.

## Root cause: disk exhaustion, not code

The job runs on a GitHub-hosted `macos-14` runner (~14 GB free after the Xcode/simulator cleanup step). It realised **all** ~100 roots into the Nix store first and copied them into the relay cache only at the end, so **the store grew monotonically across the whole run**. A cold `codex` (full codex-rs rustc workspace) plus the accumulated closures of every other root overran the disk:

- Run `28770353669`: `##[warning]You are running out of disk space ... Free space left: 95 MB`, then the last 17 roots all failed with `No space left on device (os error 28)` / `couldn't create a temp dir`.
- The "17 roots failed" list is pure ENOSPC collateral — every one of those roots (`minecraft-sound`, `codex`, `nix-2.34.7+ix`, `nu-jupyter-kernel`, `symphony`, `pi-*`, …) builds cleanly on a full-size darwin store. Verified locally on aarch64-darwin at the exact failing rev `8753308914`.

## Fix

Interleave the relay copy so the store stays flat: realise each root → copy its closure into the `file://` relay cache → `nix store gc`. The relay dir is a plain NAR directory, so once a root is copied there its store paths are redundant; gc keeps anything a later root still references (it re-substitutes as a cheap download), so the store never holds more than one root's closure at a time. A relay-copy failure now also marks the root failed (the copy is what `darwin-push` relays). The final staging step just writes `roots.txt`.

Combined with the existing `-P 1` scratch cap, peak disk is now ~one root's closure + one build's scratch instead of the sum of all roots.

## Validation

- `shellcheck --shell=bash` clean on the extracted run script.
- Locally reproduced the realise → copy-to-relay → reimport-into-chroot-store mechanic on hydra (aarch64-darwin): full 30-path `minecraft-sound` closure copies into the relay cache and reimports into a chroot store (the `darwin-push` path, unchanged) with exit 0.
- Workflow-only change: no Nix/Rust surface, so `nix flake check`/clippy do not apply.

Definition of done: the next `cache-push` run goes green and `cache-ready` advances past the stuck ref.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep darwin Nix store flat by realising, copying, and GC-ing each root immediately in cache-push
> - Each derivation root is now realised, copied into a local zstd `file://` relay cache, and garbage-collected within the same per-root child process in [cache-push.yml](.github/workflows/cache-push.yml).
> - This prevents disk pressure from accumulating across all roots, which is needed to fit within the ~14 GB disk on hosted macOS runners.
> - The previous end-of-phase batched `nix copy` step is removed; `relay/roots.txt` now just indexes outputs already copied during realisation.
> - Relay-copy failures mark the root as failed and exit the child with a non-zero status.
> - Behavioral Change: `outs` is now written inside each child process rather than via outer stdout redirection; failed roots are tracked separately in `failed_roots`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 940a73c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->