### PR TITLE
ci(update): derive built attrs from the registry, not manifest path segments

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -47,7 +47,8 @@ jobs:
       # Runs every content updater in parallel via dag-runner (see
       # lib/per-system.nix). Each regenerates its own source files relative to
       # the repo root: the Minecraft catalogs/sound pack, and each pinned
-      # package's packages/<id>/manifest.json.
+      # package's sources under its own directory (manifest.json, pins.json,
+      # ...).
       #
       # `|| true`: a content updater talks to an independent upstream (papermc,
       # fabric, mojang, the yc/claude-code release hosts). One flaky upstream
@@ -60,27 +61,45 @@ jobs:
       - name: Run updaters
         run: nix run .#update || true
 
-      # Build every changed package's x86_64-linux output. This proves the
-      # freshly pinned hash actually fetches and the package builds; it does NOT
-      # prove provenance. claude-code's updater already verified a GPG signature
-      # over all four platform checksums, but yc has no upstream signature and
-      # this step only builds the runner's platform, so for yc the four hash
-      # changes in the diff are trusted on the strength of human PR review, not a
-      # cryptographic check. Catalog updaters are validated by the PR's own
-      # flake-check CI. Assumes a package's directory name equals its flake attr
-      # (its registry `id`), which holds for every flagged package today.
+      # Build every changed updater package's x86_64-linux output. This proves
+      # the freshly pinned hash actually fetches and the package builds; it does
+      # NOT prove provenance. An updater that verifies an upstream signature
+      # (claude-code checks Anthropic's detached GPG signature over all four
+      # platform checksums) is fail-closed at write time, but most pins have no
+      # upstream signature and this step only builds the runner's platform, so
+      # those hash changes are trusted on the strength of human PR review, not a
+      # cryptographic check.
+      #
+      # Which attr to build comes from the registry, never from a manifest's
+      # path segments: `.#updatablePackages` (lib/per-system.nix) maps each
+      # `updateScript` package's directory to its flake attr for this platform.
+      # A changed file with no owner in that map (the nested Minecraft catalog
+      # manifests under packages/minecraft/catalogs/, or a platform-gated
+      # updater like the aarch64-darwin-only dia) is skipped here and validated
+      # by the PR's own flake-check CI instead (#2036).
       - name: Build changed packages
         run: |
           set -euo pipefail
-          changed=$(git diff --name-only -- 'packages/*/manifest.json' || true)
+          changed=$(git diff --name-only -- packages/)
           if [ -z "$changed" ]; then
-            echo "no package manifests changed"
+            echo "no package sources changed"
             exit 0
           fi
-          for manifest in $changed; do
-            id=$(basename "$(dirname "$manifest")")
-            echo "::group::nix build .#$id"
-            nix build ".#$id"
+          owners=$(nix eval --json ".#updatablePackages.x86_64-linux")
+          attrs=$(jq -nr --argjson owners "$owners" --arg changed "$changed" '
+            $changed | split("\n")[] as $file
+            | $owners
+            | to_entries[]
+            | select(.key as $dir | $file | startswith($dir + "/"))
+            | .value
+          ' | sort -u)
+          if [ -z "$attrs" ]; then
+            echo "no changed file is owned by an updater package on this platform"
+            exit 0
+          fi
+          for attr in $attrs; do
+            echo "::group::nix build .#$attr"
+            nix build ".#$attr"
             echo "::endgroup::"
           done
 
@@ -105,8 +124,8 @@ jobs:
           body: |
             Automated refresh of every repo content source.
 
-            `nix run .#update` ran all content updaters in parallel: the Minecraft mod / loader / sound catalogs and every package whose `package.nix` sets `updateScript = true` (currently claude-code and yc). flake.lock is handled by its own workflow.
+            `nix run .#update` ran all content updaters in parallel: the Minecraft mod / loader / sound catalogs and every package whose `package.nix` sets `updateScript = true` (discovered from packages/registry.nix). flake.lock is handled by its own workflow.
 
-            Each changed package also built on `x86_64-linux`, which proves the new hash fetches and builds but **not** that it is authentic. claude-code's updater verified Anthropic's detached GPG signature over all four platform checksums before writing. **yc has no upstream signature**, so please eyeball the yc hash changes before merging: the build only covers x86_64-linux, and the updater pins whatever bytes the release host served.
+            Each changed updater package also built on `x86_64-linux`, which proves the new hash fetches and builds but **not** that it is authentic. claude-code's updater verified Anthropic's detached GPG signature over all four platform checksums before writing. **Most pins have no upstream signature**, so please eyeball those hash changes before merging: the build only covers x86_64-linux, and the updater pins whatever bytes the release host served.
 
             Auto-bump, made with Claude Opus 4.8.

--- a/flake.nix
+++ b/flake.nix
@@ -460,6 +460,12 @@
     # `recurseForDerivations` groups are not derivations, which the flake
     # `checks` schema requires.
     ciChecks = collect "ciChecks";
+    # Registry-derived map of package directory -> flake attr for every
+    # `updateScript` package exposed on a system. update.yml's "Build changed
+    # packages" step evaluates this to find which attr owns each file the
+    # updaters changed, instead of deriving an attr from path segments
+    # (#2036). Non-schema, so surfaced through `collect` like `ciChecks`.
+    updatablePackages = collect "updatablePackages";
     # CI-only view of `packages` with each NixOS image swapped for its
     # `toplevel` closure; cache-push.yml publishes this instead of the
     # monolithic `*-oci.tar` archives, which nothing substitutes. Non-schema,

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -649,6 +649,17 @@
       entry: lib.nameValuePair entry.id {command = [(updaterFor entry)];}
     );
   updateSpec = (pkgs.formats.json {}).generate "update-dag.json" {nodes = updateNodes;};
