### PR TITLE
upstream-sync: drift subcommand + fork-sync surfacing (#2098)

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -87,6 +87,42 @@ jobs:
       # re-trigger flake-check. Repo admins may also need to enable "Allow GitHub
       # Actions to create and approve pull requests" once under Settings ->
       # Actions -> General.
+      # Drift visibility (RFC 0010, #2098): how far each pinned base trails its
+      # upstream default branch, patch stances, and retired-awaiting-drop counts.
+      # Read-only. Forge errors degrade to unknown cells inside the tool (it
+      # never fails the report over one unreachable forge), so this step fails
+      # only when the tool itself cannot run. The table lands in the job's step
+      # summary and in the rolling PR body (`body-path` below); the body file is
+      # written outside the workspace so create-pull-request cannot commit it.
+      - name: Fork drift report
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          nix run .#upstream-sync -- drift --markdown > "$RUNNER_TEMP/drift.md"
+          {
+            echo "## Fork drift"
+            echo ""
+            cat "$RUNNER_TEMP/drift.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+          {
+            cat <<'BODY'
+          Automated fork-sync: bump each auto-updatable de-forked package's upstream base and regenerate its in-repo patch series through a real `git rebase`.
+
+          Driven by `lib/fork-packages.nix` (`autoUpdate = true`): currently **codex** (`openai/codex`) and **btop** (`aristocratos/btop`). Excluded (`autoUpdate = false`, bumped by hand via `nix run .#rebase-patches -- <name>`): **clippy** is nightly-toolchain-coupled and rev-pinned, bumped alongside the rust toolchain; **nix** is our daemon toolchain, pinned at the rev the fleet daemon runs, bumped only when we deliberately move the daemon version.
+
+          Each `patched-src-<name>` check was built against the freshly bumped base in this job, so the series still applies. The PR's `flake-check` CI rebuilds the full packages.
+
+          If this PR shows no `flake-check` run, the repo needs the `AUTOBUMP_TOKEN` secret and/or "Allow GitHub Actions to create and approve pull requests" enabled once.
+
+          ### Fork drift
+
+          BODY
+            cat "$RUNNER_TEMP/drift.md"
+            echo ""
+            echo "Auto-bump, made with Claude Opus 4.8."
+          } > "$RUNNER_TEMP/pr-body.md"
+
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -96,13 +132,6 @@ jobs:
           delete-branch: true
           commit-message: "fork-sync: bump upstream bases and regenerate patches"
           title: "fork-sync: bump upstream bases and regenerate patches"
-          body: |
-            Automated fork-sync: bump each auto-updatable de-forked package's upstream base and regenerate its in-repo patch series through a real `git rebase`.
-
-            Driven by `lib/fork-packages.nix` (`autoUpdate = true`): currently **codex** (`openai/codex`) and **btop** (`aristocratos/btop`). Excluded (`autoUpdate = false`, bumped by hand via `nix run .#rebase-patches -- <name>`): **clippy** is nightly-toolchain-coupled and rev-pinned, bumped alongside the rust toolchain; **nix** is our daemon toolchain, pinned at the rev the fleet daemon runs, bumped only when we deliberately move the daemon version.
-
-            Each `patched-src-<name>` check was built against the freshly bumped base in this job, so the series still applies. The PR's `flake-check` CI rebuilds the full packages.
-
-            If this PR shows no `flake-check` run, the repo needs the `AUTOBUMP_TOKEN` secret and/or "Allow GitHub Actions to create and approve pull requests" enabled once.
-
-            Auto-bump, made with Claude Opus 4.8.
+          # The body (preamble + live fork-drift table) is assembled by the
+          # "Fork drift report" step above; body-path keeps this step dumb.
+          body-path: ${{ runner.temp }}/pr-body.md

--- a/packages/upstream-sync/default.nix
+++ b/packages/upstream-sync/default.nix
@@ -5,6 +5,14 @@
 # declarative intent, tracks the live state of the PRs we open, spots duplicate
 # upstream PRs, and retires patches that land upstream.
 #
+#
+# `nix run .#upstream-sync -- drift [--json|--markdown] [name]` is the read-only
+# companion report (RFC 0010, #2098): per fork, how far the pinned base trails
+# upstream's default branch (commits behind + base age), the declared patch
+# stances, how many tracked patches are retired-awaiting-drop, and a one-word
+# next action. The fork-sync cron surfaces it in its step summary and rolling
+# PR body.
+#
 # The two-sided design the user set:
 #   - DECLARATIVE INTENT lives in nix (lib/fork-packages.nix), hand-written: each
 #     patch's `upstream = attempt|hold|never` + one-line reason, and a per-repo
@@ -246,6 +254,187 @@
         | first
         | default "Subject: (none)"
         | str replace --regex '^Subject:\s*(\[PATCH[^\]]*\]\s*)?' ""
+      }
+
+      # --- drift report (read-only; RFC 0010, #2098) ----------------------------
+
+      # The pinned base rev of a fork's input from the committed flake.lock in
+      # the CWD (the tool runs from the repo root; a downstream --mapping repo
+      # reads its own lock the same way). Null when the lock or input is absent.
+      def "lock rev" [input: string]: nothing -> any {
+        if not ("flake.lock" | path exists) { return null }
+        let node = (open --raw flake.lock | from json | get -o nodes | default {} | get -o $input)
+        if $node == null { return null }
+        $node | get -o locked.rev
+      }
+
+      # Is this upstream on a GitLab host (e.g. mesa on gitlab.freedesktop.org)?
+      def "is gitlab" [url: string]: nothing -> bool {
+        $url | str contains "gitlab."
+      }
+
+      # A gh api read that DEGRADES instead of failing: a forge error becomes a
+      # stderr warning and a null cell, so one unreachable forge cannot take the
+      # whole drift table down.
+      def "gh read" [ctx: string, path: string, jq: string]: nothing -> any {
+        let res = (do { gh api $path --jq $jq } | complete)
+        if $res.exit_code != 0 {
+          print -e $"(ansi yellow)upstream-sync: drift: ($ctx): gh api ($path) failed; cell left unknown(ansi reset)"
+          return null
+        }
+        $res.stdout | str trim
+      }
+
+      # Base-commit committer date on a GitLab host, or null. GitLab drift is
+      # DELIBERATELY base-age-only: the compare API enumerates every commit in
+      # the range (thousands on a months-old mesa pin), so the cheap single-commit
+      # lookup is the reliable unauthenticated read and commits-behind stays
+      # unknown (the RFC allows exactly this degradation).
+      def "gitlab base-date" [url: string, rev: string]: nothing -> any {
+        let u = ($url | url parse)
+        let project = ($u.path | str trim --left --char "/" | str replace --regex '\.git$' "" | url encode --all)
+        let endpoint = $"https://($u.host)/api/v4/projects/($project)/repository/commits/($rev)"
+        try {
+          http get $endpoint | get committed_date
+        } catch {
+          print -e $"(ansi yellow)upstream-sync: drift: ($endpoint) unreachable; base age left unknown(ansi reset)"
+          null
+        }
+      }
+
+      # One fork's drift facts. A null cell means "unknown" (forge unreachable or
+      # input not in flake.lock), never a crash: the report must survive a broken
+      # forge and still render the other rows.
+      def "drift row" [fork: record]: nothing -> record {
+        let slug = (url slug $fork.url)
+        let rev = (lock rev $fork.input)
+        if $rev == null {
+          print -e $"(ansi yellow)upstream-sync: drift: ($fork.name): input ($fork.input) has no locked rev in flake.lock(ansi reset)"
+        }
+        let forge = (
+          if (is github $fork.url) { "github" }
+          else if (is gitlab $fork.url) { "gitlab" }
+          else { "other" }
+        )
+
+        # Commits behind = ahead_by of `pinned...default_branch`: how many
+        # commits upstream's default branch has that our pinned base does not.
+        let behind = (
+          if $forge != "github" or $rev == null { null } else {
+            let branch = (gh read $fork.name $"repos/($slug.owner)/($slug.repo)" ".default_branch")
+            if $branch == null { null } else {
+              let n = (gh read $fork.name $"repos/($slug.owner)/($slug.repo)/compare/($rev)...($branch)" ".ahead_by")
+              if $n == null { null } else { $n | into int }
+            }
+          }
+        )
+        let base_date = (
+          if $rev == null { null } else if $forge == "github" {
+            gh read $fork.name $"repos/($slug.owner)/($slug.repo)/commits/($rev)" ".commit.committer.date"
+          } else if $forge == "gitlab" {
+            gitlab base-date $fork.url $rev
+          } else { null }
+        )
+        let age_days = (
+          if $base_date == null { null } else {
+            ((date now) - ($base_date | into datetime)) / 1day | math floor | into int
+          }
+        )
+
+        # Patch stances walk dag.json node order (the canonical series, same as
+        # the sync loop); an unclassified patch defaults to hold (fail-safe).
+        let intent = ($fork.patches? | default {})
+        let dag_file = ($fork.patchDir | path expand | path join "dag.json")
+        let series = (
+          if ($dag_file | path exists) { open --raw $dag_file | from json | get nodes | get patch }
+          else { $intent | columns }
+        )
+        let stances = (
+          $series | each {|p|
+            let mark = ($intent | get -o $p)
+            $mark.upstream? | default "hold"
+          }
+        )
+        let retired = ((status load $fork).patches | values | where {|p| $p.retired? | default false } | length)
+
+        # Next-action heuristic, deliberately simple:
+        #   retired > 0            -> rebase-shrinks-series: a base bump drops the
+        #                             retired patches as empty cherries.
+        #   drift fully unknown    -> unknown: no basis to recommend anything.
+        #   >= 200 commits behind
+        #   or base >= 90 days old -> rebase-recommended: in practice this bites
+        #                             the manual pins (nix/clippy/mesa); autoUpdate
+        #                             forks are cron-freshened before they get here.
+        #   else                   -> ok
+        let action = (
+          if $retired > 0 { "rebase-shrinks-series" }
+          else if $behind == null and $age_days == null { "unknown" }
+          else if (($behind | default 0) >= 200) or (($age_days | default 0) >= 90) { "rebase-recommended" }
+          else { "ok" }
+        )
+        {
+          name: $fork.name
+          forge: $forge
+          input: $fork.input
+          rev: $rev
+          behind: $behind
+          baseDate: $base_date
+          ageDays: $age_days
+          attempt: ($stances | where {|s| $s == "attempt" } | length)
+          hold: ($stances | where {|s| $s == "hold" } | length)
+          never: ($stances | where {|s| $s == "never" } | length)
+          retired: $retired
+          action: $action
+          note: (
+            if $forge == "gitlab" { "base-age only (gitlab compare skipped)" }
+            else if $forge == "other" { "unsupported forge" }
+            else { "" }
+          )
+        }
+      }
+
+      # `nix run .#upstream-sync -- drift [--json|--markdown] [name]`: the
+      # read-only drift report. Network reads only; no status file is written.
+      def "main drift" [
+        name?: string     # one fork package (nix | btop | ...); all if omitted
+        --json            # machine-readable JSON to stdout, nothing else
+        --markdown        # GitHub-flavored markdown table (step summaries, PR bodies)
+        --mapping: string # fork-package JSON to drive (default: index's baked-in list)
+      ] {
+        if $json and $markdown {
+          error make {msg: "upstream-sync: drift: --json and --markdown are mutually exclusive"}
+        }
+        let rows = (fork select $name $mapping | each {|fork| drift row $fork })
+        if $json {
+          print ($rows | to json --indent 2)
+          return
+        }
+        # Human/markdown view: "?" marks an unknown cell (forge unreachable or no
+        # locked rev) so a degraded row is visibly degraded, not silently zero.
+        let view = (
+          $rows | each {|r|
+            {
+              fork: $r.name
+              base: (if $r.rev == null { "?" } else { $r.rev | str substring 0..11 })
+              behind: ($r.behind | default "?")
+              "age (days)": ($r.ageDays | default "?")
+              # action before the stance counts so an 80-column pipe still shows
+              # the verdict (nu truncates trailing table columns off-tty).
+              action: $r.action
+              attempt: $r.attempt
+              hold: $r.hold
+              never: $r.never
+              retired: $r.retired
+              note: $r.note
+            }
+          }
+        )
+        if $markdown {
+          print ($view | to md --pretty)
+        } else {
+          print $"(ansi cyan)== fork drift: pinned base vs upstream default branch ==(ansi reset)"
+          print ($view | table --index false)
+        }
       }
 
       # --- the loop -------------------------------------------------------------
