### PR TITLE
mcp: bundle cursor-sdk (official Cursor Python SDK) into the kernel interpreter

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -967,6 +967,38 @@
       doCheck = false;
     };
 
+  # cursor-sdk: Cursor's official Python SDK -- script the same agent that runs
+  # in the Cursor IDE/CLI (local or cloud runtimes) from a session, e.g.
+  # Composer as a cheap delegated codebase-search agent
+  # (`from cursor_sdk import AsyncAgent`). Wheel-only on PyPI (the sdist is a
+  # stub; each wheel bundles that platform's SDK bridge binary), so pins.json
+  # carries one wheel per nix system. Its one runtime dep is the bundled httpx.
+  # No credentials ship: the caller brings CURSOR_API_KEY or a logged-in
+  # cursor-agent. License is Cursor's proprietary SDK beta license; the marker
+  # is omitted for the same allowUnfree reason as the cursor-cli/claude-code
+  # vendored binaries.
+  cursorSdkModule = let
+    pin =
+      pypiPins."cursor_sdk-${pkgs.stdenv.hostPlatform.system}"
+        or (throw "cursor-sdk: no pinned wheel for ${pkgs.stdenv.hostPlatform.system}");
+  in
+    pkgs.python3.pkgs.buildPythonPackage {
+      pname = "cursor-sdk";
+      inherit (pin) version;
+      format = "wheel";
+      src = pkgs.fetchurl {inherit (pin) url hash;};
+      # The manylinux wheel's bridge binary needs its interpreter/rpaths
+      # rewritten to run from the store on NixOS.
+      nativeBuildInputs = lib.optional pkgs.stdenv.hostPlatform.isElf pkgs.autoPatchelfHook;
+      buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+        pkgs.stdenv.cc.cc.lib
+        pkgs.zlib
+      ];
+      dependencies = [pkgs.python3.pkgs.httpx];
+      pythonImportsCheck = ["cursor_sdk"];
+      doCheck = false;
+    };
+
   # The Spark Connect client `fleet.spark()` drives, pinned to the cluster's Spark
   # version (3.5.x, via spark-hive + spark-gluten in services.ix-spark). A Connect
   # client MUST match the server's minor, and nixpkgs' default pyspark is 4.x, so
@@ -1188,6 +1220,10 @@
       # REST API. No key is bundled: the caller brings `EXA_API_KEY` (sourced
       # from rbw/op per the secrets split), e.g. `Exa(os.environ["EXA_API_KEY"])`.
       ps.exa-py
+      # cursor-sdk: Cursor's official agent SDK (see the module definition
+      # above) so a session can run local/cloud Cursor agents with no install
+      # step.
+      cursorSdkModule
       # Gmail / Google Workspace, the "third surface" for an integration alongside
       # the MCP binding and the index CLI (RFC 0003): a session can drive the
       # Gmail and Calendar APIs directly with no install step. This is the official
@@ -1655,6 +1691,11 @@
     + "import google_auth_oauthlib, google_auth_httplib2; "
     + "build('gmail', 'v1', credentials=Credentials(token='x'), static_discovery=True); "
     + "print('gmail-libs-ok')"
+  );
+  cursorSdkBundled = importTest "cursor-sdk" (
+    "import cursor_sdk; from cursor_sdk import AsyncAgent, AsyncClient; "
+    + "assert callable(getattr(AsyncAgent, 'create', None)); "
+    + "print('cursor-sdk-ok')"
   );
   exaBundled = importTest "exa" (
     "from exa_py import Exa; e = Exa('dummy-key'); "
@@ -5869,6 +5910,7 @@ in
               dataLibsBundled
               gmailLibsBundled
               exaBundled
+              cursorSdkBundled
               googleAuthBundled
               ixGoogleBundled
               slackBundled

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -367,6 +367,18 @@ LIBRARIES: tuple[Library, ...] = (
             url="https://dashboard.exa.ai/api-keys",
         ),
     ),
+    Library(
+        "cursor_sdk",
+        # Cursor's official agent SDK: run the same agent as the Cursor IDE/CLI
+        # (local or cloud) from a cell, e.g. Composer as a cheap delegated
+        # codebase-search agent. No key is bundled; local runs also honor a
+        # logged-in `cursor-agent`.
+        credential=Credential(
+            service="Cursor",
+            env=("CURSOR_API_KEY",),
+            url="https://cursor.com/dashboard",
+        ),
+    ),
 )
 
 

