### PR TITLE
mirror-sync: mint MIRROR_TOKEN from the ix-mirror-sync GitHub App

### DIFF
--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -30,10 +30,10 @@ concurrency:
 jobs:
   # Snapshot-sync each opt-in package (a `mirror` attr in its package.nix,
   # surfaced as `.#lib.mirrorPackages`) into its standalone read-only repo.
-  # `MIRROR_TOKEN` is a secret with repo-creation + push rights on the org
-  # (see packages/mirror/README.md, "Permissions"); the default GITHUB_TOKEN
-  # cannot create repos or push outside this repository, so without the
-  # secret the job skips loudly instead of half-running.
+  # MIRROR_TOKEN is minted per run from the ix-mirror-sync GitHub App (see
+  # packages/mirror/README.md, "Permissions"); the default GITHUB_TOKEN cannot
+  # create repos or push outside this repository, so without the app secrets
+  # the job skips loudly instead of half-running.
   mirrors:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -51,12 +51,25 @@ jobs:
             extra-substituters = https://cache.ix.dev
             extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
 
+      # MIRROR_TOKEN is minted per run from the org-owned ix-mirror-sync
+      # GitHub App (repo Administration + Contents write): short-lived, no
+      # long-lived PAT to rotate. When the app secrets are absent the step is
+      # skipped and the shell guard below skips loudly instead of half-running.
+      - name: Mint mirror token
+        id: mirror-token
+        if: ${{ vars.MIRROR_APP_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.MIRROR_APP_ID }}
+          private-key: ${{ secrets.MIRROR_APP_PRIVATE_KEY }}
+          owner: indexable-inc
+
       - name: Publish package mirrors
         env:
-          MIRROR_TOKEN: ${{ secrets.MIRROR_TOKEN }}
+          MIRROR_TOKEN: ${{ steps.mirror-token.outputs.token }}
           # `mirror publish --create` shells out to `gh repo create`, which
           # reads GH_TOKEN.
-          GH_TOKEN: ${{ secrets.MIRROR_TOKEN }}
+          GH_TOKEN: ${{ steps.mirror-token.outputs.token }}
         run: |
           set -euo pipefail
           if [ -z "$MIRROR_TOKEN" ]; then
@@ -94,9 +107,22 @@ jobs:
             extra-substituters = https://cache.ix.dev
             extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
 
+      # MIRROR_TOKEN is minted per run from the org-owned ix-mirror-sync
+      # GitHub App (repo Administration + Contents write): short-lived, no
+      # long-lived PAT to rotate. When the app secrets are absent the step is
+      # skipped and the shell guard below skips loudly instead of half-running.
+      - name: Mint mirror token
+        id: mirror-token
+        if: ${{ vars.MIRROR_APP_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.MIRROR_APP_ID }}
+          private-key: ${{ secrets.MIRROR_APP_PRIVATE_KEY }}
+          owner: indexable-inc
+
       - name: Push fork branches
         env:
-          MIRROR_TOKEN: ${{ secrets.MIRROR_TOKEN }}
+          MIRROR_TOKEN: ${{ steps.mirror-token.outputs.token }}
         run: |
           set -euo pipefail
           if [ -z "$MIRROR_TOKEN" ]; then

--- a/packages/mirror/README.md
+++ b/packages/mirror/README.md
@@ -90,21 +90,20 @@ To maintain a fork repo for a de-forked package instead, add
 ## Permissions
 
 The default `GITHUB_TOKEN` can neither create repositories nor push to any
-repo other than this one, so mirror-sync needs a `MIRROR_TOKEN` secret on
-this repository. Two ways to mint it:
+repo other than this one, so mirror-sync mints `MIRROR_TOKEN` per run from
+the org-owned **ix-mirror-sync GitHub App**, installed on the `indexable-inc`
+org with
 
-- **Recommended: an org-owned GitHub App**, installed on the `indexable-inc`
-  org with
-  - Administration: **write** (create the mirror/fork repos on first publish),
-  - Contents: **write** (push `main` / `ix-patched`),
-  - Metadata: **read** (implicit baseline).
+- Administration: **write** (create the mirror/fork repos on first publish),
+- Contents: **write** (push `main` / `ix-patched`),
+- Metadata: **read** (implicit baseline).
 
-  Store its id/private key as `APP_ID` / `APP_PRIVATE_KEY` secrets and mint a
-  short-lived installation token per run with
-  `actions/create-github-app-token`, feeding the output into `MIRROR_TOKEN`.
-  Scoped, revocable, and not tied to a person's account.
+The app id lives in the `MIRROR_APP_ID` repository variable and its private
+key in the `MIRROR_APP_PRIVATE_KEY` secret; `actions/create-github-app-token`
+turns them into a short-lived installation token each run. Scoped, revocable,
+and not tied to a person's account. Fallback if the app is ever unavailable:
 
-- **Simpler: a PAT.** Fine-grained, org-owned, all-repositories (new mirror
+- **A PAT.** Fine-grained, org-owned, all-repositories (new mirror
   repos must fall inside its scope) with Administration + Contents write; or
   a classic PAT with the `repo` scope (classic PATs can create org repos,
   fine-grained repo *creation* otherwise needs the App route). Stored


### PR DESCRIPTION
Swaps the direct `MIRROR_TOKEN` secret for a short-lived installation token minted per run from the org-owned **ix-mirror-sync** GitHub App (Administration + Contents write). App id = `MIRROR_APP_ID` repo variable, key = `MIRROR_APP_PRIVATE_KEY` secret.

Without them the jobs still skip loudly (mint step skipped, shell guard exits 0), so this is safe to land before the app secrets exist. Follow-up to #2022.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mint short-lived MIRROR_TOKEN from the ix-mirror-sync GitHub App in mirror-sync workflow
> - Replaces the static `MIRROR_TOKEN` secret with a per-run installation token minted via `actions/create-github-app-token` using the `ix-mirror-sync` GitHub App (`MIRROR_APP_ID` + `MIRROR_APP_PRIVATE_KEY`).
> - Both the 'Publish mirror' and 'Push fork branches' job steps now source `MIRROR_TOKEN` and `GH_TOKEN` from the minted token output.
> - If `MIRROR_APP_ID` is absent, the mint step is skipped and subsequent steps skip due to empty `MIRROR_TOKEN` (same behavior as before when the secret was unset).
> - Updates [README.md](https://github.com/indexable-inc/index/pull/2043/files#diff-d1a17b2f73587a5ebf3ce43eae1a0fee6a68080415e59e0ca57ce7aedda437c4) to document the new app-based token flow and retains PAT guidance as a fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd52574.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->