### PR TITLE
fix(ix-fleet): create east-west groups in the VM's region via vm.apply_groups

### DIFF
--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -507,27 +507,24 @@ async def switch_node(node: FleetNode, *, dry_run: bool) -> None:
         ) from error
 
 
-async def ensure_group(group: str, *, dry_run: bool) -> None:
-    if dry_run:
-        step(f"ensure east-west group {group} exists")
-        return
-
-    try:
-        await client().create_group(group)
-    except ix_sdk.IxConflictError:
-        step(f"east-west group {group} already exists")
-
-
 async def ensure_node_groups(node: FleetNode, *, dry_run: bool) -> None:
-    for group in sorted(node.groups):
-        await ensure_group(group, dry_run=dry_run)
-        if dry_run:
-            step(f"+ add {node.name} to east-west group {group}")
-            continue
-        try:
-            await client().add_group_member(group, node.name)
-        except ix_sdk.IxConflictError:
-            step(f"{node.name} is already in east-west group {group}")
+    """Reconcile the node's east-west membership to exactly `node.groups`.
+
+    Uses `vm.apply_groups` (ENG-2752): set-based, and it get-or-creates each
+    slug **in the VM's own region**. This is the fix for a fleet driven from
+    one region's leader: the previous `group.create` + `add_group_member` pair
+    created the group with standalone `group.create`, which only ever creates
+    in the caller's local region (ENG-2754), so every other region's group was
+    stranded in the leader's region and rejected its own members. Routing
+    through the VM's region removes that class of failure.
+    """
+    groups = sorted(node.groups)
+    if not groups:
+        return
+    if dry_run:
+        step(f"+ reconcile {node.name} east-west groups -> {groups}")
+        return
+    await client().apply_vm_groups(node.name, groups)
 
 
 async def bootstrap_node(node: FleetNode, *, dry_run: bool) -> None:

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -281,51 +281,50 @@ class UpNodeTests(unittest.TestCase):
 
 
 class EastWestGroupTests(unittest.TestCase):
-    def test_ensures_group_before_adding_node(self) -> None:
-        calls: list[list[str]] = []
+    @staticmethod
+    def _recording_client(calls: list[tuple[str, list[str]]]) -> typing.Any:  # noqa: ANN401
+        class FakeClient:
+            async def apply_vm_groups(self, vm: str, groups: list[str]) -> typing.Any:  # noqa: ANN401
+                calls.append((vm, groups))
+                return type("GroupApplySummary", (), {"added": groups, "removed": []})()
 
-        async def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
-            del timeout
-            assert not dry_run
-            calls.append(command)
-            return ""
+        return FakeClient
 
+    def test_reconciles_membership_in_vm_region(self) -> None:
+        # ensure_node_groups routes through vm.apply_groups, which get-or-creates
+        # each slug in the VM's own region rather than the caller's local region
+        # (ENG-2754), so a fleet driven from one region's leader no longer
+        # strands a remote region's group. One set-based call keyed by VM name.
+        calls: list[tuple[str, list[str]]] = []
+
+        node_data = fleet_node("api")
+        node_data["groups"] = ["shared-db", "private-apps"]
+        node = ix_fleet.FleetNode.model_validate(node_data)
+
+        with patch.object(ix_fleet, "client", self._recording_client(calls)):
+            asyncio.run(ix_fleet.ensure_node_groups(node, dry_run=False))
+
+        assert calls == [("api", ["private-apps", "shared-db"])]
+
+    def test_no_groups_makes_no_live_call(self) -> None:
+        node = ix_fleet.FleetNode.model_validate(fleet_node("api"))
+
+        def fail_client() -> typing.Any:  # noqa: ANN401
+            raise AssertionError("no declared groups: apply_vm_groups must not be called")
+
+        with patch.object(ix_fleet, "client", fail_client):
+            asyncio.run(ix_fleet.ensure_node_groups(node, dry_run=False))
+
+    def test_dry_run_makes_no_live_call(self) -> None:
         node_data = fleet_node("api")
         node_data["groups"] = ["private-apps"]
         node = ix_fleet.FleetNode.model_validate(node_data)
 
-        with patch.object(ix_fleet, "run_cli", fake_run_cli):
-            asyncio.run(ix_fleet.ensure_node_groups(node, dry_run=False))
+        def fail_client() -> typing.Any:  # noqa: ANN401
+            raise AssertionError("dry-run must not touch the group surface")
 
