### PR TITLE
unibind phase 8 async: JVM CompletableFuture/Flow (wip) (#2083)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12180,6 +12180,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "unibind-conformance-jvm"
+version = "0.1.0"
+dependencies = [
+ "unibind",
+]
+
+[[package]]
 name = "unibind-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12139,7 +12139,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+ "unibind-backend-jvm",
  "unibind-backend-py",
+ "unibind-core",
+]
+
+[[package]]
+name = "unibind-backend-jvm"
+version = "0.1.0"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.118",
  "unibind-core",
 ]
 
@@ -12185,6 +12198,7 @@ dependencies = [
  "clap",
  "object",
  "serde_json",
+ "unibind-backend-jvm",
  "unibind-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ members = [
   "packages/tui/tui",
   "packages/tui/tui-node",
   "packages/tui/tui-py",
+  "packages/unibind/backend-jvm",
   "packages/unibind/backend-py",
   "packages/unibind/conformance",
   "packages/unibind/core",
@@ -348,6 +349,7 @@ tree-sitter-typescript = "0.23"
 tree-sitter-yaml = "0.7"
 tui = { path = "packages/tui/tui" }
 unibind = { path = "packages/unibind/macros" }
+unibind-backend-jvm = { path = "packages/unibind/backend-jvm" }
 unibind-backend-py = { path = "packages/unibind/backend-py" }
 unibind-core = { path = "packages/unibind/core" }
 unibind-runtime = { path = "packages/unibind/runtime" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ members = [
   "packages/unibind/backend-jvm",
   "packages/unibind/backend-py",
   "packages/unibind/conformance",
+  "packages/unibind/conformance/jvm",
   "packages/unibind/core",
   "packages/unibind/gen",
   "packages/unibind/macros",

--- a/packages/code/scipql/py/src/lib.rs
+++ b/packages/code/scipql/py/src/lib.rs
@@ -9,7 +9,7 @@
 //! `pyo3` glue (function wrappers, record classes, the exception hierarchy,
 //! and the module registration) from these declarations.
 
-#[unibind::export]
+#[unibind::export(backends(py))]
 mod _scipql {
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};

--- a/packages/unibind/backend-jvm/Cargo.toml
+++ b/packages/unibind/backend-jvm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "unibind-backend-jvm"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Render the unibind IR into JVM binding code: extern-C glue over repr(C) mirrors, Java 22 Panama/FFM sources, and Kotlin sugar"
+
+[lints]
+workspace = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+unibind-core.workspace = true
+
+[dev-dependencies]
+prettyplease.workspace = true
+serde_json.workspace = true

--- a/packages/unibind/backend-jvm/package.nix
+++ b/packages/unibind/backend-jvm/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "unibind-backend-jvm";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/unibind/backend-jvm/src/ctype.rs
+++ b/packages/unibind/backend-jvm/src/ctype.rs
@@ -31,6 +31,9 @@ pub enum CTy {
     Path,
     /// Raw bytes (`CBytes`, the `CString` shape).
     Bytes,
+    /// An opaque pointer-sized handle (a stream or an object) crossing by
+    /// value; the Rust mirror is `*mut ::core::ffi::c_void`.
+    Handle,
     /// `COption<T>`: a `u8` presence flag with the value inline, zeroed
     /// when absent.
     Option(Box<Self>),
@@ -48,8 +51,11 @@ pub enum CTy {
 }
 
 impl CTy {
-    /// The mirror of one IR type. Ownership never changes the mirror:
-    /// borrowed and owned strings cross identically.
+    /// The mirror of one plain-data IR type. Ownership never changes the
+    /// mirror: borrowed and owned strings cross identically. Streams and
+    /// object-typed returns never reach this mapping: arg/ret sites route
+    /// through [`crate::model::Model::boundary`], which maps them to
+    /// [`CTy::Handle`], and validation rejects them everywhere else.
     #[must_use]
     pub fn of(ty: &ir::Type) -> Self {
         match ty {
@@ -66,16 +72,17 @@ impl CTy {
                 value: Box::new(Self::of(value)),
             },
             ir::Type::Named(name) => Self::Record(name.clone()),
-            // Streams never reach the mirror model: `Model::new` rejects
-            // them first (the JVM async surface is issue #2083).
-            ir::Type::Stream(_) => unreachable!("streams are rejected by Model::new"),
+            // Streams cross as opaque handles via `Model::boundary`;
+            // validation rejects them in every non-return position, so the
+            // plain mirror mapping never sees one.
+            ir::Type::Stream(_) => unreachable!("streams only cross through Model::boundary"),
         }
     }
 
     /// Whether the mirror passes by value at the C boundary.
     #[must_use]
     pub const fn is_scalar(&self) -> bool {
-        matches!(self, Self::Bool | Self::Int(_) | Self::Float(_))
+        matches!(self, Self::Bool | Self::Int(_) | Self::Float(_) | Self::Handle)
     }
 
     /// A name unique per mirror, naming generated Java helpers and keying
@@ -90,6 +97,7 @@ impl CTy {
             Self::Str => "Str".to_owned(),
             Self::Path => "Path".to_owned(),
             Self::Bytes => "Bytes".to_owned(),
+            Self::Handle => "Handle".to_owned(),
             Self::Option(inner) => format!("Opt{}", inner.mangle()),
             Self::Vec(inner) => format!("List{}", inner.mangle()),
             Self::Map { key, value } => {

--- a/packages/unibind/backend-jvm/src/ctype.rs
+++ b/packages/unibind/backend-jvm/src/ctype.rs
@@ -66,6 +66,9 @@ impl CTy {
                 value: Box::new(Self::of(value)),
             },
             ir::Type::Named(name) => Self::Record(name.clone()),
+            // Streams never reach the mirror model: `Model::new` rejects
+            // them first (the JVM async surface is issue #2083).
+            ir::Type::Stream(_) => unreachable!("streams are rejected by Model::new"),
         }
     }
 

--- a/packages/unibind/backend-jvm/src/ctype.rs
+++ b/packages/unibind/backend-jvm/src/ctype.rs
@@ -1,0 +1,174 @@
+//! The C mirror model: mirror shapes and their `#[repr(C)]` layout math.
+//!
+//! [`CTy`] names the mirror of every boundary type; the layout helpers here
+//! (used through [`crate::model::Model`]) are the single source of truth
+//! both the Rust glue generator and the Java generator consume, so the two
+//! sides of the boundary always agree on sizes and field offsets. The Rust
+//! glue additionally emits `const` assertions comparing these numbers
+//! against `core::mem::{size_of, align_of, offset_of}`, so any divergence
+//! is a compile error rather than a runtime corruption.
+//!
+//! Layouts follow `#[repr(C)]` natural alignment on 64-bit targets:
+//! pointers and `usize` are 8 bytes wide and no mirror exceeds alignment 8.
+
+use unibind_core::ir;
+
+/// Pointer + length pairs (`CString`, `CVec`) on a 64-bit target.
+pub(crate) const PTR_PAIR: Layout = Layout { size: 16, align: 8 };
+
+/// The C-level mirror of one boundary type.
+#[derive(Debug, Clone)]
+pub enum CTy {
+    /// `bool` crossing as `u8` (0 or 1).
+    Bool,
+    /// A same-width integer.
+    Int(ir::IntKind),
+    /// A same-width float.
+    Float(ir::FloatKind),
+    /// UTF-8 text as `CString { ptr, len }`.
+    Str,
+    /// A filesystem path as UTF-8 text (`CPath`, the `CString` shape).
+    Path,
+    /// Raw bytes (`CBytes`, the `CString` shape).
+    Bytes,
+    /// `COption<T>`: a `u8` presence flag with the value inline, zeroed
+    /// when absent.
+    Option(Box<Self>),
+    /// `CVec<T>`: a boxed slice as pointer + length.
+    Vec(Box<Self>),
+    /// A map as `CVec<CPair<K, V>>`.
+    Map {
+        /// Key mirror.
+        key: Box<Self>,
+        /// Value mirror.
+        value: Box<Self>,
+    },
+    /// A record's generated `#[repr(C)]` mirror struct (`<Name>C`).
+    Record(String),
+}
+
+impl CTy {
+    /// The mirror of one IR type. Ownership never changes the mirror:
+    /// borrowed and owned strings cross identically.
+    #[must_use]
+    pub fn of(ty: &ir::Type) -> Self {
+        match ty {
+            ir::Type::Bool => Self::Bool,
+            ir::Type::Int(kind) => Self::Int(*kind),
+            ir::Type::Float(kind) => Self::Float(*kind),
+            ir::Type::String { .. } => Self::Str,
+            ir::Type::Path { .. } => Self::Path,
+            ir::Type::Bytes { .. } => Self::Bytes,
+            ir::Type::Option(inner) => Self::Option(Box::new(Self::of(inner))),
+            ir::Type::Vec(inner) => Self::Vec(Box::new(Self::of(inner))),
+            ir::Type::Map { key, value } => Self::Map {
+                key: Box::new(Self::of(key)),
+                value: Box::new(Self::of(value)),
+            },
+            ir::Type::Named(name) => Self::Record(name.clone()),
+        }
+    }
+
+    /// Whether the mirror passes by value at the C boundary.
+    #[must_use]
+    pub const fn is_scalar(&self) -> bool {
+        matches!(self, Self::Bool | Self::Int(_) | Self::Float(_))
+    }
+
+    /// A name unique per mirror, naming generated Java helpers and keying
+    /// deduplicated layout assertions.
+    #[must_use]
+    pub fn mangle(&self) -> String {
+        match self {
+            Self::Bool => "Bool".to_owned(),
+            Self::Int(kind) => int_mangle(*kind).to_owned(),
+            Self::Float(ir::FloatKind::F32) => "F32".to_owned(),
+            Self::Float(ir::FloatKind::F64) => "F64".to_owned(),
+            Self::Str => "Str".to_owned(),
+            Self::Path => "Path".to_owned(),
+            Self::Bytes => "Bytes".to_owned(),
+            Self::Option(inner) => format!("Opt{}", inner.mangle()),
+            Self::Vec(inner) => format!("List{}", inner.mangle()),
+            Self::Map { key, value } => {
+                format!("Map{}{}", key.mangle(), value.mangle())
+            }
+            Self::Record(name) => name.clone(),
+        }
+    }
+}
+
+const fn int_mangle(kind: ir::IntKind) -> &'static str {
+    match kind {
+        ir::IntKind::I8 => "I8",
+        ir::IntKind::I16 => "I16",
+        ir::IntKind::I32 => "I32",
+        ir::IntKind::I64 => "I64",
+        ir::IntKind::Isize => "Isize",
+        ir::IntKind::U8 => "U8",
+        ir::IntKind::U16 => "U16",
+        ir::IntKind::U32 => "U32",
+        ir::IntKind::U64 => "U64",
+        ir::IntKind::Usize => "Usize",
+    }
+}
+
+/// Size and alignment of one mirror.
+#[derive(Debug, Clone, Copy)]
+pub struct Layout {
+    /// Bytes, rounded up to the alignment.
+    pub size: u64,
+    /// Bytes; at most 8.
+    pub align: u64,
+}
+
+/// A struct layout: the whole struct plus per-field offsets.
+#[derive(Debug, Clone)]
+pub struct StructLayout {
+    /// Size and alignment of the struct itself.
+    pub layout: Layout,
+    /// Field offsets in declaration order.
+    pub offsets: Vec<u64>,
+}
+
+/// Layout of one function's return envelope.
+#[derive(Debug, Clone)]
+pub struct EnvelopeLayout {
+    /// Size and alignment of the envelope struct.
+    pub layout: Layout,
+    /// Offset of the `err_msg` text (the `code` field is always at 0).
+    pub err_msg_offset: u64,
+    /// Offset of the success payload; `None` for unit-returning functions.
+    pub value_offset: Option<u64>,
+}
+
+/// `#[repr(C)]` placement: each field starts at the next multiple of its
+/// alignment, the struct alignment is the maximum field alignment, and the
+/// size rounds up to that alignment.
+pub(crate) fn struct_layout(fields: &[Layout]) -> StructLayout {
+    let mut cursor = 0_u64;
+    let mut align = 1_u64;
+    let mut offsets = Vec::with_capacity(fields.len());
+    for field in fields {
+        let start = cursor.next_multiple_of(field.align);
+        offsets.push(start);
+        cursor = start + field.size;
+        align = align.max(field.align);
+    }
+    StructLayout {
+        layout: Layout {
+            size: cursor.next_multiple_of(align),
+            align,
+        },
+        offsets,
+    }
+}
+
+pub(crate) const fn int_layout(kind: ir::IntKind) -> Layout {
+    let size = match kind {
+        ir::IntKind::I8 | ir::IntKind::U8 => 1,
+        ir::IntKind::I16 | ir::IntKind::U16 => 2,
+        ir::IntKind::I32 | ir::IntKind::U32 => 4,
+        ir::IntKind::I64 | ir::IntKind::U64 | ir::IntKind::Isize | ir::IntKind::Usize => 8,
+    };
+    Layout { size, align: size }
+}

--- a/packages/unibind/backend-jvm/src/java/decode.rs
+++ b/packages/unibind/backend-jvm/src/java/decode.rs
@@ -1,0 +1,206 @@
+//! The private decode helpers of the module class: one per aggregate
+//! mirror reachable from return values.
+//!
+//! Every offset baked here comes from [`crate::model::Model`], the same
+//! numbers the Rust glue asserts at compile time.
+
+use std::collections::BTreeMap;
+
+use crate::ctype::CTy;
+use crate::java::{line, types};
+use crate::model::Model;
+
+/// Render every needed decode helper, ordered by mangled name.
+pub fn helpers(model: &Model<'_>, set: &BTreeMap<String, CTy>) -> String {
+    let mut out = String::new();
+    for ty in set.values() {
+        let text = helper(model, ty);
+        if !text.is_empty() {
+            out.push('\n');
+            out.push_str(&text);
+        }
+    }
+    out
+}
+
+/// The Java expression reading one mirror at `offset` inside `seg`.
+pub fn read_expr(ty: &CTy, seg: &str, offset: &str) -> String {
+    if ty.is_scalar() {
+        types::scalar_get(ty, seg, offset)
+    } else {
+        format!("decode{}({seg}, {offset})", ty.mangle())
+    }
+}
+
+fn helper(model: &Model<'_>, ty: &CTy) -> String {
+    match ty {
+        CTy::Str => str_helper(),
+        CTy::Path => path_helper(),
+        CTy::Bytes => bytes_helper(),
+        CTy::Option(inner) => option_helper(model, ty, inner),
+        CTy::Vec(inner) => list_helper(model, ty, inner),
+        CTy::Map { key, value } => map_helper(model, ty, key, value),
+        CTy::Record(name) => record_helper(model, name),
+        CTy::Bool | CTy::Int(_) | CTy::Float(_) => String::new(),
+    }
+}
+
+fn str_helper() -> String {
+    let mut out = String::new();
+    line(&mut out, 1, "private static String decodeStr(MemorySegment seg, long offset) {");
+    line(&mut out, 2, "long len = seg.get(ValueLayout.JAVA_LONG, offset + 8);");
+    line(&mut out, 2, "if (len == 0) {");
+    line(&mut out, 3, "return \"\";");
+    line(&mut out, 2, "}");
+    line(
+        &mut out,
+        2,
+        "byte[] bytes = seg.get(ValueLayout.ADDRESS, offset).reinterpret(len).toArray(ValueLayout.JAVA_BYTE);",
+    );
+    line(&mut out, 2, "return new String(bytes, StandardCharsets.UTF_8);");
+    line(&mut out, 1, "}");
+    out
+}
+
+fn bytes_helper() -> String {
+    let mut out = String::new();
+    line(&mut out, 1, "private static byte[] decodeBytes(MemorySegment seg, long offset) {");
+    line(&mut out, 2, "long len = seg.get(ValueLayout.JAVA_LONG, offset + 8);");
+    line(&mut out, 2, "if (len == 0) {");
+    line(&mut out, 3, "return new byte[0];");
+    line(&mut out, 2, "}");
+    line(
+        &mut out,
+        2,
+        "return seg.get(ValueLayout.ADDRESS, offset).reinterpret(len).toArray(ValueLayout.JAVA_BYTE);",
+    );
+    line(&mut out, 1, "}");
+    out
+}
+
+fn path_helper() -> String {
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        "private static java.nio.file.Path decodePath(MemorySegment seg, long offset) {",
+    );
+    line(&mut out, 2, "return java.nio.file.Path.of(decodeStr(seg, offset));");
+    line(&mut out, 1, "}");
+    out
+}
+
+fn option_helper(model: &Model<'_>, ty: &CTy, inner: &CTy) -> String {
+    let java = types::java_type(inner, true);
+    let value_offset = types::offset_expr("offset", model.option_value_offset(inner));
+    let read = read_expr(inner, "seg", &value_offset);
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        &format!("private static {java} decode{}(MemorySegment seg, long offset) {{", ty.mangle()),
+    );
+    line(&mut out, 2, "if (seg.get(ValueLayout.JAVA_BYTE, offset) == 0) {");
+    line(&mut out, 3, "return null;");
+    line(&mut out, 2, "}");
+    line(&mut out, 2, &format!("return {read};"));
+    line(&mut out, 1, "}");
+    out
+}
+
+fn list_helper(model: &Model<'_>, ty: &CTy, inner: &CTy) -> String {
+    let boxed = types::java_type(inner, true);
+    let stride = model.layout(inner).size;
+    let read = read_expr(inner, "data", &format!("index * {stride}"));
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        &format!(
+            "private static java.util.List<{boxed}> decode{}(MemorySegment seg, long offset) {{",
+            ty.mangle()
+        ),
+    );
+    line(&mut out, 2, "long len = seg.get(ValueLayout.JAVA_LONG, offset + 8);");
+    line(&mut out, 2, &format!("java.util.List<{boxed}> list = new java.util.ArrayList<>();"));
+    line(&mut out, 2, "if (len == 0) {");
+    line(&mut out, 3, "return list;");
+    line(&mut out, 2, "}");
+    line(
+        &mut out,
+        2,
+        &format!("MemorySegment data = seg.get(ValueLayout.ADDRESS, offset).reinterpret(len * {stride});"),
+    );
+    line(&mut out, 2, "for (long index = 0; index < len; index++) {");
+    line(&mut out, 3, &format!("list.add({read});"));
+    line(&mut out, 2, "}");
+    line(&mut out, 2, "return list;");
+    line(&mut out, 1, "}");
+    out
+}
+
+fn map_helper(model: &Model<'_>, ty: &CTy, key: &CTy, value: &CTy) -> String {
+    let key_java = types::java_type(key, true);
+    let value_java = types::java_type(value, true);
+    let pair = model.pair_struct(key, value);
+    let stride = pair.layout.size;
+    let key_read = read_expr(key, "data", &types::offset_expr(&format!("index * {stride}"), pair.offsets[0]));
+    let value_read = read_expr(value, "data", &types::offset_expr(&format!("index * {stride}"), pair.offsets[1]));
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        &format!(
+            "private static java.util.Map<{key_java}, {value_java}> decode{}(MemorySegment seg, long offset) {{",
+            ty.mangle()
+        ),
+    );
+    line(&mut out, 2, "long len = seg.get(ValueLayout.JAVA_LONG, offset + 8);");
+    line(
+        &mut out,
+        2,
+        &format!("java.util.Map<{key_java}, {value_java}> map = new java.util.LinkedHashMap<>();"),
+    );
+    line(&mut out, 2, "if (len == 0) {");
+    line(&mut out, 3, "return map;");
+    line(&mut out, 2, "}");
+    line(
+        &mut out,
+        2,
+        &format!("MemorySegment data = seg.get(ValueLayout.ADDRESS, offset).reinterpret(len * {stride});"),
+    );
+    line(&mut out, 2, "for (long index = 0; index < len; index++) {");
+    line(&mut out, 3, &format!("map.put({key_read}, {value_read});"));
+    line(&mut out, 2, "}");
+    line(&mut out, 2, "return map;");
+    line(&mut out, 1, "}");
+    out
+}
+
+fn record_helper(model: &Model<'_>, name: &str) -> String {
+    let record = model.record(name);
+    let shape = model.record_struct(name);
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        &format!("private static {name} decode{name}(MemorySegment seg, long offset) {{"),
+    );
+    line(&mut out, 2, &format!("return new {name}("));
+    let reads: Vec<String> = record
+        .fields
+        .iter()
+        .zip(&shape.offsets)
+        .map(|(field, offset)| {
+            let cty = CTy::of(&field.ty);
+            format!(
+                "                {}",
+                read_expr(&cty, "seg", &types::offset_expr("offset", *offset))
+            )
+        })
+        .collect();
+    out.push_str(&reads.join(",\n"));
+    out.push_str(");\n");
+    line(&mut out, 1, "}");
+    out
+}

--- a/packages/unibind/backend-jvm/src/java/encode.rs
+++ b/packages/unibind/backend-jvm/src/java/encode.rs
@@ -1,0 +1,202 @@
+//! The private encode helpers of the module class: one per aggregate
+//! mirror reachable from argument values.
+//!
+//! Helpers write into zero-initialized arena memory (`Arena#allocate`
+//! zeroes), which is what makes "absent option means all-zero value" hold
+//! without explicit clearing.
+
+use std::collections::BTreeMap;
+
+use crate::ctype::CTy;
+use crate::java::{line, types};
+use crate::model::Model;
+
+/// Render every needed encode helper, ordered by mangled name.
+pub fn helpers(model: &Model<'_>, set: &BTreeMap<String, CTy>) -> String {
+    let mut out = String::new();
+    for ty in set.values() {
+        let text = helper(model, ty);
+        if !text.is_empty() {
+            out.push('\n');
+            out.push_str(&text);
+        }
+    }
+    out
+}
+
+/// The Java statement (no trailing `;`) writing one mirror value at
+/// `offset` inside `seg`.
+pub fn write_stmt(ty: &CTy, seg: &str, offset: &str, value: &str) -> String {
+    if ty.is_scalar() {
+        types::scalar_set(ty, seg, offset, value)
+    } else {
+        format!("encode{}(arena, {seg}, {offset}, {value})", ty.mangle())
+    }
+}
+
+fn helper(model: &Model<'_>, ty: &CTy) -> String {
+    match ty {
+        CTy::Str => str_helper(),
+        CTy::Path => path_helper(),
+        CTy::Bytes => bytes_helper(),
+        CTy::Option(inner) => option_helper(model, ty, inner),
+        CTy::Vec(inner) => list_helper(model, ty, inner),
+        CTy::Map { key, value } => map_helper(model, ty, key, value),
+        CTy::Record(name) => record_helper(model, name),
+        CTy::Bool | CTy::Int(_) | CTy::Float(_) => String::new(),
+    }
+}
+
+fn str_helper() -> String {
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        "private static void encodeStr(Arena arena, MemorySegment seg, long offset, String value) {",
+    );
+    line(&mut out, 2, "byte[] bytes = value.getBytes(StandardCharsets.UTF_8);");
+    line(&mut out, 2, "MemorySegment data = arena.allocateFrom(ValueLayout.JAVA_BYTE, bytes);");
+    line(&mut out, 2, "seg.set(ValueLayout.ADDRESS, offset, data);");
+    line(&mut out, 2, "seg.set(ValueLayout.JAVA_LONG, offset + 8, bytes.length);");
+    line(&mut out, 1, "}");
+    out
+}
+
+fn path_helper() -> String {
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        "private static void encodePath(Arena arena, MemorySegment seg, long offset, java.nio.file.Path value) {",
+    );
+    line(&mut out, 2, "encodeStr(arena, seg, offset, value.toString());");
+    line(&mut out, 1, "}");
+    out
+}
+
+fn bytes_helper() -> String {
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        "private static void encodeBytes(Arena arena, MemorySegment seg, long offset, byte[] value) {",
+    );
+    line(&mut out, 2, "MemorySegment data = arena.allocateFrom(ValueLayout.JAVA_BYTE, value);");
+    line(&mut out, 2, "seg.set(ValueLayout.ADDRESS, offset, data);");
+    line(&mut out, 2, "seg.set(ValueLayout.JAVA_LONG, offset + 8, value.length);");
+    line(&mut out, 1, "}");
+    out
+}
+
+fn option_helper(model: &Model<'_>, ty: &CTy, inner: &CTy) -> String {
+    let java = types::java_type(inner, true);
+    let value_offset = types::offset_expr("offset", model.option_value_offset(inner));
+    let write = write_stmt(inner, "seg", &value_offset, "value");
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        &format!(
+            "private static void encode{}(Arena arena, MemorySegment seg, long offset, {java} value) {{",
+            ty.mangle()
+        ),
+    );
+    line(&mut out, 2, "if (value == null) {");
+    line(&mut out, 3, "return;");
+    line(&mut out, 2, "}");
+    line(&mut out, 2, "seg.set(ValueLayout.JAVA_BYTE, offset, (byte) 1);");
+    line(&mut out, 2, &format!("{write};"));
+    line(&mut out, 1, "}");
+    out
+}
+
+fn list_helper(model: &Model<'_>, ty: &CTy, inner: &CTy) -> String {
+    let boxed = types::java_type(inner, true);
+    let layout = model.layout(inner);
+    let stride = layout.size;
+    let write = write_stmt(inner, "data", "cursor", "element");
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        &format!(
+            "private static void encode{}(Arena arena, MemorySegment seg, long offset, java.util.List<{boxed}> value) {{",
+            ty.mangle()
+        ),
+    );
+    line(
+        &mut out,
+        2,
+        &format!("MemorySegment data = arena.allocate({stride} * (long) value.size(), {});", layout.align),
+    );
+    line(&mut out, 2, "long cursor = 0;");
+    line(&mut out, 2, &format!("for ({boxed} element : value) {{"));
+    line(&mut out, 3, &format!("{write};"));
+    line(&mut out, 3, &format!("cursor += {stride};"));
+    line(&mut out, 2, "}");
+    line(&mut out, 2, "seg.set(ValueLayout.ADDRESS, offset, data);");
+    line(&mut out, 2, "seg.set(ValueLayout.JAVA_LONG, offset + 8, value.size());");
+    line(&mut out, 1, "}");
+    out
+}
+
+fn map_helper(model: &Model<'_>, ty: &CTy, key: &CTy, value: &CTy) -> String {
+    let key_java = types::java_type(key, true);
+    let value_java = types::java_type(value, true);
+    let pair = model.pair_struct(key, value);
+    let stride = pair.layout.size;
+    let key_write = write_stmt(key, "data", &types::offset_expr("cursor", pair.offsets[0]), "entry.getKey()");
+    let value_write = write_stmt(
+        value,
+        "data",
+        &types::offset_expr("cursor", pair.offsets[1]),
+        "entry.getValue()",
+    );
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        &format!(
+            "private static void encode{}(Arena arena, MemorySegment seg, long offset, java.util.Map<{key_java}, {value_java}> value) {{",
+            ty.mangle()
+        ),
+    );
+    line(
+        &mut out,
+        2,
+        &format!("MemorySegment data = arena.allocate({stride} * (long) value.size(), {});", pair.layout.align),
+    );
+    line(&mut out, 2, "long cursor = 0;");
+    line(
+        &mut out,
+        2,
+        &format!("for (java.util.Map.Entry<{key_java}, {value_java}> entry : value.entrySet()) {{"),
+    );
+    line(&mut out, 3, &format!("{key_write};"));
+    line(&mut out, 3, &format!("{value_write};"));
+    line(&mut out, 3, &format!("cursor += {stride};"));
+    line(&mut out, 2, "}");
+    line(&mut out, 2, "seg.set(ValueLayout.ADDRESS, offset, data);");
+    line(&mut out, 2, "seg.set(ValueLayout.JAVA_LONG, offset + 8, value.size());");
+    line(&mut out, 1, "}");
+    out
+}
+
+fn record_helper(model: &Model<'_>, name: &str) -> String {
+    let record = model.record(name);
+    let shape = model.record_struct(name);
+    let mut out = String::new();
+    line(
+        &mut out,
+        1,
+        &format!("private static void encode{name}(Arena arena, MemorySegment seg, long offset, {name} value) {{"),
+    );
+    for (field, offset) in record.fields.iter().zip(&shape.offsets) {
+        let cty = CTy::of(&field.ty);
+        let accessor = format!("value.{}()", crate::names::camel(&field.name));
+        let write = write_stmt(&cty, "seg", &types::offset_expr("offset", *offset), &accessor);
+        line(&mut out, 2, &format!("{write};"));
+    }
+    line(&mut out, 1, "}");
+    out
+}

--- a/packages/unibind/backend-jvm/src/java/errors.rs
+++ b/packages/unibind/backend-jvm/src/java/errors.rs
@@ -1,0 +1,56 @@
+//! One exception hierarchy file per error enum, plus the shared panic
+//! exception.
+//!
+//! The base class carries a protected constructor: only the generated
+//! module class (via the variant subclasses) raises these.
+
+use unibind_core::ir;
+
+use crate::java::{line, types};
+use crate::names;
+
+pub fn render(interface: &ir::Interface, error: &ir::ErrorType) -> String {
+    let mut out = format!("package {};\n\n", names::java_package(&interface.name));
+    out.push_str(&types::doc_block(&error.docs, 0));
+    let name = format!("{}Exception", error.name);
+    line(&mut out, 0, &format!("public class {name} extends RuntimeException {{"));
+    line(&mut out, 0, "");
+    line(&mut out, 1, &format!("protected {name}(String message) {{"));
+    line(&mut out, 2, "super(message);");
+    line(&mut out, 1, "}");
+    for variant in &error.variants {
+        line(&mut out, 0, "");
+        out.push_str(&types::doc_block(&variant.docs, 1));
+        line(
+            &mut out,
+            1,
+            &format!("public static final class {} extends {name} {{", variant.name),
+        );
+        line(&mut out, 0, "");
+        line(&mut out, 2, &format!("public {}(String message) {{", variant.name));
+        line(&mut out, 3, "super(message);");
+        line(&mut out, 2, "}");
+        line(&mut out, 1, "}");
+    }
+    line(&mut out, 0, "}");
+    out
+}
+
+/// The per-module panic exception (envelope code -1). Generated per module
+/// so no shared runtime jar exists yet.
+pub fn panic_exception(interface: &ir::Interface) -> String {
+    let mut out = format!("package {};\n\n", names::java_package(&interface.name));
+    let doc = vec!["A Rust panic crossed the unibind boundary (envelope code -1).".to_owned()];
+    out.push_str(&types::doc_block(&doc, 0));
+    line(
+        &mut out,
+        0,
+        "public final class UnibindPanicException extends RuntimeException {",
+    );
+    line(&mut out, 0, "");
+    line(&mut out, 1, "public UnibindPanicException(String message) {");
+    line(&mut out, 2, "super(message);");
+    line(&mut out, 1, "}");
+    line(&mut out, 0, "}");
+    out
+}

--- a/packages/unibind/backend-jvm/src/java/methods.rs
+++ b/packages/unibind/backend-jvm/src/java/methods.rs
@@ -1,0 +1,230 @@
+//! The public static methods of the module class, their trailing-default
+//! overloads, and the status-to-exception mapping helpers.
+
+use unibind_core::ir;
+
+use crate::ctype::{CTy, EnvelopeLayout};
+use crate::java::{decode, encode, line, types};
+use crate::java::overloads::overloads;
+use crate::model::Model;
+use crate::{names, RenderError};
+
+/// Every public method (with overloads) followed by the error helpers.
+pub fn all(interface: &ir::Interface, model: &Model<'_>) -> Result<String, RenderError> {
+    let mut out = String::new();
+    for function in &interface.functions {
+        out.push('\n');
+        out.push_str(&method(function, model));
+        for overload in overloads(function)? {
+            out.push('\n');
+            out.push_str(&overload);
+        }
+    }
+    out.push_str(&error_helpers(interface));
+    Ok(out)
+}
+
+fn method(function: &ir::Function, model: &Model<'_>) -> String {
+    let name = names::camel(&function.name);
+    let ret = function.ret.as_ref().map(CTy::of);
+    let envelope = model.envelope(ret.as_ref());
+
+    let mut out = types::doc_block(&method_docs(function), 1);
+    line(
+        &mut out,
+        1,
+        &format!("public static {} {name}({}) {{", ret_type(ret.as_ref()), params(function)),
+    );
+
+    let has_aggregate = function
+        .args
+        .iter()
+        .any(|arg| !CTy::of(&arg.ty).is_scalar());
+    let base = if has_aggregate {
+        line(&mut out, 2, "try (Arena arena = Arena.ofConfined()) {");
+        3
+    } else {
+        2
+    };
+
+    let mut call_args = Vec::new();
+    for arg in &function.args {
+        let cty = CTy::of(&arg.ty);
+        let camel = names::camel(&arg.name);
+        if cty.is_scalar() {
+            call_args.push(types::downcall_arg(&cty, &camel));
+        } else {
+            let layout = model.layout(&cty);
+            let segment = format!("{camel}Arg");
+            line(
+                &mut out,
+                base,
+                &format!("MemorySegment {segment} = arena.allocate({}, {});", layout.size, layout.align),
+            );
+            line(&mut out, base, &format!("{};", encode::write_stmt(&cty, &segment, "0", &camel)));
+            call_args.push(segment);
+        }
+    }
+
+    let site = CallSite {
+        function,
+        envelope: &envelope,
+        ret: ret.as_ref(),
+        call_args: call_args.join(", "),
+    };
+    invoke_and_decode(&mut out, base, &site);
+    if has_aggregate {
+        line(&mut out, 2, "}");
+    }
+    line(&mut out, 1, "}");
+    out
+}
+
+/// Docs plus per-parameter notes for one method.
+fn method_docs(function: &ir::Function) -> Vec<String> {
+    let mut doc = function.docs.clone();
+    let notes: Vec<String> = function
+        .args
+        .iter()
+        .filter_map(|arg| {
+            let notes = types::doc_notes(&CTy::of(&arg.ty));
+            if notes.is_empty() {
+                None
+            } else {
+                Some(format!("@param {} {}", names::camel(&arg.name), notes.join(" ")))
+            }
+        })
+        .collect();
+    if !notes.is_empty() {
+        if !doc.is_empty() {
+            doc.push(String::new());
+        }
+        doc.extend(notes);
+    }
+    doc
+}
+
+/// The downcall a public method makes.
+struct CallSite<'a> {
+    function: &'a ir::Function,
+    envelope: &'a EnvelopeLayout,
+    ret: Option<&'a CTy>,
+    call_args: String,
+}
+
+/// Invoke the handle, map non-zero status to an exception, decode the
+/// value, and free the envelope.
+fn invoke_and_decode(out: &mut String, base: usize, site: &CallSite<'_>) {
+    let handle = names::handle_const(&site.function.name);
+    line(&mut *out, base, "MemorySegment envelope;");
+    line(&mut *out, base, "try {");
+    line(
+        &mut *out,
+        base + 1,
+        &format!("envelope = (MemorySegment) {handle}.invokeExact({});", site.call_args),
+    );
+    line(&mut *out, base, "} catch (Throwable error) {");
+    line(
+        &mut *out,
+        base + 1,
+        &format!(
+            "throw new IllegalStateException(\"unibind downcall {} failed\", error);",
+            site.function.name
+        ),
+    );
+    line(&mut *out, base, "}");
+    line(&mut *out, base, &format!("envelope = envelope.reinterpret({});", site.envelope.layout.size));
+    line(&mut *out, base, "try {");
+    line(&mut *out, base + 1, "int code = envelope.get(ValueLayout.JAVA_INT, 0);");
+    line(&mut *out, base + 1, "if (code != 0) {");
+    let raise = site.function.throws.as_ref().map_or_else(
+        || "unexpectedStatus".to_owned(),
+        |throws| format!("{}Exception", names::decapitalize(throws)),
+    );
+    line(
+        &mut *out,
+        base + 2,
+        &format!(
+            "throw {raise}(code, decodeStr(envelope, {}));",
+            site.envelope.err_msg_offset
+        ),
+    );
+    line(&mut *out, base + 1, "}");
+    if let Some(ret) = site.ret {
+        let value_offset = site
+            .envelope
+            .value_offset
+            .expect("a function with a return type has a value slot");
+        let read = decode::read_expr(ret, "envelope", &value_offset.to_string());
+        line(&mut *out, base + 1, &format!("return {read};"));
+    }
+    line(&mut *out, base, "} finally {");
+    line(&mut *out, base + 1, &format!("free({handle}_FREE, envelope);"));
+    line(&mut *out, base, "}");
+}
+
+pub(super) fn ret_type(ret: Option<&CTy>) -> String {
+    ret.map_or_else(|| "void".to_owned(), |ty| types::java_type(ty, false))
+}
+
+fn params(function: &ir::Function) -> String {
+    let rendered: Vec<String> = function
+        .args
+        .iter()
+        .map(|arg| {
+            format!(
+                "{} {}",
+                types::java_type(&CTy::of(&arg.ty), false),
+                names::camel(&arg.name)
+            )
+        })
+        .collect();
+    rendered.join(", ")
+}
+
+fn error_helpers(interface: &ir::Interface) -> String {
+    let mut out = String::new();
+    for error in &interface.errors {
+        out.push('\n');
+        line(
+            &mut out,
+            1,
+            &format!(
+                "private static RuntimeException {}Exception(int code, String message) {{",
+                names::decapitalize(&error.name)
+            ),
+        );
+        line(&mut out, 2, "return switch (code) {");
+        for (index, variant) in error.variants.iter().enumerate() {
+            line(
+                &mut out,
+                3,
+                &format!(
+                    "case {} -> new {}Exception.{}(message);",
+                    index + 1,
+                    error.name,
+                    variant.name
+                ),
+            );
+        }
+        line(&mut out, 3, "default -> unexpectedStatus(code, message);");
+        line(&mut out, 2, "};");
+        line(&mut out, 1, "}");
+    }
+    out.push('\n');
+    line(
+        &mut out,
+        1,
+        "private static RuntimeException unexpectedStatus(int code, String message) {",
+    );
+    line(&mut out, 2, "if (code == -1) {");
+    line(&mut out, 3, "return new UnibindPanicException(message);");
+    line(&mut out, 2, "}");
+    line(
+        &mut out,
+        2,
+        "return new IllegalStateException(\"unexpected unibind status \" + code + \": \" + message);",
+    );
+    line(&mut out, 1, "}");
+    out
+}

