### PR TITLE
readme sweep: examples (hermes, minecraft, fleet)

### DIFF
--- a/examples/declared/groups/README.md
+++ b/examples/declared/groups/README.md
@@ -1,22 +1,26 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="client joins the group via the fleet spec, api via its image; both union into one east-west network"></p>
+
 # Declared groups
 
-A two-VM fleet sharing one east-west network, where the group membership is
-declared in the image definition instead of at runtime. The `api` image sets
+Should a VM's group membership live in the image or in the fleet? Both work,
+and this two-VM fleet shows each source. The `api` image sets
 `ix.networking.groups = [ "declared-groups" ]` in its own module, so any fleet
-deploying that image joins the deployer's `declared-groups` network. The
-`client` shows the other source: a fleet-level `nodes.client.groups` entry on a
+deploying that image joins the deployer's `declared-groups` network; the
+`client` joins through a fleet-level `nodes.client.groups` entry on a
 group-agnostic image. Both sources union into the same plan field.
 
 ## Run
 
 ```sh
+# From the index repo root.
 nix run .#declared-groups-up
 nix run .#declared-groups-health
 ```
 
 The fleet wrapper get-or-creates the `declared-groups` group under your
 account, adds both VMs, then runs the health checks: the client curls the api
-over the private group network.
+over the private group network. Need the repo first?
+`git clone https://github.com/indexable-inc/index`.
 
 ## Verify manually
 

--- a/examples/declared/groups/assets/hero.svg
+++ b/examples/declared/groups/assets/hero.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="16" y="14" width="688" height="132" rx="10" class="group"/>
+  <text x="32" y="36" font-size="11" class="accent">declared-groups group (slug scoped to the deploying user)</text>
+  <rect x="70" y="56" width="220" height="60" rx="6" class="box"/>
+  <text x="180" y="80" font-size="13" text-anchor="middle">client</text>
+  <text x="180" y="98" font-size="11" text-anchor="middle" class="muted">groups declared in the fleet (ix.nix)</text>
+  <rect x="430" y="56" width="220" height="60" rx="6" class="box"/>
+  <text x="540" y="80" font-size="13" text-anchor="middle">api</text>
+  <text x="540" y="98" font-size="11" text-anchor="middle" class="muted">groups declared in the image (api.nix)</text>
+  <line x1="290" y1="86" x2="422" y2="86" class="edge"/>
+  <text x="356" y="78" font-size="11" text-anchor="middle" class="muted">curl http://api:8080/</text>
+  <text x="356" y="134" font-size="11" text-anchor="middle" class="muted">both sources union into one plan field</text>
+</svg>

--- a/examples/dev/fleet/README.md
+++ b/examples/dev/fleet/README.md
@@ -1,9 +1,13 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="two agent VMs mount one SMB identity volume from file-server; builder opts out"></p>
+
 # ix fleet
 
-A forkable ix environment (RFC 0007). [`ix.nix`](ix.nix) is the runnable ix
-entrypoint, and [`dev.nix`](dev.nix) is the ordinary NixOS module for the
-per-VM environment, fleet topology, and opt-in shared SMB volume that gives the
-whole fleet one Claude (and ix) login.
+How do you give a whole fleet of agent VMs one Claude login? This is the
+forkable ix environment from RFC 0007: [`dev.nix`](dev.nix) is the ordinary
+NixOS module you edit (per-VM environment, fleet topology, opt-in shared SMB
+volume), and [`ix.nix`](ix.nix) hands it to `index.lib.mkDev`. The shared
+volume carries `~/.claude` and `~/.n`, so the first `claude login` on any
+agent logs in the whole fleet.
 
 ## Run
 
@@ -11,7 +15,8 @@ whole fleet one Claude (and ix) login.
 ix up
 ```
 
-Run that from a copied example flake. In this repo root, the aggregate example
+Run that from a copied example flake. In this repo root
+(`git clone https://github.com/indexable-inc/index`), the aggregate example
 wrapper still exposes `nix run .#dev-fleet-up`; the standalone example shape is
 what `ix up` consumes.
 
@@ -31,10 +36,10 @@ scale-up.
 
 `mkDev` reads `ix.dev` and desugars this into a `mkFleet` plan:
 
-- `agent-0`, `agent-1`, `builder` — workload nodes carrying the module's
+- `agent-0`, `agent-1`, `builder`: workload nodes carrying the module's
   environment on top of the dev base module (which ships our wrapped
   `claude-code` and `codex` via `lib/dev/agents.nix`).
-- `file-server` — a dedicated node running `smbd`, exporting the share `dev`
+- `file-server`: a dedicated node running `smbd`, exporting the share `dev`
   from `/var/lib/ix-dev-share`. Keeping it separate decouples the canonical
   credentials' lifecycle from the workload VMs, so recreating an agent never
   blips the share.
@@ -46,7 +51,7 @@ scale-up.
 `agent-0` and `agent-1` bind `~/.claude` and `~/.n` onto the volume, so the
 first `claude login` on either agent logs in the whole fleet; a new replica
 costs no extra auth. `builder` is in `ix.dev.shared.excludeNodes`, so it gets
-neither the mount nor the shared identity - the per-VM opt-out - but it still
+neither the mount nor the shared identity (the per-VM opt-out), but it still
 has the agents.
 
 Only `~/.claude` and `~/.n` are shared, never the whole `~/.config`. The image's

