### PR TITLE
feat(beamvm): persistent BEAM VM with Nix-declared apps and hot code reload; symphony runs in it by default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -447,6 +447,15 @@
       symphony = import ./packages/agent/symphony/home-module.nix {
         indexPackages = system: packages.${system};
         portableServicesModule = ix.portableServices.homeModule;
+        # The beamvm runtime (services.symphony.runtime = "beamvm", the
+        # default) hosts the compiled release in the persistent VM; the
+        # module composes it directly so importing homeModules.symphony
+        # alone is enough.
+        beamvmModule = import ./packages/beamvm/home-module.nix {
+          indexPackages = system: packages.${system};
+          portableServicesModule = ix.portableServices.homeModule;
+          inherit ix;
+        };
         inherit ix;
       };
       # Workstation-facing module: persistent BEAM VMs as user services with

--- a/flake.nix
+++ b/flake.nix
@@ -449,6 +449,16 @@
         portableServicesModule = ix.portableServices.homeModule;
         inherit ix;
       };
+      # Workstation-facing module: persistent BEAM VMs as user services with
+      # the OTP applications they host declared in Nix. Updating an app
+      # hot-swaps its code in the running VM (no restart, no dropped
+      # connections); only a beamvm/toolchain update restarts. See
+      # packages/beamvm/home-module.nix and packages/beamvm/harness.ex.
+      beamvm = import ./packages/beamvm/home-module.nix {
+        indexPackages = system: packages.${system};
+        portableServicesModule = ix.portableServices.homeModule;
+        inherit ix;
+      };
     };
     overlays.default = ix.overlay;
     templates = {};

--- a/packages/agent/symphony/default.nix
+++ b/packages/agent/symphony/default.nix
@@ -100,6 +100,41 @@
       cp "${lazyHtmlNif}" "$ELIXIR_MAKE_CACHE_DIR/${lazyHtmlNif.name}"
     '';
   };
+
+  # Prod-env mix deps for the compiled release below: runtime deps only, so a
+  # separate FOD from the test-env `mixFodDeps` (different dep set, different
+  # hash). Refresh `mix-deps-prod` in pins.json whenever mix.lock changes.
+  prodMixFodDeps = pkgs.beamPackages.fetchMixDeps {
+    pname = "symphony-elixir-prod-deps";
+    version = "0.2.0"; # keep in sync with elixir/mix.exs
+    src = lib.fileset.toSource {
+      root = ./elixir;
+      fileset = lib.fileset.unions [
+        ./elixir/mix.exs
+        ./elixir/mix.lock
+      ];
+    };
+    inherit elixir;
+    mixEnv = "prod";
+    inherit (pins."mix-deps-prod") hash;
+  };
+
+  # Compiled BEAM release, the artifact the persistent-VM runtime
+  # (homeModules.beamvm) code-loads: `lib/<app>-<vsn>/ebin` for symphony and
+  # every runtime dep, plus `releases/*/runtime.exs` for the harness to replay
+  # as the config provider. The standalone launcher path (bin/run-nix) keeps
+  # staging + compiling at boot; this is the no-compile-at-boot artifact hot
+  # reload needs. Same elixir toolchain as the beamvm harness so the bytecode
+  # and stdlib the release bundles are exactly what that VM booted.
+  release = (pkgs.beamPackages.mixRelease.override {inherit elixir;}) {
+    pname = "symphony-release";
+    version = "0.2.0"; # keep in sync with elixir/mix.exs
+    src = lib.fileset.toSource {
+      root = ./elixir;
+      fileset = ./elixir;
+    };
+    mixFodDeps = prodMixFodDeps;
+  };
 in
   (writeNushellApplication {
     name = "symphony";
@@ -134,6 +169,11 @@ in
     passthru =
       (old.passthru or {})
       // {
+        inherit release;
         tests.elixir = elixirCheck;
+        # Building the release IS its test at this layer: it proves the prod
+        # dep set resolves offline and the project compiles as a release.
+        # Boot behavior is covered by beamvm's consumer smoke test.
+        tests.release = release;
       };
   })

--- a/packages/agent/symphony/default.nix
+++ b/packages/agent/symphony/default.nix
@@ -101,10 +101,20 @@
     '';
   };
 
+  # Mix 1.18+ opens a loopback TCP socket (Mix.Sync.PubSub) on every
+  # deps.loadpaths, which the darwin sandbox denies with :eperm; there is no
+  # Mix env knob to disable it (Mix.PubSub.start/0 is unconditional in
+  # deps.loadpaths). __darwinAllowLocalNetworking is the nixpkgs idiom for
+  # exactly this: loopback only, no external network. Needed on hex (built
+  # with mix), the deps FOD, and the release build; a no-op on linux.
+  hexDarwinLoopback = pkgs.beamPackages.hex.overrideAttrs (_: {
+    __darwinAllowLocalNetworking = true;
+  });
+
   # Prod-env mix deps for the compiled release below: runtime deps only, so a
   # separate FOD from the test-env `mixFodDeps` (different dep set, different
   # hash). Refresh `mix-deps-prod` in pins.json whenever mix.lock changes.
