### PR TITLE
prompt: MCP guidance lives in the MCP instructions, not here

### DIFF
--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -147,6 +147,8 @@ let
         text = ''
           Before repository edits, create or enter a dedicated `git worktree` branch.
           If you are in the primary checkout, stop and move to a worktree before editing.
+          Before commit or branch work, verify the repo root and branch match the
+          assigned worktree.
         '';
         reason = ''
           Edits in the primary checkout collided with the user's and other agents'
@@ -662,27 +664,22 @@ let
       };
     }
     {
-      shellCwd = {
+      mcpGuidanceOwnership = {
         text = ''
-          `nu` is the one shell-out path: `await nu('<pipeline>')` returns a Polars
-          DataFrame, and an external binary runs with `^cmd` (`await nu('^git status')`).
-          The retired `sh()`/`zsh()` now raise a migration hint. The nu engine is a
-          persistent REPL: `cd`, `let`, `def`, and `$env` survive across calls, so a
-          later call inherits the previous call's PWD. Address paths explicitly
-          (`git -C <worktree>`, `cwd=<abs path>`) instead of relying on inherited
-          state, and never delete a directory an earlier call `cd`'ed into without
-          moving the engine out first: the next external spawn dies with `$env.PWD
-          points to a non-existent directory` (recover with an explicit `cwd=`).
-          Before commit or branch work, verify the repo root and branch match the
-          assigned worktree.
+          Guidance for driving the index MCP surface (`python_exec` mechanics, `nu`,
+          jobs, dashboard sessions, topics, and cells, bundled modules, `pr_watch`)
+          is authored in the MCP server's own instructions
+          (`packages/mcp/ix_notebook_mcp/guide.py`) and arrives with the connection.
+          This prompt only routes work to the kernel. When editing these
+          instructions, put MCP how-to in `guide.py`, never here.
         '';
         reason = ''
-          The prompt used to claim the kernel carried no cwd between calls; the
-          engine actually persists PWD (index#1986), so a `git worktree remove` of a
-          previously `cd`'ed dir broke the following call mid-block. Relying on
-          inherited cwd also landed commit and branch work in the wrong repo.
-          DataFrame-shaped command results are easier to inspect in the dashboard
-          than dicts or scraped text.
+          Restated MCP mechanics drifted twice in one day: the prompt claimed the
+          kernel kept no cwd while the engine persisted it (index#1986), then the
+          engine changed (index#1999) and the freshly corrected prompt text was
+          stale again within hours. Non-Claude MCP clients never see this prompt,
+          so the server instructions are the only owner that reaches every
+          consumer.
         '';
       };
     }
@@ -792,14 +789,10 @@ let
     {
       indexKernel = {
         text = ''
-          Work through the index Python kernel (`python_exec`) and reuse its namespace.
-          Search with the kernel `grep` and `find` builtins; run `api()` for helpers. Do not shell
-          out to `rg` or `fd` inside the kernel. Run independent non-mutating commands
-          concurrently with `asyncio.gather` or `asyncio.TaskGroup`. If the kernel
-          wedges, restart it or report the blocker. Set a dashboard topic before
-          clusters of related kernel work and change it at phase boundaries; keep
-          several related tool calls under one topic so completed phases can fold
-          away as one group.
+          Work through the index Python kernel (`python_exec`) for shell, search,
+          and data work, and reuse its namespace across calls. If the kernel
+          wedges, restart it or report the blocker. How to drive it comes from
+          the MCP server instructions, not this prompt.
         '';
         reason = ''
           Shelling out to `rg`/`fd` or sync subprocesses froze the kernel's single
@@ -808,24 +801,16 @@ let
       };
     }
     {
-      structuredPrimitives = {
+      pythonTypes = {
         text = ''
-          Prefer structured primitives over text munging: `view.ls`, `view.tree`,
-          `view.cat`, `grep`, `find`, and `nu` pipelines. For command output you plan
-          to filter or parse, run it through `nu` so the result arrives as a Polars
-          DataFrame — pipe a `--json` mode through `from json`, or reshape text with
-          nushell pipeline commands rather than jq/awk/sed. Return tables as Polars
-          DataFrames.
-
-
           For reusable Python, write explicit annotations at function and data
           boundaries. For package Python edits, run the repo's type-checking
           entry point when one exists; do not treat an untyped compile-only
           check as equivalent.
         '';
         reason = ''
-          Ad hoc text munging of command output was fragile, and combining commands in
-          one shell call lost individual errors.
+          Untyped kernel snippets promoted into packages shipped boundary bugs a
+          type-checker would have caught.
         '';
       };
     }
@@ -839,9 +824,6 @@ let
           After pushing to a PR branch with auto-merge armed, re-read the PR
           state: if it merged without the push, the commit is unlanded, so open
           a follow-up. Claim landed only when the merge oid contains the push.
-          When the MCP `pr_watch` tool is available, use it for PR CI ownership:
-          it creates a live PR resource, shows check durations, enables auto
-          merge by default, and notifies the CLI on merge, failure, or timeout.
         '';
         reason = ''
           Tasks were reported done at an open PR that never landed; done means merged

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -96,7 +96,8 @@ BLOCKING = (
     "them), and run anything slow as a background job you "
     "poll, never inline. To shell out, reach for `nu(...)` rather than a hand-rolled "
     "`asyncio.create_subprocess_exec/_shell` + `communicate()`, which runs synchronously on the "
-    "one loop and hands back ANSI-corrupted output."
+    "one loop and hands back ANSI-corrupted output. Run independent non-mutating commands "
+    "concurrently inside one cell with `asyncio.gather` or `asyncio.TaskGroup`."
 )
 
 RESULT_CONTRACT = (
@@ -111,10 +112,7 @@ RESULT_CONTRACT = (
     "`Result` is the opt-in for splitting the two views, `Result(user_html=..., llm_result=..., "
     "llm_images=...)`, when the human should see something rich that you should not pay tokens "
     "for (note: an explicit Result suppresses the automatic stdout echo; page "
-    "jobs['<id>'].output instead). For reusable Python in the kernel, write explicit "
-    "annotations at function and data boundaries. For package Python edits, run the repo's "
-    "type-checking entry point when one exists, and do not treat an untyped compile-only "
-    "check as equivalent."
+    "jobs['<id>'].output instead)."
 )
 
 # --- kernel guide only ---
@@ -182,9 +180,12 @@ NU = (
     "json')`); pass arguments as separate tokens so nushell never re-parses prose, and for `gh "
     "... --json` clear color forcing before `from json`: `with-env {NO_COLOR: \"1\" CLICOLOR: "
     "\"0\" CLICOLOR_FORCE: \"0\" FORCE_COLOR: \"0\"} { ^gh pr view 1 --json state | complete | "
-    "get stdout | from json }`. The engine is embedded and PERSISTENT, a REPL: a `let`, a `def`, "
-    "or a `cd` in one call is visible to the next, so bind an expensive fetch once (`let data = "
-    "http get ...`) and query it across calls; `nu.reset()` clears that state. Pipe a polars "
+    "get stdout | from json }`. The engine is embedded and PERSISTENT, a REPL: a `let` or a `def` "
+    "in one call is visible to the next, so bind an expensive fetch once (`let data = "
+    "http get ...`) and query it across calls; `nu.reset()` clears that state. PWD is the "
+    "exception: every call re-syncs it to the kernel process's cwd unless you pass `cwd=`, "
+    "so a `cd` does not outlive its call; address paths explicitly (`git -C <path>`, "
+    "absolute paths, `cwd=`). Pipe a polars "
     "frame you already have THROUGH a pipeline with `await nu(\"where a > 1 | sort-by a\", "
     "input=df)`. Use `await nu.value(code)` when you want the plain Python value (a scalar, a "
     "list, a dict) rather than a frame. A failing pipeline raises `NuError` carrying nushell's "

--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -152,6 +152,19 @@ def test_empty_record_is_one_row_zero_columns() -> None:
     assert df.shape == (1, 0)
 
 
+def test_cd_does_not_outlive_its_call(tmp_path: pathlib.Path) -> None:
+    # PWD re-syncs to the process cwd on every call (index#1986/#1999): a
+    # `cd` in one call must not leak into the next, and deleting a dir a
+    # previous call cd'ed into must not break later calls.
+    target = tmp_path / "transient"
+    target.mkdir()
+    run(nu(f"cd {target}"))
+    assert run(nu.value("$env.PWD")) == str(pathlib.Path.cwd())
+    run(nu(f"cd {target}"))
+    target.rmdir()
+    assert run(nu.value("2 + 2")) == 4
+
+
 def test_cwd_is_respected(tmp_path: pathlib.Path) -> None:
     (tmp_path / "hello.txt").write_text("hi")
     df = run(nu("ls | get name", cwd=tmp_path))

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -15,8 +15,9 @@ binary runs with ``^cmd``::
     df = await nu("^gh pr list --json number,title | from json")  # JSON-mode CLI
 
 This is not a subprocess: the engine (PyO3 bindings over nu-engine) lives in
-this process and its state is persistent, like a REPL. A ``let``, a ``def``,
-or a ``cd`` in one call is visible to the next::
+this process and its state is persistent, like a REPL. A ``let`` or a ``def``
+in one call is visible to the next (``PWD`` is the exception: it re-syncs to
+the process cwd each call, so a ``cd`` never outlives its call)::
 
     await nu("let prs = (http get $url)")
     await nu("$prs | where author.login == 'andrewgazelka'")
@@ -230,7 +231,8 @@ def _discard_engine(engine: Engine) -> None:
 
 
 def reset() -> None:
-    """Discard this session's persistent engine state (bindings, defs, cwd)."""
+    """Discard this session's persistent engine state (bindings and defs;
+    PWD is per-call, synced from the process cwd)."""
     _discard_engine(_default_engine())
 
 
@@ -378,10 +380,11 @@ async def nu(
     DataFrame.
 
     Multi-statement source is fine; the last pipeline's output is the result,
-    and ``let``/``def``/``cd`` persist to later calls (REPL semantics).
-    ``input`` pipes a value in as ``$in`` -- a polars DataFrame, list, dict,
-    or scalar (datetimes must be tz-aware). ``cwd`` sets ``PWD``
-    (persistently, like ``cd``); ``env`` adds environment variables;
+    and ``let``/``def`` persist to later calls (REPL semantics). ``PWD`` does
+    not: each call re-syncs it to the process cwd, so a ``cd`` never outlives
+    its call. ``input`` pipes a value in as ``$in`` -- a polars DataFrame,
+    list, dict, or scalar (datetimes must be tz-aware). ``cwd`` sets ``PWD``
+    for this call only; ``env`` adds environment variables;
     ``timeout`` interrupts the evaluation and discards the engine state (see
     the module docstring); ``name`` labels the running job in the dashboard.
 


### PR DESCRIPTION
Adds the ownership rule to the system prompt and applies it everywhere it was violated.

**The rule** (new `mcpGuidanceOwnership` section): guidance for driving the index MCP surface (`python_exec` mechanics, `nu`, jobs, dashboard sessions/topics/cells, bundled modules, `pr_watch`) is authored in the MCP server's own instructions (`packages/mcp/ix_notebook_mcp/guide.py`) and arrives with the connection; the prompt only routes work to the kernel. Evidence for single ownership: the restated mechanics drifted twice in one day (#1986 claimed no persistent cwd while the engine persisted it; then #1999 changed the engine and the freshly corrected #1997 text was stale within hours). Non-Claude MCP clients never see the prompt, so guide.py is the only owner that reaches every consumer.

**Prompt sections fixed under the rule:**
- `shellCwd` deleted (nu mechanics live in guide.py `NU`; its worktree-verification sentence moved into `worktree`)
- `indexKernel` slimmed to routing + wedge handling (`api()`/`grep`/topics are guide.py `SESSION`/`DISCOVER`/`NO_SHELL`)
- `structuredPrimitives` dropped (guide.py `NO_SHELL`/`NU`/`POLARS`); its general Python typing paragraph survives as `pythonTypes`, and the duplicate typing tail is removed from guide.py `RESULT_CONTRACT` (code policy is prompt-owned, kernel mechanics guide-owned)
- `autonomy` loses its `pr_watch` sentence (guide.py `PR_WATCH`)
- the `asyncio.gather` concurrency advice moved into guide.py `BLOCKING`

**Docs #1999 left stale, now aligned with the per-call PWD contract:** guide.py `NU` fragment, `nu()` docstring, module docstring, `reset()` docstring all still claimed `cd` persists across calls. Also adds the regression test #1999 shipped without (`test_cd_does_not_outlive_its_call`: a `cd` must not leak into the next call, and deleting a dir a previous call `cd`'ed into must not break later calls).

Validated: `nix build .#mcp` and `.#mcp.tests.nuTests` green on aarch64-darwin; prompt rendered via `nix eval` and changed sections reread; `nix fmt` clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move MCP usage guidance from system prompt into MCP server instructions
> - Removes MCP tool guidance (python_exec, nu, jobs, dashboard, pr_watch, etc.) from [system-prompt.nix](https://github.com/indexable-inc/index/pull/2007/files#diff-79e96dbc21d7175eddadc583fb80f58bab62dfa2273228a412e4cde2c4aed0df) and replaces it with a pointer to [guide.py](https://github.com/indexable-inc/index/pull/2007/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76), preventing drift and avoiding sending irrelevant guidance to non-Claude clients.
> - Clarifies `nu` PWD semantics: `let`/`def` persist across calls, but `PWD` re-syncs to the process cwd each call, so `cd` never outlives its invocation. This is enforced by a new test in [test_nu.py](https://github.com/indexable-inc/index/pull/2007/files#diff-64ceabff54157dc4841671fdb42fdf6652de63656b70c2be5c4de568d0216ff2).
> - Extends kernel blocking guidance in [guide.py](https://github.com/indexable-inc/index/pull/2007/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) to explicitly recommend running independent non-mutating commands concurrently via `asyncio.gather` or `asyncio.TaskGroup`.
> - Moves Python typing guidance (explicit annotations, type-checking entry points) from the system prompt's `structuredPrimitives` block (renamed to `pythonTypes`) into [guide.py](https://github.com/indexable-inc/index/pull/2007/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) under `RESULT_CONTRACT`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6cf021.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->