--- a/packages/mcp/pins.json
+++ b/packages/mcp/pins.json
@@ -28,5 +28,25 @@
     "version": "9.27.0",
     "url": "https://pypi.io/packages/source/p/pymobiledevice3/pymobiledevice3-9.27.0.tar.gz",
     "hash": "sha256-pYRzvX86tRUjYDuU7fBSD0VCTfE/sITJSId012+O7+8="
+  },
+  "cursor_sdk-aarch64-darwin": {
+    "version": "0.1.9",
+    "url": "https://files.pythonhosted.org/packages/dd/6d/41851a2ee1c56e541d720fab9837b4c74222af5a0d5d1f8a35a40111a014/cursor_sdk-0.1.9-py3-none-macosx_11_0_arm64.whl",
+    "hash": "sha256-J4yuFyim24nq0DNs03JBnSTvGGrtv/6bct8t2iektDs="
+  },
+  "cursor_sdk-x86_64-darwin": {
+    "version": "0.1.9",
+    "url": "https://files.pythonhosted.org/packages/1b/cc/233da13e0d6b58728db8c288aa78c15f82a1e771379b5933adf7e0f585cf/cursor_sdk-0.1.9-py3-none-macosx_11_0_x86_64.whl",
+    "hash": "sha256-F+pff3S1sgN8bfULmJg2VE6PiNuKRQU2uqN6rWNWl80="
+  },
+  "cursor_sdk-aarch64-linux": {
+    "version": "0.1.9",
+    "url": "https://files.pythonhosted.org/packages/43/05/15da63d82878f4329888fc3ffbf5f3cd05a49656b56beeb8200b112432d4/cursor_sdk-0.1.9-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+    "hash": "sha256-ZkyJE6hm7MNUWPKr3Si60aslLDOm9WVQkNCoAzgSBtw="
+  },
+  "cursor_sdk-x86_64-linux": {
+    "version": "0.1.9",
+    "url": "https://files.pythonhosted.org/packages/e8/a0/3e5962967ce1b2c52013314799dbe9946b4699dfe90a4424d8c89a38c022/cursor_sdk-0.1.9-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+    "hash": "sha256-oKk+1FvnZCGkuXI9pALq1iJJDdDtuhcbXAxpMZ/X9sc="
   }
 }


### PR DESCRIPTION
Bundles Cursor's official Python SDK (PyPI `cursor-sdk` 0.1.9) into the ix-mcp interpreter, so a kernel session can script Cursor agents with no install step — e.g. Composer 2.5 as a cheap delegated codebase-search agent (`from cursor_sdk import AsyncAgent`). Closes #2000; follow-up to #1998 / #1987.

- pins.json: one wheel per nix system (PyPI is wheel-only; each wheel bundles that platform's SDK bridge binary). One runtime dep, the already-bundled httpx.
- Linux wheels are manylinux2014, so the module runs autoPatchelf with cc.lib + zlib.
- Registered in the instructions registry as a credentialed library (`CURSOR_API_KEY`; local runs also honor a logged-in `cursor-agent`).
- `cursorSdkBundled` import check (`nix build .#mcp.tests.cursorSdkBundled` passes on aarch64-darwin: AsyncAgent/AsyncClient import and expose `create`).

(PR by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle `cursor_sdk` into the MCP kernel interpreter
> - Adds a new Nix package derivation `cursorSdkModule` in [default.nix](https://github.com/indexable-inc/index/pull/2003/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) built from pinned per-platform wheels (version 0.1.9) sourced from PyPI via [pins.json](https://github.com/indexable-inc/index/pull/2003/files#diff-9bb64c6ecdb546a9a60587f16342cd4aa95a11a84fa42b27972e9c51a7f90ad4).
> - Applies `autoPatchelfHook` on ELF platforms and links `stdenv.cc.cc.lib`/`zlib` on Linux; declares `httpx` as a runtime dependency.
> - Registers `cursor_sdk` in [registry.py](https://github.com/indexable-inc/index/pull/2003/files#diff-92f567578e1217b8207dbbd21af1cdee4978728a8ca9e774cd65ed17170d2ae5) with credential metadata pointing to `CURSOR_API_KEY`.
> - Adds an import test verifying `AsyncAgent` and `AsyncClient` are accessible from `cursor_sdk` at build time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cdd259.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->