### PR TITLE
mcp: route job channel events to the spawning session

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -5513,6 +5513,10 @@
     {
       nativeBuildInputs = [channelTestPython];
       strictDeps = true;
+      # The SSE test binds a loopback aiohttp server; the darwin sandbox denies
+      # all binds without this. Linux sandboxes already provide a private
+      # loopback, so it is a no-op there.
+      __darwinAllowLocalNetworking = true;
     }
     ''
       export HOME=$TMPDIR/home

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -39,6 +39,7 @@ import socket
 import subprocess
 import sys
 import time
+import uuid
 import webbrowser
 from collections.abc import Callable
 from pathlib import Path
@@ -524,6 +525,11 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
     # writes there) and the private IPYTHONDIR (so the runtime startup runs)
     # before the kernel starts.
     os.environ["IX_MCP_STORE"] = str(store_path)
+    # One routing id per serve process, inherited by the kernel it spawns: outbox
+    # rows tagged with it are drained only by this process's pump, so several
+    # servers pointed at one store (pinned IX_MCP_STORE) stop stealing each
+    # other's events. setdefault so an embedder can pin the id.
+    os.environ.setdefault("IX_MCP_ROUTE", uuid.uuid4().hex[:8])
     # Surface the dashboard URL to the kernel so `DASHBOARD_URL` is one lookup
     # away (the agent should not have to spelunk the runtime dir to find it). The
     # human-facing dashboard is the Loro hub when we auto-spawn one; otherwise

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -218,6 +218,25 @@ _store = None
 _shell = None  # the InteractiveShell, set in install(); used to format rich results
 _trace_file = None  # faulthandler dump target, kept open for the kernel's lifetime
 
+# This process's channel routing id. The serve CLI mints IX_MCP_ROUTE and the
+# kernel subprocess inherits it, so both ends of one server agree; a bare
+# kernel (tests, embedders) mints its own, still stable for the process.
+_route_id: str | None = None
+
+
+def _route() -> str:
+    global _route_id
+    if _route_id is None:
+        _route_id = os.environ.get("IX_MCP_ROUTE") or uuid.uuid4().hex[:8]
+    return _route_id
+
+
+def _current_route() -> str:
+    """Delivery address for events emitted by the running job: its spawning
+    connection's route when inside one, else this process's route."""
+    job = _ix_current.get()
+    return job.route if job is not None else _route()
+
 
 def _rename_current_job(name: str) -> None:
     """Relabel the currently running job with ``name``.
@@ -304,6 +323,10 @@ class Job:
         # Carried so a read helper running inside the cell can attribute its read
         # to the right session's redundant-read counters (see readstats).
         self.session = session
+        # Where this job's channel events are delivered: the spawning connection.
+        # Distinct from `session` (the namespace selector), which stays None under
+        # stdio by contract.
+        self.route = session or _route()
         # 'cell' for a normal execution; 'replay' for a re-run performed while
         # reopening a session file. Replays never feed future replays
         # (store.replayable filters on this), so a session cannot double-run
@@ -1658,7 +1681,7 @@ async def ask(
 _META_KEY_RE = re.compile(r"[A-Za-z0-9_]+")
 
 
-async def notify(content: str, **meta: Any) -> None:
+async def notify(content: str, *, session: str | None = None, **meta: Any) -> None:
     """Push a channel event into the connected agent session.
 
     This server is a Claude Code channel (research preview): when the client
@@ -1678,6 +1701,11 @@ async def notify(content: str, **meta: Any) -> None:
     behavior), so never treat a notify as confirmed-read. Keys must be
     identifiers (``[A-Za-z0-9_]``); anything else raises here rather than being
     silently dropped client-side.