-  prodMixFodDeps = pkgs.beamPackages.fetchMixDeps {
+  prodMixFodDeps = (pkgs.beamPackages.fetchMixDeps.override {hex = hexDarwinLoopback;}) {
     pname = "symphony-elixir-prod-deps";
     version = "0.2.0"; # keep in sync with elixir/mix.exs
     src = lib.fileset.toSource {
@@ -117,6 +127,7 @@
     inherit elixir;
     mixEnv = "prod";
     inherit (pins."mix-deps-prod") hash;
+    __darwinAllowLocalNetworking = true;
   };
 
   # Compiled BEAM release, the artifact the persistent-VM runtime
@@ -126,15 +137,20 @@
   # staging + compiling at boot; this is the no-compile-at-boot artifact hot
   # reload needs. Same elixir toolchain as the beamvm harness so the bytecode
   # and stdlib the release bundles are exactly what that VM booted.
-  release = (pkgs.beamPackages.mixRelease.override {inherit elixir;}) {
-    pname = "symphony-release";
-    version = "0.2.0"; # keep in sync with elixir/mix.exs
-    src = lib.fileset.toSource {
-      root = ./elixir;
-      fileset = ./elixir;
+  release =
+    (pkgs.beamPackages.mixRelease.override {
+      inherit elixir;
+      hex = hexDarwinLoopback;
+    }) {
+      pname = "symphony-release";
+      version = "0.2.0"; # keep in sync with elixir/mix.exs
+      src = lib.fileset.toSource {
+        root = ./elixir;
+        fileset = ./elixir;
+      };
+      mixFodDeps = prodMixFodDeps;
+      __darwinAllowLocalNetworking = true;
     };
-    mixFodDeps = prodMixFodDeps;
-  };
 in
   (writeNushellApplication {
     name = "symphony";

--- a/packages/agent/symphony/default.nix
+++ b/packages/agent/symphony/default.nix
@@ -186,6 +186,11 @@ in
       (old.passthru or {})
       // {
         inherit release;
+        # The tree SYMPHONY_ROOT points at (workflow + skill catalogs, the
+        # bundled example pack): the same staged set bin/run-nix copies, for
+        # runtimes (beamvm) that run the compiled release and only need the
+        # catalogs, read-only, from the store.
+        root = src;
         tests.elixir = elixirCheck;
         # Building the release IS its test at this layer: it proves the prod
         # dep set resolves offline and the project compiles as a release.

--- a/packages/agent/symphony/default.nix
+++ b/packages/agent/symphony/default.nix
@@ -151,6 +151,23 @@
       mixFodDeps = prodMixFodDeps;
       __darwinAllowLocalNetworking = true;
     };
+  # One tool set for both runtimes: the standalone launcher's runtimeInputs
+  # and (via passthru) the beamvm VM's PATH. ExecRunner inherits this PATH
+  # for workflow scripts, and the bundled indexable pack shells out to
+  # git/gh/jq directly, so dropping any of these breaks running workflows.
+  runtimeTools = [
+    pkgs.bash
+    pkgs.cacert
+    pkgs.coreutils
+    elixir
+    erlang
+    pkgs.gh
+    pkgs.git
+    # The bundled indexable pack's exec scripts build their structured
+    # {"slack_summary": ...} output with jq, so the runtime carries it.
+    pkgs.jq
+    pkgs.openssh
+  ];
 in
   (writeNushellApplication {
     name = "symphony";
@@ -161,19 +178,7 @@ in
     # codex is intentionally absent: bin/run-nix requires an authenticated
     # codex on the operator's PATH and refuses to start otherwise, so the
     # binary and its credentials stay host-owned.
-    runtimeInputs = [
-      pkgs.bash
-      pkgs.cacert
-      pkgs.coreutils
-      elixir
-      erlang
-      pkgs.gh
-      pkgs.git
-      # The bundled indexable pack's exec scripts build their structured
-      # {"slack_summary": ...} output with jq, so the runtime carries it.
-      pkgs.jq
-      pkgs.openssh
-    ];
+    runtimeInputs = runtimeTools;
     text = ''
       # nu
       def --wrapped main [...args] {
@@ -186,6 +191,7 @@ in
       (old.passthru or {})
       // {
         inherit release;
+        inherit runtimeTools;
         # The tree SYMPHONY_ROOT points at (workflow + skill catalogs, the
         # bundled example pack): the same staged set bin/run-nix copies, for
         # runtimes (beamvm) that run the compiled release and only need the

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/components/layouts.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/components/layouts.ex
@@ -16,7 +16,7 @@ defmodule SymphonyElixirWeb.Layouts do
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="csrf-token" content={@csrf_token} />
-        <title>symphony v2-hotswap</title>
+        <title>symphony</title>
         <link
           rel="icon"
           type="image/svg+xml"

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/components/layouts.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/components/layouts.ex
@@ -16,7 +16,7 @@ defmodule SymphonyElixirWeb.Layouts do
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="csrf-token" content={@csrf_token} />
-        <title>symphony</title>
+        <title>symphony v2-hotswap</title>
         <link
           rel="icon"
           type="image/svg+xml"

--- a/packages/agent/symphony/home-module.nix
+++ b/packages/agent/symphony/home-module.nix
@@ -103,10 +103,14 @@ in {
     };
 
     releasePackage = mkOption {
-      type = types.package;
-      default = defaultPackage.release;
-      defaultText = lib.literalExpression "index.packages.\${system}.symphony.release";
-      description = "Compiled mix release the beamvm runtime code-loads (package.passthru.release).";
+      type = types.nullOr types.package;
+      default = null;
+      defaultText = lib.literalExpression "config.services.symphony.package.release";
+      description = ''
+        Compiled mix release the beamvm runtime code-loads. Null follows
+        `package` (its passthru.release), so overriding `package` alone
+        keeps code and catalogs from the same build.
+      '';
     };
 
     stateDir = mkOption {
@@ -225,14 +229,26 @@ in {
   config = mkIf cfg.enable (lib.mkMerge [
     {services.symphony.launcher = launcher;}
     (mkIf (cfg.runtime == "beamvm") {
+      # Catalog tree indirection: home-manager retargets this symlink at
+      # switch, so the VM (whose unit env carries only the stable path)
+      # reads updated catalogs without a unit change.
+      xdg.configFile."symphony/root".source = cfg.package.root;
+
       # The persistent-VM runtime: SYMPHONY_* env parity with bin/run-nix,
       # except SYMPHONY_ROOT points read-only at the store catalogs (the
       # release needs no writable staging copy) and every writable dir is
       # anchored explicitly under the state dir -- config.ex mkdir_p!'s its
       # dirs, which must never resolve to a store default.
       services.beamvm.vms.symphony = {
-        apps.symphony_elixir.package = cfg.releasePackage;
-        inherit (cfg) environmentFile secretsCommand extraPath;
+        apps.symphony_elixir.package =
+          if cfg.releasePackage != null
+          then cfg.releasePackage
+          else cfg.package.release;
+        inherit (cfg) environmentFile secretsCommand;
+        # The package's own runtime tool set first (ExecRunner inherits this
+        # PATH for workflow scripts; the bundled pack shells out to git/gh/
+        # jq), then deployment extras (codex lives there).
+        extraPath = cfg.package.runtimeTools ++ cfg.extraPath;
         environment = let
           stateDir =
             if cfg.stateDir != null
@@ -240,7 +256,11 @@ in {
             else "${config.xdg.stateHome}/symphony";
         in
           {
-            SYMPHONY_ROOT = toString cfg.package.root;
+            # Via the stable config symlink (written below), NOT the store
+            # path: a store path in the unit environment would change the
+            # unit on every symphony update and restart the VM, defeating
+            # the hot-reload contract this runtime exists for.
+            SYMPHONY_ROOT = "${config.xdg.configHome}/symphony/root";
             SYMPHONY_STATE_DIR = stateDir;
             SYMPHONY_WORKSPACES_DIR = "${stateDir}/workspaces";
             SYMPHONY_RUNS_DIR = "${stateDir}/runs";

--- a/packages/agent/symphony/home-module.nix
+++ b/packages/agent/symphony/home-module.nix
@@ -17,6 +17,7 @@
 {
   indexPackages,
   portableServicesModule,
+  beamvmModule,
   ix,
 }: {
   config,
@@ -65,7 +66,10 @@
       '';
   };
 in {
-  imports = [portableServicesModule];
+  imports = [
+    portableServicesModule
+    beamvmModule
+  ];
 
   options.services.symphony = {
     enable = mkEnableOption "the Symphony runtime as a user service";
@@ -75,6 +79,34 @@ in {
       default = defaultPackage;
       defaultText = lib.literalExpression "index.packages.\${system}.symphony";
       description = "Symphony package to run (this flake's launcher around bin/run-nix).";
+    };
+
+    runtime = mkOption {
+      type = types.enum [
+        "beamvm"
+        "standalone"
+      ];
+      default = "beamvm";
+      description = ''
+        How the runtime is hosted.
+
+        "beamvm" (the default) runs the compiled release inside the
+        persistent BEAM VM (services.beamvm): no compile at boot, and a
+        symphony update hot-swaps code in the running VM at switch time --
+        no restart, no dropped LiveView sockets or in-flight runs. Only a
+        beamvm/toolchain update restarts the VM.
+
+        "standalone" is the original path: a dedicated unit whose launcher
+        stages the source tree and runs `mix run --no-halt`, recompiling at
+        every start. Updates restart the unit.
+      '';
+    };
+
+    releasePackage = mkOption {
+      type = types.package;
+      default = defaultPackage.release;
+      defaultText = lib.literalExpression "index.packages.\${system}.symphony.release";
+      description = "Compiled mix release the beamvm runtime code-loads (package.passthru.release).";
     };
 
     stateDir = mkOption {
@@ -190,35 +222,72 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    services.symphony.launcher = launcher;
-
-    services.portable.symphony = {
-      description = "Symphony runtime";
-      command = [(lib.getExe launcher)];
-      environment =
-        {
-          SYMPHONY_HTTP_PORT = toString cfg.httpPort;
-          SYMPHONY_WORKFLOW_PACK = cfg.workflowPack;
-        }
-        // optionalAttrs (cfg.stateDir != null) {
-          SYMPHONY_STATE_DIR = toString cfg.stateDir;
-        }
-        // optionalAttrs (cfg.primaryRepo != null) {
-          SYMPHONY_PRIMARY_REPO = toString cfg.primaryRepo;
-        }
-        // optionalAttrs (cfg.repoRoot != null) {
-          SYMPHONY_REPO_ROOT = toString cfg.repoRoot;
-        }
-        // optionalAttrs (cfg.packDir != null) {
-          SYMPHONY_PACK_DIR = toString cfg.packDir;
-        }
-        // cfg.extraEnvironment;
-      # The BEAM is the scheduler: cron triggers live inside the runtime, so
-      # the unit's whole job is to keep it up from login onward. No interval;
-      # a poller here would fight the long-running daemon.
-      restart = "always";
-      runAtLoad = true;
-    };
-  };
+  config = mkIf cfg.enable (lib.mkMerge [
+    {services.symphony.launcher = launcher;}
+    (mkIf (cfg.runtime == "beamvm") {
+      # The persistent-VM runtime: SYMPHONY_* env parity with bin/run-nix,
+      # except SYMPHONY_ROOT points read-only at the store catalogs (the
+      # release needs no writable staging copy) and every writable dir is
+      # anchored explicitly under the state dir -- config.ex mkdir_p!'s its
+      # dirs, which must never resolve to a store default.
+      services.beamvm.vms.symphony = {
+        apps.symphony_elixir.package = cfg.releasePackage;
+        inherit (cfg) environmentFile secretsCommand extraPath;
+        environment = let
+          stateDir =
+            if cfg.stateDir != null
+            then toString cfg.stateDir
+            else "${config.xdg.stateHome}/symphony";
+        in
+          {
+            SYMPHONY_ROOT = toString cfg.package.root;
+            SYMPHONY_STATE_DIR = stateDir;
+            SYMPHONY_WORKSPACES_DIR = "${stateDir}/workspaces";
+            SYMPHONY_RUNS_DIR = "${stateDir}/runs";
+            SYMPHONY_LOGS_ROOT = "${stateDir}/log";
+            SYMPHONY_HTTP_PORT = toString cfg.httpPort;
+            SYMPHONY_WORKFLOW_PACK = cfg.workflowPack;
+          }
+          // optionalAttrs (cfg.primaryRepo != null) {
+            SYMPHONY_PRIMARY_REPO = toString cfg.primaryRepo;
+          }
+          // optionalAttrs (cfg.repoRoot != null) {
+            SYMPHONY_REPO_ROOT = toString cfg.repoRoot;
+          }
+          // optionalAttrs (cfg.packDir != null) {
+            SYMPHONY_PACK_DIR = toString cfg.packDir;
+          }
+          // cfg.extraEnvironment;
+      };
+    })
+    (mkIf (cfg.runtime == "standalone") {
+      services.portable.symphony = {
+        description = "Symphony runtime";
+        command = [(lib.getExe launcher)];
+        environment =
+          {
+            SYMPHONY_HTTP_PORT = toString cfg.httpPort;
+            SYMPHONY_WORKFLOW_PACK = cfg.workflowPack;
+          }
+          // optionalAttrs (cfg.stateDir != null) {
+            SYMPHONY_STATE_DIR = toString cfg.stateDir;
+          }
+          // optionalAttrs (cfg.primaryRepo != null) {
+            SYMPHONY_PRIMARY_REPO = toString cfg.primaryRepo;
+          }
+          // optionalAttrs (cfg.repoRoot != null) {
+            SYMPHONY_REPO_ROOT = toString cfg.repoRoot;
+          }
+          // optionalAttrs (cfg.packDir != null) {
+            SYMPHONY_PACK_DIR = toString cfg.packDir;
+          }
+          // cfg.extraEnvironment;
+        # The BEAM is the scheduler: cron triggers live inside the runtime,
+        # so the unit's whole job is to keep it up from login onward. No
+        # interval; a poller here would fight the long-running daemon.
+        restart = "always";
+        runAtLoad = true;
+      };
+    })
+  ]);
 }

--- a/packages/agent/symphony/pins.json
+++ b/packages/agent/symphony/pins.json
@@ -6,5 +6,8 @@
     "version": "0.1.10",
     "url": "https://github.com/dashbitco/lazy_html/releases/download/v0.1.10/lazy_html-nif-2.16-x86_64-linux-gnu-0.1.10.tar.gz",
     "hash": "sha256-Ni0JKbP6OJqQ8rT08VnF/KWjiyigoVUjqSZ3LRU9dBo="
+  },
+  "mix-deps-prod": {
+    "hash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   }
 }

--- a/packages/agent/symphony/pins.json
+++ b/packages/agent/symphony/pins.json
@@ -8,6 +8,6 @@
     "hash": "sha256-Ni0JKbP6OJqQ8rT08VnF/KWjiyigoVUjqSZ3LRU9dBo="
   },
   "mix-deps-prod": {
-    "hash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    "hash": "sha256-gLhEvh0FK4EdUUnp0498bKFcBZx2cRSRMG4aAEsyR44="
   }
 }

--- a/packages/beamvm/default.nix
+++ b/packages/beamvm/default.nix
@@ -1,0 +1,175 @@
+# beamvm: a persistent BEAM node as a user service, with the applications it
+# hosts declared in Nix and hot-swapped on update instead of restarted.
+#
+# Two binaries:
+#   beamvm-harness  the long-lived node; reads a JSON manifest of apps
+#                   (see harness.ex for the reload semantics)
+#   beamvm-ctl      pokes the harness's unix control socket (reload/status/
+#                   ping); home-manager activation calls `reload` after it
+#                   moves the manifest symlink
+#
+# The toolchain pin matches symphony (Elixir 1.19 / OTP 28) on purpose: every
+# tenant's compiled beams must load into this harness's ERTS, and the
+# skip-if-loaded rule in the harness assumes the release's bundled elixir and
+# stdlib are the very ones the harness booted.
+{
+  lib,
+  pkgs,
+  ix,
+}: let
+  elixir = ix.languages.elixir.toolchain pkgs {version = "1.19";};
+
+  harnessEbin =
+    pkgs.runCommand "beamvm-harness-ebin" {
+      nativeBuildInputs = [elixir];
+      src = ./harness.ex;
+    } ''
+      mkdir -p "$out"
+      elixirc -o "$out" "$src"
+    '';
+
+  harness = ix.writeBashApplication pkgs {
+    name = "beamvm-harness";
+    runtimeInputs = [elixir];
+    text = ''
+      : "''${BEAMVM_STATE_DIR:?beamvm-harness: BEAMVM_STATE_DIR must be set}"
+      : "''${BEAMVM_MANIFEST:?beamvm-harness: BEAMVM_MANIFEST must be set}"
+      exec elixir -pa ${harnessEbin} --no-halt -e 'BeamVM.Harness.main()'
+    '';
+  };
+
+  ctl = ix.writeBashApplication pkgs {
+    name = "beamvm-ctl";
+    runtimeInputs = [pkgs.socat pkgs.jq];
+    text = ''
+      usage() {
+        echo "usage: beamvm-ctl --socket <path> <ping|status|reload>" >&2
+        exit 64
+      }
+
+      socket=""
+      cmd=""
+      while [ $# -gt 0 ]; do
+        case $1 in
+          --socket) socket=$2; shift 2 ;;
+          ping | status | reload) cmd=$1; shift ;;
+          *) usage ;;
+        esac
+      done
+      [ -n "$socket" ] && [ -n "$cmd" ] || usage
+
+      # Exit 2, distinct from failure: "not running" is a legitimate state
+      # during activation (first install, or the unit is stopped). The caller
+      # decides whether that is fine (a fresh start reads the current
+      # manifest anyway) or fatal.
+      if [ ! -S "$socket" ]; then
+        echo "beamvm-ctl: no control socket at $socket (vm not running)" >&2
+        exit 2
+      fi
+
+      reply=$(printf '%s\n' "$cmd" | socat -t 60 - "UNIX-CONNECT:$socket")
+      printf '%s\n' "$reply"
+      [ "$(jq -r '.ok' <<<"$reply")" = "true" ]
+    '';
+  };
+
+  # Proof the hot path works: boot the harness on a v1 demo app whose
+  # gen_server heartbeats its compiled-in version and pid to a file, flip the
+  # manifest symlink to v2, `beamvm-ctl reload`, and require the heartbeat to
+  # show the new version from the SAME server pid in the SAME OS process --
+  # i.e. a code swap, not any flavor of restart.
+  hotReloadTest =
+    pkgs.runCommand "beamvm-hot-reload-test" {
+      nativeBuildInputs = [
+        elixir
+        harness
+        ctl
+        pkgs.jq
+      ];
+      demoV1 = ./test/demo-v1.ex;
+      demoV2 = ./test/demo-v2.ex;
+      demoApp = ./test/demo.app;
+    } ''
+      mkdir -p v1/ebin v2/ebin state
+      elixirc -o v1/ebin "$demoV1"
+      elixirc -o v2/ebin "$demoV2"
+      cp "$demoApp" v1/ebin/demo.app
+      cp "$demoApp" v2/ebin/demo.app
+
+      for v in v1 v2; do
+        cat > "manifest-$v.json" <<EOF
+      {"apps": {"demo": {"code_path_globs": ["$PWD/$v/ebin"], "start": true}}}
+      EOF
+      done
+
+      ln -sf "$PWD/manifest-v1.json" manifest.current
+      export BEAMVM_STATE_DIR="$PWD/state"
+      export BEAMVM_MANIFEST="$PWD/manifest.current"
+      export DEMO_OUT="$PWD/heartbeat"
+
+      beamvm-harness > harness.log 2>&1 &
+      harness_pid=$!
+
+      sock="$BEAMVM_STATE_DIR/control.sock"
+      for _ in $(seq 100); do
+        if beamvm-ctl --socket "$sock" ping > /dev/null 2>&1; then break; fi
+        sleep 0.1
+      done
+      beamvm-ctl --socket "$sock" ping > /dev/null || {
+        echo "harness never became ready; its log follows" >&2
+        cat harness.log >&2
+        exit 1
+      }
+
+      # v1 heartbeats (100 ms period): capture the server pid.
+      for _ in $(seq 50); do
+        if grep -q "vsn=1" "$DEMO_OUT" 2>/dev/null; then break; fi
+        sleep 0.1
+      done
+      grep -q "vsn=1" "$DEMO_OUT"
+      pid_v1=$(grep -m1 "vsn=1" "$DEMO_OUT" | sed 's/.*pid=//')
+
+      ln -sf "$PWD/manifest-v2.json" manifest.current
+      beamvm-ctl --socket "$sock" reload | tee reload.json
+      [ "$(jq -r '.ok' reload.json)" = "true" ]
+
+      for _ in $(seq 50); do
+        if grep -q "vsn=2" "$DEMO_OUT" 2>/dev/null; then break; fi
+        sleep 0.1
+      done
+      grep -q "vsn=2" "$DEMO_OUT"
+      pid_v2=$(grep -m1 "vsn=2" "$DEMO_OUT" | sed 's/.*pid=//')
+
+      # The same gen_server pid heartbeating the new version is the whole
+      # point: code moved, the process (and its state) did not.
+      [ "$pid_v1" = "$pid_v2" ] || {
+        echo "server pid changed across reload: $pid_v1 -> $pid_v2 (restart, not hot swap)" >&2
+        cat harness.log >&2
+        exit 1
+      }
+
+      kill "$harness_pid"
+      cat harness.log
+      touch "$out"
+    '';
+in
+  (pkgs.symlinkJoin {
+    name = "beamvm";
+    paths = [
+      harness
+      ctl
+    ];
+    meta = {
+      description = "Persistent BEAM VM user service: Nix-declared OTP apps, hot code reload on update";
+      license = lib.licenses.asl20;
+      mainProgram = "beamvm-ctl";
+    };
+  })
+  .overrideAttrs (old: {
+    passthru =
+      (old.passthru or {})
+      // {
+        inherit harness ctl;
+        tests.hot-reload = hotReloadTest;
+      };
+  })

