### PR TITLE
overseer: dispatch fixers from $HOME so they stop masquerading as pack agents

### DIFF
--- a/packages/agent/symphony/workflows/indexable/prompts/overseer.md
+++ b/packages/agent/symphony/workflows/indexable/prompts/overseer.md
@@ -51,3 +51,10 @@ tracer or helper whose ancestor is a live monitor or agent session
 (e.g. sudo fs_usage under nix-web-monitor) is owned, not orphaned.
 Every handle in an action (path, pid, command) must appear verbatim
 in the snapshot; notes are hypotheses, the snapshot is evidence.
+
+Some sessions in the snapshot are your own: fixers you dispatched on
+earlier ticks appear as claude sessions whose user brief begins
+"You are overseer-fix-". Judge their progress like any agent, but
+never re-diagnose their existence as a new problem. Likewise a
+session at age_min 0 with empty last text has just started; that is
+not evidence of a silent or stuck agent.

--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -197,8 +197,11 @@ while IFS=$'\t' read -r key title action; do
   agent_name="overseer-fix-$(printf '%s' "$key" | head -c 12)"
   # </dev/null: claude reads stdin, which inside this while-read loop is
   # the remaining TSV problem rows; without it the first dispatch swallows
-  # every later row (index#2157).
-  if out="$("$HOME/.local/bin/claude" --bg -p "You are $agent_name, dispatched by the overseer. Problem: $title. Suggested action: $action. Investigate, fix it properly (worktree + PR when it is a repo change), and report." </dev/null 2>&1)"; then
+  # every later row (index#2157). cd "$HOME": fixers inherit this script's
+  # cwd (the pack dir), so their sessions showed up in later snapshots as
+  # claude sessions inside workflows/indexable and the judge re-diagnosed
+  # its own just-spawned fixers as a silent workflow agent (index#2188).
+  if out="$(cd "$HOME" && "$HOME/.local/bin/claude" --bg -p "You are $agent_name, dispatched by the overseer. Problem: $title. Suggested action: $action. Investigate, fix it properly (worktree + PR when it is a repo change), and report." </dev/null 2>&1)"; then
     note="dispatched $agent_name"
   else
     note="dispatch failed: $(printf '%s' "$out" | head -c 120)"


### PR DESCRIPTION
Fixes #2188.

The overseer's dispatch loop spawned `claude --bg` fixers from the exec node's cwd (the pack dir), so every fixer session was recorded under `workflows/indexable` and the judge re-diagnosed its own just-spawned fixers (age_min 0, empty last text) as a silent "symphony workflow agent", dispatching another fixer: a self-referential loop. Observed 2026-07-06 22:32 PT (snapshot `20260706T222258.json`); the real workflows were healthy at the time.

- `scripts/overseer.sh`: `cd "$HOME"` inside the dispatch command substitution so fixer sessions carry a neutral cwd.
- `prompts/overseer.md`: tell the judge that sessions briefed "You are overseer-fix-" are its own fixers and that an age_min-0 session with empty last text has just started; neither is a finding.

Related: #2158, #2178.

Authored by an AI agent (Claude Code, Opus 4.5) dispatched as overseer-fix-symphony-ind.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dispatch overseer fixer sessions from $HOME and exclude them from re-diagnosis
> - Changes [overseer.sh](https://github.com/indexable-inc/index/pull/2189/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) to `cd "$HOME"` before launching fixer processes so they don't inherit the script's working directory.
> - Updates [overseer.md](https://github.com/indexable-inc/index/pull/2189/files#diff-a31238dc4da0ac6135c3a356d95617447fdd3dec34a3f7a3c6f51b07e0fa4fc0) to instruct the overseer judge not to re-diagnose sessions whose brief starts with `"You are overseer-fix-"` as new problems.
> - Sessions with `age_min 0` and empty last text are now treated as newly started, not as silent or stuck agents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 535fa33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->