### PR TITLE
fix(beamvm): post-merge review hardening of reload semantics

### DIFF
--- a/packages/beamvm/harness.ex
+++ b/packages/beamvm/harness.ex
@@ -17,14 +17,26 @@
 #   * `beamvm-ctl reload` (poked by home-manager activation after the symlink
 #     moves) makes the running VM re-read the manifest and converge.
 #
-# Reload semantics per app, in dependency-safe order:
-#   removed  -> Application.stop/unload, drop its code paths
-#   changed  -> swap code paths, then `:code.modified_modules/0` +
-#               `:code.atomic_load/1` (soft-purged, all-or-nothing); a module
-#               with lingering old-code processes fails the atomic pass and
-#               falls back to per-module purge+load, which kills only the
-#               stuck processes (their supervisors restart them on new code)
-#   added    -> add code paths, apply release runtime config, ensure_all_started
+# Reload semantics per app:
+#   removed  -> stop the tenant's own started set (reverse order, minus apps
+#               other tenants still require), unload, purge its modules, drop
+#               its code paths
+#   changed  -> swap code paths; delete modules the new release dropped; then
+#               `:code.modified_modules/0` + `:code.atomic_load/1`
+#               (soft-purged, all-or-nothing) with a per-module brutal
+#               fallback for processes stuck on old code; stale config keys
+#               the new release no longer sets are deleted; a change to the
+#               .app dependency set or to the application callback module
+#               (the supervision-tree definition) triggers a loud
+#               tenant-level restart, because neither the cached app spec nor
+#               a running supervisor picks those up from a module swap
+#   added    -> add code paths, replay the release config providers
+#               (sys.config deep-merged with runtime.exs), ensure_all_started
+#
+# Each app converges independently: one tenant failing to start does not
+# abort the others, and the tracked state always reflects what actually
+# happened (the reply carries per-app errors, so activation still fails
+# loudly).
 #
 # Toolchain libraries bundled inside a release (elixir, stdlib, logger, ...)
 # are skipped when the VM already has that application loaded: the harness and
@@ -43,7 +55,8 @@ defmodule BeamVM.Harness do
     File.rm(socket_path)
 
     log("starting: manifest=#{manifest_path} socket=#{socket_path}")
-    state = apply_manifest(%{}, read_manifest!(manifest_path))
+    {state, errors} = apply_manifest(%{}, read_manifest!(manifest_path))
+    Enum.each(errors, fn {app, msg} -> log("BOOT ERROR: #{app}: #{msg}") end)
 
     {:ok, listener} =
       :gen_tcp.listen(0, [
@@ -53,7 +66,7 @@ defmodule BeamVM.Harness do
         ifaddr: {:local, String.to_charlist(socket_path)}
       ])
 
-    log("ready: #{map_size(state)} app(s)")
+    log("ready: #{map_size(state)} app(s), #{length(errors)} boot error(s)")
     serve(listener, %{state: state, manifest_path: manifest_path})
   end
 
@@ -96,14 +109,27 @@ defmodule BeamVM.Harness do
 
   defp handle_command("reload", ctx) do
     manifest = read_manifest!(ctx.manifest_path)
-    state = apply_manifest(ctx.state, manifest)
+    {state, errors} = apply_manifest(ctx.state, manifest)
 
-    changed = Map.keys(manifest) -- Map.keys(ctx.state)
-    log("reload complete: #{map_size(state)} app(s), #{length(changed)} added")
-    {%{ok: true, os_pid: System.pid(), apps: Map.keys(state)}, %{ctx | state: state}}
+    reply =
+      if errors == [] do
+        log("reload complete: #{map_size(state)} app(s)")
+        %{ok: true, os_pid: System.pid(), apps: Map.keys(state)}
+      else
+        Enum.each(errors, fn {app, msg} -> log("RELOAD ERROR: #{app}: #{msg}") end)
+
+        %{
+          ok: false,
+          os_pid: System.pid(),
+          errors: Map.new(errors, fn {app, msg} -> {app, msg} end)
+        }
+      end
+
+    {reply, %{ctx | state: state}}
   rescue
+    # Manifest unreadable/unparseable: nothing was touched, state unchanged.
     err ->
