### PR TITLE
nix-web-monitor: `serve` subcommand for a standalone machine-builds server

### DIFF
--- a/doc/nix-web-monitor/overview.md
+++ b/doc/nix-web-monitor/overview.md
@@ -35,7 +35,17 @@ nix-web-monitor [--host H] [--port N] [--exit-when-done]
                 [--terminal-output summary|logs|quiet] [--nix-verbose]
                 [--emit ndjson]
                 -- <nix args...>
+nix-web-monitor serve [--host H] [--port N]
 ```
+
+- `serve`: run the monitor as a standalone server with no wrapped Nix command,
+  until interrupted. The machine-wide panels (the nix-daemon syscall probe and
+  the machine-builds view fed by the patched-nix `nix store builds --json`
+  poller) are the content; the build tree shows a "no wrapped command"
+  placeholder instead of a fake command. This is the mode for a long-lived
+  login service (launchd/systemd) serving the machine build dashboard on
+  `:7532`. The per-command flags (`--exit-when-done`, `--terminal-output`,
+  `--nix-verbose`, `--emit`) do not apply.
 
 - `--emit ndjson` (`server/src/emit.rs`): run headless. Instead of serving the
   web UI, spawn the nix command, feed the parser, and stream a compact

--- a/packages/nix/nix-web-monitor/server/site/src/components/BuildTable.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/BuildTable.svelte
@@ -84,8 +84,13 @@
 
   /// Placeholder shown when no build rows exist. A finished run gets a terminal
   /// message (everything substituted, or stopped before building) instead of a
-  /// "waiting" one that wrongly implies work is still pending.
+  /// "waiting" one that wrongly implies work is still pending. An empty command
+  /// label means serve mode (`nwm serve`): nothing is wrapped, the machine
+  /// panels are the content, so no build phase is ever coming. (The pre-seed
+  /// snapshot is also command-less, so a connecting client briefly shows the
+  /// same message; the seed replaces it.)
   const emptyLabel = $derived.by((): string => {
+    if (command === '') return 'no wrapped command';
     if (finished) return exitCode === 0 ? 'nothing to build' : 'stopped before building';
     if (expectedBuilds > 0) {
       return `waiting for ${String(expectedBuilds)} build${expectedBuilds === 1 ? '' : 's'}`;

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -112,6 +112,14 @@ enum NwmCommand {
     /// mirroring `darwin-rebuild switch`. Activation runs under `sudo`.
     Os(SwitchSpec),
 
+    /// Serve the web UI and the machine-wide panels (the nix-daemon probe and
+    /// the machine-builds view) without wrapping any Nix command, until
+    /// interrupted. For running the monitor as a long-lived service
+    /// (launchd/systemd). The flags that shape a wrapped command
+    /// (`--exit-when-done`, `--terminal-output`, `--nix-verbose`, `--emit`)
+    /// do not apply.
+    Serve,
+
     /// Any other arguments are passed straight to `nix` (e.g. `build .#hello`,
     /// `run .#ix -- new`, or `flake update index --flake .`).
     #[command(external_subcommand)]
