### PR TITLE
codex: refresh cargoHash for the d61ad78a codex-src bump

### DIFF
--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -180,7 +180,7 @@
     # its own name (`codex-patched`), so derive the sourceRoot from the src's
     # name rather than hardcoding `source/`.
     sourceRoot = "${codexSrc.name}/codex-rs";
-    cargoHash = "sha256-mLpfLi5Wu/t/D8il/5xkDqCTHIeaJZ2OYMZmMIsg7E0=";
+    cargoHash = "sha256-LAOk6eeSjPOcVBuPIvPjK44WZZniAJmBCJSwHPBbrrw=";
     # buildRustPackage carries cargoDeps through overrideAttrs, so retarget the
     # nested fixed-output staging derivation when swapping the upstream source.
     cargoDeps = previousAttrs.cargoDeps.overrideAttrs (_: previousCargoAttrs: {


### PR DESCRIPTION
Closes #2205.

The flake-input bot commit 847c9ac2 bumped `codex-src` `be33f80b` → `d61ad78a` and rebased the patch series, but left `cargoHash` stale. The vendor staging FOD then substitutes the old vendor tree under the declared hash and every uncached codex build fails deterministically at the Cargo.lock consistency check (`codex-network-proxy` missing from the vendor lock). Hit on hydra via `home-manager switch` against `cache-ready`; CI stayed green because codex is not in the checks blast radius for a lock bump.

One line: refresh `cargoHash` to the vendor hash for `d61ad78a` (computed via fake-hash build on aarch64-darwin; the FOD is platform-independent).

Branch is based on `cache-ready` (31770c6e) so downstream flakes can pin it directly while the queue merges it into main.

Validation: `nix build .#codex` on aarch64-darwin proceeds past vendor validation with the new hash (full build running).

🤖 Written by Claude (nwm-serve-mode agent) on behalf of @andrewgazelka


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh `cargoHash` in codex Nix build after source bump
> Updates the `cargoHash` in [default.nix](https://github.com/indexable-inc/index/pull/2215/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5) to match the cargo dependency tree introduced by the recent `codex-src` bump. Builds using the previous hash will fail vendor tree verification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ae3980.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->