### PR TITLE
readme sweep: examples (nixos, observability, oci, storage, misc)

### DIFF
--- a/examples/multi-client/file-sharing/README.md
+++ b/examples/multi-client/file-sharing/README.md
@@ -1,13 +1,13 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="two client VMs mount an SMB 3.1.1 share from a file-server VM whose smbd mediates flock and fcntl locks centrally"></p>
+
 # Multi-client file sharing
 
-Standalone consumer example for sharing files across ix VMs over SMB with
-correct POSIX locking semantics.
-
-A `file-server` node exports `/var/lib/file-share` as the share named `share`.
-Two client replicas (`client-0` and `client-1`) mount it at `/mnt/share` over
-SMB 3.1.1. Linux's `cifs.ko` translates both `fcntl` byte-range locks and
-`flock()` into native SMB byte-range locks, and `smbd` is configured to
-mediate locks centrally, so locks coordinate across both clients.
+Ever had two VMs clobber the same file because their locks never saw each
+other? This fleet shares one directory across ix VMs over SMB 3.1.1 with
+locking that actually coordinates: a `file-server` node exports
+`/var/lib/file-share`, two client replicas mount it at `/mnt/share`, and
+`smbd` mediates every `flock()` and `fcntl` byte-range lock centrally, so a
+lock taken on `client-0` blocks `client-1`.
 
 ## Run
 
@@ -16,10 +16,14 @@ mediate locks centrally, so locks coordinate across both clients.
 nix run .#multi-client-file-sharing-up
 ```
 
+`nix run .#multi-client-file-sharing-health` re-runs the health checks (smbd
+active, CIFS mounted on both clients). Get the repo with
+`git clone https://github.com/indexable-inc/index`.
+
 ## Shape
 
-- [`ix.nix`](ix.nix) defines the fleet: one server node and two
-  client replicas with `dependsOn` so the server is up first.
+- [`ix.nix`](ix.nix) defines the fleet: one server node and two client
+  replicas with `dependsOn` so the server is up first.
 - [`server.nix`](server.nix) configures Samba with the locking knobs
   (`strict locking`, `posix locking`, `kernel oplocks = no`,
   `strict sync = yes`) that keep two clients honest about each other's writes.
@@ -42,17 +46,17 @@ ix shell client-1 -- flock -nx /mnt/share/lockfile -c 'echo got-it'
 ```
 
 The second invocation exits with status 1 until the first releases. Swap
-`flock` for a `python -c 'import fcntl; fcntl.lockf(...)'` snippet to exercise
-the same path via `fcntl` byte-range locks.
+`flock` for `python -c 'import fcntl; fcntl.lockf(...)'` to exercise the same
+path via `fcntl` byte-range locks.
 
 ## Tradeoffs
 
-- The share is **guest-writable** by default so the generated up wrapper works without secrets
-  plumbing. Real deployments should drop `guest ok = yes` from
+- The share is **guest-writable** so the generated up wrapper works without
+  secrets plumbing. Real deployments should drop `guest ok = yes` from
   [`server.nix`](server.nix), add a Samba user with `smbpasswd`, and pass
   `credentials=` to the CIFS mount through a systemd `LoadCredential` (the
-  same shape [`python-daily-scraper`](../python-daily-scraper) uses for AWS
-  keys).
+  same shape [`python/daily-scraper`](../../python/daily-scraper) uses for
+  AWS keys).
 - ix VMs share the host `linux-ix` kernel, so the SMB server has to be
   userspace `smbd` rather than in-kernel `ksmbd`. The client side still rides
   on `cifs.ko` from the host kernel.

--- a/examples/multi-client/file-sharing/assets/hero.svg
+++ b/examples/multi-client/file-sharing/assets/hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 180" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="25" y="30" width="150" height="52" rx="8"/>
+  <text x="100" y="52" text-anchor="middle" font-size="14" font-weight="600">client-0</text>
+  <text x="100" y="70" text-anchor="middle" font-size="11" class="muted">/mnt/share (cifs)</text>
+
+  <rect class="box" x="25" y="100" width="150" height="52" rx="8"/>
+  <text x="100" y="122" text-anchor="middle" font-size="14" font-weight="600">client-1</text>
+  <text x="100" y="140" text-anchor="middle" font-size="11" class="muted">/mnt/share (cifs)</text>
+
+  <line class="edge" x1="175" y1="56" x2="455" y2="76"/>
+  <text x="315" y="50" text-anchor="middle" font-size="12" class="muted">mount SMB 3.1.1</text>
+
+  <line class="edge" x1="175" y1="126" x2="455" y2="106"/>
+  <text x="315" y="140" text-anchor="middle" font-size="12" class="muted">flock / fcntl byte-range locks</text>
+
+  <rect class="box" x="460" y="52" width="235" height="78" rx="8"/>
+  <text x="577" y="76" text-anchor="middle" font-size="14" font-weight="600">file-server</text>
+  <text x="577" y="94" text-anchor="middle" font-size="11" class="muted">smbd exports /var/lib/file-share</text>
+  <text x="577" y="112" text-anchor="middle" font-size="11" class="accent">locks mediated centrally</text>
+</svg>

--- a/examples/nixos/switch-multi/README.md
+++ b/examples/nixos/switch-multi/README.md
@@ -1,9 +1,13 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="one builder VM builds three closures that fan out through regional CAS to the web, worker, and edge VMs"></p>
+
 # NixOS switch: many VMs, one build VM
 
-Switch several NixOS VMs in a single command, building every closure on one
-shared build-time VM. This is the colmena-style "build once, push many" loop as a
-first-class `ix up`: the source uploads once, each closure builds on the warm
-builder, and the activations fan out to their VMs through regional CAS.
+How do you rebuild a fleet of NixOS VMs without N cold builds, and without
+routing every closure through your laptop? This example switches three VMs in
+a single command, building every closure on one shared build-time VM: the
+source uploads once, each closure builds on the warm builder, and the
+activations fan out to their VMs through regional CAS. It is the
+colmena-style "build once, push many" loop as a first-class `ix up`.
 
 ## Run
 
@@ -15,47 +19,51 @@ ix up .#builder
 ix up .#web .#worker .#edge --build-vm builder
 ```
 
-The second command creates `web`, `worker`, and `edge` from `ix/base` if they do
-not exist, builds their closures on `builder`, and activates each on its own VM.
-Re-run it to converge them, the same contract as `nixos-rebuild switch`.
+The second command creates `web`, `worker`, and `edge` from `ix/base` if they
+do not exist, builds their closures on `builder`, and activates each on its
+own VM. Re-run it to converge them, the same contract as
+`nixos-rebuild switch`.
 
 ## Why one build VM
 
-`builder` keeps a warm `/nix/store`, so the first closure pays the full build and
-the rest only build their own delta. The built closures travel builder to target
-through regional CAS, which deduplicates the shared system paths, so the bytes on
-the wire for `worker` and `edge` are a fraction of a full closure. You get fleet
-rebuilds without N cold builds and without routing closures through your laptop.
+`builder` keeps a warm `/nix/store`, so the first closure pays the full build
+and the rest only build their own delta. The built closures travel builder to
+target through regional CAS, which deduplicates the shared system paths, so
+the bytes on the wire for `worker` and `edge` are a fraction of a full
+closure. You get fleet rebuilds without N cold builds and without routing
+closures through your laptop.
 
 ## The loop
 
-1. Edit a configuration in [`flake.nix`](flake.nix): change a VM's package list.
+1. Edit a configuration in [`ix.nix`](ix.nix): change a VM's package list.
 2. Run the multi-VM `ix up` again. Only the changed closures rebuild on the
    builder; unchanged VMs are a no-op.
