### PR TITLE
update-flake-lock: let callers author the bump PR via a GitHub App

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -19,6 +19,14 @@ on:
         description: "Space-separated flake inputs to update; empty updates all."
         type: string
         default: ""
+      app-client-id:
+        description: "Client id of a GitHub App (contents + pull-requests write) that authors the bump PR; empty falls back to GITHUB_TOKEN, whose PRs never get pull_request CI on private repos."
+        type: string
+        default: ""
+    secrets:
+      app-private-key:
+        description: "Private key for app-client-id."
+        required: false
   schedule:
     - cron: "17 * * * *"
 
@@ -46,6 +54,19 @@ jobs:
       - name: Install Determinate Nix
         uses: indexable-inc/index/.github/actions/install-nix@main
 
+      # PRs authored by the default GITHUB_TOKEN never get pull_request CI on
+      # private repos: GitHub parks every run in action_required and the
+      # fork-approval API cannot clear them (ix#6566). When the caller supplies
+      # a GitHub App with contents + pull-requests write, mint a token scoped
+      # to this repository and author the PR with it so CI triggers normally.
+      - name: Mint PR token
+        id: app-token
+        if: ${{ inputs.app-client-id != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ inputs.app-client-id }}
+          private-key: ${{ secrets.app-private-key }}
+
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
         with:
@@ -56,3 +77,4 @@ jobs:
           # Empty for schedule/dispatch on index (all inputs public); a caller
           # scopes this to avoid fetching private inputs it can't auth for.
           inputs: ${{ inputs.flake-inputs }}
+          token: ${{ steps.app-token.outputs.token || github.token }}


### PR DESCRIPTION
PRs authored by the default `GITHUB_TOKEN` never get `pull_request` CI on private repos: GitHub parks every run in `action_required` and the fork-approval API cannot clear them (indexable-inc/ix#6566).

This adds an optional `app-client-id` input and `app-private-key` secret to the reusable workflow. When supplied, a repo-scoped GitHub App token is minted and threaded into `DeterminateSystems/update-flake-lock` so the bump PR is authored by the App and CI triggers normally. With no app configured, the default `GITHUB_TOKEN` path is unchanged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow the `update-flake-lock` workflow to author bump PRs via a GitHub App token
> Adds optional `app-client-id` input and `app-private-key` secret to the [update-flake-lock.yml](https://github.com/indexable-inc/index/pull/2127/files#diff-3dd117f927104ee8bdf13935f130eeb0ee70fad2c72077739b766ba1d142dc43) reusable workflow. When `app-client-id` is provided, a new "Mint PR token" step uses `actions/create-github-app-token@v3.2.0` to generate a token, which is then passed to `DeterminateSystems/update-flake-lock`. Falls back to `github.token` when no app credentials are supplied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f23f5fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->