### PR TITLE
fix: sync nu() engine PWD to current process on each call

### DIFF
--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -256,6 +256,8 @@ async def _run(
     name: str | None = None,
 ) -> object:
     """Evaluate ``code`` on the shared engine; return the plain Python value."""
+    if cwd is None:
+        cwd = os.getcwd()
     if name is not None and _rename_current_job is not None and (
         _ix_current is not None and _ix_current.get() is not None
     ):


### PR DESCRIPTION
Fixes #1986: nushell engine retained `$env.PWD` from previous calls when a worktree was deleted, causing 'No such directory' errors.

## Problem
When `nu()` was called after `cd`ing into a worktree and then deleting that worktree, subsequent calls to `nu()` would still have the old PWD set, causing failures like "No such directory".

## Solution
Default `cwd` to `os.getcwd()` when not explicitly provided to `_run()`. This ensures the engine's PWD stays in sync with the Python process's current working directory on every call, preventing stale PWD state from persisting across calls.

## Changes
- Modified `_run()` function in `packages/nu-py/python/nu/__init__.py` to default `cwd` to the current process's PWD when None

This fix ensures:
1. Each `nu()` call starts with the current Python PWD
2. Deleted worktrees don't break subsequent calls  
3. The engine PWD stays synchronized with the Python process


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `nu._run` to sync PWD from the current process when `cwd` is not provided
> Previously, omitting `cwd` left `state['cwd']` as `None`. Now [__init__.py](https://github.com/indexable-inc/index/pull/1999/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4) defaults `cwd` to `os.getcwd()` at the start of `_run`, so the recorded working directory always reflects the real process CWD.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1428e9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->