### PR TITLE
fork patches: per-attempt closure build gates (#2098)

### DIFF
--- a/.github/workflows/fork-closure-gates.yml
+++ b/.github/workflows/fork-closure-gates.yml
@@ -1,0 +1,73 @@
+name: Fork closure gates
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    # The gates re-pay only when a gated fork's series or the fork mapping
+    # moved. Path filters are static YAML, so a fork newly opting in
+    # (`closureGates = true` in lib/fork-packages.nix) must add its patch dir
+    # here; the flag's field doc points back at this list.
+    paths:
+      - packages/nix/nix/patches/**
+      - lib/fork-packages.nix
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fork-closure-gates
+  cancel-in-progress: false
+
+jobs:
+  closure-gates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Determinate Nix
+        uses: ./.github/actions/install-nix
+
+      # Per-attempt-patch closure build gates (RFC 0010 A3, #2098): for each
+      # fork opted in via `closureGates = true` and each attempt-marked patch,
+      # build the fork package with the series restricted to that patch's
+      # dag.json closure -- exactly the standalone series `upstream-pr` ships
+      # upstream, so a red gate means the upstream PR would be broken.
+      #
+      # Deliberately scheduled/post-merge, NEVER per-PR CI: these are heavy
+      # full-package builds (a cold nix closure is ~45 min; cache hits when
+      # nothing in that closure changed). Built sequentially, and every red
+      # gate is reported with the patch it belongs to before the job fails,
+      # so one broken closure does not mask another.
+      - name: Build closure gates
+        run: |
+          set -euo pipefail
+          mapfile -t forks < <(
+            nix eval --json '.#lib.forkPackages' \
+              --apply 'fs: builtins.filter (f: f.closureGates or false) fs' \
+              | nix run nixpkgs#jq -- -r '.[].name'
+          )
+          echo "closure-gated forks: ${forks[*]}"
+          failed=()
+          for fork in "${forks[@]}"; do
+            mapfile -t patches < <(
+              nix eval --json ".#forkClosureGates.x86_64-linux.$fork" \
+                --apply builtins.attrNames \
+                | nix run nixpkgs#jq -- -r '.[]'
+            )
+            echo "$fork: ${#patches[@]} attempt-patch gates"
+            for patch in "${patches[@]}"; do
+              echo "::group::gate: $fork / $patch"
+              if ! nix build --no-link ".#forkClosureGates.x86_64-linux.$fork.\"$patch\""; then
+                echo "::error::closure gate FAILED: $fork / $patch (its dag.json closure does not build standalone; the upstream PR for it would ship broken)"
+                failed+=("$fork / $patch")
+              fi
+              echo "::endgroup::"
+            done
+          done
+          if ((${#failed[@]})); then
+            printf 'failed closure gates:\n'
+            printf '  %s\n' "${failed[@]}"
+            exit 1
+          fi

--- a/flake.nix
+++ b/flake.nix
@@ -466,6 +466,13 @@
     # updaters changed, instead of deriving an attr from path segments
     # (#2036). Non-schema, so surfaced through `collect` like `ciChecks`.
     updatablePackages = collect "updatablePackages";
+    # Per-attempt-patch closure build gates (RFC 0010 A3, #2098), keyed
+    # `<system>.<fork>.<patch>`: the fork package rebuilt with the series
+    # restricted to that patch's dag.json closure. Deliberately NOT under
+    # `checks` (per-PR flake-check cost stays flat): built post-merge by the
+    # scheduled fork-closure-gates workflow and by the `upstream-sync --open`
+    # preflight. Non-schema, so surfaced through `collect` like `ciChecks`.
+    forkClosureGates = collect "forkClosureGates";
     # CI-only view of `packages` with each NixOS image swapped for its
     # `toplevel` closure; cache-push.yml publishes this instead of the
     # monolithic `*-oci.tar` archives, which nothing substitutes. Non-schema,

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -89,6 +89,11 @@
   # single source of truth for the patched-src checks, the `.#update` fork
   # nodes, and the `rebase-patches` tool. See lib/fork-packages.nix.
   inherit (import ./fork-packages.nix) forkPackages;
+  # Per-attempt-patch closure build gates (RFC 0010 A3, #2098): the pure-eval
+  # dag.json closure computation (`closureOf`) plus the gate-attrset builder
+  # (`mkGates`) an opted-in fork package wires into its passthru. See
+  # lib/fork-closure-gates.nix.
+  forkClosureGates = import ./fork-closure-gates.nix {inherit lib;};
   # Mirror-enabled packages (opt-in `mirror` attr in a package's package.nix):
   # id, repo-relative path, and mirror-repo coordinates for each package that
   # publishes a standalone read-only mirror. `nix eval --json
@@ -587,6 +592,7 @@
       deepMerge
       efx
       evalTimeSubstitutable
+      forkClosureGates
       forkPackages
       forkDagCheckSrc
       goUnit

--- a/lib/fork-closure-gates.nix
+++ b/lib/fork-closure-gates.nix
@@ -1,0 +1,66 @@
+# Per-attempt-patch closure build gates (RFC 0010 verdict A3, #2098).
+#
+# `upstream-pr` ships an attempt-marked patch upstream as the patch plus its
+# transitive dag.json ancestors (its closure), applied standalone against the
+# bare base. A closure that no longer BUILDS therefore means we would ship
+# upstream a broken PR. The gate for a patch is the fork package rebuilt with
+# its series restricted to exactly that closure -- the same package logic, a
+# shorter series -- via `patchedSrc`'s `patchNames` argument, so the gate can
+# never drift from the real build.
+#
+# Everything here is pure eval: `dag.json` is a committed repo file read with
+# `lib.importJSON` (no IFD, no derivation outputs read at eval), and the gate
+# attrset is lazy, so nothing is forced until a consumer asks for a gate.
+# Gates are DELIBERATELY not flake checks: they are heavy full-package builds,
+# and per-PR flake-check cost must stay flat. They surface on the opted-in
+# fork package's `passthru.closureGates` and the non-schema
+# `forkClosureGates.<system>.<fork>` flake output, built by the scheduled
+# fork-closure-gates workflow and the `upstream-sync --open` preflight.
+#
+# Enumeration coherence (every intent key, hence every attempt patch, names a
+# real patch file, and dag.json's node set equals the patch files) is already
+# enforced by the `patch-dag-<name>` check (packages/rebase-patches/
+# dag-check.nu); `closureOf` only adds a loud eval error for a missing node so
+# a stale dag.json fails with the patch name, not an attribute error.
+{lib}: let
+  # The patch plus its transitive dag.json ancestors, in NNNN order. NNNN
+  # order is a verified topological order of the DAG (the `patch-dag-<name>`
+  # check's (c-topo) invariant), so sorting the closure by filename is a valid
+  # application order; the recursion terminates for the same reason.
+  closureOf = nodes: patch: let
+    depsOf = lib.genAttrs' nodes (node: lib.nameValuePair node.patch node.deps);
+    go = name:
+      [name]
+      ++ lib.concatMap go (
+        depsOf.${name}
+          or (throw "fork-closure-gates: dag.json has no node for patch ${name}; regenerate it with `nix run .#rebase-patches`")
+      );
+  in
+    lib.naturalSort (lib.unique (go patch));
+in {
+  inherit closureOf;
+
+  # The gate attrset for one fork: `patch file name -> the fork package built
+  # with the series restricted to that patch's closure`, one gate per
+  # attempt-marked patch. Empty unless the fork opts in (`closureGates = true`
+  # in lib/fork-packages.nix), so flipping that one flag is the only switch.
+  #
+  #   fork     : the fork's lib/fork-packages.nix record (intent + flag).
+  #   patchDir : the committed patch dir holding the series and its dag.json.
+  #   mkSeries : `patchNames list -> package derivation`, the fork package's
+  #              own re-instantiation (see packages/nix/nix/default.nix), so
+  #              the gate reuses the real build logic instead of copying it.
+  mkGates = {
+    fork,
+    patchDir,
+    mkSeries,
+  }: let
+    dag = lib.importJSON (patchDir + "/dag.json");
+    attempts = lib.attrNames (
+      lib.filterAttrs (_: mark: (mark.upstream or "hold") == "attempt") (fork.patches or {})
+    );
+  in
+    lib.optionalAttrs (fork.closureGates or false) (
+      lib.genAttrs attempts (patch: mkSeries (closureOf dag.nodes patch))
+    );
+}

--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -24,6 +24,21 @@
 #                may free-float the base under a routine bump. `false` pins the
 #                input by rev and keeps it out of the cron; it moves only under a
 #                deliberate manual `rebase-patches` run.
+#   closureGates : optional, default false. Opt the fork into the
+#                per-attempt-patch closure build gates (RFC 0010 A3, #2098):
+#                one derivation per attempt-marked patch that rebuilds the
+#                fork package with the series restricted to that patch's
+#                dag.json closure -- exactly what `upstream-pr` ships
+#                upstream, so a red gate means the upstream PR would be
+#                broken. Heavy full-package builds, so gates are NEVER flake
+#                checks: they surface as `passthru.closureGates` on the fork
+#                package and `forkClosureGates.<system>.<name>` on the flake,
+#                built by the scheduled fork-closure-gates workflow
+#                (post-merge; its static path filters must name this fork's
+#                patch dir) and the `upstream-sync --open` preflight. Opting
+#                in also requires the package to wire `passthru.closureGates`
+#                (see packages/nix/nix/default.nix) and a `gatePackages`
+#                entry in lib/per-system.nix (missing one fails eval loudly).
 #   forkRepo   : optional GitHub `owner/name` of a real fork repo to maintain.
 #                When set, the mirror-sync workflow (packages/mirror,
 #                `mirror fork-branch --name <name> --push`) keeps that repo's
@@ -274,6 +289,11 @@
       url = "https://github.com/NixOS/nix.git";
       patchDir = "packages/nix/nix/patches";
       autoUpdate = false;
+      # nix is the one fork whose attempt patches ship upstream as standalone
+      # dag.json closures, so it pays for the per-attempt closure build gates
+      # (RFC 0010 A3): 9 attempt patches = 9 scheduled full-package builds,
+      # cache hits between changes. See the `closureGates` field doc above.
+      closureGates = true;
       upstreamPolicy = {
         prsWelcome = true;
         # NixOS/nix has no explicit AI policy (unknown). PRs are generally welcome

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -618,6 +618,35 @@
     flakeLock = lib.importJSON (paths.root + "/flake.lock");
   };
 
+  # Per-attempt-patch closure build gates (RFC 0010 A3, #2098): for each fork
+  # opted in via `closureGates = true` in lib/fork-packages.nix, the fork
+  # package rebuilt with its series restricted to each attempt-marked patch's
+  # dag.json closure -- exactly the standalone series `upstream-pr` ships
+  # upstream, so a red gate means the upstream PR would be broken. The gate
+  # derivations live on the opted-in package's `passthru.closureGates` (the
+  # package owns its own re-instantiation; see packages/nix/nix/default.nix);
+  # this map only keys them by fork name so the scheduled fork-closure-gates
+  # workflow and the `upstream-sync --open` preflight can `nix eval` the set
+  # and `nix build .#forkClosureGates.<system>.<fork>."<patch>"`. NEVER merged
+  # into `checks`/`ciChecks`: these are heavy full-package builds, and per-PR
+  # flake-check cost must stay flat (the attrset is lazy, so enumerating it
+  # forces nothing heavy).
+  forkClosureGates = let
+    # Fork name -> the repo package carrying that fork's gates. A fork flagged
+    # `closureGates = true` without an entry here fails eval loudly instead of
+    # silently publishing no gates.
+    gatePackages = {
+      nix = repoPackages.nix-ix;
+    };
+  in
+    lib.genAttrs' (lib.filter (fork: fork.closureGates or false) ix.forkPackages) (
+      fork:
+        lib.nameValuePair fork.name
+        (gatePackages.${fork.name}
+          or (throw "lib/per-system.nix: fork `${fork.name}` sets closureGates = true in lib/fork-packages.nix but gatePackages maps no package for it"))
+        .closureGates
+    );
+
   # One general updater for every content source in the repo, run in parallel
   # via dag-runner (the same engine `lint` uses). The Minecraft catalog and
   # sound updaters are fixed apps; the pinned prebuilt-binary updaters
@@ -1453,6 +1482,10 @@ in {
   # derivations, so `nix build .#checks.aarch64-darwin.patched-src-clippy`
   # validates the series against a local Darwin build right after a flake update.
   checks = catalogFor rustPackageTestSets.flat // forkChecks;
+  # Closure build gates, keyed `<fork>.<patch>` (see the binding above). A
+  # non-schema output like `ciChecks`, exposed per system so a darwin host can
+  # gate-build natively before an upstream PR.
+  inherit forkClosureGates;
   # Sharded keying for the memory-bounded CI evaluator (nix-fast-build /
   # nix-eval-jobs / blast-radius): each package's per-#[test] checks sit under one
   # `recurseForDerivations` group, so the evaluator lists cheap per-package names

--- a/lib/util/patched-src.nix
+++ b/lib/util/patched-src.nix
@@ -28,6 +28,17 @@
   name,
   src,
   patchDir,
+  # Optional restriction of the applied series to a subset of the discovered
+  # patch files (bare `NNNN-*.patch` names, any order). `null`, the default,
+  # applies the full discovered series, so every existing caller (including
+  # ix's cross-repo `index.lib.patchedSrcFor` use) is unchanged. The subset is
+  # validated against the discovered series (an unknown name is an eval error,
+  # not a silently shorter series) and applied in NNNN order; the
+  # canonical-format assertions below still run on every selected patch. Used
+  # by the per-attempt-patch closure build gates (RFC 0010 A3, #2098):
+  # `upstream-pr` ships a patch as its dag.json ancestor closure against the
+  # bare base, so that closure must build as a standalone series.
+  patchNames ? null,
 }: let
   # `rebase-patches` exports the series with `git format-patch --zero-commit
   # --no-signature --no-stat -N`, so a conforming file is byte-stable across
@@ -61,14 +72,29 @@
     else if lib.length nonEmpty >= 2 && lib.elemAt nonEmpty (lib.length nonEmpty - 2) == "-- "
     then fail "trailing signature block (--no-signature)"
     else path;
+  discovered = lib.pipe (builtins.readDir patchDir) [
+    (lib.filterAttrs (f: t: t == "regular" && lib.hasSuffix ".patch" f))
+    builtins.attrNames
+    lib.naturalSort
+  ];
+  # Filtering the discovered series (rather than sorting the request) keeps
+  # NNNN application order the single ordering owner and dedupes for free.
+  selected =
+    if patchNames == null
+    then discovered
+    else let
+      unknown = lib.subtractLists discovered patchNames;
+    in
+      if unknown != []
+      then
+        throw ''
+          ${name}: patchNames not in ${toString patchDir}: ${lib.concatStringsSep ", " unknown}.
+          The selection must name existing `NNNN-*.patch` files of the series.
+        ''
+      else lib.filter (f: lib.elem f patchNames) discovered;
 in
   evalTimeSubstitutable (applyPatches {
     name = "${name}-patched";
     inherit src;
-    patches = lib.pipe (builtins.readDir patchDir) [
-      (lib.filterAttrs (f: t: t == "regular" && lib.hasSuffix ".patch" f))
-      builtins.attrNames
-      lib.naturalSort
-      (map (f: assertCanonical f (patchDir + "/${f}")))
-    ];
+    patches = map (f: assertCanonical f (patchDir + "/${f}")) selected;
   })

--- a/packages/nix/nix/default.nix
+++ b/packages/nix/nix/default.nix
@@ -30,16 +30,6 @@ let
   # nix/* packages read `pkgs` off their argument the same way.
   inherit (ix) pkgs;
 
-  # The patched upstream tree: the ./patches series applied 0001..NNNN on top of
-  # the pinned 2.34.7 source, via the shared de-fork util. This doubles as the
-  # `checks.<system>.patched-src-nix` conflict gate (per-system wiring), so a
-  # patch that stops applying fails there in seconds.
-  patchedSrc = ix.patchedSrc {
-    name = "nix";
-    src = ix.nixSrc;
-    patchDir = ./patches;
-  };
-
   # nixpkgs builds `nixVersions.nix_2_34` as
   # `(nixComponents_2_34.overrideSource fetchedSrc).appendPatches patches_common`
   # then takes `.nix-everything` (pkgs/tools/package-management/nix/default.nix).
@@ -57,6 +47,15 @@ let
     pkgs.path + "/pkgs/tools/package-management/nix/patches/skip-flaky-darwin-tests.patch"
   );
 
+  # The whole patched pipeline as a function of the applied series, so the
+  # per-attempt-patch closure gates below rebuild the SAME logic with a
+  # restricted series instead of copying it. `patchNames = null` is the full
+  # series (the shipped package).
+  #
+  # The full-series patched tree doubles as the
+  # `checks.<system>.patched-src-nix` conflict gate (per-system wiring), so a
+  # patch that stops applying fails there in seconds.
+  #
   # Identify a patched daemon by version: `nix --version` (and
   # `builtins.nixVersion`) report the version each *component* was compiled
   # with -- the modular build's preConfigure writes the component derivation's
@@ -69,33 +68,58 @@ let
   # `-ix`: meson feeds the version to darwin ld's -current_version, which
   # rejects a `-` suffix as a "malformed 32-bit x.y.z version number" but
   # tolerates `+`.
-  patchedComponents =
-    ((base.overrideSource patchedSrc).appendPatches patchesCommon).overrideAllMesonComponents
-    (_: _: {version = "2.34.7+ix";});
+  mkPatchedNix = patchNames: let
+    patchedSrc = ix.patchedSrc {
+      name = "nix";
+      src = ix.nixSrc;
+      patchDir = ./patches;
+      inherit patchNames;
+    };
+    patchedComponents =
+      ((base.overrideSource patchedSrc).appendPatches patchesCommon).overrideAllMesonComponents
+      (_: _: {version = "2.34.7+ix";});
 
-  # The aggregate `nix` package (daemon + client + libs), the same attribute
-  # `nixVersions.nix_2_34` exposes.
-  nixEverything = patchedComponents.nix-everything;
+    # The aggregate `nix` package (daemon + client + libs), the same attribute
+    # `nixVersions.nix_2_34` exposes.
+    nixEverything = patchedComponents.nix-everything;
+  in
+    nixEverything.overrideAttrs (old: {
+      version = "2.34.7+ix";
+      # The aggregate's `doCheck = true` gates the build on `checkInputs`: the
+      # five component unit-test runners plus the entire upstream functional
+      # suite. Those dominate a cold build of this closure and re-validate
+      # nothing per consumer rebuild: patch applicability is already gated by
+      # `checks.<system>.patched-src-nix`, the series carries its own
+      # upstream-style functional test inside the patched tree, and the `smoke`
+      # passthru below executes the linked binary. With them on, the cache-push
+      # darwin lane (3-core hosted mac) blew its 4 h job budget cold-building
+      # this package and froze `cache-ready` (run 28772327218, index#1967).
+      doCheck = false;
+      meta =
+        (old.meta or {})
+        // {
+          description = "NixOS/nix 2.34.7 with the index in-repo patch series (GC-roots daemon-crash fix, lookup-path EPERM eval fix)";
+          mainProgram = "nix";
+        };
+    });
 
-  package = nixEverything.overrideAttrs (old: {
-    version = "2.34.7+ix";
-    # The aggregate's `doCheck = true` gates the build on `checkInputs`: the
-    # five component unit-test runners plus the entire upstream functional
-    # suite. Those dominate a cold build of this closure and re-validate
-    # nothing per consumer rebuild: patch applicability is already gated by
-    # `checks.<system>.patched-src-nix`, the series carries its own
-    # upstream-style functional test inside the patched tree, and the `smoke`
-    # passthru below executes the linked binary. With them on, the cache-push
-    # darwin lane (3-core hosted mac) blew its 4 h job budget cold-building
-    # this package and froze `cache-ready` (run 28772327218, index#1967).
-    doCheck = false;
-    meta =
-      (old.meta or {})
-      // {
-        description = "NixOS/nix 2.34.7 with the index in-repo patch series (GC-roots daemon-crash fix, lookup-path EPERM eval fix)";
-        mainProgram = "nix";
-      };
-  });
+  package = mkPatchedNix null;
+
+  # Per-attempt-patch closure build gates (RFC 0010 A3, #2098): one derivation
+  # per attempt-marked patch, this same package rebuilt with the series
+  # restricted to that patch's dag.json closure -- exactly the standalone
+  # series `upstream-pr` ships upstream. Lazy passthru data, never a flake
+  # check (heavy builds; the scheduled fork-closure-gates workflow and the
+  # `upstream-sync --open` preflight build them). Keyed here off the fork's
+  # own lib/fork-packages.nix entry so intent has one home.
+  closureGates = ix.forkClosureGates.mkGates {
+    fork =
+      lib.findFirst (fork: fork.name == "nix")
+      (throw "packages/nix/nix: lib/fork-packages.nix has no `nix` entry")
+      ix.forkPackages;
+    patchDir = ./patches;
+    mkSeries = mkPatchedNix;
+  };
 
   # The override's real risk is that the whole modular C++ tree still links and
   # the patched daemon still runs, so the smoke test executes the binary and
@@ -124,6 +148,7 @@ in
     passthru =
       (old.passthru or {})
       // {
+        inherit closureGates;
         tests =
           (old.passthru.tests or old.tests or {})
           // {

--- a/packages/upstream-sync/default.nix
+++ b/packages/upstream-sync/default.nix
@@ -37,6 +37,13 @@
 #      comment on the existing PR instead of opening a competing one).
 #   3. Else, if `--open` was passed, open the PR by delegating to
 #      `upstream-pr --open` (its DAG-closure/am/push/draft-PR mechanism, one owner).
+#      For forks opted into the closure build gates (`closureGates = true` in
+#      lib/fork-packages.nix; RFC 0010 A3), the patch's gate derivation
+#      (`forkClosureGates.<system>.<fork>.<patch>`) is built FIRST and a red
+#      gate aborts that patch's PR-opening: `upstream-pr` ships the patch as
+#      its dag.json closure against the bare base, so a non-building closure
+#      means the upstream PR would be broken. Only the `--open` path pays this
+#      build; refresh/search/would-open never build anything.
 #      The PR body carries AI attribution (outward-message policy) and a link back
 #      to our patch file. Opening a PR is the outward act, DOUBLY gated: the patch
 #      must be marked `attempt` in nix (intent gate) AND `--open` must be passed
@@ -69,6 +76,9 @@
   git,
   gh,
   coreutils,
+  # Pinned client for the closure-gate preflight `nix build` (same posture as
+  # lib/fork-updater.nix's updateScript).
+  nix,
   # Sibling repo packages, threaded under one name (see lib/packages.nix); we take
   # the PR mechanism (`upstream-pr`) from here rather than a bare callPackage arg,
   # which the package set does not expose flat.
@@ -88,6 +98,7 @@
       git
       gh
       coreutils
+      nix
       upstream-pr
     ];
     text = ''
@@ -583,6 +594,28 @@
               continue
             }
 
+            # Closure-gate preflight (RFC 0010 A3, #2098): `upstream-pr` ships
+            # this patch as its dag.json ancestor closure against the bare
+            # base, so for forks opted in via `closureGates = true` prove that
+            # closure BUILDS before the outward act, and abort THIS patch's
+            # PR-opening on a red gate. The gate attr is the current repo
+            # flake's (a downstream --mapping repo gates against its own
+            # flake; without the flag no fork ever pays this build).
+            let gates_on = ($fork.closureGates? | default false)
+            if $gates_on {
+              let system = (nix config show system | str trim)
+              let gate = $".#forkClosureGates.($system).($fork.name).\"($pf)\""
+              print $"(ansi cyan)upstream-sync: ($fork.name): building closure gate ($gate) before opening \(heavy full-package build; cache hit when unchanged)(ansi reset)"
+              let gate_res = (do { nix build --no-link $gate } | complete)
+              if $gate_res.exit_code != 0 {
+                print ($gate_res.stderr)
+                print $"(ansi red)upstream-sync: ($fork.name): closure gate FAILED for ($pf): its dag.json closure does not build standalone, so the upstream PR would ship broken. Fix the series; NOT opening.(ansi reset)"
+                $doc = (log append $doc $"($pf): closure gate build FAILED; PR-opening aborted")
+                $plan = ($plan | append {fork: $fork.name, patch: $pf, intent: "attempt", action: "gate-failed", detail: $gate})
+                continue
+              }
+            }
+
             # The outward act, only for attempt patches on a non-blocked repo, only
             # when --open was passed. upstream-pr owns the branch/am/push/draft-PR
             # mechanism; --mapping is threaded so a downstream repo's list is used.
@@ -712,7 +745,19 @@
     echo "  https://github.com/fakeorg/fakerepo/compare/main...indexable-inc:fakerepo:branch?expand=1"
     echo "https://github.com/fakeorg/fakerepo/pull/99999"
     STUB
-    chmod +x stubs/gh stubs/upstream-pr
+
+    # Stub nix, for the closure-gate preflight: `config show system` names the
+    # gate attr's system, `build` exits per NIX_GATE_EXIT so the stages below
+    # drive a red and a green gate through the REAL preflight branch.
+    cat > stubs/nix <<STUB
+    #!$(command -v bash)
+    case "\$1" in
+      config) echo "x86_64-stub" ;;
+      build) exit "\''${NIX_GATE_EXIT:-0}" ;;
+      *) echo "stub nix: unexpected: \$*" >&2; exit 1 ;;
+    esac
+    STUB
+    chmod +x stubs/gh stubs/upstream-pr stubs/nix
 
     cat > work/repo/patches/0001-fake-fix.patch <<'EOF'
     From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -764,6 +809,34 @@
       let d = (open repo/patches/upstream-status.json)
       if ($d.log | length) != 3 {
         error make {msg: $"stage 3: log grew on a no-change re-run: ($d.log | to json)"}
+      }'
+
+    # A closureGates fork: same patch/dag shape, its own patch dir + status
+    # file, exercising the preflight branch (RFC 0010 A3) that otherwise runs
+    # only on a real --open against a real flake.
+    mkdir -p gated/patches
+    cp repo/patches/0001-fake-fix.patch repo/patches/dag.json gated/patches/
+    cat > mapping-gated.json <<'EOF'
+    [{"name":"gated","input":"gated-src","url":"https://github.com/fakeorg/fakerepo.git",
+      "patchDir":"gated/patches","autoUpdate":false,"closureGates":true,
+      "upstreamPolicy":{"prsWelcome":true,"aiPrsAllowed":"unknown","citation":"https://example.com","notes":"t"},
+      "patches":{"0001-fake-fix.patch":{"upstream":"attempt","reason":"gate test"}}}]
+    EOF
+
+    echo "--- stage 4: a red closure gate aborts the PR-opening ---"
+    NIX_GATE_EXIT=1 nu ../script.nu --open --mapping "$PWD/mapping-gated.json" gated
+    nu -c '
+      let p = (open gated/patches/upstream-status.json | get patches."0001-fake-fix.patch")
+      if $p.pr != null {
+        error make {msg: $"stage 4: PR opened despite a failed gate: ($p | to json)"}
+      }'
+
+    echo "--- stage 5: a green gate proceeds to open and record the PR ---"
+    NIX_GATE_EXIT=0 nu ../script.nu --open --mapping "$PWD/mapping-gated.json" gated
+    nu -c '
+      let p = (open gated/patches/upstream-status.json | get patches."0001-fake-fix.patch")
+      if $p.pr.number != 99999 {
+        error make {msg: $"stage 5: PR not recorded after a green gate: ($p | to json)"}
       }'
 
     touch "$out"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2563,11 +2563,130 @@
     }
   ];
 
+  # --- fork closure gates (RFC 0010 A3, #2098) -------------------------------
+  # Pure-eval facts about the per-attempt-patch closure machinery: the dag.json
+  # closure computation (`ix.forkClosureGates.closureOf`) and `patchedSrc`'s
+  # optional series restriction. The gate derivations themselves are heavy
+  # full-package builds owned by the scheduled fork-closure-gates workflow,
+  # never checks; nothing here forces one (attrNames stays shallow).
+  syntheticDagNodes = [
+    {
+      patch = "0001-a.patch";
+      deps = [];
+    }
+    {
+      patch = "0002-b.patch";
+      deps = ["0001-a.patch"];
+    }
+    {
+      patch = "0003-c.patch";
+      deps = [];
+    }
+    {
+      patch = "0004-d.patch";
+      deps = [
+        "0002-b.patch"
+        "0003-c.patch"
+      ];
+    }
+  ];
+  # The committed clippy DAG is the known fork with real transitive chains
+  # (0014 -> 0005 -> 0003 -> 0002 and 0014 -> 0009 -> 0008 -> 0007), so it
+  # exercises closure computation against live data, not just the synthetic
+  # fixture. A rebase that reshapes these edges legitimately updates this
+  # expectation.
+  clippyDag = lib.importJSON (paths.packagesRoot + "/llm-clippy/patches/dag.json");
+  nixAttemptPatches = lib.attrNames (
+    lib.filterAttrs (_: mark: (mark.upstream or "hold") == "attempt")
+    (
+      lib.findFirst (fork: fork.name == "nix") (throw "no nix fork entry") ix.forkPackages
+    )
+    .patches
+  );
+  patchedSrcFixture = args:
+    ix.patchedSrc ({
+        name = "patched-src-fixture";
+        src = ./fixtures/patched-src;
+        patchDir = ./fixtures/patched-src;
+      }
+      // args);
+  # Forcing `.patches` runs the eval-time selection + canonical assertions
+  # without building anything.
+  patchedSrcSubsetEval = builtins.tryEval (
+    builtins.deepSeq (patchedSrcFixture {patchNames = ["0001-canonical.patch"];}).patches true
+  );
+  patchedSrcSubsetNonCanonicalEval = builtins.tryEval (
+    builtins.deepSeq (patchedSrcFixture {patchNames = ["0002-noncanonical.patch"];}).patches true
+  );
+  patchedSrcSubsetUnknownEval = builtins.tryEval (
+    builtins.deepSeq (patchedSrcFixture {patchNames = ["9999-missing.patch"];}).patches true
+  );
+  patchedSrcDefaultEval = builtins.tryEval (
+    builtins.deepSeq (patchedSrcFixture {}).patches true
+  );
+
   groups = {
     # efx terranix-port parity: the ported stacks under tests/efx must render
     # exactly the golden plan IR the efx CLI's tests parse, and everything the
     # translator cannot express must throw. See tests/efx-plan.nix.
     efx = import ./efx-plan.nix {inherit lib ix paths;};
+    fork-closure-gates = [
+      {
+        assertion =
+          ix.forkClosureGates.closureOf syntheticDagNodes "0004-d.patch"
+          == [
+            "0001-a.patch"
+            "0002-b.patch"
+            "0003-c.patch"
+            "0004-d.patch"
+          ];
+        message = "closureOf should return the patch plus its transitive dag deps in NNNN order";
+      }
+      {
+        assertion = ix.forkClosureGates.closureOf syntheticDagNodes "0001-a.patch" == ["0001-a.patch"];
+        message = "closureOf of a root patch should be just the patch itself";
+      }
+      {
+        assertion =
+          ix.forkClosureGates.closureOf clippyDag.nodes "0014-Add-anonymous-tuple-return-type-lint.patch"
+          == [
+            "0002-Add-module_file_count-lint.patch"
+            "0003-Add-excessive_file_length-lint.patch"
+            "0005-Add-underscore_in_module_filename-lint.patch"
+            "0007-Add-fallible_int_fallback-lint.patch"
+            "0008-Add-magic_number-lint.patch"
+            "0009-Add-drop_must_use-lint.patch"
+            "0014-Add-anonymous-tuple-return-type-lint.patch"
+          ];
+        message = "closureOf should reproduce the committed clippy dag.json transitive closure of 0014";
+      }
+      {
+        # Crosses the fork-packages.nix intent <-> package passthru boundary:
+        # the nix package must expose exactly one gate per attempt-marked
+        # patch (attrNames only; forcing a gate would eval a full package).
+        assertion = lib.attrNames repoPackages.nix-ix.closureGates == nixAttemptPatches;
+        message = "nix-ix should expose one closure gate per attempt-marked patch in lib/fork-packages.nix";
+      }
+      {
+        assertion = patchedSrcSubsetEval.success;
+        message = "patchedSrc should accept a patchNames subset of the discovered series";
+      }
+      {
+        assertion = !patchedSrcSubsetNonCanonicalEval.success;
+        message = "patchedSrc should still assert canonical patch format on a selected subset";
+      }
+      {
+        assertion = !patchedSrcSubsetUnknownEval.success;
+        message = "patchedSrc should reject a patchNames entry naming no patch file in the series";
+      }
+      {
+        # The default (null) selection must keep discovering the WHOLE dir:
+        # the fixture dir contains a non-canonical patch, so full discovery
+        # can only succeed by skipping files, which would be the regression.
+        assertion = !patchedSrcDefaultEval.success;
+        message = "patchedSrc default discovery should still walk every patch file (and thus trip on the non-canonical fixture)";
+      }
+    ];
     wrap-package = [
       {
         assertion = !wrapPackageTypoEval.success;

--- a/tests/fixtures/patched-src/0001-canonical.patch
+++ b/tests/fixtures/patched-src/0001-canonical.patch
@@ -1,0 +1,14 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: index tests <tests@indexable.dev>
+Date: Mon, 1 Jan 2026 00:00:00 +0000
+Subject: [PATCH] fixture: canonical patch shape
+
+The reason of record for the canonical fixture patch.
+---
+diff --git a/file.txt b/file.txt
+index 0000000..1111111 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1 +1 @@
+-old
++new

--- a/tests/fixtures/patched-src/0002-noncanonical.patch
+++ b/tests/fixtures/patched-src/0002-noncanonical.patch
@@ -1,0 +1,14 @@
+From 1234567890abcdef1234567890abcdef12345678 Mon Sep 17 00:00:00 2001
+From: index tests <tests@indexable.dev>
+Date: Mon, 1 Jan 2026 00:00:00 +0000
+Subject: [PATCH] fixture: non-canonical patch shape
+
+Hand-exported patch whose From header carries a real commit hash.
+---
+diff --git a/file.txt b/file.txt
+index 0000000..2222222 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1 +1 @@
+-old
++newer


### PR DESCRIPTION
Per-attempt-patch closure build gates, per RFC 0010 verdict A3 (#2098; PR 3 of 3 — RFC #2109, drift #2112).

**Why:** `upstream-pr` ships an attempt-marked patch upstream as the patch plus its `dag.json` ancestor closure, applied standalone against the bare base. A closure that does not build means we ship upstream a broken PR. The gate is the fork package rebuilt with the series restricted to exactly that closure — the same build logic, a shorter series.

**What:**
- `lib/util/patched-src.nix`: optional `patchNames` selection, defaulting to today's readDir discovery (additive; every existing caller unchanged, including ix's cross-repo `index.lib.patchedSrcFor`). Subsets are validated against the discovered series and still canonical-format-asserted.
- `lib/fork-closure-gates.nix`: pure-eval closure computation over the committed `dag.json` (`lib.importJSON`, no IFD) plus the gate-attrset builder; per-fork opt-in `closureGates = true` in `lib/fork-packages.nix` (nix only today).
- `packages/nix/nix`: build pipeline parameterized by the applied series; gates on `passthru.closureGates`, surfaced as the non-schema `forkClosureGates.<system>.<fork>.<patch>` flake output. Never under `checks.*`, so per-PR flake-check cost stays flat.
- `.github/workflows/fork-closure-gates.yml`: `workflow_dispatch` + push-to-main path-filtered on the gated fork's patch dir and `lib/fork-packages.nix`; enumerates gates via `nix eval`, builds them sequentially with the shared install-nix cache setup, and reports every red gate with its patch name before failing.
- `packages/upstream-sync`: the `--open` path builds the patch's gate first and aborts that patch's PR-opening on a red gate; refresh/search paths build nothing.
- Tests (eval-only, nothing heavy): closure computation vs a synthetic DAG and the committed clippy `dag.json`; gate enumeration == attempt marks (crosses the intent↔passthru boundary); patched-src subset canonical/unknown/default-discovery assertions; two new lifecycle stages drive the red/green gate preflight through stubs. Intent-keys-name-real-patches coherence is already the `patch-dag-<name>` check's invariant, so it is not duplicated here.

**Cost bound:** 9 nix closures, built scheduled/post-merge (and in the `--open` preflight) only; cache hits when nothing in a closure changed.

**Validation:** `nix run .#lint` clean; `nix eval .#forkClosureGates.<system>.nix` lists the 9 attempt gates; the smallest gate (`0009-doc-release-note…`) built end-to-end on aarch64-darwin (`nix-2.34.7+ix` output); each gate is a distinct drv and instantiates on x86_64-linux; `checks.*` still contains only the fast `patched-src-*`/`patch-dag-*` fork checks; the ix seam re-verified (3-arg `patchedSrcFor` call instantiates unchanged).

Opened by the patch-system-modernize Claude agent on Andrew's behalf.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-attempt closure build gates for fork patches
> - Introduces `forkClosureGates` machinery in [lib/fork-closure-gates.nix](https://github.com/indexable-inc/index/pull/2123/files#diff-e7ca3ceaa3936250e9651ee301db1434d81a6f21cae9de09fbca2da6956f473d): `closureOf` computes a patch's transitive closure from `dag.json`, and `mkGates` builds a lazy attrset mapping each attempt-marked patch to a derivation built from that patch's restricted series.
> - Adds a `patchNames` parameter to [lib/util/patched-src.nix](https://github.com/indexable-inc/index/pull/2123/files#diff-884080a8ece8fb33e6f399224ac8b22124189c4e4d5b42a9090ef4006c6fbb1d) to restrict the applied patch series to a validated subset, preserving NNNN order; unknown names trigger an eval-time error.
> - Opts the `nix` fork into closure gates via `closureGates = true` and exposes gate derivations on `passthru.closureGates` in [packages/nix/nix/default.nix](https://github.com/indexable-inc/index/pull/2123/files#diff-4332ad9feb37626c0ac4a68155597b10c261c0e0460cfcbca84f88d3d6125c6e).
> - Adds a preflight gate build to `upstream-sync` so that opening a PR for an opted-in fork first builds the patch's closure gate and aborts on failure.
> - A new [GitHub Actions workflow](https://github.com/indexable-inc/index/pull/2123/files#diff-ab1680e6a2ba015fbc48b0d5bacc0a710adcb59475d7afaa792844334cd39cfd) runs on pushes to `main` or manual dispatch to build all gate derivations and fail the job if any gate fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4735bbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->