### PR TITLE
fix(symphony): cron fires workflows by identity, not by schedule match

### DIFF
--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/trigger.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/trigger.ex
@@ -9,9 +9,9 @@ defmodule SymphonyElixir.Runtime.Trigger do
   `Runtime.Ingress.start_by_trigger/2`. That ingress asks
   `WorkflowCatalog.for_trigger_kind/1` for the candidates of that kind and
   keeps the ones `matches?/2` accepts. Cron does not route through here:
-  its tick evaluates one catalog entry at a time and fires it by name
-  (`Ingress.start_by_name/3`), because a schedule is not an identity;
-  matching on it would fire every workflow sharing the schedule.
+  its tick evaluates one catalog entry at a time and starts exactly that
+  entry (`Ingress.start_workflow/3`), because a schedule is not an
+  identity; matching on it would fire every workflow sharing the schedule.
 
   Keeping this predicate in one place is the point of the cutover: every
   producer used to re-implement its own `Catalog.dags() |> Enum.filter`

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/trigger.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/trigger.ex
@@ -3,12 +3,15 @@ defmodule SymphonyElixir.Runtime.Trigger do
   The one matcher every producer shares to resolve an inbound trigger event
   to the `.sym` workflows that declared interest in it.
 
-  A producer (cron, a webhook, the operator dashboard) builds a trigger
-  event map carrying `kind:` plus the kind's selector fields (a Slack
-  channel, a GitHub `repo`/`label`, a Linear `label`, a cron `schedule`),
-  then hands it to `Runtime.Ingress.start_by_trigger/2`. That ingress asks
+  A producer (a webhook, the operator dashboard) builds a trigger event
+  map carrying `kind:` plus the kind's selector fields (a Slack channel,
+  a GitHub `repo`/`label`, a Linear `label`), then hands it to
+  `Runtime.Ingress.start_by_trigger/2`. That ingress asks
   `WorkflowCatalog.for_trigger_kind/1` for the candidates of that kind and
-  keeps the ones `matches?/2` accepts.
+  keeps the ones `matches?/2` accepts. Cron does not route through here:
+  its tick evaluates one catalog entry at a time and fires it by name
+  (`Ingress.start_by_name/3`), because a schedule is not an identity;
+  matching on it would fire every workflow sharing the schedule.
 
   Keeping this predicate in one place is the point of the cutover: every
   producer used to re-implement its own `Catalog.dags() |> Enum.filter`
@@ -36,9 +39,6 @@ defmodule SymphonyElixir.Runtime.Trigger do
   The kinds already agree (the ingress filters by `kind` first), so this
   only compares the kind's selector fields:
 
-  - `:cron` matches when the declared `schedule` equals the event's
-    `schedule`. A cron tick fires one workflow at a time, so the producer
-    echoes the schedule it resolved and this re-selects exactly it.
   - `:linear` matches when the declared `label` is present on the event.
     The event carries the inbound issue's labels under `:labels`; a single
     matched label is enough.
@@ -54,9 +54,6 @@ defmodule SymphonyElixir.Runtime.Trigger do
   so a malformed event fires nothing rather than fanning out to every
   workflow of that kind.
   """
-  @spec matches?(declared(), event()) :: boolean()
-  def matches?(%{kind: :cron, schedule: schedule}, %{schedule: event_schedule}), do: schedule == event_schedule
-
   @spec matches?(declared(), event()) :: boolean()
   def matches?(%{kind: :linear, label: label}, %{labels: labels}) when is_list(labels), do: label in labels
 

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/triggers/cron.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/triggers/cron.ex
@@ -61,10 +61,10 @@ defmodule SymphonyElixir.Triggers.Cron do
   Datetimes are serialized as ISO 8601 strings because the trigger
   round-trips through JSON via `IR.Store`, and `Jason` has no built-in
   encoder for `DateTime`. Callers that need the datetime back parse it
-  with `DateTime.from_iso8601/1`. The `schedule` field is load-bearing for
-  resolution: `start_by_trigger/2` re-selects the workflow whose declared
-  cron schedule equals it, so the tick fires exactly the workflow it
-  evaluated.
+  with `DateTime.from_iso8601/1`. Resolution does not read this map: the
+  tick already holds the catalog entry it evaluated, so it starts that
+  workflow by name (`Ingress.start_by_name/3`). Matching by schedule
+  instead would fire every workflow sharing the schedule on each tick.
 
   ## Dedupe
 
@@ -87,7 +87,7 @@ defmodule SymphonyElixir.Triggers.Cron do
   require Logger
 
   @doc """
