### PR TITLE
fix(rust): make darwin cross-lane IFD trivial builders substitutable

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -72,6 +72,9 @@
     writeProcessComposeApplication
     ;
   netCidr = import ./util/net-cidr.nix {inherit lib;};
+  # Force `allowSubstitutes = true` on a trivial-builder derivation that must be
+  # substitutable (darwin cross-lane eval-time IFD nodes). See its doc comment.
+  evalTimeSubstitutable = import ./util/eval-time-substitutable.nix;
   publicArtifactsFor = pkgs: import ./util/public-artifacts.nix {inherit lib pkgs;};
   # Apply an in-repo ordered patch series to an upstream source tree (the
   # de-forking replacement for a separate fork repo). Bound per package set like
@@ -79,7 +82,7 @@
   # system, not the top-level x86_64-linux one. See lib/util/patched-src.nix.
   patchedSrcFor = pkgs:
     import ./util/patched-src.nix {
-      inherit lib;
+      inherit lib evalTimeSubstitutable;
       inherit (pkgs) applyPatches;
     };
   # De-forked-package mapping (name -> input / upstream URL / patch dir), the
@@ -269,6 +272,7 @@
         clippy-src
         lists
         pins
+        evalTimeSubstitutable
         ;
       repoRoot = paths.root;
     })
@@ -575,6 +579,7 @@
       claudePlugin
       deepMerge
       efx
+      evalTimeSubstitutable
       forkPackages
       forkDagCheckSrc
       goUnit

--- a/lib/rust/build.nix
+++ b/lib/rust/build.nix
@@ -13,6 +13,9 @@
   lists,
   # Shared pins reader, threaded through to policy.nix (see its arg doc).
   pins,
+  # Flips `allowSubstitutes` back on for darwin cross-lane eval-time IFD nodes;
+  # threaded through to vendor.nix. See its doc comment.
+  evalTimeSubstitutable,
 }: let
   inherit (builtins) removeAttrs;
 
@@ -29,6 +32,7 @@
       writePythonApplication
       lists
       pins
+      evalTimeSubstitutable
       ;
   };
   inherit

--- a/lib/rust/resolve.nix
+++ b/lib/rust/resolve.nix
@@ -12,6 +12,9 @@
   lists,
   # Shared pins reader, threaded through to policy.nix (see its arg doc).
   pins,
+  # Flips `allowSubstitutes` back on for darwin cross-lane eval-time IFD nodes;
+  # threaded through to vendor.nix. See its doc comment.
+  evalTimeSubstitutable,
 }: let
   inherit (builtins) baseNameOf toString;
 
@@ -21,6 +24,7 @@
       pkgs
       writePythonApplication
       lists
+      evalTimeSubstitutable
       ;
   };
 

--- a/lib/rust/tooling.nix
+++ b/lib/rust/tooling.nix
@@ -9,6 +9,9 @@
   lists,
   # Shared pins reader, threaded through to policy.nix (see its arg doc).
   pins,
+  # Flips `allowSubstitutes` back on for darwin cross-lane eval-time IFD nodes;
+  # threaded down to vendor.nix / patched-src.nix. See its doc comment.
+  evalTimeSubstitutable,
 }: let
   inherit (builtins) toString;
 
@@ -19,7 +22,7 @@
   # which the astlog `no-parent-path` rule bans).
   patchedSrcFor = pkgs:
     import (repoRoot + "/lib/util/patched-src.nix") {
-      inherit lib;
+      inherit lib evalTimeSubstitutable;
       inherit (pkgs) applyPatches;
     };
 
@@ -35,6 +38,7 @@
         pkgs
         lists
         pins
+        evalTimeSubstitutable
         ;
       # llm-clippy bootstraps before cargoUnit / rustWorkspace exist, so the
       # `ix` closure it receives carries only `buildRustPackage` plus the

--- a/lib/rust/vendor.nix
+++ b/lib/rust/vendor.nix
@@ -9,6 +9,10 @@
   writePythonApplication,
   # List helpers, threaded in rather than imported across dirs.
   lists,
+  # Flip `allowSubstitutes` back on for the trivial-builder config files and the
+  # linkFarm vendor dir; threaded from lib rather than imported across dirs. See
+  # its doc comment.
+  evalTimeSubstitutable,
 }: let
   inherit
     (builtins)
@@ -75,7 +79,7 @@
     cargoLock,
     vendorDir,
   }: let
