### PR TITLE
readme sweep: core tools (sqlmerge, dag-runner, astlog, scipql, mirror, unibind, indexbench)

### DIFF
--- a/packages/code/astlog/README.md
+++ b/packages/code/astlog/README.md
@@ -1,14 +1,23 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="source files become relations via tree-sitter query matches, Datalog rules join them into derived rows, and derived rows become lint findings or rewrite edits"></p>
+
 # astlog
 
-Datalog over tree-sitter syntax trees: tree-sitter query matches become
-relations, Datalog rules join them, and rewrites turn derived rows into edits.
+How do you grep for an `unwrap()` call *inside a function whose return type is `Result`*, or a call passing a variable *that was assigned from `getenv`*? Pattern tools (ast-grep, Semgrep, tree-sitter queries) answer "does this node match this shape"; those questions are joins, the first on tree position, the second on identifier text across two unrelated subtrees. astlog is Datalog over tree-sitter syntax trees: query matches become relations, rules join them, and rewrites turn derived rows into edits. Both questions are one rule.
 
-Pattern tools (ast-grep, Semgrep, tree-sitter queries) answer "does this node
-match this shape". The questions that actually need answering during a
-migration or audit are joins: *an `unwrap()` call **inside a function whose
-return type is `Result`***, or *a call passing a variable **that was assigned
-from `getenv`***. The first is a join on tree position, the second a join on
-identifier text across two unrelated subtrees. astlog makes both one rule.
+## Get it
+
+```sh
+nix run github:indexable-inc/index#astlog -- --help
+```
+
+With cargo (the CLI crate is `astlog`):
+
+```sh
+cargo install --git https://github.com/indexable-inc/index astlog
+```
+
+The Python surface ships inside the ix kernel (`import astlog`). Source lives
+in the monorepo: `git clone https://github.com/indexable-inc/index`.
 
 ## The language
 
@@ -95,7 +104,7 @@ the Datalog layer subsumes.
   value fills only `text`); `astlog.scan(...)`, `astlog.fixes(...)`, and
   `astlog.suppressed(...)` each return a `pl.DataFrame`; `astlog.fix(...,
   write=True)` returns the unified diff. The Rust bindings are
-  conversion-only — they hand back records and the Python wrapper builds the
+  conversion-only: they hand back records and the Python wrapper builds the
   frames.
 
 ## Suppression