-  `opts` may carry `:run_opts`, forwarded to `Ingress.start_by_trigger/2`
+  `opts` may carry `:run_opts`, forwarded to `Ingress.start_by_name/3`
   (`:engine`, `:store_opts`), so a test drives a full tick against a fake
   engine and an isolated store. Production passes nothing.
   """
@@ -218,11 +218,16 @@ defmodule SymphonyElixir.Triggers.Cron do
       input: entry.trigger.input
     }
 
-    case Ingress.start_by_trigger(trigger, run_opts) do
+    # Fire by identity, not by trigger matching: this tick evaluated exactly
+    # one workflow's watermark, so it must start exactly that workflow.
+    # Resolving through `start_by_trigger/2` would select EVERY cron workflow
+    # sharing this schedule, turning N same-schedule workflows into N^2 runs
+    # per window (issue #2010).
+    case Ingress.start_by_name(entry.name, trigger, run_opts) do
       {:ok, started} ->
         :ok = CronState.record_fire(entry.name, now)
 
-        Logger.info("Cron started runs=#{Enum.map_join(started, ",", & &1.run_id)} workflow=#{entry.name} scheduled_for=#{DateTime.to_iso8601(scheduled_for)}")
+        Logger.info("Cron started run=#{started.run_id} workflow=#{entry.name} scheduled_for=#{DateTime.to_iso8601(scheduled_for)}")
 
       {:error, reason} ->
         Logger.warning("Cron failed to start workflow=#{entry.name}: #{inspect(reason)}")

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/triggers/cron.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/triggers/cron.ex
@@ -62,9 +62,9 @@ defmodule SymphonyElixir.Triggers.Cron do
   round-trips through JSON via `IR.Store`, and `Jason` has no built-in
   encoder for `DateTime`. Callers that need the datetime back parse it
   with `DateTime.from_iso8601/1`. Resolution does not read this map: the
-  tick already holds the catalog entry it evaluated, so it starts that
-  workflow by name (`Ingress.start_by_name/3`). Matching by schedule
-  instead would fire every workflow sharing the schedule on each tick.
+  tick already holds the catalog entry it evaluated and starts exactly it
+  (`Ingress.start_workflow/3`). Matching by schedule instead would fire
+  every workflow sharing the schedule on each tick.
 
   ## Dedupe
 
@@ -87,7 +87,7 @@ defmodule SymphonyElixir.Triggers.Cron do
   require Logger
 
   @doc """
