### PR TITLE
overseer: surface process parentage so owned tracers are not flagged as orphans

### DIFF
--- a/packages/agent/symphony/workflows/indexable/prompts/overseer.md
+++ b/packages/agent/symphony/workflows/indexable/prompts/overseer.md
@@ -45,3 +45,9 @@ process whose transcript stopped, or a headless agent at ~0% CPU.
 one session; skip long-idle sessions entirely rather than padding the
 list. Be decisive and concrete; never hedge with "likely fine". Lead with
 what is broken or suspect; healthy agents earn one word, not a story.
+
+Before an action proposes killing a pid, read its parent_chain: a
+tracer or helper whose ancestor is a live monitor or agent session
+(e.g. sudo fs_usage under nix-web-monitor) is owned, not orphaned.
+Every handle in an action (path, pid, command) must appear verbatim
+in the snapshot; notes are hypotheses, the snapshot is evidence.

--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -28,10 +28,10 @@ now_iso="$(date +%Y-%m-%dT%H:%M:%S%z)"
 # Every process, parsed into fields once; agent/hot/stall views are jq
 # filters over this. tty="??" separates headless (launchd, cron, exec
 # nodes) from interactive terminal sessions.
-ps_json="$(ps axo pid=,pcpu=,etime=,tty=,args= | jq -Rs '
+ps_json="$(ps axo pid=,ppid=,pcpu=,etime=,tty=,args= | jq -Rs '
   [split("\n")[]
-   | capture("^ *(?<pid>[0-9]+) +(?<pcpu>[0-9.]+) +(?<etime>[0-9:-]+) +(?<tty>[^ ]+) +(?<args>.*)$")?
-   | .pid |= tonumber | .pcpu |= tonumber
+   | capture("^ *(?<pid>[0-9]+) +(?<ppid>[0-9]+) +(?<pcpu>[0-9.]+) +(?<etime>[0-9:-]+) +(?<tty>[^ ]+) +(?<args>.*)$")?
+   | .pid |= tonumber | .ppid |= tonumber | .pcpu |= tonumber
    | .args |= .[0:220]
    # elapsed minutes from etime (mm:ss, hh:mm:ss, or d-hh:mm:ss)
    | .minutes = (.etime | capture("^((?<d>[0-9]+)-)?((?<h>[0-9]+):)?(?<m>[0-9]+):(?<s>[0-9]+)$")?
@@ -51,12 +51,24 @@ cwd_map="$(
 )"
 agents="$(jq --argjson cwds "$cwd_map" 'map(. + {cwd: ($cwds[.pid | tostring] // null)})' <<<"$agents")"
 
-hot="$(jq '[.[] | select(.pcpu >= 30)] | sort_by(-.pcpu) | .[0:8]' <<<"$ps_json")"
+# parent_chain: ancestor command lines, child-first. Root helpers show as
+# bare "(name)" with no args, so ancestry is the only evidence of ownership
+# the judge gets (#2169: a root fs_usage owned by nix-web-monitor was
+# flagged as an orphan and a fixer was dispatched to kill it).
+parents_def='def parents($by): [.ppid | tostring | $by[.]? // empty
+  | recurse($by[.ppid | tostring]? // empty) | .args] | .[0:5];'
+hot="$(jq "$parents_def"'
+  INDEX(.pid | tostring) as $by
+  | [.[] | select(.pcpu >= 30) | . + {parent_chain: parents($by)}]
+  | sort_by(-.pcpu) | .[0:8]' <<<"$ps_json")"
 
 # Wedge heuristic (#2011 signature): a headless agent process idling at
 # ~0% CPU for a long time. Interactive agents idle at 0% legitimately
 # (waiting on the human), so only tty-less processes qualify.
-stalled="$(jq '[.[] | select(.tty == "??" and .pcpu < 1 and .minutes >= 15)]' <<<"$agents")"
+stalled="$(jq --argjson all "$ps_json" "$parents_def"'
+  INDEX($all[]; .pid | tostring) as $by
+  | [.[] | select(.tty == "??" and .pcpu < 1 and .minutes >= 15)
+     | . + {parent_chain: parents($by)}]' <<<"$agents")"
 
 # Claude Code sessions active in the last 12h: cwd and texts come from
 # the transcript itself (the dir-name encoding is lossy). age_min against


### PR DESCRIPTION
Fixes #2169.

The overseer dispatched a fixer to `sudo kill` a root `(fs_usage)` that was actually nwm's own ktrace holder (parent chain: `fs_usage <- sudo <- nix-web-monitor serving :7532 <- live Claude session`). The snapshot had no `ppid`, so ownership was invisible and root helpers show as bare `(name)` with no args.

- add `ppid` to the ps collector
- annotate `hot_processes` / `stalled_suspects` with `parent_chain` (up to 5 ancestor command lines, child-first)
- prompt: check `parent_chain` before proposing a kill; action handles must be snapshot-verbatim (companion to #2158)

Validated on the live host: the collectors run end to end and pid 42393 now surfaces `nix-web-monitor` in its chain.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface process parent chain in overseer so tracer/helper processes are not flagged as orphans
> - Adds `ppid` to the `ps` output in [overseer.sh](https://github.com/indexable-inc/index/pull/2171/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) and computes a `parent_chain` array (ancestor command lines, child-first) for each entry in both the hot and stalled process lists.
> - Updates [overseer.md](https://github.com/indexable-inc/index/pull/2171/files#diff-a31238dc4da0ac6135c3a356d95617447fdd3dec34a3f7a3c6f51b07e0fa4fc0) to instruct the overseer to check `parent_chain` before proposing to kill a pid, treating processes with a live monitor/agent ancestor as owned rather than orphaned.
> - Requires that all handles referenced in a kill action appear verbatim in the snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4518726.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->