### PR TITLE
prompt: nu engine persists cwd across calls; say so

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -666,15 +666,23 @@ let
         text = ''
           `nu` is the one shell-out path: `await nu('<pipeline>')` returns a Polars
           DataFrame, and an external binary runs with `^cmd` (`await nu('^git status')`).
-          The retired `sh()`/`zsh()` now raise a migration hint. The kernel carries no
-          persistent cwd or shell state between calls, so pass `cwd=<abs path>` where a
-          helper accepts it (or use `git -C <worktree>`). Before commit or branch work,
-          verify the repo root and branch match the assigned worktree.
+          The retired `sh()`/`zsh()` now raise a migration hint. The nu engine is a
+          persistent REPL: `cd`, `let`, `def`, and `$env` survive across calls, so a
+          later call inherits the previous call's PWD. Address paths explicitly
+          (`git -C <worktree>`, `cwd=<abs path>`) instead of relying on inherited
+          state, and never delete a directory an earlier call `cd`'ed into without
+          moving the engine out first: the next external spawn dies with `$env.PWD
+          points to a non-existent directory` (recover with an explicit `cwd=`).
+          Before commit or branch work, verify the repo root and branch match the
+          assigned worktree.
         '';
         reason = ''
-          Kernel shells carry no cwd between calls; commit and branch work landed in
-          the wrong repo or branch. DataFrame-shaped command results are easier to
-          inspect in the dashboard than dicts or scraped text.
+          The prompt used to claim the kernel carried no cwd between calls; the
+          engine actually persists PWD (index#1986), so a `git worktree remove` of a
+          previously `cd`'ed dir broke the following call mid-block. Relying on
+          inherited cwd also landed commit and branch work in the wrong repo.
+          DataFrame-shaped command results are easier to inspect in the dashboard
+          than dicts or scraped text.
         '';
       };
     }


### PR DESCRIPTION
Closes #1986

The system prompt's shellCwd section claimed "the kernel carries no persistent cwd or shell state between calls". The engine is deliberately the opposite (a persistent REPL: `nu()`'s docstring documents `cd`/`let`/`def` persisting and `cwd=` setting PWD persistently), and that wrong claim produced the #1986 incident: a `git worktree remove` of a directory an earlier call had `cd`'ed into killed the next external spawn with `$env.PWD points to a non-existent directory`, mid-block after partial execution.

This rewrites the section to state the REPL semantics, the explicit-path habit (`git -C`, `cwd=`), the one destructive trap (deleting the engine's inherited cwd), and the recovery (explicit `cwd=`).

Investigation notes correcting the issue as filed are on #1986: the "`;` doesn't short-circuit" claim was wrong (an erroring statement does halt the block; the partial execution was the cwd deletion happening *inside* the block), and the `from json` passthrough quirk reproduces on stock nushell 0.112.3, so it is upstream behavior, not ours.

Rendered and reread via `nix eval --raw --impure --expr 'import ./packages/agent/system-prompt.nix ...'`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update nu engine system prompt to document persistent cwd across calls
> Corrects the system prompt in [system-prompt.nix](https://github.com/indexable-inc/index/pull/1997/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) to reflect that the nu engine is a persistent REPL — `cd`, `let`, `def`, and `$env` survive across calls. Previously the prompt incorrectly stated no persistent cwd/shell state existed.
>
> - Adds guidance to use explicit paths (`git -C`, `cwd=<abs path>`) rather than relying on inherited cwd
> - Warns against deleting directories the engine has `cd`'d into without first moving out, and documents the recovery path via explicit `cwd=`
> - Updates the `reason` field to reference the persistent PWD behavior (index#1986) and call out failure modes like misdirected commit/branch work
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bda3ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->