### PR TITLE
ci: fail fast in the check gate

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -327,6 +327,13 @@
               "--eval-max-memory-size" "6144"
               "--eval-workers" "16"
               "--skip-cached"
+              # Stop scheduling new checks as soon as one fails (in-flight
+              # builds still finish). Default nix-fast-build behavior is to
+              # build every remaining check and only report at the end, which
+              # spends the full wall time before flake-check goes red (#2128).
+              # The failed-attr log replay below still works: the result file
+              # is written on failure with the records collected so far.
+              "--fail-fast"
               "--no-nom"
               "--no-link"
               "--result-format" "json"

--- a/packages/nix/nix-fast-build/default.nix
+++ b/packages/nix/nix-fast-build/default.nix
@@ -3,7 +3,7 @@
   # its `cacheStatus` as `cached` (present in a configured *remote* substituter).
   # A `local` status (output already realized in *this* runner's store, but not
   # pushed anywhere) falls through to the build queue and gets re-realized every
-  # run (__init__.py, the `elif cache_status == "local"` arm).
+  # run (workers.py, the `elif cache_status == "local"` arm).
   #
   # On index's persistent warm CI runner that is almost everything: the rust
   # workspace units default to `contentAddressed = true` (lib/rust/cargo-unit.nix)
@@ -19,6 +19,20 @@
   # needs (re)building. nix-eval-jobs#403 / nix#12128 fixed the *status*; this
   # fixes what --skip-cached does with it.
   package = pkgs.nix-fast-build.overrideAttrs (old: {
+    # Forward-pin to upstream 1.6.0 while the repo's nixpkgs pin still carries
+    # 1.5.0: the check gate passes --fail-fast, which landed upstream in 1.6.0
+    # (Mic92/nix-fast-build#343), and skip-local.patch below targets the 1.6.0
+    # module layout (workers.py; 1.5.0 was a single __init__.py). tag + hash
+    # copied from nixpkgs-unstable f205b557 pkgs/by-name/ni/nix-fast-build.
+    # Delete this version/src override (keep the patch) once the nixpkgs pin
+    # reaches nix-fast-build >= 1.6.0.
+    version = "1.6.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "Mic92";
+      repo = "nix-fast-build";
+      tag = "1.6.0";
+      hash = "sha256-PMBbenLBvn/0pSFOhwPVn171Vw7kU5YmBUNDhxllZ7c=";
+    };
     patches = (old.patches or []) ++ [./skip-local.patch];
   });
 
@@ -36,10 +50,21 @@
     }
     ''
       help=$(nix-fast-build --help 2>&1) || true
+      # --fail-fast is what the check gate passes (lib/per-system.nix); its
+      # absence from usage is exactly the failure mode that broke CI when the
+      # flag was assumed present on 1.5.0 (#2128), so assert both flags.
       case "$help" in
         *"--skip-cached"*) ;;
         *)
           echo "nix-fast-build --help did not print usage" >&2
+          printf '%s\n' "$help" >&2
+          exit 1
+          ;;
+      esac
+      case "$help" in
+        *"--fail-fast"*) ;;
+        *)
+          echo "nix-fast-build --help lacks --fail-fast (version < 1.6.0?)" >&2
           printf '%s\n' "$help" >&2
           exit 1
           ;;

--- a/packages/nix/nix-fast-build/skip-local.patch
+++ b/packages/nix/nix-fast-build/skip-local.patch
@@ -1,12 +1,11 @@
---- a/nix_fast_build/__init__.py
-+++ b/nix_fast_build/__init__.py
-@@ -1153,9 +1153,19 @@
+--- a/nix_fast_build/workers.py
++++ b/nix_fast_build/workers.py
+@@ -66,8 +66,18 @@
          # them for pushing if they are cached locally
          elif cache_status == "cached":
              continue
 -        elif cache_status == "local" and upload_queue is not None:
--            outputs = {k: v for k, v in job.get("outputs", {}).items() if v is not None}
--            upload_queue.put_nowait(Build(attr, job["drvPath"], outputs))
+-            upload_queue.put_nowait(Build(attr, job["drvPath"], _job_outputs(job)))
 +        elif cache_status == "local":
 +            # The output is already realized in the local store, so it never
 +            # needs (re)building -- skip it like a remotely-cached job. Still
@@ -17,8 +16,7 @@
 +            # continues on "cached" and falls through to the build queue for
 +            # "local". See packages/nix/nix-fast-build/default.nix.
 +            if upload_queue is not None:
-+                outputs = {k: v for k, v in job.get("outputs", {}).items() if v is not None}
-+                upload_queue.put_nowait(Build(attr, job["drvPath"], outputs))
++                upload_queue.put_nowait(Build(attr, job["drvPath"], _job_outputs(job)))
 +            continue
          system = job.get("system")
          if system and system not in opts.systems:


### PR DESCRIPTION
Pass `--fail-fast` to the nix-fast-build invocation in the `check` app so the first failed check (or eval error) stops scheduling the remaining builds, instead of building all ~1450 checks and only reporting at the end.

- ix's gate is already fail-fast: plain `nix build` with `keep-going = false` (nix default, verified on vin-compute-1); no change needed there.
- The failed-attr log replay in the check app is unaffected: nix-fast-build writes the result file on failure with the records collected so far.
- `--fail-fast` exists in the pinned nix-fast-build 1.6.0 and defaults to off upstream.

Closes #2128

(opened by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--fail-fast` to `nix-fast-build` in the CI check gate
> - Adds `--fail-fast` to the `nix-fast-build` invocation in [per-system.nix](https://github.com/indexable-inc/index/pull/2129/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) so the CI check gate stops scheduling new checks after the first failure (in-flight builds still complete).
> - Upgrades the packaged `nix-fast-build` from v1.5.0 to v1.6.0 in [default.nix](https://github.com/indexable-inc/index/pull/2129/files#diff-546aee778b5baff70866b1e83bf65c4f8e66f1b2864ac7c75a8e9b6606a7acf3), including a build-time assertion that both `--skip-cached` and `--fail-fast` appear in the binary's help output.
> - Updates [skip-local.patch](https://github.com/indexable-inc/index/pull/2129/files#diff-b8b144680a903bbdda3af8cbba80a5b74b745ff01fd188a726790ca4bd0e3f6a) to target `workers.py` (renamed in 1.6.0) and uses the `_job_outputs()` helper for both local and cached upload paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c3bd4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->