@@ -180,10 +188,11 @@ async fn main() -> Result<()> {
 
     // Headless emitter: no UI, no daemon probe -- spawn nix, stream the build
     // tree as NDJSON, exit with nix's status. Only the passthrough `nix …`
-    // subcommand has a headless form; a switch is a UI-only orchestration.
+    // subcommand has a headless form; a switch or a bare `serve` is a UI-only
+    // mode.
     if args.emit.is_some() {
         let NwmCommand::Nix(nix_args) = args.command else {
-            bail!("--emit supports only the passthrough `nix …` command, not a switch");
+            bail!("--emit supports only the passthrough `nix …` command");
         };
         let exit_code = emit::run(nix_args, args.nix_verbose).await?;
         std::process::exit(exit_code.unwrap_or(1));
@@ -194,47 +203,36 @@ async fn main() -> Result<()> {
         .context("--site-dir (or NIX_WEB_MONITOR_SITE_DIR) is required to serve the web UI")?;
     validate_site_dir(&site_dir)?;
 
+    // Serve mode: no wrapped command at all. The monitor state starts (and
+    // stays) empty -- its empty command label is what tells the UI to show the
+    // no-wrapped-command placeholder instead of a build tree -- while the
+    // machine-wide probes feed the daemon and machine-builds panels. There is
+    // no command whose exit could end the run, so it serves until interrupted.
+    if matches!(args.command, NwmCommand::Serve) {
+        let monitor = Arc::new(RwLock::new(MonitorState::default()));
+        let ui = start_ui(&args.host, args.port, site_dir, monitor).await?;
+        eprintln!("nix-web-monitor: serving the machine view (no wrapped command); Ctrl-C to stop");
+        tokio::signal::ctrl_c()
+            .await
+            .context("waiting for Ctrl-C")?;
+        ui.abort();
+        return Ok(());
+    }
+
     // Record startup before any build runs: the "what changed" reason baseline
     // uses it to exclude outputs registered during this run (see `reasons`).
     reasons::record_start_time();
 
-    let index_html =
-        Bytes::from(std::fs::read(site_dir.join("index.html")).context("reading index.html")?);
-
     let job = build_job(args.command).await.context("planning job")?;
     let monitor = Arc::new(RwLock::new(MonitorState::new(job.command_label.clone())));
-    let (deltas, _) = broadcast::channel::<Bytes>(DELTA_CHANNEL_CAPACITY);
-
-    let http_addr: SocketAddr = format!("{}:{}", args.host, args.port)
-        .parse()
-        .with_context(|| format!("invalid HTTP address {}:{}", args.host, args.port))?;
-
-    let state = AppState {
-        monitor: Arc::clone(&monitor),
-        deltas: deltas.clone(),
-        index_html,
-    };
-    let http_server = serve(http_addr, site_dir, state).await?;
-
-    eprintln!("nix-web-monitor: http://{http_addr}");
-
-    // Trace the nix-daemon's syscalls for the daemon panel. Independent of the
-    // build task: it keeps reporting (or explaining why it cannot) for the whole
-    // life of the UI. Best-effort, so its handle is just aborted at shutdown.
-    let daemon_probe = tokio::spawn(run_daemon_probe(Arc::clone(&monitor), deltas.clone()));
-
-    // Poll the machine-wide build view (all active builds on the host, and why),
-    // when the patched-nix `nix store builds --json` subcommand is present. Like
-    // the daemon probe, it lives for the whole UI and self-hides on stock nix; a
-    // best-effort overlay whose handle is just aborted at shutdown.
-    let global_probe = tokio::spawn(run_global_probe(Arc::clone(&monitor), deltas.clone()));
+    let ui = start_ui(&args.host, args.port, site_dir, monitor).await?;
 
     let build = tokio::spawn(run_job(
         job,
         args.terminal_output,
         args.nix_verbose,
-        monitor,
-        deltas,
+        Arc::clone(&ui.monitor),
+        ui.deltas.clone(),
     ));
 
     let exit_code = build.await.context("joining job task")??;
@@ -248,12 +246,72 @@ async fn main() -> Result<()> {
             .await
             .context("waiting for Ctrl-C")?;
     }
-    daemon_probe.abort();
-    global_probe.abort();
-    http_server.abort();
+    ui.abort();
     // Propagate Nix's exit status either way; otherwise the wrapper masks
     // build failures from shells and CI.
     std::process::exit(exit_code.unwrap_or(1));
+}
+
+/// The long-lived machinery behind the web UI, shared by every UI mode: the
+/// monitor state and delta broadcast the HTTP handlers read, plus the server
+/// and machine-probe tasks, all aborted together at shutdown.
+struct Ui {
+    monitor: Arc<RwLock<MonitorState>>,
+    deltas: broadcast::Sender<Bytes>,
+    http_server: tokio::task::JoinHandle<()>,
+    daemon_probe: tokio::task::JoinHandle<()>,
+    global_probe: tokio::task::JoinHandle<()>,
+}
+
+impl Ui {
+    /// Stop the server and both probes. They are best-effort background tasks
+    /// with no state to flush, so aborting is a clean shutdown.
+    fn abort(&self) {
+        self.daemon_probe.abort();
+        self.global_probe.abort();
+        self.http_server.abort();
+    }
+}
+
+/// Bind the web server on `host:port` and start the machine-wide probes: the
+/// UI, the `/api/state` snapshot, and the `/ws` delta feed on one port, plus
+/// the two best-effort overlays that live for the whole life of the UI --
+/// the nix-daemon syscall tracer for the daemon panel, and the machine-builds
+/// poller (`nix store builds --json`, patched nix only, self-hides on stock
+/// nix) for the machine panel.
+async fn start_ui(
+    host: &str,
+    port: u16,
+    site_dir: PathBuf,
+    monitor: Arc<RwLock<MonitorState>>,
+) -> Result<Ui> {
+    let index_html =
+        Bytes::from(std::fs::read(site_dir.join("index.html")).context("reading index.html")?);
+    let (deltas, _) = broadcast::channel::<Bytes>(DELTA_CHANNEL_CAPACITY);
+
+    let http_addr: SocketAddr = format!("{host}:{port}")
+        .parse()
+        .with_context(|| format!("invalid HTTP address {host}:{port}"))?;
+
+    let state = AppState {
+        monitor: Arc::clone(&monitor),
+        deltas: deltas.clone(),
+        index_html,
+    };
+    let http_server = serve(http_addr, site_dir, state).await?;
+
+    eprintln!("nix-web-monitor: http://{http_addr}");
+
+    let daemon_probe = tokio::spawn(run_daemon_probe(Arc::clone(&monitor), deltas.clone()));
+    let global_probe = tokio::spawn(run_global_probe(Arc::clone(&monitor), deltas.clone()));
+
+    Ok(Ui {
+        monitor,
+        deltas,
+        http_server,
+        daemon_probe,
+        global_probe,
+    })
 }
 
 async fn serve(
@@ -611,6 +669,9 @@ async fn build_job(command: NwmCommand) -> Result<Job> {
         }),
         NwmCommand::Home(spec) => build_switch_job(SwitchKind::Home, spec).await,
         NwmCommand::Os(spec) => build_switch_job(SwitchKind::Os, spec).await,
+        // `main` enters serve mode before job planning, so this arm is
+        // unreachable; serve wraps no command and has no job to plan.
+        NwmCommand::Serve => bail!("serve wraps no command, so it has no job to plan"),
     }
 }
 
