### PR TITLE
fix(symphony): enforce exec timeouts in wall time and kill the whole process tree

### DIFF
--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
@@ -17,6 +17,11 @@ defmodule SymphonyElixir.Runtime.ExecRunner do
   so grandchildren the script spawned cannot outlive the node, and the
   attempt fails with `{:exec_timeout, seconds, output_tail}`.
 
+  Scripts run with stdin bound to /dev/null: an exec node never receives
+  input, and the port's stdin pipe would otherwise never deliver EOF, so a
+  child that reads stdin to exhaustion (codex does, even with an argv
+  prompt) would hang until the timeout instead of proceeding.
+
   Declared inputs reach the script as environment variables: each key of
   `run_opts.resolved_inputs` (the runtime resolves `{ name: value }` DSL
   inputs, including `${node.path}` references, before the attempt) is
@@ -86,11 +91,19 @@ defmodule SymphonyElixir.Runtime.ExecRunner do
           input_env(run_opts) ++
           [{~c"SYMPHONY_OUTPUT_FILE", String.to_charlist(output_file)}]
 
+      # The wrapper rebinds stdin to /dev/null before exec-ing the script.
+      # A port's stdin pipe never sees EOF while the port lives, so anything
+      # downstream that reads stdin to exhaustion blocks forever; the #2011
+      # wedge was `codex exec` doing exactly that (it reads stdin even with
+      # an argv prompt) at 0% CPU. Exec nodes never receive stdin by
+      # contract. `exec` keeps the shell's pid, so os_pid still names the
+      # script and its process group for the timeout kill.
       port =
-        Port.open({:spawn_executable, absolute}, [
+        Port.open({:spawn_executable, "/bin/sh"}, [
           :exit_status,
           :binary,
           :stderr_to_stdout,
+          {:args, ["-c", ~S(exec "$1" </dev/null), "sh", absolute]},
           {:cd, pack_dir},
           {:env, env}
         ])

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
@@ -51,6 +51,15 @@ defmodule SymphonyElixir.Runtime.ExecRunner do
   @output_tail_bytes 64 * 1024
   @default_timeout_seconds 300
 
+  # Upper bound on each receive wait so the wall-clock deadline is
+  # re-checked at least this often. BEAM `after` timers count monotonic
+  # time, which stops while the host sleeps (macOS mach_absolute_time,
+  # Linux CLOCK_MONOTONIC across suspend), so a single full-length `after`
+  # stalls arbitrarily far past the declared timeout: the #2011 wedge was a
+  # 3600s exec still running 2h later because the laptop slept mid-run.
+  # An operator's `timeout` means wall time, so poll against os_time.
+  @timeout_poll_ms 1_000
+
   @type result :: {:ok, map(), nil} | {:error, term(), nil}
 
   @spec run(Node.t(), map()) :: result()
@@ -79,7 +88,7 @@ defmodule SymphonyElixir.Runtime.ExecRunner do
           {:env, env}
         ])
 
-      deadline = System.monotonic_time(:millisecond) + timeout_seconds * 1_000
+      deadline = System.os_time(:millisecond) + timeout_seconds * 1_000
 
       try do
         port
@@ -178,35 +187,60 @@ defmodule SymphonyElixir.Runtime.ExecRunner do
   end
 
   defp collect(port, acc, acc_bytes, deadline, run_id, node_id, timeout_seconds) do
-    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+    remaining = deadline - System.os_time(:millisecond)
 
-    receive do
-      {^port, {:data, chunk}} when is_binary(chunk) ->
-        Logger.info("[exec #{run_id}/#{node_id}] " <> String.trim_trailing(chunk))
-        {next_acc, next_bytes} = append_with_tail(acc, acc_bytes, chunk)
-        collect(port, next_acc, next_bytes, deadline, run_id, node_id, timeout_seconds)
+    if remaining <= 0 do
+      kill_timed_out(port, acc, run_id, node_id, timeout_seconds)
+    else
+      receive do
+        {^port, {:data, chunk}} when is_binary(chunk) ->
+          Logger.info("[exec #{run_id}/#{node_id}] " <> String.trim_trailing(chunk))
+          {next_acc, next_bytes} = append_with_tail(acc, acc_bytes, chunk)
+          collect(port, next_acc, next_bytes, deadline, run_id, node_id, timeout_seconds)
 
-      {^port, {:exit_status, 0}} ->
-        {:ok, %{kind: :exec, exit_code: 0, output: IO.iodata_to_binary(acc)}, nil}
+        {^port, {:exit_status, 0}} ->
+          {:ok, %{kind: :exec, exit_code: 0, output: IO.iodata_to_binary(acc)}, nil}
 