--- a/packages/unibind/backend-jvm/src/java/mod.rs
+++ b/packages/unibind/backend-jvm/src/java/mod.rs
@@ -1,0 +1,91 @@
+//! Generate the Java 22 Panama (`java.lang.foreign`) binding sources.
+
+mod decode;
+mod encode;
+mod errors;
+mod methods;
+mod module_class;
+mod overloads;
+mod records;
+pub mod types;
+
+use std::collections::BTreeMap;
+
+use unibind_core::ir;
+
+use crate::ctype::CTy;
+use crate::model::Model;
+use crate::{names, RenderError, SourceFile};
+
+/// Generate the Java sources for one interface: the module class, one file
+/// per record, one exception hierarchy per error enum, and the shared panic
+/// exception.
+///
+/// # Errors
+///
+/// Fails for surface the sync JVM backend does not implement (async
+/// functions, data enums, objects) and for unresolved or recursive record
+/// types.
+pub fn generate_java(interface: &ir::Interface) -> Result<Vec<SourceFile>, RenderError> {
+    let model = Model::new(interface)?;
+    let dir = format!("unibind/{}", interface.name);
+    let mut files = vec![SourceFile {
+        path: format!("{dir}/{}.java", names::pascal(&interface.name)),
+        content: module_class::render(interface, &model)?,
+    }];
+    for record in &interface.records {
+        files.push(SourceFile {
+            path: format!("{dir}/{}.java", record.name),
+            content: records::render(interface, record),
+        });
+    }
+    for error in &interface.errors {
+        files.push(SourceFile {
+            path: format!("{dir}/{}Exception.java", error.name),
+            content: errors::render(interface, error),
+        });
+    }
+    files.push(SourceFile {
+        path: format!("{dir}/UnibindPanicException.java"),
+        content: errors::panic_exception(interface),
+    });
+    Ok(files)
+}
+
+/// Push one line at `indent` levels of four spaces; empty text is a blank
+/// line without trailing spaces.
+pub fn line(out: &mut String, indent: usize, text: &str) {
+    if text.is_empty() {
+        out.push('\n');
+        return;
+    }
+    for _ in 0..indent {
+        out.push_str("    ");
+    }
+    out.push_str(text);
+    out.push('\n');
+}
+
+/// The aggregates the module class needs an encode helper for: everything
+/// reachable from argument types.
+pub fn encode_set(interface: &ir::Interface, model: &Model<'_>) -> BTreeMap<String, CTy> {
+    model.reachable_aggregates(
+        interface
+            .functions
+            .iter()
+            .flat_map(|function| function.args.iter().map(|arg| &arg.ty)),
+    )
+}
+
+/// The aggregates the module class needs a decode helper for: everything
+/// reachable from return types, plus text for every envelope's `err_msg`.
+pub fn decode_set(interface: &ir::Interface, model: &Model<'_>) -> BTreeMap<String, CTy> {
+    let mut set = model.reachable_aggregates(
+        interface
+            .functions
+            .iter()
+            .filter_map(|function| function.ret.as_ref()),
+    );
+    set.entry(CTy::Str.mangle()).or_insert(CTy::Str);
+    set
+}

--- a/packages/unibind/backend-jvm/src/java/module_class.rs
+++ b/packages/unibind/backend-jvm/src/java/module_class.rs
@@ -1,0 +1,158 @@
+//! Assemble the module class: library loading, downcall handles, the ABI
+//! probe, the public methods, and the private encode/decode helpers.
+
+use unibind_core::ir;
+
+use crate::ctype::CTy;
+use crate::java::{decode, decode_set, encode, encode_set, line, methods, types};
+use crate::model::Model;
+use crate::{names, RenderError};
+
+pub fn render(interface: &ir::Interface, model: &Model<'_>) -> Result<String, RenderError> {
+    let class = names::pascal(&interface.name);
+    let module = &interface.name;
+    let mut out = format!("package {};\n\n", names::java_package(module));
+    for import in [
+        "java.lang.foreign.Arena",
+        "java.lang.foreign.FunctionDescriptor",
+        "java.lang.foreign.Linker",
+        "java.lang.foreign.MemorySegment",
+        "java.lang.foreign.SymbolLookup",
+        "java.lang.foreign.ValueLayout",
+        "java.lang.invoke.MethodHandle",
+        "java.nio.charset.StandardCharsets",
+    ] {
+        line(&mut out, 0, &format!("import {import};"));
+    }
+    line(&mut out, 0, "");
+
+    let mut doc = interface.docs.clone();
+    if !doc.is_empty() {
+        doc.push(String::new());
+    }
+    doc.push(format!(
+        "Java binding for the Rust module {module}; loads the native library named by the"
+    ));
+    doc.push(format!("{{@code unibind.{module}.library}} system property."));
+    out.push_str(&types::doc_block(&doc, 0));
+    line(&mut out, 0, &format!("public final class {class} {{"));
+    line(&mut out, 0, "");
+    line(&mut out, 1, &format!("private {class}() {{"));
+    line(&mut out, 1, "}");
+    line(&mut out, 0, "");
+    line(&mut out, 1, "private static final SymbolLookup LOOKUP = loadLibrary();");
+    line(&mut out, 1, "private static final Linker LINKER = Linker.nativeLinker();");
+    for function in &interface.functions {
+        handles(&mut out, interface, function);
+    }
+    line(&mut out, 0, "");
+    abi_check(&mut out, module);
+
+    out.push_str(&methods::all(interface, model)?);
+    out.push_str(&encode::helpers(model, &encode_set(interface, model)));
+    out.push_str(&decode::helpers(model, &decode_set(interface, model)));
+    infrastructure(&mut out, module);
+    line(&mut out, 0, "}");
+    Ok(out)
+}
+
+/// The call handle and free handle for one export.
+fn handles(out: &mut String, interface: &ir::Interface, function: &ir::Function) {
+    let handle = names::handle_const(&function.name);
+    let symbol = names::export_symbol(&interface.name, &function.name);
+    let free = names::free_symbol(&interface.name, &function.name);
+    line(&mut *out, 1, &format!("private static final MethodHandle {handle} = handle("));
+    line(&mut *out, 3, &format!("\"{symbol}\","));
+    if function.args.is_empty() {
+        line(&mut *out, 3, "FunctionDescriptor.of(ValueLayout.ADDRESS));");
+    } else {
+        line(&mut *out, 3, "FunctionDescriptor.of(");
+        line(&mut *out, 5, "ValueLayout.ADDRESS,");
+        let layouts: Vec<String> = function
+            .args
+            .iter()
+            .map(|arg| format!("                    {}", types::value_layout(&CTy::of(&arg.ty))))
+            .collect();
+        out.push_str(&layouts.join(",\n"));
+        out.push_str("));\n");
+    }
+    line(&mut *out, 1, &format!("private static final MethodHandle {handle}_FREE = handle("));
+    line(&mut *out, 3, &format!("\"{free}\", FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));"));
+}
+
+fn abi_check(out: &mut String, module: &str) {
+    let symbol = names::abi_symbol(module);
+    line(&mut *out, 1, "static {");
+    line(
+        &mut *out,
+        2,
+        &format!("MethodHandle abi = handle(\"{symbol}\", FunctionDescriptor.of(ValueLayout.JAVA_INT));"),
+    );
+    line(&mut *out, 2, "int version;");
+    line(&mut *out, 2, "try {");
+    line(&mut *out, 3, "version = (int) abi.invokeExact();");
+    line(&mut *out, 2, "} catch (Throwable error) {");
+    line(&mut *out, 3, "throw new IllegalStateException(\"unibind ABI probe failed\", error);");
+    line(&mut *out, 2, "}");
+    line(&mut *out, 2, "if (version != 0) {");
+    line(
+        &mut *out,
+        3,
+        "throw new IllegalStateException(",
+    );
+    line(
+        &mut *out,
+        5,
+        "\"native library speaks unibind ABI \" + version + \"; this binding expects 0\");",
+    );
+    line(&mut *out, 2, "}");
+    line(&mut *out, 1, "}");
+}
+
+fn infrastructure(out: &mut String, module: &str) {
+    line(&mut *out, 0, "");
+    line(&mut *out, 1, "private static SymbolLookup loadLibrary() {");
+    line(
+        &mut *out,
+        2,
+        &format!("String library = System.getProperty(\"unibind.{module}.library\");"),
+    );
+    line(&mut *out, 2, "if (library == null) {");
+    line(&mut *out, 3, "throw new IllegalStateException(");
+    line(
+        &mut *out,
+        5,
+        &format!(
+            "\"set -Dunibind.{module}.library=/path/to/the/native/library before using this binding\");"
+        ),
+    );
+    line(&mut *out, 2, "}");
+    line(
+        &mut *out,
+        2,
+        "return SymbolLookup.libraryLookup(java.nio.file.Path.of(library), Arena.global());",
+    );
+    line(&mut *out, 1, "}");
+    line(&mut *out, 0, "");
+    line(
+        &mut *out,
+        1,
+        "private static MethodHandle handle(String symbol, FunctionDescriptor descriptor) {",
+    );
+    line(&mut *out, 2, "MemorySegment address = LOOKUP.find(symbol)");
+    line(
+        &mut *out,
+        4,
+        ".orElseThrow(() -> new IllegalStateException(\"native library exports no \" + symbol));",
+    );
+    line(&mut *out, 2, "return LINKER.downcallHandle(address, descriptor);");
+    line(&mut *out, 1, "}");
+    line(&mut *out, 0, "");
+    line(&mut *out, 1, "private static void free(MethodHandle handle, MemorySegment envelope) {");
+    line(&mut *out, 2, "try {");
+    line(&mut *out, 3, "handle.invokeExact(envelope);");
+    line(&mut *out, 2, "} catch (Throwable error) {");
+    line(&mut *out, 3, "throw new IllegalStateException(\"unibind envelope free failed\", error);");
+    line(&mut *out, 2, "}");
+    line(&mut *out, 1, "}");
+}

--- a/packages/unibind/backend-jvm/src/java/overloads.rs
+++ b/packages/unibind/backend-jvm/src/java/overloads.rs
@@ -1,0 +1,90 @@
+//! Overloads dropping trailing defaulted arguments, mirroring the Python
+//! surface where trailing parameters carry defaults.
+
+use unibind_core::ir;
+
+use crate::ctype::CTy;
+use crate::java::methods::ret_type;
+use crate::java::{line, types};
+use crate::{names, RenderError};
+
+/// Overloads dropping trailing arguments that carry a default (an explicit
+/// literal, or `null` for an `Option` without one).
+pub fn overloads(function: &ir::Function) -> Result<Vec<String>, RenderError> {
+    let mut defaults = Vec::new();
+    for arg in &function.args {
+        let cty = CTy::of(&arg.ty);
+        let rendered = match &arg.default {
+            Some(literal) => Some(types::java_literal(&cty, literal)?),
+            None if matches!(cty, CTy::Option(_)) => Some("null".to_owned()),
+            None => None,
+        };
+        defaults.push(rendered);
+    }
+    let total = function.args.len();
+    let mut tail = 0;
+    while tail < total && defaults[total - 1 - tail].is_some() {
+        tail += 1;
+    }
+
+    let name = names::camel(&function.name);
+    let link_types: Vec<String> = function
+        .args
+        .iter()
+        .map(|arg| erased(&types::java_type(&CTy::of(&arg.ty), false)))
+        .collect();
+    let mut out = Vec::new();
+    for dropped in 1..=tail {
+        let kept = &function.args[..total - dropped];
+        let mut call_args: Vec<String> = kept
+            .iter()
+            .map(|arg| names::camel(&arg.name))
+            .collect();
+        for default in &defaults[total - dropped..] {
+            call_args.push(default.clone().expect("trailing run carries defaults"));
+        }
+        let mut text = String::new();
+        line(
+            &mut text,
+            1,
+            &format!(
+                "/** Calls {{@link #{name}({})}} with default trailing arguments. */",
+                link_types.join(", ")
+            ),
+        );
+        let kept_params: Vec<String> = kept
+            .iter()
+            .map(|arg| {
+                format!(
+                    "{} {}",
+                    types::java_type(&CTy::of(&arg.ty), false),
+                    names::camel(&arg.name)
+                )
+            })
+            .collect();
+        line(
+            &mut text,
+            1,
+            &format!(
+                "public static {} {name}({}) {{",
+                ret_type(function.ret.as_ref().map(CTy::of).as_ref()),
+                kept_params.join(", ")
+            ),
+        );
+        let call = format!("{name}({});", call_args.join(", "));
+        if function.ret.is_some() {
+            line(&mut text, 2, &format!("return {call}"));
+        } else {
+            line(&mut text, 2, &call);
+        }
+        line(&mut text, 1, "}");
+        out.push(text);
+    }
+    Ok(out)
+}
+
+/// Generic-erased type text for a `{@link}` method signature.
+fn erased(java: &str) -> String {
+    java.split('<').next().unwrap_or(java).to_owned()
+}
+

--- a/packages/unibind/backend-jvm/src/java/records.rs
+++ b/packages/unibind/backend-jvm/src/java/records.rs
@@ -1,0 +1,53 @@
+//! One Java `record` file per IR record.
+
+use unibind_core::ir;
+
+use crate::ctype::CTy;
+use crate::java::{line, types};
+use crate::names;
+
+pub fn render(interface: &ir::Interface, record: &ir::Record) -> String {
+    let mut out = format!("package {};\n\n", names::java_package(&interface.name));
+
+    let mut doc = record.docs.clone();
+    if !record.fields.is_empty() {
+        if !doc.is_empty() {
+            doc.push(String::new());
+        }
+        for field in &record.fields {
+            let cty = CTy::of(&field.ty);
+            let mut text = format!("@param {}", names::camel(&field.name));
+            for docs_line in &field.docs {
+                text.push(' ');
+                text.push_str(docs_line);
+            }
+            for note in types::doc_notes(&cty) {
+                text.push(' ');
+                text.push_str(note);
+            }
+            doc.push(text);
+        }
+    }
+    out.push_str(&types::doc_block(&doc, 0));
+
+    if record.fields.is_empty() {
+        line(&mut out, 0, &format!("public record {}() {{", record.name));
+    } else {
+        line(&mut out, 0, &format!("public record {}(", record.name));
+        let components: Vec<String> = record
+            .fields
+            .iter()
+            .map(|field| {
+                format!(
+                    "        {} {}",
+                    types::java_type(&CTy::of(&field.ty), false),
+                    names::camel(&field.name)
+                )
+            })
+            .collect();
+        out.push_str(&components.join(",\n"));
+        out.push_str(") {\n");
+    }
+    out.push_str("}\n");
+    out
+}

