### PR TITLE
mcp: route job lifecycle channel events to the session that started the job

### DIFF
--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -39,6 +39,7 @@ import socket
 import subprocess
 import sys
 import time
+import uuid
 import webbrowser
 from collections.abc import Callable
 from pathlib import Path
@@ -494,6 +495,13 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
     # dashboard_port. A pinned IX_MCP_HUB_PORT lets an embedder reach a known hub.
     hub_port = int(os.environ.get("IX_MCP_HUB_PORT") or _free_port())
 
+    # One id per serve process: the identity of this server's single MCP client
+    # as a session, used to address channel events (job lifecycle wakes) to the
+    # session that started the job. Minted fresh per process -- a session file
+    # reopened by a new server is a new session for delivery purposes (the
+    # startup outbox clear already dropped the old one's queue).
+    server_session_id = uuid.uuid4().hex[:8]
+
     cfg = Config(
         workdir=workdir,
         host=bind_host,
@@ -517,6 +525,7 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
         api_key=api_key,
         exec_token=_exec_token(),
         exec_trust_network=_exec_trust_network(),
+        server_session_id=server_session_id,
     )
     set_config(cfg)
 
@@ -524,6 +533,10 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
     # writes there) and the private IPYTHONDIR (so the runtime startup runs)
     # before the kernel starts.
     os.environ["IX_MCP_STORE"] = str(store_path)
+    # The kernel addresses job lifecycle channel events to the session that
+    # started the job; for its stdio client that address is this server's own
+    # session id (see Config.server_session_id and runtime._server_session).
+    os.environ["IX_MCP_SERVER_SESSION"] = server_session_id
     # Surface the dashboard URL to the kernel so `DASHBOARD_URL` is one lookup
     # away (the agent should not have to spelunk the runtime dir to find it). The
     # human-facing dashboard is the Loro hub when we auto-spawn one; otherwise

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -177,6 +177,15 @@ class Config:
     # rather than widened to a LAN or wildcard bind.
     mesh_host: str | None = None
 
+    # This server process's own MCP session id, minted per `ix-mcp serve` by the
+    # CLI (and exported to the kernel as IX_MCP_SERVER_SESSION). It identifies
+    # the one stdio client as a session for channel-event addressing: the
+    # transport pump delivers broadcast outbox rows plus rows addressed to this
+    # id, so a job lifecycle event reaches only the session that started the job
+    # (issue #2165). "" (an embedder without the CLI) disables addressing --
+    # every event is then a broadcast, the pre-#2165 behavior.
+    server_session_id: str = ""
+
     # "stdio" (the default; what an MCP client launches), "http", or "none"
     # (the standalone notebook engine: kernel + dashboard, no MCP transport).
     transport: str = "stdio"

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1716,6 +1716,24 @@ async def notify(content: str, **meta: Any) -> None:
     behavior), so never treat a notify as confirmed-read. Keys must be
     identifiers (``[A-Za-z0-9_]``); anything else raises here rather than being
     silently dropped client-side.