+
+    ``session`` routes the event to the one connection whose routing id matches
+    (its transport pump alone drains the row) and stamps the owner into the
+    meta, so clients on a shared stream can filter by it; None keeps broadcast
+    delivery.
     """
     bad = [key for key in meta if not _META_KEY_RE.fullmatch(key)]
     if bad:
@@ -1690,10 +1718,14 @@ async def notify(content: str, **meta: Any) -> None:
             "notify() needs the server-managed kernel (no store is configured), "
             "so there is no channel to deliver to"
         )
+    payload = {key: str(value) for key, value in meta.items()}
+    if session is not None:
+        payload["session"] = session
     _store.add_outbox(
         _store_conn,
         content=str(content),
-        meta=json.dumps({key: str(value) for key, value in meta.items()}),
+        meta=json.dumps(payload),
+        session=session,
     )
 
 
@@ -1864,18 +1896,27 @@ async def watch_pr(
         if last.get("state") != "OPEN":
             state["status"] = "merged" if last.get("state") == "MERGED" else "closed"
             resource.close()
-            await notify(f"PR {clean_pr} finished with state {last.get('state')}", resource=resource.id, pr=clean_pr)
+            await notify(
+                f"PR {clean_pr} finished with state {last.get('state')}",
+                session=_current_route(),
+                resource=resource.id,
+                pr=clean_pr,
+            )
             return {"state": last.get("state"), "url": last.get("url"), "checks": len(checks)}
         if failures:
             state["status"] = "failed"
             state["error"] = "One or more required actions failed."
             resource.close()
-            await notify(f"PR {clean_pr} has failing checks", resource=resource.id, pr=clean_pr)
+            await notify(
+                f"PR {clean_pr} has failing checks", session=_current_route(), resource=resource.id, pr=clean_pr
+            )
             return {"state": "failed", "url": last.get("url"), "failures": failures}
         if time.time() - started > timeout:
             state["status"] = "timed out"
             resource.close()
-            await notify(f"PR {clean_pr} watch timed out", resource=resource.id, pr=clean_pr)
+            await notify(
+                f"PR {clean_pr} watch timed out", session=_current_route(), resource=resource.id, pr=clean_pr
+            )
             return {"state": "timed out", "url": last.get("url"), "checks": len(checks)}
         await asyncio.sleep(interval)
 
@@ -2493,6 +2534,7 @@ async def _runner(job: Job, ns: dict) -> None:
             with contextlib.suppress(Exception):
                 await notify(
                     f"Background job {job.name} finished with status {job.status}.",
+                    session=job.route,
                     job_id=job.id,
                     job_name=job.name,
                     status=job.status,

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -125,11 +125,14 @@ CREATE INDEX IF NOT EXISTS inputs_channel ON inputs (channel, seq);
 -- kernel code can wake the connected agent session. Same transient-message
 -- discipline as `inputs`: the drain DELETEs what it delivers, so the table stays
 -- empty between events. `meta` is a JSON object of identifier-keyed strings (they
--- become attributes on the client's <channel> tag).
+-- become attributes on the client's <channel> tag). NULL `session` = broadcast
+-- to any pump; a set session is the routing id of the one connection that
+-- should receive the row.
 CREATE TABLE IF NOT EXISTS outbox (
     seq         INTEGER PRIMARY KEY AUTOINCREMENT,
     content     TEXT NOT NULL,
     meta        TEXT NOT NULL DEFAULT '{}',
+    session     TEXT,
     created_at  REAL NOT NULL
 );
 
@@ -200,6 +203,10 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if "execution_id" not in resource_have:
         with contextlib.suppress(sqlite3.OperationalError):
             conn.execute("ALTER TABLE resources ADD COLUMN execution_id TEXT NOT NULL DEFAULT ''")
+    outbox_have = {row[1] for row in conn.execute("PRAGMA table_info(outbox)")}
+    if "session" not in outbox_have:
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute("ALTER TABLE outbox ADD COLUMN session TEXT")
 
 
 def start(
@@ -546,24 +553,45 @@ def delete_inputs(conn: sqlite3.Connection, seqs: list[int]) -> None:
 # as a subscriber might still be catching up on a slow poll tick.
 _EVENT_MAX_AGE_SECONDS = 3600.0
 
+# Owned outbox rows whose owner never drains them (its process is gone) are
+# pruned on the next take, so a shared store cannot grow without bound.
+_OUTBOX_MAX_AGE_SECONDS = 3600.0
 
-def add_outbox(conn: sqlite3.Connection, *, content: str, meta: str) -> None:
+
+def add_outbox(conn: sqlite3.Connection, *, content: str, meta: str, session: str | None = None) -> None:
     """Queue one channel event (``meta`` is a JSON object of identifier-keyed
-    strings). The kernel is the sole inserter; the MCP transport drains."""
+    strings); ``session`` is the routing id of the connection that owns the
+    event, None broadcasts. The kernel is the sole inserter; the MCP transport
+    drains."""
     conn.execute(
-        "INSERT INTO outbox (content, meta, created_at) VALUES (?, ?, ?)",
-        (content, meta, _now()),
+        "INSERT INTO outbox (content, meta, session, created_at) VALUES (?, ?, ?, ?)",
+        (content, meta, session, _now()),
     )
 
 
