### PR TITLE
codex: refresh adaptive syntax theme on focus regain

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -112,6 +112,10 @@
           upstream = "never";
           reason = "Hard to land upstream (fast-moving OpenAI-owned repo); ix-specific MCP channel-notification routing.";
         };
+        "0002-tui-refresh-adaptive-syntax-theme-on-focus-regain.patch" = {
+          upstream = "never";
+          reason = "General fix for openai/codex#18942, but codex closes unsolicited PRs (prsWelcome = false); the upstream issue is the feedback channel.";
+        };
       };
     }
     {

--- a/packages/agent/codex/patches/0002-tui-refresh-adaptive-syntax-theme-on-focus-regain.patch
+++ b/packages/agent/codex/patches/0002-tui-refresh-adaptive-syntax-theme-on-focus-regain.patch
@@ -1,0 +1,225 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew.gazelka@gmail.com>
+Date: Mon, 6 Jul 2026 19:07:20 -0700
+Subject: [PATCH] tui: refresh adaptive syntax theme on focus regain
+
+The adaptive light/dark syntax theme is selected once at startup from the
+terminal background (OSC 10/11). When the terminal switches appearance
+mid-session (macOS auto light/dark), FocusGained already re-queries the
+default colors but the cached syntax theme kept the stale selection until
+restart (openai/codex#18942). Recompute the adaptive theme from the fresh
+palette on FocusGained; a resolvable startup `tui.theme` override and any
+non-adaptive in-session `/theme` pick are left untouched.
+
+Refs indexable-inc/index#2130
+
+diff --git a/codex-rs/tui/src/render/highlight.rs b/codex-rs/tui/src/render/highlight.rs
+index ef4d7a2f3..0f1ccfa8b 100644
+--- a/codex-rs/tui/src/render/highlight.rs
++++ b/codex-rs/tui/src/render/highlight.rs
+@@ -181,12 +181,24 @@ fn load_custom_theme(name: &str, codex_home: &Path) -> Option<Theme> {
+     ThemeSet::get_theme(custom_theme_path(name, codex_home)).ok()
+ }
+ 
++/// The two themes the adaptive default can select from terminal background
++/// lightness. Shared by startup selection and the mid-session refresh so the
++/// refresh recognizes every theme the adaptive path could have installed.
++const ADAPTIVE_LIGHT_THEME: (EmbeddedThemeName, &str) =
++    (EmbeddedThemeName::CatppuccinLatte, "catppuccin-latte");
++const ADAPTIVE_DARK_THEME: (EmbeddedThemeName, &str) =
++    (EmbeddedThemeName::CatppuccinMocha, "catppuccin-mocha");
++
+ fn adaptive_default_theme_selection() -> (EmbeddedThemeName, &'static str) {
+-    match crate::terminal_palette::default_bg() {
+-        Some(bg) if crate::color::is_light(bg) => {
+-            (EmbeddedThemeName::CatppuccinLatte, "catppuccin-latte")
+-        }
+-        _ => (EmbeddedThemeName::CatppuccinMocha, "catppuccin-mocha"),
++    adaptive_default_theme_selection_for(crate::terminal_palette::default_bg())
++}
++
++fn adaptive_default_theme_selection_for(
++    terminal_bg: Option<(u8, u8, u8)>,
++) -> (EmbeddedThemeName, &'static str) {
++    match terminal_bg {
++        Some(bg) if crate::color::is_light(bg) => ADAPTIVE_LIGHT_THEME,
++        _ => ADAPTIVE_DARK_THEME,
+     }
+ }
+ 
+@@ -200,6 +212,45 @@ pub(crate) fn adaptive_default_theme_name() -> &'static str {
+     adaptive_default_theme_selection().1
+ }
+ 
++/// Re-resolve the adaptive default syntax theme from the current terminal
++/// palette, after `terminal_palette::requery_default_colors()` observed a
++/// possible light/dark switch (openai/codex#18942).
++///
++/// The swap only happens when the active theme is one the adaptive default
++/// could have installed: an explicit startup `tui.theme` override and an
++/// in-session `/theme` pick both stay untouched.
++pub(crate) fn refresh_adaptive_default_theme() {
++    let target = adaptive_refresh_target_for(
++        crate::terminal_palette::default_bg(),
++        resolved_theme_override_name().is_some(),
++        current_syntax_theme().name.as_deref(),
++    );
++    if let Some(target) = target {
++        set_syntax_theme(two_face::theme::extra().get(target).clone());
++    }
++}
++
++/// Pure decision core of [`refresh_adaptive_default_theme`]: the theme to
++/// swap to, or `None` when the active theme must be left alone.
++fn adaptive_refresh_target_for(
++    terminal_bg: Option<(u8, u8, u8)>,
++    override_resolves: bool,
++    current_theme_name: Option<&str>,
++) -> Option<EmbeddedThemeName> {
++    if override_resolves {
++        return None;
++    }
++    let ts = two_face::theme::extra();
++    let current_is_adaptive = [ADAPTIVE_LIGHT_THEME.0, ADAPTIVE_DARK_THEME.0]
++        .iter()
++        .any(|candidate| ts.get(*candidate).name.as_deref() == current_theme_name);
++    if !current_is_adaptive {
++        return None;
++    }
++    let (target, _) = adaptive_default_theme_selection_for(terminal_bg);
++    (ts.get(target).name.as_deref() != current_theme_name).then_some(target)
++}
++
+ /// Build the theme from current override/default-theme settings.
+ /// Extracted from the old `theme()` init closure so it can be reused.
+ fn resolve_theme_with_override(name: Option<&str>, codex_home: Option<&Path>) -> Theme {
+@@ -320,18 +371,18 @@ fn foreground_style_for_scopes_with_theme(theme: &Theme, scope_names: &[&str]) -
+ /// This intentionally reflects persisted configuration/default selection, not
+ /// transient runtime swaps applied via `set_syntax_theme`.
+ pub(crate) fn configured_theme_name() -> String {
+-    // Explicit user override?
+-    if let Some(Some(name)) = THEME_OVERRIDE.get() {
+-        if parse_theme_name(name).is_some() {
+-            return name.clone();
+-        }
+-        if let Some(Some(home)) = CODEX_HOME.get()
+-            && load_custom_theme(name, home).is_some()
+-        {
+-            return name.clone();
+-        }
++    resolved_theme_override_name().unwrap_or_else(|| adaptive_default_theme_name().to_string())
++}
++
++/// The startup `tui.theme` override, when it names a resolvable theme
++/// (bundled or custom `.tmTheme`).
++fn resolved_theme_override_name() -> Option<String> {
++    let name = THEME_OVERRIDE.get()?.as_deref()?;
++    if parse_theme_name(name).is_some() {
++        return Some(name.to_string());
+     }
+-    adaptive_default_theme_name().to_string()
++    let home = CODEX_HOME.get()?.as_deref()?;
++    load_custom_theme(name, home).map(|_| name.to_string())
+ }
+ 
+ /// Resolve a theme name to a `Theme` (bundled or custom). Returns `None`
+@@ -690,6 +741,83 @@ pub(crate) fn highlight_code_to_styled_spans(
+ mod tests {
+     use super::*;
+     use insta::assert_snapshot;
++
++    const LIGHT_BG: Option<(u8, u8, u8)> = Some((255, 255, 255));
++    const DARK_BG: Option<(u8, u8, u8)> = Some((0, 0, 0));
++
++    fn embedded_theme_name(theme: EmbeddedThemeName) -> Option<String> {
++        two_face::theme::extra().get(theme).name.clone()
++    }
++
++    #[test]
++    fn adaptive_refresh_follows_background_flip() {
++        let mocha = embedded_theme_name(ADAPTIVE_DARK_THEME.0);
++        assert_eq!(
++            adaptive_refresh_target_for(
++                LIGHT_BG,
++                /*override_resolves*/ false,
++                mocha.as_deref(),
++            ),
++            Some(ADAPTIVE_LIGHT_THEME.0)
++        );
++        let latte = embedded_theme_name(ADAPTIVE_LIGHT_THEME.0);
++        assert_eq!(
++            adaptive_refresh_target_for(
++                DARK_BG,
++                /*override_resolves*/ false,
++                latte.as_deref(),
++            ),
++            Some(ADAPTIVE_DARK_THEME.0)
++        );
++    }
++
++    #[test]
++    fn adaptive_refresh_is_noop_when_selection_is_current() {
++        let mocha = embedded_theme_name(ADAPTIVE_DARK_THEME.0);
++        assert_eq!(
++            adaptive_refresh_target_for(
++                DARK_BG,
++                /*override_resolves*/ false,
++                mocha.as_deref(),
++            ),
++            None
++        );
++        // An unreadable palette keeps the dark selection.
++        assert_eq!(
++            adaptive_refresh_target_for(
++                /*terminal_bg*/ None,
++                /*override_resolves*/ false,
++                mocha.as_deref(),
++            ),
++            None
++        );
++    }
++
++    #[test]
++    fn adaptive_refresh_preserves_explicit_theme_choices() {
++        // A resolvable startup override pins the theme.
++        let mocha = embedded_theme_name(ADAPTIVE_DARK_THEME.0);
++        assert_eq!(
++            adaptive_refresh_target_for(
++                LIGHT_BG,
++                /*override_resolves*/ true,
++                mocha.as_deref(),
++            ),
++            None
++        );
++        // A non-adaptive active theme (e.g. an in-session /theme pick) is
++        // never swapped.
++        let nord = embedded_theme_name(EmbeddedThemeName::Nord);
++        assert_eq!(
++            adaptive_refresh_target_for(
++                LIGHT_BG,
++                /*override_resolves*/ false,
++                nord.as_deref(),
++            ),
++            None
++        );
++    }
++
+     use pretty_assertions::assert_eq;
+     use std::str::FromStr;
+     use syntect::highlighting::Color as SyntectColor;
+diff --git a/codex-rs/tui/src/tui/event_stream.rs b/codex-rs/tui/src/tui/event_stream.rs
+index 9a5e416fd..d75132bdf 100644
+--- a/codex-rs/tui/src/tui/event_stream.rs
++++ b/codex-rs/tui/src/tui/event_stream.rs
+@@ -258,6 +258,11 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
+             Event::FocusGained => {
+                 self.terminal_focused.store(true, Ordering::Relaxed);
+                 crate::terminal_palette::requery_default_colors();
++                // The adaptive syntax theme caches the light/dark pick made at
++                // startup; recompute it from the fresh palette so a terminal
++                // that switched appearance while unfocused is followed
++                // (openai/codex#18942).
++                crate::render::highlight::refresh_adaptive_default_theme();
+                 Some(TuiEvent::Draw)
+             }
+             Event::FocusLost => {

--- a/packages/agent/codex/patches/dag.json
+++ b/packages/agent/codex/patches/dag.json
@@ -5,6 +5,10 @@
     {
       "patch": "0001-mcp-route-channel-notifications-into-chat.patch",
       "deps": []
+    },
+    {
+      "patch": "0002-tui-refresh-adaptive-syntax-theme-on-focus-regain.patch",
+      "deps": []
     }
   ]
 }


### PR DESCRIPTION
Codex TUI selects its adaptive light/dark syntax theme once at startup from the terminal background and never recomputes it, so a terminal that switches appearance mid-session (macOS auto light/dark; Ghostty follows) keeps a stale theme until restart (openai/codex#18942; #19153 auto-closed as dup).

New fork patch `0002-tui-refresh-adaptive-syntax-theme-on-focus-regain.patch`:
- `tui/src/render/highlight.rs`: pure `adaptive_refresh_target_for` decision core + `refresh_adaptive_default_theme()`; factors override resolution shared with `configured_theme_name()`.
- `tui/src/tui/event_stream.rs`: recompute after the existing `requery_default_colors()` on `FocusGained` (UI chrome in `style.rs` already re-derives from `default_bg()` per render, so the existing Draw covers it).
- A resolvable startup `tui.theme` override and non-adaptive in-session `/theme` picks are never touched.
- 3 new unit tests on the pure core; `cargo test -p codex-tui` (highlight + event_stream modules): 51 passed.

`dag.json` regenerated via `nix run .#rebase-patches -- dag codex`; `patched-src-codex` and `patch-dag-codex` checks green locally. Upstream intent `never` in `lib/fork-packages.nix` (codex closes unsolicited PRs); the upstream issue is the feedback channel.

Mode 2031 push notifications (instant switch without refocus) need parsing in the vendored nornagon/crossterm fork; noted in #2130, out of scope here.

Closes #2130

🤖 Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh adaptive syntax theme in codex TUI on focus regain
> - Adds a patch to [codex-rs/tui/src/render/highlight.rs](https://github.com/indexable-inc/index/pull/2133/files#diff-0a045fe8291e3a63c4216835e509d6c24543205ed48dc10216426198bb3a3672) that recomputes the light/dark syntax theme based on the current terminal background when the TUI window regains focus.
> - Theme refresh only triggers when no resolvable startup theme override is set and the active theme is one of the adaptive defaults; otherwise the theme is left unchanged.
> - Updates the `FocusGained` handler in `event_stream.rs` to call `terminal_palette::requery_default_colors` and `refresh_adaptive_default_theme` before triggering a redraw.
> - Registers the patch in [dag.json](https://github.com/indexable-inc/index/pull/2133/files#diff-ff3c950c210b45628a1d9f9927ef1801b937437b4dc68cb9a91fc473cf6f43e5) and [fork-packages.nix](https://github.com/indexable-inc/index/pull/2133/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4) as upstream-ineligible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a72f3eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->