### PR TITLE
mcp: surface kernel build stamp in-band (api() header, TypeError hint)

### DIFF
--- a/doc/mcp/server/overview.md
+++ b/doc/mcp/server/overview.md
@@ -78,7 +78,7 @@ session machinery; see [sessions](../sessions/overview.md).
 ## MCP tools (`tools.py`)
 
 The FastMCP server is `mcp = FastMCP("ix-mcp")` (`tools.py:75`); its
-`serverInfo.version` is stamped from `IX_MCP_VERSION` (the flake rev) onto the
+`serverInfo.version` is stamped from `IX_BUILD_REV` (the flake rev) onto the
 low-level server (`tools.py:197`). Three tools, all with
 `structured_output=False` so FastMCP does not duplicate the reply as
 `structuredContent` (which doubled image blocks and blew the token cap,
@@ -124,7 +124,9 @@ holding the store and the `dashboard-url` handoff (CWE-377 checks).
 Environment variables the server reads: `IX_MCP_HOST`, `IX_MCP_PUBLIC_HOST`,
 `IX_MCP_DASHBOARD_PORT`, `IX_MCP_HUB_PORT`, `IX_MCP_STORE`, `IX_MCP_SESSION`,
 `IX_MCP_NO_BROWSER`, `IX_MCP_EXEC_TOKEN`(`_FILE`), `IX_MCP_EXEC_TRUST_NETWORK`,
-`IX_MCP_VERSION`, `IX_MCP_DASHBOARD_URL`, `IX_MCP_KERNEL_TRACE`, plus output caps
+`IX_BUILD_REV`/`IX_BUILD_EPOCH` (the shared build-stamp names, see
+[build-version](../../build-version/overview.md)), `IX_MCP_DASHBOARD_URL`,
+`IX_MCP_KERNEL_TRACE`, plus output caps
 read in [runtime](../runtime/overview.md) and `outputs.py`
 (`IX_MCP_MAX_RESULT_CHARS`, `IX_MCP_IMAGE_MAX_BYTES`, `IX_MCP_IMAGE_MAX_DIM`).
 
@@ -160,7 +162,8 @@ matplotlib, pypdf), the execution engine (`ipykernel`, `jupyter-client`,
 other packages). `makeWrapper` then emits two binaries (`default.nix:918-948`):
 
 - `ix-mcp` (`mainProgram`): `<interpreter> -m ix_notebook_mcp`, with
-  `IX_MCP_VERSION` (flake rev), `PLAYWRIGHT_BROWSERS_PATH`, `IX_GCAL_BIN`
+  `IX_BUILD_REV`/`IX_BUILD_EPOCH` (flake rev + commit epoch),
+  `PLAYWRIGHT_BROWSERS_PATH`, `IX_GCAL_BIN`
   (the `gcal` binary), `IX_DASHBOARD_BIN` (the `dashboard` hub binary),
   `SCIPQL_SOUFFLE`, and on Darwin `IX_VMKIT_BIN`.
 - `ix-notebook`: the same interpreter entered at the `notebook` subcommand.

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1353,7 +1353,8 @@
       mkdir -p $out/bin
       makeWrapper ${lib.getExe mcpPython} $out/bin/ix-mcp \
         --add-flags "-m ix_notebook_mcp" \
-        --set IX_MCP_VERSION ${lib.escapeShellArg ix.rev} \
+        --set IX_BUILD_REV ${lib.escapeShellArg ix.rev} \
+        --set IX_BUILD_EPOCH ${lib.escapeShellArg (toString ix.revEpoch)} \
         --set PLAYWRIGHT_BROWSERS_PATH ${lib.escapeShellArg playwrightBrowsers} \
         --set IX_SVELTE_BUNDLE_BIN ${lib.escapeShellArg (lib.getExe svelteBundleBin)} \
         --set IX_GCAL_BIN ${lib.escapeShellArg "${gcalBin}/bin/gcal"} \
@@ -1374,7 +1375,8 @@
       # subcommand. Our jupyter-shaped serve; the MCP server is one client of it.
       makeWrapper ${lib.getExe mcpPython} $out/bin/ix-notebook \
         --add-flags "-m ix_notebook_mcp notebook" \
-        --set IX_MCP_VERSION ${lib.escapeShellArg ix.rev} \
+        --set IX_BUILD_REV ${lib.escapeShellArg ix.rev} \
+        --set IX_BUILD_EPOCH ${lib.escapeShellArg (toString ix.revEpoch)} \
         --set PLAYWRIGHT_BROWSERS_PATH ${lib.escapeShellArg playwrightBrowsers} \
         --set IX_SVELTE_BUNDLE_BIN ${lib.escapeShellArg (lib.getExe svelteBundleBin)} \
         --set IX_GCAL_BIN ${lib.escapeShellArg "${gcalBin}/bin/gcal"} \
