### PR TITLE
overseer: judge with the claude harness (fable, high effort)

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -124,22 +124,25 @@ jq -n \
 
 # Same secret scrub as insights.sh: ExecRunner inherits the full BEAM env;
 # codex only needs its own API key.
+# The judge is the claude harness on fable at high effort. No tools: the
+# whole world it needs is in the prompt, so --allowedTools "" doubles as
+# the read-only sandbox. --output-format json carries the reply in
+# .result, which lands in $last_msg for the same strict parse as before.
 (
   cd "$workdir"
   env -u SLACK_BOT_OAUTH_TOKEN -u SLACK_SIGNING_SECRET \
     -u GH_TOKEN -u GITHUB_TOKEN -u GITHUB_WEBHOOK_SECRET \
     -u LINEAR_API_KEY -u LINEAR_WEBHOOK_SECRET \
     -u SYMPHONY_GITHUB_APP_PRIVATE_KEY_BASE64 -u SYMPHONY_ROOM_REGISTRY_TOKEN \
-    codex exec --sandbox read-only --ignore-user-config \
-    --skip-git-repo-check \
-    --output-last-message "$last_msg" \
+    "$HOME/.local/bin/claude" -p --model fable --effort high \
+    --allowedTools "" --output-format json \
     "$(cat "$prompt_file")
 
 Your notes from previous ticks:
 $(cat "$notes")
 
 Snapshot ($now_iso):
-$(cat "$snap")" </dev/null # codex reads a non-tty stdin to EOF; the runner pipe never closes (#2011)
+$(cat "$snap")" </dev/null | jq -r '.result' > "$last_msg"
 )
 
 # The reply must be the {digest, attention, agents, notes} JSON object;


### PR DESCRIPTION
The overseer judge now runs on the claude harness: `claude -p --model fable --effort high --allowedTools ""` (toolless = read-only), same strict JSON contract. Live validation on hydra produced sharper findings than codex (caught a 17h fs_usage trace and a 4h nix eval burning cores). Part of #2139. Follow-up for making the judge a real symphony agent node (room-visible thread) is blocked on agent-turn structured output over the engine wire; issue to follow. (PR by an AI agent via Claude Code.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch overseer digest executor from `codex exec` to `claude` CLI with model `fable` at high effort
> - Replaces `codex exec --sandbox read-only` with `$HOME/.local/bin/claude -p --model fable --effort high` in the headless digest subshell of [overseer.sh](https://github.com/indexable-inc/index/pull/2155/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26)
> - Tools are disabled via `--allowedTools ""` since the judge role requires no tool use
> - Output is now captured by parsing JSON stdout with `jq -r ".result"` instead of relying on codex's `--output-last-message` flag
> - Behavioral Change: the digest step now depends on the `claude` binary being present at `~/.local/bin/claude` rather than `codex`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ca8266.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->