### PR TITLE
mcp: return nu() lone-string output as text and keep Result.value reachable

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3018,7 +3018,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068)";
     }
     ''
       export HOME=$TMPDIR/home

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -68,13 +68,14 @@ MODULES: tuple[Module, ...] = (
     Module(
         "nu",
         "structured shell, the ONE shell-out path (an embedded, persistent nushell "
-        "engine): run a pipeline and get a polars DataFrame back, always -- "
+        "engine): run a pipeline and get a polars DataFrame back -- "
         '`await nu("ls | where size > 1kb | sort-by size")`, `open Cargo.toml`, `from csv`, '
         "`http get`; run an external binary with `^cmd` (`^git status`, `^gh pr list --json .. "
-        "| from json`); `let`/`def`/`cd` persist across calls like a REPL; `input=df` pipes a "
-        "frame through a pipeline; `nu.value(code)` returns the plain Python value; a failure "
-        "raises NuError carrying nushell's own diagnostic. Replaces jq/awk/sed text munging and "
-        "the retired `sh`",
+        "| from json`); a lone string result (an external's plain stdout) returns as the full "
+        "`str`, never a clipped 1x1 frame; `let`/`def`/`cd` persist across calls like a REPL; "
+        "`input=df` pipes a frame through a pipeline; `nu.value(code)` returns the plain Python "
+        "value; a failure raises NuError carrying nushell's own diagnostic. Replaces jq/awk/sed "
+        "text munging and the retired `sh`",
         preimport=True,
     ),
     Module(

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -490,7 +490,10 @@ class Job:
         ``Job.result`` is a **property** (not a method), but since ``Result``
         is callable, both ``job.result`` and ``job.result()`` hand back the
         value. The returned Result's ``.text`` attribute is the rendered model
-        text (same as ``.llm_result``), so ``job.result.text[-100:]`` pages it."""
+        text (same as ``.llm_result``), so ``job.result.text[-100:]`` pages it.
+        Its ``.value`` is the ORIGINAL trailing-expression value (the DataFrame
+        itself, not its rendered text), and subscripting delegates to it, so
+        ``jobs['<id>'].result[0, 0]`` reads the real cell (issue #2068)."""
         if self.running():
             dur = time.time() - self.started
             raise JobStillRunning(
@@ -729,6 +732,13 @@ class Result:
     def __init__(self, *values: Any, user_html: str | None = None, user_view: dict | None = None, llm_result: str | None = None, llm_images: list | None = None) -> None:
         llm_result = _llm_text(llm_result)
         self.user_view = user_view
+        # The original Python value this Result was built from (set by
+        # `Result.of`, which also auto-wraps a cell's trailing expression), so
+        # a finished job's REAL value -- the DataFrame itself, not its rendered
+        # text -- stays reachable: `jobs['<id>'].result.value`, and
+        # subscripting delegates to it (`jobs['<id>'].result[0, 0]`). None for
+        # a Result built purely from keyword views (issue #2068).
+        self.value: Any = None
         if user_html is not None or user_view is not None:
             self.user_html = user_html or ""
             self.llm_result = llm_result if llm_result is not None else ""
@@ -747,6 +757,7 @@ class Result:
         )
         self.user_html = built.user_html
         self.user_view = built.user_view
+        self.value = built.value
         self.llm_result = built.llm_result
         self.llm_images = list(llm_images) if llm_images else built.llm_images
 
@@ -783,7 +794,21 @@ class Result:
         and hand the model concise text. For a polars DataFrame the model text is
         compact NUON (the human still gets the styled HTML table), so a wide or
         long-stringed frame is never clipped to the agent the way the boxed text
-        repr clips it. Override with ``llm_result`` or define ``__ix_llm__``."""
+        repr clips it. Override with ``llm_result`` or define ``__ix_llm__``.
+
+        The built Result also keeps ``value`` itself reachable as ``.value``
+        (and through subscripting), so the rendered wrapper never strands the
+        original: ``jobs['<id>'].result[0, 0]`` reads the real DataFrame cell
+        instead of dying inside the wrapper (issue #2068)."""
+        built = cls._of(value, llm_result=llm_result)
+        # A nested Result carries ITS original forward; anything else is the
+        # original itself.
+        built.value = value.value if isinstance(value, Result) else value
+        return built
+
+    @classmethod
+    def _of(cls, value: Any, *, llm_result: str | None = None) -> Result:
+        """The rendering body of :meth:`of` (which records ``.value`` on top)."""
         if isinstance(value, Result):
             # An existing Result is already split into its two views: copy it
             # faithfully (keeping llm_images) instead of rebuilding it from its
@@ -935,6 +960,18 @@ class Result:
         polling a finished job -- used to die with "'Result' object is not
         callable". Property and call now both hand over the value."""
         return self
+
+    def __getitem__(self, key: Any) -> Any:
+        """Subscript through to the wrapped original value: ``jobs['<id>']
+        .result[0, 0]`` -- the natural way to reach a finished cell's DataFrame
+        cell -- reads the real value instead of dying on the rendered-text
+        wrapper (issue #2068). A Result that carries no original (built purely
+        from keyword views) raises a TypeError that points at ``.text``."""
+        if self.value is not None:
+            return self.value[key]
+        raise TypeError(
+            "this Result wraps no subscriptable value; read `.text` for its rendered text"
+        )
 
     def __repr__(self) -> str:
         # Plain-text fallback (the stored result repr, non-rich hosts): the model
@@ -2149,11 +2186,15 @@ def _merge_stdout(job: Job, result: Result) -> Result:
     text = _strip_ansi(body)
     if not text.endswith("\n"):
         text += "\n"
-    return Result(
+    merged = Result(
         user_html=f'<pre class="ix-result">{_ansi_to_html(body)}</pre>' + result.user_html,
         llm_result=text + (result.llm_result or ""),
         llm_images=result.llm_images,
     )
+    # Merging stdout replaces the WRAPPER, not the value: keep the trailing
+    # expression's original reachable (`jobs['<id>'].result.value` / `[i, j]`).
+    merged.value = result.value
+    return merged
 
 
 # Cap on the stdout an auto-returned Result (see _auto_result) hands the model.

--- a/packages/mcp/tests/test_job_await_errors.py
+++ b/packages/mcp/tests/test_job_await_errors.py
@@ -11,6 +11,12 @@ Bug 2: a live/errored ``Job`` exposes ``.output``; a finished ``Result`` exposes
 ``.text``. Each now also answers its sibling (``Result.output``, ``Job.text``), so
 an agent paging a returned value does not have to guess which surface owns which
 name.
+
+Issue #2068: the Result wrapper used to STRAND the original value -- a cell whose
+trailing expression was a DataFrame kept only the rendered text, so
+``jobs[id].result[0, 0]`` died on the wrapper and the real cell string was
+unrecoverable. ``Result.of`` now records the original as ``.value`` and
+subscripting delegates to it, surviving the stdout merge.
 """
 
 from __future__ import annotations
@@ -83,6 +89,40 @@ def test_job_text_is_the_result_text(monkeypatch: pytest.MonkeyPatch) -> None:
     # `.text` is the sibling of `.output` (stdout): the finished run's result text.
     assert job.text == "rendered"
     assert job.output == ""  # the cell printed nothing to stdout
+
+
+def test_trailing_dataframe_stays_reachable_through_the_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Issue #2068: `print()` renders a frame width-clipped, and the wrapper used
+    # to be the ONLY thing a finished job kept -- the original value was gone.
+    # The trailing expression must stay reachable (including when stdout rode
+    # along via _merge_stdout) so `jobs[id].result[0, 0]` reads the real cell.
+    _wire(monkeypatch, {})
+    cell = (
+        "import polars as pl\n"
+        "print('some stdout noise that rides along with the result')\n"
+        "pl.DataFrame({'value': ['x' * 500]})"
+    )
+    job = _run(cell)
+    assert job.status == "done"
+    result = job.result
+    assert result is not None
+    # .value is the original frame, not a repr of it.
+    assert result.value is not None
+    assert result.value.shape == (1, 1)
+    # Subscripting delegates to the original: the FULL cell string comes back.
+    assert result[0, 0] == "x" * 500
+
+
+def test_view_only_result_subscript_points_at_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A Result built purely from keyword views wraps no original value;
+    # subscripting it must fail with a pointer at `.text`, not a bare
+    # "'Result' object is not subscriptable".
+    _wire(monkeypatch, {"Result": runtime.Result})
+    job = _run("Result.text('hello')")
+    result = job.result
+    assert result is not None
+    with pytest.raises(TypeError, match=r"`\.text`"):
+        result[0]
 
 
 def test_a_watchdog_interrupt_reraises_with_the_actionable_message(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -44,6 +44,29 @@ def test_scalar_and_list_become_value_column() -> None:
     assert run(nu("[1, 2, 3]"))["value"].to_list() == [1, 2, 3]
 
 
+def test_lone_string_round_trips_as_plain_text() -> None:
+    # Issue #2068: a lone string is text, not data -- framing it as a 1x1
+    # DataFrame made every print of it show polars' width-clipped box repr,
+    # and the full multiline text was unrecoverable from the captured stdout.
+    lines = [f"---VERIFY {i}: a fairly long line of stdout text, step {i} in detail---" for i in range(10)]
+    joined = " ".join(f"'{line}'" for line in lines)
+    text = run(nu(f"[{joined}] | str join (char nl)"))
+    assert isinstance(text, str)
+    assert text.splitlines() == lines
+
+
+def test_external_stdout_is_the_full_string() -> None:
+    # The reported shape (issue #2068): `^cmd` multiline stdout must come back
+    # verbatim as str, not as a frame that clips at repr time.
+    import sys
+
+    script = "print(chr(10).join('section %d: ' % i + 'x' * 60 for i in range(10)))"
+    out = run(nu(f'^{sys.executable} -c "{script}"'))
+    assert isinstance(out, str)
+    body = out.strip().splitlines()
+    assert body == [f"section {i}: " + "x" * 60 for i in range(10)]
+
+
 def test_null_and_empty_become_empty_frames() -> None:
     assert run(nu("null")).is_empty()
     assert run(nu("[] | where true")).is_empty()

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -11,7 +11,7 @@ binary runs with ``^cmd``::
     df = await nu("ps | where cpu > 5 | sort-by cpu")
     df = await nu("open Cargo.toml | get package")          # record -> 1-row frame
     df = await nu("http get https://api.github.com/repos/nushell/nushell")
-    df = await nu("^git status --short")                    # external binary via ^
+    text = await nu("^git status --short")                  # external binary via ^ (stdout str)
     df = await nu("^gh pr list --json number,title | from json")  # JSON-mode CLI
 
 This is not a subprocess: the engine (PyO3 bindings over nu-engine) lives in
@@ -35,9 +35,12 @@ build, use the bundled ``nix`` module (a live dashboard build-tree pane), not
 
 Contract:
 
-- ``await nu(code)`` returns a ``pl.DataFrame``, always: a table maps
-  directly, a record becomes one row, a list of scalars / a scalar become a
-  single ``value`` column, no output (``null``) an empty frame.
+- ``await nu(code)`` returns a ``pl.DataFrame`` for structured output: a
+  table maps directly, a record becomes one row, a list of scalars / a
+  non-str scalar become a single ``value`` column, no output (``null``) an
+  empty frame. A lone string -- an external's stdout, ``to text`` -- comes
+  back as the plain ``str``: multiline text round-trips verbatim instead of
+  hiding in a 1x1 frame whose printed repr clips the cell (issue #2068).
 - ``await nu.value(code)`` is the escape hatch when you want the plain
   Python value (a scalar, a nested dict) instead of a frame.
 - Values cross natively, not as JSON: dates arrive as UTC ``Datetime``
@@ -355,7 +358,8 @@ def _rows_frame(rows: list[dict]) -> pl.DataFrame:
 
 
 def _to_frame(decoded: object) -> pl.DataFrame:
-    """Normalize any pipeline value into a ``pl.DataFrame``."""
+    """Normalize a pipeline value into a ``pl.DataFrame`` (a lone ``str``
+    never reaches here: ``nu()`` returns it verbatim, issue #2068)."""
     import polars as pl
 
     if decoded is None:
@@ -382,9 +386,10 @@ async def nu(
     env: dict[str, str] | None = None,
     timeout: float | None = None,
     name: str | None = None,
-) -> pl.DataFrame:
+) -> pl.DataFrame | str:
     """Run ``code`` as nushell source and return the result as a polars
-    DataFrame.
+    DataFrame, or as the plain ``str`` when the pipeline's value is a lone
+    string.
 
     Multi-statement source is fine; the last pipeline's output is the result,
     and ``let``/``def`` persist to later calls (REPL semantics). ``PWD`` does
@@ -396,10 +401,19 @@ async def nu(
     the module docstring); ``name`` labels the running job in the dashboard.
 
     Shape normalization: table -> frame; record -> 1-row frame; list of
-    scalars / scalar -> a single ``value`` column; no output -> empty frame.
-    A failure raises :class:`NuError` carrying nushell's diagnostic.
+    scalars / non-str scalar -> a single ``value`` column; a lone string ->
+    the plain ``str`` (an external's stdout round-trips verbatim); no output
+    -> empty frame. A failure raises :class:`NuError` carrying nushell's
+    diagnostic.
     """
     decoded = await _run(code, input=input, cwd=cwd, env=env, timeout=timeout, name=name)
+    if isinstance(decoded, str):
+        # A lone string is TEXT (an external's stdout, `to text`), not a table:
+        # hand it back verbatim. Framing it as a 1x1 DataFrame made every
+        # `print()` of it write polars' width-clipped box repr into the
+        # captured stdout, and the full text was unrecoverable afterwards
+        # (issue #2068).
+        return decoded
     return _to_frame(decoded)
 
 


### PR DESCRIPTION
Fixes #2068.

## Root cause
- `nu()` framed a lone string (an external's multiline stdout) as a 1x1 polars DataFrame; every `print()` of it wrote polars' width-clipped box repr into the captured stdout, so `read(jobs[id].output)` could only page the clipped repr -- the full text was never captured anywhere.
- The kernel's `Result` wrapper kept only the rendered text of a cell's trailing expression and dropped the original value, so `jobs[id].result[0, 0]` died on the wrapper (`'Result' object is not subscriptable`, reproduced live) and nothing could recover the real cell.

## Fix
- `nu()` returns a lone string verbatim as `str` (an external's stdout, `to text`); structured values frame exactly as before. Contract docs + registry entry updated.
- `Result.of()` records the original value as `.value` (preserved through the stdout merge), and `Result.__getitem__` delegates to it, so `jobs[id].result[0, 0]` reads the real cell. A view-only Result raises a TypeError pointing at `.text` instead of a bare not-subscriptable.

## Validation
- Reproduced all three evidence items from the issue live against the deployed kernel before fixing.
- Regression tests: string round-trip in `tests/test_nu.py` (nuTests), wrapper reachability + stdout-merge survival in `tests/test_job_await_errors.py` (typecheckSmoke).
- Local gates green: `nix build .#mcp.tests.nuTests .#mcp.tests.typecheckSmoke .#mcp.tests.strictTypecheck` and `nix run .#lint`.

Authored by an AI agent (Claude Code, Claude Opus 4.5).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return lone string output from `nu()` as `str` and preserve `Result.value` after stdout merge
> - [`nu()`](https://github.com/indexable-inc/index/pull/2073/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4) now returns a plain `str` when the pipeline yields a lone string (e.g. external stdout or `to text`) instead of wrapping it in a 1×1 DataFrame.
> - [`Result.of`](https://github.com/indexable-inc/index/pull/2073/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now records the original input on the returned `Result` as `.value`, allowing callers to access the underlying object after rendering.
> - `Result.__getitem__` delegates subscripting to `.value` when present, raising a `TypeError` pointing to `.text` otherwise.
> - `_merge_stdout` now copies `.value` onto the merged wrapper so the underlying value (and subscripting) remains accessible after stdout is merged.
> - Behavioral Change: `nu()` callers that previously received a 1×1 DataFrame for lone-string pipelines will now receive a `str`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9c8c7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->