@@ -2999,7 +3001,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3017,10 +3019,14 @@
       # sh Output rendering regressions (issue #1766: a failed build must not
       # read as success/still-running); imports the site-packages sh module.
       cp ${./tests/test_sh_module.py} test_sh_module.py
+      # In-band kernel build staleness (#2110): the api() header row and the
+      # TypeError-hint build stamp; imports the site-packages ix_notebook_mcp.
+      cp ${./tests/test_build_info.py} test_build_info.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_fsearch_partial.py \
         test_fsearch_glob.py \
         test_sh_module.py \
+        test_build_info.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -8,11 +8,13 @@ keeps the wiring simple. The object is frozen so nothing mutates after launch.
 
 from __future__ import annotations
 
+import datetime
 import ipaddress
 import json
 import os
 import socket
 import stat
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -61,11 +63,74 @@ def mesh_enabled() -> bool:
 
 
 def server_version() -> str:
-    """The build's source revision. The nix wrapper sets ``IX_MCP_VERSION`` to
-    the flake rev (``<commit>`` / ``<commit>-dirty``); a bare run reads "dev".
-    Both the MCP ``serverInfo.version`` (tools.py) and the ``/mesh`` payload
-    report this one value, so a client and a mesh peer see the same commit."""
-    return os.environ.get("IX_MCP_VERSION") or "dev"
+    """The build's source revision. The nix wrapper sets ``IX_BUILD_REV`` (the
+    shared build-stamp name every ix tool reads; see
+    ``doc/build-version/overview.md``) to the flake rev (``<commit>`` /
+    ``<commit>-dirty``); a bare run reads "dev". The MCP ``serverInfo.version``
+    (tools.py), the ``/mesh`` payload, and the kernel's ``api()`` catalog all
+    report this one value, so a client, a mesh peer, and an agent in a cell see
+    the same commit."""
+    return os.environ.get("IX_BUILD_REV") or "dev"
+
+
+def build_epoch() -> int | None:
+    """The build's commit time (unix epoch seconds, Nix's ``self.lastModified``)
+    from ``IX_BUILD_EPOCH``. ``None`` when unset, malformed, or the ``0``
+    non-git sentinel, so an unknown epoch never renders as 1970."""
+    raw = os.environ.get("IX_BUILD_EPOCH")
+    try:
+        epoch = int(raw) if raw else 0
+    except ValueError:
+        return None
+    return epoch or None
+
+
+# Abbreviated-revision length in the stamp; mirrors build-version's SHORT_REV_LEN
+# so the Python and Rust stamps read identically.
+_SHORT_REV_LEN = 12
+
+
+def _humanize_ago(seconds: int) -> str:
+    """``just now`` / ``5 minutes ago`` / ``2 days ago`` / ``1 year ago``; the
+    Python port of build-version's ``humanize_ago`` (same buckets, so ix tools
+    and the kernel phrase age identically). Spans under a minute and negative
+    spans (build clock ahead of ours) collapse to ``just now``."""
+    if seconds < 60:
+        return "just now"
+    if seconds < 3600:
+        value, unit = seconds // 60, "minute"
+    elif seconds < 86400:
+        value, unit = seconds // 3600, "hour"
+    elif seconds < 7 * 86400:
+        value, unit = seconds // 86400, "day"
+    elif seconds < 30 * 86400:
+        value, unit = seconds // (7 * 86400), "week"
+    elif seconds < 365 * 86400:
+        value, unit = seconds // (30 * 86400), "month"
+    else:
+        value, unit = seconds // (365 * 86400), "year"
+    return f"{value} {unit}{'' if value == 1 else 's'} ago"
+
+
+def build_stamp(now: float | None = None) -> str:
+    """One line identifying this build, the shape build-version renders into
+    every ix tool's ``--version``: ``7e42ccdb1882 (2026-06-07, 2 days ago)``.
+    A reproducible build has no wall-clock build time, so the "when" is the
+    commit time, and the age is computed here at call time (against ``now``,
+    injectable for tests). Degrades to the bare short rev when the epoch is
+    unknown, and to ``dev`` outside the packaged wrapper.
+
+    This is the in-band staleness signal for agents (index#2110): a documented
+    helper or kwarg missing from a kernel whose stamp is days old points at a
+    stale deploy, not a phantom API."""
+    rev = server_version()
+    short = rev[:_SHORT_REV_LEN]
+    epoch = build_epoch()
+    if epoch is None:
+        return short
+    date = datetime.datetime.fromtimestamp(epoch, tz=datetime.UTC).strftime("%Y-%m-%d")
+    now_epoch = int(now if now is not None else time.time())
+    return f"{short} ({date}, {_humanize_ago(now_epoch - epoch)})"
 
 
 @dataclass(frozen=True)

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -54,6 +54,7 @@ from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, overload
 
 from . import readstats, registry, typecheck
