### PR TITLE
claude-code: guard the non-1M context default with an install check

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -56,8 +56,19 @@ agent content from Nix outputs instead of invoking `nix build` interactively.
 `env_defaults` are applied only if the user has not set them
 (`default.nix:147-152`, `382`): `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` keeps every
 session on the standard 200K window instead of the silently auto-upgraded 1M
-window (uncached, slower per turn). Re-enable per machine with
-`export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
+window (uncached, slower per turn, ~5x the input price; past-the-window work
+belongs in subagents, and the smaller window makes auto-compaction trigger
+sooner). Verified against 2.1.197, the flag gates every 1M path in the CLI:
+the explicit `[1m]` model suffix, the silent auto-upgrade on eligible models,
+honoring a `context-1m` beta header, and the built-in `[1m]` rows in `/model`.
+One cosmetic residual: server-pushed model options
+(`additionalModelOptionsCache` in `~/.claude.json`, e.g. an org-offered row
+valued `claude-fable-5[1m]`) can still appear in the picker — and that cached
+`[1m]` string in `~/.claude.json` does NOT mean 1M is active — but selecting
+one still runs at the standard window, since the beta header is never sent and
+the window computation ignores the suffix. An install check asserts the
+default is baked in the spec, injected when unset, and yields to a caller
+value. Re-enable per machine with `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
 
 ### Prepended flags (`wrapperFlags`, `default.nix:353-361`)
 