--- a/packages/beamvm/harness.ex
+++ b/packages/beamvm/harness.ex
@@ -125,7 +125,7 @@ defmodule BeamVM.Harness do
     Map.new(apps, fn {app, spec} ->
       {String.to_atom(app),
        %{
-         paths: expand_code_paths(Map.fetch!(spec, "code_path_globs")),
+         code_path_globs: Map.fetch!(spec, "code_path_globs"),
          start: Map.get(spec, "start", true),
          sys_config: expand_globs(Map.get(spec, "sys_config_globs", [])),
          runtime_config: expand_globs(Map.get(spec, "runtime_config_globs", []))
@@ -135,13 +135,17 @@ defmodule BeamVM.Harness do
 
   defp expand_globs(globs), do: Enum.flat_map(globs, &Path.wildcard/1)
 
-  defp expand_code_paths(globs) do
-    # Enum.filter, not a `for` with an `app = ...` binding: a nil binding
-    # would act as a comprehension filter and silently drop every ebin dir
-    # whose parent is not shaped `<app>-<vsn>`.
+  # Expanded against the tenant's PREVIOUS path set: a library this tenant
+  # itself brought last time is being replaced, not double-claimed, so it must
+  # not be skipped just because it is loaded. Only libraries loaded from
+  # somewhere OUTSIDE the tenant's own previous dirs (the harness toolchain,
+  # another tenant) are skipped. Enum.filter, not a `for` with an `app = ...`
+  # binding: a nil binding would act as a comprehension filter and silently
+  # drop every ebin dir whose parent is not shaped `<app>-<vsn>`.
+  defp expand_code_paths(globs, previous_paths) do
     globs
     |> expand_globs()
-    |> Enum.filter(fn dir -> keep_code_path?(ebin_app_name(dir), dir) end)
+    |> Enum.filter(fn dir -> keep_code_path?(ebin_app_name(dir), dir, previous_paths) end)
   end
 
   # lib/<app>-<vsn>/ebin -> :"<app>"; nil for layouts that do not encode one.
@@ -153,15 +157,16 @@ defmodule BeamVM.Harness do
   end
 
   # Drop a release-bundled library when the VM already has that application
-  # loaded and it is not one of ours: those are the toolchain apps (elixir,
-  # stdlib, logger, kernel, ...) the harness itself booted from the same
-  # Nix-pinned toolchain, or a library another tenant already claimed. First
-  # tenant wins on shared deps; a version conflict between tenants is a
-  # packaging decision for the manifest author, surfaced by the log line.
-  defp keep_code_path?(nil, _dir), do: true
+  # loaded from OUTSIDE this tenant's own previous dirs: those are the
+  # toolchain apps (elixir, stdlib, logger, kernel, ...) the harness itself
+  # booted from the same Nix-pinned toolchain, or a library another tenant
+  # already claimed. First tenant wins on shared deps; a version conflict
+  # between tenants is a packaging decision for the manifest author, surfaced
+  # by the log line.
+  defp keep_code_path?(nil, _dir, _previous_paths), do: true
 
-  defp keep_code_path?(app, dir) do
-    if loaded?(app) and not on_path_owned_by?(dir, app) do
+  defp keep_code_path?(app, dir, previous_paths) do
+    if loaded?(app) and not loaded_from_previous?(app, previous_paths) do
       log("skipping #{dir}: application #{app} already loaded in this VM")
       false
     else
@@ -173,10 +178,17 @@ defmodule BeamVM.Harness do
     Enum.any?(Application.loaded_applications(), fn {name, _, _} -> name == app end)
   end
 
-  defp on_path_owned_by?(dir, app) do
+  # Whether the loaded copy of `app` came from one of this tenant's previous
+  # ebin dirs (checked before those dirs are removed from the code path, so
+  # `:code.lib_dir/1` still resolves to the old location).
+  defp loaded_from_previous?(app, previous_paths) do
     case :code.lib_dir(app) do
-      {:error, _} -> false
-      lib_dir -> Path.expand(to_string(lib_dir)) == Path.expand(Path.dirname(dir))
+      {:error, _} ->
+        false
+
+      lib_dir ->
+        expanded = Path.expand(to_string(lib_dir))
+        Enum.any?(previous_paths, fn p -> Path.expand(Path.dirname(p)) == expanded end)
     end
   end
 
@@ -196,26 +208,29 @@ defmodule BeamVM.Harness do
     Enum.each(entry.paths, &:code.del_path(String.to_charlist(&1)))
   end
 
-  # Same paths: the store path did not change, nothing to do.
-  defp converge_app(app, %{paths: paths}, %{paths: paths} = spec) do
-    if spec.start and not started?(app), do: start_app(app)
-    spec
-  end
-
   defp converge_app(app, previous, spec) do
-    old_paths = if previous, do: previous.paths, else: []
-    Enum.each(old_paths -- spec.paths, &:code.del_path(String.to_charlist(&1)))
-    Enum.each(spec.paths -- old_paths, &:code.add_pathz(String.to_charlist(&1)))
+    previous_paths = if previous, do: previous.paths, else: []
+    new_paths = expand_code_paths(spec.code_path_globs, previous_paths)
+    entry = %{paths: new_paths, start: spec.start}
 
-    if previous do
-      hot_swap_modules(app)
+    if new_paths == previous_paths do
+      # Same expanded dirs: the store paths did not change, nothing to swap.
+      if spec.start and not started?(app), do: start_app(app)
+      entry
     else
-      log("loading #{app} (#{length(spec.paths)} code paths)")
-    end
+      Enum.each(previous_paths -- new_paths, &:code.del_path(String.to_charlist(&1)))
+      Enum.each(new_paths -- previous_paths, &:code.add_pathz(String.to_charlist(&1)))
 
-    apply_release_config(app, spec)
-    if spec.start and not started?(app), do: start_app(app)
-    spec
+      if previous do
+        hot_swap_modules(app)
+      else
+        log("loading #{app} (#{length(new_paths)} code paths)")
+      end
+
+      apply_release_config(app, spec)
+      if spec.start and not started?(app), do: start_app(app)
+      entry
+    end
   end
 
   # Replay the release boot's config pipeline: sys.config (the baked

--- a/packages/beamvm/harness.ex
+++ b/packages/beamvm/harness.ex
@@ -114,6 +114,7 @@ defmodule BeamVM.Harness do
   # Manifest shape (rendered by the Nix home-module):
   #   {"apps": {"<app>": {"code_path_globs": [...],
   #                       "start": true,
+  #                       "sys_config_globs": [...],
   #                       "runtime_config_globs": [...]}}}
   # Globs, not literal dirs: a release's lib layout (`lib/<dep>-<vsn>/ebin`)
   # is only enumerable after the package is built, and expanding at eval time
@@ -126,6 +127,7 @@ defmodule BeamVM.Harness do
        %{
          paths: expand_code_paths(Map.fetch!(spec, "code_path_globs")),
          start: Map.get(spec, "start", true),
+         sys_config: expand_globs(Map.get(spec, "sys_config_globs", [])),
          runtime_config: expand_globs(Map.get(spec, "runtime_config_globs", []))
        }}
     end)
@@ -211,9 +213,24 @@ defmodule BeamVM.Harness do
       log("loading #{app} (#{length(spec.paths)} code paths)")
     end
 
+    # Release boot order: sys.config (the baked build-time config from
+    # config.exs + prod.exs -- `server: true` for a Phoenix endpoint lives
+    # here) first, then runtime.exs overrides it, exactly as the release's
+    # own boot script would.
+    apply_sys_config(app, spec.sys_config)
     apply_runtime_config(app, spec.runtime_config)
     if spec.start and not started?(app), do: start_app(app)
     spec
+  end
+
+  # sys.config is one Erlang term: a list of {App, [{Key, Val}]} pairs.
+  defp apply_sys_config(_app, []), do: :ok
+
+  defp apply_sys_config(app, [path | _] = all) do
+    if length(all) > 1, do: log("#{app}: multiple sys.configs matched; using #{path}")
+    log("#{app}: applying sys.config #{path}")
+    {:ok, [config]} = :file.consult(String.to_charlist(path))
+    Application.put_all_env(config, persistent: true)
   end
 
   # `:code.modified_modules/0` lists exactly the loaded modules whose beam on

--- a/packages/beamvm/harness.ex
+++ b/packages/beamvm/harness.ex
@@ -1,0 +1,283 @@
+# Persistent BEAM VM harness: one long-lived node that loads and runs the OTP
+# applications a Nix-rendered manifest declares, and hot-swaps them in place
+# when the manifest changes.
+#
+# Why this exists: restarting the VM to pick up a new store path drops every
+# WebSocket, in-flight run, and supervision tree it hosts. The BEAM is built
+# for code replacement, so an update should default to a hot reload and only
+# fall back to a restart when the runtime itself (ERTS/Elixir) changed. The
+# split of responsibilities that makes this safe:
+#
+#   * The service unit's command line references ONLY the harness package and
+#     a stable manifest path ($XDG config symlink home-manager rewrites), so
+#     an app update never changes the unit definition and never restarts it.
+#   * A harness/toolchain update DOES change the unit's store path, and the
+#     portable-services layer restarts it: exactly the case where hot reload
+#     is impossible (new ERTS), handled by construction rather than detection.
+#   * `beamvm-ctl reload` (poked by home-manager activation after the symlink
+#     moves) makes the running VM re-read the manifest and converge.
+#
+# Reload semantics per app, in dependency-safe order:
+#   removed  -> Application.stop/unload, drop its code paths
+#   changed  -> swap code paths, then `:code.modified_modules/0` +
+#               `:code.atomic_load/1` (soft-purged, all-or-nothing); a module
+#               with lingering old-code processes fails the atomic pass and
+#               falls back to per-module purge+load, which kills only the
+#               stuck processes (their supervisors restart them on new code)
+#   added    -> add code paths, apply release runtime config, ensure_all_started
+#
+# Toolchain libraries bundled inside a release (elixir, stdlib, logger, ...)
+# are skipped when the VM already has that application loaded: the harness and
+# every tenant pin the same Erlang/Elixir toolchain in Nix, so the loaded copy
+# IS the release's copy, and double code paths would only add shadow-loading
+# hazards.
+defmodule BeamVM.Harness do
+  @socket_name "control.sock"
+
+  def main do
+    state_dir = System.fetch_env!("BEAMVM_STATE_DIR")
+    manifest_path = System.fetch_env!("BEAMVM_MANIFEST")
+    File.mkdir_p!(state_dir)
+    socket_path = Path.join(state_dir, @socket_name)
+    # A crash leaves the previous socket file behind; listen would EADDRINUSE.
+    File.rm(socket_path)
+
+    log("starting: manifest=#{manifest_path} socket=#{socket_path}")
+    state = apply_manifest(%{}, read_manifest!(manifest_path))
+
+    {:ok, listener} =
+      :gen_tcp.listen(0, [
+        :binary,
+        packet: :line,
+        active: false,
+        ifaddr: {:local, String.to_charlist(socket_path)}
+      ])
+
+    log("ready: #{map_size(state)} app(s)")
+    serve(listener, %{state: state, manifest_path: manifest_path})
+  end
+
+  # One connection at a time, handled synchronously: reloads must serialize,
+  # and the only clients are activation hooks and an operator's ctl calls.
+  defp serve(listener, ctx) do
+    {:ok, conn} = :gen_tcp.accept(listener)
+    ctx = handle_conn(conn, ctx)
+    :gen_tcp.close(conn)
+    serve(listener, ctx)
+  end
+
+  defp handle_conn(conn, ctx) do
+    case :gen_tcp.recv(conn, 0, 10_000) do
+      {:ok, line} ->
+        {reply, ctx} = handle_command(String.trim(line), ctx)
+        :gen_tcp.send(conn, [JSON.encode!(reply), "\n"])
+        ctx
+
+      {:error, reason} ->
+        log("control connection recv failed: #{inspect(reason)}")
+        ctx
+    end
+  end
+
+  defp handle_command("ping", ctx), do: {%{ok: true, pong: true}, ctx}
+
+  defp handle_command("status", ctx) do
+    apps =
+      Map.new(ctx.state, fn {app, entry} ->
+        {app,
+         %{
+           started: started?(app),
+           paths: length(entry.paths)
+         }}
+      end)
+
+    {%{ok: true, os_pid: System.pid(), apps: apps}, ctx}
+  end
+
+  defp handle_command("reload", ctx) do
+    manifest = read_manifest!(ctx.manifest_path)
+    state = apply_manifest(ctx.state, manifest)
+
+    changed = Map.keys(manifest) -- Map.keys(ctx.state)
+    log("reload complete: #{map_size(state)} app(s), #{length(changed)} added")
+    {%{ok: true, os_pid: System.pid(), apps: Map.keys(state)}, %{ctx | state: state}}
+  rescue
+    err ->
+      log("reload FAILED: #{Exception.message(err)}")
+      {%{ok: false, error: Exception.message(err)}, ctx}
+  end
+
+  defp handle_command(other, ctx) do
+    {%{ok: false, error: "unknown command #{inspect(other)}"}, ctx}
+  end
+
+  # Manifest shape (rendered by the Nix home-module):
+  #   {"apps": {"<app>": {"code_path_globs": [...],
+  #                       "start": true,
+  #                       "runtime_config_globs": [...]}}}
+  # Globs, not literal dirs: a release's lib layout (`lib/<dep>-<vsn>/ebin`)
+  # is only enumerable after the package is built, and expanding at eval time
+  # would be import-from-derivation.
+  defp read_manifest!(path) do
+    %{"apps" => apps} = path |> File.read!() |> JSON.decode!()
+
+    Map.new(apps, fn {app, spec} ->
+      {String.to_atom(app),
+       %{
+         paths: expand_code_paths(Map.fetch!(spec, "code_path_globs")),
+         start: Map.get(spec, "start", true),
+         runtime_config: expand_globs(Map.get(spec, "runtime_config_globs", []))
+       }}
+    end)
+  end
+
+  defp expand_globs(globs), do: Enum.flat_map(globs, &Path.wildcard/1)
+
+  defp expand_code_paths(globs) do
+    # Enum.filter, not a `for` with an `app = ...` binding: a nil binding
+    # would act as a comprehension filter and silently drop every ebin dir
+    # whose parent is not shaped `<app>-<vsn>`.
+    globs
+    |> expand_globs()
+    |> Enum.filter(fn dir -> keep_code_path?(ebin_app_name(dir), dir) end)
+  end
+
+  # lib/<app>-<vsn>/ebin -> :"<app>"; nil for layouts that do not encode one.
+  defp ebin_app_name(dir) do
+    case dir |> Path.dirname() |> Path.basename() |> String.split("-", parts: 2) do
+      [name, _vsn] -> String.to_atom(name)
+      _ -> nil
+    end
+  end
+
+  # Drop a release-bundled library when the VM already has that application
+  # loaded and it is not one of ours: those are the toolchain apps (elixir,
+  # stdlib, logger, kernel, ...) the harness itself booted from the same
+  # Nix-pinned toolchain, or a library another tenant already claimed. First
+  # tenant wins on shared deps; a version conflict between tenants is a
+  # packaging decision for the manifest author, surfaced by the log line.
+  defp keep_code_path?(nil, _dir), do: true
+
+  defp keep_code_path?(app, dir) do
+    if loaded?(app) and not on_path_owned_by?(dir, app) do
+      log("skipping #{dir}: application #{app} already loaded in this VM")
+      false
+    else
+      true
+    end
+  end
+
+  defp loaded?(app) do
+    Enum.any?(Application.loaded_applications(), fn {name, _, _} -> name == app end)
+  end
+
+  defp on_path_owned_by?(dir, app) do
+    case :code.lib_dir(app) do
+      {:error, _} -> false
+      lib_dir -> Path.expand(to_string(lib_dir)) == Path.expand(Path.dirname(dir))
+    end
+  end
+
+  defp apply_manifest(state, manifest) do
+    removed = Map.keys(state) -- Map.keys(manifest)
+    Enum.each(removed, fn app -> remove_app(app, state[app]) end)
+
+    Enum.reduce(manifest, %{}, fn {app, spec}, acc ->
+      Map.put(acc, app, converge_app(app, Map.get(state, app), spec))
+    end)
+  end
+
+  defp remove_app(app, entry) do
+    log("removing #{app}")
+    Application.stop(app)
+    Application.unload(app)
+    Enum.each(entry.paths, &:code.del_path(String.to_charlist(&1)))
+  end
+
+  # Same paths: the store path did not change, nothing to do.
+  defp converge_app(app, %{paths: paths}, %{paths: paths} = spec) do
+    if spec.start and not started?(app), do: start_app(app)
+    spec
+  end
+
+  defp converge_app(app, previous, spec) do
+    old_paths = if previous, do: previous.paths, else: []
+    Enum.each(old_paths -- spec.paths, &:code.del_path(String.to_charlist(&1)))
+    Enum.each(spec.paths -- old_paths, &:code.add_pathz(String.to_charlist(&1)))
+
+    if previous do
+      hot_swap_modules(app)
+    else
+      log("loading #{app} (#{length(spec.paths)} code paths)")
+    end
+
+    apply_runtime_config(app, spec.runtime_config)
+    if spec.start and not started?(app), do: start_app(app)
+    spec
+  end
+
+  # `:code.modified_modules/0` lists exactly the loaded modules whose beam on
+  # the (just swapped) code path differs from what is running; atomic_load is
+  # all-or-nothing and refuses while any of them still has old code, which the
+  # soft-purge pass clears for every module no process is stuck on.
+  defp hot_swap_modules(app) do
+    case :code.modified_modules() do
+      [] ->
+        log("#{app}: no modified modules")
+
+      mods ->
+        Enum.each(mods, &:code.soft_purge/1)
+
+        case :code.atomic_load(mods) do
+          :ok ->
+            log("#{app}: hot-swapped #{length(mods)} module(s): #{inspect(mods)}")
+
+          {:error, reasons} ->
+            # Some process is still executing old code (a purge would kill
+            # it). Swap module-by-module with brutal purge: only the stuck
+            # processes die, and their supervisors restart them on new code.
+            log("#{app}: atomic load failed (#{inspect(reasons)}); per-module brutal swap")
+
+            Enum.each(mods, fn mod ->
+              :code.purge(mod)
+              :code.load_file(mod)
+            end)
+        end
+    end
+  end
+
+  # A release evaluates config/runtime.exs through its boot script's config
+  # providers; the harness starts apps directly, so it replays that provider
+  # here before start. Multi-app config (`config :other_app, ...`) applies
+  # globally, which is the same semantics the release boot would have.
+  defp apply_runtime_config(_app, []), do: :ok
+
+  defp apply_runtime_config(app, [path | _] = all) do
+    if length(all) > 1, do: log("#{app}: multiple runtime configs matched; using #{path}")
+    log("#{app}: applying runtime config #{path}")
+    Application.put_all_env(Config.Reader.read!(path, env: :prod), persistent: true)
+  end
+
+  # :temporary, not :permanent: a tenant crashing past its own supervision
+  # tree must not take the whole shared VM (and every other tenant) with it.
+  # The failure is loud in the log and in `beamvm-ctl status`.
+  defp start_app(app) do
+    log("starting #{app}")
+
+    case Application.ensure_all_started(app, :temporary) do
+      {:ok, started} ->
+        log("started #{app} (#{inspect(started)})")
+
+      {:error, reason} ->
+        raise "failed to start #{app}: #{inspect(reason)}"
+    end
+  end
+
+  defp started?(app) do
+    Enum.any?(Application.started_applications(), fn {name, _, _} -> name == app end)
+  end
+
+  defp log(msg) do
+    IO.puts("#{DateTime.utc_now() |> DateTime.to_iso8601()} beamvm: #{msg}")
+  end
+end

--- a/packages/beamvm/harness.ex
+++ b/packages/beamvm/harness.ex
@@ -213,24 +213,39 @@ defmodule BeamVM.Harness do
       log("loading #{app} (#{length(spec.paths)} code paths)")
     end
 
-    # Release boot order: sys.config (the baked build-time config from
-    # config.exs + prod.exs -- `server: true` for a Phoenix endpoint lives
-    # here) first, then runtime.exs overrides it, exactly as the release's
-    # own boot script would.
-    apply_sys_config(app, spec.sys_config)
-    apply_runtime_config(app, spec.runtime_config)
+    apply_release_config(app, spec)
     if spec.start and not started?(app), do: start_app(app)
     spec
   end
 
-  # sys.config is one Erlang term: a list of {App, [{Key, Val}]} pairs.
-  defp apply_sys_config(_app, []), do: :ok
+  # Replay the release boot's config pipeline: sys.config (the baked
+  # build-time config from config.exs + prod.exs -- `server: true` for a
+  # Phoenix endpoint lives here) DEEP-MERGED with runtime.exs, exactly as
+  # the release's config provider would. Deep merge, not two sequential
+  # put_all_env passes: runtime.exs typically sets a subset of an app key's
+  # keyword list (only `http:` under the endpoint, say), and a plain
+  # overwrite of that key silently drops the baked siblings -- observed as
+  # symphony booting with `server: true` lost and no HTTP listener.
+  # Multi-app config (`config :other_app, ...`) applies globally, which is
+  # release semantics too.
+  defp apply_release_config(app, spec) do
+    base = read_sys_config(app, spec.sys_config)
+    runtime = read_runtime_config(app, spec.runtime_config)
 
-  defp apply_sys_config(app, [path | _] = all) do
+    case Config.Reader.merge(base, runtime) do
+      [] -> :ok
+      merged -> Application.put_all_env(merged, persistent: true)
+    end
+  end
+
+  # sys.config is one Erlang term: a list of {App, [{Key, Val}]} pairs.
+  defp read_sys_config(_app, []), do: []
+
+  defp read_sys_config(app, [path | _] = all) do
     if length(all) > 1, do: log("#{app}: multiple sys.configs matched; using #{path}")
     log("#{app}: applying sys.config #{path}")
     {:ok, [config]} = :file.consult(String.to_charlist(path))
-    Application.put_all_env(config, persistent: true)
+    config
   end
 
   # `:code.modified_modules/0` lists exactly the loaded modules whose beam on
@@ -263,16 +278,12 @@ defmodule BeamVM.Harness do
     end
   end
 
-  # A release evaluates config/runtime.exs through its boot script's config
-  # providers; the harness starts apps directly, so it replays that provider
-  # here before start. Multi-app config (`config :other_app, ...`) applies
-  # globally, which is the same semantics the release boot would have.
-  defp apply_runtime_config(_app, []), do: :ok
+  defp read_runtime_config(_app, []), do: []
 
-  defp apply_runtime_config(app, [path | _] = all) do
+  defp read_runtime_config(app, [path | _] = all) do
     if length(all) > 1, do: log("#{app}: multiple runtime configs matched; using #{path}")
     log("#{app}: applying runtime config #{path}")
-    Application.put_all_env(Config.Reader.read!(path, env: :prod), persistent: true)
+    Config.Reader.read!(path, env: :prod)
   end
 
   # :temporary, not :permanent: a tenant crashing past its own supervision

--- a/packages/beamvm/harness.ex
+++ b/packages/beamvm/harness.ex
@@ -166,11 +166,31 @@ defmodule BeamVM.Harness do
   defp keep_code_path?(nil, _dir, _previous_paths), do: true
 
   defp keep_code_path?(app, dir, previous_paths) do
-    if loaded?(app) and not loaded_from_previous?(app, previous_paths) do
-      log("skipping #{dir}: application #{app} already loaded in this VM")
-      false
-    else
-      true
+    cond do
+      not loaded?(app) ->
+        true
+
+      loaded_from_previous?(app, previous_paths) ->
+        true
+
+      # Orphaned leftover of a removed tenant: still loaded (stopped), but
+      # its ebin is no longer on the code path. Unload the stale spec so the
+      # claiming tenant starts from the fresh .app.
+      not started?(app) and not on_code_path?(app) ->
+        log("reclaiming #{app}: stale spec from a removed tenant")
+        Application.unload(app)
+        true
+
+      true ->
+        log("skipping #{dir}: application #{app} already loaded in this VM")
+        false
+    end
+  end
+
+  defp on_code_path?(app) do
+    case :code.lib_dir(app) do
+      {:error, _} -> false
+      lib_dir -> Enum.member?(:code.get_path(), String.to_charlist(Path.join(to_string(lib_dir), "ebin")))
     end
   end
 
@@ -203,34 +223,102 @@ defmodule BeamVM.Harness do
 
   defp remove_app(app, entry) do
     log("removing #{app}")
-    Application.stop(app)
+    # The tenant's whole started set (dependencies ensure_all_started
+    # brought up), in reverse order; a dependency another tenant later
+    # started itself is not in this list and stays up.
+    stop_started(entry.started)
     Application.unload(app)
     Enum.each(entry.paths, &:code.del_path(String.to_charlist(&1)))
   end
 
   defp converge_app(app, previous, spec) do
     previous_paths = if previous, do: previous.paths, else: []
+    previous_started = if previous, do: previous.started, else: []
     new_paths = expand_code_paths(spec.code_path_globs, previous_paths)
-    entry = %{paths: new_paths, start: spec.start}
 
-    if new_paths == previous_paths do
-      # Same expanded dirs: the store paths did not change, nothing to swap.
-      if spec.start and not started?(app), do: start_app(app)
-      entry
-    else
-      Enum.each(previous_paths -- new_paths, &:code.del_path(String.to_charlist(&1)))
-      Enum.each(new_paths -- previous_paths, &:code.add_pathz(String.to_charlist(&1)))
-
-      if previous do
-        hot_swap_modules(app)
+    started =
+      if new_paths == previous_paths do
+        # Same expanded dirs: the store paths did not change, nothing to swap.
+        converge_started(app, spec, previous_started)
       else
-        log("loading #{app} (#{length(new_paths)} code paths)")
+        Enum.each(previous_paths -- new_paths, &:code.del_path(String.to_charlist(&1)))
+        Enum.each(new_paths -- previous_paths, &:code.add_pathz(String.to_charlist(&1)))
+
+        if previous do
+          hot_swap_modules(app)
+          converge_swapped_spec(app, new_paths, previous_started)
+        else
+          log("loading #{app} (#{length(new_paths)} code paths)")
+        end
+
+        apply_release_config(app, spec)
+        converge_started(app, spec, previous_started)
       end
 
-      apply_release_config(app, spec)
-      if spec.start and not started?(app), do: start_app(app)
-      entry
+    %{paths: new_paths, start: spec.start, started: started}
+  end
+
+  # Converge the running state to the declared one, both directions: `start`
+  # flipped off stops the tenant's own started set (a disabled app must not
+  # keep serving until a VM restart), and `start` on re-runs
+  # ensure_all_started even for an already-running app, which starts any
+  # runtime dependency the swapped release added while being a no-op
+  # otherwise.
+  defp converge_started(app, %{start: true}, previous_started) do
+    newly = start_app(app)
+    Enum.uniq(previous_started ++ newly)
+  end
+
+  defp converge_started(app, %{start: false}, previous_started) do
+    if started?(app) do
+      log("stopping #{app}: manifest no longer starts it")
+      stop_started(previous_started)
     end
+
+    []
+  end
+
+  # A hot swap replaces MODULES, but the application controller keeps the
+  # .app spec it loaded at first start: a new release that adds a runtime
+  # dependency to its .app would never see it started. Detect the spec
+  # change and do a loud tenant-level restart (stop, unload, fresh start
+  # picks up the new spec) -- correctness over zero-downtime for the rare
+  # dep-set change; module-only updates never take this path.
+  defp converge_swapped_spec(app, new_paths, previous_started) do
+    loaded_deps = Application.spec(app, :applications) || []
+    declared = declared_deps(app, new_paths)
+
+    if declared != nil and Enum.sort(declared) != Enum.sort(loaded_deps) do
+      log(
+        "#{app}: .app dependency set changed (#{inspect(declared -- loaded_deps)} added, " <>
+          "#{inspect(loaded_deps -- declared)} removed); restarting the tenant to reload its spec"
+      )
+
+      stop_started(previous_started)
+      Application.unload(app)
+    end
+
+    :ok
+  end
+
+  defp declared_deps(app, paths) do
+    with dir when is_binary(dir) <- Enum.find(paths, &(ebin_app_name(&1) == app)),
+         {:ok, [{:application, ^app, props}]} <-
+           :file.consult(String.to_charlist(Path.join(dir, "#{app}.app"))) do
+      Keyword.get(props, :applications, [])
+    else
+      _ -> nil
+    end
+  end
+
+  # Reverse start order, so dependents stop before their dependencies. Only
+  # the apps THIS tenant's ensure_all_started actually started: apps another
+  # tenant (or the harness) already ran are not in the list and stay up.
+  defp stop_started(started) do
+    Enum.each(Enum.reverse(started), fn dep ->
+      log("stopping #{dep}")
+      Application.stop(dep)
+    end)
   end
 
   # Replay the release boot's config pipeline: sys.config (the baked
@@ -305,11 +393,13 @@ defmodule BeamVM.Harness do
   # tree must not take the whole shared VM (and every other tenant) with it.
   # The failure is loud in the log and in `beamvm-ctl status`.
   defp start_app(app) do
-    log("starting #{app}")
-
     case Application.ensure_all_started(app, :temporary) do
+      {:ok, []} ->
+        []
+
       {:ok, started} ->
         log("started #{app} (#{inspect(started)})")
+        started
 
       {:error, reason} ->
         raise "failed to start #{app}: #{inspect(reason)}"

--- a/packages/beamvm/home-module.nix
+++ b/packages/beamvm/home-module.nix
@@ -250,24 +250,33 @@ in {
     # poke each running VM to converge on the new manifest. "Not running"
     # (exit 2) is fine -- the next start reads the same stable path -- but a
     # running VM that fails to reload fails the switch loudly.
+    # VM names reach systemd/launchd unit names, socket paths, and this
+    # activation script; constrain them once here rather than letting a
+    # metacharacter render an invalid unit or script.
+    assertions =
+      lib.mapAttrsToList (name: _vm: {
+        assertion = builtins.match "[A-Za-z0-9_-]+" name != null;
+        message = "services.beamvm.vms.\"${name}\": VM names must match [A-Za-z0-9_-]+";
+      })
+      cfg.vms;
+
     home.activation =
       lib.mapAttrs' (
         name: vm:
           lib.nameValuePair "beamvmReload-${name}" (
+            # Plain statements, no name-derived shell identifiers: the VM
+            # name appears only inside quoted strings.
             lib.hm.dag.entryAfter ["linkGeneration" "reloadSystemd" "setupLaunchAgents"] ''
-              beamvm_reload_${lib.replaceStrings ["-"] ["_"] name}() {
-                local rc=0
-                run ${getExe' cfg.package "beamvm-ctl"} \
-                  --socket ${lib.escapeShellArg "${stateDirFor name vm}/control.sock"} \
-                  reload || rc=$?
-                if [ "$rc" -eq 2 ]; then
-                  verboseEcho "beamvm ${name}: not running; next start reads the current manifest"
-                elif [ "$rc" -ne 0 ]; then
-                  echo "beamvm ${name}: hot reload failed (exit $rc)" >&2
-                  return "$rc"
-                fi
-              }
-              beamvm_reload_${lib.replaceStrings ["-"] ["_"] name}
+              beamvmReloadRc=0
+              run ${getExe' cfg.package "beamvm-ctl"} \
+                --socket ${lib.escapeShellArg "${stateDirFor name vm}/control.sock"} \
+                reload || beamvmReloadRc=$?
+              if [ "$beamvmReloadRc" -eq 2 ]; then
+                verboseEcho ${lib.escapeShellArg "beamvm ${name}: not running; next start reads the current manifest"}
+              elif [ "$beamvmReloadRc" -ne 0 ]; then
+                echo ${lib.escapeShellArg "beamvm ${name}: hot reload failed"} "(exit $beamvmReloadRc)" >&2
+                exit "$beamvmReloadRc"
+              fi
             ''
           )
       )

--- a/packages/beamvm/home-module.nix
+++ b/packages/beamvm/home-module.nix
@@ -196,6 +196,11 @@
         '';
     };
 in {
+  # Both homeModules.beamvm and homeModules.symphony (which composes this
+  # module for its beamvm runtime) import this file through fresh `import`
+  # calls; the module-system key dedups those into one option declaration.
+  key = "index:packages/beamvm/home-module.nix";
+
   imports = [portableServicesModule];
 
   options.services.beamvm = {

--- a/packages/beamvm/home-module.nix
+++ b/packages/beamvm/home-module.nix
@@ -1,0 +1,265 @@
+# home-manager module exposing `services.beamvm`: persistent BEAM VMs as user
+# services (native launchd agent on macOS, systemd user unit on Linux via
+# portable-services), with the OTP applications each VM hosts declared in Nix
+# and hot-swapped on switch instead of restarted.
+#
+# The no-restart contract, split across three layers so it holds by
+# construction rather than by detection:
+#
+#   * The unit's command line references only the beamvm package and stable
+#     $XDG paths, never a tenant's store path, so updating an app cannot
+#     change the unit definition and cannot restart the VM.
+#   * The manifest of apps lives at a stable xdg.configFile path whose symlink
+#     home-manager rewrites at switch; an activation hook then pokes the VM's
+#     control socket and the harness converges live (add/remove apps, swap
+#     changed modules in place; see packages/beamvm/harness.ex).
+#   * Updating the beamvm package itself (new harness code or a new
+#     Erlang/Elixir toolchain) DOES change the unit and restarts it: exactly
+#     the one case where hot reload is impossible (a new ERTS cannot be
+#     entered from a running VM).
+{
+  indexPackages,
+  portableServicesModule,
+  ix,
+}: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit
+    (lib)
+    getExe'
+    mkIf
+    mkOption
+    optionalString
+    types
+    ;
+
+  cfg = config.services.beamvm;
+
+  defaultPackage = (indexPackages pkgs.stdenv.hostPlatform.system).beamvm;
+
+  jsonFormat = pkgs.formats.json {};
+
+  stateDirFor = name: vm:
+    if vm.stateDir != null
+    then toString vm.stateDir
+    else "${config.xdg.stateHome}/beamvm/${name}";
+
+  manifestTargetFor = name: "beamvm/${name}/manifest.json";
+
+  manifestFor = name: vm:
+    jsonFormat.generate "beamvm-${name}-manifest.json" {
+      apps =
+        lib.mapAttrs (_appName: app: {
+          # Globs, expanded by the harness: a release's `lib/<dep>-<vsn>/ebin`
+          # layout is only enumerable after the package builds, and expanding
+          # here would be import-from-derivation.
+          code_path_globs = ["${app.package}/lib/*/ebin"] ++ app.extraCodePathGlobs;
+          inherit (app) start;
+          runtime_config_globs =
+            lib.optional app.releaseRuntimeConfig "${app.package}/releases/*/runtime.exs";
+        })
+        vm.apps;
+    };
+
+  appSubmodule = types.submodule {
+    options = {
+      package = mkOption {
+        type = types.package;
+        description = ''
+          Mix release providing this application's compiled code
+          (`lib/<app>-<vsn>/ebin` for the app and every runtime dep). The
+          harness skips release-bundled toolchain libraries (elixir, stdlib,
+          logger, ...) that the VM already loaded, so releases built against
+          the same pinned toolchain as beamvm compose safely.
+        '';
+      };
+
+      start = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Start the application (ensure_all_started) after loading its code.
+          False loads code only, for library tenants another app calls into.
+        '';
+      };
+
+      releaseRuntimeConfig = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Replay the release's `releases/*/runtime.exs` (the config provider
+          a release boot script would run) before starting the app. Harmless
+          when the release has none.
+        '';
+      };
+
+      extraCodePathGlobs = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Additional ebin-dir globs appended to the release's own.";
+      };
+    };
+  };
+
+  vmSubmodule = types.submodule {
+    options = {
+      apps = mkOption {
+        type = types.attrsOf appSubmodule;
+        default = {};
+        description = "OTP applications this VM loads and runs, keyed by application name.";
+      };
+
+      environment = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+        description = ''
+          Environment variables for the VM process (shared by every app in
+          it). Rendered into the world-readable unit; secrets go through
+          environmentFile or secretsCommand instead.
+
+          Changing these does NOT hot-reload: the environment lives in the
+          unit definition, so the portable-services layer restarts the VM.
+          That is the honest semantics -- OS process env cannot be swapped
+          from inside.
+        '';
+      };
+
+      environmentFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          KEY=VALUE secrets file sourced by the launch wrapper at start
+          (launchd has no systemd EnvironmentFile). Point it at a runtime
+          path owned by your secret manager.
+        '';
+      };
+
+      secretsCommand = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        description = ''
+          Optional command wrapping the harness exec to inject secrets
+          (Bitwarden `bws run -- ...` or any CLI that execs its trailing
+          arguments). Put the injector on PATH via extraPath.
+        '';
+      };
+
+      extraPath = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = "Extra packages on the VM's PATH, for apps that shell out.";
+      };
+
+      stateDir = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Directory for the control socket. Null uses
+          `$XDG_STATE_HOME/beamvm/<name>`.
+        '';
+      };
+    };
+  };
+
+  # The repo's checked-bash writer, same shape as the symphony launcher: an
+  # exec-style wrapper (POSIX `.` sourcing of the secrets file, exec handoff
+  # to the optional secrets injector) is the sanctioned bash escape hatch.
+  # `runtimeInputs` prepends extraPath to PATH for apps that shell out.
+  launcherFor = name: vm:
+    ix.writeBashApplication pkgs {
+      name = "beamvm-${name}-launch";
+      runtimeInputs = vm.extraPath;
+      text =
+        optionalString (vm.environmentFile != null) ''
+          # launchd has no EnvironmentFile, so the wrapper sources the
+          # secrets file itself. set -a exports everything it sets.
+          set -a
+          # shellcheck disable=SC1090
+          . ${lib.escapeShellArg (toString vm.environmentFile)}
+          set +a
+        ''
+        + ''
+          export BEAMVM_STATE_DIR=${lib.escapeShellArg (stateDirFor name vm)}
+          export BEAMVM_MANIFEST=${lib.escapeShellArg "${config.xdg.configHome}/${manifestTargetFor name}"}
+          exec ${
+            optionalString (vm.secretsCommand != null) (lib.escapeShellArgs vm.secretsCommand + " ")
+          }${getExe' cfg.package "beamvm-harness"}
+        '';
+    };
+in {
+  imports = [portableServicesModule];
+
+  options.services.beamvm = {
+    package = mkOption {
+      type = types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "index.packages.\${system}.beamvm";
+      description = ''
+        The beamvm harness + ctl package. Updating it (or the Erlang/Elixir
+        toolchain inside it) restarts every VM; that is the one update class
+        hot reload cannot cover.
+      '';
+    };
+
+    vms = mkOption {
+      type = types.attrsOf vmSubmodule;
+      default = {};
+      description = "Persistent BEAM VMs to run, keyed by VM name.";
+    };
+  };
+
+  config = mkIf (cfg.vms != {}) {
+    xdg.configFile =
+      lib.mapAttrs' (
+        name: vm:
+          lib.nameValuePair (manifestTargetFor name) {source = manifestFor name vm;}
+      )
+      cfg.vms;
+
+    services.portable =
+      lib.mapAttrs' (
+        name: vm:
+          lib.nameValuePair "beamvm-${name}" {
+            description = "beamvm ${name}: persistent BEAM VM";
+            command = [(lib.getExe (launcherFor name vm))];
+            inherit (vm) environment;
+            # The VM hosts long-running supervision trees; the unit's whole
+            # job is keeping it up from login onward.
+            restart = "always";
+            runAtLoad = true;
+          }
+      )
+      cfg.vms;
+
+    # After home-manager rewrites the manifest symlinks (and after the
+    # platform's unit-management step handled any unit-definition changes),
+    # poke each running VM to converge on the new manifest. "Not running"
+    # (exit 2) is fine -- the next start reads the same stable path -- but a
+    # running VM that fails to reload fails the switch loudly.
+    home.activation =
+      lib.mapAttrs' (
+        name: vm:
+          lib.nameValuePair "beamvmReload-${name}" (
+            lib.hm.dag.entryAfter ["linkGeneration" "reloadSystemd" "setupLaunchAgents"] ''
+              beamvm_reload_${lib.replaceStrings ["-"] ["_"] name}() {
+                local rc=0
+                run ${getExe' cfg.package "beamvm-ctl"} \
+                  --socket ${lib.escapeShellArg "${stateDirFor name vm}/control.sock"} \
+                  reload || rc=$?
+                if [ "$rc" -eq 2 ]; then
+                  verboseEcho "beamvm ${name}: not running; next start reads the current manifest"
+                elif [ "$rc" -ne 0 ]; then
+                  echo "beamvm ${name}: hot reload failed (exit $rc)" >&2
+                  return "$rc"
+                fi
+              }
+              beamvm_reload_${lib.replaceStrings ["-"] ["_"] name}
+            ''
+          )
+      )
+      cfg.vms;
+  };
+}

