### PR TITLE
ci: shared install-nix composite action; mirror token via client-id

### DIFF
--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -1,0 +1,23 @@
+name: Install Determinate Nix
+description: >-
+  Determinate Nix pinned and configured for this repo: accept the flake's
+  nixConfig without a prompt, substitute from the ix cache, and enable
+  ca-derivations. Owns the install block so workflows cannot drift apart.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Determinate Nix
+      uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
+      with:
+        # `accept-flake-config` lets jobs consume the flake's nixConfig (the
+        # same cache.ix.dev substituter) without a prompt; pinning the
+        # substituter and key here keeps the install self-describing.
+        # ca-derivations because repo-owned artifacts (cargo-unit rlibs) are
+        # content-addressed and will not substitute without the feature
+        # enabled client-side.
+        extra-conf: |
+          accept-flake-config = true
+          extra-experimental-features = ca-derivations
+          extra-substituters = https://cache.ix.dev
+          extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=

--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -275,13 +275,8 @@ jobs:
           sudo rm -rf /Applications/Xcode_*.app ~/Library/Developer/CoreSimulator || true
           df -h / | tail -n 1
 
-      - name: Install nix
-        uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
-        with:
-          extra-conf: |
-            extra-substituters = https://cache.ix.dev
-            extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
-            extra-experimental-features = nix-command flakes ca-derivations
+      - name: Install Determinate Nix
+        uses: ./.github/actions/install-nix
 
       - name: Realise darwin roots and stage the relay cache
         shell: bash

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -31,15 +31,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # `accept-flake-config` lets the job consume the flake's cache.ix.dev
-      # substituter without a prompt.
       - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
-        with:
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://cache.ix.dev
-            extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
+        uses: ./.github/actions/install-nix
 
       # Bump base + regenerate patches for every auto-updatable fork, driven by
       # lib/fork-packages.nix (no fork names hardcoded here). Each fork's

--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -50,10 +50,10 @@ jobs:
       # skipped and the shell guard below skips loudly instead of half-running.
       - name: Mint mirror token
         id: mirror-token
-        if: ${{ vars.MIRROR_APP_ID != '' }}
+        if: ${{ vars.MIRROR_APP_CLIENT_ID != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.MIRROR_APP_ID }}
+          client-id: ${{ vars.MIRROR_APP_CLIENT_ID }}
           private-key: ${{ secrets.MIRROR_APP_PRIVATE_KEY }}
           owner: indexable-inc
 
@@ -101,10 +101,10 @@ jobs:
       # skipped and the shell guard below skips loudly instead of half-running.
       - name: Mint mirror token
         id: mirror-token
-        if: ${{ vars.MIRROR_APP_ID != '' }}
+        if: ${{ vars.MIRROR_APP_CLIENT_ID != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.MIRROR_APP_ID }}
+          client-id: ${{ vars.MIRROR_APP_CLIENT_ID }}
           private-key: ${{ secrets.MIRROR_APP_PRIVATE_KEY }}
           owner: indexable-inc
 

--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -41,16 +41,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # `accept-flake-config` lets the job consume the flake's cache.ix.dev
-      # substituter without a prompt.
       - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
-        with:
-          extra-conf: |
-            accept-flake-config = true
-            extra-experimental-features = ca-derivations
-            extra-substituters = https://cache.ix.dev
-            extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
+        uses: ./.github/actions/install-nix
 
       # MIRROR_TOKEN is minted per run from the org-owned ix-mirror-sync
       # GitHub App (repo Administration + Contents write): short-lived, no
