### PR TITLE
fix(cache-push): darwin-push cleanup trap falsified successful pushes; watchdog v2

### DIFF
--- a/.github/workflows/cache-push-watchdog.yml
+++ b/.github/workflows/cache-push-watchdog.yml
@@ -1,37 +1,50 @@
 name: Cache push watchdog
 
 # cache-push publishes packages to cache.ix.dev and advances `cache-ready`, the
-# ref darwin consumers pin (RFC 0009, #1862). On 2026-07-06 (#1968) it wedged
-# silently for 13h: GitHub materialized ZERO jobs for every cache-push run, so
-# each run sat `pending` holding the concurrency group until the next merge's
-# run superseded and auto-cancelled it. Nothing failed, so nothing alerted --
-# silence looked like success. Job-level `timeout-minutes` cannot catch this:
-# the timeout clock only starts once a job is `in_progress`, and these runs
-# never reached a single job.
+# ref darwin consumers pin (RFC 0009, #1862). On 2026-07-06 (#1968) the pin
+# froze for 13+ hours with no alert. The corrected root cause (see #1968):
 #
-# This watchdog is the out-of-band detector cache-push cannot be for itself. It
-# runs on a short cron and checks two independent liveness signals, each with
-# its own loud channel and self-heal:
+#   - The darwin lane ran multi-hour (pre-#1966 ENOSPC thrash; one run's
+#     darwin-build hit its 240-min job timeout exactly), so each acquired run
+#     held the `cache-push` concurrency group for hours.
+#   - GitHub keeps at most ONE pending run per concurrency group: every new
+#     push supersedes and auto-cancels the previously pending run (documented
+#     behavior; `cancel-in-progress: false` only protects the RUNNING run).
+#     Those superseded runs show `pending` with zero jobs -- jobs only
+#     materialize once the group is acquired.
+#   - The one run that got both builds through pushed successfully and was
+#     then falsified into `failure` by a cleanup trap bug (fixed alongside
+#     this watchdog), so advance-cache-ready never ran.
 #
-#   1. A cache-push run stuck `queued`/`in_progress` with zero jobs past a
-#      grace window (the GitHub materialization stall). Cancel it, redispatch a
-#      fresh run, and file a tracking issue.
-#   2. `cache-ready` drifted too far behind `main` (the publish is not keeping
-#      up for any reason). File a tracking issue and dispatch one self-heal run.
+# Nothing in that chain fails loudly on its own: supersede-cancels are not
+# failures, and a pin that silently stops moving looks like success. This
+# watchdog is the out-of-band detector, on a short cron, with three signals:
 #
-# Every terminal path is loud: a detected wedge files/updates a tracking issue
-# AND fails the job (red in the Actions tab); a clean check closes the tracking
-# issue. There is no success-only path. Alerts go through the repo's
-# find-or-update tracking-issue channel (same mechanism as cve-scan.yml /
-# blast-radius.yml), because this repo has no Slack webhook secret; the issue is
-# the reliable, self-contained channel.
+#   1. ZOMBIE HOLDER: a cache-push run active longer than the sum of its
+#      job timeouts. Job-level `timeout-minutes` does not cover queue wait
+#      (a job stuck "waiting for a runner" waits forever, e.g. dispatcher
+#      outage), so a run can hold the concurrency group indefinitely with a
+#      queued-but-never-assigned job. Cancel + redispatch.
+#   2. MATERIALIZATION STALL: a run pending with zero jobs past a grace
+#      window while NO other run holds the group. Zero jobs behind a holder
+#      is normal concurrency queuing and is deliberately NOT flagged; with no
+#      holder it means GitHub never scheduled the run. Cancel + redispatch.
+#   3. PIN DRIFT: cache-ready far behind main while no cache-push run is
+#      active at all (the pipeline gave up rather than being busy). Alert +
+#      one self-heal dispatch, deduped against recent heals so a slow lane
+#      cannot trigger a dispatch storm.
+#
+# Every wedge files/updates one tracking issue AND fails this job (red in the
+# Actions tab); a clean check closes the issue with a resolution comment. A
+# watchdog-internal failure (rate limit, auth) exits loudly WITHOUT claiming
+# health or closing the issue. There is no success-only path. Alerts use the
+# find-or-update tracking-issue channel (as cve-scan.yml / blast-radius.yml);
+# this repo has no Slack webhook secret.
 
 on:
   schedule:
-    # Every 15 min. cache-push runs on every merge (minutes apart at peak), and
-    # the stall window that matters is "pending with 0 jobs for STALL_GRACE_MIN
-    # minutes", so 15 min sampling catches a wedge within one grace window plus
-    # one tick without spamming the Actions queue.
+    # Every 15 min: one grace window plus one tick bounds detection latency
+    # without spamming the API.
     - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
@@ -42,8 +55,8 @@ on:
 
 # Read runs/jobs, cancel + redispatch cache-push, and maintain the tracking
 # issue. `actions: write` covers both `gh run cancel` and `gh workflow run`
-# (workflow_dispatch); issue writes do not need a PAT (#1968), unlike PR
-# creation, which the enterprise blocks for GITHUB_TOKEN.
+# (workflow_dispatch); issue writes do not need a PAT (unlike PR creation,
+# which the enterprise blocks for GITHUB_TOKEN).
 permissions:
   contents: read
   actions: write
@@ -51,25 +64,34 @@ permissions:
 
 concurrency:
   # One watchdog at a time; a slow API pass must not overlap the next tick and
-  # double-cancel. cancel-in-progress keeps the newest check authoritative.
+  # double-cancel. cancel-in-progress keeps the newest check authoritative --
+  # the superseded tick dies mid-scan, which at worst delays one detection by
+  # one tick (its heal actions are idempotent, so a partial tick cannot leave
+  # a half-applied state behind).
   group: cache-push-watchdog
   cancel-in-progress: true
 
 jobs:
   watch:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
       REPOSITORY: ${{ github.repository }}
-      # A run pending with zero jobs beyond this is the materialization stall.
-      # Healthy runs dispatch a job within ~1 min (the dispatcher recovery loop
-      # polls every ~66s); 20 min is comfortably past any normal queue wait and
-      # short enough that a wedge self-heals well inside an hour.
+      # Signal 1: sum of cache-push's serial job timeouts (push 180 + darwin
+      # relay chain) plus slack. Anything older is a zombie holding the group.
+      MAX_RUN_AGE_MIN: "520"
+      # Signal 2: a healthy dispatch takes ~1 min (the fleet dispatcher's
+      # recovery loop polls every ~66s); 20 min is far past any normal wait.
       STALL_GRACE_MIN: "20"
-      # cache-ready this many commits behind main is a drift alert even if no
-      # single run is currently stalled (e.g. a chain of auto-cancelled runs
-      # each cleared before this watchdog sampled it).
-      DRIFT_MAX_COMMITS: "10"
+      # Signal 3: merge traffic peaks at ~6 commits/hour and a cold darwin
+      # lane holds the group 1-3h, so a healthy-but-busy pipeline routinely
+      # sits 10-20 commits behind. 25 with the no-active-run gate below means
+      # "far behind AND nothing even trying".
+      DRIFT_MAX_COMMITS: "25"
+      # Signal 3 dispatch dedup: do not stack a second heal while one
+      # dispatched inside this window may still be queued behind the group.
+      HEAL_COOLDOWN_MIN: "90"
       DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
     steps:
       - name: Detect and heal cache-push wedges
@@ -81,80 +103,138 @@ jobs:
           now_epoch="$(date -u +%s)"
 
           note() { echo "::notice::watchdog: $*"; }
+          # Watchdog-internal failure: loud, and crucially it neither claims
+          # health nor closes the tracking issue (C1 in the #1969 review: a
+          # rate-limited list call must not read as "everything is fine").
+          fail_loud() { echo "::error::watchdog internal failure: $*"; exit 2; }
           finding=""   # non-empty => something is wrong; body accumulates here
           add_finding() { finding="${finding}$1"$'\n'; }