--- a/packages/beamvm/home-module.nix
+++ b/packages/beamvm/home-module.nix
@@ -58,6 +58,12 @@
           # here would be import-from-derivation.
           code_path_globs = ["${app.package}/lib/*/ebin"] ++ app.extraCodePathGlobs;
           inherit (app) start;
+          # sys.config carries the baked build-time config (config.exs +
+          # prod.exs; `server: true` for Phoenix lives there), runtime.exs the
+          # boot-time env reads; the harness applies them in that order, as a
+          # release boot would.
+          sys_config_globs =
+            lib.optional app.releaseRuntimeConfig "${app.package}/releases/*/sys.config";
           runtime_config_globs =
             lib.optional app.releaseRuntimeConfig "${app.package}/releases/*/runtime.exs";
         })

--- a/packages/beamvm/package.nix
+++ b/packages/beamvm/package.nix
@@ -1,0 +1,10 @@
+# Registry metadata. The harness + ctl pair is a flake package (`nix build
+# .#beamvm`, `index.packages.<sys>.beamvm`); the home-module that composes it
+# into a portable service is exposed as `homeModules.beamvm` from flake.nix.
+{
+  id = "beamvm";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  passthruTests = true;
+}

--- a/packages/beamvm/test/demo-v1.ex
+++ b/packages/beamvm/test/demo-v1.ex
@@ -1,0 +1,35 @@
+# Version 1 of the hot-reload demo app: a supervised gen_server that appends
+# its compiled-in version and its own pid to $DEMO_OUT every 100 ms. The test
+# swaps this module for demo-v2.ex (identical except vsn/0) and requires the
+# heartbeat to change version WITHOUT the pid changing.
+defmodule Demo.App do
+  use Application
+
+  def start(_type, _args) do
+    Supervisor.start_link([Demo.Server], strategy: :one_for_one, name: Demo.Supervisor)
+  end
+end
+
+defmodule Demo.Server do
+  use GenServer
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_args) do
+    Process.send_after(self(), :beat, 100)
+    {:ok, nil}
+  end
+
+  @impl true
+  def handle_info(:beat, state) do
+    out = System.fetch_env!("DEMO_OUT")
+    File.write!(out, "vsn=#{vsn()} pid=#{inspect(self())}\n", [:append])
+    Process.send_after(self(), :beat, 100)
+    {:noreply, state}
+  end
+
+  defp vsn, do: 1
+end