@@ -101,13 +93,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
-        with:
-          extra-conf: |
-            accept-flake-config = true
-            extra-experimental-features = ca-derivations
-            extra-substituters = https://cache.ix.dev
-            extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
+        uses: ./.github/actions/install-nix
 
       # MIRROR_TOKEN is minted per run from the org-owned ix-mirror-sync
       # GitHub App (repo Administration + Contents write): short-lived, no

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,16 +23,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
-        with:
-          # Read repo-owned artifacts from the ix public cache (the ix-public
-          # flat cache, with cache.nixos.org fallthrough). accept-flake-config
-          # would pull the same substituter from the flake nixConfig; pinning it
-          # here keeps the step self-describing.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://cache.ix.dev
-            extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
+        uses: ./.github/actions/install-nix
 
       - name: Build site
         run: nix build .#site -L

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
+        uses: ./.github/actions/install-nix
 
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -31,18 +31,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # `accept-flake-config` lets the job consume the flake's cache.ix.dev
-      # substituter without a prompt.
+      # Read-only: the updater only needs warm substitutes to verify a freshly
+      # pinned hash builds. Publishing happens when the resulting PR merges and
+      # flake-check rebuilds on the self-hosted runners (which push to ix-ci).
       - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
-        with:
-          # Read-only: the updater only needs warm substitutes to verify a freshly
-          # pinned hash builds. Publishing happens when the resulting PR merges and
-          # flake-check rebuilds on the self-hosted runners (which push to ix-ci).
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://cache.ix.dev
-            extra-trusted-public-keys = ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=
+        uses: ./.github/actions/install-nix
 
       # Runs every content updater in parallel via dag-runner (see
       # lib/per-system.nix). Each regenerates its own source files relative to

--- a/packages/mirror/README.md
+++ b/packages/mirror/README.md
@@ -98,8 +98,8 @@ org with
 - Contents: **write** (push `main` / `ix-patched`),
 - Metadata: **read** (implicit baseline).
 
-The app id lives in the `MIRROR_APP_ID` repository variable and its private
-key in the `MIRROR_APP_PRIVATE_KEY` secret; `actions/create-github-app-token`
+The app's client id lives in the `MIRROR_APP_CLIENT_ID` repository variable
+and its private key in the `MIRROR_APP_PRIVATE_KEY` secret; `actions/create-github-app-token`
 turns them into a short-lived installation token each run. Scoped, revocable,
 and not tied to a person's account. Fallback if the app is ever unavailable:
 


### PR DESCRIPTION
Every workflow hand-copied the Determinate Nix install step with drifting `extra-conf` (ca-derivations and accept-flake-config present in some copies, absent in others). A local composite action, `.github/actions/install-nix`, now owns the pinned action sha and the shared `extra-conf` (accept-flake-config, ca-derivations, cache.ix.dev substituter + trusted key); all seven install sites (pages, update, update-flake-lock, fork-sync, mirror-sync x2, cache-push darwin lane) use it. After standardizing there was no genuine per-workflow difference left, so the action takes no inputs.

Also switches the two mirror-sync `Mint mirror token` steps from the deprecated `app-id` input of actions/create-github-app-token to `client-id`. The `MIRROR_APP_CLIENT_ID` repo variable is already set; `MIRROR_APP_ID` stays in place until this merges, then can be deleted.

Fixes #2059
Fixes #2060

*Sent by an AI agent via Claude Code.*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared `install-nix` composite action and switch mirror token minting to `client-id`
> - Extracts the repeated Determinate Nix install step into a single reusable composite action at [.github/actions/install-nix/action.yml](https://github.com/indexable-inc/index/pull/2064/files#diff-49fff13dc77596c729a74479faf8126af769dd7d55e12d8fe6a8d30d55990fb4), pinned to v3 with `accept-flake-config`, `ca-derivations`, and the ix cache substituter/key.
> - Replaces inline Nix install steps across all CI workflows (`cache-push`, `fork-sync`, `mirror-sync`, `pages`, `update-flake-lock`, `update`) with a call to the new composite action.
> - Updates `mirror-sync` and the [packages/mirror/README.md](https://github.com/indexable-inc/index/pull/2064/files#diff-d1a17b2f73587a5ebf3ce43eae1a0fee6a68080415e59e0ca57ce7aedda437c4) to use `vars.MIRROR_APP_CLIENT_ID` and pass `client-id` instead of `app-id` to `actions/create-github-app-token`.
> - Behavioral Change: workflows that previously did not set `ca-derivations` now have it enabled via the shared action.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c922e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->