### PR TITLE
overseer: stop dispatch claude --bg from eating the TSV loop stdin

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -166,7 +166,10 @@ while IFS=$'\t' read -r key title action; do
   last="$(jq -r --arg k "$key" '.[$k].at // 0' "$dispatched")"
   if [ $((now_epoch - last)) -lt 21600 ]; then continue; fi
   agent_name="overseer-fix-$(printf '%s' "$key" | head -c 12)"
-  if out="$("$HOME/.local/bin/claude" --bg -p "You are $agent_name, dispatched by the overseer. Problem: $title. Suggested action: $action. Investigate, fix it properly (worktree + PR when it is a repo change), and report." 2>&1)"; then
+  # </dev/null: claude reads stdin, which inside this while-read loop is
+  # the remaining TSV problem rows; without it the first dispatch swallows
+  # every later row (index#2157).
+  if out="$("$HOME/.local/bin/claude" --bg -p "You are $agent_name, dispatched by the overseer. Problem: $title. Suggested action: $action. Investigate, fix it properly (worktree + PR when it is a repo change), and report." </dev/null 2>&1)"; then
     note="dispatched $agent_name"
   else
     note="dispatch failed: $(printf '%s' "$out" | head -c 120)"


### PR DESCRIPTION
Fixes #2157.

The fixer-dispatch loop feeds `claude --bg` from the same stdin as the `while IFS=$'\t' read` it lives in, so the first dispatch consumed every remaining TSV problem row: later problems never got a fixer and the first fixer's prompt carried the raw rows. Observed live on the 2026-07-07T03:41Z tick (`overseer-fix-overseer-cro` received the `nix-eval-burning-cpu-for-hours` row verbatim; `dispatched.json` never recorded that key).

One-line fix mirroring the `</dev/null` guard the tick-level `claude -p` call already has.

(PR by an AI agent, Claude Code.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `claude --bg` stdin consumption breaking TSV loop in `overseer.sh`
> In [overseer.sh](https://github.com/indexable-inc/index/pull/2160/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26), the `claude --bg` subprocess was consuming stdin from the enclosing `while read` loop, causing it to stop after the first TSV row. Redirecting stdin to `/dev/null` on the `claude` invocation fixes this so all rows are processed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb135fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->