### PR TITLE
oci-image-builder: embed the customisation layer blob instead of symlinking into the store

### DIFF
--- a/packages/nix/oci-image-builder/src/main.rs
+++ b/packages/nix/oci-image-builder/src/main.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::error::Error;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
-use std::os::unix::fs::{PermissionsExt, symlink};
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 
@@ -373,9 +373,16 @@ fn run_assemble_desc(args: &[String]) -> Result<(), Box<dyn Error>> {
         layers.push(desc);
     }
 
-    // Customisation layer on top. It is a prebuilt derivation output carrying its
-    // own checksum, so describing it reads a file rather than tarring anything.
-    let cust = make_customisation_layer(0, &conf.customisation_layer, &image_work()?.blobs_dir)?;
+    // Customisation layer on top. It is a prebuilt derivation output carrying
+    // its own checksum; describing it hashes the prebuilt tar (verifying that
+    // checksum) without re-tarring anything.
+    let cust_work = image_work()?;
+    let cust = make_customisation_layer(
+        0,
+        &conf.customisation_layer,
+        &cust_work.layers_dir,
+        &cust_work.blobs_dir,
+    )?;
     layers.push(LayerDesc {
         digest: format!("sha256:{}", cust.checksum),
         diff_id: format!("sha256:{}", cust.checksum),
@@ -487,6 +494,7 @@ fn assemble(
     layers.push(make_customisation_layer(
         base_layer_count + conf.store_layers.len() + 1,
         &conf.customisation_layer,
+        layers_dir,
         blobs_dir,
     )?);
     sources.push(LayerSource::Customisation {
@@ -679,8 +687,11 @@ fn regenerate_layer(
         LayerSource::Base { archive, member } => {
             regenerate_base_member(archive, member, layers_dir, blobs_dir)?
         }
+        // `make_customisation_layer` hashes the copied bytes, so the digest
+        // check below verifies real content instead of echoing the checksum
+        // file back at itself (index#2058).
         LayerSource::Customisation { dir } => {
-            make_customisation_layer(0, &dir.to_string_lossy(), blobs_dir)?
+            make_customisation_layer(0, &dir.to_string_lossy(), layers_dir, blobs_dir)?
         }
     };
 
@@ -1122,6 +1133,7 @@ fn make_store_layer(
 fn make_customisation_layer(
     number: usize,
     customisation_layer: &str,
+    layers_dir: &Path,
     blobs_dir: &Path,
 ) -> Result<Layer, Box<dyn Error>> {
     eprintln!("Creating layer {number} with customisation...");
@@ -1134,10 +1146,31 @@ fn make_customisation_layer(
         return Err(format!("oci-image-builder: invalid layer checksum: {checksum}").into());
     }
 
+    // Copy the bytes into the blob rather than symlinking into the store: a
+    // symlinked blob left the final archive depending on out-of-tar store
+    // state, and the base-image-nix-db check failed whenever the referenced
+    // path was not visible at read time (index#2058). Hashing during the copy
+    // makes the derivation's `checksum` file verified instead of trusted;
+    // that digest flows into the manifest and diff_ids, so mismatched bytes
+    // would ship a manifest lying about its content.
     let layer_path = customisation_layer.join("layer.tar");
-    let size = fs::metadata(&layer_path)?.len();
+    let tmp = layers_dir.join(format!("{number}.customisation.tar"));
+    let mut writer = HashingWriter::new(File::create(&tmp)?);
+    io::copy(&mut File::open(&layer_path)?, &mut writer)?;
+    let HashedBytes {
+        size,
+        checksum: computed,
+    } = writer.finalize();
+    if computed != checksum {
+        return Err(format!(
+            "oci-image-builder: customisation layer digest mismatch: \
+             checksum file records {checksum} but {} hashes to {computed}",
+            layer_path.display()
+        )
+        .into());
+    }
     let tar_path = blobs_dir.join(&checksum);
-    symlink(&layer_path, &tar_path)?;
+    fs::rename(&tmp, &tar_path)?;
 
     Ok(Layer {
         checksum,
@@ -1954,6 +1987,66 @@ mod tests {
             .collect())
     }
 
+    /// Assert the archive is self-contained: every blob the manifest
+    /// references (config and layers) is a regular tar entry, not a symlink
+    /// into the store, whose size matches the manifest and whose bytes hash
+    /// to its digest. A symlinked blob made the archive depend on out-of-tar
+    /// store state (index#2058).
+    fn assert_blobs_embedded(tar_path: &Path) -> Result<(), Box<dyn Error>> {
+        let index: Value = serde_json::from_slice(&read_member(tar_path, "index.json")?)?;
+        let manifest_digest = index["manifests"][0]["digest"].as_str().unwrap();
+        let manifest_member = format!(
+            "blobs/sha256/{}",
+            manifest_digest.strip_prefix("sha256:").unwrap()
+        );
+        let manifest: Value = serde_json::from_slice(&read_member(tar_path, &manifest_member)?)?;
+
+        let mut blobs: Vec<(String, u64)> = vec![(
+            manifest["config"]["digest"].as_str().unwrap().to_owned(),
+            manifest["config"]["size"].as_u64().unwrap(),
+        )];
+        for layer in manifest["layers"].as_array().unwrap() {
+            blobs.push((
+                layer["digest"].as_str().unwrap().to_owned(),
+                layer["size"].as_u64().unwrap(),
+            ));
+        }
+
+        for (digest, size) in blobs {
+            let member = format!("blobs/sha256/{}", digest.strip_prefix("sha256:").unwrap());
+            let mut found = false;
+            for entry in tar::Archive::new(File::open(tar_path)?).entries()? {
+                let mut entry = entry?;
+                if entry.path()?.to_string_lossy() != member {
+                    continue;
+                }
+                found = true;
+                assert_eq!(
+                    entry.header().entry_type(),
+                    tar::EntryType::Regular,
+                    "{member} must be a regular tar entry"
+                );
+                let mut bytes = Vec::new();
+                entry.read_to_end(&mut bytes)?;
+                assert_eq!(
+                    bytes.len() as u64,
+                    size,
+                    "{member} size differs from the manifest"
+                );
+                assert_eq!(
+                    format!("sha256:{}", sha256_bytes(&bytes)),
+                    digest,
+                    "{member} bytes do not hash to the manifest digest"
+                );
+            }
+            assert!(
+                found,
+                "{member} referenced by the manifest but absent from the archive"
+            );
+        }
+        Ok(())
+    }
+
     fn make_customisation_dir(dir: &Path) -> Result<(), Box<dyn Error>> {
         fs::create_dir_all(dir)?;
         let tar = layer_tar(&[("app/run", b"hi")]);
@@ -2035,6 +2128,9 @@ mod tests {
             .map(|layer| layer.digest.clone())
             .collect();
         assert_eq!(described, build_digests);
+
+        assert_blobs_embedded(&built)?;
+        assert_blobs_embedded(&materialized)?;
         Ok(())
     }
 
@@ -2133,6 +2229,45 @@ mod tests {
         assert_eq!(
             oci_layer_digests(&mat_one)?,
             oci_layer_digests(&mat_sharded)?
+        );
+        Ok(())
+    }
+
+    /// A rewritten `layer.tar` next to a stale checksum file must fail the
+    /// build: the recorded digest flows into the manifest and `diff_ids`, so
+    /// shipping the new bytes under the old digest would produce an image
+    /// whose manifest lies about its content (index#2058).
+    #[test]
+    fn build_rejects_tampered_customisation_layer() -> Result<(), Box<dyn Error>> {
+        let work = tempdir()?;
+        let cust = work.path().join("cust");
+        make_customisation_dir(&cust)?;
+        fs::write(
+            cust.join("layer.tar"),
+            layer_tar(&[("app/run", b"tampered")]),
+        )?;
+
+        let plan = serde_json::json!({
+            "architecture": "amd64",
+            "config": {},
+            "from_image": Value::Null,
+            "store_layers": [],
+            "customisation_layer": cust.to_string_lossy(),
+            "created": "1970-01-01T00:00:01Z",
+            "mtime": "1970-01-01T00:00:01Z",
+            "uid": "0",
+            "gid": "0",
+            "store_dir": work.path().join("store").to_string_lossy(),
+        });
+        let conf = work.path().join("conf.json");
+        fs::write(&conf, serde_json::to_vec(&plan)?)?;
+
+        let result = run_build(&conf, &work.path().join("out.tar"), None);
+
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("digest mismatch"))
         );
         Ok(())
     }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2199,6 +2199,11 @@
   # builds the real base archive and asserts exactly that, so it also proves the
   # DB survives oci-image-builder's re-streaming. It builds an OCI image, so it
   # is its own check (not the pure-eval `eval` aggregate) and runs on Linux.
+  # It also defends the self-contained invariant: every layer blob the manifest
+  # references must be embedded in the archive as a regular file. The builder
+  # once wrote the customisation blob as a symlink into /nix/store, so the
+  # archive depended on out-of-tar store state and this check failed whenever
+  # the referenced path was not visible at read time (index#2058).
   baseImageNixDb = let
     # Every `path`-type registry pin the image ships. Guard on the type so a
     # non-path entry (e.g. a default indirect/github registry row) can't break
@@ -2219,21 +2224,32 @@
         pkgs.sqlite
         pkgs.gnugrep
         pkgs.coreutils
+        pkgs.jq
       ];
       archive = base.imageConfig.ix.build.ociImage;
       requiredPaths = registryPaths ++ extraBakedPaths;
     } ''
       mkdir extract db
-      # oci-image-builder writes uncompressed tar layers as blobs/sha256/<digest>.
-      # The nix store DB lives in the customisation layer; find whichever blob
-      # carries it and extract just that file.
       tar -C extract -xf "$archive"
+      # Walk only the layer blobs the manifest declares: config/manifest JSON
+      # blobs share blobs/sha256/ and are not tars, so globbing the dir would
+      # need tar errors suppressed, and that suppression is what let a dangling
+      # store-symlink blob read as "db not here" instead of failing (index#2058).
+      manifest_digest=$(jq -r '.manifests[0].digest' extract/index.json | cut -d: -f2)
+      layer_digests=$(jq -r '.layers[].digest' "extract/blobs/sha256/$manifest_digest" | cut -d: -f2)
       found=
-      for blob in extract/blobs/sha256/*; do
-        if tar -tf "$blob" 2>/dev/null | grep -qx './nix/var/nix/db/db.sqlite'; then
+      for digest in $layer_digests; do
+        blob="extract/blobs/sha256/$digest"
+        if [ -L "$blob" ] || [ ! -f "$blob" ]; then
+          echo "error: layer blob sha256:$digest is missing or not a regular file; the archive is not self-contained (index#2058)" >&2
+          exit 1
+        fi
+        # No stderr suppression: a layer that cannot be listed is a corrupt
+        # archive and must fail loudly, not read as "db not here".
+        listing=$(tar -tf "$blob")
+        if grep -qx './nix/var/nix/db/db.sqlite' <<< "$listing"; then
           tar -C db -xf "$blob" ./nix/var/nix/db/db.sqlite
           found=1
-          break
         fi
       done
       if [ -z "$found" ]; then


### PR DESCRIPTION
Closes #2058.

## Root cause

`ix-base-oci.tar` shipped the dockerTools customisation layer — the blob carrying `/nix/var/nix/db/db.sqlite` — as a **symlink tar entry (size=0)** pointing at `/nix/store/…-base-customisation-layer/layer.tar` (`make_customisation_layer` used `symlink()`). The archive was not self-contained: reading that one blob depended on the referenced store path being visible at read time.

The `base-image-nix-db` check extracts the archive and probes blobs with `tar -tf "$blob" 2>/dev/null`. When the symlink target is momentarily unreadable in the build sandbox, tar's `Cannot open: No such file or directory` is swallowed and the check misreports `no OCI layer contains nix/var/nix/db/db.sqlite (includeNixDB off?)`.

Evidence (vin-compute-1):
- **Deterministic repro**: masking `/nix/store/1pr6qypq…-base-customisation-layer` in a mount namespace (`unshare --mount` + tmpfs) and running the exact check pipeline reproduces the exact CI error; without `2>/dev/null` tar reports the real cause. `tar -xOf s4k28w2c…-ix-base-oci.tar blobs/sha256/76e4…` yields **0 bytes** — the archive carries no layer bytes for this blob.
- **Forensics on failing run 28816009515**: the layer path was valid in the nix DB (registered 19:01:19, before the tar at 19:02:46 and the check), never re-registered, content always correct. The path simply wasn't visible inside that sandbox — a transient closure/sandbox anomaly in nix 2.34 deferred resolution under heavy concurrency (~60 same-named layer realisations registered that day). A rerun resolves a fresh check drv and passes, which is why the flake always cleared on rerun.

Whatever the daemon-level trigger, the design flaw is the artifact depending on external store state at read time; the masked stderr made each occurrence undiagnosable.

Latent second bug found on the way: the customisation layer digest was read from the derivation's `checksum` file on faith and never recomputed; the materialize path's "verification" compared that value against a digest recorded from the same file (circular). A truncated `layer.tar` beside a stale `checksum` would have shipped with a manifest lying about the blob.

## Fix

- `make_customisation_layer` embeds the layer bytes: copies `layer.tar` into the blobs dir through the existing `HashingWriter` (temp+rename like every other blob) and hard-errors on digest mismatch against the `checksum` file. The archive is now self-contained; consumers and the check depend only on the tar's own bytes.
- `regenerate_layer`'s digest verification now compares real content.
- The `base-image-nix-db` check is manifest-driven (jq: index.json → manifest → layer digests), rejects any blob that is not a regular file ("archive is not self-contained"), and runs `tar -tf` without stderr suppression, so any future anomaly reports truthfully instead of as "includeNixDB off?".
- Tests: round-trip now asserts every manifest-referenced blob is a regular tar entry with matching size and digest (both built and materialized archives); new test that a tampered `layer.tar` + stale checksum fails with the digest-mismatch error.

## Validation

- oci-image-builder unit tests: 11 passed (incl. the two new ones); per-crate clippy green; `nix run .#lint` 8/8.
- Cold-build regression evidence on vin-compute-1 to follow as a PR comment.

Authored by an AI agent (Claude Code, issue #2058 background agent).

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Embed customisation layer blobs as regular files with checksum verification in oci-image-builder
> - Replaces symlink creation with a copy-and-hash flow in `make_customisation_layer`: the layer tar is copied into a temp file while hashing, the computed digest is verified against the recorded checksum, then the file is moved into `blobs_dir` named by its checksum.
> - Adds a `layers_dir` parameter to `make_customisation_layer` so all call sites (`assemble`, `run_assemble_desc`, `regenerate_layer`) pass the work directory for the temp file.
> - Adds a `build_rejects_tampered_customisation_layer` test to verify that builds fail when layer bytes do not match the recorded checksum, and extends the `build vs materialize` test to assert all blob entries are regular files whose bytes match their declared digests.
> - Updates the `baseImageNixDb` Nix test in [tests/default.nix](https://github.com/indexable-inc/index/pull/2079/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to parse `index.json` with `jq` and assert each referenced blob is a regular file.
> - Risk: any customisation layer with a stale or mismatched checksum file will now cause a hard build failure instead of silently embedding a potentially corrupt blob.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4219d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->