-def take_outbox(conn: sqlite3.Connection) -> list[dict]:
-    """Every queued channel event, oldest first, consuming the rows. Like
-    ``_drain_inputs``: DELETE before delivering, so an event can never be emitted
-    twice; a crash between the delete and the send loses at most one batch."""
+def take_outbox(conn: sqlite3.Connection, session: str | None = None) -> list[dict]:
+    """Queued channel events, oldest first, consuming the rows. With a
+    ``session`` this is a routed drain: the caller's own rows plus unowned
+    broadcasts, and owned rows orphaned past the age cap (their owner's process
+    is gone) are pruned. With None, every row -- the legacy/single-consumer
+    drain. Like ``_drain_inputs``: DELETE before delivering, so an event can
+    never be emitted twice; a crash between the delete and the send loses at
+    most one batch."""
     conn.row_factory = sqlite3.Row
-    rows = conn.execute(
-        "SELECT seq, content, meta FROM outbox ORDER BY seq ASC"
-    ).fetchall()
+    if session is None:
+        rows = conn.execute(
+            "SELECT seq, content, meta, session FROM outbox ORDER BY seq ASC"
+        ).fetchall()
+    else:
+        conn.execute(
+            "DELETE FROM outbox WHERE session IS NOT NULL AND session != ? AND created_at < ?",
+            (session, _now() - _OUTBOX_MAX_AGE_SECONDS),
+        )
+        rows = conn.execute(
+            "SELECT seq, content, meta, session FROM outbox "
+            "WHERE session IS NULL OR session = ? ORDER BY seq ASC",
+            (session,),
+        ).fetchall()
     if not rows:
         return []
     placeholders = ",".join("?" for _ in rows)

