### PR TITLE
docs: fix nix run .#tui-dashboard references to .#dashboard

### DIFF
--- a/doc/tui-py/overview.md
+++ b/doc/tui-py/overview.md
@@ -78,10 +78,9 @@ idempotent, skipped when `IX_TUI_AUTOPUBLISH=0`, and superseded by an explicit
 `tui.publish(...)` so a process never exposes two producers
 (`src/publish.rs:38,98`). The producer/consumer transport and the aggregator
 live in the dashboard domain; the README and Python
-docstrings invoke the aggregator as `nix run .#tui-dashboard`, but the registered
-flake output for the aggregator is `nix run .#dashboard`
-([dashboard](../dashboard/overview.md)).
-<!-- TODO: verify whether `tui-dashboard` is an intended alias for the `dashboard` flake output; it is not registered in packages/*/package.nix. -->
+docstrings invoke the aggregator as `nix run .#dashboard`
+([dashboard](../dashboard/overview.md)), the registered flake output for the
+aggregator.
 
 ## Layer 3: the agent harness (`python/tui/harness.py`)
 

--- a/packages/agent/skills/experiment/SKILL.md
+++ b/packages/agent/skills/experiment/SKILL.md
@@ -59,7 +59,7 @@ one rollout, and an honest keep-or-revert decision at the end.
 When the thing under test is Claude (or Codex) performance, do **not** evaluate
 with a headless `claude -p` and do **not** wrangle `tmux`. Use the index TUI
 Python harness. It spawns the *real* agent TUI in a PTY, so the session is live
-on the web dashboard (`nix run .#tui-dashboard`) exactly like a human's: you and
+on the web dashboard (`nix run .#dashboard`) exactly like a human's: you and
 the user watch the current state, attach, and interrupt. An experiment you can
 watch beats a black box you can only diff, and the harness gives clean,
 programmatic prompt/await/read so rollouts are a `for`-loop or an `asyncio.gather`.

--- a/packages/site/src/lib/updates/tui-multiprocess-dashboard.svx
+++ b/packages/site/src/lib/updates/tui-multiprocess-dashboard.svx
@@ -17,7 +17,7 @@ Several processes can now share one `tui` web dashboard instead of each starting
 Run the standalone aggregator once to watch all of them:
 
 ```sh
-nix run .#tui-dashboard
+nix run .#dashboard
 ```
 
 It scans the discovery directory, connects to every producer socket, folds each producer's stream into one Loro document under its own scope, and serves the grid over Server-Sent Events. No producer owns the server and exactly one process binds a TCP port, so agents come and go behind a single stable URL; a producer's terminals leave the grid when it disconnects.

--- a/packages/tui/tui-py/README.md
+++ b/packages/tui/tui-py/README.md
@@ -329,7 +329,7 @@ asyncio.run(main())
 Run the aggregator once, separately, to watch every publisher:
 
 ```sh
-nix run .#tui-dashboard          # http://127.0.0.1:8080/
+nix run .#dashboard               # http://127.0.0.1:8080/
 ```
 
 Producers come and go freely: the aggregator discovers each socket in the shared
@@ -377,7 +377,7 @@ The vocabulary maps straight onto Playwright:
 
 **Why drive the real TUI, not `claude -p`?** A headless `-p` run is invisible and
 uninterruptible. A harness drives the actual TUI in a PTY, so the session shows
-up live on the web dashboard (`nix run .#tui-dashboard`) exactly like a human's:
+up live on the web dashboard (`nix run .#dashboard`) exactly like a human's:
 you watch the current state, attach, interrupt. For an experiment, observability
 beats a black box you can only diff.
 

--- a/packages/tui/tui-py/python/tui/__init__.py
+++ b/packages/tui/tui-py/python/tui/__init__.py
@@ -21,7 +21,7 @@ its methods cell by cell, and `await t.close()` when done. Evaluating
 color via `Snapshot._repr_html_`.
 
 Every spawned terminal auto-shows in the web dashboard. The first `Tui(...)`
-binds a process-global producer, so running `nix run .#tui-dashboard` (it
+binds a process-global producer, so running `nix run .#dashboard` (it
 watches `socket_dir()`) renders this process's terminals with no explicit
 `tui.publish()`. Opt out by setting `IX_TUI_AUTOPUBLISH=0`.
 
@@ -510,7 +510,7 @@ def _build_predicate(pattern: Pattern) -> Callable[[Snapshot], bool]:
 def _ensure_autopublish() -> None:
     """Bind the process-global dashboard producer once, on first `Tui(...)`.
 
-    Spawned terminals then appear in `nix run .#tui-dashboard` with no explicit
+    Spawned terminals then appear in `nix run .#dashboard` with no explicit
     `tui.publish()`. Idempotency (bind at most once per process) and the
     `IX_TUI_AUTOPUBLISH=0` opt-out both live in the Rust `ensure_published`, so
     this stays a thin call into it rather than re-implementing either guard here.
@@ -543,7 +543,7 @@ class Tui:
     are the only synchronous surface; everything else is a coroutine to await.
 
     The first `Tui(...)` auto-publishes this process to the web dashboard, so
-    `nix run .#tui-dashboard` shows the terminal without an explicit
+    `nix run .#dashboard` shows the terminal without an explicit
     `tui.publish()`. Set `IX_TUI_AUTOPUBLISH=0` to opt out.
 
     `kill()` sends SIGKILL; `interrupt()` sends a cooperative Ctrl+C; `close()`

--- a/packages/tui/tui-py/python/tui/harness.py
+++ b/packages/tui/tui-py/python/tui/harness.py
@@ -39,7 +39,7 @@ Quick start, exactly the shape of a Playwright test:
 
 Why drive the real TUI instead of `claude -p`? A headless `-p` run is invisible
 and uninterruptible. A harness drives the actual TUI in a PTY, so the session
-shows up live on the `tui` web dashboard (`nix run .#tui-dashboard`) just like a
+shows up live on the `tui` web dashboard (`nix run .#dashboard`) just like a
 human's. You watch the current state, attach, interrupt. For an *experiment*
 that is the whole point: an agent you can observe beats a black box you diff.
 


### PR DESCRIPTION
The flake package attr for the aggregator is `dashboard`, not
`tui-dashboard`. Fixes every broken `nix run .#tui-dashboard` reference:

- `packages/tui/tui-py/README.md`
- `packages/tui/tui-py/python/tui/__init__.py`
- `packages/tui/tui-py/python/tui/harness.py`
- `doc/tui-py/overview.md` (also removes the TODO flagging this exact ambiguity)
- `packages/agent/skills/experiment/SKILL.md`
- `packages/site/src/lib/updates/tui-multiprocess-dashboard.svx`

Verified via:
```
nix eval --json .#packages.aarch64-darwin --apply 'p: builtins.filter (n: builtins.match ".*dash.*" n != null) (builtins.attrNames p)'
# => ["dashboard"]
```

No alias shim added; `nix run .#lint` is green.

Fixes #2037

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `nix run .#tui-dashboard` references to `nix run .#dashboard` across docs and code
> Updates all occurrences of the outdated `nix run .#tui-dashboard` command to `nix run .#dashboard` across documentation, README files, and Python docstrings. No code logic is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f74e48b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->