### PR TITLE
fork patches: machine-enforce an inline reason in every patch's commit message

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -70,9 +70,10 @@
 # and body come from the patch's own commit message (subject = title, body = PR
 # body, plus AI attribution and a link to the patch of record; see
 # packages/upstream-pr). A nix copy would duplicate the commit message and
-# drift. One fact, one home: the commit message IS the patch's description, and
-# the `patch-dag-<name>` check fails any attempt-marked patch whose commit
-# message has no body.
+# drift. One fact, one home: the commit message IS the patch's description and
+# its reason of record, and the `patch-dag-<name>` check fails any patch whose
+# commit message states no reason (attribution trailers and bare issue refs do
+# not count).
 {
   forkPackages = [
     {

--- a/lib/mk-fork-checks.nix
+++ b/lib/mk-fork-checks.nix
@@ -48,9 +48,10 @@
   # committed `dag.json` is honest and in sync (declared ancestors sufficient,
   # independent patches commute byte-for-byte, NNNN is a topological order, and
   # regenerating reproduces the committed bytes), and that the fork's upstreaming
-  # intent (`fork.patches`, if declared) is coherent: keys name real patch files
-  # and attempt-marked patches carry a commit-message body (which becomes the
-  # upstream PR description, see packages/upstream-pr). Pure text work on the
+  # intent (`fork.patches`, if declared) is coherent: keys name real patch files.
+  # It also fails any patch that states no reason in its commit-message body:
+  # the body is the reason of record for every fork patch and, for
+  # attempt-marked ones, the upstream PR description (see packages/upstream-pr). Pure text work on the
   # fetched src tree in the sandbox, so it stays seconds-fast. The derivation and
   # verification logic is owned by `dagCheckSrc` (dag-{lib,check}.nu); the check
   # just wires the src, patch dir, pinned rev, and intent into that driver.

--- a/packages/agent/codex/patches/0001-mcp-route-channel-notifications-into-chat.patch
+++ b/packages/agent/codex/patches/0001-mcp-route-channel-notifications-into-chat.patch
@@ -3,6 +3,11 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 5 Jul 2026 13:16:14 -0700
 Subject: [PATCH] mcp: route channel notifications into chat
 
+codex surfaces no unsolicited MCP server notifications in the agent
+chat, so the index kernel's `notifications/claude/channel` events
+(interactive resources, channel replies) were silently dropped. Route
+MCP channel notifications into the chat stream so the agent sees them.
+
 Refs indexable-inc/index#1857
 
 diff --git a/codex-rs/codex-mcp/src/connection_manager.rs b/codex-rs/codex-mcp/src/connection_manager.rs

--- a/packages/llm-clippy/patches/0002-Add-module_file_count-lint.patch
+++ b/packages/llm-clippy/patches/0002-Add-module_file_count-lint.patch
@@ -3,6 +3,10 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 17 May 2026 12:19:21 -0700
 Subject: [PATCH] Add module_file_count lint
 
+House lint: flags module directories containing more than a
+configurable number of `.rs` files (default 7). Large modules are hard
+to navigate and signal missing abstraction boundaries; splitting into
+sub-modules keeps each directory focused and discoverable.
 
 diff --git a/clippy_config/src/conf.rs b/clippy_config/src/conf.rs
 index 465e88a78..30ae84669 100644

--- a/packages/llm-clippy/patches/0003-Add-excessive_file_length-lint.patch
+++ b/packages/llm-clippy/patches/0003-Add-excessive_file_length-lint.patch
@@ -3,6 +3,9 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 17 May 2026 12:19:25 -0700
 Subject: [PATCH] Add excessive_file_length lint
 
+House lint: flags source files longer than a configurable number of
+lines (default 300). Large files are harder to navigate, understand,
+and review; the lint pushes toward smaller, focused modules.
 
 diff --git a/clippy_config/src/conf.rs b/clippy_config/src/conf.rs
 index 30ae84669..c59cb7e03 100644

--- a/packages/llm-clippy/patches/0004-Add-path_segment_repetition-lint.patch
+++ b/packages/llm-clippy/patches/0004-Add-path_segment_repetition-lint.patch
@@ -3,6 +3,11 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 17 May 2026 12:19:46 -0700
 Subject: [PATCH] Add path_segment_repetition lint
 
+House lint: flags item names that repeat `_`-separated words already
+present in the crate name or an ancestor module name
+(`guest::spawn_vm_guest()` -> `guest::spawn()`). The module path
+already communicates the domain, so the repeated words add noise
+without information.
 
 diff --git a/clippy_lints/src/declared_lints.rs b/clippy_lints/src/declared_lints.rs
 index adfdde0d7..808b31419 100644

--- a/packages/llm-clippy/patches/0005-Add-underscore_in_module_filename-lint.patch
+++ b/packages/llm-clippy/patches/0005-Add-underscore_in_module_filename-lint.patch
@@ -3,6 +3,10 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 17 May 2026 12:19:49 -0700
 Subject: [PATCH] Add underscore_in_module_filename lint
 
+House lint: denies module filenames containing underscores
+(e.g. `compute_vm.rs`). Compound names should become directory
+hierarchy instead (`vm/config.rs`), keeping the filesystem structure
+aligned with the module tree.
 
 diff --git a/clippy_lints/src/declared_lints.rs b/clippy_lints/src/declared_lints.rs
 index 808b31419..0b6745f38 100644

--- a/packages/llm-clippy/patches/0006-Add-renamed_imports-lint.patch
+++ b/packages/llm-clippy/patches/0006-Add-renamed_imports-lint.patch
@@ -3,6 +3,10 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 17 May 2026 12:19:55 -0700
 Subject: [PATCH] Add renamed_imports lint
 
+House lint: flags `use` statements that rename an import with `as`.
+Renaming hides the original name and makes usages hard to grep for;
+the original name or a qualified path keeps code searchable and
+explicit.
 
 diff --git a/clippy_lints/src/declared_lints.rs b/clippy_lints/src/declared_lints.rs
 index 0b6745f38..fa38883e1 100644

--- a/packages/llm-clippy/patches/0008-Add-magic_number-lint.patch
+++ b/packages/llm-clippy/patches/0008-Add-magic_number-lint.patch
@@ -3,6 +3,9 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 17 May 2026 12:20:09 -0700
 Subject: [PATCH] Add magic_number lint
 
+House lint: flags numeric literals appearing inline in non-test code.
+Magic numbers obscure intent: a value should be a named `const` (when
+static) or a configurable struct field / function argument.
 
 diff --git a/clippy_config/src/conf.rs b/clippy_config/src/conf.rs
 index c59cb7e03..e8b699258 100644

--- a/packages/llm-clippy/patches/0009-Add-drop_must_use-lint.patch
+++ b/packages/llm-clippy/patches/0009-Add-drop_must_use-lint.patch
@@ -3,6 +3,10 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 17 May 2026 12:20:15 -0700
 Subject: [PATCH] Add drop_must_use lint
 
+House lint: flags `drop(expr)` where `expr` is `#[must_use]`. An
+explicit `drop()` consumes the value while bypassing both rustc's
+`unused_must_use` and clippy's `let_underscore_must_use`, making it a
+silent error-suppression pattern.
 
 diff --git a/clippy_lints/src/declared_lints.rs b/clippy_lints/src/declared_lints.rs
 index 4614901c4..e677892c9 100644

--- a/packages/llm-clippy/patches/0010-Add-non_trait_imports-lint.patch
+++ b/packages/llm-clippy/patches/0010-Add-non_trait_imports-lint.patch
@@ -3,6 +3,10 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 17 May 2026 12:20:23 -0700
 Subject: [PATCH] Add non_trait_imports lint
 
+House lint: flags `use` statements that import non-trait items; the
+style prefers fully qualified paths at call sites (`vm::Config`). Only
+traits need imports (as `_`) for method resolution, and owner-type
+re-exports matching the parent module name stay allowed.
 
 diff --git a/clippy_lints/src/declared_lints.rs b/clippy_lints/src/declared_lints.rs
 index e677892c9..0eb0033d9 100644

--- a/packages/llm-clippy/patches/0011-Add-ix-metadata-to-Cargo-manifests.patch
+++ b/packages/llm-clippy/patches/0011-Add-ix-metadata-to-Cargo-manifests.patch
@@ -3,6 +3,10 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Sun, 17 May 2026 12:20:26 -0700
 Subject: [PATCH] Add ix metadata to Cargo manifests
 
+Adds `[package.metadata.ix.inputs]` to clippy's own Cargo manifests so
+the repo's per-crate nix build machinery (cargo-unit) can treat the
+fork's crates like any other repo crate. Repo-specific packaging glue;
+never meant for upstream.
 
 diff --git a/Cargo.toml b/Cargo.toml
 index ca80c3fad..1b50a1156 100644

--- a/packages/llm-clippy/patches/0012-Add-string_ip_field-lint.patch
+++ b/packages/llm-clippy/patches/0012-Add-string_ip_field-lint.patch
@@ -3,6 +3,10 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Wed, 27 May 2026 09:36:03 -0700
 Subject: [PATCH] Add string_ip_field lint
 
+House lint: flags struct fields whose name suggests an IP address but
+whose type is `String`. Parsing once at the boundary into
+`IpAddr`/`Ipv4Addr`/`Ipv6Addr` guarantees validity for the rest of the
+program and states the intent at the type level.
 
 diff --git a/clippy_lints/src/declared_lints.rs b/clippy_lints/src/declared_lints.rs
 index 0eb0033d9..b2e5e93b5 100644

--- a/packages/llm-clippy/patches/0014-Add-anonymous-tuple-return-type-lint.patch
+++ b/packages/llm-clippy/patches/0014-Add-anonymous-tuple-return-type-lint.patch
@@ -3,6 +3,9 @@ From: Andrew Gazelka <andrew.gazelka@gmail.com>
 Date: Wed, 27 May 2026 23:26:42 -0700
 Subject: [PATCH] Add anonymous tuple return type lint
 
+House lint: flags anonymous tuple types in explicit function return
+types. Tuple fields carry no names; a named struct documents what each
+value means at every call site.
 
 diff --git a/CHANGELOG.md b/CHANGELOG.md
 index f53143e56..9114bbe9e 100644

--- a/packages/rebase-patches/dag-check.nu
+++ b/packages/rebase-patches/dag-check.nu
@@ -10,11 +10,13 @@
 #       and the NNNN order is a valid topological order of the DAG.
 #   (d) the hand-written upstreaming intent (lib/fork-packages.nix `patches`)
 #       is coherent with the series: every intent key names a real patch file
-#       (a rebase can renumber/rename patches and orphan intent silently), and
-#       every `attempt`-marked patch has a substantive commit-message body,
-#       because the upstream PR body IS the commit message (one fact, one home;
-#       see packages/upstream-pr). An attempt patch with a bare subject would
-#       open a description-less PR, so it fails here with "write the why".
+#       (a rebase can renumber/rename patches and orphan intent silently),
+#   (e) every patch states WHY it exists in its commit-message body. The body
+#       is the reason of record (one fact, one home): it rides the `git am` /
+#       rebase / `format-patch` round-trip, so it reaches upstream reviewers,
+#       and for attempt-marked patches it becomes the upstream PR description
+#       verbatim (see packages/upstream-pr). Attribution trailers and bare
+#       issue refs are not a reason, so a mute patch fails with "write the why".
 #
 # Args: <src-dir> <patch-dir> <expected-base-rev> [<intent-json>]. The base rev
 # is the upstream rev the fork is pinned at (flake.lock), so the committed
@@ -22,20 +24,6 @@
 # synthetic commit. `intent-json` is the fork's `patches` intent attrset
 # rendered to JSON (defaults to empty for forks with no declared intent).
 use dag-lib.nu *
-
-# The commit-message body of a format-patch file: the lines between the header
-# block (ended by the first blank line; folded Subject continuations are
-# indented, never blank) and the diff payload (`---` separator, or `diff --git`
-# directly when the series is exported with --no-stat). Blank-only lines do not
-# count as substance.
-def "patch body-lines" [file: string]: nothing -> list<string> {
-  open --raw $file
-  | lines
-  | skip until {|l| $l == "" }
-  | skip 1
-  | take until {|l| ($l == "---") or ($l | str starts-with "diff --git ") }
-  | where {|l| ($l | str trim) != "" }
-}
 
 def main [src_dir: string, patch_dir: string, expected_base: string, intent_json: string = "{}"] {
   let files = (glob ($patch_dir | path join "*.patch") | sort)
@@ -100,11 +88,8 @@ def main [src_dir: string, patch_dir: string, expected_base: string, intent_json
     $failed = true
   }
 
-  # (d) intent coherence. Keys must name real patch files (a rebase renumbers
-  # names and would orphan intent silently), and attempt-marked patches must
-  # carry the why in the commit body, because that body becomes the upstream PR
-  # description verbatim (packages/upstream-pr); nix deliberately has no
-  # duplicate description field.
+  # (d) intent coherence: keys must name real patch files (a rebase renumbers
+  # names and would orphan intent silently).
   let intent = ($intent_json | from json)
   let names = ($patches | get name)
   for key in ($intent | columns) {
@@ -113,12 +98,16 @@ def main [src_dir: string, patch_dir: string, expected_base: string, intent_json
       $failed = true
     }
   }
-  let attempts = ($intent | items {|k, v| {name: $k, mark: ($v.upstream? | default "hold")} } | where mark == "attempt" | get name)
-  for nm in $attempts {
-    if $nm not-in $names { continue }  # already reported above
-    let body = (patch body-lines ($patch_dir | path join $nm))
-    if ($body | is-empty) {
-      print $"patch-dag check: ($nm) is marked upstream = attempt but its commit message has no body; write the why in the commit body \(it becomes the upstream PR description\)."
+
+  # (e) every patch carries its reason inline. The commit-message body is the
+  # reason of record; nix deliberately has no duplicate description field
+  # (lib/fork-packages.nix `reason` explains the upstreaming STANCE, not the
+  # patch), and for attempt-marked patches the body becomes the upstream PR
+  # description verbatim (packages/upstream-pr). A bare subject is mute both
+  # here and in an upstream reviewer's inbox.
+  for p in $patches {
+    if not (dag body-has-reason $p.file) {
+      print $"patch-dag check: ($p.name) states no reason in its commit-message body; write why the patch exists in the commit body \(attribution trailers and bare issue refs do not count; for attempt patches the body becomes the upstream PR description\)."
       $failed = true
     }
   }

--- a/packages/rebase-patches/dag-lib.nu
+++ b/packages/rebase-patches/dag-lib.nu
@@ -191,6 +191,40 @@ export def "dag to-json" [doc: record] {
   ($doc | to json --indent 2) + "\n"
 }
 
+# --- Commit-message reason (invariant (e) of the patch-dag check) -------------
+
+# The commit-message body of a format-patch file: the lines between the header
+# block (ended by the first blank line; folded Subject continuations are
+# indented, never blank) and the diff payload (`---` separator, or `diff --git`
+# directly in this repo's canonical `--no-stat` serialization). Blank-only
+# lines are dropped.
+export def "dag body-lines" [file: string]: nothing -> list<string> {
+  open --raw $file
+  | lines
+  | skip until {|l| $l == "" }
+  | skip 1
+  | take until {|l| ($l == "---") or ($l | str starts-with "diff --git ") }
+  | where {|l| ($l | str trim) != "" }
+}
+
+# Does the patch state WHY it exists in its commit-message body? The body is
+# the reason of record for every fork patch: it rides the `git am` / rebase /
+# `format-patch` round-trip, so it reaches upstream reviewers, and for
+# attempt-marked patches it becomes the upstream PR description verbatim
+# (packages/upstream-pr). Attribution trailers and bare issue references are
+# not substance: `Refs #123` points at a reason without stating it, and a
+# `*-by:` trailer states no rationale at all.
+export def "dag body-has-reason" [file: string]: nothing -> bool {
+  dag body-lines $file
+  | where {|l|
+      let t = ($l | str trim)
+      let trailer = ($t =~ '(?i)^[a-z][a-z-]*-by:') or ($t =~ '(?i)^(cc|change-id):')
+      let bare_ref = ($t =~ '(?i)^(refs?|fixes|closes|resolves|see|see-also):?[ \t]+\S+$')
+      not ($trailer or $bare_ref)
+    }
+  | is-not-empty
+}
+
 # --- Invariant verification (the `patch-dag-<name>` flake check) --------------
 
 # Verify the three DAG invariants against a committed `dag.json`, plus topo

--- a/packages/rebase-patches/default.nix
+++ b/packages/rebase-patches/default.nix
@@ -178,6 +178,17 @@ in
         let edges = ($nodes | each {|n| $n.deps | length } | math sum)
         let roots = ($nodes | where {|n| ($n.deps | length) == 0 } | length)
         print $"(ansi green)rebase-patches: ($fork.name): regenerated dag.json (($patches | length)) nodes, ($edges) edges, ($roots) roots(ansi reset)"
+
+        # Surface the inline-reason requirement at authoring time: the
+        # `patch-dag-<name>` flake check fails any patch whose commit message
+        # states no reason (dag-lib.nu `dag body-has-reason`), and regenerating
+        # the DAG is the first tooling a new patch meets. A warning, not an
+        # error: this run's job is the rebase/DAG, and the flake check stays
+        # the gate, so a base bump is never blocked on a pre-existing message.
+        let mute = ($patches | where {|p| not (dag body-has-reason $p.file) } | get name)
+        if ($mute | is-not-empty) {
+          print $"(ansi yellow)rebase-patches: ($fork.name): (($mute | length)) patch\(es\) state no reason in their commit-message body and will fail the patch-dag-($fork.name) check; write the why into: (($mute | str join ', '))(ansi reset)"
+        }
         rm --recursive --force $scratch
       }
 

--- a/packages/vm/panes/guest-image/mesa/patches/0002-README.ix-document-snapshot-fork-layout.patch
+++ b/packages/vm/panes/guest-image/mesa/patches/0002-README.ix-document-snapshot-fork-layout.patch
@@ -3,6 +3,13 @@ From: Claude <noreply@anthropic.com>
 Date: Thu, 2 Jul 2026 18:31:24 -0700
 Subject: [PATCH] README.ix: document snapshot fork layout
 
+The indexable-inc/mesa fork repo is a generated serialization (snapshot
+base plus this patch series applied as commits), not a place where
+changes originate. Add README.ix.md so a reader of the fork repo learns
+the layout, why the fork exists (the venus driver-side sync-fd work for
+the panes GPU guest), and that the series in indexable-inc/index is the
+fork of record.
+
 Refs: indexable-inc/index#1686
 
 diff --git a/README.ix.md b/README.ix.md


### PR DESCRIPTION
Every fork patch must now state why it exists, machine-enforced. Closes #2087.

## Mechanism

The reason of record is the patch's own commit-message body, not a metadata file. The repo already held this doctrine for `attempt`-marked patches ("the commit message IS the patch's description"); this PR extends it to every patch in every series:

- the body rides the `git am` / rebase / `git format-patch` round-trip, so it survives base bumps and reaches upstream reviewers;
- `lib/fork-packages.nix` per-patch `reason` keeps owning only the upstreaming *stance* rationale (why attempt/hold/never), so no fact is duplicated.

## Enforcement

- `dag body-has-reason` in `packages/rebase-patches/dag-lib.nu` (the shared single owner used by both the flake check and the tool): a patch passes only if its body has at least one line that is not an attribution trailer (`*-by:`, `Cc:`, `Change-Id:`) and not a bare issue ref (`Refs #123` points at a reason without stating it).
- `patch-dag-<name>` (dag-check.nu, invariant (e)) now fails ANY patch with no reason, not just attempt-marked ones. Runs where the other fork gates run, for every entry in the fork-packages mapping; no per-package code.
- `nix run .#rebase-patches -- dag` surfaces the requirement at authoring time with a loud warning (the flake check stays the gate, so a base bump is never blocked on a pre-existing message).

## Backfill

13 patches were mute and got honest reasons: the 11 body-less clippy lint patches (each distilled from the lint's own "What it does / Why restrict this" docs carried in the same patch), plus codex 0001 and mesa 0002 whose body was a bare `Refs` line.

## Validation

- `nix build .#checks.aarch64-darwin.patch-dag-{codex,btop,clippy,mesa,nix}`: all green at HEAD.
- Negative test: building `patch-dag-clippy` from the machinery-only commit (before backfill) fails listing exactly the 11 mute patches.
- `nix run .#rebase-patches -- dag btop`: green, dag.json byte-identical; with a body stripped it prints the new warning.
- `nix run .#lint`: green.

## Downstream (ix)

ix consumes this via `index.lib.mkForkChecks` + `forkDagCheckSrc`, so its colmena/ghostty series get the rule for free on the next index bump. Audit of ix: ghostty 0001/0002 and colmena 0002-0004 already carry reasons; only `packages/colmena/patches/0001-update-nox.patch` is mute — follow-up ix PR backfills it.

Out of scope: the loose single-file patches (`packages/nix/{nix-eval-jobs,nix-fast-build,nix-output-monitor}/*.patch`) are not part of the fork-packages series machinery.

Written by an agent on Andrew's behalf.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce inline reasons in fork patch commit messages via `dag body-has-reason`
> - The `patch-dag` flake check in [dag-check.nu](https://github.com/indexable-inc/index/pull/2100/files#diff-3b8436d65230cc36c31cb65c97b9fee6efca12622c1403356f02a8ffb0b0bd32) now fails any patch whose commit-message body lacks a substantive reason, not just attempt-marked patches; attribution trailers and bare issue refs do not count.
> - Two new exported helpers in [dag-lib.nu](https://github.com/indexable-inc/index/pull/2100/files#diff-4009ca1504c087fa70a74c8f735cb5c3ad80fa208cdbfd99f16ec90f6d5861d4) implement this: `dag body-lines` extracts the commit-message body from a format-patch file, and `dag body-has-reason` returns a boolean indicating whether a substantive reason is present.
> - DAG regeneration in [default.nix](https://github.com/indexable-inc/index/pull/2100/files#diff-dd450ae43106772c7bb417e4f0f4b3d25042f7302914086c517c3c1c46e7726b) prints a warning listing patches that lack a reason but does not fail the run; the flake check remains the enforcement gate.
> - All existing patches across `packages/agent/codex`, `packages/llm-clippy`, and `packages/vm/panes/guest-image/mesa` have been updated with rationale text to satisfy the new check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58632f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->