-3. `ix shell web -- rg --version` (or `worker -- jq`, `edge -- hello`) confirms
-   the new closure is live.
-
-## Shape
-
-- [`flake.nix`](flake.nix) declares `builder` plus the target VMs `web`,
-  `worker`, and `edge`, each a NixOS system differing only by its sentinel
-  package.
-- [`configuration.nix`](configuration.nix) is the shared NixOS module every VM
-  switches onto. It imports `virtualisation/docker-image.nix` so the system
-  evaluates against the `ix/base` image without a bootloader.
+3. `ix shell web -- rg --version` (or `worker -- jq`, `edge -- hello`)
+   confirms the new closure is live.
 
 ## Rules
 
-- Multiple targets require `--build-vm`: one build-time VM is what makes this one
-  operation instead of N. The build VM must already exist (step 1).
-- Each target names its own configuration (`.#web`), so `--name` is not used with
-  multiple targets.
+- Multiple targets require `--build-vm`: one build-time VM is what makes this
+  one operation instead of N. The build VM must already exist (step 1).
+- Each target names its own configuration (`.#web`), so `--name` is not used
+  with multiple targets.
 - The builder and every target must share a region (CAS chunks are
-  region-scoped). A cross-region target is a typed error, not a silent fallback.
+  region-scoped). A cross-region target is a typed error, not a silent
+  fallback.
 - A failed target is reported on its own; its siblings still switch.
+
+## Shape
+
+- [`flake.nix`](flake.nix) is the entrypoint; unlike the `mkFleet` examples
+  it exposes raw `nixosConfigurations` (`builder`, `web`, `worker`, `edge`).
+- [`ix.nix`](ix.nix) builds those systems; each target differs only by its
+  sentinel package.
+- [`configuration.nix`](configuration.nix) is the shared NixOS module every
+  VM switches onto. It imports `virtualisation/docker-image.nix` so the
+  system evaluates against the `ix/base` image without a bootloader.
 
 ## Fork it
 
-Copy this directory, add or rename configurations in `flake.nix`, and point
-`--build-vm` at your own builder VM. No admin rights are needed: you build and
-activate your own systems onto your own VMs.
+Copy this directory, add or rename configurations in [`ix.nix`](ix.nix), and
+point `--build-vm` at your own builder VM. The `index` flake input pulls
+`github:indexable-inc/index` for you; no admin rights are needed.

--- a/examples/nixos/switch-multi/assets/hero.svg
+++ b/examples/nixos/switch-multi/assets/hero.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="73" width="150" height="56" rx="8"/>
+  <text x="95" y="96" text-anchor="middle" font-size="14" font-weight="600">builder VM</text>
+  <text x="95" y="114" text-anchor="middle" font-size="11" class="muted">warm /nix/store</text>
+
+  <line class="edge" x1="170" y1="101" x2="285" y2="101"/>
+  <text x="227" y="91" text-anchor="middle" font-size="12" class="muted">build 3 closures</text>
+
+  <rect class="box" x="287" y="73" width="160" height="56" rx="8"/>
+  <text x="367" y="96" text-anchor="middle" font-size="14" font-weight="600">regional CAS</text>
+  <text x="367" y="114" text-anchor="middle" font-size="11" class="muted">dedups shared paths</text>
+
+  <line class="edge" x1="447" y1="90" x2="540" y2="46"/>
+  <line class="edge" x1="447" y1="101" x2="540" y2="101"/>
+  <line class="edge" x1="447" y1="112" x2="540" y2="156"/>
+  <text x="493" y="76" text-anchor="middle" font-size="12" class="muted">activate</text>
+
+  <rect class="box" x="542" y="22" width="150" height="44" rx="8"/>
+  <text x="617" y="49" text-anchor="middle" font-size="13" font-weight="600">web</text>
+  <rect class="box" x="542" y="79" width="150" height="44" rx="8"/>
+  <text x="617" y="106" text-anchor="middle" font-size="13" font-weight="600">worker</text>
+  <rect class="box" x="542" y="136" width="150" height="44" rx="8"/>
+  <text x="617" y="163" text-anchor="middle" font-size="13" font-weight="600">edge</text>
+
+  <text x="20" y="172" font-size="12" class="muted">ix up .#web .#worker .#edge --build-vm builder</text>
+</svg>

--- a/examples/nixos/switch/README.md
+++ b/examples/nixos/switch/README.md
@@ -1,30 +1,31 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="ix up uploads configuration.nix, builds the closure server-side, and switches the running devbox VM in place"></p>
+
 # NixOS switch
 
-The smallest fork-and-go example of the native `ix up` loop: boot a NixOS VM
-from the `ix/base` image, add a package, and watch ix rebuild and activate the
-new system on the running VM in place.
-
-This is the native path to switch a NixOS VM via ix infrastructure. Your source
-tree is uploaded to ix, the `nix build` and `switch-to-configuration switch` run
-server-side on ix (not as remote-shell commands driven from your laptop), and
-only the result streams back. Re-running converges the VM to the current
+Want `nixos-rebuild switch` for a VM in the cloud, without building on your
+laptop or shipping closures over your uplink? `ix up .#devbox` uploads this
+source tree to ix, builds the NixOS closure server-side, and activates it on
+the running VM in place. Re-running converges the VM to the current
 configuration, the same contract as `nixos-rebuild switch`.
 
 ## Run
 
 ```sh
+# From this directory.
 ix up .#devbox
 ```
 
 The first run creates `devbox` from `ix/base:latest` and activates this
-configuration on it.
+configuration on it. From a clone of the index repo root,
+`nix run .#nixos-switch-up` brings up the same fleet through the generated
+wrapper.
 
 ## The loop
 
 1. Edit [`configuration.nix`](configuration.nix): add a package to
    `environment.systemPackages` (try `pkgs.ripgrep`).
-2. Run `ix up .#devbox` again. ix uploads the change, builds the new closure on ix, and
-   switches the running VM to it.
+2. Run `ix up .#devbox` again. ix uploads the change, builds the new closure,
+   and switches the running VM to it.
 3. `ix shell devbox` and confirm the new package is on `PATH`.
 
 The VM keeps running across switches: only its system generation changes,
@@ -41,10 +42,13 @@ nothing is recreated.
 
 ## Fork it
 
-Copy this directory into your own repo and keep `flake.nix` as the entrypoint. The switch path needs no admin rights: it builds and activates your own system onto your own VM.
+Copy this directory into your own repo and keep `flake.nix` as the
+entrypoint; its `index` input pulls `github:indexable-inc/index` for you. The
+switch path needs no admin rights: it builds and activates your own system
+onto your own VM.
 
 ## Scope
 
-This builds on the target VM itself, the `ix up` default. Building
-on a separate per-user builder VM (`--build-vm`) is a follow-up; the same-VM
-path shown here is the native switch primitive.
+This builds on the target VM itself, the `ix up` default. Building several
+VMs on one shared builder VM is what [`switch-multi`](../switch-multi)
+demonstrates with `--build-vm`.

--- a/examples/nixos/switch/assets/hero.svg
+++ b/examples/nixos/switch/assets/hero.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="50" width="180" height="56" rx="8"/>
+  <text x="110" y="73" text-anchor="middle" font-size="14" font-weight="600">configuration.nix</text>
+  <text x="110" y="91" text-anchor="middle" font-size="11" class="muted">an ordinary NixOS module</text>
+
+  <line class="edge" x1="200" y1="78" x2="290" y2="78"/>
+  <text x="245" y="68" text-anchor="middle" font-size="12" class="muted">upload</text>
+
+  <rect class="box" x="292" y="50" width="150" height="56" rx="8"/>
+  <text x="367" y="73" text-anchor="middle" font-size="14" font-weight="600">ix</text>
+  <text x="367" y="91" text-anchor="middle" font-size="11" class="muted">builds server-side</text>
+
+  <line class="edge" x1="442" y1="78" x2="532" y2="78"/>
+  <text x="487" y="68" text-anchor="middle" font-size="12" class="muted">switch</text>
+
+  <rect class="box" x="534" y="50" width="166" height="56" rx="8"/>
+  <text x="617" y="73" text-anchor="middle" font-size="14" font-weight="600">devbox VM</text>
+  <text x="617" y="91" text-anchor="middle" font-size="11" class="accent">activated in place</text>
+
+  <path class="edge" d="M617 106 C 600 150, 160 150, 113 108"/>
+  <text x="367" y="145" text-anchor="middle" font-size="12" class="muted">edit, run ix up .#devbox again, converge</text>
+</svg>

