### PR TITLE
mirror: pitchy generated READMEs + derived per-mirror CHANGELOG.md

### DIFF
--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -40,6 +40,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history: each mirror's CHANGELOG.md is derived from `git log`
+          # over the package path, and the generator refuses a shallow clone
+          # rather than publish a silently truncated changelog.
+          fetch-depth: 0
 
       - name: Install Determinate Nix
         uses: ./.github/actions/install-nix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12133,24 +12133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unic-langid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
-dependencies = [
- "unic-langid-impl",
-]
-
-[[package]]
-name = "unic-langid-impl"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
-dependencies = [
- "tinystr",
-]
-
-[[package]]
 name = "unibind"
 version = "0.1.0"
 dependencies = [
@@ -12193,6 +12175,24 @@ dependencies = [
  "object",
  "serde_json",
  "unibind-core",
+]
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "tinystr",
 ]
 
 [[package]]

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -103,6 +103,13 @@
         if entry.mirror.homepage != null
         then entry.mirror.homepage
         else "https://github.com/${repoMetadataConfig.monorepo.repo}/tree/main/packages/${entry.relativePath}";
+      # The monorepo flake output attr (`nix run .#<attr>`) when the package
+      # is flake-exposed, so the generated mirror README can print a real run
+      # command instead of guessing.
+      flakeAttr =
+        if entry.flake != null
+        then entry.flake.attrName
+        else null;
     })
     packageRegistry.mirrorEntries;
   # Declarative GitHub About-sidebar metadata (description / homepage /

--- a/packages/mirror/README.md
+++ b/packages/mirror/README.md
@@ -55,19 +55,22 @@ tree:
   activates, but it never changes a version and never touches the network for
   resolution.
 - The README and changelog are generated, never hand-written per mirror
