### PR TITLE
unibind phase 2: async, cancellation, streams, resources (python backend)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12178,6 +12178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unibind-runtime"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "pyo3",
+ "pyo3-async-runtimes",
+ "tokio",
+]
+
+[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12156,6 +12156,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "unibind-conformance"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "pyo3",
+ "tokio",
+ "unibind",
+ "unibind-runtime",
+]
+
+[[package]]
 name = "unibind-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ members = [
   "packages/tui/tui-node",
   "packages/tui/tui-py",
   "packages/unibind/backend-py",
+  "packages/unibind/conformance",
   "packages/unibind/core",
   "packages/unibind/gen",
   "packages/unibind/macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ members = [
   "packages/unibind/core",
   "packages/unibind/gen",
   "packages/unibind/macros",
+  "packages/unibind/runtime",
   "packages/vm/panes/audio",
   "packages/vm/panes/compositor",
   "packages/vm/panes/host",
@@ -348,6 +349,7 @@ tui = { path = "packages/tui/tui" }
 unibind = { path = "packages/unibind/macros" }
 unibind-backend-py = { path = "packages/unibind/backend-py" }
 unibind-core = { path = "packages/unibind/core" }
+unibind-runtime = { path = "packages/unibind/runtime" }
 url = { version = "2.5.8", default-features = false }
 uuid = "1"
 webpki-roots = "1"

--- a/packages/unibind/README.md
+++ b/packages/unibind/README.md
@@ -70,8 +70,11 @@ mod _mylib {
   class under one base class named after the enum; `py(base = "...")` picks
   the built-in the base extends. The enum implements `Display`, and the
   raised exception carries that text.
-- `#[unibind::object]` reserves the surface for stateful handles; it errors
-  until phase 2 (#1992).
+- `#[unibind::object]` marks a stateful handle: inherent methods (implicit
+  `&self`) become methods on a native class, and `#[unibind(constructor)]`
+  names the receiver-less constructor. `object(resource)` adds
+  deterministic cleanup: a generated `close()`, `async with` support, and
+  a `ResourceWarning` when the handle is dropped unclosed.
 - `#[unibind(py(name = "..."))]` renames a module, function, argument, field,
   or error variant for Python. `#[unibind(default = ...)]` gives an argument
   a default; `Option` arguments default to `None` automatically.
@@ -109,8 +112,8 @@ Crates:
 
 - `core`: the IR types (`Interface`, functions, records, enums, errors,
   objects, the boundary `Type`), the syn lowering, and the link-section
-  embed. Enums, objects, and async exist in the IR but phase 0 rejects them
-  with pointers at the phase that ships them.
+  embed. Phase 2 turned on async, streams, and
+  objects; plain (non-error) enums still wait for their phase.
 - `gen`: the `unibind-gen` binary. Reads the embedded IR out of a compiled
   artifact and emits the host-language files above; run at build time by
   `unibind.lib.build`, never at macro time.
@@ -146,13 +149,41 @@ argument-only; returns and record fields own their data.
 Phase 1 changes nothing in this table: the `.pyi` emitter renders these same
 rules (argument vs return position included) from the untouched IR.
 
+## Phase 2 surface
+
+- `pub async fn` exports as a real asyncio coroutine on the shared tokio
+  runtime. Cancellation is true cancellation: cancelling the Python task
+  drops the in-flight Rust future, so guards, locks, and connections
+  release immediately instead of leaking on a detached task.
+- `fn ... -> UniStream<T>` (bare or behind `async fn`/`Result`) exports as
+  an async iterator. It is pull-based: each `__anext__` polls exactly one
+  item, so a consumer that stops early stops the producer with it.
+- `#[unibind(blocking)]` runs the call with the GIL released, for
+  CPU-bound or thread-sleeping work that must not stall the interpreter.
+- `&[u8]` arguments cross through the buffer protocol with no copy:
+  `bytes`, `bytearray`, and contiguous `memoryview` all alias the caller's
+  memory for the duration of the call.
+- A crate exporting async functions, streams, or objects adds
+  `unibind-runtime` with the `py` feature next to its `unibind` dependency;
+  sync-only crates (scipql-py) do not need it.
+
+## Conformance suite
+
+`packages/unibind/conformance` is the runtime proof for everything above:
+a cdylib exporting the full phase-2 surface plus a stdlib-only `runner.py`
+that asserts the semantics from Python with quantitative evidence, such as
+live/dropped guard counts around `task.cancel()`, produced-vs-consumed
+stream counters, exactly one `ResourceWarning` per leaked resource, and
+`ctypes.addressof` equality for zero-copy buffers. It runs in CI as
+`checks.<system>.unibind-conformance-run`.
+
 ## Phases
 
 | Phase | Issue | Scope |
 | ----- | ----- | ----- |
 | 0     | #1990 | core IR, macro skeleton, pyo3 backend for sync functions, records, errors; proven by porting `packages/code/scipql/py` |
 | 1     | #1991 | `unibind-gen`: host files (`.pyi`) from the embedded IR, `unibind.lib.build` nix glue |
-| 2     | #1992 | async, cancellation, streams, resources/objects (Python backend) |
+| 2     | #1992 | async, cancellation, streams, resources/objects (Python backend); proven by `packages/unibind/conformance` |
 | 3     | #1993 | TypeScript backend (napi-rs) with enriched `.d.ts` |
 | 4     | #1994 | Rust client backend over a stable ABI |
 | 5     | #1995 | Elixir backend (rustler, generated `.ex`, `@spec`) |

--- a/packages/unibind/backend-py/src/ctx.rs
+++ b/packages/unibind/backend-py/src/ctx.rs
@@ -1,0 +1,30 @@
+//! The rendering context threaded through every renderer.
+
+use proc_macro2::Ident;
+use quote::format_ident;
+use unibind_core::ir;
+
+/// What renderers need besides the item at hand: the exported module's
+/// identifier (user items resolve through `super::<user>::`) and the whole
+/// interface for name resolution.
+pub struct Ctx<'a> {
+    pub user: &'a Ident,
+    pub interface: &'a ir::Interface,
+}
+
+impl Ctx<'_> {
+    /// Whether a [`ir::Type::Named`] names an object rather than a record;
+    /// the IR spells both the same way, so the interface's object list
+    /// decides which wrapper the value crosses through.
+    pub fn is_object(&self, name: &str) -> bool {
+        self.interface
+            .objects
+            .iter()
+            .any(|object| object.name == name)
+    }
+}
+
+/// The glue-side `#[pyclass]` wrapper for object `name`.
+pub fn object_wrapper_ident(name: &str) -> Ident {
+    format_ident!("UnibindObject{name}")
+}

--- a/packages/unibind/backend-py/src/function.rs
+++ b/packages/unibind/backend-py/src/function.rs
@@ -1,79 +1,162 @@
-//! Render `#[pyfunction]` wrappers around the user's functions.
+//! Render wrappers around the user's callables: `#[pyfunction]`s for free
+//! functions and `#[pymethods]` items for object methods. Sync, blocking
+//! (GIL-released), and async bodies all route through the same argument
+//! and return machinery in [`crate::sig`].
 
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use unibind_core::ir;
 
-use crate::{ty, RenderError};
+use crate::ctx::Ctx;
+use crate::sig::{self, BodyAndRet};
+use crate::RenderError;
 