@@ -1294,6 +1355,29 @@ mod tests {
             deltas,
             index_html: Bytes::from_static(b"<!doctype html><title>test</title>"),
         }
+    }
+
+    /// `serve` must parse as the dedicated no-command subcommand -- not fall
+    /// through to the external passthrough, which would exec a nonexistent
+    /// `nix serve` -- and the shared network flags must still apply to it.
+    #[test]
+    fn serve_parses_as_dedicated_subcommand() {
+        let args = Args::try_parse_from(["nwm", "serve", "--host", "127.0.0.1", "--port", "8080"])
+            .expect("serve parses");
+        assert!(matches!(args.command, NwmCommand::Serve));
+        assert_eq!(args.host, "127.0.0.1");
+        assert_eq!(args.port, 8080);
+    }
+
+    /// Adding the `serve` subcommand must not narrow the passthrough: any other
+    /// leading word still reaches `nix` verbatim.
+    #[test]
+    fn other_subcommands_still_pass_through_to_nix() {
+        let args = Args::try_parse_from(["nwm", "build", ".#hello"]).expect("passthrough parses");
+        let NwmCommand::Nix(nix_args) = args.command else {
+            panic!("expected the external passthrough");
+        };
+        assert_eq!(nix_args, ["build", ".#hello"]);
     }
 
     /// `/api/state` must be a wired route that serializes the live snapshot to


### PR DESCRIPTION
Closes #2182.

`nix-web-monitor serve [--host H] [--port N]` runs the monitor as a standalone server: web UI + daemon probe + global machine-builds probe (`nix store builds --json` polling), with **no wrapped nix command**. This replaces the workaround of wrapping a dummy command (`nix-web-monitor --terminal-output quiet nix eval --expr 1` in a tmux session), which left a stale one-off command panel and exited nonzero internally.

- **server**: new `Serve` subcommand variant; the server/probe setup shared by every UI mode is factored into `start_ui` (`Ui` struct owning the http server + probe handles). Serve mode constructs an empty `MonitorState` (empty command label) and runs until Ctrl-C, exiting 0.
- **UI**: `BuildTable` keys off the empty command label and shows a clean `no wrapped command` placeholder instead of a fake command / "waiting for build phase".
- **docs**: `doc/nix-web-monitor/overview.md` CLI surface documents `serve`.
- **tests**: clap parse tests pin that `serve` is the dedicated subcommand (not swallowed by the external `nix …` passthrough, which would exec a nonexistent `nix serve`) and that the passthrough is not narrowed.

Intended consumer: a launchd/systemd login service serving the machine build dashboard on :7532 (config repo follow-up).

Validation: `nix build .#nix-web-monitor` on aarch64-darwin (vc1 builder for the cross IFD), crate unit tests via passthru checks, Playwright e2e against a fake status dir (`NIX_STATE_DIR`) checking `/api/state` `global.detected=true` + the rendered empty state, `nix run .#lint`.

🤖 Written by Claude (nwm-serve-mode agent) on behalf of @andrewgazelka


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `serve` subcommand to nix-web-monitor for a standalone machine-builds server
> - Adds a `serve` subcommand to [main.rs](https://github.com/indexable-inc/index/pull/2185/files#diff-5f7a5a3bf017bab11020325a81b81855b5999b26a72220162e9d5873d7cd5d6d) that starts the HTTP UI and machine-wide build panels without wrapping a Nix command, running until Ctrl-C.
> - Introduces a `Ui` struct and `start_ui` helper to encapsulate server and probe startup, replacing inline setup across both `serve` and normal command modes.
> - Updates [BuildTable.svelte](https://github.com/indexable-inc/index/pull/2185/files#diff-c0f6c0efe878d902b8ed1bf17027827d03b4a1d777c0baf84612c412eb3b6064) to show `'no wrapped command'` when the command label is empty (i.e. in serve mode).
> - Documents the new subcommand in [overview.md](https://github.com/indexable-inc/index/pull/2185/files#diff-72971c55fe8e0aec179d5c7d856d064e88d6b2273b0a2eb1b2161eb72bfa341a), noting that per-command flags do not apply in `serve` mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e15280.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->