--- a/packages/mcp/ix_notebook_mcp/transport.py
+++ b/packages/mcp/ix_notebook_mcp/transport.py
@@ -8,7 +8,8 @@ The stdio transport is also a Claude Code channel (research preview,
 https://code.claude.com/docs/en/channels-reference): it advertises the
 ``claude/channel`` experimental capability and pumps the store's ``outbox``
 (what the kernel's ``notify()`` writes) as ``notifications/claude/channel``
-events, so kernel code can push into the running agent session. Channels are
+events, so kernel code can push into the running agent session; rows routed to
+another server's session id are left for that server's pump. Channels are
 stdio-only by contract (Claude Code spawns the channel server as a subprocess
 and a session opts in per-entry via ``--channels`` /
 ``--dangerously-load-development-channels``), so the HTTP transport does not
@@ -141,13 +142,18 @@ async def pump_outbox(
     write stream -- the same bytes ``ServerSession.send_notification`` would
     produce. Holds every send until the client is ``initialized`` (see
     :func:`_session_initialized`), so a startup/replay ``notify()`` never emits a
-    notification before the handshake completes. Best-effort per tick: a store
+    notification before the handshake completes. Drains unowned rows plus rows
+    owned by this process's ``IX_MCP_ROUTE``, so several servers sharing a store
+    each receive only their own jobs' events. Best-effort per tick: a store
     hiccup retries next tick, and a closed transport ends the pump (the task
     group tears it down anyway).
     """
     cfg = config()
     if not cfg.store_path:
         return
+    # None (an embedder/test that never minted a route) drains everything --
+    # exactly the single-consumer behavior routing replaced.
+    route = os.environ.get("IX_MCP_ROUTE")
     conn = store.connect(cfg.store_path)
     try:
         while True:
@@ -157,7 +163,7 @@ async def pump_outbox(
                 await anyio.sleep(_OUTBOX_POLL_SECONDS)
                 continue
             try:
-                rows = store.take_outbox(conn)
+                rows = store.take_outbox(conn, session=route)
             except Exception:
                 rows = []  # best-effort: a read error this tick just retries next tick
             for row in rows:

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -66,6 +66,45 @@ def test_mark_interrupted_clears_outbox_and_events(tmp_path: Path) -> None:
     assert store.events_after(conn, "r", 0) == []
 
 
+def test_take_outbox_routes_owned_rows(tmp_path: Path) -> None:
+    conn = store.connect(tmp_path / "c.db")
+    store.add_outbox(conn, content="owned", meta="{}", session="route-a")
+    store.add_outbox(conn, content="broadcast", meta="{}")
+    # A foreign route drains broadcasts only; another connection's row stays put.
+    rows = store.take_outbox(conn, session="route-b")
+    assert [r["content"] for r in rows] == ["broadcast"]
+    rows = store.take_outbox(conn, session="route-a")
+    assert [r["content"] for r in rows] == ["owned"]
+    assert rows[0]["session"] == "route-a"
+    assert store.take_outbox(conn) == []
+
+
+def test_take_outbox_prunes_orphaned_owned_rows(tmp_path: Path) -> None:
+    conn = store.connect(tmp_path / "c.db")
+    store.add_outbox(conn, content="orphan", meta="{}", session="gone")
+    conn.execute("UPDATE outbox SET created_at = created_at - ?", (store._OUTBOX_MAX_AGE_SECONDS + 1,))
+    # A routed drain sweeps rows whose owner never came back for them, so a
+    # shared store cannot accrete dead servers' events.
+    assert store.take_outbox(conn, session="route-b") == []
+    assert conn.execute("SELECT COUNT(*) FROM outbox").fetchone()[0] == 0
+
+
+def test_connect_migrates_outbox_session_column(tmp_path: Path) -> None:
+    db = tmp_path / "old.db"
+    old = sqlite3.connect(db)
+    old.execute(
+        "CREATE TABLE outbox (seq INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "content TEXT NOT NULL, meta TEXT NOT NULL DEFAULT '{}', created_at REAL NOT NULL)"
+    )
+    old.commit()
+    old.close()
+    # A store written by a pre-routing build gains the column idempotently.
+    conn = store.connect(db)
+    assert "session" in {row[1] for row in conn.execute("PRAGMA table_info(outbox)")}
+    store.add_outbox(conn, content="routed", meta="{}", session="x")
+    assert [r["content"] for r in store.take_outbox(conn, session="x")] == ["routed"]
+
+
 # --------------------------------------------------------------------------- #
 # runtime: notify() and interactive resource actions (the kernel end)
 # --------------------------------------------------------------------------- #
@@ -110,6 +149,47 @@ def test_notify_without_store_raises(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(runtime, "_store_conn", None)
         with pytest.raises(RuntimeError, match="no store"):
             await runtime.notify("x")
+
+    asyncio.run(run())
+
+
+def test_backgrounded_completion_event_is_owned_by_spawning_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def run() -> None:
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+        monkeypatch.setattr(runtime, "_session_namespaces", {})
+        job = await runtime.__ix_run("import asyncio\nawait asyncio.sleep(0.05)", budget=0.01, session="sess-a")
+        await job.task
+        rows = store.take_outbox(conn)
+        assert len(rows) == 1
+        # The completion event is owned by the connection that spawned the job
+        # (only its pump drains it) and the owner rides in the channel meta.
+        assert rows[0]["session"] == "sess-a"
+        meta = json.loads(rows[0]["meta"])
+        assert meta["session"] == "sess-a"
+        assert meta["job_id"] == job.id
+
+    asyncio.run(run())
+
+
+def test_backgrounded_completion_event_defaults_to_process_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def run() -> None:
+        conn = store.connect(tmp_path / "r.db")
+        _wire_runtime(monkeypatch, conn)
+        monkeypatch.setattr(runtime, "_session_namespaces", {})
+        # No HTTP session (the stdio path): the job still gets a non-broadcast
+        # owner, this process's route, so a foreign server's pump cannot steal it.
+        job = await runtime.__ix_run("import asyncio\nawait asyncio.sleep(0.05)", budget=0.01)
+        await job.task
+        rows = store.take_outbox(conn)
+        assert len(rows) == 1
+        assert rows[0]["session"] == runtime._route()
+        assert rows[0]["session"] is not None
+        assert json.loads(rows[0]["meta"])["session"] == runtime._route()
 
     asyncio.run(run())
 
@@ -332,6 +412,32 @@ def test_pump_outbox_holds_events_until_initialized(tmp_path: Path, monkeypatch:
             assert len(store.take_outbox(conn)) == 1
         finally:
             pump.cancel()
+
+    asyncio.run(run())
+
+
+def test_pump_outbox_skips_rows_owned_by_another_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        db = tmp_path / "p.db"
+        conn = store.connect(db)
+        cfg = Config(workdir=tmp_path, store_path=db)
+        monkeypatch.setattr("ix_notebook_mcp.transport.config", lambda: cfg)
+        monkeypatch.setenv("IX_MCP_ROUTE", "route-b")
+        store.add_outbox(conn, content="for-a", meta="{}", session="route-a")
+        store.add_outbox(conn, content="for-all", meta="{}")
+        send, receive = anyio.create_memory_object_stream(8)
+        pump = asyncio.ensure_future(transport.pump_outbox(send, _FakeSession(initialized=True)))
+        try:
+            message = await asyncio.wait_for(receive.receive(), timeout=5.0)
+            # The broadcast row arrives; another connection's row never does.
+            assert message.message.root.params["content"] == "for-all"
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(receive.receive(), timeout=1.0)
+        finally:
+            pump.cancel()
+        # The owned row is still queued for its owner, not stolen by this pump.
+        rows = store.take_outbox(conn, session="route-a")
+        assert [r["content"] for r in rows] == ["for-a"]
 
     asyncio.run(run())
 


### PR DESCRIPTION
Job-completion channel events were broadcast to every consumer of the outbox, spamming foreign sessions with no-op turns.

**Root cause**: outbox rows carry no addressee and `take_outbox` is a destructive SELECT-all/DELETE-all, so any pump drains every event regardless of which connection spawned the job. The broadcast was incidental: the outbox shipped one-server-one-session (#1731) and the completion notify (#1856, for #1855) predates any session routing.

**Topology** (verified): the store is per-process by default (`runtime_dir()/store-<port>.db` on a random dashboard port, wiped each ephemeral serve) and each `ix-mcp serve` spawns its own kernel — no shared daemon. Cross-process spam therefore needs several serve processes pinned to one store (`IX_MCP_STORE` / `--session`), where racing pumps steal each other's rows. In-process Claude Code subagents share the parent's single stdio connection, so for that case the fix is the owner stamp in the notification meta: the client can attribute/filter events on the shared stream.

**Design**:
- Each serve process mints a routing id (`IX_MCP_ROUTE`), inherited by the kernel it spawns.
- Jobs are tagged at spawn: `Job.route` = the HTTP session id when present, else the process route. `Job.session` (the namespace selector) is untouched, so the stdio shared-namespace and checkpoint/restore contracts hold.
- `notify(session=...)` writes a new `outbox.session` column (added via the store's existing idempotent ALTER migration pattern) and stamps the owner into the channel meta.
- `pump_outbox` drains only unowned rows plus its own (`session IS NULL OR session = route`); unowned rows keep today's broadcast behavior. The `watch_pr` notifies are routed the same way.
- Owned rows whose owner never drains them are pruned after 1h (same discipline as the events feed), so a shared store cannot grow unbounded.
- Dashboard unaffected (reads `executions`, never `outbox`). `notify()` is the sole outbox writer; resource events use the separate `events` table and are untouched.

Follow-up: #2025 (wrong topic on notifications) is the same missing per-connection attribution and can now hang off `Job.route`/meta.

Closes #2071

(AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route job channel events to their spawning session in the MCP outbox
> - Adds a `session` column to the `outbox` table in [store.py](https://github.com/indexable-inc/index/pull/2084/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976) and migrates existing databases automatically.
> - Each MCP serve process sets a per-process `IX_MCP_ROUTE` env var (8-hex id) that the kernel inherits, identifying which connection owns its events.
> - `take_outbox` now filters by session: a pump receives broadcasts and its own rows, skips foreign-owned rows, and prunes stale foreign rows older than 1 hour.
> - `notify()` and `_runner` pass the job's route as the session so PR-watch and background completion events are delivered only to the originating connection.
> - Behavioral Change: `pump_outbox` in [transport.py](https://github.com/indexable-inc/index/pull/2084/files#diff-39ae84714e8a966882f8856c976f1ebce9f5fd42dac02f22e89e4cbc672e1675) now reads `IX_MCP_ROUTE` and passes it to `take_outbox`, meaning each pump only drains its own rows and broadcasts instead of all rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef79ac5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->