### PR TITLE
nix-fast-build: drop the redundant 1.6.0 version/src override

### DIFF
--- a/packages/nix/nix-fast-build/default.nix
+++ b/packages/nix/nix-fast-build/default.nix
@@ -19,20 +19,6 @@
   # needs (re)building. nix-eval-jobs#403 / nix#12128 fixed the *status*; this
   # fixes what --skip-cached does with it.
   package = pkgs.nix-fast-build.overrideAttrs (old: {
-    # Forward-pin to upstream 1.6.0 while the repo's nixpkgs pin still carries
-    # 1.5.0: the check gate passes --fail-fast, which landed upstream in 1.6.0
-    # (Mic92/nix-fast-build#343), and skip-local.patch below targets the 1.6.0
-    # module layout (workers.py; 1.5.0 was a single __init__.py). tag + hash
-    # copied from nixpkgs-unstable f205b557 pkgs/by-name/ni/nix-fast-build.
-    # Delete this version/src override (keep the patch) once the nixpkgs pin
-    # reaches nix-fast-build >= 1.6.0.
-    version = "1.6.0";
-    src = pkgs.fetchFromGitHub {
-      owner = "Mic92";
-      repo = "nix-fast-build";
-      tag = "1.6.0";
-      hash = "sha256-PMBbenLBvn/0pSFOhwPVn171Vw7kU5YmBUNDhxllZ7c=";
-    };
     patches = (old.patches or []) ++ [./skip-local.patch];
   });
 


### PR DESCRIPTION
The override forward-pinned upstream 1.6.0 while the nixpkgs pin still carried 1.5.0 (#2129); its own comment said to delete it once the pin reached >= 1.6.0. #1671 bumped nixpkgs to `d4079514`, which ships nix-fast-build 1.6.0 with the identical src hash, so the override is now a byte-level no-op. `skip-local.patch` and the smoke test stay.

Validated on x86_64-linux (vin-compute-1): `nix build .#nix-fast-build.passthru.tests.smoke` passes against the new pin.

Follow-up to #2131 (unblocking work). (Driven by a background agent per the #2131 handoff.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop version/src override in `nix-fast-build` to use the nixpkgs pin
> Removes the explicit forward-pin to `nix-fast-build` 1.6.0 from [default.nix](https://github.com/indexable-inc/index/pull/2150/files#diff-546aee778b5baff70866b1e83bf65c4f8e66f1b2864ac7c75a8e9b6606a7acf3). The `overrideAttrs` now only applies `skip-local.patch`, letting the version and source come from the repo's nixpkgs pin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fb668e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->