--- a/examples/observability/stack/README.md
+++ b/examples/observability/stack/README.md
@@ -1,35 +1,44 @@
-# Observability Stack
+<p align="center"><img src="assets/hero.svg" width="720" alt="an app VM's collector agent forwards spans and tailed logs over OTLP to an observability VM running a collector, ClickHouse, and Grafana"></p>
 
-An ix fleet with a self-hosted OpenTelemetry collector, ClickHouse, and
-Grafana. The app node sends a span through its local collector, writes a log
-line that the collector tails, and checks that both records land in ClickHouse.
+# Observability stack
+
+Where do spans and logs go when your app runs in a VM you created five
+minutes ago? This fleet self-hosts the whole pipeline: an `observability`
+node runs an OpenTelemetry collector, ClickHouse, and Grafana, and an `app`
+node exercises both instrumentation paths by sending a span through its local
+collector agent and writing a log line the agent tails. A health check holds
+the fleet unhealthy until both records actually land in ClickHouse.
 
 For how the telemetry pipeline works end to end, with diagrams, see the
-[module README](../../modules/services/observability/README.md).
+[module README](../../../modules/services/observability/README.md).
 
 ## Run
 
 ```sh
+# From the index repo root.
 nix run .#observability-stack-up
 ```
 
-Grafana is on port `3000` through the example's L7 proxy. The ClickHouse-backed
-query helper is available inside the observability VM:
+Grafana is on port `3000` through the example's L7 proxy. The
+ClickHouse-backed query helper is available inside the observability VM:
 
 ```sh
 ix shell observability -- ix-observe logs --limit 20
 ix shell observability -- ix-observe slow-spans
 ```
 
+Get the repo with `git clone https://github.com/indexable-inc/index`.
+
 ## Shape
 
-- `observability` runs [`services.ix-observability`](../../modules/services/observability/).
+- `observability` runs
+  [`services.ix-observability`](../../../modules/services/observability/).
 - `app` enables only the local collector agent and forwards OTLP to
   `observability:4317`.
-- [`app.nix`](app.nix) proves both instrumentation paths: direct OTLP spans and
-  file-tailed logs.
+- [`app.nix`](app.nix) proves both instrumentation paths: direct OTLP spans
+  and file-tailed logs.
 
-## Swap In Your Service
+## Swap in your service
 
 Keep the observability node, then add this to an application VM:
 

--- a/examples/observability/stack/assets/hero.svg
+++ b/examples/observability/stack/assets/hero.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="55" width="180" height="80" rx="8"/>
+  <text x="110" y="80" text-anchor="middle" font-size="14" font-weight="600">app VM</text>
+  <text x="110" y="99" text-anchor="middle" font-size="11" class="muted">collector agent</text>
+  <text x="110" y="116" text-anchor="middle" font-size="11" class="muted">spans + tailed app.log</text>
+
+  <line class="edge" x1="200" y1="95" x2="348" y2="95"/>
+  <text x="274" y="85" text-anchor="middle" font-size="12" class="muted">OTLP :4317</text>
+
+  <rect class="box" x="350" y="25" width="350" height="140" rx="8"/>
+  <text x="525" y="47" text-anchor="middle" font-size="13" font-weight="600">observability VM</text>
+
+  <rect class="box" x="368" y="65" width="94" height="52" rx="6"/>
+  <text x="415" y="95" text-anchor="middle" font-size="12">collector</text>
+
+  <line class="edge" x1="462" y1="91" x2="490" y2="91"/>
+
+  <rect class="box" x="492" y="65" width="100" height="52" rx="6"/>
+  <text x="542" y="95" text-anchor="middle" font-size="12">ClickHouse</text>
+
+  <line class="edge" x1="592" y1="91" x2="614" y2="91"/>
+
+  <rect class="box" x="616" y="65" width="70" height="52" rx="6"/>
+  <text x="651" y="89" text-anchor="middle" font-size="12">Grafana</text>
+  <text x="651" y="105" text-anchor="middle" font-size="10" class="muted">:3000</text>
+
+  <text x="525" y="147" text-anchor="middle" font-size="11" class="accent">health: rows land in otel_traces + otel_logs</text>
+</svg>

--- a/examples/oci/README.md
+++ b/examples/oci/README.md
@@ -1,42 +1,51 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="a digest-pinned distro userland plus a Nix layer assemble into an OCI archive that ix image push uploads to a registry"></p>
+
 # Non-NixOS OCI images
 
-These examples build OCI images on a non-Nix base (ubuntu, debian) with Nix
-packages layered on top, using `index.lib.mkNonNixImage`. They cover the path a
-plain-distro image takes, outside the NixOS module/fleet path.
+Need an image that is plain Ubuntu or Debian inside, with Nix-built tools
+layered on top? These examples build OCI images on a non-Nix base with
+`index.lib.mkNonNixImage`: the base distro's own userland stays as the rootfs
+(so `/bin/bash`, `apt`, and the FHS are all present) and Nix store paths ride
+along as extra layers. This is the path a plain-distro image takes, outside
+the NixOS module/fleet path.
 
-Build one:
+## Build
 
-```
+```sh
+# From the index repo root.
 nix build .#non-nix-ubuntu
 nix build .#non-nix-debian
 ```
 
-Each archive is a standard OCI image, so `ix image push <name> registry.ix.dev/...`
-works for these standalone archives.
+Each result is a standard OCI archive, so
+`ix image push <name> registry.ix.dev/...` works on it directly. Get the repo
+with `git clone https://github.com/indexable-inc/index`.
 
-## Why the leading underscore
+## Not fleets
 
-The directory is `_non-nix-oci` so the example fleet discovery skips it. The
-entries under `examples/` are NixOS fleets driven by `mkFleet` (each exposes
-`ix fleet up/health/...` wrappers). These images are not fleets and not NixOS
-systems, so they are discovered separately and surfaced as opt-in image packages.
+The other entries under `examples/` are NixOS fleets driven by `mkFleet`,
+each exposing generated `<name>-up` / `<name>-health` wrapper packages. The
+[`ubuntu`](ubuntu/) and [`debian`](debian/) directories here return images
+instead of fleet plans, so example fleet discovery skips them; they surface
+as the opt-in `non-nix-*` packages above instead.
 
 ## How it differs from `mkImage`
 
 `mkImage` builds a NixOS system closure: systemd as PID 1, `/init` as the
 entrypoint, the closure as the rootfs. `mkNonNixImage` keeps the base image's
-own userland as the rootfs and adds Nix store paths as extra layers. There is no
-systemd, no `/init`; the entrypoint is whatever the base or your `config`
+own userland as the rootfs and adds Nix store paths as extra layers. There is
+no systemd, no `/init`; the entrypoint is whatever the base or your `config`
 provides.
 
 ## Reproducibility
 
 The base is pulled by digest via `dockerTools.pullImage`, not by tag, so the
-build does not depend on what `ubuntu:24.04` points at today. To bump a base:
+build does not depend on what `ubuntu:24.04` points at today. Each example
+keeps its digest and fetch hash in a sibling `pins.json`. To bump a base:
 
