### PR TITLE
assert canonical format-patch form in patched-src

### DIFF
--- a/lib/util/patched-src.nix
+++ b/lib/util/patched-src.nix
@@ -23,14 +23,47 @@
   name,
   src,
   patchDir,
-}:
-applyPatches {
-  name = "${name}-patched";
-  inherit src;
-  patches = lib.pipe (builtins.readDir patchDir) [
-    (lib.filterAttrs (f: t: t == "regular" && lib.hasSuffix ".patch" f))
-    builtins.attrNames
-    lib.naturalSort
-    (map (f: patchDir + "/${f}"))
-  ];
-}
+}: let
+  # `rebase-patches` exports the series with `git format-patch --zero-commit
+  # --no-signature --no-stat -N`, so a conforming file is byte-stable across
+  # regenerations: no commit-hash, `[PATCH N/M]` count, diffstat, or
+  # git-version churn in the diff. Hand-added patches drift from that shape,
+  # so assert it at eval and fail with the regeneration command.
+  zeroFrom = "From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001";
+  assertCanonical = fileName: path: let
+    lines = lib.splitString "\n" (builtins.readFile path);
+    nonEmpty = lib.filter (l: l != "") lines;
+    # Diffstat can only appear in the header, between the `---` separator
+    # and the first `diff --git`; scoping the scan there keeps diff content
+    # that merely mentions "files changed" from tripping the check.
+    firstDiffLine = lib.lists.findFirstIndex (lib.hasPrefix "diff --git ") (lib.length lines) lines;
+    header = lib.take firstDiffLine lines;
+    fail = why:
+      throw ''
+        ${name}: ${fileName}: ${why}.
+        The series must match its writer, `git format-patch --zero-commit
+        --no-signature --no-stat -N`; regenerate it with `nix run .#rebase-patches`.
+      '';
+  in
+    if builtins.match "[0-9]{4}-.*" fileName == null
+    then fail "filename lacks the NNNN- series prefix"
+    else if lib.head lines != zeroFrom
+    then fail "first line is not the zeroed `From ` header (--zero-commit)"
+    else if !(lib.any (lib.hasPrefix "Subject: [PATCH] ") lines)
+    then fail "missing unnumbered `Subject: [PATCH] ` header (-N; `[PATCH N/M]` renumbers the whole series on insert)"
+    else if lib.any (l: builtins.match " [0-9]+ files? changed.*" l != null) header
+    then fail "diffstat block in the header (--no-stat)"
+    else if lib.length nonEmpty >= 2 && lib.elemAt nonEmpty (lib.length nonEmpty - 2) == "-- "
+    then fail "trailing signature block (--no-signature)"
+    else path;
+in
+  applyPatches {
+    name = "${name}-patched";
+    inherit src;
+    patches = lib.pipe (builtins.readDir patchDir) [
+      (lib.filterAttrs (f: t: t == "regular" && lib.hasSuffix ".patch" f))
+      builtins.attrNames
+      lib.naturalSort
+      (map (f: assertCanonical f (patchDir + "/${f}")))
+    ];
+  }

--- a/packages/nix/nix/patches/0001-fix-libstore-don-t-crash-the-daemon-when-a-GC-roots-.patch
+++ b/packages/nix/nix/patches/0001-fix-libstore-don-t-crash-the-daemon-when-a-GC-roots-.patch
@@ -1,4 +1,4 @@
-From 365d8c7d194cbd3eba674c18c19242c9e2dfa45f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Gazelka <andrew@ix.dev>
 Date: Sun, 5 Jul 2026 19:54:54 -0700
 Subject: [PATCH] fix(libstore): don't crash the daemon when a GC roots client
@@ -19,8 +19,6 @@ mirroring the auto-GC worker thread in the same file.
 Origin: indexable-inc/nix branch fix-gc-roots-client-interrupt-crash (commit
 4a2e137b3), rebased onto the 2.34.7 base.
 ---
- src/libstore/gc.cc | 13 +++++++++++++
- 1 file changed, 13 insertions(+)
 
 diff --git a/src/libstore/gc.cc b/src/libstore/gc.cc
 index 16b81ab..3e959c8 100644
@@ -46,6 +44,3 @@ index 16b81ab..3e959c8 100644
                          }
                      }
                  });
--- 
-2.54.0
-

