### PR TITLE
mcp: export capability usage for the desktop-space graph vault

### DIFF
--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -103,6 +103,13 @@ def main(argv: list[str] | None = None) -> int:
     ev.add_argument("code")
     ex = sub.add_parser("exec", help="Run statements on a throwaway kernel")
     ex.add_argument("code")
+    tu = sub.add_parser(
+        "toolusage",
+        help="Export capability usage from store files as the ix desktop-space "
+        "vault's ToolUsage JSON (one AGENT=STORE.sqlite pair per session)",
+    )
+    tu.add_argument("stores", nargs="+", metavar="AGENT=STORE")
+    tu.add_argument("--out", type=Path, default=None, help="write here instead of stdout")
 
     args = parser.parse_args(argv)
     command = args.command or "serve"
@@ -116,6 +123,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if requirements.report(print) else 1
     if command in ("eval", "exec"):
         return _one_shot(args.code)
+    if command == "toolusage":
+        from . import toolusage
+
+        return toolusage.main_export(args.stores, args.out)
     parser.error(f"unknown command {command!r}")
     return 2
 

--- a/packages/mcp/ix_notebook_mcp/toolusage.py
+++ b/packages/mcp/ix_notebook_mcp/toolusage.py
@@ -1,0 +1,114 @@
+"""Export this store's tool usage for the ix desktop-space graph vault.
+
+The vault (``ix-desktop-space --tools <file>``) renders each capability an
+agent has used as a small crystal node linked to that agent, and wants one
+JSON document in its ``ToolUsage`` shape::
+
+    {"tools": [{"id", "label", "kind", "description"}],
+     "links": [{"agent", "tool", "calls", "last_at"}]}
+
+Everything needed already exists here: :mod:`.registry` is the catalog of
+capability modules (name + tagline), and the ``executions`` table records
+every ``python_exec`` run with the names its cell touched (``bindings``,
+introspected at finish; the cell source is the fallback for runs that never
+finished). This module only joins the two — one run that touched a module
+counts as one call to that capability — so the registry and the execution
+log stay the single sources of truth.
+
+Usage counts are per store file: one store == one MCP session == one agent.
+The exporter stamps that agent id on every link; the vault drops links whose
+agent is not in its federated graph, so an id must match the graph's
+``ix://<host>/<name>`` uri for the tools to appear.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from . import introspect, registry, store
+
+
+def export(conn: sqlite3.Connection, *, agent: str) -> dict:
+    """Fold this store's executions into the vault ``ToolUsage`` document.
+
+    A run "used" a capability module when the module's name appears among the
+    names its cell bound or referenced: the stored ``bindings`` when the run
+    finished, else a fresh parse of its source (:func:`introspect.binding_names`
+    returns empty sets for code that does not parse, so a broken cell simply
+    counts nothing). ``last_at`` is the run's end (or start) in unix millis,
+    matching the vault's timestamp unit.
+    """
+    modules = {m.name: m for m in registry.MODULES}
+    calls: dict[str, int] = {}
+    last: dict[str, int] = {}
+    for run in store.recent(conn, limit=100_000):
+        used = set((run.get("bindings") or {}).keys())
+        if not used:
+            assigned, loads = introspect.binding_names(run.get("code") or "")
+            used = assigned | loads
+        at = run.get("ended_at") or run.get("started_at")
+        for name in used & modules.keys():
+            calls[name] = calls.get(name, 0) + 1
+            if at:
+                last[name] = max(last.get(name, 0), int(at * 1000))
+    return {
+        "tools": [
+            {
+                "id": f"tool/mcp/{name}",
+                "label": name,
+                "kind": "mcp",
+                "description": modules[name].tagline,
+            }
+            for name in sorted(calls)
+        ],
+        "links": [
+            {
+                "agent": agent,
+                "tool": f"tool/mcp/{name}",
+                "calls": count,
+                "last_at": last.get(name),
+            }
+            for name, count in sorted(calls.items())
+        ],
+    }
+
+
+def export_stores(paths: list[tuple[str, Path]]) -> dict:
+    """Merge several ``(agent, store file)`` pairs into one document.
+
+    Tools dedupe on id (they all come from the same registry); links stay
+    per-agent so the vault can draw one spoke per calling agent.
+    """
+    tools: dict[str, dict] = {}
+    links: list[dict] = []
+    for agent, path in paths:
+        conn = sqlite3.connect(path)
+        try:
+            doc = export(conn, agent=agent)
+        finally:
+            conn.close()
+        for tool in doc["tools"]:
+            tools[tool["id"]] = tool
+        links.extend(doc["links"])
+    return {"tools": sorted(tools.values(), key=lambda t: t["id"]), "links": links}
+
+
+def main_export(specs: list[str], out: Path | None) -> int:
+    """CLI body for ``ix-mcp toolusage AGENT=STORE [...]``: write (or print)
+    the merged document. A malformed spec is a usage error, not a crash."""
+    pairs: list[tuple[str, Path]] = []
+    for spec in specs:
+        agent, sep, path = spec.partition("=")
+        if not sep or not agent or not path:
+            print(f"toolusage: bad spec {spec!r} (want AGENT=STORE.sqlite)")
+            return 2
+        pairs.append((agent, Path(path)))
+    doc = export_stores(pairs)
+    text = json.dumps(doc, indent=1)
+    if out is None:
+        print(text)
+    else:
+        out.write_text(text)
+    return 0

--- a/packages/mcp/tests/test_toolusage.py
+++ b/packages/mcp/tests/test_toolusage.py
@@ -1,0 +1,96 @@
+"""The vault export: executions × registry → ToolUsage JSON.
+
+Defends the join contract the ix desktop-space graph vault consumes: one run
+that touched a capability module counts as one call, unfinished runs fall
+back to parsing their source, non-module names never leak into the catalog,
+and timestamps come out in unix millis.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+
+from ix_notebook_mcp import store, toolusage
+
+
+def _mkstore(path: Path) -> sqlite3.Connection:
+    return store.connect(path)
+
+
+def _run(
+    conn: sqlite3.Connection,
+    id: str,
+    code: str,
+    *,
+    bindings: dict | None = None,
+    started_at: float = 100.0,
+    finish: bool = True,
+) -> None:
+    store.start(conn, id=id, name="run", code=code, started_at=started_at)
+    if finish:
+        store.finish(
+            conn,
+            id=id,
+            status="done",
+            ended_at=started_at + 1,
+            output="",
+            result=None,
+            error=None,
+            bindings=bindings,
+        )
+
+
+def test_export_counts_module_usage(tmp_path: Path) -> None:
+    conn = _mkstore(tmp_path / "s.sqlite")
+    # two finished runs used `fleet` (via recorded bindings), one used `search`.
+    _run(conn, "a", "fleet.deploy()", bindings={"fleet": {}}, started_at=100)
+    _run(conn, "b", "fleet.status()", bindings={"fleet": {}}, started_at=200)
+    # `df` is a plain variable, not a registry module (unlike `x`, which IS one).
+    _run(conn, "c", "df = search.web('q')", bindings={"search": {}, "df": {}}, started_at=300)
+    doc = toolusage.export(conn, agent="ix://h/ada")
+
+    by_tool = {l["tool"]: l for l in doc["links"]}
+    assert by_tool["tool/mcp/fleet"]["calls"] == 2
+    assert by_tool["tool/mcp/search"]["calls"] == 1
+    assert by_tool["tool/mcp/fleet"]["last_at"] == 201_000, "unix millis, latest run"
+    assert all(l["agent"] == "ix://h/ada" for l in doc["links"])
+    # catalog carries the registry tagline, and only for used modules.
+    tools = {t["id"]: t for t in doc["tools"]}
+    assert set(tools) == {"tool/mcp/fleet", "tool/mcp/search"}
+    assert tools["tool/mcp/fleet"]["description"], "tagline from the registry"
+    # `df` is not a registry module and must not leak into the catalog.
+    assert "tool/mcp/df" not in tools
+
+
+def test_unfinished_run_falls_back_to_source_parse(tmp_path: Path) -> None:
+    conn = _mkstore(tmp_path / "s.sqlite")
+    # still running: no bindings recorded yet, so the source parse attributes it.
+    _run(conn, "a", "import mesh\nmesh.peers()", started_at=50, finish=False)
+    doc = toolusage.export(conn, agent="ix://h/ada")
+    assert [l["tool"] for l in doc["links"]] == ["tool/mcp/mesh"]
+    assert doc["links"][0]["calls"] == 1
+
+
+def test_export_stores_merges_agents(tmp_path: Path) -> None:
+    a = tmp_path / "a.sqlite"
+    b = tmp_path / "b.sqlite"
+    _run(_mkstore(a), "r1", "fleet.x", bindings={"fleet": {}})
+    _run(_mkstore(b), "r2", "fleet.y", bindings={"fleet": {}})
+    doc = toolusage.export_stores([("ix://h/ada", a), ("ix://h/grace", b)])
+    assert len(doc["tools"]) == 1, "tools dedupe on id"
+    assert {(l["agent"], l["calls"]) for l in doc["links"]} == {
+        ("ix://h/ada", 1),
+        ("ix://h/grace", 1),
+    }
+
+
+def test_cli_writes_file(tmp_path: Path) -> None:
+    s = tmp_path / "s.sqlite"
+    _run(_mkstore(s), "r", "view.ls('.')", bindings={"view": {}})
+    out = tmp_path / "tools.json"
+    rc = toolusage.main_export([f"ix://h/ada={s}"], out)
+    assert rc == 0
+    doc = json.loads(out.read_text())
+    assert doc["links"][0]["tool"] == "tool/mcp/view"
+    # a malformed spec is a usage error, not a crash.
+    assert toolusage.main_export(["nonsense"], None) == 2