-```
+```sh
 nix run nixpkgs#nix-prefetch-docker -- --os linux --arch amd64 \
   --image-name ubuntu --image-tag 24.04
 ```
 
-Copy the `imageDigest` and `hash` it prints into the example.
+Copy the `imageDigest` and `hash` it prints into `pins.json`.

--- a/examples/oci/assets/hero.svg
+++ b/examples/oci/assets/hero.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 180" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <text x="120" y="45" text-anchor="middle" font-size="13" font-weight="600">layers</text>
+  <rect class="box" x="30" y="60" width="180" height="32" rx="4"/>
+  <text x="120" y="81" text-anchor="middle" font-size="11" class="accent">Nix layer: /bin/hello</text>
+  <rect class="box" x="30" y="100" width="180" height="32" rx="4"/>
+  <text x="120" y="121" text-anchor="middle" font-size="11">ubuntu / debian userland</text>
+  <text x="120" y="152" text-anchor="middle" font-size="10" class="muted">base pulled by digest, not tag</text>
+
+  <line class="edge" x1="210" y1="96" x2="300" y2="96"/>
+  <text x="255" y="86" text-anchor="middle" font-size="12" class="muted">assemble</text>
+
+  <rect class="box" x="302" y="68" width="170" height="56" rx="8"/>
+  <text x="387" y="91" text-anchor="middle" font-size="14" font-weight="600">mkNonNixImage</text>
+  <text x="387" y="109" text-anchor="middle" font-size="11" class="muted">OCI archive</text>
+
+  <line class="edge" x1="472" y1="96" x2="562" y2="96"/>
+  <text x="517" y="86" text-anchor="middle" font-size="12" class="muted">ix image push</text>
+
+  <rect class="box" x="564" y="68" width="136" height="56" rx="8"/>
+  <text x="632" y="91" text-anchor="middle" font-size="14" font-weight="600">registry</text>
+  <text x="632" y="109" text-anchor="middle" font-size="11" class="muted">registry.ix.dev</text>
+</svg>

--- a/examples/polyglot/dev/README.md
+++ b/examples/polyglot/dev/README.md
@@ -1,35 +1,39 @@
-# Polyglot Dev VM
+<p align="center"><img src="assets/hero.svg" width="720" alt="ix.languages helpers compose one workbench VM whose PATH carries JVM, native, scripting, functional, and BEAM toolchains plus language servers"></p>
 
-One ix fleet node with a wide spread of language toolchains pre-installed
-through [`ix.languages.*`](../../../lib/languages/), plus the matching language
-servers, so an `ix shell workbench` lands you somewhere that already has
-`cargo`, `kotlinc`, `gleam`, `dune`, `tsc`, and friends on PATH.
+# Polyglot dev VM
 
-The point of the example is to show how the `ix.languages.*` helpers compose:
-one JDK is resolved once and threaded through every JVM tool, the language
-servers travel with their compilers, and the runtime JVM profile keeps
-`JAVA_HOME` aligned with whatever `java`/`javac` end up on PATH.
+Want one VM where `cargo`, `kotlinc`, `gleam`, `dune`, and `tsc` are already
+on PATH, with their language servers next to them? This fleet builds a single
+`workbench` node from the [`ix.languages.*`](../../../lib/languages/)
+helpers. The point is how the helpers compose: one JDK is resolved once and
+threaded through every JVM tool, the language servers travel with their
+compilers, and the `ix.profiles.jvm` runtime keeps `JAVA_HOME` aligned with
+whatever `java` and `javac` end up on PATH.
 
 ## Run
 
 ```sh
 # From the index repo root.
 nix run .#polyglot-dev-up
+ix shell workbench
 ```
+
+Get the repo with `git clone https://github.com/indexable-inc/index`.
 
 ## Shape
 
 - [`tools.nix`](tools.nix) resolves every helper and assembles
-  `environment.systemPackages`. Languages are grouped by family
-  (`jvm`, `native`, `scripting`, `functional`, `beam`) so adding or
-  removing one is a single attribute edit.
+  `environment.systemPackages`. Languages are grouped by family (`jvm`,
+  `native`, `scripting`, `functional`, `beam`), so adding or removing one is
+  a single attribute edit.
 - [`ix.nix`](ix.nix) wraps it as a one-node fleet (`workbench`).
 
 ## What's on PATH
 
-- **JVM**: OpenJDK 21 (Temurin) plus `kotlinc`, `scala`, `mvn`, `gradle`.
-- **Native**: stable `rustc`/`cargo`/`clippy`/`rustfmt`, `gcc`, `cmake`, `ninja`, `zig`.
-- **Scripting**: `python` (3.14), `go`, Node 22, `bun`, `deno`, `tsc`.
+- **JVM**: OpenJDK 25 (Temurin) plus `kotlinc`, `scala`, `mvn`, `gradle`.
+- **Native**: stable `rustc`/`cargo`/`clippy`/`rustfmt`, `gcc`, `cmake`,
+  `ninja`, `zig`.
+- **Scripting**: `python` (3.14), `go`, Node 24, `bun`, `deno`, `tsc`.
 - **Functional**: `ghc`, `cabal`, `ocaml`, `dune`.
 - **BEAM**: `erl`/`erlc`, `iex`/`mix`, `gleam`.
 - **Language servers**: `clangd`, `gopls`, `haskell-language-server`,
@@ -37,29 +41,27 @@ nix run .#polyglot-dev-up
   `ocamllsp`, `metals`, `zls`.
 
 The JDK is resolved once and passed into `scala.compiler`, `java.maven`,
-`java.gradle`, `scala.languageServer`, and the `ix.profiles.jvm` runtime so
+`java.gradle`, `scala.languageServer`, and the `ix.profiles.jvm` runtime, so
 `JAVA_HOME`, the Maven launcher, and the JDK Metals parses sources against
 all point at one store path.
 
-## Bad Fit If
+## Bad fit if
 
 - You want a small image. This pulls every supported language closure into
-  one VM: expect the OCI archive to land around 6-10 GB depending on which
-  toolchains nixpkgs has cached, with the heavy hitters being `ghc`, the
-  Scala+Metals pair, and the JDK family.
+  one VM: expect the OCI archive to land around 6-10 GB, with `ghc`, the
+  Scala+Metals pair, and the JDK family as the heavy hitters.
 - You want pinned exact-minor versions of everything. Most helpers here
   accept a `version` argument (`go.toolchain`, `node`, `python.interpreter`,
   `haskell.compiler`, `zig.toolchain`, `cpp.compiler`); this example takes
-  the floating defaults on purpose, because picking one minor per language
-  is the consumer's job.
+  the floating defaults on purpose, because picking one minor per language is
+  the consumer's job.
 - You want devenv-style declarative bundles (auto-LSP-on, auto-PATH,
   auto-env). This example is the explicit-helper-composition shape: every
-  package on PATH appears in [`tools.nix`](tools.nix). Adding side effects
-  is a service-module concern.
+  package on PATH appears in [`tools.nix`](tools.nix).
 
-## Swap Languages
+## Swap languages
 
 Each family in [`tools.nix`](tools.nix) is its own `let` binding. Drop the
-ones you don't need by removing their `builtins.attrValues ...` line in the
-`environment.systemPackages` list; the toolchains they reference will fall
-out of the closure on the next build.
+ones you don't need by removing their `builtins.attrValues ...` line from the
+`environment.systemPackages` list; the toolchains they reference fall out of
+the closure on the next build.