+          healed=""    # set once a redispatch happened this tick
 
-          : > /tmp/stalled.txt
+          dispatch_heal() {
+            # full_pass heals holes left by cancelled/partial pushes.
+            if gh workflow run cache-push.yml --repo "${REPOSITORY}" --ref main -f full_pass=true; then
+              add_finding "- **Self-heal**: dispatched a fresh \`cache-push\` (full_pass) on main."
+              healed=1
+            else
+              echo "::error::watchdog failed to redispatch cache-push"
+            fi
+          }
 
-          # --- Signal 1: a cache-push run stuck with zero jobs -----------------
-          # A run is a stall suspect when it is queued/in_progress/pending AND
-          # has created no jobs yet. jobs.total_count==0 is the exact
-          # fingerprint from #1968. Read the id list first, then loop in the
-          # parent shell (a `while` on a pipe would run in a subshell and lose
-          # the appends).
-          mapfile -t suspect_runs < <(gh api \
-            "repos/${REPOSITORY}/actions/workflows/cache-push.yml/runs?per_page=20" \
-            --jq '.workflow_runs[] | select(.status=="queued" or .status=="in_progress" or .status=="pending") | "\(.id) \(.created_at)"')
+          # Every list call lands in a file with an explicit failure branch:
+          # `mapfile < <(cmd)` ignores cmd's exit status, which would turn an
+          # API outage into an empty array and a false "healthy".
+          runs_file=/tmp/active-runs.tsv
+          # shellcheck disable=SC2016  # \(...) is jq string interpolation, not shell
+          gh api "repos/${REPOSITORY}/actions/workflows/cache-push.yml/runs?per_page=20" \
+            --jq '.workflow_runs[] | select((.status=="queued" or .status=="in_progress" or .status=="pending") and .head_branch=="main") | "\(.id)\t\(.created_at)\t\(.event)"' \
+            > "$runs_file" || fail_loud "listing cache-push runs failed"
 
-          for run in "${suspect_runs[@]}"; do
-            [ -n "$run" ] || continue
-            id="${run%% *}"
-            created="${run#* }"
-            njobs="$(gh api "repos/${REPOSITORY}/actions/runs/${id}/jobs" --jq '.total_count')"
+          # One pass over the active runs: age + job count for each, and
+          # whether any run actually holds the concurrency group (has jobs).
+          annotated=/tmp/annotated-runs.tsv
+          : > "$annotated"
+          holder_exists=""
+          while IFS=$'\t' read -r id created event; do
+            njobs="$(gh api "repos/${REPOSITORY}/actions/runs/${id}/jobs" --jq '.total_count')" \
+              || fail_loud "listing jobs for run ${id} failed"
             created_epoch="$(date -u -d "$created" +%s)"
             age_min=$(( (now_epoch - created_epoch) / 60 ))
-            if [ "$njobs" -eq 0 ] && [ "$age_min" -ge "${STALL_GRACE_MIN}" ]; then
-              echo "$id $age_min" >> /tmp/stalled.txt
-            fi
-          done
+            if [ "$njobs" -gt 0 ]; then holder_exists=1; fi
+            printf '%s\t%s\t%s\t%s\n' "$id" "$age_min" "$njobs" "$event" >> "$annotated"
+          done < "$runs_file"
 
-          if [ -s /tmp/stalled.txt ]; then
-            while read -r id age_min; do
-              echo "::error::run ${id} pending with 0 jobs for ${age_min} min (>= ${STALL_GRACE_MIN} min grace): GitHub never materialized a job (see #1968)"
-              add_finding "- **Stalled run**: [${id}](https://github.com/${REPOSITORY}/actions/runs/${id}) pending with 0 jobs for ${age_min} min."
+          # --- Signal 1: zombie holder ----------------------------------------
+          while IFS=$'\t' read -r id age_min njobs event; do
+            if [ "$age_min" -ge "${MAX_RUN_AGE_MIN}" ]; then
+              echo "::error::run ${id} active for ${age_min} min (>= ${MAX_RUN_AGE_MIN}): exceeds the sum of cache-push job timeouts; a queued-but-never-assigned job holds the group with no timeout (#1968)"
+              add_finding "- **Zombie run**: [${id}](https://github.com/${REPOSITORY}/actions/runs/${id}) active ${age_min} min with ${njobs} job(s)."
               if [ -z "${DRY_RUN}" ]; then
