### PR TITLE
agent: add Cursor CLI (cursor-agent) wrapper + tui harness class

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -319,7 +319,8 @@
   Single source of truth for the MCP servers baked into the agent wrappers.
   Define a server once in a neutral shape and render it to each tool's native
   config with `mcp.toClaudeJson` (Claude Code's `mcpServers` JSON) and
-  `mcp.toCodexEntries` (dotted `mcp_servers.*` codex `-c` flags), so `index`
+  `mcp.toCodexEntries` (dotted `mcp_servers.*` codex `-c` flags) and
+  `mcp.toCursorJson` (cursor-agent's `mcp.json` object), so `index`
   is declared in one place rather than copied into both wrappers. See
   [`lib/util/mcp.nix`](lib/util/mcp.nix).
   */

--- a/lib/util/mcp/renderers.nix
+++ b/lib/util/mcp/renderers.nix
@@ -24,6 +24,26 @@
       inherit (def) url;
     };
 
+  # One neutral def -> the object cursor-agent's `mcp.json` expects (schema:
+  # `{ type = "stdio"; command; args; env; }` for local servers, `{ url; }` for
+  # remote ones). `envVars` forwarding is deliberately dropped: the CLI spawns
+  # stdio servers with its own environment inherited, and its documented
+  # `${env:NAME}` interpolation is broken in the CLI as of 2026.01
+  # (https://forum.cursor.com/t/79639), so a forwarding entry would deliver the
+  # literal placeholder instead of the value.
+  cursorOne = def:
+    if isStdio def
+    then
+      {
+        type = "stdio";
+        inherit (def) command;
+      }
+      // lib.optionalAttrs (def ? args) {inherit (def) args;}
+      // lib.optionalAttrs ((def.env or {}) != {}) {inherit (def) env;}
+    else {
+      inherit (def) url;
+    };
+
   # A TOML array literal of scalars, e.g. `[ "serve" ]`. `ix.toml.scalar` is
   # scalars-only by design (it throws on a list), so the one list leaf a server
   # carries (`args`) gets this local encoder rather than growing that helper.
@@ -87,6 +107,17 @@ in {
   - `servers`: attrset from server name to a neutral definition.
   */
   toClaudeJson = servers: lib.mapAttrs (_: claudeOne) servers;
+
+  /**
+  Render an attrset of neutral server definitions to the value cursor-agent's
+  `~/.cursor/mcp.json` `mcpServers` key expects (the `cursor-cli` wrapper
+  exposes it as `passthru.mcpJson` for config delivery, since the CLI has no
+  MCP flag).
+
+  Arguments:
+  - `servers`: attrset from server name to a neutral definition.
+  */
+  toCursorJson = servers: lib.mapAttrs (_: cursorOne) servers;
 
   /**
   Render an attrset of neutral server definitions to the value a Claude Code

--- a/lib/util/mcp/servers.nix
+++ b/lib/util/mcp/servers.nix
@@ -1,6 +1,6 @@
 # Single source of truth for the MCP servers the agent wrappers bake in. Define
 # a server ONCE in the neutral shape below and render it to each tool's native
-# config with `toClaudeJson` / `toCodexEntries`, so `index` (and any future
+# config with `toClaudeJson` / `toCodexEntries` / `toCursorJson`, so `index` (and any future
 # shared server) is declared in one place instead of copied into the Claude Code
 # and Codex wrappers in two different schemas.
 #
@@ -76,7 +76,7 @@ in {
   /**
   The default MCP server set, defined once for every wrapper that bakes it.
   Returns the neutral definitions; each consumer renders them with
-  `toClaudeJson` / `toCodexEntries`.
+  `toClaudeJson` / `toCodexEntries` / `toCursorJson`.
 
   Arguments:
   - `indexCommand`: path to the `ix-mcp` entrypoint, or `null` when the `mcp`

--- a/packages/agent/cursor-cli/default.nix
+++ b/packages/agent/cursor-cli/default.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  ix,
+  cursor-cli,
+  makeBinaryWrapper,
+  symlinkJoin,
+  formats,
+  binName ? "cursor-agent",
+  # Sibling repo packages from the flake package set (threaded by
+  # lib/packages.nix), used to locate the `ix-mcp` entrypoint for the rendered
+  # `index` MCP server. `{ }` when the `mcp` sibling is out of scope, in which
+  # case only the keyless `exa` server is rendered.
+  repoPackages ? {},
+  # Rule names dropped from the default house prompt. Only affects the computed
+  # `systemPrompt` default below; ignored when `systemPrompt` is passed
+  # explicitly.
+  omitRules ? [],
+  # Bake `--force` ("force allow commands unless explicitly denied") so every
+  # session starts without per-command approval dialogs: the same posture as
+  # claude-code's default `--dangerously-skip-permissions`, for the same reason
+  # (trusted config in disposable sandboxes where approval prompts only stall
+  # the agent). `cli-config.json` deny rules still apply; `--force` skips the
+  # allowlist prompt, not explicit denies.
+  forceAllowCommands ? true,
+  # The shared MCP server set, rendered to `passthru.mcpJson` rather than baked
+  # into argv: cursor-agent has no `--mcp-config`-style flag, so the global
+  # `~/.cursor/mcp.json` is the only injection point and delivery belongs to
+  # the consumer's config management (home-manager already owns that file).
+  mcpServers ?
+    (import (ix.paths.packagesRoot + "/agent/common.nix") {
+      inherit lib ix repoPackages;
+      promptOmitRules = omitRules;
+    }).defaultServers,
+  # The house prompt rendered for the cursor runtime. Cursor has no
+  # system-prompt flag either (rules load from a project's AGENTS.md /
+  # `.cursor/rules`), so this too ships as passthru for config delivery. Null
+  # renders no passthru prompt file.
+  systemPrompt ?
+    (import (ix.paths.packagesRoot + "/agent/common.nix") {
+      inherit lib ix repoPackages;
+      promptOmitRules = omitRules;
+    }).systemPromptFor
+    "cursor",
+}: let
+  # nixpkgs tags the vendored binary `licenses.unfree`, and the per-system
+  # flake package set evaluates nixpkgs without `allowUnfree`, so consuming
+  # `cursor-cli` as-is would block `nix run .#cursor-cli`. Same posture as
+  # claude-code: omit the license marker for the vendored binary rather than
+  # gate the output; distribution terms are Cursor's commercial license.
+  cursorAgent = cursor-cli.overrideAttrs (previousAttrs: {
+    meta = builtins.removeAttrs previousAttrs.meta ["license"];
+  });
+
+  sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
+    inherit lib;
+    indexKernelBaked = mcpServers ? index;
+    exaSearchBaked = mcpServers ? exa;
+  };
+
+  wrapperFlags = lib.optional forceAllowCommands "--force";
+in
+  symlinkJoin {
+    name = "cursor-cli-${cursorAgent.version}";
+    paths = [cursorAgent];
+    # symlinkJoin links the whole cursor-cli output (the share/cursor-agent
+    # payload tree); we only replace the bin entrypoint with our wrapper so the
+    # baked flags ride every invocation while everything else stays pristine.
+    nativeBuildInputs = [makeBinaryWrapper];
+    postBuild = ''
+      # shell
+      rm -f $out/bin/${binName}
+      makeBinaryWrapper ${cursorAgent}/share/cursor-agent/cursor-agent $out/bin/${binName} \
+        --inherit-argv0 ${lib.concatMapStringsSep " " (flag: "--add-flags ${flag}") wrapperFlags}
+    '';
+    passthru =
+      {
+        inherit mcpServers;
+        # Rendered `~/.cursor/mcp.json` content (the shared registry in
+        # cursor's schema) for a consumer to deliver; see the `mcpServers`
+        # comment for why this is passthru instead of a baked flag.
+        mcpJson = (formats.json {}).generate "cursor-mcp.json" {
+          mcpServers = ix.mcp.toCursorJson mcpServers;
+        };
+        permissions = sharedPermissions.cursor;
+      }
+      // lib.optionalAttrs (systemPrompt != null) {
+        inherit systemPrompt;
+        systemPromptFile = builtins.toFile "cursor-system-prompt.md" systemPrompt;
+      };
+    meta =
+      cursorAgent.meta
+      // {
+        description = "${cursorAgent.meta.description or "Cursor CLI"} (index wrapper with baked defaults)";
+        mainProgram = binName;
+      };
+  }

--- a/packages/agent/cursor-cli/package.nix
+++ b/packages/agent/cursor-cli/package.nix
@@ -1,0 +1,10 @@
+{
+  id = "cursor-cli";
+  packageSet = true;
+  # Flake-output only, deliberately NOT an overlay (same posture as codex):
+  # `pkgs.cursor-cli` stays the plain nixpkgs CLI; our wrapper is an additive
+  # output (`nix run .#cursor-cli`, `index.packages.<sys>.cursor-cli`) that
+  # bakes house defaults on top of that same base.
+  flake = true;
+  overlay = false;
+}

--- a/packages/agent/mcp.nix
+++ b/packages/agent/mcp.nix
@@ -6,7 +6,7 @@
 }: {
   # Rendered from the shared `ix.mcp` registry with the kernel pointed at the
   # `mcp` sibling when it is in scope. Each wrapper adapts this to its own
-  # config shape (`ix.mcp.toClaudeJson` / `ix.mcp.toCodexEntries`).
+  # config shape (`ix.mcp.toClaudeJson` / `ix.mcp.toCodexEntries` / `ix.mcp.toCursorJson`).
   defaultServers = ix.mcp.defaultServers {
     indexCommand =
       if repoPackages ? mcp

--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -1,7 +1,8 @@
 # Shared agent permission policy: one agent-neutral fact per row, rendered per
 # agent CLI. The tool vocabularies differ (Claude Code denies tool names via
 # settings `permissions.deny`; codex disables `features.*` leaves via the
-# forced `-c` layer), so each capability row carries both handles and the
+# forced `-c` layer; cursor-agent denies `Shell(...)` patterns via
+# `cli-config.json`), so each capability row carries both handles and the
 # renderers at the bottom fold in the rows a wrapper's baked MCP servers make
 # redundant.
 #
@@ -103,5 +104,15 @@ in {
       // lib.optionalAttrs exaSearchBaked exaSuperseded.codexFeatures
       // lib.optionalAttrs indexKernelBaked kernelCodexFeatures;
     inherit protectedMergeCommandPatterns;
+  };
+
+  # cursor-agent's `cli-config.json` permission vocabulary only verifiably
+  # covers shell commands (`Shell(<glob>)` deny entries), so only the
+  # protected-merge row renders here; the kernel/exa gates have no cursor
+  # handle yet. Delivery is the consumer's config management (see the
+  # cursor-cli wrapper's passthru), since the CLI reads permissions from
+  # config, not flags.
+  cursor = {
+    deniedShellPatterns = map (pattern: "Shell(${pattern})") protectedMergeCommandPatterns;
   };
 }

--- a/packages/agent/prompt.nix
+++ b/packages/agent/prompt.nix
@@ -7,12 +7,14 @@
   providerNames = {
     claude = "Claude Code";
     codex = "Codex";
+    cursor = "Cursor";
   };
   # Runtime token each provider renders as, consumed by ./system-prompt.nix to
   # filter runtime-scoped sections (a section's `runtimes` list holds these).
   providerRuntimes = {
     claude = "claude-code";
     codex = "codex";
+    cursor = "cursor";
   };
   extraSystemPrompts = {
     claude = ''
@@ -22,6 +24,10 @@
     codex = ''
       You are Codex. When naming the coding-agent runtime or disclosing AI
       authorship in outward-facing messages, say Codex.
+    '';
+    cursor = ''
+      You are Cursor. When naming the coding-agent runtime or disclosing AI
+      authorship in outward-facing messages, say Cursor.
     '';
   };
   systemPromptFor = provider:

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -4,7 +4,7 @@
   # Target agent runtime for this render. Sections may narrow themselves to a
   # subset of runtimes (see the optional `runtimes` field on a rule); this
   # argument selects which. Tokens are the provider names ./prompt.nix maps:
-  # "claude-code", "codex".
+  # "claude-code", "codex", "cursor".
   runtime ? "claude-code",
   # Rule names to drop from this build's prompt, e.g.
   # `claude-code.override { omitRules = [ "reportToPlaybook" ]; }`.

--- a/packages/tui/tui-py/python/tui/harness.py
+++ b/packages/tui/tui-py/python/tui/harness.py
@@ -1,4 +1,4 @@
-"""Playwright-style harnesses for interactive coding agents (Claude Code, Codex).
+"""Playwright-style harnesses for interactive coding agents (Claude Code, Codex, Cursor).
 
 `tui.Tui` gives you a raw PTY: send bytes, scrape the rendered screen. This
 module is the layer every agent test rig re-invents on top of it, and it
@@ -79,6 +79,7 @@ __all__ = [
     "AgentAssertions",
     "Claude",
     "Codex",
+    "Cursor",
     "Gate",
     "Keyboard",
     "expect",
@@ -523,6 +524,48 @@ class Codex(Agent):
         return "\n".join(out).strip()
 
 
+class Cursor(Agent):
+    """Cursor CLI (`cursor-agent`) in a PTY.
+
+    Grounded against cursor-agent 2026.06: idle uses the "ctrl+c to stop"
+    footer plus quiescence, launch auto-accepts the "Workspace Trust Required"
+    gate, and `parse_reply` returns the final plain answer block(s). The login
+    gate is NOT auto-cleared: a logged-out cursor-agent opens a browser OAuth
+    flow only a human can approve, so log in once interactively first.
+
+    Defaults pin the fast Composer model and pass `--force` (skip per-command
+    approval dialogs; explicit `cli-config.json` denies still apply), which
+    makes `agent.ask(...)` a cheap smart-codebase-search delegate:
+
+        async with await Cursor.launch(cwd="/repo") as cursor:
+            where = await cursor.ask("where is retry backoff implemented?")
+    """
+
+    binary = "cursor-agent"
+    #: The input caret of a ready cursor-agent box ("→ Plan, search, build
+    #: anything" / "→ Add a follow-up").
+    ready = re.compile(r"^\s*→ ", re.MULTILINE)
+    busy_marker = "ctrl+c to stop"
+    gates = (
+        # A cwd outside the trusted-workspace list opens on "Workspace Trust
+        # Required"; `a` selects "Trust this workspace".
+        Gate("trust-workspace", "Do you trust the contents of this directory", "a"),
+    )
+
+    def __init__(
+        self,
+        *args: str,
+        model: str = "composer-2.5-fast",
+        force: bool = True,
+        **kwargs: object,
+    ) -> None:
+        defaults = ("--model", model, *(("--force",) if force else ()))
+        super().__init__(*defaults, *args, **kwargs)  # type: ignore[arg-type]
+
+    def parse_reply(self, transcript: str) -> str:
+        """Keep the final cursor-agent answer block(s) from a TUI transcript."""
+        return _parse_cursor_reply(transcript)
+
 # --------------------------------------------------------------------------- #
 # Assertions (Playwright `expect`)
 # --------------------------------------------------------------------------- #
@@ -616,6 +659,48 @@ def _parse_claude_reply(transcript: str) -> str:
         out.append(ln)
     return "\n".join(out).strip()
 
+
+#: cursor-agent input-box top border: a run of `▄` (the footer starts here).
+_CURSOR_FOOTER = re.compile(r"^\s*▄+\s*$")
+#: Spinner/status lines like "⠘⠤ Composing" / "⠠⠛ Running  55 tokens".
+_CURSOR_SPINNER = re.compile(r"^\s*[\u2800-\u28ff]")
+
+
+def _parse_cursor_reply(transcript: str) -> str:
+    """The last answer block(s) in a cursor-agent transcript.
+
+    cursor-agent prints no answer marker (unlike Claude's `⏺` or Codex's `•`):
+    a turn renders as the echoed prompt, tool blocks (a `$ cmd` line with its
+    output indented beneath), and plain answer paragraphs, then the input-box
+    footer. So: cut at the footer border, drop spinner lines, split into
+    blank-line-separated blocks, drop `$`-led tool blocks and the leading
+    echoed-prompt block, and return what remains. Falls back to the stripped
+    transcript when nothing survives.
+    """
+    body: list[str] = []
+    for line in transcript.splitlines():
+        if _CURSOR_FOOTER.match(line):
+            break
+        if _CURSOR_SPINNER.match(line):
+            continue
+        body.append(line)
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in body:
+        if line.strip():
+            current.append(line)
+        elif current:
+            blocks.append(current)
+            current = []
+    if current:
+        blocks.append(current)
+    answers = [b for b in blocks if not b[0].lstrip().startswith("$ ")]
+    if len(answers) >= 2:
+        # The first surviving block of a turn is the echoed user prompt.
+        answers = answers[1:]
+    if not answers:
+        return transcript.strip()
+    return "\n\n".join("\n".join(line.strip() for line in block) for block in answers).strip()
 
 def _shquote(s: str) -> str:
     """Single-quote `s` for a POSIX shell."""

--- a/packages/tui/tui-py/python/tui/harness_test.py
+++ b/packages/tui/tui-py/python/tui/harness_test.py
@@ -13,6 +13,7 @@ import unittest
 from .harness import (
     _gate_matches,
     _parse_claude_reply,
+    _parse_cursor_reply,
     _shquote,
     _submit_probe,
     _tail_delta,
@@ -83,6 +84,54 @@ class ClaudeReplyTests(unittest.TestCase):
     def test_falls_back_when_no_marker(self) -> None:
         assert _parse_claude_reply("  plain text  ") == "plain text"
 
+
+class CursorReplyTests(unittest.TestCase):
+    # Grounded against a real cursor-agent 2026.06 session (issue #1987): the
+    # echoed prompt, a shell tool block, the answer, then the input-box footer.
+    def test_extracts_answer_after_tool_block(self) -> None:
+        transcript = (
+            "  Run `ls` in this directory, then reply with just the count.\n"
+            "\n"
+            "  $ ls -1 /private/tmp | wc -l 24s\n"
+            "    1894\n"
+            "\n"
+            "  1894\n"
+            "\n"
+            " ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n"
+            "  → Add a follow-up\n"
+            " ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀\n"
+            "  Composer 2.5 Fast · 13%\n"
+            "  /private/tmp"
+        )
+        assert _parse_cursor_reply(transcript) == "1894"
+
+    def test_plain_turn_drops_prompt_echo(self) -> None:
+        transcript = (
+            "  Reply with exactly: hello from cursor.\n"
+            "\n"
+            " ⠘⠤ Composing\n"
+            "  hello from cursor\n"
+            "\n"
+            " ▄▄▄▄▄▄▄▄\n"
+            "  → Add a follow-up\n"
+            " ▀▀▀▀▀▀▀▀"
+        )
+        assert _parse_cursor_reply(transcript) == "hello from cursor"
+
+    def test_multi_paragraph_answer_survives(self) -> None:
+        transcript = (
+            "  question\n"
+            "\n"
+            "  first paragraph\n"
+            "\n"
+            "  second paragraph\n"
+            "\n"
+            " ▄▄▄▄▄▄▄▄"
+        )
+        assert _parse_cursor_reply(transcript) == "first paragraph\n\nsecond paragraph"
+
+    def test_falls_back_when_nothing_survives(self) -> None:
+        assert _parse_cursor_reply("  $ ls 1s\n    out\n") == "$ ls 1s\n    out"
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds Cursor CLI as a first-class agent alongside claude-code and codex. Closes #1987.

**Nix** (`packages/agent/cursor-cli`)
- Wraps nixpkgs `cursor-cli` with `--force` baked (approval-skip posture, mirroring claude-code's default); license marker omitted like claude-code so the flake package set (no `allowUnfree`) can evaluate it. Flake output only, no overlay.
- cursor-agent has no `--mcp-config` / system-prompt flags (global `~/.cursor/mcp.json` is the only injection point), so the shared registry ships as `passthru.mcpJson` via a new `ix.mcp.toCursorJson`, and the house prompt via the new `cursor` provider in prompt.nix (`passthru.systemPrompt{,File}`); merge-protection globs render as `Shell(...)` denies in `passthru.permissions`.

**Python** (`tui.harness`)
- `Cursor(Agent)` grounded against a real cursor-agent 2026.06 session: `→` ready caret, `ctrl+c to stop` busy footer, auto-cleared "Workspace Trust Required" gate, marker-less reply parser (footer cut + tool/echo block drop) with unit tests from captured transcripts.
- Defaults pin `composer-2.5-fast` + `--force`, so `await (await Cursor.launch(cwd=repo)).ask("where is X?")` works as a cheap smart-codebase-search delegate.

**Validation**: `nix build .#cursor-cli` + `-v` smoke test, `passthru.mcpJson` render checked, 16/16 harness unit tests, live PTY round-trip (`run()` returned the parsed reply), repo lint clean.

(PR by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cursor CLI wrapper and `Cursor` TUI harness class for cursor-agent
> - Adds a `cursor-cli` Nix wrapper ([default.nix](https://github.com/indexable-inc/index/pull/1998/files#diff-896659e62c2d06950081ebb93b3cbfb15230a1211d922c5df9b8b437c0553a24)) around the vendored `cursor-agent` binary, baking in `--force` by default and exposing `mcpServers`, `mcpJson`, `permissions`, and optional `systemPrompt` via passthru.
> - Adds a `cursorOne`/`toCursorJson` MCP renderer ([renderers.nix](https://github.com/indexable-inc/index/pull/1998/files#diff-fb3cdbcae956fcfccc1df437d49a73e65277961a83fa0db272be6ca312b09183)) that converts neutral server definitions to the cursor-agent `mcp.json` schema.
> - Adds a `Cursor(Agent)` class to [harness.py](https://github.com/indexable-inc/index/pull/1998/files#diff-2fc410689b430c18113770dec5a98ea57e4cb0602d8df3e9c95ad810425242bf) that drives cursor-agent sessions, handles workspace-trust gating, and parses TUI transcripts via `_parse_cursor_reply`.
> - Adds `cursor` as a recognized provider in [prompt.nix](https://github.com/indexable-inc/index/pull/1998/files#diff-5559a2a80a64417c055fd920fda60b94b9e4c5b6db3e14aaaf33c17cac3ba1eb) with a self-identification system prompt, and adds cursor-agent shell deny patterns to [permissions.nix](https://github.com/indexable-inc/index/pull/1998/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c70380d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->