--- a/packages/beamvm/test/demo-v2.ex
+++ b/packages/beamvm/test/demo-v2.ex
@@ -1,0 +1,34 @@
+# Version 2 of the hot-reload demo app: identical to demo-v1.ex except vsn/0,
+# so a hot swap flips the heartbeat version while the server process (and
+# therefore its pid) survives untouched.
+defmodule Demo.App do
+  use Application
+
+  def start(_type, _args) do
+    Supervisor.start_link([Demo.Server], strategy: :one_for_one, name: Demo.Supervisor)
+  end
+end
+
+defmodule Demo.Server do
+  use GenServer
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_args) do
+    Process.send_after(self(), :beat, 100)
+    {:ok, nil}
+  end
+
+  @impl true
+  def handle_info(:beat, state) do
+    out = System.fetch_env!("DEMO_OUT")
+    File.write!(out, "vsn=#{vsn()} pid=#{inspect(self())}\n", [:append])
+    Process.send_after(self(), :beat, 100)
+    {:noreply, state}
+  end
+
+  defp vsn, do: 2
+end

--- a/packages/beamvm/test/demo.app
+++ b/packages/beamvm/test/demo.app
@@ -1,0 +1,11 @@
+%% OTP application resource for the hot-reload demo (see demo-v1.ex). Written
+%% by hand because the demo is compiled with bare elixirc, not mix, which
+%% would otherwise generate this from mix.exs.
+{application, demo, [
+  {description, "beamvm hot-reload demo"},
+  {vsn, "1.0.0"},
+  {modules, ['Elixir.Demo.App', 'Elixir.Demo.Server']},
+  {registered, []},
+  {applications, [kernel, stdlib, elixir]},
+  {mod, {'Elixir.Demo.App', []}}
+]}.

