### PR TITLE
overseer: build codex_sessions JSON with jq, not awk printf

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -81,12 +81,18 @@ claude_sessions="$(
   done | jq -s '.'
 )"
 
-# Codex sessions active in the last 12h (rollout transcripts).
+# Codex sessions active in the last 12h (rollout transcripts). jq builds
+# the JSON (never hand-printf a serialized form: an awk-printf here fed
+# jq raw control bytes under the launchd locale and failed every tick).
 codex_sessions="$(
   find "$HOME/.codex/sessions" -name '*.jsonl' -mmin -720 -print0 2>/dev/null |
   perl -0ne 'my @s = stat($_); print "$s[9] $_\n" if @s' | sort -rn | awk 'NR <= 10' |
-  awk -v now="$(date +%s)" '{printf "{\"last_active\": %d, \"age_min\": %d, \"path\": \"%s\"}\n", $1, (now - $1) / 60, $2}' |
-  jq -s '[.[] | .last_active |= todate]'
+  while read -r mtime f; do
+    jq -cn --arg m "$mtime" --arg p "$f" --arg now "$(date +%s)" \
+      '{last_active: ($m | tonumber | todate),
+        age_min: ((($now | tonumber) - ($m | tonumber)) / 60 | floor),
+        path: $p}'
+  done | jq -s '.'
 )"
 
 # Symphony runs from the local runtime. An unreachable API is itself a


### PR DESCRIPTION
Root-cause fix for the failing overseer cron ticks (02:50Z/03:00Z/03:20Z, `jq: parse error: control characters ... column 171/172`, ERR trap pinned line 90): the codex_sessions collector hand-printf-ed JSON in awk, violating the one-renderer rule, and fed jq a raw control byte under the launchd environment. jq -cn now owns the serialization end to end. Part of #2139. (PR by an AI agent via Claude Code.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build `codex_sessions` JSON with `jq` instead of `awk printf` in overseer.sh
> Replaces the `awk printf`-based JSON emitter in [overseer.sh](https://github.com/indexable-inc/index/pull/2152/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) with a `jq -cn` pipeline that properly escapes paths and other string fields. Each session file is processed individually with bound variables (`mtime`, `path`, `now`), and results are aggregated into an array with `jq -s '.'`. Previously, `awk` emitted raw unescaped strings and `last_active` was converted to an ISO timestamp only after aggregation; now the ISO timestamp is produced per-object before aggregation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d43ca80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->