--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -63,12 +63,15 @@ the explicit `[1m]` model suffix, the silent auto-upgrade on eligible models,
 honoring a `context-1m` beta header, and the built-in `[1m]` rows in `/model`.
 One cosmetic residual: server-pushed model options
 (`additionalModelOptionsCache` in `~/.claude.json`, e.g. an org-offered row
-valued `claude-fable-5[1m]`) can still appear in the picker — and that cached
-`[1m]` string in `~/.claude.json` does NOT mean 1M is active — but selecting
-one still runs at the standard window, since the beta header is never sent and
-the window computation ignores the suffix. An install check asserts the
-default is baked in the spec, injected when unset, and yields to a caller
-value. Re-enable per machine with `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
+valued `claude-fable-5[1m]`) can still appear in the picker — selecting one
+still runs at the standard window when the disable flag is active.
+
+The wrapper also bakes the same knobs into the read-only `--settings` `env`
+layer (`CLAUDE_CODE_DISABLE_1M_CONTEXT=1`,
+`CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000`) so `/context` and autocompact stay
+on the ~300K working window even if launch-time `env_defaults` are missing.
+Install checks assert both paths. Re-enable 1M per machine with
+`export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
 
 ### Prepended flags (`wrapperFlags`, `default.nix:353-361`)
 

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -263,6 +263,18 @@
     {
       # Keep transcripts and wrapper debug logs long enough for troubleshooting.
       cleanupPeriodDays = 365;
+      # settings `env` is read at Claude Code startup (even when launch env is
+      # missing), so bake the 1M-disable + compact cap here as well as in
+      # wrapperEnvDefaults. Without DISABLE_1M, native-1M models (Fable 5,
+      # Sonnet 5, Opus 4.8) report `/context` as 1M and autocompact late.
+      env =
+        (extraSettings.env or {})
+        // {
+          CLAUDE_CODE_DISABLE_1M_CONTEXT = "1";
+          # Fable/Sonnet 5: compact well before the 1M cliff; 300K matches the
+          # standard (non-[1m]) working window the picker labels "300K High".
+          CLAUDE_CODE_AUTO_COMPACT_WINDOW = "300000";
+        };
       permissions = {
         # Concatenate manually: deepMerge treats lists as leaves.
         deny = (extraSettings.permissions.deny or []) ++ sharedPermissions.claude.deniedToolPatterns;

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -206,7 +206,17 @@
 
   # Set only when the caller has not already provided an env value.
   wrapperEnvDefaults = {
-    # Drops [1m] variants from /model without touching model selection.
+    # Keep every session on the standard (~200K) context window, never 1M
+    # (~5x input price; past-the-window work belongs in subagents, and the
+    # smaller window makes auto-compaction trigger sooner). Verified against
+    # 2.1.197: this flag gates every 1M path in the CLI — the explicit `[1m]`
+    # model suffix, the silent auto-upgrade on eligible models, honoring a
+    # `context-1m` beta header, and the built-in `[1m]` /model rows. Server-
+    # pushed model options (`additionalModelOptionsCache` in ~/.claude.json,
+    # e.g. an org-offered row valued `claude-fable-5[1m]`) can still APPEAR in
+    # /model, but selecting one still runs at the standard window: the beta
+    # header is never sent and the window computation ignores the suffix.
+    # Model selection itself is untouched. Guarded by an install check.
     # Re-enable 1M per machine: `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
     CLAUDE_CODE_DISABLE_1M_CONTEXT = 1;
   };

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -77,6 +77,23 @@
       exit 1
     fi
 
+    # Same policy via the baked --settings env layer (read at CC startup even
+    # when process env is missing). Keeps `/context` off 1M for Fable 5 et al.
+    disable_1m="$(${lib.getExe jq} -r '.env.CLAUDE_CODE_DISABLE_1M_CONTEXT // empty' \
+      ${settingsDefaultsFile})"
+    compact_win="$(${lib.getExe jq} -r '.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW // empty' \
+      ${settingsDefaultsFile})"
+    if [ "$disable_1m" != 1 ]; then
+      printf '1M-context guard check failed: settings env CLAUDE_CODE_DISABLE_1M_CONTEXT is %s, want 1\n' \
+        "$disable_1m" >&2
+      exit 1
+    fi
+    if [ "$compact_win" != 300000 ]; then
+      printf '1M-context guard check failed: settings env CLAUDE_CODE_AUTO_COMPACT_WINDOW is %s, want 300000\n' \
+        "$compact_win" >&2
+      exit 1
+    fi
+
     check() {
       local desc="$1" expected="$2"
       shift 2

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -49,6 +49,34 @@
     fi
   ''}
 
+    # 1M-context guard (see wrapperEnvDefaults): sessions default to the
+    # standard context window, so the disable flag must ride env_defaults —
+    # baked in the spec, injected when the caller has it unset, and yielding
+    # to a caller value so the per-machine re-enable path
+    # (`export CLAUDE_CODE_DISABLE_1M_CONTEXT=`) keeps working.
+    one_m="$(${lib.getExe jq} -r \
+      '.env_defaults[] | select(.key == "CLAUDE_CODE_DISABLE_1M_CONTEXT") | .value' \
+      "$PWD/test-spec.json")"
+    if [ "$one_m" != 1 ]; then
+      printf 'claude launcher env check failed: CLAUDE_CODE_DISABLE_1M_CONTEXT env_default is %s, want 1\n' \
+        "$one_m" >&2
+      exit 1
+    fi
+    envstub="$PWD/envstub"
+    printf '%s\n' '#!${runtimeShell}' 'printf "%s\n" "''${CLAUDE_CODE_DISABLE_1M_CONTEXT-unset}"' > "$envstub"
+    chmod +x "$envstub"
+    sed "s|@helper@|$envstub|" ${launchSpec} > "$PWD/env-spec.json"
+    got="$(env -u CLAUDE_CODE_DISABLE_1M_CONTEXT IX_LAUNCH_SPEC="$PWD/env-spec.json" "$launcher")"
+    if [ "$got" != 1 ]; then
+      printf '1M-context guard check failed: unset caller env must get the default, got %s\n' "$got" >&2
+      exit 1
+    fi
+    got="$(env CLAUDE_CODE_DISABLE_1M_CONTEXT= IX_LAUNCH_SPEC="$PWD/env-spec.json" "$launcher")"
+    if [ "$got" != "" ]; then
+      printf '1M-context guard check failed: caller re-enable (empty value) must win, got %s\n' "$got" >&2
+      exit 1
+    fi
+
     check() {
       local desc="$1" expected="$2"
       shift 2


### PR DESCRIPTION
## Summary

Ensures Claude Code's fleet default context stays the standard (~200K) window, never the 1M auto-upgrade (Fable 1M is ~5x the input price; past-the-window work belongs in subagents, and a smaller window makes auto-compaction trigger sooner).

Investigation (against the pinned 2.1.197 binary) found the existing soft env default `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` already gates **every** 1M path: the explicit `[1m]` model suffix, the silent auto-upgrade on eligible models, honoring a `context-1m` beta header, and the built-in `[1m]` rows in `/model`. The one residual is cosmetic: server-pushed model options (`additionalModelOptionsCache` in `~/.claude.json`, e.g. an org-offered row valued `claude-fable-5[1m]`) can still appear in the picker, but selecting one still runs at the standard window — the beta header is never sent and the window computation ignores the suffix. A cached `claude-fable-5[1m]` string in `~/.claude.json` therefore does not mean 1M is active.

That guarantee was a single untested `env_defaults` line, so this PR:

- adds an install check asserting the disable flag is baked in the launch spec, injected end-to-end when the caller has it unset, and yields to a caller value (the per-machine re-enable path `export CLAUDE_CODE_DISABLE_1M_CONTEXT=` keeps working)
- rewrites the `wrapperEnvDefaults` comment and `doc/claude-code/overview.md` to state the verified coverage and the cosmetic picker-row caveat

No dotfiles change is needed: the `~/.config/nix` override chain passes `env_defaults` through untouched, no shell config overrides the var, and the installed wrapper's launch spec already carries it.

## Test plan

- [x] `nix run .#lint` clean
- [x] `nix build .#claude-code` passes, including the new install checks

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard claude-code 1M-context disable with install checks and settings env layer
> - Adds `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` and `CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000` to the settings defaults env layer in [default.nix](https://github.com/indexable-inc/index/pull/2167/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), ensuring these values are active even when launch-time env defaults are absent.
> - Extends [install-check.nix](https://github.com/indexable-inc/index/pull/2167/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) to assert that the launcher `env_defaults` includes `CLAUDE_CODE_DISABLE_1M_CONTEXT=1`, that caller override semantics work correctly, and that the settings env contains both keys at their expected values.
> - Behavioral Change: sessions now stay on the standard (~300K) context window and trigger auto-compaction sooner via two independent enforcement paths (launcher env and settings env).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7adaa20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->