### PR TITLE
agent skills: add creating-a-readme skill + root README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,14 @@
 
 # Index
 
-`index` is a shared, open-source monorepo of developer tools that anyone can
-modify. The bet: one repo everyone can edit is the fastest way for all of us to
-move. Add something useful, and everyone gets it.
+<p align="center">
+  <img src="doc/assets/hero.svg" width="760" alt="Three contributors commit tools into one shared Nix flake; everyone runs everything with nix run." />
+</p>
+
+Ever built a great little tool and watched it die on your laptop? `index` is a
+shared, open-source monorepo of developer tools that anyone can modify. The
+bet: one repo everyone can edit is the fastest way for all of us to move. Add
+something useful, and everyone gets it.
 
 It is one Nix flake holding ~45 packages (mostly Rust, with Python, Elixir,
 TypeScript, and Svelte where they fit), a corpus of NixOS modules, fleet

--- a/doc/assets/hero.svg
+++ b/doc/assets/hero.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 210" role="img"
+     aria-label="Three contributors commit tools into one shared Nix flake; everyone runs everything with nix run."
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted  { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    text    { fill: currentColor; font-size: 14px; }
+    .mono   { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+    .box    { stroke: currentColor; fill: none; stroke-width: 1.5; }
+    .edge   { stroke: currentColor; fill: none; stroke-width: 1.5; marker-end: url(#arrow); }
+    .node   { fill: none; stroke: currentColor; stroke-width: 1.5; }
+    .label  { font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted  { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 1 L 9 5 L 0 9" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    </marker>
+  </defs>
+
+  <!-- contributors -->
+  <circle class="node" cx="70" cy="55" r="14"/>
+  <circle class="node" cx="70" cy="105" r="14"/>
+  <circle class="node" cx="70" cy="155" r="14"/>
+  <text x="70" y="60" text-anchor="middle" class="label">you</text>
+  <text x="70" y="110" text-anchor="middle" class="label">team</text>
+  <text x="70" y="160" text-anchor="middle" class="label">agent</text>
+
+  <!-- commits flowing in -->
+  <path class="edge" d="M 92 55 C 160 55, 190 90, 268 98"/>
+  <path class="edge" d="M 92 105 L 268 105"/>
+  <path class="edge" d="M 92 155 C 160 155, 190 120, 268 112"/>
+  <text x="180" y="88" text-anchor="middle" class="muted label">add a tool</text>
+
+  <!-- the flake -->
+  <rect class="box" x="280" y="55" width="180" height="100" rx="10"/>
+  <text x="370" y="85" text-anchor="middle" font-weight="600" font-size="17">index</text>
+  <text x="370" y="106" text-anchor="middle" class="muted label">one Nix flake</text>
+  <text x="370" y="132" text-anchor="middle" class="accent label">packages &#183; modules &#183; agents</text>
+
+  <!-- everyone runs everything -->
+  <path class="edge" d="M 472 98 C 520 90, 540 55, 588 55"/>
+  <path class="edge" d="M 472 105 L 588 105"/>
+  <path class="edge" d="M 472 112 C 520 120, 540 155, 588 155"/>
+  <text x="530" y="88" text-anchor="middle" class="muted label">everyone gets it</text>
+
+  <text x="598" y="60" class="mono">$ nix run &#8230;#search</text>
+  <text x="598" y="110" class="mono">$ nix run &#8230;#tui</text>
+  <text x="598" y="160" class="mono">$ nix run &#8230;#vmkit</text>
+</svg>

--- a/packages/agent/skills/creating-a-readme/SKILL.md
+++ b/packages/agent/skills/creating-a-readme/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: creating-a-readme
+description: "House README style: a committed SVG hero that adapts to dark/light via embedded prefers-color-scheme CSS, a hook-question intro with a 2-3 sentence pitch, install lines derived from the flake and crate metadata, and an optional git-log version history. Use when writing, reviewing, or generating any README in this repo, including the mirror generator's output."
+---
+
+## Creating a README
+
+Every README opens with one committed SVG hero, then a pitch a human gets in
+five seconds. Short sections, no walls of text, no metadiscussion about the
+document itself. This skill is the single source of truth for README style;
+generators (e.g. `packages/mirror`) conform to it rather than restating it.
+
+### Hero SVG
+
+One symbolic SVG per README, committed next to it (convention:
+`assets/hero.svg`; the root README uses `doc/assets/`). Reference it with a
+plain image link as the first element:
+
+```markdown
+<p align="center"><img src="assets/hero.svg" width="720" alt="one line: what the diagram shows"></p>
+```
+
+Do NOT use the two-file `<picture>` dark/light hack. GitHub renders an SVG's
+own embedded `<style>`, so a single file adapts by itself. Put the theme
+switch inside the SVG:
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }        /* light-mode foreground */
+    .muted  { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box    { stroke: currentColor; fill: none; }
+    text    { fill: currentColor; }
+    .edge   { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted  { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <!-- shapes: use the classes above, never hard-coded fills -->
+</svg>
+```
+
+Rules:
+
+- Transparent background. Every themed property gets a value in both the
+  default (light) block and the dark block; verify by reading the CSS, since
+  the caveat is that `prefers-color-scheme` inside an `<img>` follows the
+  OS/browser scheme, not GitHub's manual theme toggle.
+- Symbolic and minimal: one diagram showing what the thing does (data flow,
+  before/after, the shape of the transformation). A README needs one hero,
+  not a gallery.
+- Relationships are edges (arrows, lines), never prose inside node labels.
+  Label nodes with a noun; let the arrows carry the verbs.
+- Hand-write the SVG: a dozen shapes, real `<text>` elements (no paths of
+  outlined text), no embedded rasters, no fixed `width`/`height` attributes
+  (viewBox only, so it scales).
+
+### Voice
+
+- Open with a hook question the target reader has actually asked ("Ever
+  needed to merge two SQLite files in git?"), then a 2-3 sentence pitch in
+  plain words: what it is, what it does for you, why it beats the obvious
+  alternative.
+- ADHD-concise from there: short sections with concrete headings, code blocks
+  over paragraphs, a number or path over an adjective. Cut anything the
+  reader cannot act on.
+- Follow the `writing-style` skill for the prose itself (no em dashes, lead
+  with the answer).
+
+### Install / usage: derive, do not hand-write
+
+The install section is a function of what the package is. Check metadata
+instead of guessing:
+
+- Runnable flake package (`nix eval .#<attr>.meta.mainProgram` succeeds):
+
+  ```sh
+  nix run github:indexable-inc/index#<attr> -- --help
+  ```
+
+- Rust crate (`Cargo.toml` present): also give the cargo form. For a crate
+  with a standalone mirror (its `package.nix` sets the `mirror` manifest
+  attr; list them with `nix eval .#lib.mirrorPackages`), point cargo at the
+  mirror repo:
+
+  ```sh
+  cargo install --git https://github.com/indexable-inc/<mirror-id>
+  ```
+
+  For unmirrored workspace crates, the git-dependency form against the
+  monorepo (`<crate> = { git = "https://github.com/indexable-inc/index" }`)
+  only works for a bin via `cargo install`; libraries stay Nix-consumed.
+
+- Library-only packages (polars plugins, SDKs, NixOS modules): show the one
+  consumption line native to the ecosystem (a `flake.nix` input, `pip
+  install` of the wheel output, `imports = [ ... ]`), still derived from what
+  the flake actually exposes.
+
+Always end the section with how to get the flake itself when the commands
+assume a clone: `git clone https://github.com/indexable-inc/index`.
+
+### Version history (optional)
+
+If a package wants a history section, generate it from git rather than
+maintaining it by hand, and regenerate on touch:
+
+```sh
+git log --reverse --format='- `%h` %s' -- packages/<path>
+```
+
+Keep only releases or behavior changes a user would notice; a README is not a
+changelog. Skip the section entirely for fast-moving packages.
+
+### Checklist
+
+1. `assets/hero.svg` committed, referenced first, adapts in both schemes.
+2. Hook question plus 2-3 sentence pitch above the fold.
+3. Install lines derived from flake/crate metadata, not copied from another
+   README.
+4. Mirrored packages: README plus `assets/` must make sense standalone
+   (relative links only to files that ride into the mirror).
+5. `nix run .#lint` passes (skill-lint checks this file's frontmatter too).


### PR DESCRIPTION
Adds `packages/agent/skills/creating-a-readme/SKILL.md`: the house README style (adaptive dark/light SVG hero via embedded `prefers-color-scheme` CSS, hook-question intro, install lines derived from flake/crate metadata, optional git-log version history). Applies it to the root README as the exemplar: new `doc/assets/hero.svg` plus a hook opening line.

The skill is the single source of truth for README style; the mirror README generator and the follow-up sweep PRs conform to it.

Validated: `nix run .#lint` (8/8) and `nix run .#skill-lint` (0 errors).

Refs #2072

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add creating-a-readme agent skill and hero image to root README
> - Adds a new agent skill at [packages/agent/skills/creating-a-readme/SKILL.md](https://github.com/indexable-inc/index/pull/2080/files#diff-1ccf2add7837672e672583ae3c9c39fca6de89ffbcf4a0e4b167ffa7cadf271d) defining house rules for writing READMEs: a single SVG hero with embedded `prefers-color-scheme` CSS, a hook question opener, 2-3 sentence pitch, and installation instructions derived from flake/crate metadata.
> - Updates [README.md](https://github.com/indexable-inc/index/pull/2080/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to follow the new skill: adds a centered hero image referencing [doc/assets/hero.svg](https://github.com/indexable-inc/index/pull/2080/files#diff-0b5f310c8e078e5ff04efc2d03c28fb769a776e361d9d1f0feeb00e8e9823acf) and rewrites the opening as a hook-style introduction.
> - Adds [doc/assets/hero.svg](https://github.com/indexable-inc/index/pull/2080/files#diff-0b5f310c8e078e5ff04efc2d03c28fb769a776e361d9d1f0feeb00e8e9823acf) as a new SVG asset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39d2819.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->