-      {^port, {:exit_status, status}} ->
-        {:error, {:exec_failed, status, IO.iodata_to_binary(acc)}, nil}
-    after
-      remaining ->
-        # :spawn_executable does not die on Port.close, so kill the OS
-        # process explicitly, then drain the close so the mailbox stays clean.
-        case Port.info(port, :os_pid) do
-          {:os_pid, os_pid} ->
-            Logger.warning("ExecRunner timeout run=#{run_id} node=#{node_id} after #{timeout_seconds}s; killing pid=#{os_pid}")
-            System.cmd("kill", ["-KILL", Integer.to_string(os_pid)], stderr_to_stdout: true)
-
-          _ ->
-            :ok
-        end
-
-        Port.close(port)
-        {:error, {:exec_timeout, timeout_seconds, IO.iodata_to_binary(acc)}, nil}
+        {^port, {:exit_status, status}} ->
+          {:error, {:exec_failed, status, IO.iodata_to_binary(acc)}, nil}
+      after
+        min(remaining, @timeout_poll_ms) ->
+          collect(port, acc, acc_bytes, deadline, run_id, node_id, timeout_seconds)
+      end
     end
+  end
+
+  # Kill the script's whole process group, not just its pid: erl_child_setup
+  # starts a port program in its own session, so os_pid doubles as the pgid
+  # and kill(-pgid) reaps grandchildren too. The prior pid-targeted kill left
+  # the killed script's children (the wedged `codex` in #2011) orphaned and
+  # still holding the SYMPHONY_OUTPUT_FILE contract. Group scope also makes
+  # the timeout independent of `exit_status`, which the port withholds while
+  # any descendant keeps the inherited stdout pipe open.
+  defp kill_timed_out(port, acc, run_id, node_id, timeout_seconds) do
+    # :spawn_executable does not die on Port.close, so the group kill is the
+    # terminator; the close just drains the port so the mailbox stays clean.
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} ->
+        Logger.warning("ExecRunner timeout run=#{run_id} node=#{node_id} after #{timeout_seconds}s; killing pgid=#{os_pid}")
+        System.cmd("kill", ["-KILL", "--", "-#{os_pid}"], stderr_to_stdout: true)
+
+      _ ->
+        :ok
+    end
+
+    # The kill races the port's own teardown: once the dead process's pipe
+    # hits EOF the port delivers exit_status and closes itself, and closing
+    # an already-closed port raises ArgumentError. Either side closing is
+    # fine, so swallow exactly that race (OTP itself guards port_close the
+    # same way, e.g. in os_mon).
+    try do
+      Port.close(port)
+    rescue
+      ArgumentError -> :ok
+    end
+
+    {:error, {:exec_timeout, timeout_seconds, IO.iodata_to_binary(acc)}, nil}
   end
 
   # iodata accumulator with a byte budget: keep the tail, drop the head.

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/exec_runner.ex
@@ -10,6 +10,13 @@ defmodule SymphonyElixir.Runtime.ExecRunner do
   relative to the active pack directory so a pack references its own
   scripts without carrying absolute deployment paths.
 
+  Timeouts are wall-clock: `timeout <seconds>` (default 300) bounds the
+  attempt in elapsed real time, re-checked on a bounded tick because BEAM
+  timers pause while the host sleeps. On expiry the runner SIGKILLs the
+  script's whole process group (the port program runs in its own session),
+  so grandchildren the script spawned cannot outlive the node, and the
+  attempt fails with `{:exec_timeout, seconds, output_tail}`.
+
   Declared inputs reach the script as environment variables: each key of
   `run_opts.resolved_inputs` (the runtime resolves `{ name: value }` DSL
   inputs, including `${node.path}` references, before the attempt) is

--- a/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
@@ -104,6 +104,24 @@ defmodule SymphonyElixir.Runtime.ExecRunnerTest do
     assert output =~ "tick"
   end
 
+  test "stdin is /dev/null so a script that drains stdin exits instead of hanging", %{pack: pack} do
+    # The port's stdin pipe never delivers EOF, so without the /dev/null
+    # rebind `cat` blocks until the deadline and this fails with
+    # {:exec_timeout, 3, _} instead of succeeding immediately (the codex
+    # stdin-read half of the #2011 wedge).
+    rel =
+      write_script!(pack, "scripts/drain.sh", """
+      #!/bin/sh
+      cat
+      echo drained
+      """)
+
+    assert {:ok, %{exit_code: 0, output: output}, nil} =
+             ExecRunner.run(exec_node(rel, timeout: 3), %{run_id: "r", attempt: 1, pack_dir: pack})
+
+    assert output =~ "drained"
+  end
+
   test "a timeout kills the whole process tree, not just the script", %{pack: pack} do
     # The #2011 wedge shape: the script's grandchild inherits stdout (so the
     # port would never deliver exit_status) and must not survive the timeout