-pub fn render_fn(function: &ir::Function, user: &Ident) -> Result<TokenStream, RenderError> {
-    if matches!(function.asyncness, ir::Asyncness::Async) {
-        return Err(RenderError::new(format!(
-            "`{}` is async; async functions land in phase 2 (issue #1992)",
-            function.name
-        )));
+/// Who the callable belongs to; the call target and receiver differ.
+enum Target<'a> {
+    /// A free `pub fn`: `super::<user>::<name>(...)`.
+    Free,
+    /// An object method: `self.inner.<name>(...)` sync, or the cloned
+    /// `inner` Arc inside async futures.
+    Method {
+        /// The owning object's name, which scopes per-export stream
+        /// classes.
+        object: &'a str,
+    },
+}
+
+impl Target<'_> {
+    const fn owner(&self) -> Option<&str> {
+        match self {
+            Self::Free => None,
+            Self::Method { object } => Some(object),
+        }
     }
-    let rust_name = Ident::new(&function.name, Span::call_site());
-    let rename = function.names.py.as_ref().map(|name| {
-        quote! { #[pyo3(name = #name)] }
+
+    fn sync_call(&self, name: &Ident, forwarded: &[TokenStream], user: &Ident) -> TokenStream {
+        match self {
+            Self::Free => quote!(super::#user::#name(#(#forwarded),*)),
+            Self::Method { .. } => quote!(self.inner.#name(#(#forwarded),*)),
+        }
+    }
+
+    /// Inside an async future the receiver is the cloned `inner` Arc: the
+    /// future must be `'static`, so it cannot borrow `&self`.
+    fn async_call(&self, name: &Ident, forwarded: &[TokenStream], user: &Ident) -> TokenStream {
+        match self {
+            Self::Free => quote!(super::#user::#name(#(#forwarded),*)),
+            Self::Method { .. } => quote!(inner.#name(#(#forwarded),*)),
+        }
+    }
+}
+
+pub fn render_fn(function: &ir::Function, ctx: &Ctx<'_>) -> Result<TokenStream, RenderError> {
+    render_callable(function, ctx, &Target::Free)
+}
+
+pub fn render_method(
+    function: &ir::Function,
+    ctx: &Ctx<'_>,
+    object: &str,
+) -> Result<TokenStream, RenderError> {
+    render_callable(function, ctx, &Target::Method { object })
+}
+
+fn render_callable(
+    function: &ir::Function,
+    ctx: &Ctx<'_>,
+    target: &Target<'_>,
+) -> Result<TokenStream, RenderError> {
+    let name = Ident::new(&function.name, Span::call_site());
+    let rename = function.names.py.as_ref().map(|py_name| {
+        quote! { #[pyo3(name = #py_name)] }
     });
     let docs = doc_attrs(&function.docs);
-
-    let mut params = Vec::new();
-    let mut signature = Vec::new();
-    let mut forwarded = Vec::new();
-    for arg in &function.args {
-        let ident = ty::name_ident(arg.names.py.as_ref().unwrap_or(&arg.name))?;
-        let ty = ty::rust_type(&arg.ty, user);
-        params.push(quote!(#ident: #ty));
-        signature.push(signature_entry(arg, &ident));
-        forwarded.push(quote!(#ident));
-    }
-
-    let ok_ty = function
-        .ret
-        .as_ref()
-        .map_or_else(|| quote!(()), |ret| ty::rust_type(ret, user));
-    let call = quote!(super::#user::#rust_name(#(#forwarded),*));
-    let body_and_ret = if function.throws.is_some() {
-        BodyAndRet {
-            ret: quote!(::pyo3::PyResult<#ok_ty>),
-            body: quote!(#call.map_err(::pyo3::PyErr::from)),
-        }
-    } else {
-        BodyAndRet {
-            ret: ok_ty,
-            body: call,
-        }
+    let args = sig::lower_args(function, ctx)?;
+    let ret = sig::ret_spec(function, target.owner(), ctx);
+    let pyfunction = matches!(target, Target::Free).then(|| quote!(#[::pyo3::pyfunction]));
+    let entries = &args.signature;
+    let item = match function.asyncness {
+        ir::Asyncness::Async => async_item(function, ctx, target, &name, &args, &ret),
+        ir::Asyncness::Sync => sync_item(function, ctx, target, &name, &args, &ret),
     };
-    let BodyAndRet { ret, body } = body_and_ret;
-
     Ok(quote! {
         #docs
-        #[::pyo3::pyfunction]
+        #pyfunction
         #rename
-        #[pyo3(signature = (#(#signature),*))]
-        fn #rust_name(#(#params),*) -> #ret {
-            #body
-        }
+        #[pyo3(signature = (#(#entries),*))]
+        #item
     })
 }
 
-/// A wrapper's return type and body, which vary together on `throws`.
-struct BodyAndRet {
-    ret: TokenStream,
-    body: TokenStream,
+fn sync_item(
+    function: &ir::Function,
+    ctx: &Ctx<'_>,
+    target: &Target<'_>,
+    name: &Ident,
+    args: &sig::Args,
+    ret: &sig::RetSpec,
+) -> TokenStream {
+    let call = target.sync_call(name, &args.forwarded, ctx.user);
+    // `detach` releases the GIL around the user call; the prologue built
+    // any buffer slices already and `&[u8]` is Send, so they cross into
+    // the closure.
+    let raw = if function.blocking {
+        quote!(py.detach(move || #call))
+    } else {
+        call
+    };
+    let BodyAndRet { ret: ret_ty, body } =
+        sig::finish_sync(&raw, function.throws.is_some(), args.fallible, ret);
+    let prologue = &args.prologue;
+    let params = &args.params;
+    let mut lead = Vec::new();
+    if matches!(target, Target::Method { .. }) {
+        lead.push(quote!(&self));
+    }
+    if function.blocking {
+        lead.push(quote!(py: ::pyo3::Python<'_>));
+    }
+    quote! {
+        fn #name(#(#lead,)* #(#params),*) -> #ret_ty {
+            #prologue
+            #body
+        }
+    }
 }
 
-fn signature_entry(arg: &ir::Arg, ident: &Ident) -> TokenStream {
-    if let Some(default) = &arg.default {
-        let default = ty::default_tokens(default);
-        return quote!(#ident = #default);
+fn async_item(
+    function: &ir::Function,
+    ctx: &Ctx<'_>,
+    target: &Target<'_>,
+    name: &Ident,
+    args: &sig::Args,
+    ret: &sig::RetSpec,
+) -> TokenStream {
+    let call = target.async_call(name, &args.forwarded, ctx.user);
+    let future_body = if function.throws.is_some() {
+        ret.wrap.as_ref().map_or_else(
+            || quote!(#call.await.map_err(::pyo3::PyErr::from)),
+            |class| quote!(#call.await.map(#class::__unibind_wrap).map_err(::pyo3::PyErr::from)),
+        )
+    } else {
+        let wrapped = sig::wrap_value(quote!(#call.await), ret.wrap.as_ref());
+        quote!(::pyo3::PyResult::Ok(#wrapped))
+    };
+    let receiver = matches!(target, Target::Method { .. }).then(|| quote!(&self,));
+    let clone_inner = matches!(target, Target::Method { .. }).then(|| {
+        quote!(let inner = ::std::sync::Arc::clone(&self.inner);)
+    });
+    let params = &args.params;
+    quote! {
+        fn #name<'py>(
+            #receiver
+            py: ::pyo3::Python<'py>,
+            #(#params),*
+        ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+            #clone_inner
+            ::unibind_runtime::py::future_into_py(py, async move { #future_body })
+        }
     }
-    if matches!(arg.ty, ir::Type::Option(_)) {
-        return quote!(#ident = None);
-    }
-    quote!(#ident)
 }
 
 pub fn doc_attrs(lines: &[String]) -> TokenStream {

--- a/packages/unibind/backend-py/src/lib.rs
+++ b/packages/unibind/backend-py/src/lib.rs
@@ -3,15 +3,23 @@
 //! The backend targets the incumbent binding library rather than raw FFI: it
 //! emits `#[pyo3::pyfunction]` wrappers around the user's functions, attaches
 //! `#[pyo3::pyclass]` to record structs, builds the exception hierarchy with
-//! `pyo3::create_exception!`, and registers everything in one imperative
-//! `#[pyo3::pymodule]`. The consuming crate therefore depends on `pyo3`
-//! directly (with `extension-module` for a wheel-shaped cdylib), and the
-//! generated code compiles against `pyo3` 0.28 with `abi3-py311`.
+//! `pyo3::create_exception!`, wraps objects and streams in `#[pyo3::pyclass]`
+//! handles, and registers everything in one imperative `#[pyo3::pymodule]`.
+//! The consuming crate therefore depends on `pyo3` directly (with
+//! `extension-module` for a wheel-shaped cdylib), and the generated code
+//! compiles against `pyo3` 0.28 with `abi3-py311`. Glue for async, stream,
+//! and object exports also calls `unibind_runtime::py`, so those consumers
+//! add `unibind-runtime` with the `py` feature.
 
+mod ctx;
 mod error;
 mod function;
 mod module;
+mod object;
 mod record;
+mod resource;
+mod sig;
+mod stream;
 mod ty;
 
 pub use module::render;

--- a/packages/unibind/backend-py/src/module.rs
+++ b/packages/unibind/backend-py/src/module.rs
@@ -4,25 +4,20 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use unibind_core::ir;
 
-use crate::{error, function, record, ty, RenderError, RenderedInterface};
+use crate::ctx::Ctx;
+use crate::{error, function, object, record, stream, ty, RenderError, RenderedInterface};
 
 /// Render `pyo3` glue for one interface.
 ///
 /// # Errors
 ///
-/// Fails for surface the phase 0 backend does not implement (async
-/// functions, data enums, objects), for unsupported `py(base = ...)`
-/// exception bases, and for renames that cannot become identifiers.
+/// Fails for surface the backend does not implement (data enums), for
+/// unsupported `py(base = ...)` exception bases, and for renames that
+/// cannot become identifiers.
 pub fn render(interface: &ir::Interface) -> Result<RenderedInterface, RenderError> {
-    if let Some(object) = interface.objects.first() {
-        return Err(RenderError::new(format!(
-            "`{}` is a #[unibind::object]; objects land in phase 2 (issue #1992)",
-            object.name
-        )));
-    }
     if let Some(data_enum) = interface.enums.first() {
         return Err(RenderError::new(format!(
-            "`{}` is a data enum, which phase 0 does not render",
+            "`{}` is a data enum, which unibind does not render yet",
             data_enum.name
         )));
     }
@@ -31,23 +26,34 @@ pub fn render(interface: &ir::Interface) -> Result<RenderedInterface, RenderErro
     let module_name = interface.names.py.clone().unwrap_or_else(|| interface.name.clone());
     let module_ident = ty::name_ident(&module_name)?;
     let glue_ident = format_ident!("__unibind_py_{}", interface.name.trim_start_matches('_'));
+    let ctx = Ctx {
+        user: &user,
+        interface,
+    };
 
     let exceptions = interface
         .errors
         .iter()
         .map(|err| error::render_error(err, &module_ident, &user))
         .collect::<Result<Vec<_>, _>>()?;
-    let wrappers = interface
-        .functions
-        .iter()
-        .map(|func| function::render_fn(func, &user))
-        .collect::<Result<Vec<_>, _>>()?;
     let constructors = interface
         .records
         .iter()
         .map(|rec| record::constructor(rec, &user))
         .collect::<Result<Vec<_>, _>>()?;
-    let registration = registration(interface, &user)?;
+    let wrappers = interface
+        .functions
+        .iter()
+        .map(|func| function::render_fn(func, &ctx))
+        .collect::<Result<Vec<_>, _>>()?;
+    let objects = interface
+        .objects
+        .iter()
+        .map(|obj| object::render_object(obj, &ctx))
+        .collect::<Result<Vec<_>, _>>()?;
+    let streams = stream::collect(interface);
+    let stream_classes: Vec<TokenStream> = streams.iter().map(|s| s.render(&ctx)).collect();
+    let registration = registration(&ctx, &streams)?;
     let module_docs = function::doc_attrs(&interface.docs);
 
     let glue = quote! {
@@ -59,6 +65,8 @@ pub fn render(interface: &ir::Interface) -> Result<RenderedInterface, RenderErro
             #(#exceptions)*
             #(#constructors)*
             #(#wrappers)*
+            #(#objects)*
+            #(#stream_classes)*
 
             #module_docs
             #[::pyo3::pymodule]
@@ -75,7 +83,12 @@ pub fn render(interface: &ir::Interface) -> Result<RenderedInterface, RenderErro
     Ok(RenderedInterface { glue, records })
 }
 
-fn registration(interface: &ir::Interface, user: &Ident) -> Result<TokenStream, RenderError> {
+fn registration(
+    ctx: &Ctx<'_>,
+    streams: &[stream::StreamExport<'_>],
+) -> Result<TokenStream, RenderError> {
+    let interface = ctx.interface;
+    let user = ctx.user;
     let mut statements = Vec::new();
     for func in &interface.functions {
         let ident = Ident::new(&func.name, Span::call_site());
@@ -87,6 +100,19 @@ fn registration(interface: &ir::Interface, user: &Ident) -> Result<TokenStream, 
         let ident = Ident::new(&rec.name, Span::call_site());
         statements.push(quote! {
             module.add_class::<super::#user::#ident>()?;
+        });
+    }
+    for obj in &interface.objects {
+        let wrapper = crate::ctx::object_wrapper_ident(&obj.name);
+        statements.push(quote! {
+            module.add_class::<#wrapper>()?;
+        });
+    }
+    // Stream classes register too, so `isinstance` and typing hints work.
+    for export in streams {
+        let ident = export.class_ident();
+        statements.push(quote! {
+            module.add_class::<#ident>()?;
         });
     }
     for err in &interface.errors {

--- a/packages/unibind/backend-py/src/object.rs
+++ b/packages/unibind/backend-py/src/object.rs
@@ -1,0 +1,118 @@
+//! Wrapper classes for `#[unibind::object]` types: a `#[pyclass]` holding
+//! the user struct behind an `Arc` (async methods and Python's free
+//! aliasing both need shared ownership), plus the constructor, methods,
+//! and, for resources, the close/async-with surface from
+//! [`crate::resource`].
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use unibind_core::ir;
+
+use crate::ctx::Ctx;
+use crate::function::{doc_attrs, render_method};
+use crate::{resource, sig, RenderError};
+
+pub fn render_object(object: &ir::Object, ctx: &Ctx<'_>) -> Result<TokenStream, RenderError> {
+    let user = ctx.user;
+    let wrapper = crate::ctx::object_wrapper_ident(&object.name);
+    let user_ty = Ident::new(&object.name, Span::call_site());
+    let py_name = object.names.py.as_deref().unwrap_or(&object.name);
+    let docs = doc_attrs(&object.docs);
+
+    // Resources track closedness so close() is idempotent and Drop can
+    // warn about leaks; plain objects carry no extra state.
+    let closed_field = object.resource.then(|| {
+        quote! { closed: ::std::sync::atomic::AtomicBool, }
+    });
+    let closed_init = object.resource.then(|| {
+        quote! { closed: ::std::sync::atomic::AtomicBool::new(false), }
+    });
+
+    let constructor = object
+        .constructor
+        .as_ref()
+        .map(|ctor| render_constructor(ctor, object, ctx))
+        .transpose()?;
+    let mut methods = Vec::new();
+    for method in &object.methods {
+        // The resource surface owns `close`: the generic path would render
+        // a second, non-idempotent close.
+        if object.resource && method.name == "close" {
+            continue;
+        }
+        methods.push(render_method(method, ctx, &object.name)?);
+    }
+    let resource_surface = object.resource.then(|| resource::surface(object));
+    let leak_warning = object.resource.then(|| resource::leak_warning(object));
+
+    Ok(quote! {
+        #docs
+        #[::pyo3::pyclass(name = #py_name, frozen)]
+        struct #wrapper {
+            inner: ::std::sync::Arc<super::#user::#user_ty>,
+            #closed_field
+        }
+        impl #wrapper {
+            fn __unibind_wrap(inner: super::#user::#user_ty) -> Self {
+                Self {
+                    inner: ::std::sync::Arc::new(inner),
+                    #closed_init
+                }
+            }
+        }
+        #[::pyo3::pymethods]
+        impl #wrapper {
+            #constructor
+            #(#methods)*
+            #resource_surface
+        }
+        #leak_warning
+    })
+}
+
+/// Constructors are sync and never `blocking` (lowering enforces both), so
+/// only the throws and buffer aspects apply.
+fn render_constructor(
+    ctor: &ir::Function,
+    object: &ir::Object,
+    ctx: &Ctx<'_>,
+) -> Result<TokenStream, RenderError> {
+    let user = ctx.user;
+    let object_ident = Ident::new(&object.name, Span::call_site());
+    let ctor_name = Ident::new(&ctor.name, Span::call_site());
+    let docs = doc_attrs(&ctor.docs);
+    let args = sig::lower_args(ctor, ctx)?;
+    let entries = &args.signature;
+    let params = &args.params;
+    let prologue = &args.prologue;
+    let forwarded = &args.forwarded;
+    let call = quote!(super::#user::#object_ident::#ctor_name(#(#forwarded),*));
+    let body_and_ret = if ctor.throws.is_some() {
+        sig::BodyAndRet {
+            ret: quote!(::pyo3::PyResult<Self>),
+            body: quote!(#call.map(Self::__unibind_wrap).map_err(::pyo3::PyErr::from)),
+        }
+    } else if args.fallible {
+        // The buffer contiguity check can fail even though the user
+        // constructor cannot.
+        sig::BodyAndRet {
+            ret: quote!(::pyo3::PyResult<Self>),
+            body: quote!(::pyo3::PyResult::Ok(Self::__unibind_wrap(#call))),
+        }
+    } else {
+        sig::BodyAndRet {
+            ret: quote!(Self),
+            body: quote!(Self::__unibind_wrap(#call)),
+        }
+    };
+    let sig::BodyAndRet { ret, body } = body_and_ret;
+    Ok(quote! {
+        #docs
+        #[new]
+        #[pyo3(signature = (#(#entries),*))]
+        fn __unibind_new(#(#params),*) -> #ret {
+            #prologue
+            #body
+        }
+    })
+}

--- a/packages/unibind/backend-py/src/resource.rs
+++ b/packages/unibind/backend-py/src/resource.rs
@@ -1,0 +1,157 @@
+//! The resource surface of an object: idempotent `close()`, `async with`
+//! support, and a `ResourceWarning` when a handle leaks unclosed.
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use unibind_core::ir;
+
+use crate::function::doc_attrs;
+
+/// The generated `close`, `__aenter__`, and `__aexit__` pymethods.
+pub fn surface(object: &ir::Object) -> TokenStream {
+    let close = user_close(object);
+    let close_wrapper = close_method(close);
+    let aenter = aenter();
+    let aexit = aexit(close);
+    quote! {
+        #close_wrapper
+        #aenter
+        #aexit
+    }
+}
+
+fn user_close(object: &ir::Object) -> &ir::Function {
+    object
+        .methods
+        .iter()
+        .find(|method| method.name == "close" && method.args.is_empty() && method.ret.is_none())
+        .expect("lowering guarantees resources declare close()")
+}
+
+/// The statement invoking the user's close on `receiver`, awaiting and
+/// error-mapping as its shape demands.
+fn close_stmt(close: &ir::Function, receiver: &TokenStream) -> TokenStream {
+    let call = match close.asyncness {
+        ir::Asyncness::Async => quote!(#receiver.close().await),
+        ir::Asyncness::Sync => quote!(#receiver.close()),
+    };
+    if close.throws.is_some() {
+        quote!(#call.map_err(::pyo3::PyErr::from)?;)
+    } else {
+        quote!(#call;)
+    }
+}
+
+/// `close()` is idempotent: `swap` picks one winner between racing
+/// `close()` / `__aexit__` calls, so the user's close runs exactly once.
+fn close_method(close: &ir::Function) -> TokenStream {
+    let docs = doc_attrs(&close.docs);
+    match close.asyncness {
+        ir::Asyncness::Sync => {
+            let receiver = quote!(self.inner);
+            let stmt = close_stmt(close, &receiver);
+            quote! {
+                #docs
+                fn close(&self) -> ::pyo3::PyResult<()> {
+                    if self.closed.swap(true, ::std::sync::atomic::Ordering::SeqCst) {
+                        return ::pyo3::PyResult::Ok(());
+                    }
+                    #stmt
+                    ::pyo3::PyResult::Ok(())
+                }
+            }
+        }
+        // An async user close returns a coroutine; whether the user's
+        // close runs is decided before the future is built, so a second
+        // call awaits to a no-op.
+        ir::Asyncness::Async => {
+            let receiver = quote!(inner);
+            let stmt = close_stmt(close, &receiver);
+            quote! {
+                #docs
+                fn close<'py>(
+                    &self,
+                    py: ::pyo3::Python<'py>,
+                ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+                    let first = !self.closed.swap(true, ::std::sync::atomic::Ordering::SeqCst);
+                    let inner = ::std::sync::Arc::clone(&self.inner);
+                    ::unibind_runtime::py::future_into_py(py, async move {
+                        if first {
+                            #stmt
+                        }
+                        ::pyo3::PyResult::Ok(())
+                    })
+                }
+            }
+        }
+    }
+}
+
+fn aenter() -> TokenStream {
+    quote! {
+        #[doc = "Enter `async with`: resolves to the object itself."]
+        fn __aenter__<'py>(
+            slf: ::pyo3::Bound<'py, Self>,
+        ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+            let py = slf.py();
+            let owned: ::pyo3::Py<Self> = slf.unbind();
+            ::unibind_runtime::py::future_into_py(py, async move { ::pyo3::PyResult::Ok(owned) })
+        }
+    }
+}
+
+/// `__aexit__` closes once (sharing the flag with `close()`) and resolves
+/// to `false` so the in-flight exception is never suppressed.
+fn aexit(close: &ir::Function) -> TokenStream {
+    let receiver = quote!(inner);
+    let stmt = close_stmt(close, &receiver);
+    quote! {
+        #[doc = "Exit `async with`: closes the resource, never suppresses the exception."]
+        fn __aexit__<'py>(
+            &self,
+            py: ::pyo3::Python<'py>,
+            _exc_type: ::pyo3::Bound<'py, ::pyo3::PyAny>,
+            _exc: ::pyo3::Bound<'py, ::pyo3::PyAny>,
+            _tb: ::pyo3::Bound<'py, ::pyo3::PyAny>,
+        ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+            let first = !self.closed.swap(true, ::std::sync::atomic::Ordering::SeqCst);
+            let inner = ::std::sync::Arc::clone(&self.inner);
+            ::unibind_runtime::py::future_into_py(py, async move {
+                if first {
+                    #stmt
+                }
+                ::pyo3::PyResult::Ok(false)
+            })
+        }
+    }
+}
+
+/// A `Drop` that warns when the resource was never closed. Mirrors
+/// `CPython`'s own unclosed-socket `ResourceWarning`, so leaks surface under
+/// `python -W error::ResourceWarning` and pytest `filterwarnings`.
+pub fn leak_warning(object: &ir::Object) -> TokenStream {
+    let wrapper = crate::ctx::object_wrapper_ident(&object.name);
+    let py_name = object.names.py.as_deref().unwrap_or(&object.name);
+    let text = format!("unclosed {py_name}: call close() or use 'async with'");
+    let message = syn::LitCStr::new(
+        &std::ffi::CString::new(text).expect("class names contain no NUL"),
+        Span::call_site(),
+    );
+    // `try_attach`, not `attach`: drops can run while the interpreter
+    // shuts down, where attaching would panic, and a Drop must not panic.
+    // Both Results are swallowed for the same reason (`warn` errors under
+    // warnings-as-errors).
+    quote! {
+        impl ::std::ops::Drop for #wrapper {
+            fn drop(&mut self) {
+                if self.closed.load(::std::sync::atomic::Ordering::SeqCst) {
+                    return;
+                }
+                let _ = ::pyo3::Python::try_attach(|py| {
+                    let category = py.get_type::<::pyo3::exceptions::PyResourceWarning>();
+                    let _ = ::pyo3::PyErr::warn(py, category.as_any(), #message, 1);
+                });
+            }
+        }
+    }
+}

--- a/packages/unibind/backend-py/src/sig.rs
+++ b/packages/unibind/backend-py/src/sig.rs
@@ -1,0 +1,179 @@
+//! Shared signature machinery for free functions, methods, and
+//! constructors: argument lowering (including buffer-protocol arguments),
+//! and the return conversion that routes streams and objects through their
+//! glue classes.
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::ctx::Ctx;
+use crate::{stream, ty, RenderError};
+
+/// A wrapper's argument surface, ready to splice into the generated `fn`.
+pub struct Args {
+    /// Wrapper parameters (`name: Ty`). A borrowed-bytes argument becomes
+    /// `PyBuffer<u8>` so Python passes any buffer-protocol object
+    /// zero-copy instead of forcing a `bytes` copy.
+    pub params: Vec<TokenStream>,
+    /// `#[pyo3(signature = ...)]` entries, defaults included.
+    pub signature: Vec<TokenStream>,
+    /// Statements before the user call: buffer contiguity checks plus the
+    /// borrowed-slice bindings.
+    pub prologue: TokenStream,
+    /// Argument identifiers forwarded to the user's function.
+    pub forwarded: Vec<TokenStream>,
+    /// Whether the prologue can fail: a buffer check forces a `PyResult`
+    /// return even on functions that do not throw.
+    pub fallible: bool,
+}
+
+pub fn lower_args(function: &ir::Function, ctx: &Ctx<'_>) -> Result<Args, RenderError> {
+    let mut args = Args {
+        params: Vec::new(),
+        signature: Vec::new(),
+        prologue: TokenStream::new(),
+        forwarded: Vec::new(),
+        fallible: false,
+    };
+    for arg in &function.args {
+        let ident = ty::name_ident(arg.names.py.as_ref().unwrap_or(&arg.name))?;
+        if matches!(arg.ty, ir::Type::Bytes { owned: false }) {
+            args.params.push(quote!(#ident: ::pyo3::buffer::PyBuffer<u8>));
+            args.prologue.extend(buffer_prologue(&ident, arg));
+            args.fallible = true;
+        } else {
+            let ty = ty::rust_type(&arg.ty, ctx.user);
+            args.params.push(quote!(#ident: #ty));
+        }
+        args.signature.push(signature_entry(arg, &ident));
+        args.forwarded.push(quote!(#ident));
+    }
+    Ok(args)
+}
+
+/// Turn a `PyBuffer<u8>` parameter into the `&[u8]` the user function
+/// expects. The slice shadows the buffer's name AFTER pointer and length
+/// are pulled into locals, so the `PyBuffer` itself (and the `Py_buffer`
+/// view keeping the exporter's memory alive) stays in scope for the whole
+/// call; only its name is taken over by the borrow.
+fn buffer_prologue(ident: &Ident, arg: &ir::Arg) -> TokenStream {
+    let py_name = arg.names.py.as_ref().unwrap_or(&arg.name);
+    let message = format!(
+        "argument `{py_name}` must be a C-contiguous buffer \
+         (bytes, bytearray, or a contiguous memoryview)"
+    );
+    // Raw identifiers (`r#type`) keep only the name part in the helpers.
+    let raw = ident.to_string();
+    let base = raw.trim_start_matches("r#");
+    let ptr = format_ident!("__unibind_{base}_ptr");
+    let len = format_ident!("__unibind_{base}_len");
+    // quote! cannot emit `//` comments, so the safety argument rides on the
+    // statement as an allow-with-reason the reader (and a user crate that
+    // denies `unsafe_code`) both see.
+    quote! {
+        if !#ident.is_c_contiguous() {
+            return ::pyo3::PyResult::Err(::pyo3::exceptions::PyBufferError::new_err(#message));
+        }
+        let #ptr = #ident.buf_ptr().cast::<u8>();
+        let #len = #ident.item_count();
+        #[allow(
+            unsafe_code,
+            reason = "SAFETY: contiguity was checked above, and the shadowed PyBuffer keeps \
+                      its Py_buffer view alive for the whole call, which the buffer protocol \
+                      contract says pins the exporter's memory unresized and unfreed"
+        )]
+        let #ident: &[u8] = unsafe { ::std::slice::from_raw_parts(#ptr, #len) };
+    }
+}
+
+fn signature_entry(arg: &ir::Arg, ident: &Ident) -> TokenStream {
+    if let Some(default) = &arg.default {
+        let default = ty::default_tokens(default);
+        return quote!(#ident = #default);
+    }
+    if matches!(arg.ty, ir::Type::Option(_)) {
+        return quote!(#ident = None);
+    }
+    quote!(#ident)
+}
+
+/// How a return value crosses: the wrapper's success type and, for streams
+/// and objects, the glue class the raw value is wrapped in.
+pub struct RetSpec {
+    pub ok_ty: TokenStream,
+    pub wrap: Option<Ident>,
+}
+
+/// `owner` is the object name for methods, `None` for free functions; the
+/// per-export stream class is named from it.
+pub fn ret_spec(function: &ir::Function, owner: Option<&str>, ctx: &Ctx<'_>) -> RetSpec {
+    match &function.ret {
+        None => RetSpec {
+            ok_ty: quote!(()),
+            wrap: None,
+        },
+        Some(ir::Type::Stream(_)) => {
+            let class = stream::class_ident(owner, &function.name);
+            RetSpec {
+                ok_ty: quote!(#class),
+                wrap: Some(class),
+            }
+        }
+        Some(ir::Type::Named(name)) if ctx.is_object(name) => {
+            let class = crate::ctx::object_wrapper_ident(name);
+            RetSpec {
+                ok_ty: quote!(#class),
+                wrap: Some(class),
+            }
+        }
+        Some(other) => RetSpec {
+            ok_ty: ty::rust_type(other, ctx.user),
+            wrap: None,
+        },
+    }
+}
+
+/// Route `value` through the glue class when the return needs wrapping.
+pub fn wrap_value(value: TokenStream, wrap: Option<&Ident>) -> TokenStream {
+    match wrap {
+        Some(class) => quote!(#class::__unibind_wrap(#value)),
+        None => value,
+    }
+}
+
+/// A wrapper's return type and body, which vary together on `throws` and
+/// on whether a buffer prologue can fail.
+pub struct BodyAndRet {
+    pub ret: TokenStream,
+    pub body: TokenStream,
+}
+
+/// Finish a sync body: `raw` is the expression producing the user's value
+/// (the plain call, or the `detach` closure around it).
+pub fn finish_sync(raw: &TokenStream, throws: bool, fallible: bool, ret: &RetSpec) -> BodyAndRet {
+    let ok_ty = &ret.ok_ty;
+    if throws {
+        let body = ret.wrap.as_ref().map_or_else(
+            || quote!(#raw.map_err(::pyo3::PyErr::from)),
+            |class| quote!(#raw.map(#class::__unibind_wrap).map_err(::pyo3::PyErr::from)),
+        );
+        return BodyAndRet {
+            ret: quote!(::pyo3::PyResult<#ok_ty>),
+            body,
+        };
+    }
+    let wrapped = wrap_value(raw.clone(), ret.wrap.as_ref());
+    if fallible {
+        // The buffer contiguity check can fail, so the wrapper returns
+        // PyResult even though the user function cannot.
+        return BodyAndRet {
+            ret: quote!(::pyo3::PyResult<#ok_ty>),
+            body: quote!(::pyo3::PyResult::Ok(#wrapped)),
+        };
+    }
+    BodyAndRet {
+        ret: quote!(#ok_ty),
+        body: wrapped,
+    }
+}

--- a/packages/unibind/backend-py/src/stream.rs
+++ b/packages/unibind/backend-py/src/stream.rs
@@ -1,0 +1,140 @@
+//! Per-export async-iterator classes for `UniStream` returns.
+//!
+//! Every stream-returning export gets its own `#[pyclass]`: the item type
+//! is baked into the class, so `__anext__` needs no downcasts and Python
+//! `isinstance` checks work per export.
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::ctx::Ctx;
+use crate::ty;
+
+/// One stream-returning export: the callable that produced it plus the
+/// item type its class yields.
+pub struct StreamExport<'a> {
+    /// `None` for free functions, the owning object's name for methods.
+    owner: Option<&'a str>,
+    function: &'a ir::Function,
+    item: &'a ir::Type,
+}
+
+/// Every stream-returning export in the interface, in render order (free
+/// functions first, then each object's methods).
+pub fn collect(interface: &ir::Interface) -> Vec<StreamExport<'_>> {
+    let free = interface
+        .functions
+        .iter()
+        .filter_map(|function| stream_export(None, function));
+    let methods = interface.objects.iter().flat_map(|object| {
+        object
+            .methods
+            .iter()
+            .filter_map(|method| stream_export(Some(object.name.as_str()), method))
+    });
+    free.chain(methods).collect()
+}
+
+fn stream_export<'a>(
+    owner: Option<&'a str>,
+    function: &'a ir::Function,
+) -> Option<StreamExport<'a>> {
+    let Some(ir::Type::Stream(item)) = &function.ret else {
+        return None;
+    };
+    Some(StreamExport {
+        owner,
+        function,
+        item,
+    })
+}
+
+impl StreamExport<'_> {
+    pub fn class_ident(&self) -> Ident {
+        class_ident(self.owner, &self.function.name)
+    }
+
+    pub fn render(&self, ctx: &Ctx<'_>) -> TokenStream {
+        let ident = self.class_ident();
+        let py_name = python_name(self.owner, &self.function.name);
+        let item_ty = ty::rust_type(self.item, ctx.user);
+        let produced = self.owner.map_or_else(
+            || self.function.name.clone(),
+            |object| format!("{object}.{}", self.function.name),
+        );
+        let doc_source = format!("Async iterator produced by `{produced}`.");
+        let doc_pull = "Pull-based: each `__anext__` polls exactly one item, so the \
+                        producer only runs as fast as the consumer awaits.";
+        quote! {
+            #[doc = #doc_source]
+            #[doc = ""]
+            #[doc = #doc_pull]
+            #[::pyo3::pyclass(name = #py_name, frozen)]
+            struct #ident {
+                stream: ::unibind_runtime::py::SharedStream<#item_ty>,
+            }
+            impl #ident {
+                fn __unibind_wrap(stream: ::unibind_runtime::UniStream<#item_ty>) -> Self {
+                    Self {
+                        stream: ::unibind_runtime::py::SharedStream::new(stream),
+                    }
+                }
+            }
+            #[::pyo3::pymethods]
+            impl #ident {
+                fn __aiter__(slf: ::pyo3::PyRef<'_, Self>) -> ::pyo3::PyRef<'_, Self> {
+                    slf
+                }
+                fn __anext__<'py>(
+                    &self,
+                    py: ::pyo3::Python<'py>,
+                ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+                    let next = self.stream.next();
+                    ::unibind_runtime::py::future_into_py(py, async move {
+                        match next.await {
+                            ::std::option::Option::Some(item) => ::pyo3::PyResult::Ok(item),
+                            ::std::option::Option::None => ::pyo3::PyResult::Err(
+                                ::pyo3::exceptions::PyStopAsyncIteration::new_err(()),
+                            ),
+                        }
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// The Rust identifier of a stream class. Export names are unique per
+/// scope (Rust enforces it), so classes cannot collide within a scope; a
+/// free function named exactly like an object+method concatenation would
+/// collide across scopes, and fails loudly as a duplicate item in the glue
+/// module rather than silently misbinding.
+pub fn class_ident(owner: Option<&str>, export: &str) -> Ident {
+    let export = pascal_case(export);
+    owner.map_or_else(
+        || format_ident!("UnibindStream{export}"),
+        |object| format_ident!("UnibindStream{object}{export}"),
+    )
+}
+
+/// The Python-visible class name: `TailStream` / `StoreRowsStream`.
+fn python_name(owner: Option<&str>, export: &str) -> String {
+    let export = pascal_case(export);
+    owner.map_or_else(
+        || format!("{export}Stream"),
+        |object| format!("{object}{export}Stream"),
+    )
+}
+
+/// `snake_case` -> `PascalCase` for export names.
+fn pascal_case(name: &str) -> String {
+    name.split('_')
+        .map(|segment| {
+            let mut chars = segment.chars();
+            chars.next().map_or_else(String::new, |first| {
+                first.to_ascii_uppercase().to_string() + chars.as_str()
+            })
+        })
+        .collect()
+}

--- a/packages/unibind/backend-py/src/ty.rs
+++ b/packages/unibind/backend-py/src/ty.rs
@@ -38,6 +38,10 @@ pub fn rust_type(ty: &ir::Type, user: &Ident) -> TokenStream {
             let name = Ident::new(name, Span::call_site());
             quote!(super::#user::#name)
         }
+        ir::Type::Stream(item) => {
+            let item = rust_type(item, user);
+            quote!(::unibind_runtime::UniStream<#item>)
+        }
     }
 }
 

--- a/packages/unibind/backend-py/tests/fixtures/sample.rs
+++ b/packages/unibind/backend-py/tests/fixtures/sample.rs
@@ -1,4 +1,4 @@
-/// A sample boundary exercising the phase 0 surface.
+/// A sample boundary exercising the phase 0-2 surface.
 mod sample {
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -49,5 +49,92 @@ mod sample {
     ) -> bool {
         let _ = (path, data, ratio, note, flush);
         true
+    }
+
+    /// Wait for one row.
+    pub async fn fetch_row(
+        id: u64,
+        #[unibind(default = 250)] timeout_ms: u64,
+    ) -> Result<Row, SampleError> {
+        let _ = (id, timeout_ms);
+        Err(SampleError::Invalid(String::new()))
+    }
+
+    /// Snapshot the head row.
+    pub async fn head() -> Row {
+        todo!()
+    }
+
+    /// Checksum data off the GIL.
+    #[unibind(blocking)]
+    pub fn digest(data: &[u8]) -> Vec<u8> {
+        data.to_vec()
+    }
+
+    /// Tick forever.
+    pub fn ticks(period_ms: u64) -> UniStream<u64> {
+        let _ = period_ms;
+        todo!()
+    }
+
+    /// Follow rows as they land.
+    pub async fn follow(store: String) -> Result<UniStream<Row>, SampleError> {
+        let _ = store;
+        todo!()
+    }
+
+    /// A live store handle.
+    #[unibind::object(resource)]
+    pub struct Store {
+        rows: u64,
+    }
+
+    impl Store {
+        /// Open a store.
+        #[unibind(constructor)]
+        pub fn open(path: &str) -> Result<Self, SampleError> {
+            let _ = path;
+            Err(SampleError::Invalid(String::new()))
+        }
+
+        /// Count rows.
+        pub fn len(&self) -> u64 {
+            self.rows
+        }
+
+        /// Pull one row.
+        pub async fn get(&self, id: u64) -> Result<Row, SampleError> {
+            let _ = id;
+            Err(SampleError::Invalid(String::new()))
+        }
+
+        /// Flush to disk.
+        #[unibind(py(name = "sync_all"))]
+        pub fn sync(&self) -> bool {
+            true
+        }
+
+        /// Release the store.
+        pub async fn close(&self) -> Result<(), SampleError> {
+            Ok(())
+        }
+    }
+
+    /// A cursor over rows.
+    #[unibind::object]
+    pub struct Cursor {
+        position: u64,
+    }
+
+    impl Cursor {
+        /// Step forward.
+        pub fn advance(&self, by: u64) -> u64 {
+            self.position + by
+        }
+    }
+
+    /// Open a cursor.
+    pub async fn cursor() -> Cursor {
+        Cursor { position: 0 }
     }
 }

--- a/packages/unibind/backend-py/tests/snapshots/sample.ir.json
+++ b/packages/unibind/backend-py/tests/snapshots/sample.ir.json
@@ -19,6 +19,7 @@
         "Docs become docstrings."
       ],
       "asyncness": "Sync",
+      "blocking": false,
       "args": [
         {
           "name": "store",
@@ -73,6 +74,7 @@
       },
       "docs": [],
       "asyncness": "Sync",
+      "blocking": false,
       "args": [
         {
           "name": "path",

--- a/packages/unibind/backend-py/tests/snapshots/sample.ir.json
+++ b/packages/unibind/backend-py/tests/snapshots/sample.ir.json
@@ -5,7 +5,7 @@
     "py": null
   },
   "docs": [
-    "A sample boundary exercising the phase 0 surface."
+    "A sample boundary exercising the phase 0-2 surface."
   ],
   "functions": [
     {
@@ -139,6 +139,168 @@
       ],
       "ret": "Bool",
       "throws": null
+    },
+    {
+      "name": "fetch_row",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Wait for one row."
+      ],
+      "asyncness": "Async",
+      "blocking": false,
+      "args": [
+        {
+          "name": "id",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Int": "U64"
+          },
+          "default": null
+        },
+        {
+          "name": "timeout_ms",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Int": "U64"
+          },
+          "default": {
+            "Int": 250
+          }
+        }
+      ],
+      "ret": {
+        "Named": "Row"
+      },
+      "throws": "SampleError"
+    },
+    {
+      "name": "head",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Snapshot the head row."
+      ],
+      "asyncness": "Async",
+      "blocking": false,
+      "args": [],
+      "ret": {
+        "Named": "Row"
+      },
+      "throws": null
+    },
+    {
+      "name": "digest",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Checksum data off the GIL."
+      ],
+      "asyncness": "Sync",
+      "blocking": true,
+      "args": [
+        {
+          "name": "data",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Bytes": {
+              "owned": false
+            }
+          },
+          "default": null
+        }
+      ],
+      "ret": {
+        "Bytes": {
+          "owned": true
+        }
+      },
+      "throws": null
+    },
+    {
+      "name": "ticks",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Tick forever."
+      ],
+      "asyncness": "Sync",
+      "blocking": false,
+      "args": [
+        {
+          "name": "period_ms",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Int": "U64"
+          },
+          "default": null
+        }
+      ],
+      "ret": {
+        "Stream": {
+          "Int": "U64"
+        }
+      },
+      "throws": null
+    },
+    {
+      "name": "follow",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Follow rows as they land."
+      ],
+      "asyncness": "Async",
+      "blocking": false,
+      "args": [
+        {
+          "name": "store",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "String": {
+              "owned": true
+            }
+          },
+          "default": null
+        }
+      ],
+      "ret": {
+        "Stream": {
+          "Named": "Row"
+        }
+      },
+      "throws": "SampleError"
+    },
+    {
+      "name": "cursor",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Open a cursor."
+      ],
+      "asyncness": "Async",
+      "blocking": false,
+      "args": [],
+      "ret": {
+        "Named": "Cursor"
+      },
+      "throws": null
     }
   ],
   "records": [
@@ -270,5 +432,156 @@
       ]
     }
   ],
-  "objects": []
+  "objects": [
+    {
+      "name": "Store",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "A live store handle."
+      ],
+      "resource": true,
+      "constructor": {
+        "name": "open",
+        "names": {
+          "py": null
+        },
+        "docs": [
+          "Open a store."
+        ],
+        "asyncness": "Sync",
+        "blocking": false,
+        "args": [
+          {
+            "name": "path",
+            "names": {
+              "py": null
+            },
+            "ty": {
+              "String": {
+                "owned": false
+              }
+            },
+            "default": null
+          }
+        ],
+        "ret": null,
+        "throws": "SampleError"
+      },
+      "methods": [
+        {
+          "name": "len",
+          "names": {
+            "py": null
+          },
+          "docs": [
+            "Count rows."
+          ],
+          "asyncness": "Sync",
+          "blocking": false,
+          "args": [],
+          "ret": {
+            "Int": "U64"
+          },
+          "throws": null
+        },
+        {
+          "name": "get",
+          "names": {
+            "py": null
+          },
+          "docs": [
+            "Pull one row."
+          ],
+          "asyncness": "Async",
+          "blocking": false,
+          "args": [
+            {
+              "name": "id",
+              "names": {
+                "py": null
+              },
+              "ty": {
+                "Int": "U64"
+              },
+              "default": null
+            }
+          ],
+          "ret": {
+            "Named": "Row"
+          },
+          "throws": "SampleError"
+        },
+        {
+          "name": "sync",
+          "names": {
+            "py": "sync_all"
+          },
+          "docs": [
+            "Flush to disk."
+          ],
+          "asyncness": "Sync",
+          "blocking": false,
+          "args": [],
+          "ret": "Bool",
+          "throws": null
+        },
+        {
+          "name": "close",
+          "names": {
+            "py": null
+          },
+          "docs": [
+            "Release the store."
+          ],
+          "asyncness": "Async",
+          "blocking": false,
+          "args": [],
+          "ret": null,
+          "throws": "SampleError"
+        }
+      ]
+    },
+    {
+      "name": "Cursor",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "A cursor over rows."
+      ],
+      "resource": false,
+      "constructor": null,
+      "methods": [
+        {
+          "name": "advance",
+          "names": {
+            "py": null
+          },
+          "docs": [
+            "Step forward."
+          ],
+          "asyncness": "Sync",
+          "blocking": false,
+          "args": [
+            {
+              "name": "by",
+              "names": {
+                "py": null
+              },
+              "ty": {
+                "Int": "U64"
+              },
+              "default": null
+            }
+          ],
+          "ret": {
+            "Int": "U64"
+          },
+          "throws": null
+        }
+      ]
+    }
+  ]
 }

--- a/packages/unibind/backend-py/tests/snapshots/sample.py.rs
+++ b/packages/unibind/backend-py/tests/snapshots/sample.py.rs
@@ -67,14 +67,338 @@ mod __unibind_py_sample {
     #[pyo3(signature = (path, data, ratio = 0.5, note = "note", flush = false))]
     fn touch(
         path: &::std::path::Path,
-        data: &[u8],
+        data: ::pyo3::buffer::PyBuffer<u8>,
         ratio: f64,
         note: &str,
         flush: bool,
-    ) -> bool {
-        super::sample::touch(path, data, ratio, note, flush)
+    ) -> ::pyo3::PyResult<bool> {
+        if !data.is_c_contiguous() {
+            return ::pyo3::PyResult::Err(
+                ::pyo3::exceptions::PyBufferError::new_err(
+                    "argument `data` must be a C-contiguous buffer (bytes, bytearray, or a contiguous memoryview)",
+                ),
+            );
+        }
+        let __unibind_data_ptr = data.buf_ptr().cast::<u8>();
+        let __unibind_data_len = data.item_count();
+        #[allow(
+            unsafe_code,
+            reason = "SAFETY: contiguity was checked above, and the shadowed PyBuffer keeps \
+                      its Py_buffer view alive for the whole call, which the buffer protocol \
+                      contract says pins the exporter's memory unresized and unfreed"
+        )]
+        let data: &[u8] = unsafe {
+            ::std::slice::from_raw_parts(__unibind_data_ptr, __unibind_data_len)
+        };
+        ::pyo3::PyResult::Ok(super::sample::touch(path, data, ratio, note, flush))
     }
-    ///A sample boundary exercising the phase 0 surface.
+    ///Wait for one row.
+    #[::pyo3::pyfunction]
+    #[pyo3(signature = (id, timeout_ms = 250))]
+    fn fetch_row<'py>(
+        py: ::pyo3::Python<'py>,
+        id: u64,
+        timeout_ms: u64,
+    ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+        ::unibind_runtime::py::future_into_py(
+            py,
+            async move {
+                super::sample::fetch_row(id, timeout_ms)
+                    .await
+                    .map_err(::pyo3::PyErr::from)
+            },
+        )
+    }
+    ///Snapshot the head row.
+    #[::pyo3::pyfunction]
+    #[pyo3(signature = ())]
+    fn head<'py>(
+        py: ::pyo3::Python<'py>,
+    ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+        ::unibind_runtime::py::future_into_py(
+            py,
+            async move { ::pyo3::PyResult::Ok(super::sample::head().await) },
+        )
+    }
+    ///Checksum data off the GIL.
+    #[::pyo3::pyfunction]
+    #[pyo3(signature = (data))]
+    fn digest(
+        py: ::pyo3::Python<'_>,
+        data: ::pyo3::buffer::PyBuffer<u8>,
+    ) -> ::pyo3::PyResult<::std::vec::Vec<u8>> {
+        if !data.is_c_contiguous() {
+            return ::pyo3::PyResult::Err(
+                ::pyo3::exceptions::PyBufferError::new_err(
+                    "argument `data` must be a C-contiguous buffer (bytes, bytearray, or a contiguous memoryview)",
+                ),
+            );
+        }
+        let __unibind_data_ptr = data.buf_ptr().cast::<u8>();
+        let __unibind_data_len = data.item_count();
+        #[allow(
+            unsafe_code,
+            reason = "SAFETY: contiguity was checked above, and the shadowed PyBuffer keeps \
+                      its Py_buffer view alive for the whole call, which the buffer protocol \
+                      contract says pins the exporter's memory unresized and unfreed"
+        )]
+        let data: &[u8] = unsafe {
+            ::std::slice::from_raw_parts(__unibind_data_ptr, __unibind_data_len)
+        };
+        ::pyo3::PyResult::Ok(py.detach(move || super::sample::digest(data)))
+    }
+    ///Tick forever.
+    #[::pyo3::pyfunction]
+    #[pyo3(signature = (period_ms))]
+    fn ticks(period_ms: u64) -> UnibindStreamTicks {
+        UnibindStreamTicks::__unibind_wrap(super::sample::ticks(period_ms))
+    }
+    ///Follow rows as they land.
+    #[::pyo3::pyfunction]
+    #[pyo3(signature = (store))]
+    fn follow<'py>(
+        py: ::pyo3::Python<'py>,
+        store: ::std::string::String,
+    ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+        ::unibind_runtime::py::future_into_py(
+            py,
+            async move {
+                super::sample::follow(store)
+                    .await
+                    .map(UnibindStreamFollow::__unibind_wrap)
+                    .map_err(::pyo3::PyErr::from)
+            },
+        )
+    }
+    ///Open a cursor.
+    #[::pyo3::pyfunction]
+    #[pyo3(signature = ())]
+    fn cursor<'py>(
+        py: ::pyo3::Python<'py>,
+    ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+        ::unibind_runtime::py::future_into_py(
+            py,
+            async move {
+                ::pyo3::PyResult::Ok(
+                    UnibindObjectCursor::__unibind_wrap(super::sample::cursor().await),
+                )
+            },
+        )
+    }
+    ///A live store handle.
+    #[::pyo3::pyclass(name = "Store", frozen)]
+    struct UnibindObjectStore {
+        inner: ::std::sync::Arc<super::sample::Store>,
+        closed: ::std::sync::atomic::AtomicBool,
+    }
+    impl UnibindObjectStore {
+        fn __unibind_wrap(inner: super::sample::Store) -> Self {
+            Self {
+                inner: ::std::sync::Arc::new(inner),
+                closed: ::std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+    }
+    #[::pyo3::pymethods]
+    impl UnibindObjectStore {
+        ///Open a store.
+        #[new]
+        #[pyo3(signature = (path))]
+        fn __unibind_new(path: &str) -> ::pyo3::PyResult<Self> {
+            super::sample::Store::open(path)
+                .map(Self::__unibind_wrap)
+                .map_err(::pyo3::PyErr::from)
+        }
+        ///Count rows.
+        #[pyo3(signature = ())]
+        fn len(&self) -> u64 {
+            self.inner.len()
+        }
+        ///Pull one row.
+        #[pyo3(signature = (id))]
+        fn get<'py>(
+            &self,
+            py: ::pyo3::Python<'py>,
+            id: u64,
+        ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+            let inner = ::std::sync::Arc::clone(&self.inner);
+            ::unibind_runtime::py::future_into_py(
+                py,
+                async move { inner.get(id).await.map_err(::pyo3::PyErr::from) },
+            )
+        }
+        ///Flush to disk.
+        #[pyo3(name = "sync_all")]
+        #[pyo3(signature = ())]
+        fn sync(&self) -> bool {
+            self.inner.sync()
+        }
+        ///Release the store.
+        fn close<'py>(
+            &self,
+            py: ::pyo3::Python<'py>,
+        ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+            let first = !self.closed.swap(true, ::std::sync::atomic::Ordering::SeqCst);
+            let inner = ::std::sync::Arc::clone(&self.inner);
+            ::unibind_runtime::py::future_into_py(
+                py,
+                async move {
+                    if first {
+                        inner.close().await.map_err(::pyo3::PyErr::from)?;
+                    }
+                    ::pyo3::PyResult::Ok(())
+                },
+            )
+        }
+        ///Enter `async with`: resolves to the object itself.
+        fn __aenter__<'py>(
+            slf: ::pyo3::Bound<'py, Self>,
+        ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+            let py = slf.py();
+            let owned: ::pyo3::Py<Self> = slf.unbind();
+            ::unibind_runtime::py::future_into_py(
+                py,
+                async move { ::pyo3::PyResult::Ok(owned) },
+            )
+        }
+        ///Exit `async with`: closes the resource, never suppresses the exception.
+        fn __aexit__<'py>(
+            &self,
+            py: ::pyo3::Python<'py>,
+            _exc_type: ::pyo3::Bound<'py, ::pyo3::PyAny>,
+            _exc: ::pyo3::Bound<'py, ::pyo3::PyAny>,
+            _tb: ::pyo3::Bound<'py, ::pyo3::PyAny>,
+        ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+            let first = !self.closed.swap(true, ::std::sync::atomic::Ordering::SeqCst);
+            let inner = ::std::sync::Arc::clone(&self.inner);
+            ::unibind_runtime::py::future_into_py(
+                py,
+                async move {
+                    if first {
+                        inner.close().await.map_err(::pyo3::PyErr::from)?;
+                    }
+                    ::pyo3::PyResult::Ok(false)
+                },
+            )
+        }
+    }
+    impl ::std::ops::Drop for UnibindObjectStore {
+        fn drop(&mut self) {
+            if self.closed.load(::std::sync::atomic::Ordering::SeqCst) {
+                return;
+            }
+            let _ = ::pyo3::Python::try_attach(|py| {
+                let category = py.get_type::<::pyo3::exceptions::PyResourceWarning>();
+                let _ = ::pyo3::PyErr::warn(
+                    py,
+                    category.as_any(),
+                    c"unclosed Store: call close() or use 'async with'",
+                    1,
+                );
+            });
+        }
+    }
+    ///A cursor over rows.
+    #[::pyo3::pyclass(name = "Cursor", frozen)]
+    struct UnibindObjectCursor {
+        inner: ::std::sync::Arc<super::sample::Cursor>,
+    }
+    impl UnibindObjectCursor {
+        fn __unibind_wrap(inner: super::sample::Cursor) -> Self {
+            Self {
+                inner: ::std::sync::Arc::new(inner),
+            }
+        }
+    }
+    #[::pyo3::pymethods]
+    impl UnibindObjectCursor {
+        ///Step forward.
+        #[pyo3(signature = (by))]
+        fn advance(&self, by: u64) -> u64 {
+            self.inner.advance(by)
+        }
+    }
+    ///Async iterator produced by `ticks`.
+    ///
+    ///Pull-based: each `__anext__` polls exactly one item, so the producer only runs as fast as the consumer awaits.
+    #[::pyo3::pyclass(name = "TicksStream", frozen)]
+    struct UnibindStreamTicks {
+        stream: ::unibind_runtime::py::SharedStream<u64>,
+    }
+    impl UnibindStreamTicks {
+        fn __unibind_wrap(stream: ::unibind_runtime::UniStream<u64>) -> Self {
+            Self {
+                stream: ::unibind_runtime::py::SharedStream::new(stream),
+            }
+        }
+    }
+    #[::pyo3::pymethods]
+    impl UnibindStreamTicks {
+        fn __aiter__(slf: ::pyo3::PyRef<'_, Self>) -> ::pyo3::PyRef<'_, Self> {
+            slf
+        }
+        fn __anext__<'py>(
+            &self,
+            py: ::pyo3::Python<'py>,
+        ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+            let next = self.stream.next();
+            ::unibind_runtime::py::future_into_py(
+                py,
+                async move {
+                    match next.await {
+                        ::std::option::Option::Some(item) => ::pyo3::PyResult::Ok(item),
+                        ::std::option::Option::None => {
+                            ::pyo3::PyResult::Err(
+                                ::pyo3::exceptions::PyStopAsyncIteration::new_err(()),
+                            )
+                        }
+                    }
+                },
+            )
+        }
+    }
+    ///Async iterator produced by `follow`.
+    ///
+    ///Pull-based: each `__anext__` polls exactly one item, so the producer only runs as fast as the consumer awaits.
+    #[::pyo3::pyclass(name = "FollowStream", frozen)]
+    struct UnibindStreamFollow {
+        stream: ::unibind_runtime::py::SharedStream<super::sample::Row>,
+    }
+    impl UnibindStreamFollow {
+        fn __unibind_wrap(
+            stream: ::unibind_runtime::UniStream<super::sample::Row>,
+        ) -> Self {
+            Self {
+                stream: ::unibind_runtime::py::SharedStream::new(stream),
+            }
+        }
+    }
+    #[::pyo3::pymethods]
+    impl UnibindStreamFollow {
+        fn __aiter__(slf: ::pyo3::PyRef<'_, Self>) -> ::pyo3::PyRef<'_, Self> {
+            slf
+        }
+        fn __anext__<'py>(
+            &self,
+            py: ::pyo3::Python<'py>,
+        ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
+            let next = self.stream.next();
+            ::unibind_runtime::py::future_into_py(
+                py,
+                async move {
+                    match next.await {
+                        ::std::option::Option::Some(item) => ::pyo3::PyResult::Ok(item),
+                        ::std::option::Option::None => {
+                            ::pyo3::PyResult::Err(
+                                ::pyo3::exceptions::PyStopAsyncIteration::new_err(()),
+                            )
+                        }
+                    }
+                },
+            )
+        }
+    }
+    ///A sample boundary exercising the phase 0-2 surface.
     #[::pyo3::pymodule]
     #[pyo3(name = "sample")]
     fn __unibind_module(
@@ -82,7 +406,17 @@ mod __unibind_py_sample {
     ) -> ::pyo3::PyResult<()> {
         module.add_function(::pyo3::wrap_pyfunction!(rows, module)?)?;
         module.add_function(::pyo3::wrap_pyfunction!(touch, module)?)?;
+        module.add_function(::pyo3::wrap_pyfunction!(fetch_row, module)?)?;
+        module.add_function(::pyo3::wrap_pyfunction!(head, module)?)?;
+        module.add_function(::pyo3::wrap_pyfunction!(digest, module)?)?;
+        module.add_function(::pyo3::wrap_pyfunction!(ticks, module)?)?;
+        module.add_function(::pyo3::wrap_pyfunction!(follow, module)?)?;
+        module.add_function(::pyo3::wrap_pyfunction!(cursor, module)?)?;
         module.add_class::<super::sample::Row>()?;
+        module.add_class::<UnibindObjectStore>()?;
+        module.add_class::<UnibindObjectCursor>()?;
+        module.add_class::<UnibindStreamTicks>()?;
+        module.add_class::<UnibindStreamFollow>()?;
         module.add("SampleError", module.py().get_type::<SampleError>())?;
         module.add("StoreGoneError", module.py().get_type::<StoreGoneError>())?;
         module.add("Invalid", module.py().get_type::<Invalid>())?;
@@ -90,3 +424,4 @@ mod __unibind_py_sample {
         ::pyo3::PyResult::Ok(())
     }
 }
+

--- a/packages/unibind/conformance/Cargo.toml
+++ b/packages/unibind/conformance/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "unibind-conformance"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Runtime conformance surface for the unibind Python backend: cancellation, streams, resources, GIL"
+
+[lib]
+name = "unibind_conformance"
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+futures.workspace = true
+pyo3 = { workspace = true, features = ["extension-module"] }
+tokio = { workspace = true, features = ["time"] }
+unibind = { workspace = true, features = ["py"] }
+unibind-runtime = { workspace = true, features = ["py"] }

--- a/packages/unibind/conformance/build.rs
+++ b/packages/unibind/conformance/build.rs
@@ -1,0 +1,13 @@
+//! Emit the macOS-only `-undefined dynamic_lookup` link flag that `PyO3`
+//! extension modules need: macOS rejects undefined symbols in a dylib, while
+//! Linux allows them. Scoped to the cdylib via the single-colon
+//! `rustc-cdylib-link-arg` directive that both `cargo` and `nix-cargo-unit`
+//! honor. Mirrors astlog-py / search-py; scipql-py instead rides the
+//! registry's `pyExtension` marker, which only covers nix workspace
+//! builds, while the conformance loop also links via plain `cargo build`.
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-cdylib-link-arg=-undefined");
+        println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+    }
+}

--- a/packages/unibind/conformance/default.nix
+++ b/packages/unibind/conformance/default.nix
@@ -1,0 +1,56 @@
+{
+  ix,
+  pkgs ? ix.pkgs,
+}:
+# The conformance crate ships nothing: the PyO3 cdylib comes from the shared
+# cargo-unit workspace graph, and the only artifact worth building is the
+# proof that the generated Python surface behaves. This derivation *is* that
+# proof: install the cdylib as `_conformance.abi3.so`, point the pinned
+# interpreter at it, and run `runner.py` (cancellation, backpressure,
+# resource cleanup, zero-copy, GIL release, panic containment). It is also
+# exposed as `passthru.tests.run` so it joins the CI check set as
+# `checks.<system>.unibind-conformance-run`.
+let
+  run =
+    pkgs.runCommand "unibind-conformance-run"
+    {
+      strictDeps = true;
+      meta.description = "unibind phase-2 conformance runner over the generated Python bindings";
+    }
+    ''
+      set -o pipefail
+      site="$PWD/site"
+      mkdir -p "$site"
+      cdylib=""
+      for candidate in \
+        ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib/libunibind_conformance.so \
+        ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib/libunibind_conformance-*.so \
+        ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib/libunibind_conformance.dylib \
+        ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib/libunibind_conformance-*.dylib
+      do
+        if [ -f "$candidate" ]; then
+          cdylib="$candidate"
+          break
+        fi
+      done
+      if [ -z "$cdylib" ]; then
+        echo "unibind-conformance: no cdylib under ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib" >&2
+        ls -la ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib >&2 || true
+        exit 1
+      fi
+      install -m555 "$cdylib" "$site/_conformance.abi3.so"
+      PYTHONPATH="$site" ${pkgs.python3.interpreter} ${./runner.py} 2>&1 | tee conformance.log
+      touch $out
+    '';
+in
+  run.overrideAttrs (old: {
+    passthru =
+      (old.passthru or {})
+      // {
+        tests =
+          (old.passthru.tests or {})
+          // {
+            inherit run;
+          };
+      };
+  })

--- a/packages/unibind/conformance/package.nix
+++ b/packages/unibind/conformance/package.nix
@@ -1,0 +1,14 @@
+{
+  id = "unibind-conformance";
+  inRustWorkspace = true;
+  # Nothing to ship: the crate exists to prove the generated Python surface
+  # behaves (cancellation drops the future, streams pull, resources close,
+  # buffers cross zero-copy), and default.nix wraps that proof in a runnable
+  # check. The packageSet entry only exists so the registry resolves its
+  # `passthru.tests` for the CI gate below.
+  packageSet = true;
+  # Gate the runner as `checks.<system>.unibind-conformance-run`.
+  passthruTests = {
+    prefix = "unibind-conformance";
+  };
+}

--- a/packages/unibind/conformance/runner.py
+++ b/packages/unibind/conformance/runner.py
@@ -1,0 +1,246 @@
+"""Drive the unibind phase-2 conformance surface and print a case matrix.
+
+Each case prints ``CASE <name>... ok (<evidence>)``; a failure prints the
+traceback and flips the exit code. Only the stdlib is used so the nix check
+needs nothing beyond the pinned interpreter and the built cdylib.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import ctypes
+import gc
+import threading
+import time
+import traceback
+import warnings
+from collections.abc import Awaitable, Callable
+
+import _conformance as conf
+
+
+def _addr_of(buffer: bytearray) -> int:
+    """Address of the first byte of ``buffer``, via a ctypes buffer export."""
+    view = (ctypes.c_char * len(buffer)).from_buffer(buffer)
+    address = ctypes.addressof(view)
+    del view
+    return address
+
+
+async def case_echo_types() -> str:
+    """Every scalar/container/record round-trips; errors map to ValueError."""
+    truthy = True
+    assert conf.echo_bool(truthy) is True
+    assert conf.echo_int(-(2**40)) == -(2**40)
+    assert conf.echo_float(3.5) == 3.5
+    assert conf.echo_str("héllo") == "héllo"
+    assert conf.echo_bytes(b"\x00\xffab") == b"\x00\xffab"
+    assert conf.echo_option(None) is None
+    assert conf.echo_option(7) == 7
+    assert conf.echo_vec([1, 2, 3]) == [1, 2, 3]
+    assert conf.echo_map({"a": 1.5, "b": -2.0}) == {"a": 1.5, "b": -2.0}
+    point = conf.echo_record(conf.Point(1.25, -4.5))
+    assert (point.x, point.y) == (1.25, -4.5)
+    assert conf.add_with_default(10) == 42
+    assert conf.add_with_default(10, 5) == 15
+    assert await conf.sleep_ms_then(10, 99) == 99
+    caught: ValueError | None = None
+    try:
+        conf.throw_value_error()
+    except ValueError as exc:
+        caught = exc
+    assert caught is not None, "throw_value_error did not raise"
+    assert isinstance(caught, conf.ConformanceError)
+    message = str(caught)
+    return f"all round-trips exact; raised {message!r} as ValueError subclass"
+
+
+async def case_cancel_mid_flight() -> str:
+    """asyncio cancellation must drop the in-flight Rust future."""
+    task = asyncio.ensure_future(conf.hold_guard_forever())
+    await asyncio.sleep(0.2)
+    live, dropped = conf.live_guards(), conf.dropped_guards()
+    assert (live, dropped) == (1, 0), f"pre-cancel live={live} dropped={dropped}"
+    started = time.monotonic()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    # Bounded poll (~2s): the Drop runs on a tokio worker, so give it a
+    # beat to land after the cancelled await returns.
+    for _ in range(200):
+        if conf.dropped_guards() != 0:
+            break
+        await asyncio.sleep(0.01)
+    elapsed_ms = (time.monotonic() - started) * 1000.0
+    live, dropped = conf.live_guards(), conf.dropped_guards()
+    assert (live, dropped) == (0, 1), f"post-cancel live={live} dropped={dropped}"
+    return f"live 1->0, dropped 0->1; Drop observed {elapsed_ms:.1f}ms after cancel()"
+
+
+async def case_stream_backpressure() -> str:
+    """Streams are pull-based: production tracks consumption, not creation."""
+    base = conf.produced_count()
+    stream = conf.counting_stream(1000)
+    consumed: list[int] = []
+    async for item in stream:
+        consumed.append(item)
+        if len(consumed) == 3:
+            break
+    produced = conf.produced_count() - base
+    assert consumed == [0, 1, 2], f"consumed {consumed}"
+    assert produced <= 4, f"produced {produced} for 3 consumed"
+    await asyncio.sleep(0.2)
+    settled = conf.produced_count() - base
+    assert settled == produced, f"idle production: {produced} -> {settled}"
+    del stream
+    gc.collect()
+    small_base = conf.produced_count()
+    drained = [item async for item in conf.counting_stream(5)]
+    assert drained == [0, 1, 2, 3, 4], f"drained {drained}"
+    assert conf.produced_count() - small_base == 5
+    records = await conf.record_stream(3)
+    points = [(point.x, point.y) async for point in records]
+    assert points == [(0.0, -0.0), (1.0, -1.0), (2.0, -2.0)], f"points {points}"
+    return (
+        f"consumed=3 produced={produced}, unchanged after 0.2s idle; "
+        f"counting_stream(5) drained in order to StopAsyncIteration; "
+        f"record stream yielded {points}"
+    )
+
+
+async def case_resource_lifecycle() -> str:
+    """Leaked resources warn; async-with and explicit close are clean."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        leaky = conf.Gate("leaky")
+        assert leaky.is_open()
+        assert await leaky.ping(10) == 10
+        del leaky
+        gc.collect()
+    leak_warnings = [
+        warning
+        for warning in caught
+        if issubclass(warning.category, ResourceWarning) and "Gate" in str(warning.message)
+    ]
+    texts = [str(warning.message) for warning in caught]
+    assert len(leak_warnings) == 1, f"expected one Gate ResourceWarning, saw {texts}"
+    leak_text = str(leak_warnings[0].message)
+
+    closed_base = conf.closed_gates()
+    with warnings.catch_warnings(record=True) as clean_caught:
+        warnings.simplefilter("always")
+        async with conf.Gate("clean") as gate:
+            assert gate.is_open()
+            assert gate.label() == "clean"
+        assert not gate.is_open()
+        assert conf.closed_gates() == closed_base + 1
+        idempotent = conf.Gate("idempotent")
+        await idempotent.close()
+        await idempotent.close()
+        assert conf.closed_gates() == closed_base + 2, "double close closed twice"
+        del gate, idempotent
+        gc.collect()
+    stray = [
+        str(warning.message)
+        for warning in clean_caught
+        if issubclass(warning.category, ResourceWarning)
+    ]
+    assert stray == [], f"clean paths warned: {stray}"
+    try:
+        conf.Gate("")
+    except ValueError as exc:
+        constructor_error = str(exc)
+    else:
+        raise AssertionError("empty label did not raise")
+    return (
+        f"leak warned once: {leak_text!r}; async-with closed exactly once and "
+        f"double close() bumped once; empty label raised {constructor_error!r}"
+    )
+
+
+async def case_zero_copy_gil() -> str:
+    """&[u8] args alias Python memory; blocking fns release the GIL."""
+    payload = bytearray(b"unibind" * 1024)
+    expected_addr = _addr_of(payload)
+    direct = conf.buffer_addr(payload)
+    through_view = conf.buffer_addr(memoryview(payload))
+    assert direct == expected_addr, f"bytearray copied: 0x{direct:x} != 0x{expected_addr:x}"
+    assert through_view == expected_addr, f"memoryview copied: 0x{through_view:x}"
+    started = time.monotonic()
+    workers = [
+        threading.Thread(target=conf.blocking_sleep_ms, args=(300,)) for _ in range(2)
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+    wall_ms = (time.monotonic() - started) * 1000.0
+    # Serialized (GIL held) would be >=600ms; overlapped is ~300ms.
+    assert wall_ms < 550.0, f"wall {wall_ms:.0f}ms suggests the GIL stayed held"
+    total = conf.checksum(payload)
+    assert total == sum(payload), f"checksum {total} != {sum(payload)}"
+    return (
+        f"buffer@0x{expected_addr:x} matches buffer_addr for bytearray and "
+        f"memoryview; 2x300ms blocking sleeps walled {wall_ms:.0f}ms; "
+        f"checksum {total} == python sum"
+    )
+
+
+async def case_panic_containment() -> str:
+    """Rust panics surface as catchable exceptions; the interpreter survives."""
+    # except BaseException: pyo3's PanicException deliberately derives it.
+    sync_error: BaseException | None = None
+    try:
+        conf.panic_sync()
+    except BaseException as exc:
+        sync_error = exc
+    assert sync_error is not None, "panic_sync did not raise"
+    assert "deliberate sync panic" in str(sync_error), f"sync message: {sync_error}"
+    sync_name = type(sync_error).__name__
+    async_error: BaseException | None = None
+    try:
+        await conf.panic_async()
+    except BaseException as exc:
+        async_error = exc
+    assert async_error is not None, "panic_async did not raise"
+    assert "deliberate async panic" in str(async_error), f"async message: {async_error}"
+    async_name = type(async_error).__name__
+    assert conf.echo_int(1) == 1
+    return f"sync panic -> {sync_name}, async panic -> {async_name}; interpreter still live"
+
+
+CASES: tuple[tuple[str, Callable[[], Awaitable[str]]], ...] = (
+    ("echo-types", case_echo_types),
+    ("cancel-mid-flight", case_cancel_mid_flight),
+    ("stream-backpressure", case_stream_backpressure),
+    ("drop-without-close", case_resource_lifecycle),
+    ("zero-copy-gil", case_zero_copy_gil),
+    ("panic-containment", case_panic_containment),
+)
+
+
+async def _run_all() -> int:
+    failures = 0
+    for name, case in CASES:
+        try:
+            evidence = await case()
+        except BaseException:  # report every failure, keep going
+            failures += 1
+            print(f"CASE {name}... FAIL")
+            traceback.print_exc()
+        else:
+            print(f"CASE {name}... ok ({evidence})")
+    return failures
+
+
+def main() -> None:
+    """Run every case; exit non-zero if any failed."""
+    failures = asyncio.run(_run_all())
+    if failures:
+        raise SystemExit(f"{failures} conformance case(s) failed")
+    print(f"conformance: all {len(CASES)} cases passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/unibind/conformance/src/lib.rs
+++ b/packages/unibind/conformance/src/lib.rs
@@ -1,0 +1,291 @@
+//! Conformance surface for the unibind Python backend (phase 2, #1992).
+//!
+//! Every export here exists so `runner.py` can prove one boundary behavior
+//! from Python: asyncio cancellation drops the Rust future, streams are
+//! pull-based, resources close deterministically (and warn when leaked),
+//! `&[u8]` crosses zero-copy, and `blocking` releases the GIL. The globals
+//! are the observable side of behaviors that would otherwise be invisible
+//! across the boundary.
+
+/// The exported boundary. The module name names the `PyInit_` symbol, so
+/// the built cdylib imports as `_conformance`.
+#[unibind::export]
+mod _conformance {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::time::Duration;
+
+    use unibind_runtime::UniStream;
+
+    /// A plain-data record crossing the boundary by value.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Point {
+        /// Horizontal coordinate.
+        pub x: f64,
+        /// Vertical coordinate.
+        pub y: f64,
+    }
+
+    /// Boundary failures raised by the conformance surface.
+    #[unibind::error(py(base = "ValueError"))]
+    #[derive(Debug)]
+    pub enum ConformanceError {
+        /// A deliberate failure for exception-mapping tests.
+        Deliberate { message: String },
+    }
+
+    impl std::fmt::Display for ConformanceError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deliberate { message } => write!(formatter, "{message}"),
+            }
+        }
+    }
+
+    impl std::error::Error for ConformanceError {}
+
+    /// Round-trip a bool.
+    pub fn echo_bool(value: bool) -> bool {
+        value
+    }
+
+    /// Round-trip an int.
+    pub fn echo_int(value: i64) -> i64 {
+        value
+    }
+
+    /// Round-trip a float.
+    pub fn echo_float(value: f64) -> f64 {
+        value
+    }
+
+    /// Round-trip a string.
+    pub fn echo_str(value: String) -> String {
+        value
+    }
+
+    /// Round-trip bytes; the argument view is copied into an owned return.
+    pub fn echo_bytes(data: &[u8]) -> Vec<u8> {
+        data.to_vec()
+    }
+
+    /// Round-trip an optional int.
+    pub fn echo_option(value: Option<i64>) -> Option<i64> {
+        value
+    }
+
+    /// Round-trip a list of ints.
+    pub fn echo_vec(values: Vec<i64>) -> Vec<i64> {
+        values
+    }
+
+    /// Round-trip a string-keyed map of floats.
+    pub fn echo_map(values: HashMap<String, f64>) -> HashMap<String, f64> {
+        values
+    }
+
+    /// Round-trip a record.
+    pub fn echo_record(point: Point) -> Point {
+        point
+    }
+
+    /// Add with a defaulted second operand, proving `#[unibind(default)]`.
+    pub fn add_with_default(value: i64, #[unibind(default = 32)] delta: i64) -> i64 {
+        value + delta
+    }
+
+    /// Raise the generated `ValueError` subclass.
+    ///
+    /// # Errors
+    ///
+    /// Always: proving the enum maps onto the exception hierarchy is the
+    /// point.
+    pub fn throw_value_error() -> Result<(), ConformanceError> {
+        Err(ConformanceError::Deliberate {
+            message: "conformance deliberate failure".to_owned(),
+        })
+    }
+
+    /// Address of the first byte as Rust sees the buffer; Python compares
+    /// it against `ctypes.addressof` to prove no copy happened.
+    pub fn buffer_addr(data: &[u8]) -> usize {
+        data.as_ptr() as usize
+    }
+
+    /// Sleep on the calling thread with the GIL released; two Python
+    /// threads overlapping is the observable proof of `blocking`.
+    #[unibind(blocking)]
+    pub fn blocking_sleep_ms(ms: u64) {
+        std::thread::sleep(Duration::from_millis(ms));
+    }
+
+    /// Wrapping byte sum, computed off the GIL.
+    #[unibind(blocking)]
+    pub fn checksum(data: &[u8]) -> u64 {
+        data.iter()
+            .fold(0u64, |acc, byte| acc.wrapping_add(u64::from(*byte)))
+    }
+
+    static LIVE: AtomicU64 = AtomicU64::new(0);
+    static DROPPED: AtomicU64 = AtomicU64::new(0);
+
+    /// Cancellation probe: the only way `DROPPED` moves is this guard being
+    /// dropped, which is exactly what asyncio cancellation must cause on
+    /// the Rust future holding it. (No inherent impl: inside an exported
+    /// module those are reserved for `#[unibind::object]` types.)
+    struct DropGuard;
+
+    impl Drop for DropGuard {
+        fn drop(&mut self) {
+            LIVE.fetch_sub(1, Ordering::SeqCst);
+            DROPPED.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Hold a `DropGuard` across a sleep that never ends on its own; only
+    /// cancellation from Python can release it.
+    pub async fn hold_guard_forever() {
+        LIVE.fetch_add(1, Ordering::SeqCst);
+        let _guard = DropGuard;
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+    }
+
+    /// Guards currently alive.
+    pub fn live_guards() -> u64 {
+        LIVE.load(Ordering::SeqCst)
+    }
+
+    /// Guards dropped so far.
+    pub fn dropped_guards() -> u64 {
+        DROPPED.load(Ordering::SeqCst)
+    }
+
+    /// Sleep `ms`, then resolve to `value`: the plain async round-trip.
+    pub async fn sleep_ms_then(ms: u64, value: i64) -> i64 {
+        tokio::time::sleep(Duration::from_millis(ms)).await;
+        value
+    }
+
+    static PRODUCED: AtomicU64 = AtomicU64::new(0);
+
+    /// Yield `0..n`, bumping `PRODUCED` once per yielded item. The stream is
+    /// pull-based, so the counter tracks consumer demand: after three
+    /// `__anext__` calls it must read (about) three, not `n`.
+    pub fn counting_stream(n: u64) -> UniStream<u64> {
+        UniStream::new(futures::stream::unfold(0u64, move |state| async move {
+            if state >= n {
+                return None;
+            }
+            PRODUCED.fetch_add(1, Ordering::SeqCst);
+            Some((state, state + 1))
+        }))
+    }
+
+    /// Items produced across every `counting_stream` so far.
+    pub fn produced_count() -> u64 {
+        PRODUCED.load(Ordering::SeqCst)
+    }
+
+    /// A stream of records behind an async fn, covering the
+    /// `async fn -> UniStream<record>` composition.
+    pub async fn record_stream(n: u64) -> UniStream<Point> {
+        // Conformance indices stay far below 2^53, so the lossy-cast lint
+        // does not apply in spirit; f64::from does not take u64.
+        #[allow(clippy::cast_precision_loss)]
+        fn point(index: u64) -> Point {
+            Point {
+                x: index as f64,
+                y: -(index as f64),
+            }
+        }
+        UniStream::new(futures::stream::iter((0..n).map(point)))
+    }
+
+    static CLOSED_GATES: AtomicU64 = AtomicU64::new(0);
+
+    /// A stateful handle proving resource semantics: `close` is observable
+    /// and idempotent at the boundary, and leaking without close warns.
+    #[unibind::object(resource)]
+    pub struct Gate {
+        label: String,
+        open: AtomicBool,
+    }
+
+    impl Gate {
+        /// Open a gate.
+        ///
+        /// # Errors
+        ///
+        /// Rejects an empty label, so the constructor's error path is
+        /// exercisable from Python.
+        #[unibind(constructor)]
+        pub fn new(label: String) -> Result<Self, ConformanceError> {
+            if label.is_empty() {
+                return Err(ConformanceError::Deliberate {
+                    message: "gate label must not be empty".to_owned(),
+                });
+            }
+            Ok(Self {
+                label,
+                open: AtomicBool::new(true),
+            })
+        }
+
+        /// The label the gate was opened with.
+        pub fn label(&self) -> String {
+            self.label.clone()
+        }
+
+        /// Whether `close` has not run yet.
+        pub fn is_open(&self) -> bool {
+            self.open.load(Ordering::SeqCst)
+        }
+
+        /// Await `ms` milliseconds on the runtime, then echo it back.
+        pub async fn ping(&self, ms: u64) -> u64 {
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+            ms
+        }
+
+        /// Release the gate. The generated wrapper guarantees at most one
+        /// call even when Python awaits `close()` twice, which is what
+        /// `closed_gates` verifies.
+        ///
+        /// # Errors
+        ///
+        /// Never in practice; the `Result` proves fallible close crosses
+        /// the boundary.
+        pub async fn close(&self) -> Result<(), ConformanceError> {
+            self.open.store(false, Ordering::SeqCst);
+            CLOSED_GATES.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// Gates closed through `close` so far.
+    pub fn closed_gates() -> u64 {
+        CLOSED_GATES.load(Ordering::SeqCst)
+    }
+
+    /// Panic synchronously.
+    ///
+    /// # Panics
+    ///
+    /// Always: proving panics surface as Python exceptions without killing
+    /// the interpreter is the point.
+    pub fn panic_sync() {
+        panic!("unibind conformance: deliberate sync panic");
+    }
+
+    /// Panic inside the spawned future, one timer poll in, so the panic
+    /// happens on the runtime rather than at call time.
+    ///
+    /// # Panics
+    ///
+    /// Always.
+    pub async fn panic_async() {
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        panic!("unibind conformance: deliberate async panic");
+    }
+}

--- a/packages/unibind/core/src/ir.rs
+++ b/packages/unibind/core/src/ir.rs
@@ -1,12 +1,18 @@
 //! The unibind interface representation.
 //!
 //! One [`Interface`] value describes everything a `#[unibind::export]`
-//! module exposes: functions, records, and errors today, with enums and
-//! objects reserved for later phases. Backends render it into binding code,
-//! and [`crate::embed`] serializes it into the built artifact so
-//! out-of-process generators can read the same contract.
+//! module exposes: functions, records, errors, and objects, with data enums
+//! reserved for a later phase. Backends render it into binding code, and
+//! [`crate::embed`] serializes it into the built artifact so out-of-process
+//! generators can read the same contract.
+
+mod data;
+mod ty;
 
 use serde::{Deserialize, Serialize};
+
+pub use data::{Enum, EnumVariant, ErrorType, ErrorVariant, Field, Object, Record};
+pub use ty::{FloatKind, IntKind, Literal, Type};
 
 /// Version tag written into every serialized interface so a reader can
 /// reject an IR layout it does not understand.
@@ -28,13 +34,12 @@ pub struct Interface {
     pub functions: Vec<Function>,
     /// Plain-data structs, in declaration order.
     pub records: Vec<Record>,
-    /// Plain data enums. Phase 0 lowering rejects them; the field keeps the
+    /// Plain data enums. Lowering still rejects them; the field keeps the
     /// serialized layout ready for when they land.
     pub enums: Vec<Enum>,
     /// Error enums, each rendered as an exception hierarchy in Python.
     pub errors: Vec<ErrorType>,
-    /// Stateful handles. Phase 0 lowering rejects them (they land with
-    /// resources in phase 2, issue #1992); the field keeps the layout ready.
+    /// Stateful handles, in declaration order.
     pub objects: Vec<Object>,
 }
 
@@ -45,17 +50,19 @@ pub struct Names {
     pub py: Option<String>,
 }
 
-/// How a function suspends. Phase 0 lowers only `Sync`; `Async` is the
-/// phase 2 surface (issue #1992).
+/// How a function suspends.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum Asyncness {
     /// A plain blocking call.
     Sync,
-    /// An `async fn`; reserved, never produced by phase 0 lowering.
+    /// An `async fn`; backends surface it through the language's native
+    /// event loop (a coroutine in Python).
     Async,
 }
 
-/// One exported free function.
+/// One exported free function; also the shape of object methods and
+/// constructors, whose receiver is implied by their position in
+/// [`Object`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Function {
     /// Rust function name.
@@ -66,6 +73,11 @@ pub struct Function {
     pub docs: Vec<String>,
     /// Whether the function suspends.
     pub asyncness: Asyncness,
+    /// Whether a sync body releases the GIL while it runs
+    /// (`#[unibind(blocking)]`); never set together with
+    /// [`Asyncness::Async`].
+    #[serde(default)]
+    pub blocking: bool,
     /// Arguments in declaration order.
     pub args: Vec<Arg>,
     /// Success type; `None` is unit.
@@ -86,171 +98,4 @@ pub struct Arg {
     /// Default value from `#[unibind(default = ...)]`. `Option` arguments
     /// without one default to `None` in rendered bindings.
     pub default: Option<Literal>,
-}
-
-/// A literal default from `#[unibind(default = ...)]`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Literal {
-    /// `true` / `false`.
-    Bool(bool),
-    /// An integer literal (optionally negated).
-    Int(i64),
-    /// A float literal (optionally negated).
-    Float(f64),
-    /// A string literal.
-    Str(String),
-    /// The `None` default for an `Option` argument.
-    None,
-}
-
-/// A type at the binding boundary.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Type {
-    /// `bool`.
-    Bool,
-    /// A fixed-width integer.
-    Int(IntKind),
-    /// A float.
-    Float(FloatKind),
-    /// UTF-8 text: `String` when `owned`, `&str` otherwise.
-    String {
-        /// Whether the Rust side takes ownership.
-        owned: bool,
-    },
-    /// A filesystem path: `PathBuf` when `owned`, `&Path` otherwise.
-    Path {
-        /// Whether the Rust side takes ownership.
-        owned: bool,
-    },
-    /// Binary data: `Vec<u8>` when `owned`, `&[u8]` otherwise.
-    Bytes {
-        /// Whether the Rust side takes ownership.
-        owned: bool,
-    },
-    /// `Option<T>`.
-    Option(Box<Self>),
-    /// `Vec<T>` (except `Vec<u8>`, which lowers to [`Type::Bytes`]).
-    Vec(Box<Self>),
-    /// `HashMap<K, V>`.
-    Map {
-        /// Key type; phase 0 restricts it to strings and integers.
-        key: Box<Self>,
-        /// Value type.
-        value: Box<Self>,
-    },
-    /// A record declared in the same interface.
-    Named(String),
-}
-
-/// Integer width and signedness.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub enum IntKind {
-    I8,
-    I16,
-    I32,
-    I64,
-    Isize,
-    U8,
-    U16,
-    U32,
-    U64,
-    Usize,
-}
-
-/// Float width.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub enum FloatKind {
-    F32,
-    F64,
-}
-
-/// A plain-data struct crossing the boundary by value.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Record {
-    /// Rust struct name.
-    pub name: String,
-    /// Per-language renames.
-    pub names: Names,
-    /// Doc comment lines.
-    pub docs: Vec<String>,
-    /// Fields in declaration order.
-    pub fields: Vec<Field>,
-}
-
-/// One record field.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Field {
-    /// Rust field name.
-    pub name: String,
-    /// Per-language renames.
-    pub names: Names,
-    /// Doc comment lines.
-    pub docs: Vec<String>,
-    /// Field type; always owned.
-    pub ty: Type,
-}
-
-/// A plain data enum. Reserved: phase 0 lowering rejects enums.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Enum {
-    /// Rust enum name.
-    pub name: String,
-    /// Per-language renames.
-    pub names: Names,
-    /// Doc comment lines.
-    pub docs: Vec<String>,
-    /// Variants in declaration order.
-    pub variants: Vec<EnumVariant>,
-}
-
-/// One data enum variant.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EnumVariant {
-    /// Rust variant name.
-    pub name: String,
-    /// Per-language renames.
-    pub names: Names,
-    /// Doc comment lines.
-    pub docs: Vec<String>,
-}
-
-/// An error enum, rendered as an exception hierarchy: one base class for the
-/// enum and one subclass per variant.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErrorType {
-    /// Rust enum name; also the base exception class name.
-    pub name: String,
-    /// Per-language renames for the base class.
-    pub names: Names,
-    /// Doc comment lines.
-    pub docs: Vec<String>,
-    /// Python base exception from `py(base = "...")`; `None` means
-    /// `Exception`.
-    pub py_base: Option<String>,
-    /// Variants in declaration order, each an exception subclass.
-    pub variants: Vec<ErrorVariant>,
-}
-
-/// One error variant. Its fields stay on the Rust side; the rendered
-/// exception carries the variant's `Display` text.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErrorVariant {
-    /// Rust variant name; also the exception subclass name.
-    pub name: String,
-    /// Per-language renames.
-    pub names: Names,
-    /// Doc comment lines.
-    pub docs: Vec<String>,
-}
-
-/// A stateful handle. Reserved: phase 0 lowering rejects
-/// `#[unibind::object]`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Object {
-    /// Rust type name.
-    pub name: String,
-    /// Per-language renames.
-    pub names: Names,
-    /// Doc comment lines.
-    pub docs: Vec<String>,
 }

--- a/packages/unibind/core/src/ir/data.rs
+++ b/packages/unibind/core/src/ir/data.rs
@@ -1,0 +1,109 @@
+//! Declared data shapes: records, enums, errors, and objects.
+
+use serde::{Deserialize, Serialize};
+
+use super::{Function, Names, Type};
+
+/// A plain-data struct crossing the boundary by value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Record {
+    /// Rust struct name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+    /// Fields in declaration order.
+    pub fields: Vec<Field>,
+}
+
+/// One record field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Field {
+    /// Rust field name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+    /// Field type; always owned.
+    pub ty: Type,
+}
+
+/// A plain data enum. Reserved: lowering rejects enums until they land.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Enum {
+    /// Rust enum name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+    /// Variants in declaration order.
+    pub variants: Vec<EnumVariant>,
+}
+
+/// One data enum variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnumVariant {
+    /// Rust variant name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+}
+
+/// An error enum, rendered as an exception hierarchy: one base class for the
+/// enum and one subclass per variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorType {
+    /// Rust enum name; also the base exception class name.
+    pub name: String,
+    /// Per-language renames for the base class.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+    /// Python base exception from `py(base = "...")`; `None` means
+    /// `Exception`.
+    pub py_base: Option<String>,
+    /// Variants in declaration order, each an exception subclass.
+    pub variants: Vec<ErrorVariant>,
+}
+
+/// One error variant. Its fields stay on the Rust side; the rendered
+/// exception carries the variant's `Display` text.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorVariant {
+    /// Rust variant name; also the exception subclass name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+}
+
+/// A stateful handle the target language holds by reference: the backend
+/// wraps the struct rather than copying it field by field, so its fields
+/// never cross the boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Object {
+    /// Rust type name.
+    pub name: String,
+    /// Per-language renames.
+    pub names: Names,
+    /// Doc comment lines.
+    pub docs: Vec<String>,
+    /// Whether the object is a resource: it declares a `close` method the
+    /// bindings surface as `close()` / async-with, warning when it never
+    /// runs.
+    #[serde(default)]
+    pub resource: bool,
+    /// The receiver-less constructor, if any. Its `ret` is `None` (the
+    /// object itself is implied); `throws` may name an error.
+    #[serde(default)]
+    pub constructor: Option<Function>,
+    /// Methods in declaration order; each implicitly takes `&self`.
+    #[serde(default)]
+    pub methods: Vec<Function>,
+}

--- a/packages/unibind/core/src/ir/ty.rs
+++ b/packages/unibind/core/src/ir/ty.rs
@@ -1,0 +1,82 @@
+//! Boundary types and literal defaults.
+
+use serde::{Deserialize, Serialize};
+
+/// A type at the binding boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Type {
+    /// `bool`.
+    Bool,
+    /// A fixed-width integer.
+    Int(IntKind),
+    /// A float.
+    Float(FloatKind),
+    /// UTF-8 text: `String` when `owned`, `&str` otherwise.
+    String {
+        /// Whether the Rust side takes ownership.
+        owned: bool,
+    },
+    /// A filesystem path: `PathBuf` when `owned`, `&Path` otherwise.
+    Path {
+        /// Whether the Rust side takes ownership.
+        owned: bool,
+    },
+    /// Binary data: `Vec<u8>` when `owned`, `&[u8]` otherwise.
+    Bytes {
+        /// Whether the Rust side takes ownership.
+        owned: bool,
+    },
+    /// `Option<T>`.
+    Option(Box<Self>),
+    /// `Vec<T>` (except `Vec<u8>`, which lowers to [`Type::Bytes`]).
+    Vec(Box<Self>),
+    /// `HashMap<K, V>`.
+    Map {
+        /// Key type; phase 0 restricts it to strings and integers.
+        key: Box<Self>,
+        /// Value type.
+        value: Box<Self>,
+    },
+    /// A record or object declared in the same interface.
+    Named(String),
+    /// A `UniStream<T>`, an async iterator in the target language. Streams
+    /// only appear in return position; the item type is owned.
+    Stream(Box<Self>),
+}
+
+/// Integer width and signedness.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum IntKind {
+    I8,
+    I16,
+    I32,
+    I64,
+    Isize,
+    U8,
+    U16,
+    U32,
+    U64,
+    Usize,
+}
+
+/// Float width.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum FloatKind {
+    F32,
+    F64,
+}
+
+/// A literal default from `#[unibind(default = ...)]`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Literal {
+    /// `true` / `false`.
+    Bool(bool),
+    /// An integer literal (optionally negated).
+    Int(i64),
+    /// A float literal (optionally negated).
+    Float(f64),
+    /// A string literal.
+    Str(String),
+    /// The `None` default for an `Option` argument.
+    None,
+}

--- a/packages/unibind/core/src/lower.rs
+++ b/packages/unibind/core/src/lower.rs
@@ -3,6 +3,9 @@
 mod attrs;
 mod data;
 mod func;
+mod marker;
+mod object;
+mod ret;
 mod ty;
 
 use proc_macro2::Span;
@@ -36,6 +39,7 @@ pub type Result<T> = std::result::Result<T, LowerError>;
 pub struct Declared {
     pub records: Vec<String>,
     pub errors: Vec<String>,
+    pub objects: Vec<String>,
 }
 
 /// Lower an inline `#[unibind::export]` module into an [`ir::Interface`].
@@ -45,9 +49,9 @@ pub struct Declared {
 ///
 /// # Errors
 ///
-/// Returns a positioned error for anything outside the phase 0 surface:
-/// async functions, generics, methods, data enums, `#[unibind::object]`,
-/// unsupported boundary types, or malformed `#[unibind(...)]` metadata.
+/// Returns a positioned error for anything outside the supported surface:
+/// generics, data enums, unsupported boundary types, misplaced markers or
+/// flags, or malformed `#[unibind(...)]` metadata.
 pub fn lower_module(
     module_args: proc_macro2::TokenStream,
     module: &syn::ItemMod,
@@ -55,6 +59,9 @@ pub fn lower_module(
     let meta = attrs::UnibindMeta::parse(module_args, module.span())?;
     meta.reject_default("a module")?;
     meta.reject_py_base("a module")?;
+    meta.reject_resource("a module")?;
+    meta.reject_constructor("a module")?;
+    meta.reject_blocking("a module")?;
     let Some((_, items)) = &module.content else {
         return Err(LowerError::new(
             module.span(),
@@ -64,11 +71,12 @@ pub fn lower_module(
     };
 
     let declared = collect_declared(items)?;
+    let mut objects = object::Objects::default();
     let mut interface = ir::Interface {
         version: ir::IR_VERSION,
         name: module.ident.to_string(),
         names: meta.names(),
-        docs: attrs::doc_lines(&module.attrs),
+        docs: marker::doc_lines(&module.attrs),
         functions: Vec::new(),
         records: Vec::new(),
         enums: Vec::new(),
@@ -77,82 +85,106 @@ pub fn lower_module(
     };
 
     for item in items {
-        match (item, attrs::marker(item)?) {
+        match (item, marker::marker(item)?) {
             (syn::Item::Fn(func), None) => {
                 if matches!(func.vis, syn::Visibility::Public(_)) {
                     interface.functions.push(func::lower_fn(func, &declared)?);
                 }
             }
-            (syn::Item::Struct(item), Some(marker)) => match marker.kind {
-                attrs::MarkerKind::Record => {
+            (syn::Item::Impl(item), None) => objects.lower_impl(item, &declared)?,
+            (syn::Item::Struct(item), Some(found)) => match found.kind {
+                marker::MarkerKind::Record => {
                     interface
                         .records
-                        .push(data::lower_record(item, &marker, &declared)?);
+                        .push(data::lower_record(item, &found, &declared)?);
                 }
-                attrs::MarkerKind::Error => {
+                marker::MarkerKind::Object => objects.declare(item, &found)?,
+                marker::MarkerKind::Error => {
                     return Err(LowerError::new(
-                        marker.span,
+                        found.span,
                         "#[unibind::error] goes on an enum; each variant becomes \
                          an exception class",
                     ));
                 }
-                attrs::MarkerKind::Object => return Err(object_unsupported(marker.span)),
             },
-            (syn::Item::Enum(item), Some(marker)) => match marker.kind {
-                attrs::MarkerKind::Error => {
-                    interface.errors.push(data::lower_error(item, &marker)?);
+            (syn::Item::Enum(item), Some(found)) => match found.kind {
+                marker::MarkerKind::Error => {
+                    interface.errors.push(data::lower_error(item, &found)?);
                 }
-                attrs::MarkerKind::Record => {
+                marker::MarkerKind::Record => {
                     return Err(LowerError::new(
-                        marker.span,
+                        found.span,
                         "data enums are not part of phase 0; model the value as a \
                          #[unibind::record] struct until enums land",
                     ));
                 }
-                attrs::MarkerKind::Object => return Err(object_unsupported(marker.span)),
+                marker::MarkerKind::Object => return Err(object_misplaced(found.span)),
             },
-            (_, Some(marker)) => {
-                return Err(match marker.kind {
-                    attrs::MarkerKind::Object => object_unsupported(marker.span),
-                    attrs::MarkerKind::Record | attrs::MarkerKind::Error => LowerError::new(
-                        marker.span,
+            (_, Some(found)) => {
+                return Err(match found.kind {
+                    marker::MarkerKind::Object => object_misplaced(found.span),
+                    marker::MarkerKind::Record | marker::MarkerKind::Error => LowerError::new(
+                        found.span,
                         "this unibind marker goes on a struct (record) or enum (error)",
                     ),
                 });
             }
-            // Anything unannotated that is not a pub fn passes through as
-            // plain Rust: impls, uses, consts, private helpers.
+            // Anything unannotated that is not a pub fn or an impl passes
+            // through as plain Rust: uses, consts, private helpers.
             _ => {}
         }
     }
+    interface.objects = objects.finish()?;
     Ok(interface)
 }
 
-fn object_unsupported(span: Span) -> LowerError {
+fn object_misplaced(span: Span) -> LowerError {
     LowerError::new(
         span,
-        "#[unibind::object] lands with resources in phase 2 (issue #1992); \
-         phase 0 covers sync functions, records, and errors",
+        "#[unibind::object] goes on a struct; the handle's state lives in \
+         its fields",
     )
 }
 
 fn collect_declared(items: &[syn::Item]) -> Result<Declared> {
     let mut declared = Declared::default();
     for item in items {
-        let Some(marker) = attrs::marker(item)? else {
+        let Some(found) = marker::marker(item)? else {
             continue;
         };
-        match (item, marker.kind) {
-            (syn::Item::Struct(item), attrs::MarkerKind::Record) => {
+        match (item, found.kind) {
+            (syn::Item::Struct(item), marker::MarkerKind::Record) => {
+                check_fresh(&declared, &item.ident)?;
                 declared.records.push(item.ident.to_string());
             }
-            (syn::Item::Enum(item), attrs::MarkerKind::Error) => {
+            (syn::Item::Struct(item), marker::MarkerKind::Object) => {
+                check_fresh(&declared, &item.ident)?;
+                declared.objects.push(item.ident.to_string());
+            }
+            (syn::Item::Enum(item), marker::MarkerKind::Error) => {
+                check_fresh(&declared, &item.ident)?;
                 declared.errors.push(item.ident.to_string());
             }
             _ => {}
         }
     }
     Ok(declared)
+}
+
+/// Records, errors, and objects share one type namespace: a reference like
+/// `Row` in a signature must resolve to exactly one declaration.
+fn check_fresh(declared: &Declared, ident: &syn::Ident) -> Result<()> {
+    let name = ident.to_string();
+    let taken = declared.records.contains(&name)
+        || declared.errors.contains(&name)
+        || declared.objects.contains(&name);
+    if taken {
+        return Err(LowerError::new(
+            ident.span(),
+            format!("`{name}` is declared twice; records, errors, and objects share one namespace"),
+        ));
+    }
+    Ok(())
 }
 
 /// Remove every `#[unibind...]` attribute from the module's items so the
@@ -166,11 +198,7 @@ pub fn strip_unibind_attrs(module: &mut syn::ItemMod) {
         match item {
             syn::Item::Fn(func) => {
                 strip(&mut func.attrs);
-                for input in &mut func.sig.inputs {
-                    if let syn::FnArg::Typed(arg) = input {
-                        strip(&mut arg.attrs);
-                    }
-                }
+                strip_fn_args(&mut func.sig);
             }
             syn::Item::Struct(item) => {
                 strip(&mut item.attrs);
@@ -187,11 +215,28 @@ pub fn strip_unibind_attrs(module: &mut syn::ItemMod) {
                     }
                 }
             }
+            syn::Item::Impl(item) => {
+                strip(&mut item.attrs);
+                for impl_item in &mut item.items {
+                    if let syn::ImplItem::Fn(method) = impl_item {
+                        strip(&mut method.attrs);
+                        strip_fn_args(&mut method.sig);
+                    }
+                }
+            }
             _ => {}
         }
     }
 }
 
+fn strip_fn_args(signature: &mut syn::Signature) {
+    for input in &mut signature.inputs {
+        if let syn::FnArg::Typed(arg) = input {
+            strip(&mut arg.attrs);
+        }
+    }
+}
+
 fn strip(attributes: &mut Vec<syn::Attribute>) {
-    attributes.retain(|attribute| !attrs::is_unibind_path(attribute.path()));
+    attributes.retain(|attribute| !marker::is_unibind_path(attribute.path()));
 }

--- a/packages/unibind/core/src/lower/attrs.rs
+++ b/packages/unibind/core/src/lower/attrs.rs
@@ -1,4 +1,4 @@
-//! Parse `#[unibind(...)]` metadata and `#[unibind::...]` markers.
+//! Parse `#[unibind(...)]` metadata options.
 
 use proc_macro2::{Span, TokenStream};
 use syn::spanned::Spanned as _;
@@ -6,31 +6,18 @@ use syn::spanned::Spanned as _;
 use super::{LowerError, Result};
 use crate::ir;
 
-/// Which marker attribute an item carries.
-#[derive(Debug, Clone, Copy)]
-pub enum MarkerKind {
-    Record,
-    Error,
-    Object,
-}
-
-/// A `#[unibind::record]` / `#[unibind::error]` / `#[unibind::object]`
-/// marker found on an item, with its parsed arguments.
-#[derive(Debug)]
-pub struct Marker {
-    pub(crate) kind: MarkerKind,
-    pub(crate) span: Span,
-    pub(crate) meta: UnibindMeta,
-}
-
 /// The options a `#[unibind(...)]` attribute (or marker argument list) can
-/// carry: `py(name = "...")`, `py(base = "...")`, and `default = ...`.
+/// carry: `py(name = "...")`, `py(base = "...")`, `default = ...`, and the
+/// bare flags `resource`, `constructor`, and `blocking`.
 #[derive(Debug, Default)]
 pub struct UnibindMeta {
     pub(crate) span: Option<Span>,
     pub(crate) py_name: Option<String>,
     pub(crate) py_base: Option<String>,
     pub(crate) default: Option<ir::Literal>,
+    pub(crate) resource: bool,
+    pub(crate) constructor: bool,
+    pub(crate) blocking: bool,
 }
 
 impl UnibindMeta {
@@ -91,6 +78,24 @@ impl UnibindMeta {
             }
             self.default = other.default;
         }
+        if other.resource {
+            if self.resource {
+                return Err(LowerError::new(span, "duplicate unibind `resource`"));
+            }
+            self.resource = true;
+        }
+        if other.constructor {
+            if self.constructor {
+                return Err(LowerError::new(span, "duplicate unibind `constructor`"));
+            }
+            self.constructor = true;
+        }
+        if other.blocking {
+            if self.blocking {
+                return Err(LowerError::new(span, "duplicate unibind `blocking`"));
+            }
+            self.blocking = true;
+        }
         self.span = self.span.or(Some(span));
         Ok(())
     }
@@ -120,11 +125,23 @@ impl UnibindMeta {
             self.default = Some(literal(&pair.value)?);
             return Ok(());
         }
-        Err(LowerError::new(
-            span,
-            "unknown unibind option; expected py(name = \"...\"), \
-             py(base = \"...\"), or default = ...",
-        ))
+        if let syn::Meta::Path(path) = entry {
+            let flag = if path.is_ident("resource") {
+                &mut self.resource
+            } else if path.is_ident("constructor") {
+                &mut self.constructor
+            } else if path.is_ident("blocking") {
+                &mut self.blocking
+            } else {
+                return Err(unknown_option(span));
+            };
+            if *flag {
+                return Err(LowerError::new(span, "duplicate unibind flag"));
+            }
+            *flag = true;
+            return Ok(());
+        }
+        Err(unknown_option(span))
     }
 
     fn apply_py(&mut self, entry: &syn::Meta) -> Result<()> {
@@ -182,6 +199,51 @@ impl UnibindMeta {
         }
         Ok(())
     }
+
+    /// Error out when a `resource` flag was given somewhere it cannot apply.
+    pub(crate) fn reject_resource(&self, context: &str) -> Result<()> {
+        if self.resource {
+            return Err(LowerError::new(
+                self.span.unwrap_or_else(Span::call_site),
+                format!("`resource` applies to #[unibind::object] markers, not {context}"),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Error out when a `constructor` flag was given somewhere it cannot
+    /// apply.
+    pub(crate) fn reject_constructor(&self, context: &str) -> Result<()> {
+        if self.constructor {
+            return Err(LowerError::new(
+                self.span.unwrap_or_else(Span::call_site),
+                format!(
+                    "`constructor` applies to associated functions in an \
+                     object impl block, not {context}"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Error out when a `blocking` flag was given somewhere it cannot apply.
+    pub(crate) fn reject_blocking(&self, context: &str) -> Result<()> {
+        if self.blocking {
+            return Err(LowerError::new(
+                self.span.unwrap_or_else(Span::call_site),
+                format!("`blocking` applies to exported functions and object methods, not {context}"),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn unknown_option(span: Span) -> LowerError {
+    LowerError::new(
+        span,
+        "unknown unibind option; expected py(name = \"...\"), \
+         py(base = \"...\"), default = ..., resource, constructor, or blocking",
+    )
 }
 
 fn literal(expr: &syn::Expr) -> Result<ir::Literal> {
@@ -222,87 +284,4 @@ fn literal_from_lit(lit: &syn::Lit) -> Result<ir::Literal> {
             "`default` takes a literal (bool, int, float, string) or None",
         )),
     }
-}
-
-/// Classify the unibind marker on an item, parsing its arguments.
-pub fn marker(item: &syn::Item) -> Result<Option<Marker>> {
-    let attributes = match item {
-        syn::Item::Struct(item) => &item.attrs,
-        syn::Item::Enum(item) => &item.attrs,
-        syn::Item::Fn(item) => &item.attrs,
-        _ => return Ok(None),
-    };
-    let mut found = None;
-    for attribute in attributes {
-        let Some(kind) = marker_kind(attribute.path()) else {
-            continue;
-        };
-        if found.is_some() {
-            return Err(LowerError::new(
-                attribute.span(),
-                "an item takes at most one unibind marker",
-            ));
-        }
-        let tokens = match &attribute.meta {
-            syn::Meta::Path(_) => TokenStream::new(),
-            syn::Meta::List(list) => list.tokens.clone(),
-            syn::Meta::NameValue(_) => {
-                return Err(LowerError::new(
-                    attribute.span(),
-                    "unibind markers take parenthesized options",
-                ));
-            }
-        };
-        found = Some(Marker {
-            kind,
-            span: attribute.span(),
-            meta: UnibindMeta::parse(tokens, attribute.span())?,
-        });
-    }
-    Ok(found)
-}
-
-fn marker_kind(path: &syn::Path) -> Option<MarkerKind> {
-    let mut segments = path.segments.iter();
-    let (first, second, rest) = (segments.next(), segments.next(), segments.next());
-    if rest.is_some() || first.is_none_or(|segment| segment.ident != "unibind") {
-        return None;
-    }
-    match second {
-        Some(segment) if segment.ident == "record" => Some(MarkerKind::Record),
-        Some(segment) if segment.ident == "error" => Some(MarkerKind::Error),
-        Some(segment) if segment.ident == "object" => Some(MarkerKind::Object),
-        _ => None,
-    }
-}
-
-/// Whether an attribute path belongs to unibind (`unibind` or
-/// `unibind::...`), for stripping.
-pub fn is_unibind_path(path: &syn::Path) -> bool {
-    path.segments
-        .first()
-        .is_some_and(|segment| segment.ident == "unibind")
-}
-
-/// Extract `///` doc comment lines, trimming the customary leading space.
-pub fn doc_lines(attributes: &[syn::Attribute]) -> Vec<String> {
-    let mut lines = Vec::new();
-    for attribute in attributes {
-        if !attribute.path().is_ident("doc") {
-            continue;
-        }
-        let syn::Meta::NameValue(pair) = &attribute.meta else {
-            continue;
-        };
-        let syn::Expr::Lit(syn::ExprLit {
-            lit: syn::Lit::Str(text),
-            ..
-        }) = &pair.value
-        else {
-            continue;
-        };
-        let text = text.value();
-        lines.push(text.strip_prefix(' ').unwrap_or(&text).to_owned());
-    }
-    lines
 }

--- a/packages/unibind/core/src/lower/data.rs
+++ b/packages/unibind/core/src/lower/data.rs
@@ -3,16 +3,17 @@
 use syn::spanned::Spanned as _;
 
 use super::ty::{lower_type, Position};
-use super::{attrs, Declared, LowerError, Result};
+use super::{attrs, marker, Declared, LowerError, Result};
 use crate::ir;
 
 pub(super) fn lower_record(
     item: &syn::ItemStruct,
-    marker: &attrs::Marker,
+    found: &marker::Marker,
     declared: &Declared,
 ) -> Result<ir::Record> {
-    marker.meta.reject_default("a record")?;
-    marker.meta.reject_py_base("a record")?;
+    reject_flags(&found.meta, "a record")?;
+    found.meta.reject_default("a record")?;
+    found.meta.reject_py_base("a record")?;
     require_pub(&item.vis, item.ident.span(), "record")?;
     if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
         return Err(LowerError::new(
@@ -35,25 +36,27 @@ pub(super) fn lower_record(
         };
         require_pub(&field.vis, ident.span(), "record field")?;
         let meta = attrs::UnibindMeta::from_attrs(&field.attrs)?;
+        reject_flags(&meta, "a record field")?;
         meta.reject_default("a record field")?;
         meta.reject_py_base("a record field")?;
         lowered.push(ir::Field {
             name: ident.to_string(),
             names: meta.names(),
-            docs: attrs::doc_lines(&field.attrs),
+            docs: marker::doc_lines(&field.attrs),
             ty: lower_type(&field.ty, declared, Position::Owned)?,
         });
     }
     Ok(ir::Record {
         name: item.ident.to_string(),
-        names: marker.meta.names(),
-        docs: attrs::doc_lines(&item.attrs),
+        names: found.meta.names(),
+        docs: marker::doc_lines(&item.attrs),
         fields: lowered,
     })
 }
 
-pub(super) fn lower_error(item: &syn::ItemEnum, marker: &attrs::Marker) -> Result<ir::ErrorType> {
-    marker.meta.reject_default("an error enum")?;
+pub(super) fn lower_error(item: &syn::ItemEnum, found: &marker::Marker) -> Result<ir::ErrorType> {
+    reject_flags(&found.meta, "an error enum")?;
+    found.meta.reject_default("an error enum")?;
     require_pub(&item.vis, item.ident.span(), "error enum")?;
     if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
         return Err(LowerError::new(
@@ -71,21 +74,28 @@ pub(super) fn lower_error(item: &syn::ItemEnum, marker: &attrs::Marker) -> Resul
     let mut variants = Vec::new();
     for variant in &item.variants {
         let meta = attrs::UnibindMeta::from_attrs(&variant.attrs)?;
+        reject_flags(&meta, "an error variant")?;
         meta.reject_default("an error variant")?;
         meta.reject_py_base("an error variant")?;
         variants.push(ir::ErrorVariant {
             name: variant.ident.to_string(),
             names: meta.names(),
-            docs: attrs::doc_lines(&variant.attrs),
+            docs: marker::doc_lines(&variant.attrs),
         });
     }
     Ok(ir::ErrorType {
         name: item.ident.to_string(),
-        names: marker.meta.names(),
-        docs: attrs::doc_lines(&item.attrs),
-        py_base: marker.meta.py_base.clone(),
+        names: found.meta.names(),
+        docs: marker::doc_lines(&item.attrs),
+        py_base: found.meta.py_base.clone(),
         variants,
     })
+}
+
+fn reject_flags(meta: &attrs::UnibindMeta, context: &str) -> Result<()> {
+    meta.reject_resource(context)?;
+    meta.reject_constructor(context)?;
+    meta.reject_blocking(context)
 }
 
 fn require_pub(vis: &syn::Visibility, span: proc_macro2::Span, what: &str) -> Result<()> {

--- a/packages/unibind/core/src/lower/func.rs
+++ b/packages/unibind/core/src/lower/func.rs
@@ -1,20 +1,46 @@
-//! Lower exported functions.
+//! Lower exported functions, object methods, and constructors.
 
 use syn::spanned::Spanned as _;
 
 use super::ty::{lower_type, Position};
-use super::{attrs, Declared, LowerError, Result};
+use super::{attrs, marker, ret, Declared, LowerError, Result};
 use crate::ir;
 
-pub(super) fn lower_fn(func: &syn::ItemFn, declared: &Declared) -> Result<ir::Function> {
-    let signature = &func.sig;
-    if let Some(asyncness) = signature.asyncness {
-        return Err(LowerError::new(
-            asyncness.span(),
-            "async functions land in phase 2 (issue #1992); phase 0 exports \
-             sync functions only",
-        ));
+/// What a signature lowers as; receivers and return conventions differ.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Kind<'a> {
+    /// A free `pub fn` in the exported module.
+    Free,
+    /// An object method; the `&self` receiver was validated by the caller
+    /// and is skipped here.
+    Method,
+    /// An object constructor: sync, receiver-less, returning the object.
+    Constructor {
+        /// The object type the constructor must return.
+        object: &'a str,
+    },
+}
+
+impl Kind<'_> {
+    const fn context(self) -> &'static str {
+        match self {
+            Self::Free => "a function",
+            Self::Method => "a method",
+            Self::Constructor { .. } => "a constructor",
+        }
     }
+}
+
+pub(super) fn lower_fn(func: &syn::ItemFn, declared: &Declared) -> Result<ir::Function> {
+    lower_callable(&func.attrs, &func.sig, declared, Kind::Free)
+}
+
+pub(super) fn lower_callable(
+    attributes: &[syn::Attribute],
+    signature: &syn::Signature,
+    declared: &Declared,
+    kind: Kind<'_>,
+) -> Result<ir::Function> {
     if let Some(unsafety) = signature.unsafety {
         return Err(LowerError::new(
             unsafety.span(),
@@ -34,37 +60,101 @@ pub(super) fn lower_fn(func: &syn::ItemFn, declared: &Declared) -> Result<ir::Fu
             "variadic functions do not cross the binding boundary",
         ));
     }
+    let asyncness = match signature.asyncness {
+        Some(token) => {
+            if matches!(kind, Kind::Constructor { .. }) {
+                return Err(LowerError::new(
+                    token.span(),
+                    "Python constructors are synchronous; expose an async \
+                     factory function instead",
+                ));
+            }
+            ir::Asyncness::Async
+        }
+        None => ir::Asyncness::Sync,
+    };
 
-    let meta = attrs::UnibindMeta::from_attrs(&func.attrs)?;
-    meta.reject_default("a function")?;
-    meta.reject_py_base("a function")?;
+    let meta = attrs::UnibindMeta::from_attrs(attributes)?;
+    meta.reject_default(kind.context())?;
+    meta.reject_py_base(kind.context())?;
+    meta.reject_resource(kind.context())?;
+    match kind {
+        // A `constructor` flag routed the signature here already, so only
+        // the other kinds can carry it by mistake.
+        Kind::Free | Kind::Method => meta.reject_constructor(kind.context())?,
+        Kind::Constructor { .. } => meta.reject_blocking(kind.context())?,
+    }
+    let blocking = meta.blocking;
+    if blocking && matches!(asyncness, ir::Asyncness::Async) {
+        return Err(LowerError::new(
+            meta.span.unwrap_or_else(proc_macro2::Span::call_site),
+            "async bodies already run off the GIL; `blocking` applies to \
+             sync exports",
+        ));
+    }
 
     let mut args = Vec::new();
     for input in &signature.inputs {
         let arg = match input {
             syn::FnArg::Receiver(receiver) => {
+                if matches!(kind, Kind::Method) {
+                    continue;
+                }
                 return Err(LowerError::new(
                     receiver.span(),
-                    "methods belong to #[unibind::object], which lands in \
-                     phase 2 (issue #1992)",
+                    "a free function takes no receiver; methods live in an \
+                     impl block for a #[unibind::object] type",
                 ));
             }
             syn::FnArg::Typed(arg) => arg,
         };
-        args.push(lower_arg(arg, declared)?);
+        let lowered = lower_arg(arg, declared)?;
+        if matches!(asyncness, ir::Asyncness::Async) && borrows(&lowered.ty, true) {
+            return Err(LowerError::new(
+                arg.span(),
+                "async exports take owned arguments (String, PathBuf, \
+                 Vec<u8>); borrowed data cannot outlive the call into the \
+                 Python event loop",
+            ));
+        }
+        if blocking && borrows(&lowered.ty, false) {
+            return Err(LowerError::new(
+                arg.span(),
+                "a blocking export releases the GIL, so it takes owned \
+                 String/PathBuf arguments; &[u8] stays zero-copy through the \
+                 buffer protocol",
+            ));
+        }
+        args.push(lowered);
     }
     check_default_order(signature, &args)?;
 
-    let returned = lower_return(&signature.output, declared)?;
+    let returned = match kind {
+        Kind::Constructor { object } => ret::lower_ctor_return(&signature.output, object, declared)?,
+        Kind::Free | Kind::Method => ret::lower_return(&signature.output, declared)?,
+    };
     Ok(ir::Function {
         name: signature.ident.to_string(),
         names: meta.names(),
-        docs: attrs::doc_lines(&func.attrs),
-        asyncness: ir::Asyncness::Sync,
+        docs: marker::doc_lines(attributes),
+        asyncness,
+        blocking,
         args,
         ret: returned.ty,
         throws: returned.throws,
     })
+}
+
+/// Whether `ty` borrows caller data (directly or under `Option`, the only
+/// places phase 0 allows borrows); `include_bytes` is off for blocking
+/// exports, whose `&[u8]` stays a zero-copy buffer-protocol view.
+fn borrows(ty: &ir::Type, include_bytes: bool) -> bool {
+    match ty {
+        ir::Type::String { owned } | ir::Type::Path { owned } => !owned,
+        ir::Type::Bytes { owned } => include_bytes && !owned,
+        ir::Type::Option(inner) => borrows(inner, include_bytes),
+        _ => false,
+    }
 }
 
 fn lower_arg(arg: &syn::PatType, declared: &Declared) -> Result<ir::Arg> {
@@ -76,6 +166,9 @@ fn lower_arg(arg: &syn::PatType, declared: &Declared) -> Result<ir::Arg> {
     };
     let meta = attrs::UnibindMeta::from_attrs(&arg.attrs)?;
     meta.reject_py_base("an argument")?;
+    meta.reject_resource("an argument")?;
+    meta.reject_constructor("an argument")?;
+    meta.reject_blocking("an argument")?;
     Ok(ir::Arg {
         name: pattern.ident.to_string(),
         names: meta.names(),
@@ -103,93 +196,4 @@ fn check_default_order(signature: &syn::Signature, args: &[ir::Arg]) -> Result<(
         defaults_started = defaults_started || has_default;
     }
     Ok(())
-}
-
-/// A lowered return position: the success type and the thrown error, if any.
-struct Returned {
-    ty: Option<ir::Type>,
-    throws: Option<String>,
-}
-
-fn lower_return(output: &syn::ReturnType, declared: &Declared) -> Result<Returned> {
-    let syn::ReturnType::Type(_, ty) = output else {
-        return Ok(Returned {
-            ty: None,
-            throws: None,
-        });
-    };
-    if is_unit(ty) {
-        return Ok(Returned {
-            ty: None,
-            throws: None,
-        });
-    }
-    if let syn::Type::Path(path) = &**ty
-        && let Some(segment) = path.path.segments.last()
-        && segment.ident == "Result"
-    {
-        return lower_result(segment, declared);
-    }
-    Ok(Returned {
-        ty: Some(lower_type(ty, declared, Position::Owned)?),
-        throws: None,
-    })
-}
-
-fn lower_result(segment: &syn::PathSegment, declared: &Declared) -> Result<Returned> {
-    let syn::PathArguments::AngleBracketed(arguments) = &segment.arguments else {
-        return Err(LowerError::new(
-            segment.span(),
-            "spell the Result out as Result<T, YourError>",
-        ));
-    };
-    let types: Vec<&syn::Type> = arguments
-        .args
-        .iter()
-        .filter_map(|argument| match argument {
-            syn::GenericArgument::Type(ty) => Some(ty),
-            _ => None,
-        })
-        .collect();
-    let [ok, error]: [&syn::Type; 2] = types.as_slice().try_into().map_err(|_| {
-        LowerError::new(
-            segment.span(),
-            "spell the Result out as Result<T, YourError>; type aliases hide \
-             the error type from the macro",
-        )
-    })?;
-    let syn::Type::Path(error_path) = error else {
-        return Err(bad_error_type(error));
-    };
-    let Some(error_ident) = error_path.path.get_ident() else {
-        return Err(bad_error_type(error));
-    };
-    if !declared
-        .errors
-        .iter()
-        .any(|name| error_ident == name.as_str())
-    {
-        return Err(bad_error_type(error));
-    }
-    let ty = if is_unit(ok) {
-        None
-    } else {
-        Some(lower_type(ok, declared, Position::Owned)?)
-    };
-    Ok(Returned {
-        ty,
-        throws: Some(error_ident.to_string()),
-    })
-}
-
-fn bad_error_type(ty: &syn::Type) -> LowerError {
-    LowerError::new(
-        ty.span(),
-        "the error type of an exported function must be a #[unibind::error] \
-         enum declared in the same module",
-    )
-}
-
-fn is_unit(ty: &syn::Type) -> bool {
-    matches!(ty, syn::Type::Tuple(tuple) if tuple.elems.is_empty())
 }

--- a/packages/unibind/core/src/lower/marker.rs
+++ b/packages/unibind/core/src/lower/marker.rs
@@ -1,0 +1,107 @@
+//! Classify `#[unibind::...]` markers and extract doc comments.
+
+use proc_macro2::{Span, TokenStream};
+use syn::spanned::Spanned as _;
+
+use super::attrs::UnibindMeta;
+use super::{LowerError, Result};
+
+/// Which marker attribute an item carries.
+#[derive(Debug, Clone, Copy)]
+pub enum MarkerKind {
+    Record,
+    Error,
+    Object,
+}
+
+/// A `#[unibind::record]` / `#[unibind::error]` / `#[unibind::object]`
+/// marker found on an item, with its parsed arguments.
+#[derive(Debug)]
+pub struct Marker {
+    pub(crate) kind: MarkerKind,
+    pub(crate) span: Span,
+    pub(crate) meta: UnibindMeta,
+}
+
+/// Classify the unibind marker on an item, parsing its arguments.
+pub fn marker(item: &syn::Item) -> Result<Option<Marker>> {
+    let attributes = match item {
+        syn::Item::Struct(item) => &item.attrs,
+        syn::Item::Enum(item) => &item.attrs,
+        syn::Item::Fn(item) => &item.attrs,
+        _ => return Ok(None),
+    };
+    let mut found = None;
+    for attribute in attributes {
+        let Some(kind) = marker_kind(attribute.path()) else {
+            continue;
+        };
+        if found.is_some() {
+            return Err(LowerError::new(
+                attribute.span(),
+                "an item takes at most one unibind marker",
+            ));
+        }
+        let tokens = match &attribute.meta {
+            syn::Meta::Path(_) => TokenStream::new(),
+            syn::Meta::List(list) => list.tokens.clone(),
+            syn::Meta::NameValue(_) => {
+                return Err(LowerError::new(
+                    attribute.span(),
+                    "unibind markers take parenthesized options",
+                ));
+            }
+        };
+        found = Some(Marker {
+            kind,
+            span: attribute.span(),
+            meta: UnibindMeta::parse(tokens, attribute.span())?,
+        });
+    }
+    Ok(found)
+}
+
+fn marker_kind(path: &syn::Path) -> Option<MarkerKind> {
+    let mut segments = path.segments.iter();
+    let (first, second, rest) = (segments.next(), segments.next(), segments.next());
+    if rest.is_some() || first.is_none_or(|segment| segment.ident != "unibind") {
+        return None;
+    }
+    match second {
+        Some(segment) if segment.ident == "record" => Some(MarkerKind::Record),
+        Some(segment) if segment.ident == "error" => Some(MarkerKind::Error),
+        Some(segment) if segment.ident == "object" => Some(MarkerKind::Object),
+        _ => None,
+    }
+}
+
+/// Whether an attribute path belongs to unibind (`unibind` or
+/// `unibind::...`), for stripping.
+pub fn is_unibind_path(path: &syn::Path) -> bool {
+    path.segments
+        .first()
+        .is_some_and(|segment| segment.ident == "unibind")
+}
+
+/// Extract `///` doc comment lines, trimming the customary leading space.
+pub fn doc_lines(attributes: &[syn::Attribute]) -> Vec<String> {
+    let mut lines = Vec::new();
+    for attribute in attributes {
+        if !attribute.path().is_ident("doc") {
+            continue;
+        }
+        let syn::Meta::NameValue(pair) = &attribute.meta else {
+            continue;
+        };
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(text),
+            ..
+        }) = &pair.value
+        else {
+            continue;
+        };
+        let text = text.value();
+        lines.push(text.strip_prefix(' ').unwrap_or(&text).to_owned());
+    }
+    lines
+}

--- a/packages/unibind/core/src/lower/object.rs
+++ b/packages/unibind/core/src/lower/object.rs
@@ -1,0 +1,223 @@
+//! Lower `#[unibind::object]` structs and their `impl` blocks.
+
+use proc_macro2::Span;
+use syn::spanned::Spanned as _;
+
+use super::{attrs, func, marker, Declared, LowerError, Result};
+use crate::ir;
+
+/// Objects under construction: struct declarations plus the methods and
+/// constructor their `impl` blocks contribute. Blocks may precede the
+/// struct in source order, so everything merges in [`Self::finish`].
+#[derive(Debug, Default)]
+pub(super) struct Objects {
+    declarations: Vec<Declaration>,
+    impls: Vec<ImplBlock>,
+}
+
+#[derive(Debug)]
+struct Declaration {
+    object: ir::Object,
+    /// Points resource-validation errors at the struct.
+    span: Span,
+}
+
+#[derive(Debug)]
+struct ImplBlock {
+    name: String,
+    constructor: Option<SpannedFn>,
+    methods: Vec<ir::Function>,
+}
+
+/// A lowered constructor with the span its diagnostics point at.
+#[derive(Debug)]
+struct SpannedFn {
+    function: ir::Function,
+    span: Span,
+}
+
+impl Objects {
+    /// Lower a `#[unibind::object]` struct. The struct itself passes
+    /// through untouched (the backend wraps it rather than splicing
+    /// attributes), so its fields carry no visibility rules.
+    pub(super) fn declare(&mut self, item: &syn::ItemStruct, found: &marker::Marker) -> Result<()> {
+        found.meta.reject_default("an object")?;
+        found.meta.reject_py_base("an object")?;
+        found.meta.reject_constructor("an object")?;
+        found.meta.reject_blocking("an object")?;
+        if !matches!(item.vis, syn::Visibility::Public(_)) {
+            return Err(LowerError::new(
+                item.ident.span(),
+                "a unibind object must be `pub` so the generated glue can reach it",
+            ));
+        }
+        if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
+            return Err(LowerError::new(
+                item.generics.span(),
+                "generic objects cannot cross the binding boundary",
+            ));
+        }
+        self.declarations.push(Declaration {
+            object: ir::Object {
+                name: item.ident.to_string(),
+                names: found.meta.names(),
+                docs: marker::doc_lines(&item.attrs),
+                resource: found.meta.resource,
+                constructor: None,
+                methods: Vec::new(),
+            },
+            span: item.ident.span(),
+        });
+        Ok(())
+    }
+
+    /// Lower one `impl` block from the exported module. Trait impls stay
+    /// plain Rust (records and errors need `Display` and friends); an
+    /// inherent block must target a declared object.
+    pub(super) fn lower_impl(&mut self, item: &syn::ItemImpl, declared: &Declared) -> Result<()> {
+        if item.trait_.is_some() {
+            return Ok(());
+        }
+        let name = match impl_target(item) {
+            Some(name) if declared.objects.contains(&name) => name,
+            _ => {
+                return Err(LowerError::new(
+                    item.self_ty.span(),
+                    "impl blocks inside an exported module belong to \
+                     #[unibind::object] types",
+                ));
+            }
+        };
+        if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
+            return Err(LowerError::new(
+                item.generics.span(),
+                "generic impl blocks cannot cross the binding boundary",
+            ));
+        }
+        let mut block = ImplBlock {
+            name,
+            constructor: None,
+            methods: Vec::new(),
+        };
+        for impl_item in &item.items {
+            // Consts, types, and private helpers stay plain Rust.
+            let syn::ImplItem::Fn(method) = impl_item else {
+                continue;
+            };
+            if !matches!(method.vis, syn::Visibility::Public(_)) {
+                continue;
+            }
+            block.lower_method(method, declared)?;
+        }
+        self.impls.push(block);
+        Ok(())
+    }
+
+    /// Merge impl blocks into their declarations and validate resources.
+    pub(super) fn finish(self) -> Result<Vec<ir::Object>> {
+        let Self {
+            mut declarations,
+            impls,
+        } = self;
+        for block in impls {
+            let declaration = declarations
+                .iter_mut()
+                .find(|declaration| declaration.object.name == block.name)
+                .expect("impl targets were validated against declared objects");
+            declaration.object.methods.extend(block.methods);
+            if let Some(constructor) = block.constructor {
+                if declaration.object.constructor.is_some() {
+                    return Err(LowerError::new(constructor.span, "an object takes one constructor"));
+                }
+                declaration.object.constructor = Some(constructor.function);
+            }
+        }
+        for declaration in &declarations {
+            if declaration.object.resource && !has_close(&declaration.object) {
+                return Err(LowerError::new(
+                    declaration.span,
+                    "a resource needs a close method (zero arguments, no \
+                     return value); unibind maps it to close()/aexit and \
+                     warns when it never runs",
+                ));
+            }
+        }
+        Ok(declarations
+            .into_iter()
+            .map(|declaration| declaration.object)
+            .collect())
+    }
+}
+
+impl ImplBlock {
+    fn lower_method(&mut self, method: &syn::ImplItemFn, declared: &Declared) -> Result<()> {
+        if let Some(receiver) = method.sig.receiver() {
+            validate_receiver(receiver)?;
+            self.methods.push(func::lower_callable(
+                &method.attrs,
+                &method.sig,
+                declared,
+                func::Kind::Method,
+            )?);
+            return Ok(());
+        }
+        let meta = attrs::UnibindMeta::from_attrs(&method.attrs)?;
+        if !meta.constructor {
+            return Err(LowerError::new(
+                method.sig.ident.span(),
+                "associated functions do not cross the boundary; mark the \
+                 constructor with #[unibind(constructor)] or take &self",
+            ));
+        }
+        if self.constructor.is_some() {
+            return Err(LowerError::new(
+                method.sig.ident.span(),
+                "an object takes one constructor",
+            ));
+        }
+        let function = func::lower_callable(
+            &method.attrs,
+            &method.sig,
+            declared,
+            func::Kind::Constructor { object: &self.name },
+        )?;
+        self.constructor = Some(SpannedFn {
+            function,
+            span: method.sig.ident.span(),
+        });
+        Ok(())
+    }
+}
+
+/// The bare type name an inherent impl block targets, if it is one.
+fn impl_target(item: &syn::ItemImpl) -> Option<String> {
+    let syn::Type::Path(path) = &*item.self_ty else {
+        return None;
+    };
+    if path.qself.is_some() {
+        return None;
+    }
+    path.path.get_ident().map(ToString::to_string)
+}
+
+fn validate_receiver(receiver: &syn::Receiver) -> Result<()> {
+    // `&self` is a plain shared reference: no `mut`, no `self: Ty` form.
+    if receiver.reference.is_some() && receiver.mutability.is_none() && receiver.colon_token.is_none()
+    {
+        return Ok(());
+    }
+    Err(LowerError::new(
+        receiver.span(),
+        "&mut self cannot cross the boundary: Python aliases objects \
+         freely; use interior mutability (Mutex, atomics) and take &self",
+    ))
+}
+
+/// `close` counts with zero arguments and no success value; `Result<(), E>`
+/// and async both stay valid teardown shapes.
+fn has_close(object: &ir::Object) -> bool {
+    object
+        .methods
+        .iter()
+        .any(|method| method.name == "close" && method.args.is_empty() && method.ret.is_none())
+}

--- a/packages/unibind/core/src/lower/ret.rs
+++ b/packages/unibind/core/src/lower/ret.rs
@@ -76,20 +76,19 @@ pub(super) fn lower_ctor_return(
             throws: None,
         });
     }
-    if let syn::Type::Path(path) = &**ty {
-        if let Some(segment) = path.path.segments.last() {
-            if segment.ident == "Result" {
-                let parts = result_parts(segment)?;
-                if !is_object(parts.ok, object) {
-                    return Err(bad_ctor(parts.ok.span(), object));
-                }
-                let throws = error_name(parts.error, declared)?;
-                return Ok(Returned {
-                    ty: None,
-                    throws: Some(throws),
-                });
-            }
+    if let syn::Type::Path(path) = &**ty
+        && let Some(segment) = path.path.segments.last()
+        && segment.ident == "Result"
+    {
+        let parts = result_parts(segment)?;
+        if !is_object(parts.ok, object) {
+            return Err(bad_ctor(parts.ok.span(), object));
         }
+        let throws = error_name(parts.error, declared)?;
+        return Ok(Returned {
+            ty: None,
+            throws: Some(throws),
+        });
     }
     Err(bad_ctor(ty.span(), object))
 }
@@ -163,16 +162,15 @@ fn lower_stream(segment: &syn::PathSegment, declared: &Declared) -> Result<ir::T
             "streams do not nest; yield the inner stream's items directly",
         ));
     }
-    if let syn::Type::Path(path) = item {
-        if let Some(ident) = path.path.get_ident() {
-            if declared.objects.iter().any(|name| ident == name.as_str()) {
-                return Err(LowerError::new(
-                    item.span(),
-                    "streams of objects do not cross the boundary yet; \
-                     stream a #[unibind::record] snapshot instead",
-                ));
-            }
-        }
+    if let syn::Type::Path(path) = item
+        && let Some(ident) = path.path.get_ident()
+        && declared.objects.iter().any(|name| ident == name.as_str())
+    {
+        return Err(LowerError::new(
+            item.span(),
+            "streams of objects do not cross the boundary yet; \
+             stream a #[unibind::record] snapshot instead",
+        ));
     }
     Ok(ir::Type::Stream(Box::new(lower_type(
         item,

--- a/packages/unibind/core/src/lower/ret.rs
+++ b/packages/unibind/core/src/lower/ret.rs
@@ -1,0 +1,218 @@
+//! Lower return positions: plain types, `Result`, streams, and
+//! constructor returns.
+
+use syn::spanned::Spanned as _;
+
+use super::ty::{lower_type, one_generic, Position};
+use super::{Declared, LowerError, Result};
+use crate::ir;
+
+/// A lowered return position: the success type and the thrown error, if any.
+pub(super) struct Returned {
+    pub(super) ty: Option<ir::Type>,
+    pub(super) throws: Option<String>,
+}
+
+pub(super) fn lower_return(output: &syn::ReturnType, declared: &Declared) -> Result<Returned> {
+    let syn::ReturnType::Type(_, ty) = output else {
+        return Ok(Returned {
+            ty: None,
+            throws: None,
+        });
+    };
+    if is_unit(ty) {
+        return Ok(Returned {
+            ty: None,
+            throws: None,
+        });
+    }
+    if let Some(segment) = stream_segment(ty) {
+        return Ok(Returned {
+            ty: Some(lower_stream(segment, declared)?),
+            throws: None,
+        });
+    }
+    if let syn::Type::Path(path) = &**ty
+        && let Some(segment) = path.path.segments.last()
+        && segment.ident == "Result"
+    {
+        return lower_result(segment, declared);
+    }
+    Ok(Returned {
+        ty: Some(lower_type(ty, declared, Position::Return)?),
+        throws: None,
+    })
+}
+
+fn lower_result(segment: &syn::PathSegment, declared: &Declared) -> Result<Returned> {
+    let parts = result_parts(segment)?;
+    let throws = error_name(parts.error, declared)?;
+    let ty = if is_unit(parts.ok) {
+        None
+    } else if let Some(stream) = stream_segment(parts.ok) {
+        Some(lower_stream(stream, declared)?)
+    } else {
+        Some(lower_type(parts.ok, declared, Position::Return)?)
+    };
+    Ok(Returned {
+        ty,
+        throws: Some(throws),
+    })
+}
+
+/// A constructor returns the object (or `Result` of it): the IR leaves
+/// `ret` empty because the object itself is implied.
+pub(super) fn lower_ctor_return(
+    output: &syn::ReturnType,
+    object: &str,
+    declared: &Declared,
+) -> Result<Returned> {
+    let syn::ReturnType::Type(_, ty) = output else {
+        return Err(bad_ctor(output.span(), object));
+    };
+    if is_object(ty, object) {
+        return Ok(Returned {
+            ty: None,
+            throws: None,
+        });
+    }
+    if let syn::Type::Path(path) = &**ty {
+        if let Some(segment) = path.path.segments.last() {
+            if segment.ident == "Result" {
+                let parts = result_parts(segment)?;
+                if !is_object(parts.ok, object) {
+                    return Err(bad_ctor(parts.ok.span(), object));
+                }
+                let throws = error_name(parts.error, declared)?;
+                return Ok(Returned {
+                    ty: None,
+                    throws: Some(throws),
+                });
+            }
+        }
+    }
+    Err(bad_ctor(ty.span(), object))
+}
+
+/// The `(ok, error)` types of a spelled-out `Result`.
+struct OkErr<'a> {
+    ok: &'a syn::Type,
+    error: &'a syn::Type,
+}
+
+fn result_parts(segment: &syn::PathSegment) -> Result<OkErr<'_>> {
+    let syn::PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return Err(LowerError::new(
+            segment.span(),
+            "spell the Result out as Result<T, YourError>",
+        ));
+    };
+    let types: Vec<&syn::Type> = arguments
+        .args
+        .iter()
+        .filter_map(|argument| match argument {
+            syn::GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .collect();
+    let [ok, error]: [&syn::Type; 2] = types.as_slice().try_into().map_err(|_| {
+        LowerError::new(
+            segment.span(),
+            "spell the Result out as Result<T, YourError>; type aliases hide \
+             the error type from the macro",
+        )
+    })?;
+    Ok(OkErr { ok, error })
+}
+
+fn error_name(error: &syn::Type, declared: &Declared) -> Result<String> {
+    let syn::Type::Path(error_path) = error else {
+        return Err(bad_error_type(error));
+    };
+    let Some(error_ident) = error_path.path.get_ident() else {
+        return Err(bad_error_type(error));
+    };
+    if !declared
+        .errors
+        .iter()
+        .any(|name| error_ident == name.as_str())
+    {
+        return Err(bad_error_type(error));
+    }
+    Ok(error_ident.to_string())
+}
+
+/// The `UniStream` path segment of a type, when it names a stream.
+pub(super) fn stream_segment(ty: &syn::Type) -> Option<&syn::PathSegment> {
+    let syn::Type::Path(path) = ty else {
+        return None;
+    };
+    if path.qself.is_some() {
+        return None;
+    }
+    let segment = path.path.segments.last()?;
+    (segment.ident == "UniStream").then_some(segment)
+}
+
+/// Lower the item of a `UniStream<T>` return into [`ir::Type::Stream`].
+fn lower_stream(segment: &syn::PathSegment, declared: &Declared) -> Result<ir::Type> {
+    let item = one_generic(segment)?;
+    if let Some(nested) = stream_segment(item) {
+        return Err(LowerError::new(
+            nested.span(),
+            "streams do not nest; yield the inner stream's items directly",
+        ));
+    }
+    if let syn::Type::Path(path) = item {
+        if let Some(ident) = path.path.get_ident() {
+            if declared.objects.iter().any(|name| ident == name.as_str()) {
+                return Err(LowerError::new(
+                    item.span(),
+                    "streams of objects do not cross the boundary yet; \
+                     stream a #[unibind::record] snapshot instead",
+                ));
+            }
+        }
+    }
+    Ok(ir::Type::Stream(Box::new(lower_type(
+        item,
+        declared,
+        Position::Owned,
+    )?)))
+}
+
+
+/// `Self` or the object's own name, as a bare path.
+fn is_object(ty: &syn::Type, object: &str) -> bool {
+    let syn::Type::Path(path) = ty else {
+        return false;
+    };
+    path.qself.is_none()
+        && path
+            .path
+            .get_ident()
+            .is_some_and(|ident| ident == "Self" || ident == object)
+}
+
+fn bad_ctor(span: proc_macro2::Span, object: &str) -> LowerError {
+    LowerError::new(
+        span,
+        format!(
+            "a constructor returns `Self` (or `Result<Self, YourError>`) so \
+             Python gets a `{object}`; move other signatures to methods or \
+             free functions"
+        ),
+    )
+}
+
+fn bad_error_type(ty: &syn::Type) -> LowerError {
+    LowerError::new(
+        ty.span(),
+        "the error type of an exported function must be a #[unibind::error] \
+         enum declared in the same module",
+    )
+}
+
+fn is_unit(ty: &syn::Type) -> bool {
+    matches!(ty, syn::Type::Tuple(tuple) if tuple.elems.is_empty())
+}

--- a/packages/unibind/core/src/lower/ty.rs
+++ b/packages/unibind/core/src/lower/ty.rs
@@ -6,14 +6,18 @@ use syn::spanned::Spanned as _;
 use super::{Declared, LowerError, Result};
 use crate::ir;
 
-/// Where a type appears; borrowed forms are only legal in argument position.
+/// Where a type appears; borrowed forms are only legal in argument
+/// position, and object names only in return position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Position {
     /// A function argument (borrowed `&str` / `&Path` / `&[u8]` allowed,
     /// also directly under `Option`).
     Arg,
-    /// A return type or record field: owned types only.
+    /// A record field or container element: owned data types only.
     Owned,
+    /// A function or method return type: owned data, plus bare object
+    /// names.
+    Return,
 }
 
 pub fn lower_type(ty: &syn::Type, declared: &Declared, position: Position) -> Result<ir::Type> {
@@ -81,9 +85,20 @@ fn lower_path(path: &syn::TypePath, declared: &Declared, position: Position) -> 
         "f64" => no_generics(segment).map(|()| ir::Type::Float(ir::FloatKind::F64)),
         "String" => no_generics(segment).map(|()| ir::Type::String { owned: true }),
         "PathBuf" => no_generics(segment).map(|()| ir::Type::Path { owned: true }),
+        "UniStream" => Err(LowerError::new(
+            segment.span(),
+            "UniStream only crosses the boundary as a return type; \
+             arguments, fields, and container elements take concrete values",
+        )),
         "Option" => {
             let inner = one_generic(segment)?;
-            Ok(ir::Type::Option(Box::new(lower_type(inner, declared, position)?)))
+            // An object handle only crosses bare, so under Option the
+            // return position drops to Owned and object names reject.
+            let inner_position = match position {
+                Position::Arg => Position::Arg,
+                Position::Owned | Position::Return => Position::Owned,
+            };
+            Ok(ir::Type::Option(Box::new(lower_type(inner, declared, inner_position)?)))
         }
         "Vec" => {
             let inner = one_generic(segment)?;
@@ -112,7 +127,7 @@ fn lower_path(path: &syn::TypePath, declared: &Declared, position: Position) -> 
                 value: Box::new(lower_type(pair.value, declared, Position::Owned)?),
             })
         }
-        _ => lower_named(path, segment, &ident, declared),
+        _ => lower_named(path, segment, &ident, declared, position),
     }
 }
 
@@ -121,6 +136,7 @@ fn lower_named(
     segment: &syn::PathSegment,
     ident: &str,
     declared: &Declared,
+    position: Position,
 ) -> Result<ir::Type> {
     no_generics(segment)?;
     if path.path.segments.len() != 1 {
@@ -128,6 +144,18 @@ fn lower_named(
     }
     if declared.records.iter().any(|name| name == ident) {
         return Ok(ir::Type::Named(ident.to_owned()));
+    }
+    if declared.objects.iter().any(|name| name == ident) {
+        if position == Position::Return {
+            return Ok(ir::Type::Named(ident.to_owned()));
+        }
+        return Err(LowerError::new(
+            segment.span(),
+            format!(
+                "`{ident}` is a #[unibind::object]; objects cross the \
+                 boundary as return values only"
+            ),
+        ));
     }
     if declared.errors.iter().any(|name| name == ident) {
         return Err(LowerError::new(
@@ -192,7 +220,7 @@ fn generic_types(segment: &syn::PathSegment) -> Result<Vec<&syn::Type>> {
         .collect())
 }
 
-fn one_generic(segment: &syn::PathSegment) -> Result<&syn::Type> {
+pub(super) fn one_generic(segment: &syn::PathSegment) -> Result<&syn::Type> {
     let types = generic_types(segment)?;
     if let [inner] = types.as_slice() {
         Ok(inner)

--- a/packages/unibind/core/tests/lower.rs
+++ b/packages/unibind/core/tests/lower.rs
@@ -128,18 +128,6 @@ fn module_rename_comes_from_the_attribute_args() {
 }
 
 #[test]
-fn async_functions_point_at_phase_2() {
-    let message = error_message("mod m { pub async fn go() {} }");
-    assert!(message.contains("phase 2"), "{message}");
-}
-
-#[test]
-fn objects_point_at_phase_2() {
-    let message = error_message("mod m { #[unibind::object] pub struct Handle { pub id: u64 } }");
-    assert!(message.contains("phase 2"), "{message}");
-}
-
-#[test]
 fn data_enums_are_rejected() {
     let message = error_message("mod m { #[unibind::record] pub enum Kind { A, B } }");
     assert!(message.contains("data enums"), "{message}");

--- a/packages/unibind/core/tests/lower_phase2.rs
+++ b/packages/unibind/core/tests/lower_phase2.rs
@@ -1,0 +1,220 @@
+//! Lowering across the phase 2 surface: async, blocking, streams, and
+//! objects, plus the positioned errors that police their edges.
+
+use proc_macro2::TokenStream;
+use unibind_core::ir;
+
+fn lower(source: &str) -> Result<ir::Interface, unibind_core::LowerError> {
+    let file: syn::File = syn::parse_str(source).expect("fixture parses");
+    let Some(syn::Item::Mod(module)) = file.items.first() else {
+        panic!("fixture starts with a module");
+    };
+    unibind_core::lower_module(TokenStream::new(), module)
+}
+
+fn error_message(source: &str) -> String {
+    lower(source).expect_err("lowering should fail").message
+}
+
+const OBJECTS: &str = r#"
+/// A stateful boundary.
+mod sample {
+    /// Boundary failures.
+    #[unibind::error]
+    pub enum StoreError {
+        Gone { message: String },
+    }
+
+    /// A live store handle.
+    #[unibind::object(resource)]
+    pub struct Store {
+        rows: u64,
+    }
+
+    impl Store {
+        /// Open a store.
+        #[unibind(constructor)]
+        pub fn open(path: &str) -> Result<Self, StoreError> {
+            let _ = path;
+            Err(StoreError::Gone { message: String::new() })
+        }
+
+        /// Stream rows out.
+        pub async fn rows(&self, limit: usize) -> Result<UniStream<String>, StoreError> {
+            let _ = limit;
+            todo!()
+        }
+
+        /// Compact off the GIL.
+        #[unibind(blocking)]
+        pub fn compact(&self) -> u64 {
+            self.rows
+        }
+
+        pub async fn close(&self) {}
+
+        fn helper(&self) {}
+    }
+
+    /// The default store.
+    pub fn default_store() -> Store {
+        Store { rows: 0 }
+    }
+
+    /// Watch a counter.
+    pub async fn watch(from: u64) -> UniStream<u64> {
+        let _ = from;
+        todo!()
+    }
+}
+"#;
+
+#[test]
+fn objects_lower_with_constructor_methods_and_resource() {
+    let interface = lower(OBJECTS).expect("lowering succeeds");
+    let [store] = interface.objects.as_slice() else {
+        panic!("one object");
+    };
+    assert_eq!(store.name, "Store");
+    assert!(store.resource);
+    assert_eq!(store.docs, vec!["A live store handle.".to_owned()]);
+
+    let constructor = store.constructor.as_ref().expect("a constructor");
+    assert_eq!(constructor.name, "open");
+    assert!(matches!(constructor.asyncness, ir::Asyncness::Sync));
+    assert!(constructor.ret.is_none(), "the object itself is implied");
+    assert_eq!(constructor.throws.as_deref(), Some("StoreError"));
+    assert!(matches!(constructor.args[0].ty, ir::Type::String { owned: false }));
+
+    let [rows, compact, close] = store.methods.as_slice() else {
+        panic!("three methods (the private helper is skipped)");
+    };
+    assert!(matches!(rows.asyncness, ir::Asyncness::Async));
+    assert!(matches!(rows.ret, Some(ir::Type::Stream(_))));
+    assert_eq!(rows.throws.as_deref(), Some("StoreError"));
+    assert!(compact.blocking);
+    assert!(matches!(close.asyncness, ir::Asyncness::Async));
+    assert!(close.ret.is_none());
+}
+
+#[test]
+fn object_names_return_as_named_types() {
+    let interface = lower(OBJECTS).expect("lowering succeeds");
+    let default_store = &interface.functions[0];
+    let Some(ir::Type::Named(name)) = &default_store.ret else {
+        panic!("object return lowers to Named");
+    };
+    assert_eq!(name, "Store");
+}
+
+#[test]
+fn async_functions_lower_with_owned_args() {
+    let interface = lower(OBJECTS).expect("lowering succeeds");
+    let watch = &interface.functions[1];
+    assert!(matches!(watch.asyncness, ir::Asyncness::Async));
+    let Some(ir::Type::Stream(item)) = &watch.ret else {
+        panic!("bare UniStream return lowers to Stream");
+    };
+    assert!(matches!(**item, ir::Type::Int(ir::IntKind::U64)));
+}
+
+#[test]
+fn async_borrowed_args_are_rejected() {
+    let message = error_message("mod m { pub async fn go(name: &str) {} }");
+    assert!(message.contains("owned arguments"), "{message}");
+}
+
+#[test]
+fn blocking_sets_the_flag_and_keeps_borrowed_bytes() {
+    let interface =
+        lower("mod m { #[unibind(blocking)] pub fn go(data: &[u8]) -> u64 { 0 } }")
+            .expect("lowering succeeds");
+    let go = &interface.functions[0];
+    assert!(go.blocking);
+    assert!(matches!(go.args[0].ty, ir::Type::Bytes { owned: false }));
+}
+
+#[test]
+fn blocking_on_async_is_rejected() {
+    let message = error_message("mod m { #[unibind(blocking)] pub async fn go() {} }");
+    assert!(message.contains("sync exports"), "{message}");
+}
+
+#[test]
+fn blocking_borrowed_strings_are_rejected() {
+    let message = error_message("mod m { #[unibind(blocking)] pub fn go(name: &str) {} }");
+    assert!(message.contains("releases the GIL"), "{message}");
+}
+
+#[test]
+fn result_wrapped_streams_lower() {
+    let interface = lower(
+        "mod m { #[unibind::error] pub enum E { A { m: String } } \
+         pub fn go() -> Result<UniStream<String>, E> { todo!() } }",
+    )
+    .expect("lowering succeeds");
+    let go = &interface.functions[0];
+    assert!(matches!(go.ret, Some(ir::Type::Stream(_))));
+    assert_eq!(go.throws.as_deref(), Some("E"));
+}
+
+#[test]
+fn streams_in_argument_position_are_rejected() {
+    let message = error_message("mod m { pub fn go(stream: UniStream<u64>) {} }");
+    assert!(message.contains("return type"), "{message}");
+}
+
+#[test]
+fn resources_without_close_are_rejected() {
+    let message =
+        error_message("mod m { #[unibind::object(resource)] pub struct H { id: u64 } }");
+    assert!(message.contains("close method"), "{message}");
+}
+
+#[test]
+fn mut_receivers_are_rejected() {
+    let message = error_message(
+        "mod m { #[unibind::object] pub struct H { id: u64 } \
+         impl H { pub fn poke(&mut self) {} } }",
+    );
+    assert!(message.contains("interior mutability"), "{message}");
+}
+
+#[test]
+fn object_names_in_argument_position_are_rejected() {
+    let message = error_message(
+        "mod m { #[unibind::object] pub struct H { id: u64 } \
+         pub fn take(handle: H) {} }",
+    );
+    assert!(message.contains("return values only"), "{message}");
+}
+
+#[test]
+fn associated_fns_need_the_constructor_marker() {
+    let message = error_message(
+        "mod m { #[unibind::object] pub struct H { id: u64 } \
+         impl H { pub fn make() -> Self { H { id: 0 } } } }",
+    );
+    assert!(message.contains("#[unibind(constructor)]"), "{message}");
+}
+
+#[test]
+fn async_constructors_are_rejected() {
+    let message = error_message(
+        "mod m { #[unibind::object] pub struct H { id: u64 } \
+         impl H { #[unibind(constructor)] pub async fn open() -> Self { H { id: 0 } } } }",
+    );
+    assert!(message.contains("synchronous"), "{message}");
+}
+
+#[test]
+fn strip_removes_impl_block_attributes() {
+    let file: syn::File = syn::parse_str(OBJECTS).expect("fixture parses");
+    let Some(syn::Item::Mod(module)) = file.items.first() else {
+        panic!("fixture starts with a module");
+    };
+    let mut module = module.clone();
+    unibind_core::strip_unibind_attrs(&mut module);
+    let rendered = quote::quote!(#module).to_string();
+    assert!(!rendered.contains("unibind"), "{rendered}");
+}

--- a/packages/unibind/core/tests/lower_phase2.rs
+++ b/packages/unibind/core/tests/lower_phase2.rs
@@ -16,7 +16,7 @@ fn error_message(source: &str) -> String {
     lower(source).expect_err("lowering should fail").message
 }
 
-const OBJECTS: &str = r#"
+const OBJECTS: &str = r"
 /// A stateful boundary.
 mod sample {
     /// Boundary failures.
@@ -67,7 +67,7 @@ mod sample {
         todo!()
     }
 }
-"#;
+";
 
 #[test]
 fn objects_lower_with_constructor_methods_and_resource() {

--- a/packages/unibind/gen/src/py/mod.rs
+++ b/packages/unibind/gen/src/py/mod.rs
@@ -9,7 +9,7 @@ mod stub;
 mod types;
 mod wrapper;
 
-use unibind_core::ir::{Asyncness, Interface};
+use unibind_core::ir::Interface;
 
 use crate::host::{EmitError, HostEmitter, HostFile};
 
@@ -57,13 +57,13 @@ impl HostEmitter for PyEmitter {
     }
 }
 
-/// Refuse the IR surface the phase 1 stub emitter does not render, with the
+/// Refuse the IR surface the stub emitter does not render yet, with the
 /// same pointers the pyo3 backend gives.
 fn reject_unrendered_surface(interface: &Interface) -> Result<(), EmitError> {
     if let Some(object) = interface.objects.first() {
         return Err(EmitError {
             message: format!(
-                "`{}` is a #[unibind::object]; objects land in phase 2 (issue #1992)",
+                "`{}` is a #[unibind::object]; class stubs are not rendered yet (issue #1991)",
                 object.name
             ),
         });
@@ -71,18 +71,6 @@ fn reject_unrendered_surface(interface: &Interface) -> Result<(), EmitError> {
     if let Some(data_enum) = interface.enums.first() {
         return Err(EmitError {
             message: format!("`{}` is a data enum, which phase 1 does not render", data_enum.name),
-        });
-    }
-    if let Some(function) = interface
-        .functions
-        .iter()
-        .find(|function| matches!(function.asyncness, Asyncness::Async))
-    {
-        return Err(EmitError {
-            message: format!(
-                "`{}` is async; async functions land in phase 2 (issue #1992)",
-                function.name
-            ),
         });
     }
     Ok(())

--- a/packages/unibind/gen/src/py/stub.rs
+++ b/packages/unibind/gen/src/py/stub.rs
@@ -1,7 +1,8 @@
 //! Render the `.pyi` stub for one interface.
 //!
-//! Ordering is deterministic: module docstring, `import os` (only when an
-//! argument accepts a path), errors, records, functions, and the trailing
+//! Ordering is deterministic: module docstring, imports (`collections.abc`
+//! when a stream return needs it, `os` when an argument accepts a path),
+//! errors, records, functions, and the trailing
 //! `__version__` the generated `pymodule` sets. Everything keeps the
 //! interface's declaration order within its group, so the stub diffs the way
 //! the Rust module does.
@@ -18,8 +19,9 @@ pub fn render(interface: &ir::Interface) -> String {
     if !interface.docs.is_empty() {
         blocks.push(docstring(&interface.docs, 0));
     }
-    if needs_os_import(interface) {
-        blocks.push("import os".to_owned());
+    let imports = imports(interface);
+    if !imports.is_empty() {
+        blocks.push(imports.join("\n"));
     }
     for error in &interface.errors {
         error_classes(error, &mut blocks);
@@ -61,8 +63,30 @@ pub fn docstring(lines: &[String], indent: usize) -> String {
     out
 }
 
-/// `import os` is needed exactly when a path can appear in argument position:
-/// function arguments and record constructor arguments (fields).
+/// The stub's imports, alphabetized: `collections.abc` exactly when a
+/// function returns a stream (its annotation is
+/// `collections.abc.AsyncIterator`), `os` exactly when a path can appear in
+/// argument position.
+fn imports(interface: &ir::Interface) -> Vec<String> {
+    let mut imports = Vec::new();
+    if needs_abc_import(interface) {
+        imports.push("import collections.abc".to_owned());
+    }
+    if needs_os_import(interface) {
+        imports.push("import os".to_owned());
+    }
+    imports
+}
+
+fn needs_abc_import(interface: &ir::Interface) -> bool {
+    interface
+        .functions
+        .iter()
+        .any(|function| matches!(function.ret, Some(ir::Type::Stream(_))))
+}
+
+/// A path in argument position: function arguments and record constructor
+/// arguments (fields).
 fn needs_os_import(interface: &ir::Interface) -> bool {
     let function_args = interface
         .functions
@@ -141,7 +165,9 @@ fn record_class(interface: &ir::Interface, record: &ir::Record) -> String {
 
 /// A function stub: literal defaults, `None` for undefaulted `Option`
 /// arguments, and a docstring that names the raised exception base when the
-/// function throws (stub signatures cannot express `raises`).
+/// function throws (stub signatures cannot express `raises`). Async functions
+/// render `async def`: the extension returns a coroutine resolving to the
+/// annotated type.
 fn function_def(interface: &ir::Interface, function: &ir::Function) -> String {
     let name = types::py_name(&function.names, &function.name);
     let params: Vec<String> = function.args.iter().map(|arg| parameter(interface, arg)).collect();
@@ -149,7 +175,11 @@ fn function_def(interface: &ir::Interface, function: &ir::Function) -> String {
         || "None".to_owned(),
         |ty| types::annotation(interface, ty, Position::Return),
     );
-    let header = format!("def {name}({}) -> {ret}:", params.join(", "));
+    let def = match function.asyncness {
+        ir::Asyncness::Async => "async def",
+        ir::Asyncness::Sync => "def",
+    };
+    let header = format!("{def} {name}({}) -> {ret}:", params.join(", "));
 
     let mut doc_lines = function.docs.clone();
     if let Some(throws) = &function.throws {

--- a/packages/unibind/gen/src/py/types.rs
+++ b/packages/unibind/gen/src/py/types.rs
@@ -35,6 +35,12 @@ pub fn annotation(interface: &ir::Interface, ty: &ir::Type, position: Position) 
             annotation(interface, value, position)
         ),
         ir::Type::Named(name) => record_py_name(interface, name),
+        // Stream items are always produced, never accepted, so the item
+        // renders in return position regardless of where the stream sits.
+        ir::Type::Stream(item) => format!(
+            "collections.abc.AsyncIterator[{}]",
+            annotation(interface, item, Position::Return)
+        ),
     }
 }
 
@@ -43,7 +49,9 @@ pub fn annotation(interface: &ir::Interface, ty: &ir::Type, position: Position) 
 pub fn mentions_path(ty: &ir::Type) -> bool {
     match ty {
         ir::Type::Path { .. } => true,
-        ir::Type::Option(inner) | ir::Type::Vec(inner) => mentions_path(inner),
+        ir::Type::Option(inner) | ir::Type::Vec(inner) | ir::Type::Stream(inner) => {
+            mentions_path(inner)
+        }
         ir::Type::Map { key, value } => mentions_path(key) || mentions_path(value),
         ir::Type::Bool
         | ir::Type::Int(_)

--- a/packages/unibind/gen/tests/render.rs
+++ b/packages/unibind/gen/tests/render.rs
@@ -48,6 +48,7 @@ fn function(name: &str, py: Option<&str>, doc_lines: &[&str], args: Vec<ir::Arg>
         names: names(py),
         docs: docs(doc_lines),
         asyncness: ir::Asyncness::Sync,
+        blocking: false,
         args,
         ret: None,
         throws: None,
@@ -107,7 +108,21 @@ fn sample_functions() -> Vec<ir::Function> {
             ],
         )
     };
-    vec![rows, write, find, greet]
+    let tail = ir::Function {
+        ret: Some(ir::Type::Stream(Box::new(owned_string()))),
+        ..function(
+            "tail",
+            None,
+            &["Follow appended rows."],
+            vec![arg("store", ir::Type::String { owned: false }, None)],
+        )
+    };
+    let ping = ir::Function {
+        asyncness: ir::Asyncness::Async,
+        ret: Some(ir::Type::Bool),
+        ..function("ping", None, &["Probe the store."], vec![])
+    };
+    vec![rows, write, find, greet, tail, ping]
 }
 
 fn sample_records() -> Vec<ir::Record> {

--- a/packages/unibind/gen/tests/snapshots/sample.init.py
+++ b/packages/unibind/gen/tests/snapshots/sample.init.py
@@ -12,7 +12,9 @@ from ._sample import (
     __version__,
     find,
     greet,
+    ping,
     rows,
+    tail,
     write_file,
 )
 
@@ -25,6 +27,8 @@ __all__ = [
     "__version__",
     "find",
     "greet",
+    "ping",
     "rows",
+    "tail",
     "write_file",
 ]

--- a/packages/unibind/gen/tests/snapshots/sample.pyi
+++ b/packages/unibind/gen/tests/snapshots/sample.pyi
@@ -4,6 +4,7 @@ Everything the phase 1 generator renders appears here once.
 """
 
 
+import collections.abc
 import os
 
 
@@ -65,4 +66,13 @@ def find(pattern: str, root: str | os.PathLike[str] | None = None) -> dict[str, 
 def greet(name: str = "hello \"world\"\n", ratio: float = 1.0, note: str | None = None) -> str: ...
 
 
+def tail(store: str) -> collections.abc.AsyncIterator[str]:
+    """Follow appended rows."""
+
+
+async def ping() -> bool:
+    """Probe the store."""
+
+
 __version__: str
+

--- a/packages/unibind/macros/src/lib.rs
+++ b/packages/unibind/macros/src/lib.rs
@@ -42,6 +42,10 @@ use proc_macro::TokenStream;
 /// untouched. The attribute accepts `py(name = "...")` to rename the Python
 /// module (it defaults to the Rust module name, which also names the
 /// `PyInit_` symbol of the built extension).
+///
+/// Glue for async functions, `UniStream` returns, and `#[unibind::object]`
+/// types calls into `unibind_runtime::py`, so a crate exporting any of
+/// those adds `unibind-runtime` with the `py` feature to its dependencies.
 #[proc_macro_attribute]
 pub fn export(args: TokenStream, item: TokenStream) -> TokenStream {
     expand::export(args.into(), item.into()).into()
@@ -87,7 +91,8 @@ pub fn error(_args: TokenStream, item: TokenStream) -> TokenStream {
 /// marked `#[unibind(constructor)]` makes the object constructible, and
 /// methods may be async or return streams. `object(resource)` requires a
 /// `close` method and adds close()/async-with plus a warning when the
-/// resource leaks unclosed.
+/// resource leaks unclosed. The wrapped struct crosses threads inside an
+/// `Arc`, so it must be `Send + Sync`.
 #[proc_macro_attribute]
 pub fn object(_args: TokenStream, item: TokenStream) -> TokenStream {
     expand::marker_outside_export(

--- a/packages/unibind/macros/src/lib.rs
+++ b/packages/unibind/macros/src/lib.rs
@@ -79,14 +79,21 @@ pub fn error(_args: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Reserved for stateful handles; lands with resources in phase 2
-/// (issue #1992).
+/// Mark a stateful handle inside a `#[unibind::export]` module.
+///
+/// The struct crosses the boundary by reference: the target language holds
+/// a wrapped handle whose state stays on the Rust side. Methods take
+/// `&self` (use interior mutability for state), one associated function
+/// marked `#[unibind(constructor)]` makes the object constructible, and
+/// methods may be async or return streams. `object(resource)` requires a
+/// `close` method and adds close()/async-with plus a warning when the
+/// resource leaks unclosed.
 #[proc_macro_attribute]
 pub fn object(_args: TokenStream, item: TokenStream) -> TokenStream {
     expand::marker_outside_export(
         item.into(),
-        "#[unibind::object] lands with resources in phase 2 (issue #1992); \
-         phase 0 covers sync functions, records, and errors",
+        "#[unibind::object] only takes effect inside a #[unibind::export] \
+         module; declare the struct inside the exported module",
     )
     .into()
 }

--- a/packages/unibind/runtime/Cargo.toml
+++ b/packages/unibind/runtime/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "unibind-runtime"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Boundary types exported code references at runtime: UniStream and the Python async helpers"
+
+[lints]
+workspace = true
+
+[features]
+py = ["dep:pyo3", "dep:pyo3-async-runtimes", "dep:tokio", "tokio/sync"]
+
+[dependencies]
+futures.workspace = true
+pyo3 = { workspace = true, optional = true }
+pyo3-async-runtimes = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }

--- a/packages/unibind/runtime/package.nix
+++ b/packages/unibind/runtime/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "unibind-runtime";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/unibind/runtime/src/lib.rs
+++ b/packages/unibind/runtime/src/lib.rs
@@ -1,0 +1,57 @@
+//! Boundary types exported code references at runtime.
+//!
+//! [`UniStream`] is the stream half of the unibind surface: an exported
+//! `fn` returning `UniStream<T>` becomes an async iterator in the target
+//! language, and items flow one poll per consumer request (pull-based
+//! backpressure). The `py` feature adds the Python async helpers the
+//! generated glue calls into.
+
+use std::fmt;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::Stream;
+use futures::StreamExt as _;
+
+#[cfg(feature = "py")]
+pub mod py;
+
+/// A boxed stream crossing the binding boundary.
+///
+/// Exported functions return it by value; the backend wraps it in the
+/// target language's async iterator, so each `__anext__` (or equivalent)
+/// pulls exactly one item and the producer sees backpressure for free.
+pub struct UniStream<T> {
+    inner: Pin<Box<dyn Stream<Item = T> + Send + 'static>>,
+}
+
+impl<T> UniStream<T> {
+    /// Box `stream` for the boundary.
+    #[must_use]
+    pub fn new(stream: impl Stream<Item = T> + Send + 'static) -> Self {
+        Self {
+            inner: Box::pin(stream),
+        }
+    }
+
+    /// Pull the next item; `None` once the stream ends.
+    pub async fn next(&mut self) -> Option<T> {
+        self.inner.next().await
+    }
+}
+
+impl<T> Stream for UniStream<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+// Opaque by hand: the boxed stream has no useful state to show, and a
+// derive would demand `T: Debug` from every exported item type.
+impl<T> fmt::Debug for UniStream<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("UniStream").finish_non_exhaustive()
+    }
+}

--- a/packages/unibind/runtime/src/py.rs
+++ b/packages/unibind/runtime/src/py.rs
@@ -1,0 +1,102 @@
+//! Python async helpers the generated glue calls.
+//!
+//! Everything here is a thin layer over `pyo3-async-runtimes`, so generated
+//! code only ever names `unibind_runtime`.
+
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+
+use pyo3::{Bound, PyAny, PyResult, Python};
+
+use crate::UniStream;
+
+/// Convert a Rust future into an awaitable Python object.
+///
+/// Single indirection point so generated glue only names `unibind-runtime`;
+/// the asyncio-cancel-drops-the-future guarantee is inherited from
+/// `pyo3-async-runtimes`.
+///
+/// # Errors
+///
+/// Fails when no asyncio event loop can be resolved for the calling
+/// context.
+pub fn future_into_py<'py, F, T>(py: Python<'py>, fut: F) -> PyResult<Bound<'py, PyAny>>
+where
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: for<'a> pyo3::IntoPyObject<'a> + Send + 'static,
+{
+    pyo3_async_runtimes::tokio::future_into_py(py, fut)
+}
+
+/// A [`UniStream`] shared with Python's async iterator protocol.
+///
+/// `__anext__` is called on one shared object from whichever task drives
+/// the iterator, so the stream sits behind a `tokio::sync::Mutex`: the
+/// lock serializes polls and keeps the returned future `Send`.
+pub struct SharedStream<T> {
+    inner: Arc<tokio::sync::Mutex<UniStream<T>>>,
+}
+
+// Manual impl: cloning shares the underlying stream, so `T: Clone` is not
+// required.
+impl<T> Clone for SharedStream<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T> SharedStream<T> {
+    /// Wrap `stream` for shared consumption.
+    #[must_use]
+    pub fn new(stream: UniStream<T>) -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(stream)),
+        }
+    }
+
+    /// Pull the next item. The future owns its own `Arc`, so it outlives
+    /// the `&self` borrow that produced it (pyo3 futures must be
+    /// `'static`).
+    #[must_use]
+    pub fn next(&self) -> impl Future<Output = Option<T>> + Send + 'static + use<T>
+    where
+        T: Send + 'static,
+    {
+        let inner = Arc::clone(&self.inner);
+        async move { inner.lock().await.next().await }
+    }
+}
+
+impl<T> fmt::Debug for SharedStream<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("SharedStream").finish_non_exhaustive()
+    }
+}
+    /// Wrap `stream` for shared consumption.
+    #[must_use]
+    pub fn new(stream: UniStream<T>) -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(stream)),
+        }
+    }
+
+    /// Pull the next item. The future owns its own `Arc`, so it outlives
+    /// the `&self` borrow that produced it (pyo3 futures must be
+    /// `'static`).
+    pub fn next(&self) -> impl Future<Output = Option<T>> + Send + 'static + use<T>
+    where
+        T: Send + 'static,
+    {
+        let inner = Arc::clone(&self.inner);
+        async move { inner.lock().await.next().await }
+    }
+}
+
+impl<T> fmt::Debug for SharedStream<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("SharedStream").finish_non_exhaustive()
+    }
+}

--- a/packages/unibind/runtime/src/py.rs
+++ b/packages/unibind/runtime/src/py.rs
@@ -5,7 +5,10 @@
 
 use std::fmt;
 use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+
+use futures::FutureExt as _;
 
 use pyo3::{Bound, PyAny, PyResult, Python};
 
@@ -17,6 +20,12 @@ use crate::UniStream;
 /// the asyncio-cancel-drops-the-future guarantee is inherited from
 /// `pyo3-async-runtimes`.
 ///
+/// The unwind is caught here because `pyo3-async-runtimes` reports a
+/// panicking future as `RustPanic: rust future panicked: unknown error`,
+/// discarding the payload; re-raising `pyo3::panic::PanicException` with
+/// the panic text matches the sync boundary, where pyo3 itself raises
+/// `PanicException` carrying the message.
+///
 /// # Errors
 ///
 /// Fails when no asyncio event loop can be resolved for the calling
@@ -26,7 +35,24 @@ where
     F: Future<Output = PyResult<T>> + Send + 'static,
     T: for<'a> pyo3::IntoPyObject<'a> + Send + 'static,
 {
-    pyo3_async_runtimes::tokio::future_into_py(py, fut)
+    let caught = AssertUnwindSafe(fut).catch_unwind();
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        match caught.await {
+            Ok(result) => result,
+            Err(payload) => Err(pyo3::panic::PanicException::new_err(panic_text(
+                payload.as_ref(),
+            ))),
+        }
+    })
+}
+
+/// Best-effort panic payload text, mirroring std's default panic hook.
+fn panic_text(payload: &(dyn std::any::Any + Send)) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|text| (*text).to_owned())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "Box<dyn Any>".to_owned())
 }
 
 /// A [`UniStream`] shared with Python's async iterator protocol.
@@ -49,32 +75,6 @@ impl<T> Clone for SharedStream<T> {
 }
 
 impl<T> SharedStream<T> {
-    /// Wrap `stream` for shared consumption.
-    #[must_use]
-    pub fn new(stream: UniStream<T>) -> Self {
-        Self {
-            inner: Arc::new(tokio::sync::Mutex::new(stream)),
-        }
-    }
-
-    /// Pull the next item. The future owns its own `Arc`, so it outlives
-    /// the `&self` borrow that produced it (pyo3 futures must be
-    /// `'static`).
-    #[must_use]
-    pub fn next(&self) -> impl Future<Output = Option<T>> + Send + 'static + use<T>
-    where
-        T: Send + 'static,
-    {
-        let inner = Arc::clone(&self.inner);
-        async move { inner.lock().await.next().await }
-    }
-}
-
-impl<T> fmt::Debug for SharedStream<T> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.debug_struct("SharedStream").finish_non_exhaustive()
-    }
-}
     /// Wrap `stream` for shared consumption.
     #[must_use]
     pub fn new(stream: UniStream<T>) -> Self {

--- a/packages/unibind/runtime/tests/stream.rs
+++ b/packages/unibind/runtime/tests/stream.rs
@@ -1,0 +1,39 @@
+//! `UniStream` drains in order and pulls items lazily, one per request.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use futures::executor::block_on;
+use futures::StreamExt as _;
+use unibind_runtime::UniStream;
+
+#[test]
+fn next_drains_a_stream_in_order() {
+    let mut stream = UniStream::new(futures::stream::iter([1, 2, 3]));
+    assert_eq!(block_on(stream.next()), Some(1));
+    assert_eq!(block_on(stream.next()), Some(2));
+    assert_eq!(block_on(stream.next()), Some(3));
+    assert_eq!(block_on(stream.next()), None);
+}
+
+#[test]
+fn items_are_produced_one_pull_at_a_time() {
+    let produced = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&produced);
+    let mut stream = UniStream::new(futures::stream::iter(0..).map(move |item: usize| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        item
+    }));
+    assert_eq!(produced.load(Ordering::SeqCst), 0, "nothing runs before the first pull");
+    assert_eq!(block_on(stream.next()), Some(0));
+    assert_eq!(produced.load(Ordering::SeqCst), 1);
+    assert_eq!(block_on(stream.next()), Some(1));
+    assert_eq!(produced.load(Ordering::SeqCst), 2, "an unbounded source only advances per next()");
+}
+
+#[test]
+fn unistream_is_itself_a_stream() {
+    let stream = UniStream::new(futures::stream::iter(["a", "b"]));
+    let items: Vec<&str> = block_on(stream.collect());
+    assert_eq!(items, ["a", "b"]);
+}


### PR DESCRIPTION
Phase 2 of unibind: exported `async fn`s become real asyncio coroutines with true cancellation, `UniStream<T>` returns become pull-based async iterators, `#[unibind::object]` / `object(resource)` ship stateful handles with deterministic cleanup, `#[unibind(blocking)]` releases the GIL, and `&[u8]` arguments cross zero-copy through the buffer protocol. Part of #1989. Closes #1992.

## What is here

- **unibind core: async, streams, objects, blocking in IR and lowering** -- the IR and syn lowering learn the phase-2 surface (`Asyncness::Async` now produced, `Function.blocking`, `Type::Stream`, `Object { resource, constructor, methods }`), with positioned errors for what still waits (plain enums).
- **unibind backend-py: async coroutines, streams, resources, buffer args** -- the pyo3 backend renders coroutines through `unibind_runtime::py::future_into_py`, per-function stream classes over `SharedStream` (`__aiter__` / `__anext__`, one poll per `__anext__`), frozen object wrappers with idempotent `close()`, `__aenter__` / `__aexit__`, and a `ResourceWarning` on drop-without-close, `py.detach` for `blocking`, and `PyBuffer<u8>` zero-copy `&[u8]` arguments. New `unibind-runtime` crate (`UniStream`, `SharedStream`, `future_into_py`); consumers exporting async/streams/objects add it with the `py` feature.
- **unibind conformance: spec cases, python runner, nix check** -- `packages/unibind/conformance`: a cdylib exporting the full phase-2 surface plus a stdlib-only, fully annotated `runner.py` that asserts the semantics from Python with quantitative evidence, wired as `checks.<system>.unibind-conformance-run`. The suite caught a runtime bug, fixed here: `pyo3-async-runtimes` reports a panicking future as `RustPanic: rust future panicked: unknown error`, discarding the message, so `unibind_runtime::py::future_into_py` now catches the unwind and re-raises `pyo3.PanicException` carrying the real panic text, matching the sync boundary.

## Conformance matrix

Full passing runner output (`cargo build -p unibind-conformance`, cdylib installed as `_conformance.abi3.so`, python 3.13; the two panic lines are the deliberate panic-containment probes writing to stderr):

```

thread '<unnamed>' (20646913) panicked at packages/unibind/conformance/src/lib.rs:278:9:
unibind conformance: deliberate sync panic
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'tokio-rt-worker' (20646963) panicked at packages/unibind/conformance/src/lib.rs:289:9:
unibind conformance: deliberate async panic
CASE echo-types... ok (all round-trips exact; raised 'conformance deliberate failure' as ValueError subclass)
CASE cancel-mid-flight... ok (live 1->0, dropped 0->1; Drop observed 11.1ms after cancel())
CASE stream-backpressure... ok (consumed=3 produced=3, unchanged after 0.2s idle; counting_stream(5) drained in order to StopAsyncIteration; record stream yielded [(0.0, -0.0), (1.0, -1.0), (2.0, -2.0)])
CASE drop-without-close... ok (leak warned once: "unclosed Gate: call close() or use 'async with'"; async-with closed exactly once and double close() bumped once; empty label raised 'gate label must not be empty')
CASE zero-copy-gil... ok (buffer@0x92b1e4000 matches buffer_addr for bytearray and memoryview; 2x300ms blocking sleeps walled 302ms; checksum 762880 == python sum)
CASE panic-containment... ok (sync panic -> PanicException, async panic -> PanicException; interpreter still live)
conformance: all 6 cases passed
```

## Evidence

### Cancellation drops the Rust future mid-flight

> CASE cancel-mid-flight... ok (live 1->0, dropped 0->1; Drop observed 11.1ms after cancel())

`hold_guard_forever()` parks a drop-guard behind a one-hour sleep; the only way `dropped_guards()` moves is the Rust future actually being dropped. `task.cancel()` from asyncio observed the Drop ~11ms later. This is the non-negotiable phase-2 semantic.

### Streams are pull-based (backpressure)

> CASE stream-backpressure... ok (consumed=3 produced=3, unchanged after 0.2s idle; counting_stream(5) drained in order to StopAsyncIteration; record stream yielded [(0.0, -0.0), (1.0, -1.0), (2.0, -2.0)])

`counting_stream(1000)` produced exactly 3 items for 3 `__anext__` calls (break after 3), unchanged after 0.2s idle; a full drain preserves order and ends in a natural `StopAsyncIteration`.

### Resources warn on leak; async-with and close are deterministic

> CASE drop-without-close... ok (leak warned once: "unclosed Gate: call close() or use 'async with'"; async-with closed exactly once and double close() bumped once; empty label raised 'gate label must not be empty')

Exactly one `ResourceWarning` for the leaked `Gate`; the `async with` path closes exactly once with no warning, and two awaited `close()` calls reach the Rust close once.

### Zero-copy buffers and GIL release

> CASE zero-copy-gil... ok (buffer@0x92b1e4000 matches buffer_addr for bytearray and memoryview; 2x300ms blocking sleeps walled 302ms; checksum 762880 == python sum)

`ctypes.addressof` of the `bytearray`'s buffer equals the address Rust sees, for both the `bytearray` and a `memoryview` of it. Two 300ms `#[unibind(blocking)]` sleeps on two Python threads walled ~302ms; a held GIL would serialize them to >=600ms.

Async panics now surface as `pyo3.PanicException` with the panic message (previously `pyo3_async_runtimes.RustPanic: rust future panicked: unknown error`); sync panics already did.

## IR changes (additive)

Old IR JSON stays parseable; every new field has a serde default:

- `Function.asyncness` is now produced as `Async` (the variant existed; phase 0 rejected it at lowering).
- `Function.blocking: bool` (`#[serde(default)]`).
- `Type::Stream(Box<Type>)`, return-position-only.
- `Object` gains `resource: bool`, `constructor: Option<Function>` (receiver-less; `ret = None` implies the object), and `methods: Vec<Function>` (implicit `&self`).

Authored by an AI agent (Claude Code) working issue #1992.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add async, blocking, streams, objects, and resources to the unibind Python backend
> - Extends the unibind macro and IR to support `async` functions, `#[unibind(blocking)]` sync functions (GIL-released), `UniStream<T>` return types, and `#[unibind::object]` structs with methods and constructors.
> - Adds a new `unibind-runtime` crate providing `UniStream<T>`, `SharedStream<T>`, and `future_into_py` for bridging Rust async and streams into Python awaitables and async iterators via pyo3-async-runtimes.
> - The Python backend now generates: async wrappers using `future_into_py`, per-export `#[pyclass]` stream iterators with `__anext__`, object wrappers backed by `Arc<T>`, and resource objects with idempotent `close()`/`__aenter__`/`__aexit__` and a `Drop`-based `ResourceWarning`.
> - Borrowed `&[u8]` arguments are lowered to `PyBuffer<u8>` with a C-contiguity check, making buffer-taking wrappers fallible even when the function does not throw.
> - Adds a new `unibind-conformance` cdylib crate with a Python runner that exercises all phase 2 surface areas end-to-end.
> - Generated `.pyi` stubs now emit `async def` for async functions and `collections.abc.AsyncIterator[T]` for stream returns.
> - Risk: wrappers that accept `&[u8]` now return `PyResult` unconditionally due to the buffer check, which is a behavioral change for callers expecting infallible signatures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a32f68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->