### PR DESCRIPTION
Adds `ix-mcp toolusage AGENT=STORE.sqlite [...] [--out file]`: exports the vault's `ToolUsage` JSON (tool catalog from `registry.MODULES` taglines + per-agent call aggregates from the `executions` table) for `ix-desktop-space --tools`. One run that touched a capability module = one call; unfinished runs attribute from a parse of their source. Companion to indexable-inc/ix#6610.

Tested: `packages/mcp/tests/test_toolusage.py` (counts, source-parse fallback, multi-store merge, CLI) — 4/4 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export MCP capability usage from desktop-space graph vault stores
> - Adds a `toolusage` subcommand to the `ix-mcp` CLI, accepting one or more `AGENT=STORE` specs and an optional `--out` path, implemented in [cli.py](https://github.com/indexable-inc/index/pull/2210/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5)
> - Adds [toolusage.py](https://github.com/indexable-inc/index/pull/2210/files#diff-bc77e4bcf23570ecd858efcaca3b622366db9b0627e0cd81e5c6551e45a67582) with `export`, `export_stores`, and `main_export` functions that aggregate per-agent capability call counts and timestamps from SQLite stores into a ToolUsage JSON document
> - Usage is counted by inspecting `bindings` on recent executions (up to 100,000), falling back to source-code introspection for runs without recorded bindings
> - Multiple stores are merged with deduplicated tools by id and per-agent links preserved
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f1686b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->