--- a/packages/nix/nix/patches/0002-fix-libexpr-treat-inaccessible-default-lookup-path-e.patch
+++ b/packages/nix/nix/patches/0002-fix-libexpr-treat-inaccessible-default-lookup-path-e.patch
@@ -1,4 +1,4 @@
-From 315554e6dcd5e281a855605c570935d52a9d0e67 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Gazelka <andrew@ix.dev>
 Date: Sun, 5 Jul 2026 21:29:59 -0700
 Subject: [PATCH] fix(libexpr): treat inaccessible default lookup-path entries
@@ -17,8 +17,6 @@ Switch to the non-throwing overload: an entry that cannot be stat'd is
 simply not offered as a default lookup path, matching how a missing entry
 already behaves.
 ---
- src/libexpr/eval-settings.cc | 11 ++++++++++-
- 1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/src/libexpr/eval-settings.cc b/src/libexpr/eval-settings.cc
 index 5cf0ae0..69c2494 100644
@@ -42,6 +40,3 @@ index 5cf0ae0..69c2494 100644
              if (s.empty()) {
                  res.push_back(p.string());
              } else {
--- 
-2.54.0
-

--- a/packages/nix/nix/patches/0003-libutil-add-build-status-dir-experimental-feature.patch
+++ b/packages/nix/nix/patches/0003-libutil-add-build-status-dir-experimental-feature.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Gazelka <andrew@ix.dev>
 Date: Sun, 5 Jul 2026 20:12:08 -0700
-Subject: [PATCH 1/7] libutil: add build-status-dir experimental feature
+Subject: [PATCH] libutil: add build-status-dir experimental feature
 
 Introduces the `build-status-dir` experimental feature. It gates the
 daemon-independent build status directory: when enabled, build and

--- a/packages/nix/nix/patches/0004-libstore-add-build-status-directory-writer.patch
+++ b/packages/nix/nix/patches/0004-libstore-add-build-status-directory-writer.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Gazelka <andrew@ix.dev>
 Date: Sun, 5 Jul 2026 20:12:16 -0700
-Subject: [PATCH 2/7] libstore: add build status directory writer
+Subject: [PATCH] libstore: add build status directory writer
 
 Adds a `BuildStatus` RAII writer that records what a goal is doing to a JSON
 file under `<store-state-dir>/status/` (e.g. `/nix/var/nix/status/`). The

--- a/packages/nix/nix/patches/0005-libstore-write-status-files-from-build-and-substitut.patch
+++ b/packages/nix/nix/patches/0005-libstore-write-status-files-from-build-and-substitut.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Gazelka <andrew@ix.dev>
 Date: Sun, 5 Jul 2026 20:12:30 -0700
-Subject: [PATCH 3/7] libstore: write status files from build and substitution
+Subject: [PATCH] libstore: write status files from build and substitution
  goals
 
 Instantiate a `BuildStatus` at the point each goal starts doing real work:

--- a/packages/nix/nix/patches/0006-libstore-daemon-record-client-uid-and-user-for-build.patch
+++ b/packages/nix/nix/patches/0006-libstore-daemon-record-client-uid-and-user-for-build.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Gazelka <andrew@ix.dev>
 Date: Sun, 5 Jul 2026 20:12:38 -0700
-Subject: [PATCH 4/7] libstore/daemon: record client uid and user for build
+Subject: [PATCH] libstore/daemon: record client uid and user for build
  status
 
 Thread the connecting client's uid and user name from the daemon's

--- a/packages/nix/nix/patches/0007-nix-add-nix-store-builds-command.patch
+++ b/packages/nix/nix/patches/0007-nix-add-nix-store-builds-command.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Gazelka <andrew@ix.dev>
 Date: Sun, 5 Jul 2026 20:12:45 -0700
-Subject: [PATCH 5/7] nix: add 'nix store builds' command
+Subject: [PATCH] nix: add 'nix store builds' command
 
 Adds `nix store builds`, which reports the builds and substitutions currently
 in progress by reading the status directory directly, *without* connecting to

--- a/packages/nix/nix/patches/0008-tests-functional-test-build-status-directory.patch
+++ b/packages/nix/nix/patches/0008-tests-functional-test-build-status-directory.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Gazelka <andrew@ix.dev>
 Date: Sun, 5 Jul 2026 20:21:14 -0700
-Subject: [PATCH 6/7] tests/functional: test build status directory
+Subject: [PATCH] tests/functional: test build status directory
 
 Adds `build-status.sh`: with the `build-status-dir` feature enabled it starts
 a sleeping build, polls `nix store builds --json` until the build's status

--- a/packages/nix/nix/patches/0009-doc-release-note-for-build-status-directory-and-nix-.patch
+++ b/packages/nix/nix/patches/0009-doc-release-note-for-build-status-directory-and-nix-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Gazelka <andrew@ix.dev>
 Date: Sun, 5 Jul 2026 20:21:19 -0700
-Subject: [PATCH 7/7] doc: release note for build status directory and 'nix
+Subject: [PATCH] doc: release note for build status directory and 'nix
  store builds'
 
 

--- a/packages/vm/panes/guest-image/mesa/patches/0001-venus-handle-temporary-sync-fd-semaphore-imports-dri.patch
+++ b/packages/vm/panes/guest-image/mesa/patches/0001-venus-handle-temporary-sync-fd-semaphore-imports-dri.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Thu, 2 Jul 2026 17:34:18 -0700
-Subject: [PATCH 1/3] venus: handle temporary sync fd semaphore imports
+Subject: [PATCH] venus: handle temporary sync fd semaphore imports
  driver-side
 
 When the renderer cannot import sync fd semaphores (no SYNC_FD import in

--- a/packages/vm/panes/guest-image/mesa/patches/0002-README.ix-document-snapshot-fork-layout.patch
+++ b/packages/vm/panes/guest-image/mesa/patches/0002-README.ix-document-snapshot-fork-layout.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Thu, 2 Jul 2026 18:31:24 -0700
-Subject: [PATCH 2/3] README.ix: document snapshot fork layout
+Subject: [PATCH] README.ix: document snapshot fork layout
 
 Refs: indexable-inc/index#1686
 

--- a/packages/vm/panes/guest-image/mesa/patches/0003-venus-fail-sparse-batches-waiting-on-driver-side-syn.patch
+++ b/packages/vm/panes/guest-image/mesa/patches/0003-venus-fail-sparse-batches-waiting-on-driver-side-syn.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Thu, 2 Jul 2026 20:12:59 -0700
-Subject: [PATCH 3/3] venus: fail sparse batches waiting on driver-side sync fd
+Subject: [PATCH] venus: fail sparse batches waiting on driver-side sync fd
  imports
 
 The previous fallback relied on an assert that compiles out under NDEBUG (nixpkgs release builds), leaving a silent renderer hang on the (currently unreachable) sparse+imported+non-importable combination. Log and return VK_ERROR_DEVICE_LOST explicitly; keep the assert for debug builds. Review follow-up for indexable-inc/index#1763.


### PR DESCRIPTION
Closes #1981

The writer (`rebase-patches`, `git format-patch --zero-commit --no-signature --no-stat -N`) already defines a canonical byte-stable patch form, but nothing enforced it on hand-added files. This:

- asserts the shape at eval in `lib/util/patched-src.nix` (zeroed `From` hash, unnumbered `Subject: [PATCH]`, no diffstat, no signature trailer, `NNNN-` filename), failing with the exact regeneration command
- normalizes the 12 drifted files (`packages/nix/nix/patches/0001-0002` had real hashes + signature + diffstat; nix `0003-0009` and mesa were `[PATCH N/M]`-numbered)

Validated: all five `patched-src-*` checks build on aarch64-darwin; a doctored numbered subject makes eval throw the new error. ix's own fork stacks (colmena, ghostty) are already canonical, so the next index bump there is clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce canonical git-format-patch format in `patched-src`
> - Adds `assertCanonical` to [patched-src.nix](https://github.com/indexable-inc/index/pull/1982/files#diff-884080a8ece8fb33e6f399224ac8b22124189c4e4d5b42a9090ef4006c6fbb1d), which validates each patch file against a canonical `git format-patch` shape: zeroed `From` hash, unnumbered `[PATCH]` subject, presence of a diffstat block, and a trailing signature.
> - Normalizes existing patch files under `packages/nix/nix/patches/` and `packages/vm/panes/guest-image/mesa/patches/` to conform: zeroed `From` lines, stripped series numbering (e.g. `[PATCH 3/7]` → `[PATCH]`), and removed footers.
> - Risk: Nix evaluation now aborts if any patch file in `patched-src` fails the canonical checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d59e0d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->