--- a/examples/polyglot/dev/assets/hero.svg
+++ b/examples/polyglot/dev/assets/hero.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="68" width="170" height="56" rx="8"/>
+  <text x="105" y="91" text-anchor="middle" font-size="14" font-weight="600">ix.languages.*</text>
+  <text x="105" y="109" text-anchor="middle" font-size="11" class="muted">typed toolchain helpers</text>
+
+  <line class="edge" x1="190" y1="96" x2="268" y2="96"/>
+  <text x="229" y="86" text-anchor="middle" font-size="12" class="muted">compose</text>
+
+  <rect class="box" x="270" y="15" width="430" height="160" rx="8"/>
+  <text x="485" y="38" text-anchor="middle" font-size="13" font-weight="600">workbench VM: one PATH</text>
+
+  <rect class="box" x="288" y="52" width="126" height="40" rx="6"/>
+  <text x="351" y="69" text-anchor="middle" font-size="11">JVM</text>
+  <text x="351" y="84" text-anchor="middle" font-size="10" class="muted">kotlinc scala mvn</text>
+
+  <rect class="box" x="424" y="52" width="126" height="40" rx="6"/>
+  <text x="487" y="69" text-anchor="middle" font-size="11">native</text>
+  <text x="487" y="84" text-anchor="middle" font-size="10" class="muted">cargo gcc zig</text>
+
+  <rect class="box" x="560" y="52" width="126" height="40" rx="6"/>
+  <text x="623" y="69" text-anchor="middle" font-size="11">scripting</text>
+  <text x="623" y="84" text-anchor="middle" font-size="10" class="muted">python go node</text>
+
+  <rect class="box" x="288" y="102" width="126" height="40" rx="6"/>
+  <text x="351" y="119" text-anchor="middle" font-size="11">functional</text>
+  <text x="351" y="134" text-anchor="middle" font-size="10" class="muted">ghc ocaml dune</text>
+
+  <rect class="box" x="424" y="102" width="126" height="40" rx="6"/>
+  <text x="487" y="119" text-anchor="middle" font-size="11">BEAM</text>
+  <text x="487" y="134" text-anchor="middle" font-size="10" class="muted">erl mix gleam</text>
+
+  <rect class="box" x="560" y="102" width="126" height="40" rx="6"/>
+  <text x="623" y="119" text-anchor="middle" font-size="11">LSPs</text>
+  <text x="623" y="134" text-anchor="middle" font-size="10" class="muted">clangd gopls metals</text>
+
+  <text x="485" y="163" text-anchor="middle" font-size="11" class="accent">one JDK threaded through every JVM tool</text>
+</svg>

--- a/examples/python/daily-scraper/README.md
+++ b/examples/python/daily-scraper/README.md
@@ -1,13 +1,13 @@
-# Daily Python Scraper
+<p align="center"><img src="assets/hero.svg" width="720" alt="a systemd timer runs the uv-packaged scraper daily; it fetches GitHub metrics, writes parquet, and optionally syncs to S3"></p>
 
-A daily Python job on ix.
+# Daily Python scraper
 
-It defines a uv project packaged with
-[`ix.buildUvApplication`](../../../lib/build/uv-application.nix), runs it as a
-`systemd` oneshot service on a persistent daily timer, writes Parquet under
-`/var/lib/daily-scraper/parquet`, and can sync the result to S3.
-
-The Python stays ordinary Python. The ix-specific parts are
+How do you run an ordinary Python script once a day on a VM, with packaging,
+scheduling, and credentials all handled? This example packages a uv project
+with [`ix.buildUvApplication`](../../../lib/build/uv-application.nix), runs
+it as a hardened `systemd` oneshot on a persistent daily timer, writes
+Parquet under `/var/lib/daily-scraper/parquet`, and can sync the result to
+S3. The Python stays ordinary Python; the ix-specific parts are
 [`package.nix`](package.nix) and [`service.nix`](service.nix).
 
 ## Run
@@ -16,6 +16,8 @@ The Python stays ordinary Python. The ix-specific parts are
 # From the index repo root.
 nix run .#python-daily-scraper-up
 ```
+
+Get the repo with `git clone https://github.com/indexable-inc/index`.
 
 ## Shape
 
@@ -26,7 +28,7 @@ nix run .#python-daily-scraper-up
   timer, and optional S3 sync.
 - [`package.nix`](package.nix) packages the uv project as a store executable.
 
-## S3 Output
+## S3 output
 
 The example leaves S3 sync disabled. [`service.nix`](service.nix) reads a
 `dailyScraper` module argument, so a fleet can enable S3 without forking the
@@ -56,8 +58,8 @@ then have the fleet attach it as a runtime file:
 };
 ```
 
-The AWS file is read at service start through `LoadCredential`, so the keys are
-kept out of the Nix store. Its contents use systemd `EnvironmentFile` syntax:
+The AWS file is read at service start through `LoadCredential`, so the keys
+stay out of the Nix store. Its contents use systemd `EnvironmentFile` syntax:
 
 ```ini
 AWS_ACCESS_KEY_ID=...
@@ -65,31 +67,9 @@ AWS_SECRET_ACCESS_KEY=...
 AWS_REGION=us-east-1
 ```
 
-The generated fleet plan carries the ix store key and VM-facing delivery target:
+## Swap in your script
 
-```json
-{
-  "nodes": {
-    "scraper": {
-      "secrets": [
-        {
-          "name": "daily_scraper_aws_env",
-          "target": {
-            "name": "daily-scraper/aws.env",
-            "injectAs": "file",
-            "owner": "root",
-            "mode": "0400"
-          }
-        }
-      ]
-    }
-  }
-}
-```
-
-## Swap In Your Script
-
-Keep [`service.nix`](service.nix) and [`package.nix`](package.nix), then replace
-the Python module and dependencies. The service already handles timer catch-up,
-durable VM state, journald logs, and an S3 sync step that runs only after the
-scraper succeeds.
+Keep [`service.nix`](service.nix) and [`package.nix`](package.nix), then
+replace the Python module and dependencies. The service already handles timer
+catch-up, durable VM state, journald logs, and an S3 sync step that runs only
+after the scraper succeeds.

--- a/examples/python/daily-scraper/assets/hero.svg
+++ b/examples/python/daily-scraper/assets/hero.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 150" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="15" y="70" width="130" height="52" rx="8"/>
+  <text x="80" y="92" text-anchor="middle" font-size="13" font-weight="600">timer</text>
+  <text x="80" y="109" text-anchor="middle" font-size="10" class="muted">daily 03:17 UTC</text>
+
+  <line class="edge" x1="145" y1="96" x2="193" y2="96"/>
+  <text x="169" y="86" text-anchor="middle" font-size="11" class="muted">runs</text>
+
+  <rect class="box" x="195" y="70" width="160" height="52" rx="8"/>
+  <text x="275" y="92" text-anchor="middle" font-size="13" font-weight="600">daily-scraper</text>
+  <text x="275" y="109" text-anchor="middle" font-size="10" class="muted">uv app, oneshot unit</text>
+
+  <rect class="box" x="195" y="8" width="160" height="38" rx="8"/>
+  <text x="275" y="32" text-anchor="middle" font-size="12">GitHub API</text>
+
+  <line class="edge" x1="275" y1="70" x2="275" y2="48"/>
+  <text x="285" y="62" font-size="10" class="muted">fetch repo metrics</text>
+
+  <line class="edge" x1="355" y1="96" x2="443" y2="96"/>
+  <text x="399" y="86" text-anchor="middle" font-size="11" class="muted">write parquet</text>
+
+  <rect class="box" x="445" y="70" width="170" height="52" rx="8"/>
+  <text x="530" y="92" text-anchor="middle" font-size="12" font-weight="600">/var/lib/daily-scraper</text>
+  <text x="530" y="109" text-anchor="middle" font-size="10" class="muted">parquet/ (zstd)</text>
+
+  <line class="edge" x1="615" y1="96" x2="653" y2="96" stroke-dasharray="4 3"/>
+  <text x="634" y="86" text-anchor="middle" font-size="10" class="muted">sync</text>
+
+  <rect class="box" x="655" y="70" width="50" height="52" rx="8"/>
+  <text x="680" y="92" text-anchor="middle" font-size="12" font-weight="600">S3</text>
+  <text x="680" y="109" text-anchor="middle" font-size="9" class="muted">opt-in</text>
+</svg>

--- a/examples/ray/cluster/README.md
+++ b/examples/ray/cluster/README.md
@@ -1,14 +1,15 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="a driver fans tasks to a ray-head VM that two ray-worker replicas join over the east-west network"></p>
+
 # Ray cluster
 
-A multi-node [Ray](https://docs.ray.io) cluster across ix VMs: one head and two
-workers that schedule Python tasks over each other.
-
-A `ray-head` node runs the Ray GCS; two `ray-worker` replicas join it over the
-east-west network. A driver packaged with
-[`ix.buildUvApplication`](../../../lib/build/uv-application.nix) attaches to the
-head, fans `@ray.remote` tasks across the cluster, and reports which node ran
-each one. The driver doubles as the head's health check, so the generated up wrapper does not
-report healthy until every worker has joined.
+What does it take to run a real multi-node [Ray](https://docs.ray.io) cluster
+on VMs you can actually firewall? This fleet runs one `ray-head` (the Ray
+GCS) and two `ray-worker` replicas that join it over the east-west network. A
+driver packaged with
+[`ix.buildUvApplication`](../../../lib/build/uv-application.nix) attaches to
+the head, fans `@ray.remote` tasks across the cluster, and reports which node
+ran each one. The driver doubles as the head's health check, so the fleet
+does not report healthy until every worker has joined.
 
 The Python stays ordinary Ray. The ix-specific parts are
 [`head.nix`](head.nix), [`worker.nix`](worker.nix), and the shared
@@ -21,17 +22,20 @@ The Python stays ordinary Ray. The ix-specific parts are
 nix run .#ray-cluster-up
 ```
 
