### PR TITLE
ci: make the reusable update-flake-lock job work from cross-repo callers again

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -36,8 +36,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Fully qualified, not `./.github/actions/install-nix`: this workflow is
+      # reusable (`workflow_call`), and for a cross-repo caller (ix) the
+      # `actions/checkout` above checks out the CALLER's repository, which does
+      # not contain index's local composite action. A local-path `uses:` then
+      # fails with "Can't find 'action.yml'" (broke ix's hourly flake bump when
+      # #2064 introduced the local action). Referencing the action by repo
+      # resolves it from index@main regardless of which repo called the job.
       - name: Install Determinate Nix
-        uses: ./.github/actions/install-nix
+        uses: indexable-inc/index/.github/actions/install-nix@main
 
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28


### PR DESCRIPTION
Since #2064 the reusable `update-flake-lock` job uses the local composite action `./.github/actions/install-nix`. Under `workflow_call` from another repo (ix), `actions/checkout` checks out the caller's repository, which has no such path, so every ix hourly flake bump since 19:56Z today fails with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.../.github/actions/install-nix'
```

Fix: reference the action fully qualified (`indexable-inc/index/.github/actions/install-nix@main`) so it resolves from index regardless of the caller. index's own scheduled runs are unaffected (same action, fetched instead of local).

This also unblocks ix#6373 (its flake-lock PR is stale/conflicting because the bot can no longer refresh the branch).

Written by an agent on Andrew's behalf.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix reusable `update-flake-lock` workflow to use a fully qualified action reference
> The `install-nix` step in [update-flake-lock.yml](https://github.com/indexable-inc/index/pull/2118/files#diff-3dd117f927104ee8bdf13935f130eeb0ee70fad2c72077739b766ba1d142dc43) was referencing a local action path (`./.github/actions/install-nix`), which fails when the workflow is called from external repositories. It now references the fully qualified action `indexable-inc/index/.github/actions/install-nix@main`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa77ae9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->