-      log("reload FAILED: #{Exception.message(err)}")
+      log("reload FAILED before converging: #{Exception.message(err)}")
       {%{ok: false, error: Exception.message(err)}, ctx}
   end
 
@@ -134,6 +160,299 @@ defmodule BeamVM.Harness do
   end
 
   defp expand_globs(globs), do: Enum.flat_map(globs, &Path.wildcard/1)
+
+  # Each app converges in isolation: a raise (start failure, unreadable
+  # config) records an error and keeps that tenant's previous entry, so the
+  # tracked state matches what actually happened and the other tenants still
+  # converge. Converging is idempotent, so the next reload retries the
+  # failed tenant from wherever it stopped.
+  defp apply_manifest(state, manifest) do
+    removed = Map.keys(state) -- Map.keys(manifest)
+
+    Enum.each(removed, fn app ->
+      remove_app(app, state[app], required_by_others(state, manifest, app))
+    end)
+
+    Enum.reduce(manifest, {%{}, []}, fn {app, spec}, {acc, errors} ->
+      keep = required_by_others(state, manifest, app)
+
+      try do
+        {Map.put(acc, app, converge_app(app, Map.get(state, app), spec, keep)), errors}
+      rescue
+        err ->
+          entry = Map.get(state, app)
+          acc = if entry, do: Map.put(acc, app, entry), else: acc
+          {acc, errors ++ [{app, Exception.message(err)}]}
+      end
+    end)
+  end
+
+  # Applications some OTHER tenant still needs: their top-level apps plus the
+  # dependencies their .app files declare (one level deep -- transitive dep
+  # sharing across tenants beyond that falls under the documented shared-VM
+  # caveat). stop_started skips these so removing or restarting one tenant
+  # cannot stop a dependency a surviving tenant is using.
+  defp required_by_others(state, manifest, excluding_app) do
+    manifest
+    |> Map.keys()
+    |> Enum.reject(&(&1 == excluding_app))
+    |> Enum.flat_map(fn other ->
+      deps =
+        case Map.get(state, other) do
+          %{paths: paths} -> read_app_spec(other, paths)[:applications] || []
+          _ -> []
+        end
+
+      [other | deps]
+    end)
+    |> MapSet.new()
+  end
+
+  defp remove_app(app, entry, keep) do
+    log("removing #{app}")
+    # The tenant's whole started set (dependencies ensure_all_started
+    # brought up), in reverse order, minus what other tenants require.
+    stop_started(entry.started, keep)
+    Application.unload(app)
+    # Its modules must not stay callable from stale references after the
+    # release is gone; a cold VM would not have them either.
+    delete_modules(loaded_modules_in(entry.paths), "#{app} removed")
+    Enum.each(entry.paths, &:code.del_path(String.to_charlist(&1)))
+  end
+
+  defp converge_app(app, previous, spec, keep) do
+    previous_paths = if previous, do: previous.paths, else: []
+    previous_started = if previous, do: previous.started, else: []
+    previous_config = if previous, do: previous.config, else: []
+    new_paths = expand_code_paths(spec.code_path_globs, previous_paths)
+
+    if new_paths == previous_paths do
+      # Same expanded dirs: the store paths did not change, nothing to swap.
+      started = converge_started(app, spec, previous_started, keep)
+      %{paths: new_paths, start: spec.start, started: started, config: previous_config}
+    else
+      old_mods = loaded_modules_in(previous_paths)
+      Enum.each(previous_paths -- new_paths, &:code.del_path(String.to_charlist(&1)))
+      Enum.each(new_paths -- previous_paths, &:code.add_pathz(String.to_charlist(&1)))
+
+      if previous do
+        # Modules the new release no longer ships: without this they stay
+        # loaded and callable forever, which a cold boot would not have.
+        delete_modules(old_mods -- modules_in(new_paths), "dropped by #{app}'s new release")
+        swapped = hot_swap_modules(app)
+        converge_swapped_spec(app, new_paths, previous_started, swapped, keep)
+      else
+        log("loading #{app} (#{length(new_paths)} code paths)")
+      end
+
+      config = apply_release_config(app, spec, previous_config)
+      started = converge_started(app, spec, previous_started, keep)
+      %{paths: new_paths, start: spec.start, started: started, config: config}
+    end
+  end
+
+  # Converge the running state to the declared one, both directions: `start`
+  # flipped off stops the tenant's own started set (a disabled app must not
+  # keep serving until a VM restart), and `start` on re-runs
+  # ensure_all_started even for an already-running app, which starts any
+  # runtime dependency the swapped release added while being a no-op
+  # otherwise.
+  defp converge_started(app, %{start: true}, previous_started, _keep) do
+    newly = start_app(app)
+    Enum.uniq(previous_started ++ newly)
+  end
+
+  defp converge_started(app, %{start: false}, previous_started, keep) do
+    if started?(app) do
+      log("stopping #{app}: manifest no longer starts it")
+      stop_started(previous_started, keep)
+    end
+
+    []
+  end
+
+  # A hot swap replaces MODULES; two things it cannot replace force a loud
+  # tenant-level restart (stop, unload, fresh start):
+  #
+  #   * the .app dependency set -- the application controller caches the spec
+  #     it loaded at first start, so an added runtime dep would never start;
+  #   * the application callback module (`mod` in .app) -- it defines the
+  #     supervision tree in `start/2`, which only runs at app start, so a new
+  #     supervised child would otherwise stay inactive until a VM restart.
+  #
+  # Module-only updates never take this path.
+  defp converge_swapped_spec(app, new_paths, previous_started, swapped_mods, keep) do
+    props = read_app_spec(app, new_paths)
+    loaded_deps = Application.spec(app, :applications) || []
+    declared = props[:applications]
+
+    callback_mod =
+      case props[:mod] do
+        {mod, _args} -> mod
+        _ -> nil
+      end
+
+    restart_reason =
+      cond do
+        declared != nil and Enum.sort(declared) != Enum.sort(loaded_deps) ->
+          ".app dependency set changed (#{inspect(declared -- loaded_deps)} added, " <>
+            "#{inspect(loaded_deps -- declared)} removed)"
+
+        callback_mod != nil and callback_mod in swapped_mods ->
+          "application callback #{inspect(callback_mod)} (the supervision tree) changed"
+
+        true ->
+          nil
+      end
+
+    if restart_reason do
+      log("#{app}: #{restart_reason}; restarting the tenant")
+      stop_started(previous_started, keep)
+      Application.unload(app)
+    end
+
+    :ok
+  end
+
+  # The tenant's own .app resource from its code paths; empty when absent.
+  defp read_app_spec(app, paths) do
+    with dir when is_binary(dir) <- Enum.find(paths, &(ebin_app_name(&1) == app)),
+         {:ok, [{:application, ^app, props}]} <-
+           :file.consult(String.to_charlist(Path.join(dir, "#{app}.app"))) do
+      props
+    else
+      _ -> []
+    end
+  end
+
+  # Reverse start order, so dependents stop before their dependencies. Only
+  # the apps THIS tenant's ensure_all_started actually started, minus what
+  # other tenants require (a shared dependency the first tenant happened to
+  # start must outlive that tenant while anyone else declares it).
+  defp stop_started(started, keep) do
+    Enum.each(Enum.reverse(started), fn dep ->
+      if MapSet.member?(keep, dep) do
+        log("keeping #{dep}: another tenant requires it")
+      else
+        log("stopping #{dep}")
+        Application.stop(dep)
+      end
+    end)
+  end
+
+  # Replay the release boot's config pipeline: sys.config (the baked
+  # build-time config from config.exs + prod.exs -- `server: true` for a
+  # Phoenix endpoint lives here) DEEP-MERGED with runtime.exs, exactly as
+  # the release's config provider would. Deep merge, not two sequential
+  # put_all_env passes: runtime.exs typically sets a subset of an app key's
+  # keyword list (only `http:` under the endpoint, say), and a plain
+  # overwrite of that key silently drops the baked siblings -- observed as
+  # symphony booting with `server: true` lost and no HTTP listener.
+  # Multi-app config (`config :other_app, ...`) applies globally, which is
+  # release semantics too.
+  #
+  # Keys the previous release set but the new one does not are deleted, so a
+  # hot reload converges to the same env a cold boot of the new release
+  # would have (a stale feature flag must not survive the swap). Returns the
+  # merged config for the tenant's state entry.
+  defp apply_release_config(app, spec, previous_config) do
+    base = read_sys_config(app, spec.sys_config)
+    runtime = read_runtime_config(app, spec.runtime_config)
+    merged = Config.Reader.merge(base, runtime)
+
+    delete_stale_config(previous_config, merged)
+    if merged != [], do: Application.put_all_env(merged, persistent: true)
+    merged
+  end
+
+  defp delete_stale_config(previous_config, merged) do
+    Enum.each(previous_config, fn {config_app, old_kvs} ->
+      new_keys = Keyword.keys(Keyword.get(merged, config_app, []))
+
+      for {key, _} <- old_kvs, key not in new_keys do
+        log("deleting stale config #{config_app}.#{key}")
+        Application.delete_env(config_app, key, persistent: true)
+      end
+    end)
+  end
+
+  # sys.config is one Erlang term: a list of {App, [{Key, Val}]} pairs.
+  defp read_sys_config(_app, []), do: []
+
+  defp read_sys_config(app, [path | _] = all) do
+    if length(all) > 1, do: log("#{app}: multiple sys.configs matched; using #{path}")
+    log("#{app}: applying sys.config #{path}")
+    {:ok, [config]} = :file.consult(String.to_charlist(path))
+    config
+  end
+
+  defp read_runtime_config(_app, []), do: []
+
+  defp read_runtime_config(app, [path | _] = all) do
+    if length(all) > 1, do: log("#{app}: multiple runtime configs matched; using #{path}")
+    log("#{app}: applying runtime config #{path}")
+    Config.Reader.read!(path, env: :prod)
+  end
+
+  # `:code.modified_modules/0` lists exactly the loaded modules whose beam on
+  # the (just swapped) code path differs from what is running; atomic_load is
+  # all-or-nothing and refuses while any of them still has old code, which the
+  # soft-purge pass clears for every module no process is stuck on. Returns
+  # the swapped modules so the caller can detect a supervision-tree change.
+  defp hot_swap_modules(app) do
+    case :code.modified_modules() do
+      [] ->
+        log("#{app}: no modified modules")
+        []
+
+      mods ->
+        Enum.each(mods, &:code.soft_purge/1)
+
+        case :code.atomic_load(mods) do
+          :ok ->
+            log("#{app}: hot-swapped #{length(mods)} module(s): #{inspect(mods)}")
+
+          {:error, reasons} ->
+            # Some process is still executing old code (a purge would kill
+            # it). Swap module-by-module with brutal purge: only the stuck
+            # processes die, and their supervisors restart them on new code.
+            log("#{app}: atomic load failed (#{inspect(reasons)}); per-module brutal swap")
+
+            Enum.each(mods, fn mod ->
+              :code.purge(mod)
+              :code.load_file(mod)
+            end)
+        end
+
+        mods
+    end
+  end
+
+  # Module atoms named by the .beam files under `paths`.
+  defp modules_in(paths) do
+    for dir <- paths,
+        file <- Path.wildcard(Path.join(dir, "*.beam")) do
+      file |> Path.basename(".beam") |> String.to_atom()
+    end
+  end
+
+  defp loaded_modules_in(paths) do
+    Enum.filter(modules_in(paths), &(:code.is_loaded(&1) != false))
+  end
+
+  # `:code.delete/1` retires the current version (new calls fail to resolve),
+  # then the purge drops the old code; a process still running it is killed,
+  # which matches the module no longer existing in the release.
+  defp delete_modules([], _why), do: :ok
+
+  defp delete_modules(mods, why) do
+    log("deleting #{length(mods)} module(s) (#{why}): #{inspect(mods)}")
+
+    Enum.each(mods, fn mod ->
+      :code.delete(mod)
+      unless :code.soft_purge(mod), do: :code.purge(mod)
+    end)
+  end
 
   # Expanded against the tenant's PREVIOUS path set: a library this tenant
   # itself brought last time is being replaced, not double-claimed, so it must
