### PR TITLE
mirror-sync: enable ca-derivations

### DIFF
--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           extra-conf: |
             accept-flake-config = true
+            extra-experimental-features = ca-derivations
             extra-substituters = https://cache.ix.dev
             extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
 
@@ -104,6 +105,7 @@ jobs:
         with:
           extra-conf: |
             accept-flake-config = true
+            extra-experimental-features = ca-derivations
             extra-substituters = https://cache.ix.dev
             extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
 


### PR DESCRIPTION
`nix run .#mirror` in the mirrors job died with `error: experimental Nix feature 'ca-derivations' is disabled` (run 28815522074). Adds `extra-experimental-features = ca-derivations` to the Determinate Nix extra-conf in both jobs, matching the other workflows. Follow-up to #2043.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable `ca-derivations` experimental feature in mirror-sync workflow
> Adds `ca-derivations` to the `extra-experimental-features` config in the 'Install Determinate Nix' step for both jobs in [mirror-sync.yml](.github/workflows/mirror-sync.yml).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9382cc1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->