### PR TITLE
nu-py: export GH_PROMPT_DISABLED=1 to engine externals

### DIFF
--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -405,12 +405,18 @@ def test_externals_run_color_free_even_when_host_forces_color(
         "sys.stdout.write(esc + '[1;37m' + body + esc + '[m' if on else body)"
     )
     try:
-        env = run(nu.value("$env | select -o NO_COLOR CLICOLOR CLICOLOR_FORCE FORCE_COLOR"))
+        env = run(
+            nu.value(
+                "$env | select -o NO_COLOR CLICOLOR CLICOLOR_FORCE FORCE_COLOR GH_PROMPT_DISABLED"
+            )
+        )
         assert env == {
             "NO_COLOR": "1",
             "CLICOLOR": "0",
             "CLICOLOR_FORCE": "0",
             "FORCE_COLOR": "0",
+            # issue #2163: gh must never try to prompt into a captured pipe.
+            "GH_PROMPT_DISABLED": "1",
         }
         # GH_FORCE_TTY (TTY-style gh rendering into a pipe) must not cross over.
         assert run(nu.value("'GH_FORCE_TTY' in $env")) is False

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -55,7 +55,9 @@ Contract:
 - Externals run color-free by default: the engine env overrides
   ``NO_COLOR=1`` / ``CLICOLOR=0`` / ``CLICOLOR_FORCE=0`` / ``FORCE_COLOR=0``
   and never inherits ``GH_FORCE_TTY``, so a JSON-mode CLI pipes parseable
-  bytes into ``from json`` even when the host process forces color. A call
+  bytes into ``from json`` even when the host process forces color. It
+  also sets ``GH_PROMPT_DISABLED=1`` so gh errors out instead of trying
+  to prompt into a captured pipe. A call
   that wants ANSI re-enables it with ``env={"NO_COLOR": "",
   "CLICOLOR_FORCE": "1"}`` (or ``with-env`` inside the pipeline).
 - Each kernel session gets its OWN engine (stored in the session's

--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -84,11 +84,15 @@ fn initial_engine_state() -> EngineState {
     // Overriding the values (not merely unsetting them) beats every CLI color
     // convention; a caller that wants ANSI back re-enables it for one call via
     // `env=` (the per-eval stack shadows these) or `with-env`.
+    // GH_PROMPT_DISABLED (issue #2163): output here is parsed, never a
+    // terminal, so gh must fail fast with a usable error instead of ever
+    // attempting an interactive prompt.
     for (key, value) in [
         ("NO_COLOR", "1"),
         ("CLICOLOR", "0"),
         ("CLICOLOR_FORCE", "0"),
         ("FORCE_COLOR", "0"),
+        ("GH_PROMPT_DISABLED", "1"),
     ] {
         engine_state.add_env_var(key.into(), Value::string(value, Span::unknown()));
     }


### PR DESCRIPTION
`^gh ... --json | from json` fails in the kernel because the host process (Claude Code) exports `CLICOLOR_FORCE=1` / `FORCE_COLOR=1`, and gh's `EnvColorForced()` forces ANSI-wrapped JSON into the captured pipe. The color half of this was already fixed on main by #2062 (engine overrides `NO_COLOR=1` / `CLICOLOR=0` / `CLICOLOR_FORCE=0` / `FORCE_COLOR=0`); the deployed kernel that prompted the issue simply predates it.

**Repro evidence** (live deployed kernel, gh 2.96.0):
- `^gh pr list --json number | from json` -> `Error while parsing JSON text ... trailing characters`; raw bytes are `\x1b[1;37m[\x1b[m\n  \x1b[1;37m{...` (SGR-wrapped JSON).
- Knob check against the inherited env: `NO_COLOR=1` alone still ANSI, `CLICOLOR=0` alone still ANSI, `CLICOLOR_FORCE=0` -> clean `[{"number":2126}]` (matches gh's env-precedence: `CLICOLOR_FORCE` wins unless zeroed). Main's override set already covers all of these.

**What this PR adds:** the remaining knob from the issue, `GH_PROMPT_DISABLED=1` (gh: "set to any value to disable interactive prompting"), in the same engine env-override block, so gh fails fast instead of ever prompting into the captured pipe. Docstring contract and the existing color-free engine test extended to pin it.

Fixes #2163


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `GH_PROMPT_DISABLED=1` to nu engine external environment
> Adds `GH_PROMPT_DISABLED=1` to the default env vars injected by `initial_engine_state` in [lib.rs](https://github.com/indexable-inc/index/pull/2168/files#diff-424ce210c45fc8f162c45814067651d48d245471a2e86b63c39b71c370ffe7fe), preventing `gh` and similar tools from rendering interactive prompts when run as externals. Updates the module docstring and adds test coverage asserting the variable is present with value `"1"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c46098e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->