-  `opts` may carry `:run_opts`, forwarded to `Ingress.start_by_name/3`
+  `opts` may carry `:run_opts`, forwarded to `Ingress.start_workflow/3`
   (`:engine`, `:store_opts`), so a test drives a full tick against a fake
   engine and an isolated store. Production passes nothing.
   """
@@ -218,12 +218,12 @@ defmodule SymphonyElixir.Triggers.Cron do
       input: entry.trigger.input
     }
 
-    # Fire by identity, not by trigger matching: this tick evaluated exactly
-    # one workflow's watermark, so it must start exactly that workflow.
-    # Resolving through `start_by_trigger/2` would select EVERY cron workflow
-    # sharing this schedule, turning N same-schedule workflows into N^2 runs
-    # per window (issue #2010).
-    case Ingress.start_by_name(entry.name, trigger, run_opts) do
+    # Fire the entry this tick evaluated, not a re-resolved one: resolving
+    # through `start_by_trigger/2` selected EVERY cron workflow sharing this
+    # schedule, turning N same-schedule workflows into N^2 runs per window
+    # (issue #2010). A by-name lookup would be wrong too: the catalog is
+    # keyed by file basename while `entry.name` is the DSL display name.
+    case Ingress.start_workflow(entry, trigger, run_opts) do
       {:ok, started} ->
         :ok = CronState.record_fire(entry.name, now)
 

--- a/packages/agent/symphony/elixir/test/symphony_elixir/runtime/trigger_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/runtime/trigger_test.exs
@@ -4,12 +4,6 @@ defmodule SymphonyElixir.Runtime.TriggerTest do
   alias SymphonyElixir.Runtime.Trigger
 
   describe "matches?/2" do
-    test "cron matches on the declared schedule" do
-      declared = %{kind: :cron, schedule: "0 9 * * *", timezone: "UTC", input: %{}}
-      assert Trigger.matches?(declared, %{kind: :cron, schedule: "0 9 * * *"})
-      refute Trigger.matches?(declared, %{kind: :cron, schedule: "@daily"})
-    end
-
     test "linear matches when the declared label is on the event" do
       declared = %{kind: :linear, label: "[sym] triage"}
       assert Trigger.matches?(declared, %{kind: :linear, labels: ["a", "[sym] triage"]})
@@ -39,9 +33,9 @@ defmodule SymphonyElixir.Runtime.TriggerTest do
       assert Trigger.matches?(%{kind: :manual}, %{kind: :manual, input: %{}})
     end
 
-    test "a nil or mismatched declared trigger never matches" do
+    test "a nil or unknown declared trigger never matches" do
       refute Trigger.matches?(nil, %{kind: :manual})
-      refute Trigger.matches?(%{kind: :cron, schedule: "x"}, %{kind: :cron})
+      refute Trigger.matches?(%{kind: :unknown}, %{kind: :unknown})
     end
   end
 end

--- a/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
@@ -267,8 +267,17 @@ defmodule SymphonyElixir.Triggers.CronTest do
       # workflows produced N runs per workflow per window (N^2 total).
       name_a = unique_name("shared-a")
       name_b = unique_name("shared-b")
-      write_cron_sym!(dir, name_a, ~s|"0 9 * * *" tz "America/Los_Angeles"|)
-      write_cron_sym!(dir, name_b, ~s|"0 9 * * *" tz "America/Los_Angeles"|)
+
+      # File basenames differ from the DSL workflow names on purpose: the
+      # catalog is keyed by basename while the tick works in display names,
+      # so a by-name re-lookup (instead of firing the held entry) would
+      # miss both workflows here.
+      for name <- [name_a, name_b] do
+        source = ~s|workflow "#{name}" on cron "0 9 * * *" tz "America/Los_Angeles" { a <- agent { engine: codex, model: "m", prompt: inline "go" } }|
+        File.write!(Path.join(dir, "file-#{name}.sym"), source)
+      end
+
+      WorkflowCatalog.scan(dir)
 
       seeded = DateTime.add(DateTime.utc_now(), -2, :day)
       :ok = CronState.seed_if_unset(name_a, seeded)

--- a/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/triggers/cron_test.exs
@@ -261,6 +261,38 @@ defmodule SymphonyElixir.Triggers.CronTest do
     end
 
     @tag :tmp_dir
+    test "two workflows sharing a schedule each fire exactly once per window", %{store_opts: store_opts, workflows_dir: dir} do
+      # Regression for issue #2010: firing by trigger matching selected
+      # every cron workflow with an equal schedule, so N same-schedule
+      # workflows produced N runs per workflow per window (N^2 total).
+      name_a = unique_name("shared-a")
+      name_b = unique_name("shared-b")
+      write_cron_sym!(dir, name_a, ~s|"0 9 * * *" tz "America/Los_Angeles"|)
+      write_cron_sym!(dir, name_b, ~s|"0 9 * * *" tz "America/Los_Angeles"|)
+
+      seeded = DateTime.add(DateTime.utc_now(), -2, :day)
+      :ok = CronState.seed_if_unset(name_a, seeded)
+      :ok = CronState.seed_if_unset(name_b, seeded)
+
+      assert :ok = Cron.poll_now()
+      run_files = wait_run_count(store_opts, 2)
+
+      # One run per workflow, not two: the run id carries the workflow slug.
+      run_ids = Enum.map(run_files, &Path.rootname/1)
+      assert Enum.count(run_ids, &String.starts_with?(&1, "#{name_a}-")) == 1
+      assert Enum.count(run_ids, &String.starts_with?(&1, "#{name_b}-")) == 1
+
+      # Let both runs finish so no snapshot persist races test teardown.
+      for run_id <- run_ids do
+        assert wait_terminal(run_id, store_opts).status == :succeeded
+      end
+
+      # Both watermarks advanced past the rewound seed.
+      assert DateTime.after?(CronState.get_last_fired(name_a), seeded)
+      assert DateTime.after?(CronState.get_last_fired(name_b), seeded)
+    end
+
+    @tag :tmp_dir
     test "an unparseable schedule is logged and skipped without poisoning the tick", %{workflows_dir: dir} do
       bad = unique_name("bad")
       good = unique_name("good")

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -75,6 +75,7 @@ import contextlib
 import html as _html
 import inspect as _inspect
 import os
+import pathlib
 import re
 import time
 from typing import TYPE_CHECKING
@@ -259,7 +260,7 @@ async def _run(
 ) -> object:
     """Evaluate ``code`` on the shared engine; return the plain Python value."""
     if cwd is None:
-        cwd = os.getcwd()
+        cwd = pathlib.Path.cwd()
     if name is not None and _rename_current_job is not None and (
         _ix_current is not None and _ix_current.get() is not None
     ):


### PR DESCRIPTION
Fixes #2010.

**Bug:** `Triggers.Cron.fire/4` resolved its run through `Ingress.start_by_trigger/2`, whose `:cron` matcher selects every workflow with an equal schedule. N workflows sharing one schedule -> N runs per workflow per window (N^2 total). Live-reproduced with the indexable pack's insights + triage both on `0 9 * * *` tz `America/Los_Angeles`.

**Fix:** the tick already holds the exact catalog entry it evaluated, so it now fires by identity via `Ingress.start_by_name(entry.name, trigger, run_opts)`. The trigger context payload is unchanged (`kind`/`schedule`/`timezone`/`scheduled_for`/`fired_at`/`input`), so `RunNotifier`, `IR.View`, and the store read it exactly as before.

**Dead code deleted:** with cron off the matcher path, no producer builds `:cron` events into `start_by_trigger` (checked github/linear/slack webhooks, the Slack poller, and the manual enqueue API; the dashboard has no manual cron-trigger form). The `Runtime.Trigger` `:cron` clause and its tests are removed rather than left as an unreachable path.

**Regression test:** two workflows sharing one schedule, watermarks rewound one window, one `poll_now` -> exactly one run per workflow (distinct workflow slugs in run ids) and both watermarks advanced.

Also carries a one-line ruff PTH109 fix in `packages/nu-py/python/nu/__init__.py` (`os.getcwd()` -> `pathlib.Path.cwd()`): whole-tree ruff fails on main there and blocks every pre-commit hook run; `cwd` already routes through `os.fspath`, so the change is behavior-neutral.

**Validation** (nix shell nixpkgs#elixir_1_19, in `packages/agent/symphony/elixir`):
- `mix compile --warnings-as-errors`: clean
- `mix test`: 447 tests, 0 failures
- `mix format --check-formatted`: clean
- `mix credo --strict --config-file ../../../../lib/elixir/credo.exs`: no issues

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cron trigger to fire workflows by catalog entry identity, not schedule match
> - Previously, cron ticks called `Ingress.start_by_trigger/2`, which re-selected all workflows sharing the same schedule, causing multiple workflows on the same schedule to each fire multiple times.
> - [`cron.ex`](https://github.com/indexable-inc/index/pull/2014/files#diff-c2c70653322a20575e59b51c3970a843166eeab10e2f76fe2f12996951b5bc9c) now calls `Ingress.start_workflow/3` with the specific evaluated catalog entry, so each cron tick starts exactly one run for the intended workflow.
> - The `matches?/2` predicate in [`trigger.ex`](https://github.com/indexable-inc/index/pull/2014/files#diff-95f6441b36dc1a4367cf5c30586ed7fa4155ecb473d472acfe9add87d4965815) no longer handles `:cron` triggers, since cron resolution bypasses schedule-based routing entirely.
> - A regression test confirms two workflows sharing a schedule each fire exactly once per window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c5a523.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->