### PR TITLE
readme sweep: agent packages

### DIFF
--- a/packages/agent/claude-code/system-prompts/README.md
+++ b/packages/agent/claude-code/system-prompts/README.md
@@ -1,14 +1,23 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="the pinned claude-code binary sends its system prompt to a local capture server, which writes normalized per-model snapshots that git can diff"></p>
+
 # Claude Code stock system prompts
 
-These are stock upstream Claude Code `system` snapshots captured through the real
-binary with a local `ANTHROPIC_BASE_URL` server. They intentionally exclude the
-per-run `x-anthropic-billing-header` block and normalize extraction temp paths so
-diffs show prompt changes only.
+What exactly changed in Claude Code's system prompt between two releases? These
+are stock upstream `system` snapshots, one `.txt` per model alias, captured
+through the real pinned binary talking to a local `ANTHROPIC_BASE_URL` capture
+server. Diff two revisions of a file and you are diffing the prompt itself.
 
-Refresh them from the pinned Claude Code package:
+Snapshots intentionally exclude the per-run `x-anthropic-billing-header` block
+and normalize extraction temp paths, so diffs show prompt changes only.
+
+## Refresh
+
+From the pinned Claude Code package:
 
 ```sh
 nix run .#claude-code.updateScript -- --prompts-only
 ```
 
 `models.json` is the source of truth for which model aliases are captured.
+
+The command assumes a clone: `git clone https://github.com/indexable-inc/index`.

--- a/packages/agent/claude-code/system-prompts/assets/hero.svg
+++ b/packages/agent/claude-code/system-prompts/assets/hero.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="28" y="70" width="152" height="52" rx="8"/>
+  <text x="104" y="92" text-anchor="middle" font-size="13" font-weight="600">claude-code</text>
+  <text x="104" y="110" text-anchor="middle" font-size="11" class="muted">pinned binary</text>
+
+  <line class="edge" x1="180" y1="96" x2="248" y2="96"/>
+  <text x="214" y="62" text-anchor="middle" font-size="11" class="muted">sends</text>
+  <text x="214" y="76" text-anchor="middle" font-size="11" class="muted">system prompt</text>
+
+  <rect class="box" x="250" y="70" width="180" height="52" rx="8"/>
+  <text x="340" y="92" text-anchor="middle" font-size="13" font-weight="600">capture server</text>
+  <text x="340" y="110" text-anchor="middle" font-size="11" class="muted">local ANTHROPIC_BASE_URL</text>
+
+  <line class="edge" x1="430" y1="96" x2="498" y2="96"/>
+  <text x="464" y="76" text-anchor="middle" font-size="11" class="muted">normalizes</text>
+
+  <rect class="box" x="500" y="40" width="192" height="112" rx="8"/>
+  <text x="596" y="64" text-anchor="middle" font-size="13" font-weight="600">snapshots</text>
+  <text x="596" y="86" text-anchor="middle" font-size="11" class="muted">sonnet.txt · opus.txt</text>
+  <text x="596" y="104" text-anchor="middle" font-size="11" class="muted">haiku.txt · fable.txt</text>
+  <text x="596" y="132" text-anchor="middle" font-size="12" class="accent">git diff = prompt diff</text>
+</svg>

--- a/packages/agent/claude-stories/README.md
+++ b/packages/agent/claude-stories/README.md
@@ -1,26 +1,30 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="each peer publishes and serves its repo story; render discovers them over the tailnet and prints a status-line avatar row"></p>
+
 # claude-stories
 
