### PR TITLE
nu-py: disable nushell pipefail to fix nu() eval deadlock (#2015)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6818,6 +6818,7 @@ dependencies = [
  "nu-cmd-lang",
  "nu-command",
  "nu-engine",
+ "nu-experimental",
  "nu-parser",
  "nu-protocol",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ nu-command = { version = "0.113.1", default-features = false, features = [
   "rustls-tls",
 ] }
 nu-engine = "0.113.1"
+nu-experimental = "0.113.1"
 nu-parser = "0.113.1"
 nu-protocol = "0.113.1"
 numpy = "0.28"

--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -139,6 +139,43 @@ def test_trailing_external_output_is_collected(tmp_path: pathlib.Path) -> None:
     assert out.strip() == "collected"
 
 
+def test_big_external_output_inside_try_does_not_deadlock() -> None:
+    # index#2015: nushell's experimental `pipefail` (the 0.113 default) made
+    # try/catch collection wait on the child's exit status BEFORE draining its
+    # stdout. A child with more pending output than the OS pipe buffer
+    # (64 KiB) then never exits -- it blocks in write(2) and no EPIPE arrives
+    # because the engine still holds the read end -- so the eval hung forever
+    # and wedged the engine for every later call. The bindings disable
+    # pipefail, so this must complete and hand back all the output.
+    import sys
+
+    async def guarded() -> object:
+        writer = f"^{sys.executable} -c 'import sys; sys.stdout.write(\"x\"*130000)'"
+        # wait_for is a tripwire, not part of the contract: on regression this
+        # fails in seconds instead of hanging the test run forever.
+        return await asyncio.wait_for(
+            nu.value("try { " + writer + " } catch { 'caught' }"),
+            timeout=60,
+        )
+
+    out = run(guarded())
+    assert out == "x" * 130_000
+
+
+def test_failing_external_raises_and_try_catches_without_pipefail() -> None:
+    # Disabling pipefail must not cost error reporting: a trailing external's
+    # non-zero exit still raises through ByteStream's consume-then-wait check,
+    # and try/catch still routes it to the catch block.
+    import sys
+
+    with pytest.raises(nu.NuError, match="non-zero exit code"):
+        run(nu(f"^{sys.executable} -c 'raise SystemExit(7)'"))
+    caught = run(
+        nu.value("try { ^" + sys.executable + " -c 'raise SystemExit(7)' } catch { 'caught' }")
+    )
+    assert caught == "caught"
+
+
 def test_naive_datetime_input_gets_a_clear_error() -> None:
     naive = datetime.datetime(2024, 1, 2, 3, 4, 5)  # noqa: DTZ001 -- naive on purpose: it IS the case under test
     with pytest.raises(nu.NuError, match="naive datetime"):

--- a/packages/nu-py/Cargo.toml
+++ b/packages/nu-py/Cargo.toml
@@ -18,6 +18,7 @@ nu-cmd-extra.workspace = true
 nu-cmd-lang.workspace = true
 nu-command.workspace = true
 nu-engine.workspace = true
+nu-experimental.workspace = true
 nu-parser.workspace = true
 nu-protocol.workspace = true
 pyo3 = { workspace = true, features = ["extension-module", "chrono"] }

--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -419,6 +419,24 @@ impl Engine {
 
 #[pymodule]
 fn _nu(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Nushell's experimental `pipefail` option is ON by default (OptOut since
+    // 0.107), and its try/catch collection path (`Instruction::TryCollect` ->
+    // eval_ir.rs `collect`) waits on an external's exit status BEFORE draining
+    // its stdout pipe. A child with more output pending than the OS pipe
+    // buffer (64 KiB) can then never exit: it blocks in write(2), no EPIPE
+    // ever arrives because this process still holds the read end, and the
+    // eval deadlocks in waitpid -- wedging the engine's mutex and with it
+    // every later `nu()` call in the session (indexable-inc/index#2015;
+    // upstream ordering discussed in nushell/nushell#17571 / #17764, which
+    // fixed the sibling `collect_reg` path but left `TryCollect` checking
+    // first). Externals still fail loudly without pipefail: trailing and
+    // statement externals raise through ByteStream's own consume-then-wait
+    // checks, and these bindings drop the pipeline's exit-guard vector at the
+    // boundary anyway, so the option bought nothing observable here.
+    //
+    // SAFETY: `set` is unsafe only to discourage mid-run flips; this runs
+    // once at module import, before any `Engine` can exist.
+    unsafe { nu_experimental::PIPE_FAIL.set(false) };
     module.add_class::<Engine>()?;
     module.add_class::<EvalHandle>()?;
     module.add("NuError", module.py().get_type::<NuError>())?;


### PR DESCRIPTION
Fixes #2015.

## Root cause

`await nu('^...')` hangs come from a deadlock inside the embedded nushell engine (stock 0.113.1), not from concurrent spawns:

- Nushell's experimental **`pipefail` option is ON by default** (OptOut since 0.107); nu-py never touched it.
- In the try/catch collection path (`Instruction::TryCollect` -> `eval_ir.rs collect`), nushell **waits on the external's exit status BEFORE draining its stdout pipe** (`check_exit_status_future(pipe.exit)` runs before `data.into_value(span)`).
- An external with more pending output than the OS pipe buffer (64 KiB) can then never exit: it blocks in `write(2)`, and no EPIPE arrives because the engine still holds the pipe's read end. Nushell blocks in `waitpid`. Permanent mutual deadlock.
- The per-session engine serializes evals behind a mutex, so one wedged eval hangs **every later `nu()` call in that session** -- that is why agents saw hangs on innocent small `git` commands with no child in `ps`: those evals were queued behind the wedged one and had never spawned anything.

## Evidence

- Live corpse in the shared kernel (macOS `sample` of pid 32952): an `exit status waiter` thread parked in `ForegroundChild::wait -> __wait4`, and the eval thread parked in `eval_ir::collect -> check_exit_status_future -> ExitStatusFuture::wait -> mpsc recv`.
- The waited-on child was `curl -sf --max-time 15 https://playbook.ix.dev/` (spawned via nushell: null stdin), alive for 70+ minutes with its TCP connection CLOSED and **exactly 65536 bytes buffered in its stdout pipe**; `lsof` showed the kernel process still holding the read end (fd 126). `--max-time` cannot fire while curl is stuck in a blocking `write`.
- Deterministic repro (no concurrency involved): `try { ^sh -c 'yes x | head -c 130000; exit 0' } catch { 'caught' }` wedges forever on 0.113.1; the same external outside `try` completes.
- Killing the stuck curl released the waiter and the eval in the live kernel, un-wedging that session's engine.

Upstream fixed the sibling `collect_reg` path (nushell/nushell#17571, "wrong order because if the command has too much output, it hangs") and made plain `Instruction::Collect` skip pipefail (nushell/nushell#17764), but `TryCollect` still checks before draining on current `main`, so a version bump does not fix this.

## Fix

Disable the `pipefail` experimental option at `_nu` module init (`packages/nu-py/src/lib.rs`). This removes every check-before-drain call site by construction. Nothing observable is lost at the nu-py boundary:

- trailing and statement externals still raise on non-zero exit through `ByteStream`'s own consume-then-wait checks (regression-tested), and
- nu-py drops the pipeline's exit-guard vector (`PipelineExecutionData.exit`) at the boundary anyway, so full pipefail semantics never reached Python callers.

Worth reporting the `TryCollect` ordering upstream to nushell as a follow-up.

## Tests

- `test_big_external_output_inside_try_does_not_deadlock`: 130 kB external output inside `try/catch` must complete and return all output (wedges forever without the fix; a `wait_for` tripwire makes regression fail loudly in seconds instead of hanging CI).
- `test_failing_external_raises_and_try_catches_without_pipefail`: non-zero externals still raise `NuError`, and `try/catch` still catches them.

Also fixes a pre-existing ruff PTH109 (`os.getcwd()` -> `Path.cwd()`) in `nu/__init__.py` that the whole-tree lint surfaced on commit.

Root-caused and fixed by an AI agent (Claude Code).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable nushell `PIPE_FAIL` in `nu-py` to fix `nu()` eval deadlock in try/catch
> - Sets `nu_experimental::PIPE_FAIL` to `false` at module init in [lib.rs](https://github.com/indexable-inc/index/pull/2066/files#diff-424ce210c45fc8f162c45814067651d48d245471a2e86b63c39b71c370ffe7fe), disabling pipefail semantics for all sessions using this module.
> - Without this, a try/catch block over an external command producing large stdout could deadlock due to pipefail interaction with buffer backpressure.
> - Adds two tests: one asserting ~130 KiB stdout from an external inside try/catch completes without hanging, and one asserting non-zero exit raises `NuError` and is catchable.
> - Behavioral Change: external commands run via `nu()` no longer propagate non-zero exit codes as pipeline failures; errors are now only raised explicitly via `NuError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f644bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->