### PR TITLE
fix(nu-py): Path.cwd() over os.getcwd() to unbreak lint on main

### DIFF
--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -75,6 +75,7 @@ import contextlib
 import html as _html
 import inspect as _inspect
 import os
+from pathlib import Path
 import re
 import time
 from typing import TYPE_CHECKING
@@ -259,7 +260,7 @@ async def _run(
 ) -> object:
     """Evaluate ``code`` on the shared engine; return the plain Python value."""
     if cwd is None:
-        cwd = os.getcwd()
+        cwd = Path.cwd()
     if name is not None and _rename_current_job is not None and (
         _ix_current is not None and _ix_current.get() is not None
     ):


### PR DESCRIPTION
`nix run .#lint` is red whole-tree on main: `os.getcwd()` at `packages/nu-py/python/nu/__init__.py:260` trips ruff PTH109 (introduced by #1999). This blocks the shared pre-commit + CI lint entry point on every new branch. `cwd` is typed `str | os.PathLike` and flows through `os.fspath`, so `Path.cwd()` is a drop-in.

Closes #2012.

(PR by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix lint failure in `nu.__init__` by replacing `os.getcwd()` with `Path.cwd()`
> Replaces `os.getcwd()` with `Path.cwd()` from `pathlib` in the `nu._run` coroutine when `cwd` is `None`. This fixes a lint failure on main in [__init__.py](https://github.com/indexable-inc/index/pull/2013/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e80480.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->