-  (house style: the `creating-a-readme` skill). The README: a symbolic
-  `.github/hero.svg` (name, tagline, deterministic mark; dark/light via CSS
-  `prefers-color-scheme` embedded in the SVG), the banner naming the mirror
-  a read-only generated artifact (exact monorepo tree link, issues/PRs to
-  the monorepo), a hook question and pitch from the declarative
-  `mirror.description` (crate `[package] description` as fallback), an
-  Install section derived from what the package *is* (flake-exposed ->
-  `nix run github:indexable-inc/index#<attr>`, binary -> `cargo install
-  --git`, library -> a git-dependency snippet), the package's own README
-  when it has one (duplicate title stripped; else a minimal generated Use
-  section), and a one-line pointer to `CHANGELOG.md`. Pass `gen`
-  `--mirror-json` (the rendered `.#lib.mirrorPackages`) to source the
-  repo/description/flake attr; `publish` resolves it automatically.
+  (house style: the `creating-a-readme` skill, which the generator conforms
+  to). A package with its own README leads the mirror with it verbatim --
+  the skill already makes it open with an `assets/hero.svg` and a hook, and
+  the assets ride along -- behind a banner naming the mirror a read-only
+  generated artifact (exact monorepo tree link, issues/PRs to the monorepo);
+  a derived Install section is appended only when the body has none
+  (flake-exposed -> `nix run github:indexable-inc/index#<attr>`, binary ->
+  `cargo install --git`, library -> a git-dependency snippet). A package
+  without a README gets the whole skill shape synthesized from metadata: a
+  generated `assets/hero.svg` (name, tagline, deterministic mark; dark/light
+  via CSS `prefers-color-scheme` embedded in the SVG), a hook question and
+  pitch from the declarative `mirror.description` (crate `[package]
+  description` fallback), Install, and a minimal Use section. Every README
+  ends with a one-line pointer to `CHANGELOG.md`. Pass `gen` `--mirror-json`
+  (the rendered `.#lib.mirrorPackages`) to source the repo/description/flake
+  attr; `publish` resolves it automatically.
 - `CHANGELOG.md` is derived from the monorepo commits that touched the
   package path (`git log -- packages/<pkg>`): Keep a Changelog section
   names picked from conventional-commit prefixes, grouped by month (a

--- a/packages/mirror/README.md
+++ b/packages/mirror/README.md
@@ -54,10 +54,27 @@ tree:
   a mirror's first `cargo build` may drop entries the mirrored crate never
   activates, but it never changes a version and never touches the network for
   resolution.
-- The README leads with a banner naming the mirror a read-only generated
-  artifact, linking the exact monorepo tree (path + commit) it came from and
-  pointing issues/PRs at the monorepo. Below it: the package's own README
-  when it has one, else a minimal generated body from the crate metadata.
+- The README and changelog are generated, never hand-written per mirror
+  (house style: the `creating-a-readme` skill). The README: a symbolic
+  `.github/hero.svg` (name, tagline, deterministic mark; dark/light via CSS
+  `prefers-color-scheme` embedded in the SVG), the banner naming the mirror
+  a read-only generated artifact (exact monorepo tree link, issues/PRs to
+  the monorepo), a hook question and pitch from the declarative
+  `mirror.description` (crate `[package] description` as fallback), an
+  Install section derived from what the package *is* (flake-exposed ->
+  `nix run github:indexable-inc/index#<attr>`, binary -> `cargo install
+  --git`, library -> a git-dependency snippet), the package's own README
+  when it has one (duplicate title stripped; else a minimal generated Use
+  section), and a one-line pointer to `CHANGELOG.md`. Pass `gen`
+  `--mirror-json` (the rendered `.#lib.mirrorPackages`) to source the
+  repo/description/flake attr; `publish` resolves it automatically.
+- `CHANGELOG.md` is derived from the monorepo commits that touched the
+  package path (`git log -- packages/<pkg>`): Keep a Changelog section
+  names picked from conventional-commit prefixes, grouped by month (a
+  mirror tracks the monorepo continuously; there are no versioned releases),
+  every entry linking its monorepo commit. It needs full history, so the
+  generator refuses a shallow clone and mirror-sync checks out with
+  `fetch-depth: 0`.
 
 `mirror publish --package packages/<path> [--create]` runs `gen` into a
 scratch directory, clones the mirror repo, swaps its working tree for the

--- a/packages/mirror/src/changelog.rs
+++ b/packages/mirror/src/changelog.rs
@@ -1,0 +1,232 @@
+//! The mirror changelog, derived mechanically from the monorepo commits that
+//! touched the package path (`git log -- packages/<pkg>`), never
+//! hand-maintained. Section names follow Keep a Changelog; entries are
+//! grouped by month because a mirror tracks the monorepo continuously and
+//! has no versioned releases to head the sections with. A
+//! conventional-commit prefix picks the section (feat -> Added, fix ->
+//! Fixed, ...); any other subject lands under Changed, unstripped.
+
+use std::fmt::Write as _;
+
+use crate::workspace::Change;
+
+pub struct Request<'a> {
+    /// Monorepo `owner/name`, e.g. `indexable-inc/index`.
+    pub monorepo: &'a str,
+    /// Repo-relative package path, e.g. `packages/progress-style`.
+    pub package_path: &'a str,
+    pub crate_name: &'a str,
+    /// Monorepo commits that touched `package_path`, newest first.
+    pub history: &'a [Change],
+}
+
+/// Keep a Changelog's section names, in its canonical order.
+const SECTIONS: [&str; 6] = [
+    "Added",
+    "Changed",
+    "Deprecated",
+    "Removed",
+    "Fixed",
+    "Security",
+];
+
+pub fn compose(request: &Request<'_>) -> String {
+    let Request {
+        monorepo,
+        package_path,
+        crate_name,
+        history,
+    } = *request;
+    let mut out = format!(
+        "# Changelog\n\n\
+         All notable changes to `{crate_name}`, derived mechanically from the \
+         [monorepo commits](https://github.com/{monorepo}/commits/main/{package_path}) that \
+         touched [`{package_path}`](https://github.com/{monorepo}/tree/main/{package_path}). \
+         Section names follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the \
+         mirror tracks the monorepo continuously, so entries are grouped by month instead of \
+         by release.\n"
+    );
+    for (month, changes) in by_month(history) {
+        let _ = write!(out, "\n## {month}\n");
+        for section in SECTIONS {
+            let entries: Vec<&&Change> = changes
+                .iter()
+                .filter(|change| classify(&change.subject).0 == section)
+                .collect();
+            if entries.is_empty() {
+                continue;
+            }
+            let _ = write!(out, "\n### {section}\n\n");
+            for change in entries {
+                out.push_str(&entry(monorepo, change));
+            }
+        }
+    }
+    out
+}
+
+/// Group by `YYYY-MM`, preserving the newest-first order of first
+/// appearance. Grouping (not splitting on month changes) keeps a month whole
+/// even when commit dates are not strictly monotonic.
+fn by_month(history: &[Change]) -> Vec<(&str, Vec<&Change>)> {
+    let mut months: Vec<(&str, Vec<&Change>)> = Vec::new();
+    for change in history {
+        let month = change.date.get(..7).unwrap_or(&change.date);
+        match months.iter_mut().find(|(existing, _)| *existing == month) {
+            Some((_, changes)) => changes.push(change),
+            None => months.push((month, vec![change])),
+        }
+    }
+    months
+}
+
+fn entry(monorepo: &str, change: &Change) -> String {
+    let (_, scope, rest) = classify(&change.subject);
+    let short = change.sha.get(..7).unwrap_or(&change.sha);
+    let mut text = String::new();
+    if let Some(scope) = scope {
+        let _ = write!(text, "{}: ", subject_markdown(monorepo, scope));
+    }
+    text.push_str(&subject_markdown(monorepo, rest));
+    format!(
+        "- {text} ([`{short}`](https://github.com/{monorepo}/commit/{}), {})\n",
+        change.sha, change.date
+    )
+}
+
+/// Map a subject to its Keep a Changelog section. Only a recognized
+/// conventional-commit type is stripped (its scope survives as a prefix);
+/// anything else keeps the whole subject, under Changed.
+fn classify(subject: &str) -> (&'static str, Option<&str>, &str) {
+    let Some((prefix, rest)) = subject.split_once(':') else {
+        return ("Changed", None, subject);
+    };
+    let prefix = prefix.trim_end_matches('!');
+    let (kind, scope) = match prefix.split_once('(') {
+        Some((kind, scope)) => match scope.strip_suffix(')') {
+            Some(scope) => (kind, Some(scope)),
+            None => return ("Changed", None, subject),
+        },
+        None => (prefix, None),
+    };
+    let Some(section) = section_for(kind) else {
+        return ("Changed", None, subject);
+    };
+    (section, scope, rest.trim_start())
+}
+
+fn section_for(kind: &str) -> Option<&'static str> {
+    Some(match kind {
+        "feat" => "Added",
+        "fix" => "Fixed",
+        "revert" => "Removed",
+        "build" | "chore" | "ci" | "docs" | "perf" | "refactor" | "style" | "test" => "Changed",
+        _ => return None,
+    })
+}
+
+/// A commit subject as safe inline markdown: formatting characters escaped
+/// so a subject cannot inject markup, and `#123` references linked to the
+/// monorepo (GitHub would otherwise autolink them to the mirror repo's own,
+/// meaningless, issue numbers).
+fn subject_markdown(monorepo: &str, subject: &str) -> String {
+    let mut out = String::with_capacity(subject.len());
+    let mut chars = subject.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' | '`' | '*' | '_' | '[' | ']' | '<' | '>' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            '#' if chars.peek().is_some_and(char::is_ascii_digit) => {
+                let mut number = String::new();
+                while let Some(digit) = chars.next_if(char::is_ascii_digit) {
+                    number.push(digit);
+                }
+                let _ = write!(
+                    out,
+                    "[#{number}](https://github.com/{monorepo}/issues/{number})"
+                );
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn change(sha: &str, date: &str, subject: &str) -> Change {
+        Change {
+            sha: sha.to_owned(),
+            date: date.to_owned(),
+            subject: subject.to_owned(),
+        }
+    }
+
+    fn render(history: &[Change]) -> String {
+        compose(&Request {
+            monorepo: "indexable-inc/index",
+            package_path: "packages/sqlmerge",
+            crate_name: "sqlmerge",
+            history,
+        })
+    }
+
+    #[test]
+    fn groups_by_month_then_keep_a_changelog_section() {
+        let history = [
+            change("a".repeat(40).as_str(), "2026-07-03", "feat(sqlmerge): add policies"),
+            change("b".repeat(40).as_str(), "2026-07-01", "fix: reject shallow merge"),
+            change("c".repeat(40).as_str(), "2026-06-20", "sqlmerge: initial import"),
+        ];
+        let out = render(&history);
+        let july = out.find("## 2026-07").expect("july section");
+        let june = out.find("## 2026-06").expect("june section");
+        assert!(july < june, "newest month first:\n{out}");
+        assert!(out.contains("### Added\n\n- sqlmerge: add policies"), "{out}");
+        assert!(out.contains("### Fixed\n\n- reject shallow merge"), "{out}");
+        // Not a conventional type: whole subject survives, under Changed.
+        assert!(out.contains("### Changed\n\n- sqlmerge: initial import"), "{out}");
+    }
+
+    #[test]
+    fn links_shas_and_monorepo_pull_references() {
+        let history = [change(
+            "0123456789abcdef0123456789abcdef01234567",
+            "2026-07-03",
+            "feat: land mirrors (#2022)",
+        )];
+        let out = render(&history);
+        assert!(
+            out.contains(
+                "[`0123456`](https://github.com/indexable-inc/index/commit/0123456789abcdef0123456789abcdef01234567)"
+            ),
+            "{out}"
+        );
+        assert!(
+            out.contains("[#2022](https://github.com/indexable-inc/index/issues/2022)"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn escapes_markdown_in_subjects() {
+        let history = [change("d".repeat(40).as_str(), "2026-07-03", "add [bracket] <tag>")];
+        let out = render(&history);
+        assert!(out.contains(r"add \[bracket\] \<tag\>"), "{out}");
+    }
+
+    #[test]
+    fn breaking_marker_and_malformed_scope_do_not_panic() {
+        let history = [
+            change("e".repeat(40).as_str(), "2026-07-03", "feat!: new wire format"),
+            change("f".repeat(40).as_str(), "2026-07-02", "fix(unclosed: scope"),
+        ];
+        let out = render(&history);
+        assert!(out.contains("### Added\n\n- new wire format"), "{out}");
+        assert!(out.contains(r"- fix(unclosed: scope"), "{out}");
+    }
+}

--- a/packages/mirror/src/changelog.rs
+++ b/packages/mirror/src/changelog.rs
@@ -46,12 +46,13 @@ pub fn compose(request: &Request<'_>) -> String {
          mirror tracks the monorepo continuously, so entries are grouped by month instead of \
          by release.\n"
     );
-    for (month, changes) in by_month(history) {
-        let _ = write!(out, "\n## {month}\n");
+    for group in by_month(history) {
+        let _ = write!(out, "\n## {}\n", group.month);
         for section in SECTIONS {
-            let entries: Vec<&&Change> = changes
+            let entries: Vec<&&Change> = group
+                .changes
                 .iter()
-                .filter(|change| classify(&change.subject).0 == section)
+                .filter(|change| classify(&change.subject).section == section)
                 .collect();
             if entries.is_empty() {
                 continue;
@@ -65,23 +66,33 @@ pub fn compose(request: &Request<'_>) -> String {
     out
 }
 
+/// One month of history, newest month first.
+struct MonthGroup<'a> {
+    /// `YYYY-MM`.
+    month: &'a str,
+    changes: Vec<&'a Change>,
+}
+
 /// Group by `YYYY-MM`, preserving the newest-first order of first
 /// appearance. Grouping (not splitting on month changes) keeps a month whole
 /// even when commit dates are not strictly monotonic.
-fn by_month(history: &[Change]) -> Vec<(&str, Vec<&Change>)> {
-    let mut months: Vec<(&str, Vec<&Change>)> = Vec::new();
+fn by_month(history: &[Change]) -> Vec<MonthGroup<'_>> {
+    let mut months: Vec<MonthGroup<'_>> = Vec::new();
     for change in history {
         let month = change.date.get(..7).unwrap_or(&change.date);
-        match months.iter_mut().find(|(existing, _)| *existing == month) {
-            Some((_, changes)) => changes.push(change),
-            None => months.push((month, vec![change])),
+        match months.iter_mut().find(|group| group.month == month) {
+            Some(group) => group.changes.push(change),
+            None => months.push(MonthGroup {
+                month,
+                changes: vec![change],
+            }),
         }
     }
     months
 }
 
 fn entry(monorepo: &str, change: &Change) -> String {
-    let (_, scope, rest) = classify(&change.subject);
+    let Classified { scope, rest, .. } = classify(&change.subject);
     let short = change.sha.get(..7).unwrap_or(&change.sha);
     let mut text = String::new();
     if let Some(scope) = scope {
@@ -94,25 +105,43 @@ fn entry(monorepo: &str, change: &Change) -> String {
     )
 }
 
+/// A subject sorted into its Keep a Changelog section.
+struct Classified<'a> {
+    section: &'static str,
+    /// Conventional-commit scope, kept as a prefix on the rendered entry.
+    scope: Option<&'a str>,
+    /// The subject with a recognized conventional-commit type stripped.
+    rest: &'a str,
+}
+
 /// Map a subject to its Keep a Changelog section. Only a recognized
 /// conventional-commit type is stripped (its scope survives as a prefix);
 /// anything else keeps the whole subject, under Changed.
-fn classify(subject: &str) -> (&'static str, Option<&str>, &str) {
+fn classify(subject: &str) -> Classified<'_> {
+    let unclassified = Classified {
+        section: "Changed",
+        scope: None,
+        rest: subject,
+    };
     let Some((prefix, rest)) = subject.split_once(':') else {
-        return ("Changed", None, subject);
+        return unclassified;
     };
     let prefix = prefix.trim_end_matches('!');
     let (kind, scope) = match prefix.split_once('(') {
         Some((kind, scope)) => match scope.strip_suffix(')') {
             Some(scope) => (kind, Some(scope)),
-            None => return ("Changed", None, subject),
+            None => return unclassified,
         },
         None => (prefix, None),
     };
     let Some(section) = section_for(kind) else {
-        return ("Changed", None, subject);
+        return unclassified;
     };
-    (section, scope, rest.trim_start())
+    Classified {
+        section,
+        scope,
+        rest: rest.trim_start(),
+    }
 }
 
 fn section_for(kind: &str) -> Option<&'static str> {

--- a/packages/mirror/src/generate.rs
+++ b/packages/mirror/src/generate.rs
@@ -12,13 +12,18 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 
 use crate::workspace::Workspace;
-use crate::{MONOREPO_SLUG, lockfile, manifest, readme};
+use crate::{MONOREPO_SLUG, changelog, lockfile, manifest, readme};
 
 pub struct Request<'a> {
     /// Repo-relative package path, e.g. `packages/progress-style`.
     pub package: &'a Path,
     pub out: &'a Path,
     pub mirror_repo: Option<&'a str>,
+    /// Pitch for the generated README (the resolved `mirror.description`);
+    /// `None` falls back to the crate's `[package] description`.
+    pub description: Option<&'a str>,
+    /// Monorepo flake output attr when the package is flake-exposed.
+    pub flake_attr: Option<&'a str>,
 }
 
 pub struct Generated {
@@ -38,6 +43,9 @@ pub fn run(workspace: &Workspace, request: &Request<'_>) -> Result<Generated> {
         name: crate_name,
         description,
     } = manifest::package_info(&primary_manifest)?;
+    // The declarative mirror metadata is the single source of truth for the
+    // pitch; the crate's own description is the fallback, never a second copy.
+    let description = request.description.map(str::to_owned).or(description);
     let internal = dependency_closure(workspace, &primary_manifest)?;
 
     ensure_empty(request.out)?;
@@ -95,18 +103,42 @@ pub fn run(workspace: &Workspace, request: &Request<'_>) -> Result<Generated> {
         .to_str()
         .context("package path is not UTF-8")?
         .trim_end_matches('/');
+
+    let history = workspace.package_history(package_path)?;
+    if !history.is_empty() {
+        fs::write(
+            request.out.join("CHANGELOG.md"),
+            changelog::compose(&changelog::Request {
+                monorepo: MONOREPO_SLUG,
+                package_path,
+                crate_name: &crate_name,
+                history: &history,
+            }),
+        )
+        .context("writing CHANGELOG.md")?;
+    }
+
+    let hero = request.out.join(readme::HERO_PATH);
+    fs::create_dir_all(hero.parent().context("hero path has a parent")?)
+        .context("creating the hero's directory")?;
+    fs::write(&hero, readme::hero_svg(&crate_name, description.as_deref()))
+        .context("writing the hero SVG")?;
+
     let existing = fs::read_to_string(package_dir.join("README.md")).ok();
-    let banner = readme::Banner {
+    let package = readme::Package {
         monorepo: MONOREPO_SLUG,
-        package_path,
+        path: package_path,
         commit: &workspace.head_commit()?,
         crate_name: &crate_name,
         description: description.as_deref(),
         mirror_repo: request.mirror_repo,
+        flake_attr: request.flake_attr,
+        has_binary: has_binary(&package_dir, &primary_manifest)?,
+        has_changelog: !history.is_empty(),
     };
     fs::write(
         request.out.join("README.md"),
-        readme::compose(&banner, existing.as_deref()),
+        readme::compose(&package, existing.as_deref()),
     )
     .context("writing README.md")?;
 
@@ -132,6 +164,15 @@ fn dependency_closure(workspace: &Workspace, primary: &str) -> Result<BTreeMap<S
         }
     }
     Ok(closure)
+}
+
+/// Whether the crate builds an executable: `src/main.rs`, a `src/bin/`
+/// directory (cargo's auto-discovered targets), or an explicit `[[bin]]`.
+fn has_binary(package_dir: &Path, manifest: &str) -> Result<bool> {
+    if package_dir.join("src/main.rs").is_file() || package_dir.join("src/bin").is_dir() {
+        return Ok(true);
+    }
+    manifest::declares_binary(manifest)
 }
 
 fn read_manifest(crate_dir: &Path) -> Result<String> {

--- a/packages/mirror/src/generate.rs
+++ b/packages/mirror/src/generate.rs
@@ -118,13 +118,6 @@ pub fn run(workspace: &Workspace, request: &Request<'_>) -> Result<Generated> {
         .context("writing CHANGELOG.md")?;
     }
 
-    let hero = request.out.join(readme::HERO_PATH);
-    fs::create_dir_all(hero.parent().context("hero path has a parent")?)
-        .context("creating the hero's directory")?;
-    fs::write(&hero, readme::hero_svg(&crate_name, description.as_deref()))
-        .context("writing the hero SVG")?;
-
-    let existing = fs::read_to_string(package_dir.join("README.md")).ok();
     let package = readme::Package {
         monorepo: MONOREPO_SLUG,
         path: package_path,
@@ -136,11 +129,7 @@ pub fn run(workspace: &Workspace, request: &Request<'_>) -> Result<Generated> {
         has_binary: has_binary(&package_dir, &primary_manifest)?,
         has_changelog: !history.is_empty(),
     };
-    fs::write(
-        request.out.join("README.md"),
-        readme::compose(&package, existing.as_deref()),
-    )
-    .context("writing README.md")?;
+    write_readme(request.out, &package_dir, &package)?;
 
     Ok(Generated {
         crate_name,
@@ -164,6 +153,27 @@ fn dependency_closure(workspace: &Workspace, primary: &str) -> Result<BTreeMap<S
         }
     }
     Ok(closure)
+}
+
+/// Compose the mirror README, synthesizing an `assets/hero.svg` first when
+/// the package ships no README of its own; a curated README references its
+/// own hero (already copied with the crate) per the creating-a-readme skill.
+fn write_readme(out: &Path, package_dir: &Path, package: &readme::Package<'_>) -> Result<()> {
+    let existing = fs::read_to_string(package_dir.join("README.md")).ok();
+    if existing.is_none() {
+        let hero = out.join(readme::HERO_PATH);
+        if !hero.exists() {
+            fs::create_dir_all(hero.parent().context("hero path has a parent")?)
+                .context("creating the hero's directory")?;
+            fs::write(&hero, readme::hero_svg(package.crate_name, package.description))
+                .context("writing the hero SVG")?;
+        }
+    }
+    fs::write(
+        out.join("README.md"),
+        readme::compose(package, existing.as_deref()),
+    )
+    .context("writing README.md")
 }
 
 /// Whether the crate builds an executable: `src/main.rs`, a `src/bin/`

--- a/packages/mirror/src/main.rs
+++ b/packages/mirror/src/main.rs
@@ -13,11 +13,13 @@
 //!
 //! CI drives both from `.github/workflows/mirror-sync.yml`.
 
+mod changelog;
 mod exec;
 mod fork;
 mod generate;
 mod lockfile;
 mod manifest;
+mod mirrors;
 mod publish;
 mod readme;
 mod workspace;
@@ -59,6 +61,12 @@ enum Command {
         /// Mirror repo `owner/name`, named in the generated README banner.
         #[arg(long)]
         repo: Option<String>,
+        /// Mirror manifest as a JSON file (the rendered `.#lib.mirrorPackages`
+        /// list), sourcing the repo, description, and flake attr for the
+        /// generated README; without it the README falls back to the crate's
+        /// own metadata (`publish` always resolves the manifest itself).
+        #[arg(long)]
+        mirror_json: Option<PathBuf>,
     },
     /// Generate a package's tree and snapshot-sync it into its mirror repo.
     Publish {
@@ -99,13 +107,26 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     let workspace = Workspace::locate(cli.root.as_deref())?;
     match cli.command {
-        Command::Gen { package, out, repo } => {
+        Command::Gen {
+            package,
+            out,
+            repo,
+            mirror_json,
+        } => {
+            let entry = mirror_json
+                .as_deref()
+                .map(|json| mirrors::entry_for(&workspace, &package, Some(json)))
+                .transpose()?;
             let generated = generate::run(
                 &workspace,
                 &generate::Request {
                     package: &package,
                     out: &out,
-                    mirror_repo: repo.as_deref(),
+                    mirror_repo: repo
+                        .as_deref()
+                        .or_else(|| entry.as_ref().map(|entry| entry.repo.as_str())),
+                    description: entry.as_ref().and_then(|entry| entry.description.as_deref()),
+                    flake_attr: entry.as_ref().and_then(|entry| entry.flake_attr.as_deref()),
                 },
             )?;
             println!(

--- a/packages/mirror/src/manifest.rs
+++ b/packages/mirror/src/manifest.rs
@@ -97,6 +97,12 @@ pub fn inherited_dependency_names(manifest: &str) -> Result<Vec<String>> {
     Ok(names)
 }
 
+/// Whether the manifest declares an explicit `[[bin]]` target.
+pub fn declares_binary(manifest: &str) -> Result<bool> {
+    let doc: DocumentMut = manifest.parse().context("parsing member Cargo.toml")?;
+    Ok(doc.get("bin").is_some())
+}
+
 /// The `name` and `description` of a manifest's `[package]`.
 pub struct PackageInfo {
     pub name: String,

--- a/packages/mirror/src/mirrors.rs
+++ b/packages/mirror/src/mirrors.rs
@@ -1,0 +1,77 @@
+//! Access to the rendered `.#lib.mirrorPackages` manifest: the declarative
+//! per-package mirror metadata (repo, description, topics, flake attr) that
+//! `mirror` attrs in package.nix render to. The single source of truth for
+//! everything curated about a mirror; the generator derives the rest.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::exec;
+use crate::workspace::Workspace;
+
+pub struct Entry {
+    /// Repo-relative package path, e.g. `packages/progress-style`.
+    pub path: String,
+    /// Mirror repo `owner/name`.
+    pub repo: String,
+    pub description: Option<String>,
+    pub topics: Vec<String>,
+    /// Monorepo flake output attr when the package is flake-exposed.
+    pub flake_attr: Option<String>,
+}
+
+/// The manifest entry for `package`, from `json` when given, else by
+/// rendering `.#lib.mirrorPackages` with `nix eval`. Loud when the package
+/// has no entry: without one there is no mirror to generate for.
+pub fn entry_for(workspace: &Workspace, package: &Path, json: Option<&Path>) -> Result<Entry> {
+    let package = package.to_str().context("package path is not UTF-8")?;
+    let package = package.trim_end_matches('/');
+    load(workspace, json)?
+        .into_iter()
+        .find(|entry| entry.path == package)
+        .with_context(|| format!("`{package}` has no `mirror` attr in its package.nix"))
+}
+
+fn load(workspace: &Workspace, json: Option<&Path>) -> Result<Vec<Entry>> {
+    let text = match json {
+        Some(path) => {
+            fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?
+        }
+        None => exec::run(
+            &workspace.root,
+            "nix",
+            &["eval", "--json", ".#lib.mirrorPackages"],
+        )?,
+    };
+    let value: Value = serde_json::from_str(&text).context("parsing mirrorPackages JSON")?;
+    value
+        .as_array()
+        .context("mirrorPackages JSON is not a list")?
+        .iter()
+        .map(parse)
+        .collect()
+}
+
+fn parse(value: &Value) -> Result<Entry> {
+    let field = |key: &str| value.get(key).and_then(Value::as_str).map(str::to_owned);
+    Ok(Entry {
+        path: field("path").context("mirror entry without `path`")?,
+        repo: field("repo").context("mirror entry without `repo`")?,
+        description: field("description"),
+        flake_attr: field("flakeAttr"),
+        topics: value
+            .get("topics")
+            .and_then(Value::as_array)
+            .map(|topics| {
+                topics
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_owned)
+                    .collect()
+            })
+            .unwrap_or_default(),
+    })
+}

--- a/packages/mirror/src/publish.rs
+++ b/packages/mirror/src/publish.rs
@@ -9,10 +9,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use serde_json::Value;
 
 use crate::workspace::Workspace;
-use crate::{MONOREPO_SLUG, exec, generate, manifest};
+use crate::{MONOREPO_SLUG, exec, generate, manifest, mirrors};
 
 pub struct Request {
     /// Repo-relative package path, e.g. `packages/progress-style`.
@@ -28,6 +27,7 @@ struct Target {
     repo: Option<String>,
     description: Option<String>,
     topics: Vec<String>,
+    flake_attr: Option<String>,
 }
 
 pub fn run(workspace: &Workspace, request: &Request) -> Result<()> {
@@ -41,6 +41,8 @@ pub fn run(workspace: &Workspace, request: &Request) -> Result<()> {
             package: &request.package,
             out: &tree,
             mirror_repo: target.repo.as_deref(),
+            description: target.description.as_deref(),
+            flake_attr: target.flake_attr.as_deref(),
         },
     )?;
 
@@ -109,6 +111,7 @@ fn configured_target(workspace: &Workspace, request: &Request) -> Result<Target>
             repo: request.repo.clone(),
             description: None,
             topics: Vec::new(),
+            flake_attr: None,
         });
     }
     if let Some(repo) = &request.repo {
@@ -117,40 +120,16 @@ fn configured_target(workspace: &Workspace, request: &Request) -> Result<Target>
             repo: Some(repo.clone()),
             description: None,
             topics: Vec::new(),
+            flake_attr: None,
         });
     }
-    let entries = mirror_entries(workspace, request.mirror_json.as_deref())?;
-    let package = request
-        .package
-        .to_str()
-        .context("package path is not UTF-8")?;
-    let entry = entries
-        .iter()
-        .find(|entry| entry.get("path").and_then(Value::as_str) == Some(package))
-        .with_context(|| format!("`{package}` has no `mirror` attr in its package.nix"))?;
-    let repo = entry
-        .get("repo")
-        .and_then(Value::as_str)
-        .context("mirror entry without `repo`")?
-        .to_owned();
+    let entry = mirrors::entry_for(workspace, &request.package, request.mirror_json.as_deref())?;
     Ok(Target {
-        remote_url: format!("https://github.com/{repo}.git"),
-        repo: Some(repo),
-        description: entry
-            .get("description")
-            .and_then(Value::as_str)
-            .map(str::to_owned),
-        topics: entry
-            .get("topics")
-            .and_then(Value::as_array)
-            .map(|topics| {
-                topics
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .map(str::to_owned)
-                    .collect()
-            })
-            .unwrap_or_default(),
+        remote_url: format!("https://github.com/{}.git", entry.repo),
+        repo: Some(entry.repo),
+        description: entry.description,
+        topics: entry.topics,
+        flake_attr: entry.flake_attr,
     })
 }
 