-                # Cancel the wedged run so it stops holding the cache-push
-                # concurrency group.
                 gh run cancel "${id}" --repo "${REPOSITORY}" || echo "::warning::could not cancel ${id} (may have just completed)"
               fi
-            done < /tmp/stalled.txt
-            if [ -z "${DRY_RUN}" ]; then
-              # full_pass heals any holes the cancelled runs left behind.
-              gh workflow run cache-push.yml --repo "${REPOSITORY}" --ref main -f full_pass=true \
-                && add_finding "- **Self-heal**: dispatched a fresh \`cache-push\` (full_pass) on main." \
-                || echo "::error::watchdog failed to redispatch cache-push"
             fi
-          else
-            note "no cache-push run stalled with zero jobs"
+          done < "$annotated"
+
+          # --- Signal 2: materialization stall (0 jobs, nothing holding) ------
+          # Zero jobs BEHIND a holder is normal: a run queued on the concurrency
+          # group materializes no jobs until it acquires the group, and GitHub
+          # keeps one such pending run per group by design. Only a 0-job run
+          # with NO holder anywhere means GitHub never scheduled it.
+          if [ -z "$holder_exists" ]; then
+            while IFS=$'\t' read -r id age_min njobs event; do
+              if [ "$njobs" -eq 0 ] && [ "$age_min" -ge "${STALL_GRACE_MIN}" ]; then
+                echo "::error::run ${id} pending with 0 jobs for ${age_min} min with no group holder: GitHub never materialized a job (#1968)"
+                add_finding "- **Stalled run**: [${id}](https://github.com/${REPOSITORY}/actions/runs/${id}) pending with 0 jobs for ${age_min} min, no holder."
+                if [ -z "${DRY_RUN}" ]; then
+                  gh run cancel "${id}" --repo "${REPOSITORY}" || echo "::warning::could not cancel ${id} (may have just completed)"
+                fi
+              fi
+            done < "$annotated"
+          fi
+          # One redispatch covers however many runs signals 1-2 cancelled.
+          if [ -n "$finding" ] && [ -z "${DRY_RUN}" ]; then
+            dispatch_heal
           fi
 
