### PR TITLE
claude: clamp repo sessions to the 300K context window

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "env": {
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "300000",
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1"
+  },
   "extraKnownMarketplaces": {
     "mixedbread-skills": {
       "source": {


### PR DESCRIPTION
Project-level mirror of the wrapper guard (#2167): CLAUDE_CODE_DISABLE_1M_CONTEXT=1 + CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000 in .claude/settings.json env, so stock-CLI sessions in this repo stay on the ~300K working window too. Same pair as ix#6608.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clamp Claude repo sessions to the 300K context window
> Sets `CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000` and `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` in [.claude/settings.json](https://github.com/indexable-inc/index/pull/2214/files#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546) to cap context usage at 300K tokens. Behavioral Change: sessions will auto-compact at 300K tokens rather than expanding to the full 1M context window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01338f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->