### PR TITLE
mirror: fall back to crate description when the mirror entry has none

### DIFF
--- a/packages/mirror/README.md
+++ b/packages/mirror/README.md
@@ -72,7 +72,7 @@ patch DAG.
 
    ```nix
    mirror.repo = "indexable-inc/<name>";
-   # optional:
+   # optional (defaults to the crate's `[package] description`):
    # mirror.description = "One-line GitHub repo description";
    # mirror.topics = ["rust" "cli"];
    ```

--- a/packages/mirror/src/publish.rs
+++ b/packages/mirror/src/publish.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
 use crate::workspace::Workspace;
-use crate::{MONOREPO_SLUG, exec, generate};
+use crate::{MONOREPO_SLUG, exec, generate, manifest};
 
 pub struct Request {
     /// Repo-relative package path, e.g. `packages/progress-style`.
@@ -91,8 +91,18 @@ pub fn run(workspace: &Workspace, request: &Request) -> Result<()> {
 
 /// Push coordinates for the package: an explicit `--remote-url`/`--repo`
 /// wins, otherwise the entry for this package in the rendered
-/// `.#lib.mirrorPackages` list (from `--mirror-json` or `nix eval`).
+/// `.#lib.mirrorPackages` list (from `--mirror-json` or `nix eval`). A target
+/// without a description falls back to the crate's own `[package]
+/// description`, so packages needn't duplicate it in their `mirror` attr.
 fn resolve_target(workspace: &Workspace, request: &Request) -> Result<Target> {
+    let mut target = configured_target(workspace, request)?;
+    if target.description.is_none() {
+        target.description = crate_description(workspace, &request.package)?;
+    }
+    Ok(target)
+}
+
+fn configured_target(workspace: &Workspace, request: &Request) -> Result<Target> {
     if let Some(remote_url) = &request.remote_url {
         return Ok(Target {
             remote_url: remote_url.clone(),
@@ -142,6 +152,13 @@ fn resolve_target(workspace: &Workspace, request: &Request) -> Result<Target> {
             })
             .unwrap_or_default(),
     })
+}
+
+/// The `[package] description` of the package's own `Cargo.toml`.
+fn crate_description(workspace: &Workspace, package: &Path) -> Result<Option<String>> {
+    let path = workspace.root.join(package).join("Cargo.toml");
+    let text = fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(manifest::package_info(&text)?.description)
 }
 
 fn mirror_entries(workspace: &Workspace, json: Option<&Path>) -> Result<Vec<Value>> {
@@ -229,4 +246,60 @@ pub fn authenticated_url(url: &str) -> String {
         || url.to_owned(),
         |rest| format!("https://x-access-token:{token}@github.com/{rest}"),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scratch monorepo: a workspace root, one member crate, and a rendered
+    /// mirror manifest naming that crate.
+    struct Scratch {
+        /// Owns the on-disk tree for the duration of the test.
+        _dir: tempfile::TempDir,
+        workspace: Workspace,
+        request: Request,
+    }
+
+    fn scratch(member_manifest: &str, mirror_entries: &str) -> Scratch {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("Cargo.toml"), "[workspace]\n").expect("root manifest");
+        let package = dir.path().join("packages").join("example");
+        fs::create_dir_all(&package).expect("package dir");
+        fs::write(package.join("Cargo.toml"), member_manifest).expect("member manifest");
+        let mirror_json = dir.path().join("mirror.json");
+        fs::write(&mirror_json, mirror_entries).expect("mirror manifest");
+        let workspace = Workspace::locate(Some(dir.path())).expect("workspace");
+        Scratch {
+            _dir: dir,
+            workspace,
+            request: Request {
+                package: PathBuf::from("packages/example"),
+                remote_url: None,
+                repo: None,
+                create: true,
+                mirror_json: Some(mirror_json),
+            },
+        }
+    }
+
+    #[test]
+    fn mirror_entry_description_wins_over_crate_manifest() {
+        let scratch = scratch(
+            "[package]\nname = \"example\"\ndescription = \"from Cargo.toml\"\n",
+            r#"[{"path": "packages/example", "repo": "owner/example", "description": "from package.nix"}]"#,
+        );
+        let target = resolve_target(&scratch.workspace, &scratch.request).expect("resolves");
+        assert_eq!(target.description.as_deref(), Some("from package.nix"));
+    }
+
+    #[test]
+    fn missing_mirror_description_falls_back_to_crate_manifest() {
+        let scratch = scratch(
+            "[package]\nname = \"example\"\ndescription = \"from Cargo.toml\"\n",
+            r#"[{"path": "packages/example", "repo": "owner/example"}]"#,
+        );
+        let target = resolve_target(&scratch.workspace, &scratch.request).expect("resolves");
+        assert_eq!(target.description.as_deref(), Some("from Cargo.toml"));
+    }
 }


### PR DESCRIPTION
Freshly created mirror repos had a null GitHub description: the `mirror.description` manifest key is optional and no enabled package sets it, even though each crate already carries a `[package] description` in its Cargo.toml.

`mirror publish` now resolves the repo description with a fallback: an explicit `mirror.description` still wins, otherwise the primary crate's `[package] description` (via the existing `manifest::package_info`) is used for `gh repo create`. Documented the default in the crate README and added two `resolve_target` tests covering precedence and the fallback.

Fixes #2061

_(PR authored by an AI agent via Claude Code)_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to crate's `[package]` description when mirror entry has no description
> When a mirror manifest entry omits `description`, `resolve_target` in [publish.rs](https://github.com/indexable-inc/index/pull/2065/files#diff-6aeb5c5c12f39366e5527fe55110be9322765fc997b20f5078c34c79bfe3384f) now reads the crate's own `Cargo.toml` via a new `crate_description` helper and uses that value instead of leaving the field empty. The previous logic is extracted into `configured_target`, which returns `None` for description when the mirror entry omits it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52f526e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->