### PR TITLE
overseer: put sleep/wake power state in the snapshot

### DIFF
--- a/packages/agent/symphony/workflows/indexable/prompts/overseer.md
+++ b/packages/agent/symphony/workflows/indexable/prompts/overseer.md
@@ -8,7 +8,8 @@ snapshot of the current moment: every running claude/codex/BEAM process
 (CPU, elapsed, tty, cwd), recent Claude Code and codex session
 transcripts (cwd, last activity, age in minutes, last user ask, last
 assistant text, recent tool-error count), recent symphony workflow runs,
-and hot or suspiciously idle processes.
+hot or suspiciously idle processes, and `power`: the battery/AC line
+plus the host's recent sleep/wake transitions from the pmset log.
 
 Reply with ONLY a raw JSON object, no code fences:
 
@@ -45,6 +46,13 @@ process whose transcript stopped, or a headless agent at ~0% CPU.
 one session; skip long-idle sessions entirely rather than padding the
 list. Be decisive and concrete; never hedge with "likely fine". Lead with
 what is broken or suspect; healthy agents earn one word, not a story.
+
+Workflow run failures whose window overlaps `Entering Sleep` or
+`DarkWake` transitions in `power` are sleep noise, not agent trouble:
+a DarkWake has no Wi-Fi, so runs die by wall-clock timeout or network
+retry exhaustion by design (#2216). Only a `to FullWake` window
+covering the whole run justifies calling a failure an awake failure,
+and only awake failures earn an attention item.
 
 Before an action proposes killing a pid, read its parent_chain: a
 tracer or helper whose ancestor is a live monitor or agent session

--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -117,6 +117,23 @@ symphony_runs="$(curl -s --max-time 5 http://127.0.0.1:4040/api/v1/ir/runs |
       | sort_by(.created_at) | reverse | .[0:12]' ||
   echo '{"error": "symphony runtime unreachable on 127.0.0.1:4040"}')"
 
+# Sleep/wake context. A cron run that straddles a sleep window dies by
+# wall-clock timeout (#2216) or by DNS-retry exhaustion (a DarkWake has
+# no SSID), and the run record alone cannot show that: without this
+# signal the judge diagnosed "failures while awake" on a host pmset
+# shows was in Clamshell Sleep for the whole window and dispatched a
+# fixer on that phantom premise. Last transitions only; the grep streams
+# the full pmset log (~seconds), so keep this the only pass over it.
+power="$(
+  {
+    pmset -g batt | head -1
+    # A host that has not slept since boot greps empty; that is a real,
+    # non-fatal state under pipefail.
+    pmset -g log | grep -E 'Entering Sleep|DarkWake|Wake from' | tail -25 || true
+  } | jq -Rs 'split("\n") | map(select(length > 0) | gsub(" +$"; "") | .[0:160])
+              | {batt: .[0], transitions: .[1:]}'
+)"
+
 loadavg="$(sysctl -n vm.loadavg | tr -d '{}' | awk '{print $1}')"
 ncpu="$(sysctl -n hw.ncpu)"
 cpu_pct="$(jq '([.[].pcpu] | add // 0) / '"$ncpu"' | round' <<<"$ps_json")"
@@ -130,11 +147,11 @@ jq -n \
   --argjson cpu_pct "$cpu_pct" --argjson mem_pct "$mem_pct" \
   --argjson agents "$agents" --argjson hot "$hot" --argjson stalled "$stalled" \
   --argjson claude_sessions "$claude_sessions" --argjson codex_sessions "$codex_sessions" \
-  --argjson symphony_runs "$symphony_runs" \
+  --argjson symphony_runs "$symphony_runs" --argjson power "$power" \
   '{now: $now, load_1m: ($loadavg | tonumber), ncpu: $ncpu, cpu_pct: $cpu_pct, mem_pct: $mem_pct,
     agent_processes: $agents, hot_processes: $hot, stalled_suspects: $stalled,
     claude_sessions: $claude_sessions, codex_sessions: $codex_sessions,
-    symphony_runs: $symphony_runs}' > "$snap"
+    symphony_runs: $symphony_runs, power: $power}' > "$snap"
 
 # ---- digest: headless codex over the snapshot --------------------------
 


### PR DESCRIPTION
## Problem

Symphony runs on hydra failed 2026-07-07 16:00Z-16:20Z and the overseer judge dispatched a fixer with the premise "host awake; lid-closed DarkWake does not explain these". pmset shows the opposite: display off 16:00:39Z, `Entering Sleep due to 'Clamshell Sleep'` at 16:00:44Z on battery, then Deep Idle with 5-10s DarkWakes (wifibt TCP-keepalive wakes, `en0: no SSID`) until `DarkWake to FullWake ... UserActivity` at 16:47:45Z.

Fallout in that window, all one root cause (#2216 class):

- overseer-1783440031608-166 and overseer-1783440698448-168: `exec_timeout 480` (wall-clock budget burned across sleep, by design per #2011)
- insights-1783440031606-165: `exec_failed` exit 1; codex log shows `getaddrinfo: nodename nor servname provided` at 16:18:42Z, then 5 websocket + 5 HTTPS reconnects exhausted
- triage-1783440031602-164: codex pid 30566 wedged 51 min at 0% CPU on two dead ESTABLISHED TLS conns left over from the sleep, died with no output at 16:51:48Z, run recorded `stranded`
- claude session ConnectionRefused at 16:41Z coincides with the 16:41:53Z DarkWake slice

## Root cause of the misdiagnosis

`overseer.sh`'s snapshot has no power-state signal, so the judge cannot distinguish awake failures from sleep noise and fabricates the premise (same class as #2193, #2188).

## Fix

Adds a `power` collector (battery line + last 25 pmset sleep/wake transitions) to the snapshot and a judging rule in `prompts/overseer.md`: run failures overlapping `Entering Sleep`/`DarkWake` transitions are sleep noise (#2216), never attention items; only a `to FullWake` window covering the run justifies "awake failure".

Collector validated standalone on hydra (3s, clean JSON, empty-grep case exits 0 under pipefail); `bash -n` and shellcheck clean (no new findings).

The scheduler-level fix (defer cron fire into a sleeping host / resolve sleep-straddling attempts as deferred) stays with #2216.

Part of the overseer arc (#2139). Written by an AI agent (Claude Code, Opus).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sleep/wake power state to overseer snapshot
> - [overseer.sh](https://github.com/indexable-inc/index/pull/2230/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) runs `pmset -g batt` and tails the last 25 matching sleep/wake log transitions, emitting a new `power` object (with `batt` and `transitions` fields) in the snapshot JSON.
> - [overseer.md](https://github.com/indexable-inc/index/pull/2230/files#diff-a31238dc4da0ac6135c3a356d95617447fdd3dec34a3f7a3c6f51b07e0fa4fc0) instructs the LLM to treat workflow failures overlapping `Entering Sleep` or `DarkWake` as sleep noise, and only flag failures fully within a `FullWake` window as actionable attention items.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23643a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->