@@ -579,11 +768,86 @@
 
     touch "$out"
   '';
+  # Drift-report test for the pure parts no live run pins deterministically:
+  # flake.lock rev extraction, stance + retired counting, the next-action
+  # heuristic, and the degrade path (a failing forge yields unknown cells and a
+  # zero exit, never a crashed report). gh is stubbed with fixed `--jq`'d
+  # responses; nothing elaborate, the forge is not what is under test.
+  drift = runCommand "upstream-sync-drift-test" {nativeBuildInputs = [nushell];} ''
+    mkdir -p stubs work/repo/patches work/bad/patches
+    export HOME="$PWD"
+
+    # Stub gh: `gh api <path> --jq <expr>` keyed on the path. Every bad-fork
+    # endpoint fails, exercising degrade-to-unknown.
+    cat > stubs/gh <<STUB
+    #!$(command -v bash)
+    case "\$2" in
+      repos/fakeorg/fakerepo) echo "main" ;;
+      repos/fakeorg/fakerepo/compare/*) echo "123" ;;
+      repos/fakeorg/fakerepo/commits/*) echo "2026-01-01T00:00:00Z" ;;
+      *) echo "stub gh: unexpected: \$*" >&2; exit 1 ;;
+    esac
+    STUB
+    chmod +x stubs/gh
+
+    cat > work/flake.lock <<'EOF'
+    {"nodes": {"fake-src": {"locked": {"rev": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
+               "bad-src": {"locked": {"rev": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}}}
+    EOF
+    echo '{"comment":"t","base":"deadbeef","nodes":[{"patch":"0001-sent.patch","deps":[]},{"patch":"0002-kept.patch","deps":[]},{"patch":"0003-unclassified.patch","deps":[]}]}' \
+      > work/repo/patches/dag.json
+    cat > work/repo/patches/upstream-status.json <<'EOF'
+    {"comment":"t","lastChecked":"2026-01-01T00:00:00Z","patches":{"0001-sent.patch":{"upstream":"attempt","pr":{"url":"u","number":1,"state":"merged","checkedAt":"t"},"retired":true,"duplicates":[]}},"log":[]}
+    EOF
+    echo '{"comment":"t","base":"deadbeef","nodes":[{"patch":"0001-x.patch","deps":[]}]}' > work/bad/patches/dag.json
+    cat > work/mapping.json <<'EOF'
+    [{"name":"fake","input":"fake-src","url":"https://github.com/fakeorg/fakerepo.git",
+      "patchDir":"repo/patches","autoUpdate":false,
+      "patches":{"0001-sent.patch":{"upstream":"attempt","reason":"t"},"0002-kept.patch":{"upstream":"never","reason":"t"}}},
+     {"name":"bad","input":"bad-src","url":"https://github.com/badorg/badrepo.git",
+      "patchDir":"bad/patches","autoUpdate":false,"patches":{}}]
+    EOF
+
+    awk '/^# nu$/,0' ${package}/bin/upstream-sync > script.nu
+    export PATH="$PWD/stubs:$PATH"
+    cd work
+
+    # --json is the machine surface: stdout must parse as JSON alone (warnings
+    # go to stderr), the fake row carries the stubbed forge facts plus the
+    # retired-driven action, and the bad row (gh failing) is unknown, not fatal.
+    nu ../script.nu drift --json --mapping "$PWD/mapping.json" > drift.json
+    nu -c '
+      let rows = (open --raw drift.json | from json)
+      let fake = ($rows | where name == "fake" | first)
+      if $fake.rev != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" or $fake.behind != 123 or $fake.ageDays < 1 {
+        error make {msg: $"fake drift facts: ($fake | to json)"}
+      }
+      if $fake.attempt != 1 or $fake.hold != 1 or $fake.never != 1 or $fake.retired != 1 {
+        error make {msg: $"fake stance counts: ($fake | to json)"}
+      }
+      if $fake.action != "rebase-shrinks-series" {
+        error make {msg: $"fake action: ($fake | to json)"}
+      }
+      let bad = ($rows | where name == "bad" | first)
+      if $bad.behind != null or $bad.ageDays != null or $bad.action != "unknown" {
+        error make {msg: $"bad row should degrade to unknown: ($bad | to json)"}
+      }'
+
+    # The markdown surface renders every fork as a table row, "?" for unknowns.
+    nu ../script.nu drift --markdown --mapping "$PWD/mapping.json" > drift.md
+    nu -c '
+      let md = (open --raw drift.md)
+      if not ((($md | str contains "| fake") and ($md | str contains "| bad")) and ($md | str contains "?")) {
+        error make {msg: $"markdown table missing rows: ($md)"}
+      }'
+
+    touch "$out"
+  '';
 in
   package.overrideAttrs (old: {
     passthru =
       (old.passthru or {})
       // {
-        tests = (old.passthru.tests or {}) // {inherit lifecycle;};
+        tests = (old.passthru.tests or {}) // {inherit drift lifecycle;};
       };
   })


### PR DESCRIPTION
Implements the `drift` metric from #2098 (RFC 0010, verdict A2), PR 2 of 3.

**What:** `nix run .#upstream-sync -- drift [--json|--markdown] [name]` — a read-only per-fork drift report: pinned base rev (from the committed `flake.lock`), commits behind upstream's default branch (`gh api .../compare/{pinned}...{default_branch}`, `ahead_by`), base age in days, patch stances (attempt/hold/never from `lib/fork-packages.nix`, dag.json order, unclassified defaults to hold), retired-awaiting-drop count (from committed `upstream-status.json`), and a one-word next action (`retired>0` → rebase-shrinks-series; ≥200 behind or base ≥90 days → rebase-recommended; else ok).

**Why:** drift of the manual-pin forks (nix, clippy, mesa) was invisible; the fork-sync cron now appends the markdown table to its step summary and to the rolling PR body (`body-path`, assembled in `$RUNNER_TEMP` so `create-pull-request` cannot commit it), using the workflow's existing `github.token`.

**Degradation (per the RFC):** mesa is on GitLab; its compare API enumerates every commit in the range, so the row is base-age-only via one unauthenticated commit lookup, with the cell marked. Any forge error becomes a stderr warning and `?`/null cells — one unreachable forge never fails the report.

Real output from this branch (`drift --markdown`):

| fork   | base         | behind | age (days) | action             | attempt | hold | never | retired | note                                   |
| ------ | ------------ | ------ | ---------- | ------------------ | ------- | ---- | ----- | ------- | -------------------------------------- |
| codex  | be33f80bc651 | 20     | 1          | ok                 | 0       | 0    | 1     | 0       |                                        |
| btop   | 9527231dfbcb | 0      | 4          | ok                 | 0       | 2    | 0     | 0       |                                        |
| clippy | 512551c839fc | 420    | 40         | rebase-recommended | 0       | 11   | 3     | 0       |                                        |
| mesa   | b3d356db66d9 | ?      | 33         | ok                 | 0       | 0    | 3     | 0       | base-age only (gitlab compare skipped) |
| nix    | 2c6d06e9387c | 902    | 63         | rebase-recommended | 9       | 0    | 0     | 0       |                                        |

`--json` emits the same rows as machine-readable JSON with nulls for unknowns; the human table shows the same with ansi + `?`. A hermetic `passthru.tests.drift` (stubbed `gh`) pins the pure parts: flake.lock rev extraction, stance/retired counting, the action heuristic, and the degrade-to-unknown path.

Validated: `nix run .#lint` (8/8), `nix build .#upstream-sync{,.tests.drift}`, `nix eval .#lib.forkPackages`, plus the real runs above.

Refs #2098. By the patch-system-modernize Claude agent for Andrew.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `drift` subcommand to upstream-sync and surface drift report in fork-sync PR body
> - Adds a new read-only `drift` subcommand to the upstream-sync CLI ([default.nix](https://github.com/indexable-inc/index/pull/2112/files#diff-3d0cd20c95c906e3682e499bb8770e39528f41e5ed009b7463e3a5f380ff98a8)) that computes per-fork drift data including locked rev, commits behind, base date/age, patch stance counts, and a next-action classification.
> - Outputs drift as JSON, a GitHub-flavored Markdown table, or a colored TTY table; network failures degrade individual cells to null/unknown rather than aborting.
> - Updates the [fork-sync workflow](https://github.com/indexable-inc/index/pull/2112/files#diff-ab7221dc3add2293b66a01dadb4f0232b8c16b141fdf61004bdc95d49f07eb49) to run `drift --markdown`, append the result to the job summary, and write it into the PR body via a temp file instead of a hardcoded inline string.
> - Adds a `runCommand`-based Nix test that stubs `gh`, exercises both `drift --json` and `drift --markdown`, and validates field values, action logic, and degradation behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82534c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->