--- a/tests/symphony-home-module.nix
+++ b/tests/symphony-home-module.nix
@@ -37,6 +37,7 @@
       passthru = {
         release = releaseStub;
         root = "/stub/symphony-root";
+        runtimeTools = [pkgs.jq];
       };
     } ''
       mkdir -p "$out/bin"
@@ -60,12 +61,23 @@
     };
   };
 
-  # The beamvm branch anchors the default state dir at xdg.stateHome, which
+  # The beamvm branch anchors the default state dir at xdg.stateHome and
+  # writes the catalog symlink through xdg.configFile, both of which
   # home-manager normally declares.
   xdgDecl = {
-    options.xdg.stateHome = lib.mkOption {
-      type = lib.types.str;
-      default = "/home/dev/.local/state";
+    options.xdg = {
+      stateHome = lib.mkOption {
+        type = lib.types.str;
+        default = "/home/dev/.local/state";
+      };
+      configHome = lib.mkOption {
+        type = lib.types.str;
+        default = "/home/dev/.config";
+      };
+      configFile = lib.mkOption {
+        type = lib.types.attrsOf lib.types.anything;
+        default = {};
+      };
     };
   };
 
@@ -225,8 +237,18 @@
       message = "beamvm runtime should host the compiled release (package.release)";
     }
     {
-      assertion = beamvmVm.environment.SYMPHONY_ROOT == "/stub/symphony-root";
-      message = "SYMPHONY_ROOT should point at the package's read-only catalog tree";
+      # The stable config symlink, NOT the store path: a store path in the
+      # unit environment would restart the VM on every symphony update.
+      assertion = beamvmVm.environment.SYMPHONY_ROOT == "/home/dev/.config/symphony/root";
+      message = "SYMPHONY_ROOT should go through the stable config symlink";
+    }
+    {
+      assertion = beamvm.xdg.configFile."symphony/root".source == "/stub/symphony-root";
+      message = "the catalog symlink should retarget to the package root at switch";
+    }
+    {
+      assertion = lib.elem pkgs.jq beamvmVm.extraPath;
+      message = "the package's runtimeTools should reach the VM PATH (workflow scripts shell out)";
     }
     {
       # config.ex mkdir_p!'s these; a store-rooted default would crash, so

--- a/tests/symphony-home-module.nix
+++ b/tests/symphony-home-module.nix
@@ -24,15 +24,55 @@
     };
   };
 