--- a/packages/unibind/backend-jvm/src/java/types.rs
+++ b/packages/unibind/backend-jvm/src/java/types.rs
@@ -1,0 +1,211 @@
+//! Java spellings, `ValueLayout` names, literals, and doc plumbing for
+//! boundary types.
+
+use std::fmt::Write as _;
+
+use unibind_core::ir;
+
+use crate::ctype::CTy;
+use crate::RenderError;
+
+/// The Java type at one boundary position; `boxed` for generic slots and
+/// optional values.
+pub fn java_type(ty: &CTy, boxed: bool) -> String {
+    match ty {
+        CTy::Bool => scalar_name("boolean", "Boolean", boxed),
+        CTy::Int(kind) => int_type(*kind, boxed),
+        CTy::Float(ir::FloatKind::F32) => scalar_name("float", "Float", boxed),
+        CTy::Float(ir::FloatKind::F64) => scalar_name("double", "Double", boxed),
+        CTy::Str => "String".to_owned(),
+        CTy::Path => "java.nio.file.Path".to_owned(),
+        CTy::Bytes => "byte[]".to_owned(),
+        CTy::Option(inner) => java_type(inner, true),
+        CTy::Vec(inner) => format!("java.util.List<{}>", java_type(inner, true)),
+        CTy::Map { key, value } => format!(
+            "java.util.Map<{}, {}>",
+            java_type(key, true),
+            java_type(value, true)
+        ),
+        CTy::Record(name) => name.clone(),
+    }
+}
+
+fn scalar_name(primitive: &str, boxed_name: &str, boxed: bool) -> String {
+    if boxed { boxed_name } else { primitive }.to_owned()
+}
+
+fn int_type(kind: ir::IntKind, boxed: bool) -> String {
+    match kind {
+        ir::IntKind::I8 | ir::IntKind::U8 => scalar_name("byte", "Byte", boxed),
+        ir::IntKind::I16 | ir::IntKind::U16 => scalar_name("short", "Short", boxed),
+        ir::IntKind::I32 | ir::IntKind::U32 => scalar_name("int", "Integer", boxed),
+        ir::IntKind::I64 | ir::IntKind::U64 | ir::IntKind::Isize | ir::IntKind::Usize => {
+            scalar_name("long", "Long", boxed)
+        }
+    }
+}
+
+/// The `ValueLayout` constant carrying one mirror in a downcall descriptor:
+/// scalars by width, aggregates as pointers.
+pub const fn value_layout(ty: &CTy) -> &'static str {
+    match ty {
+        CTy::Bool => "ValueLayout.JAVA_BYTE",
+        CTy::Int(kind) => int_layout_name(*kind),
+        CTy::Float(ir::FloatKind::F32) => "ValueLayout.JAVA_FLOAT",
+        CTy::Float(ir::FloatKind::F64) => "ValueLayout.JAVA_DOUBLE",
+        CTy::Str
+        | CTy::Path
+        | CTy::Bytes
+        | CTy::Option(_)
+        | CTy::Vec(_)
+        | CTy::Map { .. }
+        | CTy::Record(_) => "ValueLayout.ADDRESS",
+    }
+}
+
+const fn int_layout_name(kind: ir::IntKind) -> &'static str {
+    match kind {
+        ir::IntKind::I8 | ir::IntKind::U8 => "ValueLayout.JAVA_BYTE",
+        ir::IntKind::I16 | ir::IntKind::U16 => "ValueLayout.JAVA_SHORT",
+        ir::IntKind::I32 | ir::IntKind::U32 => "ValueLayout.JAVA_INT",
+        ir::IntKind::I64 | ir::IntKind::U64 | ir::IntKind::Isize | ir::IntKind::Usize => {
+            "ValueLayout.JAVA_LONG"
+        }
+    }
+}
+
+/// The Java expression reading a scalar mirror at `offset` inside `seg`.
+pub fn scalar_get(ty: &CTy, seg: &str, offset: &str) -> String {
+    let layout = value_layout(ty);
+    let get = format!("{seg}.get({layout}, {offset})");
+    if matches!(ty, CTy::Bool) {
+        format!("{get} != 0")
+    } else {
+        get
+    }
+}
+
+/// The Java statement (no trailing `;`) writing scalar `value` at `offset`
+/// inside `seg`.
+pub fn scalar_set(ty: &CTy, seg: &str, offset: &str, value: &str) -> String {
+    let layout = value_layout(ty);
+    let value = if matches!(ty, CTy::Bool) {
+        format!("(byte) ({value} ? 1 : 0)")
+    } else {
+        value.to_owned()
+    };
+    format!("{seg}.set({layout}, {offset}, {value})")
+}
+
+/// The downcall argument expression for a scalar Java parameter.
+pub fn downcall_arg(ty: &CTy, expr: &str) -> String {
+    if matches!(ty, CTy::Bool) {
+        format!("(byte) ({expr} ? 1 : 0)")
+    } else {
+        expr.to_owned()
+    }
+}
+
+/// `offset` plus a constant, folding away `+ 0`.
+pub fn offset_expr(base: &str, delta: u64) -> String {
+    if delta == 0 {
+        base.to_owned()
+    } else {
+        format!("{base} + {delta}")
+    }
+}
+
+/// Doc notes for spellings that lose information in Java.
+pub fn doc_notes(ty: &CTy) -> Vec<&'static str> {
+    let mut notes = Vec::new();
+    if let CTy::Option(inner) = ty {
+        notes.push("May be null.");
+        notes.extend(doc_notes(inner));
+        return notes;
+    }
+    if matches!(
+        ty,
+        CTy::Int(
+            ir::IntKind::U8
+                | ir::IntKind::U16
+                | ir::IntKind::U32
+                | ir::IntKind::U64
+                | ir::IntKind::Usize
+        )
+    ) {
+        notes.push("Unsigned in Rust; a negative value is the raw two's-complement bit pattern.");
+    }
+    notes
+}
+
+/// Render a doc-comment block (javadoc and `KDoc` share the syntax) at
+/// `indent` levels of four spaces.
+pub fn doc_block(lines: &[String], indent: usize) -> String {
+    if lines.is_empty() {
+        return String::new();
+    }
+    let pad = "    ".repeat(indent);
+    let mut out = format!("{pad}/**\n");
+    for line in lines {
+        if line.is_empty() {
+            let _ = writeln!(out, "{pad} *");
+        } else {
+            let _ = writeln!(out, "{pad} * {line}");
+        }
+    }
+    let _ = writeln!(out, "{pad} */");
+    out
+}
+
+/// The Java expression for a default literal at type `ty`.
+pub fn java_literal(ty: &CTy, literal: &ir::Literal) -> Result<String, RenderError> {
+    match (ty, literal) {
+        (CTy::Option(_), ir::Literal::None) => Ok("null".to_owned()),
+        (CTy::Option(inner), _) => java_literal(inner, literal),
+        (CTy::Bool, ir::Literal::Bool(value)) => Ok(value.to_string()),
+        (CTy::Int(kind), ir::Literal::Int(value)) => Ok(int_literal(*kind, *value)),
+        (CTy::Float(ir::FloatKind::F32), ir::Literal::Int(value)) => Ok(format!("{value}.0f")),
+        (CTy::Float(ir::FloatKind::F64), ir::Literal::Int(value)) => Ok(format!("{value}.0")),
+        (CTy::Float(ir::FloatKind::F32), ir::Literal::Float(value)) => Ok(format!("{value:?}f")),
+        (CTy::Float(ir::FloatKind::F64), ir::Literal::Float(value)) => Ok(format!("{value:?}")),
+        (CTy::Str, ir::Literal::Str(value)) => Ok(quoted(value, false)),
+        (ty, literal) => Err(RenderError::new(format!(
+            "default `{literal:?}` does not fit the `{}` parameter type",
+            java_type(ty, false)
+        ))),
+    }
+}
+
+fn int_literal(kind: ir::IntKind, value: i64) -> String {
+    match kind {
+        ir::IntKind::I8 | ir::IntKind::U8 => format!("(byte) {value}"),
+        ir::IntKind::I16 | ir::IntKind::U16 => format!("(short) {value}"),
+        ir::IntKind::I32 | ir::IntKind::U32 => value.to_string(),
+        ir::IntKind::I64 | ir::IntKind::U64 | ir::IntKind::Isize | ir::IntKind::Usize => {
+            format!("{value}L")
+        }
+    }
+}
+
+/// A double-quoted Java or Kotlin string literal; Kotlin additionally needs
+/// `$` escaped out of template position.
+pub fn quoted(value: &str, escape_dollar: bool) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for character in value.chars() {
+        match character {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '$' if escape_dollar => out.push_str("\\$"),
+            other if (other as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", other as u32);
+            }
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/packages/unibind/backend-jvm/src/kotlin.rs
+++ b/packages/unibind/backend-jvm/src/kotlin.rs
@@ -1,0 +1,138 @@
+//! Generate the Kotlin sugar layer: top-level functions with real default
+//! parameter values delegating to the generated Java class. Same package,
+//! same types, no second FFI path.
+
+use std::fmt::Write as _;
+
+use unibind_core::ir;
+
+use crate::ctype::CTy;
+use crate::java::types;
+use crate::model::Model;
+use crate::{names, RenderError, SourceFile};
+
+/// Generate the Kotlin source for one interface: a single `<Module>.kt`
+/// next to the Java sources.
+///
+/// # Errors
+///
+/// Fails for surface the sync JVM backend does not implement (async
+/// functions, data enums, objects) and for defaults that do not fit their
+/// parameter type.
+pub fn generate_kotlin(interface: &ir::Interface) -> Result<Vec<SourceFile>, RenderError> {
+    // Validation only: the Kotlin layer reuses the Java type surface.
+    Model::new(interface)?;
+    let class = names::pascal(&interface.name);
+    let mut out = format!(
+        "// Kotlin sugar over the Java Panama binding [{class}]; no second FFI path.\n\
+         // suspend/Flow sugar lands with async IR (#2083 follow-up)\n\
+         package {}\n",
+        names::java_package(&interface.name)
+    );
+    for function in &interface.functions {
+        out.push('\n');
+        out.push_str(&render_fn(function, &class)?);
+    }
+    Ok(vec![SourceFile {
+        path: format!("unibind/{}/{class}.kt", interface.name),
+        content: out,
+    }])
+}
+
+fn render_fn(function: &ir::Function, class: &str) -> Result<String, RenderError> {
+    let name = names::camel(&function.name);
+
+    let mut doc = function.docs.clone();
+    let notes: Vec<String> = function
+        .args
+        .iter()
+        .filter_map(|arg| {
+            let notes = types::doc_notes(&CTy::of(&arg.ty));
+            if notes.is_empty() {
+                None
+            } else {
+                Some(format!("@param {} {}", names::camel(&arg.name), notes.join(" ")))
+            }
+        })
+        .collect();
+    if !notes.is_empty() {
+        if !doc.is_empty() {
+            doc.push(String::new());
+        }
+        doc.extend(notes);
+    }
+
+    let mut out = types::doc_block(&doc, 0);
+    let mut params = Vec::new();
+    let mut forwarded = Vec::new();
+    for arg in &function.args {
+        let cty = CTy::of(&arg.ty);
+        let camel = names::camel(&arg.name);
+        let mut param = format!("    {camel}: {}", kotlin_type(&cty));
+        let default = match &arg.default {
+            Some(literal) => Some(kotlin_literal(&cty, literal)?),
+            None if matches!(cty, CTy::Option(_)) => Some("null".to_owned()),
+            None => None,
+        };
+        if let Some(default) = default {
+            let _ = write!(param, " = {default}");
+        }
+        params.push(param);
+        forwarded.push(camel);
+    }
+
+    let ret = function
+        .ret
+        .as_ref()
+        .map_or_else(|| "Unit".to_owned(), |ty| kotlin_type(&CTy::of(ty)));
+    if params.is_empty() {
+        let _ = writeln!(out, "fun {name}(): {ret} =");
+    } else {
+        let _ = writeln!(out, "fun {name}(\n{},\n): {ret} =", params.join(",\n"));
+    }
+    let _ = writeln!(out, "    {class}.{name}({})", forwarded.join(", "));
+    Ok(out)
+}
+
+fn kotlin_type(ty: &CTy) -> String {
+    match ty {
+        CTy::Bool => "Boolean".to_owned(),
+        CTy::Int(kind) => int_type(*kind).to_owned(),
+        CTy::Float(ir::FloatKind::F32) => "Float".to_owned(),
+        CTy::Float(ir::FloatKind::F64) => "Double".to_owned(),
+        CTy::Str => "String".to_owned(),
+        CTy::Path => "java.nio.file.Path".to_owned(),
+        CTy::Bytes => "ByteArray".to_owned(),
+        CTy::Option(inner) => format!("{}?", kotlin_type(inner)),
+        CTy::Vec(inner) => format!("List<{}>", kotlin_type(inner)),
+        CTy::Map { key, value } => format!("Map<{}, {}>", kotlin_type(key), kotlin_type(value)),
+        CTy::Record(name) => name.clone(),
+    }
+}
+
+const fn int_type(kind: ir::IntKind) -> &'static str {
+    match kind {
+        ir::IntKind::I8 | ir::IntKind::U8 => "Byte",
+        ir::IntKind::I16 | ir::IntKind::U16 => "Short",
+        ir::IntKind::I32 | ir::IntKind::U32 => "Int",
+        ir::IntKind::I64 | ir::IntKind::U64 | ir::IntKind::Isize | ir::IntKind::Usize => "Long",
+    }
+}
+
+fn kotlin_literal(ty: &CTy, literal: &ir::Literal) -> Result<String, RenderError> {
+    match (ty, literal) {
+        (CTy::Option(_), ir::Literal::None) => Ok("null".to_owned()),
+        (CTy::Option(inner), _) => kotlin_literal(inner, literal),
+        (CTy::Bool, ir::Literal::Bool(value)) => Ok(value.to_string()),
+        (CTy::Int(_), ir::Literal::Int(value)) => Ok(value.to_string()),
+        (CTy::Float(ir::FloatKind::F32), ir::Literal::Int(value)) => Ok(format!("{value}.0f")),
+        (CTy::Float(ir::FloatKind::F64), ir::Literal::Int(value)) => Ok(format!("{value}.0")),
+        (CTy::Float(ir::FloatKind::F32), ir::Literal::Float(value)) => Ok(format!("{value:?}f")),
+        (CTy::Float(ir::FloatKind::F64), ir::Literal::Float(value)) => Ok(format!("{value:?}")),
+        (CTy::Str, ir::Literal::Str(value)) => Ok(types::quoted(value, true)),
+        (ty, literal) => Err(RenderError::new(format!(
+            "default `{literal:?}` does not fit the `{}` parameter type",
+            kotlin_type(ty)
+        ))),
+    }
+}

--- a/packages/unibind/backend-jvm/src/lib.rs
+++ b/packages/unibind/backend-jvm/src/lib.rs
@@ -1,0 +1,60 @@
+//! Render a lowered [`unibind_core::ir::Interface`] into JVM binding code.
+//!
+//! Three artifacts come out of the same interface, and all three consume the
+//! one layout model in [`ctype`] / [`model`], so the two sides of the
+//! boundary can never disagree about a struct layout or a symbol name:
+//!
+//! - [`render`]: a hidden Rust glue module of plain `extern "C"` exports
+//!   (no JNI, no binding library), spliced into the user's crate by the
+//!   `unibind` macro when its `jvm` feature is on.
+//! - [`generate_java`]: Java 22 Panama (`java.lang.foreign`) sources that
+//!   call those exports through `Linker#downcallHandle`, reading and writing
+//!   mirror structs at the model's precomputed offsets.
+//! - [`generate_kotlin`]: a thin Kotlin sugar layer delegating to the Java
+//!   binding (default parameter values, nullable types); never a second FFI
+//!   path.
+
+pub mod ctype;
+mod java;
+mod kotlin;
+pub mod model;
+mod names;
+mod rust_glue;
+
+pub use java::generate_java;
+pub use kotlin::generate_kotlin;
+pub use rust_glue::render;
+
+/// The rendered Rust glue for one interface.
+#[derive(Debug)]
+pub struct RenderedJvm {
+    /// Sibling items for the exported module: one hidden module holding the
+    /// C mirror types, their layout assertions, and the `extern "C"`
+    /// exports.
+    pub glue: proc_macro2::TokenStream,
+}
+
+/// One generated host-language source file.
+#[derive(Debug)]
+pub struct SourceFile {
+    /// Slash-separated path relative to the source root, following the Java
+    /// package, e.g. `unibind/sample/Row.java`.
+    pub path: String,
+    /// Complete file text.
+    pub content: String,
+}
+
+/// A rendering failure; the macro positions it at the exported module.
+#[derive(Debug)]
+pub struct RenderError {
+    /// What went wrong and what to do instead.
+    pub message: String,
+}
+
+impl RenderError {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}

--- a/packages/unibind/backend-jvm/src/model.rs
+++ b/packages/unibind/backend-jvm/src/model.rs
@@ -23,12 +23,14 @@ impl<'ir> Model<'ir> {
     /// # Errors
     ///
     /// Fails for surface this backend does not implement (async functions,
-    /// data enums, objects), for unresolved or recursive record types, and
-    /// for a `throws` name with no matching error enum.
+    /// streams, data enums, objects; the async surface is issue #2083), for
+    /// unresolved or recursive record types, and for a `throws` name with no
+    /// matching error enum.
     pub fn new(interface: &'ir ir::Interface) -> Result<Self, RenderError> {
         if let Some(object) = interface.objects.first() {
             return Err(RenderError::new(format!(
-                "`{}` is a #[unibind::object]; objects land in phase 2 (issue #1992)",
+                "`{}` is a #[unibind::object]; the JVM backend's object support lands with the \
+                 async surface (issue #2083)",
                 object.name
             )));
         }
@@ -44,7 +46,7 @@ impl<'ir> Model<'ir> {
             .find(|function| matches!(function.asyncness, ir::Asyncness::Async))
         {
             return Err(RenderError::new(format!(
-                "`{}` is async; async functions land in phase 2 (issue #1992)",
+                "`{}` is async; the JVM backend's async support lands with issue #2083",
                 function.name
             )));
         }
@@ -86,6 +88,10 @@ impl<'ir> Model<'ir> {
                 self.check_type(value, stack)
             }
             ir::Type::Named(name) => self.check_record(name, stack),
+            ir::Type::Stream(_) => Err(RenderError::new(
+                "`UniStream` crosses as an async iterator; the JVM backend's stream \
+                 support lands with issue #2083",
+            )),
             ir::Type::Bool
             | ir::Type::Int(_)
             | ir::Type::Float(_)

--- a/packages/unibind/backend-jvm/src/model.rs
+++ b/packages/unibind/backend-jvm/src/model.rs
@@ -1,11 +1,15 @@
 //! The validated type model of one interface.
 //!
 //! [`Model::new`] is the shared gate all three generators pass through: it
-//! rejects the surface the sync JVM backend does not implement and resolves
-//! every `Named` type, so the layout queries and the per-record lookups can
-//! assume a well-formed interface.
+//! rejects the surface the JVM backend does not implement (data enums) and
+//! everything that cannot cross the boundary (streams outside return
+//! position, objects outside handle position, unresolved or recursive
+//! records), so the layout queries and the per-record lookups can assume a
+//! well-formed interface.
 
-use std::collections::BTreeMap;
+mod validate;
+
+use std::collections::{BTreeMap, BTreeSet};
 
 use unibind_core::ir;
 
@@ -15,110 +19,54 @@ use crate::RenderError;
 /// Record lookup plus layout queries for every reachable mirror.
 pub struct Model<'ir> {
     records: BTreeMap<&'ir str, &'ir ir::Record>,
+    /// Names declared as `#[unibind::object]`; a `Named` return naming one
+    /// crosses as an opaque handle instead of a record mirror.
+    objects: BTreeSet<&'ir str>,
 }
 
 impl<'ir> Model<'ir> {
-    /// Validate the sync JVM surface and build the model.
+    /// Validate the JVM surface and build the model.
     ///
     /// # Errors
     ///
-    /// Fails for surface this backend does not implement (async functions,
-    /// streams, data enums, objects; the async surface is issue #2083), for
-    /// unresolved or recursive record types, and for a `throws` name with no
-    /// matching error enum.
+    /// Fails for data enums (not rendered yet), for streams or objects in
+    /// a position where they cannot cross (arguments, record fields,
+    /// nested inside another type), for unresolved or recursive record
+    /// types, and for a `throws` name with no matching error enum.
     pub fn new(interface: &'ir ir::Interface) -> Result<Self, RenderError> {
-        if let Some(object) = interface.objects.first() {
-            return Err(RenderError::new(format!(
-                "`{}` is a #[unibind::object]; the JVM backend's object support lands with the \
-                 async surface (issue #2083)",
-                object.name
-            )));
-        }
-        if let Some(data_enum) = interface.enums.first() {
-            return Err(RenderError::new(format!(
-                "`{}` is a data enum, which the sync JVM backend does not render (issue #2083)",
-                data_enum.name
-            )));
-        }
-        if let Some(function) = interface
-            .functions
-            .iter()
-            .find(|function| matches!(function.asyncness, ir::Asyncness::Async))
-        {
-            return Err(RenderError::new(format!(
-                "`{}` is async; the JVM backend's async support lands with issue #2083",
-                function.name
-            )));
-        }
         let model = Self {
             records: interface
                 .records
                 .iter()
                 .map(|record| (record.name.as_str(), record))
                 .collect(),
+            objects: interface
+                .objects
+                .iter()
+                .map(|object| object.name.as_str())
+                .collect(),
         };
-        for record in &interface.records {
-            model.check_record(&record.name, &mut Vec::new())?;
-        }
-        for function in &interface.functions {
-            for arg in &function.args {
-                model.check_type(&arg.ty, &mut Vec::new())?;
-            }
-            if let Some(ret) = &function.ret {
-                model.check_type(ret, &mut Vec::new())?;
-            }
-            if let Some(throws) = &function.throws
-                && !interface.errors.iter().any(|error| error.name == *throws)
-            {
-                return Err(RenderError::new(format!(
-                    "`{}` returns `Result<_, {throws}>`, but `{throws}` is not a \
-                     #[unibind::error] in this module",
-                    function.name
-                )));
-            }
-        }
+        validate::interface(&model, interface)?;
         Ok(model)
     }
 
-    fn check_type(&self, ty: &ir::Type, stack: &mut Vec<String>) -> Result<(), RenderError> {
-        match ty {
-            ir::Type::Option(inner) | ir::Type::Vec(inner) => self.check_type(inner, stack),
-            ir::Type::Map { key, value } => {
-                self.check_type(key, stack)?;
-                self.check_type(value, stack)
-            }
-            ir::Type::Named(name) => self.check_record(name, stack),
-            ir::Type::Stream(_) => Err(RenderError::new(
-                "`UniStream` crosses as an async iterator; the JVM backend's stream \
-                 support lands with issue #2083",
-            )),
-            ir::Type::Bool
-            | ir::Type::Int(_)
-            | ir::Type::Float(_)
-            | ir::Type::String { .. }
-            | ir::Type::Path { .. }
-            | ir::Type::Bytes { .. } => Ok(()),
-        }
+    /// Whether `name` is a `#[unibind::object]` in this interface.
+    #[must_use]
+    pub fn is_object(&self, name: &str) -> bool {
+        self.objects.contains(name)
     }
 
-    fn check_record(&self, name: &str, stack: &mut Vec<String>) -> Result<(), RenderError> {
-        if stack.iter().any(|seen| seen == name) {
-            return Err(RenderError::new(format!(
-                "record `{name}` is part of a reference cycle; recursive records cannot \
-                 cross the boundary by value"
-            )));
+    /// The boundary mirror of one argument or return type: streams and
+    /// objects cross as opaque handles, everything else through
+    /// [`CTy::of`]. Record fields keep using [`CTy::of`] directly, because
+    /// validation rejects streams and objects inside records.
+    #[must_use]
+    pub fn boundary(&self, ty: &ir::Type) -> CTy {
+        match ty {
+            ir::Type::Stream(_) => CTy::Handle,
+            ir::Type::Named(name) if self.is_object(name) => CTy::Handle,
+            _ => CTy::of(ty),
         }
-        let Some(record) = self.records.get(name) else {
-            return Err(RenderError::new(format!(
-                "`{name}` is not a #[unibind::record] in this module"
-            )));
-        };
-        stack.push(name.to_owned());
-        for field in &record.fields {
-            self.check_type(&field.ty, stack)?;
-        }
-        stack.pop();
-        Ok(())
     }
 
     /// The record behind a validated [`CTy::Record`] name.
@@ -140,7 +88,7 @@ impl<'ir> Model<'ir> {
             CTy::Bool => Layout { size: 1, align: 1 },
             CTy::Int(kind) => ctype::int_layout(*kind),
             CTy::Float(ir::FloatKind::F32) => Layout { size: 4, align: 4 },
-            CTy::Float(ir::FloatKind::F64) => Layout { size: 8, align: 8 },
+            CTy::Float(ir::FloatKind::F64) | CTy::Handle => Layout { size: 8, align: 8 },
             CTy::Str | CTy::Path | CTy::Bytes | CTy::Vec(_) | CTy::Map { .. } => ctype::PTR_PAIR,
             CTy::Option(inner) => self.option_struct(inner).layout,
             CTy::Record(name) => self.record_struct(name).layout,
@@ -183,7 +131,7 @@ impl<'ir> Model<'ir> {
 
     /// Layout of a function's return envelope: `code: i32` at 0, then the
     /// `err_msg` text, then the success payload when the function returns
-    /// one.
+    /// one. Item envelopes reuse the same shape with a `COption` payload.
     #[must_use]
     pub fn envelope(&self, ret: Option<&CTy>) -> EnvelopeLayout {
         let mut fields = vec![Layout { size: 4, align: 4 }, ctype::PTR_PAIR];
@@ -200,14 +148,21 @@ impl<'ir> Model<'ir> {
     }
 
     /// Every distinct aggregate mirror reachable from `roots`, keyed and
-    /// ordered by mangled name.
+    /// ordered by mangled name. A stream root contributes `COption` of its
+    /// item (the shape its item envelope carries); handles are scalars and
+    /// contribute nothing.
     pub fn reachable_aggregates<'ty>(
         &self,
         roots: impl Iterator<Item = &'ty ir::Type>,
     ) -> BTreeMap<String, CTy> {
         let mut found = BTreeMap::new();
         for ty in roots {
-            self.visit(&CTy::of(ty), &mut found);
+            match ty {
+                ir::Type::Stream(item) => {
+                    self.visit(&CTy::Option(Box::new(CTy::of(item))), &mut found);
+                }
+                _ => self.visit(&self.boundary(ty), &mut found),
+            }
         }
         found
     }
@@ -234,7 +189,7 @@ impl<'ir> Model<'ir> {
                     self.visit(&CTy::of(&field.ty), found);
                 }
             }
-            CTy::Bool | CTy::Int(_) | CTy::Float(_) | CTy::Str | CTy::Bytes => {}
+            CTy::Bool | CTy::Int(_) | CTy::Float(_) | CTy::Str | CTy::Bytes | CTy::Handle => {}
         }
     }
 }

--- a/packages/unibind/backend-jvm/src/model.rs
+++ b/packages/unibind/backend-jvm/src/model.rs
@@ -1,0 +1,234 @@
+//! The validated type model of one interface.
+//!
+//! [`Model::new`] is the shared gate all three generators pass through: it
+//! rejects the surface the sync JVM backend does not implement and resolves
+//! every `Named` type, so the layout queries and the per-record lookups can
+//! assume a well-formed interface.
+
+use std::collections::BTreeMap;
+
+use unibind_core::ir;
+
+use crate::ctype::{self, CTy, EnvelopeLayout, Layout, StructLayout};
+use crate::RenderError;
+
+/// Record lookup plus layout queries for every reachable mirror.
+pub struct Model<'ir> {
+    records: BTreeMap<&'ir str, &'ir ir::Record>,
+}
+
+impl<'ir> Model<'ir> {
+    /// Validate the sync JVM surface and build the model.
+    ///
+    /// # Errors
+    ///
+    /// Fails for surface this backend does not implement (async functions,
+    /// data enums, objects), for unresolved or recursive record types, and
+    /// for a `throws` name with no matching error enum.
+    pub fn new(interface: &'ir ir::Interface) -> Result<Self, RenderError> {
+        if let Some(object) = interface.objects.first() {
+            return Err(RenderError::new(format!(
+                "`{}` is a #[unibind::object]; objects land in phase 2 (issue #1992)",
+                object.name
+            )));
+        }
+        if let Some(data_enum) = interface.enums.first() {
+            return Err(RenderError::new(format!(
+                "`{}` is a data enum, which the sync JVM backend does not render (issue #2083)",
+                data_enum.name
+            )));
+        }
+        if let Some(function) = interface
+            .functions
+            .iter()
+            .find(|function| matches!(function.asyncness, ir::Asyncness::Async))
+        {
+            return Err(RenderError::new(format!(
+                "`{}` is async; async functions land in phase 2 (issue #1992)",
+                function.name
+            )));
+        }
+        let model = Self {
+            records: interface
+                .records
+                .iter()
+                .map(|record| (record.name.as_str(), record))
+                .collect(),
+        };
+        for record in &interface.records {
+            model.check_record(&record.name, &mut Vec::new())?;
+        }
+        for function in &interface.functions {
+            for arg in &function.args {
+                model.check_type(&arg.ty, &mut Vec::new())?;
+            }
+            if let Some(ret) = &function.ret {
+                model.check_type(ret, &mut Vec::new())?;
+            }
+            if let Some(throws) = &function.throws
+                && !interface.errors.iter().any(|error| error.name == *throws)
+            {
+                return Err(RenderError::new(format!(
+                    "`{}` returns `Result<_, {throws}>`, but `{throws}` is not a \
+                     #[unibind::error] in this module",
+                    function.name
+                )));
+            }
+        }
+        Ok(model)
+    }
+
+    fn check_type(&self, ty: &ir::Type, stack: &mut Vec<String>) -> Result<(), RenderError> {
+        match ty {
+            ir::Type::Option(inner) | ir::Type::Vec(inner) => self.check_type(inner, stack),
+            ir::Type::Map { key, value } => {
+                self.check_type(key, stack)?;
+                self.check_type(value, stack)
+            }
+            ir::Type::Named(name) => self.check_record(name, stack),
+            ir::Type::Bool
+            | ir::Type::Int(_)
+            | ir::Type::Float(_)
+            | ir::Type::String { .. }
+            | ir::Type::Path { .. }
+            | ir::Type::Bytes { .. } => Ok(()),
+        }
+    }
+
+    fn check_record(&self, name: &str, stack: &mut Vec<String>) -> Result<(), RenderError> {
+        if stack.iter().any(|seen| seen == name) {
+            return Err(RenderError::new(format!(
+                "record `{name}` is part of a reference cycle; recursive records cannot \
+                 cross the boundary by value"
+            )));
+        }
+        let Some(record) = self.records.get(name) else {
+            return Err(RenderError::new(format!(
+                "`{name}` is not a #[unibind::record] in this module"
+            )));
+        };
+        stack.push(name.to_owned());
+        for field in &record.fields {
+            self.check_type(&field.ty, stack)?;
+        }
+        stack.pop();
+        Ok(())
+    }
+
+    /// The record behind a validated [`CTy::Record`] name.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `name` was not validated by [`Model::new`].
+    #[must_use]
+    pub fn record(&self, name: &str) -> &'ir ir::Record {
+        self.records
+            .get(name)
+            .expect("record names are validated when the model is built")
+    }
+
+    /// Layout of one mirror.
+    #[must_use]
+    pub fn layout(&self, ty: &CTy) -> Layout {
+        match ty {
+            CTy::Bool => Layout { size: 1, align: 1 },
+            CTy::Int(kind) => ctype::int_layout(*kind),
+            CTy::Float(ir::FloatKind::F32) => Layout { size: 4, align: 4 },
+            CTy::Float(ir::FloatKind::F64) => Layout { size: 8, align: 8 },
+            CTy::Str | CTy::Path | CTy::Bytes | CTy::Vec(_) | CTy::Map { .. } => ctype::PTR_PAIR,
+            CTy::Option(inner) => self.option_struct(inner).layout,
+            CTy::Record(name) => self.record_struct(name).layout,
+        }
+    }
+
+    fn option_struct(&self, inner: &CTy) -> StructLayout {
+        ctype::struct_layout(&[Layout { size: 1, align: 1 }, self.layout(inner)])
+    }
+
+    /// Offset of the payload inside `COption<inner>` (the presence flag is
+    /// at 0).
+    #[must_use]
+    pub fn option_value_offset(&self, inner: &CTy) -> u64 {
+        self.option_struct(inner).offsets[1]
+    }
+
+    /// Layout of the `CPair<key, value>` entry a map crosses as.
+    #[must_use]
+    pub fn pair_struct(&self, key: &CTy, value: &CTy) -> StructLayout {
+        ctype::struct_layout(&[self.layout(key), self.layout(value)])
+    }
+
+    /// Layout of a record's `#[repr(C)]` mirror, offsets aligned with the
+    /// record's fields.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `name` was not validated by [`Model::new`].
+    #[must_use]
+    pub fn record_struct(&self, name: &str) -> StructLayout {
+        let fields: Vec<Layout> = self
+            .record(name)
+            .fields
+            .iter()
+            .map(|field| self.layout(&CTy::of(&field.ty)))
+            .collect();
+        ctype::struct_layout(&fields)
+    }
+
+    /// Layout of a function's return envelope: `code: i32` at 0, then the
+    /// `err_msg` text, then the success payload when the function returns
+    /// one.
+    #[must_use]
+    pub fn envelope(&self, ret: Option<&CTy>) -> EnvelopeLayout {
+        let mut fields = vec![Layout { size: 4, align: 4 }, ctype::PTR_PAIR];
+        if let Some(ret) = ret {
+            fields.push(self.layout(ret));
+        }
+        let shape = ctype::struct_layout(&fields);
+        let value_offset = ret.map(|_| shape.offsets[2]);
+        EnvelopeLayout {
+            layout: shape.layout,
+            err_msg_offset: shape.offsets[1],
+            value_offset,
+        }
+    }
+
+    /// Every distinct aggregate mirror reachable from `roots`, keyed and
+    /// ordered by mangled name.
+    pub fn reachable_aggregates<'ty>(
+        &self,
+        roots: impl Iterator<Item = &'ty ir::Type>,
+    ) -> BTreeMap<String, CTy> {
+        let mut found = BTreeMap::new();
+        for ty in roots {
+            self.visit(&CTy::of(ty), &mut found);
+        }
+        found
+    }
+
+    fn visit(&self, ty: &CTy, found: &mut BTreeMap<String, CTy>) {
+        if ty.is_scalar() {
+            return;
+        }
+        let mangle = ty.mangle();
+        if found.contains_key(&mangle) {
+            return;
+        }
+        found.insert(mangle, ty.clone());
+        match ty {
+            // The path helpers decode and encode through the text helpers.
+            CTy::Path => self.visit(&CTy::Str, found),
+            CTy::Option(inner) | CTy::Vec(inner) => self.visit(inner, found),
+            CTy::Map { key, value } => {
+                self.visit(key, found);
+                self.visit(value, found);
+            }
+            CTy::Record(name) => {
+                for field in &self.record(name).fields {
+                    self.visit(&CTy::of(&field.ty), found);
+                }
+            }
+            CTy::Bool | CTy::Int(_) | CTy::Float(_) | CTy::Str | CTy::Bytes => {}
+        }
+    }
+}

--- a/packages/unibind/backend-jvm/src/model/validate.rs
+++ b/packages/unibind/backend-jvm/src/model/validate.rs
@@ -1,0 +1,178 @@
+//! Interface validation: what the JVM backend accepts, with errors that
+//! say why a shape cannot cross.
+//!
+//! Lowering already guarantees most of this (objects never in arguments,
+//! streams only in return position, constructors sync); the checks repeat
+//! the rules against the serialized IR anyway, so an out-of-process
+//! generator fed a hand-built interface fails with a message instead of a
+//! panic deeper in the layout code.
+
+use unibind_core::ir;
+
+use crate::RenderError;
+
+use super::Model;
+
+pub(super) fn interface(
+    model: &Model<'_>,
+    interface: &ir::Interface,
+) -> Result<(), RenderError> {
+    if let Some(data_enum) = interface.enums.first() {
+        return Err(RenderError::new(format!(
+            "`{}` is a data enum, which the JVM backend does not render yet",
+            data_enum.name
+        )));
+    }
+    for record in &interface.records {
+        check_record(model, &record.name, &mut Vec::new())?;
+    }
+    for function in &interface.functions {
+        check_function(model, interface, function, None)?;
+    }
+    for object in &interface.objects {
+        if let Some(ctor) = &object.constructor {
+            check_function(model, interface, ctor, Some(&object.name))?;
+        }
+        for method in &object.methods {
+            check_function(model, interface, method, Some(&object.name))?;
+        }
+    }
+    Ok(())
+}
+
+fn check_function(
+    model: &Model<'_>,
+    interface: &ir::Interface,
+    function: &ir::Function,
+    owner: Option<&str>,
+) -> Result<(), RenderError> {
+    let site = owner.map_or_else(
+        || function.name.clone(),
+        |object| format!("{object}.{}", function.name),
+    );
+    for arg in &function.args {
+        check_arg(model, &arg.ty, &site)?;
+    }
+    if let Some(ret) = &function.ret {
+        check_ret(model, ret, &site)?;
+    }
+    if let Some(throws) = &function.throws
+        && !interface.errors.iter().any(|error| error.name == *throws)
+    {
+        return Err(RenderError::new(format!(
+            "`{site}` returns `Result<_, {throws}>`, but `{throws}` is not a \
+             #[unibind::error] in this module"
+        )));
+    }
+    Ok(())
+}
+
+/// Arguments carry plain data only: streams cross only as return values,
+/// and objects only as handles the target language already holds.
+fn check_arg(model: &Model<'_>, ty: &ir::Type, site: &str) -> Result<(), RenderError> {
+    match ty {
+        ir::Type::Stream(_) => Err(RenderError::new(format!(
+            "`{site}` takes a `UniStream` argument; streams cross only as return values"
+        ))),
+        ir::Type::Named(name) if model.is_object(name) => Err(RenderError::new(format!(
+            "`{site}` takes the object `{name}` by value; objects never cross as arguments"
+        ))),
+        ir::Type::Named(name) => check_record(model, name, &mut Vec::new()),
+        ir::Type::Option(inner) | ir::Type::Vec(inner) => check_arg(model, inner, site),
+        ir::Type::Map { key, value } => {
+            check_arg(model, key, site)?;
+            check_arg(model, value, site)
+        }
+        ir::Type::Bool
+        | ir::Type::Int(_)
+        | ir::Type::Float(_)
+        | ir::Type::String { .. }
+        | ir::Type::Path { .. }
+        | ir::Type::Bytes { .. } => Ok(()),
+    }
+}
+
+/// Return types additionally allow a top-level stream (whose items must be
+/// plain data) and a top-level object (crossing as a handle).
+fn check_ret(model: &Model<'_>, ty: &ir::Type, site: &str) -> Result<(), RenderError> {
+    match ty {
+        ir::Type::Stream(item) => check_item(model, item, site),
+        ir::Type::Named(name) if model.is_object(name) => Ok(()),
+        _ => check_arg(model, ty, site),
+    }
+}
+
+/// Stream items cross inside item envelopes, so they must be plain data:
+/// no nested streams, no objects.
+fn check_item(model: &Model<'_>, ty: &ir::Type, site: &str) -> Result<(), RenderError> {
+    match ty {
+        ir::Type::Stream(_) => Err(RenderError::new(format!(
+            "`{site}` returns a stream of streams; stream items must be plain data"
+        ))),
+        ir::Type::Named(name) if model.is_object(name) => Err(RenderError::new(format!(
+            "`{site}` streams the object `{name}`; stream items must be plain data"
+        ))),
+        ir::Type::Named(name) => check_record(model, name, &mut Vec::new()),
+        ir::Type::Option(inner) | ir::Type::Vec(inner) => check_item(model, inner, site),
+        ir::Type::Map { key, value } => {
+            check_item(model, key, site)?;
+            check_item(model, value, site)
+        }
+        ir::Type::Bool
+        | ir::Type::Int(_)
+        | ir::Type::Float(_)
+        | ir::Type::String { .. }
+        | ir::Type::Path { .. }
+        | ir::Type::Bytes { .. } => Ok(()),
+    }
+}
+
+fn check_record(model: &Model<'_>, name: &str, stack: &mut Vec<String>) -> Result<(), RenderError> {
+    if stack.iter().any(|seen| seen == name) {
+        return Err(RenderError::new(format!(
+            "record `{name}` is part of a reference cycle; recursive records cannot \
+             cross the boundary by value"
+        )));
+    }
+    let Some(record) = model.records.get(name) else {
+        return Err(RenderError::new(format!(
+            "`{name}` is not a #[unibind::record] in this module"
+        )));
+    };
+    stack.push(name.to_owned());
+    for field in &record.fields {
+        check_field(model, &record.name, &field.ty, stack)?;
+    }
+    stack.pop();
+    Ok(())
+}
+
+/// Record fields cross by value inside the record's mirror struct, so they
+/// hold plain data only.
+fn check_field(
+    model: &Model<'_>,
+    record: &str,
+    ty: &ir::Type,
+    stack: &mut Vec<String>,
+) -> Result<(), RenderError> {
+    match ty {
+        ir::Type::Stream(_) => Err(RenderError::new(format!(
+            "record `{record}` holds a `UniStream` field; streams cross only as return values"
+        ))),
+        ir::Type::Named(name) if model.is_object(name) => Err(RenderError::new(format!(
+            "record `{record}` holds the object `{name}`; record fields carry plain data only"
+        ))),
+        ir::Type::Named(name) => check_record(model, name, stack),
+        ir::Type::Option(inner) | ir::Type::Vec(inner) => check_field(model, record, inner, stack),
+        ir::Type::Map { key, value } => {
+            check_field(model, record, key, stack)?;
+            check_field(model, record, value, stack)
+        }
+        ir::Type::Bool
+        | ir::Type::Int(_)
+        | ir::Type::Float(_)
+        | ir::Type::String { .. }
+        | ir::Type::Path { .. }
+        | ir::Type::Bytes { .. } => Ok(()),
+    }
+}

--- a/packages/unibind/backend-jvm/src/names.rs
+++ b/packages/unibind/backend-jvm/src/names.rs
@@ -1,0 +1,71 @@
+//! Naming: `snake_case` Rust names to Java and Kotlin spellings, plus the
+//! exported symbol names the Rust glue and the Java binding share.
+
+use crate::RenderError;
+
+/// `snake_case` to `camelCase`.
+pub fn camel(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut upper_next = false;
+    for character in name.chars() {
+        if character == '_' {
+            upper_next = true;
+        } else if upper_next {
+            out.extend(character.to_uppercase());
+            upper_next = false;
+        } else {
+            out.push(character);
+        }
+    }
+    out
+}
+
+/// `snake_case` to `PascalCase`.
+pub fn pascal(name: &str) -> String {
+    let camel = camel(name.trim_start_matches('_'));
+    let mut characters = camel.chars();
+    characters.next().map_or_else(String::new, |first| {
+        first.to_uppercase().chain(characters).collect()
+    })
+}
+
+/// A type name with its first character lowered, for generated Java helper
+/// methods (`SampleError` becomes `sampleErrorException`).
+pub fn decapitalize(name: &str) -> String {
+    let mut characters = name.chars();
+    characters.next().map_or_else(String::new, |first| {
+        first.to_lowercase().chain(characters).collect()
+    })
+}
+
+/// The `extern "C"` export for one function.
+pub fn export_symbol(module: &str, function: &str) -> String {
+    format!("unibind_jvm_{module}_{function}")
+}
+
+/// The companion export that frees one function's return envelope.
+pub fn free_symbol(module: &str, function: &str) -> String {
+    format!("{}__free", export_symbol(module, function))
+}
+
+/// The ABI version probe the Java binding calls at load.
+pub fn abi_symbol(module: &str) -> String {
+    format!("unibind_jvm_{module}_abi_version")
+}
+
+/// The Java package one interface lands in.
+pub fn java_package(module: &str) -> String {
+    format!("unibind.{module}")
+}
+
+/// The `SCREAMING_SNAKE` method-handle constant for one function.
+pub fn handle_const(function: &str) -> String {
+    format!("H_{}", function.to_uppercase())
+}
+
+/// An identifier for a Rust-side name coming out of the IR.
+pub fn rust_ident(name: &str) -> Result<syn::Ident, RenderError> {
+    syn::parse_str::<syn::Ident>(name)
+        .or_else(|_| syn::parse_str::<syn::Ident>(&format!("r#{name}")))
+        .map_err(|_| RenderError::new(format!("`{name}` is not usable as an identifier")))
+}

--- a/packages/unibind/backend-jvm/src/names.rs
+++ b/packages/unibind/backend-jvm/src/names.rs
@@ -45,7 +45,50 @@ pub fn export_symbol(module: &str, function: &str) -> String {
 
 /// The companion export that frees one function's return envelope.
 pub fn free_symbol(module: &str, function: &str) -> String {
-    format!("{}__free", export_symbol(module, function))
+    free_suffix(&export_symbol(module, function))
+}
+
+/// The `extern "C"` export for one object constructor or method; the
+/// object keeps its Rust PascalCase inside the symbol.
+pub fn object_export_symbol(module: &str, object: &str, method: &str) -> String {
+    format!("unibind_jvm_{module}_{object}_{method}")
+}
+
+/// The export releasing one object handle (dropping its `Arc`).
+pub fn object_free_symbol(module: &str, object: &str) -> String {
+    format!("unibind_jvm_{module}_{object}__free")
+}
+
+/// The `__free` companion on an arbitrary export symbol; methods share the
+/// suffix scheme with free functions, so companions build on the base
+/// symbol rather than on module + function.
+pub fn free_suffix(base: &str) -> String {
+    format!("{base}__free")
+}
+
+/// The companion export requesting cancellation of an async export's task.
+pub fn cancel_suffix(base: &str) -> String {
+    format!("{base}__cancel")
+}
+
+/// The companion export releasing an async export's task handle.
+pub fn task_free_suffix(base: &str) -> String {
+    format!("{base}__task_free")
+}
+
+/// The companion export pulling one item from a stream export's handle.
+pub fn stream_next_suffix(base: &str) -> String {
+    format!("{base}__stream_next")
+}
+
+/// The companion export releasing a stream export's handle.
+pub fn stream_free_suffix(base: &str) -> String {
+    format!("{base}__stream_free")
+}
+
+/// The companion export freeing one of a stream export's item envelopes.
+pub fn item_free_suffix(base: &str) -> String {
+    format!("{base}__item_free")
 }
 
 /// The ABI version probe the Java binding calls at load.

--- a/packages/unibind/backend-jvm/src/rust_glue/asserts.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/asserts.rs
@@ -11,22 +11,27 @@ use unibind_core::ir;
 use crate::ctype::CTy;
 use crate::model::Model;
 use crate::names;
-use crate::rust_glue::types::{envelope_ident, mirror_tokens};
+use crate::rust_glue::types::{envelope_ident, item_envelope_ident, mirror_tokens};
+use crate::rust_glue::Export;
 
-/// The `const _: () = { ... }` block checking every reachable aggregate and
-/// every function envelope.
-pub fn layout_asserts(interface: &ir::Interface, model: &Model<'_>) -> TokenStream {
+/// The `const _: () = { ... }` block checking every reachable aggregate,
+/// every export envelope, and every stream export's item envelope.
+pub fn layout_asserts(
+    interface: &ir::Interface,
+    model: &Model<'_>,
+    exports: &[Export<'_>],
+) -> TokenStream {
     let mut checks = Vec::new();
 
-    let roots = interface
-        .functions
+    let roots = exports
         .iter()
-        .flat_map(|function| {
-            function
+        .flat_map(|export| {
+            export
+                .function
                 .args
                 .iter()
                 .map(|arg| &arg.ty)
-                .chain(function.ret.as_ref())
+                .chain(export.ret.as_ref())
         })
         .chain(
             interface
@@ -43,22 +48,14 @@ pub fn layout_asserts(interface: &ir::Interface, model: &Model<'_>) -> TokenStre
         checks.push(field_checks(ty, model));
     }
 
-    for function in &interface.functions {
-        let ident = envelope_ident(&function.name);
-        let tokens = quote!(#ident);
-        let ret = function.ret.as_ref().map(CTy::of);
-        let envelope = model.envelope(ret.as_ref());
-        checks.push(size_align(&tokens, envelope.layout.size, envelope.layout.align));
-        let err_msg = Literal::u64_unsuffixed(envelope.err_msg_offset);
-        checks.push(quote! {
-            assert!(::core::mem::offset_of!(#tokens, code) == 0);
-            assert!(::core::mem::offset_of!(#tokens, err_msg) == #err_msg);
-        });
-        if let Some(value_offset) = envelope.value_offset {
-            let value = Literal::u64_unsuffixed(value_offset);
-            checks.push(quote! {
-                assert!(::core::mem::offset_of!(#tokens, value) == #value);
-            });
+    for export in exports {
+        let ident = envelope_ident(export.owner, &export.function.name);
+        let ret = export.ret.as_ref().map(|ty| model.boundary(ty));
+        checks.push(envelope_checks(&quote!(#ident), model, ret.as_ref()));
+        if let Some(ir::Type::Stream(item)) = &export.ret {
+            let item_ident = item_envelope_ident(export.owner, &export.function.name);
+            let payload = CTy::Option(Box::new(CTy::of(item)));
+            checks.push(envelope_checks(&quote!(#item_ident), model, Some(&payload)));
         }
     }
 
@@ -67,6 +64,24 @@ pub fn layout_asserts(interface: &ir::Interface, model: &Model<'_>) -> TokenStre
             #(#checks)*
         };
     }
+}
+
+/// Size, alignment, and field offsets of one envelope-shaped struct.
+fn envelope_checks(tokens: &TokenStream, model: &Model<'_>, ret: Option<&CTy>) -> TokenStream {
+    let envelope = model.envelope(ret);
+    let mut checks = vec![size_align(tokens, envelope.layout.size, envelope.layout.align)];
+    let err_msg = Literal::u64_unsuffixed(envelope.err_msg_offset);
+    checks.push(quote! {
+        assert!(::core::mem::offset_of!(#tokens, code) == 0);
+        assert!(::core::mem::offset_of!(#tokens, err_msg) == #err_msg);
+    });
+    if let Some(value_offset) = envelope.value_offset {
+        let value = Literal::u64_unsuffixed(value_offset);
+        checks.push(quote! {
+            assert!(::core::mem::offset_of!(#tokens, value) == #value);
+        });
+    }
+    quote!(#(#checks)*)
 }
 
 fn size_align(tokens: &TokenStream, size: u64, align: u64) -> TokenStream {
@@ -123,6 +138,6 @@ fn field_checks(ty: &CTy, model: &Model<'_>) -> TokenStream {
             }
             quote!(#(#checks)*)
         }
-        CTy::Bool | CTy::Int(_) | CTy::Float(_) => TokenStream::new(),
+        CTy::Bool | CTy::Int(_) | CTy::Float(_) | CTy::Handle => TokenStream::new(),
     }
 }

--- a/packages/unibind/backend-jvm/src/rust_glue/asserts.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/asserts.rs
@@ -1,0 +1,128 @@
+//! `const` assertions pinning every mirror layout to the computed numbers.
+//!
+//! The Java generator bakes the same numbers into its reads and writes, so
+//! a Rust compiler that lays a mirror out differently fails the user's
+//! build instead of corrupting memory at runtime.
+
+use proc_macro2::{Literal, TokenStream};
+use quote::quote;
+use unibind_core::ir;
+
+use crate::ctype::CTy;
+use crate::model::Model;
+use crate::names;
+use crate::rust_glue::types::{envelope_ident, mirror_tokens};
+
+/// The `const _: () = { ... }` block checking every reachable aggregate and
+/// every function envelope.
+pub fn layout_asserts(interface: &ir::Interface, model: &Model<'_>) -> TokenStream {
+    let mut checks = Vec::new();
+
+    let roots = interface
+        .functions
+        .iter()
+        .flat_map(|function| {
+            function
+                .args
+                .iter()
+                .map(|arg| &arg.ty)
+                .chain(function.ret.as_ref())
+        })
+        .chain(
+            interface
+                .records
+                .iter()
+                .flat_map(|record| record.fields.iter().map(|field| &field.ty)),
+        );
+    let mut aggregates = model.reachable_aggregates(roots);
+    // `err_msg` makes the text mirror reachable from every envelope.
+    aggregates.entry(CTy::Str.mangle()).or_insert(CTy::Str);
+
+    for ty in aggregates.values() {
+        checks.push(size_align(&mirror_tokens(ty), model.layout(ty).size, model.layout(ty).align));
+        checks.push(field_checks(ty, model));
+    }
+
+    for function in &interface.functions {
+        let ident = envelope_ident(&function.name);
+        let tokens = quote!(#ident);
+        let ret = function.ret.as_ref().map(CTy::of);
+        let envelope = model.envelope(ret.as_ref());
+        checks.push(size_align(&tokens, envelope.layout.size, envelope.layout.align));
+        let err_msg = Literal::u64_unsuffixed(envelope.err_msg_offset);
+        checks.push(quote! {
+            assert!(::core::mem::offset_of!(#tokens, code) == 0);
+            assert!(::core::mem::offset_of!(#tokens, err_msg) == #err_msg);
+        });
+        if let Some(value_offset) = envelope.value_offset {
+            let value = Literal::u64_unsuffixed(value_offset);
+            checks.push(quote! {
+                assert!(::core::mem::offset_of!(#tokens, value) == #value);
+            });
+        }
+    }
+
+    quote! {
+        const _: () = {
+            #(#checks)*
+        };
+    }
+}
+
+fn size_align(tokens: &TokenStream, size: u64, align: u64) -> TokenStream {
+    let size = Literal::u64_unsuffixed(size);
+    let align = Literal::u64_unsuffixed(align);
+    quote! {
+        assert!(::core::mem::size_of::<#tokens>() == #size);
+        assert!(::core::mem::align_of::<#tokens>() == #align);
+    }
+}
+
+fn field_checks(ty: &CTy, model: &Model<'_>) -> TokenStream {
+    let tokens = mirror_tokens(ty);
+    match ty {
+        CTy::Str | CTy::Path | CTy::Bytes | CTy::Vec(_) => quote! {
+            assert!(::core::mem::offset_of!(#tokens, ptr) == 0);
+            assert!(::core::mem::offset_of!(#tokens, len) == 8);
+        },
+        CTy::Map { key, value } => {
+            let pair = model.pair_struct(key, value);
+            let key_tokens = mirror_tokens(key);
+            let value_tokens = mirror_tokens(value);
+            let pair_tokens = quote!(CPair<#key_tokens, #value_tokens>);
+            let pair_checks = size_align(&pair_tokens, pair.layout.size, pair.layout.align);
+            let key_offset = Literal::u64_unsuffixed(pair.offsets[0]);
+            let value_offset = Literal::u64_unsuffixed(pair.offsets[1]);
+            quote! {
+                assert!(::core::mem::offset_of!(#tokens, ptr) == 0);
+                assert!(::core::mem::offset_of!(#tokens, len) == 8);
+                #pair_checks
+                assert!(::core::mem::offset_of!(#pair_tokens, key) == #key_offset);
+                assert!(::core::mem::offset_of!(#pair_tokens, value) == #value_offset);
+            }
+        }
+        CTy::Option(inner) => {
+            let value_offset = Literal::u64_unsuffixed(model.option_value_offset(inner));
+            quote! {
+                assert!(::core::mem::offset_of!(#tokens, present) == 0);
+                assert!(::core::mem::offset_of!(#tokens, value) == #value_offset);
+            }
+        }
+        CTy::Record(name) => {
+            let shape = model.record_struct(name);
+            let mut checks = Vec::new();
+            for (field, offset) in model.record(name).fields.iter().zip(&shape.offsets) {
+                let Ok(ident) = names::rust_ident(&field.name) else {
+                    // The mirror-struct emitter already errored on this name.
+                    continue;
+                };
+                let offset = Literal::u64_unsuffixed(*offset);
+                checks.push(quote! {
+                    assert!(::core::mem::offset_of!(#tokens, #ident) == #offset);
+                });
+            }
+            quote!(#(#checks)*)
+        }
+        CTy::Bool | CTy::Int(_) | CTy::Float(_) => TokenStream::new(),
+    }
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/asyncfn.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/asyncfn.rs
@@ -1,0 +1,160 @@
+//! Render async `extern "C"` exports: the spawning export plus its
+//! `__cancel` / `__task_free` companions.
+//!
+//! Arguments decode to owned values (lowering guarantees async signatures
+//! own their arguments) before anything is spawned, so Java may release
+//! the argument arena the moment the downcall returns. The callback fires
+//! exactly once per call: from the spawned task's finish closure, or
+//! synchronously when argument decoding panics.
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::model::Model;
+use crate::rust_glue::envelope::{self, EnvelopeParts};
+use crate::rust_glue::{function, types, Export};
+use crate::{names, RenderError};
+
+/// One async export and its task companions.
+pub(crate) fn render_async(
+    export: &Export<'_>,
+    interface: &ir::Interface,
+    model: &Model<'_>,
+    user: &Ident,
+) -> Result<TokenStream, RenderError> {
+    let base = export.symbol(interface);
+    let export_ident = format_ident!("{base}");
+    let envelope = types::envelope_ident(export.owner, &export.function.name);
+    let plan = function::arg_plan(export.function, model, user)?;
+
+    let mut params = Vec::new();
+    let mut receiver_setup = None;
+    if export.has_receiver {
+        let owner_ident = names::rust_ident(export.owner.expect("methods have an owner"))?;
+        params.push(quote!(this: *mut ::core::ffi::c_void));
+        // The task owns a strong count of its own: Java may free the
+        // object handle while the call is still in flight.
+        receiver_setup = Some(quote! {
+            let this = this.cast_const().cast::<super::#user::#owner_ident>();
+            unsafe { ::std::sync::Arc::increment_strong_count(this) };
+            let this = unsafe { ::std::sync::Arc::from_raw(this) };
+        });
+    }
+    params.extend(plan.params.iter().cloned());
+
+    let path = function::call_path(export, user)?;
+    let idents = &plan.idents;
+    let call = if export.has_receiver {
+        quote!(#path(&this #(, #idents)*).await)
+    } else {
+        quote!(#path(#(#idents),*).await)
+    };
+
+    let parts = EnvelopeParts {
+        interface,
+        model,
+        user,
+        function: export.function,
+        ret: export.ret.as_ref(),
+        envelope: &envelope,
+    };
+    let completed = envelope::envelope_expr(&parts, &quote!(value))?;
+    let zero_value = envelope::zero_value(&parts);
+    let bindings = &plan.bindings;
+    let docs = &export.function.docs;
+    let free = free_companions(&base, &envelope);
+
+    Ok(quote! {
+        #(#[doc = #docs])*
+        #[doc = ""]
+        #[doc = "Asynchronous: returns an opaque task handle and fires `cb` exactly once with a boxed envelope (`code` -2 when cancelled). When argument decoding panics, `cb` fires synchronously with `code` -1 and the returned handle is an inert task whose finish closure does nothing, so `__cancel`/`__task_free` stay uniform and `cb` never fires twice."]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #export_ident(
+            #(#params,)*
+            cb: unsafe extern "C" fn(*mut ::core::ffi::c_void, *mut #envelope),
+            user_data: *mut ::core::ffi::c_void,
+        ) -> *mut ::core::ffi::c_void {
+            let user_data = SendPtr(user_data);
+            let decoded = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+                #(#bindings)*
+                (#(#idents,)*)
+            }));
+            match decoded {
+                ::std::result::Result::Ok((#(#idents,)*)) => {
+                    #receiver_setup
+                    ::unibind_runtime::jvm::spawn_cancellable(
+                        async move { #call },
+                        move |outcome| {
+                            let envelope = match outcome {
+                                ::unibind_runtime::jvm::TaskOutcome::Completed(value) => #completed,
+                                ::unibind_runtime::jvm::TaskOutcome::Panicked(text) => #envelope {
+                                    code: -1,
+                                    err_msg: string_value(text),
+                                    #zero_value
+                                },
+                                ::unibind_runtime::jvm::TaskOutcome::Cancelled => #envelope {
+                                    code: -2,
+                                    err_msg: null_string(),
+                                    #zero_value
+                                },
+                            };
+                            unsafe {
+                                cb(user_data.0, ::std::boxed::Box::into_raw(::std::boxed::Box::new(envelope)))
+                            }
+                        },
+                    )
+                }
+                ::std::result::Result::Err(payload) => {
+                    let envelope = #envelope {
+                        code: -1,
+                        err_msg: string_value(panic_text(payload.as_ref())),
+                        #zero_value
+                    };
+                    unsafe {
+                        cb(user_data.0, ::std::boxed::Box::into_raw(::std::boxed::Box::new(envelope)))
+                    };
+                    ::unibind_runtime::jvm::spawn_cancellable(
+                        async {},
+                        |_outcome: ::unibind_runtime::jvm::TaskOutcome<()>| {},
+                    )
+                }
+            }
+        }
+
+        #free
+    })
+}
+
+fn free_companions(base: &str, envelope: &Ident) -> TokenStream {
+    let free_ident = format_ident!("{}", names::free_suffix(base));
+    let cancel_ident = format_ident!("{}", names::cancel_suffix(base));
+    let task_free_ident = format_ident!("{}", names::task_free_suffix(base));
+    quote! {
+        /// Reclaim an envelope delivered to the paired export's callback.
+        /// Null is a no-op; anything else must come from that callback,
+        /// exactly once.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #free_ident(envelope: *mut #envelope) {
+            if envelope.is_null() {
+                return;
+            }
+            drop(unsafe { ::std::boxed::Box::from_raw(envelope) });
+        }
+
+        /// Request cancellation of a task returned by the paired export.
+        /// Idempotent and safe after completion; never call it after
+        /// `__task_free`. Does not free the handle.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #cancel_ident(task: *mut ::core::ffi::c_void) {
+            unsafe { ::unibind_runtime::jvm::task_cancel(task) }
+        }
+
+        /// Release a task handle returned by the paired export, exactly
+        /// once, after its callback fired.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #task_free_ident(task: *mut ::core::ffi::c_void) {
+            unsafe { ::unibind_runtime::jvm::task_free(task) }
+        }
+    }
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/decode.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/decode.rs
@@ -94,6 +94,12 @@ pub fn expr(
                     .collect::<::std::collections::HashMap<_, _>>()
             }
         }
+        ir::Type::Stream(_) => {
+            return Err(RenderError::new(
+                "`UniStream` crosses as an async iterator; the JVM backend's stream \
+                 support lands with issue #2083",
+            ));
+        }
         ir::Type::Named(name) => {
             let ident = names::rust_ident(name)?;
             let mut fields = Vec::new();

--- a/packages/unibind/backend-jvm/src/rust_glue/decode.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/decode.rs
@@ -1,0 +1,132 @@
+//! Decode C mirrors into the Rust values the user's function takes.
+//!
+//! Arguments are owned by the Java arena: borrowed parameter types (`&str`,
+//! `&Path`, `&[u8]`) view the Java memory zero-copy, owned ones copy out of
+//! it, and nothing here ever frees it.
+
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use unibind_core::ir;
+
+use crate::model::Model;
+use crate::{names, RenderError};
+
+/// The borrow helpers the generated decoders call.
+pub fn helpers() -> TokenStream {
+    quote! {
+        /// View a Java-owned buffer; empty buffers may carry a null pointer.
+        unsafe fn view<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
+            if len == 0 {
+                &[]
+            } else {
+                unsafe { ::core::slice::from_raw_parts(ptr, len) }
+            }
+        }
+
+        /// Borrow Java-owned text; panics (caught at the export boundary)
+        /// on invalid UTF-8.
+        unsafe fn str_value(value: &CString) -> &str {
+            ::core::str::from_utf8(unsafe { view(value.ptr, value.len) })
+                .expect("unibind: text crossing the boundary is not valid UTF-8")
+        }
+    }
+}
+
+/// The expression decoding `access` into `ty`. `access` is a mirror value
+/// for scalars and a mirror reference for aggregates; every generated
+/// `unsafe` operation carries its own block, so the result is usable in
+/// safe positions.
+pub fn expr(
+    model: &Model<'_>,
+    ty: &ir::Type,
+    access: &TokenStream,
+    user: &Ident,
+) -> Result<TokenStream, RenderError> {
+    Ok(match ty {
+        ir::Type::Bool => quote!((#access != 0)),
+        ir::Type::Int(_) | ir::Type::Float(_) => quote!(#access),
+        ir::Type::String { owned: false } => quote!(unsafe { str_value(#access) }),
+        ir::Type::String { owned: true } => {
+            quote!(::std::borrow::ToOwned::to_owned(unsafe { str_value(#access) }))
+        }
+        ir::Type::Path { owned: false } => {
+            quote!(::std::path::Path::new(unsafe { str_value(#access) }))
+        }
+        ir::Type::Path { owned: true } => {
+            quote!(::std::path::PathBuf::from(unsafe { str_value(#access) }))
+        }
+        ir::Type::Bytes { owned: false } => {
+            quote!(unsafe { view((#access).ptr, (#access).len) })
+        }
+        ir::Type::Bytes { owned: true } => {
+            quote!(unsafe { view((#access).ptr, (#access).len) }.to_vec())
+        }
+        ir::Type::Option(inner) => {
+            let value_place = place(access, &quote!(value), inner);
+            let value = expr(model, inner, &value_place, user)?;
+            quote! {
+                if (#access).present != 0 {
+                    ::std::option::Option::Some(#value)
+                } else {
+                    ::std::option::Option::None
+                }
+            }
+        }
+        ir::Type::Vec(inner) => {
+            let element_place = element_place(inner);
+            let element = expr(model, inner, &element_place, user)?;
+            quote! {
+                unsafe { view((#access).ptr, (#access).len) }
+                    .iter()
+                    .map(|element| #element)
+                    .collect::<::std::vec::Vec<_>>()
+            }
+        }
+        ir::Type::Map { key, value } => {
+            let key_place = place(&quote!(entry), &quote!(key), key);
+            let value_place = place(&quote!(entry), &quote!(value), value);
+            let key = expr(model, key, &key_place, user)?;
+            let value = expr(model, value, &value_place, user)?;
+            quote! {
+                unsafe { view((#access).ptr, (#access).len) }
+                    .iter()
+                    .map(|entry| (#key, #value))
+                    .collect::<::std::collections::HashMap<_, _>>()
+            }
+        }
+        ir::Type::Named(name) => {
+            let ident = names::rust_ident(name)?;
+            let mut fields = Vec::new();
+            for field in &model.record(name).fields {
+                let field_ident = names::rust_ident(&field.name)?;
+                let field_place = place(access, &quote!(#field_ident), &field.ty);
+                let value = expr(model, &field.ty, &field_place, user)?;
+                fields.push(quote!(#field_ident: #value));
+            }
+            quote!(super::#user::#ident { #(#fields),* })
+        }
+    })
+}
+
+/// The place expression for `parent.field`: value form for scalars,
+/// reference form for aggregates.
+fn place(parent: &TokenStream, field: &TokenStream, ty: &ir::Type) -> TokenStream {
+    if is_scalar(ty) {
+        quote!(((#parent).#field))
+    } else {
+        quote!((&(#parent).#field))
+    }
+}
+
+/// The place expression for one `&mirror` iterator element.
+fn element_place(ty: &ir::Type) -> TokenStream {
+    if is_scalar(ty) {
+        quote!((*element))
+    } else {
+        quote!(element)
+    }
+}
+
+const fn is_scalar(ty: &ir::Type) -> bool {
+    matches!(ty, ir::Type::Bool | ir::Type::Int(_) | ir::Type::Float(_))
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/encode.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/encode.rs
@@ -108,6 +108,12 @@ pub fn expr(model: &Model<'_>, ty: &ir::Type, access: &TokenStream) -> Result<To
                 )
             }
         }
+        ir::Type::Stream(_) => {
+            return Err(RenderError::new(
+                "`UniStream` crosses as an async iterator; the JVM backend's stream \
+                 support lands with issue #2083",
+            ));
+        }
         ir::Type::Named(name) => {
             let mirror = format_ident!("{name}C");
             let mut fields = Vec::new();

--- a/packages/unibind/backend-jvm/src/rust_glue/encode.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/encode.rs
@@ -1,0 +1,129 @@
+//! Encode owned Rust return values into Rust-heap-owned C mirrors.
+//!
+//! Every allocation made here is reclaimed by the envelope's `Drop` when
+//! Java calls the function's `__free` export.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::model::Model;
+use crate::{names, RenderError};
+
+/// The owning helpers the generated encoders call.
+pub fn helpers() -> TokenStream {
+    quote! {
+        /// An absent or empty text value; drops as a no-op.
+        fn null_string() -> CString {
+            CString {
+                ptr: ::core::ptr::null_mut(),
+                len: 0,
+            }
+        }
+
+        /// Leak owned bytes into a mirror; `Drop` reclaims them.
+        fn bytes_value(value: ::std::vec::Vec<u8>) -> CBytes {
+            let boxed = value.into_boxed_slice();
+            let len = boxed.len();
+            CBytes {
+                ptr: ::std::boxed::Box::into_raw(boxed).cast::<u8>(),
+                len,
+            }
+        }
+
+        /// Leak an owned string into a mirror.
+        fn string_value(value: ::std::string::String) -> CString {
+            bytes_value(value.into_bytes())
+        }
+
+        /// Leak an owned path as UTF-8 text; panics (caught at the export
+        /// boundary) on non-UTF-8 paths.
+        fn path_value(value: ::std::path::PathBuf) -> CPath {
+            let text = value
+                .into_os_string()
+                .into_string()
+                .expect("unibind: path crossing the boundary is not valid UTF-8");
+            string_value(text)
+        }
+
+        /// Leak an owned vec of mirrors.
+        fn vec_value<T>(values: ::std::vec::Vec<T>) -> CVec<T> {
+            let boxed = values.into_boxed_slice();
+            let len = boxed.len();
+            CVec {
+                ptr: ::std::boxed::Box::into_raw(boxed).cast::<T>(),
+                len,
+            }
+        }
+    }
+}
+
+/// The expression encoding the owned Rust value `access` into `ty`'s
+/// mirror.
+pub fn expr(model: &Model<'_>, ty: &ir::Type, access: &TokenStream) -> Result<TokenStream, RenderError> {
+    Ok(match ty {
+        ir::Type::Bool => quote!(u8::from(#access)),
+        ir::Type::Int(_) | ir::Type::Float(_) => quote!(#access),
+        ir::Type::String { .. } => quote!(string_value(#access)),
+        ir::Type::Path { .. } => quote!(path_value(#access)),
+        ir::Type::Bytes { .. } => quote!(bytes_value(#access)),
+        ir::Type::Option(inner) => {
+            let value = expr(model, inner, &quote!(value))?;
+            quote! {
+                match #access {
+                    ::std::option::Option::Some(value) => COption {
+                        present: 1,
+                        value: #value,
+                    },
+                    ::std::option::Option::None => COption {
+                        present: 0,
+                        value: unsafe { ::core::mem::zeroed() },
+                    },
+                }
+            }
+        }
+        ir::Type::Vec(inner) => {
+            let element = expr(model, inner, &quote!(element))?;
+            quote! {
+                vec_value(
+                    (#access)
+                        .into_iter()
+                        .map(|element| #element)
+                        .collect::<::std::vec::Vec<_>>(),
+                )
+            }
+        }
+        ir::Type::Map { key, value } => {
+            let key = expr(model, key, &quote!(key))?;
+            let value = expr(model, value, &quote!(value))?;
+            quote! {
+                vec_value(
+                    (#access)
+                        .into_iter()
+                        .map(|(key, value)| CPair {
+                            key: #key,
+                            value: #value,
+                        })
+                        .collect::<::std::vec::Vec<_>>(),
+                )
+            }
+        }
+        ir::Type::Named(name) => {
+            let mirror = format_ident!("{name}C");
+            let mut fields = Vec::new();
+            for field in &model.record(name).fields {
+                let field_ident = names::rust_ident(&field.name)?;
+                let value = expr(model, &field.ty, &quote!(record.#field_ident))?;
+                fields.push(quote!(#field_ident: #value));
+            }
+            quote! {
+                {
+                    let record = #access;
+                    #mirror {
+                        #(#fields),*
+                    }
+                }
+            }
+        }
+    })
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/envelope.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/envelope.rs
@@ -1,0 +1,155 @@
+//! Build one envelope value from a success expression.
+//!
+//! The sync exports evaluate the user call directly and the async exports
+//! evaluate the `TaskOutcome::Completed` payload, so the construction here
+//! takes an arbitrary value expression and both paths share the `throws`
+//! matching and the success-value encoding.
+
+use proc_macro2::{Ident, Literal, TokenStream};
+use quote::quote;
+use unibind_core::ir;
+
+use crate::model::Model;
+use crate::rust_glue::encode;
+use crate::{names, RenderError};
+
+/// Everything envelope construction needs besides the value expression.
+pub(crate) struct EnvelopeParts<'a> {
+    pub interface: &'a ir::Interface,
+    pub model: &'a Model<'a>,
+    pub user: &'a Ident,
+    pub function: &'a ir::Function,
+    /// The boundary success type; `None` for unit. Constructors pass the
+    /// object's own type here even though their IR `ret` is `None`.
+    pub ret: Option<&'a ir::Type>,
+    pub envelope: &'a Ident,
+}
+
+/// The `value: ...` field tokens zeroing the payload on the error, panic,
+/// and cancel arms; `None` when the envelope has no payload.
+pub(crate) fn zero_value(parts: &EnvelopeParts<'_>) -> Option<TokenStream> {
+    parts
+        .ret
+        .map(|_| quote!(value: unsafe { ::core::mem::zeroed() },))
+}
+
+/// The expression building the envelope from `value_expr`, which evaluates
+/// to the function's raw return (a `Result` when it throws).
+pub(crate) fn envelope_expr(
+    parts: &EnvelopeParts<'_>,
+    value_expr: &TokenStream,
+) -> Result<TokenStream, RenderError> {
+    let ok_value = match parts.ret {
+        Some(ty) => {
+            let encoded = ret_encode(parts.model, ty, &quote!(value))?;
+            Some(quote!(value: #encoded,))
+        }
+        None => None,
+    };
+    match &parts.function.throws {
+        Some(throws) => throws_expr(parts, throws, value_expr, ok_value.as_ref()),
+        None => Ok(plain_expr(parts, value_expr, ok_value.as_ref())),
+    }
+}
+
+/// Encode one boundary success value: streams and objects leave as raw
+/// handles, everything else through the mirror encoders. Streams hand the
+/// runtime a boxed shared stream; objects leak an `Arc` whose count the
+/// object's `__free` export releases.
+fn ret_encode(
+    model: &Model<'_>,
+    ty: &ir::Type,
+    access: &TokenStream,
+) -> Result<TokenStream, RenderError> {
+    match ty {
+        ir::Type::Stream(_) => Ok(quote! {
+            ::unibind_runtime::jvm::stream_into_raw(#access)
+        }),
+        ir::Type::Named(name) if model.is_object(name) => Ok(quote! {
+            ::std::sync::Arc::into_raw(::std::sync::Arc::new(#access))
+                .cast_mut()
+                .cast::<::core::ffi::c_void>()
+        }),
+        _ => encode::expr(model, ty, access),
+    }
+}
+
+fn plain_expr(
+    parts: &EnvelopeParts<'_>,
+    value_expr: &TokenStream,
+    ok_value: Option<&TokenStream>,
+) -> TokenStream {
+    let envelope = parts.envelope;
+    if parts.ret.is_some() {
+        quote! {
+            {
+                let value = #value_expr;
+                #envelope {
+                    code: 0,
+                    err_msg: null_string(),
+                    #ok_value
+                }
+            }
+        }
+    } else {
+        // `let () = ...` both consumes the unit value without tripping the
+        // `path_statements` lint (the async path's value expression is a
+        // bare binding) and proves the expression really is unit.
+        quote! {
+            {
+                let () = #value_expr;
+                #envelope {
+                    code: 0,
+                    err_msg: null_string(),
+                }
+            }
+        }
+    }
+}
+
+fn throws_expr(
+    parts: &EnvelopeParts<'_>,
+    throws: &str,
+    value_expr: &TokenStream,
+    ok_value: Option<&TokenStream>,
+) -> Result<TokenStream, RenderError> {
+    let error = parts
+        .interface
+        .errors
+        .iter()
+        .find(|error| error.name == *throws)
+        .expect("throws names are validated when the model is built");
+    let envelope = parts.envelope;
+    let user = parts.user;
+    let error_ident = names::rust_ident(&error.name)?;
+    let mut arms = Vec::new();
+    for (index, variant) in error.variants.iter().enumerate() {
+        let variant_ident = names::rust_ident(&variant.name)?;
+        let code = Literal::usize_unsuffixed(index + 1);
+        arms.push(quote! {
+            super::#user::#error_ident::#variant_ident { .. } => #code,
+        });
+    }
+    let ok_pattern = if parts.ret.is_some() {
+        quote!(value)
+    } else {
+        quote!(())
+    };
+    let zero_value = zero_value(parts);
+    Ok(quote! {
+        match #value_expr {
+            ::std::result::Result::Ok(#ok_pattern) => #envelope {
+                code: 0,
+                err_msg: null_string(),
+                #ok_value
+            },
+            ::std::result::Result::Err(error) => #envelope {
+                code: match &error {
+                    #(#arms)*
+                },
+                err_msg: string_value(::std::string::ToString::to_string(&error)),
+                #zero_value
+            },
+        }
+    })
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/function.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/function.rs
@@ -1,17 +1,21 @@
-//! Render one `extern "C"` export, its `__free` companion, and the shared
-//! panic plumbing.
+//! Render sync `extern "C"` exports and the plumbing every export kind
+//! shares: argument decoding plans and the panic-text helper.
 //!
 //! Every export wraps its body in `catch_unwind`, so unwinding never
 //! crosses the C boundary: a panic becomes an envelope with `code == -1`
 //! carrying the payload text.
+//!
+//! `#[unibind(blocking)]` needs no special sync handling here: the JVM has
+//! no GIL to release, so the calling Java thread blocking for the call's
+//! duration is the whole blocking contract.
 
-use proc_macro2::{Ident, Literal, TokenStream};
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use unibind_core::ir;
 
-use crate::ctype::CTy;
 use crate::model::Model;
-use crate::rust_glue::{decode, encode, types};
+use crate::rust_glue::envelope::{self, EnvelopeParts};
+use crate::rust_glue::{decode, types, Export};
 use crate::{names, RenderError};
 
 /// The shared panic-payload helper.
@@ -43,80 +47,126 @@ pub fn abi_version(module: &str) -> TokenStream {
     }
 }
 
-/// One function's export and free pair.
-pub fn render_fn(
+/// How one export's arguments cross: the `extern "C"` parameters, the
+/// decode bindings turning them into the user function's values, and the
+/// decoded identifiers to forward.
+pub(crate) struct ArgPlan {
+    pub params: Vec<TokenStream>,
+    pub bindings: Vec<TokenStream>,
+    pub idents: Vec<Ident>,
+}
+
+/// Plan the argument crossing for one export. Scalars pass by value,
+/// aggregates by `*const` mirror pointer into Java-owned memory.
+pub(crate) fn arg_plan(
     function: &ir::Function,
-    interface: &ir::Interface,
     model: &Model<'_>,
     user: &Ident,
-) -> Result<TokenStream, RenderError> {
-    let export_ident = format_ident!("{}", names::export_symbol(&interface.name, &function.name));
-    let free_ident = format_ident!("{}", names::free_symbol(&interface.name, &function.name));
-    let envelope = types::envelope_ident(&function.name);
-
-    let mut params = Vec::new();
-    let mut bindings = Vec::new();
-    let mut forwarded = Vec::new();
+) -> Result<ArgPlan, RenderError> {
+    let mut plan = ArgPlan {
+        params: Vec::new(),
+        bindings: Vec::new(),
+        idents: Vec::new(),
+    };
     for arg in &function.args {
         let ident = names::rust_ident(&arg.name)?;
-        let cty = CTy::of(&arg.ty);
+        let cty = model.boundary(&arg.ty);
         let mirror = types::mirror_tokens(&cty);
         if cty.is_scalar() {
-            params.push(quote!(#ident: #mirror));
+            plan.params.push(quote!(#ident: #mirror));
             if matches!(arg.ty, ir::Type::Bool) {
-                bindings.push(quote!(let #ident = #ident != 0;));
+                plan.bindings.push(quote!(let #ident = #ident != 0;));
             }
         } else {
-            params.push(quote!(#ident: *const #mirror));
+            plan.params.push(quote!(#ident: *const #mirror));
             let decoded = decode::expr(model, &arg.ty, &quote!(#ident), user)?;
-            bindings.push(quote! {
+            plan.bindings.push(quote! {
                 let #ident = unsafe { &*#ident };
                 let #ident = #decoded;
             });
         }
-        forwarded.push(quote!(#ident));
+        plan.idents.push(ident);
     }
+    Ok(plan)
+}
 
-    let rust_name = names::rust_ident(&function.name)?;
-    let call = quote!(super::#user::#rust_name(#(#forwarded),*));
-    let ok_value = match &function.ret {
-        Some(ret) => {
-            let encoded = encode::expr(model, ret, &quote!(value))?;
-            Some(quote!(value: #encoded,))
+/// The `super::<user>::...` call target for one export.
+pub(crate) fn call_path(
+    export: &Export<'_>,
+    user: &Ident,
+) -> Result<TokenStream, RenderError> {
+    let name = names::rust_ident(&export.function.name)?;
+    match export.owner {
+        Some(owner) => {
+            let owner_ident = names::rust_ident(owner)?;
+            Ok(quote!(super::#user::#owner_ident::#name))
         }
-        None => None,
-    };
-    let zero_value = function
-        .ret
-        .as_ref()
-        .map(|_| quote!(value: unsafe { ::core::mem::zeroed() },));
+        None => Ok(quote!(super::#user::#name)),
+    }
+}
 
-    let body = match &function.throws {
-        Some(throws) => {
-            let error = interface
-                .errors
-                .iter()
-                .find(|error| error.name == *throws)
-                .expect("throws names are validated when the model is built");
-            throws_body(ThrowsBody {
-                function,
-                error,
-                call: &call,
-                envelope: &envelope,
-                ok_value: ok_value.as_ref(),
-                zero_value: zero_value.as_ref(),
-                user,
-            })?
+/// One sync export and its `__free` companion. Constructors render here
+/// too (lowering keeps them sync): their envelope carries the new object
+/// as an opaque handle.
+pub(crate) fn render_sync(
+    export: &Export<'_>,
+    interface: &ir::Interface,
+    model: &Model<'_>,
+    user: &Ident,
+) -> Result<TokenStream, RenderError> {
+    let base = export.symbol(interface);
+    let export_ident = format_ident!("{base}");
+    let free_ident = format_ident!("{}", names::free_suffix(&base));
+    let envelope = types::envelope_ident(export.owner, &export.function.name);
+    let plan = arg_plan(export.function, model, user)?;
+
+    let mut params = Vec::new();
+    let mut receiver_binding = None;
+    if export.has_receiver {
+        let owner_ident = names::rust_ident(export.owner.expect("methods have an owner"))?;
+        params.push(quote!(this: *mut ::core::ffi::c_void));
+        // The read stays a shared borrow: Java's per-object read lock
+        // guarantees the handle outlives every sync downcall.
+        receiver_binding = Some(quote! {
+            let this = unsafe { &*this.cast_const().cast::<super::#user::#owner_ident>() };
+        });
+    }
+    params.extend(plan.params.iter().cloned());
+
+    let path = call_path(export, user)?;
+    let forwarded = &plan.idents;
+    let call = if export.has_receiver {
+        quote!(#path(this #(, #forwarded)*))
+    } else {
+        quote!(#path(#(#forwarded),*))
+    };
+
+    let parts = EnvelopeParts {
+        interface,
+        model,
+        user,
+        function: export.function,
+        ret: export.ret.as_ref(),
+        envelope: &envelope,
+    };
+    let body = envelope::envelope_expr(&parts, &call)?;
+    let zero_value = envelope::zero_value(&parts);
+    let bindings = &plan.bindings;
+    let docs = &export.function.docs;
+    let blocking_doc = export.function.blocking.then(|| {
+        quote! {
+            #[doc = ""]
+            #[doc = "`#[unibind(blocking)]`: the calling Java thread blocks for the duration; the JVM has no GIL to release, so blocking the caller is the whole contract."]
         }
-        None => plain_body(function, &call, &envelope, ok_value.as_ref()),
-    };
+    });
 
-    let docs = &function.docs;
     Ok(quote! {
         #(#[doc = #docs])*
+        #blocking_doc
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn #export_ident(#(#params),*) -> *mut #envelope {
             let outcome = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+                #receiver_binding
                 #(#bindings)*
                 #body
             }));
@@ -139,86 +189,6 @@ pub fn render_fn(
                 return;
             }
             drop(unsafe { ::std::boxed::Box::from_raw(envelope) });
-        }
-    })
-}
-
-fn plain_body(
-    function: &ir::Function,
-    call: &TokenStream,
-    envelope: &Ident,
-    ok_value: Option<&TokenStream>,
-) -> TokenStream {
-    if function.ret.is_some() {
-        quote! {
-            let value = #call;
-            #envelope {
-                code: 0,
-                err_msg: null_string(),
-                #ok_value
-            }
-        }
-    } else {
-        quote! {
-            #call;
-            #envelope {
-                code: 0,
-                err_msg: null_string(),
-            }
-        }
-    }
-}
-
-/// Everything a `throws` function's match body needs.
-#[derive(Clone, Copy)]
-struct ThrowsBody<'a> {
-    function: &'a ir::Function,
-    error: &'a ir::ErrorType,
-    call: &'a TokenStream,
-    envelope: &'a Ident,
-    ok_value: Option<&'a TokenStream>,
-    zero_value: Option<&'a TokenStream>,
-    user: &'a Ident,
-}
-
-fn throws_body(parts: ThrowsBody<'_>) -> Result<TokenStream, RenderError> {
-    let ThrowsBody {
-        function,
-        error,
-        call,
-        envelope,
-        ok_value,
-        zero_value,
-        user,
-    } = parts;
-    let error_ident = names::rust_ident(&error.name)?;
-    let mut arms = Vec::new();
-    for (index, variant) in error.variants.iter().enumerate() {
-        let variant_ident = names::rust_ident(&variant.name)?;
-        let code = Literal::usize_unsuffixed(index + 1);
-        arms.push(quote! {
-            super::#user::#error_ident::#variant_ident { .. } => #code,
-        });
-    }
-    let ok_pattern = if function.ret.is_some() {
-        quote!(value)
-    } else {
-        quote!(())
-    };
-    Ok(quote! {
-        match #call {
-            ::std::result::Result::Ok(#ok_pattern) => #envelope {
-                code: 0,
-                err_msg: null_string(),
-                #ok_value
-            },
-            ::std::result::Result::Err(error) => #envelope {
-                code: match &error {
-                    #(#arms)*
-                },
-                err_msg: string_value(::std::string::ToString::to_string(&error)),
-                #zero_value
-            },
         }
     })
 }

--- a/packages/unibind/backend-jvm/src/rust_glue/function.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/function.rs
@@ -1,0 +1,224 @@
+//! Render one `extern "C"` export, its `__free` companion, and the shared
+//! panic plumbing.
+//!
+//! Every export wraps its body in `catch_unwind`, so unwinding never
+//! crosses the C boundary: a panic becomes an envelope with `code == -1`
+//! carrying the payload text.
+
+use proc_macro2::{Ident, Literal, TokenStream};
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::ctype::CTy;
+use crate::model::Model;
+use crate::rust_glue::{decode, encode, types};
+use crate::{names, RenderError};
+
+/// The shared panic-payload helper.
+pub fn helpers() -> TokenStream {
+    quote! {
+        /// Best-effort text from a caught panic payload.
+        fn panic_text(payload: &(dyn ::std::any::Any + ::core::marker::Send)) -> ::std::string::String {
+            if let ::std::option::Option::Some(text) = payload.downcast_ref::<&str>() {
+                return ::std::borrow::ToOwned::to_owned(*text);
+            }
+            if let ::std::option::Option::Some(text) = payload.downcast_ref::<::std::string::String>() {
+                return ::std::clone::Clone::clone(text);
+            }
+            ::std::borrow::ToOwned::to_owned("panic across the unibind boundary")
+        }
+    }
+}
+
+/// The ABI version probe.
+pub fn abi_version(module: &str) -> TokenStream {
+    let ident = format_ident!("{}", names::abi_symbol(module));
+    quote! {
+        /// ABI revision of these exports; the Java binding checks it at
+        /// load.
+        #[unsafe(no_mangle)]
+        pub extern "C" fn #ident() -> u32 {
+            0
+        }
+    }
+}
+
+/// One function's export and free pair.
+pub fn render_fn(
+    function: &ir::Function,
+    interface: &ir::Interface,
+    model: &Model<'_>,
+    user: &Ident,
+) -> Result<TokenStream, RenderError> {
+    let export_ident = format_ident!("{}", names::export_symbol(&interface.name, &function.name));
+    let free_ident = format_ident!("{}", names::free_symbol(&interface.name, &function.name));
+    let envelope = types::envelope_ident(&function.name);
+
+    let mut params = Vec::new();
+    let mut bindings = Vec::new();
+    let mut forwarded = Vec::new();
+    for arg in &function.args {
+        let ident = names::rust_ident(&arg.name)?;
+        let cty = CTy::of(&arg.ty);
+        let mirror = types::mirror_tokens(&cty);
+        if cty.is_scalar() {
+            params.push(quote!(#ident: #mirror));
+            if matches!(arg.ty, ir::Type::Bool) {
+                bindings.push(quote!(let #ident = #ident != 0;));
+            }
+        } else {
+            params.push(quote!(#ident: *const #mirror));
+            let decoded = decode::expr(model, &arg.ty, &quote!(#ident), user)?;
+            bindings.push(quote! {
+                let #ident = unsafe { &*#ident };
+                let #ident = #decoded;
+            });
+        }
+        forwarded.push(quote!(#ident));
+    }
+
+    let rust_name = names::rust_ident(&function.name)?;
+    let call = quote!(super::#user::#rust_name(#(#forwarded),*));
+    let ok_value = match &function.ret {
+        Some(ret) => {
+            let encoded = encode::expr(model, ret, &quote!(value))?;
+            Some(quote!(value: #encoded,))
+        }
+        None => None,
+    };
+    let zero_value = function
+        .ret
+        .as_ref()
+        .map(|_| quote!(value: unsafe { ::core::mem::zeroed() },));
+
+    let body = match &function.throws {
+        Some(throws) => {
+            let error = interface
+                .errors
+                .iter()
+                .find(|error| error.name == *throws)
+                .expect("throws names are validated when the model is built");
+            throws_body(ThrowsBody {
+                function,
+                error,
+                call: &call,
+                envelope: &envelope,
+                ok_value: ok_value.as_ref(),
+                zero_value: zero_value.as_ref(),
+                user,
+            })?
+        }
+        None => plain_body(function, &call, &envelope, ok_value.as_ref()),
+    };
+
+    let docs = &function.docs;
+    Ok(quote! {
+        #(#[doc = #docs])*
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #export_ident(#(#params),*) -> *mut #envelope {
+            let outcome = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+                #(#bindings)*
+                #body
+            }));
+            let envelope = match outcome {
+                ::std::result::Result::Ok(envelope) => envelope,
+                ::std::result::Result::Err(payload) => #envelope {
+                    code: -1,
+                    err_msg: string_value(panic_text(payload.as_ref())),
+                    #zero_value
+                },
+            };
+            ::std::boxed::Box::into_raw(::std::boxed::Box::new(envelope))
+        }
+
+        /// Reclaim an envelope returned by the paired export. Null is a
+        /// no-op; anything else must come from that export, exactly once.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #free_ident(envelope: *mut #envelope) {
+            if envelope.is_null() {
+                return;
+            }
+            drop(unsafe { ::std::boxed::Box::from_raw(envelope) });
+        }
+    })
+}
+
+fn plain_body(
+    function: &ir::Function,
+    call: &TokenStream,
+    envelope: &Ident,
+    ok_value: Option<&TokenStream>,
+) -> TokenStream {
+    if function.ret.is_some() {
+        quote! {
+            let value = #call;
+            #envelope {
+                code: 0,
+                err_msg: null_string(),
+                #ok_value
+            }
+        }
+    } else {
+        quote! {
+            #call;
+            #envelope {
+                code: 0,
+                err_msg: null_string(),
+            }
+        }
+    }
+}
+
+/// Everything a `throws` function's match body needs.
+#[derive(Clone, Copy)]
+struct ThrowsBody<'a> {
+    function: &'a ir::Function,
+    error: &'a ir::ErrorType,
+    call: &'a TokenStream,
+    envelope: &'a Ident,
+    ok_value: Option<&'a TokenStream>,
+    zero_value: Option<&'a TokenStream>,
+    user: &'a Ident,
+}
+
+fn throws_body(parts: ThrowsBody<'_>) -> Result<TokenStream, RenderError> {
+    let ThrowsBody {
+        function,
+        error,
+        call,
+        envelope,
+        ok_value,
+        zero_value,
+        user,
+    } = parts;
+    let error_ident = names::rust_ident(&error.name)?;
+    let mut arms = Vec::new();
+    for (index, variant) in error.variants.iter().enumerate() {
+        let variant_ident = names::rust_ident(&variant.name)?;
+        let code = Literal::usize_unsuffixed(index + 1);
+        arms.push(quote! {
+            super::#user::#error_ident::#variant_ident { .. } => #code,
+        });
+    }
+    let ok_pattern = if function.ret.is_some() {
+        quote!(value)
+    } else {
+        quote!(())
+    };
+    Ok(quote! {
+        match #call {
+            ::std::result::Result::Ok(#ok_pattern) => #envelope {
+                code: 0,
+                err_msg: null_string(),
+                #ok_value
+            },
+            ::std::result::Result::Err(error) => #envelope {
+                code: match &error {
+                    #(#arms)*
+                },
+                err_msg: string_value(::std::string::ToString::to_string(&error)),
+                #zero_value
+            },
+        }
+    })
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/mod.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/mod.rs
@@ -1,41 +1,118 @@
 //! Assemble the hidden glue module of plain `extern "C"` exports.
 
 mod asserts;
+mod asyncfn;
 mod decode;
 mod encode;
+mod envelope;
 mod function;
+mod object;
+mod rusty;
+mod stream;
 mod types;
 
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use unibind_core::ir;
 
 use crate::model::Model;
-use crate::{names, RenderError, RenderedJvm};
+use crate::{names, RenderedJvm, RenderError};
+
+/// One `extern "C"` export site: a free function, an object constructor,
+/// or an object method. Constructors and methods share the free-function
+/// machinery; only the receiver and the envelope naming differ.
+pub(crate) struct Export<'a> {
+    /// The owning object's name; `None` for free functions.
+    pub owner: Option<&'a str>,
+    pub function: &'a ir::Function,
+    /// The boundary success type: the function's `ret`, or the object's
+    /// own type for constructors (whose IR `ret` is `None`).
+    pub ret: Option<ir::Type>,
+    /// Whether the export takes a leading `this` handle (methods only).
+    pub has_receiver: bool,
+}
+
+impl Export<'_> {
+    /// The base `extern "C"` symbol; companions suffix onto it.
+    pub(crate) fn symbol(&self, interface: &ir::Interface) -> String {
+        match self.owner {
+            Some(object) => {
+                names::object_export_symbol(&interface.name, object, &self.function.name)
+            }
+            None => names::export_symbol(&interface.name, &self.function.name),
+        }
+    }
+
+    /// A human-readable call site for docs and errors.
+    pub(crate) fn site(&self) -> String {
+        self.owner.map_or_else(
+            || self.function.name.clone(),
+            |object| format!("{object}.{}", self.function.name),
+        )
+    }
+}
+
+/// Every export site in the interface, in render order: free functions,
+/// then each object's constructor and methods.
+pub(crate) fn exports(interface: &ir::Interface) -> Vec<Export<'_>> {
+    let mut out = Vec::new();
+    for function in &interface.functions {
+        out.push(Export {
+            owner: None,
+            function,
+            ret: function.ret.clone(),
+            has_receiver: false,
+        });
+    }
+    for object in &interface.objects {
+        if let Some(ctor) = &object.constructor {
+            out.push(Export {
+                owner: Some(&object.name),
+                function: ctor,
+                ret: Some(ir::Type::Named(object.name.clone())),
+                has_receiver: false,
+            });
+        }
+        for method in &object.methods {
+            out.push(Export {
+                owner: Some(&object.name),
+                function: method,
+                ret: method.ret.clone(),
+                has_receiver: true,
+            });
+        }
+    }
+    out
+}
 
 /// Render the `extern "C"` glue for one interface.
 ///
 /// # Errors
 ///
-/// Fails for surface the sync JVM backend does not implement (async
-/// functions, data enums, objects) and for types that cannot mirror into
-/// `#[repr(C)]` structs (unresolved or recursive records).
+/// Fails for surface the JVM backend does not implement (data enums) and
+/// for types that cannot cross the boundary (streams outside return
+/// position, objects outside handle position, unresolved or recursive
+/// records).
 pub fn render(interface: &ir::Interface) -> Result<RenderedJvm, RenderError> {
     let model = Model::new(interface)?;
     let user = names::rust_ident(&interface.name)?;
     let glue_ident = format_ident!("__unibind_jvm_{}", interface.name.trim_start_matches('_'));
+    let sites = exports(interface);
 
     let runtime = types::runtime();
     let records = types::record_mirrors(interface)?;
-    let envelopes = types::envelopes(interface);
-    let asserts = asserts::layout_asserts(interface, &model);
+    let envelopes = types::envelopes(&model, &sites);
+    let asserts = asserts::layout_asserts(interface, &model, &sites);
     let decode_helpers = decode::helpers();
     let encode_helpers = encode::helpers();
     let panic_helpers = function::helpers();
-    let functions = interface
-        .functions
-        .iter()
-        .map(|func| function::render_fn(func, interface, &model, &user))
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut items = Vec::new();
+    for export in &sites {
+        items.push(render_export(export, interface, &model, &user)?);
+    }
+    for object in &interface.objects {
+        items.push(object::free_export(object, interface, &user)?);
+    }
     let abi = function::abi_version(&interface.name);
     let module_doc = format!(
         "unibind JVM glue for `{}`: `extern \"C\"` exports consumed by the generated Java \
@@ -63,9 +140,30 @@ pub fn render(interface: &ir::Interface) -> Result<RenderedJvm, RenderError> {
             #decode_helpers
             #encode_helpers
             #panic_helpers
-            #(#functions)*
+            #(#items)*
             #abi
         }
     };
     Ok(RenderedJvm { glue })
+}
+
+/// One export's items: the base export by asyncness, plus the stream
+/// companions when it returns a stream.
+fn render_export(
+    export: &Export<'_>,
+    interface: &ir::Interface,
+    model: &Model<'_>,
+    user: &proc_macro2::Ident,
+) -> Result<TokenStream, RenderError> {
+    let base = match export.function.asyncness {
+        ir::Asyncness::Sync => function::render_sync(export, interface, model, user)?,
+        ir::Asyncness::Async => asyncfn::render_async(export, interface, model, user)?,
+    };
+    let companions = match &export.ret {
+        Some(ir::Type::Stream(item)) => {
+            Some(stream::companions(export, interface, model, user, item)?)
+        }
+        _ => None,
+    };
+    Ok(quote!(#base #companions))
 }

--- a/packages/unibind/backend-jvm/src/rust_glue/mod.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/mod.rs
@@ -1,0 +1,71 @@
+//! Assemble the hidden glue module of plain `extern "C"` exports.
+
+mod asserts;
+mod decode;
+mod encode;
+mod function;
+mod types;
+
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::model::Model;
+use crate::{names, RenderError, RenderedJvm};
+
+/// Render the `extern "C"` glue for one interface.
+///
+/// # Errors
+///
+/// Fails for surface the sync JVM backend does not implement (async
+/// functions, data enums, objects) and for types that cannot mirror into
+/// `#[repr(C)]` structs (unresolved or recursive records).
+pub fn render(interface: &ir::Interface) -> Result<RenderedJvm, RenderError> {
+    let model = Model::new(interface)?;
+    let user = names::rust_ident(&interface.name)?;
+    let glue_ident = format_ident!("__unibind_jvm_{}", interface.name.trim_start_matches('_'));
+
+    let runtime = types::runtime();
+    let records = types::record_mirrors(interface)?;
+    let envelopes = types::envelopes(interface);
+    let asserts = asserts::layout_asserts(interface, &model);
+    let decode_helpers = decode::helpers();
+    let encode_helpers = encode::helpers();
+    let panic_helpers = function::helpers();
+    let functions = interface
+        .functions
+        .iter()
+        .map(|func| function::render_fn(func, interface, &model, &user))
+        .collect::<Result<Vec<_>, _>>()?;
+    let abi = function::abi_version(&interface.name);
+    let module_doc = format!(
+        "unibind JVM glue for `{}`: `extern \"C\"` exports consumed by the generated Java \
+         Panama binding.",
+        interface.name
+    );
+
+    let glue = quote! {
+        #[doc = #module_doc]
+        #[doc(hidden)]
+        #[allow(
+            clippy::all,
+            clippy::pedantic,
+            clippy::nursery,
+            dead_code,
+            missing_docs,
+            unsafe_code,
+            unused_qualifications
+        )]
+        mod #glue_ident {
+            #runtime
+            #records
+            #envelopes
+            #asserts
+            #decode_helpers
+            #encode_helpers
+            #panic_helpers
+            #(#functions)*
+            #abi
+        }
+    };
+    Ok(RenderedJvm { glue })
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/object.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/object.rs
@@ -1,0 +1,42 @@
+//! Render the per-object handle release export.
+//!
+//! Constructors and methods flow through the shared function/async
+//! renderers (an object handle is just another export site); the only
+//! object-specific export is `<O>__free`, releasing the `Arc` strong count
+//! the constructor or a returning function leaked to Java.
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::{names, RenderError};
+
+/// The `<O>__free` export dropping one object handle.
+pub(crate) fn free_export(
+    object: &ir::Object,
+    interface: &ir::Interface,
+    user: &Ident,
+) -> Result<TokenStream, RenderError> {
+    let free_ident = format_ident!(
+        "{}",
+        names::object_free_symbol(&interface.name, &object.name)
+    );
+    let object_ident = names::rust_ident(&object.name)?;
+    let doc = format!(
+        "Release one `{}` handle, exactly once; null is a no-op. In-flight async method \
+         tasks own their own strong count, so freeing during a call is safe.",
+        object.name
+    );
+    Ok(quote! {
+        #[doc = #doc]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #free_ident(this: *mut ::core::ffi::c_void) {
+            if this.is_null() {
+                return;
+            }
+            drop(unsafe {
+                ::std::sync::Arc::from_raw(this.cast_const().cast::<super::#user::#object_ident>())
+            });
+        }
+    })
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/rusty.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/rusty.rs
@@ -1,0 +1,64 @@
+//! Render owned IR types back into Rust token streams.
+//!
+//! Mirrors `backend-py`'s `ty.rs`: the glue needs the user-facing Rust
+//! spelling for stream item turbofish (`stream_next::<T>`) and inside the
+//! spawned async bodies, resolving `Named` types through
+//! `super::<user>::`. Only owned spellings ever appear in those positions
+//! (stream items and async arguments are owned by lowering), but the
+//! borrowed spellings render too so the mapping stays total.
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+/// The Rust spelling of one boundary type inside the glue module.
+pub fn rust_type(ty: &ir::Type, user: &Ident) -> TokenStream {
+    match ty {
+        ir::Type::Bool => quote!(bool),
+        ir::Type::Int(kind) => int_tokens(*kind),
+        ir::Type::Float(ir::FloatKind::F32) => quote!(f32),
+        ir::Type::Float(ir::FloatKind::F64) => quote!(f64),
+        ir::Type::String { owned: true } => quote!(::std::string::String),
+        ir::Type::String { owned: false } => quote!(&str),
+        ir::Type::Path { owned: true } => quote!(::std::path::PathBuf),
+        ir::Type::Path { owned: false } => quote!(&::std::path::Path),
+        ir::Type::Bytes { owned: true } => quote!(::std::vec::Vec<u8>),
+        ir::Type::Bytes { owned: false } => quote!(&[u8]),
+        ir::Type::Option(inner) => {
+            let inner = rust_type(inner, user);
+            quote!(::std::option::Option<#inner>)
+        }
+        ir::Type::Vec(inner) => {
+            let inner = rust_type(inner, user);
+            quote!(::std::vec::Vec<#inner>)
+        }
+        ir::Type::Map { key, value } => {
+            let key = rust_type(key, user);
+            let value = rust_type(value, user);
+            quote!(::std::collections::HashMap<#key, #value>)
+        }
+        ir::Type::Named(name) => {
+            let name = format_ident!("{name}");
+            quote!(super::#user::#name)
+        }
+        ir::Type::Stream(item) => {
+            let item = rust_type(item, user);
+            quote!(::unibind_runtime::UniStream<#item>)
+        }
+    }
+}
+
+fn int_tokens(kind: ir::IntKind) -> TokenStream {
+    match kind {
+        ir::IntKind::I8 => quote!(i8),
+        ir::IntKind::I16 => quote!(i16),
+        ir::IntKind::I32 => quote!(i32),
+        ir::IntKind::I64 => quote!(i64),
+        ir::IntKind::Isize => quote!(isize),
+        ir::IntKind::U8 => quote!(u8),
+        ir::IntKind::U16 => quote!(u16),
+        ir::IntKind::U32 => quote!(u32),
+        ir::IntKind::U64 => quote!(u64),
+        ir::IntKind::Usize => quote!(usize),
+    }
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/stream.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/stream.rs
@@ -1,0 +1,91 @@
+//! Render the companion exports of a stream-returning export:
+//! `__stream_next`, `__stream_free`, and `__item_free`.
+//!
+//! The producing export's envelope carries the stream as an opaque handle;
+//! these companions pull items one at a time (pull-based backpressure) and
+//! release the handle and each delivered item envelope.
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::model::Model;
+use crate::rust_glue::{encode, rusty, types, Export};
+use crate::{names, RenderError};
+
+/// The three companion exports for one stream-returning export.
+pub(crate) fn companions(
+    export: &Export<'_>,
+    interface: &ir::Interface,
+    model: &Model<'_>,
+    user: &Ident,
+    item: &ir::Type,
+) -> Result<TokenStream, RenderError> {
+    let base = export.symbol(interface);
+    let next_ident = format_ident!("{}", names::stream_next_suffix(&base));
+    let stream_free_ident = format_ident!("{}", names::stream_free_suffix(&base));
+    let item_free_ident = format_ident!("{}", names::item_free_suffix(&base));
+    let item_envelope = types::item_envelope_ident(export.owner, &export.function.name);
+    let item_ty = rusty::rust_type(item, user);
+    // The item envelope's payload is `COption<item>`, so the existing
+    // option encoder covers both the item and the end-of-stream case.
+    let option_encode = encode::expr(
+        model,
+        &ir::Type::Option(Box::new(item.clone())),
+        &quote!(item),
+    )?;
+
+    Ok(quote! {
+        /// Pull one item from a stream handle produced by the paired
+        /// export. `cb` fires exactly once per call with a boxed item
+        /// envelope: `code` 0 with a present value is an item, 0 with an
+        /// absent value is end-of-stream, -1 is a producer panic. Never
+        /// issue a second pull before the previous callback fired.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #next_ident(
+            handle: *mut ::core::ffi::c_void,
+            cb: unsafe extern "C" fn(*mut ::core::ffi::c_void, *mut #item_envelope),
+            user_data: *mut ::core::ffi::c_void,
+        ) {
+            let user_data = SendPtr(user_data);
+            unsafe {
+                ::unibind_runtime::jvm::stream_next::<#item_ty>(handle, move |outcome| {
+                    let envelope = match outcome {
+                        ::unibind_runtime::jvm::NextOutcome::Item(item) => #item_envelope {
+                            code: 0,
+                            err_msg: null_string(),
+                            value: #option_encode,
+                        },
+                        ::unibind_runtime::jvm::NextOutcome::Panicked(text) => #item_envelope {
+                            code: -1,
+                            err_msg: string_value(text),
+                            value: unsafe { ::core::mem::zeroed() },
+                        },
+                    };
+                    unsafe {
+                        cb(user_data.0, ::std::boxed::Box::into_raw(::std::boxed::Box::new(envelope)))
+                    }
+                })
+            }
+        }
+
+        /// Release a stream handle produced by the paired export, exactly
+        /// once. Safe while a pull is in flight: the pull holds its own
+        /// reference.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #stream_free_ident(handle: *mut ::core::ffi::c_void) {
+            unsafe { ::unibind_runtime::jvm::stream_free::<#item_ty>(handle) }
+        }
+
+        /// Reclaim an item envelope delivered to a `__stream_next`
+        /// callback. Null is a no-op; anything else must come from that
+        /// callback, exactly once.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #item_free_ident(envelope: *mut #item_envelope) {
+            if envelope.is_null() {
+                return;
+            }
+            drop(unsafe { ::std::boxed::Box::from_raw(envelope) });
+        }
+    })
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/types.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/types.rs
@@ -1,0 +1,180 @@
+//! The `#[repr(C)]` mirror structs the glue module carries.
+//!
+//! Shapes here must stay in lockstep with the layout math in
+//! [`crate::ctype`]; the assertions in [`crate::rust_glue::asserts`] make
+//! the compiler prove it.
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use unibind_core::ir;
+
+use crate::ctype::CTy;
+use crate::{names, RenderError};
+
+/// The fixed mirror types every glue module defines. Drops are null-safe on
+/// purpose: an all-zero mirror (an absent `COption`, an error-path `value`)
+/// drops as a no-op, so envelopes free unconditionally.
+pub fn runtime() -> TokenStream {
+    quote! {
+        /// UTF-8 text as pointer + length. Argument values are Java-owned
+        /// and only viewed; returned values leak a boxed slice that the
+        /// envelope's `Drop` reclaims.
+        #[repr(C)]
+        pub struct CString {
+            pub ptr: *mut u8,
+            pub len: usize,
+        }
+
+        impl ::core::ops::Drop for CString {
+            fn drop(&mut self) {
+                if self.ptr.is_null() {
+                    return;
+                }
+                drop(unsafe {
+                    ::std::boxed::Box::from_raw(::core::ptr::slice_from_raw_parts_mut(
+                        self.ptr, self.len,
+                    ))
+                });
+            }
+        }
+
+        /// Raw bytes cross exactly like text.
+        pub type CBytes = CString;
+        /// Paths cross as UTF-8 text.
+        pub type CPath = CString;
+
+        /// A boxed slice as pointer + length.
+        #[repr(C)]
+        pub struct CVec<T> {
+            pub ptr: *mut T,
+            pub len: usize,
+        }
+
+        impl<T> ::core::ops::Drop for CVec<T> {
+            fn drop(&mut self) {
+                if self.ptr.is_null() {
+                    return;
+                }
+                drop(unsafe {
+                    ::std::boxed::Box::from_raw(::core::ptr::slice_from_raw_parts_mut(
+                        self.ptr, self.len,
+                    ))
+                });
+            }
+        }
+
+        /// Inline optional: absent means `present == 0` with `value` all
+        /// zeroed.
+        #[repr(C)]
+        pub struct COption<T> {
+            pub present: u8,
+            pub value: T,
+        }
+
+        /// One map entry; a map crosses as `CVec<CPair<K, V>>`.
+        #[repr(C)]
+        pub struct CPair<K, V> {
+            pub key: K,
+            pub value: V,
+        }
+    }
+}
+
+/// The Rust spelling of one mirror inside the glue module.
+pub fn mirror_tokens(ty: &CTy) -> TokenStream {
+    match ty {
+        CTy::Bool => quote!(u8),
+        CTy::Int(kind) => int_tokens(*kind),
+        CTy::Float(ir::FloatKind::F32) => quote!(f32),
+        CTy::Float(ir::FloatKind::F64) => quote!(f64),
+        CTy::Str => quote!(CString),
+        CTy::Path => quote!(CPath),
+        CTy::Bytes => quote!(CBytes),
+        CTy::Option(inner) => {
+            let inner = mirror_tokens(inner);
+            quote!(COption<#inner>)
+        }
+        CTy::Vec(inner) => {
+            let inner = mirror_tokens(inner);
+            quote!(CVec<#inner>)
+        }
+        CTy::Map { key, value } => {
+            let key = mirror_tokens(key);
+            let value = mirror_tokens(value);
+            quote!(CVec<CPair<#key, #value>>)
+        }
+        CTy::Record(name) => {
+            let ident = format_ident!("{name}C");
+            quote!(#ident)
+        }
+    }
+}
+
+fn int_tokens(kind: ir::IntKind) -> TokenStream {
+    match kind {
+        ir::IntKind::I8 => quote!(i8),
+        ir::IntKind::I16 => quote!(i16),
+        ir::IntKind::I32 => quote!(i32),
+        ir::IntKind::I64 => quote!(i64),
+        ir::IntKind::Isize => quote!(isize),
+        ir::IntKind::U8 => quote!(u8),
+        ir::IntKind::U16 => quote!(u16),
+        ir::IntKind::U32 => quote!(u32),
+        ir::IntKind::U64 => quote!(u64),
+        ir::IntKind::Usize => quote!(usize),
+    }
+}
+
+/// One `#[repr(C)]` mirror struct per record, fields in declaration order.
+pub fn record_mirrors(interface: &ir::Interface) -> Result<TokenStream, RenderError> {
+    let mut out = TokenStream::new();
+    for record in &interface.records {
+        let ident = format_ident!("{}C", record.name);
+        let doc = format!("C mirror of `{}`, fields in declaration order.", record.name);
+        let mut fields = Vec::new();
+        for field in &record.fields {
+            let name = names::rust_ident(&field.name)?;
+            let ty = mirror_tokens(&CTy::of(&field.ty));
+            fields.push(quote!(pub #name: #ty));
+        }
+        out.extend(quote! {
+            #[doc = #doc]
+            #[repr(C)]
+            pub struct #ident {
+                #(#fields,)*
+            }
+        });
+    }
+    Ok(out)
+}
+
+/// One return envelope struct per function.
+pub fn envelopes(interface: &ir::Interface) -> TokenStream {
+    let mut out = TokenStream::new();
+    for function in &interface.functions {
+        let ident = envelope_ident(&function.name);
+        let doc = format!(
+            "Return envelope for `{}`: `code` 0 ok, N the N-th `throws` variant, -1 panic.",
+            function.name
+        );
+        let value = function.ret.as_ref().map(|ret| {
+            let ty = mirror_tokens(&CTy::of(ret));
+            quote!(pub value: #ty,)
+        });
+        out.extend(quote! {
+            #[doc = #doc]
+            #[repr(C)]
+            pub struct #ident {
+                pub code: i32,
+                pub err_msg: CString,
+                #value
+            }
+        });
+    }
+    out
+}
+
+/// The envelope struct identifier for one function.
+pub fn envelope_ident(function: &str) -> Ident {
+    format_ident!("{}Envelope", names::pascal(function))
+}

--- a/packages/unibind/backend-jvm/src/rust_glue/types.rs
+++ b/packages/unibind/backend-jvm/src/rust_glue/types.rs
@@ -9,6 +9,8 @@ use quote::{format_ident, quote};
 use unibind_core::ir;
 
 use crate::ctype::CTy;
+use crate::model::Model;
+use crate::rust_glue::Export;
 use crate::{names, RenderError};
 
 /// The fixed mirror types every glue module defines. Drops are null-safe on
@@ -77,6 +79,14 @@ pub fn runtime() -> TokenStream {
             pub key: K,
             pub value: V,
         }
+
+        /// A raw pointer moved into a spawned task's completion closure.
+        /// The Java side routes every callback through a static upcall
+        /// stub plus a registry id, so carrying the pointer across threads
+        /// is sound by that contract.
+        pub struct SendPtr(pub *mut ::core::ffi::c_void);
+
+        unsafe impl ::core::marker::Send for SendPtr {}
     }
 }
 
@@ -90,6 +100,7 @@ pub fn mirror_tokens(ty: &CTy) -> TokenStream {
         CTy::Str => quote!(CString),
         CTy::Path => quote!(CPath),
         CTy::Bytes => quote!(CBytes),
+        CTy::Handle => quote!(*mut ::core::ffi::c_void),
         CTy::Option(inner) => {
             let inner = mirror_tokens(inner);
             quote!(COption<#inner>)
@@ -148,17 +159,19 @@ pub fn record_mirrors(interface: &ir::Interface) -> Result<TokenStream, RenderEr
     Ok(out)
 }
 
-/// One return envelope struct per function.
-pub fn envelopes(interface: &ir::Interface) -> TokenStream {
+/// One return envelope struct per export (free function, constructor, or
+/// method), plus one item envelope per stream-returning export.
+pub fn envelopes(model: &Model<'_>, exports: &[Export<'_>]) -> TokenStream {
     let mut out = TokenStream::new();
-    for function in &interface.functions {
-        let ident = envelope_ident(&function.name);
+    for export in exports {
+        let ident = envelope_ident(export.owner, &export.function.name);
         let doc = format!(
-            "Return envelope for `{}`: `code` 0 ok, N the N-th `throws` variant, -1 panic.",
-            function.name
+            "Return envelope for `{}`: `code` 0 ok, N the N-th `throws` variant, -1 panic, \
+             -2 cancelled (async exports only).",
+            export.site()
         );
-        let value = function.ret.as_ref().map(|ret| {
-            let ty = mirror_tokens(&CTy::of(ret));
+        let value = export.ret.as_ref().map(|ret| {
+            let ty = mirror_tokens(&model.boundary(ret));
             quote!(pub value: #ty,)
         });
         out.extend(quote! {
@@ -170,11 +183,41 @@ pub fn envelopes(interface: &ir::Interface) -> TokenStream {
                 #value
             }
         });
+        if let Some(ir::Type::Stream(item)) = &export.ret {
+            let item_ident = item_envelope_ident(export.owner, &export.function.name);
+            let item_doc = format!(
+                "Item envelope for `{}`: `code` 0 with a present value is an item, 0 with an \
+                 absent value is end-of-stream, -1 is a producer panic.",
+                export.site()
+            );
+            let value_ty = mirror_tokens(&CTy::Option(Box::new(CTy::of(item))));
+            out.extend(quote! {
+                #[doc = #item_doc]
+                #[repr(C)]
+                pub struct #item_ident {
+                    pub code: i32,
+                    pub err_msg: CString,
+                    pub value: #value_ty,
+                }
+            });
+        }
     }
     out
 }
 
-/// The envelope struct identifier for one function.
-pub fn envelope_ident(function: &str) -> Ident {
-    format_ident!("{}Envelope", names::pascal(function))
+/// The envelope struct identifier for one export; methods and constructors
+/// scope theirs by the owning object's name.
+pub fn envelope_ident(owner: Option<&str>, function: &str) -> Ident {
+    match owner {
+        Some(object) => format_ident!("{object}{}Envelope", names::pascal(function)),
+        None => format_ident!("{}Envelope", names::pascal(function)),
+    }
+}
+
+/// The item envelope struct identifier for one stream export.
+pub fn item_envelope_ident(owner: Option<&str>, function: &str) -> Ident {
+    match owner {
+        Some(object) => format_ident!("{object}{}ItemEnvelope", names::pascal(function)),
+        None => format_ident!("{}ItemEnvelope", names::pascal(function)),
+    }
 }

--- a/packages/unibind/backend-jvm/tests/fixtures/sample.rs
+++ b/packages/unibind/backend-jvm/tests/fixtures/sample.rs
@@ -1,0 +1,53 @@
+/// A sample boundary exercising the phase 0 surface.
+mod sample {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    /// A row.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Row {
+        /// Identifier.
+        pub id: u64,
+        #[unibind(py(name = "label"))]
+        pub name: String,
+        pub tags: Vec<String>,
+        pub weights: HashMap<String, f64>,
+        pub blob: Vec<u8>,
+        pub home: Option<PathBuf>,
+    }
+
+    /// Boundary failures.
+    #[unibind::error(py(base = "RuntimeError"))]
+    pub enum SampleError {
+        /// The store is gone.
+        #[unibind(py(name = "StoreGoneError"))]
+        StoreGone { message: String },
+        /// Bad input.
+        Invalid(String),
+    }
+
+    /// Fetch rows.
+    ///
+    /// Docs become docstrings.
+    pub fn rows(
+        store: &str,
+        #[unibind(default = 10)] limit: usize,
+        root: Option<&str>,
+    ) -> Result<Vec<Row>, SampleError> {
+        let _ = (store, limit, root);
+        Ok(Vec::new())
+    }
+
+    #[unibind(py(name = "touch_path"))]
+    pub fn touch(
+        path: &std::path::Path,
+        data: &[u8],
+        #[unibind(default = 0.5)] ratio: f64,
+        #[unibind(default = "note")] note: &str,
+        #[unibind(default = false)] flush: bool,
+    ) -> bool {
+        let _ = (path, data, ratio, note, flush);
+        true
+    }
+}

--- a/packages/unibind/backend-jvm/tests/layout.rs
+++ b/packages/unibind/backend-jvm/tests/layout.rs
@@ -1,0 +1,128 @@
+//! Prove the computed `#[repr(C)]` layout model against the real compiler.
+//!
+//! The generators bake these numbers into both sides of the boundary, so
+//! the layout algorithm itself is defended here with `size_of`/`align_of`/
+//! `offset_of` over hand-written mirror structs shaped like the generated
+//! ones.
+
+// The mirror structs exist only to be measured; their fields are never read.
+#![allow(dead_code)]
+
+use core::mem::{align_of, offset_of, size_of};
+
+use unibind_backend_jvm::ctype::CTy;
+use unibind_backend_jvm::model::Model;
+use unibind_core::ir;
+
+#[repr(C)]
+struct CString {
+    ptr: *mut u8,
+    len: usize,
+}
+
+#[repr(C)]
+struct CVec<T> {
+    ptr: *mut T,
+    len: usize,
+}
+
+#[repr(C)]
+struct COption<T> {
+    present: u8,
+    value: T,
+}
+
+#[repr(C)]
+struct CPair<K, V> {
+    key: K,
+    value: V,
+}
+
+/// The mirror the generator emits for the sample fixture's `Row`.
+#[repr(C)]
+struct RowC {
+    id: u64,
+    name: CString,
+    tags: CVec<CString>,
+    weights: CVec<CPair<CString, f64>>,
+    blob: CString,
+    home: COption<CString>,
+}
+
+/// The envelope the generator emits for the sample fixture's `rows`.
+#[repr(C)]
+struct RowsEnvelope {
+    code: i32,
+    err_msg: CString,
+    value: CVec<RowC>,
+}
+
+fn model_interface() -> ir::Interface {
+    serde_json::from_str(include_str!("snapshots/sample.ir.json")).expect("IR snapshot parses")
+}
+
+fn assert_layout<T>(model: &Model<'_>, ty: &CTy) {
+    let layout = model.layout(ty);
+    assert_eq!(layout.size, size_of::<T>() as u64, "size of {}", ty.mangle());
+    assert_eq!(layout.align, align_of::<T>() as u64, "align of {}", ty.mangle());
+}
+
+#[test]
+fn layouts_match_the_compiler() {
+    let interface = model_interface();
+    let model = Model::new(&interface).expect("sample interface validates");
+
+    assert_layout::<CString>(&model, &CTy::Str);
+    assert_layout::<CString>(&model, &CTy::Path);
+    assert_layout::<CString>(&model, &CTy::Bytes);
+    assert_layout::<CVec<CString>>(&model, &CTy::Vec(Box::new(CTy::Str)));
+    assert_layout::<COption<u8>>(&model, &CTy::Option(Box::new(CTy::Bool)));
+    assert_layout::<COption<i32>>(&model, &CTy::Option(Box::new(CTy::Int(ir::IntKind::I32))));
+    assert_layout::<COption<CString>>(&model, &CTy::Option(Box::new(CTy::Str)));
+    assert_layout::<RowC>(&model, &CTy::Record("Row".to_owned()));
+
+    assert_eq!(
+        model.option_value_offset(&CTy::Str),
+        offset_of!(COption<CString>, value) as u64
+    );
+    assert_eq!(
+        model.option_value_offset(&CTy::Bool),
+        offset_of!(COption<u8>, value) as u64
+    );
+
+    let pair = model.pair_struct(&CTy::Str, &CTy::Float(ir::FloatKind::F64));
+    assert_eq!(pair.layout.size, size_of::<CPair<CString, f64>>() as u64);
+    assert_eq!(pair.offsets[0], offset_of!(CPair<CString, f64>, key) as u64);
+    assert_eq!(pair.offsets[1], offset_of!(CPair<CString, f64>, value) as u64);
+
+    let row = model.record_struct("Row");
+    let expected = [
+        offset_of!(RowC, id),
+        offset_of!(RowC, name),
+        offset_of!(RowC, tags),
+        offset_of!(RowC, weights),
+        offset_of!(RowC, blob),
+        offset_of!(RowC, home),
+    ];
+    let actual: Vec<u64> = row.offsets;
+    let expected: Vec<u64> = expected.iter().map(|offset| *offset as u64).collect();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn envelopes_match_the_compiler() {
+    let interface = model_interface();
+    let model = Model::new(&interface).expect("sample interface validates");
+
+    let ret = CTy::Vec(Box::new(CTy::Record("Row".to_owned())));
+    let envelope = model.envelope(Some(&ret));
+    assert_eq!(envelope.layout.size, size_of::<RowsEnvelope>() as u64);
+    assert_eq!(envelope.layout.align, align_of::<RowsEnvelope>() as u64);
+    assert_eq!(envelope.err_msg_offset, offset_of!(RowsEnvelope, err_msg) as u64);
+    assert_eq!(envelope.value_offset, Some(offset_of!(RowsEnvelope, value) as u64));
+
+    let unit = model.envelope(None);
+    assert_eq!(unit.value_offset, None);
+    assert_eq!(unit.err_msg_offset, 8);
+    assert_eq!(unit.layout.size, 24);
+}

--- a/packages/unibind/backend-jvm/tests/render.rs
+++ b/packages/unibind/backend-jvm/tests/render.rs
@@ -102,7 +102,7 @@ fn async_functions_are_rejected() {
     interface.functions[0].asyncness = ir::Asyncness::Async;
     let error = unibind_backend_jvm::render(&interface).expect_err("async must not render");
     assert!(
-        error.message.contains("issue #1992"),
+        error.message.contains("issue #2083"),
         "missing phase pointer: {}",
         error.message
     );

--- a/packages/unibind/backend-jvm/tests/render.rs
+++ b/packages/unibind/backend-jvm/tests/render.rs
@@ -1,0 +1,126 @@
+//! Snapshot the lowering and the three JVM renders for the sample module.
+//! The committed snapshots are the review surface for what the macro and
+//! the generators produce; on drift the test prints the new content to copy
+//! over the snapshot file. (trybuild/macrotest would invoke cargo at test
+//! runtime, which the nix test sandbox cannot do, so the render output is
+//! snapshotted directly.)
+
+use proc_macro2::TokenStream;
+use unibind_core::ir;
+
+fn interface() -> ir::Interface {
+    let file: syn::File =
+        syn::parse_str(include_str!("fixtures/sample.rs")).expect("fixture parses");
+    let Some(syn::Item::Mod(module)) = file.items.first() else {
+        panic!("fixture starts with a module");
+    };
+    unibind_core::lower_module(TokenStream::new(), module).expect("fixture lowers")
+}
+
+fn assert_snapshot(actual: &str, expected: &str, name: &str) {
+    if actual.trim() == expected.trim() {
+        return;
+    }
+    println!("=== actual {name} ===");
+    println!("{actual}");
+    println!("=== end {name} ===");
+    panic!("{name} drifted; copy the printed block into tests/snapshots/{name}");
+}
+
+/// One expected generated file.
+struct Expected {
+    path: &'static str,
+    snapshot: &'static str,
+    name: &'static str,
+}
+
+#[test]
+fn ir_json_snapshot() {
+    let json = serde_json::to_string_pretty(&interface()).expect("serializes");
+    assert_snapshot(&json, include_str!("snapshots/sample.ir.json"), "sample.ir.json");
+}
+
+#[test]
+fn rust_glue_snapshot() {
+    let rendered = unibind_backend_jvm::render(&interface()).expect("renders");
+    let glue: syn::File = syn::parse2(rendered.glue).expect("glue parses");
+    assert_snapshot(
+        &prettyplease::unparse(&glue),
+        include_str!("snapshots/sample.jvm.rs"),
+        "sample.jvm.rs",
+    );
+}
+
+#[test]
+fn java_snapshot() {
+    let files = unibind_backend_jvm::generate_java(&interface()).expect("generates");
+    let expected = [
+        Expected {
+            path: "unibind/sample/Sample.java",
+            snapshot: include_str!("snapshots/sample.Sample.java"),
+            name: "sample.Sample.java",
+        },
+        Expected {
+            path: "unibind/sample/Row.java",
+            snapshot: include_str!("snapshots/sample.Row.java"),
+            name: "sample.Row.java",
+        },
+        Expected {
+            path: "unibind/sample/SampleErrorException.java",
+            snapshot: include_str!("snapshots/sample.SampleErrorException.java"),
+            name: "sample.SampleErrorException.java",
+        },
+        Expected {
+            path: "unibind/sample/UnibindPanicException.java",
+            snapshot: include_str!("snapshots/sample.UnibindPanicException.java"),
+            name: "sample.UnibindPanicException.java",
+        },
+    ];
+    let actual_paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
+    let expected_paths: Vec<&str> = expected.iter().map(|entry| entry.path).collect();
+    assert_eq!(actual_paths, expected_paths);
+    for (file, entry) in files.iter().zip(&expected) {
+        assert_snapshot(&file.content, entry.snapshot, entry.name);
+    }
+}
+
+#[test]
+fn kotlin_snapshot() {
+    let files = unibind_backend_jvm::generate_kotlin(&interface()).expect("generates");
+    let actual_paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
+    assert_eq!(actual_paths, ["unibind/sample/Sample.kt"]);
+    assert_snapshot(
+        &files[0].content,
+        include_str!("snapshots/sample.Sample.kt"),
+        "sample.Sample.kt",
+    );
+}
+
+#[test]
+fn async_functions_are_rejected() {
+    let mut interface = interface();
+    interface.functions[0].asyncness = ir::Asyncness::Async;
+    let error = unibind_backend_jvm::render(&interface).expect_err("async must not render");
+    assert!(
+        error.message.contains("issue #1992"),
+        "missing phase pointer: {}",
+        error.message
+    );
+}
+
+#[test]
+fn data_enums_are_rejected() {
+    let mut interface = interface();
+    interface.enums.push(ir::Enum {
+        name: "Kind".to_owned(),
+        names: ir::Names::default(),
+        docs: Vec::new(),
+        variants: Vec::new(),
+    });
+    let error = unibind_backend_jvm::generate_java(&interface).expect_err("enums must not render");
+    assert!(
+        error.message.contains("data enum"),
+        "missing enum rejection: {}",
+        error.message
+    );
+}

--- a/packages/unibind/backend-jvm/tests/snapshots/sample.Row.java
+++ b/packages/unibind/backend-jvm/tests/snapshots/sample.Row.java
@@ -1,0 +1,21 @@
+package unibind.sample;
+
+/**
+ * A row.
+ *
+ * @param id Identifier. Unsigned in Rust; a negative value is the raw two's-complement bit pattern.
+ * @param name
+ * @param tags
+ * @param weights
+ * @param blob
+ * @param home May be null.
+ */
+public record Row(
+        long id,
+        String name,
+        java.util.List<String> tags,
+        java.util.Map<String, Double> weights,
+        byte[] blob,
+        java.nio.file.Path home) {
+}
+

--- a/packages/unibind/backend-jvm/tests/snapshots/sample.Sample.java
+++ b/packages/unibind/backend-jvm/tests/snapshots/sample.Sample.java
@@ -1,0 +1,285 @@
+package unibind.sample;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A sample boundary exercising the phase 0 surface.
+ *
+ * Java binding for the Rust module sample; loads the native library named by the
+ * {@code unibind.sample.library} system property.
+ */
+public final class Sample {
+
+    private Sample() {
+    }
+
+    private static final SymbolLookup LOOKUP = loadLibrary();
+    private static final Linker LINKER = Linker.nativeLinker();
+    private static final MethodHandle H_ROWS = handle(
+            "unibind_jvm_sample_rows",
+            FunctionDescriptor.of(
+                    ValueLayout.ADDRESS,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.JAVA_LONG,
+                    ValueLayout.ADDRESS));
+    private static final MethodHandle H_ROWS_FREE = handle(
+            "unibind_jvm_sample_rows__free", FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+    private static final MethodHandle H_TOUCH = handle(
+            "unibind_jvm_sample_touch",
+            FunctionDescriptor.of(
+                    ValueLayout.ADDRESS,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.JAVA_DOUBLE,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.JAVA_BYTE));
+    private static final MethodHandle H_TOUCH_FREE = handle(
+            "unibind_jvm_sample_touch__free", FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+    static {
+        MethodHandle abi = handle("unibind_jvm_sample_abi_version", FunctionDescriptor.of(ValueLayout.JAVA_INT));
+        int version;
+        try {
+            version = (int) abi.invokeExact();
+        } catch (Throwable error) {
+            throw new IllegalStateException("unibind ABI probe failed", error);
+        }
+        if (version != 0) {
+            throw new IllegalStateException(
+                    "native library speaks unibind ABI " + version + "; this binding expects 0");
+        }
+    }
+
+    /**
+     * Fetch rows.
+     *
+     * Docs become docstrings.
+     *
+     * @param limit Unsigned in Rust; a negative value is the raw two's-complement bit pattern.
+     * @param root May be null.
+     */
+    public static java.util.List<Row> rows(String store, long limit, String root) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment storeArg = arena.allocate(16, 8);
+            encodeStr(arena, storeArg, 0, store);
+            MemorySegment rootArg = arena.allocate(24, 8);
+            encodeOptStr(arena, rootArg, 0, root);
+            MemorySegment envelope;
+            try {
+                envelope = (MemorySegment) H_ROWS.invokeExact(storeArg, limit, rootArg);
+            } catch (Throwable error) {
+                throw new IllegalStateException("unibind downcall rows failed", error);
+            }
+            envelope = envelope.reinterpret(40);
+            try {
+                int code = envelope.get(ValueLayout.JAVA_INT, 0);
+                if (code != 0) {
+                    throw sampleErrorException(code, decodeStr(envelope, 8));
+                }
+                return decodeListRow(envelope, 24);
+            } finally {
+                free(H_ROWS_FREE, envelope);
+            }
+        }
+    }
+
+    /** Calls {@link #rows(String, long, String)} with default trailing arguments. */
+    public static java.util.List<Row> rows(String store, long limit) {
+        return rows(store, limit, null);
+    }
+
+    /** Calls {@link #rows(String, long, String)} with default trailing arguments. */
+    public static java.util.List<Row> rows(String store) {
+        return rows(store, 10L, null);
+    }
+
+    public static boolean touch(java.nio.file.Path path, byte[] data, double ratio, String note, boolean flush) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment pathArg = arena.allocate(16, 8);
+            encodePath(arena, pathArg, 0, path);
+            MemorySegment dataArg = arena.allocate(16, 8);
+            encodeBytes(arena, dataArg, 0, data);
+            MemorySegment noteArg = arena.allocate(16, 8);
+            encodeStr(arena, noteArg, 0, note);
+            MemorySegment envelope;
+            try {
+                envelope = (MemorySegment) H_TOUCH.invokeExact(pathArg, dataArg, ratio, noteArg, (byte) (flush ? 1 : 0));
+            } catch (Throwable error) {
+                throw new IllegalStateException("unibind downcall touch failed", error);
+            }
+            envelope = envelope.reinterpret(32);
+            try {
+                int code = envelope.get(ValueLayout.JAVA_INT, 0);
+                if (code != 0) {
+                    throw unexpectedStatus(code, decodeStr(envelope, 8));
+                }
+                return envelope.get(ValueLayout.JAVA_BYTE, 24) != 0;
+            } finally {
+                free(H_TOUCH_FREE, envelope);
+            }
+        }
+    }
+
+    /** Calls {@link #touch(java.nio.file.Path, byte[], double, String, boolean)} with default trailing arguments. */
+    public static boolean touch(java.nio.file.Path path, byte[] data, double ratio, String note) {
+        return touch(path, data, ratio, note, false);
+    }
+
+    /** Calls {@link #touch(java.nio.file.Path, byte[], double, String, boolean)} with default trailing arguments. */
+    public static boolean touch(java.nio.file.Path path, byte[] data, double ratio) {
+        return touch(path, data, ratio, "note", false);
+    }
+
+    /** Calls {@link #touch(java.nio.file.Path, byte[], double, String, boolean)} with default trailing arguments. */
+    public static boolean touch(java.nio.file.Path path, byte[] data) {
+        return touch(path, data, 0.5, "note", false);
+    }
+
+    private static RuntimeException sampleErrorException(int code, String message) {
+        return switch (code) {
+            case 1 -> new SampleErrorException.StoreGone(message);
+            case 2 -> new SampleErrorException.Invalid(message);
+            default -> unexpectedStatus(code, message);
+        };
+    }
+
+    private static RuntimeException unexpectedStatus(int code, String message) {
+        if (code == -1) {
+            return new UnibindPanicException(message);
+        }
+        return new IllegalStateException("unexpected unibind status " + code + ": " + message);
+    }
+
+    private static void encodeBytes(Arena arena, MemorySegment seg, long offset, byte[] value) {
+        MemorySegment data = arena.allocateFrom(ValueLayout.JAVA_BYTE, value);
+        seg.set(ValueLayout.ADDRESS, offset, data);
+        seg.set(ValueLayout.JAVA_LONG, offset + 8, value.length);
+    }
+
+    private static void encodeOptStr(Arena arena, MemorySegment seg, long offset, String value) {
+        if (value == null) {
+            return;
+        }
+        seg.set(ValueLayout.JAVA_BYTE, offset, (byte) 1);
+        encodeStr(arena, seg, offset + 8, value);
+    }
+
+    private static void encodePath(Arena arena, MemorySegment seg, long offset, java.nio.file.Path value) {
+        encodeStr(arena, seg, offset, value.toString());
+    }
+
+    private static void encodeStr(Arena arena, MemorySegment seg, long offset, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        MemorySegment data = arena.allocateFrom(ValueLayout.JAVA_BYTE, bytes);
+        seg.set(ValueLayout.ADDRESS, offset, data);
+        seg.set(ValueLayout.JAVA_LONG, offset + 8, bytes.length);
+    }
+
+    private static byte[] decodeBytes(MemorySegment seg, long offset) {
+        long len = seg.get(ValueLayout.JAVA_LONG, offset + 8);
+        if (len == 0) {
+            return new byte[0];
+        }
+        return seg.get(ValueLayout.ADDRESS, offset).reinterpret(len).toArray(ValueLayout.JAVA_BYTE);
+    }
+
+    private static java.util.List<Row> decodeListRow(MemorySegment seg, long offset) {
+        long len = seg.get(ValueLayout.JAVA_LONG, offset + 8);
+        java.util.List<Row> list = new java.util.ArrayList<>();
+        if (len == 0) {
+            return list;
+        }
+        MemorySegment data = seg.get(ValueLayout.ADDRESS, offset).reinterpret(len * 96);
+        for (long index = 0; index < len; index++) {
+            list.add(decodeRow(data, index * 96));
+        }
+        return list;
+    }
+
+    private static java.util.List<String> decodeListStr(MemorySegment seg, long offset) {
+        long len = seg.get(ValueLayout.JAVA_LONG, offset + 8);
+        java.util.List<String> list = new java.util.ArrayList<>();
+        if (len == 0) {
+            return list;
+        }
+        MemorySegment data = seg.get(ValueLayout.ADDRESS, offset).reinterpret(len * 16);
+        for (long index = 0; index < len; index++) {
+            list.add(decodeStr(data, index * 16));
+        }
+        return list;
+    }
+
+    private static java.util.Map<String, Double> decodeMapStrF64(MemorySegment seg, long offset) {
+        long len = seg.get(ValueLayout.JAVA_LONG, offset + 8);
+        java.util.Map<String, Double> map = new java.util.LinkedHashMap<>();
+        if (len == 0) {
+            return map;
+        }
+        MemorySegment data = seg.get(ValueLayout.ADDRESS, offset).reinterpret(len * 24);
+        for (long index = 0; index < len; index++) {
+            map.put(decodeStr(data, index * 24), data.get(ValueLayout.JAVA_DOUBLE, index * 24 + 16));
+        }
+        return map;
+    }
+
+    private static java.nio.file.Path decodeOptPath(MemorySegment seg, long offset) {
+        if (seg.get(ValueLayout.JAVA_BYTE, offset) == 0) {
+            return null;
+        }
+        return decodePath(seg, offset + 8);
+    }
+
+    private static java.nio.file.Path decodePath(MemorySegment seg, long offset) {
+        return java.nio.file.Path.of(decodeStr(seg, offset));
+    }
+
+    private static Row decodeRow(MemorySegment seg, long offset) {
+        return new Row(
+                seg.get(ValueLayout.JAVA_LONG, offset),
+                decodeStr(seg, offset + 8),
+                decodeListStr(seg, offset + 24),
+                decodeMapStrF64(seg, offset + 40),
+                decodeBytes(seg, offset + 56),
+                decodeOptPath(seg, offset + 72));
+    }
+
+    private static String decodeStr(MemorySegment seg, long offset) {
+        long len = seg.get(ValueLayout.JAVA_LONG, offset + 8);
+        if (len == 0) {
+            return "";
+        }
+        byte[] bytes = seg.get(ValueLayout.ADDRESS, offset).reinterpret(len).toArray(ValueLayout.JAVA_BYTE);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private static SymbolLookup loadLibrary() {
+        String library = System.getProperty("unibind.sample.library");
+        if (library == null) {
+            throw new IllegalStateException(
+                    "set -Dunibind.sample.library=/path/to/the/native/library before using this binding");
+        }
+        return SymbolLookup.libraryLookup(java.nio.file.Path.of(library), Arena.global());
+    }
+
+    private static MethodHandle handle(String symbol, FunctionDescriptor descriptor) {
+        MemorySegment address = LOOKUP.find(symbol)
+                .orElseThrow(() -> new IllegalStateException("native library exports no " + symbol));
+        return LINKER.downcallHandle(address, descriptor);
+    }
+
+    private static void free(MethodHandle handle, MemorySegment envelope) {
+        try {
+            handle.invokeExact(envelope);
+        } catch (Throwable error) {
+            throw new IllegalStateException("unibind envelope free failed", error);
+        }
+    }
+}
+

--- a/packages/unibind/backend-jvm/tests/snapshots/sample.Sample.kt
+++ b/packages/unibind/backend-jvm/tests/snapshots/sample.Sample.kt
@@ -1,0 +1,28 @@
+// Kotlin sugar over the Java Panama binding [Sample]; no second FFI path.
+// suspend/Flow sugar lands with async IR (#2083 follow-up)
+package unibind.sample
+
+/**
+ * Fetch rows.
+ *
+ * Docs become docstrings.
+ *
+ * @param limit Unsigned in Rust; a negative value is the raw two's-complement bit pattern.
+ * @param root May be null.
+ */
+fun rows(
+    store: String,
+    limit: Long = 10,
+    root: String? = null,
+): List<Row> =
+    Sample.rows(store, limit, root)
+
+fun touch(
+    path: java.nio.file.Path,
+    data: ByteArray,
+    ratio: Double = 0.5,
+    note: String = "note",
+    flush: Boolean = false,
+): Boolean =
+    Sample.touch(path, data, ratio, note, flush)
+

--- a/packages/unibind/backend-jvm/tests/snapshots/sample.SampleErrorException.java
+++ b/packages/unibind/backend-jvm/tests/snapshots/sample.SampleErrorException.java
@@ -1,0 +1,32 @@
+package unibind.sample;
+
+/**
+ * Boundary failures.
+ */
+public class SampleErrorException extends RuntimeException {
+
+    protected SampleErrorException(String message) {
+        super(message);
+    }
+
+    /**
+     * The store is gone.
+     */
+    public static final class StoreGone extends SampleErrorException {
+
+        public StoreGone(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Bad input.
+     */
+    public static final class Invalid extends SampleErrorException {
+
+        public Invalid(String message) {
+            super(message);
+        }
+    }
+}
+

--- a/packages/unibind/backend-jvm/tests/snapshots/sample.UnibindPanicException.java
+++ b/packages/unibind/backend-jvm/tests/snapshots/sample.UnibindPanicException.java
@@ -1,0 +1,12 @@
+package unibind.sample;
+
+/**
+ * A Rust panic crossed the unibind boundary (envelope code -1).
+ */
+public final class UnibindPanicException extends RuntimeException {
+
+    public UnibindPanicException(String message) {
+        super(message);
+    }
+}
+

--- a/packages/unibind/backend-jvm/tests/snapshots/sample.ir.json
+++ b/packages/unibind/backend-jvm/tests/snapshots/sample.ir.json
@@ -1,0 +1,272 @@
+{
+  "version": 0,
+  "name": "sample",
+  "names": {
+    "py": null
+  },
+  "docs": [
+    "A sample boundary exercising the phase 0 surface."
+  ],
+  "functions": [
+    {
+      "name": "rows",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Fetch rows.",
+        "",
+        "Docs become docstrings."
+      ],
+      "asyncness": "Sync",
+      "args": [
+        {
+          "name": "store",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "String": {
+              "owned": false
+            }
+          },
+          "default": null
+        },
+        {
+          "name": "limit",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Int": "Usize"
+          },
+          "default": {
+            "Int": 10
+          }
+        },
+        {
+          "name": "root",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Option": {
+              "String": {
+                "owned": false
+              }
+            }
+          },
+          "default": null
+        }
+      ],
+      "ret": {
+        "Vec": {
+          "Named": "Row"
+        }
+      },
+      "throws": "SampleError"
+    },
+    {
+      "name": "touch",
+      "names": {
+        "py": "touch_path"
+      },
+      "docs": [],
+      "asyncness": "Sync",
+      "args": [
+        {
+          "name": "path",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Path": {
+              "owned": false
+            }
+          },
+          "default": null
+        },
+        {
+          "name": "data",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Bytes": {
+              "owned": false
+            }
+          },
+          "default": null
+        },
+        {
+          "name": "ratio",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "Float": "F64"
+          },
+          "default": {
+            "Float": 0.5
+          }
+        },
+        {
+          "name": "note",
+          "names": {
+            "py": null
+          },
+          "ty": {
+            "String": {
+              "owned": false
+            }
+          },
+          "default": {
+            "Str": "note"
+          }
+        },
+        {
+          "name": "flush",
+          "names": {
+            "py": null
+          },
+          "ty": "Bool",
+          "default": {
+            "Bool": false
+          }
+        }
+      ],
+      "ret": "Bool",
+      "throws": null
+    }
+  ],
+  "records": [
+    {
+      "name": "Row",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "A row."
+      ],
+      "fields": [
+        {
+          "name": "id",
+          "names": {
+            "py": null
+          },
+          "docs": [
+            "Identifier."
+          ],
+          "ty": {
+            "Int": "U64"
+          }
+        },
+        {
+          "name": "name",
+          "names": {
+            "py": "label"
+          },
+          "docs": [],
+          "ty": {
+            "String": {
+              "owned": true
+            }
+          }
+        },
+        {
+          "name": "tags",
+          "names": {
+            "py": null
+          },
+          "docs": [],
+          "ty": {
+            "Vec": {
+              "String": {
+                "owned": true
+              }
+            }
+          }
+        },
+        {
+          "name": "weights",
+          "names": {
+            "py": null
+          },
+          "docs": [],
+          "ty": {
+            "Map": {
+              "key": {
+                "String": {
+                  "owned": true
+                }
+              },
+              "value": {
+                "Float": "F64"
+              }
+            }
+          }
+        },
+        {
+          "name": "blob",
+          "names": {
+            "py": null
+          },
+          "docs": [],
+          "ty": {
+            "Bytes": {
+              "owned": true
+            }
+          }
+        },
+        {
+          "name": "home",
+          "names": {
+            "py": null
+          },
+          "docs": [],
+          "ty": {
+            "Option": {
+              "Path": {
+                "owned": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "enums": [],
+  "errors": [
+    {
+      "name": "SampleError",
+      "names": {
+        "py": null
+      },
+      "docs": [
+        "Boundary failures."
+      ],
+      "py_base": "RuntimeError",
+      "variants": [
+        {
+          "name": "StoreGone",
+          "names": {
+            "py": "StoreGoneError"
+          },
+          "docs": [
+            "The store is gone."
+          ]
+        },
+        {
+          "name": "Invalid",
+          "names": {
+            "py": null
+          },
+          "docs": [
+            "Bad input."
+          ]
+        }
+      ]
+    }
+  ],
+  "objects": []
+}

--- a/packages/unibind/backend-jvm/tests/snapshots/sample.ir.json
+++ b/packages/unibind/backend-jvm/tests/snapshots/sample.ir.json
@@ -19,6 +19,7 @@
         "Docs become docstrings."
       ],
       "asyncness": "Sync",
+      "blocking": false,
       "args": [
         {
           "name": "store",
@@ -73,6 +74,7 @@
       },
       "docs": [],
       "asyncness": "Sync",
+      "blocking": false,
       "args": [
         {
           "name": "path",

--- a/packages/unibind/backend-jvm/tests/snapshots/sample.jvm.rs
+++ b/packages/unibind/backend-jvm/tests/snapshots/sample.jvm.rs
@@ -1,0 +1,369 @@
+///unibind JVM glue for `sample`: `extern "C"` exports consumed by the generated Java Panama binding.
+#[doc(hidden)]
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    clippy::nursery,
+    dead_code,
+    missing_docs,
+    unsafe_code,
+    unused_qualifications
+)]
+mod __unibind_jvm_sample {
+    /// UTF-8 text as pointer + length. Argument values are Java-owned
+    /// and only viewed; returned values leak a boxed slice that the
+    /// envelope's `Drop` reclaims.
+    #[repr(C)]
+    pub struct CString {
+        pub ptr: *mut u8,
+        pub len: usize,
+    }
+    impl ::core::ops::Drop for CString {
+        fn drop(&mut self) {
+            if self.ptr.is_null() {
+                return;
+            }
+            drop(unsafe {
+                ::std::boxed::Box::from_raw(
+                    ::core::ptr::slice_from_raw_parts_mut(self.ptr, self.len),
+                )
+            });
+        }
+    }
+    /// Raw bytes cross exactly like text.
+    pub type CBytes = CString;
+    /// Paths cross as UTF-8 text.
+    pub type CPath = CString;
+    /// A boxed slice as pointer + length.
+    #[repr(C)]
+    pub struct CVec<T> {
+        pub ptr: *mut T,
+        pub len: usize,
+    }
+    impl<T> ::core::ops::Drop for CVec<T> {
+        fn drop(&mut self) {
+            if self.ptr.is_null() {
+                return;
+            }
+            drop(unsafe {
+                ::std::boxed::Box::from_raw(
+                    ::core::ptr::slice_from_raw_parts_mut(self.ptr, self.len),
+                )
+            });
+        }
+    }
+    /// Inline optional: absent means `present == 0` with `value` all
+    /// zeroed.
+    #[repr(C)]
+    pub struct COption<T> {
+        pub present: u8,
+        pub value: T,
+    }
+    /// One map entry; a map crosses as `CVec<CPair<K, V>>`.
+    #[repr(C)]
+    pub struct CPair<K, V> {
+        pub key: K,
+        pub value: V,
+    }
+    ///C mirror of `Row`, fields in declaration order.
+    #[repr(C)]
+    pub struct RowC {
+        pub id: u64,
+        pub name: CString,
+        pub tags: CVec<CString>,
+        pub weights: CVec<CPair<CString, f64>>,
+        pub blob: CBytes,
+        pub home: COption<CPath>,
+    }
+    ///Return envelope for `rows`: `code` 0 ok, N the N-th `throws` variant, -1 panic.
+    #[repr(C)]
+    pub struct RowsEnvelope {
+        pub code: i32,
+        pub err_msg: CString,
+        pub value: CVec<RowC>,
+    }
+    ///Return envelope for `touch`: `code` 0 ok, N the N-th `throws` variant, -1 panic.
+    #[repr(C)]
+    pub struct TouchEnvelope {
+        pub code: i32,
+        pub err_msg: CString,
+        pub value: u8,
+    }
+    const _: () = {
+        assert!(::core::mem::size_of:: < CBytes > () == 16);
+        assert!(::core::mem::align_of:: < CBytes > () == 8);
+        assert!(::core::mem::offset_of!(CBytes, ptr) == 0);
+        assert!(::core::mem::offset_of!(CBytes, len) == 8);
+        assert!(::core::mem::size_of:: < CVec < RowC > > () == 16);
+        assert!(::core::mem::align_of:: < CVec < RowC > > () == 8);
+        assert!(::core::mem::offset_of!(CVec < RowC >, ptr) == 0);
+        assert!(::core::mem::offset_of!(CVec < RowC >, len) == 8);
+        assert!(::core::mem::size_of:: < CVec < CString > > () == 16);
+        assert!(::core::mem::align_of:: < CVec < CString > > () == 8);
+        assert!(::core::mem::offset_of!(CVec < CString >, ptr) == 0);
+        assert!(::core::mem::offset_of!(CVec < CString >, len) == 8);
+        assert!(::core::mem::size_of:: < CVec < CPair < CString, f64 >> > () == 16);
+        assert!(::core::mem::align_of:: < CVec < CPair < CString, f64 >> > () == 8);
+        assert!(::core::mem::offset_of!(CVec < CPair < CString, f64 >>, ptr) == 0);
+        assert!(::core::mem::offset_of!(CVec < CPair < CString, f64 >>, len) == 8);
+        assert!(::core::mem::size_of:: < CPair < CString, f64 > > () == 24);
+        assert!(::core::mem::align_of:: < CPair < CString, f64 > > () == 8);
+        assert!(::core::mem::offset_of!(CPair < CString, f64 >, key) == 0);
+        assert!(::core::mem::offset_of!(CPair < CString, f64 >, value) == 16);
+        assert!(::core::mem::size_of:: < COption < CPath > > () == 24);
+        assert!(::core::mem::align_of:: < COption < CPath > > () == 8);
+        assert!(::core::mem::offset_of!(COption < CPath >, present) == 0);
+        assert!(::core::mem::offset_of!(COption < CPath >, value) == 8);
+        assert!(::core::mem::size_of:: < COption < CString > > () == 24);
+        assert!(::core::mem::align_of:: < COption < CString > > () == 8);
+        assert!(::core::mem::offset_of!(COption < CString >, present) == 0);
+        assert!(::core::mem::offset_of!(COption < CString >, value) == 8);
+        assert!(::core::mem::size_of:: < CPath > () == 16);
+        assert!(::core::mem::align_of:: < CPath > () == 8);
+        assert!(::core::mem::offset_of!(CPath, ptr) == 0);
+        assert!(::core::mem::offset_of!(CPath, len) == 8);
+        assert!(::core::mem::size_of:: < RowC > () == 96);
+        assert!(::core::mem::align_of:: < RowC > () == 8);
+        assert!(::core::mem::offset_of!(RowC, id) == 0);
+        assert!(::core::mem::offset_of!(RowC, name) == 8);
+        assert!(::core::mem::offset_of!(RowC, tags) == 24);
+        assert!(::core::mem::offset_of!(RowC, weights) == 40);
+        assert!(::core::mem::offset_of!(RowC, blob) == 56);
+        assert!(::core::mem::offset_of!(RowC, home) == 72);
+        assert!(::core::mem::size_of:: < CString > () == 16);
+        assert!(::core::mem::align_of:: < CString > () == 8);
+        assert!(::core::mem::offset_of!(CString, ptr) == 0);
+        assert!(::core::mem::offset_of!(CString, len) == 8);
+        assert!(::core::mem::size_of:: < RowsEnvelope > () == 40);
+        assert!(::core::mem::align_of:: < RowsEnvelope > () == 8);
+        assert!(::core::mem::offset_of!(RowsEnvelope, code) == 0);
+        assert!(::core::mem::offset_of!(RowsEnvelope, err_msg) == 8);
+        assert!(::core::mem::offset_of!(RowsEnvelope, value) == 24);
+        assert!(::core::mem::size_of:: < TouchEnvelope > () == 32);
+        assert!(::core::mem::align_of:: < TouchEnvelope > () == 8);
+        assert!(::core::mem::offset_of!(TouchEnvelope, code) == 0);
+        assert!(::core::mem::offset_of!(TouchEnvelope, err_msg) == 8);
+        assert!(::core::mem::offset_of!(TouchEnvelope, value) == 24);
+    };
+    /// View a Java-owned buffer; empty buffers may carry a null pointer.
+    unsafe fn view<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
+        if len == 0 { &[] } else { unsafe { ::core::slice::from_raw_parts(ptr, len) } }
+    }
+    /// Borrow Java-owned text; panics (caught at the export boundary)
+    /// on invalid UTF-8.
+    unsafe fn str_value(value: &CString) -> &str {
+        ::core::str::from_utf8(unsafe { view(value.ptr, value.len) })
+            .expect("unibind: text crossing the boundary is not valid UTF-8")
+    }
+    /// An absent or empty text value; drops as a no-op.
+    fn null_string() -> CString {
+        CString {
+            ptr: ::core::ptr::null_mut(),
+            len: 0,
+        }
+    }
+    /// Leak owned bytes into a mirror; `Drop` reclaims them.
+    fn bytes_value(value: ::std::vec::Vec<u8>) -> CBytes {
+        let boxed = value.into_boxed_slice();
+        let len = boxed.len();
+        CBytes {
+            ptr: ::std::boxed::Box::into_raw(boxed).cast::<u8>(),
+            len,
+        }
+    }
+    /// Leak an owned string into a mirror.
+    fn string_value(value: ::std::string::String) -> CString {
+        bytes_value(value.into_bytes())
+    }
+    /// Leak an owned path as UTF-8 text; panics (caught at the export
+    /// boundary) on non-UTF-8 paths.
+    fn path_value(value: ::std::path::PathBuf) -> CPath {
+        let text = value
+            .into_os_string()
+            .into_string()
+            .expect("unibind: path crossing the boundary is not valid UTF-8");
+        string_value(text)
+    }
+    /// Leak an owned vec of mirrors.
+    fn vec_value<T>(values: ::std::vec::Vec<T>) -> CVec<T> {
+        let boxed = values.into_boxed_slice();
+        let len = boxed.len();
+        CVec {
+            ptr: ::std::boxed::Box::into_raw(boxed).cast::<T>(),
+            len,
+        }
+    }
+    /// Best-effort text from a caught panic payload.
+    fn panic_text(
+        payload: &(dyn ::std::any::Any + ::core::marker::Send),
+    ) -> ::std::string::String {
+        if let ::std::option::Option::Some(text) = payload.downcast_ref::<&str>() {
+            return ::std::borrow::ToOwned::to_owned(*text);
+        }
+        if let ::std::option::Option::Some(text) = payload
+            .downcast_ref::<::std::string::String>()
+        {
+            return ::std::clone::Clone::clone(text);
+        }
+        ::std::borrow::ToOwned::to_owned("panic across the unibind boundary")
+    }
+    ///Fetch rows.
+    ///
+    ///Docs become docstrings.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn unibind_jvm_sample_rows(
+        store: *const CString,
+        limit: usize,
+        root: *const COption<CString>,
+    ) -> *mut RowsEnvelope {
+        let outcome = ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                let store = unsafe { &*store };
+                let store = unsafe { str_value(store) };
+                let root = unsafe { &*root };
+                let root = if (root).present != 0 {
+                    ::std::option::Option::Some(unsafe { str_value((&(root).value)) })
+                } else {
+                    ::std::option::Option::None
+                };
+                match super::sample::rows(store, limit, root) {
+                    ::std::result::Result::Ok(value) => {
+                        RowsEnvelope {
+                            code: 0,
+                            err_msg: null_string(),
+                            value: vec_value(
+                                (value)
+                                    .into_iter()
+                                    .map(|element| {
+                                        let record = element;
+                                        RowC {
+                                            id: record.id,
+                                            name: string_value(record.name),
+                                            tags: vec_value(
+                                                (record.tags)
+                                                    .into_iter()
+                                                    .map(|element| string_value(element))
+                                                    .collect::<::std::vec::Vec<_>>(),
+                                            ),
+                                            weights: vec_value(
+                                                (record.weights)
+                                                    .into_iter()
+                                                    .map(|(key, value)| CPair {
+                                                        key: string_value(key),
+                                                        value: value,
+                                                    })
+                                                    .collect::<::std::vec::Vec<_>>(),
+                                            ),
+                                            blob: bytes_value(record.blob),
+                                            home: match record.home {
+                                                ::std::option::Option::Some(value) => {
+                                                    COption {
+                                                        present: 1,
+                                                        value: path_value(value),
+                                                    }
+                                                }
+                                                ::std::option::Option::None => {
+                                                    COption {
+                                                        present: 0,
+                                                        value: unsafe { ::core::mem::zeroed() },
+                                                    }
+                                                }
+                                            },
+                                        }
+                                    })
+                                    .collect::<::std::vec::Vec<_>>(),
+                            ),
+                        }
+                    }
+                    ::std::result::Result::Err(error) => {
+                        RowsEnvelope {
+                            code: match &error {
+                                super::sample::SampleError::StoreGone { .. } => 1,
+                                super::sample::SampleError::Invalid { .. } => 2,
+                            },
+                            err_msg: string_value(
+                                ::std::string::ToString::to_string(&error),
+                            ),
+                            value: unsafe { ::core::mem::zeroed() },
+                        }
+                    }
+                }
+            }),
+        );
+        let envelope = match outcome {
+            ::std::result::Result::Ok(envelope) => envelope,
+            ::std::result::Result::Err(payload) => {
+                RowsEnvelope {
+                    code: -1,
+                    err_msg: string_value(panic_text(payload.as_ref())),
+                    value: unsafe { ::core::mem::zeroed() },
+                }
+            }
+        };
+        ::std::boxed::Box::into_raw(::std::boxed::Box::new(envelope))
+    }
+    /// Reclaim an envelope returned by the paired export. Null is a
+    /// no-op; anything else must come from that export, exactly once.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn unibind_jvm_sample_rows__free(envelope: *mut RowsEnvelope) {
+        if envelope.is_null() {
+            return;
+        }
+        drop(unsafe { ::std::boxed::Box::from_raw(envelope) });
+    }
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn unibind_jvm_sample_touch(
+        path: *const CPath,
+        data: *const CBytes,
+        ratio: f64,
+        note: *const CString,
+        flush: u8,
+    ) -> *mut TouchEnvelope {
+        let outcome = ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                let path = unsafe { &*path };
+                let path = ::std::path::Path::new(unsafe { str_value(path) });
+                let data = unsafe { &*data };
+                let data = unsafe { view((data).ptr, (data).len) };
+                let note = unsafe { &*note };
+                let note = unsafe { str_value(note) };
+                let flush = flush != 0;
+                let value = super::sample::touch(path, data, ratio, note, flush);
+                TouchEnvelope {
+                    code: 0,
+                    err_msg: null_string(),
+                    value: u8::from(value),
+                }
+            }),
+        );
+        let envelope = match outcome {
+            ::std::result::Result::Ok(envelope) => envelope,
+            ::std::result::Result::Err(payload) => {
+                TouchEnvelope {
+                    code: -1,
+                    err_msg: string_value(panic_text(payload.as_ref())),
+                    value: unsafe { ::core::mem::zeroed() },
+                }
+            }
+        };
+        ::std::boxed::Box::into_raw(::std::boxed::Box::new(envelope))
+    }
+    /// Reclaim an envelope returned by the paired export. Null is a
+    /// no-op; anything else must come from that export, exactly once.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn unibind_jvm_sample_touch__free(
+        envelope: *mut TouchEnvelope,
+    ) {
+        if envelope.is_null() {
+            return;
+        }
+        drop(unsafe { ::std::boxed::Box::from_raw(envelope) });
+    }
+    /// ABI revision of these exports; the Java binding checks it at
+    /// load.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn unibind_jvm_sample_abi_version() -> u32 {
+        0
+    }
+}
+

--- a/packages/unibind/conformance/jvm/Cargo.toml
+++ b/packages/unibind/conformance/jvm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "unibind-conformance-jvm"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Runtime conformance surface for the unibind JVM backend: the sync phase-0 boundary from Java and Kotlin"
+
+[lib]
+name = "unibind_conformance_jvm"
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+unibind = { workspace = true, features = ["jvm"] }

--- a/packages/unibind/conformance/jvm/default.nix
+++ b/packages/unibind/conformance/jvm/default.nix
@@ -1,0 +1,94 @@
+{
+  ix,
+  pkgs ? ix.pkgs,
+}:
+# The conformance crate ships nothing: the cdylib comes from the shared
+# cargo-unit workspace graph with the unibind `jvm` feature on, and the only
+# artifact worth building is the proof that the generated JVM surface
+# behaves from both host languages. This derivation *is* that proof: compile
+# the unibind-generated Java + Kotlin sources together with the committed
+# runners, point them at the built cdylib, and run both (envelope decoding,
+# mirror layouts, unicode, defaults and overloads, exception mapping, panic
+# containment). Both transcripts land in $out as java.txt / kotlin.txt.
+# `passthru.tests` gates it in CI as
+# `checks.<system>.unibind-conformance-jvm-run`, next to the crate's own
+# unit gates (clippy over the expanded glue included).
+let
+  inherit
+    (ix.unibind.build {
+      crate = "unibind-conformance-jvm";
+      targets.jvm = {};
+    })
+    jvm
+    ;
+
+  units = ix.cargoUnit.selectLibraryWithTests ix.rustWorkspace.units {
+    library = "unibind_conformance_jvm";
+    packageName = "unibind-conformance-jvm";
+  };
+
+  runner = ./runner;
+
+  # `java.lang.foreign` is final since JDK 22; jdk25 is the lowest JDK past
+  # that line in the pinned nixpkgs (22-24 are non-LTS and already dropped).
+  jdk = pkgs.jdk25;
+
+  run =
+    pkgs.runCommand "unibind-conformance-jvm-run"
+    {
+      strictDeps = true;
+      nativeBuildInputs = [
+        jdk
+        pkgs.kotlin
+      ];
+      meta.description = "unibind JVM conformance: the Java and Kotlin Panama runners over the generated bindings";
+    }
+    ''
+      set -o pipefail
+      cdylib=""
+      for candidate in \
+        ${jvm.library}/lib/libunibind_conformance_jvm.so \
+        ${jvm.library}/lib/libunibind_conformance_jvm-*.so \
+        ${jvm.library}/lib/libunibind_conformance_jvm.dylib \
+        ${jvm.library}/lib/libunibind_conformance_jvm-*.dylib
+      do
+        if [ -f "$candidate" ]; then
+          cdylib="$candidate"
+          break
+        fi
+      done
+      if [ -z "$cdylib" ]; then
+        echo "unibind-conformance-jvm: no cdylib under ${jvm.library}/lib" >&2
+        ls -la ${jvm.library}/lib >&2 || true
+        exit 1
+      fi
+
+      # kotlinc writes compiler caches under $HOME.
+      export HOME="$TMPDIR"
+      mkdir classes
+      javac -d classes ${jvm.sources}/unibind/conformance/*.java ${runner}/Main.java
+      kotlinc -classpath classes -d classes \
+        ${jvm.sources}/unibind/conformance/Conformance.kt ${runner}/main.kt
+
+      mkdir -p "$out"
+      java -cp classes \
+        --enable-native-access=ALL-UNNAMED \
+        -Dunibind.conformance.library="$cdylib" \
+        Main | tee "$out/java.txt"
+      java -cp classes:${pkgs.kotlin}/lib/kotlin-stdlib.jar \
+        --enable-native-access=ALL-UNNAMED \
+        -Dunibind.conformance.library="$cdylib" \
+        MainKt | tee "$out/kotlin.txt"
+    '';
+in
+  run.overrideAttrs (old: {
+    passthru =
+      (old.passthru or {})
+      // {
+        tests =
+          (units.passthru.tests or {})
+          // {
+            inherit run;
+          };
+      };
+  })

--- a/packages/unibind/conformance/jvm/package.nix
+++ b/packages/unibind/conformance/jvm/package.nix
@@ -1,0 +1,15 @@
+{
+  id = "unibind-conformance-jvm";
+  inRustWorkspace = true;
+  # Nothing to ship: the crate exists to prove the generated JVM surface
+  # behaves (envelope decoding, mirror layouts, exception mapping, panic
+  # containment) from both Java and Kotlin, and default.nix wraps that proof
+  # in a runnable check. The packageSet entry only exists so the registry
+  # resolves its `passthru.tests` for the CI gates below.
+  packageSet = true;
+  # Gate the runners as `checks.<system>.unibind-conformance-jvm-run`, next
+  # to the crate's own unit gates (clippy over the expanded glue included).
+  passthruTests = {
+    prefix = "unibind-conformance-jvm";
+  };
+}

--- a/packages/unibind/conformance/jvm/runner/Main.java
+++ b/packages/unibind/conformance/jvm/runner/Main.java
@@ -1,0 +1,199 @@
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import unibind.conformance.Conformance;
+import unibind.conformance.ConformanceErrorException;
+import unibind.conformance.Point;
+import unibind.conformance.Row;
+import unibind.conformance.UnibindPanicException;
+
+/**
+ * Drives every sync phase-0 conformance case through the generated Java
+ * Panama binding. One {@code OK <case>} line per case; exits 1 with
+ * {@code FAIL <case>: <detail>} on the first mismatch.
+ */
+public final class Main {
+
+    private Main() {
+    }
+
+    private static int passed = 0;
+
+    public static void main(String[] args) {
+        check("echo_bool", () -> {
+            expect(true, Conformance.echoBool(true));
+            expect(false, Conformance.echoBool(false));
+        });
+        check("echo_int", () -> {
+            expect(0L, Conformance.echoInt(0L));
+            expect(-5L, Conformance.echoInt(-5L));
+            expect(Long.MAX_VALUE, Conformance.echoInt(Long.MAX_VALUE));
+            expect(Long.MIN_VALUE, Conformance.echoInt(Long.MIN_VALUE));
+        });
+        check("echo_i8", () -> {
+            expect((byte) -128, Conformance.echoI8((byte) -128));
+            expect((byte) 127, Conformance.echoI8((byte) 127));
+        });
+        check("echo_i16", () -> expect((short) -12345, Conformance.echoI16((short) -12345)));
+        check("echo_i32", () -> expect(-123456789, Conformance.echoI32(-123456789)));
+        check("echo_u8", () -> expect((byte) -1, Conformance.echoU8((byte) -1)));
+        check("echo_u16", () -> expect((short) -1, Conformance.echoU16((short) -1)));
+        check("echo_u32", () -> expect(-1, Conformance.echoU32(-1)));
+        check("echo_u64", () -> expect(-1L, Conformance.echoU64(-1L)));
+        check("echo_usize", () -> expect(4096L, Conformance.echoUsize(4096L)));
+        check("echo_isize", () -> expect(-4096L, Conformance.echoIsize(-4096L)));
+        check("echo_f32", () -> expect(1.25f, Conformance.echoF32(1.25f)));
+        check("echo_float", () -> expect(-3.5, Conformance.echoFloat(-3.5)));
+        check("echo_str", () -> {
+            expect("h\u00e9llo \ud83c\udf0d \u65e5\u672c\u8a9e", Conformance.echoStr("h\u00e9llo \ud83c\udf0d \u65e5\u672c\u8a9e"));
+            expect("", Conformance.echoStr(""));
+        });
+        check("str_len", () -> expect(4L, Conformance.strLen("\ud83c\udf0d")));
+        check("echo_path", () -> expect(Path.of("/tmp/unibind"), Conformance.echoPath(Path.of("/tmp/unibind"))));
+        check("path_join", () -> expect(Path.of("/tmp/base/child"), Conformance.pathJoin(Path.of("/tmp/base"), "child")));
+        check("echo_bytes", () -> {
+            expectBytes(new byte[] {1, 2, 3}, Conformance.echoBytes(new byte[] {1, 2, 3}));
+            expectBytes(new byte[0], Conformance.echoBytes(new byte[0]));
+        });
+        check("reverse_bytes", () -> expectBytes(new byte[] {3, 2, 1}, Conformance.reverseBytes(new byte[] {1, 2, 3})));
+        check("echo_option", () -> {
+            expect(null, Conformance.echoOption(null));
+            expect(7L, Conformance.echoOption(7L));
+        });
+        check("echo_option_str", () -> {
+            expect(null, Conformance.echoOptionStr(null));
+            expect("present", Conformance.echoOptionStr("present"));
+        });
+        check("echo_vec", () -> {
+            expect(List.of(1L, 2L, 3L), Conformance.echoVec(List.of(1L, 2L, 3L)));
+            expect(List.of(), Conformance.echoVec(List.of()));
+        });
+        check("echo_vec_str", () -> expect(List.of("a", "\u03b2"), Conformance.echoVecStr(List.of("a", "\u03b2"))));
+        check("echo_map", () -> {
+            expect(Map.of("pi", 3.14, "e", 2.71), Conformance.echoMap(Map.of("pi", 3.14, "e", 2.71)));
+            expect(Map.of(), Conformance.echoMap(Map.of()));
+        });
+        check("echo_record", () -> expect(new Point(1.5, -2.5), Conformance.echoRecord(new Point(1.5, -2.5))));
+        check("echo_row", () -> {
+            expectRow(sampleRow(), Conformance.echoRow(sampleRow()));
+            expectRow(bareRow(), Conformance.echoRow(bareRow()));
+        });
+        check("echo_rows", () -> {
+            List<Row> rows = Conformance.echoRows(List.of(sampleRow(), bareRow()));
+            expect(2, rows.size());
+            expectRow(sampleRow(), rows.get(0));
+            expectRow(bareRow(), rows.get(1));
+        });
+        check("make_row", () -> expectRow(
+                sampleRow(),
+                Conformance.makeRow(
+                        7L,
+                        "sample",
+                        List.of("alpha", "\u03b2\u03b5\u03c4\u03b1"),
+                        Map.of("recall", 0.75, "precision", 1.0),
+                        new byte[] {0, -1, 42},
+                        Path.of("/var/data/rows"))));
+        check("add_with_default", () -> {
+            expect(42L, Conformance.addWithDefault(10L));
+            expect(15L, Conformance.addWithDefault(10L, 5L));
+        });
+        check("greet_defaults", () -> {
+            expect("friend Ada x1.5!", Conformance.greet("Ada"));
+            expect("friend Ada x2.5!", Conformance.greet("Ada", 2.5));
+            expect("dr Ada x2.5!", Conformance.greet("Ada", 2.5, "dr"));
+            expect("dr Ada x2.5.", Conformance.greet("Ada", 2.5, "dr", false));
+            expect("dr Ada x2.5. (hi)", Conformance.greet("Ada", 2.5, "dr", false, "hi"));
+        });
+        check("throw_value_error", () -> {
+            try {
+                Conformance.throwValueError();
+                throw new AssertionError("no exception raised");
+            } catch (ConformanceErrorException.Deliberate error) {
+                expect("conformance deliberate failure", error.getMessage());
+            }
+        });
+        check("throw_missing", () -> {
+            try {
+                Conformance.throwMissing("gate");
+                throw new AssertionError("no exception raised");
+            } catch (ConformanceErrorException.Missing error) {
+                expect("no such name: gate", error.getMessage());
+            }
+        });
+        check("checked_add", () -> {
+            expect(5L, Conformance.checkedAdd(2L, 3L));
+            try {
+                Conformance.checkedAdd(Long.MAX_VALUE, 1L);
+                throw new AssertionError("no exception raised");
+            } catch (ConformanceErrorException.Deliberate error) {
+                expect("i64 overflow", error.getMessage());
+            }
+        });
+        check("panic_sync", () -> {
+            try {
+                Conformance.panicSync();
+                throw new AssertionError("no exception raised");
+            } catch (UnibindPanicException error) {
+                if (!error.getMessage().contains("deliberate sync panic")) {
+                    throw new AssertionError("unexpected panic message: " + error.getMessage());
+                }
+            }
+        });
+        System.out.println("ALL " + passed + " CASES PASSED (java)");
+    }
+
+    private static Row sampleRow() {
+        return new Row(
+                7L,
+                "sample",
+                List.of("alpha", "\u03b2\u03b5\u03c4\u03b1"),
+                Map.of("recall", 0.75, "precision", 1.0),
+                new byte[] {0, -1, 42},
+                Path.of("/var/data/rows"));
+    }
+
+    private static Row bareRow() {
+        return new Row(0L, "", List.of(), Map.of(), new byte[0], null);
+    }
+
+    private interface Body {
+        void run() throws Exception;
+    }
+
+    private static void check(String name, Body body) {
+        try {
+            body.run();
+        } catch (Throwable error) {
+            System.out.println("FAIL " + name + ": " + error);
+            System.exit(1);
+        }
+        passed++;
+        System.out.println("OK " + name);
+    }
+
+    private static void expect(Object expected, Object actual) {
+        if (!Objects.equals(expected, actual)) {
+            throw new AssertionError("expected " + expected + ", got " + actual);
+        }
+    }
+
+    private static void expectBytes(byte[] expected, byte[] actual) {
+        if (!Arrays.equals(expected, actual)) {
+            throw new AssertionError(
+                    "expected " + Arrays.toString(expected) + ", got " + Arrays.toString(actual));
+        }
+    }
+
+    /** Field-wise comparison: the {@code blob} array makes record equality identity-based. */
+    private static void expectRow(Row expected, Row actual) {
+        expect(expected.id(), actual.id());
+        expect(expected.label(), actual.label());
+        expect(expected.tags(), actual.tags());
+        expect(expected.scores(), actual.scores());
+        expectBytes(expected.blob(), actual.blob());
+        expect(expected.origin(), actual.origin());
+    }
+}

--- a/packages/unibind/conformance/jvm/runner/main.kt
+++ b/packages/unibind/conformance/jvm/runner/main.kt
@@ -1,0 +1,219 @@
+// Drives the sync phase-0 conformance cases through the generated Kotlin
+// sugar (real default parameter values, nullable types), which delegates to
+// the same Java Panama binding. One `OK <case>` line per case; exits 1 with
+// `FAIL <case>: <detail>` on the first mismatch.
+import java.nio.file.Path
+import kotlin.system.exitProcess
+import unibind.conformance.ConformanceErrorException
+import unibind.conformance.Point
+import unibind.conformance.Row
+import unibind.conformance.UnibindPanicException
+import unibind.conformance.addWithDefault
+import unibind.conformance.checkedAdd
+import unibind.conformance.echoBool
+import unibind.conformance.echoBytes
+import unibind.conformance.echoF32
+import unibind.conformance.echoFloat
+import unibind.conformance.echoI16
+import unibind.conformance.echoI32
+import unibind.conformance.echoI8
+import unibind.conformance.echoInt
+import unibind.conformance.echoIsize
+import unibind.conformance.echoMap
+import unibind.conformance.echoOption
+import unibind.conformance.echoOptionStr
+import unibind.conformance.echoPath
+import unibind.conformance.echoRecord
+import unibind.conformance.echoRow
+import unibind.conformance.echoRows
+import unibind.conformance.echoStr
+import unibind.conformance.echoU16
+import unibind.conformance.echoU32
+import unibind.conformance.echoU64
+import unibind.conformance.echoU8
+import unibind.conformance.echoUsize
+import unibind.conformance.echoVec
+import unibind.conformance.echoVecStr
+import unibind.conformance.greet
+import unibind.conformance.makeRow
+import unibind.conformance.panicSync
+import unibind.conformance.pathJoin
+import unibind.conformance.reverseBytes
+import unibind.conformance.strLen
+import unibind.conformance.throwMissing
+import unibind.conformance.throwValueError
+
+private var passed = 0
+
+private fun check(name: String, body: () -> Unit) {
+    try {
+        body()
+    } catch (error: Throwable) {
+        println("FAIL $name: $error")
+        exitProcess(1)
+    }
+    passed++
+    println("OK $name")
+}
+
+private fun expect(expected: Any?, actual: Any?) {
+    if (expected != actual) {
+        throw AssertionError("expected $expected, got $actual")
+    }
+}
+
+private fun expectBytes(expected: ByteArray, actual: ByteArray) {
+    if (!expected.contentEquals(actual)) {
+        throw AssertionError(
+            "expected ${expected.contentToString()}, got ${actual.contentToString()}",
+        )
+    }
+}
+
+// Field-wise comparison: the `blob` array makes record equality identity-based.
+private fun expectRow(expected: Row, actual: Row) {
+    expect(expected.id(), actual.id())
+    expect(expected.label(), actual.label())
+    expect(expected.tags(), actual.tags())
+    expect(expected.scores(), actual.scores())
+    expectBytes(expected.blob(), actual.blob())
+    expect(expected.origin(), actual.origin())
+}
+
+private fun sampleRow(): Row =
+    Row(
+        7L,
+        "sample",
+        listOf("alpha", "\u03b2\u03b5\u03c4\u03b1"),
+        mapOf("recall" to 0.75, "precision" to 1.0),
+        byteArrayOf(0, -1, 42),
+        Path.of("/var/data/rows"),
+    )
+
+private fun bareRow(): Row = Row(0L, "", listOf(), mapOf(), ByteArray(0), null)
+
+fun main() {
+    check("echo_bool") {
+        expect(true, echoBool(true))
+        expect(false, echoBool(false))
+    }
+    check("echo_int") {
+        expect(0L, echoInt(0L))
+        expect(Long.MAX_VALUE, echoInt(Long.MAX_VALUE))
+        expect(Long.MIN_VALUE, echoInt(Long.MIN_VALUE))
+    }
+    check("echo_i8") { expect((-128).toByte(), echoI8((-128).toByte())) }
+    check("echo_i16") { expect((-12345).toShort(), echoI16((-12345).toShort())) }
+    check("echo_i32") { expect(-123456789, echoI32(-123456789)) }
+    check("echo_u8") { expect((-1).toByte(), echoU8((-1).toByte())) }
+    check("echo_u16") { expect((-1).toShort(), echoU16((-1).toShort())) }
+    check("echo_u32") { expect(-1, echoU32(-1)) }
+    check("echo_u64") { expect(-1L, echoU64(-1L)) }
+    check("echo_usize") { expect(4096L, echoUsize(4096L)) }
+    check("echo_isize") { expect(-4096L, echoIsize(-4096L)) }
+    check("echo_f32") { expect(1.25f, echoF32(1.25f)) }
+    check("echo_float") { expect(-3.5, echoFloat(-3.5)) }
+    check("echo_str") {
+        expect("h\u00e9llo \uD83C\uDF0D \u65E5\u672C\u8A9E", echoStr("h\u00e9llo \uD83C\uDF0D \u65E5\u672C\u8A9E"))
+        expect("", echoStr(""))
+    }
+    check("str_len") { expect(4L, strLen("\uD83C\uDF0D")) }
+    check("echo_path") { expect(Path.of("/tmp/unibind"), echoPath(Path.of("/tmp/unibind"))) }
+    check("path_join") { expect(Path.of("/tmp/base/child"), pathJoin(Path.of("/tmp/base"), "child")) }
+    check("echo_bytes") {
+        expectBytes(byteArrayOf(1, 2, 3), echoBytes(byteArrayOf(1, 2, 3)))
+        expectBytes(ByteArray(0), echoBytes(ByteArray(0)))
+    }
+    check("reverse_bytes") { expectBytes(byteArrayOf(3, 2, 1), reverseBytes(byteArrayOf(1, 2, 3))) }
+    check("echo_option") {
+        expect(null, echoOption(null))
+        expect(7L, echoOption(7L))
+        expect(null, echoOption())
+    }
+    check("echo_option_str") {
+        expect(null, echoOptionStr(null))
+        expect("present", echoOptionStr("present"))
+    }
+    check("echo_vec") {
+        expect(listOf(1L, 2L, 3L), echoVec(listOf(1L, 2L, 3L)))
+        expect(listOf<Long>(), echoVec(listOf()))
+    }
+    check("echo_vec_str") { expect(listOf("a", "\u03b2"), echoVecStr(listOf("a", "\u03b2"))) }
+    check("echo_map") {
+        expect(mapOf("pi" to 3.14, "e" to 2.71), echoMap(mapOf("pi" to 3.14, "e" to 2.71)))
+        expect(mapOf<String, Double>(), echoMap(mapOf()))
+    }
+    check("echo_record") { expect(Point(1.5, -2.5), echoRecord(Point(1.5, -2.5))) }
+    check("echo_row") {
+        expectRow(sampleRow(), echoRow(sampleRow()))
+        expectRow(bareRow(), echoRow(bareRow()))
+    }
+    check("echo_rows") {
+        val rows = echoRows(listOf(sampleRow(), bareRow()))
+        expect(2, rows.size)
+        expectRow(sampleRow(), rows[0])
+        expectRow(bareRow(), rows[1])
+    }
+    check("make_row") {
+        expectRow(
+            sampleRow(),
+            makeRow(
+                7L,
+                "sample",
+                listOf("alpha", "\u03b2\u03b5\u03c4\u03b1"),
+                mapOf("recall" to 0.75, "precision" to 1.0),
+                byteArrayOf(0, -1, 42),
+                Path.of("/var/data/rows"),
+            ),
+        )
+        expectRow(bareRow(), makeRow(0L, "", listOf(), mapOf(), ByteArray(0), null))
+    }
+    check("add_with_default") {
+        expect(42L, addWithDefault(10L))
+        expect(15L, addWithDefault(10L, 5L))
+    }
+    check("greet_defaults") {
+        expect("friend Ada x1.5!", greet("Ada"))
+        expect("friend Ada x2.5!", greet("Ada", ratio = 2.5))
+        expect("dr Ada x1.5!", greet("Ada", title = "dr"))
+        expect("friend Ada x1.5.", greet("Ada", excited = false))
+        expect("friend Ada x1.5! (hi)", greet("Ada", note = "hi"))
+        expect("dr Ada x2.5. (hi)", greet("Ada", 2.5, "dr", false, "hi"))
+    }
+    check("throw_value_error") {
+        try {
+            throwValueError()
+            throw AssertionError("no exception raised")
+        } catch (error: ConformanceErrorException.Deliberate) {
+            expect("conformance deliberate failure", error.message)
+        }
+    }
+    check("throw_missing") {
+        try {
+            throwMissing("gate")
+            throw AssertionError("no exception raised")
+        } catch (error: ConformanceErrorException.Missing) {
+            expect("no such name: gate", error.message)
+        }
+    }
+    check("checked_add") {
+        expect(5L, checkedAdd(2L, 3L))
+        try {
+            checkedAdd(Long.MAX_VALUE, 1L)
+            throw AssertionError("no exception raised")
+        } catch (error: ConformanceErrorException.Deliberate) {
+            expect("i64 overflow", error.message)
+        }
+    }
+    check("panic_sync") {
+        try {
+            panicSync()
+            throw AssertionError("no exception raised")
+        } catch (error: UnibindPanicException) {
+            if (error.message?.contains("deliberate sync panic") != true) {
+                throw AssertionError("unexpected panic message: ${error.message}")
+            }
+        }
+    }
+    println("ALL $passed CASES PASSED (kotlin)")
+}

--- a/packages/unibind/conformance/jvm/src/lib.rs
+++ b/packages/unibind/conformance/jvm/src/lib.rs
@@ -1,0 +1,288 @@
+//! Conformance surface for the unibind JVM backend (phase 8, #2083).
+//!
+//! The sync phase-0 subset of the Python suite one directory up
+//! (`packages/unibind/conformance`), under the same case names, plus width
+//! and container coverage the JVM ABI needs proven: every integer width,
+//! both floats, borrowed and owned text/paths/bytes, `Option` in both
+//! states, containers (empty and full), record round-trips with nested
+//! aggregates, every default-literal kind, the exception hierarchy, and
+//! panic containment. `runner/Main.java` and `runner/main.kt` drive each
+//! export through the generated Panama binding; the async/stream/object
+//! cases join when the JVM async surface lands (#2083 phase D).
+
+/// The exported boundary: Java package `unibind.conformance`, loaded via
+/// the `unibind.conformance.library` system property.
+// The exported signatures ARE the conformance cases: owned arguments and
+// non-const bodies are the shapes being proven across the boundary, so the
+// perf-shape lints do not apply to them.
+#[allow(clippy::missing_const_for_fn, clippy::needless_pass_by_value)]
+#[unibind::export(backends(jvm))]
+mod conformance {
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+
+    /// A plain-data record crossing the boundary by value.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Point {
+        /// Horizontal coordinate.
+        pub x: f64,
+        /// Vertical coordinate.
+        pub y: f64,
+    }
+
+    /// A record with nested aggregates, proving container fields round-trip.
+    #[unibind::record]
+    #[derive(Clone)]
+    pub struct Row {
+        /// Identifier.
+        pub id: u64,
+        /// Display label.
+        pub label: String,
+        /// Plain string list.
+        pub tags: Vec<String>,
+        /// String-keyed float map.
+        pub scores: HashMap<String, f64>,
+        /// Raw payload bytes.
+        pub blob: Vec<u8>,
+        /// Optional origin path.
+        pub origin: Option<PathBuf>,
+    }
+
+    /// Boundary failures raised by the conformance surface.
+    #[unibind::error]
+    #[derive(Debug)]
+    pub enum ConformanceError {
+        /// A deliberate failure for exception-mapping tests.
+        Deliberate { message: String },
+        /// A missing name, proving status N maps onto the N-th variant.
+        Missing { name: String },
+    }
+
+    impl std::fmt::Display for ConformanceError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deliberate { message } => write!(formatter, "{message}"),
+                Self::Missing { name } => write!(formatter, "no such name: {name}"),
+            }
+        }
+    }
+
+    impl std::error::Error for ConformanceError {}
+
+    /// Round-trip a bool.
+    pub fn echo_bool(value: bool) -> bool {
+        value
+    }
+
+    /// Round-trip an int.
+    pub fn echo_int(value: i64) -> i64 {
+        value
+    }
+
+    /// Round-trip an `i8`.
+    pub fn echo_i8(value: i8) -> i8 {
+        value
+    }
+
+    /// Round-trip an `i16`.
+    pub fn echo_i16(value: i16) -> i16 {
+        value
+    }
+
+    /// Round-trip an `i32`.
+    pub fn echo_i32(value: i32) -> i32 {
+        value
+    }
+
+    /// Round-trip a `u8`.
+    pub fn echo_u8(value: u8) -> u8 {
+        value
+    }
+
+    /// Round-trip a `u16`.
+    pub fn echo_u16(value: u16) -> u16 {
+        value
+    }
+
+    /// Round-trip a `u32`.
+    pub fn echo_u32(value: u32) -> u32 {
+        value
+    }
+
+    /// Round-trip a `u64`; `u64::MAX` reads back as `-1` bits in Java.
+    pub fn echo_u64(value: u64) -> u64 {
+        value
+    }
+
+    /// Round-trip a `usize`.
+    pub fn echo_usize(value: usize) -> usize {
+        value
+    }
+
+    /// Round-trip an `isize`.
+    pub fn echo_isize(value: isize) -> isize {
+        value
+    }
+
+    /// Round-trip an `f32`.
+    pub fn echo_f32(value: f32) -> f32 {
+        value
+    }
+
+    /// Round-trip a float.
+    pub fn echo_float(value: f64) -> f64 {
+        value
+    }
+
+    /// Round-trip a string; unicode crosses as UTF-8.
+    pub fn echo_str(value: String) -> String {
+        value
+    }
+
+    /// Byte length of a borrowed string view.
+    pub fn str_len(value: &str) -> usize {
+        value.len()
+    }
+
+    /// Round-trip an owned path.
+    pub fn echo_path(value: PathBuf) -> PathBuf {
+        value
+    }
+
+    /// Join a borrowed path with a child segment.
+    pub fn path_join(base: &Path, child: String) -> PathBuf {
+        base.join(child)
+    }
+
+    /// Round-trip bytes; the argument view is copied into an owned return.
+    pub fn echo_bytes(data: &[u8]) -> Vec<u8> {
+        data.to_vec()
+    }
+
+    /// Reverse owned bytes, proving `Vec<u8>` crosses in both directions.
+    pub fn reverse_bytes(data: Vec<u8>) -> Vec<u8> {
+        data.into_iter().rev().collect()
+    }
+
+    /// Round-trip an optional int.
+    pub fn echo_option(value: Option<i64>) -> Option<i64> {
+        value
+    }
+
+    /// Round-trip an optional string.
+    pub fn echo_option_str(value: Option<String>) -> Option<String> {
+        value
+    }
+
+    /// Round-trip a list of ints.
+    pub fn echo_vec(values: Vec<i64>) -> Vec<i64> {
+        values
+    }
+
+    /// Round-trip a list of strings.
+    pub fn echo_vec_str(values: Vec<String>) -> Vec<String> {
+        values
+    }
+
+    /// Round-trip a string-keyed map of floats.
+    pub fn echo_map(values: HashMap<String, f64>) -> HashMap<String, f64> {
+        values
+    }
+
+    /// Round-trip a record.
+    pub fn echo_record(point: Point) -> Point {
+        point
+    }
+
+    /// Round-trip a record with nested aggregate fields.
+    pub fn echo_row(row: Row) -> Row {
+        row
+    }
+
+    /// Round-trip a list of records.
+    pub fn echo_rows(rows: Vec<Row>) -> Vec<Row> {
+        rows
+    }
+
+    /// Build a row from parts: aggregates in argument position, a record in
+    /// return position.
+    pub fn make_row(
+        id: u64,
+        label: String,
+        tags: Vec<String>,
+        scores: HashMap<String, f64>,
+        blob: Vec<u8>,
+        origin: Option<PathBuf>,
+    ) -> Row {
+        Row {
+            id,
+            label,
+            tags,
+            scores,
+            blob,
+            origin,
+        }
+    }
+
+    /// Add with a defaulted second operand, proving `#[unibind(default)]`.
+    pub fn add_with_default(value: i64, #[unibind(default = 32)] delta: i64) -> i64 {
+        value + delta
+    }
+
+    /// Format a greeting through every default-literal kind: float, string,
+    /// bool, and the implicit `None` of a defaultless `Option`.
+    pub fn greet(
+        name: String,
+        #[unibind(default = 1.5)] ratio: f64,
+        #[unibind(default = "friend")] title: &str,
+        #[unibind(default = true)] excited: bool,
+        note: Option<String>,
+    ) -> String {
+        let punctuation = if excited { "!" } else { "." };
+        let suffix = note.map(|text| format!(" ({text})")).unwrap_or_default();
+        format!("{title} {name} x{ratio}{punctuation}{suffix}")
+    }
+
+    /// Raise the first error variant.
+    ///
+    /// # Errors
+    ///
+    /// Always: proving the enum maps onto the exception hierarchy is the
+    /// point.
+    pub fn throw_value_error() -> Result<(), ConformanceError> {
+        Err(ConformanceError::Deliberate {
+            message: "conformance deliberate failure".to_owned(),
+        })
+    }
+
+    /// Raise the second error variant through a value-returning signature.
+    ///
+    /// # Errors
+    ///
+    /// Always, with the variant carrying `name`.
+    pub fn throw_missing(name: String) -> Result<i64, ConformanceError> {
+        Err(ConformanceError::Missing { name })
+    }
+
+    /// Add through a fallible signature, exercising the `Ok` path.
+    ///
+    /// # Errors
+    ///
+    /// On `i64` overflow.
+    pub fn checked_add(a: i64, b: i64) -> Result<i64, ConformanceError> {
+        a.checked_add(b).ok_or_else(|| ConformanceError::Deliberate {
+            message: "i64 overflow".to_owned(),
+        })
+    }
+
+    /// Panic synchronously.
+    ///
+    /// # Panics
+    ///
+    /// Always: proving panics surface as `UnibindPanicException` without
+    /// killing the JVM is the point.
+    pub fn panic_sync() {
+        panic!("unibind conformance: deliberate sync panic");
+    }
+}

--- a/packages/unibind/conformance/src/lib.rs
+++ b/packages/unibind/conformance/src/lib.rs
@@ -9,7 +9,7 @@
 
 /// The exported boundary. The module name names the `PyInit_` symbol, so
 /// the built cdylib imports as `_conformance`.
-#[unibind::export]
+#[unibind::export(backends(py))]
 mod _conformance {
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/packages/unibind/gen/Cargo.toml
+++ b/packages/unibind/gen/Cargo.toml
@@ -21,4 +21,5 @@ anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 object.workspace = true
 serde_json.workspace = true
+unibind-backend-jvm.workspace = true
 unibind-core.workspace = true

--- a/packages/unibind/gen/src/jvm.rs
+++ b/packages/unibind/gen/src/jvm.rs
@@ -1,0 +1,39 @@
+//! Emit the JVM host files for one interface.
+//!
+//! The Java Panama binding and the Kotlin sugar come straight from
+//! `unibind-backend-jvm` -- the same generators that share a layout model
+//! with the macro-side `extern "C"` glue -- so this module only adapts them
+//! onto the [`HostEmitter`] seam.
+
+use unibind_core::ir::Interface;
+
+use crate::host::{EmitError, HostEmitter, HostFile};
+
+/// The JVM emitter; writes `unibind/<module>/*.java` plus `<Module>.kt`
+/// under the output root.
+pub struct JvmEmitter;
+
+impl HostEmitter for JvmEmitter {
+    fn target(&self) -> &'static str {
+        "jvm"
+    }
+
+    fn emit(&self, interface: &Interface) -> Result<Vec<HostFile>, EmitError> {
+        let mut sources = unibind_backend_jvm::generate_java(interface)
+            .map_err(|error| EmitError {
+                message: error.message,
+            })?;
+        sources.extend(
+            unibind_backend_jvm::generate_kotlin(interface).map_err(|error| EmitError {
+                message: error.message,
+            })?,
+        );
+        Ok(sources
+            .into_iter()
+            .map(|file| HostFile {
+                path: file.path,
+                contents: file.content,
+            })
+            .collect())
+    }
+}

--- a/packages/unibind/gen/src/lib.rs
+++ b/packages/unibind/gen/src/lib.rs
@@ -11,4 +11,5 @@
 
 pub mod artifact;
 pub mod host;
+pub mod jvm;
 pub mod py;

--- a/packages/unibind/gen/src/main.rs
+++ b/packages/unibind/gen/src/main.rs
@@ -12,6 +12,7 @@ use anyhow::{bail, Context as _};
 use clap::Parser as _;
 use unibind_gen::artifact;
 use unibind_gen::host::{self, HostEmitter as _};
+use unibind_gen::jvm::JvmEmitter;
 use unibind_gen::py::PyEmitter;
 
 /// Render host-language files (stubs, markers, wrapper modules) from the
@@ -27,9 +28,23 @@ struct Cli {
 /// (phase 5, issue #1995) join alongside `py` with their backends.
 #[derive(clap::Subcommand)]
 enum Command {
+    /// Emit the JVM host files: the Java Panama binding and the Kotlin
+    /// sugar under `unibind/<module>/`.
+    Jvm(JvmArgs),
     /// Emit the Python host files: `<package>/<module>.pyi`,
     /// `<package>/py.typed`, and the wrapper `<package>/__init__.py`.
     Py(PyArgs),
+}
+
+#[derive(clap::Args)]
+struct JvmArgs {
+    /// Compiled cdylib (or any object file) carrying the embedded IR.
+    #[arg(long)]
+    artifact: PathBuf,
+
+    /// Output root; files are written at paths relative to it.
+    #[arg(long)]
+    out: PathBuf,
 }
 
 #[derive(clap::Args)]
@@ -54,19 +69,24 @@ struct PyArgs {
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
+        Command::Jvm(args) => run_jvm(&args),
         Command::Py(args) => run_py(&args),
     }
 }
 
-fn run_py(args: &PyArgs) -> anyhow::Result<()> {
-    let embedded = artifact::read(&args.artifact)?;
-    let interface = match embedded.interfaces.as_slice() {
-        [interface] => interface,
-        [] => bail!("{} embeds no unibind interface", args.artifact.display()),
+/// The one embedded interface, or a diagnostic naming what was found.
+fn single_interface<'a>(
+    embedded: &'a artifact::EmbeddedInterfaces,
+    artifact: &std::path::Path,
+    target: &str,
+) -> anyhow::Result<&'a unibind_core::ir::Interface> {
+    match embedded.interfaces.as_slice() {
+        [interface] => Ok(interface),
+        [] => bail!("{} embeds no unibind interface", artifact.display()),
         several => bail!(
-            "{} embeds {} unibind interfaces ({}); the py generator handles exactly one \
-             per artifact",
-            args.artifact.display(),
+            "{} embeds {} unibind interfaces ({}); the {target} generator handles exactly \
+             one per artifact",
+            artifact.display(),
             several.len(),
             several
                 .iter()
@@ -74,7 +94,28 @@ fn run_py(args: &PyArgs) -> anyhow::Result<()> {
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
-    };
+    }
+}
+
+fn run_jvm(args: &JvmArgs) -> anyhow::Result<()> {
+    let embedded = artifact::read(&args.artifact)?;
+    let interface = single_interface(&embedded, &args.artifact, "jvm")?;
+
+    let emitter = JvmEmitter;
+    let files = emitter
+        .emit(interface)
+        .with_context(|| format!("emitting the {} host files", emitter.target()))?;
+    host::write_host_files(&args.out, &files)?;
+
+    for file in &files {
+        println!("{}", file.path);
+    }
+    Ok(())
+}
+
+fn run_py(args: &PyArgs) -> anyhow::Result<()> {
+    let embedded = artifact::read(&args.artifact)?;
+    let interface = single_interface(&embedded, &args.artifact, "py")?;
 
     let emitter = PyEmitter {
         package: args.package.clone(),

--- a/packages/unibind/gen/tests/render.rs
+++ b/packages/unibind/gen/tests/render.rs
@@ -8,6 +8,7 @@
 use unibind_core::ir;
 use unibind_gen::artifact::parse_ir_bytes;
 use unibind_gen::host::HostEmitter as _;
+use unibind_gen::jvm::JvmEmitter;
 use unibind_gen::py::PyEmitter;
 
 fn names(py: Option<&str>) -> ir::Names {
@@ -245,6 +246,37 @@ fn skip_init_drops_the_wrapper() {
     let files = emitter.emit(&interface()).expect("emits");
     let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
     assert_eq!(paths, ["sample/_sample.pyi", "sample/py.typed"]);
+}
+
+#[test]
+fn jvm_emitter_emits_java_and_kotlin() {
+    // The JVM backend's async/stream surface is phase D (#2083); emit the
+    // sync subset of the fixture here and pin only the emitter seam.
+    let mut sync_only = interface();
+    sync_only.functions.retain(|function| {
+        matches!(function.asyncness, ir::Asyncness::Sync)
+            && !matches!(function.ret, Some(ir::Type::Stream(_)))
+    });
+    let files = JvmEmitter.emit(&sync_only).expect("emits");
+    let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        [
+            "unibind/_sample/Sample.java",
+            "unibind/_sample/Row.java",
+            "unibind/_sample/Source.java",
+            "unibind/_sample/SampleErrorException.java",
+            "unibind/_sample/UnibindPanicException.java",
+            "unibind/_sample/Sample.kt",
+        ]
+    );
+    // Content is snapshot-tested in unibind-backend-jvm; here we only pin
+    // the seam: the module class binds the export symbols of this module.
+    let module_class = &files[0].contents;
+    assert!(
+        module_class.contains("unibind_jvm__sample_rows"),
+        "module class misses the rows export: {module_class}"
+    );
 }
 
 #[test]

--- a/packages/unibind/macros/Cargo.toml
+++ b/packages/unibind/macros/Cargo.toml
@@ -16,11 +16,13 @@ doctest = false
 workspace = true
 
 [features]
+jvm = ["dep:unibind-backend-jvm"]
 py = ["dep:unibind-backend-py"]
 
 [dependencies]
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
+unibind-backend-jvm = { workspace = true, optional = true }
 unibind-backend-py = { workspace = true, optional = true }
 unibind-core.workspace = true

--- a/packages/unibind/macros/src/expand.rs
+++ b/packages/unibind/macros/src/expand.rs
@@ -12,6 +12,10 @@ pub fn export(args: TokenStream, item: TokenStream) -> TokenStream {
             return quote! { #item #error };
         }
     };
+    let (args, selection) = match split_backends(args) {
+        Ok(split) => split,
+        Err(error) => return with_error(&mut module, &error),
+    };
     let interface = match unibind_core::lower_module(args, &module) {
         Ok(interface) => interface,
         Err(error) => return with_error(&mut module, &error),
@@ -21,7 +25,7 @@ pub fn export(args: TokenStream, item: TokenStream) -> TokenStream {
         Ok(embed) => embed,
         Err(error) => return with_error(&mut module, &error),
     };
-    let glue = match backends(&interface, &mut module) {
+    let glue = match backends(&interface, &mut module, selection) {
         Ok(glue) => glue,
         Err(error) => return with_error(&mut module, &error),
     };
@@ -40,22 +44,129 @@ fn with_error(module: &mut syn::ItemMod, error: &LowerError) -> TokenStream {
     quote! { #module #error }
 }
 
-/// Concatenate the glue of every enabled backend. With no backend feature
-/// the macro still validates the surface and embeds the IR; there is just
-/// no binding code to add.
+/// Which backends `backends(...)` selected on the export attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BackendSelection {
+    py: bool,
+    jvm: bool,
+}
+
+/// Pull a `backends(py, jvm)` entry out of the export arguments, leaving
+/// the rest (e.g. `py(name = "...")`) for lowering. `None` means the module
+/// renders every feature-enabled backend. Arguments that do not parse as an
+/// option list pass through untouched so lowering owns their diagnostics.
+fn split_backends(args: TokenStream) -> Result<(TokenStream, Option<BackendSelection>), LowerError> {
+    use syn::spanned::Spanned as _;
+    if args.is_empty() {
+        return Ok((args, None));
+    }
+    let parser = syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated;
+    let Ok(entries) = syn::parse::Parser::parse2(parser, args.clone()) else {
+        return Ok((args, None));
+    };
+    let mut rest: Vec<syn::Meta> = Vec::new();
+    let mut selection = None;
+    for entry in entries {
+        if !entry.path().is_ident("backends") {
+            rest.push(entry);
+            continue;
+        }
+        let span = entry.span();
+        if selection.is_some() {
+            return Err(LowerError {
+                span,
+                message: "duplicate unibind `backends(...)`".to_owned(),
+            });
+        }
+        let syn::Meta::List(list) = entry else {
+            return Err(LowerError {
+                span,
+                message: "`backends` takes a list: backends(py), backends(jvm), or backends(py, jvm)"
+                    .to_owned(),
+            });
+        };
+        let names = syn::parse::Parser::parse2(
+            syn::punctuated::Punctuated::<syn::Ident, syn::Token![,]>::parse_terminated,
+            list.tokens.clone(),
+        )
+        .map_err(|error| LowerError {
+            span,
+            message: format!("bad `backends` options: {error}"),
+        })?;
+        let mut selected = BackendSelection {
+            py: false,
+            jvm: false,
+        };
+        for name in &names {
+            match name.to_string().as_str() {
+                "py" => selected.py = true,
+                "jvm" => selected.jvm = true,
+                other => {
+                    return Err(LowerError {
+                        span: name.span(),
+                        message: format!("unknown backend `{other}`; expected `py` or `jvm`"),
+                    });
+                }
+            }
+        }
+        if selected == (BackendSelection { py: false, jvm: false }) {
+            return Err(LowerError {
+                span,
+                message: "`backends(...)` needs at least one of `py`, `jvm`".to_owned(),
+            });
+        }
+        selection = Some(selected);
+    }
+    let rest = quote!(#(#rest),*);
+    Ok((rest, selection))
+}
+
+/// Concatenate the glue of the selected backends: the `backends(...)`
+/// argument when given, every feature-enabled backend otherwise. Cargo
+/// unifies the facade's features across a workspace, so a module whose
+/// surface only one backend renders (e.g. async python bindings while the
+/// JVM backend is still sync-only) declares that backend explicitly instead
+/// of inheriting a neighbor crate's features. With no backend feature the
+/// macro still validates the surface and embeds the IR; there is just no
+/// binding code to add.
 fn backends(
     interface: &unibind_core::ir::Interface,
     module: &mut syn::ItemMod,
+    selection: Option<BackendSelection>,
 ) -> Result<TokenStream, LowerError> {
-    let mut glue = py_glue(interface, module)?;
-    glue.extend(jvm_glue(interface)?);
+    let explicit = selection.is_some();
+    let mut glue = TokenStream::new();
+    if selection.is_none_or(|selected| selected.py) {
+        glue.extend(py_glue(interface, module, explicit).map_err(|error| implicit_hint(error, explicit, "py"))?);
+    }
+    if selection.is_none_or(|selected| selected.jvm) {
+        glue.extend(jvm_glue(interface, explicit).map_err(|error| implicit_hint(error, explicit, "jvm"))?);
+    }
     Ok(glue)
+}
+
+/// A render failure from a backend nobody asked for by name deserves the
+/// way out: point at the `backends(...)` selection.
+fn implicit_hint(error: LowerError, explicit: bool, backend: &str) -> LowerError {
+    if explicit {
+        return error;
+    }
+    LowerError {
+        span: error.span,
+        message: format!(
+            "{message}\n(the `{backend}` backend came in through cargo feature \
+             unification; if this module should not render it, select the \
+             intended backends explicitly: #[unibind::export(backends(...))])",
+            message = error.message
+        ),
+    }
 }
 
 #[cfg(feature = "py")]
 fn py_glue(
     interface: &unibind_core::ir::Interface,
     module: &mut syn::ItemMod,
+    _explicit: bool,
 ) -> Result<TokenStream, LowerError> {
     let rendered = unibind_backend_py::render(interface).map_err(|error| LowerError {
         span: proc_macro2::Span::call_site(),
@@ -69,14 +180,26 @@ fn py_glue(
 fn py_glue(
     _interface: &unibind_core::ir::Interface,
     _module: &mut syn::ItemMod,
+    explicit: bool,
 ) -> Result<TokenStream, LowerError> {
+    if explicit {
+        return Err(LowerError {
+            span: proc_macro2::Span::call_site(),
+            message: "`backends(py)` needs the unibind `py` cargo feature: \
+                      unibind = { features = [\"py\"] }"
+                .to_owned(),
+        });
+    }
     Ok(TokenStream::new())
 }
 
 /// The JVM glue is self-contained `extern "C"` exports; unlike `py` it
 /// attaches nothing to the record structs.
 #[cfg(feature = "jvm")]
-fn jvm_glue(interface: &unibind_core::ir::Interface) -> Result<TokenStream, LowerError> {
+fn jvm_glue(
+    interface: &unibind_core::ir::Interface,
+    _explicit: bool,
+) -> Result<TokenStream, LowerError> {
     let rendered = unibind_backend_jvm::render(interface).map_err(|error| LowerError {
         span: proc_macro2::Span::call_site(),
         message: error.message,
@@ -85,7 +208,18 @@ fn jvm_glue(interface: &unibind_core::ir::Interface) -> Result<TokenStream, Lowe
 }
 
 #[cfg(not(feature = "jvm"))]
-fn jvm_glue(_interface: &unibind_core::ir::Interface) -> Result<TokenStream, LowerError> {
+fn jvm_glue(
+    _interface: &unibind_core::ir::Interface,
+    explicit: bool,
+) -> Result<TokenStream, LowerError> {
+    if explicit {
+        return Err(LowerError {
+            span: proc_macro2::Span::call_site(),
+            message: "`backends(jvm)` needs the unibind `jvm` cargo feature: \
+                      unibind = { features = [\"jvm\"] }"
+                .to_owned(),
+        });
+    }
     Ok(TokenStream::new())
 }
 

--- a/packages/unibind/macros/src/expand.rs
+++ b/packages/unibind/macros/src/expand.rs
@@ -40,8 +40,20 @@ fn with_error(module: &mut syn::ItemMod, error: &LowerError) -> TokenStream {
     quote! { #module #error }
 }
 
-#[cfg(feature = "py")]
+/// Concatenate the glue of every enabled backend. With no backend feature
+/// the macro still validates the surface and embeds the IR; there is just
+/// no binding code to add.
 fn backends(
+    interface: &unibind_core::ir::Interface,
+    module: &mut syn::ItemMod,
+) -> Result<TokenStream, LowerError> {
+    let mut glue = py_glue(interface, module)?;
+    glue.extend(jvm_glue(interface)?);
+    Ok(glue)
+}
+
+#[cfg(feature = "py")]
+fn py_glue(
     interface: &unibind_core::ir::Interface,
     module: &mut syn::ItemMod,
 ) -> Result<TokenStream, LowerError> {
@@ -53,13 +65,27 @@ fn backends(
     Ok(rendered.glue)
 }
 
-/// With no backend feature enabled the macro still validates the surface
-/// and embeds the IR; there is just no binding code to add.
 #[cfg(not(feature = "py"))]
-fn backends(
+fn py_glue(
     _interface: &unibind_core::ir::Interface,
     _module: &mut syn::ItemMod,
 ) -> Result<TokenStream, LowerError> {
+    Ok(TokenStream::new())
+}
+
+/// The JVM glue is self-contained `extern "C"` exports; unlike `py` it
+/// attaches nothing to the record structs.
+#[cfg(feature = "jvm")]
+fn jvm_glue(interface: &unibind_core::ir::Interface) -> Result<TokenStream, LowerError> {
+    let rendered = unibind_backend_jvm::render(interface).map_err(|error| LowerError {
+        span: proc_macro2::Span::call_site(),
+        message: error.message,
+    })?;
+    Ok(rendered.glue)
+}
+
+#[cfg(not(feature = "jvm"))]
+fn jvm_glue(_interface: &unibind_core::ir::Interface) -> Result<TokenStream, LowerError> {
     Ok(TokenStream::new())
 }
 

--- a/packages/unibind/macros/src/lib.rs
+++ b/packages/unibind/macros/src/lib.rs
@@ -46,6 +46,13 @@ use proc_macro::TokenStream;
 /// Glue for async functions, `UniStream` returns, and `#[unibind::object]`
 /// types calls into `unibind_runtime::py`, so a crate exporting any of
 /// those adds `unibind-runtime` with the `py` feature to its dependencies.
+///
+/// `backends(py)` / `backends(jvm)` / `backends(py, jvm)` selects which
+/// enabled backends render glue for this module; without it every
+/// feature-enabled backend renders. Cargo unifies this crate's features
+/// across a workspace, so a module whose surface only one backend accepts
+/// (e.g. async python bindings while the JVM backend is sync-only) names
+/// its backends instead of inheriting a neighbor crate's features.
 #[proc_macro_attribute]
 pub fn export(args: TokenStream, item: TokenStream) -> TokenStream {
     expand::export(args.into(), item.into()).into()

--- a/packages/unibind/nix/build.nix
+++ b/packages/unibind/nix/build.nix
@@ -10,26 +10,33 @@
   rustWorkspace,
   buildPyStrictCheck,
 }: let
+  buildJvm = import ./jvm.nix {
+    inherit lib pkgs rustWorkspace;
+  };
+
   buildPy = import ./py.nix {
     inherit lib pkgs packageRegistry rustWorkspace buildPyStrictCheck;
   };
 
-  supportedTargets = ["py"];
+  supportedTargets = ["jvm" "py"];
 in {
   /**
   Build host-language outputs for one unibind-annotated crate.
 
-  - `crate`: the Cargo package name (e.g. `scipql-py`). The crate must be
-    marked `pyExtension = true` in its package.nix; the marker is what makes
-    the shared workspace inject the darwin `dynamic_lookup` link args its
-    cdylib needs (lib/rust/workspace.nix).
-  - `targets.<language>`: selects and configures each language target. Phase
-    1 supports `py` (see [./py.nix](./py.nix) for its arguments); the `ts`
-    target lands with issue #1993 and `ex` with issue #1995.
+  - `crate`: the Cargo package name (e.g. `scipql-py`). For the `py`
+    target the crate must be marked `pyExtension = true` in its package.nix;
+    the marker is what makes the shared workspace inject the darwin
+    `dynamic_lookup` link args its cdylib needs (lib/rust/workspace.nix).
+  - `targets.<language>`: selects and configures each language target:
+    `py` (see [./py.nix](./py.nix) for its arguments) and `jvm` (see
+    [./jvm.nix](./jvm.nix)); the `ts` target lands with issue #1993 and
+    `ex` with issue #1995.
 
   Returns one attrset per requested target; `py` is
   `{ wheel; module; pythonSite; library; tests.pyStrict; }` (`wheel` is
-  Linux-only and throws when forced on darwin).
+  Linux-only and throws when forced on darwin), and `jvm` is
+  `{ sources; library; }` (`sources` is the unibind-gen output tree of
+  `.java`/`.kt` files under `unibind/<module>/`).
   */
   build = {
     crate,
@@ -39,8 +46,11 @@ in {
   in
     assert lib.assertMsg (unknown == []) ''
       unibind.lib.build: unsupported target(s) for `${crate}`: ${lib.concatStringsSep ", " unknown}
-      Phase 1 supports: ${lib.concatStringsSep ", " supportedTargets}. (`ts` is issue #1993; `ex` is issue #1995.)'';
-      lib.optionalAttrs (targets ? py) {
+      Supported: ${lib.concatStringsSep ", " supportedTargets}. (`ts` is issue #1993; `ex` is issue #1995.)'';
+      lib.optionalAttrs (targets ? jvm) {
+        jvm = buildJvm {inherit crate;};
+      }
+      // lib.optionalAttrs (targets ? py) {
         py = buildPy ({inherit crate;} // targets.py);
       };
 }

--- a/packages/unibind/nix/jvm.nix
+++ b/packages/unibind/nix/jvm.nix
@@ -1,0 +1,56 @@
+# The `jvm` target of `unibind.lib.build`: generated Java Panama + Kotlin
+# host sources straight from the crate's built cdylib (the IR travels in its
+# link section). Compilation of the generated sources (a JDK 22+ toolchain)
+# is the consumer's concern; this target only materializes them.
+{
+  lib,
+  pkgs,
+  rustWorkspace,
+}: {crate}: let
+  libraryKey = lib.replaceStrings ["-"] ["_"] crate;
+  library =
+    rustWorkspace.units.libraries.${libraryKey}
+    or (throw "unibind.lib.build: the shared workspace graph has no library unit `${libraryKey}` for `${crate}`; the crate must build a cdylib with the unibind `jvm` feature enabled");
+
+  genBin = rustWorkspace.units.binaries."unibind-gen";
+
+  # Locate the built extension: the unit output may suffix the metadata
+  # hash, and the extension differs per OS. Same loop as ./py.nix.
+  findCdylib = ''
+    cdylib=""
+    for candidate in \
+      ${library}/lib/lib${libraryKey}.so \
+      ${library}/lib/lib${libraryKey}-*.so \
+      ${library}/lib/lib${libraryKey}.dylib \
+      ${library}/lib/lib${libraryKey}-*.dylib
+    do
+      if [ -f "$candidate" ]; then
+        cdylib="$candidate"
+        break
+      fi
+    done
+    if [ -z "$cdylib" ]; then
+      echo "unibind: no cdylib under ${library}/lib" >&2
+      ls -la ${library}/lib >&2 || true
+      exit 1
+    fi
+  '';
+
+  sources =
+    pkgs.runCommand "unibind-${crate}-jvm-sources"
+    {
+      strictDeps = true;
+      nativeBuildInputs = [genBin];
+      meta.description = "unibind-generated Java + Kotlin host sources for ${crate}";
+    }
+    ''
+      set -euo pipefail
+      ${findCdylib}
+      mkdir -p "$out"
+      unibind-gen jvm \
+        --artifact "$cdylib" \
+        --out "$out"
+    '';
+in {
+  inherit library sources;
+}

--- a/packages/unibind/runtime/Cargo.toml
+++ b/packages/unibind/runtime/Cargo.toml
@@ -3,13 +3,21 @@ name = "unibind-runtime"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
-description = "Boundary types exported code references at runtime: UniStream and the Python async helpers"
+description = "Boundary types exported code references at runtime: UniStream plus the Python and JVM async helpers"
 
 [lints]
 workspace = true
 
 [features]
 py = ["dep:pyo3", "dep:pyo3-async-runtimes", "dep:tokio", "tokio/sync"]
+jvm = [
+  "dep:tokio",
+  "tokio/rt-multi-thread",
+  "tokio/sync",
+  "tokio/time",
+  "tokio/net",
+  "tokio/macros",
+]
 
 [dependencies]
 futures.workspace = true

--- a/packages/unibind/runtime/src/jvm.rs
+++ b/packages/unibind/runtime/src/jvm.rs
@@ -1,0 +1,174 @@
+//! JVM async helpers the generated glue calls.
+//!
+//! Generated `extern "C"` exports never name `tokio` directly: they spawn
+//! through [`spawn_cancellable`] and pull streams through [`stream_next`],
+//! so this module is the single indirection point pinning the runtime
+//! semantics: one shared multi-thread runtime, cancellation drops the
+//! in-flight future, and panics cross as text.
+
+use std::ffi::c_void;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::sync::{Arc, OnceLock};
+
+use futures::FutureExt as _;
+
+use crate::shared::{panic_text, SharedStream};
+use crate::UniStream;
+
+/// The process-wide runtime every exported async call and stream pull runs
+/// on.
+///
+/// Started lazily, with all drivers enabled, and never shut down: task and
+/// stream handles held by Java can outlive any scope on the Rust side, so
+/// the runtime's lifetime is the process's.
+///
+/// # Panics
+///
+/// Panics when the runtime cannot start (worker thread spawn failure).
+#[must_use]
+pub fn runtime() -> &'static tokio::runtime::Runtime {
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("unibind: the shared tokio runtime failed to start")
+    })
+}
+
+/// How a task spawned by [`spawn_cancellable`] ended.
+#[derive(Debug)]
+pub enum TaskOutcome<T> {
+    /// The future ran to completion with this value.
+    Completed(T),
+    /// The future panicked; the payload rendered as text.
+    Panicked(String),
+    /// [`task_cancel`] won: the future was dropped mid-flight.
+    Cancelled,
+}
+
+/// The state behind an opaque task handle: cancellation is a one-way
+/// notification into the spawned task.
+struct CancelState {
+    notify: tokio::sync::Notify,
+}
+
+/// Spawn `fut` on the shared runtime; `finish` fires exactly once with the
+/// outcome. Returns an opaque handle for [`task_cancel`] / [`task_free`].
+///
+/// Cancellation races completion inside a `select!`: whichever side wins
+/// calls `finish`, and losing the race to a cancel drops the user future
+/// mid-flight (that drop is the cancellation contract).
+#[must_use]
+pub fn spawn_cancellable<F, T>(
+    fut: F,
+    finish: impl FnOnce(TaskOutcome<T>) + Send + 'static,
+) -> *mut c_void
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let state = Arc::new(CancelState {
+        notify: tokio::sync::Notify::new(),
+    });
+    let task_state = Arc::clone(&state);
+    runtime().spawn(async move {
+        let caught = AssertUnwindSafe(fut).catch_unwind();
+        tokio::select! {
+            outcome = caught => match outcome {
+                Ok(value) => finish(TaskOutcome::Completed(value)),
+                Err(payload) => finish(TaskOutcome::Panicked(panic_text(payload.as_ref()))),
+            },
+            // `notified()` consumes the permit `notify_one` stores, so a
+            // cancel that lands before this select is first polled still
+            // wins the race.
+            () = task_state.notify.notified() => finish(TaskOutcome::Cancelled),
+        }
+    });
+    Arc::into_raw(state).cast_mut().cast::<c_void>()
+}
+
+/// Request cancellation of a task spawned by [`spawn_cancellable`].
+///
+/// Idempotent, and a no-op once the task completed; null is ignored.
+///
+/// # Safety
+///
+/// `task` must be null or a handle returned by [`spawn_cancellable`] that
+/// has not yet been passed to [`task_free`].
+pub unsafe fn task_cancel(task: *mut c_void) {
+    if task.is_null() {
+        return;
+    }
+    let state = unsafe { &*task.cast_const().cast::<CancelState>() };
+    state.notify.notify_one();
+}
+
+/// Release a task handle returned by [`spawn_cancellable`].
+///
+/// Null is ignored. The spawned task holds its own reference, so freeing
+/// while the task is still running is safe.
+///
+/// # Safety
+///
+/// `task` must be null or a handle returned by [`spawn_cancellable`],
+/// passed here exactly once and never used afterwards.
+pub unsafe fn task_free(task: *mut c_void) {
+    if task.is_null() {
+        return;
+    }
+    drop(unsafe { Arc::from_raw(task.cast_const().cast::<CancelState>()) });
+}
+
+/// How one stream pull issued by [`stream_next`] ended.
+#[derive(Debug)]
+pub enum NextOutcome<T> {
+    /// The next item, or `None` once the stream is exhausted.
+    Item(Option<T>),
+    /// The stream panicked while producing; the payload as text.
+    Panicked(String),
+}
+
+/// Box a stream behind an opaque handle for [`stream_next`] /
+/// [`stream_free`].
+#[must_use]
+pub fn stream_into_raw<T: Send + 'static>(stream: UniStream<T>) -> *mut c_void {
+    Box::into_raw(Box::new(SharedStream::new(stream))).cast::<c_void>()
+}
+
+/// Pull one item from a stream handle; `finish` fires exactly once on the
+/// shared runtime.
+///
+/// The shared stream is cloned out of the handle before the pull is
+/// spawned, so a [`stream_free`] that lands while the pull is in flight
+/// cannot invalidate it.
+///
+/// # Safety
+///
+/// `handle` must come from [`stream_into_raw::<T>`](stream_into_raw) with
+/// the same `T`, and [`stream_free`] must not have been called before this
+/// call returns.
+pub unsafe fn stream_next<T: Send + 'static>(
+    handle: *mut c_void,
+    finish: impl FnOnce(NextOutcome<T>) + Send + 'static,
+) {
+    let shared = SharedStream::clone(unsafe { &*handle.cast_const().cast::<SharedStream<T>>() });
+    runtime().spawn(async move {
+        let caught = AssertUnwindSafe(shared.next()).catch_unwind();
+        match caught.await {
+            Ok(item) => finish(NextOutcome::Item(item)),
+            Err(payload) => finish(NextOutcome::Panicked(panic_text(payload.as_ref()))),
+        }
+    });
+}
+
+/// Release a stream handle returned by [`stream_into_raw`].
+///
+/// # Safety
+///
+/// `handle` must come from [`stream_into_raw::<T>`](stream_into_raw) with
+/// the same `T`, passed here exactly once and never used afterwards.
+pub unsafe fn stream_free<T: Send + 'static>(handle: *mut c_void) {
+    drop(unsafe { Box::from_raw(handle.cast::<SharedStream<T>>()) });
+}

--- a/packages/unibind/runtime/src/lib.rs
+++ b/packages/unibind/runtime/src/lib.rs
@@ -4,7 +4,8 @@
 //! `fn` returning `UniStream<T>` becomes an async iterator in the target
 //! language, and items flow one poll per consumer request (pull-based
 //! backpressure). The `py` feature adds the Python async helpers the
-//! generated glue calls into.
+//! generated glue calls into; the `jvm` feature adds the shared tokio
+//! runtime and raw-handle task/stream helpers the JVM glue calls into.
 
 use std::fmt;
 use std::pin::Pin;
@@ -13,8 +14,12 @@ use std::task::{Context, Poll};
 use futures::Stream;
 use futures::StreamExt as _;
 
+#[cfg(feature = "jvm")]
+pub mod jvm;
 #[cfg(feature = "py")]
 pub mod py;
+#[cfg(any(feature = "py", feature = "jvm"))]
+mod shared;
 
 /// A boxed stream crossing the binding boundary.
 ///

--- a/packages/unibind/runtime/src/py.rs
+++ b/packages/unibind/runtime/src/py.rs
@@ -3,16 +3,17 @@
 //! Everything here is a thin layer over `pyo3-async-runtimes`, so generated
 //! code only ever names `unibind_runtime`.
 
-use std::fmt;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
-use std::sync::Arc;
 
 use futures::FutureExt as _;
 
 use pyo3::{Bound, PyAny, PyResult, Python};
 
-use crate::UniStream;
+use crate::shared::panic_text;
+// Generated glue names `unibind_runtime::py::SharedStream`; the definition
+// moved to the shared backend module when the JVM backend started using it.
+pub use crate::shared::SharedStream;
 
 /// Convert a Rust future into an awaitable Python object.
 ///
@@ -44,59 +45,4 @@ where
             ))),
         }
     })
-}
-
-/// Best-effort panic payload text, mirroring std's default panic hook.
-fn panic_text(payload: &(dyn std::any::Any + Send)) -> String {
-    payload
-        .downcast_ref::<&str>()
-        .map(|text| (*text).to_owned())
-        .or_else(|| payload.downcast_ref::<String>().cloned())
-        .unwrap_or_else(|| "Box<dyn Any>".to_owned())
-}
-
-/// A [`UniStream`] shared with Python's async iterator protocol.
-///
-/// `__anext__` is called on one shared object from whichever task drives
-/// the iterator, so the stream sits behind a `tokio::sync::Mutex`: the
-/// lock serializes polls and keeps the returned future `Send`.
-pub struct SharedStream<T> {
-    inner: Arc<tokio::sync::Mutex<UniStream<T>>>,
-}
-
-// Manual impl: cloning shares the underlying stream, so `T: Clone` is not
-// required.
-impl<T> Clone for SharedStream<T> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
-    }
-}
-
-impl<T> SharedStream<T> {
-    /// Wrap `stream` for shared consumption.
-    #[must_use]
-    pub fn new(stream: UniStream<T>) -> Self {
-        Self {
-            inner: Arc::new(tokio::sync::Mutex::new(stream)),
-        }
-    }
-
-    /// Pull the next item. The future owns its own `Arc`, so it outlives
-    /// the `&self` borrow that produced it (pyo3 futures must be
-    /// `'static`).
-    pub fn next(&self) -> impl Future<Output = Option<T>> + Send + 'static + use<T>
-    where
-        T: Send + 'static,
-    {
-        let inner = Arc::clone(&self.inner);
-        async move { inner.lock().await.next().await }
-    }
-}
-
-impl<T> fmt::Debug for SharedStream<T> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.debug_struct("SharedStream").finish_non_exhaustive()
-    }
 }

--- a/packages/unibind/runtime/src/shared.rs
+++ b/packages/unibind/runtime/src/shared.rs
@@ -1,0 +1,67 @@
+//! Pieces the Python and JVM async backends share.
+//!
+//! Lives behind `any(py, jvm)` rather than in the crate body so a
+//! backend-less build never pulls `tokio` in; both backends re-export or
+//! call into these, keeping one definition of the boundary stream wrapper
+//! and the panic-text convention.
+
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+
+use crate::UniStream;
+
+/// Best-effort panic payload text, mirroring std's default panic hook.
+pub fn panic_text(payload: &(dyn std::any::Any + Send)) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|text| (*text).to_owned())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "Box<dyn Any>".to_owned())
+}
+
+/// A [`UniStream`] shared between boundary pulls.
+///
+/// Each pull is issued against one shared object from whichever task
+/// drives the iteration, so the stream sits behind a `tokio::sync::Mutex`:
+/// the lock serializes polls and keeps the returned future `Send`.
+pub struct SharedStream<T> {
+    inner: Arc<tokio::sync::Mutex<UniStream<T>>>,
+}
+
+// Manual impl: cloning shares the underlying stream, so `T: Clone` is not
+// required.
+impl<T> Clone for SharedStream<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T> SharedStream<T> {
+    /// Wrap `stream` for shared consumption.
+    #[must_use]
+    pub fn new(stream: UniStream<T>) -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(stream)),
+        }
+    }
+
+    /// Pull the next item. The future owns its own `Arc`, so it outlives
+    /// the `&self` borrow that produced it (both backends need `'static`
+    /// pull futures: pyo3 coroutines and spawned JVM pulls alike).
+    pub fn next(&self) -> impl Future<Output = Option<T>> + Send + 'static + use<T>
+    where
+        T: Send + 'static,
+    {
+        let inner = Arc::clone(&self.inner);
+        async move { inner.lock().await.next().await }
+    }
+}
+
+impl<T> fmt::Debug for SharedStream<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("SharedStream").finish_non_exhaustive()
+    }
+}

--- a/packages/unibind/runtime/tests/jvm.rs
+++ b/packages/unibind/runtime/tests/jvm.rs
@@ -3,13 +3,13 @@
 
 #![cfg(feature = "jvm")]
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use unibind_runtime::UniStream;
 use unibind_runtime::jvm::{self, NextOutcome, TaskOutcome};
+use unibind_runtime::UniStream;
 
 /// Wait for a finish callback, failing loudly instead of hanging CI.
 fn recv<T>(rx: &mpsc::Receiver<T>) -> T {

--- a/packages/unibind/runtime/tests/jvm.rs
+++ b/packages/unibind/runtime/tests/jvm.rs
@@ -1,0 +1,130 @@
+//! The JVM helpers: task outcomes across spawn/cancel/panic and shared
+//! stream pulls through raw handles.
+
+#![cfg(feature = "jvm")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use unibind_runtime::UniStream;
+use unibind_runtime::jvm::{self, NextOutcome, TaskOutcome};
+
+/// Wait for a finish callback, failing loudly instead of hanging CI.
+fn recv<T>(rx: &mpsc::Receiver<T>) -> T {
+    rx.recv_timeout(Duration::from_secs(10)).expect("finish fires")
+}
+
+/// Poll `condition` until it holds or a generous deadline passes.
+fn wait_until(what: &str, condition: impl Fn() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !condition() {
+        assert!(Instant::now() < deadline, "timed out waiting: {what}");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[test]
+fn spawn_cancellable_completes() {
+    let (tx, rx) = mpsc::channel();
+    let task = jvm::spawn_cancellable(async { 41_u32 + 1 }, move |outcome| {
+        tx.send(outcome).expect("receiver lives");
+    });
+    match recv(&rx) {
+        TaskOutcome::Completed(value) => assert_eq!(value, 42),
+        other => panic!("expected completion, got {other:?}"),
+    }
+    unsafe { jvm::task_free(task) };
+}
+
+/// Sets its flag when dropped, observing the cancelled future's teardown.
+struct DropFlag(Arc<AtomicBool>);
+
+impl Drop for DropFlag {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn spawn_cancellable_cancel_drops_the_future() {
+    let dropped = Arc::new(AtomicBool::new(false));
+    let guard = DropFlag(Arc::clone(&dropped));
+    let (tx, rx) = mpsc::channel();
+    let task = jvm::spawn_cancellable(
+        async move {
+            let _guard = guard;
+            std::future::pending::<()>().await;
+        },
+        move |outcome| {
+            tx.send(outcome).expect("receiver lives");
+        },
+    );
+    unsafe { jvm::task_cancel(task) };
+    assert!(matches!(recv(&rx), TaskOutcome::Cancelled));
+    // The select drops the losing future on the worker; observe it rather
+    // than assume ordering against the finish callback.
+    wait_until("cancel drops the pending future", || {
+        dropped.load(Ordering::SeqCst)
+    });
+    // Cancel is idempotent, including after completion.
+    unsafe { jvm::task_cancel(task) };
+    unsafe { jvm::task_free(task) };
+}
+
+#[test]
+fn spawn_cancellable_reports_the_panic_text() {
+    let (tx, rx) = mpsc::channel();
+    let task = jvm::spawn_cancellable(
+        async { panic!("boom 7") },
+        move |outcome: TaskOutcome<()>| {
+            tx.send(outcome).expect("receiver lives");
+        },
+    );
+    match recv(&rx) {
+        TaskOutcome::Panicked(text) => assert!(text.contains("boom 7"), "payload text: {text}"),
+        other => panic!("expected a panic outcome, got {other:?}"),
+    }
+    unsafe { jvm::task_free(task) };
+}
+
+#[test]
+fn stream_next_pulls_one_item_at_a_time() {
+    let handle = jvm::stream_into_raw(UniStream::new(futures::stream::iter([1_u64, 2])));
+    for expected in [Some(1), Some(2), None] {
+        let (tx, rx) = mpsc::channel();
+        unsafe {
+            jvm::stream_next::<u64>(handle, move |outcome| {
+                tx.send(outcome).expect("receiver lives");
+            });
+        }
+        match recv(&rx) {
+            NextOutcome::Item(item) => assert_eq!(item, expected),
+            NextOutcome::Panicked(text) => panic!("unexpected panic: {text}"),
+        }
+    }
+    unsafe { jvm::stream_free::<u64>(handle) };
+}
+
+#[test]
+fn stream_free_during_an_in_flight_pull_is_safe() {
+    let (item_tx, item_rx) = futures::channel::oneshot::channel::<u64>();
+    let handle = jvm::stream_into_raw(UniStream::new(futures::stream::once(async move {
+        item_rx.await.unwrap_or(0)
+    })));
+    let (tx, rx) = mpsc::channel();
+    unsafe {
+        jvm::stream_next::<u64>(handle, move |outcome| {
+            tx.send(outcome).expect("receiver lives");
+        });
+    }
+    // Free while the pull is parked on the oneshot: the pull's own clone
+    // of the shared stream keeps it alive.
+    unsafe { jvm::stream_free::<u64>(handle) };
+    item_tx.send(7).expect("the pull holds the receiver");
+    match recv(&rx) {
+        NextOutcome::Item(item) => assert_eq!(item, Some(7)),
+        NextOutcome::Panicked(text) => panic!("unexpected panic: {text}"),
+    }
+}


### PR DESCRIPTION
Part of #1989. Draft toward #2083 (async half; sync half is #2222).

## What is here

In-progress async/streams/objects work for the JVM backend: runtime jvm module + rust glue toward CompletableFuture cancellation, Flow.Publisher streams, and AutoCloseable resources.

Authored by an AI agent (Claude Code) working issue #2083.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add JVM (Java/Kotlin) backend to unibind code generation
> - Introduces a new `unibind-backend-jvm` crate that generates Java Panama bindings and Kotlin sugar from a unibind interface IR, producing strongly-typed method handles, encode/decode helpers, exception hierarchies, and record classes.
> - Adds `unibind_runtime::jvm` (behind a new `jvm` feature) with a shared tokio runtime, `spawn_cancellable` for async exports, and `stream_into_raw` for pull-based stream crossing.
> - Extends the `#[unibind::export]` macro with an optional `backends(py)` / `backends(jvm)` / `backends(py, jvm)` selector to control which backends emit glue per module.
> - Adds a `jvm` subcommand to the `unibind-gen` CLI that reads embedded IR from a compiled artifact and writes Java and Kotlin sources to a specified output root.
> - Integrates the JVM target into `unibind.lib.build` in Nix, including a conformance test suite that compiles and runs Java and Kotlin runners against the generated bindings.
> - Risk: async function exports are explicitly rejected by the JVM renderer in this phase (marked WIP); streams are pull-based and require callers to manage handle lifetimes via companion free/cancel symbols.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c90f05c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->