--- a/examples/dev/fleet/assets/hero.svg
+++ b/examples/dev/fleet/assets/hero.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 170" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="16" y="12" width="688" height="146" rx="10" class="group"/>
+  <text x="32" y="34" font-size="11" class="accent">ix-dev-shared east-west group</text>
+  <rect x="48" y="44" width="140" height="44" rx="6" class="box"/>
+  <text x="118" y="63" font-size="13" text-anchor="middle">agent-0</text>
+  <text x="118" y="79" font-size="11" text-anchor="middle" class="muted">claude-code, codex</text>
+  <rect x="48" y="100" width="140" height="44" rx="6" class="box"/>
+  <text x="118" y="119" font-size="13" text-anchor="middle">agent-1</text>
+  <text x="118" y="135" font-size="11" text-anchor="middle" class="muted">claude-code, codex</text>
+  <rect x="340" y="66" width="190" height="56" rx="6" class="box"/>
+  <text x="435" y="88" font-size="13" text-anchor="middle">file-server</text>
+  <text x="435" y="106" font-size="11" text-anchor="middle" class="muted">smbd //file-server/dev</text>
+  <line x1="188" y1="66" x2="332" y2="82" class="edge"/>
+  <line x1="188" y1="122" x2="332" y2="106" class="edge"/>
+  <text x="260" y="98" font-size="11" text-anchor="middle" class="muted">mount ~/.claude, ~/.n</text>
+  <rect x="570" y="66" width="112" height="56" rx="6" class="box"/>
+  <text x="626" y="88" font-size="13" text-anchor="middle">builder</text>
+  <text x="626" y="106" font-size="11" text-anchor="middle" class="muted">no shared mount</text>
+</svg>

--- a/examples/east-west/firewall/README.md
+++ b/examples/east-west/firewall/README.md
@@ -1,18 +1,24 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="allowed-client reaches service inside the east-west group; outside-client has no route"></p>
+
 # East-west firewall
 
-A small fleet where the useful boundary is an ix VM group. The HTTP service and
-`allowed-client` share one east-west group; `outside-client` is left out, and
-its health check expects the private URL to fail.
+How do you prove one VM can reach a service and another cannot? Put the
+boundary where ix already has one: the east-west group. The HTTP service and
+`allowed-client` share a group, so the client gets a private route and DNS
+name; `outside-client` is left out, and its health check passes only when the
+same URL fails.
 
 ## Run
 
 ```sh
+# From the index repo root.
 nix run .#east-west-firewall-up
 nix run .#east-west-firewall-health
 ```
 
 The fleet wrapper creates the `east-west-firewall` group, adds `service` and
-`allowed-client`, then runs the health checks.
+`allowed-client`, then runs the health checks. Need the repo first?
+`git clone https://github.com/indexable-inc/index`.
 
 ## Verify manually
 

