### PR TITLE
overseer: snapshot the newest symphony runs, not the oldest

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -109,8 +109,12 @@ codex_sessions="$(
 
 # Symphony runs from the local runtime. An unreachable API is itself a
 # finding, so the failure is recorded in the snapshot, never swallowed.
+# The API lists runs grouped by workflow, oldest-first; sort to keep the
+# NEWEST runs, or the window freezes in the past as the store grows and
+# the judge sees phantom cron outages (#2183).
 symphony_runs="$(curl -s --max-time 5 http://127.0.0.1:4040/api/v1/ir/runs |
-  jq '[.runs[] | {run_id, status, states, trigger, created_at, updated_at}] | .[0:12]' ||
+  jq '[.runs[] | {run_id, status, states, trigger, created_at, updated_at}]
+      | sort_by(.created_at) | reverse | .[0:12]' ||
   echo '{"error": "symphony runtime unreachable on 127.0.0.1:4040"}')"
 
 loadavg="$(sysctl -n vm.loadavg | tr -d '{}' | awk '{print $1}')"


### PR DESCRIPTION
Fixes #2183.

The overseer snapshot's `symphony_runs` used `.[0:12]` on `/api/v1/ir/runs`, which lists runs grouped by workflow, oldest-first. The snapshot therefore kept the **oldest** 12 runs and froze in the past as the run store grew: at 2026-07-07T05:12Z the judge saw nothing newer than the 03:40Z run, concluded the cron scheduler had been silent for 90 minutes, and dispatched a fixer agent for a phantom outage (runs actually existed for every 10-min boundary through 05:10Z).

Sort by `created_at` and keep the newest 12. Validated the jq against the live API: it now returns 05:20Z first.

Disjoint hunk from open #2181 (also touches overseer.sh); no overlap with its envelope-check changes.

(opened by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix overseer snapshot to select the 12 newest Symphony runs instead of oldest
> The [overseer.sh](https://github.com/indexable-inc/index/pull/2184/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) script was snapshotting the first 12 runs returned by the API, which defaulted to oldest-first order. The `jq` filter now sorts runs by `created_at`, reverses to newest-first, then selects the first 12.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1baf866.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->