### PR TITLE
base image: bake db.sqlite in the journal mode the guest nix.conf selects

### DIFF
--- a/lib/image/oci-layer.nix
+++ b/lib/image/oci-layer.nix
@@ -58,6 +58,13 @@
     build.ociImage = let
       inherit (config.system.build) toplevel;
 
+      # The SQLite journal mode the guest's nix will use on /nix/var/nix/db,
+      # derived from this image's own nix.conf (`use-sqlite-wal`, default true).
+      dbJournalMode =
+        if config.nix.settings.use-sqlite-wal or true
+        then "WAL"
+        else "DELETE";
+
       # FHS layout pointing into the NixOS toplevel. Keep activation-owned
       # paths writable: NixOS first boot populates /etc and creates /bin/sh
       # and /usr/bin/env, so those cannot be symlinks into the immutable store.
@@ -94,6 +101,21 @@
         # The `base-image-nix-db` check asserts the baked DB actually registers
         # the nixpkgs source as valid (a bare db.sqlite is not enough).
         includeNixDB = true;
+        # dockerTools' load-db runs under the BUILD nix's default
+        # `use-sqlite-wal = true`, so the baked db.sqlite header is WAL-marked.
+        # The guest opens that DB with whatever journal mode this image's own
+        # nix.conf selects: with `use-sqlite-wal = false` (the base profile's
+        # VCFS mitigation, ix#6259) nix picks SQLite's `unix-dotfile` VFS,
+        # which has no shared-memory support and refuses WAL-marked databases
+        # (SQLITE_CANTOPEN). Every per-connection nix-daemon child then dies
+        # and clients see "Connection reset by peer" (ix#6563). Rewrite the
+        # journal mode to match the image's nix.conf, so the baked DB and the
+        # runtime flag agree by construction. This composes AFTER load-db in
+        # the same customisation-layer script, with cwd at the layer root.
+        extraCommands = ''
+          ${lib.getExe pkgs.buildPackages.sqlite} nix/var/nix/db/db.sqlite \
+            'PRAGMA journal_mode=${dbJournalMode};'
+        '';
       };
 
       efficiency = config.ix.build.ociEfficiency;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2181,9 +2181,14 @@
   #   3. missing DB       — the OCI image baked no /nix/var/nix/db/db.sqlite at
   #      all, so the pinned source (present in the image) was never valid; fixed
   #      by `includeNixDB = true` in oci-layer.nix
+  #   4. wrong journal mode — the DB was baked WAL-marked (build nix defaults
+  #      `use-sqlite-wal = true`) while the image's nix.conf set it false; the
+  #      guest's shm-less dotfile-VFS open then fails outright and every
+  #      nix-daemon connection resets (ix#6563)
   # The boundary this defends: the built base OCI archive must ship a populated
   # /nix/var/nix/db/db.sqlite whose ValidPaths includes EVERY source the image
-  # bakes for in-guest eval — otherwise the first in-guest `nix` re-ingests it.
+  # bakes for in-guest eval — otherwise the first in-guest `nix` re-ingests it —
+  # and whose journal mode the image's own nix.conf can actually open.
   # Two classes of baked source, both covered here:
   #   - flake registry pins (nixpkgs and, once baked, index), read off
   #     `nix.registry.*.to.path`; and
@@ -2228,6 +2233,13 @@
       ];
       archive = base.imageConfig.ix.build.ociImage;
       requiredPaths = registryPaths ++ extraBakedPaths;
+      # SQLite header bytes 18/19 (file-format versions): "1 1" = rollback
+      # journal, "2 2" = WAL. Derived from the image's OWN nix.conf so the
+      # assertion tracks the setting instead of hardcoding a mode.
+      expectedDbFormat =
+        if base.imageConfig.nix.settings.use-sqlite-wal or true
+        then "2 2"
+        else "1 1";
     } ''
       mkdir extract db
       tar -C extract -xf "$archive"
@@ -2269,6 +2281,17 @@
           exit 1
         fi
       done
+      # Journal-mode agreement (regression 4, ix#6563). A complete ValidPaths
+      # is worthless if the guest cannot open the DB at all: with
+      # `use-sqlite-wal = false` nix opens it on SQLite's unix-dotfile VFS (no
+      # shared memory), which refuses WAL-marked databases (SQLITE_CANTOPEN),
+      # and every nix-daemon connection dies with "Connection reset by peer".
+      format=$(od -An -tu1 -j18 -N2 "$dbfile")
+      format=$(echo $format)
+      if [ "$format" != "$expectedDbFormat" ]; then
+        echo "error: baked db.sqlite header format is '$format' but the image's use-sqlite-wal setting requires '$expectedDbFormat'; the guest cannot open this DB (ix#6563)" >&2
+        exit 1
+      fi
       mkdir -p "$out"
     '';
 


### PR DESCRIPTION
## What

Fresh ix guest VMs fail every `nix` command with `cannot open connection to remote store 'daemon': ... Connection reset by peer` (indexable-inc/ix#6563).

The base image bakes `/nix/var/nix/db/db.sqlite` via dockerTools `includeNixDB`, whose `nix-store --load-db` runs under the **build** nix's default `use-sqlite-wal = true`, leaving a WAL-marked header. Since #1847 the guest's nix.conf sets `use-sqlite-wal = false` (VCFS WAL-corruption mitigation, ix#6259, kept as-is), so the guest opens the DB on SQLite's shm-less `unix-dotfile` VFS, which refuses WAL-marked databases: every forked nix-daemon child dies with `SQLITE_CANTOPEN` and the client sees a connection reset. Deterministic on every fresh VM, invisible to boot telemetry.

## Fix

- `lib/image/oci-layer.nix`: after dockerTools' load-db (caller `extraCommands` composes after `mkDbExtraCommand` in the same customisation-layer script), rewrite the baked DB's journal mode to whatever the image's own `nix.conf` selects (`config.nix.settings.use-sqlite-wal`), so the flag and the DB agree by construction.
- `tests/default.nix`: extend the `base-image-nix-db` fence (regression 4 in this family) to fail the build when db.sqlite header bytes 18/19 disagree with the image's `use-sqlite-wal` setting.

Fix proof on live VM `repro-nixd-1` (bad image `80ef14c1`): `NIX_CONFIG="use-sqlite-wal = true" nix run nixpkgs#hello` succeeds where the default fails; details in ix#6563.

Fixes indexable-inc/ix#6563

Assisted-by: Claude <noreply@anthropic.com>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bake db.sqlite journal mode in OCI base image to match guest nix.conf setting
> - In [oci-layer.nix](https://github.com/indexable-inc/index/pull/2121/files#diff-2f593cc5e1a07acba76a950c1132a06b5d7646750989d806816be811310a32f4), when `includeNixDB = true`, runs `sqlite` against the baked `db.sqlite` after DB creation to set `PRAGMA journal_mode` to `WAL` or `DELETE` based on `config.nix.settings.use-sqlite-wal` (defaults to `WAL`).
> - Previously, the baked DB always used the SQLite default journal mode, causing guests to fail to open the DB when `use-sqlite-wal = false`.
> - Extends [tests/default.nix](https://github.com/indexable-inc/index/pull/2121/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to verify the baked `db.sqlite` header bytes 18–19 match the expected format for the image's `use-sqlite-wal` setting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61ca44a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->