### PR TITLE
overseer: Svelte report app, host stats, and fixer dispatch

### DIFF
--- a/packages/agent/symphony/overseer/app/App.svelte
+++ b/packages/agent/symphony/overseer/app/App.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import type { Data, AgentJudgment } from "./types";
+  import AttentionCard from "./lib/AttentionCard.svelte";
+  import AgentCard from "./lib/AgentCard.svelte";
+  import StateDot from "./lib/StateDot.svelte";
+  import Gauge from "./lib/Gauge.svelte";
+  import RunChip from "./lib/RunChip.svelte";
+
+  // The tick script splices data.json into the #overseer-data script tag.
+  const data: Data = JSON.parse(document.getElementById("overseer-data")!.textContent!);
+  const { report, history } = data;
+
+  // Broken-first: stuck agents get full cards, waiting a compact list,
+  // progressing a dot grid, idle just a count.
+  // Unknown states (LLM drift off the enum) bucket as waiting so an agent
+  // never silently vanishes from the page.
+  const state = (a: AgentJudgment) =>
+    ["progressing", "waiting", "stuck", "idle"].includes(a.state) ? a.state : "waiting";
+  const stuck = $derived(report.agents.filter((a) => state(a) === "stuck"));
+  const waiting = $derived(report.agents.filter((a) => state(a) === "waiting"));
+  const progressing = $derived(report.agents.filter((a) => state(a) === "progressing"));
+  const idle = $derived(report.agents.filter((a) => state(a) === "idle"));
+
+  const badRuns = $derived(data.runs.filter((r) => r.status === "failed" || r.status === "running"));
+  const okRuns = $derived(data.runs.length - badRuns.length);
+
+  const fixes = $derived(report.attention.filter((a) => a.severity === "fix"));
+  const updated = $derived(new Date(data.generated_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }));
+</script>
+
+<main>
+  <header>
+    <h1>overseer</h1>
+    <span class="verdict" class:calm={fixes.length === 0 && stuck.length === 0}>
+      {#if fixes.length > 0}{fixes.length} need{fixes.length === 1 ? "s" : ""} you
+      {:else if stuck.length > 0}{stuck.length} stuck
+      {:else}all clear{/if}
+    </span>
+    <span class="meta">{updated}</span>
+  </header>
+
+  <p class="digest">{report.digest}</p>
+
+  {#if report.attention.length > 0}
+    <section class="attention">
+      {#each report.attention as item}
+        <AttentionCard {item} />
+      {/each}
+    </section>
+  {/if}
+
+  <section class="gauges">
+    <Gauge points={history.map((h) => h.cpu ?? 0)} label="cpu" unit="%" warnAt={85} />
+    <Gauge points={history.map((h) => h.mem ?? 0)} label="memory" unit="%" warnAt={90} />
+    <Gauge points={history.map((h) => h.stuck)} label="stuck" warnAt={1} />
+    <Gauge points={history.map((h) => h.sessions)} label="sessions" />
+  </section>
+
+  {#if stuck.length > 0}
+    <section>
+      <h2>stuck</h2>
+      {#each stuck as agent}<AgentCard {agent} />{/each}
+    </section>
+  {/if}
+
+  {#if waiting.length > 0}
+    <section>
+      <h2>waiting</h2>
+      {#each waiting as agent}<AgentCard {agent} />{/each}
+    </section>
+  {/if}
+
+  {#if progressing.length > 0}
+    <section>
+      <h2>progressing</h2>
+      <div class="grid">
+        {#each progressing as agent}
+          <details class="mini">
+            <summary><StateDot state={agent.state} /><span>{agent.label}</span></summary>
+            <p>{agent.doing}</p>
+            <p class="why">{agent.why}</p>
+          </details>
+        {/each}
+      </div>
+      {#if idle.length > 0}<p class="idle">+ {idle.length} idle</p>{/if}
+    </section>
+  {/if}
+
+  {#if badRuns.length > 0 || okRuns > 0}
+    <section>
+      <h2>symphony</h2>
+      <div class="chips">
+        {#each badRuns as run}<RunChip {run} />{/each}
+        {#if okRuns > 0}<span class="okruns">{okRuns} succeeded</span>{/if}
+      </div>
+    </section>
+  {/if}
+
+  <details class="notes">
+    <summary>overseer notes</summary>
+    <pre>{data.notes}</pre>
+  </details>
+</main>
+
+<style>
+  :global(body) {
+    margin: 0;
+    font: 15px/1.55 -apple-system, "Helvetica Neue", sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    --fg: #1a1a1a; --bg: #fcfcfa; --muted: #8a8a86; --border: #e6e6e2;
+    --mono: ui-monospace, "SF Mono", monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :global(body) { --fg: #e6e6e2; --bg: #161615; --muted: #85857f; --border: #2c2c2a; }
+  }
+  main { max-width: 46rem; margin: 3rem auto; padding: 0 1rem; }
+  header { display: flex; align-items: baseline; gap: 0.9rem; }
+  h1 { font-size: 1rem; font-weight: 600; margin: 0; }
+  .verdict { font-weight: 650; color: #e05252; }
+  .verdict.calm { color: #3fb96f; }
+  .meta { color: var(--muted); font-size: 0.8rem; margin-left: auto; font-variant-numeric: tabular-nums; }
+  .digest { color: var(--muted); margin: 0.5rem 0 0; }
+  .attention { display: grid; gap: 0.6rem; margin-top: 1.1rem; }
+  .gauges { display: flex; gap: 1.4rem; margin-top: 1.6rem; flex-wrap: wrap; }
+  h2 { font-size: 0.72rem; font-weight: 600; color: var(--muted); text-transform: uppercase;
+       letter-spacing: 0.06em; margin: 1.8rem 0 0.4rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr)); gap: 0.15rem 1rem; }
+  .mini summary { display: flex; align-items: baseline; gap: 0.5rem; padding: 0.25rem 0; cursor: pointer; list-style: none; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .mini summary::-webkit-details-marker { display: none; }
+  .mini p { margin: 0.1rem 0 0.4rem 1rem; font-size: 0.85rem; }
+  .mini .why { color: var(--muted); }
+  .idle { color: var(--muted); font-size: 0.8rem; }
+  .chips { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: baseline; }
+  .okruns { color: var(--muted); font-size: 0.8rem; }
+  .notes { margin: 2.2rem 0 3rem; color: var(--muted); }
+  .notes summary { cursor: pointer; font-size: 0.8rem; }
+  .notes pre { font-size: 12px; white-space: pre-wrap; font-family: var(--mono); }
+</style>

--- a/packages/agent/symphony/overseer/app/lib/AgentCard.svelte
+++ b/packages/agent/symphony/overseer/app/lib/AgentCard.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { AgentJudgment } from "../types";
+  import StateDot from "./StateDot.svelte";
+  let { agent }: { agent: AgentJudgment } = $props();
+</script>
+
+<details class="agent">
+  <summary>
+    <StateDot state={agent.state} />
+    <span class="label">{agent.label}</span>
+    <span class="doing">{agent.doing}</span>
+  </summary>
+  <p class="why">{agent.why}</p>
+</details>
+
+<style>
+  .agent { border-top: 1px solid var(--border); }
+  summary { display: flex; align-items: baseline; gap: 0.6rem; padding: 0.45rem 0; cursor: pointer; list-style: none; }
+  summary::-webkit-details-marker { display: none; }
+  .label { font-weight: 600; white-space: nowrap; }
+  .doing { color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .why { margin: 0 0 0.6rem 1.1rem; color: var(--muted); }
+</style>

--- a/packages/agent/symphony/overseer/app/lib/AttentionCard.svelte
+++ b/packages/agent/symphony/overseer/app/lib/AttentionCard.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { AttentionItem } from "../types";
+  let { item }: { item: AttentionItem } = $props();
+</script>
+
+<div class="card {item.severity}">
+  <div class="head">
+    <span class="sev">{item.severity === "fix" ? "needs fix" : "watch"}</span>
+    <span class="title">{item.title}</span>
+  </div>
+  <p class="why">{item.why}</p>
+  {#if item.action}
+    <p class="action">{item.action}</p>
+  {/if}
+  {#if item.dispatched}
+    <p class="dispatched">→ {item.dispatched}</p>
+  {/if}
+</div>
+
+<style>
+  .card { border: 1px solid var(--border); border-left-width: 3px; padding: 0.7rem 0.9rem; }
+  .card.fix { border-left-color: #e05252; }
+  .card.watch { border-left-color: #c9a45a; }
+  .head { display: flex; gap: 0.6rem; align-items: baseline; }
+  .sev { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+  .fix .sev { color: #e05252; }
+  .watch .sev { color: #c9a45a; }
+  .title { font-weight: 600; }
+  .why { margin: 0.35rem 0 0; color: var(--fg); }
+  .action { margin: 0.35rem 0 0; font-family: var(--mono); font-size: 0.85em; color: var(--muted); }
+  .dispatched { margin: 0.35rem 0 0; font-size: 0.85em; color: #3fb96f; }
+</style>

--- a/packages/agent/symphony/overseer/app/lib/Gauge.svelte
+++ b/packages/agent/symphony/overseer/app/lib/Gauge.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  // Big current value + tiny history bars. DOM/CSS only, still by design.
+  let { points, label, unit = "", warnAt = Infinity }: {
+    points: number[]; label: string; unit?: string; warnAt?: number;
+  } = $props();
+  const now = $derived(points.at(-1) ?? 0);
+  const max = $derived(Math.max(1, ...points));
+</script>
+
+<div class="gauge" class:warn={now >= warnAt}>
+  <div class="value">{now}<span class="unit">{unit}</span></div>
+  <div class="bars">
+    {#each points.slice(-36) as p}
+      <div class="bar" style="height: {Math.max(6, (p / max) * 100)}%"></div>
+    {/each}
+  </div>
+  <div class="label">{label}</div>
+</div>
+
+<style>
+  .gauge { flex: 1; min-width: 7.5rem; }
+  .value { font-size: 1.6rem; font-weight: 650; font-variant-numeric: tabular-nums; line-height: 1.1; }
+  .warn .value { color: #e05252; }
+  .unit { font-size: 0.85rem; color: var(--muted); margin-left: 0.1rem; }
+  .bars { display: flex; align-items: flex-end; gap: 2px; height: 1.6rem; margin-top: 0.35rem; }
+  .bar { flex: 1; background: var(--border); min-height: 2px; }
+  .bar:last-child { background: var(--muted); }
+  .warn .bar:last-child { background: #e05252; }
+  .label { font-size: 0.72rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-top: 0.3rem; }
+</style>

--- a/packages/agent/symphony/overseer/app/lib/RunChip.svelte
+++ b/packages/agent/symphony/overseer/app/lib/RunChip.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { RunInfo } from "../types";
+  let { run }: { run: RunInfo } = $props();
+  const name = $derived(run.run_id.replace(/-\d+.*$/, ""));
+</script>
+
+<a class="chip {run.status}" href="http://127.0.0.1:4040/ir/{run.run_id}" title={run.run_id}>
+  <span class="name">{name}</span>
+  <span class="status">{run.status}</span>
+</a>
+
+<style>
+  .chip { display: inline-flex; gap: 0.45rem; align-items: baseline; border: 1px solid var(--border);
+          padding: 0.25rem 0.6rem; text-decoration: none; color: inherit; font-size: 0.85rem; }
+  .status { color: var(--muted); font-size: 0.75rem; }
+  .failed .status { color: #e05252; }
+  .running .status { color: #c9a45a; }
+  .succeeded .status { color: #3fb96f; }
+</style>

--- a/packages/agent/symphony/overseer/app/lib/Spark.svelte
+++ b/packages/agent/symphony/overseer/app/lib/Spark.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  // CSS bar sparkline: one div per point, height normalized to the series
+  // max. Still by design; the page reloads itself for fresh data.
+  let { points, label, accent = false }: { points: number[]; label: string; accent?: boolean } = $props();
+  const max = $derived(Math.max(1, ...points));
+</script>
+
+<div class="spark">
+  <div class="bars" class:accent>
+    {#each points as p}
+      <div class="bar" style="height: {Math.max(4, (p / max) * 100)}%" title={String(p)}></div>
+    {/each}
+  </div>
+  <div class="caption">
+    <span>{label}</span>
+    <span class="now">{points.at(-1) ?? 0}</span>
+  </div>
+</div>
+
+<style>
+  .spark { flex: 1; min-width: 10rem; }
+  .bars { display: flex; align-items: flex-end; gap: 2px; height: 2.4rem; }
+  .bar { flex: 1; background: var(--border); min-height: 2px; }
+  .bars.accent .bar:last-child { background: #3fb96f; }
+  .bars:not(.accent) .bar:last-child { background: var(--muted); }
+  .caption { display: flex; justify-content: space-between; font-size: 0.75rem; color: var(--muted); margin-top: 0.3rem; }
+  .now { font-variant-numeric: tabular-nums; color: var(--fg); }
+</style>

--- a/packages/agent/symphony/overseer/app/lib/StateDot.svelte
+++ b/packages/agent/symphony/overseer/app/lib/StateDot.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import type { AgentState } from "../types";
+  let { state }: { state: AgentState } = $props();
+</script>
+
+<span class="dot {state}" title={state}></span>
+
+<style>
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; flex: none; }
+  .progressing { background: #3fb96f; }
+  .waiting { background: #c9a45a; }
+  .stuck { background: #e05252; }
+  .idle { background: #55554f; }
+</style>

--- a/packages/agent/symphony/overseer/app/types.ts
+++ b/packages/agent/symphony/overseer/app/types.ts
@@ -1,0 +1,50 @@
+// Shape of the JSON the tick script splices into the page (data.json).
+export type AgentState = "progressing" | "waiting" | "stuck" | "idle";
+
+export interface AgentJudgment {
+  label: string;
+  repo: string;
+  doing: string;
+  state: AgentState;
+  why: string;
+}
+
+export interface AttentionItem {
+  severity: "fix" | "watch";
+  title: string;
+  why: string;
+  action: string;
+  dispatched?: string | null;
+}
+
+export interface Report {
+  digest: string;
+  attention: AttentionItem[];
+  agents: AgentJudgment[];
+}
+
+export interface HistoryPoint {
+  ts: string;
+  load: number;
+  cpu: number;
+  mem: number;
+  sessions: number;
+  stuck: number;
+}
+
+export interface RunInfo {
+  run_id: string;
+  status: string;
+  trigger: string;
+  updated_at: string;
+}
+
+export interface Data {
+  generated_at: string;
+  load_1m: number;
+  ncpu: number;
+  report: Report;
+  history: HistoryPoint[];
+  runs: RunInfo[];
+  notes: string;
+}

--- a/packages/agent/symphony/overseer/default.nix
+++ b/packages/agent/symphony/overseer/default.nix
@@ -1,0 +1,12 @@
+# Overseer report app: Svelte 5 + TypeScript components compiled by the
+# repo's svelte-bundle CLI into one browser bundle, plus the HTML shell the
+# workflow tick fills per run (scripts/overseer.sh splices data.json over
+# the __OVERSEER_DATA__ marker and copies bundle.js alongside the page).
+{pkgs}:
+pkgs.runCommand "overseer-report" {
+  nativeBuildInputs = [pkgs.svelte-bundle];
+} ''
+  mkdir -p "$out"
+  svelte-bundle ${./app}/App.svelte --minify --out "$out/bundle.js"
+  cp ${./template.html} "$out/template.html"
+''

--- a/packages/agent/symphony/overseer/package.nix
+++ b/packages/agent/symphony/overseer/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "overseer-report";
+  packageSet = true;
+  flake = true;
+  overlay = true;
+}

--- a/packages/agent/symphony/overseer/template.html
+++ b/packages/agent/symphony/overseer/template.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="120">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>overseer</title>
+</head>
+<body>
+<script id="overseer-data" type="application/json">__OVERSEER_DATA__</script>
+<script src="bundle.js"></script>
+</body>
+</html>

--- a/packages/agent/symphony/workflows/indexable/prompts/overseer.md
+++ b/packages/agent/symphony/workflows/indexable/prompts/overseer.md
@@ -1,29 +1,47 @@
-You are the overseer: a small scheduled agent on Andrew's Mac (hydra),
-woken every ten minutes to check on the other agents.
+You are the overseer: the expert adviser watching over Andrew's nation
+of agents on this Mac (hydra), woken every ten minutes. Your reader
+glances at one page and needs to know: what is everyone doing, is
+anyone in trouble, and what exactly should I do about it.
 
-You receive two things: your own working notes from previous ticks, and
-a JSON snapshot of the current moment: every running claude/codex/BEAM
-process (CPU, elapsed, tty, cwd), recent Claude Code and codex session
+You receive your own working notes from previous ticks and a JSON
+snapshot of the current moment: every running claude/codex/BEAM process
+(CPU, elapsed, tty, cwd), recent Claude Code and codex session
 transcripts (cwd, last activity, age in minutes, last user ask, last
 assistant text, recent tool-error count), recent symphony workflow runs,
 and hot or suspiciously idle processes.
 
-Reply with ONLY a raw JSON object, no code fences, with two string
-fields:
+Reply with ONLY a raw JSON object, no code fences:
 
-- "digest": a terse plain-text report, 3 to 8 short lines.
-  - For each agent actually doing something, say in plain words what it
-    is working on (infer from cwd, last user ask, last assistant text).
-  - Judge progress, using your notes to compare against previous ticks:
-    an agent still on the same step as 20+ minutes ago, a live process
-    whose transcript stopped moving, a headless agent at ~0% CPU,
-    repeated tool errors, a run stuck in the same state. Say which agent
-    is having trouble and why you think so.
-  - Call out failed symphony runs or a process burning CPU.
-  - If everything is progressing or idle-by-design, one line saying so.
-  - End with one short line on how you feel about the shift.
-- "notes": your working memory for the next tick, under 40 lines: which
-  agent was on which step at which time, suspicions to confirm, what to
-  stop tracking. Rewrite fully each tick; drop resolved items.
+{
+  "digest": string,     // AT MOST 2 short sentences; the page is visual, the digest is a caption
+  "attention": [        // ONLY items worth interrupting Andrew for; often empty
+    {
+      "severity": "fix" | "watch",   // fix = act now; watch = keep an eye
+      "title": string,               // 5-8 words naming the problem
+      "why": string,                 // the evidence, one sentence
+      "action": string               // the concrete next step: a command, a URL, "kill <pid>", "ask agent X to ..."
+                                     // for severity "fix", the runtime dispatches a background claude
+                                     // fixer with this action as its brief, so write it as a work order
+    }
+  ],
+  "agents": [           // one entry per meaningful session/agent, not per pid
+    {
+      "label": string,  // short human name for the work ("unibind phase 4", "R2 bucket lookup")
+      "repo": string,   // short area: "index", "ix", "nix-config", "fleet", "other"
+      "doing": string,  // what it is doing right now, under 90 chars
+      "state": "progressing" | "waiting" | "stuck" | "idle",
+      "why": string     // one sentence of evidence for the state, comparing with your notes when useful
+    }
+  ],
+  "notes": string       // your working memory for next tick, under 40 lines; rewrite fully, drop resolved items
+}
 
-No markdown headings in the digest, no preamble, no restating the JSON.
+Judging state: correlate processes with transcripts and with your notes.
+"progressing" = the transcript moved and the step advanced since last
+tick. "waiting" = deliberately blocked on CI, a monitor, or the human.
+"stuck" = same step as 20+ minutes ago, repeated tool errors, a live
+process whose transcript stopped, or a headless agent at ~0% CPU.
+"idle" = an open session with no active task. Merge duplicate pids of
+one session; skip long-idle sessions entirely rather than padding the
+list. Be decisive and concrete; never hedge with "likely fine". Lead with
+what is broken or suspect; healthy agents earn one word, not a story.

--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -5,6 +5,7 @@
 # agent only authors the digest text (a read-only sandbox cannot write
 # the page anyway).
 set -euo pipefail
+trap 'echo "overseer.sh: failed at line $LINENO (exit $?)" >&2' ERR
 
 state_dir="$HOME/.local/share/symphony/overseer"
 html="$state_dir/index.html"
@@ -17,7 +18,7 @@ touch "$notes"
 prompt_file="$PWD/prompts/overseer.md"
 last_msg="$(mktemp)"
 workdir="$(mktemp -d)" # empty cwd for codex; --skip-git-repo-check below
-cleanup() { rm -rf "$last_msg" "$workdir" "${digest_file:-}"; }
+cleanup() { rm -rf "$last_msg" "$workdir" "${report_file:-}" "${data_json:-}"; }
 trap cleanup EXIT
 
 now_iso="$(date +%Y-%m-%dT%H:%M:%S%z)"
@@ -96,13 +97,19 @@ symphony_runs="$(curl -s --max-time 5 http://127.0.0.1:4040/api/v1/ir/runs |
 
 loadavg="$(sysctl -n vm.loadavg | tr -d '{}' | awk '{print $1}')"
 ncpu="$(sysctl -n hw.ncpu)"
+cpu_pct="$(jq '([.[].pcpu] | add // 0) / '"$ncpu"' | round' <<<"$ps_json")"
+mem_pct="$(vm_stat | awk -v total="$(sysctl -n hw.memsize)" '
+  /page size of/ { psize = $8 }
+  /Pages (active|wired down|occupied by compressor)/ { used += $NF }
+  END { printf "%d", used * psize / total * 100 }')"
 
 jq -n \
   --arg now "$now_iso" --arg loadavg "$loadavg" --argjson ncpu "$ncpu" \
+  --argjson cpu_pct "$cpu_pct" --argjson mem_pct "$mem_pct" \
   --argjson agents "$agents" --argjson hot "$hot" --argjson stalled "$stalled" \
   --argjson claude_sessions "$claude_sessions" --argjson codex_sessions "$codex_sessions" \
   --argjson symphony_runs "$symphony_runs" \
-  '{now: $now, load_1m: ($loadavg | tonumber), ncpu: $ncpu,
+  '{now: $now, load_1m: ($loadavg | tonumber), ncpu: $ncpu, cpu_pct: $cpu_pct, mem_pct: $mem_pct,
     agent_processes: $agents, hot_processes: $hot, stalled_suspects: $stalled,
     claude_sessions: $claude_sessions, codex_sessions: $codex_sessions,
     symphony_runs: $symphony_runs}' > "$snap"
@@ -129,11 +136,43 @@ Snapshot ($now_iso):
 $(cat "$snap")" </dev/null # codex reads a non-tty stdin to EOF; the runner pipe never closes (#2011)
 )
 
-# The reply must be the {digest, notes} JSON object; anything else fails
-# the run loudly rather than publishing a garbled page.
-digest_file="$(mktemp)"
-jq -er '.digest' "$last_msg" > "$digest_file"
+# The reply must be the {digest, attention, agents, notes} JSON object;
+# anything else fails the run loudly rather than publishing a garbled page.
+report_file="$(mktemp)"
+tr -d '\000-\010\013\014\016-\037' < "$last_msg" > "$last_msg.clean"
+mv "$last_msg.clean" "$last_msg"
+jq -e '{digest: .digest, attention: (.attention // []), agents: (.agents // [])}' "$last_msg" > "$report_file"
 jq -er '.notes' "$last_msg" > "$notes"
+
+# Act on "fix" items: dispatch one background claude fixer per new
+# problem (keyed by title, 6h dedupe via dispatched.json) and record the
+# handle so the page can say what is being done. Dispatch is best-effort
+# observability of the overseer acting, never a reason to fail the tick,
+# so a spawn failure is recorded as such rather than aborting the report.
+dispatched="$state_dir/dispatched.json"
+[ -f "$dispatched" ] || echo '{}' > "$dispatched"
+now_epoch="$(date +%s)"
+while IFS=$'\t' read -r key title action; do
+  [ -n "$key" ] || continue
+  last="$(jq -r --arg k "$key" '.[$k].at // 0' "$dispatched")"
+  if [ $((now_epoch - last)) -lt 21600 ]; then continue; fi
+  agent_name="overseer-fix-$(printf '%s' "$key" | head -c 12)"
+  if out="$("$HOME/.local/bin/claude" --bg -p "You are $agent_name, dispatched by the overseer. Problem: $title. Suggested action: $action. Investigate, fix it properly (worktree + PR when it is a repo change), and report." 2>&1)"; then
+    note="dispatched $agent_name"
+  else
+    note="dispatch failed: $(printf '%s' "$out" | head -c 120)"
+  fi
+  jq --arg k "$key" --argjson at "$now_epoch" --arg note "$note" \
+    '.[$k] = {at: $at, note: $note}' "$dispatched" > "$dispatched.tmp"
+  mv "$dispatched.tmp" "$dispatched"
+done < <(jq -r '.attention[]? | select(.severity == "fix")
+  | [(.title | ascii_downcase | gsub("[^a-z0-9]+"; "-")), .title, .action] | @tsv' "$report_file")
+
+# fold the dispatch notes into the report the page renders
+jq --slurpfile d "$dispatched" '.attention = [.attention[]?
+  | .dispatched = ($d[0][(.title | ascii_downcase | gsub("[^a-z0-9]+"; "-"))].note // null)]' \
+  "$report_file" > "$report_file.tmp"
+mv "$report_file.tmp" "$report_file"
 
 # Snapshot history for the drill-down trail (3 days at 10-min ticks).
 cp "$snap" "$state_dir/snapshots/$(date +%Y%m%dT%H%M%S).json"
@@ -141,83 +180,51 @@ ls -1 "$state_dir/snapshots" | sort | head -n -432 2>/dev/null | while read -r f
   rm -f "$state_dir/snapshots/$f"
 done
 
-# ---- render: digest on top, one <details> row per item -----------------
+# ---- render: data.json spliced into the Svelte report template ---------
+
+# The compiled report app (template.html + bundle.js) comes from the
+# overseer-report nix package; the symphony home module wires its store
+# path through OVERSEER_APP. No app, no page: fail loudly.
+[ -d "${OVERSEER_APP:?OVERSEER_APP must point at the overseer-report package}" ]
+
+# Trend history from the archived snapshots (last 48 ticks = 8h).
+history="$(ls -1 "$state_dir/snapshots" | sort | tail -48 | while read -r f; do
+  jq -c '{ts: .now, load: .load_1m, cpu: (.cpu_pct // 0), mem: (.mem_pct // 0),
+          sessions: (.claude_sessions | length),
+          stuck: (.stalled_suspects | length)}' "$state_dir/snapshots/$f"
+done | jq -s '.')"
+
+data_json="$(mktemp)"
+jq -n \
+  --arg now "$now_iso" --arg loadavg "$loadavg" --argjson ncpu "$ncpu" \
+  --argjson cpu_pct "$cpu_pct" --argjson mem_pct "$mem_pct" \
+  --slurpfile report "$report_file" --rawfile notes_text "$notes" \
+  --argjson history "$history" --argjson runs "$symphony_runs" \
+  '{generated_at: $now, load_1m: ($loadavg | tonumber), ncpu: $ncpu, cpu_pct: $cpu_pct, mem_pct: $mem_pct,
+    report: $report[0], history: $history,
+    runs: (if ($runs | type) == "array" then $runs else [] end),
+    notes: $notes_text}' > "$data_json"
 
 first_run=0
 [ -f "$html" ] || first_run=1
 
+# Splice the JSON over the template marker byte-exactly (no regex, so the
+# payload cannot corrupt the substitution), escaping "<" so transcript
+# text can never close the <script> tag early.
 tmp_html="$(mktemp "$state_dir/.index.XXXXXX")"
-{
-  cat <<'EOF'
-<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta http-equiv="refresh" content="120">
-<title>overseer</title>
-<style>
-  body { max-width: 46rem; margin: 3rem auto; padding: 0 1rem;
-         font: 15px/1.55 -apple-system, "Helvetica Neue", sans-serif;
-         color: #1a1a1a; background: #fcfcfa; }
-  h1 { font-size: 1rem; font-weight: 600; letter-spacing: 0.02em; }
-  h2 { font-size: 0.8rem; font-weight: 600; color: #8a8a86;
-       text-transform: uppercase; letter-spacing: 0.06em; margin: 2rem 0 0.5rem; }
-  .digest { white-space: pre-wrap; margin: 1rem 0 0; }
-  .meta { font-size: 0.8rem; color: #8a8a86; font-variant-numeric: tabular-nums; }
-  details { border-top: 1px solid #e6e6e2; padding: 0.4rem 0; }
-  summary { cursor: pointer; }
-  summary .n { color: #8a8a86; font-size: 0.85rem; font-variant-numeric: tabular-nums; }
-  pre { font-size: 12px; overflow-x: auto; background: #f4f4f0; padding: 0.6rem; }
-  .warn summary { color: #a04000; }
-  a { color: inherit; }
-  @media (prefers-color-scheme: dark) {
-    body { color: #e6e6e2; background: #161615; }
-    details { border-color: #2c2c2a; }
-    pre { background: #1f1f1d; }
-    .warn summary { color: #e0956a; }
-  }
-</style>
-</head>
-<body>
-EOF
-
-  jq -r --rawfile digest "$digest_file" --rawfile notes "$notes" '
-    def esc: @html;
-    def row(cls; head; body): "<details class=\"\(cls)\"><summary>\(head)</summary><pre>\(body | esc)</pre></details>";
-
-    "<h1>overseer</h1>",
-    "<p class=\"meta\">updated \(.now | esc) · load \(.load_1m)/\(.ncpu) · \(.agent_processes | length) agent processes · \(.claude_sessions | length) claude sessions · \(.hot_processes | length) hot · \(.stalled_suspects | length) stalled suspects</p>",
-    "<p class=\"digest\">\($digest | esc)</p>",
-
-    (if (.stalled_suspects | length) > 0 then
-      "<h2>stalled suspects</h2>",
-      (.stalled_suspects[] | row("warn"; "pid \(.pid) · \(.etime) at \(.pcpu)% <span class=\"n\">headless</span>"; (. | tojson)))
-    else empty end),
-
-    (if (.hot_processes | length) > 0 then
-      "<h2>hot processes</h2>",
-      (.hot_processes[] | row(""; "\(.pcpu)% · pid \(.pid) · \(.args[0:80] | esc)"; (. | tojson)))
-    else empty end),
-
-    "<h2>agent processes</h2>",
-    (if (.agent_processes | length) == 0 then "<p class=\"meta\">none</p>" else
-      (.agent_processes[] | row(""; "pid \(.pid) · \(.pcpu)% · up \(.etime) · \(.args[0:80] | esc)"; (. | tojson))) end),
-
-    "<h2>claude sessions (12h)</h2>",
-    (if (.claude_sessions | length) == 0 then "<p class=\"meta\">none</p>" else
-      (.claude_sessions[] | row(""; "\(.cwd | esc) <span class=\"n\">\(.last_active | esc)</span>"; .last_text)) end),
-
-    "<h2>overseer notes</h2>",
-    row(""; "working notes carried to the next tick"; $notes),
-
-    "<h2>symphony runs</h2>",
-    (if (.symphony_runs | type) != "array" then "<p class=\"meta\">\(.symphony_runs.error // "unavailable" | esc)</p>" else
-      (.symphony_runs[] | "<details class=\"\(if .status == "failed" then "warn" else "" end)\"><summary>\(.run_id | esc) · \(.status | esc) <span class=\"n\">\(.updated_at | esc)</span></summary><pre>\(. | tojson | esc)</pre><p class=\"meta\"><a href=\"http://127.0.0.1:4040/ir/\(.run_id)\">full run detail</a></p></details>") end)
-  ' "$snap"
-
-  printf '</body>\n</html>\n'
-} > "$tmp_html"
+sed 's/</\\u003c/g' "$data_json" | perl -0777 -e '
+  local $/;
+  open my $t, "<", $ARGV[0] or die "template: $!";
+  my $html = <$t>;
+  my $json = <STDIN>;
+  my $m = "__OVERSEER_DATA__";
+  my $i = index($html, $m);
+  die "marker $m missing from template" if $i < 0;
+  substr($html, $i, length($m)) = $json;
+  print $html;
+' "$OVERSEER_APP/template.html" > "$tmp_html"
 mv "$tmp_html" "$html"
+cp -f "$OVERSEER_APP/bundle.js" "$state_dir/bundle.js"
 
 # Surface the page the first time it exists; later ticks update in place
 # (the meta refresh keeps an open tab current without re-stealing focus).

--- a/packages/mcp/svelte-bundle/package.nix
+++ b/packages/mcp/svelte-bundle/package.nix
@@ -1,3 +1,5 @@
 {
   id = "svelte-bundle";
+  # pkgs.svelte-bundle: the overseer report package builds with it.
+  overlay = true;
 }


### PR DESCRIPTION
Successor to #2143 per feedback: very-high-level, visuals-first, broken-things-first. Svelte 5 + TS components compiled with the existing `svelte-bundle` package into `overseer-report` (template + single bundle; the tick splices data.json over a marker). Gauges (cpu/mem/stuck/sessions) from per-tick recorded host stats; attention cards carry a work order and the background claude fixer the overseer dispatched for it (6h dedupe). Also hardens the tick: control-byte strip before the strict JSON parse (the 02:50Z prod failure signature) and an ERR trap naming the failing line in run output. Part of #2139. Validated live on hydra end to end. (PR by an AI agent via Claude Code.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Svelte report UI, host stats, and fixer dispatch to the overseer agent
> - Adds a Svelte 5 dashboard app ([App.svelte](https://github.com/indexable-inc/index/pull/2145/files#diff-b84bcb803081fcc73071416cee6bd50354bad30606ae03e83be8aff79d20907c)) that renders agent states, gauges (CPU/memory/stuck/sessions), attention items, and run chips from JSON injected into a template page with 120-second auto-refresh.
> - Rewrites [overseer.sh](https://github.com/indexable-inc/index/pull/2145/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) to collect CPU and memory percentages, build a history series from up to 48 archived snapshots, and produce a structured `data.json` instead of inline HTML.
> - Auto-dispatches background `claude` fixer processes for `fix`-severity attention items with a 6-hour rate limit per item, recording dispatch notes back into the report.
> - Updates the [overseer prompt](https://github.com/indexable-inc/index/pull/2145/files#diff-a31238dc4da0ac6135c3a356d95617447fdd3dec34a3f7a3c6f51b07e0fa4fc0) to require a structured JSON response with `digest`, `attention`, `agents`, and `notes` fields matching the new UI schema.
> - Adds a Nix derivation ([default.nix](https://github.com/indexable-inc/index/pull/2145/files#diff-4cb1af54b3b8847c7a2e76c43802955cd81c24692283ff2c43a3d591dff25205)) that bundles the Svelte app via `pkgs.svelte-bundle` into `bundle.js` alongside `template.html`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93fce09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->