-  # Eval-only stand-in for the symphony package: lib.getExe only constructs
-  # the /bin path string, so the stub is instantiated but never built.
-  symphonyStub = pkgs.runCommand "symphony" {meta.mainProgram = "symphony";} ''
-    mkdir -p "$out/bin"
+  # Eval-only stand-ins: lib.getExe and the manifest render only construct
+  # store-path strings, so the stubs are instantiated but never built. The
+  # release/root passthrus mirror the real package's (home-module defaults
+  # dereference them).
+  releaseStub = pkgs.runCommand "symphony-release" {} ''
+    mkdir -p "$out"
   '';
+  symphonyStub =
+    pkgs.runCommand "symphony" {
+      meta.mainProgram = "symphony";
+      passthru = {
+        release = releaseStub;
+        root = "/stub/symphony-root";
+      };
+    } ''
+      mkdir -p "$out/bin"
+    '';
+
+  # Options-only stand-in for the beamvm home-module, mirroring
+  # portableDecl: the mapping from services.symphony onto services.beamvm is
+  # what this test owns; the beamvm module's own rendering (manifest, unit,
+  # activation) is exercised by its package checks and real home-manager
+  # evals.
+  beamvmDecl = {
+    options.services.beamvm = {
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.hello;
+      };
+      vms = lib.mkOption {
+        type = lib.types.attrsOf lib.types.anything;
+        default = {};
+      };
+    };
+  };
+
+  # The beamvm branch anchors the default state dir at xdg.stateHome, which
+  # home-manager normally declares.
+  xdgDecl = {
+    options.xdg.stateHome = lib.mkOption {
+      type = lib.types.str;
+      default = "/home/dev/.local/state";
+    };
+  };
 
   homeModule = import (paths.root + "/packages/agent/symphony/home-module.nix") {
     indexPackages = _system: {symphony = symphonyStub;};
     portableServicesModule = portableDecl;
+    beamvmModule = beamvmDecl;
     inherit ix;
   };
 