-        assert calls == [
-            ["ix", "group", "create", "private-apps"],
-            ["ix", "group", "add", "private-apps", "api"],
-        ]
-
-    def test_existing_group_membership_is_idempotent(self) -> None:
-        calls: list[list[str]] = []
-
-        async def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
-            del timeout
-            assert not dry_run
-            calls.append(command)
-            if command[:3] == ["ix", "group", "create"]:
-                raise ix_fleet.CliError(command, 1, "", "group already exists")
-            if command[:3] == ["ix", "group", "add"]:
-                raise ix_fleet.CliError(command, 1, "", "vm is already a member of group")
-            return ""
-
-        node_data = fleet_node("api")
-        node_data["groups"] = ["private-apps"]
-        node = ix_fleet.FleetNode.model_validate(node_data)
-
-        with patch.object(ix_fleet, "run_cli", fake_run_cli):
-            asyncio.run(ix_fleet.ensure_node_groups(node, dry_run=False))
-
-        assert calls == [
-            ["ix", "group", "create", "private-apps"],
-            ["ix", "group", "add", "private-apps", "api"],
-        ]
+        with patch.object(ix_fleet, "client", fail_client):
+            asyncio.run(ix_fleet.ensure_node_groups(node, dry_run=True))
 
 
 class BootstrapTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

`status.ix.dev`'s **New VMs - US East** heartbeat is red (and East ray legs fail every run) because ix-fleet creates east-west groups in the wrong region.

`ensure_node_groups` created each group with the standalone `group.create` RPC, then joined the member with `add_group_member`. `group.create` only ever creates in the **caller's local region** (ENG-2754 deliberately deferred remote standalone group-create). The public-status New VMs suite runs **every region from the single prod leader** (us-west-1), so the us-east ray group was created in us-west-1 on every run, and every us-east member was then rejected:

```
ix-fleet: VM 'health-check-us-east-1-ray-head' is in region us-east-1 but group
'health-check-us-east-1-ray-cluster' is in region us-west-1; group members must
be in the group's region
```

Deleting the group does not help - the next run recreates it in us-west-1 again (verified live on prod).

## Fix

Reconcile membership through **`vm.apply_groups`** (ENG-2752) instead of `group.create` + `add_group_member`. `apply_vm_groups` resolves the VM's own region and get-or-creates each slug **there**, so the group is always born where its members live. It is set-based and idempotent, so re-running a fleet is a no-op. The now-unused `ensure_group` helper is removed.

This uses the intended region model (region-scoped groups, created through a VM in the target region); it does not change the group model or touch `group.create`.

## Scope / follow-up

- Fixes **US East** (cross-region group create) deterministically.
- **US West** failed on a different symptom: the post-create membership change hot-plugs the running VM and trips an orchestrator live-network reconfigure (`SIOCSIFHWADDR: No such device` on `eth1`). `apply_vm_groups` still performs a membership change, so West needs verification on a real node; if it still trips, the durable fixes are either declarative groups on the create path (needs an `ix_sdk` wheel bump - the pinned wheel exposes `apply_vm_groups` but not `create(groups=)`) or fixing the orchestrator `eth1` reconfigure in ix. Tracked separately.

## Tests

`EastWestGroupTests` rewritten to assert the single region-correct `apply_vm_groups(vm, groups)` reconcile (the previous tests asserted the old `ix group create`/`add` CLI shell-outs, which no longer matched the committed SDK-based source).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix east-west group membership in `ensure_node_groups` to use `apply_vm_groups` in the VM's region
> - Replaces per-group `create_group` + `add_group_member` calls in `ensure_node_groups` with a single `client().apply_vm_groups(node.name, groups)` call, matching the VM's region.
> - Removes the `ensure_group` helper entirely; any external code importing it will break.
> - When no groups are declared, no client call is made; in dry-run mode, emits a single reconcile step without touching the client.
> - Risk: `ensure_group` is removed and is no longer importable from [ix_fleet/__init__.py](https://github.com/indexable-inc/index/pull/2101/files#diff-d83777ed2e90ee1f7371ffa0e55fe375c817b07e2cb2a15a5b58423ad93dae3e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 203c9bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->