-          # --- Signal 2: cache-ready drifted behind main ----------------------
-          # Independent of signal 1: a chain of auto-cancelled runs can leave
-          # cache-ready stale even when nothing is stalled at sample time.
-          main_sha="$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
-          if ready_sha="$(gh api "repos/${REPOSITORY}/git/ref/heads/cache-ready" --jq '.object.sha' 2>/dev/null)"; then
-            # ahead_by counts commits main has that cache-ready lacks.
-            behind="$(gh api "repos/${REPOSITORY}/compare/${ready_sha}...${main_sha}" --jq '.ahead_by')"
-            note "cache-ready is ${behind} commit(s) behind main (ready=${ready_sha:0:8}, main=${main_sha:0:8})"
-            if [ "${behind}" -ge "${DRIFT_MAX_COMMITS}" ]; then
-              echo "::error::cache-ready is ${behind} commits behind main (>= ${DRIFT_MAX_COMMITS}); consumers pinning cache-ready are stale (see #1862, #1968)"
-              add_finding "- **cache-ready drift**: ${behind} commits behind main (\`${ready_sha:0:8}\` vs \`${main_sha:0:8}\`)."
-              # Self-heal only if signal 1 did not already redispatch, to avoid
-              # queuing two heals in one tick.
-              if [ -z "${DRY_RUN}" ] && [ ! -s /tmp/stalled.txt ]; then
-                gh workflow run cache-push.yml --repo "${REPOSITORY}" --ref main -f full_pass=true \
-                  && add_finding "- **Self-heal**: dispatched a fresh \`cache-push\` (full_pass) on main." \
-                  || echo "::error::watchdog failed to redispatch cache-push"
+          # --- Signal 3: pin drift with an idle pipeline ----------------------
+          main_sha="$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')" \
+            || fail_loud "reading main ref failed"
+          ready_sha=""
+          if ! ready_sha="$(gh api "repos/${REPOSITORY}/git/ref/heads/cache-ready" --jq '.object.sha')"; then
+            note "cache-ready ref does not exist yet; nothing to compare"
+          fi
+          if [ -n "$ready_sha" ]; then
+            cmp_file=/tmp/compare.json
+            gh api "repos/${REPOSITORY}/compare/${ready_sha}...${main_sha}" > "$cmp_file" \
+              || fail_loud "comparing cache-ready to main failed"
+            behind="$(jq -r '.ahead_by' "$cmp_file")"
+            cmp_status="$(jq -r '.status' "$cmp_file")"
+            note "cache-ready is ${behind} commit(s) behind main (ready=${ready_sha:0:8}, main=${main_sha:0:8}, status=${cmp_status})"
+            # ahead/identical are the only healthy shapes for base=cache-ready,
+            # head=main. diverged means cache-ready carries commits main does
+            # not (a force-move past the fast-forward-only guard) -- alert,
+            # never self-heal over it.
+            if [ "$cmp_status" != "ahead" ] && [ "$cmp_status" != "identical" ]; then
+              echo "::error::cache-ready...main compare status is '${cmp_status}': the pin has diverged from main and needs operator attention"
+              add_finding "- **cache-ready diverged**: compare status \`${cmp_status}\` (\`${ready_sha:0:8}\` vs \`${main_sha:0:8}\`)."
+            elif [ "${behind}" -ge "${DRIFT_MAX_COMMITS}" ]; then
+              if [ -s "$runs_file" ]; then
+                # A run is queued or in progress: the pipeline is working on
+                # it, so the drift is backlog, not a wedge. Signals 1-2 above
+                # own the case where that run itself is stuck.
+                note "cache-ready is ${behind} behind but a cache-push run is active; not healing"
+              else
+                echo "::error::cache-ready is ${behind} commits behind main (>= ${DRIFT_MAX_COMMITS}) with NO cache-push run active: the pipeline gave up (#1862, #1968)"
+                add_finding "- **cache-ready drift**: ${behind} commits behind main (\`${ready_sha:0:8}\` vs \`${main_sha:0:8}\`) with no active run."
+                # Dedup: a heal dispatched recently may still be realising (a
+                # full pass runs long); do not stack another behind it. The
+                # cutoff is interpolated into the jq program because gh's
+                # --jq flag does not accept jq --arg; it is a shell-generated
+                # ISO timestamp, so no quoting hazard.
+                cutoff="$(date -u -d "@$(( now_epoch - HEAL_COOLDOWN_MIN * 60 ))" +%Y-%m-%dT%H:%M:%SZ)"
+                recent_heal="$(gh api \
+                  "repos/${REPOSITORY}/actions/workflows/cache-push.yml/runs?event=workflow_dispatch&per_page=5" \
+                  --jq "[.workflow_runs[] | select(.created_at > \"${cutoff}\")] | length")" \
+                  || fail_loud "listing recent heal dispatches failed"
+                if [ -z "${DRY_RUN}" ] && [ -z "$healed" ] && [ "$recent_heal" -eq 0 ]; then
+                  dispatch_heal
+                elif [ "$recent_heal" -gt 0 ]; then
+                  note "a heal dispatched within the last ${HEAL_COOLDOWN_MIN} min; not stacking another"
+                fi
               fi
             fi
-          else
-            note "cache-ready ref does not exist yet; nothing to compare"
           fi
 
           # --- Maintain the tracking issue ------------------------------------
-          number="$(gh issue list --repo "${REPOSITORY}" --state open \
-                      --search "in:body \"${issue_marker}\"" \
-                      --json number --jq '.[0].number // empty')"
+          # --state all so a closed issue is reopened instead of minting a new
+          # one per wedge/heal cycle (C3 in the #1969 review).
+          issue_json=/tmp/issue.json
+          gh issue list --repo "${REPOSITORY}" --state all \
+              --search "in:body \"${issue_marker}\"" \
+              --json number,state --jq '.[0] // empty' > "$issue_json" \
+            || fail_loud "searching for the tracking issue failed"
+          number="$(jq -r '.number // empty' "$issue_json")"
+          issue_state="$(jq -r '.state // empty' "$issue_json")"
 
           if [ -n "${finding}" ]; then
             {
@@ -165,7 +245,7 @@ jobs:
               echo
               echo "${finding}"
               echo
-              echo "The watchdog cancels stalled runs and redispatches automatically. If this issue keeps reopening, GitHub's job scheduler is repeatedly failing to materialize cache-push jobs (root cause is GitHub-side, see #1968); the self-heal is working but the underlying flakiness persists."
+              echo "The watchdog cancels wedged runs and redispatches automatically. If this issue keeps reopening, the underlying failure is recurring faster than the self-heal; see #1968 for the failure taxonomy."
               echo
               echo "_Filed by cache-push-watchdog.yml. Made with Claude Opus 4.8._"
             } > /tmp/watchdog-issue.md