--- a/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
@@ -107,37 +107,36 @@ defmodule SymphonyElixir.Runtime.ExecRunnerTest do
   test "a timeout kills the whole process tree, not just the script", %{pack: pack} do
     # The #2011 wedge shape: the script's grandchild inherits stdout (so the
     # port would never deliver exit_status) and must not survive the timeout
-    # kill. The marker rides in the grandchild's argv so pgrep can find it;
-    # the compound command keeps sh from exec-ing sleep directly, which
-    # would drop the marker argv and make the survivor check vacuous.
-    marker = "sym-exec-2011-#{System.unique_integer([:positive])}"
-
+    # kill. The script records the grandchild pid so the test can probe it
+    # with `kill -0` (already on the sandbox PATH; pgrep is not).
     rel =
       write_script!(pack, "scripts/tree.sh", """
       #!/bin/sh
-      /bin/sh -c 'sleep 300; :' #{marker} &
+      sleep 300 &
+      echo $! > grandchild.pid
       wait
       """)
 
     assert {:error, {:exec_timeout, 1, _output}, nil} =
              ExecRunner.run(exec_node(rel, timeout: 1), %{run_id: "r", attempt: 1, pack_dir: pack})
 
-    assert await_no_process(marker), "grandchild #{marker} survived the timeout kill"
+    grandchild = pack |> Path.join("grandchild.pid") |> File.read!() |> String.trim()
+    assert await_dead(grandchild), "grandchild pid #{grandchild} survived the timeout kill"
   end
 
   # SIGKILL delivery is immediate but reparent-and-reap is not; poll briefly
-  # before declaring a survivor.
-  defp await_no_process(marker, tries \\ 50) do
-    case System.cmd("pgrep", ["-f", marker]) do
-      {_, 1} ->
-        true
-
+  # before declaring a survivor. kill -0 probes liveness without signaling.
+  defp await_dead(pid, tries \\ 50) do
+    case System.cmd("kill", ["-0", pid], stderr_to_stdout: true) do
       {_, 0} when tries > 0 ->
         Process.sleep(100)
-        await_no_process(marker, tries - 1)
+        await_dead(pid, tries - 1)
 
-      _ ->
+      {_, 0} ->
         false
+
+      {_, _} ->
+        true
     end
   end
 

--- a/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
@@ -86,6 +86,59 @@ defmodule SymphonyElixir.Runtime.ExecRunnerTest do
              ExecRunner.run(exec_node(rel, timeout: 1), %{run_id: "r", attempt: 1, pack_dir: pack})
   end
 