@@ -42,6 +82,7 @@
         # Inject `pkgs` the way home-manager does (a module arg), not via
         # specialArgs.
         {_module.args.pkgs = pkgs;}
+        xdgDecl
         homeModule
         {services.symphony = settings;}
       ];
@@ -50,6 +91,9 @@
   # Full configuration: every knob that changes the rendered units.
   full = evalSymphony {
     enable = true;
+    # These assertions cover the dedicated-unit render; the beamvm mapping
+    # has its own set below.
+    runtime = "standalone";
     httpPort = 4141;
     stateDir = "/home/dev/.local/state/symphony";
     primaryRepo = "/home/dev/src/index";
@@ -66,7 +110,14 @@
 
   # Defaults: only enable set, so the launcher owns state-dir and pack
   # resolution and the wrapper is a bare exec.
-  minimal = evalSymphony {enable = true;};
+  minimal = evalSymphony {
+    enable = true;
+    runtime = "standalone";
+  };
+
+  # The default runtime: the compiled release hosted in the persistent VM.
+  beamvm = evalSymphony {enable = true;};
+  beamvmVm = beamvm.services.beamvm.vms.symphony;
 
   fullSpec = full.services.portable.symphony;
   fullLaunchd = ps.toLaunchdConfig fullSpec;
@@ -162,6 +213,35 @@
         hasDrvInfix "exec ${symphonyStub}/bin/symphony \"$@\"" minimalLauncher.text
         && !(lib.hasInfix "set -a" minimalLauncher.text);
       message = "without environmentFile/secretsCommand the wrapper should be a bare exec";
+    }
+
+    # --- beamvm runtime (the default): mapping onto services.beamvm ---
+    {
+      assertion = !(beamvm.services.portable ? symphony);
+      message = "beamvm runtime should not also render the standalone unit";
+    }
+    {
+      assertion = beamvmVm.apps.symphony_elixir.package == releaseStub;
+      message = "beamvm runtime should host the compiled release (package.release)";
+    }
+    {
+      assertion = beamvmVm.environment.SYMPHONY_ROOT == "/stub/symphony-root";
+      message = "SYMPHONY_ROOT should point at the package's read-only catalog tree";
+    }
+    {
+      # config.ex mkdir_p!'s these; a store-rooted default would crash, so
+      # every writable dir must be anchored explicitly under the state dir.
+      assertion =
+        beamvmVm.environment.SYMPHONY_STATE_DIR
+        == "/home/dev/.local/state/symphony"
+        && beamvmVm.environment.SYMPHONY_WORKSPACES_DIR == "/home/dev/.local/state/symphony/workspaces"
+        && beamvmVm.environment.SYMPHONY_RUNS_DIR == "/home/dev/.local/state/symphony/runs"
+        && beamvmVm.environment.SYMPHONY_LOGS_ROOT == "/home/dev/.local/state/symphony/log";
+      message = "beamvm runtime should anchor every writable dir under the state dir";
+    }
+    {
+      assertion = beamvmVm.environment.SYMPHONY_HTTP_PORT == "4040";
+      message = "beamvm runtime should keep env parity for the HTTP port";
     }
   ];
 


### PR DESCRIPTION
## What

A generic persistent-BEAM-VM layer: one long-lived Erlang node as a user service (native launchd agent on macOS, systemd user unit on Linux via portable-services), the OTP applications it hosts declared in Nix, and **updates hot-swapped into the running VM instead of restarting it**. Symphony is the first tenant and now runs this way by default.

## How the no-restart contract holds (by construction, not detection)

- The unit's command line references only the beamvm package and stable `$XDG` paths, never a tenant's store path: an app update cannot change the unit definition, so nothing restarts.
- The app manifest is an `xdg.configFile` symlink home-manager rewrites at switch; an activation hook then pokes the VM's unix control socket (`beamvm-ctl reload`) and the harness converges live.
- Updating beamvm itself (harness code or the Erlang/Elixir toolchain) does change the unit and restarts it: exactly the one case hot reload cannot cover (you cannot enter a new ERTS from a running VM).

## The harness (packages/beamvm/harness.ex)

- Manifest of apps with code-path globs (`lib/*/ebin`), expanded in the VM because a release's lib layout is only enumerable post-build (eval-time expansion would be IFD).
- Reload: swap the tenant's code paths, `:code.modified_modules/0` + soft-purge + `:code.atomic_load/1` (all-or-nothing), falling back to per-module brutal purge+load where a process is stuck on old code (its supervisor restarts it on new code).
- Release boot parity: `releases/*/sys.config` deep-merged with `runtime.exs` via `Config.Reader.merge`, exactly as a release's config provider chain would. (Sequential `put_all_env` clobbers sibling keys: symphony's `server: true` lives in sys.config while runtime.exs sets only `http:` under the same endpoint key, and the naive order booted Phoenix with no listener.)
- Toolchain libs bundled in a release (elixir, stdlib, logger, ...) are skipped when already loaded, but a tenant's OWN previous dirs count as replaceable, not double-claimed, so a v2 release actually swaps.
- `:temporary` app starts: a tenant crashing out must not take other tenants' VM down; failures are loud in the log and `beamvm-ctl status`.

## Symphony integration

- `packages/agent/symphony` gains `passthru.release`: a real `mixRelease` (prod-env FOD pinned in pins.json), so nothing compiles at boot anymore in this mode. `__darwinAllowLocalNetworking` on hex/FOD/release: Mix 1.18+ opens a loopback TCP socket (Mix.Sync.PubSub) unconditionally, which the darwin sandbox otherwise denies.
- `services.symphony.runtime = "beamvm"` (default) hosts the release in `services.beamvm.vms.symphony` with full env parity with bin/run-nix, except `SYMPHONY_ROOT` points read-only at the store catalogs and every writable dir is anchored explicitly (config.ex `mkdir_p!`s them, which must never resolve to a store default). `"standalone"` keeps the exact previous behavior.

## Validation (all exercised, not asserted)

- **Sandbox check** `beamvm.tests.hot-reload`: boots a supervised gen_server heartbeating its compiled-in version + pid, flips the manifest, reloads, and requires the new version from the SAME server pid in the SAME OS process. Passing.
- **Live end-to-end with the real symphony release**: booted in the harness (36 apps), LiveView dashboard served HTTP 200; patched a template, built release v2, `beamvm-ctl reload` hot-swapped 5 modules (`SymphonyElixirWeb.Layouts` et al) and the same OS pid immediately served the new title. Zero downtime observed.
- home-manager eval smoke: `homeModules.symphony` (beamvm default), `runtime = "standalone"`, and bare `homeModules.beamvm` all render generations.
- Repo lint clean.

## Notes for review

- The symphony `runtime` default flip is deliberate per the operator's ask ("even when symphony updates it should by default just hot reload the beam vm without downtime"); flip back per-host with one line if a deployment needs the old path.
- VM-level `environment` changes DO restart (env lives in the unit; OS process env cannot be swapped from inside) — documented on the option.

_Made with Claude Opus 4.8._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add persistent BEAM VM with Nix-declared apps and hot code reload, defaulting symphony to run in it
> - Introduces a new [`beamvm` package](https://github.com/indexable-inc/index/pull/2002/files#diff-728c98356df07c2218a2f2a550d816d9c5eb51defcc4fc096f8d0c7c540534db) consisting of `beamvm-harness` (an Elixir OTP process that listens on a UNIX control socket) and `beamvm-ctl` (a bash client using `socat`/`jq`) to manage a long-lived BEAM node.
> - Adds [packages/beamvm/harness.ex](https://github.com/indexable-inc/index/pull/2002/files#diff-32a161d97e0e0d9d6a4fb55fa4ea9684d6a433b4c35a3c17fced234bde0a743f), which reads a JSON manifest of apps, hot-swaps code via `:code` soft-purge/atomic-load, and applies `sys.config`/`runtime.exs` without restarting the VM.
> - Adds [packages/beamvm/home-module.nix](https://github.com/indexable-inc/index/pull/2002/files#diff-87a70526d701e0f03dd22ef53d040ba367ce8c5fc39339c43d8b0a7083807400), a home-manager module (`services.beamvm`) that renders a portable service per VM and runs `beamvm-ctl reload` on activation to hot-reload apps after each `home-manager switch`.
> - Extends [packages/agent/symphony/home-module.nix](https://github.com/indexable-inc/index/pull/2002/files#diff-0b5afdb67fffaefb032bf05aadaaef8312dc2037c837d885503184d758fa064f) with a `runtime` option (`"beamvm"` | `"standalone"`); the default `"beamvm"` provisions symphony as a BEAM VM app instead of a standalone portable service unit.
> - Behavioral Change: existing symphony deployments switch to the `beamvm` runtime by default; set `services.symphony.runtime = "standalone"` to preserve prior behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 646c379.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->