@@ -173,6 +253,9 @@ jobs:
               note "DRY_RUN: would file/update tracking issue with findings"
               cat /tmp/watchdog-issue.md
             elif [ -n "${number}" ]; then
+              if [ "${issue_state}" = "CLOSED" ]; then
+                gh issue reopen "${number}" --repo "${REPOSITORY}"
+              fi
               gh issue edit "${number}" --repo "${REPOSITORY}" --body-file /tmp/watchdog-issue.md
               gh issue comment "${number}" --repo "${REPOSITORY}" \
                 --body "Re-detected at \`$(date -u +'%Y-%m-%dT%H:%M:%SZ')\` (run ${GITHUB_RUN_ID}); self-heal re-triggered."
@@ -185,7 +268,7 @@ jobs:
             exit 1
           else
             note "cache-push pipeline healthy"
-            if [ -z "${DRY_RUN}" ] && [ -n "${number}" ]; then
+            if [ -z "${DRY_RUN}" ] && [ -n "${number}" ] && [ "${issue_state}" = "OPEN" ]; then
               gh issue comment "${number}" --repo "${REPOSITORY}" \
                 --body "Resolved: cache-push pipeline healthy at \`$(date -u +'%Y-%m-%dT%H:%M:%SZ')\` (run ${GITHUB_RUN_ID}). Closing."
               gh issue close "${number}" --repo "${REPOSITORY}"

--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -509,7 +509,14 @@ jobs:
           # Token via config file, never `attic login`: argv is world-readable
           # through /proc/<pid>/cmdline.
           workdir="$(mktemp -d)"
