### PR TITLE
nix-cargo-unit: omit extra-filename when rustc gets an explicit -o

### DIFF
--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1060,7 +1060,7 @@ fn render_driver_build_phase(
     }
     append_direct_dependency_metadata_exports(&mut script, graph, prepared, index)?;
 
-    push_rustc_args(&mut script, unit, &prepared.hashes[index]);
+    push_rustc_args(&mut script, unit, &prepared.hashes[index], driver);
     append_target_linker_arg(&mut script, unit);
     append_extra_rustc_args(&mut script, unit);
 
@@ -1107,7 +1107,7 @@ fn render_driver_build_phase(
 
     match driver {
         Driver::Rustc => {
-            if unit.is_bin() || unit.is_test() {
+            if uses_explicit_output_path(unit, driver) {
                 writeln!(
                     script,
                     "rustc_args+=( -o {} )",
@@ -1214,7 +1214,17 @@ fn collects_unused_crate_dependencies(unit: &Unit, options: &RenderOptions) -> b
     options.deny_unused_crate_dependencies && !unit.is_external()
 }
 
-fn push_rustc_args(script: &mut String, unit: &Unit, hash: &str) {
+// A root (bin) or test unit gets an explicit `-o build/<name>` path (see the
+// `Driver::Rustc` match arm below), which alone fixes the output filename.
+// `-C extra-filename` only matters for `--out-dir`-style outputs (libs, rlibs,
+// proc-macros) where multiple units can otherwise collide; combining both
+// flags is what makes rustc warn "ignoring -C extra-filename flag due to -o
+// flag" on every such build (index#1975).
+fn uses_explicit_output_path(unit: &Unit, driver: Driver) -> bool {
+    driver == Driver::Rustc && (unit.is_bin() || unit.is_test())
+}
+
+fn push_rustc_args(script: &mut String, unit: &Unit, hash: &str, driver: Driver) {
     push_arg(script, "--crate-name");
     push_arg(script, &unit.target.name.replace('-', "_"));
     push_arg(script, "--edition");
@@ -1273,7 +1283,13 @@ fn push_rustc_args(script: &mut String, unit: &Unit, hash: &str) {
         push_arg(script, "rpath=yes");
     }
     push_codegen(script, "metadata", hash);
-    push_codegen(script, "extra-filename", &format!("-{hash}"));
+    // rustc warns "ignoring -C extra-filename flag due to -o flag" when both
+    // are given; the explicit `-o build/<name>` path fully determines a bin/test
+    // unit's output name, so extra-filename (which only disambiguates
+    // `--out-dir`-style outputs) would be a no-op there anyway.
+    if !uses_explicit_output_path(unit, driver) {
+        push_codegen(script, "extra-filename", &format!("-{hash}"));
+    }
 
     for rustflag in &unit.profile.rustflags {
         push_arg(script, rustflag);
@@ -3424,6 +3440,87 @@ mod tests {
         assert!(rendered.contains("cp \"$split_debuginfo_sidecar\" \"$out/lib/\""));
         assert!(rendered.contains("case \"$build_artifact\" in\n    *.dwo|*.dwp) continue ;;"));
         assert!(!rendered.contains("cp -R build/* $out/lib/"));
+    }
+
+    #[test]
+    fn omits_extra_filename_when_output_path_is_explicit() {
+        // Bin (and test) units get an explicit `-o build/<name>` path, which by
+        // itself fully determines the output filename. Also emitting
+        // `-C extra-filename` there is what makes rustc warn "ignoring -C
+        // extra-filename flag due to -o flag" on every such build (index#1975).
+        // Lib units use `--out-dir` instead, so they still need extra-filename
+        // to disambiguate same-named outputs.
+        let graph: UnitGraph = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "units": [
+                {
+                  "pkg_id": "path+file:///workspace#hello@0.1.0",
+                  "target": {
+                    "kind": ["lib"],
+                    "crate_types": ["lib"],
+                    "name": "hello",
+                    "src_path": "/workspace/src/lib.rs",
+                    "edition": "2024"
+                  },
+                  "profile": { "name": "release", "opt_level": "3" },
+                  "features": [],
+                  "mode": "build",
+                  "dependencies": []
+                },
+                {
+                  "pkg_id": "path+file:///workspace#hello@0.1.0",
+                  "target": {
+                    "kind": ["bin"],
+                    "crate_types": ["bin"],
+                    "name": "hello-cli",
+                    "src_path": "/workspace/src/main.rs",
+                    "edition": "2024"
+                  },
+                  "profile": { "name": "release", "opt_level": "3" },
+                  "features": [],
+                  "mode": "build",
+                  "dependencies": []
+                }
+              ],
+              "roots": [0, 1]
+            }"#,
+        )
+        .unwrap();
+
+        let rendered = render_units_nix(
+            &graph,
+            &RenderOptions {
+                workspace_root: PathBuf::from("/workspace"),
+                vendor_root: None,
+                cargo_lock_sources: CargoLockSources::default(),
+                content_addressed: false,
+                toolchain_id: Some("rustc-test".to_string()),
+                deny_unused_crate_dependencies: false,
+                deny_panics: false,
+            },
+        )
+        .unwrap();
+
+        // The bin unit's rustc (link) invocation carries the explicit `-o`
+        // path immediately after the source-path arg, with no
+        // `extra-filename` anywhere in between -- that adjacency is exactly
+        // what makes rustc emit "ignoring -C extra-filename flag due to -o
+        // flag".
+        let bin_rustc_invocation = rendered
+            .split("rustc_args+=( \"$src/src/main.rs\" )")
+            .nth(1)
+            .and_then(|rest| rest.split("env \"''${rustc_env[@]}\" rustc").next())
+            .expect("bin unit's rustc build phase");
+        assert!(bin_rustc_invocation.contains("rustc_args+=( -o 'build/hello-cli' )"));
+        assert!(!bin_rustc_invocation.contains("extra-filename"));
+
+        // Sibling clippy-driver units still use `--out-dir` (never `-o`), so
+        // they keep extra-filename for both the lib and the bin target; only
+        // the bin's *rustc* link step drops it. Three occurrences total: the
+        // lib's rustc build, the lib's clippy build, and the bin's clippy
+        // build.
+        assert_eq!(rendered.matches("'extra-filename=").count(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Every root (bin) unit build logs:

```
warning: ignoring -C extra-filename flag due to -o flag
```

The renderer emits both `-C extra-filename=<hash>` and `-o build/<name>` for
root (bin) and test units. `-o` alone fully determines the output path, so the
`extra-filename` flag is a no-op there -- and rustc warns about it on every
final link.

## Fix

`packages/nix/nix-cargo-unit/src/render.rs`: extract the existing `-o` vs
`--out-dir` predicate (`driver == Driver::Rustc && (unit.is_bin() ||
unit.is_test())`) into `uses_explicit_output_path`, reuse it at the `-o`
call site, and skip `push_codegen(..., "extra-filename", ...)` in
`push_rustc_args` when it's true. Lib/proc-macro units (which use
`--out-dir`) and the clippy/object-emit drivers (which never use `-o`) are
unaffected and keep `extra-filename` to disambiguate same-named outputs.

## Testing

- Added `render::tests::omits_extra_filename_when_output_path_is_explicit`:
  builds a graph with a lib + bin unit sharing a package, and asserts the
  bin unit's rustc (link) invocation has `-o` with no `extra-filename`
  nearby, while the lib's rustc build and both units' clippy builds
  (`--out-dir`-based) still carry it.
- `cargo test` in `packages/nix/nix-cargo-unit`: 53 passed (52 existing + 1
  new).
- `cargo fmt --check` / `cargo clippy --all-targets`: clean.
- `nix run .#lint`: all 8 checks pass.

Fixes #1975

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit `-C extra-filename` from rustc invocations that use an explicit `-o` output path
> When rustc is invoked for bin or test units, an explicit `-o` path is passed instead of `--out-dir`, making `-C extra-filename` redundant. This PR adds a `uses_explicit_output_path` helper in [render.rs](https://github.com/indexable-inc/index/pull/1985/files#diff-91be6a053ea25b59c072a514f469215dbbfeb6abbba3ddb8d77ad99ffa244e7f) and uses it to skip emitting `-C extra-filename` in `push_rustc_args` for those cases. Lib, proc-macro, and Clippy driver invocations continue to include `extra-filename` unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f078cdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->