### PR TITLE
unibind phase 0: core IR, macro surface, pyo3 backend; port scipql-py (#1990)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11999,6 +11999,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "unibind"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "unibind-backend-py",
+ "unibind-core",
+]
+
+[[package]]
+name = "unibind-backend-py"
+version = "0.1.0"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.118",
+ "unibind-core",
+]
+
+[[package]]
+name = "unibind-core"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9469,6 +9469,7 @@ version = "0.1.0"
 dependencies = [
  "pyo3",
  "scipql-core",
+ "unibind",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,9 @@ members = [
   "packages/tui/tui",
   "packages/tui/tui-node",
   "packages/tui/tui-py",
+  "packages/unibind/backend-py",
+  "packages/unibind/core",
+  "packages/unibind/macros",
   "packages/vm/panes/audio",
   "packages/vm/panes/compositor",
   "packages/vm/panes/host",
@@ -236,6 +239,8 @@ panes-protocol = { path = "packages/vm/panes/protocol" }
 parking_lot = "0.12"
 parquet = { version = "59", features = ["arrow"] }
 percent-encoding = "2"
+prettyplease = "0.2"
+proc-macro2 = "1"
 progress-style = { path = "packages/progress-style" }
 protobuf = "3"
 pty-process = { version = "0.5", features = ["async"] }
@@ -243,6 +248,7 @@ pyo3 = { version = "0.28", features = ["abi3-py311"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 pythonize = "0.28"
 quartz_nbt = "0.2.9"
+quote = "1"
 rayon = "1"
 regex = "1"
 repo-walker = { path = "packages/repo-walker" }
@@ -273,6 +279,7 @@ sink-mixedbread = { path = "packages/search/sink/mixedbread" }
 sink-parquet = { path = "packages/search/sink/parquet" }
 snafu = "0.9"
 strip-ansi-escapes = "0.2"
+syn = { version = "2", features = ["full"] }
 tango-bench = "0.7"
 tantivy = "0.26"
 tao = "0.35"
@@ -322,6 +329,9 @@ tree-sitter-toml-ng = "0.7"
 tree-sitter-typescript = "0.23"
 tree-sitter-yaml = "0.7"
 tui = { path = "packages/tui/tui" }
+unibind = { path = "packages/unibind/macros" }
+unibind-backend-py = { path = "packages/unibind/backend-py" }
+unibind-core = { path = "packages/unibind/core" }
 url = { version = "2.5.8", default-features = false }
 uuid = "1"
 webpki-roots = "1"

--- a/packages/code/scipql/py/Cargo.toml
+++ b/packages/code/scipql/py/Cargo.toml
@@ -15,3 +15,4 @@ workspace = true
 [dependencies]
 pyo3 = { workspace = true, features = ["extension-module"] }
 scipql-core.workspace = true
+unibind = { workspace = true, features = ["py"] }

--- a/packages/code/scipql/py/bench/ab_bench.py
+++ b/packages/code/scipql/py/bench/ab_bench.py
@@ -1,0 +1,73 @@
+"""A/B micro-benchmark for the scipql binding boundary.
+
+Runs the same workload against whichever `scipql` module is importable, and
+prints one JSON document. Drive it twice, once with the hand-written pyo3
+build on `sys.path` and once with the unibind-generated build, and compare:
+
+    <old-env>/bin/python3 ab_bench.py --fixture <two-sockets> --label hand
+    <new-env>/bin/python3 ab_bench.py --fixture <two-sockets> --label unibind
+
+The workload exercises the boundary, not the engine: `facts` crosses with
+thousands of record values per call, `facts_frames` adds the polars wrapping
+of the public API, and `rename` (dry-run) returns one string.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from collections.abc import Callable
+
+
+def _time(fn: Callable[[], object], iterations: int) -> dict[str, float]:
+    samples: list[float] = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - start)
+    return {
+        "mean_us": statistics.fmean(samples) * 1e6,
+        "stdev_us": (statistics.stdev(samples) if len(samples) > 1 else 0.0) * 1e6,
+        "min_us": min(samples) * 1e6,
+        "iterations": float(iterations),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", required=True, help="two-sockets fixture directory")
+    parser.add_argument("--label", required=True, help="which build is under test")
+    parser.add_argument("--iterations", type=int, default=300)
+    args = parser.parse_args()
+
+    import scipql
+
+    # The public API wraps the extension module; time the raw boundary too.
+    from scipql import _scipql
+
+    index_path = args.fixture + "/index.scip"
+    raw_facts = _scipql.facts
+    # Warm up caches and the first-import costs before sampling.
+    for _ in range(20):
+        raw_facts(index_path, args.fixture)
+        scipql.facts(index_path, args.fixture)
+        scipql.rename(index_path, "net/Socket#", "Stream", args.fixture)
+
+    results = {
+        "label": args.label,
+        "facts_boundary": _time(lambda: raw_facts(index_path, args.fixture), args.iterations),
+        "facts_frames": _time(
+            lambda: scipql.facts(index_path, args.fixture), args.iterations
+        ),
+        "rename_dry": _time(
+            lambda: scipql.rename(index_path, "net/Socket#", "Stream", args.fixture),
+            args.iterations,
+        ),
+    }
+    print(json.dumps(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/code/scipql/py/python/scipql/__init__.py
+++ b/packages/code/scipql/py/python/scipql/__init__.py
@@ -25,20 +25,40 @@ modules and a rename touches only the real definition and its references::
 
 Results come back as polars DataFrames, like every other bundled kernel module.
 ``index``/``fix``/``rename`` return plain ``str`` (a path, or a unified diff).
-The same engine backs the ``scipql`` CLI.
+The same engine backs the ``scipql`` CLI. Failures raise ``ScipqlError`` (a
+``ValueError``), with ``IndexingError`` / ``SouffleError`` / ``EditError``
+subclasses per pipeline stage.
 """
 
 from __future__ import annotations
 
 import polars as pl
 
-from ._scipql import __version__, index
+from ._scipql import (
+    EditError,
+    IndexingError,
+    ScipqlError,
+    SouffleError,
+    __version__,
+    index,
+)
 from ._scipql import facts as _facts
 from ._scipql import fix as _fix
 from ._scipql import query as _query
 from ._scipql import rename as _rename
 
-__all__ = ["__version__", "facts", "fix", "index", "query", "rename"]
+__all__ = [
+    "EditError",
+    "IndexingError",
+    "ScipqlError",
+    "SouffleError",
+    "__version__",
+    "facts",
+    "fix",
+    "index",
+    "query",
+    "rename",
+]
 
 # A polars dtype as `pl.DataFrame(schema=...)` accepts it: the class (`pl.Utf8`)
 # or an instance. The schema tables below hold the classes.
@@ -67,14 +87,28 @@ def facts(index_path: str, root: str | None = None) -> dict[str, pl.DataFrame]:
     the index's project root.
     """
     raw = _facts(index_path, root)
-    # Pair each relation's row list (typed per-key on the `Facts` TypedDict) with
-    # its schema. Listed explicitly rather than indexed by a dynamic name so the
-    # rows keep their precise row-dict type instead of widening to `object`.
+    # The binding returns native record classes; flatten each relation back to
+    # row dicts, listed explicitly so every field keeps its precise type.
     relations: dict[str, list[dict[str, object]]] = {
-        "occurrence": [dict(row) for row in raw["occurrence"]],
-        "symbol_info": [dict(row) for row in raw["symbol_info"]],
-        "document": [dict(row) for row in raw["document"]],
-        "relationship": [dict(row) for row in raw["relationship"]],
+        "occurrence": [
+            {
+                "symbol": row.symbol,
+                "path": row.path,
+                "start": row.start,
+                "end": row.end,
+                "role": row.role,
+            }
+            for row in raw.occurrence
+        ],
+        "symbol_info": [
+            {"symbol": row.symbol, "kind": row.kind, "display_name": row.display_name}
+            for row in raw.symbol_info
+        ],
+        "document": [{"path": row.path} for row in raw.document],
+        "relationship": [
+            {"symbol": row.symbol, "related": row.related, "kind": row.kind}
+            for row in raw.relationship
+        ],
     }
     return {
         name: pl.DataFrame(relations[name], schema=schema)
@@ -90,10 +124,9 @@ def query(index_path: str, program: str, root: str | None = None) -> dict[str, p
     """
     out: dict[str, pl.DataFrame] = {}
     for name, relation in _query(index_path, program, root).items():
-        columns = relation["columns"]
         out[name] = pl.DataFrame(
-            relation["rows"],
-            schema=dict.fromkeys(columns, pl.Utf8),
+            relation.rows,
+            schema=dict.fromkeys(relation.columns, pl.Utf8),
         )
     return out
 

--- a/packages/code/scipql/py/python/scipql/_scipql.pyi
+++ b/packages/code/scipql/py/python/scipql/_scipql.pyi
@@ -1,16 +1,35 @@
-"""Type stub for the PyO3 extension module backing `scipql`.
+"""Type stub for the unibind-generated extension module backing `scipql`.
 
-Hand-maintained to mirror packages/code/scipql/py/src/lib.rs. Keep in sync when
-changing the binding. The public `scipql` API (`__init__.py`) lowers these dict
-shapes into polars DataFrames.
+Hand-maintained to mirror packages/code/scipql/py/src/lib.rs (the
+`#[unibind::export]` module). Keep in sync when changing the binding; stub
+generation from the embedded IR lands with unibind phase 1 (#1991). The
+public `scipql` API (`__init__.py`) lowers these record classes into polars
+DataFrames.
 """
 
-from typing import TypedDict
+from typing import final
 
 __version__: str
 
 
-class Occurrence(TypedDict):
+class ScipqlError(ValueError):
+    """Everything the scipql boundary raises, split by pipeline stage."""
+
+
+class IndexingError(ScipqlError):
+    """Producing, loading, or lowering the SCIP index failed."""
+
+
+class SouffleError(ScipqlError):
+    """Materializing facts or running Soufflé failed."""
+
+
+class EditError(ScipqlError):
+    """Computing or applying edits failed."""
+
+
+@final
+class Occurrence:
     """One `occurrence` fact: a symbol use site with its byte range and role."""
 
     symbol: str
@@ -19,30 +38,42 @@ class Occurrence(TypedDict):
     end: int
     role: str
 
+    def __init__(self, symbol: str, path: str, start: int, end: int, role: str) -> None: ...
 
-class SymbolInfo(TypedDict):
+
+@final
+class SymbolInfo:
     """One `symbol_info` fact: a symbol's kind and display name."""
 
     symbol: str
     kind: str
     display_name: str
 
+    def __init__(self, symbol: str, kind: str, display_name: str) -> None: ...
 
-class Document(TypedDict):
+
+@final
+class Document:
     """One `document` fact: an indexed source path."""
 
     path: str
 
+    def __init__(self, path: str) -> None: ...
 
-class Relationship(TypedDict):
+
+@final
+class Relationship:
     """One `relationship` fact: a typed edge between two symbols."""
 
     symbol: str
     related: str
     kind: str
 
+    def __init__(self, symbol: str, related: str, kind: str) -> None: ...
 
-class Facts(TypedDict):
+
+@final
+class Facts:
     """The four fact relations a SCIP index lowers into."""
 
     occurrence: list[Occurrence]
@@ -50,12 +81,23 @@ class Facts(TypedDict):
     document: list[Document]
     relationship: list[Relationship]
 
+    def __init__(
+        self,
+        occurrence: list[Occurrence],
+        symbol_info: list[SymbolInfo],
+        document: list[Document],
+        relationship: list[Relationship],
+    ) -> None: ...
 
-class Relation(TypedDict):
+
+@final
+class Relation:
     """One Soufflé `.output` relation: its column names and untyped string rows."""
 
     columns: list[str]
     rows: list[dict[str, str]]
+
+    def __init__(self, columns: list[str], rows: list[dict[str, str]]) -> None: ...
 
 
 def index(project: str, output: str = ...) -> str:

--- a/packages/code/scipql/py/src/lib.rs
+++ b/packages/code/scipql/py/src/lib.rs
@@ -1,169 +1,260 @@
-//! Python bindings for `scipql-core`.
+//! Python bindings for `scipql-core`, declared through `unibind`.
 //!
-//! Thin sync entry points: [`index`] runs `rust-analyzer scip`, [`facts`]
-//! lowers an index to relations, [`query`] runs a Soufflé program and returns
-//! its output relations, and [`fix`]/[`rename`] apply edits (returning the
-//! unified diff). All logic lives in the core crate; this module only converts
-//! at the boundary, returning plain records the Python wrapper turns into
-//! polars frames.
+//! The boundary keeps the same thin sync shape the hand-written `pyo3`
+//! version had: [`_scipql::index`] runs `rust-analyzer scip`,
+//! [`_scipql::facts`] lowers an index to relations, [`_scipql::query`] runs
+//! a Soufflé program, and [`_scipql::fix`] / [`_scipql::rename`] apply edits
+//! (returning the unified diff). All logic lives in the core crate; the
+//! exported module only converts at the boundary, and `unibind` renders the
+//! `pyo3` glue (function wrappers, record classes, the exception hierarchy,
+//! and the module registration) from these declarations.
 
-use std::path::{Path, PathBuf};
+#[unibind::export]
+mod _scipql {
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
 
-use pyo3::exceptions::PyValueError;
-use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
-use scipql_core::Error;
-
-fn to_py_err(error: &Error) -> PyErr {
-    let mut message = error.to_string();
-    let mut source = std::error::Error::source(error);
-    while let Some(cause) = source {
-        message.push_str(": ");
-        message.push_str(&cause.to_string());
-        source = cause.source();
+    /// One `occurrence` fact: a symbol use site with its byte range and role.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Occurrence {
+        pub symbol: String,
+        pub path: String,
+        pub start: usize,
+        pub end: usize,
+        pub role: String,
     }
-    PyValueError::new_err(message)
-}
 
-/// Run `rust-analyzer scip` on `project`, writing the index to `output`
-/// (default `index.scip`). Returns the output path.
-#[pyfunction]
-#[pyo3(signature = (project, output = "index.scip"))]
-fn index(project: &str, output: &str) -> PyResult<String> {
-    scipql_core::index(Path::new(project), Path::new(output)).map_err(|error| to_py_err(&error))?;
-    Ok(output.to_owned())
-}
-
-/// Lower a SCIP index into the four fact relations, each a list of row dicts:
-/// `occurrence` {symbol, path, start, end, role}, `symbol_info`
-/// {symbol, kind, `display_name`}, `document` {path}, `relationship`
-/// {symbol, related, kind}.
-#[pyfunction]
-#[pyo3(signature = (index_path, root = None))]
-fn facts<'py>(
-    py: Python<'py>,
-    index_path: &str,
-    root: Option<&str>,
-) -> PyResult<Bound<'py, PyDict>> {
-    let loaded = scipql_core::load_index(Path::new(index_path)).map_err(|error| to_py_err(&error))?;
-    let root = root.map(PathBuf::from);
-    let facts = scipql_core::facts_from_index(&loaded, root.as_deref())
-        .map_err(|error| to_py_err(&error))?;
-
-    let out = PyDict::new(py);
-
-    let occurrences = PyList::empty(py);
-    for row in &facts.occurrences {
-        let cell = PyDict::new(py);
-        cell.set_item("symbol", &row.symbol)?;
-        cell.set_item("path", &row.path)?;
-        cell.set_item("start", row.start)?;
-        cell.set_item("end", row.end)?;
-        cell.set_item("role", &row.role)?;
-        occurrences.append(cell)?;
+    /// One `symbol_info` fact: a symbol's kind and display name.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct SymbolInfo {
+        pub symbol: String,
+        pub kind: String,
+        pub display_name: String,
     }
-    out.set_item("occurrence", occurrences)?;
 
-    let symbols = PyList::empty(py);
-    for row in &facts.symbols {
-        let cell = PyDict::new(py);
-        cell.set_item("symbol", &row.symbol)?;
-        cell.set_item("kind", &row.kind)?;
-        cell.set_item("display_name", &row.display_name)?;
-        symbols.append(cell)?;
+    /// One `document` fact: an indexed source path.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Document {
+        pub path: String,
     }
-    out.set_item("symbol_info", symbols)?;
 
-    let documents = PyList::empty(py);
-    for path in &facts.documents {
-        let cell = PyDict::new(py);
-        cell.set_item("path", path)?;
-        documents.append(cell)?;
+    /// One `relationship` fact: a typed edge between two symbols.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Relationship {
+        pub symbol: String,
+        pub related: String,
+        pub kind: String,
     }
-    out.set_item("document", documents)?;
 
-    let relationships = PyList::empty(py);
-    for row in &facts.relationships {
-        let cell = PyDict::new(py);
-        cell.set_item("symbol", &row.symbol)?;
-        cell.set_item("related", &row.related)?;
-        cell.set_item("kind", &row.kind)?;
-        relationships.append(cell)?;
+    /// The four fact relations a SCIP index lowers into.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Facts {
+        pub occurrence: Vec<Occurrence>,
+        pub symbol_info: Vec<SymbolInfo>,
+        pub document: Vec<Document>,
+        pub relationship: Vec<Relationship>,
     }
-    out.set_item("relationship", relationships)?;
 
-    Ok(out)
-}
+    /// One Soufflé `.output` relation: its column names and untyped string
+    /// rows.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Relation {
+        pub columns: Vec<String>,
+        pub rows: Vec<HashMap<String, String>>,
+    }
 
-/// Run a Soufflé `program` over the index's facts. Returns
-/// `{relation: {"columns": [name], "rows": [{column: value}]}}`, one entry per
-/// `.output` relation. The fact relations are already in scope.
-#[pyfunction]
-#[pyo3(signature = (index_path, program, root = None))]
-fn query<'py>(
-    py: Python<'py>,
-    index_path: &str,
-    program: &str,
-    root: Option<&str>,
-) -> PyResult<Bound<'py, PyDict>> {
-    let loaded = scipql_core::load_index(Path::new(index_path)).map_err(|error| to_py_err(&error))?;
-    let root = root.map(PathBuf::from);
-    let output = scipql_core::query(&loaded, root.as_deref(), program)
-        .map_err(|error| to_py_err(&error))?;
+    /// Everything the boundary raises, split by pipeline stage. Python sees
+    /// `ScipqlError` (a `ValueError`, matching the exception the hand-written
+    /// binding raised) with one subclass per variant.
+    #[unibind::error(py(base = "ValueError"))]
+    #[derive(Debug)]
+    pub enum ScipqlError {
+        /// Producing, loading, or lowering the SCIP index failed.
+        #[unibind(py(name = "IndexingError"))]
+        Indexing { message: String },
+        /// Materializing facts or running Soufflé failed.
+        #[unibind(py(name = "SouffleError"))]
+        Souffle { message: String },
+        /// Computing or applying edits failed.
+        #[unibind(py(name = "EditError"))]
+        Edit { message: String },
+    }
 
-    let out = PyDict::new(py);
-    for relation in &output.relations {
-        let entry = PyDict::new(py);
-        entry.set_item("columns", &relation.columns)?;
-        let rows = PyList::empty(py);
-        for row in &relation.rows {
-            let cells = PyDict::new(py);
-            for (column, value) in relation.columns.iter().zip(row) {
-                cells.set_item(column, value)?;
-            }
-            rows.append(cells)?;
+    impl std::fmt::Display for ScipqlError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let (Self::Indexing { message } | Self::Souffle { message } | Self::Edit { message }) =
+                self;
+            formatter.write_str(message)
         }
-        entry.set_item("rows", rows)?;
-        out.set_item(&relation.name, entry)?;
     }
-    Ok(out)
-}
 
-/// Run a `fix` program (one that `.output`s `edit(path, start, end,
-/// replacement)`) and return the unified diff. With `write=True` the files
-/// under `root` are rewritten on disk.
-#[pyfunction]
-#[pyo3(signature = (index_path, program, root = None, write = false))]
-fn fix(index_path: &str, program: &str, root: Option<&str>, write: bool) -> PyResult<String> {
-    let loaded = scipql_core::load_index(Path::new(index_path)).map_err(|error| to_py_err(&error))?;
-    let root = root.map(PathBuf::from);
-    scipql_core::fix(&loaded, root.as_deref(), program, write).map_err(|error| to_py_err(&error))
-}
+    impl std::error::Error for ScipqlError {}
 
-/// Rename every occurrence whose SCIP moniker ends with `selector` to
-/// `new_name`. Returns the unified diff; `write=True` applies it.
-#[pyfunction]
-#[pyo3(signature = (index_path, selector, new_name, root = None, write = false))]
-fn rename(
-    index_path: &str,
-    selector: &str,
-    new_name: &str,
-    root: Option<&str>,
-    write: bool,
-) -> PyResult<String> {
-    let loaded = scipql_core::load_index(Path::new(index_path)).map_err(|error| to_py_err(&error))?;
-    let root = root.map(PathBuf::from);
-    scipql_core::rename(&loaded, root.as_deref(), selector, new_name, write)
-        .map_err(|error| to_py_err(&error))
-}
+    /// Flatten a core error and its source chain into one message, matching
+    /// the text the hand-written binding put on its `ValueError`.
+    fn chain(error: &scipql_core::Error) -> String {
+        let mut message = error.to_string();
+        let mut source = std::error::Error::source(error);
+        while let Some(cause) = source {
+            message.push_str(": ");
+            message.push_str(&cause.to_string());
+            source = cause.source();
+        }
+        message
+    }
 
-#[pymodule]
-fn _scipql(module: &Bound<'_, PyModule>) -> PyResult<()> {
-    module.add_function(wrap_pyfunction!(index, module)?)?;
-    module.add_function(wrap_pyfunction!(facts, module)?)?;
-    module.add_function(wrap_pyfunction!(query, module)?)?;
-    module.add_function(wrap_pyfunction!(fix, module)?)?;
-    module.add_function(wrap_pyfunction!(rename, module)?)?;
-    module.add("__version__", env!("CARGO_PKG_VERSION"))?;
-    Ok(())
+    /// Sort a core error into the boundary's exception classes.
+    fn classify(error: &scipql_core::Error) -> ScipqlError {
+        use scipql_core::Error;
+        let message = chain(error);
+        match error {
+            Error::RunRustAnalyzer { .. }
+            | Error::RustAnalyzerFailed { .. }
+            | Error::ReadIndex { .. }
+            | Error::ParseIndex { .. }
+            | Error::ReadSource { .. }
+            | Error::Offset { .. } => ScipqlError::Indexing { message },
+            Error::ReadProgram { .. }
+            | Error::WriteFacts { .. }
+            | Error::Scratch { .. }
+            | Error::RunSouffle { .. }
+            | Error::SouffleFailed { .. }
+            | Error::ReadOutput { .. } => ScipqlError::Souffle { message },
+            Error::BadEditRow { .. }
+            | Error::EditUnknownPath { .. }
+            | Error::EmptySelector
+            | Error::Overlap { .. }
+            | Error::WriteRewrite { .. } => ScipqlError::Edit { message },
+        }
+    }
+
+    /// Run `rust-analyzer scip` on `project`, writing the index to `output`
+    /// (default `index.scip`). Returns the output path.
+    pub fn index(
+        project: &str,
+        #[unibind(default = "index.scip")] output: &str,
+    ) -> Result<String, ScipqlError> {
+        scipql_core::index(Path::new(project), Path::new(output))
+            .map_err(|error| classify(&error))?;
+        Ok(output.to_owned())
+    }
+
+    /// Lower a SCIP index into the four fact relations.
+    ///
+    /// `root` resolves relative document paths for byte offsets; it defaults
+    /// to the index's project root.
+    pub fn facts(index_path: &str, root: Option<&str>) -> Result<Facts, ScipqlError> {
+        let loaded =
+            scipql_core::load_index(Path::new(index_path)).map_err(|error| classify(&error))?;
+        let root = root.map(PathBuf::from);
+        let facts = scipql_core::facts_from_index(&loaded, root.as_deref())
+            .map_err(|error| classify(&error))?;
+        Ok(Facts {
+            occurrence: facts
+                .occurrences
+                .into_iter()
+                .map(|row| Occurrence {
+                    symbol: row.symbol,
+                    path: row.path,
+                    start: row.start,
+                    end: row.end,
+                    role: row.role,
+                })
+                .collect(),
+            symbol_info: facts
+                .symbols
+                .into_iter()
+                .map(|row| SymbolInfo {
+                    symbol: row.symbol,
+                    kind: row.kind,
+                    display_name: row.display_name,
+                })
+                .collect(),
+            document: facts
+                .documents
+                .into_iter()
+                .map(|path| Document { path })
+                .collect(),
+            relationship: facts
+                .relationships
+                .into_iter()
+                .map(|row| Relationship {
+                    symbol: row.symbol,
+                    related: row.related,
+                    kind: row.kind,
+                })
+                .collect(),
+        })
+    }
+
+    /// Run a Soufflé `program` over the index's facts. Returns one relation
+    /// per `.output` declaration, keyed by relation name. The fact relations
+    /// are already in scope.
+    pub fn query(
+        index_path: &str,
+        program: &str,
+        root: Option<&str>,
+    ) -> Result<HashMap<String, Relation>, ScipqlError> {
+        let loaded =
+            scipql_core::load_index(Path::new(index_path)).map_err(|error| classify(&error))?;
+        let root = root.map(PathBuf::from);
+        let output = scipql_core::query(&loaded, root.as_deref(), program)
+            .map_err(|error| classify(&error))?;
+        Ok(output
+            .relations
+            .into_iter()
+            .map(|relation| {
+                let rows = relation
+                    .rows
+                    .into_iter()
+                    .map(|row| relation.columns.iter().cloned().zip(row).collect())
+                    .collect();
+                (
+                    relation.name,
+                    Relation {
+                        columns: relation.columns,
+                        rows,
+                    },
+                )
+            })
+            .collect())
+    }
+
+    /// Run a `fix` program (one that `.output`s `edit(path, start, end,
+    /// replacement)`) and return the unified diff. With `write=True` the
+    /// files under `root` are rewritten on disk.
+    pub fn fix(
+        index_path: &str,
+        program: &str,
+        root: Option<&str>,
+        #[unibind(default = false)] write: bool,
+    ) -> Result<String, ScipqlError> {
+        let loaded =
+            scipql_core::load_index(Path::new(index_path)).map_err(|error| classify(&error))?;
+        let root = root.map(PathBuf::from);
+        scipql_core::fix(&loaded, root.as_deref(), program, write)
+            .map_err(|error| classify(&error))
+    }
+
+    /// Rename every occurrence whose SCIP moniker ends with `selector` to
+    /// `new_name`. Returns the unified diff; `write=True` applies it.
+    pub fn rename(
+        index_path: &str,
+        selector: &str,
+        new_name: &str,
+        root: Option<&str>,
+        #[unibind(default = false)] write: bool,
+    ) -> Result<String, ScipqlError> {
+        let loaded =
+            scipql_core::load_index(Path::new(index_path)).map_err(|error| classify(&error))?;
+        let root = root.map(PathBuf::from);
+        scipql_core::rename(&loaded, root.as_deref(), selector, new_name, write)
+            .map_err(|error| classify(&error))
+    }
 }

--- a/packages/nix/nix-cargo-unit/src/model.rs
+++ b/packages/nix/nix-cargo-unit/src/model.rs
@@ -553,6 +553,13 @@ impl Unit {
     pub fn has_doctests(&self) -> bool {
         self.target.doctest
             && self.is_library()
+            // The rendered doctest command compiles the crate under test as a
+            // plain library, but a proc-macro target only compiles under
+            // `--crate-type proc-macro` (cargo special-cases this when it
+            // drives rustdoc): every `#[proc_macro_attribute]` item and the
+            // `proc_macro` import error out otherwise. Skip the doctest unit
+            // until the renderer mirrors cargo's proc-macro rustdoc setup.
+            && !self.is_proc_macro()
             && !self.is_external()
             && self.mode != UnitMode::Test
     }

--- a/packages/unibind/README.md
+++ b/packages/unibind/README.md
@@ -1,0 +1,136 @@
+# unibind
+
+One Rust attribute surface, one language-agnostic interface representation,
+one code generator per target language. A crate annotates the functions,
+records, and errors it wants to expose; unibind lowers that surface into an
+IR at macro time and renders bindings through the incumbent binding library
+of each enabled language backend.
+
+## The bet
+
+UniFFI-style tools settle for a C-ABI lowest common denominator: every value
+crosses a serialization shim, and async, cancellation, and resource cleanup
+are bolted on. unibind inverts that. The interface definition stays
+write-once, but each backend emits code for the best binding library in its
+ecosystem (pyo3 for Python, napi-rs for TypeScript, rustler for Elixir), so
+every language gets native semantics: real exception hierarchies, native
+async and cancellation, RAII-shaped resource cleanup, and types that flow end
+to end with no RustBuffer tax.
+
+## Surface
+
+There is no UDL or spec file. The Rust module is the source of truth:
+
+```rust
+#[unibind::export]
+mod _mylib {
+    /// Rows come back as native classes.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Row {
+        pub id: u64,
+        pub name: String,
+    }
+
+    /// Everything the boundary raises.
+    #[unibind::error(py(base = "ValueError"))]
+    pub enum MyError {
+        /// The store is gone.
+        StoreGone { message: String },
+    }
+
+    /// Doc comments become docstrings.
+    pub fn rows(store: &str, #[unibind(default = 10)] limit: usize) -> Result<Vec<Row>, MyError> {
+        ...
+    }
+}
+```
+
+- `#[unibind::export]` on an inline module lowers every `pub fn` in it, plus
+  the annotated types, into one interface value in a single parse. Private
+  items pass through as plain Rust.
+- `#[unibind::record]` marks a plain-data struct that crosses the boundary by
+  value: a native class per language, one read-only attribute per field, and
+  a positional constructor. Fields are `pub` and owned; the struct derives
+  `Clone`.
+- `#[unibind::error]` marks an error enum. Each variant becomes an exception
+  class under one base class named after the enum; `py(base = "...")` picks
+  the built-in the base extends. The enum implements `Display`, and the
+  raised exception carries that text.
+- `#[unibind::object]` reserves the surface for stateful handles; it errors
+  until phase 2 (#1992).
+- `#[unibind(py(name = "..."))]` renames a module, function, argument, field,
+  or error variant for Python. `#[unibind(default = ...)]` gives an argument
+  a default; `Option` arguments default to `None` automatically.
+
+## Pipeline
+
+```
+annotated module --syn lowering--> Interface IR --backend render--> binding code
+     (macros)      (core)                           (backend-py, ...)
+```
+
+The `unibind` proc-macro crate parses the module once, `unibind-core` lowers
+it to the IR and validates the surface, and each backend enabled by a cargo
+feature renders code into the expansion. The serialized IR also lands in a
+link section of the built artifact (`.unibind_ir`, `__DATA,__unibind_ir` on
+Apple), wasm-bindgen style, so out-of-process generators in later phases can
+read the interface without the Rust source: generated `.pyi` stubs and nix
+glue are phase 1 (#1991), `.d.ts` and Elixir specs come with their backends.
+
+Crates:
+
+- `core`: the IR types (`Interface`, functions, records, enums, errors,
+  objects, the boundary `Type`), the syn lowering, and the link-section
+  embed. Enums, objects, and async exist in the IR but phase 0 rejects them
+  with pointers at the phase that ships them.
+- `macros`: the `unibind` proc-macro crate. Parse once to IR, dispatch to the
+  backends the consuming crate enabled through features (`py` today).
+- `backend-py`: renders the IR into pyo3 0.28 (abi3-py311) code:
+  `#[pyfunction]` wrappers with `#[pyo3(signature = ...)]` defaults,
+  `#[pyclass]` records, `create_exception!` hierarchies plus a
+  `From<YourError> for PyErr` impl, and one imperative `#[pymodule]` that
+  registers everything and sets `__version__`. Doc comments become
+  docstrings. The consuming crate depends on `pyo3` directly with
+  `extension-module`.
+
+## Type mapping (phase 0)
+
+| Rust                  | IR              | Python        |
+| --------------------- | --------------- | ------------- |
+| `bool`                | `Bool`          | `bool`        |
+| `i8..i64`, `u8..u64`, `isize`, `usize` | `Int` | `int` |
+| `f32`, `f64`          | `Float`         | `float`       |
+| `String` / `&str`     | `String`        | `str`         |
+| `PathBuf` / `&Path`   | `Path`          | accepts `str \| os.PathLike`, returns `str` |
+| `Vec<u8>` / `&[u8]`   | `Bytes`         | `bytes`       |
+| `Option<T>`           | `Option`        | `T \| None`   |
+| `Vec<T>`              | `Vec`           | `list[T]`     |
+| `HashMap<K, V>`       | `Map`           | `dict[K, V]`  |
+| `#[unibind::record]`  | `Named`         | native class  |
+| `Result<T, E>`        | `ret` + `throws`| `T`, raises `E`'s hierarchy |
+
+Borrowed forms (`&str`, `&Path`, `&[u8]`, including under `Option`) are
+argument-only; returns and record fields own their data.
+
+## Phases
+
+| Phase | Issue | Scope |
+| ----- | ----- | ----- |
+| 0     | #1990 | core IR, macro skeleton, pyo3 backend for sync functions, records, errors; proven by porting `packages/code/scipql/py` |
+| 1     | #1991 | `unibind-gen`: host files (`.pyi`) from the embedded IR, `unibind.lib.build` nix glue |
+| 2     | #1992 | async, cancellation, streams, resources/objects (Python backend) |
+| 3     | #1993 | TypeScript backend (napi-rs) with enriched `.d.ts` |
+| 4     | #1994 | Rust client backend over a stable ABI |
+| 5     | #1995 | Elixir backend (rustler, generated `.ex`, `@spec`) |
+| 6     | #1996 | adopt for ix-sdk, delete sdk-py and sdk-ts |
+
+## Phase 0 in the tree
+
+`packages/code/scipql/py` is the proving port: the same five functions, the
+same `_scipql` module name and cdylib layout the mcp interpreter bundles, but
+the 169 lines of hand-written pyo3 conversion replaced by the annotated
+module above plus record and error declarations. The exception surface
+stays compatible (`ScipqlError` extends `ValueError`, which is what the
+hand-written binding raised), and `packages/unibind/backend-py/tests`
+snapshots the exact code the macro generates.

--- a/packages/unibind/backend-py/Cargo.toml
+++ b/packages/unibind/backend-py/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "unibind-backend-py"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Render the unibind IR into pyo3 binding code: pyfunction wrappers, pyclass records, exception hierarchies, and the pymodule"
+
+[lints]
+workspace = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+unibind-core.workspace = true
+
+[dev-dependencies]
+prettyplease.workspace = true
+serde_json.workspace = true

--- a/packages/unibind/backend-py/package.nix
+++ b/packages/unibind/backend-py/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "unibind-backend-py";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/unibind/backend-py/src/error.rs
+++ b/packages/unibind/backend-py/src/error.rs
@@ -1,0 +1,82 @@
+//! Render error enums as exception hierarchies.
+//!
+//! One `create_exception!` base class per enum (extending the requested
+//! Python built-in), one subclass per variant, and a `From<Enum> for PyErr`
+//! impl that picks the subclass and carries the enum's `Display` text.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use unibind_core::ir;
+
+use crate::function::doc_attrs;
+use crate::RenderError;
+
+pub(crate) fn render_error(
+    error: &ir::ErrorType,
+    module_name: &Ident,
+    user: &Ident,
+) -> Result<TokenStream, RenderError> {
+    let rust_name = Ident::new(&error.name, Span::call_site());
+    let base_class = Ident::new(error.names.py.as_deref().unwrap_or(&error.name), Span::call_site());
+    let builtin = builtin_base(error.py_base.as_deref())?;
+    let base_doc = error.docs.join("\n");
+
+    let mut classes = vec![quote! {
+        ::pyo3::create_exception!(#module_name, #base_class, #builtin, #base_doc);
+    }];
+    let mut arms = Vec::new();
+    for variant in &error.variants {
+        let variant_ident = Ident::new(&variant.name, Span::call_site());
+        let class = Ident::new(
+            variant.names.py.as_deref().unwrap_or(&variant.name),
+            Span::call_site(),
+        );
+        let doc = variant.docs.join("\n");
+        classes.push(quote! {
+            ::pyo3::create_exception!(#module_name, #class, #base_class, #doc);
+        });
+        arms.push(quote! {
+            super::#user::#rust_name::#variant_ident { .. } => #class::new_err(message),
+        });
+    }
+
+    let from_docs = doc_attrs(&[format!(
+        "Map `{}` onto its exception class, message from `Display`.",
+        error.name
+    )]);
+    Ok(quote! {
+        #(#classes)*
+        #from_docs
+        impl ::std::convert::From<super::#user::#rust_name> for ::pyo3::PyErr {
+            fn from(error: super::#user::#rust_name) -> Self {
+                let message = ::std::string::ToString::to_string(&error);
+                match error {
+                    #(#arms)*
+                }
+            }
+        }
+    })
+}
+
+/// Exception classes the base can extend, by Python name.
+fn builtin_base(name: Option<&str>) -> Result<TokenStream, RenderError> {
+    let path = match name.unwrap_or("Exception") {
+        "Exception" => quote!(::pyo3::exceptions::PyException),
+        "ValueError" => quote!(::pyo3::exceptions::PyValueError),
+        "TypeError" => quote!(::pyo3::exceptions::PyTypeError),
+        "RuntimeError" => quote!(::pyo3::exceptions::PyRuntimeError),
+        "OSError" => quote!(::pyo3::exceptions::PyOSError),
+        "IOError" => quote!(::pyo3::exceptions::PyIOError),
+        "KeyError" => quote!(::pyo3::exceptions::PyKeyError),
+        "LookupError" => quote!(::pyo3::exceptions::PyLookupError),
+        "NotImplementedError" => quote!(::pyo3::exceptions::PyNotImplementedError),
+        other => {
+            return Err(RenderError::new(format!(
+                "`py(base = \"{other}\")` is not a supported base exception; use one of \
+                 Exception, ValueError, TypeError, RuntimeError, OSError, IOError, \
+                 KeyError, LookupError, NotImplementedError"
+            )));
+        }
+    };
+    Ok(path)
+}

--- a/packages/unibind/backend-py/src/error.rs
+++ b/packages/unibind/backend-py/src/error.rs
@@ -11,7 +11,7 @@ use unibind_core::ir;
 use crate::function::doc_attrs;
 use crate::RenderError;
 
-pub(crate) fn render_error(
+pub fn render_error(
     error: &ir::ErrorType,
     module_name: &Ident,
     user: &Ident,

--- a/packages/unibind/backend-py/src/function.rs
+++ b/packages/unibind/backend-py/src/function.rs
@@ -1,0 +1,81 @@
+//! Render `#[pyfunction]` wrappers around the user's functions.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use unibind_core::ir;
+
+use crate::{ty, RenderError};
+
+pub(crate) fn render_fn(function: &ir::Function, user: &Ident) -> Result<TokenStream, RenderError> {
+    if matches!(function.asyncness, ir::Asyncness::Async) {
+        return Err(RenderError::new(format!(
+            "`{}` is async; async functions land in phase 2 (issue #1992)",
+            function.name
+        )));
+    }
+    let rust_name = Ident::new(&function.name, Span::call_site());
+    let rename = function.names.py.as_ref().map(|name| {
+        quote! { #[pyo3(name = #name)] }
+    });
+    let docs = doc_attrs(&function.docs);
+
+    let mut params = Vec::new();
+    let mut signature = Vec::new();
+    let mut forwarded = Vec::new();
+    for arg in &function.args {
+        let ident = ty::name_ident(arg.names.py.as_ref().unwrap_or(&arg.name))?;
+        let ty = ty::rust_type(&arg.ty, user);
+        params.push(quote!(#ident: #ty));
+        signature.push(signature_entry(arg, &ident));
+        forwarded.push(quote!(#ident));
+    }
+
+    let ok_ty = function
+        .ret
+        .as_ref()
+        .map_or_else(|| quote!(()), |ret| ty::rust_type(ret, user));
+    let call = quote!(super::#user::#rust_name(#(#forwarded),*));
+    let body_and_ret = if function.throws.is_some() {
+        BodyAndRet {
+            ret: quote!(::pyo3::PyResult<#ok_ty>),
+            body: quote!(#call.map_err(::pyo3::PyErr::from)),
+        }
+    } else {
+        BodyAndRet {
+            ret: ok_ty,
+            body: call,
+        }
+    };
+    let BodyAndRet { ret, body } = body_and_ret;
+
+    Ok(quote! {
+        #docs
+        #[::pyo3::pyfunction]
+        #rename
+        #[pyo3(signature = (#(#signature),*))]
+        fn #rust_name(#(#params),*) -> #ret {
+            #body
+        }
+    })
+}
+
+/// A wrapper's return type and body, which vary together on `throws`.
+struct BodyAndRet {
+    ret: TokenStream,
+    body: TokenStream,
+}
+
+fn signature_entry(arg: &ir::Arg, ident: &Ident) -> TokenStream {
+    if let Some(default) = &arg.default {
+        let default = ty::default_tokens(default);
+        return quote!(#ident = #default);
+    }
+    if matches!(arg.ty, ir::Type::Option(_)) {
+        return quote!(#ident = None);
+    }
+    quote!(#ident)
+}
+
+pub(crate) fn doc_attrs(lines: &[String]) -> TokenStream {
+    quote! { #(#[doc = #lines])* }
+}

--- a/packages/unibind/backend-py/src/function.rs
+++ b/packages/unibind/backend-py/src/function.rs
@@ -6,7 +6,7 @@ use unibind_core::ir;
 
 use crate::{ty, RenderError};
 
-pub(crate) fn render_fn(function: &ir::Function, user: &Ident) -> Result<TokenStream, RenderError> {
+pub fn render_fn(function: &ir::Function, user: &Ident) -> Result<TokenStream, RenderError> {
     if matches!(function.asyncness, ir::Asyncness::Async) {
         return Err(RenderError::new(format!(
             "`{}` is async; async functions land in phase 2 (issue #1992)",
@@ -76,6 +76,6 @@ fn signature_entry(arg: &ir::Arg, ident: &Ident) -> TokenStream {
     quote!(#ident)
 }
 
-pub(crate) fn doc_attrs(lines: &[String]) -> TokenStream {
+pub fn doc_attrs(lines: &[String]) -> TokenStream {
     quote! { #(#[doc = #lines])* }
 }

--- a/packages/unibind/backend-py/src/lib.rs
+++ b/packages/unibind/backend-py/src/lib.rs
@@ -17,7 +17,6 @@ mod ty;
 pub use module::render;
 
 /// The rendered output for one interface.
-#[derive(Debug)]
 pub struct RenderedInterface {
     /// Sibling items for the exported module: the hidden glue module with
     /// the exception types, `From` impls, `pyfunction` wrappers, record
@@ -29,7 +28,6 @@ pub struct RenderedInterface {
 }
 
 /// `#[pyclass]`-shaped attributes for one record struct.
-#[derive(Debug)]
 pub struct RenderedRecord {
     /// Outer attributes for the struct itself.
     pub outer: Vec<syn::Attribute>,

--- a/packages/unibind/backend-py/src/lib.rs
+++ b/packages/unibind/backend-py/src/lib.rs
@@ -1,0 +1,53 @@
+//! Render a lowered [`unibind_core::ir::Interface`] into `pyo3` binding code.
+//!
+//! The backend targets the incumbent binding library rather than raw FFI: it
+//! emits `#[pyo3::pyfunction]` wrappers around the user's functions, attaches
+//! `#[pyo3::pyclass]` to record structs, builds the exception hierarchy with
+//! `pyo3::create_exception!`, and registers everything in one imperative
+//! `#[pyo3::pymodule]`. The consuming crate therefore depends on `pyo3`
+//! directly (with `extension-module` for a wheel-shaped cdylib), and the
+//! generated code compiles against `pyo3` 0.28 with `abi3-py311`.
+
+mod error;
+mod function;
+mod module;
+mod record;
+mod ty;
+
+pub use module::render;
+
+/// The rendered output for one interface.
+#[derive(Debug)]
+pub struct RenderedInterface {
+    /// Sibling items for the exported module: the hidden glue module with
+    /// the exception types, `From` impls, `pyfunction` wrappers, record
+    /// constructors, and the `pymodule` registration.
+    pub glue: proc_macro2::TokenStream,
+    /// Attributes to attach to each record struct, index-aligned with the
+    /// interface's records.
+    pub records: Vec<RenderedRecord>,
+}
+
+/// `#[pyclass]`-shaped attributes for one record struct.
+#[derive(Debug)]
+pub struct RenderedRecord {
+    /// Outer attributes for the struct itself.
+    pub outer: Vec<syn::Attribute>,
+    /// Attributes for each field, index-aligned with the record's fields.
+    pub fields: Vec<Vec<syn::Attribute>>,
+}
+
+/// A rendering failure; the macro positions it at the exported module.
+#[derive(Debug)]
+pub struct RenderError {
+    /// What went wrong and what to do instead.
+    pub message: String,
+}
+
+impl RenderError {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}

--- a/packages/unibind/backend-py/src/module.rs
+++ b/packages/unibind/backend-py/src/module.rs
@@ -1,0 +1,108 @@
+//! Assemble the glue module and the `#[pymodule]` registration.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::{error, function, record, ty, RenderError, RenderedInterface};
+
+/// Render `pyo3` glue for one interface.
+///
+/// # Errors
+///
+/// Fails for surface the phase 0 backend does not implement (async
+/// functions, data enums, objects), for unsupported `py(base = ...)`
+/// exception bases, and for renames that cannot become identifiers.
+pub fn render(interface: &ir::Interface) -> Result<RenderedInterface, RenderError> {
+    if let Some(object) = interface.objects.first() {
+        return Err(RenderError::new(format!(
+            "`{}` is a #[unibind::object]; objects land in phase 2 (issue #1992)",
+            object.name
+        )));
+    }
+    if let Some(data_enum) = interface.enums.first() {
+        return Err(RenderError::new(format!(
+            "`{}` is a data enum, which phase 0 does not render",
+            data_enum.name
+        )));
+    }
+
+    let user = ty::name_ident(&interface.name)?;
+    let module_name = interface.names.py.clone().unwrap_or_else(|| interface.name.clone());
+    let module_ident = ty::name_ident(&module_name)?;
+    let glue_ident = format_ident!("__unibind_py_{}", interface.name.trim_start_matches('_'));
+
+    let exceptions = interface
+        .errors
+        .iter()
+        .map(|err| error::render_error(err, &module_ident, &user))
+        .collect::<Result<Vec<_>, _>>()?;
+    let wrappers = interface
+        .functions
+        .iter()
+        .map(|func| function::render_fn(func, &user))
+        .collect::<Result<Vec<_>, _>>()?;
+    let constructors = interface
+        .records
+        .iter()
+        .map(|rec| record::constructor(rec, &user))
+        .collect::<Result<Vec<_>, _>>()?;
+    let registration = registration(interface, &user)?;
+    let module_docs = function::doc_attrs(&interface.docs);
+
+    let glue = quote! {
+        #[doc(hidden)]
+        #[allow(clippy::all, clippy::pedantic, clippy::nursery, unused_qualifications)]
+        mod #glue_ident {
+            #(#exceptions)*
+            #(#constructors)*
+            #(#wrappers)*
+
+            #module_docs
+            #[::pyo3::pymodule]
+            #[pyo3(name = #module_name)]
+            fn __unibind_module(
+                module: &::pyo3::Bound<'_, ::pyo3::types::PyModule>,
+            ) -> ::pyo3::PyResult<()> {
+                #registration
+                ::pyo3::PyResult::Ok(())
+            }
+        }
+    };
+    let records = interface.records.iter().map(record::record_attrs).collect();
+    Ok(RenderedInterface { glue, records })
+}
+
+fn registration(interface: &ir::Interface, user: &Ident) -> Result<TokenStream, RenderError> {
+    let mut statements = Vec::new();
+    for func in &interface.functions {
+        let ident = Ident::new(&func.name, Span::call_site());
+        statements.push(quote! {
+            module.add_function(::pyo3::wrap_pyfunction!(#ident, module)?)?;
+        });
+    }
+    for rec in &interface.records {
+        let ident = Ident::new(&rec.name, Span::call_site());
+        statements.push(quote! {
+            module.add_class::<super::#user::#ident>()?;
+        });
+    }
+    for err in &interface.errors {
+        let base_name = err.names.py.as_deref().unwrap_or(&err.name);
+        let base_ident = ty::name_ident(base_name)?;
+        statements.push(quote! {
+            module.add(#base_name, module.py().get_type::<#base_ident>())?;
+        });
+        for variant in &err.variants {
+            let class_name = variant.names.py.as_deref().unwrap_or(&variant.name);
+            let class_ident = ty::name_ident(class_name)?;
+            statements.push(quote! {
+                module.add(#class_name, module.py().get_type::<#class_ident>())?;
+            });
+        }
+    }
+    statements.push(quote! {
+        module.add("__version__", ::std::env!("CARGO_PKG_VERSION"))?;
+    });
+    Ok(quote! { #(#statements)* })
+}

--- a/packages/unibind/backend-py/src/module.rs
+++ b/packages/unibind/backend-py/src/module.rs
@@ -54,6 +54,8 @@ pub fn render(interface: &ir::Interface) -> Result<RenderedInterface, RenderErro
         #[doc(hidden)]
         #[allow(clippy::all, clippy::pedantic, clippy::nursery, unused_qualifications)]
         mod #glue_ident {
+            use ::pyo3::types::PyModuleMethods as _;
+
             #(#exceptions)*
             #(#constructors)*
             #(#wrappers)*

--- a/packages/unibind/backend-py/src/record.rs
+++ b/packages/unibind/backend-py/src/record.rs
@@ -10,19 +10,19 @@ use crate::{ty, RenderError, RenderedRecord};
 
 /// The attributes the exported struct gains: `#[pyclass]` on the item and a
 /// read-only getter per field.
-pub(crate) fn record_attrs(record: &ir::Record) -> RenderedRecord {
-    let outer: syn::Attribute = match &record.names.py {
-        Some(name) => parse_quote!(#[::pyo3::pyclass(from_py_object, name = #name)]),
-        None => parse_quote!(#[::pyo3::pyclass(from_py_object)]),
-    };
+pub fn record_attrs(record: &ir::Record) -> RenderedRecord {
+    let outer: syn::Attribute = record.names.py.as_ref().map_or_else(
+        || parse_quote!(#[::pyo3::pyclass(from_py_object)]),
+        |name| parse_quote!(#[::pyo3::pyclass(from_py_object, name = #name)]),
+    );
     let fields = record
         .fields
         .iter()
         .map(|field| {
-            let attr: syn::Attribute = match &field.names.py {
-                Some(name) => parse_quote!(#[pyo3(get, name = #name)]),
-                None => parse_quote!(#[pyo3(get)]),
-            };
+            let attr: syn::Attribute = field.names.py.as_ref().map_or_else(
+                || parse_quote!(#[pyo3(get)]),
+                |name| parse_quote!(#[pyo3(get, name = #name)]),
+            );
             vec![attr]
         })
         .collect();
@@ -34,7 +34,7 @@ pub(crate) fn record_attrs(record: &ir::Record) -> RenderedRecord {
 
 /// A `#[pymethods]` block giving the record a positional-or-keyword
 /// constructor, so Python can build values as well as receive them.
-pub(crate) fn constructor(record: &ir::Record, user: &Ident) -> Result<TokenStream, RenderError> {
+pub fn constructor(record: &ir::Record, user: &Ident) -> Result<TokenStream, RenderError> {
     let name = Ident::new(&record.name, Span::call_site());
     let mut params = Vec::new();
     let mut field_idents = Vec::new();

--- a/packages/unibind/backend-py/src/record.rs
+++ b/packages/unibind/backend-py/src/record.rs
@@ -12,8 +12,8 @@ use crate::{ty, RenderError, RenderedRecord};
 /// read-only getter per field.
 pub(crate) fn record_attrs(record: &ir::Record) -> RenderedRecord {
     let outer: syn::Attribute = match &record.names.py {
-        Some(name) => parse_quote!(#[::pyo3::pyclass(name = #name)]),
-        None => parse_quote!(#[::pyo3::pyclass]),
+        Some(name) => parse_quote!(#[::pyo3::pyclass(from_py_object, name = #name)]),
+        None => parse_quote!(#[::pyo3::pyclass(from_py_object)]),
     };
     let fields = record
         .fields

--- a/packages/unibind/backend-py/src/record.rs
+++ b/packages/unibind/backend-py/src/record.rs
@@ -1,0 +1,64 @@
+//! Attach `#[pyclass]` to record structs and render their constructors.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::parse_quote;
+use unibind_core::ir;
+
+use crate::function::doc_attrs;
+use crate::{ty, RenderError, RenderedRecord};
+
+/// The attributes the exported struct gains: `#[pyclass]` on the item and a
+/// read-only getter per field.
+pub(crate) fn record_attrs(record: &ir::Record) -> RenderedRecord {
+    let outer: syn::Attribute = match &record.names.py {
+        Some(name) => parse_quote!(#[::pyo3::pyclass(name = #name)]),
+        None => parse_quote!(#[::pyo3::pyclass]),
+    };
+    let fields = record
+        .fields
+        .iter()
+        .map(|field| {
+            let attr: syn::Attribute = match &field.names.py {
+                Some(name) => parse_quote!(#[pyo3(get, name = #name)]),
+                None => parse_quote!(#[pyo3(get)]),
+            };
+            vec![attr]
+        })
+        .collect();
+    RenderedRecord {
+        outer: vec![outer],
+        fields,
+    }
+}
+
+/// A `#[pymethods]` block giving the record a positional-or-keyword
+/// constructor, so Python can build values as well as receive them.
+pub(crate) fn constructor(record: &ir::Record, user: &Ident) -> Result<TokenStream, RenderError> {
+    let name = Ident::new(&record.name, Span::call_site());
+    let mut params = Vec::new();
+    let mut field_idents = Vec::new();
+    let mut signature = Vec::new();
+    for field in &record.fields {
+        let ident = Ident::new(&field.name, Span::call_site());
+        let py_ident = ty::name_ident(field.names.py.as_ref().unwrap_or(&field.name))?;
+        let ty = ty::rust_type(&field.ty, user);
+        params.push(quote!(#py_ident: #ty));
+        signature.push(quote!(#py_ident));
+        field_idents.push(quote!(#ident: #py_ident));
+    }
+    let docs = doc_attrs(&record.docs);
+    Ok(quote! {
+        #[::pyo3::pymethods]
+        impl super::#user::#name {
+            #docs
+            #[new]
+            #[pyo3(signature = (#(#signature),*))]
+            fn __unibind_new(#(#params),*) -> Self {
+                Self {
+                    #(#field_idents),*
+                }
+            }
+        }
+    })
+}

--- a/packages/unibind/backend-py/src/ty.rs
+++ b/packages/unibind/backend-py/src/ty.rs
@@ -1,0 +1,82 @@
+//! Render IR types back into Rust token streams for the generated glue.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use unibind_core::ir;
+
+use crate::RenderError;
+
+/// The Rust spelling of a boundary type, as the wrapper signatures use it.
+/// `user` is the exported module's identifier; named types resolve through
+/// `super::<user>::`.
+pub(crate) fn rust_type(ty: &ir::Type, user: &Ident) -> TokenStream {
+    match ty {
+        ir::Type::Bool => quote!(bool),
+        ir::Type::Int(kind) => int_tokens(*kind),
+        ir::Type::Float(ir::FloatKind::F32) => quote!(f32),
+        ir::Type::Float(ir::FloatKind::F64) => quote!(f64),
+        ir::Type::String { owned: true } => quote!(::std::string::String),
+        ir::Type::String { owned: false } => quote!(&str),
+        ir::Type::Path { owned: true } => quote!(::std::path::PathBuf),
+        ir::Type::Path { owned: false } => quote!(&::std::path::Path),
+        ir::Type::Bytes { owned: true } => quote!(::std::vec::Vec<u8>),
+        ir::Type::Bytes { owned: false } => quote!(&[u8]),
+        ir::Type::Option(inner) => {
+            let inner = rust_type(inner, user);
+            quote!(::std::option::Option<#inner>)
+        }
+        ir::Type::Vec(inner) => {
+            let inner = rust_type(inner, user);
+            quote!(::std::vec::Vec<#inner>)
+        }
+        ir::Type::Map { key, value } => {
+            let key = rust_type(key, user);
+            let value = rust_type(value, user);
+            quote!(::std::collections::HashMap<#key, #value>)
+        }
+        ir::Type::Named(name) => {
+            let name = Ident::new(name, Span::call_site());
+            quote!(super::#user::#name)
+        }
+    }
+}
+
+fn int_tokens(kind: ir::IntKind) -> TokenStream {
+    match kind {
+        ir::IntKind::I8 => quote!(i8),
+        ir::IntKind::I16 => quote!(i16),
+        ir::IntKind::I32 => quote!(i32),
+        ir::IntKind::I64 => quote!(i64),
+        ir::IntKind::Isize => quote!(isize),
+        ir::IntKind::U8 => quote!(u8),
+        ir::IntKind::U16 => quote!(u16),
+        ir::IntKind::U32 => quote!(u32),
+        ir::IntKind::U64 => quote!(u64),
+        ir::IntKind::Usize => quote!(usize),
+    }
+}
+
+/// The default-value expression for a `#[pyo3(signature = ...)]` entry.
+pub(crate) fn default_tokens(literal: &ir::Literal) -> TokenStream {
+    match literal {
+        ir::Literal::Bool(value) => quote!(#value),
+        ir::Literal::Int(value) => {
+            let value = proc_macro2::Literal::i64_unsuffixed(*value);
+            quote!(#value)
+        }
+        ir::Literal::Float(value) => {
+            let value = proc_macro2::Literal::f64_unsuffixed(*value);
+            quote!(#value)
+        }
+        ir::Literal::Str(value) => quote!(#value),
+        ir::Literal::None => quote!(None),
+    }
+}
+
+/// An identifier for a possibly-keyword name (Python renames like `type`
+/// fall back to raw identifiers, whose `r#` prefix `pyo3` strips again).
+pub(crate) fn name_ident(name: &str) -> Result<Ident, RenderError> {
+    syn::parse_str::<Ident>(name)
+        .or_else(|_| syn::parse_str::<Ident>(&format!("r#{name}")))
+        .map_err(|_| RenderError::new(format!("`{name}` is not usable as an identifier")))
+}

--- a/packages/unibind/backend-py/src/ty.rs
+++ b/packages/unibind/backend-py/src/ty.rs
@@ -9,7 +9,7 @@ use crate::RenderError;
 /// The Rust spelling of a boundary type, as the wrapper signatures use it.
 /// `user` is the exported module's identifier; named types resolve through
 /// `super::<user>::`.
-pub(crate) fn rust_type(ty: &ir::Type, user: &Ident) -> TokenStream {
+pub fn rust_type(ty: &ir::Type, user: &Ident) -> TokenStream {
     match ty {
         ir::Type::Bool => quote!(bool),
         ir::Type::Int(kind) => int_tokens(*kind),
@@ -57,7 +57,7 @@ fn int_tokens(kind: ir::IntKind) -> TokenStream {
 }
 
 /// The default-value expression for a `#[pyo3(signature = ...)]` entry.
-pub(crate) fn default_tokens(literal: &ir::Literal) -> TokenStream {
+pub fn default_tokens(literal: &ir::Literal) -> TokenStream {
     match literal {
         ir::Literal::Bool(value) => quote!(#value),
         ir::Literal::Int(value) => {
@@ -75,7 +75,7 @@ pub(crate) fn default_tokens(literal: &ir::Literal) -> TokenStream {
 
 /// An identifier for a possibly-keyword name (Python renames like `type`
 /// fall back to raw identifiers, whose `r#` prefix `pyo3` strips again).
-pub(crate) fn name_ident(name: &str) -> Result<Ident, RenderError> {
+pub fn name_ident(name: &str) -> Result<Ident, RenderError> {
     syn::parse_str::<Ident>(name)
         .or_else(|_| syn::parse_str::<Ident>(&format!("r#{name}")))
         .map_err(|_| RenderError::new(format!("`{name}` is not usable as an identifier")))

--- a/packages/unibind/backend-py/tests/fixtures/sample.rs
+++ b/packages/unibind/backend-py/tests/fixtures/sample.rs
@@ -1,0 +1,53 @@
+/// A sample boundary exercising the phase 0 surface.
+mod sample {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    /// A row.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Row {
+        /// Identifier.
+        pub id: u64,
+        #[unibind(py(name = "label"))]
+        pub name: String,
+        pub tags: Vec<String>,
+        pub weights: HashMap<String, f64>,
+        pub blob: Vec<u8>,
+        pub home: Option<PathBuf>,
+    }
+
+    /// Boundary failures.
+    #[unibind::error(py(base = "RuntimeError"))]
+    pub enum SampleError {
+        /// The store is gone.
+        #[unibind(py(name = "StoreGoneError"))]
+        StoreGone { message: String },
+        /// Bad input.
+        Invalid(String),
+    }
+
+    /// Fetch rows.
+    ///
+    /// Docs become docstrings.
+    pub fn rows(
+        store: &str,
+        #[unibind(default = 10)] limit: usize,
+        root: Option<&str>,
+    ) -> Result<Vec<Row>, SampleError> {
+        let _ = (store, limit, root);
+        Ok(Vec::new())
+    }
+
+    #[unibind(py(name = "touch_path"))]
+    pub fn touch(
+        path: &std::path::Path,
+        data: &[u8],
+        #[unibind(default = 0.5)] ratio: f64,
+        #[unibind(default = "note")] note: &str,
+        #[unibind(default = false)] flush: bool,
+    ) -> bool {
+        let _ = (path, data, ratio, note, flush);
+        true
+    }
+}

--- a/packages/unibind/backend-py/tests/render.rs
+++ b/packages/unibind/backend-py/tests/render.rs
@@ -1,0 +1,60 @@
+//! Snapshot the lowering and the pyo3 render for the sample module. The
+//! committed snapshots are the review surface for what the macro generates;
+//! on drift the test prints the new content to copy over the snapshot file.
+//! (trybuild/macrotest would invoke cargo at test runtime, which the nix
+//! test sandbox cannot do, so the render output is snapshotted directly.)
+
+use proc_macro2::TokenStream;
+use unibind_core::ir;
+
+fn interface() -> ir::Interface {
+    let file: syn::File =
+        syn::parse_str(include_str!("fixtures/sample.rs")).expect("fixture parses");
+    let Some(syn::Item::Mod(module)) = file.items.first() else {
+        panic!("fixture starts with a module");
+    };
+    unibind_core::lower_module(TokenStream::new(), module).expect("fixture lowers")
+}
+
+fn assert_snapshot(actual: &str, expected: &str, name: &str) {
+    if actual.trim() == expected.trim() {
+        return;
+    }
+    println!("=== actual {name} ===");
+    println!("{actual}");
+    println!("=== end {name} ===");
+    panic!("{name} drifted; copy the printed block into tests/snapshots/{name}");
+}
+
+#[test]
+fn ir_json_snapshot() {
+    let json = serde_json::to_string_pretty(&interface()).expect("serializes");
+    assert_snapshot(&json, include_str!("snapshots/sample.ir.json"), "sample.ir.json");
+}
+
+#[test]
+fn pyo3_glue_snapshot() {
+    let interface = interface();
+    let rendered = unibind_backend_py::render(&interface).expect("renders");
+
+    let mut shown = String::new();
+    for (record, attrs) in interface.records.iter().zip(&rendered.records) {
+        let outer = &attrs.outer;
+        shown.push_str(&format!(
+            "// struct {}: {}\n",
+            record.name,
+            quote::quote!(#(#outer)*)
+        ));
+        for (field, field_attrs) in record.fields.iter().zip(&attrs.fields) {
+            shown.push_str(&format!(
+                "//   field {}: {}\n",
+                field.name,
+                quote::quote!(#(#field_attrs)*)
+            ));
+        }
+    }
+    shown.push('\n');
+    let glue: syn::File = syn::parse2(rendered.glue).expect("glue parses");
+    shown.push_str(&prettyplease::unparse(&glue));
+    assert_snapshot(&shown, include_str!("snapshots/sample.py.rs"), "sample.py.rs");
+}

--- a/packages/unibind/backend-py/tests/render.rs
+++ b/packages/unibind/backend-py/tests/render.rs
@@ -4,6 +4,8 @@
 //! (trybuild/macrotest would invoke cargo at test runtime, which the nix
 //! test sandbox cannot do, so the render output is snapshotted directly.)
 
+use std::fmt::Write as _;
+
 use proc_macro2::TokenStream;
 use unibind_core::ir;
 
@@ -40,17 +42,16 @@ fn pyo3_glue_snapshot() {
     let mut shown = String::new();
     for (record, attrs) in interface.records.iter().zip(&rendered.records) {
         let outer = &attrs.outer;
-        shown.push_str(&format!(
-            "// struct {}: {}\n",
-            record.name,
-            quote::quote!(#(#outer)*)
-        ));
+        writeln!(shown, "// struct {}: {}", record.name, quote::quote!(#(#outer)*))
+            .expect("write to string");
         for (field, field_attrs) in record.fields.iter().zip(&attrs.fields) {
-            shown.push_str(&format!(
-                "//   field {}: {}\n",
+            writeln!(
+                shown,
+                "//   field {}: {}",
                 field.name,
                 quote::quote!(#(#field_attrs)*)
-            ));
+            )
+            .expect("write to string");
         }
     }
     shown.push('\n');

--- a/packages/unibind/backend-py/tests/snapshots/sample.ir.json
+++ b/packages/unibind/backend-py/tests/snapshots/sample.ir.json
@@ -1,0 +1,272 @@
+{
+  "version": 0,
+  "name": "sample",
+  "names": {
+    "py": null
+  },
+  "docs": [
+    "A sample boundary exercising the phase 0 surface."
+  ],
+  "functions": [
+    {
+      "name": "rows",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Fetch rows.",
+        "",
+        "Docs become docstrings."
+      ],
+      "asyncness": "Sync",
+      "args": [
+        {
+          "name": "store",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "String": {
+              "owned": false
+            }
+          },
+          "default": null
+        },
+        {
+          "name": "limit",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Int": "Usize"
+          },
+          "default": {
+            "Int": 10
+          }
+        },
+        {
+          "name": "root",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Option": {
+              "String": {
+                "owned": false
+              }
+            }
+          },
+          "default": null
+        }
+      ],
+      "ret": {
+        "Vec": {
+          "Named": "Row"
+        }
+      },
+      "throws": "SampleError"
+    },
+    {
+      "name": "touch",
+      "names": {
+        "py": "touch_path"
+      },
+      "docs": [],
+      "asyncness": "Sync",
+      "args": [
+        {
+          "name": "path",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Path": {
+              "owned": false
+            }
+          },
+          "default": null
+        },
+        {
+          "name": "data",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Bytes": {
+              "owned": false
+            }
+          },
+          "default": null
+        },
+        {
+          "name": "ratio",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Float": "F64"
+          },
+          "default": {
+            "Float": 0.5
+          }
+        },
+        {
+          "name": "note",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "String": {
+              "owned": false
+            }
+          },
+          "default": {
+            "Str": "note"
+          }
+        },
+        {
+          "name": "flush",
+          "names": {
+            "py": null
+          },
+          "ty": "Bool",
+          "default": {
+            "Bool": false
+          }
+        }
+      ],
+      "ret": "Bool",
+      "throws": null
+    }
+  ],
+  "records": [
+    {
+      "name": "Row",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "A row."
+      ],
+      "fields": [
+        {
+          "name": "id",
+          "names": {
+            "py": null
+          },
+          "docs": [
+            "Identifier."
+          ],
+          "ty": {
+            "Int": "U64"
+          }
+        },
+        {
+          "name": "name",
+          "names": {
+            "py": "label"
+          },
+          "docs": [],
+          "ty": {
+            "String": {
+              "owned": true
+            }
+          }
+        },
+        {
+          "name": "tags",
+          "names": {
+            "py": null
+          },
+          "docs": [],
+          "ty": {
+            "Vec": {
+              "String": {
+                "owned": true
+              }
+            }
+          }
+        },
+        {
+          "name": "weights",
+          "names": {
+            "py": null
+          },
+          "docs": [],
+          "ty": {
+            "Map": {
+              "key": {
+                "String": {
+                  "owned": true
+                }
+              },
+              "value": {
+                "Float": "F64"
+              }
+            }
+          }
+        },
+        {
+          "name": "blob",
+          "names": {
+            "py": null
+          },
+          "docs": [],
+          "ty": {
+            "Bytes": {
+              "owned": true
+            }
+          }
+        },
+        {
+          "name": "home",
+          "names": {
+            "py": null
+          },
+          "docs": [],
+          "ty": {
+            "Option": {
+              "Path": {
+                "owned": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "enums": [],
+  "errors": [
+    {
+      "name": "SampleError",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Boundary failures."
+      ],
+      "py_base": "RuntimeError",
+      "variants": [
+        {
+          "name": "StoreGone",
+          "names": {
+            "py": "StoreGoneError"
+          },
+          "docs": [
+            "The store is gone."
+          ]
+        },
+        {
+          "name": "Invalid",
+          "names": {
+            "py": null
+          },
+          "docs": [
+            "Bad input."
+          ]
+        }
+      ]
+    }
+  ],
+  "objects": []
+}

--- a/packages/unibind/backend-py/tests/snapshots/sample.py.rs
+++ b/packages/unibind/backend-py/tests/snapshots/sample.py.rs
@@ -1,0 +1,92 @@
+// struct Row: # [:: pyo3 :: pyclass (from_py_object)]
+//   field id: # [pyo3 (get)]
+//   field name: # [pyo3 (get , name = "label")]
+//   field tags: # [pyo3 (get)]
+//   field weights: # [pyo3 (get)]
+//   field blob: # [pyo3 (get)]
+//   field home: # [pyo3 (get)]
+
+#[doc(hidden)]
+#[allow(clippy::all, clippy::pedantic, clippy::nursery, unused_qualifications)]
+mod __unibind_py_sample {
+    use ::pyo3::types::PyModuleMethods as _;
+    ::pyo3::create_exception!(
+        sample, SampleError, ::pyo3::exceptions::PyRuntimeError, "Boundary failures."
+    );
+    ::pyo3::create_exception!(sample, StoreGoneError, SampleError, "The store is gone.");
+    ::pyo3::create_exception!(sample, Invalid, SampleError, "Bad input.");
+    ///Map `SampleError` onto its exception class, message from `Display`.
+    impl ::std::convert::From<super::sample::SampleError> for ::pyo3::PyErr {
+        fn from(error: super::sample::SampleError) -> Self {
+            let message = ::std::string::ToString::to_string(&error);
+            match error {
+                super::sample::SampleError::StoreGone { .. } => {
+                    StoreGoneError::new_err(message)
+                }
+                super::sample::SampleError::Invalid { .. } => Invalid::new_err(message),
+            }
+        }
+    }
+    #[::pyo3::pymethods]
+    impl super::sample::Row {
+        ///A row.
+        #[new]
+        #[pyo3(signature = (id, label, tags, weights, blob, home))]
+        fn __unibind_new(
+            id: u64,
+            label: ::std::string::String,
+            tags: ::std::vec::Vec<::std::string::String>,
+            weights: ::std::collections::HashMap<::std::string::String, f64>,
+            blob: ::std::vec::Vec<u8>,
+            home: ::std::option::Option<::std::path::PathBuf>,
+        ) -> Self {
+            Self {
+                id: id,
+                name: label,
+                tags: tags,
+                weights: weights,
+                blob: blob,
+                home: home,
+            }
+        }
+    }
+    ///Fetch rows.
+    ///
+    ///Docs become docstrings.
+    #[::pyo3::pyfunction]
+    #[pyo3(signature = (store, limit = 10, root = None))]
+    fn rows(
+        store: &str,
+        limit: usize,
+        root: ::std::option::Option<&str>,
+    ) -> ::pyo3::PyResult<::std::vec::Vec<super::sample::Row>> {
+        super::sample::rows(store, limit, root).map_err(::pyo3::PyErr::from)
+    }
+    #[::pyo3::pyfunction]
+    #[pyo3(name = "touch_path")]
+    #[pyo3(signature = (path, data, ratio = 0.5, note = "note", flush = false))]
+    fn touch(
+        path: &::std::path::Path,
+        data: &[u8],
+        ratio: f64,
+        note: &str,
+        flush: bool,
+    ) -> bool {
+        super::sample::touch(path, data, ratio, note, flush)
+    }
+    ///A sample boundary exercising the phase 0 surface.
+    #[::pyo3::pymodule]
+    #[pyo3(name = "sample")]
+    fn __unibind_module(
+        module: &::pyo3::Bound<'_, ::pyo3::types::PyModule>,
+    ) -> ::pyo3::PyResult<()> {
+        module.add_function(::pyo3::wrap_pyfunction!(rows, module)?)?;
+        module.add_function(::pyo3::wrap_pyfunction!(touch, module)?)?;
+        module.add_class::<super::sample::Row>()?;
+        module.add("SampleError", module.py().get_type::<SampleError>())?;
+        module.add("StoreGoneError", module.py().get_type::<StoreGoneError>())?;
+        module.add("Invalid", module.py().get_type::<Invalid>())?;
+        module.add("__version__", ::std::env!("CARGO_PKG_VERSION"))?;
+        ::pyo3::PyResult::Ok(())
+    }
+}

--- a/packages/unibind/core/Cargo.toml
+++ b/packages/unibind/core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "unibind-core"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Language-agnostic interface IR for unibind: syn lowering, serialization, and the link-section embed"
+
+[lints]
+workspace = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+syn.workspace = true

--- a/packages/unibind/core/package.nix
+++ b/packages/unibind/core/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "unibind-core";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/unibind/core/src/embed.rs
+++ b/packages/unibind/core/src/embed.rs
@@ -1,0 +1,42 @@
+//! Serialize the interface into a link-section constant.
+//!
+//! The macro plants the JSON-serialized [`Interface`] as a `#[used]` static
+//! in a dedicated section of the built artifact, the way `wasm-bindgen`
+//! ships its metadata. Later phases (the `unibind-gen` host-file generator,
+//! issue #1991) read the interface straight from the compiled library, so
+//! generated `.pyi` stubs or `.d.ts` files never need the Rust source.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::ir::Interface;
+use crate::lower::LowerError;
+
+/// Section name in ELF (and other non-Apple) objects.
+pub const LINK_SECTION_ELF: &str = ".unibind_ir";
+
+/// Mach-O `segment,section` pair; section names cap at 16 bytes.
+pub const LINK_SECTION_MACH_O: &str = "__DATA,__unibind_ir";
+
+/// Render the `#[used]` static carrying the serialized `interface`.
+///
+/// # Errors
+///
+/// Fails only when the interface cannot serialize, which would be a bug in
+/// the IR types rather than in the annotated module.
+pub fn ir_static(interface: &Interface) -> Result<TokenStream, LowerError> {
+    let json = serde_json::to_vec(interface).map_err(|error| LowerError {
+        span: proc_macro2::Span::call_site(),
+        message: format!("serializing the unibind interface failed: {error}"),
+    })?;
+    let len = json.len();
+    let bytes = proc_macro2::Literal::byte_string(&json);
+    Ok(quote! {
+        const _: () = {
+            #[cfg_attr(target_vendor = "apple", unsafe(link_section = #LINK_SECTION_MACH_O))]
+            #[cfg_attr(not(target_vendor = "apple"), unsafe(link_section = #LINK_SECTION_ELF))]
+            #[used]
+            static UNIBIND_IR: [u8; #len] = *#bytes;
+        };
+    })
+}

--- a/packages/unibind/core/src/ir.rs
+++ b/packages/unibind/core/src/ir.rs
@@ -1,0 +1,256 @@
+//! The unibind interface representation.
+//!
+//! One [`Interface`] value describes everything a `#[unibind::export]`
+//! module exposes: functions, records, and errors today, with enums and
+//! objects reserved for later phases. Backends render it into binding code,
+//! and [`crate::embed`] serializes it into the built artifact so
+//! out-of-process generators can read the same contract.
+
+use serde::{Deserialize, Serialize};
+
+/// Version tag written into every serialized interface so a reader can
+/// reject an IR layout it does not understand.
+pub const IR_VERSION: u32 = 0;
+
+/// Everything one `#[unibind::export]` module exposes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Interface {
+    /// IR layout version, [`IR_VERSION`] when produced by this crate.
+    pub version: u32,
+    /// The Rust module identifier the interface was lowered from; the
+    /// exported module name defaults to it.
+    pub name: String,
+    /// Per-language module renames.
+    pub names: Names,
+    /// Module doc comment, one entry per line.
+    pub docs: Vec<String>,
+    /// Exported free functions, in declaration order.
+    pub functions: Vec<Function>,
+    /// Plain-data structs, in declaration order.
+    pub records: Vec<Record>,
+    /// Plain data enums. Phase 0 lowering rejects them; the field keeps the
+    /// serialized layout ready for when they land.
+    pub enums: Vec<Enum>,
+    /// Error enums, each rendered as an exception hierarchy in Python.
+    pub errors: Vec<ErrorType>,
+    /// Stateful handles. Phase 0 lowering rejects them (they land with
+    /// resources in phase 2, issue #1992); the field keeps the layout ready.
+    pub objects: Vec<Object>,
+}
+
+/// Per-language name overrides, from `#[unibind(py(name = "..."))]`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Names {
+    /// Python name override.
+    pub py: Option<String>,
+}
+
+/// How a function suspends. Phase 0 lowers only `Sync`; `Async` is the
+/// phase 2 surface (issue #1992).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum Asyncness {
+    /// A plain blocking call.
+    Sync,
+    /// An `async fn`; reserved, never produced by phase 0 lowering.
+    Async,
+}
+
+/// One exported free function.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Function {
+    /// Rust function name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines; backends turn them into docstrings.
+    pub docs: Vec<String>,
+    /// Whether the function suspends.
+    pub asyncness: Asyncness,
+    /// Arguments in declaration order.
+    pub args: Vec<Arg>,
+    /// Success type; `None` is unit.
+    pub ret: Option<Type>,
+    /// The `#[unibind::error]` enum named in the function's `Result`, if any.
+    pub throws: Option<String>,
+}
+
+/// One function argument.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Arg {
+    /// Rust argument name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Boundary type.
+    pub ty: Type,
+    /// Default value from `#[unibind(default = ...)]`. `Option` arguments
+    /// without one default to `None` in rendered bindings.
+    pub default: Option<Literal>,
+}
+
+/// A literal default from `#[unibind(default = ...)]`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Literal {
+    /// `true` / `false`.
+    Bool(bool),
+    /// An integer literal (optionally negated).
+    Int(i64),
+    /// A float literal (optionally negated).
+    Float(f64),
+    /// A string literal.
+    Str(String),
+    /// The `None` default for an `Option` argument.
+    None,
+}
+
+/// A type at the binding boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Type {
+    /// `bool`.
+    Bool,
+    /// A fixed-width integer.
+    Int(IntKind),
+    /// A float.
+    Float(FloatKind),
+    /// UTF-8 text: `String` when `owned`, `&str` otherwise.
+    String {
+        /// Whether the Rust side takes ownership.
+        owned: bool,
+    },
+    /// A filesystem path: `PathBuf` when `owned`, `&Path` otherwise.
+    Path {
+        /// Whether the Rust side takes ownership.
+        owned: bool,
+    },
+    /// Binary data: `Vec<u8>` when `owned`, `&[u8]` otherwise.
+    Bytes {
+        /// Whether the Rust side takes ownership.
+        owned: bool,
+    },
+    /// `Option<T>`.
+    Option(Box<Type>),
+    /// `Vec<T>` (except `Vec<u8>`, which lowers to [`Type::Bytes`]).
+    Vec(Box<Type>),
+    /// `HashMap<K, V>`.
+    Map {
+        /// Key type; phase 0 restricts it to strings and integers.
+        key: Box<Type>,
+        /// Value type.
+        value: Box<Type>,
+    },
+    /// A record declared in the same interface.
+    Named(String),
+}
+
+/// Integer width and signedness.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum IntKind {
+    I8,
+    I16,
+    I32,
+    I64,
+    Isize,
+    U8,
+    U16,
+    U32,
+    U64,
+    Usize,
+}
+
+/// Float width.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum FloatKind {
+    F32,
+    F64,
+}
+
+/// A plain-data struct crossing the boundary by value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Record {
+    /// Rust struct name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+    /// Fields in declaration order.
+    pub fields: Vec<Field>,
+}
+
+/// One record field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Field {
+    /// Rust field name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+    /// Field type; always owned.
+    pub ty: Type,
+}
+
+/// A plain data enum. Reserved: phase 0 lowering rejects enums.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Enum {
+    /// Rust enum name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+    /// Variants in declaration order.
+    pub variants: Vec<EnumVariant>,
+}
+
+/// One data enum variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnumVariant {
+    /// Rust variant name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+}
+
+/// An error enum, rendered as an exception hierarchy: one base class for the
+/// enum and one subclass per variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorType {
+    /// Rust enum name; also the base exception class name.
+    pub name: String,
+    /// Per-language renames for the base class.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+    /// Python base exception from `py(base = "...")`; `None` means
+    /// `Exception`.
+    pub py_base: Option<String>,
+    /// Variants in declaration order, each an exception subclass.
+    pub variants: Vec<ErrorVariant>,
+}
+
+/// One error variant. Its fields stay on the Rust side; the rendered
+/// exception carries the variant's `Display` text.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorVariant {
+    /// Rust variant name; also the exception subclass name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+}
+
+/// A stateful handle. Reserved: phase 0 lowering rejects
+/// `#[unibind::object]`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Object {
+    /// Rust type name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+}

--- a/packages/unibind/core/src/ir.rs
+++ b/packages/unibind/core/src/ir.rs
@@ -128,15 +128,15 @@ pub enum Type {
         owned: bool,
     },
     /// `Option<T>`.
-    Option(Box<Type>),
+    Option(Box<Self>),
     /// `Vec<T>` (except `Vec<u8>`, which lowers to [`Type::Bytes`]).
-    Vec(Box<Type>),
+    Vec(Box<Self>),
     /// `HashMap<K, V>`.
     Map {
         /// Key type; phase 0 restricts it to strings and integers.
-        key: Box<Type>,
+        key: Box<Self>,
         /// Value type.
-        value: Box<Type>,
+        value: Box<Self>,
     },
     /// A record declared in the same interface.
     Named(String),

--- a/packages/unibind/core/src/lib.rs
+++ b/packages/unibind/core/src/lib.rs
@@ -1,0 +1,14 @@
+//! Language-agnostic interface representation for unibind.
+//!
+//! `#[unibind::export]` hands the annotated module here: [`lower_module`]
+//! turns the syn items into an [`ir::Interface`], and [`embed`] renders the
+//! serialized interface into a link-section constant so later phases can
+//! read the contract straight from a built artifact. Backends such as
+//! `unibind-backend-py` consume the IR and render the language-specific
+//! binding code.
+
+pub mod embed;
+pub mod ir;
+mod lower;
+
+pub use lower::{lower_module, strip_unibind_attrs, LowerError};

--- a/packages/unibind/core/src/lower.rs
+++ b/packages/unibind/core/src/lower.rs
@@ -1,0 +1,197 @@
+//! Lower a `#[unibind::export]` module's syn items into [`crate::ir`].
+
+mod attrs;
+mod data;
+mod func;
+mod ty;
+
+use proc_macro2::Span;
+use syn::spanned::Spanned as _;
+
+use crate::ir;
+
+/// A lowering failure, positioned so the macro can emit `compile_error!` at
+/// the offending tokens.
+#[derive(Debug)]
+pub struct LowerError {
+    /// Where the diagnostic points.
+    pub span: Span,
+    /// What went wrong and what to do instead.
+    pub message: String,
+}
+
+impl LowerError {
+    pub(crate) fn new(span: Span, message: impl Into<String>) -> Self {
+        Self {
+            span,
+            message: message.into(),
+        }
+    }
+}
+
+pub(crate) type Result<T> = std::result::Result<T, LowerError>;
+
+/// Type names declared in the exported module, used to validate references.
+#[derive(Debug, Default)]
+pub(crate) struct Declared {
+    pub(crate) records: Vec<String>,
+    pub(crate) errors: Vec<String>,
+}
+
+/// Lower an inline `#[unibind::export]` module into an [`ir::Interface`].
+///
+/// `module_args` is the token stream the attribute itself carried, for
+/// example `py(name = "...")` from `#[unibind::export(py(name = "..."))]`.
+///
+/// # Errors
+///
+/// Returns a positioned error for anything outside the phase 0 surface:
+/// async functions, generics, methods, data enums, `#[unibind::object]`,
+/// unsupported boundary types, or malformed `#[unibind(...)]` metadata.
+pub fn lower_module(
+    module_args: proc_macro2::TokenStream,
+    module: &syn::ItemMod,
+) -> Result<ir::Interface> {
+    let meta = attrs::UnibindMeta::parse(module_args, module.span())?;
+    meta.reject_default("a module")?;
+    meta.reject_py_base("a module")?;
+    let Some((_, items)) = &module.content else {
+        return Err(LowerError::new(
+            module.span(),
+            "#[unibind::export] needs an inline module (`mod name { ... }`); \
+             out-of-line modules are not supported",
+        ));
+    };
+
+    let declared = collect_declared(items)?;
+    let mut interface = ir::Interface {
+        version: ir::IR_VERSION,
+        name: module.ident.to_string(),
+        names: meta.names(),
+        docs: attrs::doc_lines(&module.attrs),
+        functions: Vec::new(),
+        records: Vec::new(),
+        enums: Vec::new(),
+        errors: Vec::new(),
+        objects: Vec::new(),
+    };
+
+    for item in items {
+        match (item, attrs::marker(item)?) {
+            (syn::Item::Fn(func), None) => {
+                if matches!(func.vis, syn::Visibility::Public(_)) {
+                    interface.functions.push(func::lower_fn(func, &declared)?);
+                }
+            }
+            (syn::Item::Struct(item), Some(marker)) => match marker.kind {
+                attrs::MarkerKind::Record => {
+                    interface
+                        .records
+                        .push(data::lower_record(item, &marker, &declared)?);
+                }
+                attrs::MarkerKind::Error => {
+                    return Err(LowerError::new(
+                        marker.span,
+                        "#[unibind::error] goes on an enum; each variant becomes \
+                         an exception class",
+                    ));
+                }
+                attrs::MarkerKind::Object => return Err(object_unsupported(marker.span)),
+            },
+            (syn::Item::Enum(item), Some(marker)) => match marker.kind {
+                attrs::MarkerKind::Error => {
+                    interface.errors.push(data::lower_error(item, &marker)?);
+                }
+                attrs::MarkerKind::Record => {
+                    return Err(LowerError::new(
+                        marker.span,
+                        "data enums are not part of phase 0; model the value as a \
+                         #[unibind::record] struct until enums land",
+                    ));
+                }
+                attrs::MarkerKind::Object => return Err(object_unsupported(marker.span)),
+            },
+            (_, Some(marker)) => {
+                return Err(match marker.kind {
+                    attrs::MarkerKind::Object => object_unsupported(marker.span),
+                    attrs::MarkerKind::Record | attrs::MarkerKind::Error => LowerError::new(
+                        marker.span,
+                        "this unibind marker goes on a struct (record) or enum (error)",
+                    ),
+                });
+            }
+            // Anything unannotated that is not a pub fn passes through as
+            // plain Rust: impls, uses, consts, private helpers.
+            _ => {}
+        }
+    }
+    Ok(interface)
+}
+
+fn object_unsupported(span: Span) -> LowerError {
+    LowerError::new(
+        span,
+        "#[unibind::object] lands with resources in phase 2 (issue #1992); \
+         phase 0 covers sync functions, records, and errors",
+    )
+}
+
+fn collect_declared(items: &[syn::Item]) -> Result<Declared> {
+    let mut declared = Declared::default();
+    for item in items {
+        let Some(marker) = attrs::marker(item)? else {
+            continue;
+        };
+        match (item, marker.kind) {
+            (syn::Item::Struct(item), attrs::MarkerKind::Record) => {
+                declared.records.push(item.ident.to_string());
+            }
+            (syn::Item::Enum(item), attrs::MarkerKind::Error) => {
+                declared.errors.push(item.ident.to_string());
+            }
+            _ => {}
+        }
+    }
+    Ok(declared)
+}
+
+/// Remove every `#[unibind...]` attribute from the module's items so the
+/// re-emitted Rust compiles without the markers.
+pub fn strip_unibind_attrs(module: &mut syn::ItemMod) {
+    strip(&mut module.attrs);
+    let Some((_, items)) = &mut module.content else {
+        return;
+    };
+    for item in items {
+        match item {
+            syn::Item::Fn(func) => {
+                strip(&mut func.attrs);
+                for input in &mut func.sig.inputs {
+                    if let syn::FnArg::Typed(arg) = input {
+                        strip(&mut arg.attrs);
+                    }
+                }
+            }
+            syn::Item::Struct(item) => {
+                strip(&mut item.attrs);
+                for field in &mut item.fields {
+                    strip(&mut field.attrs);
+                }
+            }
+            syn::Item::Enum(item) => {
+                strip(&mut item.attrs);
+                for variant in &mut item.variants {
+                    strip(&mut variant.attrs);
+                    for field in &mut variant.fields {
+                        strip(&mut field.attrs);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn strip(attributes: &mut Vec<syn::Attribute>) {
+    attributes.retain(|attribute| !attrs::is_unibind_path(attribute.path()));
+}

--- a/packages/unibind/core/src/lower.rs
+++ b/packages/unibind/core/src/lower.rs
@@ -29,13 +29,13 @@ impl LowerError {
     }
 }
 
-pub(crate) type Result<T> = std::result::Result<T, LowerError>;
+pub type Result<T> = std::result::Result<T, LowerError>;
 
 /// Type names declared in the exported module, used to validate references.
 #[derive(Debug, Default)]
-pub(crate) struct Declared {
-    pub(crate) records: Vec<String>,
-    pub(crate) errors: Vec<String>,
+pub struct Declared {
+    pub records: Vec<String>,
+    pub errors: Vec<String>,
 }
 
 /// Lower an inline `#[unibind::export]` module into an [`ir::Interface`].

--- a/packages/unibind/core/src/lower/attrs.rs
+++ b/packages/unibind/core/src/lower/attrs.rs
@@ -8,7 +8,7 @@ use crate::ir;
 
 /// Which marker attribute an item carries.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum MarkerKind {
+pub enum MarkerKind {
     Record,
     Error,
     Object,
@@ -17,7 +17,7 @@ pub(crate) enum MarkerKind {
 /// A `#[unibind::record]` / `#[unibind::error]` / `#[unibind::object]`
 /// marker found on an item, with its parsed arguments.
 #[derive(Debug)]
-pub(crate) struct Marker {
+pub struct Marker {
     pub(crate) kind: MarkerKind,
     pub(crate) span: Span,
     pub(crate) meta: UnibindMeta,
@@ -26,7 +26,7 @@ pub(crate) struct Marker {
 /// The options a `#[unibind(...)]` attribute (or marker argument list) can
 /// carry: `py(name = "...")`, `py(base = "...")`, and `default = ...`.
 #[derive(Debug, Default)]
-pub(crate) struct UnibindMeta {
+pub struct UnibindMeta {
     pub(crate) span: Option<Span>,
     pub(crate) py_name: Option<String>,
     pub(crate) py_base: Option<String>,
@@ -225,7 +225,7 @@ fn literal_from_lit(lit: &syn::Lit) -> Result<ir::Literal> {
 }
 
 /// Classify the unibind marker on an item, parsing its arguments.
-pub(crate) fn marker(item: &syn::Item) -> Result<Option<Marker>> {
+pub fn marker(item: &syn::Item) -> Result<Option<Marker>> {
     let attributes = match item {
         syn::Item::Struct(item) => &item.attrs,
         syn::Item::Enum(item) => &item.attrs,
@@ -265,7 +265,7 @@ pub(crate) fn marker(item: &syn::Item) -> Result<Option<Marker>> {
 fn marker_kind(path: &syn::Path) -> Option<MarkerKind> {
     let mut segments = path.segments.iter();
     let (first, second, rest) = (segments.next(), segments.next(), segments.next());
-    if rest.is_some() || first.map(|segment| segment.ident != "unibind") != Some(false) {
+    if rest.is_some() || first.is_none_or(|segment| segment.ident != "unibind") {
         return None;
     }
     match second {
@@ -278,14 +278,14 @@ fn marker_kind(path: &syn::Path) -> Option<MarkerKind> {
 
 /// Whether an attribute path belongs to unibind (`unibind` or
 /// `unibind::...`), for stripping.
-pub(crate) fn is_unibind_path(path: &syn::Path) -> bool {
+pub fn is_unibind_path(path: &syn::Path) -> bool {
     path.segments
         .first()
         .is_some_and(|segment| segment.ident == "unibind")
 }
 
 /// Extract `///` doc comment lines, trimming the customary leading space.
-pub(crate) fn doc_lines(attributes: &[syn::Attribute]) -> Vec<String> {
+pub fn doc_lines(attributes: &[syn::Attribute]) -> Vec<String> {
     let mut lines = Vec::new();
     for attribute in attributes {
         if !attribute.path().is_ident("doc") {

--- a/packages/unibind/core/src/lower/attrs.rs
+++ b/packages/unibind/core/src/lower/attrs.rs
@@ -1,0 +1,308 @@
+//! Parse `#[unibind(...)]` metadata and `#[unibind::...]` markers.
+
+use proc_macro2::{Span, TokenStream};
+use syn::spanned::Spanned as _;
+
+use super::{LowerError, Result};
+use crate::ir;
+
+/// Which marker attribute an item carries.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum MarkerKind {
+    Record,
+    Error,
+    Object,
+}
+
+/// A `#[unibind::record]` / `#[unibind::error]` / `#[unibind::object]`
+/// marker found on an item, with its parsed arguments.
+#[derive(Debug)]
+pub(crate) struct Marker {
+    pub(crate) kind: MarkerKind,
+    pub(crate) span: Span,
+    pub(crate) meta: UnibindMeta,
+}
+
+/// The options a `#[unibind(...)]` attribute (or marker argument list) can
+/// carry: `py(name = "...")`, `py(base = "...")`, and `default = ...`.
+#[derive(Debug, Default)]
+pub(crate) struct UnibindMeta {
+    pub(crate) span: Option<Span>,
+    pub(crate) py_name: Option<String>,
+    pub(crate) py_base: Option<String>,
+    pub(crate) default: Option<ir::Literal>,
+}
+
+impl UnibindMeta {
+    /// Parse one argument token stream, as carried by the attribute itself.
+    pub(crate) fn parse(tokens: TokenStream, span: Span) -> Result<Self> {
+        let mut meta = Self {
+            span: Some(span),
+            ..Self::default()
+        };
+        if tokens.is_empty() {
+            return Ok(meta);
+        }
+        let parser = syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated;
+        let entries = syn::parse::Parser::parse2(parser, tokens)
+            .map_err(|error| LowerError::new(span, format!("bad unibind options: {error}")))?;
+        for entry in entries {
+            meta.apply(&entry)?;
+        }
+        Ok(meta)
+    }
+
+    /// Parse and merge every `#[unibind(...)]` attribute in `attributes`.
+    pub(crate) fn from_attrs(attributes: &[syn::Attribute]) -> Result<Self> {
+        let mut merged = Self::default();
+        for attribute in attributes {
+            if !attribute.path().is_ident("unibind") {
+                continue;
+            }
+            let syn::Meta::List(list) = &attribute.meta else {
+                return Err(LowerError::new(
+                    attribute.span(),
+                    "#[unibind] takes options: #[unibind(py(name = \"...\"))] or \
+                     #[unibind(default = ...)]",
+                ));
+            };
+            let parsed = Self::parse(list.tokens.clone(), attribute.span())?;
+            merged.merge(parsed, attribute.span())?;
+        }
+        Ok(merged)
+    }
+
+    fn merge(&mut self, other: Self, span: Span) -> Result<()> {
+        if other.py_name.is_some() {
+            if self.py_name.is_some() {
+                return Err(LowerError::new(span, "duplicate unibind `py(name = ...)`"));
+            }
+            self.py_name = other.py_name;
+        }
+        if other.py_base.is_some() {
+            if self.py_base.is_some() {
+                return Err(LowerError::new(span, "duplicate unibind `py(base = ...)`"));
+            }
+            self.py_base = other.py_base;
+        }
+        if other.default.is_some() {
+            if self.default.is_some() {
+                return Err(LowerError::new(span, "duplicate unibind `default`"));
+            }
+            self.default = other.default;
+        }
+        self.span = self.span.or(Some(span));
+        Ok(())
+    }
+
+    fn apply(&mut self, entry: &syn::Meta) -> Result<()> {
+        let span = entry.span();
+        if entry.path().is_ident("py") {
+            let syn::Meta::List(list) = entry else {
+                return Err(LowerError::new(
+                    span,
+                    "`py` takes a list: py(name = \"...\") or py(base = \"...\")",
+                ));
+            };
+            let parser =
+                syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated;
+            let entries = syn::parse::Parser::parse2(parser, list.tokens.clone())
+                .map_err(|error| LowerError::new(span, format!("bad `py` options: {error}")))?;
+            for nested in entries {
+                self.apply_py(&nested)?;
+            }
+            return Ok(());
+        }
+        if entry.path().is_ident("default") {
+            let syn::Meta::NameValue(pair) = entry else {
+                return Err(LowerError::new(span, "`default` takes a value: default = ..."));
+            };
+            self.default = Some(literal(&pair.value)?);
+            return Ok(());
+        }
+        Err(LowerError::new(
+            span,
+            "unknown unibind option; expected py(name = \"...\"), \
+             py(base = \"...\"), or default = ...",
+        ))
+    }
+
+    fn apply_py(&mut self, entry: &syn::Meta) -> Result<()> {
+        let span = entry.span();
+        let syn::Meta::NameValue(pair) = entry else {
+            return Err(LowerError::new(
+                span,
+                "`py` options are name = \"...\" and base = \"...\"",
+            ));
+        };
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(value),
+            ..
+        }) = &pair.value
+        else {
+            return Err(LowerError::new(span, "`py` options take string literals"));
+        };
+        if pair.path.is_ident("name") {
+            self.py_name = Some(value.value());
+        } else if pair.path.is_ident("base") {
+            self.py_base = Some(value.value());
+        } else {
+            return Err(LowerError::new(
+                span,
+                "unknown `py` option; expected name = \"...\" or base = \"...\"",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn names(&self) -> ir::Names {
+        ir::Names {
+            py: self.py_name.clone(),
+        }
+    }
+
+    /// Error out when a `default` was given somewhere it cannot apply.
+    pub(crate) fn reject_default(&self, context: &str) -> Result<()> {
+        if self.default.is_some() {
+            return Err(LowerError::new(
+                self.span.unwrap_or_else(Span::call_site),
+                format!("`default` applies to function arguments, not {context}"),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Error out when a `py(base = ...)` was given somewhere it cannot apply.
+    pub(crate) fn reject_py_base(&self, context: &str) -> Result<()> {
+        if self.py_base.is_some() {
+            return Err(LowerError::new(
+                self.span.unwrap_or_else(Span::call_site),
+                format!("`py(base = ...)` applies to #[unibind::error] enums, not {context}"),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn literal(expr: &syn::Expr) -> Result<ir::Literal> {
+    let span = expr.span();
+    match expr {
+        syn::Expr::Lit(lit) => literal_from_lit(&lit.lit),
+        syn::Expr::Path(path) if path.path.is_ident("None") => Ok(ir::Literal::None),
+        syn::Expr::Unary(syn::ExprUnary {
+            op: syn::UnOp::Neg(_),
+            expr,
+            ..
+        }) => match literal(expr)? {
+            ir::Literal::Int(value) => Ok(ir::Literal::Int(-value)),
+            ir::Literal::Float(value) => Ok(ir::Literal::Float(-value)),
+            _ => Err(LowerError::new(span, "only numbers can be negated")),
+        },
+        _ => Err(LowerError::new(
+            span,
+            "`default` takes a literal (bool, int, float, string) or None",
+        )),
+    }
+}
+
+fn literal_from_lit(lit: &syn::Lit) -> Result<ir::Literal> {
+    match lit {
+        syn::Lit::Bool(value) => Ok(ir::Literal::Bool(value.value())),
+        syn::Lit::Int(value) => value
+            .base10_parse()
+            .map(ir::Literal::Int)
+            .map_err(|error| LowerError::new(lit.span(), format!("bad integer default: {error}"))),
+        syn::Lit::Float(value) => value
+            .base10_parse()
+            .map(ir::Literal::Float)
+            .map_err(|error| LowerError::new(lit.span(), format!("bad float default: {error}"))),
+        syn::Lit::Str(value) => Ok(ir::Literal::Str(value.value())),
+        _ => Err(LowerError::new(
+            lit.span(),
+            "`default` takes a literal (bool, int, float, string) or None",
+        )),
+    }
+}
+
+/// Classify the unibind marker on an item, parsing its arguments.
+pub(crate) fn marker(item: &syn::Item) -> Result<Option<Marker>> {
+    let attributes = match item {
+        syn::Item::Struct(item) => &item.attrs,
+        syn::Item::Enum(item) => &item.attrs,
+        syn::Item::Fn(item) => &item.attrs,
+        _ => return Ok(None),
+    };
+    let mut found = None;
+    for attribute in attributes {
+        let Some(kind) = marker_kind(attribute.path()) else {
+            continue;
+        };
+        if found.is_some() {
+            return Err(LowerError::new(
+                attribute.span(),
+                "an item takes at most one unibind marker",
+            ));
+        }
+        let tokens = match &attribute.meta {
+            syn::Meta::Path(_) => TokenStream::new(),
+            syn::Meta::List(list) => list.tokens.clone(),
+            syn::Meta::NameValue(_) => {
+                return Err(LowerError::new(
+                    attribute.span(),
+                    "unibind markers take parenthesized options",
+                ));
+            }
+        };
+        found = Some(Marker {
+            kind,
+            span: attribute.span(),
+            meta: UnibindMeta::parse(tokens, attribute.span())?,
+        });
+    }
+    Ok(found)
+}
+
+fn marker_kind(path: &syn::Path) -> Option<MarkerKind> {
+    let mut segments = path.segments.iter();
+    let (first, second, rest) = (segments.next(), segments.next(), segments.next());
+    if rest.is_some() || first.map(|segment| segment.ident != "unibind") != Some(false) {
+        return None;
+    }
+    match second {
+        Some(segment) if segment.ident == "record" => Some(MarkerKind::Record),
+        Some(segment) if segment.ident == "error" => Some(MarkerKind::Error),
+        Some(segment) if segment.ident == "object" => Some(MarkerKind::Object),
+        _ => None,
+    }
+}
+
+/// Whether an attribute path belongs to unibind (`unibind` or
+/// `unibind::...`), for stripping.
+pub(crate) fn is_unibind_path(path: &syn::Path) -> bool {
+    path.segments
+        .first()
+        .is_some_and(|segment| segment.ident == "unibind")
+}
+
+/// Extract `///` doc comment lines, trimming the customary leading space.
+pub(crate) fn doc_lines(attributes: &[syn::Attribute]) -> Vec<String> {
+    let mut lines = Vec::new();
+    for attribute in attributes {
+        if !attribute.path().is_ident("doc") {
+            continue;
+        }
+        let syn::Meta::NameValue(pair) = &attribute.meta else {
+            continue;
+        };
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(text),
+            ..
+        }) = &pair.value
+        else {
+            continue;
+        };
+        let text = text.value();
+        lines.push(text.strip_prefix(' ').unwrap_or(&text).to_owned());
+    }
+    lines
+}

--- a/packages/unibind/core/src/lower/data.rs
+++ b/packages/unibind/core/src/lower/data.rs
@@ -1,0 +1,100 @@
+//! Lower records and error enums.
+
+use syn::spanned::Spanned as _;
+
+use super::ty::{lower_type, Position};
+use super::{attrs, Declared, LowerError, Result};
+use crate::ir;
+
+pub(super) fn lower_record(
+    item: &syn::ItemStruct,
+    marker: &attrs::Marker,
+    declared: &Declared,
+) -> Result<ir::Record> {
+    marker.meta.reject_default("a record")?;
+    marker.meta.reject_py_base("a record")?;
+    require_pub(&item.vis, item.ident.span(), "record")?;
+    if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
+        return Err(LowerError::new(
+            item.generics.span(),
+            "generic records cannot cross the binding boundary",
+        ));
+    }
+    let syn::Fields::Named(fields) = &item.fields else {
+        return Err(LowerError::new(
+            item.fields.span(),
+            "records need named fields; tuple and unit structs are not part \
+             of phase 0",
+        ));
+    };
+
+    let mut lowered = Vec::new();
+    for field in &fields.named {
+        let Some(ident) = &field.ident else {
+            continue;
+        };
+        require_pub(&field.vis, ident.span(), "record field")?;
+        let meta = attrs::UnibindMeta::from_attrs(&field.attrs)?;
+        meta.reject_default("a record field")?;
+        meta.reject_py_base("a record field")?;
+        lowered.push(ir::Field {
+            name: ident.to_string(),
+            names: meta.names(),
+            docs: attrs::doc_lines(&field.attrs),
+            ty: lower_type(&field.ty, declared, Position::Owned)?,
+        });
+    }
+    Ok(ir::Record {
+        name: item.ident.to_string(),
+        names: marker.meta.names(),
+        docs: attrs::doc_lines(&item.attrs),
+        fields: lowered,
+    })
+}
+
+pub(super) fn lower_error(item: &syn::ItemEnum, marker: &attrs::Marker) -> Result<ir::ErrorType> {
+    marker.meta.reject_default("an error enum")?;
+    require_pub(&item.vis, item.ident.span(), "error enum")?;
+    if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
+        return Err(LowerError::new(
+            item.generics.span(),
+            "generic error enums cannot cross the binding boundary",
+        ));
+    }
+    if item.variants.is_empty() {
+        return Err(LowerError::new(
+            item.ident.span(),
+            "an error enum needs at least one variant",
+        ));
+    }
+
+    let mut variants = Vec::new();
+    for variant in &item.variants {
+        let meta = attrs::UnibindMeta::from_attrs(&variant.attrs)?;
+        meta.reject_default("an error variant")?;
+        meta.reject_py_base("an error variant")?;
+        variants.push(ir::ErrorVariant {
+            name: variant.ident.to_string(),
+            names: meta.names(),
+            docs: attrs::doc_lines(&variant.attrs),
+        });
+    }
+    Ok(ir::ErrorType {
+        name: item.ident.to_string(),
+        names: marker.meta.names(),
+        docs: attrs::doc_lines(&item.attrs),
+        py_base: marker.meta.py_base.clone(),
+        variants,
+    })
+}
+
+fn require_pub(vis: &syn::Visibility, span: proc_macro2::Span, what: &str) -> Result<()> {
+    if matches!(vis, syn::Visibility::Public(_)) {
+        Ok(())
+    } else {
+        Err(LowerError::new(
+            span,
+            format!("a unibind {what} must be `pub` so the generated glue can reach it"),
+        ))
+    }
+}

--- a/packages/unibind/core/src/lower/func.rs
+++ b/packages/unibind/core/src/lower/func.rs
@@ -124,12 +124,11 @@ fn lower_return(output: &syn::ReturnType, declared: &Declared) -> Result<Returne
             throws: None,
         });
     }
-    if let syn::Type::Path(path) = &**ty {
-        if let Some(segment) = path.path.segments.last() {
-            if segment.ident == "Result" {
-                return lower_result(segment, declared);
-            }
-        }
+    if let syn::Type::Path(path) = &**ty
+        && let Some(segment) = path.path.segments.last()
+        && segment.ident == "Result"
+    {
+        return lower_result(segment, declared);
     }
     Ok(Returned {
         ty: Some(lower_type(ty, declared, Position::Owned)?),

--- a/packages/unibind/core/src/lower/func.rs
+++ b/packages/unibind/core/src/lower/func.rs
@@ -1,0 +1,196 @@
+//! Lower exported functions.
+
+use syn::spanned::Spanned as _;
+
+use super::ty::{lower_type, Position};
+use super::{attrs, Declared, LowerError, Result};
+use crate::ir;
+
+pub(super) fn lower_fn(func: &syn::ItemFn, declared: &Declared) -> Result<ir::Function> {
+    let signature = &func.sig;
+    if let Some(asyncness) = signature.asyncness {
+        return Err(LowerError::new(
+            asyncness.span(),
+            "async functions land in phase 2 (issue #1992); phase 0 exports \
+             sync functions only",
+        ));
+    }
+    if let Some(unsafety) = signature.unsafety {
+        return Err(LowerError::new(
+            unsafety.span(),
+            "unsafe functions do not cross the binding boundary",
+        ));
+    }
+    if !signature.generics.params.is_empty() || signature.generics.where_clause.is_some() {
+        return Err(LowerError::new(
+            signature.generics.span(),
+            "generic functions cannot cross the binding boundary; export a \
+             monomorphic wrapper",
+        ));
+    }
+    if let Some(variadic) = &signature.variadic {
+        return Err(LowerError::new(
+            variadic.span(),
+            "variadic functions do not cross the binding boundary",
+        ));
+    }
+
+    let meta = attrs::UnibindMeta::from_attrs(&func.attrs)?;
+    meta.reject_default("a function")?;
+    meta.reject_py_base("a function")?;
+
+    let mut args = Vec::new();
+    for input in &signature.inputs {
+        let arg = match input {
+            syn::FnArg::Receiver(receiver) => {
+                return Err(LowerError::new(
+                    receiver.span(),
+                    "methods belong to #[unibind::object], which lands in \
+                     phase 2 (issue #1992)",
+                ));
+            }
+            syn::FnArg::Typed(arg) => arg,
+        };
+        args.push(lower_arg(arg, declared)?);
+    }
+    check_default_order(signature, &args)?;
+
+    let returned = lower_return(&signature.output, declared)?;
+    Ok(ir::Function {
+        name: signature.ident.to_string(),
+        names: meta.names(),
+        docs: attrs::doc_lines(&func.attrs),
+        asyncness: ir::Asyncness::Sync,
+        args,
+        ret: returned.ty,
+        throws: returned.throws,
+    })
+}
+
+fn lower_arg(arg: &syn::PatType, declared: &Declared) -> Result<ir::Arg> {
+    let syn::Pat::Ident(pattern) = &*arg.pat else {
+        return Err(LowerError::new(
+            arg.pat.span(),
+            "exported function arguments need plain identifier names",
+        ));
+    };
+    let meta = attrs::UnibindMeta::from_attrs(&arg.attrs)?;
+    meta.reject_py_base("an argument")?;
+    Ok(ir::Arg {
+        name: pattern.ident.to_string(),
+        names: meta.names(),
+        ty: lower_type(&arg.ty, declared, Position::Arg)?,
+        default: meta.default,
+    })
+}
+
+/// Python only accepts defaulted parameters after other defaulted ones, so
+/// enforce the same shape here: once an argument has a default (explicit, or
+/// the implicit `None` of an `Option`), every later argument needs one.
+fn check_default_order(signature: &syn::Signature, args: &[ir::Arg]) -> Result<()> {
+    let mut defaults_started = false;
+    for arg in args {
+        let has_default = arg.default.is_some() || matches!(arg.ty, ir::Type::Option(_));
+        if defaults_started && !has_default {
+            return Err(LowerError::new(
+                signature.span(),
+                format!(
+                    "argument `{}` needs a default: it follows a defaulted argument",
+                    arg.name
+                ),
+            ));
+        }
+        defaults_started = defaults_started || has_default;
+    }
+    Ok(())
+}
+
+/// A lowered return position: the success type and the thrown error, if any.
+struct Returned {
+    ty: Option<ir::Type>,
+    throws: Option<String>,
+}
+
+fn lower_return(output: &syn::ReturnType, declared: &Declared) -> Result<Returned> {
+    let syn::ReturnType::Type(_, ty) = output else {
+        return Ok(Returned {
+            ty: None,
+            throws: None,
+        });
+    };
+    if is_unit(ty) {
+        return Ok(Returned {
+            ty: None,
+            throws: None,
+        });
+    }
+    if let syn::Type::Path(path) = &**ty {
+        if let Some(segment) = path.path.segments.last() {
+            if segment.ident == "Result" {
+                return lower_result(segment, declared);
+            }
+        }
+    }
+    Ok(Returned {
+        ty: Some(lower_type(ty, declared, Position::Owned)?),
+        throws: None,
+    })
+}
+
+fn lower_result(segment: &syn::PathSegment, declared: &Declared) -> Result<Returned> {
+    let syn::PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return Err(LowerError::new(
+            segment.span(),
+            "spell the Result out as Result<T, YourError>",
+        ));
+    };
+    let types: Vec<&syn::Type> = arguments
+        .args
+        .iter()
+        .filter_map(|argument| match argument {
+            syn::GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .collect();
+    let [ok, error]: [&syn::Type; 2] = types.as_slice().try_into().map_err(|_| {
+        LowerError::new(
+            segment.span(),
+            "spell the Result out as Result<T, YourError>; type aliases hide \
+             the error type from the macro",
+        )
+    })?;
+    let syn::Type::Path(error_path) = error else {
+        return Err(bad_error_type(error));
+    };
+    let Some(error_ident) = error_path.path.get_ident() else {
+        return Err(bad_error_type(error));
+    };
+    if !declared
+        .errors
+        .iter()
+        .any(|name| error_ident == name.as_str())
+    {
+        return Err(bad_error_type(error));
+    }
+    let ty = if is_unit(ok) {
+        None
+    } else {
+        Some(lower_type(ok, declared, Position::Owned)?)
+    };
+    Ok(Returned {
+        ty,
+        throws: Some(error_ident.to_string()),
+    })
+}
+
+fn bad_error_type(ty: &syn::Type) -> LowerError {
+    LowerError::new(
+        ty.span(),
+        "the error type of an exported function must be a #[unibind::error] \
+         enum declared in the same module",
+    )
+}
+
+fn is_unit(ty: &syn::Type) -> bool {
+    matches!(ty, syn::Type::Tuple(tuple) if tuple.elems.is_empty())
+}

--- a/packages/unibind/core/src/lower/ty.rs
+++ b/packages/unibind/core/src/lower/ty.rs
@@ -1,0 +1,233 @@
+//! Lower syn types into [`crate::ir::Type`].
+
+use quote::ToTokens as _;
+use syn::spanned::Spanned as _;
+
+use super::{Declared, LowerError, Result};
+use crate::ir;
+
+/// Where a type appears; borrowed forms are only legal in argument position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Position {
+    /// A function argument (borrowed `&str` / `&Path` / `&[u8]` allowed,
+    /// also directly under `Option`).
+    Arg,
+    /// A return type or record field: owned types only.
+    Owned,
+}
+
+pub(crate) fn lower_type(ty: &syn::Type, declared: &Declared, position: Position) -> Result<ir::Type> {
+    match ty {
+        syn::Type::Reference(reference) => lower_reference(reference, position),
+        syn::Type::Path(path) => lower_path(path, declared, position),
+        syn::Type::Paren(inner) => lower_type(&inner.elem, declared, position),
+        _ => Err(unsupported(ty)),
+    }
+}
+
+fn lower_reference(reference: &syn::TypeReference, position: Position) -> Result<ir::Type> {
+    if position != Position::Arg {
+        return Err(LowerError::new(
+            reference.span(),
+            "borrowed types only work as argument types; own the data \
+             (String, PathBuf, Vec<u8>) everywhere else",
+        ));
+    }
+    if reference.mutability.is_some() {
+        return Err(LowerError::new(
+            reference.span(),
+            "&mut does not cross the binding boundary; return the new value instead",
+        ));
+    }
+    match &*reference.elem {
+        syn::Type::Path(path) if path.qself.is_none() && path.path.is_ident("str") => {
+            Ok(ir::Type::String { owned: false })
+        }
+        syn::Type::Path(path)
+            if path.qself.is_none() && last_ident(&path.path).is_some_and(|i| i == "Path") =>
+        {
+            Ok(ir::Type::Path { owned: false })
+        }
+        syn::Type::Slice(slice) => match &*slice.elem {
+            syn::Type::Path(path) if path.path.is_ident("u8") => {
+                Ok(ir::Type::Bytes { owned: false })
+            }
+            _ => Err(LowerError::new(
+                slice.span(),
+                "only &[u8] slices cross the boundary; use Vec<T> for lists",
+            )),
+        },
+        _ => Err(LowerError::new(
+            reference.span(),
+            "unsupported borrowed type; pass &str, &Path, or &[u8]",
+        )),
+    }
+}
+
+fn lower_path(path: &syn::TypePath, declared: &Declared, position: Position) -> Result<ir::Type> {
+    if path.qself.is_some() {
+        return Err(unsupported(&syn::Type::Path(path.clone())));
+    }
+    let Some(segment) = path.path.segments.last() else {
+        return Err(unsupported(&syn::Type::Path(path.clone())));
+    };
+    let ident = segment.ident.to_string();
+    if let Some(kind) = int_kind(&ident) {
+        return no_generics(segment).map(|()| ir::Type::Int(kind));
+    }
+    match ident.as_str() {
+        "bool" => no_generics(segment).map(|()| ir::Type::Bool),
+        "f32" => no_generics(segment).map(|()| ir::Type::Float(ir::FloatKind::F32)),
+        "f64" => no_generics(segment).map(|()| ir::Type::Float(ir::FloatKind::F64)),
+        "String" => no_generics(segment).map(|()| ir::Type::String { owned: true }),
+        "PathBuf" => no_generics(segment).map(|()| ir::Type::Path { owned: true }),
+        "Option" => {
+            let inner = one_generic(segment)?;
+            Ok(ir::Type::Option(Box::new(lower_type(inner, declared, position)?)))
+        }
+        "Vec" => {
+            let inner = one_generic(segment)?;
+            if let syn::Type::Path(inner_path) = inner {
+                if inner_path.path.is_ident("u8") {
+                    return Ok(ir::Type::Bytes { owned: true });
+                }
+            }
+            Ok(ir::Type::Vec(Box::new(lower_type(
+                inner,
+                declared,
+                Position::Owned,
+            )?)))
+        }
+        "HashMap" => {
+            let pair = two_generics(segment)?;
+            let key = lower_type(pair.key, declared, Position::Owned)?;
+            if !matches!(key, ir::Type::String { .. } | ir::Type::Int(_)) {
+                return Err(LowerError::new(
+                    segment.span(),
+                    "map keys are strings or integers in phase 0",
+                ));
+            }
+            Ok(ir::Type::Map {
+                key: Box::new(key),
+                value: Box::new(lower_type(pair.value, declared, Position::Owned)?),
+            })
+        }
+        _ => lower_named(path, segment, &ident, declared),
+    }
+}
+
+fn lower_named(
+    path: &syn::TypePath,
+    segment: &syn::PathSegment,
+    ident: &str,
+    declared: &Declared,
+) -> Result<ir::Type> {
+    no_generics(segment)?;
+    if path.path.segments.len() != 1 {
+        return Err(unsupported(&syn::Type::Path(path.clone())));
+    }
+    if declared.records.iter().any(|name| name == ident) {
+        return Ok(ir::Type::Named(ident.to_owned()));
+    }
+    if declared.errors.iter().any(|name| name == ident) {
+        return Err(LowerError::new(
+            segment.span(),
+            "an error enum crosses the boundary only through Result",
+        ));
+    }
+    Err(LowerError::new(
+        segment.span(),
+        format!(
+            "`{ident}` is not a #[unibind::record] in this module; only records \
+             and boundary primitives cross"
+        ),
+    ))
+}
+
+fn int_kind(ident: &str) -> Option<ir::IntKind> {
+    Some(match ident {
+        "i8" => ir::IntKind::I8,
+        "i16" => ir::IntKind::I16,
+        "i32" => ir::IntKind::I32,
+        "i64" => ir::IntKind::I64,
+        "isize" => ir::IntKind::Isize,
+        "u8" => ir::IntKind::U8,
+        "u16" => ir::IntKind::U16,
+        "u32" => ir::IntKind::U32,
+        "u64" => ir::IntKind::U64,
+        "usize" => ir::IntKind::Usize,
+        _ => return None,
+    })
+}
+
+fn last_ident(path: &syn::Path) -> Option<&syn::Ident> {
+    path.segments.last().map(|segment| &segment.ident)
+}
+
+fn no_generics(segment: &syn::PathSegment) -> Result<()> {
+    if matches!(segment.arguments, syn::PathArguments::None) {
+        Ok(())
+    } else {
+        Err(LowerError::new(
+            segment.span(),
+            "unexpected generic arguments on this type",
+        ))
+    }
+}
+
+fn generic_types(segment: &syn::PathSegment) -> Result<Vec<&syn::Type>> {
+    let syn::PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return Err(LowerError::new(
+            segment.span(),
+            "this container needs angle-bracketed type arguments",
+        ));
+    };
+    Ok(arguments
+        .args
+        .iter()
+        .filter_map(|argument| match argument {
+            syn::GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .collect())
+}
+
+fn one_generic(segment: &syn::PathSegment) -> Result<&syn::Type> {
+    let types = generic_types(segment)?;
+    if let [inner] = types.as_slice() {
+        Ok(inner)
+    } else {
+        Err(LowerError::new(
+            segment.span(),
+            "expected exactly one type argument",
+        ))
+    }
+}
+
+/// The `(key, value)` pair of a two-argument container.
+struct KeyValue<'a> {
+    key: &'a syn::Type,
+    value: &'a syn::Type,
+}
+
+fn two_generics(segment: &syn::PathSegment) -> Result<KeyValue<'_>> {
+    let types = generic_types(segment)?;
+    if let [key, value] = types.as_slice() {
+        Ok(KeyValue { key, value })
+    } else {
+        Err(LowerError::new(
+            segment.span(),
+            "expected exactly two type arguments",
+        ))
+    }
+}
+
+fn unsupported(ty: &syn::Type) -> LowerError {
+    LowerError::new(
+        ty.span(),
+        format!(
+            "unsupported type `{}` at the unibind boundary",
+            ty.to_token_stream()
+        ),
+    )
+}

--- a/packages/unibind/core/src/lower/ty.rs
+++ b/packages/unibind/core/src/lower/ty.rs
@@ -8,7 +8,7 @@ use crate::ir;
 
 /// Where a type appears; borrowed forms are only legal in argument position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Position {
+pub enum Position {
     /// A function argument (borrowed `&str` / `&Path` / `&[u8]` allowed,
     /// also directly under `Option`).
     Arg,
@@ -16,7 +16,7 @@ pub(crate) enum Position {
     Owned,
 }
 
-pub(crate) fn lower_type(ty: &syn::Type, declared: &Declared, position: Position) -> Result<ir::Type> {
+pub fn lower_type(ty: &syn::Type, declared: &Declared, position: Position) -> Result<ir::Type> {
     match ty {
         syn::Type::Reference(reference) => lower_reference(reference, position),
         syn::Type::Path(path) => lower_path(path, declared, position),
@@ -87,10 +87,10 @@ fn lower_path(path: &syn::TypePath, declared: &Declared, position: Position) -> 
         }
         "Vec" => {
             let inner = one_generic(segment)?;
-            if let syn::Type::Path(inner_path) = inner {
-                if inner_path.path.is_ident("u8") {
-                    return Ok(ir::Type::Bytes { owned: true });
-                }
+            if let syn::Type::Path(inner_path) = inner
+                && inner_path.path.is_ident("u8")
+            {
+                return Ok(ir::Type::Bytes { owned: true });
             }
             Ok(ir::Type::Vec(Box::new(lower_type(
                 inner,

--- a/packages/unibind/core/tests/lower.rs
+++ b/packages/unibind/core/tests/lower.rs
@@ -1,0 +1,185 @@
+//! Lowering across the phase 0 surface: the golden IR for a full-featured
+//! module, and the positioned errors for everything out of scope.
+
+use proc_macro2::TokenStream;
+use unibind_core::ir;
+
+fn lower(source: &str) -> Result<ir::Interface, unibind_core::LowerError> {
+    lower_with(TokenStream::new(), source)
+}
+
+fn lower_with(
+    args: TokenStream,
+    source: &str,
+) -> Result<ir::Interface, unibind_core::LowerError> {
+    let file: syn::File = syn::parse_str(source).expect("fixture parses");
+    let Some(syn::Item::Mod(module)) = file.items.first() else {
+        panic!("fixture starts with a module");
+    };
+    unibind_core::lower_module(args, module)
+}
+
+fn error_message(source: &str) -> String {
+    lower(source).expect_err("lowering should fail").message
+}
+
+const FULL: &str = r#"
+/// A sample boundary.
+mod sample {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    /// A row.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Row {
+        /// Identifier.
+        pub id: u64,
+        #[unibind(py(name = "label"))]
+        pub name: String,
+        pub tags: Vec<String>,
+        pub weights: HashMap<String, f64>,
+        pub blob: Vec<u8>,
+        pub home: Option<PathBuf>,
+    }
+
+    /// Boundary failures.
+    #[unibind::error(py(base = "RuntimeError"))]
+    pub enum SampleError {
+        /// The store is gone.
+        #[unibind(py(name = "StoreGoneError"))]
+        StoreGone { message: String },
+        /// Bad input.
+        Invalid(String),
+    }
+
+    /// Count rows.
+    pub fn rows(
+        store: &str,
+        #[unibind(default = 10)] limit: usize,
+        root: Option<&str>,
+    ) -> Result<Vec<Row>, SampleError> {
+        let _ = (store, limit, root);
+        Ok(Vec::new())
+    }
+
+    #[unibind(py(name = "touch_path"))]
+    pub fn touch(path: &std::path::Path, data: &[u8], #[unibind(default = 0.5)] ratio: f64) -> bool {
+        let _ = (path, data, ratio);
+        true
+    }
+
+    fn helper() {}
+}
+"#;
+
+#[test]
+fn lowers_the_full_surface() {
+    let interface = lower(FULL).expect("lowering succeeds");
+    assert_eq!(interface.version, ir::IR_VERSION);
+    assert_eq!(interface.name, "sample");
+    assert_eq!(interface.docs, vec!["A sample boundary.".to_owned()]);
+
+    let [rows, touch] = interface.functions.as_slice() else {
+        panic!("two exported functions (the private helper is skipped)");
+    };
+    assert_eq!(rows.name, "rows");
+    assert!(matches!(rows.ret, Some(ir::Type::Vec(_))));
+    assert_eq!(rows.throws.as_deref(), Some("SampleError"));
+    assert!(matches!(rows.args[0].ty, ir::Type::String { owned: false }));
+    assert!(matches!(rows.args[1].default, Some(ir::Literal::Int(10))));
+    assert!(matches!(rows.args[2].ty, ir::Type::Option(_)));
+
+    assert_eq!(touch.names.py.as_deref(), Some("touch_path"));
+    assert!(matches!(touch.args[0].ty, ir::Type::Path { owned: false }));
+    assert!(matches!(touch.args[1].ty, ir::Type::Bytes { owned: false }));
+    assert!(touch.throws.is_none());
+    assert!(matches!(touch.ret, Some(ir::Type::Bool)));
+
+    let [row] = interface.records.as_slice() else {
+        panic!("one record");
+    };
+    assert_eq!(row.fields[1].names.py.as_deref(), Some("label"));
+    assert!(matches!(row.fields[4].ty, ir::Type::Bytes { owned: true }));
+    assert!(matches!(row.fields[5].ty, ir::Type::Option(_)));
+
+    let [error] = interface.errors.as_slice() else {
+        panic!("one error enum");
+    };
+    assert_eq!(error.py_base.as_deref(), Some("RuntimeError"));
+    assert_eq!(error.variants[0].names.py.as_deref(), Some("StoreGoneError"));
+    assert_eq!(error.variants[1].name, "Invalid");
+}
+
+#[test]
+fn ir_round_trips_through_json() {
+    let interface = lower(FULL).expect("lowering succeeds");
+    let json = serde_json::to_string(&interface).expect("serializes");
+    let back: ir::Interface = serde_json::from_str(&json).expect("deserializes");
+    assert_eq!(back.functions.len(), interface.functions.len());
+    assert_eq!(back.records.len(), interface.records.len());
+}
+
+#[test]
+fn module_rename_comes_from_the_attribute_args() {
+    let args: TokenStream = r#"py(name = "_other")"#.parse().expect("args parse");
+    let interface = lower_with(args, "mod sample { }").expect("lowering succeeds");
+    assert_eq!(interface.names.py.as_deref(), Some("_other"));
+}
+
+#[test]
+fn async_functions_point_at_phase_2() {
+    let message = error_message("mod m { pub async fn go() {} }");
+    assert!(message.contains("phase 2"), "{message}");
+}
+
+#[test]
+fn objects_point_at_phase_2() {
+    let message = error_message("mod m { #[unibind::object] pub struct Handle { pub id: u64 } }");
+    assert!(message.contains("phase 2"), "{message}");
+}
+
+#[test]
+fn data_enums_are_rejected() {
+    let message = error_message("mod m { #[unibind::record] pub enum Kind { A, B } }");
+    assert!(message.contains("data enums"), "{message}");
+}
+
+#[test]
+fn unknown_types_name_the_offender() {
+    let message = error_message("mod m { pub fn go(value: Mystery) {} }");
+    assert!(message.contains("`Mystery`"), "{message}");
+}
+
+#[test]
+fn required_after_defaulted_is_rejected() {
+    let message =
+        error_message("mod m { pub fn go(#[unibind(default = 1)] a: u32, b: u32) {} }");
+    assert!(message.contains("needs a default"), "{message}");
+}
+
+#[test]
+fn foreign_error_types_are_rejected() {
+    let message =
+        error_message("mod m { pub fn go() -> Result<(), std::io::Error> { Ok(()) } }");
+    assert!(message.contains("#[unibind::error]"), "{message}");
+}
+
+#[test]
+fn private_record_fields_are_rejected() {
+    let message =
+        error_message("mod m { #[unibind::record] pub struct Row { id: u64 } }");
+    assert!(message.contains("must be `pub`"), "{message}");
+}
+
+#[test]
+fn strip_removes_every_unibind_attribute() {
+    let file: syn::File = syn::parse_str(FULL).expect("fixture parses");
+    let Some(syn::Item::Mod(module)) = file.items.first() else {
+        panic!("fixture starts with a module");
+    };
+    let mut module = module.clone();
+    unibind_core::strip_unibind_attrs(&mut module);
+    let rendered = quote::quote!(#module).to_string();
+    assert!(!rendered.contains("unibind"), "{rendered}");
+}

--- a/packages/unibind/macros/Cargo.toml
+++ b/packages/unibind/macros/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "unibind"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Write-once binding attributes: lower an annotated module to the unibind IR and render the enabled language backends"
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true
+
+[features]
+py = ["dep:unibind-backend-py"]
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+unibind-backend-py = { workspace = true, optional = true }
+unibind-core.workspace = true

--- a/packages/unibind/macros/Cargo.toml
+++ b/packages/unibind/macros/Cargo.toml
@@ -7,6 +7,10 @@ description = "Write-once binding attributes: lower an annotated module to the u
 
 [lib]
 proc-macro = true
+# The doctest pipeline compiles the crate as a plain lib to extract examples,
+# which cannot link `proc_macro`; the usage example in lib.rs is `ignore`d
+# anyway.
+doctest = false
 
 [lints]
 workspace = true

--- a/packages/unibind/macros/package.nix
+++ b/packages/unibind/macros/package.nix
@@ -1,0 +1,4 @@
+{
+  id = "unibind";
+  inRustWorkspace = true;
+}

--- a/packages/unibind/macros/src/expand.rs
+++ b/packages/unibind/macros/src/expand.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use unibind_core::LowerError;
 
-pub(crate) fn export(args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn export(args: TokenStream, item: TokenStream) -> TokenStream {
     let mut module = match syn::parse2::<syn::ItemMod>(item.clone()) {
         Ok(module) => module,
         Err(error) => {
@@ -93,7 +93,7 @@ fn splice_record_attrs(
     }
 }
 
-pub(crate) fn marker_outside_export(item: TokenStream, message: &str) -> TokenStream {
+pub fn marker_outside_export(item: TokenStream, message: &str) -> TokenStream {
     let error = syn::Error::new(proc_macro2::Span::call_site(), message).to_compile_error();
     quote! { #item #error }
 }

--- a/packages/unibind/macros/src/expand.rs
+++ b/packages/unibind/macros/src/expand.rs
@@ -1,0 +1,99 @@
+//! Expansion pipeline: parse once, lower to IR, dispatch to backends.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use unibind_core::LowerError;
+
+pub(crate) fn export(args: TokenStream, item: TokenStream) -> TokenStream {
+    let mut module = match syn::parse2::<syn::ItemMod>(item.clone()) {
+        Ok(module) => module,
+        Err(error) => {
+            let error = error.to_compile_error();
+            return quote! { #item #error };
+        }
+    };
+    let interface = match unibind_core::lower_module(args, &module) {
+        Ok(interface) => interface,
+        Err(error) => return with_error(&mut module, &error),
+    };
+    unibind_core::strip_unibind_attrs(&mut module);
+    let embed = match unibind_core::embed::ir_static(&interface) {
+        Ok(embed) => embed,
+        Err(error) => return with_error(&mut module, &error),
+    };
+    let glue = match backends(&interface, &mut module) {
+        Ok(glue) => glue,
+        Err(error) => return with_error(&mut module, &error),
+    };
+    quote! {
+        #module
+        #embed
+        #glue
+    }
+}
+
+/// Emit the module (markers stripped, so nothing cascades) plus the
+/// positioned diagnostic.
+fn with_error(module: &mut syn::ItemMod, error: &LowerError) -> TokenStream {
+    unibind_core::strip_unibind_attrs(module);
+    let error = syn::Error::new(error.span, &error.message).to_compile_error();
+    quote! { #module #error }
+}
+
+#[cfg(feature = "py")]
+fn backends(
+    interface: &unibind_core::ir::Interface,
+    module: &mut syn::ItemMod,
+) -> Result<TokenStream, LowerError> {
+    let rendered = unibind_backend_py::render(interface).map_err(|error| LowerError {
+        span: proc_macro2::Span::call_site(),
+        message: error.message,
+    })?;
+    splice_record_attrs(interface, module, &rendered);
+    Ok(rendered.glue)
+}
+
+/// With no backend feature enabled the macro still validates the surface
+/// and embeds the IR; there is just no binding code to add.
+#[cfg(not(feature = "py"))]
+fn backends(
+    _interface: &unibind_core::ir::Interface,
+    _module: &mut syn::ItemMod,
+) -> Result<TokenStream, LowerError> {
+    Ok(TokenStream::new())
+}
+
+/// Attach the backend's `#[pyclass]`-shaped attributes to the record
+/// structs the IR was lowered from. Records and rendered attribute sets are
+/// index-aligned by construction.
+#[cfg(feature = "py")]
+fn splice_record_attrs(
+    interface: &unibind_core::ir::Interface,
+    module: &mut syn::ItemMod,
+    rendered: &unibind_backend_py::RenderedInterface,
+) {
+    let Some((_, items)) = &mut module.content else {
+        return;
+    };
+    for (record, attrs) in interface.records.iter().zip(&rendered.records) {
+        for item in &mut *items {
+            let syn::Item::Struct(item) = item else {
+                continue;
+            };
+            if item.ident != record.name {
+                continue;
+            }
+            let mut outer = attrs.outer.clone();
+            outer.append(&mut item.attrs);
+            item.attrs = outer;
+            for (field, field_attrs) in item.fields.iter_mut().zip(&attrs.fields) {
+                field.attrs.extend(field_attrs.iter().cloned());
+            }
+        }
+    }
+}
+
+pub(crate) fn marker_outside_export(item: TokenStream, message: &str) -> TokenStream {
+    let error = syn::Error::new(proc_macro2::Span::call_site(), message).to_compile_error();
+    quote! { #item #error }
+}

--- a/packages/unibind/macros/src/lib.rs
+++ b/packages/unibind/macros/src/lib.rs
@@ -1,0 +1,92 @@
+//! Write-once binding attributes.
+//!
+//! `#[unibind::export]` on an inline module lowers every `pub fn` in it,
+//! together with the `#[unibind::record]` and `#[unibind::error]` items,
+//! into one language-agnostic interface (see `unibind-core`), embeds the
+//! serialized interface in the built artifact, and renders binding code for
+//! every backend enabled by cargo features (`py` renders `pyo3`).
+//!
+//! ```ignore
+//! #[unibind::export]
+//! mod _mylib {
+//!     /// Rows come back as native classes.
+//!     #[unibind::record]
+//!     #[derive(Clone)]
+//!     pub struct Row {
+//!         pub id: u64,
+//!         pub name: String,
+//!     }
+//!
+//!     /// Everything the boundary raises.
+//!     #[unibind::error(py(base = "ValueError"))]
+//!     pub enum MyError {
+//!         /// The store is gone.
+//!         StoreGone { message: String },
+//!     }
+//!
+//!     /// Doc comments become docstrings.
+//!     pub fn rows(store: &str, #[unibind(default = 10)] limit: usize) -> Result<Vec<Row>, MyError> {
+//!         let _ = (store, limit);
+//!         Ok(Vec::new())
+//!     }
+//! }
+//! ```
+
+mod expand;
+
+use proc_macro::TokenStream;
+
+/// Export an inline module as the crate's binding boundary.
+///
+/// Every `pub fn` in the module is exported; private items pass through
+/// untouched. The attribute accepts `py(name = "...")` to rename the Python
+/// module (it defaults to the Rust module name, which also names the
+/// `PyInit_` symbol of the built extension).
+#[proc_macro_attribute]
+pub fn export(args: TokenStream, item: TokenStream) -> TokenStream {
+    expand::export(args.into(), item.into()).into()
+}
+
+/// Mark a plain-data struct inside a `#[unibind::export]` module.
+///
+/// The struct crosses the boundary by value: Python sees a native class
+/// with one read-only attribute per field and a positional constructor.
+/// Fields must be `pub` and owned; `#[unibind(py(name = "..."))]` renames a
+/// field. The struct needs `Clone` for attribute access from Python.
+#[proc_macro_attribute]
+pub fn record(_args: TokenStream, item: TokenStream) -> TokenStream {
+    expand::marker_outside_export(
+        item.into(),
+        "#[unibind::record] only takes effect inside a #[unibind::export] \
+         module; declare the struct inside the exported module",
+    )
+    .into()
+}
+
+/// Mark an error enum inside a `#[unibind::export]` module.
+///
+/// The enum becomes an exception hierarchy: one base class named after the
+/// enum and one subclass per variant, carrying the variant's `Display`
+/// text. `py(base = "...")` picks the Python built-in the base class
+/// extends (`Exception` by default); the enum must implement `Display`.
+#[proc_macro_attribute]
+pub fn error(_args: TokenStream, item: TokenStream) -> TokenStream {
+    expand::marker_outside_export(
+        item.into(),
+        "#[unibind::error] only takes effect inside a #[unibind::export] \
+         module; declare the enum inside the exported module",
+    )
+    .into()
+}
+
+/// Reserved for stateful handles; lands with resources in phase 2
+/// (issue #1992).
+#[proc_macro_attribute]
+pub fn object(_args: TokenStream, item: TokenStream) -> TokenStream {
+    expand::marker_outside_export(
+        item.into(),
+        "#[unibind::object] lands with resources in phase 2 (issue #1992); \
+         phase 0 covers sync functions, records, and errors",
+    )
+    .into()
+}


### PR DESCRIPTION
Phase 0 of unibind: the language-agnostic IR, the proc-macro surface, the pyo3 backend for sync functions/records/errors, and the proving port of `packages/code/scipql/py`. Part of #1989. Closes #1990.

## What is here

- `packages/unibind/core` (`unibind-core`): IR types (`Interface`, functions/args, records, enums, errors, objects; `Type` covers Option/Vec/HashMap/String/PathBuf/bytes/primitives with owned/borrowed distinction), syn lowering with positioned errors, and the wasm-bindgen-style link-section embed (`.unibind_ir` / `__DATA,__unibind_ir`) that phase 1's `unibind-gen` (#1991) will read.
- `packages/unibind/macros` (crate `unibind`, proc-macro): `#[unibind::export]` on an inline module parses once to IR and dispatches to backends by cargo feature; `#[unibind::record]` / `#[unibind::error]` markers inside the module; `#[unibind::object]` reserved with a clear error pointing at #1992. `#[unibind(py(name = ...))]` renames and `#[unibind(default = ...)]` argument defaults work now.
- `packages/unibind/backend-py`: renders pyo3 0.28 (abi3-py311) code targeting pyo3's own macro surface: `#[pyfunction]` wrappers with generated `#[pyo3(signature = ...)]` (Option args default to None), `#[pyclass(from_py_object)]` records with per-field getters and a `#[new]` constructor, `create_exception!` hierarchies (base per enum, subclass per variant, `py(base = ...)` picks the built-in) plus `From<Enum> for PyErr`, one imperative `#[pymodule]`, doc comments as docstrings.
- scipql port: the five functions keep signatures, defaults, and docstrings; dict/list payloads become record classes; the flat `ValueError` becomes `ScipqlError(ValueError)` with `IndexingError`/`SouffleError`/`EditError` subclasses. Same crate name, cdylib layout, and `_scipql` module, so the mcp bundling is unchanged.
- `packages/unibind/README.md` distills the design (surface, pipeline, type mapping, phase table).

## Validation

- `nix build .#packages.aarch64-darwin.mcp` builds green end to end (unibind crates, macro expansion, generated glue compiling into `scipql_py`, kernel env assembly).
- Snapshot tests in `packages/unibind/backend-py/tests` pin the IR JSON and the exact generated glue; lowering tests in `packages/unibind/core/tests` cover the golden path and the phase 0 error surface.
- A/B benchmark (hand-written pyo3 on main vs unibind-generated) and kernel e2e numbers land in a follow-up comment on this PR.

## Deviations from the task spec (noted, not silent)

- trybuild/macrotest invoke cargo at test runtime, which neither the nix test sandbox nor the repo's cargo policy allows; the expansion is snapshot-tested by rendering the IR directly (same review surface, no cargo-in-test).
- scipql-py has no mkwheel.py flow: its cdylib is bundled into the ix-mcp interpreter by `packages/mcp/default.nix` (unchanged) rather than shipped as a wheel; the port keeps that exact layout.
- No `packages/unibind/runtime` crate: the embedded IR constant is self-contained bytes, so phase 0 needs no runtime support crate.

Authored by an AI agent (Claude Code) working issue #1990.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unibind phase 0: core IR, proc-macro surface, and PyO3 backend; port scipql-py to use it
> - Introduces the `unibind` system for generating FFI bindings from annotated Rust modules: `unibind-core` defines the language-agnostic IR and lowering pipeline, `unibind-macros` exposes `#[unibind::export]`, `#[unibind::record]`, and `#[unibind::error]` proc-macros, and `unibind-backend-py` renders PyO3 glue from the IR.
> - The macro pipeline parses an inline `#[unibind::export]` module, lowers it to an `Interface` IR (validating signatures, types, defaults ordering, error types), embeds the IR in a link section, and emits PyO3 wrapper code when built with the `py` feature.
> - Ports [packages/code/scipql/py/src/lib.rs](https://github.com/indexable-inc/index/pull/2028/files#diff-807902b598358c7a5f5928befac9004aba1aa22ec2259ce3f5f1e691e9ae8748) from hand-authored PyO3 bindings to unibind annotations: `facts()` now returns typed record objects (`Facts`, `Occurrence`, `SymbolInfo`, etc.) instead of nested dicts, `query()` returns `Relation` objects, and errors are raised as typed `ScipqlError` subclasses (`IndexingError`, `SouffleError`, `EditError`) extending `ValueError`.
> - Updates [packages/code/scipql/py/python/scipql/__init__.py](https://github.com/indexable-inc/index/pull/2028/files#diff-954c04580cad2e2ef9be79982b22898e255a7d5b3c5b04cbb160d49665c0c36f) to access record attributes (e.g. `row.symbol`) instead of dict keys, and exports the new error classes.
> - Fixes `Unit::has_doctests` in [packages/nix/nix-cargo-unit/src/model.rs](https://github.com/indexable-inc/index/pull/2028/files#diff-b03b1c6d15b1af800cef1988e81a429e556b8bf080fae7d226730e5fab818ec4) to return `false` for proc-macro targets.
> - Behavioral Change: Python callers of `facts()` and `query()` receive objects with attributes instead of dicts; callers catching `ValueError` now receive a typed subclass.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b97fb37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->