+from .config import build_stamp
 
 _ix_current: contextvars.ContextVar = contextvars.ContextVar("ix_current_job", default=None)
 
@@ -3169,13 +3170,31 @@ def doc(obj: Any) -> Result:
     return Result.text(f"{sig}\n\n{body}" if sig else body)
 
 
+def _build_row() -> dict:
+    """The catalog's header row: which build this kernel IS. The in-band
+    staleness signal (index#2110): when an agent's docs promise a helper or
+    kwarg this catalog lacks, the stamp attributes the gap to a stale deploy
+    instead of a phantom API. Prepended after filtering, so even a filtered
+    miss (`api('check')` finding nothing) still shows it."""
+    return {
+        "where": "kernel",
+        "name": "build",
+        "kind": "build",
+        "sig": f"ix-mcp {build_stamp()}",
+        "summary": "this kernel's build rev and commit age; a documented helper or "
+        "kwarg missing below means the running deploy predates it -- redeploy ix-mcp",
+    }
+
+
 def api(filter: str | None = None) -> Any:
     """A live catalog of every helper the kernel gives you: the always-present
     namespace builtins (`Result`, `cells`, `jobs`, `sh`, ...) and the public
     surface of each bundled module (`view`, `nix`, `fleet`, ...), each with
     its signature and a one-line summary. Call `api()` to discover what exists
     instead of guessing names or grepping source; pass `filter` to match a
-    substring against the name, summary, or module.
+    substring against the name, summary, or module. The first row is always the
+    kernel's own build stamp (rev, commit date, age), so a catalog that lacks
+    something your docs describe is attributable to a stale deploy.
 
     Returns a polars DataFrame (filter/sort it further, e.g.
     `api().filter(pl.col("where") == "view")`), or plain text if polars is absent.
@@ -3187,6 +3206,7 @@ def api(filter: str | None = None) -> Any:
             r for r in rows
             if q in r["name"].lower() or q in r["summary"].lower() or q in r["where"].lower()
         ]
+    rows.insert(0, _build_row())
     try:
         import polars as _pl
 
@@ -3256,9 +3276,34 @@ def _type_error_hint(exc: TypeError) -> str:
         if obj is None or not callable(obj):
             return ""
         sig = inspect.signature(obj)
-        return f"\nHint: the signature is {func_name}{sig}; see doc({func_name})."
+        hint = f"\nHint: the signature is {func_name}{sig}; see doc({func_name})."
+        if _is_kernel_surface(func_name, obj):
+            # The exact confusion of index#2110: a binding error against a
+            # bundled helper reads identically whether the kwarg never existed
+            # or the running kernel predates it. Only OUR surface can be stale
+            # relative to an agent's docs, so user-defined callables get no
+            # stamp.
+            hint += (
+                f" Kernel build: {build_stamp()}; if your docs describe a newer"
+                f" {func_name}(), this deploy predates them -- redeploy ix-mcp."
+            )
+        return hint
     except Exception:
         return ""
+
+
+def _is_kernel_surface(func_name: str, obj: Any) -> bool:
+    """Whether a callable is part of the kernel's own catalog surface (a
+    namespace builtin like ``grep``, a bundled module like ``nu``, or anything
+    defined in this package), as opposed to something the user defined in a
+    cell. Checks the resolved name's first segment against the registry and the
+    object's defining module root, either signal suffices."""
+    first = func_name.split(".", 1)[0]
+    if first in _API_BUILTINS or first in _API_MODULES:
+        return True
+    mod = getattr(obj, "__module__", None) or getattr(type(obj), "__module__", None) or ""
+    root = mod.split(".", 1)[0]
+    return root == "ix_notebook_mcp" or root in _API_MODULES
 
 
 async def _sweep_resources() -> None:

--- a/packages/mcp/tests/test_build_info.py
+++ b/packages/mcp/tests/test_build_info.py
@@ -1,0 +1,84 @@
+"""In-band kernel build staleness (index#2110).
+
+A stale deploy used to surface only as a confusing call-binding TypeError
+("nu() got an unexpected keyword argument 'check'") with no way to tell whether
+the API never existed or the running kernel predates it. Two surfaces now carry
+the build stamp: the `api()` catalog's header row, and the TypeError hint when
+the callable is the kernel's own surface (never a user-defined one).
+"""
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import ix_notebook_mcp.runtime as rt
+
+
+def test_api_first_row_is_build_stamp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IX_BUILD_REV", "7e42ccdb18827401226635")
+    monkeypatch.setenv("IX_BUILD_EPOCH", "86400")
+    frame = rt.api()
+    first = frame.row(0, named=True)
+    assert first["where"] == "kernel"
+    assert first["name"] == "build"
+    assert "7e42ccdb1882" in first["sig"]
+    assert "1970-01-02" in first["sig"]
+    assert "redeploy" in first["summary"]
+
+
+def test_api_filtered_miss_still_shows_build(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The row survives any filter: the staleness signal matters MOST when a
+    lookup comes back empty (the helper the docs promised is not deployed)."""
+    monkeypatch.setenv("IX_BUILD_REV", "7e42ccdb18827401226635")
+    frame = rt.api("no-helper-matches-this-9f3a")
+    assert frame.height == 1
+    assert frame.row(0, named=True)["name"] == "build"
+
+
+def _binding_error(fn: Callable[..., object]) -> TypeError:
+    try:
+        fn(bogus_kwarg_from_the_future=1)
+    except TypeError as e:
+        return e
+    raise AssertionError("expected TypeError")
+
+
+def kernel_shaped(*, query: str = "") -> None:
+    pass
+
+
+def test_hint_stamps_kernel_surface(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A binding error against a registry-known name carries the build stamp,
+    so the mismatch is attributable to a stale deploy in the error itself."""
+    monkeypatch.setenv("IX_BUILD_REV", "7e42ccdb18827401226635")
+    # "grep" is a registry builtin; the namespace object is stand-in, the gate
+    # keys on the resolved name.
+    exc = TypeError("grep() got an unexpected keyword argument 'bogus'")
+    old_ns = rt._user_ns
+    try:
+        rt._user_ns = {"grep": kernel_shaped}
+        hint = rt._type_error_hint(exc)
+    finally:
+        rt._user_ns = old_ns
+    assert "signature" in hint
+    assert "Kernel build: 7e42ccdb1882" in hint
+    assert "redeploy" in hint
+
+
+def test_hint_leaves_user_callables_unstamped() -> None:
+    """Only the kernel's own surface can be stale relative to an agent's docs;
+    a user-defined function keeps the plain signature hint."""
+    exc = _binding_error(kernel_shaped)
+    old_ns = rt._user_ns
+    try:
+        rt._user_ns = {"kernel_shaped": kernel_shaped}
+        hint = rt._type_error_hint(exc)
+    finally:
+        rt._user_ns = old_ns
+    assert "signature" in hint
+    assert "Kernel build" not in hint

--- a/packages/mcp/tests/test_mesh.py
+++ b/packages/mcp/tests/test_mesh.py
@@ -48,6 +48,7 @@ from ix_notebook_mcp import mesh as server_mesh
 from ix_notebook_mcp.config import (
     DEFAULT_MESH_PORT,
     Config,
+    build_stamp,
     is_tailnet_ipv4,
     mesh_enabled,
     mesh_port,
@@ -129,10 +130,29 @@ def test_mesh_enabled_default_on(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_server_version_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("IX_MCP_VERSION", raising=False)
+    monkeypatch.delenv("IX_BUILD_REV", raising=False)
     assert server_version() == "dev"
-    monkeypatch.setenv("IX_MCP_VERSION", "abc123")
+    monkeypatch.setenv("IX_BUILD_REV", "abc123")
     assert server_version() == "abc123"
+
+
+def test_build_stamp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The stamp mirrors build-version's shape: short rev, commit date, age;
+    an unknown epoch (unset or the 0 non-git sentinel) degrades to the bare
+    short rev instead of rendering 1970."""
+    rev = "7e42ccdb18827401226635"
+    monkeypatch.setenv("IX_BUILD_REV", rev)
+    monkeypatch.delenv("IX_BUILD_EPOCH", raising=False)
+    assert build_stamp() == "7e42ccdb1882"
+    monkeypatch.setenv("IX_BUILD_EPOCH", "0")
+    assert build_stamp() == "7e42ccdb1882"
+    monkeypatch.setenv("IX_BUILD_EPOCH", "not-a-number")
+    assert build_stamp() == "7e42ccdb1882"
+    # 1970-01-02T00:00:00Z, viewed just over two days later: the same fixture
+    # as build-version's own stamp test, so the two implementations provably
+    # render the identical line.
+    monkeypatch.setenv("IX_BUILD_EPOCH", "86400")
+    assert build_stamp(now=3 * 86400 + 1) == "7e42ccdb1882 (1970-01-02, 2 days ago)"
 
 
 def test_is_tailnet_ipv4_gate() -> None:
@@ -169,7 +189,7 @@ def _fetch_card(app: web.Application) -> dict[str, Any]:
 
 
 def test_mesh_card_fields(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("IX_MCP_VERSION", "deadbeef")
+    monkeypatch.setenv("IX_BUILD_REV", "deadbeef")
     cfg = Config(workdir=tmp_path)
     app = server_mesh.build_app(
         cfg,
@@ -375,7 +395,7 @@ def test_peers_and_sessions_discover_live_server(
     port = _free_port()
     monkeypatch.delenv("IX_MCP_MESH", raising=False)
     monkeypatch.setenv("IX_MCP_MESH_PORT", str(port))
-    monkeypatch.setenv("IX_MCP_VERSION", "cafebabe")
+    monkeypatch.setenv("IX_BUILD_REV", "cafebabe")
     stub = _write_stub_tailscale(tmp_path, _status(self_ip="127.0.0.1"))
     monkeypatch.setenv(mesh_client._TAILSCALE_BIN_ENV, str(stub))
     cfg = Config(workdir=tmp_path, mesh_host="127.0.0.1")


### PR DESCRIPTION
## Problem

#2110: a stale ix-mcp deploy surfaces only as a confusing call-binding TypeError (`nu() got an unexpected keyword argument 'check'`) with nothing in-band to tell whether the kwarg never existed or the running kernel predates it.

## Change

- **Adopt the shared build-stamp contract** in the ix-mcp wrapper: `IX_BUILD_REV` + `IX_BUILD_EPOCH` (the names every ix tool reads, `packages/build-version`), replacing the mcp-local `IX_MCP_VERSION`. `config.build_stamp()` is a Python port of build-version's `stamp`/`humanize_ago`, pinned to the same fixture so both render the identical line: `7e42ccdb1882 (2026-06-07, 2 days ago)`.
- **`api()` header row**: the catalog's first row is now the kernel's own build stamp, kept even under a filter, so a filtered miss (`api('check')` finding nothing) still shows what build you are talking to.
- **TypeError hint**: when the callable is the kernel's own surface (registry builtin/module or `ix_notebook_mcp`), the signature hint appends `Kernel build: <stamp>` and a redeploy nudge. User-defined callables stay unstamped.
- `serverInfo.version` already carried the rev (#793); unchanged, now fed by `IX_BUILD_REV`.

Skipped an exact `rev..origin/main` behind-count: the kernel's cwd is rarely an index checkout, and the commit age answers "is this deploy stale?" cheaply everywhere.

## Validation

- `nix run .#lint`: 8/8 succeeded
- `nix build .#mcp.tests.{typecheckSmoke,meshTests,serverTools,strictTypecheck}`: 67 + 27 passed, zuban --strict clean
- `nix build .#mcp`: built; wrapper stamps `IX_BUILD_REV='64f0348…'` / `IX_BUILD_EPOCH='1783380668'`

Closes #2110

---

Authored by an AI agent (Claude, Fable 5) via Claude Code; driven end-to-end including validation above.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface kernel build stamp in `api()` header and `TypeError` hints for ix-mcp
> - Replaces `IX_MCP_VERSION` with `IX_BUILD_REV` and adds `IX_BUILD_EPOCH` in the Nix wrappers for `ix-mcp` and `ix-notebook`, aligning build identity with the kernel's native stamp variables.
> - Adds `build_stamp()` to [config.py](https://github.com/indexable-inc/index/pull/2114/files#diff-33f6f17aed79724ba72211bc8bf9dc1da1bbdb38de56be7ace76cc09837929ca), composing a short revision hash with a human-readable commit date and relative age (e.g. `abc123def456 (2024-05-01, 3 weeks ago)`).
> - `api()` in [runtime.py](https://github.com/indexable-inc/index/pull/2114/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now always prepends a build-info row so callers can see the running kernel version at a glance, even when a filter returns no other results.
> - `_type_error_hint()` appends the build stamp and a redeploy suggestion when the mismatched callable belongs to the kernel surface, aiding diagnosis of stale deployments.
> - Behavioral Change: `server_version()` now reads `IX_BUILD_REV` instead of `IX_MCP_VERSION`; deployments that set only `IX_MCP_VERSION` will fall back to `"dev"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64f0348.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->