-          trap 'rm -rf "$workdir"' EXIT
+          # `nix copy` writes the chroot store below with store permissions
+          # (read-only files and dirs), which a bare `rm -rf` cannot delete;
+          # run 28787288386 pushed all 2485 paths successfully and then FAILED
+          # on exactly this trap (~300k "Permission denied" lines), which
+          # skipped advance-cache-ready and kept the consumer pin frozen
+          # (#1968). chmod first; cleanup of the job-private tmpdir must never
+          # outweigh a completed push, so it warns instead of failing.
+          trap 'chmod -R u+w "$workdir" || true; rm -rf "$workdir" || echo "::warning::could not clean $workdir (job-private tmp, reaped with the runner unit)"' EXIT
           export XDG_CONFIG_HOME="$workdir/config"
           install -d -m700 "$XDG_CONFIG_HOME/attic"
           ( umask 077


### PR DESCRIPTION
## Corrected root cause (#1968)

The audit log + full run history overturned the initial "GitHub materialization stall" theory:

1. **darwin lane ran multi-hour** all day (pre-#1966 ENOSPC thrash; run 28772327218's darwin-build hit its 240-min job timeout to the minute), so each acquired run held the `cache-push` concurrency group for hours.
2. **GitHub keeps ONE pending run per concurrency group** and auto-cancels the older pending run on every new push (documented; `cancel-in-progress: false` only protects the running run). The "cancelled with 0 jobs" chain was normal queuing: jobs only materialize once the group is acquired. No audit events for these — GitHub-internal.
3. **The one run that got both builds through (28787288386) pushed all 2485 paths successfully** (`darwin-push phase 'push' took 129s`) and was then **falsified into failure by the cleanup trap**: `nix copy` writes the relay chroot store read-only, `rm -rf "$workdir"` emitted ~300k permission-denied lines and exited 1, skipping advance-cache-ready. That is the terminal bug that kept `cache-ready` frozen.
4. The in_progress heal run's 14:31:20 cancellation was an `andrewgazelka`-credentialed API call (org audit log), not GitHub or automation in this repo.

## Fixes

- **darwin-push trap**: chmod before rm; cleanup of the job-private tmpdir warns instead of failing. The push result is the job's purpose.
- **Watchdog v2** per the #1969 adversarial review:
  - **C1**: every list call captures to a file with an explicit `fail_loud` branch (exit 2, does NOT close the tracking issue). API outage can no longer read as healthy.
  - **C2**: drift heal requires **no active cache-push run** (busy != wedged), threshold 25, plus a 90-min heal cooldown checked against recent `workflow_dispatch` runs.
  - **C3**: `--state all` + reopen; one living tracking issue.
  - **Signal rework**: 0-jobs-pending behind a group holder is normal and not flagged; new **zombie-holder** signal cancels runs older than the sum of job timeouts (covers queued-job-never-assigned, which job `timeout-minutes` cannot).
  - **M1** head_branch filter, **M2** diverged-pin alert (no self-heal over it), **M3** partial-tick comment.
  - Fixed a latent bug: `gh --jq` rejects jq `--arg`; cutoff now shell-interpolated.

## Validation

- actionlint clean on both workflows.
- Live dry-run against the current recovery state: holder run 28799201241 (in_progress, 2 jobs, 16 min) not flagged; drift 46 with an active run correctly withholds the heal; recent-heal dedup query returns 1 (the 14:15 manual heal) as expected.

Refs #1968

_Made with Claude Opus 4.8._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix darwin cache-push EXIT trap to avoid failing on read-only store paths and harden cache-push watchdog
> - Fixes the EXIT trap in [cache-push.yml](https://github.com/indexable-inc/index/pull/1972/files#diff-56c6f531ecd11b28cb14d6aa2ec8abf63b2cb701d82ce2f772c5a324c3bbbfb8) to `chmod -R u+w` before `rm -rf` on the temp directory; deletion failures now emit a warning instead of failing the job, preventing false failures when `nix copy` leaves read-only store contents.
> - Rewrites the watchdog in [cache-push-watchdog.yml](https://github.com/indexable-inc/index/pull/1972/files#diff-cb8b898c2e45019e2f02fd2c4cf01821ddf930ce6d6b978684ad819e7ccf6eda) to cancel "zombie" runs exceeding a configurable age (`MAX_RUN_AGE_MIN=520`), suppress false stall signals when a run already holds the concurrency group, and add cooldown-based dedup (`HEAL_COOLDOWN_MIN=90`) for self-heal dispatches.
> - Watchdog now exits loudly (`fail_loud()`) on API/operational errors instead of silently reporting health or closing the tracking issue; it also reopens a closed tracking issue when re-detecting a wedge.
> - Risk: two defects are introduced — a shell syntax error in the recent-heal `jq` invocation and a mismatched temp filename in the issue-edit path; both will cause the watchdog run to fail with an internal error until corrected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b530c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->