@@ -159,24 +138,6 @@ fn crate_description(workspace: &Workspace, package: &Path) -> Result<Option<Str
     let path = workspace.root.join(package).join("Cargo.toml");
     let text = fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
     Ok(manifest::package_info(&text)?.description)
-}
-
-fn mirror_entries(workspace: &Workspace, json: Option<&Path>) -> Result<Vec<Value>> {
-    let text = match json {
-        Some(path) => {
-            fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?
-        }
-        None => exec::run(
-            &workspace.root,
-            "nix",
-            &["eval", "--json", ".#lib.mirrorPackages"],
-        )?,
-    };
-    let value: Value = serde_json::from_str(&text).context("parsing mirrorPackages JSON")?;
-    value
-        .as_array()
-        .cloned()
-        .context("mirrorPackages JSON is not a list")
 }
 
 fn clone_or_create(

--- a/packages/mirror/src/readme.rs
+++ b/packages/mirror/src/readme.rs
@@ -1,21 +1,23 @@
-//! The mirror README, composed to the house README style (the
-//! `creating-a-readme` skill, in flight on a sibling branch as of this
-//! writing): a symbolic SVG hero up top that adapts to dark/light via CSS
-//! `prefers-color-scheme` embedded in the SVG, then a hook question, a short
-//! plain-language pitch, install, usage, and a one-line pointer to the
-//! derived changelog. A banner still declares the repo a read-only generated
-//! mirror. Everything is derived, nothing hand-maintained per mirror: the
-//! pitch is the declarative `mirror.description` (falling back to the
-//! crate's own `[package] description`), install/use branch on what the
-//! package *is* (flake-exposed? binary? library?), and the deep
-//! documentation is the package's own README.
+//! The mirror README, composed to the house README style
+//! (packages/agent/skills/creating-a-readme/SKILL.md, the single source of
+//! truth the skill says generators conform to). A package with its own
+//! README leads the mirror with it verbatim -- the skill already makes it
+//! open with an `assets/hero.svg` and a hook question, and the skill's
+//! mirror checklist requires it to make sense standalone -- behind a banner
+//! declaring the repo a read-only generated mirror; a derived Install
+//! section is appended only when the body has none. A package without a
+//! README gets the whole skill shape synthesized from metadata: hero, hook,
+//! pitch (the declarative `mirror.description`, falling back to the crate's
+//! `[package] description`), Install branched on what the package *is*
+//! (flake-exposed? binary? library?), and a minimal Use section. Nothing is
+//! hand-maintained per mirror.
 
 use std::fmt::Write as _;
 
-/// Where the generated hero lands in the mirror tree: outside the crate's
-/// own sources (a package may legitimately own an `assets/` directory) and
-/// where GitHub tooling conventionally keeps repo-page furniture.
-pub const HERO_PATH: &str = ".github/hero.svg";
+/// Where a hero lives relative to its README (the skill's convention), both
+/// for a package-committed hero riding into the mirror and for the one this
+/// module synthesizes.
+pub const HERO_PATH: &str = "assets/hero.svg";
 
 pub struct Package<'a> {
     /// Monorepo `owner/name`, e.g. `indexable-inc/index`.
@@ -40,24 +42,27 @@ pub struct Package<'a> {
 }
 
 pub fn compose(pkg: &Package<'_>, existing: Option<&str>) -> String {
-    let body = existing.map(without_title);
-    // A curated README usually opens by restating the package description;
-    // repeating the metadata pitch right above it would be pure duplication,
-    // so the pitch paragraph yields to the body's own opening (the hook, and
-    // the hero tagline, still come from the metadata).
-    let pitch = pkg.description.filter(|description| {
-        !body.is_some_and(|body| restates(body, description))
-    });
-    let mut sections = vec![
-        format!("![{}]({HERO_PATH})", pkg.crate_name),
-        banner(pkg),
-        lead(pkg, pitch),
-        install(pkg),
-    ];
-    match body {
-        Some(body) => sections.push(body.to_owned()),
-        None => sections.push(usage(pkg)),
-    }
+    // A curated README already opens with its own hero and hook (the
+    // creating-a-readme skill), so behind the banner the generator adds only
+    // what the package cannot know about itself.
+    let mut sections = existing.map_or_else(
+        || {
+            vec![
+                hero_reference(pkg),
+                banner(pkg),
+                lead(pkg),
+                install(pkg),
+                usage(pkg),
+            ]
+        },
+        |body| {
+            let mut sections = vec![banner(pkg), body.to_owned()];
+            if !has_install(body) {
+                sections.push(install(pkg));
+            }
+            sections
+        },
+    );
     if pkg.has_changelog {
         sections.push(format!(
             "Changes: [CHANGELOG.md](CHANGELOG.md), derived from the \
@@ -70,6 +75,23 @@ pub fn compose(pkg: &Package<'_>, existing: Option<&str>) -> String {
         .map(|section| format!("{}\n", section.trim_end()))
         .collect();
     sections.join("\n")
+}
+
+/// Whether the body already tells the reader how to get the package (a
+/// skill-conformant README derives its own install lines); an older body
+/// without any gets the generated section appended.
+fn has_install(body: &str) -> bool {
+    body.contains("cargo install")
+        || body.contains("nix run github:")
+        || body.contains("{ git = ")
+}
+
+fn hero_reference(pkg: &Package<'_>) -> String {
+    let alt = pkg.description.unwrap_or(pkg.crate_name);
+    format!(
+        "<p align=\"center\"><img src=\"{HERO_PATH}\" width=\"720\" alt=\"{}\"></p>",
+        xml_escape(alt)
+    )
 }
 
 fn banner(pkg: &Package<'_>) -> String {
@@ -96,13 +118,10 @@ fn banner(pkg: &Package<'_>) -> String {
     )
 }
 
-fn lead(pkg: &Package<'_>, pitch: Option<&str>) -> String {
+fn lead(pkg: &Package<'_>) -> String {
     let mut out = format!("# {}\n", pkg.crate_name);
     if let Some(description) = pkg.description {
-        let _ = write!(out, "\n**{}**\n", hook(description, pkg));
-    }
-    if let Some(pitch) = pitch {
-        let _ = write!(out, "\n{pitch}\n");
+        let _ = write!(out, "\n**{}**\n\n{description}\n", hook(description, pkg));
     }
     out
 }
@@ -188,77 +207,12 @@ fn usage(pkg: &Package<'_>) -> String {
     }
 }
 
-/// Whether `body` opens by restating `description`: their normalized forms
-/// (markdown markup and link targets dropped, whitespace collapsed, a
-/// leading "the" ignored, lowercased) share the first 40 characters.
-fn restates(body: &str, description: &str) -> bool {
-    const PREFIX: usize = 40;
-    let body = normalize(body);
-    let description = normalize(description);
-    let prefix: String = description.chars().take(PREFIX).collect();
-    !prefix.is_empty() && body.starts_with(&prefix)
-}
-
-fn normalize(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut chars = text.chars();
-    let mut was_space = true;
-    while let Some(ch) = chars.next() {
-        match ch {
-            '[' | ']' | '`' | '*' | '_' => {}
-            // A link target right after its text: `](url)` had its `]`
-            // dropped above, so strip the parenthesized URL too.
-            '(' => {
-                let mut group = String::new();
-                for inner in chars.by_ref() {
-                    if inner == ')' {
-                        break;
-                    }
-                    group.push(inner);
-                }
-                if !group.contains("://") {
-                    out.push('(');
-                    out.push_str(&group);
-                    out.push(')');
-                    was_space = false;
-                }
-            }
-            _ if ch.is_whitespace() => {
-                if !was_space {
-                    out.push(' ');
-                }
-                was_space = true;
-            }
-            _ => {
-                out.extend(ch.to_lowercase());
-                was_space = false;
-            }
-        }
-    }
-    let out = out.trim_end();
-    out.strip_prefix("the ")
-        .map_or_else(|| out.to_owned(), str::to_owned)
-}
-
-/// Drop a package README's leading `# <title>` line (it duplicates the hero
-/// and the generated heading) plus the blank lines after it; everything else
-/// is the package author's.
-fn without_title(body: &str) -> &str {
-    let Some(rest) = body.strip_prefix("# ") else {
-        return body;
-    };
-    let after = rest.split_once('\n').map_or("", |(_, after)| after);
-    after.trim_start_matches('\n')
-}
-
-/// The symbolic hero: crate name and tagline in monospace with a
-/// deterministic geometric mark derived from the crate name (same name, same
-/// mark; no per-package art to maintain). Dark/light adapts via CSS
-/// `prefers-color-scheme` embedded in the SVG, the one mechanism that works
-/// for a README `<img>` on GitHub without maintaining two images.
+/// The synthesized hero for a package that ships neither a README nor its
+/// own `assets/hero.svg`: crate name and tagline with a deterministic
+/// geometric mark derived from the crate name (same name, same mark; no
+/// per-package art to maintain). One SVG adapts to dark/light via its
+/// embedded `prefers-color-scheme` CSS, per the creating-a-readme skill.
 pub fn hero_svg(name: &str, tagline: Option<&str>) -> String {
-    const MONO: &str =
-        "ui-monospace, 'SFMono-Regular', 'Cascadia Mono', Menlo, Consolas, monospace";
     let hash = fnv1a(name.as_bytes());
     let hue = hash % 360;
     let mut marks = String::new();
@@ -267,7 +221,7 @@ pub fn hero_svg(name: &str, tagline: Option<&str>) -> String {
         let y = 58 + cell.row * 34;
         let _ = writeln!(
             marks,
-            "  <rect class=\"mark\" x=\"{x}\" y=\"{y}\" width=\"26\" height=\"26\" rx=\"7\"/>"
+            "  <rect class=\"accent\" x=\"{x}\" y=\"{y}\" width=\"26\" height=\"26\" rx=\"7\"/>"
         );
     }
     // A long name shrinks instead of overflowing the fixed viewBox.
@@ -282,24 +236,26 @@ pub fn hero_svg(name: &str, tagline: Option<&str>) -> String {
         let y = 138 + 30 * index;
         let _ = writeln!(
             tags,
-            "  <text class=\"tag\" x=\"160\" y=\"{y}\">{}</text>",
+            "  <text class=\"muted\" font-size=\"22\" x=\"160\" y=\"{y}\">{}</text>",
             xml_escape(line)
         );
     }
     format!(
-        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 880 220\" role=\"img\" aria-label=\"{name}\">\n\
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 880 220\" role=\"img\" aria-label=\"{name}\"\n\
+         \x20    font-family=\"system-ui, -apple-system, 'Segoe UI', sans-serif\">\n\
          <title>{name}</title>\n\
          <style>\n\
-         .name {{ font: 700 {name_size}px {MONO}; fill: #1f2328; }}\n\
-         .tag {{ font: 400 22px {MONO}; fill: #59636e; }}\n\
-         .mark {{ fill: hsl({hue} 70% 45%); }}\n\
+         svg {{ color: #1f2328; }}\n\
+         text {{ fill: currentColor; }}\n\
+         .muted {{ fill: #656d76; }}\n\
+         .accent {{ fill: hsl({hue} 70% 45%); }}\n\
          @media (prefers-color-scheme: dark) {{\n\
-         .name {{ fill: #f0f6fc; }}\n\
-         .tag {{ fill: #9198a1; }}\n\
-         .mark {{ fill: hsl({hue} 75% 65%); }}\n\
+         svg {{ color: #e6edf3; }}\n\
+         .muted {{ fill: #8b949e; }}\n\
+         .accent {{ fill: hsl({hue} 75% 65%); }}\n\
          }}\n\
          </style>\n\
-         {marks}  <text class=\"name\" x=\"160\" y=\"104\">{escaped}</text>\n\
+         {marks}  <text font-size=\"{name_size}\" font-weight=\"700\" x=\"160\" y=\"104\">{escaped}</text>\n\
          {tags}</svg>\n",
         name = xml_escape(name),
         escaped = xml_escape(name),
@@ -397,9 +353,12 @@ mod tests {
     }
 
     #[test]
-    fn hero_then_banner_lead_the_readme() {
+    fn synthesized_readme_leads_hero_then_banner() {
         let out = compose(&package(), None);
-        assert!(out.starts_with("![progress-style](.github/hero.svg)\n"), "{out}");
+        assert!(
+            out.starts_with("<p align=\"center\"><img src=\"assets/hero.svg\" width=\"720\""),
+            "{out}"
+        );
         assert!(
             out.contains(
                 "https://github.com/indexable-inc/index/tree/0123456789abcdef0123456789abcdef01234567/packages/progress-style"
@@ -460,29 +419,27 @@ mod tests {
     }
 
     #[test]
-    fn existing_body_rides_along_without_its_duplicate_title() {
-        let out = compose(&package(), Some("# progress-style\n\nHand-written body.\n"));
-        assert!(!out.contains("# progress-style\n\nHand-written"), "{out}");
-        assert!(out.ends_with("Hand-written body.\n\nChanges: [CHANGELOG.md](CHANGELOG.md), derived from the [monorepo history](https://github.com/indexable-inc/index/commits/main/packages/progress-style) of the package.\n"), "{out}");
-    }
-
-    #[test]
-    fn pitch_yields_to_a_body_that_restates_it() {
-        let body = "# progress-style\n\nThe shared [`indicatif`](https://docs.rs/indicatif) styling for ix tools, so every CLI\nmatches: one owner for the glyphs.\n";
+    fn curated_body_rides_verbatim_behind_the_banner() {
+        let body = "<p align=\"center\"><img src=\"assets/hero.svg\"></p>\n\n# sqlmerge\n\n\
+                    Ever needed this? A pitch.\n\n## Get it\n\n```sh\ncargo install --git x\n```\n";
         let out = compose(&package(), Some(body));
-        assert!(
-            out.contains("**Shared indicatif styling for ix tools: one dependency line away?**"),
-            "{out}"
-        );
-        assert_eq!(out.matches("styling for ix tools").count(), 2, "hook + body only:\n{out}");
-        assert!(!out.contains("so every CLI matches."), "metadata pitch dropped:\n{out}");
+        assert!(out.starts_with("> [!NOTE]\n"), "banner first:\n{out}");
+        assert!(out.contains(body.trim_end()), "body verbatim:\n{out}");
+        // The body derives its own install lines; no generated section.
+        assert!(!out.contains("## Install"), "{out}");
+        assert!(out.ends_with(
+            "Changes: [CHANGELOG.md](CHANGELOG.md), derived from the [monorepo history](https://github.com/indexable-inc/index/commits/main/packages/progress-style) of the package.\n"
+        ), "{out}");
     }
 
     #[test]
-    fn pitch_stays_when_the_body_opens_differently() {
-        let out = compose(&package(), Some("# progress-style\n\nDeep dive into the styling system.\n"));
+    fn install_is_appended_when_the_body_has_none() {
+        let out = compose(&package(), Some("# progress-style\n\nUsage docs only.\n"));
+        assert!(out.contains("## Install"), "{out}");
         assert!(
-            out.contains("Shared indicatif styling for ix tools, so every CLI matches."),
+            out.contains(
+                "progress-style = { git = \"https://github.com/indexable-inc/progress-style\" }"
+            ),
             "{out}"
         );
     }
@@ -501,9 +458,10 @@ mod tests {
     fn hero_svg_adapts_via_prefers_color_scheme_and_escapes() {
         let svg = hero_svg("a<b", Some("styling & \"quotes\""));
         assert!(svg.contains("@media (prefers-color-scheme: dark)"), "{svg}");
+        assert!(svg.contains("text { fill: currentColor; }"), "{svg}");
         assert!(svg.contains("a&lt;b"), "{svg}");
         assert!(svg.contains("styling &amp; &quot;quotes&quot;"), "{svg}");
-        assert!(svg.contains("class=\"mark\""), "{svg}");
+        assert!(svg.contains("class=\"accent\""), "{svg}");
         assert_eq!(svg, hero_svg("a<b", Some("styling & \"quotes\"")), "deterministic");
     }
 }

--- a/packages/mirror/src/readme.rs
+++ b/packages/mirror/src/readme.rs
@@ -262,9 +262,9 @@ pub fn hero_svg(name: &str, tagline: Option<&str>) -> String {
     let hash = fnv1a(name.as_bytes());
     let hue = hash % 360;
     let mut marks = String::new();
-    for (col, row) in mark_cells(hash) {
-        let x = 44 + col * 34;
-        let y = 58 + row * 34;
+    for cell in mark_cells(hash) {
+        let x = 44 + cell.col * 34;
+        let y = 58 + cell.row * 34;
         let _ = writeln!(
             marks,
             "  <rect class=\"mark\" x=\"{x}\" y=\"{y}\" width=\"26\" height=\"26\" rx=\"7\"/>"
@@ -306,22 +306,28 @@ pub fn hero_svg(name: &str, tagline: Option<&str>) -> String {
     )
 }
 
+/// One filled cell of the hero mark's 3x3 grid.
+struct Cell {
+    col: u64,
+    row: u64,
+}
+
 /// A 3x3 grid mirrored around its vertical axis (symmetry reads as a mark,
 /// raw bits read as noise): bits 0-2 fill the outer columns per row, bits
 /// 3-5 the middle column; a hash with none set gets the center cell.
-fn mark_cells(hash: u64) -> Vec<(u64, u64)> {
+fn mark_cells(hash: u64) -> Vec<Cell> {
     let mut cells = Vec::new();
     for row in 0..3 {
         if hash >> row & 1 == 1 {
-            cells.push((0, row));
-            cells.push((2, row));
+            cells.push(Cell { col: 0, row });
+            cells.push(Cell { col: 2, row });
         }
         if hash >> (3 + row) & 1 == 1 {
-            cells.push((1, row));
+            cells.push(Cell { col: 1, row });
         }
     }
     if cells.is_empty() {
-        cells.push((1, 1));
+        cells.push(Cell { col: 1, row: 1 });
     }
     cells
 }

--- a/packages/mirror/src/readme.rs
+++ b/packages/mirror/src/readme.rs
@@ -1,54 +1,372 @@
-//! The mirror README: a banner at the top declaring the repo a read-only
-//! generated mirror (source of truth, exact monorepo tree link, where to file
-//! issues/PRs), followed by the package's own README when it has one, or a
-//! minimal generated body when it does not.
+//! The mirror README, composed to the house README style (the
+//! `creating-a-readme` skill, in flight on a sibling branch as of this
+//! writing): a symbolic SVG hero up top that adapts to dark/light via CSS
+//! `prefers-color-scheme` embedded in the SVG, then a hook question, a short
+//! plain-language pitch, install, usage, and a one-line pointer to the
+//! derived changelog. A banner still declares the repo a read-only generated
+//! mirror. Everything is derived, nothing hand-maintained per mirror: the
+//! pitch is the declarative `mirror.description` (falling back to the
+//! crate's own `[package] description`), install/use branch on what the
+//! package *is* (flake-exposed? binary? library?), and the deep
+//! documentation is the package's own README.
 
-pub struct Banner<'a> {
+use std::fmt::Write as _;
+
+/// Where the generated hero lands in the mirror tree: outside the crate's
+/// own sources (a package may legitimately own an `assets/` directory) and
+/// where GitHub tooling conventionally keeps repo-page furniture.
+pub const HERO_PATH: &str = ".github/hero.svg";
+
+pub struct Package<'a> {
     /// Monorepo `owner/name`, e.g. `indexable-inc/index`.
     pub monorepo: &'a str,
     /// Repo-relative package path, e.g. `packages/progress-style`.
-    pub package_path: &'a str,
+    pub path: &'a str,
     /// Monorepo commit the tree was generated from (full sha).
     pub commit: &'a str,
     pub crate_name: &'a str,
+    /// The pitch: `mirror.description` when the caller resolved the mirror
+    /// manifest, else the crate's `[package] description`.
     pub description: Option<&'a str>,
     /// The mirror repo's own `owner/name`, when known.
     pub mirror_repo: Option<&'a str>,
+    /// The monorepo flake output attr (`nix run .#<attr>`) when the package
+    /// is exposed on the flake.
+    pub flake_attr: Option<&'a str>,
+    /// The crate builds an executable (`src/main.rs`, `src/bin/`, `[[bin]]`).
+    pub has_binary: bool,
+    /// A generated `CHANGELOG.md` sits next to the README.
+    pub has_changelog: bool,
 }
 
-pub fn compose(banner: &Banner<'_>, existing: Option<&str>) -> String {
-    let Banner {
+pub fn compose(pkg: &Package<'_>, existing: Option<&str>) -> String {
+    let body = existing.map(without_title);
+    // A curated README usually opens by restating the package description;
+    // repeating the metadata pitch right above it would be pure duplication,
+    // so the pitch paragraph yields to the body's own opening (the hook, and
+    // the hero tagline, still come from the metadata).
+    let pitch = pkg.description.filter(|description| {
+        !body.is_some_and(|body| restates(body, description))
+    });
+    let mut sections = vec![
+        format!("![{}]({HERO_PATH})", pkg.crate_name),
+        banner(pkg),
+        lead(pkg, pitch),
+        install(pkg),
+    ];
+    match body {
+        Some(body) => sections.push(body.to_owned()),
+        None => sections.push(usage(pkg)),
+    }
+    if pkg.has_changelog {
+        sections.push(format!(
+            "Changes: [CHANGELOG.md](CHANGELOG.md), derived from the \
+             [monorepo history](https://github.com/{}/commits/main/{}) of the package.",
+            pkg.monorepo, pkg.path
+        ));
+    }
+    let sections: Vec<String> = sections
+        .iter()
+        .map(|section| format!("{}\n", section.trim_end()))
+        .collect();
+    sections.join("\n")
+}
+
+fn banner(pkg: &Package<'_>) -> String {
+    let Package {
         monorepo,
-        package_path,
+        path,
         commit,
-        crate_name,
-        description,
         mirror_repo,
-    } = *banner;
+        ..
+    } = *pkg;
     let short = commit.get(..12).unwrap_or(commit);
     let subject = mirror_repo.map_or_else(
         || "This repository".to_owned(),
         |repo| format!("[`{repo}`](https://github.com/{repo})"),
     );
-    let mut out = format!(
+    format!(
         "> [!NOTE]\n\
          > {subject} is a read-only mirror, generated from \
-         [`{package_path}`](https://github.com/{monorepo}/tree/{commit}/{package_path}) in \
+         [`{path}`](https://github.com/{monorepo}/tree/{commit}/{path}) in \
          [`{monorepo}`](https://github.com/{monorepo}) at commit `{short}`. \
          The monorepo is the source of truth: please open issues and pull requests \
          [there](https://github.com/{monorepo}). This mirror is regenerated automatically; \
-         anything pushed directly here will be overwritten.\n\n"
-    );
-    if let Some(body) = existing {
-        out.push_str(body);
+         anything pushed directly here will be overwritten."
+    )
+}
+
+fn lead(pkg: &Package<'_>, pitch: Option<&str>) -> String {
+    let mut out = format!("# {}\n", pkg.crate_name);
+    if let Some(description) = pkg.description {
+        let _ = write!(out, "\n**{}**\n", hook(description, pkg));
+    }
+    if let Some(pitch) = pitch {
+        let _ = write!(out, "\n{pitch}\n");
+    }
+    out
+}
+
+/// The opening hook: the description's leading clause recast as a question
+/// about how little it takes to adopt the package. Mechanical on purpose:
+/// the curation lives in the declarative `mirror.description` (one source of
+/// truth), and the clause split leans on the house description shape
+/// ("What it is: how/why.").
+fn hook(description: &str, pkg: &Package<'_>) -> String {
+    let clause = description
+        .split_once(": ")
+        .map_or(description, |(clause, _)| clause);
+    let clause = clause.split_once(". ").map_or(clause, |(clause, _)| clause);
+    // A trailing purpose clause ("..., so every CLI matches") is the part a
+    // hook drops; a clause that is still a long sentence keeps its first limb.
+    let clause = clause.split_once(", so ").map_or(clause, |(clause, _)| clause);
+    let clause = if clause.len() > 72 {
+        clause.split_once(", ").map_or(clause, |(clause, _)| clause)
     } else {
-        out.push_str("# ");
-        out.push_str(crate_name);
-        out.push('\n');
-        if let Some(description) = description {
-            out.push('\n');
-            out.push_str(description);
-            out.push('\n');
+        clause
+    };
+    let clause = clause.trim_end_matches('.');
+    let tail = if pkg.flake_attr.is_some() && pkg.has_binary {
+        "one `nix run` away?"
+    } else if pkg.has_binary {
+        "one `cargo install` away?"
+    } else {
+        "one dependency line away?"
+    };
+    format!("{clause}: {tail}")
+}
+
+fn install(pkg: &Package<'_>) -> String {
+    let mut out = String::from("## Install\n");
+    let git_url = pkg.mirror_repo.map_or_else(
+        || format!("https://github.com/{}", pkg.monorepo),
+        |repo| format!("https://github.com/{repo}"),
+    );
+    if let Some(attr) = pkg.flake_attr {
+        let verb = if pkg.has_binary { "Run" } else { "Build" };
+        let command = if pkg.has_binary { "run" } else { "build" };
+        let _ = write!(
+            out,
+            "\n{verb} it straight from the monorepo flake, nothing to clone \
+             ([install Nix](https://nixos.org/download/) first):\n\n\
+             ```console\nnix {command} github:{}#{attr}\n```\n",
+            pkg.monorepo
+        );
+    }
+    if pkg.has_binary {
+        let lead = if pkg.flake_attr.is_some() {
+            "Or install the binary with cargo:"
+        } else {
+            "Install the binary with cargo:"
+        };
+        let _ = write!(
+            out,
+            "\n{lead}\n\n```console\ncargo install --git {git_url} {}\n```\n",
+            pkg.crate_name
+        );
+    } else {
+        let _ = write!(
+            out,
+            "\n`{name}` is not on crates.io; add it as a git dependency:\n\n\
+             ```toml\n[dependencies]\n{name} = {{ git = \"{git_url}\" }}\n```\n",
+            name = pkg.crate_name
+        );
+    }
+    out
+}
+
+/// The minimal usage section for a package without its own README.
+fn usage(pkg: &Package<'_>) -> String {
+    if pkg.has_binary {
+        format!("## Use\n\n```console\n{} --help\n```\n", pkg.crate_name)
+    } else {
+        format!(
+            "## Use\n\nAdd the dependency, then browse the API locally:\n\n\
+             ```console\ncargo doc --open -p {}\n```\n",
+            pkg.crate_name
+        )
+    }
+}
+
+/// Whether `body` opens by restating `description`: their normalized forms
+/// (markdown markup and link targets dropped, whitespace collapsed, a
+/// leading "the" ignored, lowercased) share the first 40 characters.
+fn restates(body: &str, description: &str) -> bool {
+    const PREFIX: usize = 40;
+    let body = normalize(body);
+    let description = normalize(description);
+    let prefix: String = description.chars().take(PREFIX).collect();
+    !prefix.is_empty() && body.starts_with(&prefix)
+}
+
+fn normalize(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars();
+    let mut was_space = true;
+    while let Some(ch) = chars.next() {
+        match ch {
+            '[' | ']' | '`' | '*' | '_' => {}
+            // A link target right after its text: `](url)` had its `]`
+            // dropped above, so strip the parenthesized URL too.
+            '(' => {
+                let mut group = String::new();
+                for inner in chars.by_ref() {
+                    if inner == ')' {
+                        break;
+                    }
+                    group.push(inner);
+                }
+                if !group.contains("://") {
+                    out.push('(');
+                    out.push_str(&group);
+                    out.push(')');
+                    was_space = false;
+                }
+            }
+            _ if ch.is_whitespace() => {
+                if !was_space {
+                    out.push(' ');
+                }
+                was_space = true;
+            }
+            _ => {
+                out.extend(ch.to_lowercase());
+                was_space = false;
+            }
+        }
+    }
+    let out = out.trim_end();
+    out.strip_prefix("the ")
+        .map_or_else(|| out.to_owned(), str::to_owned)
+}
+
+/// Drop a package README's leading `# <title>` line (it duplicates the hero
+/// and the generated heading) plus the blank lines after it; everything else
+/// is the package author's.
+fn without_title(body: &str) -> &str {
+    let Some(rest) = body.strip_prefix("# ") else {
+        return body;
+    };
+    let after = rest.split_once('\n').map_or("", |(_, after)| after);
+    after.trim_start_matches('\n')
+}
+
+/// The symbolic hero: crate name and tagline in monospace with a
+/// deterministic geometric mark derived from the crate name (same name, same
+/// mark; no per-package art to maintain). Dark/light adapts via CSS
+/// `prefers-color-scheme` embedded in the SVG, the one mechanism that works
+/// for a README `<img>` on GitHub without maintaining two images.
+pub fn hero_svg(name: &str, tagline: Option<&str>) -> String {
+    const MONO: &str =
+        "ui-monospace, 'SFMono-Regular', 'Cascadia Mono', Menlo, Consolas, monospace";
+    let hash = fnv1a(name.as_bytes());
+    let hue = hash % 360;
+    let mut marks = String::new();
+    for (col, row) in mark_cells(hash) {
+        let x = 44 + col * 34;
+        let y = 58 + row * 34;
+        let _ = writeln!(
+            marks,
+            "  <rect class=\"mark\" x=\"{x}\" y=\"{y}\" width=\"26\" height=\"26\" rx=\"7\"/>"
+        );
+    }
+    // A long name shrinks instead of overflowing the fixed viewBox.
+    let name_size = if name.len() > 16 { 40 } else { 52 };
+    let mut tags = String::new();
+    for (index, line) in tagline
+        .map(|tagline| wrap(tagline, 58, 2))
+        .unwrap_or_default()
+        .iter()
+        .enumerate()
+    {
+        let y = 138 + 30 * index;
+        let _ = writeln!(
+            tags,
+            "  <text class=\"tag\" x=\"160\" y=\"{y}\">{}</text>",
+            xml_escape(line)
+        );
+    }
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 880 220\" role=\"img\" aria-label=\"{name}\">\n\
+         <title>{name}</title>\n\
+         <style>\n\
+         .name {{ font: 700 {name_size}px {MONO}; fill: #1f2328; }}\n\
+         .tag {{ font: 400 22px {MONO}; fill: #59636e; }}\n\
+         .mark {{ fill: hsl({hue} 70% 45%); }}\n\
+         @media (prefers-color-scheme: dark) {{\n\
+         .name {{ fill: #f0f6fc; }}\n\
+         .tag {{ fill: #9198a1; }}\n\
+         .mark {{ fill: hsl({hue} 75% 65%); }}\n\
+         }}\n\
+         </style>\n\
+         {marks}  <text class=\"name\" x=\"160\" y=\"104\">{escaped}</text>\n\
+         {tags}</svg>\n",
+        name = xml_escape(name),
+        escaped = xml_escape(name),
+    )
+}
+
+/// A 3x3 grid mirrored around its vertical axis (symmetry reads as a mark,
+/// raw bits read as noise): bits 0-2 fill the outer columns per row, bits
+/// 3-5 the middle column; a hash with none set gets the center cell.
+fn mark_cells(hash: u64) -> Vec<(u64, u64)> {
+    let mut cells = Vec::new();
+    for row in 0..3 {
+        if hash >> row & 1 == 1 {
+            cells.push((0, row));
+            cells.push((2, row));
+        }
+        if hash >> (3 + row) & 1 == 1 {
+            cells.push((1, row));
+        }
+    }
+    if cells.is_empty() {
+        cells.push((1, 1));
+    }
+    cells
+}
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+    }
+    hash
+}
+
+/// Greedy word wrap into at most `max_lines` lines of about `width` columns;
+/// a truncated tagline ends in an ellipsis rather than overflowing the hero.
+fn wrap(text: &str, width: usize, max_lines: usize) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+    for word in text.split_whitespace() {
+        match lines.last_mut() {
+            Some(line) if line.len() + 1 + word.len() <= width => {
+                line.push(' ');
+                line.push_str(word);
+            }
+            _ => lines.push(word.to_owned()),
+        }
+    }
+    if lines.len() > max_lines {
+        lines.truncate(max_lines);
+        if let Some(last) = lines.last_mut() {
+            last.push('…');
+        }
+    }
+    lines
+}
+
+fn xml_escape(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(ch),
         }
     }
     out
@@ -58,21 +376,24 @@ pub fn compose(banner: &Banner<'_>, existing: Option<&str>) -> String {
 mod tests {
     use super::*;
 
-    fn banner() -> Banner<'static> {
-        Banner {
+    fn package() -> Package<'static> {
+        Package {
             monorepo: "indexable-inc/index",
-            package_path: "packages/progress-style",
+            path: "packages/progress-style",
             commit: "0123456789abcdef0123456789abcdef01234567",
             crate_name: "progress-style",
-            description: Some("Shared indicatif styling"),
+            description: Some("Shared indicatif styling for ix tools, so every CLI matches."),
             mirror_repo: Some("indexable-inc/progress-style"),
+            flake_attr: None,
+            has_binary: false,
+            has_changelog: true,
         }
     }
 
     #[test]
-    fn banner_leads_and_links_the_exact_tree() {
-        let out = compose(&banner(), Some("# progress-style\n\nHand-written body.\n"));
-        assert!(out.starts_with("> [!NOTE]\n"), "{out}");
+    fn hero_then_banner_lead_the_readme() {
+        let out = compose(&package(), None);
+        assert!(out.starts_with("![progress-style](.github/hero.svg)\n"), "{out}");
         assert!(
             out.contains(
                 "https://github.com/indexable-inc/index/tree/0123456789abcdef0123456789abcdef01234567/packages/progress-style"
@@ -80,15 +401,103 @@ mod tests {
             "{out}"
         );
         assert!(out.contains("`0123456789ab`"), "{out}");
-        assert!(out.ends_with("Hand-written body.\n"), "{out}");
     }
 
     #[test]
-    fn synthesizes_a_body_when_the_package_has_no_readme() {
-        let out = compose(&banner(), None);
+    fn library_gets_hook_pitch_and_git_dependency_snippet() {
+        let out = compose(&package(), None);
         assert!(
-            out.contains("# progress-style\n\nShared indicatif styling\n"),
+            out.contains("**Shared indicatif styling for ix tools: one dependency line away?**"),
             "{out}"
         );
+        assert!(
+            out.contains(
+                "progress-style = { git = \"https://github.com/indexable-inc/progress-style\" }"
+            ),
+            "{out}"
+        );
+        assert!(!out.contains("nix run"), "{out}");
+    }
+
+    #[test]
+    fn flake_exposed_binary_gets_nix_run_and_cargo_install() {
+        let pkg = Package {
+            crate_name: "sqlmerge",
+            mirror_repo: Some("indexable-inc/sqlmerge"),
+            flake_attr: Some("sqlmerge"),
+            has_binary: true,
+            description: Some("A git merge driver for SQLite database files: a real merge."),
+            ..package()
+        };
+        let out = compose(&pkg, None);
+        assert!(
+            out.contains("**A git merge driver for SQLite database files: one `nix run` away?**"),
+            "{out}"
+        );
+        assert!(out.contains("nix run github:indexable-inc/index#sqlmerge"), "{out}");
+        assert!(
+            out.contains("cargo install --git https://github.com/indexable-inc/sqlmerge sqlmerge"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn binary_without_flake_attr_installs_via_cargo_only() {
+        let pkg = Package {
+            flake_attr: None,
+            has_binary: true,
+            ..package()
+        };
+        let out = compose(&pkg, None);
+        assert!(!out.contains("nix run"), "{out}");
+        assert!(out.contains("cargo install --git"), "{out}");
+    }
+
+    #[test]
+    fn existing_body_rides_along_without_its_duplicate_title() {
+        let out = compose(&package(), Some("# progress-style\n\nHand-written body.\n"));
+        assert!(!out.contains("# progress-style\n\nHand-written"), "{out}");
+        assert!(out.ends_with("Hand-written body.\n\nChanges: [CHANGELOG.md](CHANGELOG.md), derived from the [monorepo history](https://github.com/indexable-inc/index/commits/main/packages/progress-style) of the package.\n"), "{out}");
+    }
+
+    #[test]
+    fn pitch_yields_to_a_body_that_restates_it() {
+        let body = "# progress-style\n\nThe shared [`indicatif`](https://docs.rs/indicatif) styling for ix tools, so every CLI\nmatches: one owner for the glyphs.\n";
+        let out = compose(&package(), Some(body));
+        assert!(
+            out.contains("**Shared indicatif styling for ix tools: one dependency line away?**"),
+            "{out}"
+        );
+        assert_eq!(out.matches("styling for ix tools").count(), 2, "hook + body only:\n{out}");
+        assert!(!out.contains("so every CLI matches."), "metadata pitch dropped:\n{out}");
+    }
+
+    #[test]
+    fn pitch_stays_when_the_body_opens_differently() {
+        let out = compose(&package(), Some("# progress-style\n\nDeep dive into the styling system.\n"));
+        assert!(
+            out.contains("Shared indicatif styling for ix tools, so every CLI matches."),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn no_changelog_means_no_changelog_line() {
+        let pkg = Package {
+            has_changelog: false,
+            ..package()
+        };
+        let out = compose(&pkg, None);
+        assert!(!out.contains("CHANGELOG.md"), "{out}");
+    }
+
+    #[test]
+    fn hero_svg_adapts_via_prefers_color_scheme_and_escapes() {
+        let svg = hero_svg("a<b", Some("styling & \"quotes\""));
+        assert!(svg.contains("@media (prefers-color-scheme: dark)"), "{svg}");
+        assert!(svg.contains("a&lt;b"), "{svg}");
+        assert!(svg.contains("styling &amp; &quot;quotes&quot;"), "{svg}");
+        assert!(svg.contains("class=\"mark\""), "{svg}");
+        assert_eq!(svg, hero_svg("a<b", Some("styling & \"quotes\"")), "deterministic");
     }
 }

--- a/packages/mirror/src/workspace.rs
+++ b/packages/mirror/src/workspace.rs
@@ -14,6 +14,16 @@ pub struct Workspace {
     doc: DocumentMut,
 }
 
+/// One monorepo commit that touched a package path.
+pub struct Change {
+    /// Full commit sha.
+    pub sha: String,
+    /// Committer date, `YYYY-MM-DD`.
+    pub date: String,
+    /// First line of the commit message.
+    pub subject: String,
+}
+
 impl Workspace {
     /// Load the workspace rooted at `root`, or when `None`, at the nearest
     /// ancestor of the current directory whose `Cargo.toml` has a
@@ -57,6 +67,38 @@ impl Workspace {
 
     pub fn head_commit(&self) -> Result<String> {
         exec::git(&self.root, &["rev-parse", "HEAD"])
+    }
+
+    /// Every monorepo commit that touched `path`, newest first. Refuses a
+    /// shallow clone: `git log` over truncated history would silently
+    /// produce a shorter-than-real changelog, so CI checks out with
+    /// `fetch-depth: 0` (.github/workflows/mirror-sync.yml).
+    pub fn package_history(&self, path: &str) -> Result<Vec<Change>> {
+        if exec::git(&self.root, &["rev-parse", "--is-shallow-repository"])? == "true" {
+            bail!(
+                "{} is a shallow clone, which would truncate the generated changelog; \
+                 fetch full history (actions/checkout `fetch-depth: 0`)",
+                self.root.display()
+            );
+        }
+        let log = exec::git(
+            &self.root,
+            &["log", "--format=%H%x09%cs%x09%s", "HEAD", "--", path],
+        )?;
+        log.lines()
+            .filter(|line| !line.is_empty())
+            .map(|line| {
+                let mut parts = line.splitn(3, '\t');
+                match (parts.next(), parts.next(), parts.next()) {
+                    (Some(sha), Some(date), Some(subject)) => Ok(Change {
+                        sha: sha.to_owned(),
+                        date: date.to_owned(),
+                        subject: subject.to_owned(),
+                    }),
+                    _ => bail!("unexpected `git log` line: {line}"),
+                }
+            })
+            .collect()
     }
 
     fn workspace_table(&self, name: &str) -> Result<&Table> {


### PR DESCRIPTION
Closes #2081. Follows up #2022 / #2069.

Mirror repos now get a pitchy, fully derived README plus a derived changelog; nothing is hand-maintained per mirror.

**README** (house style: the `creating-a-readme` skill, in flight on a sibling branch; until it lands, packages/mirror/src/readme.rs carries the style contract in its module doc):
- `.github/hero.svg`: symbolic hero (name, tagline, deterministic mark from the crate name), dark/light auto via CSS `prefers-color-scheme` embedded in the SVG
- hook question + pitch from the declarative `mirror.description` (#2069's single source of truth; crate `[package] description` fallback). The pitch paragraph yields when the package's own README already opens by restating it.
- Install branches on what the package IS: flake-exposed -> `nix run github:indexable-inc/index#<attr>` (new `flakeAttr` on `.#lib.mirrorPackages`), binary -> `cargo install --git <mirror-url>`, library -> git-dependency snippet
- the package's own README rides along as the deep docs (duplicate title stripped); a package without one gets a minimal generated Use section

**CHANGELOG.md**: derived from `git log -- packages/<pkg>` by the same generator `mirror publish` already runs. Keep a Changelog section names picked from conventional-commit prefixes (feat -> Added, fix -> Fixed, ...; anything else Changed, unstripped), grouped by month (mirrors track the monorepo continuously; no versioned releases), every entry linking its monorepo commit, `#N` references linked to the monorepo so GitHub cannot autolink them to the mirror's own issue numbers. README links it in one line. The generator refuses a shallow clone rather than emit a truncated changelog; mirror-sync now checks out with `fetch-depth: 0`.

Validated locally: `cargo test -p mirror` (26 tests), `cargo clippy -p mirror --all-targets` clean on the touched files, `nix run .#lint` 8/8, and `mirror gen` run against `packages/sqlmerge` (flake-exposed binary) and `packages/progress-style` (library) with the rendered manifest; outputs inspected.

Sample generated README head (sqlmerge):

```markdown
![sqlmerge](.github/hero.svg)

> [!NOTE]
> [`indexable-inc/sqlmerge`](https://github.com/indexable-inc/sqlmerge) is a read-only mirror, ...

# sqlmerge

**A git merge driver for SQLite database files: one `nix run` away?**

## Install

Run it straight from the monorepo flake, nothing to clone ([install Nix](https://nixos.org/download/) first):

    nix run github:indexable-inc/index#sqlmerge

Or install the binary with cargo:

    cargo install --git https://github.com/indexable-inc/sqlmerge sqlmerge
```

Generated with Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pitchy generated READMEs and per-mirror CHANGELOG.md to mirrored packages
> - Adds `changelog::compose` in [changelog.rs](https://github.com/indexable-inc/index/pull/2091/files#diff-77ea8ddf861ad446593633a26450e903368fc0778203bcc2c6de0867764b8eec) to generate a monthly-grouped Keep a Changelog formatted `CHANGELOG.md` from per-package git history, linking SHAs and `#123` refs back to the monorepo.
> - Reworks `readme::compose` in [readme.rs](https://github.com/indexable-inc/index/pull/2091/files#diff-a91611e7a3f3deeb727c42d7958cec72171cc39acd9d6363803c6f1c75532f0f) to produce a full README: packages with an existing README get a banner prepended (plus an Install section if absent); packages without one get a synthesized hero SVG, hook, pitch, and install/usage sections tailored to binary vs. library and flake availability.
> - Adds `workspace::package_history` in [workspace.rs](https://github.com/indexable-inc/index/pull/2091/files#diff-e60d84fd71051ed63e0fedc8ef0071a34be2c1d594568561bce978df1cd7ba6a) to collect per-package git log entries; errors on shallow clones to prevent truncated changelogs.
> - Extends `mirrors::Entry` and the `Gen`/`publish` commands to resolve `description` and `flake_attr` from the `.#lib.mirrorPackages` JSON, informing README install instructions (`nix run`, `cargo install`, git dep).
> - The mirror-sync workflow now checks out full git history (`fetch-depth: 0`) to support changelog generation.
> - Behavioral Change: mirrors without a README now get a fully generated one including a synthesized `hero.svg`; existing READMEs are preserved verbatim with additions only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93fe2bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->