### PR TITLE
nix: drop test suites from nix-ix build; raise darwin cache-push budget

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -240,8 +240,13 @@ jobs:
     # downloads instead of doomed platform-mismatch builds.
     needs: push
     # A cold codex (full codex-rs workspace rustc build) is 40-80 min on this
-    # runner; warm runs are probe + substitution only.
-    timeout-minutes: 240
+    # runner; warm runs are probe + substitution only. Since #1916 the roots
+    # also carry nix-ix (the full modular nixComponents_2_34 C++ closure):
+    # even with its test suites disabled (#1967), a cold nix-ix plus a cold
+    # codex plus the ~27 min eval can brush the old 240-minute budget on
+    # 3 cores, and run 28772327218 showed a timeout here silently freezes
+    # cache-ready. 330 leaves margin under GitHub's 360-minute job hard cap.
+    timeout-minutes: 330
     env:
       # Replaces the workflow-level NIX_CONFIG: `cores = 1` there fits the
       # shared self-hosted pool, but this runner is dedicated, so each build

--- a/packages/nix/nix/default.nix
+++ b/packages/nix/nix/default.nix
@@ -79,6 +79,16 @@ let
 
   package = nixEverything.overrideAttrs (old: {
     version = "2.34.7+ix";
+    # The aggregate's `doCheck = true` gates the build on `checkInputs`: the
+    # five component unit-test runners plus the entire upstream functional
+    # suite. Those dominate a cold build of this closure and re-validate
+    # nothing per consumer rebuild: patch applicability is already gated by
+    # `checks.<system>.patched-src-nix`, the series carries its own
+    # upstream-style functional test inside the patched tree, and the `smoke`
+    # passthru below executes the linked binary. With them on, the cache-push
+    # darwin lane (3-core hosted mac) blew its 4 h job budget cold-building
+    # this package and froze `cache-ready` (run 28772327218, index#1967).
+    doCheck = false;
     meta =
       (old.meta or {})
       // {


### PR DESCRIPTION
Fixes #1967.

`cache-ready` has been frozen since ~06:00Z: #1916 put `nix-ix` (the full modular `nixComponents_2_34` closure) into `cachePushRoots.aarch64-darwin`, and the 3-core hosted mac in the `Cache push` `darwin-build` job cannot cold-build it plus its test suites inside 240 minutes (run 28772327218 was killed at exactly 4 h, skipping `darwin-push` and `advance-cache-ready`).

Two changes:

- **`packages/nix/nix/default.nix`**: `doCheck = false` on the `nix-everything` aggregate. Its `checkInputs` were the five component unit-test runners plus the entire upstream functional suite; the drv diff confirms those six derivations are exactly what leaves the build graph. They re-validate nothing per consumer rebuild: patch applicability is gated by `checks.<system>.patched-src-nix`, the patch series carries its own upstream-style functional test, and the `smoke` passthru still executes the linked binary and asserts `2.34.7+ix`.
- **`.github/workflows/cache-push.yml`**: `darwin-build` `timeout-minutes` 240 -> 330. Even without the test suites, a cold nix-ix plus a cold codex (40-80 min) plus the ~27 min eval can brush 240 on 3 cores, and a timeout here silently freezes `cache-ready`. 330 leaves margin under GitHub's 360-minute hard cap.

Validated locally on aarch64-darwin: `nix build .#nix-ix` succeeds, `nix --version` reports `2.34.7+ix`, the `smoke` passthru passes, and `.#packages.x86_64-linux.nix-ix.drvPath` still evals (linux lane builds the same package). `nix run .#lint` clean. Measured test-suite cost on an M5 Max follows in a comment; the hosted runner is roughly 4-5x slower.

Considered and rejected: dropping `nix-ix` from the darwin cache roots would unwedge CI but push the full cold build onto every darwin consumer, against the cache-ready contract.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop test suite execution from nix `nixEverything` build and raise macOS cache-push timeout
> - Sets `doCheck = false` in [default.nix](https://github.com/indexable-inc/index/pull/1970/files#diff-4332ad9feb37626c0ac4a68155597b10c261c0e0460cfcbca84f88d3d6125c6e) for the `nixEverything` aggregate derivation, disabling component unit-test runners and the upstream functional suite during the build.
> - Increases `timeout-minutes` from 240 to 330 for the macOS-14 job in [cache-push.yml](https://github.com/indexable-inc/index/pull/1970/files#diff-56c6f531ecd11b28cb14d6aa2ec8abf63b2cb701d82ce2f772c5a324c3bbbfb8) to accommodate the longer build times on Darwin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94cc016.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->