@@ -189,8 +508,11 @@ defmodule BeamVM.Harness do
 
   defp on_code_path?(app) do
     case :code.lib_dir(app) do
-      {:error, _} -> false
-      lib_dir -> Enum.member?(:code.get_path(), String.to_charlist(Path.join(to_string(lib_dir), "ebin")))
+      {:error, _} ->
+        false
+
+      lib_dir ->
+        Enum.member?(:code.get_path(), String.to_charlist(Path.join(to_string(lib_dir), "ebin")))
     end
   end
 
@@ -210,183 +532,6 @@ defmodule BeamVM.Harness do
         expanded = Path.expand(to_string(lib_dir))
         Enum.any?(previous_paths, fn p -> Path.expand(Path.dirname(p)) == expanded end)
     end
-  end
-
-  defp apply_manifest(state, manifest) do
-    removed = Map.keys(state) -- Map.keys(manifest)
-    Enum.each(removed, fn app -> remove_app(app, state[app]) end)
-
-    Enum.reduce(manifest, %{}, fn {app, spec}, acc ->
-      Map.put(acc, app, converge_app(app, Map.get(state, app), spec))
-    end)
-  end
-
-  defp remove_app(app, entry) do
-    log("removing #{app}")
-    # The tenant's whole started set (dependencies ensure_all_started
-    # brought up), in reverse order; a dependency another tenant later
-    # started itself is not in this list and stays up.
-    stop_started(entry.started)
-    Application.unload(app)
-    Enum.each(entry.paths, &:code.del_path(String.to_charlist(&1)))
-  end
-
-  defp converge_app(app, previous, spec) do
-    previous_paths = if previous, do: previous.paths, else: []
-    previous_started = if previous, do: previous.started, else: []
-    new_paths = expand_code_paths(spec.code_path_globs, previous_paths)
-
-    started =
-      if new_paths == previous_paths do
-        # Same expanded dirs: the store paths did not change, nothing to swap.
-        converge_started(app, spec, previous_started)
-      else
-        Enum.each(previous_paths -- new_paths, &:code.del_path(String.to_charlist(&1)))
-        Enum.each(new_paths -- previous_paths, &:code.add_pathz(String.to_charlist(&1)))
-
-        if previous do
-          hot_swap_modules(app)
-          converge_swapped_spec(app, new_paths, previous_started)
-        else
-          log("loading #{app} (#{length(new_paths)} code paths)")
-        end
-
-        apply_release_config(app, spec)
-        converge_started(app, spec, previous_started)
-      end
-
-    %{paths: new_paths, start: spec.start, started: started}
-  end
-
-  # Converge the running state to the declared one, both directions: `start`
-  # flipped off stops the tenant's own started set (a disabled app must not
-  # keep serving until a VM restart), and `start` on re-runs
-  # ensure_all_started even for an already-running app, which starts any
-  # runtime dependency the swapped release added while being a no-op
-  # otherwise.
-  defp converge_started(app, %{start: true}, previous_started) do
-    newly = start_app(app)
-    Enum.uniq(previous_started ++ newly)
-  end
-
-  defp converge_started(app, %{start: false}, previous_started) do
-    if started?(app) do
-      log("stopping #{app}: manifest no longer starts it")
-      stop_started(previous_started)
-    end
-
-    []
-  end
-
-  # A hot swap replaces MODULES, but the application controller keeps the
-  # .app spec it loaded at first start: a new release that adds a runtime
-  # dependency to its .app would never see it started. Detect the spec
-  # change and do a loud tenant-level restart (stop, unload, fresh start
-  # picks up the new spec) -- correctness over zero-downtime for the rare
-  # dep-set change; module-only updates never take this path.
-  defp converge_swapped_spec(app, new_paths, previous_started) do
-    loaded_deps = Application.spec(app, :applications) || []
-    declared = declared_deps(app, new_paths)
-
-    if declared != nil and Enum.sort(declared) != Enum.sort(loaded_deps) do
-      log(
-        "#{app}: .app dependency set changed (#{inspect(declared -- loaded_deps)} added, " <>
-          "#{inspect(loaded_deps -- declared)} removed); restarting the tenant to reload its spec"
-      )
-
-      stop_started(previous_started)
-      Application.unload(app)
-    end
-
-    :ok
-  end
-
-  defp declared_deps(app, paths) do
-    with dir when is_binary(dir) <- Enum.find(paths, &(ebin_app_name(&1) == app)),
-         {:ok, [{:application, ^app, props}]} <-
-           :file.consult(String.to_charlist(Path.join(dir, "#{app}.app"))) do
-      Keyword.get(props, :applications, [])
-    else
-      _ -> nil
-    end
-  end
-
-  # Reverse start order, so dependents stop before their dependencies. Only
-  # the apps THIS tenant's ensure_all_started actually started: apps another
-  # tenant (or the harness) already ran are not in the list and stay up.
-  defp stop_started(started) do
-    Enum.each(Enum.reverse(started), fn dep ->
-      log("stopping #{dep}")
-      Application.stop(dep)
-    end)
-  end
-
-  # Replay the release boot's config pipeline: sys.config (the baked
-  # build-time config from config.exs + prod.exs -- `server: true` for a
-  # Phoenix endpoint lives here) DEEP-MERGED with runtime.exs, exactly as
-  # the release's config provider would. Deep merge, not two sequential
-  # put_all_env passes: runtime.exs typically sets a subset of an app key's
-  # keyword list (only `http:` under the endpoint, say), and a plain
-  # overwrite of that key silently drops the baked siblings -- observed as
-  # symphony booting with `server: true` lost and no HTTP listener.
-  # Multi-app config (`config :other_app, ...`) applies globally, which is
-  # release semantics too.
-  defp apply_release_config(app, spec) do
-    base = read_sys_config(app, spec.sys_config)
-    runtime = read_runtime_config(app, spec.runtime_config)
-
-    case Config.Reader.merge(base, runtime) do
-      [] -> :ok
-      merged -> Application.put_all_env(merged, persistent: true)
-    end
-  end
-
-  # sys.config is one Erlang term: a list of {App, [{Key, Val}]} pairs.
-  defp read_sys_config(_app, []), do: []
-
-  defp read_sys_config(app, [path | _] = all) do
-    if length(all) > 1, do: log("#{app}: multiple sys.configs matched; using #{path}")
-    log("#{app}: applying sys.config #{path}")
-    {:ok, [config]} = :file.consult(String.to_charlist(path))
-    config
-  end
-
-  # `:code.modified_modules/0` lists exactly the loaded modules whose beam on
-  # the (just swapped) code path differs from what is running; atomic_load is
-  # all-or-nothing and refuses while any of them still has old code, which the
-  # soft-purge pass clears for every module no process is stuck on.
-  defp hot_swap_modules(app) do
-    case :code.modified_modules() do
-      [] ->
-        log("#{app}: no modified modules")
-
-      mods ->
-        Enum.each(mods, &:code.soft_purge/1)
-
-        case :code.atomic_load(mods) do
-          :ok ->
-            log("#{app}: hot-swapped #{length(mods)} module(s): #{inspect(mods)}")
-
-          {:error, reasons} ->
-            # Some process is still executing old code (a purge would kill
-            # it). Swap module-by-module with brutal purge: only the stuck
-            # processes die, and their supervisors restart them on new code.
-            log("#{app}: atomic load failed (#{inspect(reasons)}); per-module brutal swap")
-
-            Enum.each(mods, fn mod ->
-              :code.purge(mod)
-              :code.load_file(mod)
-            end)
-        end
-    end
-  end
-
-  defp read_runtime_config(_app, []), do: []
-
-  defp read_runtime_config(app, [path | _] = all) do
-    if length(all) > 1, do: log("#{app}: multiple runtime configs matched; using #{path}")
-    log("#{app}: applying runtime config #{path}")
-    Config.Reader.read!(path, env: :prod)
   end
 
   # :temporary, not :permanent: a tenant crashing past its own supervision

