### PR TITLE
fix(symphony): pack codex invocations take stdin from /dev/null

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/insights.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/insights.sh
@@ -40,7 +40,7 @@ git -C "$SYMPHONY_PRIMARY_REPO" worktree add --detach "$digest_root/repo" HEAD
     -u SYMPHONY_GITHUB_APP_PRIVATE_KEY_BASE64 -u SYMPHONY_ROOM_REGISTRY_TOKEN \
     codex exec --sandbox read-only --ignore-user-config \
     --output-last-message "$last_msg" \
-    "$(cat "$prompt_file")"
+    "$(cat "$prompt_file")" </dev/null # codex reads a non-tty stdin to EOF; the runner pipe never closes (#2011)
 )
 
 # An empty final message means nothing postable; fail the node loudly so

--- a/packages/agent/symphony/workflows/indexable/scripts/triage.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/triage.sh
@@ -53,7 +53,7 @@ git -C "$SYMPHONY_PRIMARY_REPO" worktree add --detach "$triage_root/repo" HEAD
     -c 'shell_environment_policy.exclude=["*KEY*","*SECRET*"]' \
     --ignore-user-config \
     --output-last-message "$last_msg" \
-    "$(cat "$prompt_file")"
+    "$(cat "$prompt_file")" </dev/null # codex reads a non-tty stdin to EOF; the runner pipe never closes (#2011)
 )
 
 # An empty final message means nothing postable; fail the node loudly so


### PR DESCRIPTION
Immediate unblock for the live wedge behind #2011: `codex exec` blocks reading a never-closing non-tty stdin pipe even with an argv prompt, so every scheduled insights/triage run wedged at 0% CPU. Differential proof: identical invocation completes in 3s with `</dev/null`. Kept as pack-level defense in depth alongside #2011's runner class fix.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix codex invocations in pack scripts to redirect stdin from `/dev/null`
> In [insights.sh](https://github.com/indexable-inc/index/pull/2031/files#diff-364a554c8d8c5f993ce44303d0a5507cc5c8755ead4b9e983b2e789d0d05929f) and [triage.sh](https://github.com/indexable-inc/index/pull/2031/files#diff-c02bd9185a76655182e4da86b56a025e3078b95a3218050b1b20e613a4143354), the `codex exec` command now redirects stdin from `/dev/null` instead of inheriting the parent shell's stdin. This prevents the codex process from blocking indefinitely waiting for input on a never-closing pipe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3733d17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->