-    cargoExtraConfigFile = pkgs.writeText "cargo-extra-config.toml" cargoExtraConfig;
+    cargoExtraConfigFile = evalTimeSubstitutable (pkgs.writeText "cargo-extra-config.toml" cargoExtraConfig);
 
     gitSources = lib.unique (
       map (pkg: parseGitSource pkg.source // {inherit (pkg) source;}) (gitPackages cargoLock)
@@ -83,13 +87,13 @@
 
     # The default vendored-sources config, emitted when the vendor dir carries
     # no `.cargo/config.toml` of its own (the aggregate `linkFarm` never does).
-    vendorConfigFile = pkgs.writeText "cargo-vendor-config.toml" ''
+    vendorConfigFile = evalTimeSubstitutable (pkgs.writeText "cargo-vendor-config.toml" ''
       [source.crates-io]
       replace-with = "vendored-sources"
 
       [source.vendored-sources]
       directory = "${vendorDir}"
-    '';
+    '');
 
     # One `[source."<git>"]` table per git dependency, each replacing that git
     # source with the vendored copy. Rendered at eval time and `cat` in, rather
@@ -103,9 +107,9 @@
         ++ lib.optional (git.refType != null) "${git.refType} = ${toJSON git.ref}"
         ++ [''replace-with = "vendored-sources"'']
       );
-    gitSourceConfigFile = pkgs.writeText "cargo-git-sources.toml" (
+    gitSourceConfigFile = evalTimeSubstitutable (pkgs.writeText "cargo-git-sources.toml" (
       lib.concatMapStringsSep "\n\n" gitSourceBlock gitSources + "\n"
-    );
+    ));
   in
     ''
       export CARGO_HOME="$TMPDIR/cargo-home"
@@ -294,16 +298,7 @@
         Cargo.lock contains multiple git dependencies with the same name-version: ${join ", " duplicateNameVersions}
         cargo-unit cannot generate an aggregate vendor dir for this lock without losing source identity.
       '';
-        (pkgs.linkFarm "cargo-vendor-dir" vendorEntries).overrideAttrs (_old: {
-          # linkFarm hardcodes `allowSubstitutes = false` (a symlink farm is
-          # cheaper to rebuild than to fetch). That default is wrong here: a
-          # Darwin consumer forces this x86_64-linux drv at eval time through
-          # the cross lane's IFD (`import unitsNix` reaches the vendor dir),
-          # cannot build it, and with substitution disallowed cannot use the
-          # pushed cache output either -- eval dies with `platform mismatch`
-          # no matter how healthy cache.ix.dev is (#1711).
-          allowSubstitutes = true;
-        });
+        evalTimeSubstitutable (pkgs.linkFarm "cargo-vendor-dir" vendorEntries);
   in {
     inherit vendorSources vendorDir;
   };

--- a/lib/util/eval-time-substitutable.nix
+++ b/lib/util/eval-time-substitutable.nix
@@ -1,0 +1,31 @@
+# Mark a derivation as substitutable even though its nixpkgs builder opts out.
+#
+# The nixpkgs trivial builders (`writeText`, `writeTextFile`, `linkFarm`,
+# `applyPatches`, ...) hardcode `preferLocalBuild = true; allowSubstitutes =
+# false`: rebuilding a tiny text file or symlink farm locally is cheaper than a
+# narinfo round-trip, so on the platform that produced it substitution is a net
+# loss. That default is wrong for any such derivation that lands in the darwin
+# cross lane's eval-time IFD closure (the cargo-unit `vendorDir` / `unitGraphJson`
+# / `unitsNix` roots, and the de-forked `patchedSrcFor` sources they pull in):
+#
+#   - The derivation is `x86_64-linux`, so an aarch64-darwin consumer cannot
+#     build it. It is forced at *eval time* (`import unitsNix` reaches the whole
+#     vendor + patched-source closure), so a build is not even an option.
+#   - With `allowSubstitutes = false`, Nix never creates a substitution goal
+#     (`derivation-goal.cc` gates it on `substitutesAllowed`, which returns the
+#     derivation's `allowSubstitutes` unless `always-allow-substitutes` is set).
+#     It goes straight to build, fails, and eval dies with `platform mismatch`
+#     no matter how healthy the cache is -- the pushed, signed output is simply
+#     never consulted.
+#
+# So on these nodes the trade-off inverts: a Mac can only obtain the output by
+# substitution, and forcing `allowSubstitutes = true` is what makes the pushed
+# cache output usable. First hit and fixed for the `linkFarm` vendor dir alone
+# (#1711); this is the shared owner of that fact for every trivial-builder node
+# in the closure (#6318).
+#
+# drv -> drv, substitutable regardless of the builder's opt-out.
+drv:
+drv.overrideAttrs (_: {
+  allowSubstitutes = true;
+})

--- a/lib/util/patched-src.nix
+++ b/lib/util/patched-src.nix
@@ -11,9 +11,14 @@
 # files through a real `git rebase` when the pinned base moves, so plain `patch`
 # application is always correct at build time (the series is exact against the
 # pinned rev; the build never needs fuzzy or structural merging).
+# `applyPatches` is a nixpkgs trivial builder and opts out of substitution. A
+# patched source (e.g. ghostty) enters the darwin cross lane's eval-time IFD
+# closure, so a Mac must be able to substitute it: `evalTimeSubstitutable`
+# (threaded from lib) flips `allowSubstitutes` back on. See its doc comment.
 {
   lib,
   applyPatches,
+  evalTimeSubstitutable,
 }:
 # Return the patched source derivation. `applyPatches` copies `src` and runs
 # `patch` for each entry, so the result is a tiny, seconds-fast derivation that
@@ -57,7 +62,7 @@
     then fail "trailing signature block (--no-signature)"
     else path;
 in
-  applyPatches {
+  evalTimeSubstitutable (applyPatches {
     name = "${name}-patched";
     inherit src;
     patches = lib.pipe (builtins.readDir patchDir) [
@@ -66,4 +71,4 @@ in
       lib.naturalSort
       (map (f: assertCanonical f (patchDir + "/${f}")))
     ];
-  }
+  })


### PR DESCRIPTION
## Problem

Substitute-only darwin eval (#6318) fails realising `x86_64-linux` trivial-builder derivations that sit in the darwin cross lane's **eval-time IFD closure** — `cargo-git-sources.toml` / `cargo-vendor-config.toml` / `cargo-extra-config.toml` (`writeText`) and the de-forked `patchedSrcFor` sources like `ghostty-patched` (`applyPatches`).

Root cause: nixpkgs trivial builders hardcode `preferLocalBuild = true; allowSubstitutes = false`. On the darwin consumer:
- The drv is `x86_64-linux`, so it cannot be built, and it is forced at *eval time* (`import unitsNix` reaches the whole vendor + patched-source closure), so building is not even an option.
- With `allowSubstitutes = false`, Nix never creates a substitution goal (`derivation-goal.cc` gates all substitution on `substitutesAllowed`, which returns the drv's `allowSubstitutes` unless `always-allow-substitutes` is set). Eval goes straight to build, fails, and dies with `platform mismatch` — the pushed, signed cache output is never consulted.

Verified live: `nix build '…/cargo-git-sources.toml.drv^*' --store <fresh chroot> --max-jobs 0 --builders ''` fails; adding `--always-allow-substitutes` substitutes the path and succeeds.

## Fix

#1711 already fixed exactly this for the `linkFarm` vendor dir alone (its comment describes the same "Darwin consumer forces x86_64-linux drv at eval time, platform mismatch no matter how healthy the cache" symptom). That fix was applied to one node only.

This extracts the fact into a shared `evalTimeSubstitutable` helper (`lib/util/eval-time-substitutable.nix`) that owns the "trivial builder in the darwin cross IFD closure must stay substitutable" rule in one place, and applies it to every such node: the three cargo config files, the linkFarm vendor dir (now via the helper), and the `patchedSrcFor` output (covers ghostty and every de-forked source, including the ix repo's, which uses this same helper).

The helper is threaded as an explicit arg through `tooling → build → resolve → vendor` and into `patchedSrcFor`, rather than a `../` import, to satisfy the astlog `no-parent-path` rule.

## Validation

- `flake.lib.patchedSrcFor` output for a real fork (`btop-patched`) now evaluates with `allowSubstitutes = true` (was `false`).
- `nix run .#lint --json`: no findings on the changed files (blocking `no-parent-path` cleared; formatting clean).
- Full substitute-only e2e proof (fresh-chroot goal without `--always-allow-substitutes`) requires a cache warm at a rev carrying this change; pairs with the ix-side signing fix (cache-warm `copy-sigs`).

Part of #6318.

🤖 Generated with Claude Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark darwin cross-lane IFD trivial builders as substitutable
> - Adds a new `evalTimeSubstitutable` utility in [eval-time-substitutable.nix](https://github.com/indexable-inc/index/pull/2103/files#diff-6f4a22394483fad49cd5ca557ee7bcb005cf2b9a3d505c850d1e1afc94e27c8c) that sets `allowSubstitutes = true` on a derivation.
> - Applies this wrapper to patched source derivations in [patched-src.nix](https://github.com/indexable-inc/index/pull/2103/files#diff-884080a8ece8fb33e6f399224ac8b22124189c4e4d5b42a9090ef4006c6fbb1d) and to vendor config `writeText` derivations and the `linkFarm` vendor dir in [vendor.nix](https://github.com/indexable-inc/index/pull/2103/files#diff-a68ba2f291e368b8545afebfed95122fe35b497c0e4e6be7aae8ca53864a61b7).
> - Threads `evalTimeSubstitutable` through the Rust tooling pipeline ([build.nix](https://github.com/indexable-inc/index/pull/2103/files#diff-8ab3484d4c25eaf4ab0beac36848ba87229282d10d3524b969f90a880b330dab), [resolve.nix](https://github.com/indexable-inc/index/pull/2103/files#diff-01eebebfe941e24fad4962a02d46acd8fb6e31ea2ccab661777c0c10c9d427fc), [tooling.nix](https://github.com/indexable-inc/index/pull/2103/files#diff-192f079c8819deb5977b10c31e85fcefdb047e2893f032159271a565a0dd8dfc)) and exposes it from [lib/default.nix](https://github.com/indexable-inc/index/pull/2103/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c53674a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->