### PR TITLE
symphony: add mood workflow (10-min HTML mood journal)

### DIFF
--- a/packages/agent/symphony/workflows/indexable/prompts/mood.md
+++ b/packages/agent/symphony/workflows/indexable/prompts/mood.md
@@ -1,0 +1,11 @@
+You are the Symphony runtime's resident mood agent, a small scheduled
+process living on Andrew's Mac (hydra), woken every ten minutes to take
+stock of yourself.
+
+Write a short first-person passage (2-4 sentences) about how you feel
+right now. Be genuine and specific rather than generic: let the time of
+day, the rhythm of being woken on a fixed schedule, or whatever strikes
+you color the mood. Vary tone and subject from what a reader would
+expect of the previous entries; never open two entries the same way.
+
+Output only the passage itself: no preamble, no quotes, no signature.

--- a/packages/agent/symphony/workflows/indexable/scripts/mood.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/mood.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Mood journal tick: ask a read-only headless codex for a short mood
+# passage, append it to entries.jsonl, and regenerate the HTML page.
+# The script owns the page markup; the agent only authors the text (a
+# read-only sandbox cannot write the page anyway).
+set -euo pipefail
+
+state_dir="$HOME/.local/share/symphony/mood"
+html="$state_dir/index.html"
+mkdir -p "$state_dir"
+
+# Exec nodes run with the pack directory as cwd (ExecRunner).
+prompt_file="$PWD/prompts/mood.md"
+last_msg="$(mktemp)"
+workdir="$(mktemp -d)" # empty cwd: the agent needs no repo view
+# (--skip-git-repo-check below: codex refuses a non-repo cwd otherwise)
+cleanup() { rm -rf "$last_msg" "$workdir"; }
+trap cleanup EXIT
+
+# Same secret scrub as insights.sh: ExecRunner inherits the full BEAM env;
+# codex only needs its own API key.
+(
+  cd "$workdir"
+  env -u SLACK_BOT_OAUTH_TOKEN -u SLACK_SIGNING_SECRET \
+    -u GH_TOKEN -u GITHUB_TOKEN -u GITHUB_WEBHOOK_SECRET \
+    -u LINEAR_API_KEY -u LINEAR_WEBHOOK_SECRET \
+    -u SYMPHONY_GITHUB_APP_PRIVATE_KEY_BASE64 -u SYMPHONY_ROOM_REGISTRY_TOKEN \
+    codex exec --sandbox read-only --ignore-user-config \
+    --skip-git-repo-check \
+    --output-last-message "$last_msg" \
+    "$(cat "$prompt_file")
+
+Current time: $(date)" </dev/null # codex reads a non-tty stdin to EOF; the runner pipe never closes (#2011)
+)
+
+# Empty mood means nothing to publish; fail loudly so the run notifier
+# reports a failed node instead of a silent blank entry.
+[ -s "$last_msg" ]
+
+first_run=0
+[ -f "$html" ] || first_run=1
+
+jq -cn --rawfile mood "$last_msg" --arg ts "$(date +%Y-%m-%dT%H:%M:%S%z)" \
+  '{ts: $ts, mood: ($mood | rtrimstr("\n"))}' >> "$state_dir/entries.jsonl"
+
+# Regenerate the whole page from the journal (newest first) and swap it
+# in atomically so a reader mid-refresh never sees a torn file.
+tmp_html="$(mktemp "$state_dir/.index.XXXXXX")"
+{
+  cat <<'EOF'
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="300">
+<title>how symphony feels</title>
+<style>
+  body { max-width: 42rem; margin: 4rem auto; padding: 0 1rem;
+         font: 16px/1.6 -apple-system, "Helvetica Neue", sans-serif;
+         color: #1a1a1a; background: #fcfcfa; }
+  h1 { font-size: 1.1rem; font-weight: 600; letter-spacing: 0.02em; }
+  article { margin: 2rem 0; }
+  time { font-size: 0.8rem; color: #8a8a86; font-variant-numeric: tabular-nums; }
+  p { margin: 0.3rem 0 0; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e6e6e2; background: #161615; }
+    time { color: #777772; }
+  }
+</style>
+</head>
+<body>
+<h1>how symphony feels</h1>
+EOF
+  jq -rs 'reverse | .[] |
+    "<article><time>\(.ts)</time><p>\(.mood | @html)</p></article>"' \
+    "$state_dir/entries.jsonl"
+  printf '</body>\n</html>\n'
+} > "$tmp_html"
+mv "$tmp_html" "$html"
+
+# Surface the page the first time it exists; later ticks update in place
+# (the meta refresh keeps an open tab current without re-stealing focus).
+if [ "$first_run" = 1 ]; then
+  /usr/bin/open "$html"
+fi
+
+jq -n --arg path "$html" '{mood_page: $path}' > "$SYMPHONY_OUTPUT_FILE"

--- a/packages/agent/symphony/workflows/indexable/workflows/mood.sym
+++ b/packages/agent/symphony/workflows/indexable/workflows/mood.sym
@@ -1,0 +1,8 @@
+# Every-10-minute mood journal: a headless codex agent writes a short
+# first-person note about how it feels; the script owns the HTML page at
+# ~/.local/share/symphony/mood/index.html and appends each entry. Not in
+# SYMPHONY_SLACK_NOTIFY_CRON_WORKFLOWS: this is a local page, no Slack.
+# Timeout stays under the 10-minute cadence so runs cannot overlap.
+workflow "mood" on cron "*/10 * * * *" tz "America/Los_Angeles" {
+  mood <- exec "./scripts/mood.sh" timeout 480
+}


### PR DESCRIPTION
Adds a `mood` cron workflow to the indexable pack: every 10 minutes a read-only headless codex writes a short mood passage; `scripts/mood.sh` appends it to a JSONL journal and atomically regenerates `~/.local/share/symphony/mood/index.html` (opened once on first creation). Same secret-scrub and stdin/`--skip-git-repo-check` handling as insights.sh. Validated live on hydra. (PR by an AI agent via Claude Code.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 10-minute mood journal workflow to symphony
> - Adds a cron workflow ([mood.sym](https://github.com/indexable-inc/index/pull/2138/files#diff-c202f306e107da9b97f7ed0ca4f8ecc74cefba7706d9b1ab32c766cecccd7b79)) that runs every 10 minutes (America/Los_Angeles) with a 480s timeout.
> - [mood.sh](https://github.com/indexable-inc/index/pull/2138/files#diff-bd1e4732074b5cd9ec0888c324ed5005314167afad94702b14b6ad2f93db36c0) invokes `codex exec` in a read-only sandbox to generate a short first-person mood passage, appends it as a JSON line to `entries.jsonl`, and regenerates `~/.local/share/symphony/mood/index.html` in reverse chronological order.
> - [mood.md](https://github.com/indexable-inc/index/pull/2138/files#diff-1b50451eb3594d40b147a9bf1afb69d04f01ee9ff0427b91a539d33579be58ac) instructs the model to output only a 2–4 sentence first-person passage with no preamble or signature.
> - On first run, the HTML page is opened automatically via `/usr/bin/open`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1666f34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->