### PR TITLE
mcp: scope job cancellation to the awaiter, not the shared task

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3001,7 +3001,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3014,6 +3014,8 @@
       # a single .py is read by pytest as a directory).
       cp ${./tests/test_typecheck.py} test_typecheck.py
       cp ${./tests/test_job_await_errors.py} test_job_await_errors.py
+      # Issue #2104: one session's wait must never cancel another session's job.
+      cp ${./tests/test_job_cancel_scope.py} test_job_cancel_scope.py
       cp ${./tests/test_fsearch_partial.py} test_fsearch_partial.py
       cp ${./tests/test_fsearch_glob.py} test_fsearch_glob.py
       # sh Output rendering regressions (issue #1766: a failed build must not
@@ -3023,7 +3025,8 @@
       # TypeError-hint build stamp; imports the site-packages ix_notebook_mcp.
       cp ${./tests/test_build_info.py} test_build_info.py
       ${lib.getExe typecheckTestPython} -m pytest \
-        test_typecheck.py test_job_await_errors.py test_fsearch_partial.py \
+        test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
+        test_fsearch_partial.py \
         test_fsearch_glob.py \
         test_sh_module.py \
         test_build_info.py \

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -284,6 +284,18 @@ class JobStillRunning(RuntimeError):
     """
 
 
+class JobCancelled(RuntimeError):
+    """Raised by ``await jobs['<id>']`` when the awaited job was cancelled.
+
+    ``jobs`` is one kernel-wide registry, so several sessions may await the same
+    job. A cancelled job used to throw ``CancelledError`` into every awaiting
+    cell, which ``_runner`` then recorded as "cancelled" too -- one explicit
+    ``jobs['<id>'].cancel()`` silently killed other agents' waiter cells (issue
+    #2104). Raising an ordinary error instead keeps the awaiting cell alive and
+    names the job that was cancelled.
+    """
+
+
 class Job:
     """A single ``python_exec`` execution: an awaitable handle over the asyncio
     task running the code, with its captured output, result, and status."""
@@ -529,7 +541,32 @@ class Job:
         # contract is that awaiting raises rather than return a misleading None.
         async def _await_result() -> Result | None:
             if self.task is not None:
-                await self.task
+                try:
+                    # Shield the job's task: ``jobs`` is one kernel-wide registry,
+                    # so several sessions may await the same job, and an awaiter's
+                    # own cancellation -- the common shape is an
+                    # ``asyncio.wait_for(jobs['<id>'], t)`` timeout -- must not
+                    # propagate INTO the shared task and kill the job for everyone
+                    # (issue #2104). Cancelling a job stays explicit:
+                    # ``jobs['<id>'].cancel()``.
+                    await asyncio.shield(self.task)
+                except asyncio.CancelledError:
+                    current = asyncio.current_task()
+                    if current is not None and current.cancelling():
+                        # The AWAITER itself is being cancelled (its cell was
+                        # cancelled, or its wait timed out): propagate that,
+                        # leaving the job running for its other awaiters.
+                        raise
+                    if self.task.cancelled():
+                        # The JOB was cancelled out from under this await. Surface
+                        # an ordinary error naming the job, so the awaiting cell
+                        # records what happened instead of dying "cancelled"
+                        # itself (the cross-session cascade in issue #2104).
+                        raise JobCancelled(
+                            f"job {self.id} ({self.name}) was cancelled while "
+                            f"awaited; jobs[{self.id!r}] holds its partial output"
+                        ) from None
+                    raise
             if self._exc is not None:
                 # Re-raise the original exception object, so its type, message,
                 # and traceback (the cell's own frames) all reach the caller --

--- a/packages/mcp/tests/test_job_cancel_scope.py
+++ b/packages/mcp/tests/test_job_cancel_scope.py
@@ -1,0 +1,132 @@
+"""One session's wait must never cancel another session's job (issue #2104).
+
+``jobs`` is a single kernel-wide registry, and ``await jobs['<id>']`` used to
+await the job's task DIRECTLY. Two cascades followed under multi-agent load:
+
+- an awaiter's own cancellation -- the common shape being an
+  ``asyncio.wait_for(jobs['<id>'], t)`` timeout -- propagated into the shared
+  task and cancelled the job for every session (production: job b20422b5 died
+  exactly 45s after another agent's ``wait_for(j, timeout=45)`` began);
+- cancelling a job threw ``CancelledError`` into every other cell awaiting it,
+  so those innocent cells were recorded "cancelled" too (production: c772591c
+  and c821f156, two agents' waiter cells, both died the instant 61bd699b was
+  explicitly cancelled).
+
+Awaiting now shields the job's task: a wait timing out (or the awaiting cell
+being cancelled) leaves the job running, and a cancelled job surfaces
+``JobCancelled`` -- an ordinary error naming the job -- in its awaiters.
+Explicit ``jobs['<id>'].cancel()`` remains the one way to cancel a job.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ix_notebook_mcp import runtime
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+
+
+def test_wait_for_timeout_leaves_the_job_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Session A backgrounds a slow job; session B awaits it with a short
+    # wait_for. B's timeout must expire WITHOUT cancelling A's job, which then
+    # runs to completion.
+    _wire(monkeypatch, {"asyncio": asyncio})
+
+    async def scenario() -> runtime.Job:
+        job = await runtime.__ix_run(
+            "await asyncio.sleep(0.3)\n'A finished'", budget=0.01, session="agent-a"
+        )
+        assert job.running()
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(runtime.jobs[job.id], timeout=0.05)
+        assert job.status == "running"  # the wait died; the job must not have
+        await job.wait(10)
+        return job
+
+    job = asyncio.run(scenario())
+    assert job.status == "done"
+    assert "A finished" in (job.text or "")
+
+
+def test_cancelling_a_job_errors_its_awaiters_instead_of_cancelling_them(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Two other sessions await one shared job; its owner cancels it. The
+    # awaiting cells must record an ERROR naming the cancelled job -- not be
+    # marked "cancelled" themselves.
+    _wire(monkeypatch, {"asyncio": asyncio, "jobs": runtime.jobs})
+
+    async def scenario() -> tuple[runtime.Job, runtime.Job, runtime.Job]:
+        slow = await runtime.__ix_run(
+            "await asyncio.sleep(30)", budget=0.01, session="agent-a"
+        )
+        w1 = await runtime.__ix_run(
+            f"await jobs[{slow.id!r}]", budget=0.01, session="agent-b"
+        )
+        w2 = await runtime.__ix_run(
+            f"await jobs[{slow.id!r}]", budget=0.01, session="agent-c"
+        )
+        assert slow.running()
+        assert w1.running()
+        assert w2.running()
+        slow.cancel()
+        await w1.wait(10)
+        await w2.wait(10)
+        return slow, w1, w2
+
+    slow, w1, w2 = asyncio.run(scenario())
+    assert slow.status == "cancelled"
+    for waiter in (w1, w2):
+        assert waiter.status == "error"
+        assert slow.id in (waiter.error or "")
+
+
+def test_awaiting_an_already_cancelled_job_raises_job_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(monkeypatch, {"asyncio": asyncio})
+
+    async def scenario() -> None:
+        slow = await runtime.__ix_run(
+            "await asyncio.sleep(30)", budget=0.01, session="agent-a"
+        )
+        slow.cancel()
+        await slow.wait(10)
+        assert slow.status == "cancelled"
+        with pytest.raises(runtime.JobCancelled, match=slow.id):
+            await runtime.jobs[slow.id]
+
+    asyncio.run(scenario())
+
+
+def test_cancelling_an_awaiting_cell_leaves_the_job_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The inverse direction: cancelling the WAITER cell must stop only that
+    # cell; the awaited job keeps running and finishes.
+    _wire(monkeypatch, {"asyncio": asyncio, "jobs": runtime.jobs})
+
+    async def scenario() -> runtime.Job:
+        slow = await runtime.__ix_run(
+            "await asyncio.sleep(0.3)\n'still here'", budget=0.01, session="agent-a"
+        )
+        waiter = await runtime.__ix_run(
+            f"await jobs[{slow.id!r}]", budget=0.01, session="agent-b"
+        )
+        assert waiter.running()
+        waiter.cancel()
+        await waiter.wait(10)
+        assert waiter.status == "cancelled"
+        assert slow.status == "running"
+        await slow.wait(10)
+        return slow
+
+    slow = asyncio.run(scenario())
+    assert slow.status == "done"


### PR DESCRIPTION
Fixes #2104.

## Root cause

`await jobs['<id>']` awaited the job's asyncio task **directly** (`Job.__await__` -> `await self.task`). `jobs` is one kernel-wide registry shared by every MCP session, so two cancellation cascades crossed sessions under multi-agent load:

- **A waiter's cancellation killed the job.** `asyncio.wait_for(jobs[id], t)` cancels its awaitable on timeout, and that cancellation propagated into the shared task. Production evidence (from the live kernel's job records): job `b20422b5` (`merge health snapshot`) died at 15:13:24, exactly 45s after another cell's `await asyncio.wait_for(j, timeout=45)` started at 15:12:39.
- **Cancelling a job killed every cell awaiting it.** `jobs[id].cancel()` raised `CancelledError` inside every other awaiting cell, whose `_runner` recorded them as "cancelled" too. Production evidence: `c772591c` and `c821f156` (two agents' `wait for ix ls result` cells, both `await jobs['61bd699b']`) died at 15:18:17, the same second a third agent explicitly cancelled `61bd699b`.

## Fix

`Job.__await__` now awaits `asyncio.shield(self.task)`:

- an awaiter being cancelled (wait_for timeout, its cell cancelled) propagates in the awaiter only; the job keeps running for everyone else;
- a job cancelled out from under an await surfaces as `JobCancelled` (an ordinary error naming the job) in each awaiter, so those cells record what happened instead of dying "cancelled" themselves.

Cancellation is now scoped to explicit `jobs['<id>'].cancel()`. The SIGUSR2 wedge watchdog is untouched as the kernel-wide escape hatch for a synchronously blocked loop.

## Tests

`packages/mcp/tests/test_job_cancel_scope.py` (wired into `mcp.tests.typecheckSmoke`) encodes the two-session repro: session A backgrounds a job, session B's `wait_for` times out, A's job must still be running and finish; plus the cancel-cascade, already-cancelled-await, and waiter-cancel directions.

Validated: `nix build .#mcp.tests.typecheckSmoke` (67 passed) and `.#mcp.tests.runtimeSmoke`, plus a live interpreter smoke of all four scenarios against the patched runtime.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope job cancellation to the awaiter in `Job.__await__` to prevent shared task cancellation
> - Uses `asyncio.shield` when awaiting a job's task so that cancelling the awaiter (e.g. a `wait_for` timeout) does not cancel the underlying shared job task.
> - Adds a new `JobCancelled` exception raised when an awaiter detects the job itself was cancelled, replacing propagation of raw `CancelledError`.
> - Adds [test_job_cancel_scope.py](https://github.com/indexable-inc/index/pull/2115/files#diff-4fa8a4c9ac3c32e3ba53272a7aaa8b780d33badc61434c12c543e794acb08150) with four tests covering timeout, job cancellation, already-cancelled jobs, and cell cancellation scenarios.
> - Behavioral Change: `await jobs['<id>']` no longer cancels a running job when the awaiter is cancelled or times out; awaiting a cancelled job now raises `JobCancelled` instead of `CancelledError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ee8c90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->