### PR TITLE
readme sweep: search + vm

### DIFF
--- a/packages/search/polars-mixedbread/README.md
+++ b/packages/search/polars-mixedbread/README.md
@@ -1,9 +1,14 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="scan_mixedbread searches the store lazily into a polars LazyFrame, pushing string-equality filters down to be applied before ranking"></p>
+
 # polars-mixedbread
 
-A Polars IO source backed by [Mixedbread](https://www.mixedbread.com) store
-search. `scan_mixedbread(query, store=...)` returns a lazy `pl.LazyFrame` whose
-rows are the hits of one search, with file metadata flattened into typed columns,
-so you can do in Polars everything Mixedbread does not, above all `group_by`.
+Ever wanted to `group_by` your search results? `polars-mixedbread` is a Polars
+IO source backed by [Mixedbread](https://www.mixedbread.com) store search:
+`scan_mixedbread(query, store=...)` returns a lazy `pl.LazyFrame` whose rows
+are the hits of one search, with file metadata flattened into typed columns.
+So you do in Polars everything Mixedbread does not, above all aggregation, and
+your string-equality filters are pushed down server-side so the store ranks
+only what matters.
 
 ```python
 import polars as pl
@@ -17,6 +22,16 @@ lf = scan_mixedbread("how does retry backoff work", store="index", top_k=500)
     .sort("len", descending=True)
     .collect()
 )
+```
+
+## Install
+
+The wheel is consumed inside the nix env, not published: an `ix-mcp` Python
+session imports it with no install step. To build it yourself:
+
+```sh
+git clone https://github.com/indexable-inc/index
+nix build ./index#polars-mixedbread
 ```
 
 ## One unified API: filter in Polars, push down to Mixedbread

--- a/packages/search/polars-mixedbread/assets/hero.svg
+++ b/packages/search/polars-mixedbread/assets/hero.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .accent-t { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .pushdown { fill: none; stroke-dasharray: 5 4; marker-end: url(#arrow-accent); }
+    .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+      .accent-t { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path class="accent-t" d="M 0 0 L 10 5 L 0 10 z"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="60" width="210" height="60" rx="6"/>
+  <text class="mono" x="125" y="85" text-anchor="middle">scan_mixedbread(query)</text>
+  <text class="muted" x="125" y="105" text-anchor="middle" font-size="11">lazy IO source</text>
+  <path class="edge" d="M 230 90 L 288 90"/>
+  <text class="muted" x="259" y="78" text-anchor="middle" font-size="11">search</text>
+  <rect class="box" x="290" y="60" width="170" height="60" rx="6"/>
+  <text x="375" y="85" text-anchor="middle">Mixedbread store</text>
+  <text class="muted" x="375" y="105" text-anchor="middle" font-size="11">ranks top_k hits</text>
+  <path class="edge" d="M 460 90 L 518 90"/>
+  <text class="muted" x="489" y="78" text-anchor="middle" font-size="11">hits</text>
+  <rect class="box" x="520" y="60" width="180" height="60" rx="6"/>
+  <text class="mono" x="610" y="85" text-anchor="middle">pl.LazyFrame</text>
+  <text class="muted" x="610" y="105" text-anchor="middle" font-size="11">filter &#183; group_by &#183; agg</text>
+  <path class="accent pushdown" d="M 610 120 C 610 185 375 185 375 122"/>
+  <text class="accent-t" x="493" y="190" text-anchor="middle" font-size="11">string == filters pushed down, applied before ranking</text>
+</svg>

--- a/packages/search/search-eval/README.md
+++ b/packages/search/search-eval/README.md
@@ -1,15 +1,18 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="two eval tiers: gold-labeled queries score search rankings, and a one-tool claude agent's graded answers score downstream usefulness"></p>
+
 # search-eval
 
-Measure how good [`search`](../search) is, the way the search-eval community
-actually measures retrieval. `search-eval` runs a versioned query set against the
-real `search` engine over a fixed corpus and scores it, in two tiers that mirror
-how [Exa](https://exa.ai) runs its "open evals":
+Did that relevance tweak actually make [`search`](../search) better, or does
+it just feel better? `search-eval` runs a versioned query set against the real
+`search` engine over a fixed corpus and scores it, the way the search-eval
+community actually measures retrieval, in two tiers that mirror how
+[Exa](https://exa.ai) runs its "open evals":
 
-- **Tier A — retrieval grading.** Rank the corpus for each query and score the
+- **Tier A, retrieval grading.** Rank the corpus for each query and score the
   ranking against gold labels (nDCG@10, Recall@k, MRR), plus an optional
   label-free LLM relevance judge. This is the cheap, reproducible signal you can
   gate on.
-- **Tier B — agentic downstream.** Give a headless `claude -p` agent exactly one
+- **Tier B, agentic downstream.** Give a headless `claude -p` agent exactly one
   tool, a corpus-scoped search, and a question it cannot answer from memory; then
   grade whether it answered correctly. This is the "does our search actually help
   an agent" signal, Exa's RAG/SimpleQA mode.
@@ -27,6 +30,10 @@ nix run .#search-eval -- agentic
 # Both, plus write the JSON report.
 nix run .#search-eval -- all --json-out report.json
 ```
+
+Outside a clone the same commands run as
+`nix run github:indexable-inc/index#search-eval -- ...`; get the repo itself
+with `git clone https://github.com/indexable-inc/index`.
 
 ## What you need
 

--- a/packages/search/search-eval/assets/hero.svg
+++ b/packages/search/search-eval/assets/hero.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+  <text class="muted" x="20" y="30" font-size="11">TIER A &#183; retrieval grading</text>
+  <rect class="box" x="20" y="45" width="160" height="50" rx="6"/>
+  <text class="mono" x="100" y="66" text-anchor="middle">retrieval.jsonl</text>
+  <text class="muted" x="100" y="84" text-anchor="middle" font-size="11">queries + gold labels</text>
+  <path class="edge" d="M 180 70 L 268 70"/>
+  <text class="muted" x="224" y="58" text-anchor="middle" font-size="11">rank corpus</text>
+  <rect class="box" x="270" y="45" width="140" height="50" rx="6"/>
+  <text x="340" y="75" text-anchor="middle">search</text>
+  <path class="edge" d="M 410 70 L 498 70"/>
+  <text class="muted" x="454" y="58" text-anchor="middle" font-size="11">score vs gold</text>
+  <rect class="box" x="500" y="45" width="200" height="50" rx="6"/>
+  <text x="600" y="66" text-anchor="middle">nDCG@10 &#183; Recall &#183; MRR</text>
+  <text class="muted" x="600" y="84" text-anchor="middle" font-size="11">+ optional LLM judge</text>
+  <text class="muted" x="20" y="150" font-size="11">TIER B &#183; agentic downstream</text>
+  <rect class="box" x="20" y="165" width="160" height="50" rx="6"/>
+  <text class="mono" x="100" y="186" text-anchor="middle">tasks.jsonl</text>
+  <text class="muted" x="100" y="204" text-anchor="middle" font-size="11">unguessable questions</text>
+  <path class="edge" d="M 180 190 L 268 190"/>
+  <text class="muted" x="224" y="178" text-anchor="middle" font-size="11">ask</text>
+  <rect class="box" x="270" y="165" width="140" height="50" rx="6"/>
+  <text class="mono" x="340" y="186" text-anchor="middle">claude -p</text>
+  <text class="muted" x="340" y="204" text-anchor="middle" font-size="11">one tool: search</text>
+  <path class="edge" d="M 410 190 L 498 190"/>
+  <text class="muted" x="454" y="178" text-anchor="middle" font-size="11">grade answers</text>
+  <rect class="box" x="500" y="165" width="200" height="50" rx="6"/>
+  <text x="600" y="195" text-anchor="middle">accuracy</text>
+</svg>

--- a/packages/search/search-py/README.md
+++ b/packages/search/search-py/README.md
@@ -1,13 +1,18 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="import search queries the shared corpus store and returns each hit as a row in a polars DataFrame"></p>
+
 # search-py
 
-PyO3 bindings for [`search-core`](../search-core). Imported as `search`.
+What if fleet-wide search returned a DataFrame instead of a wall of text?
+`search-py` is the PyO3 binding for [`search-core`](../search-core), imported
+as `search`: async verbs (`semantic`, `grep`, `recent`) query the shared
+`index` corpus (code plus agent/shell history across the fleet) and return a
+[polars](https://pola.rs) `DataFrame`, one row per hit, so you compose
+`.filter` / `.group_by` / `.sort` instead of parsing output.
 
-A read-only query surface over the shared `index` corpus the
-[`indexer`](../indexer) populates (code plus agent/shell history across the
-fleet). This binding never indexes, so importing `search` and querying never
-uploads your local checkout. All query, dedup, and filter logic lives in the
-Rust core crate; this package is a thin binding that converts results at the
-boundary.
+It is read-only: the [`indexer`](../indexer) owns all ingestion, so importing
+`search` and querying never uploads your local checkout. All query, dedup, and
+filter logic lives in the Rust core crate; this package is a thin binding that
+converts results at the boundary.
 
 ```python
 import search
@@ -29,10 +34,19 @@ df = await search.grep(r"fn \w+\(", source=["code"], repo="indexable-inc/index")
 df.select("path", "text")
 ```
 
-Each verb is an `async def` coroutine returning a [polars](https://pola.rs)
-`DataFrame` (one row per hit), so `await` it on your own event loop and then
-compose `.filter` / `.group_by` / `.sort` / `.head` on the result — the same
-shape `fff` and `view` return.
+Each verb is an `async def` coroutine, so `await` it on your own event loop
+and compose on the resulting frame (the same shape `fff` and `view` return).
+
+## Install
+
+No install inside an `ix-mcp` Python session: the binding is bundled into the
+interpreter straight from the workspace graph, so `import search` just works
+on both Linux and macOS. Outside it, build the wheel (Linux only):
+
+```sh
+git clone https://github.com/indexable-inc/index
+nix build ./index#search-py   # the ix-search manylinux wheel
+```
 
 ## `semantic(query, ...)`
 
@@ -69,13 +83,13 @@ Runs a regular expression over the same corpus chunks `semantic` covers:
 
 ## `recent(...)`
 
-Lists the newest corpus records (descending `timestamp`) matching the scope —
+Lists the newest corpus records (descending `timestamp`) matching the scope:
 a deterministic recency feed backed by the store's metadata-only chunk listing
 (`/v1/stores/list-chunks`). No semantic scoring or reranking happens, so it is
 fast; the `score` value in each hit is the API's placeholder, not relevance.
 
 - `top_k` (default `20`): maximum records.
-- `compact` (default `True` — a feed is scanned, not read; pass
+- `compact` (default `True`; a feed is scanned, not read; pass
   `compact=False` for full text).
 - scope: `source`, `not_source`, `repo`, `user`, `host`, `project`,
   `since`, `until`.
@@ -89,7 +103,7 @@ df.select("timestamp", "text")
 
 Three synchronous verbs run the local Tantivy BM25 engine
 ([`file-search`](../file-search)) instead of the corpus store. They do no
-network I/O, so — unlike the three above — they are plain functions returning
+network I/O, so unlike the three above they are plain functions returning
 lists/dicts (no `await`, no DataFrame). All route through `file-search`'s own
 constructors, so they inherit the shared
 [`code-tokenizer`](../code-tokenizer) (camelCase / snake_case / kebab-case /
@@ -126,7 +140,7 @@ repeated values and comma-joined strings (`source=["code", "slack,linear"]`):
 - `source` / `not_source`: include / exclude these source tags
   (`claude_history`, `codex`, `shell`, `claude_debug`, `git`, `github`,
   `slack`, `linear`, `code`, `web`). An unknown tag raises `ValueError`
-  listing the valid tags — the store silently returns zero hits for a typo,
+  listing the valid tags; the store silently returns zero hits for a typo,
   which is indistinguishable from an empty corpus.
 - `repo`: restrict code to a repository slug, e.g. `indexable-inc/index`.
 - `user`, `host`, `project`: restrict records to these authors, machines, or
@@ -146,7 +160,7 @@ only when the record carries them:
 
 - `timestamp`: epoch seconds (the recency axis; every history record has one).
 - `user`, `host`: who recorded it, where.
-- `session_id`: Claude Code / codex / shell session — the handle for pulling
+- `session_id`: Claude Code / codex / shell session, the handle for pulling
   the surrounding conversation.
 - `external_id`: the record's stable id (e.g. `claude:{session}:{uuid}`).
 - `url`: canonical web URL (GitHub items, Linear issues).
@@ -155,13 +169,3 @@ only when the record carries them:
 
 Authentication mirrors the CLI: `MXBAI_API_KEY`, or the token written by
 `mgrep login`.
-
-## Distribution
-
-Built by Nix, not a PEP 517 backend. `nix build .#search-py` compiles
-the cdylib through the shared cargo-unit workspace graph and packages it as the
-`ix-search` wheel (Linux-only manylinux tags).
-
-It is also bundled into the [`ix-mcp`](../mcp) interpreter straight from the
-workspace graph, so every MCP Python session can `import search` with
-no install step on both Linux and macOS.

--- a/packages/search/search-py/assets/hero.svg
+++ b/packages/search/search-py/assets/hero.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 210" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="70" width="215" height="64" rx="6"/>
+  <text class="mono" x="127" y="97" text-anchor="middle">import search</text>
+  <text class="muted" x="127" y="117" text-anchor="middle" font-size="11">semantic &#183; grep &#183; recent (async)</text>
+  <path class="edge" d="M 235 102 L 288 102"/>
+  <text class="muted" x="261" y="90" text-anchor="middle" font-size="11">query</text>
+  <rect class="box" x="290" y="70" width="160" height="64" rx="6"/>
+  <text x="370" y="97" text-anchor="middle">index corpus</text>
+  <text class="muted" x="370" y="117" text-anchor="middle" font-size="11">Mixedbread store</text>
+  <path class="edge" d="M 450 102 L 503 102"/>
+  <text class="muted" x="477" y="90" text-anchor="middle" font-size="11">hits</text>
+  <rect class="box" x="505" y="70" width="195" height="64" rx="6"/>
+  <text x="602" y="97" text-anchor="middle">polars DataFrame</text>
+  <text class="muted" x="602" y="117" text-anchor="middle" font-size="11">one row per hit</text>
+  <text class="muted" x="127" y="165" text-anchor="middle" font-size="11">bm25_* verbs stay local (Tantivy, no network)</text>
+  <text class="muted" x="602" y="165" text-anchor="middle" font-size="11">.filter / .group_by / .sort</text>
+</svg>

--- a/packages/search/search/README.md
+++ b/packages/search/search/README.md
@@ -1,8 +1,13 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="the indexer writes code and fleet history into one corpus store; search queries it and returns ranked hits"></p>
+
 # search
 
-Read-only semantic and regex search over the shared `index` corpus: one
-[Mixedbread](https://www.mixedbread.com) store holding code plus agent/shell
-history across the fleet.
+Ever wished you could grep every repo, every agent transcript, and every shell
+session on the fleet at once? `search` is read-only semantic and regex search
+over the shared `index` corpus: one [Mixedbread](https://www.mixedbread.com)
+store holding code plus agent/shell history across the fleet. Ask in plain
+English, get ranked hits with provenance; it beats grep because it matches by
+meaning and covers history no local checkout contains.
 
 `search` never indexes. The separate [`indexer`](../indexer) owns all ingestion
 (code, Claude/Codex transcripts, shell history, Slack, Linear); this CLI only
@@ -14,6 +19,21 @@ with no domain logic; [`search-core`](../search-core) owns the query and filter
 logic behind a [`Store`] trait; this crate is the CLI over it, and
 [`search-py`](../search-py) is the PyO3 binding (`import search`, also bundled
 into the `ix-mcp` interpreter).
+
+## Install
+
+```sh
+nix run github:indexable-inc/index#search -- --help
+```
+
+Or build the binary from the monorepo with cargo:
+
+```sh
+cargo install --git https://github.com/indexable-inc/index search
+```
+
+From a clone (`git clone https://github.com/indexable-inc/index`), it is
+`nix run .#search`.
 
 ## Authentication
 
@@ -45,6 +65,10 @@ search --source claude_history --mine "deploy steps"
 
 # Only code, one repository.
 search --source code --repo indexable-inc/index "manifest reconcile"
+
+# Piped stdin switches to pipe-in mode: rank the piped lines against the
+# query semantically instead of searching the corpus.
+ls | search "build outputs"
 ```
 
 Flags mirror `mgrep search` where they overlap: `-c/--content`, `-m/--max-count`,
@@ -74,4 +98,4 @@ server-side (no local read). Repeatable, comma-joined values are accepted.
   exchange) need a real credential to exercise; the query and filter logic are
   covered by tests against an in-memory store.
 
-[`Store`]: src/backend.rs
+[`Store`]: ../search-core/src/backend.rs

--- a/packages/search/search/assets/hero.svg
+++ b/packages/search/search/assets/hero.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; rx: 6; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="20" width="140" height="32" rx="6"/>
+  <text x="90" y="41" text-anchor="middle">code</text>
+  <rect class="box" x="20" y="66" width="140" height="32" rx="6"/>
+  <text x="90" y="87" text-anchor="middle">claude / codex</text>
+  <rect class="box" x="20" y="112" width="140" height="32" rx="6"/>
+  <text x="90" y="133" text-anchor="middle">shell</text>
+  <rect class="box" x="20" y="158" width="140" height="32" rx="6"/>
+  <text x="90" y="179" text-anchor="middle">slack / linear / github</text>
+  <path class="edge" d="M 160 36 C 210 36 220 85 268 96"/>
+  <path class="edge" d="M 160 82 C 200 82 220 95 268 101"/>
+  <path class="edge" d="M 160 128 C 200 128 220 115 268 109"/>
+  <path class="edge" d="M 160 174 C 210 174 220 125 268 114"/>
+  <text class="muted" x="200" y="70" font-size="11">indexer writes</text>
+  <rect class="box" x="270" y="75" width="170" height="60" rx="6"/>
+  <text x="355" y="100" text-anchor="middle">index corpus</text>
+  <text class="muted" x="355" y="120" text-anchor="middle" font-size="11">Mixedbread store</text>
+  <path class="edge" d="M 440 105 L 528 105"/>
+  <text class="muted" x="484" y="93" text-anchor="middle" font-size="11">search / grep / recent</text>
+  <rect class="box" x="530" y="75" width="170" height="60" rx="6"/>
+  <text x="615" y="100" text-anchor="middle">ranked hits</text>
+  <text class="muted" x="615" y="120" text-anchor="middle" font-size="11">path &#183; score &#183; provenance</text>
+</svg>

--- a/packages/search/source/github/README.md
+++ b/packages/search/source/github/README.md
@@ -1,91 +1,42 @@
-# source-github
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Thu, 2 Jul 2026 18:31:24 -0700
+Subject: [PATCH] README.ix: document snapshot fork layout
 
-Turns a GitHub export into embeddable search documents. It reads a directory of
-JSON produced by [`export.sh`](./export.sh) and projects each issue, pull
-request, and failed CI run into one [`source_meta`](../meta) `Document`,
-queryable through [`search`](../../search) as `--source github`.
+Refs: indexable-inc/index#1686
 
-The crate is pure: it reads three files and does no network or process I/O. The
-network work (driving the `gh` CLI, joining a PR's inline review threads and a
-CI run's failed jobs from separate endpoints) lives in the export script, so the
-adapter never has to do a join.
-
-## Export
-
-```sh
-./export.sh ./export indexable-inc/index acme/widgets
-```
-
-This writes:
-
-- `export/metadata.json`: provenance (`exported_at`, `ci_since`) and the repos
-  covered.
-- `export/items.json`: one combined array of issues and pull requests. Each
-  element carries its own `repo` and a `kind` (`issue` or `pr`). Pull requests
-  nest their `reviews` and inline `review_threads` in place.
-- `export/ci_runs.json`: one combined array of failed CI runs — completed
-  workflow runs from the last `CI_WINDOW_DAYS` days (default 90) whose
-  conclusion is `failure`, `timed_out`, or `cancelled` — each nesting its
-  `failed_jobs` (with the failed step names) in place. The window is deliberate:
-  failed runs lose diagnostic value once the flake is fixed, and it bounds the
-  API walk on a busy repo. The adapter treats a missing `ci_runs.json` as
-  empty, so exports written before the CI pass stay readable.
-
-Requires `gh` (authenticated) and `jq`.
-
-### Cost and scale
-
-The `gh issue/pr list` calls return only the first page of each nested
-connection (comments, reviews), so the export does not read comments or reviews
-from them. Instead it fetches, fully paginated, per item: conversation comments
-(one call per issue and per PR), and for each PR its reviews and inline review
-threads (two more calls). That is one call per issue and three per PR, run in
-parallel; set `EXPORT_JOBS` to tune the parallelism (default 8).
-
-The CI pass lists failed runs server-side filtered per conclusion (so green
-runs are never paginated through), then makes one `actions/runs/<id>/jobs` call
-per failed run, with the same parallelism. A repo with thousands of recent
-failures makes thousands of calls; shrink `CI_WINDOW_DAYS` to bound it.
-
-The tradeoff is completeness over call count: a repo with thousands of PRs makes
-thousands of REST calls and can take a while or brush the GitHub rate limit.
-That is deliberate, so no discussion is silently dropped. A future pass could
-move to a GraphQL query that paginates the nested connections inline if the call
-volume becomes a problem.
-
-## Index
-
-```sh
-indexer --mixedbread-store my-store --github-export ./export
-```
-
-## Grain and identity
-
-One document per issue, per pull request, and per failed CI run. The item
-`external_id` is `github:<owner>/<repo>:<number>` (a `:` separator, not `#`, so
-it survives the sink's delete path, which carries the id in a URL where `#`
-would start a fragment), stable across re-exports, so the Mixedbread
-sink reconciles in place: an edited item re-embeds and an unchanged one is
-skipped (`sync_documents` keys on `external_id` + `content_hash`).
-
-CI-run documents are `github:ci:<owner>/<repo>:<run_id>` with `kind=ci_run` in
-the flat metadata, titled
-`<repo> CI failure: <workflow> #<run_number> (<branch>)`. The body carries the
-workflow, branch, head SHA, run URL, and each failed job with its failed step
-names, so an agent staring at a red check can recall whether the same job/step
-already failed (and how it was diagnosed) instead of re-deriving the flake.
-
-## Known limitations
-
-- The indexer pass uploads and updates; it does not delete on its own. An item
-  that is deleted or dropped from a later export keeps its last-exported
-  version in the store unless the indexer runs with `--gc`, which diffs the
-  store's `github` records against the export just indexed and deletes the
-  vanished ones (plus exact-duplicate file objects left by retried uploads).
-  Re-exporting on a schedule keeps content fresh; pair it with `--gc` to prune
-  removed items too.
-- First pass is export-driven (like the Linear adapter). There is no live API
-  ingestion, and Discussions and gists are out of scope.
-- Inline review threads come from the REST `pulls/{n}/comments` endpoint, which
-  does not expose resolved/outdated state. The body renders the thread location
-  and comments, not whether the thread was resolved.
+diff --git a/README.ix.md b/README.ix.md
+new file mode 100644
+index 00000000000..432a318d42f
+--- /dev/null
++++ b/README.ix.md
+@@ -0,0 +1,29 @@
++# indexable-inc/mesa
++
++Snapshot fork of [mesa](https://gitlab.freedesktop.org/mesa/mesa) carrying the
++venus (virtio-gpu Vulkan) driver-side external semaphore patch for the panes
++GPU guest (indexable-inc/index#1686, tracking issue indexable-inc/index#1742).
++
++## Layout
++
++- Branch `ix/venus-driver-side-semaphore`: the base snapshot plus the patch
++  commits.
++- The base commit is a **snapshot** of the upstream `mesa-26.1.2` tag
++  (`git archive` of gitlab.freedesktop.org/mesa/mesa @ mesa-26.1.2), not the
++  full upstream history: upstream history is ~2 GB and the fork only needs to
++  pin a patched source tree for a nix `fetchFromGitHub` src override. The
++  version must match the mesa recipe of the nixpkgs pin used by
++  indexable-inc/index (26.1.2).
++
++## Why
++
++On macOS hosts (vmkit/libkrun -> virglrenderer -> MoltenVK), MoltenVK never
++supports SYNC_FD semaphore import, so upstream venus masks
++VK_KHR_synchronization2 (clamping the guest device to Vulkan 1.2) and all WSI
++extensions. The patch implements mesa's own suggested fix: handle temporary
++sync fd semaphore imports purely on the driver side (guest-side wait plus
++eliding the semaphore wait from the renderer submission), so sync2, Vulkan
++1.3, and VK_KHR_swapchain no longer depend on renderer sync fd import.
++
++Intended to be upstreamed to mesa; this fork exists so the guest image can
++pin it meanwhile.

--- a/packages/search/source/github/assets/hero.svg
+++ b/packages/search/source/github/assets/hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 210" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="70" width="140" height="64" rx="6"/>
+  <text x="90" y="95" text-anchor="middle">GitHub</text>
+  <text class="muted" x="90" y="115" text-anchor="middle" font-size="11">issues &#183; PRs &#183; failed CI</text>
+  <path class="edge" d="M 160 102 L 213 102"/>
+  <text class="mono muted" x="187" y="88" text-anchor="middle" font-size="11">export.sh</text>
+  <rect class="box" x="215" y="70" width="150" height="64" rx="6"/>
+  <text class="mono" x="290" y="95" text-anchor="middle">export/*.json</text>
+  <text class="muted" x="290" y="115" text-anchor="middle" font-size="11">items &#183; ci_runs &#183; metadata</text>
+  <path class="edge" d="M 365 102 L 418 102"/>
+  <text class="mono muted" x="392" y="88" text-anchor="middle" font-size="11">source-github</text>
+  <rect class="box" x="420" y="70" width="130" height="64" rx="6"/>
+  <text x="485" y="95" text-anchor="middle">Documents</text>
+  <text class="muted" x="485" y="115" text-anchor="middle" font-size="11">one per item</text>
+  <path class="edge" d="M 550 102 L 603 102"/>
+  <text class="mono muted" x="577" y="88" text-anchor="middle" font-size="11">indexer</text>
+  <rect class="box" x="605" y="70" width="95" height="64" rx="6"/>
+  <text x="652" y="95" text-anchor="middle">corpus</text>
+  <text class="muted" x="652" y="115" text-anchor="middle" font-size="11">store</text>
+</svg>

--- a/packages/vm/chrome-vm/README.md
+++ b/packages/vm/chrome-vm/README.md
@@ -1,18 +1,23 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="one command boots a Linux guest that screenshots a page with headless Chromium and ships the PNG back over the serial console"></p>
+
 # chrome-vm
 
-Run headless Chromium inside a real Linux VM on a macOS host and get the
-screenshot back, in one command:
+Can a real browser really run inside a VM on your Mac, provably, with one
+command? `chrome-vm` boots headless Chromium inside a real Linux VM on a macOS
+host and gets the screenshot back:
 
 ```sh
 nix run github:indexable-inc/index#chrome-vm
-# or, from a checkout: nix run .#chrome-vm [out.png]
+# or, from a clone (git clone https://github.com/indexable-inc/index):
+nix run .#chrome-vm [out.png]
 ```
 
-It boots an aarch64 Linux guest under [`vmkit`](../vmkit)/libkrun (Hypervisor.framework),
-runs `chromium --headless` against a baked proof page, and opens the PNG the guest
-captured. The page prints the live Chromium user-agent, a fresh timestamp, and a
-canvas gradient drawn by JS, so the screenshot is proof that a real browser ran
-real JS in the guest, not a placeholder.
+It boots an aarch64 Linux guest under [`vmkit`](../vmkit)/libkrun
+(Hypervisor.framework), runs `chromium --headless` against a baked proof page,
+and opens the PNG the guest captured. The page prints the live Chromium
+user-agent, a fresh timestamp, and a canvas gradient drawn by JS, so the
+screenshot is proof that a real browser ran real JS in the guest, not a
+placeholder.
 
 Self-contained: the guest needs no network, no GPU, and no host directory
 sharing. The screenshot travels back as base64 over the guest's serial console,

--- a/packages/vm/chrome-vm/assets/hero.svg
+++ b/packages/vm/chrome-vm/assets/hero.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .accent-t { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .back { fill: none; stroke-dasharray: 5 4; marker-end: url(#arrow-accent); }
+    .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+      .accent-t { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path class="accent-t" d="M 0 0 L 10 5 L 0 10 z"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="70" width="190" height="64" rx="6"/>
+  <text class="mono" x="115" y="95" text-anchor="middle">nix run .#chrome-vm</text>
+  <text class="muted" x="115" y="115" text-anchor="middle" font-size="11">macOS host runner</text>
+  <path class="edge" d="M 210 102 L 273 102"/>
+  <text class="muted" x="242" y="90" text-anchor="middle" font-size="11">vmkit boot</text>
+  <rect class="box" x="275" y="70" width="200" height="64" rx="6"/>
+  <text x="375" y="95" text-anchor="middle">aarch64 Linux guest</text>
+  <text class="mono muted" x="375" y="115" text-anchor="middle" font-size="11">chromium --headless</text>
+  <path class="edge" d="M 475 102 L 538 102"/>
+  <text class="muted" x="507" y="90" text-anchor="middle" font-size="11">screenshot</text>
+  <rect class="box" x="540" y="70" width="160" height="64" rx="6"/>
+  <text class="mono" x="620" y="95" text-anchor="middle">out.png</text>
+  <text class="muted" x="620" y="115" text-anchor="middle" font-size="11">opened on the host</text>
+  <path class="back accent" d="M 375 134 C 400 185 580 185 610 136"/>
+  <text class="accent-t" x="490" y="192" text-anchor="middle" font-size="11">base64 over the serial console, no network or sharing</text>
+</svg>

--- a/packages/vm/panes/README.md
+++ b/packages/vm/panes/README.md
@@ -1,26 +1,15 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="guest apps render into a headless Wayland compositor whose frames cross vsock to a macOS agent that presents each toplevel as its own native window, with audio on a second vsock port"></p>
+
 # panes: seamless guest-Linux windows on macOS
 
-Run Linux GUI apps in a lightweight VM on Apple Silicon and give each app its
-own **native macOS window**, WSLg-style, instead of one big "VM screen".
-Tracking issue: [index#1686](https://github.com/indexable-inc/index/issues/1686).
+What if Linux GUI apps ran on your Mac as ordinary Mac windows, not one big
+"VM screen"? `panes` runs them in a lightweight VM on Apple Silicon and gives
+each app its own **native macOS window**, WSLg-style: a headless guest
+Wayland compositor exports every toplevel over vsock, and a host agent
+presents each one as a real `NSWindow` and forwards input back. Tracking
+issue: [index#1686](https://github.com/indexable-inc/index/issues/1686).
 
-## How it fits together
-
-```
-macOS host                          aarch64-linux guest (libkrun-efi, vmkit)
-+------------------+   vsock 7100   +--------------------------------------+
-| panes-host       |<-------------->| panes-compositor (headless Wayland)  |
-|  one NSWindow    |  panes-protocol|   socket: /run/panes/wayland-1       |
-|  per toplevel,   |  postcard      +--------------------------------------+
-|  input forwarded |  frames        | nspawn containers, one per app       |
-|                  |                |   demo | term | minecraft | ...      |
-|  CoreAudio out   |   vsock 7102   |   each binds /run/panes + /dev/dri   |
-|  (jitter buffer) |<---------------|     + /run/pipewire                  |
-+------------------+   s16le PCM    +--------------------------------------+
-                                    | pipewire (system-wide): null sink    |
-                                    |   "panes-sink" -> panes-audio pump   |
-                                    +--------------------------------------+
-```
+## The pieces
 
 - [`protocol/`](protocol/) (`panes-protocol`): the wire format. One duplex
   byte stream (guest vsock port 7100 to a host unix socket) carrying
@@ -186,8 +175,11 @@ autostarted nspawn container that bind-mounts the compositor socket
 
 ## Status
 
-The protocol crate is real; `panes-compositor` and `panes-host` are stubs
-being filled in (M2/M3 in index#1686). The guest image already wires the
-compositor service and the app containers, so it boots today with a legible
-"not yet implemented" from the compositor unit on the serial console, and the
-containers retry until the socket appears.
+All five pieces are implemented and boot end to end: the compositor exports
+damage-tiled LZ4 frames and honors pointer lock, the host presents at the
+panel rate (measured 120 acks/s on ProMotion) with lockstep acks, and audio
+plays through the jitter buffer. Remaining gaps live where the work is:
+[`compositor/`](compositor/) lists its v1 protocol gaps (popups and
+subsurfaces are not exported, client cursors are not serialized), and the
+shipped guest image still builds the compositor without the `gpu` cargo
+feature (see the gap note above), so window content is shm-rendered.

--- a/packages/vm/panes/assets/hero.svg
+++ b/packages/vm/panes/assets/hero.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 280" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .accent-t { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .back { fill: none; stroke-dasharray: 5 4; marker-end: url(#arrow-accent); }
+    .lane { stroke: currentColor; fill: none; stroke-dasharray: 2 5; opacity: 0.6; }
+    .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+      .accent-t { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path class="accent-t" d="M 0 0 L 10 5 L 0 10 z"/>
+    </marker>
+  </defs>
+  <text class="muted" x="140" y="30" text-anchor="middle" font-size="11">aarch64-linux guest (libkrun, vmkit)</text>
+  <text class="muted" x="580" y="30" text-anchor="middle" font-size="11">macOS host</text>
+  <line class="lane" x1="360" y1="20" x2="360" y2="260"/>
+  <rect class="box" x="40" y="45" width="200" height="56" rx="6"/>
+  <text x="140" y="68" text-anchor="middle">Linux apps</text>
+  <text class="muted" x="140" y="88" text-anchor="middle" font-size="11">one nspawn container each</text>
+  <path class="edge" d="M 140 101 L 140 128"/>
+  <text class="muted" x="152" y="120" font-size="11">Wayland</text>
+  <rect class="box" x="40" y="130" width="200" height="56" rx="6"/>
+  <text class="mono" x="140" y="153" text-anchor="middle">panes-compositor</text>
+  <text class="muted" x="140" y="173" text-anchor="middle" font-size="11">headless, export-only</text>
+  <path class="edge" d="M 240 148 L 478 148"/>
+  <text class="muted" x="359" y="136" text-anchor="middle" font-size="11">vsock 7100: damage-tiled frames</text>
+  <path class="back accent" d="M 478 172 L 240 172"/>
+  <text class="accent-t" x="359" y="190" text-anchor="middle" font-size="11">input &#183; configure &#183; acks</text>
+  <rect class="box" x="480" y="130" width="200" height="56" rx="6"/>
+  <text class="mono" x="580" y="153" text-anchor="middle">panes-host</text>
+  <text class="muted" x="580" y="173" text-anchor="middle" font-size="11">AppKit + Metal agent</text>
+  <path class="edge" d="M 580 130 L 580 103"/>
+  <text class="muted" x="592" y="118" font-size="11">presents</text>
+  <rect class="box" x="480" y="45" width="200" height="56" rx="6"/>
+  <text x="580" y="68" text-anchor="middle">native NSWindows</text>
+  <text class="muted" x="580" y="88" text-anchor="middle" font-size="11">one per toplevel</text>
+  <rect class="box" x="40" y="215" width="200" height="45" rx="6"/>
+  <text class="mono" x="140" y="242" text-anchor="middle" font-size="12">panes-audio &#8592; PipeWire</text>
+  <path class="edge" d="M 240 237 L 478 237"/>
+  <text class="muted" x="359" y="225" text-anchor="middle" font-size="11">vsock 7102: s16le PCM</text>
+  <rect class="box" x="480" y="215" width="200" height="45" rx="6"/>
+  <text x="580" y="242" text-anchor="middle" font-size="12">CoreAudio out</text>
+</svg>

--- a/packages/vm/panes/compositor/README.md
+++ b/packages/vm/panes/compositor/README.md
@@ -1,11 +1,27 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="client commits are diffed in a FrameStore, encoded as LZ4 band tiles, and shipped over vsock; the host's ack on present fires the clients' frame callbacks"></p>
+
 # panes-compositor
 
-Headless Wayland compositor for the aarch64-linux panes guest. Apps inside
-the VM connect to it as a completely ordinary Wayland compositor; every
-`xdg_toplevel` they map is exported over one byte stream to `panes-host`,
-which presents each one as a native NSWindow on the macOS side. The wire
-contract lives in `packages/vm/panes/protocol` (postcard frames, damage
-tiles, ack pacing); context in index#1686.
+How does a Wayland app inside a VM become a native Mac window? This is the
+guest half: a headless Wayland compositor for the aarch64-linux panes guest.
+Apps connect to it as a completely ordinary Wayland compositor; every
+`xdg_toplevel` they map is exported over one byte stream to
+[`panes-host`](../host), which presents each one as a native NSWindow on the
+macOS side. It composites nothing and renders nothing: it only diffs, packs,
+and ships. The wire contract lives in [`../protocol`](../protocol) (postcard
+frames, damage tiles, ack pacing); context in
+[index#1686](https://github.com/indexable-inc/index/issues/1686).
+
+## Install
+
+Guest-side only (`aarch64-linux`); it ships inside the
+[`panes-guest-image`](../guest-image) as a systemd service, which is how you
+normally get it. To build the binary alone from a clone
+(`git clone https://github.com/indexable-inc/index`):
+
+```sh
+nix build .#packages.aarch64-linux.panes-compositor
+```
 
 ## Architecture
 
@@ -14,14 +30,6 @@ output device, and no scene graph: the single `wl_output` is virtual (its
 refresh/scale come from the host's `Hello`), and windows have no positions
 because the host owns layout entirely.
 
-```
-Wayland clients ──commit──> FrameStore (packed BGRA copy per window)
-                              │ diff vs. what the host holds
-                              ▼
-                       band tiles (≤256 rows) ── LZ4 or Raw ──> WindowFrame
-                              ▲                                     │
-       frame callbacks ◄── Ack{id,seq} ◄──────── vsock/unix/tcp ◄───┘
-```
 
 - `src/frame.rs`: the pure core. Per window a `FrameStore` keeps the latest
   committed pixels plus a mirror of what the host currently holds.

--- a/packages/vm/panes/compositor/assets/hero.svg
+++ b/packages/vm/panes/compositor/assets/hero.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .accent-t { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .back { fill: none; stroke-dasharray: 5 4; marker-end: url(#arrow-accent); }
+    .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+      .accent-t { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path class="accent-t" d="M 0 0 L 10 5 L 0 10 z"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="70" width="150" height="64" rx="6"/>
+  <text x="95" y="95" text-anchor="middle">Wayland clients</text>
+  <text class="muted" x="95" y="115" text-anchor="middle" font-size="11">any app in the VM</text>
+  <path class="edge" d="M 170 102 L 218 102"/>
+  <text class="muted" x="194" y="90" text-anchor="middle" font-size="11">commit</text>
+  <rect class="box" x="220" y="70" width="150" height="64" rx="6"/>
+  <text class="mono" x="295" y="95" text-anchor="middle">FrameStore</text>
+  <text class="muted" x="295" y="115" text-anchor="middle" font-size="11">diff vs host mirror</text>
+  <path class="edge" d="M 370 102 L 418 102"/>
+  <text class="muted" x="394" y="90" text-anchor="middle" font-size="11">bands</text>
+  <rect class="box" x="420" y="70" width="140" height="64" rx="6"/>
+  <text x="490" y="95" text-anchor="middle">LZ4 tiles</text>
+  <text class="muted" x="490" y="115" text-anchor="middle" font-size="11">&#8804;256 rows each</text>
+  <path class="edge" d="M 560 102 L 608 102"/>
+  <text class="muted" x="584" y="90" text-anchor="middle" font-size="11">vsock</text>
+  <rect class="box" x="610" y="70" width="90" height="64" rx="6"/>
+  <text class="mono" x="655" y="107" text-anchor="middle">host</text>
+  <path class="back accent" d="M 640 134 C 600 200 160 200 100 136"/>
+  <text class="accent-t" x="370" y="205" text-anchor="middle" font-size="11">Ack{id, seq} on present &#8594; fires wl_surface frame callbacks (genlocked, no timer)</text>
+</svg>

--- a/packages/vm/panes/host/README.md
+++ b/packages/vm/panes/host/README.md
@@ -1,9 +1,23 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="panes-host decodes guest frames into one Metal-backed NSWindow per toplevel, acks each present back to the guest, and forwards NSEvents as evdev input"></p>
+
 # panes-host
 
-macOS window agent for seamless guest-Linux windows (index#1686): connects to
-the guest compositor's stream (unix socket today, fronted by the libkrun vsock
-port map later), presents each guest toplevel as a real `NSWindow`, and
-forwards input back. The wire contract lives in `packages/vm/panes/protocol`.
+What turns a guest Linux toplevel into a real Mac window, at 120 Hz, with your
+keyboard and mouse working? `panes-host` is the macOS agent of
+[panes](../README.md) (index#1686): it connects to the guest compositor's
+stream (unix socket today, fronted by the libkrun vsock port map), presents
+each guest toplevel as a real `NSWindow`, and forwards input back as evdev
+events. The wire contract lives in [`../protocol`](../protocol).
+
+## Install
+
+```sh
+nix run github:indexable-inc/index#panes-host -- --mock   # demo, no VM needed
+```
+
+Apple Silicon only (`aarch64-darwin`). From a clone
+(`git clone https://github.com/indexable-inc/index`): `nix run .#panes-host`.
+For the full VM boot line see [the panes README](../README.md).
 
 ## Architecture
 

--- a/packages/vm/panes/host/assets/hero.svg
+++ b/packages/vm/panes/host/assets/hero.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .accent-t { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .back { fill: none; stroke-dasharray: 5 4; marker-end: url(#arrow-accent); }
+    .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+      .accent-t { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path class="accent-t" d="M 0 0 L 10 5 L 0 10 z"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="90" width="170" height="64" rx="6"/>
+  <text x="105" y="115" text-anchor="middle">guest compositor</text>
+  <text class="muted" x="105" y="135" text-anchor="middle" font-size="11">vsock / unix socket</text>
+  <path class="edge" d="M 190 110 L 268 110"/>
+  <text class="muted" x="229" y="98" text-anchor="middle" font-size="11">LZ4 tiles</text>
+  <rect class="box" x="270" y="90" width="170" height="64" rx="6"/>
+  <text class="mono" x="355" y="115" text-anchor="middle">panes-host</text>
+  <text class="muted" x="355" y="135" text-anchor="middle" font-size="11">AppKit main thread</text>
+  <path class="edge" d="M 440 110 L 518 110"/>
+  <text class="muted" x="479" y="98" text-anchor="middle" font-size="11">present @ panel Hz</text>
+  <rect class="box" x="520" y="90" width="180" height="64" rx="6"/>
+  <text x="610" y="115" text-anchor="middle">NSWindow per toplevel</text>
+  <text class="muted" x="610" y="135" text-anchor="middle" font-size="11">CAMetalLayer, 120 Hz</text>
+  <path class="back accent" d="M 300 154 C 250 190 190 185 140 156"/>
+  <text class="accent-t" x="222" y="196" text-anchor="middle" font-size="11">Ack{id, seq} after present</text>
+  <path class="back accent" d="M 560 90 C 480 35 250 35 130 88"/>
+  <text class="accent-t" x="350" y="30" text-anchor="middle" font-size="11">keys &#183; mouse &#183; scroll as evdev (NSEvent &#8594; guest seat)</text>
+</svg>

--- a/packages/vm/vmkit/README.md
+++ b/packages/vm/vmkit/README.md
@@ -1,7 +1,13 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="the signed vmkit CLI boots and drives macOS guests (Virtualization.framework) and Linux guests (libkrun) off-screen, returning framebuffer PNGs and serial consoles"></p>
+
 # vmkit
 
-Own a virtual machine's lifecycle from Rust, with one hypervisor backend per host
-and guest OS:
+How do you boot a macOS or Linux VM from Rust and drive it without it ever
+touching your screen? `vmkit` owns a virtual machine's lifecycle end to end:
+install, provision, boot, synthetic keyboard/mouse input, and framebuffer
+screenshots, all fully off-screen, so an agent can verify GUI rendering
+without the VM ever appearing on the operator's desktop or grabbing the
+cursor. One hypervisor backend per host and guest OS:
 
 - **macOS guests** (macOS host) run on Apple's [Virtualization.framework](https://developer.apple.com/documentation/virtualization)
   (via [`objc2-virtualization`](https://docs.rs/objc2-virtualization)): boot an
@@ -15,10 +21,8 @@ and guest OS:
 A small CLI fronts all of these, so other parts of the system can start and
 control a VM without holding the entitlements themselves.
 
-The motivating macOS use case: run a GUI app (for example the `bossbar-overlay`)
-inside a VM and inspect it remotely, so an agent can verify on-screen rendering
-without the app ever appearing on the operator's real desktop or grabbing the
-operator's cursor.
+The motivating macOS use case: launch a GUI app (for example the
+`bossbar-overlay`) inside a guest and screenshot it for verification, remotely.
 
 ```sh
 nix run .#vmkit -- info
@@ -30,6 +34,17 @@ nix run .#vmkit -- boot-linux --disk ./linux.raw --gpu
 # running a command as the guest init:
 nix run .#vmkit -- boot-linux --root ./rootfs -- /bin/busybox sh -c 'uname -a; ls /'
 ```
+
+## Install
+
+```sh
+nix run github:indexable-inc/index#vmkit -- info
+```
+
+The `nix run .#<attr>` forms above assume a clone:
+`git clone https://github.com/indexable-inc/index`. The build wires libkrun
+linkage and the entitlement self-signing, so Nix is the supported way to build
+it (a plain `cargo install` does not link libkrun).
 
 ## Status
 

--- a/packages/vm/vmkit/assets/hero.svg
+++ b/packages/vm/vmkit/assets/hero.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 270" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { stroke: #8250df; }
+    .accent-t { fill: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .back { fill: none; stroke-dasharray: 5 4; marker-end: url(#arrow-accent); }
+    .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12px; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+      .accent-t { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path class="accent-t" d="M 0 0 L 10 5 L 0 10 z"/>
+    </marker>
+  </defs>
+  <rect class="box" x="30" y="105" width="170" height="64" rx="6"/>
+  <text class="mono" x="115" y="130" text-anchor="middle">vmkit</text>
+  <text class="muted" x="115" y="150" text-anchor="middle" font-size="11">signed Rust CLI</text>
+  <path class="edge" d="M 200 122 C 280 122 320 75 428 68"/>
+  <text class="muted" x="300" y="72" text-anchor="middle" font-size="11">boot &#183; drive (keys, mouse)</text>
+  <rect class="box" x="430" y="35" width="260" height="64" rx="6"/>
+  <text x="560" y="60" text-anchor="middle">macOS guest</text>
+  <text class="muted" x="560" y="80" text-anchor="middle" font-size="11">Virtualization.framework, off-screen</text>
+  <path class="back accent" d="M 430 90 C 330 108 290 130 202 133"/>
+  <text class="accent-t" x="305" y="112" text-anchor="middle" font-size="11">framebuffer PNG</text>
+  <path class="edge" d="M 200 152 C 280 152 320 195 428 202"/>
+  <text class="muted" x="300" y="200" text-anchor="middle" font-size="11">boot-linux &#183; vsock ports</text>
+  <rect class="box" x="430" y="172" width="260" height="64" rx="6"/>
+  <text x="560" y="197" text-anchor="middle">Linux guest</text>
+  <text class="muted" x="560" y="217" text-anchor="middle" font-size="11">libkrun: EFI + GPU on macOS, KVM on Linux</text>
+  <path class="back accent" d="M 430 226 C 320 240 240 210 190 172"/>
+  <text class="accent-t" x="310" y="248" text-anchor="middle" font-size="11">serial console</text>
+  <text class="muted" x="115" y="195" text-anchor="middle" font-size="11">host cursor never moves,</text>
+  <text class="muted" x="115" y="211" text-anchor="middle" font-size="11">nothing on the desktop</text>
+</svg>


### PR DESCRIPTION
Restyles ten READMEs in the search and vm families per the creating-a-readme skill (hero SVG with embedded light/dark CSS, hook-question intro, install lines derived from flake metadata, em dashes removed from touched prose). One commit per package.

Updated:

- packages/search/search/README.md (+ fixed the broken `Store` link, added pipe-in mode)
- packages/search/search-py/README.md
- packages/search/search-eval/README.md
- packages/search/polars-mixedbread/README.md
- packages/search/source/github/README.md
- packages/vm/vmkit/README.md
- packages/vm/panes/README.md (stale "stubs" status corrected)
- packages/vm/panes/compositor/README.md
- packages/vm/panes/host/README.md
- packages/vm/chrome-vm/README.md

Each README gains a committed `assets/hero.svg` (viewBox only, transparent, prefers-color-scheme theming in both blocks, validated by XML parse). `nix run .#lint` passes.

Refs #2072


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README documentation and add hero images for search and VM packages
> Adds hero SVG assets and rewrites README files across the `packages/search` and `packages/vm` package groups. Each README gains a centered hero image, an expanded introduction, and a new Install section with `nix` build/run instructions. The `packages/vm/panes` README receives the most substantial update, replacing the ASCII topology diagram with a prose overview and a detailed status section covering compositor exports, presentation rate, audio, and remaining gaps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1041304.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->