+Get the repo with `git clone https://github.com/indexable-inc/index`.
+
 ## Shape
 
 - [`pyproject.toml`](pyproject.toml), [`uv.lock`](uv.lock), and [`src/`](src/)
   are the Ray driver (`ray-demo`).
-- [`ix.nix`](ix.nix) defines the fleet: one head and two worker
-  replicas, all in one east-west group. Workers retry their Ray startup until
-  the head is reachable, so the fleet can boot the whole cluster together while
-  the head's health check waits for every node to join.
+- [`ix.nix`](ix.nix) defines the fleet: one head and two worker replicas, all
+  in one east-west group. Workers retry their Ray startup until the head is
+  reachable, so the fleet can boot the whole cluster together while the
+  head's health check waits for every node to join.
 - [`cluster-node.nix`](cluster-node.nix) owns one Ray node: the package, the
-  pinned ports, the `nix-ld` loader environment, and the hardened long-running
-  service. Head and worker differ only by their `ray start` flags.
+  pinned ports, the `nix-ld` loader environment, and the hardened
+  long-running service. Head and worker differ only by their `ray start`
+  flags.
 - [`head.nix`](head.nix) adds `--head`, opens the GCS and client ports, and
   declares the cluster health check.
 - [`worker.nix`](worker.nix) points `ray start --address` at the head.
@@ -51,14 +55,15 @@ ix shell ray-head -- ray-demo --min-nodes 3
 ```
 
 It prints a per-node task count and exits non-zero unless the cluster has at
-least `--min-nodes` alive nodes. Both `ray` and `ray-demo` default to the head's
-address (`RAY_ADDRESS`), so no `--address` flag is needed on a cluster node.
+least `--min-nodes` alive nodes. Both `ray` and `ray-demo` default to the
+head's address (`RAY_ADDRESS`), so no `--address` flag is needed on a cluster
+node.
 
 ## Scale
 
-Worker count is one line. Raise `ray-worker.replicas` in
-[`ix.nix`](ix.nix); the head's health check waits for the new total
-because it counts fleet nodes rather than hard-coding three.
+Worker count is one line. Raise `ray-worker.replicas` in [`ix.nix`](ix.nix);
+the head's health check waits for the new total because it counts fleet nodes
+rather than hard-coding three.
 
 ## Ports
 
@@ -67,14 +72,11 @@ ports are pinned and opened explicitly: GCS `6379` and the Ray Client server
 `10001` on the head, the node manager `6380`, object manager `6381`, and the
 worker range `10002-10031` on every node. Widen the worker range in
 [`cluster-node.nix`](cluster-node.nix) for clusters that run many concurrent
-tasks per node.
-
-Ray also starts node-local agents (a dashboard agent, a metrics exporter, a
-runtime-env agent) on other ports. Nothing crosses nodes to reach them in this
-example, so they are left on their defaults and unexposed. Each node binds Ray to
-its east-west IP (read from the routing table, since these VMs have no internet
-egress to autodetect against), and workers reach the head by its `ray-head`
-hostname.
+tasks per node. Each node binds Ray to its east-west IP (read from the
+routing table, since these VMs have no internet egress to autodetect
+against), and workers reach the head by its `ray-head` hostname. Ray's
+node-local agents (dashboard, metrics, runtime-env) stay on their defaults
+and unexposed, since nothing crosses nodes to reach them here.
 
 ## Known limitations
 
@@ -83,16 +85,17 @@ hostname.
   north-south (internet-facing) address to these nodes without a gateway in
   front. Ray treats task submission as arbitrary code execution.
 - **Unpatched wheel binaries via `nix-ld`.** Ray ships prebuilt `raylet` and
-  `gcs_server` ELF binaries that expect an FHS dynamic linker. They run because
-  the ix base image enables `programs.nix-ld`; the services set `NIX_LD` and
-  `NIX_LD_LIBRARY_PATH` so the stub linker finds libstdc++ and friends. An
-  image built with `programs.nix-ld.enable = false` will not start Ray.
-- **Single head.** The head's GCS is a single point of failure. Ray's
-  GCS fault tolerance (an external Redis) is out of scope for this example.
+  `gcs_server` ELF binaries that expect an FHS dynamic linker. They run
+  because the ix base image enables `programs.nix-ld`; the services set
+  `NIX_LD` and `NIX_LD_LIBRARY_PATH` so the stub linker finds libstdc++ and
+  friends. An image built with `programs.nix-ld.enable = false` will not
+  start Ray.
+- **Single head.** The head's GCS is a single point of failure. Ray's GCS
+  fault tolerance (an external Redis) is out of scope for this example.
 - **Core Ray, no dashboard.** The dashboard needs the `ray[default]` extras.
   Add that to [`pyproject.toml`](pyproject.toml), drop
-  `--include-dashboard false` from [`head.nix`](head.nix), then open and claim
-  the dashboard port `8265`.
-- **Ephemeral session state.** Ray's session lives in `/run/ray` (a short path
-  keeps its sockets under the `AF_UNIX` limit) and is cleared on reboot, which
-  is the intended lifecycle for a worker that rejoins from scratch.
+  `--include-dashboard false` from [`head.nix`](head.nix), then open and
+  claim the dashboard port `8265`.
+- **Ephemeral session state.** Ray's session lives in `/run/ray` (a short
+  path keeps its sockets under the `AF_UNIX` limit) and is cleared on reboot,
+  which is the intended lifecycle for a worker that rejoins from scratch.

--- a/examples/ray/cluster/assets/hero.svg
+++ b/examples/ray/cluster/assets/hero.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="25" width="170" height="56" rx="8"/>
+  <text x="105" y="48" text-anchor="middle" font-size="14" font-weight="600">ray-demo driver</text>
+  <text x="105" y="66" text-anchor="middle" font-size="11" class="muted">doubles as health check</text>
+
+  <line class="edge" x1="190" y1="53" x2="278" y2="53"/>
+  <text x="234" y="43" text-anchor="middle" font-size="12" class="muted">fan out tasks</text>
+
+  <rect class="box" x="280" y="25" width="200" height="56" rx="8"/>
+  <text x="380" y="48" text-anchor="middle" font-size="14" font-weight="600">ray-head</text>
+  <text x="380" y="66" text-anchor="middle" font-size="11" class="muted">GCS :6379 · client :10001</text>
+
+  <text x="600" y="53" text-anchor="middle" font-size="11" class="accent">tasks land on every node</text>
+
+  <rect class="box" x="180" y="125" width="170" height="52" rx="8"/>
+  <text x="265" y="147" text-anchor="middle" font-size="13" font-weight="600">ray-worker-0</text>
+  <text x="265" y="164" text-anchor="middle" font-size="10" class="muted">joins over east-west</text>
+
+  <rect class="box" x="410" y="125" width="170" height="52" rx="8"/>
+  <text x="495" y="147" text-anchor="middle" font-size="13" font-weight="600">ray-worker-1</text>
+  <text x="495" y="164" text-anchor="middle" font-size="10" class="muted">replicas: one line to scale</text>
+
+  <line class="edge" x1="290" y1="125" x2="345" y2="81"/>
+  <line class="edge" x1="470" y1="125" x2="415" y2="81"/>
+  <text x="380" y="108" text-anchor="middle" font-size="12" class="muted">join GCS</text>
+</svg>

--- a/examples/s3/storage/README.md
+++ b/examples/s3/storage/README.md
@@ -1,25 +1,33 @@
-# s3-storage
+<p align="center"><img src="assets/hero.svg" width="720" alt="any S3 client talks to port 8333 on one ix VM where SeaweedFS serves the S3 API and stores objects in its state directory"></p>
 
-A single-node, S3-compatible object store running in one ix VM, backed by
-[SeaweedFS](https://github.com/seaweedfs/seaweedfs). Bring it up, point any S3
-client at port 8333, and read/write buckets.
+# S3 storage
 
-## Run it
+Need an S3 endpoint for a demo or a test suite without an AWS account? This
+example runs a single-node, S3-compatible object store in one ix VM, backed
+by [SeaweedFS](https://github.com/seaweedfs/seaweedfs): the
+[`services.ix-seaweedfs`](../../../modules/services/seaweedfs/) module runs
+one `weed server -s3` process (master, volume, filer, and S3 gateway in one
+binary) and opens only the S3 port in the firewall. Point any S3 client at
+port `8333` and read/write buckets.
+
+## Run
 
 ```sh
