### PR TITLE
skills: add unknowns (blind spot pass) and quiz (comprehension gate)

### DIFF
--- a/packages/agent/skills/quiz/SKILL.md
+++ b/packages/agent/skills/quiz/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: quiz
+description: "Verify the user actually understands a change before merging; build a short explainer (context, intuition, what was done) then quiz them interactively and grade the answers. Use when the user says quiz me, asks to check their understanding of a change, PR, or session, or wants a comprehension gate before merge."
+---
+
+# quiz
+
+After a long working session the diff understates what happened, because behavior depends on existing code paths the diff never shows. Close that gap before merge.
+
+1. **Scope the change.** Default to the current branch against its base (or this session's work); accept a PR number or path range instead.
+2. **Brief first.** Before any question, give a compact explainer: the why, the shape of the solution, what was done, and the non-obvious interactions with existing code paths. Use an HTML artifact for large changes, inline prose otherwise.
+3. **Quiz interactively.** 4-7 multiple-choice questions via AskUserQuestion, one at a time, each with one defensible correct answer. Aim at what the diff hides: behavior on existing paths, failure modes, why an approach beat its alternative, what breaks if a given line is removed. No trivia the diff states verbatim.
+4. **Grade honestly.** After each answer, say correct or incorrect and why. At the end report the score and re-explain anything missed.
+5. **Gate.** The bar is a perfect pass before merge; on misses, run a second targeted round on just those areas rather than repeating the whole quiz.

--- a/packages/agent/skills/unknowns/SKILL.md
+++ b/packages/agent/skills/unknowns/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: unknowns
+description: "Run a blind spot pass before starting unfamiliar work; surface the user's unknown unknowns (architecture-changing decisions, what good looks like, prior art, potholes, vocabulary) and end with a rewritten prompt. Use when the user says blind spot pass, unknown unknowns, find my unknowns, what am I missing, or starts work in a domain or codebase area they say they don't know."
+---
+
+# unknowns
+
+Map the gap between what the user asked for and what the territory requires, before work begins.
+
+1. **Anchor on the user's starting point.** Infer from context (or ask once, briefly) what they already know, their experience with this domain and codebase area, and the outcome they care about. The pass is calibrated to them, not to a generic reader.
+2. **Sweep the territory.** In parallel where possible: the relevant code paths and their history (git log, prior PRs and issues), existing conventions and prior art in the repo, and external references when the domain itself is unfamiliar. Hunt specifically for what would surprise the user given their stated starting point.
+3. **Report by category**, shortest useful form:
+   - **Decisions that change the architecture.** Choices where the user's answer redirects the work; frame each as a question with a recommended default.
+   - **What good looks like.** The quality bar, reference implementations, or examples the user can react to.
+   - **Prior art and potholes.** Historical attempts, known failure modes, guards, and constraints not visible from the entry point.
+   - **Vocabulary.** Terms the user needs in order to prompt precisely.
+4. **End with a rewritten prompt.** Produce the prompt the user should have written, with the resolved unknowns folded in, then offer to proceed with it directly.
+
+Keep it a pass, not a project: minutes of scanning, one structured reply. Deep dives happen only after the user picks which unknown matters.


### PR DESCRIPTION
Two new global agent skills, adapted from https://claude.com/blog/a-field-guide-to-claude-fable-finding-your-unknowns (interview pattern already exists as /spec).

Closes #2020

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `quiz` and `unknowns` agent skills for comprehension gating and blind spot detection
> - Adds [quiz/SKILL.md](https://github.com/indexable-inc/index/pull/2023/files#diff-1c3f869517720a96d3f1ffc7baa079a232b1cf123bc719245d29d0da3e893b5e): a skill that runs an interactive multiple-choice quiz to verify user understanding, grades responses, and requires a perfect score (with targeted re-quiz on misses) before proceeding.
> - Adds [unknowns/SKILL.md](https://github.com/indexable-inc/index/pull/2023/files#diff-06253c27d4784426905c43f488afe364793d650bc4b00a37a5fecbec77aa504f): a skill that anchors on the user's starting point, sweeps relevant context (repo history, conventions, prior art, vocabulary), and rewrites the user's prompt with discovered blind spots filled in.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08b63a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->