### PR TITLE
mcp: jobs.spawn registers an ad-hoc awaitable as a first-class job

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3001,7 +3001,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + jobs.spawn ad-hoc awaitables (#2164)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3016,6 +3016,8 @@
       cp ${./tests/test_job_await_errors.py} test_job_await_errors.py
       # Issue #2104: one session's wait must never cancel another session's job.
       cp ${./tests/test_job_cancel_scope.py} test_job_cancel_scope.py
+      # Issue #2164: jobs.spawn registers an ad-hoc awaitable as a first-class job.
+      cp ${./tests/test_jobs_spawn.py} test_jobs_spawn.py
       cp ${./tests/test_fsearch_partial.py} test_fsearch_partial.py
       cp ${./tests/test_fsearch_glob.py} test_fsearch_glob.py
       # sh Output rendering regressions (issue #1766: a failed build must not
@@ -3026,6 +3028,7 @@
       cp ${./tests/test_build_info.py} test_build_info.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
+        test_jobs_spawn.py \
         test_fsearch_partial.py \
         test_fsearch_glob.py \
         test_sh_module.py \

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -71,7 +71,9 @@ JOBS = (
     "before it backgrounds, so keep it small and poll: do NOT pass a huge budget to sit on a "
     "long `await jobs['ab12']` in the foreground — it blocks every other call for that whole "
     "time and is capped server-side anyway. Let the work background, then re-await or poll "
-    "`.done()` in a later cell."
+    "`.done()` in a later cell. `jobs.spawn(coro, name=...)` registers an awaitable you created "
+    "yourself as a first-class job with the same lifecycle (appears in `jobs`, notifies on "
+    "completion, result via `await jobs['<id>']`)."
 )
 
 PAGING = (

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -276,7 +276,10 @@ BUILTINS: tuple[Builtin, ...] = (
     Builtin("Result", "split a cell's value into the human view and your view; a cell must end with or yield one"),
     Builtin("cells", "curate the dashboard's highlight reel (`cells.add` / `set` / `remove` / `clear`)"),
     Builtin("session", "this session's dashboard identity — set `session.name = '...'` first so a human can tell your runs apart"),
-    Builtin("jobs", "the background-run registry (inspect / await / cancel / page each run)"),
+    Builtin(
+        "jobs",
+        "the background-run registry (inspect / await / cancel / page each run); `jobs.spawn(coro, name=...)` registers your own awaitable as a first-class job (dashboard card + completion notification + awaitable result)",
+    ),
     Builtin("history", "list recent runs"),
     Builtin("doc", "the signature + docstring of any object, returned as a Result (help() only prints and returns None)"),
     Builtin("resources", "the live, self-updating views (a terminal, a widget)"),

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -50,7 +50,7 @@ import time
 import traceback
 import types
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any, overload
 
 from . import readstats, registry, typecheck
@@ -1434,7 +1434,54 @@ def register_resource(
     return res
 
 
-jobs: dict[str, Job] = {}
+class Jobs(dict[str, Job]):
+    """The kernel-wide run registry (``jobs``): every execution this kernel has
+    run, keyed by job id. Beyond the dict surface, :meth:`spawn` registers an
+    ad-hoc awaitable as a first-class background job, so work an agent started
+    itself (a coroutine, a Task) gets the same lifecycle as a backgrounded cell:
+    a dashboard card, a completion notification, and a pageable/awaitable
+    ``jobs['<id>']`` handle (issue #2164)."""
+
+    def spawn(self, aw: Awaitable[Any], *, name: str | None = None, topic: str | None = None) -> Job:
+        """Register ``aw`` (any awaitable: a coroutine, Task, or Future) as a
+        first-class background job and return its :class:`Job` handle at once.
+
+        The awaitable gets the full job lifecycle: it appears in ``jobs`` /
+        ``history()`` and on the dashboard, its completion pushes a channel
+        notification exactly like a backgrounded cell, and its value is
+        retrieved with ``await jobs['<id>']`` (or ``.result`` once done; a
+        failure re-raises there, like any other job). ``name`` labels the job
+        (defaults to the coroutine's qualname); ``topic`` files it under a
+        dashboard topic (defaults to the session's current one). Must be called
+        with the kernel's event loop running (i.e. from inside a cell)."""
+        if not inspect.isawaitable(aw):
+            raise TypeError(
+                f"jobs.spawn() needs an awaitable (coroutine, Task, or Future), got {type(aw).__name__}"
+            )
+        # Raises RuntimeError outside the loop, BEFORE the job is registered, so
+        # a misuse never leaves a forever-"running" phantom in the registry.
+        loop = asyncio.get_running_loop()
+        parent = _ix_current.get()
+        label = name or getattr(aw, "__qualname__", None) or type(aw).__name__
+        job = Job(
+            f"jobs.spawn({label!r})",
+            name=label,
+            # No foreground wait: a spawned job is background from birth, so
+            # there is no budget window to draw (0 is /api/exec's floor too).
+            budget=0.0,
+            kind="spawn",
+            topic=topic or session.topic,
+            session=parent.session if parent is not None else None,
+        )
+        # Background from birth: completion notifies the agent session the same
+        # way a budget-expired cell does (see the runners' shared finally tail).
+        job.backgrounded = True
+        self[job.id] = job
+        job.task = loop.create_task(_spawn_runner(job, aw))
+        return job
+
+
+jobs: Jobs = Jobs()
 resources: dict[str, Resource] = {}
 
 # A safe id for an INTERACTIVE resource: it is interpolated into the injected
@@ -2559,6 +2606,76 @@ def _persist_final(job: Job) -> None:
             bindings=_cell_bindings(job),
             namespace=_namespace_snapshot(job),
         )
+
+
+async def _spawn_runner(job: Job, aw: Awaitable[Any]) -> None:
+    """:func:`_runner`'s sibling for :meth:`Jobs.spawn`: there is no cell code
+    to typecheck or compile -- just await the registered awaitable -- but the
+    rest of the lifecycle is identical: prints captured under the job, the value
+    wrapped like a trailing expression, the same persistence, and the same
+    completion notification a backgrounded cell sends."""
+    token = _ix_current.set(job)
+    _install_task_failure_watch(asyncio.get_running_loop())
+    if _store is not None and _store_conn is not None:
+        with contextlib.suppress(Exception):  # best-effort: store write must not abort the job
+            _store.start(
+                _store_conn,
+                id=job.id,
+                name=job.name,
+                code=job.code,
+                started_at=job.started,
+                budget=job.budget,
+                kind=job.kind,
+                topic=job.topic,
+            )
+    try:
+        value = await aw
+        if value is None:
+            # Same contract as a None-valued cell: the captured stdout (or a
+            # quiet ok) is the result, so a print-only awaitable reports what
+            # it printed.
+            result = _auto_result(job)
+        elif isinstance(value, Result):
+            # An explicit Result is the author's full statement of both views;
+            # stdout stays out of it (page jobs['<id>'].output), like a cell's.
+            result = value
+        else:
+            result = _merge_stdout(job, Result.of(value))
+        job._result = result
+        job.status = "done"
+    except asyncio.CancelledError:
+        job.status = "cancelled"
+        # `job.cancel()` cancels THIS runner; a pre-created Task/Future keeps
+        # running unless the cancellation is forwarded to it. Forward it, so
+        # cancelling the job cancels the work whatever shape was registered.
+        if isinstance(aw, asyncio.Future):
+            aw.cancel()
+        raise
+    except (Exception, KeyboardInterrupt, SystemExit) as _exc:
+        # Isolate like _runner: a failed awaitable becomes a failed job
+        # (traceback captured, `await jobs['<id>']` re-raises) instead of
+        # escaping the task and dying as an unretrieved background failure.
+        job.status = "error"
+        job.error = _user_traceback(_exc)
+        job._exc = _exc
+        job._exc_tb = _exc.__traceback__
+        job._append(job.error)
+    finally:
+        job.ended = time.time()
+        _ix_current.reset(token)
+        _persist_final(job)
+        _mark_snapshot_dirty()
+        # Spawned jobs are backgrounded by construction, so completion always
+        # notifies (the suppress mirrors _runner: a session without the channel
+        # has nothing to deliver to, and that must not fail the job's cleanup).
+        with contextlib.suppress(Exception):
+            await notify(
+                f"Background job {job.name} finished with status {job.status}.",
+                job_id=job.id,
+                job_name=job.name,
+                status=job.status,
+                topic=job.topic,
+            )
 
 
 def _cell_bindings(job: Job) -> dict:

--- a/packages/mcp/tests/test_jobs_spawn.py
+++ b/packages/mcp/tests/test_jobs_spawn.py
@@ -1,0 +1,221 @@
+"""``jobs.spawn`` registers an ad-hoc awaitable as a first-class background job
+(issue #2164).
+
+The kernel's job lifecycle (dashboard card, completion notification, pageable
+``jobs['<id>']`` handle, ``await`` yields the value / re-raises the failure) used
+to be reachable only through ``python_exec`` cells; an awaitable an agent created
+itself (a coroutine, a Task) had none of it. ``jobs.spawn(coro, name=...)`` gives
+any awaitable the same lifecycle: it appears in ``jobs``, its completion sends
+the same channel notification a backgrounded cell sends, and its result follows
+the existing Job contract (``.result`` raises while running, a failure re-raises
+on ``await``, cancel works).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from ix_notebook_mcp import runtime
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+
+
+def test_spawn_registers_and_awaiting_yields_the_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+
+    async def work() -> str:
+        await asyncio.sleep(0)
+        return "payload"
+
+    async def drive() -> tuple[runtime.Job, Any]:
+        job = runtime.jobs.spawn(work(), name="my-work")
+        # First-class from the moment spawn returns: registered and running.
+        assert runtime.jobs[job.id] is job
+        assert job.name == "my-work"
+        assert job.kind == "spawn"
+        assert job.backgrounded
+        return job, await job
+
+    job, result = asyncio.run(drive())
+    assert job.status == "done"
+    assert job.ok
+    # The value follows the cell contract: wrapped in a Result whose .value is
+    # the ORIGINAL object and whose .text is the model-facing rendering.
+    assert result.value == "payload"
+    assert "payload" in result.text
+    # `.result` hands back the same thing once the job is done.
+    assert job.result is result
+
+
+def test_spawn_name_defaults_to_the_coroutine_qualname(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+
+    async def named_work() -> None:
+        return None
+
+    async def drive() -> runtime.Job:
+        job = runtime.jobs.spawn(named_work())
+        await job.wait(5)
+        return job
+
+    job = asyncio.run(drive())
+    assert "named_work" in job.name
+
+
+def test_spawned_stdout_is_captured_under_the_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Prints made while the awaitable runs must land in the job's buffer (the
+    # pageable `jobs['<id>'].output`), exactly like a cell's prints.
+    _wire(monkeypatch, {})
+
+    async def chatty() -> None:
+        print("spawned hello")
+
+    async def drive() -> runtime.Job:
+        job = runtime.jobs.spawn(chatty(), name="chatty")
+        await job
+        return job
+
+    job = asyncio.run(drive())
+    assert job.status == "done"
+    assert "spawned hello" in job.output
+    # A None-valued awaitable reports its stdout, like a print-only cell.
+    assert "spawned hello" in job.result.text
+
+
+def test_awaiting_a_failed_spawn_reraises_the_original_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+
+    async def boom() -> None:
+        raise ValueError("spawn boom")
+
+    async def drive() -> runtime.Job:
+        job = runtime.jobs.spawn(boom(), name="boom")
+        await job.wait(5)
+        return job
+
+    job = asyncio.run(drive())
+    assert job.status == "error"
+    assert "spawn boom" in (job.error or "")
+
+    async def await_it() -> Any:
+        return await runtime.jobs[job.id]
+
+    with pytest.raises(ValueError, match="spawn boom"):
+        asyncio.run(await_it())
+
+
+def test_result_while_running_raises_job_still_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+
+    async def drive() -> None:
+        started = asyncio.Event()
+
+        async def hang() -> None:
+            started.set()
+            await asyncio.sleep(60)
+
+        job = runtime.jobs.spawn(hang(), name="hang")
+        await started.wait()
+        with pytest.raises(runtime.JobStillRunning):
+            _ = job.result
+        job.cancel()
+        await job.wait(5)
+        assert job.status == "cancelled"
+
+    asyncio.run(drive())
+
+
+def test_cancelling_a_spawned_task_shape_cancels_the_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A pre-created Task keeps running when only the runner is cancelled; spawn
+    # forwards the cancellation so `job.cancel()` stops the work itself.
+    _wire(monkeypatch, {})
+
+    async def drive() -> None:
+        started = asyncio.Event()
+
+        async def hang() -> None:
+            started.set()
+            await asyncio.sleep(60)
+
+        inner = asyncio.ensure_future(hang())
+        job = runtime.jobs.spawn(inner, name="hang-task")
+        await started.wait()
+        job.cancel()
+        await job.wait(5)
+        assert job.status == "cancelled"
+        # The forwarded cancellation reaches the inner task itself.
+        await asyncio.wait({inner}, timeout=5)
+        assert inner.cancelled()
+
+    asyncio.run(drive())
+
+
+def test_completion_sends_the_backgrounded_job_notification(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+    sent: list[tuple[str, dict]] = []
+
+    async def fake_notify(content: str, **meta: Any) -> None:
+        sent.append((content, meta))
+
+    monkeypatch.setattr(runtime, "notify", fake_notify)
+
+    async def work() -> int:
+        return 7
+
+    async def drive() -> runtime.Job:
+        job = runtime.jobs.spawn(work(), name="notified")
+        await job
+        return job
+
+    job = asyncio.run(drive())
+    assert job.status == "done"
+    assert len(sent) == 1
+    content, meta = sent[0]
+    assert "notified" in content and "done" in content
+    assert meta["job_id"] == job.id
+    assert meta["status"] == "done"
+
+
+def test_spawn_rejects_a_non_awaitable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+
+    async def drive() -> None:
+        with pytest.raises(TypeError, match="awaitable"):
+            runtime.jobs.spawn(42)  # type: ignore[arg-type]  -- the rejection under test
+
+    asyncio.run(drive())
+
+
+def test_spawn_outside_the_loop_fails_without_registering(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Misuse from a sync context must not leave a forever-"running" phantom job.
+    _wire(monkeypatch, {})
+    before = set(runtime.jobs)
+
+    coro = asyncio.sleep(0)
+    with pytest.raises(RuntimeError):
+        runtime.jobs.spawn(coro, name="no-loop")
+    coro.close()  # the coroutine was never scheduled; close it quietly
+    assert set(runtime.jobs) == before
+
+
+def test_spawned_job_shows_up_in_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+
+    async def work() -> str:
+        return "x"
+
+    async def drive() -> runtime.Job:
+        job = runtime.jobs.spawn(work(), name="hist-entry")
+        await job
+        return job
+
+    job = asyncio.run(drive())
+    listing = runtime.history(200).text
+    assert job.id in listing

--- a/packages/mcp/tests/test_jobs_spawn.py
+++ b/packages/mcp/tests/test_jobs_spawn.py
@@ -14,7 +14,7 @@ on ``await``, cancel works).
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+import sys
 
 import pytest
 
@@ -34,7 +34,7 @@ def test_spawn_registers_and_awaiting_yields_the_value(monkeypatch: pytest.Monke
         await asyncio.sleep(0)
         return "payload"
 
-    async def drive() -> tuple[runtime.Job, Any]:
+    async def drive() -> tuple[runtime.Job, runtime.Result | None]:
         job = runtime.jobs.spawn(work(), name="my-work")
         # First-class from the moment spawn returns: registered and running.
         assert runtime.jobs[job.id] is job
@@ -71,8 +71,11 @@ def test_spawn_name_defaults_to_the_coroutine_qualname(monkeypatch: pytest.Monke
 
 def test_spawned_stdout_is_captured_under_the_job(monkeypatch: pytest.MonkeyPatch) -> None:
     # Prints made while the awaitable runs must land in the job's buffer (the
-    # pageable `jobs['<id>'].output`), exactly like a cell's prints.
+    # pageable `jobs['<id>'].output`), exactly like a cell's prints. Capture
+    # rides the same _Tee + _ix_current plumbing install() wires up, so give the
+    # bare test process the tee (install() is not run here).
     _wire(monkeypatch, {})
+    monkeypatch.setattr(sys, "stdout", runtime._Tee(sys.stdout))
 
     async def chatty() -> None:
         print("spawned hello")
@@ -104,7 +107,7 @@ def test_awaiting_a_failed_spawn_reraises_the_original_exception(monkeypatch: py
     assert job.status == "error"
     assert "spawn boom" in (job.error or "")
 
-    async def await_it() -> Any:
+    async def await_it() -> object:
         return await runtime.jobs[job.id]
 
     with pytest.raises(ValueError, match="spawn boom"):
@@ -161,7 +164,7 @@ def test_completion_sends_the_backgrounded_job_notification(monkeypatch: pytest.
     _wire(monkeypatch, {})
     sent: list[tuple[str, dict]] = []
 
-    async def fake_notify(content: str, **meta: Any) -> None:
+    async def fake_notify(content: str, **meta: object) -> None:
         sent.append((content, meta))
 
     monkeypatch.setattr(runtime, "notify", fake_notify)
@@ -178,7 +181,8 @@ def test_completion_sends_the_backgrounded_job_notification(monkeypatch: pytest.
     assert job.status == "done"
     assert len(sent) == 1
     content, meta = sent[0]
-    assert "notified" in content and "done" in content
+    assert "notified" in content
+    assert "done" in content
     assert meta["job_id"] == job.id
     assert meta["status"] == "done"
 


### PR DESCRIPTION
`jobs.spawn(aw, name=..., topic=...)` registers any awaitable (coroutine, Task, Future) as a first-class kernel job, giving ad-hoc work the same lifecycle as a backgrounded `python_exec` cell:

- appears in `jobs` / `history()` with a dashboard card (store row, `kind="spawn"`, excluded from session replay)
- completion pushes the same channel notification a backgrounded cell sends
- value follows the existing Job contract: `await jobs['<id>']` yields it (wrapped like a trailing expression), `.result` raises `JobStillRunning` while running, a failure re-raises on await, prints route into the job's pageable output
- `job.cancel()` also forwards the cancellation into a pre-created Task, so cancelling the job stops the work

Implementation: `jobs` becomes a `Jobs(dict[str, Job])` subclass (dict surface unchanged) and `_spawn_runner` mirrors `_runner` minus the typecheck/compile stage. Catalog tagline updated in `registry.py`, one line in `guide.py`, tests in `tests/test_jobs_spawn.py` wired into the `typecheckSmoke` check (81 pass locally; repo lint clean).

Fixes #2164

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `jobs.spawn()` to register an ad-hoc awaitable as a first-class background job
> - Introduces a `Jobs` class in [runtime.py](https://github.com/indexable-inc/index/pull/2175/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) (subclassing `dict[str, Job]`) with a `spawn(aw, name=None, topic=None)` method that schedules any awaitable as a `kind='spawn'` job, immediately visible in the jobs registry.
> - Adds `_spawn_runner` coroutine that handles result capture (including stdout merging), status transitions (`done`/`cancelled`/`error`), exception storage, state persistence, and a completion notification.
> - Cancellation is forwarded to the inner `asyncio.Future`/`Task`; exceptions are re-raised when the caller awaits the job handle.
> - Updates JOBS help text in [guide.py](https://github.com/indexable-inc/index/pull/2175/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) and adds tests in [test_jobs_spawn.py](https://github.com/indexable-inc/index/pull/2175/files#diff-cfdf9fb8011e6354dfbad3aed4283976015a0ffaf3df64772ce48ebd0ea67ab1) covering the full lifecycle.
> - Behavioral Change: `jobs` is now a `Jobs` instance rather than a plain `dict`; existing dict-like access is preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ceba6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->