-ix-fleet up ./examples/s3/storage
+# From the index repo root.
+nix run .#s3-storage-up
 ```
 
-The node enables the `services.ix-seaweedfs` module, which runs a single
-`weed server -s3` process (master, volume, filer, and S3 gateway in one
-binary) and opens only the S3 port in the firewall.
+The node holds object data, so it persists across `up` runs instead of being
+recreated. The module also publishes a `/healthz` readiness check on the S3
+port, so ix reports the node healthy only once the gateway is actually
+serving. Get the repo with `git clone https://github.com/indexable-inc/index`.
 
 ## Smoke test
 
 Shell into the node and run a round-trip with the bundled
 [`s5cmd`](https://github.com/peak/s5cmd). The demo endpoint and credentials
-are exported as environment variables (`S3_ENDPOINT_URL`, `AWS_ACCESS_KEY_ID`,
-`AWS_SECRET_ACCESS_KEY`), so the commands need no flags:
+are exported as environment variables (`S3_ENDPOINT_URL`,
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`), so the commands need no flags:
 
 ```sh
 s5cmd mb s3://demo-bucket
@@ -32,14 +40,11 @@ s5cmd ls s3://demo-bucket/
 Create the bucket with `mb` before the first write; SeaweedFS does not
 auto-create buckets on PUT.
 
-The module also publishes a `/healthz` readiness check on the S3 port, so
-`ix` reports the node healthy only once the gateway is actually serving.
-
 ## Credentials
 
 This example bakes a demo access/secret key pair into the image on purpose so
 it runs with no setup. The keys are `ix-demo-access-key` /
-`ix-demo-secret-key`, defined in `service.nix`.
+`ix-demo-secret-key`, defined in [`service.nix`](service.nix).
 
 For anything real, drop the demo config and point the module at a runtime
 secret file so keys never enter the Nix store:
@@ -53,15 +58,16 @@ services.ix-seaweedfs = {
 
 The file is SeaweedFS's S3 identities format: an `identities` array of
 `{ name, credentials: [{ accessKey, secretKey }], actions }`. Running with no
-`configFile` requires setting `allowAnonymous = true`, since an unauthenticated
-S3 endpoint is otherwise refused at evaluation.
+`configFile` requires setting `allowAnonymous = true`, since an
+unauthenticated S3 endpoint is otherwise refused at evaluation.
 
 ## Bad fit if
 
 - **You need replication or HA.** This is one node with one copy of the data.
   SeaweedFS scales out, but that is a multi-node deployment this example does
   not cover.
-- **You need the full AWS S3 feature set.** Core object, bucket, and multipart
-  operations work; lifecycle, versioning, and object-lock support is partial.
+- **You need the full AWS S3 feature set.** Core object, bucket, and
+  multipart operations work; lifecycle, versioning, and object-lock support
+  is partial.
 - **The data must survive node loss.** Object data lives in the node's state
   directory; back it up or snapshot the VM.

--- a/examples/s3/storage/assets/hero.svg
+++ b/examples/s3/storage/assets/hero.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="55" width="170" height="56" rx="8"/>
+  <text x="105" y="78" text-anchor="middle" font-size="14" font-weight="600">any S3 client</text>
+  <text x="105" y="96" text-anchor="middle" font-size="11" class="muted">s5cmd, aws cli, SDKs</text>
+
+  <line class="edge" x1="190" y1="83" x2="318" y2="83"/>
+  <text x="254" y="73" text-anchor="middle" font-size="12" class="muted">S3 API :8333</text>
+
+  <rect class="box" x="320" y="20" width="380" height="120" rx="8"/>
+  <text x="510" y="42" text-anchor="middle" font-size="13" font-weight="600">s3 node (one ix VM)</text>
+
+  <rect class="box" x="340" y="58" width="170" height="52" rx="6"/>
+  <text x="425" y="80" text-anchor="middle" font-size="12" font-weight="600">weed server -s3</text>
+  <text x="425" y="97" text-anchor="middle" font-size="10" class="muted">master · volume · filer · s3</text>
+
+  <line class="edge" x1="510" y1="84" x2="548" y2="84"/>
+
+  <rect class="box" x="550" y="58" width="130" height="52" rx="6"/>
+  <text x="615" y="80" text-anchor="middle" font-size="12">state dir</text>
+  <text x="615" y="97" text-anchor="middle" font-size="10" class="muted">persists across up</text>
+
+  <text x="510" y="130" text-anchor="middle" font-size="11" class="accent">/healthz gates node readiness</text>
+</svg>

--- a/examples/synced-github/auth/README.md
+++ b/examples/synced-github/auth/README.md
@@ -1,8 +1,11 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="one token in the ix secret store materializes on three agent VMs whose git credential helpers authenticate to github.com"></p>
+
 # Synced GitHub auth
 
-Give a whole fleet of agent VMs one GitHub identity without running
-`gh auth login` on each box. The fleet declares a single token; every node
-wires `git` to use it. Adding a replica needs no extra auth step.
+How do you give a whole fleet of agent VMs one GitHub identity without
+running `gh auth login` on each box? The fleet declares a single token; every
+node wires `git` to use it through a credential helper that reads the secret
+file on demand. Adding a replica needs no extra auth step.
 
 ## Run
 
@@ -10,6 +13,8 @@ wires `git` to use it. Adding a replica needs no extra auth step.
 # From the index repo root.
 nix run .#synced-github-auth-up
 ```
+
+Get the repo with `git clone https://github.com/indexable-inc/index`.
 
 ## Shape
 
@@ -23,8 +28,8 @@ nix run .#synced-github-auth-up
 
 Store the value once with `ix secret set github_token`. The fleet declaration
 maps that account key to `/run/secrets/github/token` for every node. Only the
-key and target path enter the fleet plan; the token bytes stay in the ix secret
-store and are materialized when the VM is created.
+key and target path enter the fleet plan; the token bytes stay in the ix
+secret store and are materialized when the VM is created.
 
 [`agent.nix`](agent.nix) registers a credential helper in `/etc/gitconfig`
 scoped to `https://github.com`. When `git` needs a credential it runs the
@@ -32,9 +37,10 @@ helper, which reads the file and prints `username=x-access-token` plus the
 token. The token is never exported into any process environment and is read
 only at the moment `git` asks. The helper also parses the request `git` feeds
 it and emits the token only when the host is `github.com` over `https`, so it
-cannot hand the token to another host even if invoked outside its config scope.
-A `url.insteadOf` rule rewrites both `git@github.com:` and
-`ssh://git@github.com/` remotes to HTTPS so SSH-style clones use the same token.
+cannot hand the token to another host even if invoked outside its config
+scope. A `url.insteadOf` rule rewrites both `git@github.com:` and
+`ssh://git@github.com/` remotes to HTTPS so SSH-style clones use the same
+token.
 
 The helper is deliberately silent when the file is missing: it exits `0` with
 no output, so a node boots and anonymous fetches work even before a token is
@@ -45,11 +51,11 @@ where no real token exists.
 
 ## The `gh` CLI
 
-`gh` ignores git's credential helper; it reads `GH_TOKEN` (or `GITHUB_TOKEN`).
-This example does not export it globally, because an exported token is visible
-in that process's `/proc/<pid>/environ`, is inherited by every descendant
-process, and can land in a core dump. To authenticate `gh` in a shell, point it
-at the same file:
+`gh` ignores git's credential helper; it reads `GH_TOKEN` (or
+`GITHUB_TOKEN`). This example does not export it globally, because an
+exported token is visible in that process's `/proc/<pid>/environ`, is
+inherited by every descendant process, and can land in a core dump. To
+authenticate `gh` in a shell, point it at the same file:
 
 ```sh
 export GH_TOKEN="$(cat /run/secrets/github/token)"
@@ -59,8 +65,8 @@ export GH_TOKEN="$(cat /run/secrets/github/token)"
 
 A tempting shortcut is to mount the operator's whole `~/.config` (or
 `~/.config/gh`) into every VM over a shared folder, so `gh` and `git` pick up
-the host's existing login. It works, and for a single local dev VM driven by
-[`packages/vmkit`](../../packages/vmkit) over virtio-fs it can be
+the host's existing login. For a single local dev VM driven by
+[`packages/vm/vmkit`](../../../packages/vm/vmkit) over virtio-fs it can be
 reasonable. As a fleet primitive it has sharp edges:
 
 - It shares far more than a token. `~/.config` holds unrelated app state,
@@ -70,11 +76,10 @@ reasonable. As a fleet primitive it has sharp edges:
 - The host token is usually a broad personal credential. Per-VM scoped tokens
   (a fine-grained PAT or a GitHub App installation token) cannot be expressed
   by copying one shared file.
-- Remote fleet VMs have no host filesystem to share in the first place. The
-  shared-folder story only exists for a co-located dev VM.
+- Remote fleet VMs have no host filesystem to share in the first place.
 
 Declaring one scoped secret and consuming it per node keeps the surface to a
-single credential with a single owner. Whether ix should *also* offer a
+single credential with a single owner. Whether ix should also offer a
 config-sync primitive for the local dev-VM case is an open design question:
 [#465](https://github.com/indexable-inc/index/issues/465).
 

--- a/examples/synced-github/auth/assets/hero.svg
+++ b/examples/synced-github/auth/assets/hero.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 190" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="20" y="70" width="170" height="56" rx="8"/>
+  <text x="105" y="93" text-anchor="middle" font-size="14" font-weight="600">ix secret store</text>
+  <text x="105" y="111" text-anchor="middle" font-size="11" class="muted">github_token, set once</text>
+
+  <line class="edge" x1="190" y1="85" x2="288" y2="40"/>
+  <line class="edge" x1="190" y1="98" x2="288" y2="98"/>
+  <line class="edge" x1="190" y1="111" x2="288" y2="156"/>
+  <text x="239" y="76" text-anchor="middle" font-size="11" class="muted">materialize</text>
+
+  <rect class="box" x="290" y="18" width="220" height="44" rx="8"/>
+  <text x="400" y="37" text-anchor="middle" font-size="12" font-weight="600">agent-0</text>
+  <text x="400" y="53" text-anchor="middle" font-size="10" class="muted">/run/secrets/github/token</text>
+
+  <rect class="box" x="290" y="76" width="220" height="44" rx="8"/>
+  <text x="400" y="95" text-anchor="middle" font-size="12" font-weight="600">agent-1</text>
+  <text x="400" y="111" text-anchor="middle" font-size="10" class="muted">git credential helper</text>
+
+  <rect class="box" x="290" y="134" width="220" height="44" rx="8"/>
+  <text x="400" y="153" text-anchor="middle" font-size="12" font-weight="600">agent-2</text>
+  <text x="400" y="169" text-anchor="middle" font-size="10" class="muted">no gh auth login</text>
+
+  <line class="edge" x1="510" y1="98" x2="588" y2="98"/>
+  <text x="549" y="88" text-anchor="middle" font-size="11" class="muted">HTTPS push / fetch</text>
+
+  <rect class="box" x="590" y="70" width="110" height="56" rx="8"/>
+  <text x="645" y="93" text-anchor="middle" font-size="13" font-weight="600">github.com</text>
+  <text x="645" y="111" text-anchor="middle" font-size="10" class="accent">one identity</text>
+</svg>


### PR DESCRIPTION
Restyles the example-fleet READMEs (plus the oci example) per the `creating-a-readme` skill: committed dark/light-adaptive `assets/hero.svg` for each, hook-question intros, and Run sections verified against the flake's actual outputs.

Updated READMEs:

- examples/multi-client/file-sharing/README.md
- examples/nixos/switch/README.md
- examples/nixos/switch-multi/README.md
- examples/observability/stack/README.md
- examples/oci/README.md
- examples/polyglot/dev/README.md
- examples/python/daily-scraper/README.md
- examples/ray/cluster/README.md
- examples/s3/storage/README.md
- examples/synced-github/auth/README.md

Also fixes stale content found along the way: broken relative links (observability module README, vmkit -> packages/vm/vmkit, python-daily-scraper path), the oci README's leftover "leading underscore" discovery note, s3-storage's stale `ix-fleet up` command (now `nix run .#s3-storage-up`, verified against the flake), and polyglot's JDK/Node versions (tools.nix pins JDK 25 / Node 24).

Refs #2072


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README files and add hero images across examples (nixos, observability, oci, storage, misc)
> Rewrites and expands README documentation across 10+ example directories, adding hero SVG images and improving clarity of introductions, commands, and configuration explanations.
>
> - Adds a centered hero image to each example's README via a new `assets/hero.svg` file
> - Rewrites introductions to be more specific about components, behavior, and commands (e.g. SMB locking in file-sharing, CAS fan-out in nixos/switch-multi, SeaweedFS gateway in s3/storage)
> - Adds repo clone hints and explicit run commands (e.g. `nix run .#s3-storage-up`) to each example
> - Updates toolchain versions in the polyglot dev VM README (OpenJDK 21→25, Node 22→24) and corrects a broken link in file-sharing from `python-daily-scraper` to `python/daily-scraper`
> - Removes embedded generated fleet plan JSON from the Python scraper README and clarifies credential handling via `LoadCredential`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a76a9d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->