--- a/packages/code/astlog/assets/hero.svg
+++ b/packages/code/astlog/assets/hero.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; stroke-width: 1.2; }
+    .accent { stroke: #8250df; fill: none; stroke-width: 1.4; }
+    .edge { stroke: currentColor; fill: none; stroke-width: 1.2; marker-end: url(#arrow); }
+    .head { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="head"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="98" width="110" height="34" rx="6"/>
+  <text x="75" y="119" text-anchor="middle">source files</text>
+
+  <path class="edge" d="M130,115 L196,115"/>
+  <text class="muted" x="163" y="100" text-anchor="middle" font-size="12">match</text>
+  <text class="muted" x="163" y="146" text-anchor="middle" font-size="11">tree-sitter query</text>
+
+  <rect class="box" x="200" y="98" width="110" height="34" rx="6"/>
+  <text x="255" y="119" text-anchor="middle">relations</text>
+
+  <path class="edge" d="M310,115 L396,115"/>
+  <text class="muted" x="353" y="100" text-anchor="middle" font-size="12">join</text>
+  <text class="muted" x="353" y="146" text-anchor="middle" font-size="11">Datalog rules</text>
+
+  <rect class="accent" x="400" y="98" width="125" height="34" rx="6"/>
+  <text x="462" y="119" text-anchor="middle">derived rows</text>
+
+  <path class="edge" d="M525,106 C570,98 570,61 596,59"/>
+  <path class="edge" d="M525,124 C570,132 570,169 596,171"/>
+  <text class="muted" x="560" y="52" text-anchor="middle" font-size="12">scan / lint</text>
+  <text class="muted" x="560" y="192" text-anchor="middle" font-size="12">rewrite</text>
+
+  <rect class="box" x="600" y="42" width="100" height="34" rx="6"/>
+  <text x="650" y="63" text-anchor="middle">findings</text>
+  <rect class="box" x="600" y="154" width="100" height="34" rx="6"/>
+  <text x="650" y="175" text-anchor="middle">edits</text>
+</svg>

--- a/packages/code/scipql/README.md
+++ b/packages/code/scipql/README.md
@@ -1,32 +1,32 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="a Rust project is indexed to index.scip, lowered to Soufflé facts keyed by moniker, and souffle-derived relations become either applied edits or polars tables"></p>
+
 # scipql
 
-Soufflé datalog + find/replace over a **SCIP semantic index**.
+Want to rename `net::Socket` without touching `mock::Socket`, or query your codebase by symbol identity instead of by string? scipql runs Soufflé datalog plus find/replace over a **SCIP semantic index**: every occurrence carries its SCIP **moniker**, so queries and rewrites operate on resolved identities, not text. Renaming one `Socket` never touches the other (or the struct's own `fd` field).
 
 Where [`astlog`](../astlog) runs datalog over tree-sitter *syntax*, scipql runs
-it over a *resolved* index: every occurrence carries its SCIP **moniker**, so a
-`net::Socket` and a `mock::Socket` are distinct symbols. Queries and rewrites
-operate on identities, not text, so renaming one `Socket` never touches the
-other (or the struct's own `fd` field).
+it over the *resolved* index rust-analyzer produces.
 
-```mermaid
-flowchart LR
-  src["Rust project"] -->|"rust-analyzer scip"| scip["index.scip"]
-  scip -->|"scip crate"| facts["Soufflé facts (by moniker)"]
-  facts --> souffle["souffle (your .dl)"]
-  souffle -->|"edit relation"| applier["edit-applier"]
-  souffle -->|"any relation"| out["tables / polars"]
-  applier -->|"default"| diff["unified diff (dry run)"]
-  applier -->|"--write"| disk["files on disk"]
+## Get it
+
+```sh
+nix run github:indexable-inc/index#scipql -- --help
 ```
+
+The nix package wraps the repo's pinned Rust toolchain (rust-analyzer,
+rust-src, cargo/rustc) and puts `souffle` on `PATH`. A bare
+`cargo install --git https://github.com/indexable-inc/index scipql` builds the
+same binary, but then `rust-analyzer` and `souffle` are yours to supply.
+Source: `git clone https://github.com/indexable-inc/index`.
 
 ## Layout
 
-- `core/` (`scipql-core`) — index (run `rust-analyzer scip`), lower the SCIP
+- `core/` (`scipql-core`): index (run `rust-analyzer scip`), lower the SCIP
   index to Soufflé facts, run queries, and apply the `edit` relation via the
   shared [`edit-applier`](../edit-applier) crate.
-- `cli/` (`scipql`) — the `scipql` binary, wrapped with the repo's pinned Rust
+- `cli/` (`scipql`): the `scipql` binary, wrapped with the repo's pinned Rust
   toolchain (rust-analyzer + rust-src + cargo/rustc) and `souffle` on `PATH`.
-- `py/` (`scipql-py`) — PyO3 bindings; `import scipql` in the ix-mcp kernel,
+- `py/` (`scipql-py`): PyO3 bindings; `import scipql` in the ix-mcp kernel,
   returning polars frames.
 
 ## CLI
@@ -68,7 +68,7 @@ columns (the schema is prepended automatically):
 ```
 
 `rename` is just a generated `fix` that suffix-matches the moniker; for anything
-more selective, write the `.dl` yourself — nothing is hidden.
+more selective, write the `.dl` yourself: nothing is hidden.
 
 ## Python (ix-mcp kernel)
 
@@ -88,5 +88,5 @@ CLI (which bakes the toolchain) rather than the kernel.
 ## Languages
 
 Rust today (via `rust-analyzer scip`). The facts/query/edit layers are
-language-agnostic — other SCIP indexers (`scip-typescript`, `scip-python`, …)
+language-agnostic: other SCIP indexers (`scip-typescript`, `scip-python`, ...)
 plug in by adding an indexer command.

--- a/packages/code/scipql/assets/hero.svg
+++ b/packages/code/scipql/assets/hero.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; stroke-width: 1.2; }
+    .accent { stroke: #8250df; fill: none; stroke-width: 1.4; }
+    .edge { stroke: currentColor; fill: none; stroke-width: 1.2; marker-end: url(#arrow); }
+    .head { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="head"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="108" width="110" height="34" rx="6"/>
+  <text x="75" y="129" text-anchor="middle">Rust project</text>
+
+  <path class="edge" d="M130,125 L186,125"/>
+  <text class="muted" x="158" y="110" text-anchor="middle" font-size="11">rust-analyzer scip</text>
+
+  <rect class="box" x="190" y="108" width="105" height="34" rx="6"/>
+  <text x="242" y="129" text-anchor="middle">index.scip</text>
+
+  <path class="edge" d="M295,125 L356,125"/>
+  <text class="muted" x="326" y="110" text-anchor="middle" font-size="11">lower by moniker</text>
+
+  <rect class="accent" x="360" y="108" width="115" height="34" rx="6"/>
+  <text x="417" y="129" text-anchor="middle">Soufflé facts</text>
+
+  <path class="edge" d="M475,117 C520,108 520,64 546,62"/>
+  <path class="edge" d="M475,133 C520,142 520,186 546,188"/>
+  <text class="muted" x="520" y="50" text-anchor="middle" font-size="11">edit relation</text>
+  <text class="muted" x="520" y="212" text-anchor="middle" font-size="11">any relation</text>
+
+  <rect class="box" x="550" y="45" width="150" height="34" rx="6"/>
+  <text x="625" y="66" text-anchor="middle">diff / --write</text>
+  <rect class="box" x="550" y="171" width="150" height="34" rx="6"/>
+  <text x="625" y="192" text-anchor="middle">tables / polars</text>
+
+  <text class="muted" x="417" y="88" text-anchor="middle" font-size="11">souffle runs your .dl</text>
+</svg>

--- a/packages/dag-runner/README.md
+++ b/packages/dag-runner/README.md
@@ -1,8 +1,20 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="a spec.json fans out into a validated DAG where independent nodes run in parallel and the runner exits with the worst outcome"></p>
+
 # dag-runner
 
-A tiny task runner that takes a JSON DAG of shell commands, runs nodes in parallel as their dependencies finish, and renders inline progress. It powers `nix run .#health-checks` today and is the planned replacement for [`ix-fleet`](../ix-fleet/)'s sequential per-node loops.
+Need to fan out a handful of shell commands with dependencies between them and get one honest exit code back? dag-runner takes a JSON DAG of commands, runs each node as soon as its dependencies succeed (independent nodes in parallel), renders inline progress, and exits with the worst outcome. It powers `nix run .#health-checks` today and is the planned replacement for [`ix-fleet`](../ix-fleet/)'s sequential per-node loops.
 
 The runner is meant for short, hands-off batches: spawn a fan-out of independent jobs, follow their progress, and exit with a worst-case status. It is not a long-running supervisor. For the design rationale (why not `process-compose`, why not `devenv-tasks`), see [the corresponding AGENTS.md section](../../AGENTS.md#why-dag-runner-and-not-process-compose-or-devenv-tasks).
+
+## Get it
+
+```sh
+cargo install --git https://github.com/indexable-inc/index dag-runner
+```
+
+Inside a clone of the monorepo it is also the `dag-runner` flake package
+(`nix run .#dag-runner`). Get the repo with
+`git clone https://github.com/indexable-inc/index`.
 
 ## Usage
 

--- a/packages/dag-runner/assets/hero.svg
+++ b/packages/dag-runner/assets/hero.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; stroke-width: 1.2; }
+    .accent { stroke: #8250df; fill: none; stroke-width: 1.4; }
+    .edge { stroke: currentColor; fill: none; stroke-width: 1.2; marker-end: url(#arrow); }
+    .head { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="head"/>
+    </marker>
+  </defs>
+  <rect class="box" x="25" y="98" width="110" height="34" rx="6"/>
+  <text x="80" y="119" text-anchor="middle">spec.json</text>
+
+  <path class="edge" d="M135,115 L216,115"/>
+  <text class="muted" x="176" y="104" text-anchor="middle" font-size="12">validate</text>
+
+  <rect class="accent" x="220" y="98" width="100" height="34" rx="6"/>
+  <text x="270" y="119" text-anchor="middle">fetch</text>
+
+  <path class="edge" d="M320,106 C370,98 370,61 401,59"/>
+  <path class="edge" d="M320,124 C370,132 370,169 401,171"/>
+
+  <rect class="box" x="405" y="42" width="100" height="34" rx="6"/>
+  <text x="455" y="63" text-anchor="middle">lint</text>
+  <rect class="box" x="405" y="154" width="100" height="34" rx="6"/>
+  <text x="455" y="175" text-anchor="middle">convert</text>
+  <text class="muted" x="455" y="121" text-anchor="middle" font-size="12">run in parallel</text>
+
+  <path class="edge" d="M505,59 C560,61 560,98 581,106"/>
+  <path class="edge" d="M505,171 C560,169 560,132 581,124"/>
+
+  <rect class="box" x="585" y="98" width="105" height="34" rx="6"/>
+  <text x="637" y="119" text-anchor="middle">upload</text>
+
+  <text class="muted" x="360" y="216" text-anchor="middle" font-size="12">exit = worst outcome; a failed dependency skips its dependents</text>
+</svg>

--- a/packages/indexbench/README.md
+++ b/packages/indexbench/README.md
@@ -1,12 +1,23 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="micro closures, macro commands, and @bench lines all produce metric Runs that append to the bench-history branch and feed a comparator that exits non-zero on regression"></p>
+
 # indexbench
 
-A metric-centric continuous-benchmarking framework for the index repo.
+How do you gate CI on performance without the gate flaking every time the runner has a noisy neighbor? indexbench is a metric-centric continuous-benchmarking framework: harnesses produce named metrics, history lives on an orphan git branch, and a comparator applies the right test per metric kind (a statistical test for timings, an exact compare for deterministic counts), exiting non-zero only on a real regression.
 
 The core abstraction is a **Metric**, not a time. A metric is any named number
 with a unit and a direction (`lower_is_better`): wall-clock nanoseconds, peak RSS
 bytes, allocation counts, a match rate, NAR bytes, force-resolve steps. Harnesses
 produce metrics; the comparator and reporter consume them. Adding a new kind of
 measurement never touches the schema.
+
+## Get it
+
+```sh
+nix run github:indexable-inc/index#indexbench -- --help
+```
+
+Suites, history, and the profiling shell assume a checkout:
+`git clone https://github.com/indexable-inc/index`.
 
 ## Schema
 
@@ -23,8 +34,8 @@ that form is the contract.
 ## Three metric sources
 
 - **Micro harness** (`micro`): times a Rust closure with a warm-up + batched
-  sampling loop (distributional `wall_clock`), and — behind the
-  `CountingAllocator` `#[global_allocator]` shim — reports a deterministic
+  sampling loop (distributional `wall_clock`), and, behind the
+  `CountingAllocator` `#[global_allocator]` shim, reports a deterministic
   `allocations` count.
 - **Macro harness** (`macro_harness`): runs an external command N times, reading
   `wall_clock` in the parent and `max_rss` from `libc::wait4`'s **per-child**
@@ -75,7 +86,7 @@ Default baseline: the previous run on the same machine (override with
   that reports an identical peak each run): the effect-size threshold alone
   decides, so a sub-threshold environmental wobble does not trip the gate.
 - **Deterministic** metrics (no `samples`, e.g. an allocation count): exact
-  compare. Any worsening is a regression — there is no noise to absorb.
+  compare. Any worsening is a regression: there is no noise to absorb.
 
 The CLI exits non-zero on any regression (the CI gate).
 
@@ -83,34 +94,34 @@ The CLI exits non-zero on any regression (the CI gate).
 
 ```sh
 # Run the built-in self-demo suite, record to history, compare to the previous run:
-nix run index#bench               # the apps.bench perf job
-nix run index#indexbench -- run   # the bare CLI
+nix run .#bench               # the apps.bench perf job
+nix run .#indexbench -- run   # the bare CLI
 
 # Run an ad-hoc macro bench, 10 runs, gate on regression vs the previous run:
-nix run index#indexbench -- run --suite mysuite --cmd "my-tool --work" --runs 10
+nix run .#indexbench -- run --suite mysuite --cmd "my-tool --work" --runs 10
 
 # Compare against a fixed commit instead of the previous run:
-nix run index#indexbench -- run --suite mysuite --cmd "my-tool" --baseline <sha>
+nix run .#indexbench -- run --suite mysuite --cmd "my-tool" --baseline <sha>
 
 # Gate only on deterministic (reproducible) metrics, comparing to history:
-nix run index#indexbench -- run --cmd "my-tool" --gate deterministic
+nix run .#indexbench -- run --cmd "my-tool" --gate deterministic
 
 # Gate a metric against a fixed budget with NO history (the hermetic flake-check
 # path): fails if the measured allocation count exceeds 64.
-nix run index#indexbench -- assert --cmd "my-tool" --runs 1 --max allocations=64
+nix run .#indexbench -- assert --cmd "my-tool" --runs 1 --max allocations=64
 
 # JSON output for CI / the (stubbed) viewer:
-nix run index#indexbench -- run --output-json
+nix run .#indexbench -- run --output-json
 
 # Inspect history:
-nix run index#indexbench -- history --suite mysuite --bench my-tool
+nix run .#indexbench -- history --suite mysuite --bench my-tool
 ```
 
 By default runs record to the `bench-history` git branch; pass `--store local
 --local-dir <dir>` for a directory-backed store. `assert` needs no store: it
 compares each measured metric against a fixed `--max` budget, which is what makes
 a reproducible metric (an allocation count) usable as a hermetic `nix flake
-check` — a self-comparing run could only ever compare a binary against itself.
+check`. A self-comparing run could only ever compare a binary against itself.
 
 ## Declaring a suite (Nix)
 
@@ -145,7 +156,7 @@ suite description.
 ## Profiling shell
 
 ```sh
-nix develop index#bench   # indexbench + hyperfine + valgrind + samply + jemalloc
+nix develop .#bench   # indexbench + hyperfine + valgrind + samply + jemalloc
 ```
 
 `tango-bench` is already a workspace dependency for paired A/B micro comparisons

--- a/packages/indexbench/assets/hero.svg
+++ b/packages/indexbench/assets/hero.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; stroke-width: 1.2; }
+    .accent { stroke: #8250df; fill: none; stroke-width: 1.4; }
+    .edge { stroke: currentColor; fill: none; stroke-width: 1.2; marker-end: url(#arrow); }
+    .head { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="head"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="30" width="140" height="34" rx="6"/>
+  <text x="90" y="51" text-anchor="middle">micro closure</text>
+  <rect class="box" x="20" y="98" width="140" height="34" rx="6"/>
+  <text x="90" y="119" text-anchor="middle">macro command</text>
+  <rect class="box" x="20" y="166" width="140" height="34" rx="6"/>
+  <text x="90" y="187" text-anchor="middle">@bench lines</text>
+
+  <path class="edge" d="M160,47 C210,49 210,106 236,110"/>
+  <path class="edge" d="M160,115 L236,115"/>
+  <path class="edge" d="M160,183 C210,181 210,124 236,120"/>
+  <text class="muted" x="198" y="98" text-anchor="middle" font-size="11">measure</text>
+
+  <rect class="accent" x="240" y="98" width="150" height="34" rx="6"/>
+  <text x="315" y="119" text-anchor="middle">Run { metrics }</text>
+
+  <path class="edge" d="M390,107 C440,98 440,49 476,47"/>
+  <text class="muted" x="440" y="34" text-anchor="middle" font-size="11">append</text>
+
+  <rect class="box" x="480" y="30" width="200" height="34" rx="6"/>
+  <text x="580" y="51" text-anchor="middle">bench-history branch</text>
+
+  <path class="edge" d="M580,64 L580,162"/>
+  <text class="muted" x="623" y="116" text-anchor="middle" font-size="11">baseline run</text>
+
+  <path class="edge" d="M390,124 C440,132 440,181 476,183"/>
+  <text class="muted" x="428" y="200" text-anchor="middle" font-size="11">current run</text>
+
+  <rect class="box" x="480" y="166" width="200" height="34" rx="6"/>
+  <text x="580" y="187" text-anchor="middle">comparator</text>
+  <text class="muted" x="580" y="222" text-anchor="middle" font-size="11">exit non-zero on regression</text>
+</svg>

--- a/packages/indexbench/filesystem/README.md
+++ b/packages/indexbench/filesystem/README.md
@@ -1,9 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="two target directories run the same fio and metadata workloads and report throughput, IOPS, and file rates for relative comparison"></p>
+
 # Filesystem Bench
 
-Small benchmark for comparing the filesystem a VM sees.
-
-Run it inside the VM against the real target path. Compare that result with
-`/tmp` or another normal disk-backed directory on the same VM.
+Is the filesystem your VM sees actually slower than plain ext4, and by how much? This is a small fio-based benchmark you run inside the VM against the real target path, then run again against `/tmp` or another disk-backed directory on the same VM. Same parameters, two numbers, one honest ratio.
 
 ## Run
 
@@ -11,7 +10,7 @@ Run it inside the VM against the real target path. Compare that result with
 nix run github:indexable-inc/index#bench-filesystem -- --target /path/to/vcfs
 ```
 
-For a local checkout:
+For a local checkout (`git clone https://github.com/indexable-inc/index`):
 
 ```sh
 nix run .#bench-filesystem -- --target /path/to/vcfs
@@ -26,12 +25,26 @@ nix run .#bench-filesystem -- --target /path/to/vcfs --quick
 To compare two file systems, run the same command twice with different targets,
 for example `/path/to/vcfs` and `/tmp` or another ext4-backed directory.
 
+## Flags
+
+| flag | default | meaning |
+| --- | --- | --- |
+| `--target DIR` | `$VCFS_BENCH_TARGET` | directory to benchmark (required one way or the other) |
+| `--runtime N` | `8` | seconds per fio workload |
+| `--ramp-time N` | `1` | fio ramp seconds excluded from stats |
+| `--size S` | `256m` | file size per fio workload |
+| `--files N` | `5000` | tiny files for the create/stat/delete phases |
+| `--iodepth N` | `1` | fio iodepth (sync ioengine) |
+| `--quick` | off | 2s runtime, 64m size, 1000 files |
+| `--json` | off | machine-readable result on stdout |
+| `--keep` | off | keep the scratch directory afterwards |
+
 ## Output
 
 The benchmark reports:
 
-- Sequential read and write throughput using 1 MiB blocks.
-- Random read and write IOPS using 4 KiB blocks.
+- Sequential read and write throughput using 1 MiB blocks (with p99 latency).
+- Random read and write IOPS using 4 KiB blocks (with p99 latency).
 - Create, stat, and delete rates for many tiny files.
 
 Use `--json` when collecting results:

--- a/packages/indexbench/filesystem/assets/hero.svg
+++ b/packages/indexbench/filesystem/assets/hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; stroke-width: 1.2; }
+    .accent { stroke: #8250df; fill: none; stroke-width: 1.4; }
+    .edge { stroke: currentColor; fill: none; stroke-width: 1.2; marker-end: url(#arrow); }
+    .head { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="head"/>
+    </marker>
+  </defs>
+  <rect class="box" x="25" y="35" width="130" height="34" rx="6"/>
+  <text x="90" y="56" text-anchor="middle">vcfs mount</text>
+  <rect class="box" x="25" y="120" width="130" height="34" rx="6"/>
+  <text x="90" y="141" text-anchor="middle">/tmp (ext4)</text>
+
+  <path class="edge" d="M155,52 C210,54 210,90 246,94"/>
+  <path class="edge" d="M155,137 C210,135 210,104 246,100"/>
+  <text class="muted" x="200" y="90" text-anchor="middle" font-size="11">same params</text>
+
+  <rect class="accent" x="250" y="77" width="200" height="44" rx="6"/>
+  <text x="350" y="95" text-anchor="middle">fio workloads</text>
+  <text class="muted" x="350" y="112" text-anchor="middle" font-size="11">+ create/stat/delete</text>
+
+  <path class="edge" d="M450,99 L531,99"/>
+  <text class="muted" x="490" y="86" text-anchor="middle" font-size="11">report</text>
+
+  <rect class="box" x="535" y="77" width="165" height="44" rx="6"/>
+  <text x="617" y="95" text-anchor="middle">MiB/s, IOPS, files/s</text>
+  <text class="muted" x="617" y="112" text-anchor="middle" font-size="11">compare relatively</text>
+</svg>

--- a/packages/mirror/README.md
+++ b/packages/mirror/README.md
@@ -1,21 +1,31 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="the monorepo feeds two generators: mirror gen plus publish syncs a read-only mirror repo, and mirror fork-branch regenerates a fork repo's ix-patched branch"></p>
+
 # mirror
 
-Opt-in standalone GitHub repos, generated from this monorepo. Two products,
-one source-generation core:
+How does one crate in a monorepo get its own GitHub repo that a stranger can clone and `cargo build`, without the repo drifting from the source? mirror generates opt-in standalone repos from this monorepo and keeps them equal to it in CI. Two products, one source-generation core:
 
 - **Package mirrors**: a package under `packages/` opts in via its
   `package.nix` and gets a self-contained, read-only GitHub repo that a
   visitor can clone and `cargo build` without ever seeing the monorepo. The
   monorepo stays the single source of truth; CI keeps the mirror equal to it.
 - **Fork branches**: a de-forked package (lib/fork-packages.nix) can opt into
-  a real GitHub fork repo whose `ix-patched` branch is defined declaratively —
-  the upstream base pinned in `flake.lock` plus the in-repo `patches/` series
-  applied as commits — so opening an upstream PR is one push away.
+  a real GitHub fork repo whose `ix-patched` branch is defined declaratively
+  (the upstream base pinned in `flake.lock` plus the in-repo `patches/` series
+  applied as commits), so opening an upstream PR is one push away.
 
 Rust packages are what the generator understands today, but the interface
 (the `mirror` manifest attr, `.#lib.mirrorPackages`, the sync workflow) is
 language-neutral by design; another ecosystem adds a generator, not a new
 pipeline.
+
+## Run it
+
+```sh
+nix run github:indexable-inc/index#mirror -- --help
+```
+
+Every subcommand takes `--package packages/<path>` relative to a monorepo
+checkout, so get one first: `git clone https://github.com/indexable-inc/index`.
 
 ## How a mirror is made
 
@@ -32,16 +42,16 @@ tree:
   version with member feature additions merged (cargo's own inheritance
   semantics), internal deps become `path = "crates/<name>"`, `publish =
   false` is pinned, `license = "MIT"` is injected (the root LICENSE rides
-  along), and the `[lints]` table is dropped — the workspace lint set names
-  lints only the org's patched clippy knows. Comments survive; the rewrite is
+  along), and the `[lints]` table is dropped (the workspace lint set names
+  lints only the org's patched clippy knows). Comments survive; the rewrite is
   format-preserving.
 - The `Cargo.lock` is **pruned, never re-resolved**: the subset of the root
   lock reachable from the mirrored crates, so a mirror builds against exactly
   the versions the monorepo builds against. `rust-toolchain.toml` is copied
   for the same reason. One nuance: the monorepo lock records feature-union
   dependency edges (an optional dep activated by *any* workspace member shows
-  up on the shared entry), so the pruned lock is a version-exact **superset**
-  — a mirror's first `cargo build` may drop entries the mirrored crate never
+  up on the shared entry), so the pruned lock is a version-exact **superset**:
+  a mirror's first `cargo build` may drop entries the mirrored crate never
   activates, but it never changes a version and never touches the network for
   resolution.
 - The README leads with a banner naming the mirror a read-only generated
@@ -60,7 +70,7 @@ creates the GitHub repo via `gh repo create` when it does not exist yet.
 `mirror fork-branch --name <fork> [--push]` reads the fork mapping
 (`.#lib.forkPackages`, or `--mapping <json>`), fetches the upstream repo at
 the rev `flake.lock` pins for the fork's input, applies the `patches/` series
-with `git am --3way` onto branch `ix-patched`, and — with `--push` — force
+with `git am --3way` onto branch `ix-patched`, and, with `--push`, force
 pushes that branch to the entry's `forkRepo`. Without `--push` it is a pure
 verification that the series still applies. The branch is regenerated, never
 merged into, so it is always a clean, properly rebased serialization of the
@@ -86,9 +96,9 @@ patch DAG.
    that into a red PR status). (`mirror publish` itself still falls back to
    the crate's `[package] description` when a hand-written manifest entry
    omits one, but registry entries must be explicit.) The package also needs
-   a `README.md` -- it
-   becomes the mirror repo's front page (see CONTRIBUTING.md, READMEs). The
-   entry surfaces in `nix eval --json '.#lib.mirrorPackages'`.
+   a `README.md`: it becomes the mirror repo's front page (see
+   CONTRIBUTING.md, READMEs). The entry surfaces in
+   `nix eval --json '.#lib.mirrorPackages'`.
 
 2. That's it. The mirror-sync workflow (`.github/workflows/mirror-sync.yml`)
    publishes on the next push to `main` touching `packages/**` (plus a daily

--- a/packages/mirror/assets/hero.svg
+++ b/packages/mirror/assets/hero.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; stroke-width: 1.2; }
+    .accent { stroke: #8250df; fill: none; stroke-width: 1.4; }
+    .edge { stroke: currentColor; fill: none; stroke-width: 1.2; marker-end: url(#arrow); }
+    .head { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="head"/>
+    </marker>
+  </defs>
+  <rect class="box" x="25" y="103" width="150" height="44" rx="6"/>
+  <text x="100" y="121" text-anchor="middle">monorepo</text>
+  <text class="muted" x="100" y="139" text-anchor="middle" font-size="11">packages/&lt;pkg&gt;</text>
+
+  <path class="edge" d="M175,115 C215,110 215,62 246,62"/>
+  <text class="muted" x="212" y="42" text-anchor="middle" font-size="11">crate + dep closure,</text>
+  <text class="muted" x="212" y="56" text-anchor="middle" font-size="11">pruned lock</text>
+
+  <path class="edge" d="M175,135 C215,140 215,188 246,188"/>
+  <text class="muted" x="212" y="216" text-anchor="middle" font-size="11">flake.lock pin</text>
+  <text class="muted" x="212" y="230" text-anchor="middle" font-size="11">+ patches/</text>
+
+  <rect class="accent" x="250" y="45" width="160" height="34" rx="6"/>
+  <text x="330" y="66" text-anchor="middle">mirror gen + publish</text>
+
+  <rect class="accent" x="250" y="171" width="160" height="34" rx="6"/>
+  <text x="330" y="192" text-anchor="middle">mirror fork-branch</text>
+
+  <path class="edge" d="M410,62 L516,62"/>
+  <text class="muted" x="463" y="48" text-anchor="middle" font-size="11">sync on main</text>
+
+  <path class="edge" d="M410,188 L516,188"/>
+  <text class="muted" x="463" y="174" text-anchor="middle" font-size="11">git am --3way, push</text>
+
+  <rect class="box" x="520" y="45" width="180" height="34" rx="6"/>
+  <text x="610" y="66" text-anchor="middle">read-only mirror repo</text>
+  <rect class="box" x="520" y="171" width="180" height="34" rx="6"/>
+  <text x="610" y="192" text-anchor="middle">fork repo, ix-patched</text>
+</svg>

--- a/packages/sqlmerge/README.md
+++ b/packages/sqlmerge/README.md
@@ -1,10 +1,26 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="base, ours, and theirs SQLite files flow through sqlmerge into a merged database on clean rows or a per-row conflict report on exit 1"></p>
+
 # sqlmerge
 
-A git merge driver for SQLite database files: a real three-way merge of row
-data via the [SQLite session extension](https://sqlite.org/sessionintro.html),
-instead of git's default "binary files conflict".
+Ever rebased a branch and had git call your SQLite file a binary conflict? sqlmerge is a git merge driver that gives `.db` files a real three-way merge: it computes the `base -> theirs` changeset with the [SQLite session extension](https://sqlite.org/sessionintro.html) and applies it onto ours, row by row, keyed by primary key. Rows only one side touched merge silently; genuinely conflicting rows get a per-row report instead of a shrug.
 
 Built by Claude Code.
+
+## Get it
+
+```sh
+nix run github:indexable-inc/index#sqlmerge   # prints usage + git wiring
+```
+
+With cargo, from the standalone mirror:
+
+```sh
+cargo install --git https://github.com/indexable-inc/sqlmerge
+```
+
+The mirror is generated read-only; the source of truth is
+[indexable-inc/index](https://github.com/indexable-inc/index)
+(`git clone https://github.com/indexable-inc/index`), where issues and PRs go.
 
 ## How it works
 
@@ -43,10 +59,10 @@ sqlmerge, everything else keeps [mergiraf](https://mergiraf.org/). By hand:
 
 ## Exit codes
 
-| code | meaning                                                            |
-| ---- | ------------------------------------------------------------------ |
-| 0    | merged clean; `%A` now holds the merged database                   |
-| 1    | conflict or refusal (details on stderr); git marks the file conflicted |
+| code | meaning                                                                 |
+| ---- | ----------------------------------------------------------------------- |
+| 0    | merged clean; `%A` now holds the merged database                        |
+| 1    | conflict or refusal (details on stderr); git marks the file conflicted  |
 
 ## Refusals (by design, no fallbacks)
 
@@ -81,23 +97,23 @@ to a policy:
 Globs use the usual `*` (any run), `?` (one char), and `[...]` class syntax.
 When several globs match one table, **the first one listed wins** (declaration
 order). A table matched by no glob uses `abort`. An absent config file means
-every table aborts — identical to the pre-config behavior. A malformed config
+every table aborts, identical to the pre-config behavior. A malformed config
 (bad TOML, unknown policy name, invalid glob) is a loud refusal, never a silent
 fall-back.
 
-| policy        | on a conflicting row                                              |
-| ------------- | ---------------------------------------------------------------- |
-| `abort`       | abort the whole merge (default)                                  |
-| `ours`        | keep ours; drop the incoming change                              |
-| `theirs`      | take theirs where SQLite allows it; otherwise abort (see below)  |
+| policy        | on a conflicting row                                                |
+| ------------- | ------------------------------------------------------------------- |
+| `abort`       | abort the whole merge (default)                                     |
+| `ours`        | keep ours; drop the incoming change                                 |
+| `theirs`      | take theirs where SQLite allows it; otherwise abort (see below)     |
 | `append-only` | a conflicting insert keeps ours; a conflicting update/delete aborts |
 
 **The `theirs` REPLACE caveat.** "Take theirs" maps to SQLite's
 `SQLITE_CHANGESET_REPLACE`, which the [session
 docs](https://sqlite.org/session/sqlite3changeset_apply.html) permit **only**
 for the `DATA` (both sides edited the same row) and `CONFLICT` (both inserted
-the same primary key) conflict types. For a `NOTFOUND` conflict — theirs edited
-a row ours had deleted, so there is no target row to overwrite — or a
+the same primary key) conflict types. For a `NOTFOUND` conflict (theirs edited
+a row ours had deleted, so there is no target row to overwrite) or a
 `CONSTRAINT` violation, returning REPLACE is illegal and would fail the entire
 apply with `SQLITE_MISUSE`. `theirs` therefore still **aborts** on those types
 rather than force an invalid resolution.

--- a/packages/sqlmerge/assets/hero.svg
+++ b/packages/sqlmerge/assets/hero.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; stroke-width: 1.2; }
+    .accent { stroke: #8250df; fill: none; stroke-width: 1.4; }
+    .edge { stroke: currentColor; fill: none; stroke-width: 1.2; marker-end: url(#arrow); }
+    .head { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="head"/>
+    </marker>
+  </defs>
+  <rect class="box" x="30" y="25" width="130" height="34" rx="6"/>
+  <text x="95" y="46" text-anchor="middle">base (%O)</text>
+  <rect class="box" x="30" y="98" width="130" height="34" rx="6"/>
+  <text x="95" y="119" text-anchor="middle">ours (%A)</text>
+  <rect class="box" x="30" y="171" width="130" height="34" rx="6"/>
+  <text x="95" y="192" text-anchor="middle">theirs (%B)</text>
+
+  <path class="edge" d="M160,42 C230,42 240,98 296,106"/>
+  <path class="edge" d="M160,115 L296,115"/>
+  <path class="edge" d="M160,188 C230,188 240,132 296,124"/>
+  <text class="muted" x="228" y="66" text-anchor="middle" font-size="12">session diff</text>
+  <text class="muted" x="228" y="108" text-anchor="middle" font-size="12">apply in place</text>
+
+  <rect class="accent" x="300" y="98" width="140" height="34" rx="6"/>
+  <text x="370" y="119" text-anchor="middle">sqlmerge</text>
+
+  <path class="edge" d="M440,106 C500,98 500,69 541,69"/>
+  <path class="edge" d="M440,124 C500,132 500,161 541,161"/>
+  <text class="muted" x="492" y="56" text-anchor="middle" font-size="12">clean rows</text>
+  <text class="muted" x="492" y="148" text-anchor="middle" font-size="12">conflicting rows</text>
+
+  <rect class="box" x="545" y="52" width="150" height="34" rx="6"/>
+  <text x="620" y="73" text-anchor="middle">merged %A, exit 0</text>
+  <rect class="box" x="545" y="144" width="150" height="34" rx="6"/>
+  <text x="620" y="165" text-anchor="middle">report, exit 1</text>
+</svg>

--- a/packages/unibind/README.md
+++ b/packages/unibind/README.md
@@ -1,10 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="an annotated Rust module is lowered by syn into an Interface IR, which renders through pyo3 today and napi-rs and rustler in planned phases"></p>
+
 # unibind
 
-One Rust attribute surface, one language-agnostic interface representation,
-one code generator per target language. A crate annotates the functions,
-records, and errors it wants to expose; unibind lowers that surface into an
-IR at macro time and renders bindings through the incumbent binding library
-of each enabled language backend.
+Why should every language binding pay a C-ABI serialization tax when pyo3, napi-rs, and rustler already exist? unibind is one Rust attribute surface, one language-agnostic interface representation, and one code generator per target language: a crate annotates the functions, records, and errors it wants to expose, unibind lowers that surface into an IR at macro time, and each backend renders bindings through the incumbent binding library of its ecosystem.
 
 ## The bet
 
@@ -16,6 +14,21 @@ ecosystem (pyo3 for Python, napi-rs for TypeScript, rustler for Elixir), so
 every language gets native semantics: real exception hierarchies, native
 async and cancellation, RAII-shaped resource cleanup, and types that flow end
 to end with no RustBuffer tax.
+
+## Use it
+
+unibind is a proc-macro library consumed inside this workspace. Depend on it
+with the backend you want as a feature, plus the binding library the backend
+targets:
+
+```toml
+[dependencies]
+unibind = { workspace = true, features = ["py"] }
+pyo3 = { workspace = true, features = ["extension-module"] }
+```
+
+(`packages/code/scipql/py` is the reference consumer.) The workspace lives in
+the monorepo: `git clone https://github.com/indexable-inc/index`.
 
 ## Surface
 

--- a/packages/unibind/assets/hero.svg
+++ b/packages/unibind/assets/hero.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; stroke-width: 1.2; }
+    .accent { stroke: #8250df; fill: none; stroke-width: 1.4; }
+    .edge { stroke: currentColor; fill: none; stroke-width: 1.2; marker-end: url(#arrow); }
+    .head { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="head"/>
+    </marker>
+  </defs>
+  <rect class="box" x="20" y="100" width="200" height="50" rx="6"/>
+  <text x="120" y="121" text-anchor="middle">annotated Rust module</text>
+  <text class="muted" x="120" y="139" text-anchor="middle" font-size="11">#[unibind::export]</text>
+
+  <path class="edge" d="M220,125 L296,125"/>
+  <text class="muted" x="258" y="110" text-anchor="middle" font-size="11">syn lowering</text>
+
+  <rect class="accent" x="300" y="108" width="120" height="34" rx="6"/>
+  <text x="360" y="129" text-anchor="middle">Interface IR</text>
+
+  <path class="edge" d="M420,117 C470,108 470,59 526,57"/>
+  <path class="edge" d="M420,125 L526,125" stroke-dasharray="5 4"/>
+  <path class="edge" d="M420,133 C470,142 470,191 526,193" stroke-dasharray="5 4"/>
+  <text class="muted" x="472" y="98" text-anchor="middle" font-size="11">render</text>
+
+  <rect class="box" x="530" y="40" width="170" height="34" rx="6"/>
+  <text x="615" y="61" text-anchor="middle">pyo3 (Python)</text>
+  <rect class="box" x="530" y="108" width="170" height="34" rx="6" stroke-dasharray="5 4"/>
+  <text x="615" y="129" text-anchor="middle">napi-rs (TypeScript)</text>
+  <rect class="box" x="530" y="176" width="170" height="34" rx="6" stroke-dasharray="5 4"/>
+  <text x="615" y="197" text-anchor="middle">rustler (Elixir)</text>
+  <text class="muted" x="615" y="230" text-anchor="middle" font-size="11">dashed = planned phases</text>
+</svg>


### PR DESCRIPTION
README sweep for the core-tools batch, per the creating-a-readme skill (hero SVG with embedded light/dark CSS referenced first, hook-question intro, derived install lines, no em dashes).

Updated:

- packages/sqlmerge/README.md (+ assets/hero.svg)
- packages/dag-runner/README.md (+ assets/hero.svg)
- packages/code/astlog/README.md (+ assets/hero.svg)
- packages/code/scipql/README.md (+ assets/hero.svg; mermaid diagram replaced by the hero)
- packages/mirror/README.md (+ assets/hero.svg)
- packages/unibind/README.md (+ assets/hero.svg)
- packages/indexbench/README.md (+ assets/hero.svg)
- packages/indexbench/filesystem/README.md (+ assets/hero.svg)

`nix run .#lint` passes (8/8 tasks).

Refs #2072


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update READMEs for sqlmerge, dag-runner, astlog, scipql, mirror, unibind, and indexbench
> Rewrites the introductions and adds installation sections (`Get it` / `Run it` / `Use it`) to seven package READMEs. Each README gains a centered hero SVG, clearer motivation, and concrete nix/cargo install commands. Copyedits improve phrasing, punctuation, and example accuracy throughout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbff051.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->