+
+    Explicit notify() is a broadcast: an armed watch (``pr_watch``, a slack/CI
+    watch loop) must reach its agent regardless of which session runs the
+    watcher. Automatic job lifecycle events do NOT go through here -- they are
+    addressed to the session that started the job (see
+    :func:`_notify_job_finished`), so one session's routine background jobs
+    cannot wake another session's agent (issue #2165).
+    """
+    _queue_channel_event(str(content), meta, session="")
+
+
+def _queue_channel_event(content: str, meta: dict[str, Any], *, session: str) -> None:
+    """Validate and queue one channel event on the store outbox.
+
+    ``session`` is the delivery address: '' broadcasts (every transport pump may
+    deliver it), a session id restricts the row to that MCP session's pump. The
+    shared write path behind :func:`notify` (broadcast) and
+    :func:`_notify_job_finished` (addressed).
     """
     bad = [key for key in meta if not _META_KEY_RE.fullmatch(key)]
     if bad:
@@ -1730,8 +1748,47 @@ async def notify(content: str, **meta: Any) -> None:
         )
     _store.add_outbox(
         _store_conn,
-        content=str(content),
+        content=content,
         meta=json.dumps({key: str(value) for key, value in meta.items()}),
+        session=session,
+    )
+
+
+def _server_session() -> str:
+    """This server process's own MCP session id, or '' when unmanaged.
+
+    ``IX_MCP_SERVER_SESSION`` is minted per ``ix-mcp serve`` process (see
+    ``cli._serve``) and inherited by the kernel: it identifies the one stdio
+    client as a session, so jobs it starts can be addressed back to it and only
+    it. An embedder driving the runtime without the CLI has no id; '' degrades
+    an addressed event to a broadcast, today's pre-#2165 behavior.
+    """
+    return os.environ.get("IX_MCP_SERVER_SESSION", "")
+
+
+def _notify_job_finished(job: Job) -> None:
+    """Queue the job's terminal lifecycle event, addressed to the session that
+    started it.
+
+    Only a backgrounded real cell notifies: a job that finished within its
+    budget already returned its summary in the tool reply, and a replay is
+    history, not news. The address is the job's own MCP session
+    (``job.session``, set for HTTP-transport sessions) falling back to this
+    server's session id (the stdio client), so the wake reaches the session
+    that started the job and no other -- the dashboard still shows every job
+    globally from the executions table (issue #2165).
+    """
+    if not job.backgrounded or job.kind == "replay":
+        return
+    _queue_channel_event(
+        f"Background job {job.name} finished with status {job.status}.",
+        {
+            "job_id": job.id,
+            "job_name": job.name,
+            "status": job.status,
+            "topic": job.topic,
+        },
+        session=job.session or _server_session(),
     )
 
 
@@ -2527,15 +2584,8 @@ async def _runner(job: Job, ns: dict) -> None:
         _ix_current.reset(token)
         _persist_final(job)
         _mark_snapshot_dirty()
-        if job.backgrounded and job.kind != "replay":
-            with contextlib.suppress(Exception):
-                await notify(
-                    f"Background job {job.name} finished with status {job.status}.",
-                    job_id=job.id,
-                    job_name=job.name,
-                    status=job.status,
-                    topic=job.topic,
-                )
+        with contextlib.suppress(Exception):  # best-effort wake; the job row is already persisted
+            _notify_job_finished(job)
 
 
 def _persist_final(job: Job) -> None:

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -125,11 +125,18 @@ CREATE INDEX IF NOT EXISTS inputs_channel ON inputs (channel, seq);
 -- kernel code can wake the connected agent session. Same transient-message
 -- discipline as `inputs`: the drain DELETEs what it delivers, so the table stays
 -- empty between events. `meta` is a JSON object of identifier-keyed strings (they
--- become attributes on the client's <channel> tag).
+-- become attributes on the client's <channel> tag). `session` addresses the row:
+-- '' is a broadcast every pump may deliver (explicit notify() -- pr_watch, user
+-- watch loops); a session id restricts delivery to the MCP session that started
+-- the work (job lifecycle events, issue #2165), so one session's routine job
+-- completions never wake another session's agent. Undeliverable addressed rows
+-- (their session is gone, or the transport has no pump) are pruned by age on
+-- write rather than lingering forever.
 CREATE TABLE IF NOT EXISTS outbox (
     seq         INTEGER PRIMARY KEY AUTOINCREMENT,
     content     TEXT NOT NULL,
     meta        TEXT NOT NULL DEFAULT '{}',
+    session     TEXT NOT NULL DEFAULT '',
     created_at  REAL NOT NULL
 );
 
@@ -200,6 +207,10 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if "execution_id" not in resource_have:
         with contextlib.suppress(sqlite3.OperationalError):
             conn.execute("ALTER TABLE resources ADD COLUMN execution_id TEXT NOT NULL DEFAULT ''")
+    outbox_have = {row[1] for row in conn.execute("PRAGMA table_info(outbox)")}
+    if "session" not in outbox_have:
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute("ALTER TABLE outbox ADD COLUMN session TEXT NOT NULL DEFAULT ''")
 
 
 def start(
@@ -547,22 +558,44 @@ def delete_inputs(conn: sqlite3.Connection, seqs: list[int]) -> None:
 _EVENT_MAX_AGE_SECONDS = 3600.0
 
 
-def add_outbox(conn: sqlite3.Connection, *, content: str, meta: str) -> None:
+# Outbox rows older than this are pruned on write. A drained transport never
+# lets a deliverable row age this far (the pump polls sub-second); the cap only
+# reaps rows addressed to a session nothing serves (an HTTP session -- that
+# transport has no channel pump -- or a session that disconnected), so an
+# addressed queue cannot grow the store without bound.
+_OUTBOX_MAX_AGE_SECONDS = 3600.0
+
+
+def add_outbox(conn: sqlite3.Connection, *, content: str, meta: str, session: str = "") -> None:
     """Queue one channel event (``meta`` is a JSON object of identifier-keyed
-    strings). The kernel is the sole inserter; the MCP transport drains."""
+    strings). ``session`` addresses delivery: '' broadcasts to every pump, a
+    session id restricts the row to that MCP session's pump (see
+    :func:`take_outbox`). The kernel is the sole inserter; the MCP transport
+    drains. Rows past the age cap are pruned on write (see
+    ``_OUTBOX_MAX_AGE_SECONDS``)."""
+    now = _now()
     conn.execute(
-        "INSERT INTO outbox (content, meta, created_at) VALUES (?, ?, ?)",
-        (content, meta, _now()),
+        "INSERT INTO outbox (content, meta, session, created_at) VALUES (?, ?, ?, ?)",
+        (content, meta, session, now),
+    )
+    conn.execute(
+        "DELETE FROM outbox WHERE created_at < ?", (now - _OUTBOX_MAX_AGE_SECONDS,)
     )
 
 
-def take_outbox(conn: sqlite3.Connection) -> list[dict]:
-    """Every queued channel event, oldest first, consuming the rows. Like
-    ``_drain_inputs``: DELETE before delivering, so an event can never be emitted
-    twice; a crash between the delete and the send loses at most one batch."""
+def take_outbox(conn: sqlite3.Connection, *, session: str = "") -> list[dict]:
+    """The queued channel events this ``session``'s pump may deliver -- broadcast
+    rows (``session = ''``) plus rows addressed to it -- oldest first, consuming
+    exactly the rows returned. Rows addressed to OTHER sessions are left queued
+    for their own pump (a job's lifecycle event reaches only the session that
+    started the job, issue #2165). Like ``_drain_inputs``: DELETE before
+    delivering, so an event can never be emitted twice; a crash between the
+    delete and the send loses at most one batch."""
     conn.row_factory = sqlite3.Row
     rows = conn.execute(
-        "SELECT seq, content, meta FROM outbox ORDER BY seq ASC"
+        "SELECT seq, content, meta, session FROM outbox "
+        "WHERE session = '' OR session = ? ORDER BY seq ASC",
+        (session,),
     ).fetchall()
     if not rows:
         return []

--- a/packages/mcp/ix_notebook_mcp/transport.py
+++ b/packages/mcp/ix_notebook_mcp/transport.py
@@ -134,7 +134,9 @@ async def pump_outbox(
     write_stream: ObjectSendStream[SessionMessage],
     session: ServerSession | None,
 ) -> None:
-    """Drain the store's outbox into ``notifications/claude/channel`` events.
+    """Drain this session's share of the store outbox into
+    ``notifications/claude/channel`` events (broadcast rows plus rows addressed
+    to ``config().server_session_id`` -- see ``store.take_outbox``).
 
     Custom notification methods are not in the SDK's typed ``ServerNotification``
     union, so the JSON-RPC message is built directly and sent on the transport's
@@ -157,7 +159,12 @@ async def pump_outbox(
                 await anyio.sleep(_OUTBOX_POLL_SECONDS)
                 continue
             try:
-                rows = store.take_outbox(conn)
+                # Serve only this session's mail: broadcast rows (explicit
+                # notify() -- pr_watch and friends) plus rows addressed to this
+                # server's own session id. A job lifecycle event addressed to
+                # another session stays queued for its own pump instead of
+                # waking this client (issue #2165).
+                rows = store.take_outbox(conn, session=cfg.server_session_id)
             except Exception:
                 rows = []  # best-effort: a read error this tick just retries next tick
             for row in rows:

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -35,6 +35,67 @@ def test_outbox_roundtrip_consumes_in_order(tmp_path: Path) -> None:
     assert store.take_outbox(conn) == []
 
 
+def test_take_outbox_routes_addressed_rows_to_their_session(tmp_path: Path) -> None:
+    """The routing decision (issue #2165): a session's pump receives broadcast
+    rows plus rows addressed to it, and never another session's rows -- those
+    stay queued for their own pump."""
+    conn = store.connect(tmp_path / "route.db")
+    store.add_outbox(conn, content="broadcast", meta="{}")
+    store.add_outbox(conn, content="mine", meta="{}", session="s1")
+    store.add_outbox(conn, content="theirs", meta="{}", session="s2")
+    rows = store.take_outbox(conn, session="s1")
+    assert [(r["content"], r["session"]) for r in rows] == [("broadcast", ""), ("mine", "s1")]
+    # s2's row was neither delivered nor consumed; its own pump still gets it.
+    assert store.take_outbox(conn, session="s1") == []
+    rows = store.take_outbox(conn, session="s2")
+    assert [r["content"] for r in rows] == ["theirs"]
+    assert store.take_outbox(conn, session="s2") == []
+
+
+def test_take_outbox_default_serves_broadcast_only(tmp_path: Path) -> None:
+    """A pump with no session id ('' -- an embedder without the CLI) delivers
+    broadcasts but never rows addressed to a real session."""
+    conn = store.connect(tmp_path / "solo.db")
+    store.add_outbox(conn, content="broadcast", meta="{}")
+    store.add_outbox(conn, content="addressed", meta="{}", session="s1")
+    assert [r["content"] for r in store.take_outbox(conn)] == ["broadcast"]
+    assert [r["content"] for r in store.take_outbox(conn, session="s1")] == ["addressed"]
+
+
+def test_add_outbox_prunes_rows_past_age_cap(tmp_path: Path) -> None:
+    """A row nothing serves (addressed to a gone session, or queued on a
+    transport with no pump) is reaped on a later write instead of growing the
+    store forever."""
+    conn = store.connect(tmp_path / "prune.db")
+    stale_at = store._now() - store._OUTBOX_MAX_AGE_SECONDS - 1.0
+    conn.execute(
+        "INSERT INTO outbox (content, meta, session, created_at) VALUES (?, ?, ?, ?)",
+        ("stale", "{}", "gone-session", stale_at),
+    )
+    store.add_outbox(conn, content="fresh", meta="{}")
+    remaining = [r[0] for r in conn.execute("SELECT content FROM outbox ORDER BY seq")]
+    assert remaining == ["fresh"]
+
+
+def test_migrate_adds_session_column_to_old_outbox(tmp_path: Path) -> None:
+    """A store written before the outbox carried delivery addressing gains the
+    column on open, defaulting every old row to broadcast."""
+    path = tmp_path / "old.db"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE outbox (seq INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "content TEXT NOT NULL, meta TEXT NOT NULL DEFAULT '{}', created_at REAL NOT NULL)"
+    )
+    conn.execute(
+        "INSERT INTO outbox (content, meta, created_at) VALUES ('old', '{}', 1.0)"
+    )
+    conn.commit()
+    conn.close()
+    migrated = store.connect(path)
+    rows = store.take_outbox(migrated, session="anything")
+    assert [(r["content"], r["session"]) for r in rows] == [("old", "")]
+
+
 def test_events_stream_after_seq_and_live_gate(tmp_path: Path) -> None:
     conn = store.connect(tmp_path / "c.db")
     assert store.latest_event_seq(conn, "res1") == 0
@@ -88,8 +149,78 @@ def test_notify_queues_event_with_stringified_meta(tmp_path: Path, monkeypatch: 
         assert rows[0]["content"] == "build failed"
         # Values are stringified: they become <channel> tag attributes.
         assert json.loads(rows[0]["meta"]) == {"severity": "high", "run_id": "1234"}
+        # An explicit notify() is a broadcast: an armed watch (pr_watch, a slack
+        # watch loop) must reach its agent whichever session runs the watcher.
+        assert rows[0]["session"] == ""
 
     asyncio.run(run())
+
+
+def _finished_job(*, session: str | None, backgrounded: bool = True, kind: str = "cell") -> runtime.Job:
+    job = runtime.Job("1 + 1", name="poll ci", kind=kind, topic="ci", session=session)
+    job.status = "done"
+    job.backgrounded = backgrounded
+    return job
+
+
+def test_job_finished_event_is_addressed_to_starting_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The routing decision at the source (issue #2165): a backgrounded job's
+    terminal wake is addressed to the MCP session that started the job -- its
+    own session id when it has one (HTTP transport), else this server's session
+    id (the stdio client) -- never broadcast to every session."""
+    conn = store.connect(tmp_path / "r.db")
+    _wire_runtime(monkeypatch, conn)
+    monkeypatch.setenv("IX_MCP_SERVER_SESSION", "srv1")
+
+    # A job started by an HTTP session carries that session id.
+    job = _finished_job(session="abc123")
+    runtime._notify_job_finished(job)
+    rows = store.take_outbox(conn, session="abc123")
+    assert [r["session"] for r in rows] == ["abc123"]
+    assert rows[0]["content"] == "Background job poll ci finished with status done."
+    assert json.loads(rows[0]["meta"]) == {
+        "job_id": job.id,
+        "job_name": "poll ci",
+        "status": "done",
+        "topic": "ci",
+    }
+
+    # A stdio-session job (no per-call session id) belongs to this server's own
+    # session, so its wake reaches this server's client and no other.
+    runtime._notify_job_finished(_finished_job(session=None))
+    rows = store.take_outbox(conn, session="srv1")
+    assert [r["session"] for r in rows] == ["srv1"]
+
+    # No other session's pump sees either event.
+    assert store.take_outbox(conn, session="other") == []
+
+
+def test_job_finished_event_broadcasts_without_server_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An embedder without the CLI has no server session id; the wake degrades
+    to a broadcast (the pre-#2165 behavior) rather than being lost."""
+    conn = store.connect(tmp_path / "r.db")
+    _wire_runtime(monkeypatch, conn)
+    monkeypatch.delenv("IX_MCP_SERVER_SESSION", raising=False)
+    runtime._notify_job_finished(_finished_job(session=None))
+    rows = store.take_outbox(conn)
+    assert [r["session"] for r in rows] == [""]
+
+
+def test_job_finished_event_skips_foreground_and_replay_jobs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A job that finished within its budget already returned its summary in the
+    tool reply, and a session-reopen replay is history: neither queues a wake."""
+    conn = store.connect(tmp_path / "r.db")
+    _wire_runtime(monkeypatch, conn)
+    monkeypatch.setenv("IX_MCP_SERVER_SESSION", "srv1")
+    runtime._notify_job_finished(_finished_job(session=None, backgrounded=False))
+    runtime._notify_job_finished(_finished_job(session=None, kind="replay"))
+    assert store.take_outbox(conn, session="srv1") == []
 
 
 def test_notify_rejects_non_identifier_meta_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -309,6 +440,40 @@ def test_pump_outbox_emits_channel_notifications(tmp_path: Path, monkeypatch: py
         assert wire.params == {"content": "hello agent", "meta": {"severity": "high"}}
         # The row was consumed: a redelivery cannot happen.
         assert store.take_outbox(conn) == []
+
+    asyncio.run(run())
+
+
+def test_pump_outbox_delivers_own_session_and_skips_others(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The delivery half of the routing decision (issue #2165): the pump emits
+    broadcast rows and rows addressed to its own server session; a row addressed
+    to another session is neither emitted nor consumed."""
+
+    async def run() -> None:
+        db = tmp_path / "p.db"
+        conn = store.connect(db)
+        cfg = Config(workdir=tmp_path, store_path=db, server_session_id="me")
+        monkeypatch.setattr("ix_notebook_mcp.transport.config", lambda: cfg)
+        store.add_outbox(conn, content="for everyone", meta="{}")
+        store.add_outbox(conn, content="for me", meta="{}", session="me")
+        store.add_outbox(conn, content="for someone else", meta="{}", session="other")
+        send, receive = anyio.create_memory_object_stream(8)
+        pump = asyncio.ensure_future(transport.pump_outbox(send, _FakeSession(initialized=True)))
+        try:
+            first = await asyncio.wait_for(receive.receive(), timeout=5.0)
+            second = await asyncio.wait_for(receive.receive(), timeout=5.0)
+            # Only the broadcast and this session's row arrive, in queue order.
+            assert first.message.root.params["content"] == "for everyone"
+            assert second.message.root.params["content"] == "for me"
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(receive.receive(), timeout=1.0)
+        finally:
+            pump.cancel()
+        # The other session's row is still queued for its own pump.
+        rows = store.take_outbox(conn, session="other")
+        assert [r["content"] for r in rows] == ["for someone else"]
 
     asyncio.run(run())
 


### PR DESCRIPTION
Fixes #2165

## Root cause

The store `outbox` (what `notify()` writes and the transport pump drains into `notifications/claude/channel` events) had **no session addressing**: every row was a broadcast, and the pump delivered all of them to its client, where Claude Code injects channel events into the parent conversation. The automatic "Background job X finished" wake fires for every backgrounded job, so a kernel shared by several sessions floods the parent with other sessions' routine job completions (~20 no-op model turns observed).

Job -> session attribution was half-missing: `Job.session` records the per-connection id for streamable-HTTP sessions, but it was never carried onto the outbox row, and the stdio client had no session identity at all.

## Change

- **`store.outbox` gains a `session` column** (idempotent two-process-safe migration): `''` = broadcast, else the id of the one MCP session the row is addressed to. Undeliverable addressed rows are pruned by age on write.
- **`take_outbox(conn, session=...)`** consumes only broadcast rows plus rows addressed to that session; other sessions' rows stay queued for their own pump. This is the routing decision.
- **Job lifecycle events are now addressed, not broadcast**: `_notify_job_finished(job)` tags the wake with the session that started the job (`job.session` for HTTP sessions, else this server's own session id). Explicit `notify()` (pr_watch, slack/CI watch loops, user code) stays a broadcast, as before.
- **Every `ix-mcp serve` process mints a server session id** (`Config.server_session_id`, exported to the kernel as `IX_MCP_SERVER_SESSION`), giving the stdio client a session identity. The pump serves exactly that id. An embedder without the CLI has no id and degrades to broadcast (pre-change behavior).
- Dashboard visibility is untouched: it reads `executions`, which records every job globally.

## Known limit (upstream)

When one Claude Code process multiplexes its parent conversation and in-process subagents onto a single stdio MCP connection, they are one MCP session on the wire: Claude Code sends only `claudecode/toolUseId` in tool-call `_meta` (no agent/session identity, see anthropics/claude-code#54629), so the server cannot split them further. This PR fixes the routing for everything the server can distinguish (per-connection sessions) and establishes the attribution + addressed-delivery plumbing that per-agent identity will slot into when the client exposes it.

## Tests

`packages/mcp/tests/test_channel.py`: store routing (addressed vs broadcast vs foreign rows, default-'' pump, age prune, old-store migration), the kernel-side addressing decision (`job.session`, server-session fallback, broadcast degradation, foreground/replay exclusion), and the transport pump (delivers own + broadcast, leaves other sessions' rows queued).

Validated locally: `nix run .#lint` clean; `.#mcp.tests.channelTests` passes except the pre-existing darwin-sandbox `test_sse_streams_new_events_only` socket-bind failure (fails identically on `main`); `runtimeSmoke`/`sessionIdentitySmoke`/`sessionSmoke` build.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route job lifecycle channel events to the MCP session that started the job
> - Adds a `server_session_id` field to [`Config`](https://github.com/indexable-inc/index/pull/2190/files#diff-33f6f17aed79724ba72211bc8bf9dc1da1bbdb38de56be7ace76cc09837929ca) and generates a unique id per `_serve` invocation, exposing it via the `IX_MCP_SERVER_SESSION` environment variable.
> - Extends the [`outbox` table](https://github.com/indexable-inc/index/pull/2190/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976) with a `session` column (default `''` = broadcast) and updates `add_outbox`/`take_outbox` to support per-session addressing; rows older than 1 hour are pruned on write.
> - Adds `_notify_job_finished` in [`runtime.py`](https://github.com/indexable-inc/index/pull/2190/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) to enqueue job completion events addressed to the HTTP session id (if present) or the server's MCP session id, rather than broadcasting to all sessions.
> - `pump_outbox` in [`transport.py`](https://github.com/indexable-inc/index/pull/2190/files#diff-39ae84714e8a966882f8856c976f1ebce9f5fd42dac02f22e89e4cbc672e1675) now drains only broadcast rows plus rows addressed to its own `server_session_id`.
> - Behavioral Change: foreground and replay jobs still emit no completion event; background job completion events are no longer broadcast and will only be delivered to the originating session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3165bcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->