--- a/examples/east-west/firewall/assets/hero.svg
+++ b/examples/east-west/firewall/assets/hero.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    .fail { stroke: #cf222e; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+      .fail { stroke: #f85149; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="16" y="14" width="436" height="132" rx="10" class="group"/>
+  <text x="32" y="36" font-size="11" class="accent">east-west-firewall group</text>
+  <rect x="40" y="56" width="150" height="56" rx="6" class="box"/>
+  <text x="115" y="80" font-size="13" text-anchor="middle">service</text>
+  <text x="115" y="97" font-size="11" text-anchor="middle" class="muted">nginx :8080</text>
+  <rect x="280" y="56" width="150" height="56" rx="6" class="box"/>
+  <text x="355" y="80" font-size="13" text-anchor="middle">allowed-client</text>
+  <text x="355" y="97" font-size="11" text-anchor="middle" class="muted">health: curl OK</text>
+  <line x1="280" y1="84" x2="198" y2="84" class="edge"/>
+  <rect x="530" y="56" width="160" height="56" rx="6" class="box"/>
+  <text x="610" y="80" font-size="13" text-anchor="middle">outside-client</text>
+  <text x="610" y="97" font-size="11" text-anchor="middle" class="muted">health: curl fails</text>
+  <line x1="530" y1="84" x2="474" y2="84" class="edge"/>
+  <line x1="455" y1="74" x2="471" y2="94" class="fail"/>
+  <line x1="455" y1="94" x2="471" y2="74" class="fail"/>
+  <text x="502" y="130" font-size="11" text-anchor="middle" class="muted">no route, no DNS name</text>
+</svg>

--- a/examples/fleet/hello/README.md
+++ b/examples/fleet/hello/README.md
@@ -1,13 +1,13 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="three worker replicas resolving one web node by name inside the fleet-hello east-west group"></p>
+
 # Fleet hello
 
-The smallest multi-node fleet: one `web` node and three `worker` replicas,
-the ix analog of a Kubernetes Service plus a 3-replica Deployment.
-
-`web` serves a static page over HTTP and exposes it to the fleet's east-west
-group. Each worker resolves the listener by name with
-`ix.endpointOf nodes.web "http"` and proves reachability through its health
-check, so the generated up wrapper only reports healthy once every worker can
-reach the web node.
+What does a Kubernetes Service plus a three-replica Deployment look like as
+one Nix file? This is the smallest multi-node fleet: one `web` node serving a
+static page and three `worker` replicas that resolve it by name with
+`ix.endpointOf nodes.web "http"` and curl it as their health check. The
+generated up wrapper reports healthy only once every worker can reach the web
+node.
 
 ## Run
 
@@ -15,6 +15,8 @@ reach the web node.
 # From the index repo root.
 nix run .#fleet-hello-up
 ```
+
+Need the repo first? `git clone https://github.com/indexable-inc/index`.
 
 ## Shape
 

--- a/examples/fleet/hello/assets/hero.svg
+++ b/examples/fleet/hello/assets/hero.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="16" y="14" width="688" height="132" rx="10" class="group"/>
+  <text x="32" y="36" font-size="11" class="accent">fleet-hello east-west group</text>
+  <rect x="72" y="52" width="170" height="52" rx="6" class="box"/>
+  <rect x="66" y="58" width="170" height="52" rx="6" class="box"/>
+  <rect x="60" y="64" width="170" height="52" rx="6" class="box"/>
+  <text x="145" y="86" font-size="13" text-anchor="middle">worker-0..2</text>
+  <text x="145" y="103" font-size="11" text-anchor="middle" class="muted">replicas = 3</text>
+  <rect x="480" y="58" width="180" height="52" rx="6" class="box"/>
+  <text x="570" y="80" font-size="13" text-anchor="middle">web</text>
+  <text x="570" y="97" font-size="11" text-anchor="middle" class="muted">nginx :8080</text>
+  <line x1="246" y1="84" x2="472" y2="84" class="edge"/>
+  <text x="359" y="76" font-size="11" text-anchor="middle" class="muted">health check: curl http://web:8080/</text>
+  <text x="359" y="102" font-size="11" text-anchor="middle" class="muted">resolved by node name</text>
+</svg>

--- a/examples/hermes/agent/README.md
+++ b/examples/hermes/agent/README.md
@@ -1,8 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="you chat with the hermes daemon in one ix VM; the only network traffic is outbound to the model API"></p>
+
 # Hermes Operator VM
 
-One ix node running [Nous Research's Hermes agent](https://hermes-agent.nousresearch.com/) as a long-lived daemon. The upstream NixOS module (`services.hermes-agent.*`) is wired in through [`index.lib.hermesAgent`](../../../lib/default.nix); this preset only chooses the model provider, the persona, and which integrations are turned on.
-
-Defaults: OpenRouter for the model, local SQLite memory, Edge TTS, a filesystem MCP server pointed at the workspace, no messaging platforms. Everything else is opt-in through `_module.args.hermes.*`.
+What does it take to run a long-lived AI agent as a boring system service? This is one ix node running [Nous Research's Hermes agent](https://hermes-agent.nousresearch.com/) as a daemon: the upstream NixOS module (`services.hermes-agent.*`) is wired in through [`index.lib.hermesAgent`](../../../lib/default.nix), and this preset only chooses the model provider, the persona, and which integrations are turned on. Defaults: OpenRouter for the model, local SQLite memory, Edge TTS, a filesystem MCP server pointed at the workspace, no messaging platforms. Everything else is opt-in through `_module.args.hermes.*`.
 
 ## Run
 
@@ -19,7 +19,7 @@ nix run .#hermes-agent-up
 ix shell hermes -- hermes chat
 ```
 
-The fleet maps `hermes_env` to `/run/secrets/hermes.env`, owned by the `hermes` user. The file lives outside `/nix/store`. To rotate, run `ix secret set hermes_env` again and restart the unit if the process needs to re-read it.
+The fleet maps `hermes_env` to `/run/secrets/hermes.env`, owned by the `hermes` user. The file lives outside `/nix/store`. To rotate, run `ix secret set hermes_env` again and restart the unit if the process needs to re-read it. Need the repo first? `git clone https://github.com/indexable-inc/index`.
 
 ## Shape
 
@@ -82,9 +82,9 @@ Per-integration env file overrides (`telegramEnvFile`, `webSearchEnvFile`, etc.)
 
 Three ready-made shapes build on this composition instead of forking it:
 
-- [`examples/hermes/telegram`](../telegram/) — Telegram chat companion (`telegram = true`, chat-tuned `SOUL.md`, BotFather walkthrough).
-- [`examples/hermes/minecraft-operator`](../minecraft-operator/) — the agent operating a Paper Minecraft server through a typed RCON `run_command` MCP tool.
-- [`examples/hermes/api-server`](../api-server/) — `apiServer = true` in an east-west group, so LobeChat / Open WebUI / LibreChat on sibling VMs use the agent as their OpenAI endpoint.
+- [`examples/hermes/telegram`](../telegram/): Telegram chat companion (`telegram = true`, chat-tuned `SOUL.md`, BotFather walkthrough).
+- [`examples/hermes/minecraft-operator`](../minecraft-operator/): the agent operating a Paper Minecraft server through a typed RCON `run_command` MCP tool.
+- [`examples/hermes/api-server`](../api-server/): `apiServer = true` in an east-west group, so LobeChat / Open WebUI / LibreChat on sibling VMs use the agent as their OpenAI endpoint.
 
 ## Bad fit if
 

--- a/examples/hermes/agent/assets/hero.svg
+++ b/examples/hermes/agent/assets/hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="30" y="56" width="130" height="48" rx="6" class="box"/>
+  <text x="95" y="77" font-size="13" text-anchor="middle">you</text>
+  <text x="95" y="94" font-size="11" text-anchor="middle" class="muted">hermes chat</text>
+  <rect x="240" y="30" width="250" height="100" rx="6" class="box"/>
+  <text x="365" y="52" font-size="13" text-anchor="middle">hermes VM</text>
+  <text x="365" y="74" font-size="11" text-anchor="middle" class="muted">hermes-agent daemon</text>
+  <text x="365" y="92" font-size="11" text-anchor="middle" class="muted">SOUL.md persona</text>
+  <text x="365" y="110" font-size="11" text-anchor="middle" class="muted">/run/secrets/hermes.env</text>
+  <rect x="570" y="56" width="120" height="48" rx="6" class="box"/>
+  <text x="630" y="77" font-size="13" text-anchor="middle">OpenRouter</text>
+  <text x="630" y="94" font-size="11" text-anchor="middle" class="muted">model API</text>
+  <line x1="160" y1="80" x2="232" y2="80" class="edge"/>
+  <text x="196" y="72" font-size="11" text-anchor="middle" class="muted">chat</text>
+  <line x1="490" y1="80" x2="562" y2="80" class="edge"/>
+  <text x="526" y="72" font-size="11" text-anchor="middle" class="muted">outbound</text>
+</svg>

--- a/examples/hermes/api-server/README.md
+++ b/examples/hermes/api-server/README.md
@@ -1,6 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="frontends in the hermes-api group call the agent's OpenAI-compatible endpoint on 9119; the agent dials out to the model API"></p>
+
 # Hermes API Server
 
-The [Hermes operator VM](../agent/) exposing the OpenAI-compatible `hermes api-server` on port `9119`. Chat frontends on sibling VMs (LobeChat, Open WebUI, LibreChat, or anything that speaks `/v1/chat/completions`) point their OpenAI base URL at this node and get the full agent — tools, memory, persona — behind a plain chat-completions endpoint.
+Can a chat frontend treat a full agent as just another OpenAI endpoint? This is the [Hermes operator VM](../agent/) exposing the OpenAI-compatible `hermes api-server` on port `9119`: chat frontends on sibling VMs (LobeChat, Open WebUI, LibreChat, or anything that speaks `/v1/chat/completions`) point their OpenAI base URL at this node and get the full agent (tools, memory, persona) behind a plain chat-completions endpoint.
 
 Unlike every other hermes preset this one is inbound: the node claims TCP `9119` via `ix.networking.expose.hermes-api`, which registers the port claim, opens the in-guest firewall, and makes the listener discoverable to siblings. Reachability is scoped by the east-west group: only VMs in the `hermes-api` group have a route or a DNS name to it. Nothing here is public; there is no `deployment.ipv4` and no L7 proxy.
 
@@ -16,6 +18,8 @@ Unlike every other hermes preset this one is inbound: the node claims TCP `9119`
 # From the index repo root.
 nix run .#hermes-api-server-up
 ```
+
+Need the repo first? `git clone https://github.com/indexable-inc/index`.
 
 Store the env-file secret before launch. `API_SERVER_KEY` is the bearer token your frontends will present; generate a long random one:
 

--- a/examples/hermes/api-server/assets/hero.svg
+++ b/examples/hermes/api-server/assets/hero.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="16" y="14" width="500" height="132" rx="10" class="group"/>
+  <text x="32" y="36" font-size="11" class="accent">hermes-api east-west group</text>
+  <rect x="44" y="56" width="190" height="56" rx="6" class="box"/>
+  <text x="139" y="79" font-size="13" text-anchor="middle">chat frontend</text>
+  <text x="139" y="97" font-size="11" text-anchor="middle" class="muted">LobeChat / Open WebUI</text>
+  <rect x="306" y="56" width="184" height="56" rx="6" class="box"/>
+  <text x="398" y="79" font-size="13" text-anchor="middle">hermes</text>
+  <text x="398" y="97" font-size="11" text-anchor="middle" class="muted">api-server :9119</text>
+  <line x1="234" y1="84" x2="298" y2="84" class="edge"/>
+  <text x="266" y="76" font-size="10" text-anchor="middle" class="muted">/v1/chat</text>
+  <text x="266" y="132" font-size="11" text-anchor="middle" class="muted">Bearer API_SERVER_KEY</text>
+  <rect x="580" y="56" width="110" height="56" rx="6" class="box"/>
+  <text x="635" y="79" font-size="13" text-anchor="middle">model API</text>
+  <text x="635" y="97" font-size="11" text-anchor="middle" class="muted">OpenRouter</text>
+  <line x1="490" y1="84" x2="572" y2="84" class="edge"/>
+  <text x="531" y="76" font-size="11" text-anchor="middle" class="muted">outbound</text>
+</svg>

--- a/examples/hermes/minecraft-operator/README.md
+++ b/examples/hermes/minecraft-operator/README.md
@@ -1,23 +1,18 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="players reach the Paper server over public ipv4; the hermes agent reaches only its RCON console over the east-west group"></p>
+
 # Hermes Minecraft Operator
 
-A [Hermes agent](../agent/) operating a Paper Minecraft server. Two nodes in one east-west group:
+What if your Minecraft server's admin was an agent you could just message? Here a [Hermes agent](../agent/) operates a Paper server: two nodes in one east-west group, where players reach the game over public ipv4 and the agent reaches only the console. Its single game-facing capability is a typed `run_command(command) -> response` MCP tool that speaks RCON ([`mcp/rcon_mcp.py`](mcp/rcon_mcp.py)), so "whitelist my friend", "shrink the world border to 2000", or a daily player-count report become chat requests instead of console sessions.
 
-```
-players ──ipv4──> minecraft (Paper 26.1.2 + RCON)
-                      ^
-                      | RCON (east-west only)
-                  hermes (agent + MCP `run_command` tool)
-```
-
-The agent gets exactly one game-facing capability: a typed `run_command(command) -> response` MCP tool that speaks RCON to the server console ([`mcp/rcon_mcp.py`](mcp/rcon_mcp.py)). "Whitelist my friend", "shrink the world border to 2000", or a daily player-count report become chat requests instead of console sessions, and the tool's schema is the whole attack surface: one console-command string, parsed by the Minecraft server's own grammar and permission model — no argv, no shell, no file access on the game node.
+The tool's schema is the whole attack surface: one console-command string, parsed by the Minecraft server's own grammar and permission model. No argv, no shell, no file access on the game node.
 
 ## Shape
 
-- [`ix.nix`](ix.nix) — the two-node fleet. Players reach the game over public ipv4; RCON is only routable inside the `hermes-minecraft` group.
-- [`minecraft.nix`](minecraft.nix) — Paper with `rcon.enable = true` and whitelist enforcement from first boot.
-- [`operator.nix`](operator.nix) — layers the MCP server and an operator persona on the shared `ix.hermes.profile` composition. The RCON host/port are read off the minecraft node's evaluated config, so they cannot drift.
-- [`rcon.nix`](rcon.nix) — the shared RCON credential. Committed plaintext like the survival example's forwarding secret: east-west-scoped, obviously a change-me.
-- [`documents/SOUL.md`](documents/SOUL.md) — the persona: read-before-write, quote real server responses, destructive commands only on explicit request.
+- [`ix.nix`](ix.nix): the two-node fleet. Players reach the game over public ipv4; RCON is only routable inside the `hermes-minecraft` group.
+- [`minecraft.nix`](minecraft.nix): Paper with `rcon.enable = true` and whitelist enforcement from first boot.
+- [`operator.nix`](operator.nix): layers the MCP server and an operator persona on the shared `ix.hermes.profile` composition. The RCON host/port are read off the minecraft node's evaluated config, so they cannot drift.
+- [`rcon.nix`](rcon.nix): the shared RCON credential. Committed plaintext like the survival example's forwarding secret: east-west-scoped, obviously a change-me.
+- [`documents/SOUL.md`](documents/SOUL.md): the persona; read-before-write, quote real server responses, destructive commands only on explicit request.
 
 ## Run
 
@@ -25,6 +20,8 @@ The agent gets exactly one game-facing capability: a typed `run_command(command)
 # From the index repo root.
 nix run .#hermes-minecraft-operator-up
 ```
+
+Need the repo first? `git clone https://github.com/indexable-inc/index`.
 
 Store the model key env file, bring the fleet up, and open a chat:
 
@@ -48,7 +45,7 @@ World-border tweaks:
 
 > **you:** shrink the border to 2000 blocks over 10 minutes
 >
-> **hermes:** Current border is 60000 wide. Running `worldborder set 2000 600` — server replied `Setting the border to 2000.0 blocks wide over 600 seconds`. I announced it in-game first with `say`.
+> **hermes:** Current border is 60000 wide. Running `worldborder set 2000 600`; the server replied `Setting the border to 2000.0 blocks wide over 600 seconds`. I announced it in-game first with `say`.
 
 The daily player-count report:
 
@@ -56,7 +53,7 @@ The daily player-count report:
 >
 > **hermes:** Scheduled: a cron job at 19:00 runs `list` and posts the result here. You can check it with `hermes cron` from a shell, or just ask me.
 
-The cron job lives in Hermes' own scheduler (`$HERMES_HOME/cron/jobs.json`), created conversationally — nothing to deploy.
+The cron job lives in Hermes' own scheduler (`$HERMES_HOME/cron/jobs.json`), created conversationally, nothing to deploy.
 
 ## The credential, honestly
 

--- a/examples/hermes/minecraft-operator/assets/hero.svg
+++ b/examples/hermes/minecraft-operator/assets/hero.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 170" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="300" y="8" width="330" height="152" rx="10" class="group"/>
+  <text x="316" y="26" font-size="11" class="accent">hermes-minecraft group</text>
+  <rect x="330" y="34" width="270" height="50" rx="6" class="box"/>
+  <text x="465" y="55" font-size="13" text-anchor="middle">minecraft</text>
+  <text x="465" y="72" font-size="11" text-anchor="middle" class="muted">Paper, RCON east-west only</text>
+  <rect x="330" y="102" width="270" height="50" rx="6" class="box"/>
+  <text x="465" y="123" font-size="13" text-anchor="middle">hermes</text>
+  <text x="465" y="140" font-size="11" text-anchor="middle" class="muted">agent + run_command MCP tool</text>
+  <line x1="420" y1="102" x2="420" y2="88" class="edge"/>
+  <text x="432" y="98" font-size="11" class="muted">RCON</text>
+  <rect x="60" y="36" width="120" height="44" rx="6" class="box"/>
+  <text x="120" y="62" font-size="13" text-anchor="middle">players</text>
+  <line x1="180" y1="58" x2="322" y2="58" class="edge"/>
+  <text x="251" y="50" font-size="11" text-anchor="middle" class="muted">ipv4 :25565</text>
+  <rect x="60" y="104" width="120" height="44" rx="6" class="box"/>
+  <text x="120" y="130" font-size="13" text-anchor="middle">you</text>
+  <line x1="180" y1="126" x2="322" y2="126" class="edge"/>
+  <text x="251" y="118" font-size="11" text-anchor="middle" class="muted">chat</text>
+</svg>

--- a/examples/hermes/telegram/README.md
+++ b/examples/hermes/telegram/README.md
@@ -1,6 +1,8 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="the hermes VM long-polls the Telegram API; you message the bot from the app, no inbound port anywhere"></p>
+
 # Hermes Telegram Companion
 
-The [Hermes operator VM](../agent/) tuned as a Telegram chat companion: same one-node, outbound-only shape, plus the long-poll Telegram platform and a chat-tuned persona. No inbound port, no webhook, no public hostname; the bot long-polls Telegram's API, so it works from any network the VM can dial out of.
+Want an agent in your pocket without opening a single inbound port? This is the [Hermes operator VM](../agent/) tuned as a Telegram chat companion: the same one-node, outbound-only shape, plus the long-poll Telegram platform and a chat-tuned persona. No webhook, no public hostname; the bot long-polls Telegram's API, so it works from any network the VM can dial out of.
 
 ## Shape
 
@@ -22,6 +24,8 @@ The [Hermes operator VM](../agent/) tuned as a Telegram chat companion: same one
 nix run .#hermes-telegram-up
 ```
 
+Need the repo first? `git clone https://github.com/indexable-inc/index`.
+
 Store the env-file secret, then bring the VM up. To rotate later, run `ix secret set hermes_env` again and restart the unit.
 
 ```sh
@@ -41,7 +45,7 @@ Now open your bot's chat in Telegram and say hello.
 
 > **you:** hey, what machine are you on?
 >
-> **bot:** Hi! I'm on a NixOS VM called `hermes` — 1 vCPU bursting higher, systemd as PID 1, nushell for a shell. Root inside the guest, no access to the ix host.
+> **bot:** Hi! I'm on a NixOS VM called `hermes`: 1 vCPU bursting higher, systemd as PID 1, nushell for a shell. Root inside the guest, no access to the ix host.
 >
 > **you:** is anything eating cpu right now
 >
@@ -49,7 +53,7 @@ Now open your bot's chat in Telegram and say hello.
 >
 > **you:** remind me to rotate the api key on friday morning
 >
-> **bot:** Done — cron job set for Friday 09:00 (VM time, UTC). I'll message you here when it fires.
+> **bot:** Done, cron job set for Friday 09:00 (VM time, UTC). I'll message you here when it fires.
 
 ## Notes
 

--- a/examples/hermes/telegram/assets/hero.svg
+++ b/examples/hermes/telegram/assets/hero.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="40" y="56" width="140" height="48" rx="6" class="box"/>
+  <text x="110" y="77" font-size="13" text-anchor="middle">you</text>
+  <text x="110" y="94" font-size="11" text-anchor="middle" class="muted">Telegram app</text>
+  <rect x="290" y="56" width="160" height="48" rx="6" class="box"/>
+  <text x="370" y="86" font-size="13" text-anchor="middle">Telegram API</text>
+  <rect x="540" y="56" width="150" height="48" rx="6" class="box"/>
+  <text x="615" y="77" font-size="13" text-anchor="middle">hermes VM</text>
+  <text x="615" y="94" font-size="11" text-anchor="middle" class="muted">agent + bot</text>
+  <line x1="180" y1="80" x2="282" y2="80" class="edge"/>
+  <text x="231" y="72" font-size="11" text-anchor="middle" class="muted">messages</text>
+  <line x1="540" y1="80" x2="458" y2="80" class="edge"/>
+  <text x="499" y="72" font-size="11" text-anchor="middle" class="muted">long-poll</text>
+  <text x="380" y="132" font-size="11" text-anchor="middle" class="muted">outbound only: no inbound port, no webhook, no public hostname</text>
+</svg>

--- a/examples/minecraft/blocks/README.md
+++ b/examples/minecraft/blocks/README.md
@@ -1,15 +1,15 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="block placements flow from the Paper producer through a Kafka log into a ClickHouse spatial view; telemetry takes a separate collector path"></p>
+
 # Minecraft Blocks
 
-Watch a single block placement flow from a Minecraft server to a 3D spatial
-query. A player places a block, the placement becomes a durable fact in a log,
-the log materializes into a ClickHouse table ordered by a space-filling curve,
-and a bounding-box query over that table scans only the storage it needs.
-
-This example is a working tour of the data architecture: a producer, one
-durable log, and a view derived from that log. It also shows the contrast that
-the architecture turns on: a block placement is a domain fact and travels the
-log path, while the server's own telemetry travels a separate collector path
-into the same database.
+What happens to a block placement after the click? Here it becomes a durable
+fact: the placement lands in a Kafka log, the log materializes into a
+ClickHouse table ordered by a space-filling curve, and a bounding-box query
+over that table scans only the storage it needs. Three VMs carry the tour
+(`producer`, `log`, `view`), and the fleet also shows the contrast the
+architecture turns on: a block placement is a domain fact and travels the log
+path, while the server's own telemetry travels a separate collector path into
+the same database.
 
 ## Run
 
@@ -19,7 +19,8 @@ nix run .#minecraft-blocks-up
 
 That brings up three VMs: `log` (the Kafka broker), `view` (ClickHouse, the
 OTel collector, and Grafana), and `producer` (the Paper server with the
-block-events plugin). Grafana is on port `3000` through the example's L7 proxy.
+block-events plugin). Grafana is on port `3000` through the example's L7 proxy. The wrapper
+lives on the index root flake: `git clone https://github.com/indexable-inc/index`.
 
 Query the spatial view from inside the view VM:
 

--- a/examples/minecraft/blocks/assets/hero.svg
+++ b/examples/minecraft/blocks/assets/hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="30" y="30" width="190" height="54" rx="6" class="box"/>
+  <text x="125" y="52" font-size="13" text-anchor="middle">producer</text>
+  <text x="125" y="70" font-size="11" text-anchor="middle" class="muted">Paper + BlockEvents plugin</text>
+  <rect x="285" y="30" width="150" height="54" rx="6" class="box"/>
+  <text x="360" y="52" font-size="13" text-anchor="middle">log</text>
+  <text x="360" y="70" font-size="11" text-anchor="middle" class="muted">Kafka block_events</text>
+  <rect x="495" y="30" width="195" height="54" rx="6" class="box"/>
+  <text x="592" y="52" font-size="13" text-anchor="middle">view</text>
+  <text x="592" y="70" font-size="11" text-anchor="middle" class="muted">ClickHouse Morton view</text>
+  <line x1="220" y1="57" x2="277" y2="57" class="edge"/>
+  <text x="249" y="49" font-size="11" text-anchor="middle" class="muted">ship</text>
+  <line x1="435" y1="57" x2="487" y2="57" class="edge"/>
+  <text x="461" y="49" font-size="11" text-anchor="middle" class="muted">replay</text>
+  <path d="M125,84 L125,124 L592,124 L592,92" class="edge"/>
+  <text x="360" y="116" font-size="11" text-anchor="middle" class="muted">telemetry (OTel collector, otel_* tables, Grafana)</text>
+</svg>

--- a/examples/minecraft/crazy-terrain/README.md
+++ b/examples/minecraft/crazy-terrain/README.md
@@ -1,13 +1,15 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="a diffusion model generates neural terrain inside one Fabric VM that players join on 25565"></p>
+
 # Crazy Terrain
 
-One ix fleet node running a Fabric `1.21.11` server with
+What does Minecraft terrain look like when a diffusion model generates it at
+the absolute Java height limit? This is one ix fleet node running a Fabric
+`1.21.11` server with
 [`terrain-diffusion`](https://github.com/xandergos/terrain-diffusion-mc), a
-diffusion-model world generator that replaces vanilla noise with neural
-terrain. The server is set up so generation runs against the absolute Java
-max world height: every dimension is built at `min_y = -2032`, `height =
-4064` (top `y = 2031`), and the mod's per-world `World Scale` is locked to
-its `MAX_SCALE` of `6`, which puts the diffusion pipeline's `10 km` peak at
-roughly `y ~2060`.
+world generator that replaces vanilla noise with neural terrain. Every
+dimension is built at `min_y = -2032`, `height = 4064` (top `y = 2031`), and
+the mod's per-world `World Scale` is locked to its `MAX_SCALE` of `6`, which
+puts the diffusion pipeline's `10 km` peak at roughly `y ~2060`.
 
 ## Run
 
@@ -15,6 +17,8 @@ roughly `y ~2060`.
 # From the index repo root.
 nix run .#minecraft-crazy-terrain-up
 ```
+
+Need the repo first? `git clone https://github.com/indexable-inc/index`.
 
 ## Shape
 

--- a/examples/minecraft/crazy-terrain/assets/hero.svg
+++ b/examples/minecraft/crazy-terrain/assets/hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    .terrain { stroke: #8250df; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+      .terrain { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="40" y="56" width="180" height="52" rx="6" class="box"/>
+  <text x="130" y="78" font-size="13" text-anchor="middle">terrain-diffusion</text>
+  <text x="130" y="95" font-size="11" text-anchor="middle" class="muted">neural generator</text>
+  <rect x="300" y="24" width="250" height="112" rx="6" class="box"/>
+  <text x="425" y="44" font-size="13" text-anchor="middle">crazy-terrain VM (Fabric)</text>
+  <text x="425" y="60" font-size="11" text-anchor="middle" class="muted">min_y -2032, top y 2031, scale 6</text>
+  <polyline points="316,126 346,84 372,104 404,68 436,110 466,74 496,118 534,126" class="terrain"/>
+  <line x1="220" y1="82" x2="292" y2="82" class="edge"/>
+  <text x="256" y="74" font-size="11" text-anchor="middle" class="muted">generates</text>
+  <rect x="610" y="56" width="80" height="52" rx="6" class="box"/>
+  <text x="650" y="86" font-size="13" text-anchor="middle">players</text>
+  <line x1="610" y1="82" x2="558" y2="82" class="edge"/>
+  <text x="584" y="74" font-size="11" text-anchor="middle" class="muted">:25565</text>
+</svg>

--- a/examples/minecraft/factions/README.md
+++ b/examples/minecraft/factions/README.md
@@ -1,13 +1,13 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="one Paper factions VM with three public listeners: game, BlueMap web map, and voice chat"></p>
+
 # Factions Server
 
-Standalone consumer example for a Paper factions server on ix.
-
-It defines one Paper `26.1.2` server with a curated plugin set, a `12000` block
+What does a production-shaped factions server look like as one Nix file? This
+standalone consumer example defines a single Paper `26.1.2` node with a curated
+plugin set (factions, economy, audit, map, voice, scripting), a `12000` block
 world border, a 4064-block max-height datapack, BlueMap on TCP `8100`, Simple
-Voice Chat on UDP `24454`, and local-only RCON for managed reloads.
-
-Customize real player UUIDs and spawn/claim policy before using it with real
-players.
+Voice Chat on UDP `24454`, and local-only RCON for managed reloads. Customize
+real player UUIDs and spawn/claim policy before using it with real players.
 
 ## Run
 
@@ -15,6 +15,8 @@ players.
 # From the index repo root.
 nix run .#minecraft-factions-up
 ```
+
+Need the repo first? `git clone https://github.com/indexable-inc/index`.
 
 ## Shape
 

--- a/examples/minecraft/factions/assets/hero.svg
+++ b/examples/minecraft/factions/assets/hero.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="40" y="24" width="300" height="112" rx="6" class="box"/>
+  <text x="190" y="50" font-size="13" text-anchor="middle">factions VM</text>
+  <text x="190" y="72" font-size="11" text-anchor="middle" class="muted">Paper 26.1.2, curated plugin set</text>
+  <text x="190" y="90" font-size="11" text-anchor="middle" class="muted">12000-block border, max-height datapack</text>
+  <text x="190" y="108" font-size="11" text-anchor="middle" class="muted">local-only RCON</text>
+  <rect x="480" y="18" width="210" height="36" rx="6" class="box"/>
+  <text x="585" y="41" font-size="12" text-anchor="middle">Java players</text>
+  <line x1="480" y1="36" x2="348" y2="36" class="edge"/>
+  <text x="414" y="29" font-size="11" text-anchor="middle" class="muted">:25565 tcp</text>
+  <rect x="480" y="62" width="210" height="36" rx="6" class="box"/>
+  <text x="585" y="85" font-size="12" text-anchor="middle">BlueMap browser</text>
+  <line x1="480" y1="80" x2="348" y2="80" class="edge"/>
+  <text x="414" y="73" font-size="11" text-anchor="middle" class="muted">:8100 tcp</text>
+  <rect x="480" y="106" width="210" height="36" rx="6" class="box"/>
+  <text x="585" y="129" font-size="12" text-anchor="middle">Simple Voice Chat</text>
+  <line x1="480" y1="124" x2="348" y2="124" class="edge"/>
+  <text x="414" y="117" font-size="11" text-anchor="middle" class="muted">:24454 udp</text>
+</svg>

--- a/examples/minecraft/survival/README.md
+++ b/examples/minecraft/survival/README.md
@@ -1,10 +1,14 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="Java and Bedrock clients enter through Velocity and Geyser; the Paper backend port stays private"></p>
+
 # Survival Server
 
-One ix fleet node running a [Paper](https://papermc.io/software/paper)
-survival backend behind [Velocity](https://papermc.io/software/velocity), with
+Can Java and Bedrock players share one world from a single VM? This is one ix
+fleet node running a [Paper](https://papermc.io/software/paper) survival
+backend behind [Velocity](https://papermc.io/software/velocity), with
 [Geyser](https://geysermc.org/) and
-[Floodgate](https://geysermc.org/wiki/floodgate/) on the proxy so Java and
-Bedrock clients share the same world.
+[Floodgate](https://geysermc.org/wiki/floodgate/) on the proxy so both client
+families land in the same world. The backend port stays private to the image
+firewall; only the proxy listeners are public.
 
 ## Run
 
@@ -12,6 +16,8 @@ Bedrock clients share the same world.
 # From the index repo root.
 nix run .#minecraft-survival-up
 ```
+
+Need the repo first? `git clone https://github.com/indexable-inc/index`.
 
 ## Shape
 

--- a/examples/minecraft/survival/assets/hero.svg
+++ b/examples/minecraft/survival/assets/hero.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    text { fill: currentColor; }
+    .muted { fill: #656d76; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .arrow { fill: #1f2328; }
+    .group { stroke: #8250df; fill: none; stroke-dasharray: 6 4; }
+    .accent { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .arrow { fill: #e6edf3; }
+      .group { stroke: #a371f7; }
+      .accent { fill: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+  <rect x="250" y="14" width="440" height="132" rx="8" class="box"/>
+  <text x="268" y="34" font-size="12">survival VM</text>
+  <rect x="280" y="40" width="150" height="40" rx="6" class="box"/>
+  <text x="355" y="64" font-size="12" text-anchor="middle">Velocity</text>
+  <rect x="280" y="102" width="150" height="40" rx="6" class="box"/>
+  <text x="355" y="126" font-size="12" text-anchor="middle">Geyser + Floodgate</text>
+  <rect x="520" y="60" width="140" height="44" rx="6" class="box"/>
+  <text x="590" y="79" font-size="12" text-anchor="middle">Paper</text>
+  <text x="590" y="95" font-size="11" text-anchor="middle" class="muted">:25566 private</text>
+  <rect x="40" y="40" width="150" height="40" rx="6" class="box"/>
+  <text x="115" y="64" font-size="12" text-anchor="middle">Java clients</text>
+  <line x1="190" y1="60" x2="272" y2="60" class="edge"/>
+  <text x="231" y="52" font-size="11" text-anchor="middle" class="muted">:25565 tcp</text>
+  <rect x="40" y="102" width="150" height="40" rx="6" class="box"/>
+  <text x="115" y="126" font-size="12" text-anchor="middle">Bedrock clients</text>
+  <line x1="190" y1="122" x2="272" y2="122" class="edge"/>
+  <text x="231" y="114" font-size="11" text-anchor="middle" class="muted">:19132 udp</text>
+  <line x1="355" y1="102" x2="355" y2="88" class="edge"/>
+  <line x1="430" y1="60" x2="512" y2="78" class="edge"/>
+  <text x="470" y="60" font-size="11" text-anchor="middle" class="muted">forwarding</text>
+</svg>


### PR DESCRIPTION
Restyles every example-fleet README per the `creating-a-readme` skill: one committed `assets/hero.svg` (single-file, adapts to dark/light via embedded `prefers-color-scheme` CSS, viewBox only), a hook-question intro with a short pitch, verified run commands (all `nix run .#<example>-{up,health}` wrappers exist on the root flake), and a pointer to `git clone https://github.com/indexable-inc/index`. Em dashes removed from touched prose per the writing-style skill.

Updated READMEs (each with a new hero SVG):

- examples/hermes/agent/README.md
- examples/hermes/api-server/README.md
- examples/hermes/minecraft-operator/README.md
- examples/hermes/telegram/README.md
- examples/minecraft/blocks/README.md
- examples/minecraft/crazy-terrain/README.md
- examples/minecraft/factions/README.md
- examples/minecraft/survival/README.md
- examples/fleet/hello/README.md
- examples/dev/fleet/README.md
- examples/declared/groups/README.md
- examples/east-west/firewall/README.md

`nix run .#lint` passes at the branch root (8/8 tasks). All SVGs parse (xml.etree) and every themed CSS property has both a light default and a dark override.

Refs #2072

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update READMEs for hermes, minecraft, and fleet examples with hero images and improved descriptions
> - Adds a centered hero SVG image to the top of each example README across the `hermes`, `minecraft`, `fleet`, `east-west/firewall`, and `declared/groups` directories.
> - Rewrites introductory prose in each README to clarify topology, behavior, and key parameters (e.g., port exposure, east-west groups, public vs private listeners).
> - Adds repository clone instructions to the run sections of all affected READMEs.
> - Standardizes bullet formatting (colon separators) and applies minor copy edits throughout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f824bca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->