--- a/packages/beamvm/home-module.nix
+++ b/packages/beamvm/home-module.nix
@@ -236,6 +236,14 @@ in {
           lib.nameValuePair "beamvm-${name}" {
             description = "beamvm ${name}: persistent BEAM VM";
             command = [(lib.getExe (launcherFor name vm))];
+            # A defined, writable cwd instead of wherever the init system
+            # spawns us: BEAM apps commonly derive file defaults from cwd
+            # (symphony's disk log handler writes cwd-relative
+            # `log/symphony.log` when no explicit :log_file env is set), and
+            # $HOME must not silently collect those. Created by the
+            # activation hook below; a missing WorkingDirectory fails the
+            # spawn on both init systems.
+            workingDirectory = stateDirFor name vm;
             inherit (vm) environment;
             # The VM hosts long-running supervision trees; the unit's whole
             # job is keeping it up from login onward.
@@ -261,7 +269,19 @@ in {
       cfg.vms;
 
     home.activation =
+      # State dirs first: the unit's WorkingDirectory must exist before the
+      # platform service step (re)starts anything, and the harness only
+      # creates it AFTER spawn, which is too late for the cwd.
       lib.mapAttrs' (
+        name: vm:
+          lib.nameValuePair "beamvmStateDir-${name}" (
+            lib.hm.dag.entryBetween ["reloadSystemd" "setupLaunchAgents"] ["writeBoundary"] ''
+              run mkdir -p ${lib.escapeShellArg (stateDirFor name vm)}
+            ''
+          )
+      )
+      cfg.vms
+      // lib.mapAttrs' (
         name: vm:
           lib.nameValuePair "beamvmReload-${name}" (
             # Plain statements, no name-derived shell identifiers: the VM


### PR DESCRIPTION
Addresses the six #2002 review threads that landed after merge (each replied-to and resolved pointing here):

- **Per-app error isolation**: `apply_manifest` converges every tenant even when one raises; the failed tenant keeps its previous entry so tracked state matches reality; the reload reply carries per-app errors and activation still fails loudly. A manifest parse failure touches nothing.
- **Shared-dependency guard**: stopping a tenant (removal, `start=false`, spec restart) skips apps other tenants require (their top-level apps + one level of declared .app deps).
- **Stale config keys**: the merged release config is tracked per tenant; keys the new release no longer sets are `delete_env`'d, so hot reload converges to a cold boot's env.
- **Deleted modules**: modules the new release dropped (or a removed tenant owned) are `:code.delete`'d + purged instead of staying callable.
- **Supervision-tree changes**: a swap touching the application callback module (`mod` in .app) triggers the loud tenant restart — `start/2` only runs at app start, so a new supervised child would otherwise stay inactive.
- **Working directory**: the VM runs with `WorkingDirectory = stateDir` (activation hook creates it before the service step); symphony's disk-log handler writes cwd-relative `log/symphony.log`, which now lands in the state dir instead of `$HOME`.

## Validation

- `beamvm.tests.hot-reload` passes on the hardened harness (swap + same-pid + boot-error accounting).
- Live: symphony release rebuilt from current main (includes #2014/#2019/#2031) boots in the harness, dashboard HTTP 200, idempotent `beamvm-ctl reload` ok.
- Repo lint clean.

Refs #2002

_Made with Claude Opus 4.8._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden BeamVM reload semantics with per-app fault isolation and shared-dependency awareness
> - `apply_manifest` in [harness.ex](https://github.com/indexable-inc/index/pull/2213/files#diff-32a161d97e0e0d9d6a4fb55fa4ea9684d6a433b4c35a3c17fced234bde0a743f) now converges each app in isolation, returning `{state, errors}` so one app's failure no longer aborts others; previous state is retained for failed apps.
> - The `reload` command returns `%{ok: false, errors: %{app => message}}` when any app fails, and `%{ok: true, apps: [...]}` only when all apps converge cleanly.
> - `remove_app` and `stop_started` now accept a `keep` set of apps required by other tenants, skipping shared dependencies during stop/unload.
> - `converge_app` deletes modules dropped by the new release, detects `.app` spec or callback module changes after hot swap (triggering a tenant-level restart), and removes stale config keys via `apply_release_config`.
> - Each beamvm unit in [home-module.nix](https://github.com/indexable-inc/index/pull/2213/files#diff-87a70526d701e0f03dd22ef53d040ba367ce8c5fc39339c43d8b0a7083807400) now starts in a defined working directory, created during activation.
> - Behavioral Change: startup no longer aborts on per-app boot errors; the `ready` log now includes an error count, and reload responses have a new shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b8a1f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->