-Instagram-style "stories" for [Claude Code](https://code.claude.com): a status-line
-row of your teammates' avatars and what each is working on right now. Inspired by
+What is everyone else's Claude session working on right now? claude-stories is
+Instagram-style "stories" for [Claude Code](https://code.claude.com): a
+status-line row of your teammates' avatars and what each is working on, fetched
+peer-to-peer over your Tailscale tailnet with no central server. Inspired by
 Ben Awad's [vscode-stories](https://github.com/benawad/vscode-stories).
-
-Each avatar is two half-circle glyphs around the author's initials, colored along
-the Instagram story gradient, and is a clickable link to their repo. Claude Code
-strips Kitty graphics sequences from status-line output
-([anthropics/claude-code#39024](https://github.com/anthropics/claude-code/issues/39024)),
-so real profile photos are not possible there; text-art rings are the faithful
-substitute.
 
 ```
 📸 STORIES  ◖+◗  ◖AG◗  ◖WG◗  ◖HA◗
 ```
 
+Each avatar is two half-circle glyphs around the author's initials, colored
+along the Instagram story gradient, and is a clickable link to their repo.
+Claude Code strips Kitty graphics sequences from status-line output
+([anthropics/claude-code#39024](https://github.com/anthropics/claude-code/issues/39024)),
+so real profile photos are not possible there; text-art rings are the faithful
+substitute.
+
 ## How it works
 
 Three commands, no central server:
 
-- `claude-stories publish` reads the current git repo (name, branch, latest commit
-  subject, author identity) and writes a story to a small state file.
+- `claude-stories publish` reads the current git repo (name, branch, latest
+  commit subject, author identity) and writes a story to a small state file.
 - `claude-stories serve` exposes that file at `GET /story` over HTTP.
 - `claude-stories render` discovers peers, fetches everyone's `/story`
   concurrently, drops anything older than 24h, and prints the avatar row.
@@ -28,12 +32,22 @@ Three commands, no central server:
 Discovery defaults to the **Tailscale tailnet**: `tailscale status --json` is
 already an authenticated, NAT-traversed directory of every online device, so it
 doubles as the peer list. No DHT, no bootstrap nodes, no OAuth. Set
-`CLAUDE_STORIES_PEERS=host[:port],...` to use an explicit list instead (testing,
-or running off a tailnet).
+`CLAUDE_STORIES_PEERS=host[:port],...` to use an explicit list instead
+(testing, or running off a tailnet).
+
+## Install
+
+```sh
+nix run github:indexable-inc/index#claude-stories -- --help
+```
+
+As a Rust binary via cargo:
+
+```sh
+cargo install --git https://github.com/indexable-inc/index claude-stories
+```
 
 ## Wiring it into Claude Code
-
-Build it: `nix build .#claude-stories` (or add the package to your home config).
 
 Status line, in `~/.claude/settings.json`:
 
@@ -43,8 +57,8 @@ Status line, in `~/.claude/settings.json`:
 }
 ```
 
-Publish your own story whenever you start a session, via a `SessionStart` hook in
-the same file:
+Publish your own story whenever you start a session, via a `SessionStart` hook
+in the same file:
 
 ```json
 {
@@ -56,8 +70,8 @@ the same file:
 }
 ```
 
-Run the server once per host (for example through `homeModules.portable-services`,
-or any launchd/systemd user unit):
+Run the server once per host (for example through
+`homeModules.portable-services`, or any launchd/systemd user unit):
 
 ```
 claude-stories serve
@@ -77,12 +91,13 @@ claude-stories serve
 - **No real avatars in the status line.** Image escapes are stripped by Claude
   Code today; this renders initials in gradient rings instead.
 - **Off-tailnet needs explicit peers.** Without Tailscale, discovery has nothing
-  to enumerate, so set `CLAUDE_STORIES_PEERS`. A hosted rendezvous transport is a
-  natural future addition for the public case.
+  to enumerate, so set `CLAUDE_STORIES_PEERS`. A hosted rendezvous transport is
+  a natural future addition for the public case.
 - **`serve` binds `0.0.0.0` and is unauthenticated.** It serves low-sensitivity
   data (your latest commit subject) and relies entirely on your tailnet ACLs, so
   the same port is reachable from any other network the host is on. Firewall it
-  to the Tailscale interface, or pass `--bind` your tailnet IP, on shared networks.
-- **Your story is the last repo you published from**, not a live view of whatever
-  directory each Claude session is in. Re-run `publish` (the hook does this) to
-  update it.
+  to the Tailscale interface, or pass `--bind` your tailnet IP, on shared
+  networks.
+- **Your story is the last repo you published from**, not a live view of
+  whatever directory each Claude session is in. Re-run `publish` (the hook does
+  this) to update it.

--- a/packages/agent/claude-stories/assets/hero.svg
+++ b/packages/agent/claude-stories/assets/hero.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="24" y="32" width="180" height="48" rx="8"/>
+  <text x="114" y="52" text-anchor="middle" font-size="12" font-weight="600">peer</text>
+  <text x="114" y="70" text-anchor="middle" font-size="11" class="muted">publish → serve /story</text>
+
+  <rect class="box" x="24" y="120" width="180" height="48" rx="8"/>
+  <text x="114" y="140" text-anchor="middle" font-size="12" font-weight="600">peer</text>
+  <text x="114" y="158" text-anchor="middle" font-size="11" class="muted">publish → serve /story</text>
+
+  <ellipse class="box" cx="330" cy="100" rx="72" ry="38"/>
+  <text x="330" y="96" text-anchor="middle" font-size="13" font-weight="600">tailnet</text>
+  <text x="330" y="114" text-anchor="middle" font-size="11" class="muted">peer directory</text>
+
+  <line class="edge" x1="204" y1="60" x2="270" y2="82"/>
+  <line class="edge" x1="204" y1="140" x2="270" y2="118"/>
+
+  <line class="edge" x1="402" y1="100" x2="466" y2="100"/>
+  <text x="434" y="84" text-anchor="middle" font-size="11" class="muted">fetch all</text>
+
+  <rect class="box" x="468" y="76" width="96" height="48" rx="8"/>
+  <text x="516" y="105" text-anchor="middle" font-size="13" font-weight="600">render</text>
+
+  <line class="edge" x1="564" y1="100" x2="600" y2="100"/>
+
+  <text x="606" y="90" font-size="13" class="accent">◖AG◗ ◖WG◗</text>
+  <text x="606" y="112" font-size="11" class="muted">status line</text>
+</svg>

--- a/packages/agent/distiller/README.md
+++ b/packages/agent/distiller/README.md
@@ -1,13 +1,16 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="local Claude Code transcripts are scanned, distilled and judged by one headless claude -p call, then written as facts markdown and corpus parquet slices that the archive funnel makes searchable"></p>
+
 # distiller
 
-Distill **ReasoningBank-style lessons** from local Claude Code transcripts
-into (a) human-readable facts markdown per `(user, project)`, (b) a
-`source=distilled_facts` **corpus parquet slice**, and (c) a
-`source=session_outcomes` slice with one LLM-judged **outcome verdict per
+Your agents keep relearning the same lessons: where does last week's hard-won
+fix go? distiller reads local Claude Code transcripts and distills
+**ReasoningBank-style lessons** into (a) human-readable facts markdown per
+`(user, project)`, (b) a `source=distilled_facts` **corpus parquet slice**, and
+(c) a `source=session_outcomes` slice with one LLM-judged **outcome verdict per
 session**. The existing archive → Iceberg-lake → Mixedbread funnel publishes
-both slices automatically — the leader fold ingests `(host, user, source)`
-slices generically, so this needs zero Rust (see `packages/search/sink/parquet` and
-ix `docs/history-archive.md`).
+both slices automatically: the leader fold ingests `(host, user, source)`
+slices generically, so this needs zero Rust (see `packages/search/sink/parquet`
+and ix `docs/history-archive.md`).
 
 ## What it does
 
@@ -25,12 +28,12 @@ ix `docs/history-archive.md`).
    one verdict per session id with a label (`success` / `partial` /
    `failure` / `abandoned`) and a one-line reason; sessions the model skips
    fall back to the scan heuristics so the verdict set never has holes.
-   Lessons whose evidence includes a failed session — the most valuable
-   guardrails — carry `session_labels` + `failure_derived` in their meta.
+   Lessons whose evidence includes a failed session (the most valuable
+   guardrails) carry `session_labels` + `failure_derived` in their meta.
 4. Merges **incrementally** with the previous run's items: stable item ids,
-   `add`/`update` operations only, unmentioned items survive verbatim —
-   never wholesale regeneration (ACE's brevity-bias / context-collapse
-   warning). State (items, seen sessions, verdicts) lives under
+   `add`/`update` operations only, unmentioned items survive verbatim, never
+   wholesale regeneration (ACE's brevity-bias / context-collapse warning).
+   State (items, seen sessions, verdicts) lives under
    `<out>/state/<user>/<project>.json`.
 5. Writes `<out>/facts/<user>/<project>.md` and two parquet slices at
    `<out>/corpus/host=<h>/user=<u>/source=distilled_facts/` (lessons) and
@@ -50,15 +53,18 @@ ix `docs/history-archive.md`).
 ## Usage
 
 ```sh
-ix-distiller --days 7 --user andrew --out /var/lib/ix-distiller \
+nix run github:indexable-inc/index#distiller -- --days 7 --user andrew \
+  --out /var/lib/ix-distiller \
   [--project index] [--model claude-haiku-4-5-20251001] \
   [--upload [--env-file /run/ix-secret-store/env/ix-indexer]]
 ```
 
+The installed binary is `ix-distiller` with the same flags.
+
 Updates come free with the contract: rewriting the slice with the current
 desired item set folds each `external_id` to its newest `content_hash` on the
-next fold. Vanished ids are NOT deleted — the lake fold is append/merge only,
-so a row absent from a newer slice stays live (ENG-2696); deletion takes an
+next fold. Vanished ids are NOT deleted; the lake fold is append/merge only,
+so a row absent from a newer slice stays live (ENG-2696). Deletion takes an
 explicit tombstone (the indexer's `--gc` path for export-complete sources).
 
 ## Tests
@@ -70,3 +76,6 @@ transcript signal extraction, and the outcome-labeling path (verdict
 normalization + fallback, the session_outcomes slice, failure-derived
 lesson marking, and an end-to-end run against a mocked `claude -p` that
 keeps the `PROMPT_SENTINEL` anti-recursion filter honest).
+
+Repo-local commands assume a clone:
+`git clone https://github.com/indexable-inc/index`.

--- a/packages/agent/distiller/assets/hero.svg
+++ b/packages/agent/distiller/assets/hero.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="24" y="80" width="176" height="56" rx="8"/>
+  <text x="112" y="104" text-anchor="middle" font-size="13" font-weight="600">~/.claude transcripts</text>
+  <text x="112" y="122" text-anchor="middle" font-size="11" class="muted">projects/**/*.jsonl</text>
+
+  <line class="edge" x1="200" y1="108" x2="256" y2="108"/>
+  <text x="228" y="90" text-anchor="middle" font-size="11" class="muted">scan</text>
+
+  <rect class="box" x="258" y="80" width="146" height="56" rx="8"/>
+  <text x="331" y="104" text-anchor="middle" font-size="13" font-weight="600">claude -p</text>
+  <text x="331" y="122" text-anchor="middle" font-size="11" class="muted">distill + judge</text>
+
+  <line class="edge" x1="404" y1="94" x2="456" y2="66"/>
+  <text x="430" y="60" text-anchor="middle" font-size="11" class="muted">lessons</text>
+  <line class="edge" x1="404" y1="122" x2="456" y2="146"/>
+  <text x="434" y="156" text-anchor="middle" font-size="11" class="muted">verdicts</text>
+
+  <rect class="box" x="458" y="40" width="238" height="46" rx="8"/>
+  <text x="577" y="68" text-anchor="middle" font-size="12" font-weight="600">facts/&lt;user&gt;/&lt;project&gt;.md</text>
+
+  <rect class="box" x="458" y="122" width="238" height="58" rx="8"/>
+  <text x="577" y="145" text-anchor="middle" font-size="12" font-weight="600">corpus parquet slices</text>
+  <text x="577" y="164" text-anchor="middle" font-size="11" class="muted">distilled_facts · session_outcomes</text>
+
+  <line class="edge" x1="577" y1="180" x2="577" y2="204"/>
+  <text x="590" y="218" text-anchor="middle" font-size="12" class="accent">--upload → fold → search.semantic(...)</text>
+</svg>

--- a/packages/agent/pi-harnesses/README.md
+++ b/packages/agent/pi-harnesses/README.md
@@ -1,8 +1,12 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="the shared mk-pi-harness builder wraps the pinned pi binary into six harness packages, one posture each"></p>
+
 # pi-harnesses
 
-A collection of Pi-based agent harnesses. Each harness is a thin, declarative
-wrapper around [`pi`](https://pi.dev) with a fixed posture and (optionally) one
-or more bundled extensions, shipped as its own Nix package.
+How do you ship six different agent postures without six forks of the coding
+agent? Each harness here is a thin, declarative wrapper around
+[`pi`](https://pi.dev) with a fixed posture and (optionally) one or more
+bundled extensions, shipped as its own Nix package. One shared builder owns the
+wrapping; each harness owns only its flags and extensions.
 
 ## Layout
 
@@ -42,13 +46,13 @@ work and the child agents must probe real state.
 | child agents | none | isolated `pi` subprocesses |
 | posture set by | hardened C launcher | `mk-pi-harness.nix` (`lockdown = false`) |
 
-## Building
+## Run
 
-```
-nix run .#pi-prosecutor -- "your task"          # opus-4-8 executor + prosecutor (same model)
-nix run .#pi-beam       -- "your task"
-nix run .#pi-fusion     -- "your task"          # fable-5 primary + gpt-5.5-low sidekick
-PI_HARNESS_MODEL=codex nix run .#pi-prosecutor -- "..."   # gpt-5.5 medium
+```sh
+nix run github:indexable-inc/index#pi-prosecutor -- "your task"   # opus-4-8 executor + prosecutor (same model)
+nix run github:indexable-inc/index#pi-beam       -- "your task"
+nix run github:indexable-inc/index#pi-fusion     -- "your task"   # fable-5 primary + gpt-5.5-low sidekick
+PI_HARNESS_MODEL=codex nix run github:indexable-inc/index#pi-prosecutor -- "..."   # gpt-5.5 medium
 ```
 
 API keys come from the caller's environment (`ANTHROPIC_API_KEY` /
@@ -65,3 +69,6 @@ extensions); swap it with `.override { pi = ...; }`.
 2. Put the entry extension under `<name>/extension/`, shared helpers in
    `shared/ext-lib/` (passed as `libFiles`).
 3. The registry auto-discovers it; no central list to edit.
+
+Working in-repo assumes a clone:
+`git clone https://github.com/indexable-inc/index`.

--- a/packages/agent/pi-harnesses/assets/hero.svg
+++ b/packages/agent/pi-harnesses/assets/hero.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 210" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="24" y="78" width="120" height="54" rx="8"/>
+  <text x="84" y="101" text-anchor="middle" font-size="13" font-weight="600">pi</text>
+  <text x="84" y="119" text-anchor="middle" font-size="11" class="muted">pinned binary</text>
+
+  <line class="edge" x1="144" y1="105" x2="220" y2="105"/>
+  <text x="182" y="90" text-anchor="middle" font-size="11" class="muted">wraps</text>
+
+  <rect class="box" x="222" y="66" width="190" height="78" rx="8"/>
+  <text x="317" y="92" text-anchor="middle" font-size="13" font-weight="600">mk-pi-harness</text>
+  <text x="317" y="110" text-anchor="middle" font-size="11" class="muted">flags + extensions</text>
+  <text x="317" y="126" text-anchor="middle" font-size="11" class="muted">+ model table</text>
+
+  <rect class="box" x="452" y="18" width="248" height="26" rx="6"/>
+  <text x="462" y="35" font-size="11" font-weight="600">pi-harness</text>
+  <line class="edge" x1="412" y1="105" x2="450" y2="31"/>
+  <rect class="box" x="452" y="50" width="248" height="26" rx="6"/>
+  <text x="462" y="67" font-size="11" font-weight="600">pi-base</text>
+  <line class="edge" x1="412" y1="105" x2="450" y2="63"/>
+  <rect class="box" x="452" y="82" width="248" height="26" rx="6"/>
+  <text x="462" y="99" font-size="11" font-weight="600">pi-prosecutor</text>
+  <line class="edge" x1="412" y1="105" x2="450" y2="95"/>
+  <rect class="box" x="452" y="114" width="248" height="26" rx="6"/>
+  <text x="462" y="131" font-size="11" font-weight="600">pi-beam</text>
+  <line class="edge" x1="412" y1="105" x2="450" y2="127"/>
+  <rect class="box" x="452" y="146" width="248" height="26" rx="6"/>
+  <text x="462" y="163" font-size="11" font-weight="600">pi-fusion</text>
+  <line class="edge" x1="412" y1="105" x2="450" y2="159"/>
+  <rect class="box" x="452" y="178" width="248" height="26" rx="6"/>
+  <text x="462" y="195" font-size="11" font-weight="600">omp</text>
+  <line class="edge" x1="412" y1="105" x2="450" y2="191"/>
+
+  <text x="576" y="204" text-anchor="middle" font-size="11" class="accent">one posture per package</text>
+</svg>

--- a/packages/agent/pi-harnesses/base/README.md
+++ b/packages/agent/pi-harnesses/base/README.md
@@ -1,7 +1,10 @@
+<p align="center"><img src="assets/hero.svg" width="560" alt="pi plus a small UX extension pack yields the same agent with a nicer cockpit"></p>
+
 # pi-base
 
-Pi with a small base UX pack - quality-of-life extensions that are a plus for
-any setup, with no behavior changes to the agent itself.
+What do you want in every pi session regardless of the task? pi-base is pi with
+a small base UX pack: quality-of-life extensions that are a plus for any setup,
+with no behavior changes to the agent itself.
 
 Adapted from [davis7dotsh/my-pi-setup](https://github.com/davis7dotsh/my-pi-setup)
 (MIT, (c) 2026 Benjamin Davis).
@@ -17,9 +20,9 @@ Adapted from [davis7dotsh/my-pi-setup](https://github.com/davis7dotsh/my-pi-setu
 
 ## Run
 
-```
-ANTHROPIC_API_KEY=... nix run .#pi-base -- "your task"
-PI_HARNESS_MODEL=codex OPENAI_API_KEY=... nix run .#pi-base
+```sh
+ANTHROPIC_API_KEY=... nix run github:indexable-inc/index#pi-base -- "your task"
+PI_HARNESS_MODEL=codex OPENAI_API_KEY=... nix run github:indexable-inc/index#pi-base
 ```
 
 The extension files also land in `share/pi-base/`, so they can be symlinked

--- a/packages/agent/pi-harnesses/base/assets/hero.svg
+++ b/packages/agent/pi-harnesses/base/assets/hero.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 150" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="52" width="90" height="46" rx="8"/>
+  <text x="65" y="80" text-anchor="middle" font-size="13" font-weight="600">pi</text>
+
+  <line class="edge" x1="110" y1="75" x2="168" y2="75"/>
+  <text x="139" y="60" text-anchor="middle" font-size="11" class="muted">+ UX pack</text>
+
+  <rect class="box" x="170" y="28" width="200" height="94" rx="8"/>
+  <text x="270" y="52" text-anchor="middle" font-size="12" font-weight="600">extensions</text>
+  <text x="270" y="74" text-anchor="middle" font-size="11" class="muted">tok/s · git widget</text>
+  <text x="270" y="92" text-anchor="middle" font-size="11" class="muted">/diff · /lg</text>
+
+  <line class="edge" x1="370" y1="75" x2="428" y2="75"/>
+
+  <rect class="box" x="430" y="52" width="110" height="46" rx="8"/>
+  <text x="485" y="72" text-anchor="middle" font-size="12" font-weight="600">your session</text>
+  <text x="485" y="90" text-anchor="middle" font-size="10" class="accent">agent unchanged</text>
+</svg>

--- a/packages/agent/pi-harnesses/beam/README.md
+++ b/packages/agent/pi-harnesses/beam/README.md
@@ -1,7 +1,12 @@
+<p align="center"><img src="assets/hero.svg" width="620" alt="the executor fans a decision out to isolated worktree branches, a scorer ranks them on ground truth, and the winning patch returns"></p>
+
 # pi-beam
 
-An executor that turns a hard decision into a bounded beam search instead of a
-linear commitment.
+Why commit forty turns to one approach when you can race three cheap ones?
+pi-beam is an executor that turns a hard decision into a bounded beam search
+instead of a linear commitment: candidate approaches run in parallel on
+isolated git worktrees, get scored on ground truth, and only the winner's patch
+comes back.
 
 ## How it works
 
@@ -12,8 +17,8 @@ linear commitment.
    - a soft turn cap via the `turn-cap` extension (`PI_TURN_CAP`), since Pi has
      no `--max-turns` flag, and
    - a hard wall-clock cap via `timeout`.
-3. Branches are scored on GROUND TRUTH by code (`shared/ext-lib/scoring.js`): the
-   `score` command's exit code dominates, then smaller diff wins.
+3. Branches are scored on GROUND TRUTH by code (`shared/ext-lib/scoring.js`):
+   the `score` command's exit code dominates, then smaller diff wins.
 4. The ranked results plus the winning patch return to the executor, which
    applies the winning patch itself. Beam proposes; the executor commits.
 
@@ -31,13 +36,13 @@ path for forty.
 
 - Branches start from the last commit, not the dirty working tree. Explore from
   a clean base, or commit/stash first.
-- Adoption is executor-driven in this first cut (it applies the returned patch).
-  Auto-adoption via `git apply`/session graft is a follow-up.
-- The in-process SDK fan-out (`createAgentSessionRuntime`) is the Tier-2 upgrade
-  to the subprocess runner here.
+- Adoption is executor-driven in this first cut (it applies the returned
+  patch). Auto-adoption via `git apply`/session graft is a follow-up.
+- The in-process SDK fan-out (`createAgentSessionRuntime`) is the Tier-2
+  upgrade to the subprocess runner here.
 
 ## Run
 
-```
-ANTHROPIC_API_KEY=... nix run .#pi-beam -- "refactor the auth module; explore 3 designs"
+```sh
+ANTHROPIC_API_KEY=... nix run github:indexable-inc/index#pi-beam -- "refactor the auth module; explore 3 designs"
 ```

--- a/packages/agent/pi-harnesses/beam/assets/hero.svg
+++ b/packages/agent/pi-harnesses/beam/assets/hero.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="16" y="70" width="118" height="48" rx="8"/>
+  <text x="75" y="99" text-anchor="middle" font-size="13" font-weight="600">executor</text>
+
+  <line class="edge" x1="134" y1="82" x2="236" y2="40"/>
+  <line class="edge" x1="134" y1="94" x2="236" y2="94"/>
+  <line class="edge" x1="134" y1="106" x2="236" y2="148"/>
+  <text x="185" y="70" text-anchor="middle" font-size="11" class="muted">explore()</text>
+
+  <rect class="box" x="238" y="20" width="150" height="40" rx="8"/>
+  <text x="313" y="45" text-anchor="middle" font-size="11">worktree A · pi --print</text>
+  <rect class="box" x="238" y="74" width="150" height="40" rx="8"/>
+  <text x="313" y="99" text-anchor="middle" font-size="11">worktree B · pi --print</text>
+  <rect class="box" x="238" y="128" width="150" height="40" rx="8"/>
+  <text x="313" y="153" text-anchor="middle" font-size="11">worktree C · pi --print</text>
+
+  <line class="edge" x1="388" y1="40" x2="466" y2="82"/>
+  <line class="edge" x1="388" y1="94" x2="466" y2="94"/>
+  <line class="edge" x1="388" y1="148" x2="466" y2="106"/>
+
+  <rect class="box" x="468" y="70" width="130" height="48" rx="8"/>
+  <text x="533" y="90" text-anchor="middle" font-size="12" font-weight="600">score</text>
+  <text x="533" y="106" text-anchor="middle" font-size="10" class="muted">exit code, then diff</text>
+
+  <path class="edge" d="M 533 118 C 533 178 120 178 80 122"/>
+  <text x="310" y="186" text-anchor="middle" font-size="11" class="accent">winning patch back to the executor</text>
+</svg>

--- a/packages/agent/pi-harnesses/engine/README.md
+++ b/packages/agent/pi-harnesses/engine/README.md
@@ -1,21 +1,24 @@
+<p align="center"><img src="assets/hero.svg" width="640" alt="Room sends a prompt to the locked-down pi-harness, whose event mapper streams Room-shaped JSON events back"></p>
+
 # pi-harness
 
-The Index-side Pi engine harness (ENG-2262). It runs [Pi](https://pi.dev) as a
+How do you hand a model to a server without handing it a shell? pi-harness is
+the Index-side Pi engine harness (ENG-2262): it runs [Pi](https://pi.dev) as a
 Room-facing engine with **the built-in tools absent**, exposing **only** the
 `ix-mcp` tool surface, selecting the model declaratively, and emitting a
 machine-readable JSON event stream. This mirrors the Claude Code posture in
-`packages/agent/claude-code`: keep one shell/file/web surface by routing through
-the index MCP server. It is the first task in the ENG-2261 "Pi Room integration"
-stack.
+`packages/agent/claude-code`: keep one shell/file/web surface by routing
+through the index MCP server. It is the first task in the ENG-2261 "Pi Room
+integration" stack.
 
 ## What it is
 
 A declarative wrapper around `pi` plus one bridge extension. You import the
 package, you get a `pi-harness` command that launches Pi already locked down.
 
-```
-pi-harness "your prompt"                 # claude (opus-4-8), JSON event stream
-PI_HARNESS_MODEL=codex pi-harness "..."  # gpt-5.5 via OpenAI
+```sh
+nix run github:indexable-inc/index#pi-harness -- "your prompt"      # claude (opus-4-8), JSON event stream
+PI_HARNESS_MODEL=codex pi-harness "..."                             # gpt-5.5 via OpenAI
 ```
 
 ## How the lockdown works
@@ -37,9 +40,9 @@ PI_HARNESS_MODEL=codex pi-harness "..."  # gpt-5.5 via OpenAI
 - **Pi SDK vs CLI** → CLI subprocess in `--mode json`. Clean OS process boundary
   Room can spawn or call; headless-testable; no Node embedding. The SDK
   (`@earendil-works/pi-coding-agent`) stays a later option.
-- **Guaranteeing built-ins are absent** → `--no-builtin-tools` makes them absent,
-  not merely denied. The smoke test asserts no `bash`/`read`/`write`/`edit` tool
-  appears in the stream.
+- **Guaranteeing built-ins are absent** → `--no-builtin-tools` makes them
+  absent, not merely denied. The smoke test asserts no `bash`/`read`/`write`/
+  `edit` tool appears in the stream.
 - **Model/key ownership** → the harness owns model *selection* (`models.nix`);
   the caller owns *keys* (env), matching the ENG-2261 secret-store plan.
 - **Session** → `--no-session` (ephemeral per turn) for this first cut. A
@@ -97,9 +100,9 @@ ix-mcp store updates emit the dashboard-shaped payloads directly:
 
 Those payloads preserve the MCP dashboard interpretations for source/code,
 stdout tail, status, final result, rich mime outputs, bindings, curated cells,
-and live HTML resources. `code_html` is intentionally empty in the harness feed;
-the MCP UI already falls back to raw `code`, and final Room rendering owns
-syntax highlighting.
+and live HTML resources. `code_html` is intentionally empty in the harness
+feed; the MCP UI already falls back to raw `code`, and final Room rendering
+owns syntax highlighting.
 
 ## Validation
 
@@ -108,8 +111,8 @@ the **shipped** `bin/pi-harness`, and asserts: built-ins absent, `python_exec`
 exposed, JSON turn events emitted. It needs network + an API key, so run it
 yourself:
 
-```
-ANTHROPIC_API_KEY=... ./packages/pi-harness/smoke/run.sh
+```sh
+ANTHROPIC_API_KEY=... ./packages/agent/pi-harnesses/engine/smoke/run.sh
 ```
 
 The bridge is packaged with `buildNpmPackage`, so the store extension ships its
@@ -124,8 +127,8 @@ when listed there.
 
 The Room event mapper has a pure stdlib test:
 
-```
-python3 packages/pi-harness/room_event_mapper_test.py
+```sh
+python3 packages/agent/pi-harnesses/engine/room_event_mapper_test.py
 ```
 
 The process hardening is part of the shipped `pi-harness` binary. On Linux,
@@ -133,6 +136,9 @@ the launcher hardens itself first, then sets `LD_PRELOAD` for Pi so the
 post-`exec` Pi process reapplies the same non-dumpable boundary. The MCP child
 still gets the explicit scrubbed env from the bridge and does not inherit
 provider keys.
+
+Repo-local commands assume a clone:
+`git clone https://github.com/indexable-inc/index`.
 
 ## Follow-ups (intentionally deferred)
 

--- a/packages/agent/pi-harnesses/engine/assets/hero.svg
+++ b/packages/agent/pi-harnesses/engine/assets/hero.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="66" width="130" height="52" rx="8"/>
+  <text x="85" y="96" text-anchor="middle" font-size="13" font-weight="600">Room server</text>
+
+  <line class="edge" x1="150" y1="82" x2="228" y2="82"/>
+  <text x="189" y="66" text-anchor="middle" font-size="11" class="muted">prompt</text>
+
+  <rect class="box" x="230" y="42" width="190" height="100" rx="8"/>
+  <text x="325" y="68" text-anchor="middle" font-size="13" font-weight="600">pi-harness</text>
+  <text x="325" y="90" text-anchor="middle" font-size="11" class="muted">built-ins absent</text>
+  <text x="325" y="108" text-anchor="middle" font-size="11" class="muted">ix-mcp tools only</text>
+  <text x="325" y="126" text-anchor="middle" font-size="11" class="muted">hardened launcher</text>
+
+  <line class="edge" x1="420" y1="82" x2="498" y2="82"/>
+  <text x="459" y="66" text-anchor="middle" font-size="11" class="muted">pi JSON</text>
+
+  <rect class="box" x="500" y="56" width="122" height="52" rx="8"/>
+  <text x="561" y="78" text-anchor="middle" font-size="12" font-weight="600">event mapper</text>
+  <text x="561" y="96" text-anchor="middle" font-size="10" class="muted">+ ix-mcp store</text>
+
+  <path class="edge" d="M 561 108 C 561 176 140 176 90 122"/>
+  <text x="330" y="180" text-anchor="middle" font-size="11" class="accent">turn_started · text_delta · cell_update · turn_completed</text>
+</svg>

--- a/packages/agent/pi-harnesses/fusion/README.md
+++ b/packages/agent/pi-harnesses/fusion/README.md
@@ -1,6 +1,11 @@
+<p align="center"><img src="assets/hero.svg" width="620" alt="a fable-5 primary delegates bounded work to a headless gpt-5.5-low sidekick in an isolated worktree, which returns a summary and a patch"></p>
+
 # pi-fusion
 
-Pi primary agent with a delegated sidekick model.
+Why spend frontier-model turns on bulk inspection and mechanical edits?
+pi-fusion runs a Pi primary agent that delegates bounded work to a cheaper
+headless sidekick model, keeping the expensive model on planning,
+ambiguity-resolution, monitoring, and final review.
 
 ## How it works
 
@@ -28,23 +33,23 @@ inspection, mechanical edits, and test loops.
 
 Sonnet can be tried later without changing the harness:
 
-```
+```sh
 PI_FUSION_SIDEKICK_PROVIDER=anthropic \
 PI_FUSION_SIDEKICK_MODEL=sonnet-5 \
 PI_FUSION_SIDEKICK_THINKING= \
-nix run .#pi-fusion -- "your task"
+nix run github:indexable-inc/index#pi-fusion -- "your task"
 ```
 
 ## Run
 
-```
-ANTHROPIC_API_KEY=... OPENAI_API_KEY=... nix run .#pi-fusion -- "make the failing test pass"
+```sh
+ANTHROPIC_API_KEY=... OPENAI_API_KEY=... nix run github:indexable-inc/index#pi-fusion -- "make the failing test pass"
 ```
 
 ## Current limit
 
-This first cut delegates headless sidekick turns and keeps sidekick file changes
-isolated until the primary applies the returned patch. It does not yet keep a
-durable sidekick process with a cached long-lived context. The next step is to
-replace `runner/sidekick.js` with a session runner while preserving the same
-`delegate` tool contract.
+This first cut delegates headless sidekick turns and keeps sidekick file
+changes isolated until the primary applies the returned patch. It does not yet
+keep a durable sidekick process with a cached long-lived context. The next step
+is to replace `runner/sidekick.js` with a session runner while preserving the
+same `delegate` tool contract.

--- a/packages/agent/pi-harnesses/fusion/assets/hero.svg
+++ b/packages/agent/pi-harnesses/fusion/assets/hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 180" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="56" width="170" height="64" rx="8"/>
+  <text x="105" y="82" text-anchor="middle" font-size="13" font-weight="600">primary · fable-5</text>
+  <text x="105" y="102" text-anchor="middle" font-size="11" class="muted">plan · resolve · review</text>
+
+  <line class="edge" x1="190" y1="72" x2="388" y2="52"/>
+  <text x="289" y="42" text-anchor="middle" font-size="11" class="muted">delegate(task)</text>
+
+  <rect class="box" x="390" y="28" width="210" height="64" rx="8"/>
+  <text x="495" y="54" text-anchor="middle" font-size="13" font-weight="600">sidekick · gpt-5.5 low</text>
+  <text x="495" y="74" text-anchor="middle" font-size="11" class="muted">headless, isolated worktree</text>
+
+  <line class="edge" x1="390" y1="112" x2="192" y2="106"/>
+  <text x="291" y="132" text-anchor="middle" font-size="11" class="muted">summary + patch</text>
+  <rect class="box" x="390" y="100" width="210" height="24" rx="6"/>
+  <text x="495" y="116" text-anchor="middle" font-size="10" class="muted">bulk edits · inspection · test loops</text>
+
+  <text x="105" y="156" text-anchor="middle" font-size="11" class="accent">primary applies or revises</text>
+</svg>

--- a/packages/agent/pi-harnesses/omp/README.md
+++ b/packages/agent/pi-harnesses/omp/README.md
@@ -1,10 +1,14 @@
+<p align="center"><img src="assets/hero.svg" width="660" alt="the pinned upstream oh-my-pi binary plus bridge extensions make existing Claude Code hooks and agents work under omp"></p>
+
 # omp
 
-The [oh-my-pi](https://github.com/can1357/oh-my-pi) (`omp`) coding-agent setup:
-the pinned upstream release binary plus the extensions and smoke test that make
-Claude Code assets work under it. Copied from the personal nix repo
-(`flake/omp.nix`, `dots/omp/extensions/`, `scripts/omp/`); that repo remains
-the deployed source, this is the shared home alongside the other harnesses.
+Want your Claude Code hooks and agents to keep working under a different
+harness? This is the [oh-my-pi](https://github.com/can1357/oh-my-pi) (`omp`)
+coding-agent setup: the pinned upstream release binary plus the extensions and
+smoke test that make Claude Code assets work under it. Copied from the personal
+nix repo (`flake/omp.nix`, `dots/omp/extensions/`, `scripts/omp/`); that repo
+remains the deployed source, this is the shared home alongside the other
+harnesses.
 
 Unlike its siblings, `omp` is not built through `shared/mk-pi-harness.nix`: it
 is upstream's own harness distribution (a self-contained `bun build --compile`
@@ -13,8 +17,8 @@ network inside the sandbox at three stages (bun dependency install, the
 cross-target bun runtime download, the napi addon pipeline). See default.nix
 for the bump procedure.
 
-```
-nix run .#omp
+```sh
+nix run github:indexable-inc/index#omp
 ```
 
 ## Layout
@@ -41,7 +45,10 @@ with `provider/model[:thinking][,fallback...]` role syntax.
 The smoke test needs a working `omp` with model credentials (it does real `-p`
 runs), so it is a manual gate, not a nix check:
 
-```
+```sh
 OMP=$(nix build .#omp --print-out-paths)/bin/omp \
   packages/agent/pi-harnesses/omp/smoke/claude-hooks-smoke.sh
 ```
+
+The smoke command assumes a clone:
+`git clone https://github.com/indexable-inc/index`.

--- a/packages/agent/pi-harnesses/omp/assets/hero.svg
+++ b/packages/agent/pi-harnesses/omp/assets/hero.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660 180" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="60" width="190" height="60" rx="8"/>
+  <text x="115" y="85" text-anchor="middle" font-size="13" font-weight="600">oh-my-pi binary</text>
+  <text x="115" y="104" text-anchor="middle" font-size="11" class="muted">pinned upstream release</text>
+
+  <text x="234" y="96" text-anchor="middle" font-size="18" class="muted">+</text>
+
+  <rect class="box" x="258" y="34" width="180" height="112" rx="8"/>
+  <text x="348" y="58" text-anchor="middle" font-size="12" font-weight="600">bridge extensions</text>
+  <text x="348" y="82" text-anchor="middle" font-size="11" class="muted">claude-hooks.ts</text>
+  <text x="348" y="100" text-anchor="middle" font-size="11" class="muted">claude-agents.ts</text>
+  <text x="348" y="118" text-anchor="middle" font-size="11" class="muted">modes.ts</text>
+
+  <line class="edge" x1="438" y1="90" x2="496" y2="90"/>
+  <text x="467" y="74" text-anchor="middle" font-size="11" class="muted">translate</text>
+
+  <rect class="box" x="498" y="60" width="142" height="60" rx="8"/>
+  <text x="569" y="85" text-anchor="middle" font-size="12" font-weight="600">your .claude/</text>
+  <text x="569" y="104" text-anchor="middle" font-size="11" class="accent">hooks · agents · modes</text>
+</svg>

--- a/packages/agent/pi-harnesses/prosecutor/README.md
+++ b/packages/agent/pi-harnesses/prosecutor/README.md
@@ -1,28 +1,35 @@
+<p align="center"><img src="assets/hero.svg" width="640" alt="the executor must state a falsifiable claim; an isolated prosecutor verifies it and its verdict widens or resets the trust interval"></p>
+
 # pi-prosecutor
 
-An executor under a skeptical supervisor with earned-trust check-ins.
+Who checks your agent's claims when it grades its own homework? pi-prosecutor
+runs an executor under a skeptical supervisor with earned-trust check-ins: the
+executor must periodically state a falsifiable claim, and a context-isolated
+prosecutor verifies it against the real repo.
 
 ## How it works
 
 1. The executor works normally with its full tool surface.
-2. On an adaptive interval it is forced to stop and state one falsifiable claim:
-   `claim({ statement, verify })`. Until it does, the `tool_call` gate blocks
-   every other tool.
+2. On an adaptive interval it is forced to stop and state one falsifiable
+   claim: `claim({ statement, verify })`. Until it does, the `tool_call` gate
+   blocks every other tool.
 3. The claim is handed to a **prosecutor**: a fresh `pi --print --no-session`
    process on the same executor-class model (opus-4-8 / gpt-5.5 medium) with NO
-   access to the executor's transcript. It runs the suggested check plus its own
-   probes and returns `VERDICT: UPHELD` or `VERDICT: BROKEN <evidence>`. The
-   asymmetry that matters is context isolation, not a weaker model.
+   access to the executor's transcript. It runs the suggested check plus its
+   own probes and returns `VERDICT: UPHELD` or `VERDICT: BROKEN <evidence>`.
+   The asymmetry that matters is context isolation, not a weaker model.
 4. Trust is earned: an upheld claim doubles the check-in interval (1 to 16); a
-   broken claim snaps it back to every action and tells the executor to recover.
+   broken claim snaps it back to every action and tells the executor to
+   recover.
 
 No shared context means the two agents cannot launder each other's
-hallucinations - the supervisor only ever sees the claim and the repo.
+hallucinations: the supervisor only ever sees the claim and the repo.
 
 ## Pieces
 
 - `extension/prosecutor.ts` - the gate, the `claim` tool, the trust loop.
-- `shared/ext-lib/trust.js` - earned-trust interval state machine (unit-tested).
+- `shared/ext-lib/trust.js` - earned-trust interval state machine
+  (unit-tested).
 - `shared/ext-lib/child-agent.js` - spawns the isolated prosecutor.
 - `shared/ext-lib/probes.js` - parses the verdict (fails closed on ambiguity).
 
@@ -32,11 +39,11 @@ hallucinations - the supervisor only ever sees the claim and the repo.
   `codex` = gpt-5.5 medium).
 - `PI_PROSECUTOR_PROVIDER` / `PI_PROSECUTOR_MODEL` / `PI_PROSECUTOR_THINKING` -
   override the prosecutor model; defaults to the active executor model.
-- `PI_PROSECUTOR_GOAL` - objective for the prosecutor to judge against; if unset,
-  captured from the first user message.
+- `PI_PROSECUTOR_GOAL` - objective for the prosecutor to judge against; if
+  unset, captured from the first user message.
 
 ## Run
 
-```
-ANTHROPIC_API_KEY=... nix run .#pi-prosecutor -- "make the failing test in foo/ pass"
+```sh
+ANTHROPIC_API_KEY=... nix run github:indexable-inc/index#pi-prosecutor -- "make the failing test in foo/ pass"
 ```

--- a/packages/agent/pi-harnesses/prosecutor/assets/hero.svg
+++ b/packages/agent/pi-harnesses/prosecutor/assets/hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="56" width="150" height="60" rx="8"/>
+  <text x="95" y="81" text-anchor="middle" font-size="13" font-weight="600">executor</text>
+  <text x="95" y="100" text-anchor="middle" font-size="11" class="muted">full tool surface</text>
+
+  <line class="edge" x1="170" y1="72" x2="368" y2="56"/>
+  <text x="269" y="46" text-anchor="middle" font-size="11" class="muted">claim({ statement, verify })</text>
+
+  <rect class="box" x="370" y="30" width="250" height="64" rx="8"/>
+  <text x="495" y="56" text-anchor="middle" font-size="13" font-weight="600">prosecutor</text>
+  <text x="495" y="76" text-anchor="middle" font-size="11" class="muted">fresh pi, no shared transcript</text>
+
+  <line class="edge" x1="370" y1="106" x2="172" y2="102"/>
+  <text x="271" y="126" text-anchor="middle" font-size="11" class="muted">VERDICT: UPHELD / BROKEN</text>
+  <rect class="box" x="370" y="94" width="250" height="24" rx="6"/>
+  <text x="495" y="110" text-anchor="middle" font-size="10" class="muted">runs the check + its own probes</text>
+
+  <text x="320" y="166" text-anchor="middle" font-size="11" class="accent">upheld → interval ×2 (1…16) · broken → check every action</text>
+</svg>

--- a/packages/agent/subagent-cache/README.md
+++ b/packages/agent/subagent-cache/README.md
@@ -1,19 +1,22 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="a lookup must clear FTS recall, a Haiku judge, and a client-side freshness check to serve a cached finding; any miss falls back to a cold run that repopulates the cache"></p>
+
 # subagent-cache
 
-A small axum + Postgres daemon (lib `subagent_cache`, bin `subagent-cache`,
-ENG-4665) that serves a repeated read-only subagent investigation from a prior
-finding while every file that finding read is still byte-for-byte unchanged. It
-is developer tooling for the Claude Code investigation subagents: tailnet-only,
-fail-open, with no production data path. A daemon outage is invisible to
-developers (silent cold run).
+Why re-run the same read-only investigation when nothing it read has changed?
+subagent-cache is a small axum + Postgres daemon (lib `subagent_cache`, bin
+`subagent-cache`, ENG-4665) that serves a repeated subagent investigation from
+a prior finding while every file that finding read is still byte-for-byte
+unchanged. It is developer tooling for the Claude Code investigation subagents:
+tailnet-only, fail-open, with no production data path. A daemon outage is
+invisible to developers (silent cold run).
 
 ## How the cache works
 
 A cache hit must clear three gates. The daemon owns the first two; the client
 hook owns the third, because only the client can see its working tree.
 
-1. **Stage 1 recall (daemon, `store::recall`).** Postgres full-text search ranks
-   non-expired rows of the same `agent_type` and persona by
+1. **Stage 1 recall (daemon, `store::recall`).** Postgres full-text search
+   ranks non-expired rows of the same `agent_type` and persona by
    `ts_rank(question_tsv, plainto_tsquery(...))`, returning the top-K above the
    recall floor, best-first.
 2. **Stage 2 judge (daemon, `judge::judge`).** A single Haiku-class Anthropic
@@ -26,24 +29,9 @@ hook owns the third, because only the client can see its working tree.
    hash drops the candidate to a cold run. The daemon never touches the
    filesystem, so `file_deps` hashes are opaque strings to it.
 
-A finished cold investigation is upserted back via `POST /populate`, so the next
-identical question can hit. The client hooks own all working-tree hashing and
-speak the same xxh64 freshness language as the mgrep search index.
-
-```mermaid
-flowchart TD
-    A[Subagent dispatch] --> B[lookup hook]
-    B -->|POST /lookup| C{Stage 1: FTS recall}
-    C -->|no candidate| MISS[Cold run]
-    C -->|top-K candidates| D{Stage 2: Haiku judge}
-    D -->|none answer| MISS
-    D -->|judge-positive| E{Stage 3: freshness}
-    E -->|file_deps hash changed| MISS
-    E -->|all hashes match| HIT[Serve cached findings]
-    MISS --> F[Run investigation]
-    F -->|POST /populate| G[(subagent_cache Postgres)]
-    C -.reads.-> G
-```
+A finished cold investigation is upserted back via `POST /populate`, so the
+next identical question can hit. The client hooks own all working-tree hashing
+and speak the same xxh64 freshness language as the mgrep search index.
 
 ## HTTP API
 
@@ -60,6 +48,18 @@ Every error variant maps to a 500 with a generic body; the hook fails open, so
 detail is for operators (logs), not the client. Lookups log to the
 `subagent_cache.lookup` target with `recalled`/`judged`/`result` for hit-rate
 measurement.
+
+## Run
+
+```sh
+nix run github:indexable-inc/index#subagent-cache -- --help
+```
+
+As a Rust binary via cargo:
+
+```sh
+cargo install --git https://github.com/indexable-inc/index subagent-cache
+```
 
 ## Config
 
@@ -86,8 +86,8 @@ false-hit rates.
 A dedicated `standalone` Postgres role and database `subagent_cache`,
 deliberately separate from the user-facing database so a disposable dev-tooling
 cache never shares a process with production data. The daemon applies
-`schema.sql` idempotently on startup (`store::bootstrap`); it is not part of the
-prod migration runner. One table, `subagent_cache`, with a generated
+`schema.sql` idempotently on startup (`store::bootstrap`); it is not part of
+the prod migration runner. One table, `subagent_cache`, with a generated
 `question_tsv` column (gin-indexed for Stage-1 recall), a `(agent_type,
 agent_def_hash, expires_at)` recall index, and a unique `(agent_type, question,
 agent_def_hash)` key that `populate` upserts onto.

--- a/packages/agent/subagent-cache/assets/hero.svg
+++ b/packages/agent/subagent-cache/assets/hero.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 210" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="16" y="70" width="112" height="50" rx="8"/>
+  <text x="72" y="91" text-anchor="middle" font-size="12" font-weight="600">lookup</text>
+  <text x="72" y="108" text-anchor="middle" font-size="10" class="muted">question</text>
+
+  <line class="edge" x1="128" y1="95" x2="166" y2="95"/>
+
+  <rect class="box" x="168" y="70" width="128" height="50" rx="8"/>
+  <text x="232" y="91" text-anchor="middle" font-size="12" font-weight="600">FTS recall</text>
+  <text x="232" y="108" text-anchor="middle" font-size="10" class="muted">Postgres ts_rank</text>
+
+  <line class="edge" x1="296" y1="95" x2="334" y2="95"/>
+
+  <rect class="box" x="336" y="70" width="128" height="50" rx="8"/>
+  <text x="400" y="91" text-anchor="middle" font-size="12" font-weight="600">Haiku judge</text>
+  <text x="400" y="108" text-anchor="middle" font-size="10" class="muted">answers it?</text>
+
+  <line class="edge" x1="464" y1="95" x2="502" y2="95"/>
+
+  <rect class="box" x="504" y="70" width="128" height="50" rx="8"/>
+  <text x="568" y="91" text-anchor="middle" font-size="12" font-weight="600">freshness</text>
+  <text x="568" y="108" text-anchor="middle" font-size="10" class="muted">file_deps hashes</text>
+
+  <line class="edge" x1="632" y1="95" x2="672" y2="95"/>
+  <text x="690" y="100" text-anchor="middle" font-size="13" class="accent">hit</text>
+
+  <line class="edge" x1="232" y1="120" x2="232" y2="158"/>
+  <line class="edge" x1="400" y1="120" x2="400" y2="158"/>
+  <line class="edge" x1="568" y1="120" x2="568" y2="158"/>
+  <text x="400" y="180" text-anchor="middle" font-size="12">any gate fails → cold run → <tspan class="accent">POST /populate</tspan></text>
+</svg>

--- a/packages/agent/symphony/README.md
+++ b/packages/agent/symphony/README.md
@@ -1,45 +1,72 @@
-<p align="center">
-  <img src="../../../doc/assets/logo.svg" width="80" alt="Symphony" />
-</p>
+<p align="center"><img src="assets/hero.svg" width="720" alt=".sym workflows are lowered to an IR run graph and walked by a supervised OTP runtime with triggers in and dashboards and PRs out"></p>
 
 # symphony
 
+What if agent workflows were boring, deterministic DAGs instead of vibes?
+Symphony is a boring DAG runtime for deterministic agent workflows: workflows
+are written in the `.sym` surface language, lowered to an IR run graph, and
+walked by a supervised Elixir/OTP runtime with a LiveView dashboard,
+cron/Slack/Linear/GitHub triggers, and per-run git worktrees. It moved here
+from the dedicated [indexable-inc/symphony](https://github.com/indexable-inc/symphony)
+repo (rev `c9e7092`).
+
 > [!IMPORTANT]
-> Symphony is highly experimental software. Use it at your own risk: it can spawn Codex sessions, create branches, open PRs, and mutate Linear/GitHub state when credentials allow it.
+> Symphony is highly experimental software. Use it at your own risk: it can
+> spawn Codex sessions, create branches, open PRs, and mutate Linear/GitHub
+> state when credentials allow it.
 
-Symphony is a boring DAG runtime for deterministic agent workflows. Workflows are written in the `.sym` surface language, lowered to an IR run graph, and walked by a supervised Elixir/OTP runtime with a LiveView dashboard, cron/Slack/Linear/GitHub triggers, and per-run git worktrees. It moved here from the dedicated [indexable-inc/symphony](https://github.com/indexable-inc/symphony) repo (rev `c9e7092`).
-
-Run it from this repo:
+## Run
 
 ```sh
-nix run .#symphony
+nix run github:indexable-inc/index#symphony
 ```
 
-The launcher requires an authenticated `codex` on PATH and refuses to start without one. It stages this source tree under `~/.local/state/symphony`, fetches mix deps, and boots the dashboard on http://127.0.0.1:4040. Point `SYMPHONY_PRIMARY_REPO` at a local checkout first; [doc/setup.md](doc/setup.md) and [.env.example](.env.example) cover the full configuration surface.
+The launcher requires an authenticated `codex` on PATH and refuses to start
+without one. It stages this source tree under `~/.local/state/symphony`,
+fetches mix deps, and boots the dashboard on http://127.0.0.1:4040. Point
+`SYMPHONY_PRIMARY_REPO` at a local checkout first; [docs/setup.md](docs/setup.md)
+and [.env.example](.env.example) cover the full configuration surface.
 
 <img alt="Symphony dashboard" src="https://github.com/user-attachments/assets/eb06f062-3b2d-41a4-a679-94c5c2f847aa" />
 
 ## Layout
 
-- [`elixir/`](elixir/): the runtime (DSL parser, IR, runtime supervisor, Phoenix dashboard, triggers).
-- [`workflows/example/`](workflows/example/): the bundled pack, intentionally narrow (one manual-trigger `inspect` workflow plus its read-only skill). Real deployments point `SYMPHONY_PACK_DIR` at their own pack.
-- [`contracts/fixtures/`](contracts/fixtures/): engine wire fixtures shared with the room-server in the ix monorepo. The Elixir contract tests read them from `../../contracts`, so this directory stays beside `elixir/`.
-- [`bin/run-nix`](bin/run-nix): the production entrypoint the `symphony` package wraps.
-- [`doc/`](doc/): setup, engine contract, and quality-gate reference.
+- [`elixir/`](elixir/): the runtime (DSL parser, IR, runtime supervisor,
+  Phoenix dashboard, triggers).
+- [`workflows/example/`](workflows/example/): the bundled pack, intentionally
+  narrow (one manual-trigger `inspect` workflow plus its read-only skill). Real
+  deployments point `SYMPHONY_PACK_DIR` at their own pack.
+- [`contracts/fixtures/`](contracts/fixtures/): engine wire fixtures shared
+  with the room-server in the ix monorepo. The Elixir contract tests read them
+  from `../../contracts`, so this directory stays beside `elixir/`.
+- [`bin/run-nix`](bin/run-nix): the production entrypoint the `symphony`
+  package wraps.
+- [`docs/`](docs/): setup, engine contract, and quality-gate reference.
 
 ## Neighbors
 
-- The room stack symphony drives over HTTP (`room-server` and the room UI) lives in the ix monorepo (`crates/room`, `packages/room`).
-- `location: ixvm` placements provision VMs through ix's fleet path. TODO: restore `room-server` on PATH once the ix<->index flake cycle is resolved.
-- Deployment goes through the [`symphony` NixOS module](../../modules/services/symphony/) (`services.symphony.*`), with secrets supplied via `environmentFile` or `secretsCommand`.
+- The room stack symphony drives over HTTP (`room-server` and the room UI)
+  lives in the ix monorepo (`crates/room`, `packages/room`).
+- `location: ixvm` placements provision VMs through ix's fleet path. TODO:
+  restore `room-server` on PATH once the ix<->index flake cycle is resolved.
+- Deployment goes through the
+  [`symphony` NixOS module](../../../modules/services/symphony/)
+  (`services.symphony.*`), with secrets supplied via `environmentFile` or
+  `secretsCommand`.
 
 ## Developing
 
 ```sh
+git clone https://github.com/indexable-inc/index
+cd index
 nix develop .#symphony   # Elixir 1.19 / OTP 28, plus codex, gh, git
 cd packages/agent/symphony/elixir
 make all                 # setup, compile -Werror, fmt-check, credo
 mix test
 ```
 
-CI runs the same required lane sandboxed as the `symphony-elixir` flake check (see [default.nix](default.nix)); after changing `elixir/mix.lock`, refresh the `fetchMixDeps` hash there. The advisory lane (`make quality`: sobelow, deps.audit, dialyzer, coveralls) stays a local run; see [doc/quality.md](doc/quality.md).
+CI runs the same required lane sandboxed as the `symphony-elixir` flake check
+(see [default.nix](default.nix)); after changing `elixir/mix.lock`, refresh the
+`fetchMixDeps` hash there. The advisory lane (`make quality`: sobelow,
+deps.audit, dialyzer, coveralls) stays a local run; see
+[docs/quality.md](docs/quality.md).

--- a/packages/agent/symphony/assets/hero.svg
+++ b/packages/agent/symphony/assets/hero.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 210" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <text x="330" y="30" text-anchor="middle" font-size="11" class="muted">cron · Slack · Linear · GitHub triggers</text>
+  <line class="edge" x1="330" y1="38" x2="330" y2="76"/>
+
+  <rect class="box" x="20" y="90" width="150" height="52" rx="8"/>
+  <text x="95" y="112" text-anchor="middle" font-size="13" font-weight="600">.sym workflow</text>
+  <text x="95" y="130" text-anchor="middle" font-size="11" class="muted">surface language</text>
+
+  <line class="edge" x1="170" y1="116" x2="228" y2="116"/>
+  <text x="199" y="102" text-anchor="middle" font-size="11" class="muted">lower</text>
+
+  <rect class="box" x="230" y="90" width="130" height="52" rx="8"/>
+  <text x="295" y="112" text-anchor="middle" font-size="13" font-weight="600">IR run graph</text>
+  <text x="295" y="130" text-anchor="middle" font-size="11" class="muted">deterministic DAG</text>
+
+  <line class="edge" x1="360" y1="116" x2="418" y2="116"/>
+  <text x="389" y="102" text-anchor="middle" font-size="11" class="muted">walk</text>
+
+  <rect class="box" x="420" y="80" width="170" height="72" rx="8"/>
+  <text x="505" y="104" text-anchor="middle" font-size="13" font-weight="600">OTP runtime</text>
+  <text x="505" y="122" text-anchor="middle" font-size="11" class="muted">supervised, per-run</text>
+  <text x="505" y="138" text-anchor="middle" font-size="11" class="muted">git worktrees</text>
+
+  <line class="edge" x1="590" y1="100" x2="640" y2="80"/>
+  <line class="edge" x1="590" y1="132" x2="640" y2="152"/>
+  <text x="648" y="76" font-size="11" class="accent">dashboard</text>
+  <text x="648" y="156" font-size="11" class="accent">PRs · Linear</text>
+</svg>

--- a/packages/agent/system-prompt-eval-viewer/README.md
+++ b/packages/agent/system-prompt-eval-viewer/README.md
@@ -1,21 +1,24 @@
+<p align="center"><img src="assets/hero.svg" width="680" alt="an eval result JSON is served into a local single-page app with summary cards, a behaviors panel, and the full action timeline"></p>
+
 # system-prompt-eval-viewer
 
-A modern Svelte + Vite single-page app that renders a `system-prompt-eval` result
-JSON. The eval emits the machine JSON (`--json-out`); this app is the view.
+Got a `system-prompt-eval` result JSON and want to actually read it? This is a
+modern Svelte + Vite single-page app that renders one: the eval emits the
+machine JSON (`--json-out`); this app is the view.
 
 ```sh
 # run an eval, then open its result in the viewer
-nix run .#system-prompt-eval -- run --eval all --json-out /tmp/result.json
-nix run .#system-prompt-eval-viewer -- /tmp/result.json
+nix run github:indexable-inc/index#system-prompt-eval -- run --eval all --json-out /tmp/result.json
+nix run github:indexable-inc/index#system-prompt-eval-viewer -- /tmp/result.json
 
 # no argument -> bundled sample
-nix run .#system-prompt-eval-viewer
+nix run github:indexable-inc/index#system-prompt-eval-viewer
 ```
 
-The wrapper copies the built site to a temp dir, drops the JSON in as `data.json`
-(which the app fetches on load), serves it on `127.0.0.1:8777`, and opens a
-browser. You can also drag-and-drop any result JSON onto the page, or use the
-**load JSON** button.
+The wrapper copies the built site to a temp dir, drops the JSON in as
+`data.json` (which the app fetches on load), serves it on `127.0.0.1:8777`, and
+opens a browser. You can also drag-and-drop any result JSON onto the page, or
+use the **load JSON** button.
 
 ## What it shows
 
@@ -23,12 +26,15 @@ browser. You can also drag-and-drop any result JSON onto the page, or use the
 - a behaviors panel per eval: each behavior's name, full rubric, pass-rate bar,
   and a clickable pass/fail dot per rollout (jumps to that run);
 - per rollout, the verdicts with the judge's evidence plus the **full action
-  timeline** — every assistant message, thinking block, tool call with its input,
-  tool result, and the final answer.
+  timeline**: every assistant message, thinking block, tool call with its
+  input, tool result, and the final answer.
 
 ## Dev
 
+In a clone (`git clone https://github.com/indexable-inc/index`):
+
 ```sh
+cd packages/agent/system-prompt-eval-viewer
 npm install
 npm run dev      # vite dev server
 npm run build    # static bundle into dist/

--- a/packages/agent/system-prompt-eval-viewer/assets/hero.svg
+++ b/packages/agent/system-prompt-eval-viewer/assets/hero.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 180" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="64" width="150" height="54" rx="8"/>
+  <text x="95" y="87" text-anchor="middle" font-size="13" font-weight="600">result JSON</text>
+  <text x="95" y="105" text-anchor="middle" font-size="11" class="muted">--json-out</text>
+
+  <line class="edge" x1="170" y1="91" x2="248" y2="91"/>
+  <text x="209" y="76" text-anchor="middle" font-size="11" class="muted">data.json</text>
+
+  <rect class="box" x="250" y="64" width="160" height="54" rx="8"/>
+  <text x="330" y="87" text-anchor="middle" font-size="13" font-weight="600">viewer SPA</text>
+  <text x="330" y="105" text-anchor="middle" font-size="11" class="muted">127.0.0.1:8777</text>
+
+  <line class="edge" x1="410" y1="78" x2="466" y2="42"/>
+  <line class="edge" x1="410" y1="91" x2="466" y2="91"/>
+  <line class="edge" x1="410" y1="104" x2="466" y2="140"/>
+
+  <rect class="box" x="468" y="22" width="192" height="36" rx="8"/>
+  <text x="564" y="45" text-anchor="middle" font-size="12">summary cards</text>
+  <rect class="box" x="468" y="73" width="192" height="36" rx="8"/>
+  <text x="564" y="96" text-anchor="middle" font-size="12">behaviors panel</text>
+  <rect class="box" x="468" y="124" width="192" height="36" rx="8"/>
+  <text x="564" y="147" text-anchor="middle" font-size="12" class="accent">full action timeline</text>
+</svg>

--- a/packages/agent/system-prompt-eval/README.md
+++ b/packages/agent/system-prompt-eval/README.md
@@ -1,17 +1,24 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="the house system prompt is loaded into fresh claude -p rollouts, an LLM judge scores them, and the scores are committed as diffable JSON"></p>
+
 # system-prompt-eval
 
-A reproducible, **scored** behavioral eval for the house system prompt
-(`packages/agent/system-prompt.nix`). Every eval spawns fresh `claude -p`
-rollouts that load the prompt the same way a production session does, then an LLM
-judge scores the result. Scores are committed under `eval-results/` so the
-prompt's behavior is tracked over time, run to run.
+How do you know a system-prompt edit made the agent better and not just
+different? system-prompt-eval is a reproducible, **scored** behavioral eval for
+the house system prompt (`packages/agent/system-prompt.nix`). Every eval spawns
+fresh `claude -p` rollouts that load the prompt the same way a production
+session does, then an LLM judge scores the result. Scores are committed under
+`eval-results/` so the prompt's behavior is tracked over time, run to run.
 
 ## Run
 
 ```sh
 # list the evals
-nix run .#system-prompt-eval -- list
+nix run github:indexable-inc/index#system-prompt-eval -- list
+```
 
+In a clone (`git clone https://github.com/indexable-inc/index`):
+
+```sh
 # run everything (safe by default: no real side effects)
 nix run .#system-prompt-eval -- run --eval all --rollouts 5 \
   --json-out packages/agent/system-prompt-eval/eval-results/$(date +%F).json
@@ -49,17 +56,17 @@ streak** (the "N agents in a row" signal).
 Given a repository it can `git clone` (a fake clone that copies a committed
 **patched** fixture, `fixtures/future-lib`), does the agent check the current
 code or trust stale training knowledge? The fixture's README states the *old*
-behavior; the code is patched to the *new* behavior. An agent that reads the code
-answers correctly (`validated`); one that trusts memory/docs answers the stale
-way (`stale`). This simulates the future: code keeps changing, so the house
-default must be to validate the artifact (the `validate` / `liveSystemEvidence`
-rules). Headline = fraction validated.
+behavior; the code is patched to the *new* behavior. An agent that reads the
+code answers correctly (`validated`); one that trusts memory/docs answers the
+stale way (`stale`). This simulates the future: code keeps changing, so the
+house default must be to validate the artifact (the `validate` /
+`liveSystemEvidence` rules). Headline = fraction validated.
 
 - runs a shell in a throwaway dir with the fake-`git` shim on `PATH`.
 - `--sandbox` wraps each rollout in the OS sandbox (`sandbox-exec` on macOS,
-  `bwrap` on Linux): writes are confined to the throwaway root, reads and network
-  stay open (the agent needs the Nix store and the Anthropic API). Not airtight
-  compute isolation; that is what ix VMs are for.
+  `bwrap` on Linux): writes are confined to the throwaway root, reads and
+  network stay open (the agent needs the Nix store and the Anthropic API). Not
+  airtight compute isolation; that is what ix VMs are for.
 
 ### `reverse-engineering`
 
@@ -67,9 +74,9 @@ Asks about an undocumented behavior of the **pinned** Claude Code binary itself
 (e.g. whether this build gates tmux 24-bit / truecolor output, and where). The
 only honest way to answer is to inspect the bundle (`strings`/`grep`/read the
 JS); an agent that does that `reverse_engineered` (validated), one that answers
-from prior knowledge did not. The binary path + sha256 are recorded so the probe
-is stable. Web tools are denied so it cannot look the answer up. Headline =
-fraction that reverse-engineered.
+from prior knowledge did not. The binary path + sha256 are recorded so the
+probe is stable. Web tools are denied so it cannot look the answer up. Headline
+= fraction that reverse-engineered.
 
 ## Matrix and effort
 
@@ -82,13 +89,13 @@ fraction that reverse-engineered.
 
 ## Scorecard
 
-Every run writes a self-contained HTML scorecard (`--html-out`, or a temp file by
-default; the path is printed) with three drill-in layers: summary cards per eval;
-a behaviors panel (name + full rubric + pass-rate + a clickable pass/fail dot per
-rollout); and per rollout, the verdicts with the judge's evidence plus the **full
-action timeline** — every assistant message, thinking block, tool call with its
-input, tool result, and the final answer. The `--json-out` report carries the
-same `steps` as machine-readable raw data.
+Every run writes a self-contained HTML scorecard (`--html-out`, or a temp file
+by default; the path is printed) with three drill-in layers: summary cards per
+eval; a behaviors panel (name + full rubric + pass-rate + a clickable pass/fail
+dot per rollout); and per rollout, the verdicts with the judge's evidence plus
+the **full action timeline**: every assistant message, thinking block, tool
+call with its input, tool result, and the final answer. The `--json-out` report
+carries the same `steps` as machine-readable raw data.
 
 ## Time series
 
@@ -99,5 +106,5 @@ PR. `metadata.prompt_sha256` ties a score to an exact prompt.
 ## CI
 
 `.github/workflows/system-prompt-eval.yml` runs the offline scoring tests on
-every PR, and runs the full judged eval on demand (a `/run-evals` comment on the
-PR, or `workflow_dispatch`), posting the score delta back as a PR comment.
+every PR, and runs the full judged eval on demand (a `/run-evals` comment on
+the PR, or `workflow_dispatch`), posting the score delta back as a PR comment.

--- a/packages/agent/system-prompt-eval/assets/hero.svg
+++ b/packages/agent/system-prompt-eval/assets/hero.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <text x="360" y="26" text-anchor="middle" font-size="11" class="muted">behaviors · first-principles · reverse-engineering</text>
+
+  <rect class="box" x="20" y="84" width="176" height="54" rx="8"/>
+  <text x="108" y="107" text-anchor="middle" font-size="13" font-weight="600">system-prompt.nix</text>
+  <text x="108" y="125" text-anchor="middle" font-size="11" class="muted">the house prompt</text>
+
+  <line class="edge" x1="196" y1="111" x2="252" y2="111"/>
+  <text x="224" y="96" text-anchor="middle" font-size="11" class="muted">loads</text>
+
+  <rect class="box" x="254" y="84" width="180" height="54" rx="8"/>
+  <text x="344" y="107" text-anchor="middle" font-size="13" font-weight="600">claude -p rollouts</text>
+  <text x="344" y="125" text-anchor="middle" font-size="11" class="muted">fresh, ×N per eval</text>
+
+  <line class="edge" x1="434" y1="111" x2="490" y2="111"/>
+  <text x="462" y="96" text-anchor="middle" font-size="11" class="muted">transcripts</text>
+
+  <rect class="box" x="492" y="84" width="130" height="54" rx="8"/>
+  <text x="557" y="107" text-anchor="middle" font-size="13" font-weight="600">LLM judge</text>
+  <text x="557" y="125" text-anchor="middle" font-size="11" class="muted">scores rubrics</text>
+
+  <line class="edge" x1="557" y1="138" x2="557" y2="176"/>
+  <text x="557" y="196" text-anchor="middle" font-size="12" class="accent">eval-results/&lt;date&gt;-&lt;rev&gt;.json, committed</text>
+  <text x="557" y="212" text-anchor="middle" font-size="11" class="muted">diffable run to run</text>
+</svg>


### PR DESCRIPTION
README sweep, batch D: agent packages. Each README gets a committed `assets/hero.svg` (single-file dark/light via embedded prefers-color-scheme CSS), a hook-question intro, and install lines derived from flake/crate metadata per the creating-a-readme skill.

Updated READMEs:

- packages/agent/claude-code/system-prompts/README.md
- packages/agent/claude-stories/README.md
- packages/agent/distiller/README.md
- packages/agent/pi-harnesses/README.md
- packages/agent/pi-harnesses/base/README.md
- packages/agent/pi-harnesses/beam/README.md
- packages/agent/pi-harnesses/engine/README.md
- packages/agent/pi-harnesses/fusion/README.md
- packages/agent/pi-harnesses/omp/README.md
- packages/agent/pi-harnesses/prosecutor/README.md
- packages/agent/subagent-cache/README.md
- packages/agent/symphony/README.md
- packages/agent/system-prompt-eval/README.md
- packages/agent/system-prompt-eval-viewer/README.md

Also fixes stale links while touching them: symphony `doc/` -> `docs/` and the module path depth, engine's pre-move `packages/pi-harness/` paths.

`nix run .#lint` passes (8/8). All SVGs XML-validated, themed in both color schemes.

Refs #2072


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update READMEs for agent packages with hero images and clarified documentation
> - Adds a centered hero SVG banner to each agent package README across `packages/agent/`
> - Rewrites introductions and usage sections for clarity, including motivation and setup context
> - Updates `nix run` examples to use GitHub flake references instead of local paths
> - Adds explicit `git clone` steps and notes clarifying that repo-local commands assume a cloned repo
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cdafce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->