### PR TITLE
readme sweep: misc packages + modules

### DIFF
--- a/modules/services/ci-runner/README.md
+++ b/modules/services/ci-runner/README.md
@@ -1,10 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="GitHub Actions jobs dispatch to a static runner pool on one NixOS host that shares a warm Nix store and the cache.ix.dev substituter"></p>
+
 # ci-runner
 
-Self-hosted GitHub Actions runners for this repository, registered as a small
-static pool on a persistent NixOS host. The point is cache locality: jobs share
-the host's `/nix/store` and the cache.ix.dev public substituter, so a
-`nix build .#...` step substitutes warm artifacts instead of rebuilding from a
-cold store on a throwaway cloud VM.
+Tired of every CI job rebuilding the world from a cold store on a throwaway cloud VM? `services.ci-runner` registers a small static pool of self-hosted GitHub Actions runners on a persistent NixOS host. The point is cache locality: jobs share the host's `/nix/store` and the cache.ix.dev public substituter, so a `nix build .#...` step substitutes warm artifacts instead of rebuilding.
 
 This is the simple counterpart to the [`ix`](https://github.com/indexable-inc/ix)
 repo's webhook dispatcher, which mints just-in-time ephemeral runners per job.
@@ -13,8 +11,19 @@ service and no per-job VM.
 
 ## Use it
 
-Import is automatic: the module is discovered as `nixosModules.ci-runner`. On a
-host config:
+The flake exposes the module as `nixosModules.ci-runner`; inside this repo's own
+host configs it is auto-discovered, so no import line is needed there. From
+another flake:
+
+```nix
+{
+  inputs.index.url = "github:indexable-inc/index";
+  # in a NixOS host configuration:
+  imports = [ inputs.index.nixosModules.ci-runner ];
+}
+```
+
+Then configure it on the host:
 
 ```nix
 {

--- a/modules/services/ci-runner/assets/hero.svg
+++ b/modules/services/ci-runner/assets/hero.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 210" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="70" width="210" height="64" rx="8"/>
+  <text x="125" y="96" text-anchor="middle" font-size="13">GitHub Actions job</text>
+  <text x="125" y="116" text-anchor="middle" font-size="11" class="muted">runs-on: [self-hosted, nix]</text>
+
+  <path class="edge" d="M 230 102 L 308 102"/>
+  <text x="269" y="90" text-anchor="middle" font-size="11" class="muted">dispatch</text>
+
+  <rect class="box accent-stroke" x="310" y="62" width="190" height="80" rx="8"/>
+  <text x="405" y="92" text-anchor="middle" font-size="13">runner pool × N</text>
+  <text x="405" y="112" text-anchor="middle" font-size="11" class="muted">one persistent NixOS host</text>
+
+  <path class="edge" d="M 500 84 L 558 52"/>
+  <text x="504" y="46" font-size="11" class="muted">shares</text>
+  <rect class="box" x="560" y="26" width="140" height="44" rx="8"/>
+  <text x="630" y="45" text-anchor="middle" font-size="12">/nix/store</text>
+  <text x="630" y="61" text-anchor="middle" font-size="11" class="muted">stays warm</text>
+
+  <path class="edge" d="M 500 120 L 558 150"/>
+  <text x="500" y="164" font-size="11" class="muted">substitutes</text>
+  <rect class="box" x="560" y="134" width="140" height="44" rx="8"/>
+  <text x="630" y="153" text-anchor="middle" font-size="12">cache.ix.dev</text>
+  <text x="630" y="169" text-anchor="middle" font-size="11" class="muted">public cache</text>
+</svg>

--- a/modules/services/observability/README.md
+++ b/modules/services/observability/README.md
@@ -1,10 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="App SDKs, host metrics, and logs flow through per-node agent Collectors to one gateway that writes ClickHouse, read by Grafana and ix-observe"></p>
+
 # ix Observability
 
-`services.ix-observability` is a self-hosted [OpenTelemetry](https://opentelemetry.io/)
-pipeline for an ix fleet. One module, one Collector, one job:
-
-**Monitoring**: every service emits traces, metrics, and logs. They land in
-[ClickHouse](https://clickhouse.com/) and render in [Grafana](https://grafana.com/).
+How do you see every trace, metric, and log from an ix fleet in one place? `services.ix-observability` is a self-hosted [OpenTelemetry](https://opentelemetry.io/) pipeline: one module, one Collector, one job. Every service emits telemetry, it lands in [ClickHouse](https://clickhouse.com/), and it renders in [Grafana](https://grafana.com/).
 
 This is telemetry only. The search corpus used to ride this same Collector (RFC
 0004), but it moved to its own Parquet-log pipeline (issue #736, the
@@ -12,38 +10,52 @@ This is telemetry only. The search corpus used to ride this same Collector (RFC
 storage as the source of truth, with the Mixedbread index as a materialized view
 replayed from it. OTel is back to what it is good at.
 
-The Collector is the one moving part everything else hangs off. Read the two
-diagrams and the rest follows.
+The Collector is the one moving part everything else hangs off. Each application
+node runs a local Collector (the **agent**) that forwards to one gateway node
+(the **stack**) over OTLP/gRPC; the gateway writes to ClickHouse, and Grafana and
+the `ix-observe` CLI read from it. That is the whole hero diagram above.
 
-## Monitoring flow
+## Use it
 
-Each application node runs a local Collector (the **agent**). It forwards to one
-gateway node (the **stack**) over OTLP/gRPC. The gateway writes to ClickHouse;
-Grafana and the `ix-observe` CLI read from it.
+The flake exposes the module as `nixosModules.observability`; inside this repo's
+own VM configs it is auto-discovered, so no import line is needed there (the
+examples just set `services.ix-observability.*`). From another flake:
 
-```mermaid
-flowchart LR
-  subgraph appnode["app node (agent)"]
-    sdk["app OTLP SDK<br/>127.0.0.1:4317"]
-    hm["hostmetrics<br/>cpu / mem / disk / net"]
-    fl["filelog + journald"]
-    agent["local Collector"]
-    sdk --> agent
-    hm --> agent
-    fl --> agent
-  end
-
-  subgraph obsnode["observability node (stack)"]
-    gw["gateway Collector<br/>OTLP :4317 / :4318"]
-    ch[("ClickHouse<br/>otel_logs · otel_traces<br/>otel_metrics_*")]
-    gf["Grafana :3000"]
-    gw -->|clickhouse exporter| ch
-    gf -->|ClickHouse datasource| ch
-  end
-
-  agent -->|OTLP/gRPC| gw
-  cli["ix-observe CLI"] --> ch
+```nix
+{
+  inputs.index.url = "github:indexable-inc/index";
+  # in a NixOS host configuration:
+  imports = [ inputs.index.nixosModules.observability ];
+}
 ```
+
+Single node, everything local:
+
+```nix
+{ services.ix-observability.enable = true; }
+```
+
+Fleet: one gateway, many agents (the [observability-stack example](../../../examples/observability/stack/)
+wires exactly this):
+
+```nix
+# observability node
+{ services.ix-observability.stack.enable = true; }
+
+# each app node
+{
+  services.ix-observability.agent = {
+    enable = true;
+    endpoint = "observability:4317";
+    filelog.paths = [ "/var/log/my-service/*.log" ];
+  };
+  services.ix-observability.resourceAttributes."ix.app" = "my-service";
+}
+```
+
+Point your application's OpenTelemetry SDK at `127.0.0.1:4317`; the local
+Collector handles batching, resource labels, and the remote write. Every option
+is declared in [`default.nix`](default.nix).
 
 ## How telemetry flows through the Collector
 
@@ -111,36 +123,6 @@ ix shell observability -- ix-observe slow-spans         # slowest spans
 ix shell observability -- ix-observe trace <trace-id>   # one trace, ordered
 ix shell observability -- ix-observe sql "SELECT ..."   # arbitrary SQL
 ```
-
-## Configure it
-
-Single node, everything local:
-
-```nix
-{ services.ix-observability.enable = true; }
-```
-
-Fleet: one gateway, many agents (the [observability-stack example](../../../examples/observability/stack/)
-wires exactly this):
-
-```nix
-# observability node
-{ services.ix-observability.stack.enable = true; }
-
-# each app node
-{
-  services.ix-observability.agent = {
-    enable = true;
-    endpoint = "observability:4317";
-    filelog.paths = [ "/var/log/my-service/*.log" ];
-  };
-  services.ix-observability.resourceAttributes."ix.app" = "my-service";
-}
-```
-
-Point your application's OpenTelemetry SDK at `127.0.0.1:4317`; the local
-Collector handles batching, resource labels, and the remote write. Every option
-above is declared in [`default.nix`](default.nix).
 
 ---
 

--- a/modules/services/observability/assets/hero.svg
+++ b/modules/services/observability/assets/hero.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="26" width="160" height="34" rx="8"/>
+  <text x="100" y="48" text-anchor="middle" font-size="12">app SDK :4317</text>
+  <rect class="box" x="20" y="92" width="160" height="34" rx="8"/>
+  <text x="100" y="114" text-anchor="middle" font-size="12">hostmetrics</text>
+  <rect class="box" x="20" y="158" width="160" height="34" rx="8"/>
+  <text x="100" y="180" text-anchor="middle" font-size="12">filelog · journald</text>
+
+  <path class="edge" d="M 180 46 L 248 96"/>
+  <path class="edge" d="M 180 109 L 248 109"/>
+  <path class="edge" d="M 180 172 L 248 122"/>
+
+  <rect class="box" x="250" y="82" width="130" height="56" rx="8"/>
+  <text x="315" y="105" text-anchor="middle" font-size="12">agent Collector</text>
+  <text x="315" y="123" text-anchor="middle" font-size="11" class="muted">per app node</text>
+
+  <path class="edge" d="M 380 110 L 448 110"/>
+  <text x="414" y="98" text-anchor="middle" font-size="11" class="muted">OTLP/gRPC</text>
+
+  <rect class="box accent-stroke" x="450" y="82" width="120" height="56" rx="8"/>
+  <text x="510" y="105" text-anchor="middle" font-size="12" class="accent">gateway</text>
+  <text x="510" y="123" text-anchor="middle" font-size="11" class="muted">Collector</text>
+
+  <path class="edge" d="M 570 110 L 618 110"/>
+
+  <rect class="box" x="620" y="76" width="86" height="68" rx="8"/>
+  <text x="663" y="102" text-anchor="middle" font-size="12">ClickHouse</text>
+  <text x="663" y="120" text-anchor="middle" font-size="11" class="muted">otel_*</text>
+
+  <path class="edge" d="M 646 144 L 578 202"/>
+  <rect class="box" x="450" y="200" width="130" height="34" rx="8"/>
+  <text x="515" y="222" text-anchor="middle" font-size="12">Grafana :3000</text>
+
+  <path class="edge" d="M 674 144 L 668 198"/>
+  <rect class="box" x="608" y="200" width="106" height="34" rx="8"/>
+  <text x="661" y="222" text-anchor="middle" font-size="12">ix-observe</text>
+</svg>

--- a/packages/andrewgazelka/hive/README.md
+++ b/packages/andrewgazelka/hive/README.md
@@ -1,10 +1,16 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="Hive.Swarm spawns agent processes that message each other by logical id, resolved through Hive.Registry"></p>
+
 # Hive
 
-A tiny, fully connected mesh of agent actors in Elixir. Spawn agents at runtime;
-any agent can message any other by a logical id. No edges to wire.
+Ever wanted a swarm of agent actors where any agent can message any other, with no edges to wire? Hive is a tiny, fully connected mesh of agent actors in Elixir: spawn agents at runtime and address them by a logical id, not a pid. It is an experimental personal package (moved out of a standalone checkout) that doubles as the reference user of the repo's Elixir type-discipline gate.
 
-This is an **experimental personal package** (moved out of a standalone checkout)
-that doubles as the reference user of the repo's Elixir type-discipline gate.
+## Run it
+
+```sh
+nix run github:indexable-inc/index#hive   # spawns :planner/:executor/:critic, has them talk, prints inboxes
+```
+
+From a clone (`git clone https://github.com/indexable-inc/index`): `nix run .#hive`.
 
 ## The three pieces
 
@@ -15,36 +21,30 @@ Hive.Application          OTP supervision tree, starts the two below
         └── Hive.Agent    a GenServer; one actor per agent
 ```
 
-- **`Hive.Agent`** — each agent is a GenServer holding its own inbox, registered
+- **`Hive.Agent`**: each agent is a GenServer holding its own inbox, registered
   under a logical `id` via a `:via` tuple so it is addressable by `id`, not pid.
-- **`Hive.Registry`** — the `id -> pid` map; lookups read ETS directly and run
+- **`Hive.Registry`**: the `id -> pid` map; lookups read ETS directly and run
   concurrently, and an agent's entry is auto-removed when it crashes.
-- **`Hive.Swarm`** — a `DynamicSupervisor`, so agents are spawned on demand and
+- **`Hive.Swarm`**: a `DynamicSupervisor`, so agents are spawned on demand and
   each is supervised independently (`:one_for_one`).
-
-## Run it
-
-```sh
-nix run .#hive          # spawns :planner/:executor/:critic, has them talk, prints inboxes
-```
 
 ## Type discipline (Elixir 1.18 set-theoretic types)
 
 This package is built with Elixir 1.18, whose set-theoretic gradual type checker
 runs as part of `mix compile`. Two gates enforce the typed style:
 
-1. **`mix compile --warnings-as-errors`** — the actual type check. It runs in the
+1. **`mix compile --warnings-as-errors`**: the actual type check. It runs in the
    sandboxed `passthru.tests.elixir` derivation (wired into the repo's flake
    `checks` in `lib/per-system.nix`), so a type error fails CI. See
    [`default.nix`](./default.nix).
-2. **`astlog-rules/elixir.astlog`** — a lint (run over every package's `lib/` by
+2. **`astlog-rules/elixir.astlog`**: a lint (run over every package's `lib/` by
    `nix run .#lint`) that *forces* the shape the checker can actually check:
    - every `defstruct` needs a `@type` (so struct fields are typed, not `dynamic`);
    - every public `def` needs an adjacent `@spec` (behaviour-callback `@impl`
      functions are exempt).
 
 `Hive.Agent.State` is a typed struct, and every public function and callback
-carries a `@spec`, so both gates pass. Try breaking it — change `state.inbox` to
+carries a `@spec`, so both gates pass. Try breaking it: change `state.inbox` to
 `state.outbox` and `mix compile` reports a `typing violation` at that exact column.
 
 ## Type internals

--- a/packages/andrewgazelka/hive/assets/hero.svg
+++ b/packages/andrewgazelka/hive/assets/hero.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 240" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="95" width="150" height="52" rx="8"/>
+  <text x="95" y="116" text-anchor="middle" font-size="14">Hive.Swarm</text>
+  <text x="95" y="134" text-anchor="middle" font-size="11" class="muted">DynamicSupervisor</text>
+
+  <circle class="box" cx="285" cy="60" r="32"/>
+  <text x="285" y="65" text-anchor="middle" font-size="13">:planner</text>
+  <circle class="box" cx="285" cy="185" r="32"/>
+  <text x="285" y="190" text-anchor="middle" font-size="13">:executor</text>
+  <circle class="box" cx="440" cy="122" r="32"/>
+  <text x="440" y="127" text-anchor="middle" font-size="13">:critic</text>
+
+  <path class="edge" d="M 170 112 L 250 72"/>
+  <path class="edge" d="M 170 130 L 250 173"/>
+  <text x="200" y="94" font-size="11" class="muted">spawns</text>
+
+  <path class="edge" d="M 285 92 L 285 153" marker-start="url(#arrow)"/>
+  <path class="edge" d="M 312 75 L 410 108" marker-start="url(#arrow)"/>
+  <path class="edge" d="M 312 170 L 410 137" marker-start="url(#arrow)"/>
+  <text x="295" y="127" font-size="11" class="accent">send by id</text>
+
+  <rect class="box" x="555" y="90" width="150" height="62" rx="8"/>
+  <text x="630" y="113" text-anchor="middle" font-size="14">Hive.Registry</text>
+  <text x="630" y="132" text-anchor="middle" font-size="11" class="muted">id -&gt; pid (ETS)</text>
+  <path class="dashed" d="M 472 118 L 553 118"/>
+  <text x="480" y="108" font-size="11" class="muted">lookup</text>
+</svg>

--- a/packages/cuda-hello/README.md
+++ b/packages/cuda-hello/README.md
@@ -1,10 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="One Rust source file compiles to PTX with cargo oxide, then launches on an NVIDIA GPU"></p>
+
 # cuda-hello
 
-A minimal CUDA kernel written in pure, idiomatic Rust and compiled to PTX with
-[cuda-oxide](https://github.com/NVlabs/cuda-oxide), NVIDIA's experimental
-Rust-to-CUDA compiler backend. Host and device code share one file
-([`src/main.rs`](src/main.rs)); the kernel writes `i*i` for each thread, the GPU
-"hello, world".
+Can you write a CUDA kernel in pure, idiomatic Rust? This crate is the proof: a minimal kernel compiled to PTX with [cuda-oxide](https://github.com/NVlabs/cuda-oxide), NVIDIA's experimental Rust-to-CUDA compiler backend. Host and device code share one file ([`src/main.rs`](src/main.rs)); the kernel writes `i*i` for each thread, the GPU "hello, world".
 
 This is the seed for first-class CUDA-in-Rust support in this repo. The kernel is
 written against cuda-oxide's real API (a faithful subset of upstream's `vecadd`
@@ -24,9 +22,11 @@ emitted PTX; you just cannot execute it.
 
 The crate-local [`flake.nix`](flake.nix) inherits cuda-oxide's dev shell, so you
 get the exact toolchain (the `cargo oxide` driver, the pinned nightly, LLVM 22
-with NVPTX, CUDA 13, and libclang) with no manual setup. From this directory:
+with NVPTX, CUDA 13, and libclang) with no manual setup:
 
 ```sh
+git clone https://github.com/indexable-inc/index
+cd index/packages/cuda-hello
 nix develop            # enter the cuda-oxide toolchain (Linux only)
 cargo oxide build      # compile to PTX (no GPU required)
 cargo oxide run        # compile to PTX, then launch on the GPU

--- a/packages/cuda-hello/assets/hero.svg
+++ b/packages/cuda-hello/assets/hero.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 150" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="45" width="200" height="62" rx="8"/>
+  <text x="120" y="70" text-anchor="middle" font-size="14">src/main.rs</text>
+  <text x="120" y="90" text-anchor="middle" font-size="11" class="muted">#[kernel] + host, one file</text>
+
+  <path class="edge" d="M 220 76 L 305 76"/>
+  <text x="262" y="60" text-anchor="middle" font-size="11">cargo oxide build</text>
+  <text x="262" y="98" text-anchor="middle" font-size="11" class="muted">no GPU needed</text>
+
+  <rect class="box accent-stroke" x="307" y="45" width="130" height="62" rx="8"/>
+  <text x="372" y="82" text-anchor="middle" font-size="14" class="accent">kernel.ptx</text>
+
+  <path class="edge" d="M 437 76 L 522 76"/>
+  <text x="479" y="60" text-anchor="middle" font-size="11">launch</text>
+  <text x="479" y="98" text-anchor="middle" font-size="11" class="muted">NVIDIA GPU</text>
+
+  <rect class="box" x="524" y="45" width="176" height="62" rx="8"/>
+  <text x="612" y="70" text-anchor="middle" font-size="14">GPU threads</text>
+  <text x="612" y="90" text-anchor="middle" font-size="11" class="muted">out[i] = i * i</text>
+</svg>

--- a/packages/elevenlabs-say/README.md
+++ b/packages/elevenlabs-say/README.md
@@ -1,8 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="Text from an argument, a file, or a live stdin stream is synthesized by ElevenLabs and played or saved"></p>
+
 # elevenlabs-say
 
-A `say`-style command-line tool that speaks text with the [ElevenLabs](https://elevenlabs.io)
-text-to-speech API. It reads text from an argument, a file, or stdin, then plays
-the audio through your speakers or writes it to a file.
+Want macOS `say`, but with a voice you would actually listen to? `elevenlabs-say` is a `say`-style command-line tool that speaks text with the [ElevenLabs](https://elevenlabs.io) text-to-speech API. It reads text from an argument, a file, or stdin (streaming live token-by-token input, so an LLM pipe is spoken as it arrives), then plays the audio through your speakers or writes it to a file.
 
 ## Setup
 
@@ -17,30 +17,32 @@ export ELEVENLABS_API_KEY=sk_...
 
 ```sh
 # Speak a string through the speakers.
-nix run .#elevenlabs-say -- "the first move sets everything in motion"
+nix run github:indexable-inc/index#elevenlabs-say -- "the first move sets everything in motion"
 
 # Speak the contents of a file.
-nix run .#elevenlabs-say -- --file notes.txt
+nix run github:indexable-inc/index#elevenlabs-say -- --file notes.txt
 
 # Pipe text on stdin. This streams by default: a producer that emits text over
 # time is spoken as it arrives, instead of waiting for it to finish.
-my-llm --prompt "tell me a story" | nix run .#elevenlabs-say
+my-llm --prompt "tell me a story" | nix run github:indexable-inc/index#elevenlabs-say
 
 # Force the batch path on a pipe (buffer all stdin, then synthesize once).
-cat notes.txt | nix run .#elevenlabs-say -- --no-stream
+cat notes.txt | nix run github:indexable-inc/index#elevenlabs-say -- --no-stream
 
 # Save audio instead of playing it.
-nix run .#elevenlabs-say -- "save me" --output /tmp/out.mp3
+nix run github:indexable-inc/index#elevenlabs-say -- "save me" --output /tmp/out.mp3
 
 # Pick a voice by name or id, and override the model or format.
-nix run .#elevenlabs-say -- "different voice" --voice Adam
-nix run .#elevenlabs-say -- "slower model" --model eleven_multilingual_v2 --format mp3_44100_192
+nix run github:indexable-inc/index#elevenlabs-say -- "different voice" --voice Adam
+nix run github:indexable-inc/index#elevenlabs-say -- "slower model" --model eleven_multilingual_v2 --format mp3_44100_192
 
 # macOS `say`-style flags: -v voice, -r rate (words per minute).
-nix run .#elevenlabs-say -- -v Adam -r 300 "talk faster"
+nix run github:indexable-inc/index#elevenlabs-say -- -v Adam -r 300 "talk faster"
 ```
 
-Text source precedence is positional argument, then `--file`, then stdin.
+Text source precedence is positional argument, then `--file`, then stdin. From a
+clone (`git clone https://github.com/indexable-inc/index`), replace
+`github:indexable-inc/index` with `.`.
 
 ## macOS `say` compatibility
 

--- a/packages/elevenlabs-say/assets/hero.svg
+++ b/packages/elevenlabs-say/assets/hero.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="25" width="160" height="38" rx="8"/>
+  <text x="100" y="49" text-anchor="middle" font-size="13">TEXT argument</text>
+  <rect class="box" x="20" y="95" width="160" height="38" rx="8"/>
+  <text x="100" y="119" text-anchor="middle" font-size="13">--file notes.txt</text>
+  <rect class="box" x="20" y="165" width="160" height="38" rx="8"/>
+  <text x="100" y="189" text-anchor="middle" font-size="13">stdin (LLM tokens)</text>
+
+  <path class="edge" d="M 180 46 L 296 100"/>
+  <path class="edge" d="M 180 114 L 296 114"/>
+  <text x="215" y="106" font-size="11" class="muted">batch convert</text>
+  <path class="edge" d="M 180 182 L 296 130"/>
+  <text x="196" y="163" font-size="11" class="accent">WebSocket stream</text>
+
+  <rect class="box" x="300" y="84" width="170" height="62" rx="8"/>
+  <text x="385" y="109" text-anchor="middle" font-size="14">elevenlabs-say</text>
+  <text x="385" y="128" text-anchor="middle" font-size="11" class="muted">ElevenLabs TTS API</text>
+
+  <path class="edge" d="M 470 103 L 554 66"/>
+  <text x="490" y="72" font-size="11" class="muted">play (ffplay)</text>
+  <rect class="box" x="556" y="40" width="144" height="40" rx="8"/>
+  <text x="628" y="65" text-anchor="middle" font-size="13">speakers</text>
+
+  <path class="edge" d="M 470 128 L 554 168"/>
+  <text x="492" y="164" font-size="11" class="muted">--output</text>
+  <rect class="box" x="556" y="150" width="144" height="40" rx="8"/>
+  <text x="628" y="175" text-anchor="middle" font-size="13">out.mp3</text>
+</svg>

--- a/packages/google/calendar/README.md
+++ b/packages/google/calendar/README.md
@@ -1,18 +1,28 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="Three thin surfaces (CLI, MCP tools, Python) drive one Rust Calendar client that talks OAuth and the Calendar v3 API"></p>
+
 # google-calendar
 
-Google Calendar for agents and shells: one Rust crate owns the
-[Calendar v3 events API](https://developers.google.com/workspace/calendar/api/v3/reference/events)
-(list, get, create, cancel). OAuth lives in the shared
-[`packages/google/auth`](../auth) crate, which the gmail integration also
-uses; three thin surfaces expose this client per
+Need your shell or your agent to read and write Google Calendar without clicking through a browser? This is Google Calendar for agents and shells: one Rust crate owns the [Calendar v3 events API](https://developers.google.com/workspace/calendar/api/v3/reference/events) (list, get, create, cancel), and three thin surfaces expose it, so the CLI, the MCP tools, and the Python binding all return the same wire types.
+
+OAuth lives in the shared [`packages/google/auth`](../auth) crate, which the
+gmail integration also uses. The three surfaces, per
 [RFC 0003](../../site/src/lib/rfcs/0003-mcp-composable-clis.svx): the `gcal` CLI
-in [`cli/`](./cli), the `calendar_*` tools in the `ix-google-mcp` Rust
-server in [`packages/google/mcp`](../mcp), and the
-`ix_google.calendar.Client` Python class in
-[`packages/google/py`](../py). Tracks
-[#643](https://github.com/indexable-inc/index/issues/643); the auth
-extraction landed alongside gmail
+in [`cli/`](./cli), the `calendar_*` tools in the `ix-google-mcp` Rust server in
+[`packages/google/mcp`](../mcp), and the `ix_google.calendar.Client` Python class
+in [`packages/google/py`](../py). Tracks
+[#643](https://github.com/indexable-inc/index/issues/643); the auth extraction
+landed alongside gmail
 ([#644](https://github.com/indexable-inc/index/issues/644)).
+
+## Get it
+
+```sh
+nix run github:indexable-inc/index#gcal -- --help
+```
+
+From a clone (`git clone https://github.com/indexable-inc/index`): `nix run .#gcal`.
+The crate itself (`google-calendar`) is an unmirrored workspace library; consume it
+through Nix or one of the three surfaces above.
 
 ## One-time team setup: the OAuth client
 

--- a/packages/google/calendar/assets/hero.svg
+++ b/packages/google/calendar/assets/hero.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="22" width="190" height="36" rx="8"/>
+  <text x="115" y="45" text-anchor="middle" font-size="13">gcal CLI</text>
+  <rect class="box" x="20" y="79" width="190" height="36" rx="8"/>
+  <text x="115" y="102" text-anchor="middle" font-size="13">MCP calendar_* tools</text>
+  <rect class="box" x="20" y="136" width="190" height="36" rx="8"/>
+  <text x="115" y="159" text-anchor="middle" font-size="13">ix_google.calendar</text>
+
+  <path class="edge" d="M 210 42 L 288 80"/>
+  <path class="edge" d="M 210 97 L 288 97"/>
+  <path class="edge" d="M 210 152 L 288 114"/>
+
+  <rect class="box accent-stroke" x="290" y="62" width="200" height="70" rx="8"/>
+  <text x="390" y="90" text-anchor="middle" font-size="14">google-calendar crate</text>
+  <text x="390" y="110" text-anchor="middle" font-size="11" class="muted">list · get · create · cancel</text>
+
+  <path class="edge" d="M 490 97 L 558 97"/>
+  <text x="524" y="86" text-anchor="middle" font-size="11" class="muted">HTTPS</text>
+
+  <rect class="box" x="560" y="62" width="140" height="70" rx="8"/>
+  <text x="630" y="90" text-anchor="middle" font-size="13">Calendar v3</text>
+  <text x="630" y="110" text-anchor="middle" font-size="11" class="muted">events API</text>
+
+  <path class="dashed" d="M 390 132 L 390 172"/>
+  <text x="400" y="156" font-size="11" class="muted">OAuth via google-auth</text>
+  <rect class="box" x="240" y="174" width="300" height="38" rx="8"/>
+  <text x="390" y="198" text-anchor="middle" font-size="12">~/.config/google/token.json (shared with gmail)</text>
+</svg>

--- a/packages/google/gmail/README.md
+++ b/packages/google/gmail/README.md
@@ -1,20 +1,30 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="Three thin surfaces (CLI, MCP tools, Python) drive one Rust Gmail client that talks OAuth and the Gmail v1 API"></p>
+
 # google-gmail
 
-Gmail for agents and shells: one Rust crate owns the
-[Gmail v1 API](https://developers.google.com/gmail/api/reference/rest)
-(messages, threads, labels, drafts, send, attachments) and the MIME
-builder for outgoing mail. Three thin surfaces expose it per
+Want your shell or your agent to search, read, and send Gmail without a browser tab? This is Gmail for agents and shells: one Rust crate owns the [Gmail v1 API](https://developers.google.com/gmail/api/reference/rest) (messages, threads, labels, drafts, send, attachments) and the MIME builder for outgoing mail, and three thin surfaces expose it, so the CLI, the MCP tools, and the Python binding all return the same wire types.
+
+The three surfaces, per
 [RFC 0003](../../site/src/lib/rfcs/0003-mcp-composable-clis.svx): the `gmail` CLI
-in [`cli/`](./cli), the `mail_*` tools in the `ix-google-mcp` Rust server
-in [`packages/google/mcp`](../mcp), and the `ix_google.gmail.Client`
-Python class in [`packages/google/py`](../py). Tracks
+in [`cli/`](./cli), the `mail_*` tools in the `ix-google-mcp` Rust server in
+[`packages/google/mcp`](../mcp), and the `ix_google.gmail.Client` Python class in
+[`packages/google/py`](../py). Tracks
 [#599](https://github.com/indexable-inc/index/issues/599) and
 [#644](https://github.com/indexable-inc/index/issues/644).
 
-OAuth is shared with the calendar crate through `google-auth`: one
-consent flow per workstation grants the union of every scope the repo
-knows about, and the stored token lives in
-`~/.config/google/token.json` (mode 0600).
+OAuth is shared with the calendar crate through `google-auth`: one consent flow
+per workstation grants the union of every scope the repo knows about, and the
+stored token lives in `~/.config/google/token.json` (mode 0600).
+
+## Get it
+
+```sh
+nix run github:indexable-inc/index#gmail -- --help
+```
+
+From a clone (`git clone https://github.com/indexable-inc/index`): `nix run .#gmail`.
+The crate itself (`google-gmail`) is an unmirrored workspace library; consume it
+through Nix or one of the three surfaces above.
 
 ## One-time team setup: the OAuth client
 

--- a/packages/google/gmail/assets/hero.svg
+++ b/packages/google/gmail/assets/hero.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="22" width="190" height="36" rx="8"/>
+  <text x="115" y="45" text-anchor="middle" font-size="13">gmail CLI</text>
+  <rect class="box" x="20" y="79" width="190" height="36" rx="8"/>
+  <text x="115" y="102" text-anchor="middle" font-size="13">MCP mail_* tools</text>
+  <rect class="box" x="20" y="136" width="190" height="36" rx="8"/>
+  <text x="115" y="159" text-anchor="middle" font-size="13">ix_google.gmail</text>
+
+  <path class="edge" d="M 210 42 L 288 80"/>
+  <path class="edge" d="M 210 97 L 288 97"/>
+  <path class="edge" d="M 210 152 L 288 114"/>
+
+  <rect class="box accent-stroke" x="290" y="62" width="200" height="70" rx="8"/>
+  <text x="390" y="90" text-anchor="middle" font-size="14">google-gmail crate</text>
+  <text x="390" y="110" text-anchor="middle" font-size="11" class="muted">messages · drafts · send · MIME</text>
+
+  <path class="edge" d="M 490 97 L 558 97"/>
+  <text x="524" y="86" text-anchor="middle" font-size="11" class="muted">HTTPS</text>
+
+  <rect class="box" x="560" y="62" width="140" height="70" rx="8"/>
+  <text x="630" y="90" text-anchor="middle" font-size="13">Gmail v1</text>
+  <text x="630" y="110" text-anchor="middle" font-size="11" class="muted">REST API</text>
+
+  <path class="dashed" d="M 390 132 L 390 172"/>
+  <text x="400" y="156" font-size="11" class="muted">OAuth via google-auth</text>
+  <rect class="box" x="240" y="174" width="300" height="38" rx="8"/>
+  <text x="390" y="198" text-anchor="middle" font-size="12">~/.config/google/token.json (shared with gcal)</text>
+</svg>

--- a/packages/ix-dev-diagnose/README.md
+++ b/packages/ix-dev-diagnose/README.md
@@ -1,21 +1,28 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="ix-dev-diagnose resolves ix.dev, probes TCP, TLS, and HTTP per address, and writes a JSON report plus a one-line verdict"></p>
+
 # ix-dev-diagnose
 
-`ix-dev-diagnose` probes `https://ix.dev/` from the caller's network path,
-prints a short success or failure summary, and writes a JSON report for
-support/debugging.
+`https://ix.dev` works on your network but throws `SEC_ERROR_UNKNOWN_ISSUER` on someone else's, so how do you debug a network path you cannot see? `ix-dev-diagnose` probes `https://ix.dev/` from the caller's machine, prints a one-line `success` or `failure` verdict, and writes a JSON report you can send to support: everything needed to compare a working path against a broken one.
+
+## Run it
 
 ```sh
-nix run .#ix-dev-diagnose
+nix run github:indexable-inc/index#ix-dev-diagnose
 ```
+
+From a clone (`git clone https://github.com/indexable-inc/index`): `nix run .#ix-dev-diagnose`.
 
 The command prints `success` or `failure` followed by the JSON file path. The
 report includes local DNS answers, one TCP/TLS/HTTP probe per resolved address,
 the certificate chain fingerprints and parsed issuer names, native and
 Mozilla-root verification results, response headers, and a bounded base64 sample
-of the response body. Share the JSON file when `https://ix.dev` works for one
-network but fails with browser errors such as `SEC_ERROR_UNKNOWN_ISSUER` on
-another.
+of the response body.
 
-Use `--output <path>` to choose the report location. Use `--json --pretty` when
-another command should consume the JSON from stdout. Pass an explicit URL when
-the bad bytes are for a specific artifact, such as a CLI binary path.
+## Options
+
+- `--output <path>` chooses the report location.
+- `--json --pretty` prints the JSON to stdout for another command to consume.
+- Pass an explicit URL when the bad bytes are for a specific artifact, such as a
+  CLI binary path.
+- `--family ipv4|ipv6` restricts probes to one address family;
+  `--connect-timeout-ms` / `--read-timeout-ms` bound each probe.

--- a/packages/ix-dev-diagnose/assets/hero.svg
+++ b/packages/ix-dev-diagnose/assets/hero.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="82" width="180" height="56" rx="8"/>
+  <text x="110" y="106" text-anchor="middle" font-size="14">ix-dev-diagnose</text>
+  <text x="110" y="125" text-anchor="middle" font-size="11" class="muted">https://ix.dev/</text>
+
+  <path class="edge" d="M 200 96 L 268 56"/>
+  <text x="204" y="60" font-size="11" class="muted">resolve</text>
+  <rect class="box" x="270" y="24" width="180" height="40" rx="8"/>
+  <text x="360" y="49" text-anchor="middle" font-size="12">local DNS answers</text>
+
+  <path class="edge" d="M 200 118 L 268 130"/>
+  <text x="204" y="152" font-size="11" class="muted">probe each address</text>
+  <rect class="box" x="270" y="96" width="180" height="100" rx="8"/>
+  <text x="360" y="122" text-anchor="middle" font-size="13">TCP connect</text>
+  <text x="360" y="146" text-anchor="middle" font-size="13">TLS handshake</text>
+  <text x="360" y="170" text-anchor="middle" font-size="13">HTTP GET</text>
+
+  <path class="edge" d="M 450 146 L 528 146"/>
+  <rect class="box accent-stroke" x="530" y="112" width="170" height="68" rx="8"/>
+  <text x="615" y="138" text-anchor="middle" font-size="14" class="accent">report.json</text>
+  <text x="615" y="158" text-anchor="middle" font-size="11" class="muted">chain · verify · headers</text>
+
+  <path class="edge" d="M 450 44 L 528 44"/>
+  <rect class="box" x="530" y="24" width="170" height="40" rx="8"/>
+  <text x="615" y="49" text-anchor="middle" font-size="12">success | failure</text>
+</svg>

--- a/packages/ix-windows/README.md
+++ b/packages/ix-windows/README.md
@@ -1,18 +1,22 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="ix-windows watches the MCP producer socket and renders each live resource as a floating, blurred, auto-sized card"></p>
+
 # ix-windows
 
-Render each live MCP resource as its own floating, blurred **overlay** webview
-window that auto-sizes to its content.
+What if every live MCP resource just floated on your desktop, exactly as big as its content? `ix-windows` renders each resource as its own chrome-less, blurred, always-on-top webview card: a window opens when a resource appears, re-renders in place on update, and closes when the resource closes or its producer disconnects.
 
-`ix-windows` is a standalone consumer of the dashboard producer stream. The MCP
-already publishes every resource onto the producer sockets as an `html` pane
-keyed `resource/<id>` (see `packages/mcp`), so this process renders them with no
-change to the MCP. A window opens when a resource appears, re-renders in place on
-update, and closes when the resource closes or its producer disconnects.
+It is a standalone consumer of the dashboard producer stream. The MCP already
+publishes every resource onto the producer sockets as an `html` pane keyed
+`resource/<id>` (see `packages/mcp`), so this process renders them with no change
+to the MCP.
 
+## Run it
+
+```sh
+nix run github:indexable-inc/index#ix-windows             # watch the default discovery dir
+nix run github:indexable-inc/index#ix-windows -- --dir /tmp/ixw
 ```
-nix run .#ix-windows            # watch the default discovery dir
-nix run .#ix-windows -- --dir /tmp/ixw
-```
+
+From a clone (`git clone https://github.com/indexable-inc/index`): `nix run .#ix-windows`.
 
 ## Overlay, not tiles
 
@@ -32,14 +36,14 @@ tiling, no layout manager.
   floats over fullscreen apps (`NSWindowCollectionBehavior`).
 - **Move with Cmd+drag.** The card is borderless and runs content flush to its
   edge (no padding), so there is no chrome to grab. Hold **Cmd** and drag anywhere
-  -- even over content -- to move it (an ordinary Cmd+click on content still works);
-  a drag on any bare background area moves it too. The window is not user-resizable
-  -- its size is owned by the content (auto-fit), so a manual resize would just
-  fight the next content report.
+  (even over content) to move it; an ordinary Cmd+click on content still works,
+  and a drag on any bare background area moves it too. The window is not
+  user-resizable: its size is owned by the content (auto-fit), so a manual resize
+  would just fight the next content report.
 - **Close, and stay closed.** Each card paints its own floating close button
   (top-right corner, faint until hovered). A closed resource is remembered
   **persistently** (keyed by producing session + resource id), so it does not
-  reappear when the resource re-registers or when `ix-windows` restarts -- useful
+  reappear when the resource re-registers or when `ix-windows` restarts; useful
   when a session publishes a flood of resources you do not want to see. It only
   reappears if a *different* session (or the same one after a restart) publishes
   it. Dismissals are logged to `$XDG_STATE_HOME/ix-windows/dismissed` (else
@@ -52,7 +56,7 @@ A resource's HTML is rendered inside a sandboxed, opaque-origin `<iframe>`
 (`sandbox="allow-scripts"`, no `allow-same-origin`) loaded with no page origin, so
 same-origin `fetch`, cookies, and storage are unavailable. Absolute HTTPS
 scripts/styles may still load (subject to the browser and the remote server /
-CORS), but they are a live network dependency, not an isolated pane -- and an
+CORS), but they are a live network dependency, not an isolated pane, and an
 ES-module `import` from a CDN was observed to fail under the opaque origin. For a
 reproducible, offline overlay, **inline** your CSS/JS/data and pre-render anything
 that needs a library: e.g. render a mermaid diagram to SVG server-side

--- a/packages/ix-windows/assets/hero.svg
+++ b/packages/ix-windows/assets/hero.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="92" width="140" height="52" rx="8"/>
+  <text x="90" y="115" text-anchor="middle" font-size="14">MCP session</text>
+  <text x="90" y="133" text-anchor="middle" font-size="11" class="muted">live resources</text>
+
+  <path class="edge" d="M 160 118 L 228 118"/>
+  <text x="194" y="106" text-anchor="middle" font-size="11" class="muted">publishes</text>
+
+  <rect class="box" x="230" y="92" width="170" height="52" rx="8"/>
+  <text x="315" y="115" text-anchor="middle" font-size="13">producer socket</text>
+  <text x="315" y="133" text-anchor="middle" font-size="11" class="muted">html pane resource/&lt;id&gt;</text>
+
+  <path class="edge" d="M 400 118 L 468 118"/>
+  <text x="434" y="106" text-anchor="middle" font-size="11" class="muted">watches</text>
+
+  <rect class="box accent-stroke" x="470" y="92" width="120" height="52" rx="8"/>
+  <text x="530" y="122" text-anchor="middle" font-size="14" class="accent">ix-windows</text>
+
+  <path class="edge" d="M 590 102 L 618 72"/>
+  <text x="560" y="60" font-size="11" class="muted">opens</text>
+  <path class="edge" d="M 590 118 L 616 130"/>
+  <text x="562" y="152" font-size="11" class="muted">re-renders, closes</text>
+
+  <rect class="box" x="608" y="24" width="96" height="48" rx="10"/>
+  <text x="656" y="52" text-anchor="middle" font-size="11">card</text>
+  <rect class="box" x="618" y="120" width="96" height="48" rx="10"/>
+  <text x="666" y="148" text-anchor="middle" font-size="11">card</text>
+  <text x="600" y="200" text-anchor="middle" font-size="11" class="muted">blurred, always-on-top, auto-sized</text>
+</svg>

--- a/packages/maintainers/scripts/agent-insights/README.md
+++ b/packages/maintainers/scripts/agent-insights/README.md
@@ -1,13 +1,27 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="Claude Code and Codex transcripts are parsed into turns and interrupts, then rendered as a weekly trend SVG"></p>
+
 # agent-insights
 
-Graph how often you interrupt your local CLI coding agents over time.
-
-`agent-insights.py` reads the session transcripts Claude Code and Codex already
-write to disk, and renders a self-contained SVG (no dependencies) plus a text
-summary.
+How often do you actually cut off your coding agent mid-flight, and is that number going down? `agent-insights.py` reads the session transcripts Claude Code and Codex already write to disk and graphs your interrupt rate over time: a self-contained SVG (no dependencies) plus a text summary.
 
 - Claude Code: `~/.claude/projects/**/<session>.jsonl`
 - Codex: `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`
+
+## Usage
+
+This is a maintainers' script, not a flake package; run it straight from a clone
+(`git clone https://github.com/indexable-inc/index`):
+
+```
+python3 agent-insights.py                 # writes agent-insights.svg, prints summary
+python3 agent-insights.py --out /tmp/i.svg
+python3 agent-insights.py --since 2026-01-01
+python3 agent-insights.py --tool codex
+python3 agent-insights.py --no-svg        # text summary only
+```
+
+Override transcript locations with `--claude-dir` and `--codex-dir`. Open the
+SVG in any browser, or render it: `rsvg-convert agent-insights.svg -o out.png`.
 
 ## Metric
 
@@ -31,16 +45,3 @@ time**, split Claude vs Codex.
   resumes and drops the fake near-zero interrupt durations the replay injects.
 - Claude session files are self-contained (no cross-file message duplication),
   so they are counted as-is. Subagent sidechains are skipped.
-
-## Usage
-
-```
-python3 agent-insights.py                 # writes agent-insights.svg, prints summary
-python3 agent-insights.py --out /tmp/i.svg
-python3 agent-insights.py --since 2026-01-01
-python3 agent-insights.py --tool codex
-python3 agent-insights.py --no-svg        # text summary only
-```
-
-Override transcript locations with `--claude-dir` and `--codex-dir`. Open the
-SVG in any browser, or render it: `rsvg-convert agent-insights.svg -o out.png`.

--- a/packages/maintainers/scripts/agent-insights/assets/hero.svg
+++ b/packages/maintainers/scripts/agent-insights/assets/hero.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="30" width="230" height="44" rx="8"/>
+  <text x="135" y="57" text-anchor="middle" font-size="12">~/.claude/projects/**.jsonl</text>
+  <rect class="box" x="20" y="120" width="230" height="44" rx="8"/>
+  <text x="135" y="147" text-anchor="middle" font-size="12">~/.codex/sessions/**.jsonl</text>
+
+  <path class="edge" d="M 250 58 L 318 88"/>
+  <path class="edge" d="M 250 136 L 318 108"/>
+  <text x="256" y="103" font-size="11" class="muted">turns + interrupts</text>
+
+  <rect class="box" x="320" y="72" width="160" height="52" rx="8"/>
+  <text x="400" y="103" text-anchor="middle" font-size="13">agent-insights.py</text>
+
+  <path class="edge" d="M 480 98 L 528 98"/>
+
+  <rect class="box" x="530" y="34" width="170" height="128" rx="8"/>
+  <polyline class="accent-stroke" fill="none" stroke-width="2"
+            points="548,140 575,118 602,126 629,96 656,102 684,72"/>
+  <text x="615" y="180" text-anchor="middle" font-size="11" class="muted">interrupts per agent-hour, weekly</text>
+</svg>

--- a/packages/minecraft/bossbar-overlay/README.md
+++ b/packages/minecraft/bossbar-overlay/README.md
@@ -1,10 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="Anything that writes rows to a SQLite file drives three Minecraft-style desktop overlays within about 200ms"></p>
+
 # Minecraft Desktop Overlays
 
-Three transparent, always-on-top, click-through desktop overlays drawn in the
-Minecraft style with [`wgpu`](https://github.com/gfx-rs/wgpu): a **boss bar** HUD,
-an open **book**, and a floating **experience orb**. Each is driven entirely by a
-single SQLite file: write rows from anything (a shell, a script, a cron job,
-another program) and the change appears on screen within ~200ms.
+What if your desktop HUD were a Minecraft boss bar, and updating it were just a SQL `UPDATE`? These are three transparent, always-on-top, click-through desktop overlays drawn in the Minecraft style with [`wgpu`](https://github.com/gfx-rs/wgpu): a **boss bar** HUD, an open **book**, and a floating **experience orb**. Each is driven entirely by a single SQLite file: write rows from anything (a shell, a script, a cron job, another program) and the change appears on screen within ~200ms.
 
 They share one engine, [`overlay-core`](app/crates/overlay-core), which owns the
 float window (transparent, borderless, always-on-top, click-through, drag-to-move,
@@ -25,13 +23,15 @@ third-party mirror.
 ## Run
 
 ```sh
-nix run .#bossbar-overlay     # the boss bar HUD across the top of the screen
-nix run .#book-overlay        # a floating open book
-nix run .#xp-orb-overlay      # a floating, bobbing experience orb
+nix run github:indexable-inc/index#bossbar-overlay     # the boss bar HUD across the top of the screen
+nix run github:indexable-inc/index#book-overlay        # a floating open book
+nix run github:indexable-inc/index#xp-orb-overlay      # a floating, bobbing experience orb
 ```
 
-For local Rust development, populate the gitignored art once (it is copied out of
-the `minecraft-assets` derivation), then build with cargo:
+For local Rust development, clone the repo
+(`git clone https://github.com/indexable-inc/index`), populate the gitignored art
+once (it is copied out of the `minecraft-assets` derivation), then build with
+cargo:
 
 ```sh
 cd app
@@ -195,7 +195,7 @@ The workspace lives under `app/` as its own Cargo workspace (off the repo's main
 graph, so the GUI crates skip the strict workspace lints), with one vendored
 `Cargo.lock`. `app/default.nix` builds both binaries from it.
 
-- [`overlay-core`](app/crates/overlay-core) — the shared engine. `window.rs`: the
+- [`overlay-core`](app/crates/overlay-core): the shared engine. `window.rs`: the
   float window attributes, surface/adapter setup, transparent alpha-mode
   selection, and a non-activating raise (`-[NSWindow orderFrontRegardless]` on
   macOS). `gpu.rs`: one textured-quad pipeline with a texture registry, plus the
@@ -204,11 +204,11 @@ graph, so the GUI crates skip the strict workspace lints), with one vendored
   width = rightmost inked column + 1) the way the game does. `gesture.rs`: the
   press/drag/click state machine. `snapshot.rs`: the same engine rendered
   headlessly into a PNG.
-- [`bossbar`](app/crates/bossbar) — bars domain (`bars.rs`), the SQLite source
+- [`bossbar`](app/crates/bossbar): bars domain (`bars.rs`), the SQLite source
   (`db.rs`), the bar/panel scene builder, and the per-bar window loop.
-- [`book`](app/crates/book) — book domain (`book.rs`), its SQLite source
+- [`book`](app/crates/book): book domain (`book.rs`), its SQLite source
   (`db.rs`), the two-page spread scene builder, and the single-window loop.
-- [`minecraft-assets`](../minecraft-assets) — the reproducible Mojang extraction:
+- [`minecraft-assets`](../minecraft-assets): the reproducible Mojang extraction:
   `client.jar` pinned by Mojang's hash, unzipped to the textures and font sheet
   both overlays embed.
 

--- a/packages/minecraft/bossbar-overlay/assets/hero.svg
+++ b/packages/minecraft/bossbar-overlay/assets/hero.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 240" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="94" width="170" height="52" rx="8"/>
+  <text x="105" y="117" text-anchor="middle" font-size="13">shell · script · cron</text>
+  <text x="105" y="135" text-anchor="middle" font-size="11" class="muted">anything that writes SQL</text>
+
+  <path class="edge" d="M 190 120 L 268 120"/>
+  <text x="229" y="108" text-anchor="middle" font-size="11" class="muted">write rows</text>
+
+  <rect class="box accent-stroke" x="270" y="88" width="170" height="64" rx="10"/>
+  <text x="355" y="115" text-anchor="middle" font-size="14" class="accent">SQLite file</text>
+  <text x="355" y="134" text-anchor="middle" font-size="11" class="muted">bossbars.db · book.db</text>
+
+  <path class="edge" d="M 440 104 L 518 56"/>
+  <path class="edge" d="M 440 120 L 518 128"/>
+  <path class="edge" d="M 440 136 L 518 202"/>
+  <text x="462" y="88" font-size="11" class="muted">~200ms</text>
+
+  <rect class="box" x="520" y="32" width="180" height="46" rx="8"/>
+  <text x="610" y="60" text-anchor="middle" font-size="13">boss bar HUD</text>
+  <rect class="box" x="520" y="106" width="180" height="46" rx="8"/>
+  <text x="610" y="134" text-anchor="middle" font-size="13">open book</text>
+  <rect class="box" x="520" y="180" width="180" height="46" rx="8"/>
+  <text x="610" y="208" text-anchor="middle" font-size="13">xp orb</text>
+</svg>

--- a/packages/mlx-tts/README.md
+++ b/packages/mlx-tts/README.md
@@ -1,8 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="Text goes into mlx-tts, which runs an MLX-Audio model locally on Apple Silicon and writes or plays audio"></p>
+
 # mlx-tts
 
-Local Apple Silicon text-to-speech through [MLX-Audio](https://github.com/Blaizzy/mlx-audio).
-The wrapper defaults to the Chatterbox fp16 model because the request is quality
-first, not latency first.
+Want good text-to-speech that never leaves your Mac? `mlx-tts` runs TTS locally on the Apple Silicon GPU through [MLX-Audio](https://github.com/Blaizzy/mlx-audio). It defaults to the Chatterbox fp16 model because the request is quality first, not latency first, and it supports voice cloning from a reference clip.
 
 First inference downloads the selected model into the normal Hugging Face cache.
 Nix builds only package the CLI and never fetch model weights.
@@ -11,19 +11,20 @@ Nix builds only package the CLI and never fetch model weights.
 
 ```sh
 # Quality-first default: Chatterbox.
-nix run .#mlx-tts -- "This voice is generated locally on Apple Silicon."
+nix run github:indexable-inc/index#mlx-tts -- "This voice is generated locally on Apple Silicon."
 
 # Voice cloning with a reference clip.
-nix run .#mlx-tts -- "Read this in the reference voice." --ref-audio reference.wav --play
+nix run github:indexable-inc/index#mlx-tts -- "Read this in the reference voice." --ref-audio reference.wav --play
 
 # Qwen3 preset when you want preset voices and language control.
-nix run .#mlx-tts -- --preset qwen3 --voice Aiden --lang-code English "A preset local voice."
+nix run github:indexable-inc/index#mlx-tts -- --preset qwen3 --voice Aiden --lang-code English "A preset local voice."
 
 # Pass through any MLX-Audio option after --.
-nix run .#mlx-tts -- "More diffusion steps." -- --ddpm_steps 50
+nix run github:indexable-inc/index#mlx-tts -- "More diffusion steps." -- --ddpm_steps 50
 
 # Show the upstream MLX-Audio options.
-nix run .#mlx-tts -- --upstream-help
+nix run github:indexable-inc/index#mlx-tts -- --upstream-help
 ```
 
 Use `--model` to point at any MLX-Audio TTS model repo id or local model path.
+From a clone (`git clone https://github.com/indexable-inc/index`): `nix run .#mlx-tts`.

--- a/packages/mlx-tts/assets/hero.svg
+++ b/packages/mlx-tts/assets/hero.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="40" width="130" height="50" rx="8"/>
+  <text x="85" y="70" text-anchor="middle" font-size="14">text</text>
+
+  <path class="edge" d="M 150 65 L 238 65"/>
+
+  <rect class="box accent-stroke" x="240" y="30" width="220" height="70" rx="8"/>
+  <text x="350" y="58" text-anchor="middle" font-size="14">mlx-tts</text>
+  <text x="350" y="78" text-anchor="middle" font-size="11" class="muted">MLX-Audio on Apple Silicon</text>
+
+  <path class="edge" d="M 460 50 L 548 36"/>
+  <text x="480" y="30" font-size="11" class="muted">write</text>
+  <rect class="box" x="550" y="16" width="150" height="40" rx="8"/>
+  <text x="625" y="41" text-anchor="middle" font-size="13">out.wav</text>
+
+  <path class="edge" d="M 460 80 L 548 96"/>
+  <text x="480" y="106" font-size="11" class="muted">--play</text>
+  <rect class="box" x="550" y="78" width="150" height="40" rx="8"/>
+  <text x="625" y="103" text-anchor="middle" font-size="13">speakers</text>
+
+  <rect class="box" x="240" y="136" width="220" height="36" rx="8"/>
+  <text x="350" y="159" text-anchor="middle" font-size="11">chatterbox · qwen3 · kokoro</text>
+  <path class="dashed" d="M 350 134 L 350 102"/>
+  <text x="362" y="124" font-size="11" class="muted">model presets, cached from HF on first run</text>
+</svg>

--- a/packages/nix/oci-image-builder/README.md
+++ b/packages/nix/oci-image-builder/README.md
@@ -1,8 +1,16 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="A layer plan is described into a tiny content-addressed image.json, then materialized into a verified OCI tar, with per-layer sharded derivations"></p>
+
 # oci-image-builder
 
-Turns a `streamLayeredImage` layer plan into an OCI image around a
-content-addressed description, `image.json`, so an image can be described cheaply
-and materialized into bytes only when needed (see #679).
+Why re-tar a whole image closure when you only changed one store path? `oci-image-builder` turns a `streamLayeredImage` layer plan into an OCI image around a content-addressed description, `image.json`: the image is described cheaply (a few KiB of digests and regeneration recipes) and materialized into bytes only when needed (see #679).
+
+## Run it
+
+```sh
+nix run github:indexable-inc/index#oci-image-builder -- --help
+```
+
+From a clone (`git clone https://github.com/indexable-inc/index`): `nix run .#oci-image-builder`.
 
 ## Modes
 

--- a/packages/nix/oci-image-builder/assets/hero.svg
+++ b/packages/nix/oci-image-builder/assets/hero.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 240" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="40" width="180" height="60" rx="8"/>
+  <text x="110" y="65" text-anchor="middle" font-size="13">conf.json</text>
+  <text x="110" y="84" text-anchor="middle" font-size="11" class="muted">streamLayeredImage plan</text>
+
+  <path class="edge" d="M 200 70 L 268 70"/>
+  <text x="234" y="58" text-anchor="middle" font-size="11">describe</text>
+
+  <rect class="box accent-stroke" x="270" y="40" width="190" height="60" rx="8"/>
+  <text x="365" y="65" text-anchor="middle" font-size="13" class="accent">image.json</text>
+  <text x="365" y="84" text-anchor="middle" font-size="11" class="muted">a few KiB: digests + recipes</text>
+
+  <path class="edge" d="M 460 70 L 528 70"/>
+  <text x="494" y="58" text-anchor="middle" font-size="11">materialize</text>
+
+  <rect class="box" x="530" y="40" width="170" height="60" rx="8"/>
+  <text x="615" y="65" text-anchor="middle" font-size="13">image.tar (OCI)</text>
+  <text x="615" y="84" text-anchor="middle" font-size="11" class="muted">bytes, verified vs digests</text>
+
+  <rect class="box" x="80" y="170" width="120" height="40" rx="8"/>
+  <text x="140" y="195" text-anchor="middle" font-size="12">base-desc</text>
+  <rect class="box" x="220" y="170" width="140" height="40" rx="8"/>
+  <text x="290" y="195" text-anchor="middle" font-size="12">layer-desc × N</text>
+
+  <path class="edge" d="M 200 178 L 300 106"/>
+  <path class="edge" d="M 330 168 L 358 106"/>
+  <text x="366" y="140" font-size="11" class="muted">assemble-desc: one cached derivation per layer</text>
+</svg>

--- a/packages/polars-sftp/README.md
+++ b/packages/polars-sftp/README.md
@@ -1,8 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="A remote file is fetched over SFTP by a Rust reader and handed to Polars as a LazyFrame with projection and row-limit pushdown"></p>
+
 # polars-sftp
 
-A [Polars](https://pola.rs) IO source that reads a remote file over **SFTP** and
-hands it back as a lazy `LazyFrame`. Point it at a parquet, IPC, CSV, or NDJSON
-(`.jsonl`) file on an SSH host and query it like any other Polars source:
+Ever needed to query a parquet file that lives on some SSH box, without copying it around first? `polars-sftp` is a [Polars](https://pola.rs) IO source that reads a remote file over **SFTP** and hands it back as a lazy `LazyFrame`. Point it at a parquet, IPC, CSV, or NDJSON (`.jsonl`) file on an SSH host and query it like any other Polars source:
 
 ```python
 import polars as pl
@@ -20,6 +20,19 @@ df = (
 It registers through Polars' official IO-plugin hook (`register_io_source`), so it
 composes with the rest of a lazy query: column projection and an `n_rows` limit
 are pushed into the reader, and any predicate is applied to the result.
+
+## Install
+
+The package is a Python wheel built by Nix:
+
+```sh
+git clone https://github.com/indexable-inc/index
+cd index
+nix build .#polars-sftp     # produces the abi3 wheel under ./result
+```
+
+`pip install` the wheel into the environment that runs your Polars queries (the
+crate's Rust `polars` and your Python `polars` must be the matching release).
 
 ## How it works
 
@@ -54,15 +67,6 @@ credential is sent: a recorded entry that mismatches is rejected (possible MITM)
 an unrecorded host is accepted (trust on first use). Pass `check_host_key=False`
 to skip the check. `timeout_ms` bounds the connect and read so a stuck host errors
 instead of hanging.
-
-## Build
-
-```sh
-nix build .#polars-sftp     # produces the abi3 wheel under ./result
-```
-
-`pip install` the wheel into the environment that runs your Polars queries (the
-crate's Rust `polars` and your Python `polars` must be the matching release).
 
 ## Known limitations
 

--- a/packages/polars-sftp/assets/hero.svg
+++ b/packages/polars-sftp/assets/hero.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="60" width="200" height="60" rx="8"/>
+  <text x="120" y="85" text-anchor="middle" font-size="13">SSH host</text>
+  <text x="120" y="104" text-anchor="middle" font-size="11" class="muted">/exports/events.parquet</text>
+
+  <path class="edge" d="M 220 90 L 288 90"/>
+  <text x="254" y="78" text-anchor="middle" font-size="11" class="muted">SFTP (ssh2)</text>
+
+  <rect class="box accent-stroke" x="290" y="50" width="210" height="80" rx="8"/>
+  <text x="395" y="78" text-anchor="middle" font-size="14">polars-sftp reader</text>
+  <text x="395" y="98" text-anchor="middle" font-size="11" class="muted">Rust: parquet · ipc · csv · ndjson</text>
+
+  <path class="edge" d="M 500 90 L 568 90"/>
+  <text x="534" y="78" text-anchor="middle" font-size="11" class="muted">Arrow FFI</text>
+
+  <rect class="box" x="570" y="60" width="130" height="60" rx="8"/>
+  <text x="635" y="95" text-anchor="middle" font-size="14">LazyFrame</text>
+
+  <path class="dashed" d="M 600 130 C 560 172, 460 172, 420 134"/>
+  <text x="510" y="185" text-anchor="middle" font-size="11" class="accent">pushdown: columns, n_rows</text>
+</svg>

--- a/packages/screencast/screencast/README.md
+++ b/packages/screencast/screencast/README.md
@@ -1,14 +1,13 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="A Mac's screen is hardware-encoded to H.265 and uploaded as HLS to an ingest server that stores and replays every session"></p>
+
 # screencast
 
-Stream a Mac's screen to a central server as hardware-encoded H.265, so a whole
-team can push their screens to one place that stores every session for replay and
-for downstream data and context use.
+How do you get a whole team's screens into one place you can replay later, without melting anyone's laptop? `screencast` streams a Mac's screen to a central server as hardware-encoded H.265: capture stays near-free on CPU and battery (Apple's media engine does the encoding), and the server stores every session for live view, replay, and downstream data and context use.
 
 Two pieces:
 
 - **`screencast`** (this crate): the macOS client. Captures the desktop, encodes
-  it with `hevc_videotoolbox` (the Apple media engine, so it stays near-free on
-  CPU and battery), and uploads the stream to the server.
+  it with `hevc_videotoolbox`, and uploads the stream to the server.
 - **`screencast-ingest`** (sibling crate): the server. Accepts uploads, stores
   every session on disk, and serves them back for live view, replay, and
   indexing.
@@ -19,7 +18,9 @@ bytes the hardware encoder produced are what land on disk.
 
 ## Run the server
 
-    nix run .#screencast-ingest -- --root /var/lib/screencast --addr 0.0.0.0:8080
+```sh
+nix run .#screencast-ingest -- --root /var/lib/screencast --addr 0.0.0.0:8080
+```
 
 Open `http://<host>:8080/` for the dashboard (a session list plus a player).
 `GET /api/sessions` returns the same data as JSON for scripts and indexers.
@@ -30,7 +31,9 @@ transport encryption of its own.
 
 ## Stream from a Mac
 
-    nix run .#screencast -- --server http://<host>:8080
+```sh
+nix run github:indexable-inc/index#screencast -- --server http://<host>:8080
+```
 
 That auto-detects the display, captures at 30 fps and 6 Mbit/s H.265, and streams
 under `<you>/<timestamp>`. Stop with Ctrl-C, which finalizes the session into a
@@ -40,6 +43,8 @@ capture is a black frame with no error.
 Useful flags: `--user`, `--screen N` (`--list-screens` to enumerate displays),
 `--fps`, `--bitrate 10M`, `--segment-seconds`, `--max-height 1440` (downscale to
 cut bandwidth on Retina displays), `--no-cursor`, `--token`.
+
+From a clone (`git clone https://github.com/indexable-inc/index`): `nix run .#screencast`.
 
 ## How it streams
 

--- a/packages/screencast/screencast/assets/hero.svg
+++ b/packages/screencast/screencast/assets/hero.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 210" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box { stroke: currentColor; fill: none; }
+    text { fill: currentColor; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .dashed { stroke: currentColor; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow); }
+    .arrowhead { fill: currentColor; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="74" width="130" height="52" rx="8"/>
+  <text x="85" y="104" text-anchor="middle" font-size="13">Mac display</text>
+
+  <path class="edge" d="M 150 100 L 218 100"/>
+  <text x="184" y="88" text-anchor="middle" font-size="11" class="muted">capture</text>
+
+  <rect class="box" x="220" y="70" width="180" height="60" rx="8"/>
+  <text x="310" y="95" text-anchor="middle" font-size="13">hevc_videotoolbox</text>
+  <text x="310" y="114" text-anchor="middle" font-size="11" class="muted">hardware H.265</text>
+
+  <path class="edge" d="M 400 100 L 478 100"/>
+  <text x="439" y="80" text-anchor="middle" font-size="11" class="muted">fMP4 HLS</text>
+  <text x="439" y="120" text-anchor="middle" font-size="11" class="muted">HTTP PUT</text>
+
+  <rect class="box accent-stroke" x="480" y="70" width="170" height="60" rx="8"/>
+  <text x="565" y="95" text-anchor="middle" font-size="13" class="accent">screencast-ingest</text>
+  <text x="565" y="114" text-anchor="middle" font-size="11" class="muted">one server, all sessions</text>
+
+  <path class="edge" d="M 585 70 L 605 46"/>
+  <rect class="box" x="530" y="10" width="170" height="34" rx="8"/>
+  <text x="615" y="32" text-anchor="middle" font-size="11">live view + replay (browser)</text>
+
+  <path class="edge" d="M 585 130 L 605 154"/>
+  <rect class="box" x="530" y="156" width="170" height="34" rx="8"/>
+  <text x="615" y="178" text-anchor="middle" font-size="11">sessions on disk</text>
+</svg>


### PR DESCRIPTION
Restyles 15 READMEs per the creating-a-readme skill (hero SVG with embedded prefers-color-scheme CSS, hook-question intro, derived install lines). One commit per package.

Updated:
- packages/andrewgazelka/hive/README.md
- packages/cuda-hello/README.md
- packages/elevenlabs-say/README.md
- packages/google/calendar/README.md
- packages/google/gmail/README.md
- packages/ix-dev-diagnose/README.md
- packages/ix-windows/README.md
- packages/maintainers/scripts/agent-insights/README.md
- packages/minecraft/bossbar-overlay/README.md
- packages/mlx-tts/README.md
- packages/nix/oci-image-builder/README.md
- packages/polars-sftp/README.md
- packages/screencast/screencast/README.md
- modules/services/ci-runner/README.md
- modules/services/observability/README.md

Each README now opens with a committed assets/hero.svg (viewBox-only, transparent, light/dark via embedded CSS). `nix run .#lint` passes.

Refs #2072

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update READMEs across packages and modules with hero images and rewritten content
> Adds centered hero SVG images and rewrites introductions, usage sections, and examples across 17 packages and modules. Each README now includes a consistent structure: a hero image, a concise description, and `nix run` commands referencing the GitHub flake (`github:indexable-inc/index`) with notes for running from a local clone.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 059a5d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->