+  # Machine-readable registry view for update.yml's "Build changed packages"
+  # step: repo-relative package directory -> the flake attr that builds it on
+  # this system. The workflow maps each file the updaters changed to its owning
+  # package through this table instead of guessing an attr from path segments,
+  # which breaks for nested catalog manifests (#2036). Restricted to entries
+  # with a `flake` target enabled here, so a platform-gated updater (dia is
+  # aarch64-darwin-only) is absent from the Linux map and gets skipped rather
+  # than built as a missing attr.
+  updatablePackages = lib.genAttrs' (
+    lib.filter (entry: entry.updateScript) (packageRegistry.flakeEntriesFor system)
+  ) (entry: lib.nameValuePair "packages/${entry.relativePath}" entry.flake.attrName);
   update = ix.writeNushellApplication pkgs {
     name = "update";
     meta.description = "Refresh every repo content source (Minecraft catalogs + pinned binaries) in parallel via dag-runner";
@@ -1364,6 +1375,10 @@
     // healthChecks.lifecyclePackages;
 in {
   packages = packageSet;
+
+  # Non-schema output consumed by update.yml via `nix eval --json`; see the
+  # binding above for what it maps.
+  inherit updatablePackages;
 
   # CI-only push roots for cache-push.yml. Two adjustments to `packages` keep the
   # cache useful to `ix up` while cutting the monolithic `*-oci.tar` archives that


### PR DESCRIPTION
Fixes #2036.

The update workflow's "Build changed packages" step guessed `nix build .#$id` from a manifest's parent directory name. Git pathspec `*` crosses `/`, so a nested catalog manifest like `packages/minecraft/catalogs/loaders/fabric/manifest.json` derived `.#fabric` (does not exist), and the aarch64-darwin-only `dia` would have failed on the Linux runner. The comments also still said "currently claude-code and yc" while 14 packages set `updateScript = true` today, most writing `pins.json` the old `packages/*/manifest.json` diff never build-verified.

Changes:
- New non-schema flake output `.#updatablePackages.<system>` (lib/per-system.nix, collected in flake.nix): registry-derived map of package directory -> flake attr, restricted to `updateScript` entries with a `flake` target enabled on that system.
- update.yml diffs all of `packages/` and maps each changed file to its owning updater through that table (jq prefix match). Files with no owner (catalog manifests, platform-gated updaters like dia on Linux) are skipped and validated by the PR's own flake-check, as before.
- Stale comments and PR-body text updated.

Validation (dry mapping over every `manifest.json`/`pins.json` in the tree, using the workflow's exact jq):
- all 6 `packages/minecraft/catalogs/**/manifest.json` -> skipped (previously `.#fabric` etc.)
- `packages/dia/manifest.json` -> skipped on x86_64-linux (in the aarch64-darwin map as `dia`)
- 11 owned files map to their registry attr (claude-code, humanlayer, yc, blender-{lab-,}mcp, lakekeeper, spark-gluten, spark-hive, tonbo-artifacts, vector-bin, wasm-bindgen-cli); codex/btop own their `default.nix`-writing updaters via the same prefix rule
- every mapped attr asserted to eval (`.#packages.x86_64-linux.<attr>.drvPath`) on an x86_64-linux host
- actionlint and `nix run .#lint` green

Auto-fix, made with Claude (Fable 5).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive updatable package attrs from a flake registry map in the CI update workflow
> - Adds an `updatablePackages` output to the flake (in [flake.nix](https://github.com/indexable-inc/index/pull/2040/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) and [lib/per-system.nix](https://github.com/indexable-inc/index/pull/2040/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683)) that maps each package directory path to its flake attr name for updater-enabled packages on the current system.
> - Updates [.github/workflows/update.yml](https://github.com/indexable-inc/index/pull/2040/files#diff-571e661e1640e6f1f415c087c9a72af346ea9fd4655ff5545e5ad6ea596bab97) to detect any changed file under `packages/` (not just `packages/*/manifest.json`) and look up the owning attr via `nix eval .#updatablePackages.x86_64-linux`.
> - Build step iterates over resolved attr names directly instead of deriving an id from directory path segments; files with no owning attr are skipped.
> - Behavioral Change: packages whose directory name differs from their flake attr name will now build correctly, and changes to non-manifest files under `packages/` will trigger updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 772ba14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->