+  test "a chatty script cannot outlive its timeout by streaming output", %{pack: pack} do
+    # Ticks land between deadline polls; exit code 7 is the sentinel that
+    # would surface as {:exec_failed, 7} if the runner ever waited for the
+    # script to finish instead of enforcing the deadline.
+    rel =
+      write_script!(pack, "scripts/chatty.sh", """
+      #!/bin/sh
+      i=0
+      while [ $i -lt 40 ]; do echo tick; sleep 0.2; i=$((i+1)); done
+      exit 7
+      """)
+
+    assert {:error, {:exec_timeout, 1, output}, nil} =
+             ExecRunner.run(exec_node(rel, timeout: 1), %{run_id: "r", attempt: 1, pack_dir: pack})
+
+    assert output =~ "tick"
+  end
+
+  test "a timeout kills the whole process tree, not just the script", %{pack: pack} do
+    # The #2011 wedge shape: the script's grandchild inherits stdout (so the
+    # port would never deliver exit_status) and must not survive the timeout
+    # kill. The marker rides in the grandchild's argv so pgrep can find it.
+    marker = "sym-exec-2011-#{System.unique_integer([:positive])}"
+
+    rel =
+      write_script!(pack, "scripts/tree.sh", """
+      #!/bin/sh
+      /bin/sh -c 'sleep 300' #{marker} &
+      wait
+      """)
+
+    assert {:error, {:exec_timeout, 1, _output}, nil} =
+             ExecRunner.run(exec_node(rel, timeout: 1), %{run_id: "r", attempt: 1, pack_dir: pack})
+
+    assert await_no_process(marker), "grandchild #{marker} survived the timeout kill"
+  end
+
+  # SIGKILL delivery is immediate but reparent-and-reap is not; poll briefly
+  # before declaring a survivor.
+  defp await_no_process(marker, tries \\ 50) do
+    case System.cmd("pgrep", ["-f", marker]) do
+      {_, 1} ->
+        true
+
+      {_, 0} when tries > 0 ->
+        Process.sleep(100)
+        await_no_process(marker, tries - 1)
+
+      _ ->
+        false
+    end
+  end
+
   test "resolved DSL inputs reach the script as SYMPHONY_INPUT_* env vars", %{pack: pack} do
     rel =
       write_script!(pack, "scripts/env.sh", """

--- a/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/runtime/exec_runner_test.exs
@@ -107,13 +107,15 @@ defmodule SymphonyElixir.Runtime.ExecRunnerTest do
   test "a timeout kills the whole process tree, not just the script", %{pack: pack} do
     # The #2011 wedge shape: the script's grandchild inherits stdout (so the
     # port would never deliver exit_status) and must not survive the timeout
-    # kill. The marker rides in the grandchild's argv so pgrep can find it.
+    # kill. The marker rides in the grandchild's argv so pgrep can find it;
+    # the compound command keeps sh from exec-ing sleep directly, which
+    # would drop the marker argv and make the survivor check vacuous.
     marker = "sym-exec-2011-#{System.unique_integer([:positive])}"
 
     rel =
       write_script!(pack, "scripts/tree.sh", """
       #!/bin/sh
-      /bin/sh -c 'sleep 300' #{marker} &
+      /bin/sh -c 'sleep 300; :' #{marker} &
       wait
       """)
 


### PR DESCRIPTION
Fixes #2011.

## Root cause (from live forensics on the wedged host)

Two independent defects combined into the 2h+ wedge:

1. **Frozen deadline.** The 3600s timeout was armed as a single monotonic `receive after`. BEAM `after` timers count monotonic time, which **stops while the host sleeps** (macOS `mach_absolute_time`; Linux `CLOCK_MONOTONIC` across suspend). The wedged insights exec started 08:34 PDT; `pmset -g log` shows the machine slept 09:15 to 10:31; the run store shows both stale runs' attempts were then failed at the identical instant (17:33:33.132Z) by restart recovery, never by the timeout. `collect/7`'s arithmetic itself was correct.
2. **stdin that never EOFs.** The port's stdin pipe never delivers EOF, and `codex exec` reads stdin to exhaustion even with an argv prompt, so it sat at 0% CPU forever: this is why the script was still wedged for the timeout to miss in the first place.

## Fix

- Deadline is now wall-clock (`System.os_time`) re-checked on a bounded 1s poll tick, so a sleep gap delays enforcement by at most one tick.
- The timeout kill targets the process group (`kill -KILL -- -pgid`), not the script pid: `erl_child_setup` runs a port program in its own session (verified empirically on darwin and linux: `os_pid == pgid`), so grandchildren like the orphaned `codex` are reaped too. This also makes the timeout independent of `exit_status`, which the port withholds while any descendant holds the inherited stdout pipe.
- Scripts are spawned through a `/bin/sh` `exec` wrapper that rebinds stdin to `/dev/null` (exec preserves the pid, so the group kill is unchanged): an exec node never receives input by contract, and a stdin-draining child now proceeds instead of hanging to the deadline. Pack-script-level `</dev/null` guards stay as defense in depth.
- Closing the port after the kill races the port's EOF self-teardown; that specific `ArgumentError` is swallowed (same guard OTP uses around `port_close`).

## Regression tests (each mutation-verified)

- A chatty script streaming output cannot outlive its timeout (exit-code sentinel proves the deadline, not completion, ended it).
- A timed-out script's backgrounded grandchild holding stdout (the codex wedge shape) is provably reaped (`kill -0` probe; fails under a pid-only kill).
- A script that drains stdin (`cat`) succeeds immediately (fails with `exec_timeout` under the old direct spawn).

Gate: `mix compile --warnings-as-errors`, `mix test` (450 tests), `mix format --check-formatted`, `mix credo --strict` all green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix exec timeouts in `ExecRunner` to enforce wall-clock deadlines and kill the whole process group
> - Scripts are now spawned via `/bin/sh` with `exec` and stdin rebound to `/dev/null`, preventing hangs when child processes drain stdin.
> - Timeout deadlines switch from monotonic time to wall-clock time (`System.os_time/1`) and are enforced via periodic polling in `collect/6`.
> - On timeout, `kill_timed_out/6` sends `kill -KILL` to the negative OS pid (the process group), ensuring descendant processes are also killed.
> - Three new tests cover: chatty scripts that exceed their timeout, stdin-draining scripts that should exit cleanly, and process-tree kill verification via a background `sleep`.
> - Behavioral Change: timed-out runs now return `{:error, {:exec_timeout, seconds, output_tail}, nil}` and terminate the entire process group, not just the top-level script pid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60bb38e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->