### PR TITLE
unibind-gen(py): render object, resource, and stream class stubs (#1991 follow-up)

### DIFF
--- a/packages/unibind/conformance/default.nix
+++ b/packages/unibind/conformance/default.nix
@@ -3,14 +3,41 @@
   pkgs ? ix.pkgs,
 }:
 # The conformance crate ships nothing: the PyO3 cdylib comes from the shared
-# cargo-unit workspace graph, and the only artifact worth building is the
-# proof that the generated Python surface behaves. This derivation *is* that
-# proof: install the cdylib as `_conformance.abi3.so`, point the pinned
-# interpreter at it, and run `runner.py` (cancellation, backpressure,
-# resource cleanup, zero-copy, GIL release, panic containment). It is also
-# exposed as `passthru.tests.run` so it joins the CI check set as
-# `checks.<system>.unibind-conformance-run`.
+# cargo-unit workspace graph, and the only artifacts worth building are the
+# proofs that the generated Python surface behaves and stays describable.
+# `run` installs the cdylib as `_conformance.abi3.so`, points the pinned
+# interpreter at it, and runs `runner.py` (cancellation, backpressure,
+# resource cleanup, zero-copy, GIL release, panic containment). `stubs`
+# renders the host files with `unibind-gen py` from the same cdylib -- the
+# surface exports objects, a resource, and streams, so it proves the stub
+# emitter covers the whole phase-2 shape -- and strict-type-checks the
+# result. Both join the CI check set through `passthru.tests` as
+# `checks.<system>.unibind-conformance-{run,stubs}`.
 let
+  library = ix.rustWorkspace.units.libraries.unibind_conformance;
+
+  # Locate the built extension: the unit output may suffix the metadata
+  # hash, and the extension differs per OS. Same loop unibind's py.nix uses.
+  findCdylib = ''
+    cdylib=""
+    for candidate in \
+      ${library}/lib/libunibind_conformance.so \
+      ${library}/lib/libunibind_conformance-*.so \
+      ${library}/lib/libunibind_conformance.dylib \
+      ${library}/lib/libunibind_conformance-*.dylib
+    do
+      if [ -f "$candidate" ]; then
+        cdylib="$candidate"
+        break
+      fi
+    done
+    if [ -z "$cdylib" ]; then
+      echo "unibind-conformance: no cdylib under ${library}/lib" >&2
+      ls -la ${library}/lib >&2 || true
+      exit 1
+    fi
+  '';
+
   run =
     pkgs.runCommand "unibind-conformance-run"
     {
@@ -21,26 +48,29 @@ let
       set -o pipefail
       site="$PWD/site"
       mkdir -p "$site"
-      cdylib=""
-      for candidate in \
-        ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib/libunibind_conformance.so \
-        ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib/libunibind_conformance-*.so \
-        ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib/libunibind_conformance.dylib \
-        ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib/libunibind_conformance-*.dylib
-      do
-        if [ -f "$candidate" ]; then
-          cdylib="$candidate"
-          break
-        fi
-      done
-      if [ -z "$cdylib" ]; then
-        echo "unibind-conformance: no cdylib under ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib" >&2
-        ls -la ${ix.rustWorkspace.units.libraries.unibind_conformance}/lib >&2 || true
-        exit 1
-      fi
+      ${findCdylib}
       install -m555 "$cdylib" "$site/_conformance.abi3.so"
       PYTHONPATH="$site" ${pkgs.python3.interpreter} ${./runner.py} 2>&1 | tee conformance.log
       touch $out
+    '';
+
+  stubs =
+    pkgs.runCommand "unibind-conformance-stubs"
+    {
+      strictDeps = true;
+      nativeBuildInputs = [
+        ix.rustWorkspace.units.binaries."unibind-gen"
+        pkgs.mypy
+      ];
+      meta.description = "unibind-gen py host files for the conformance surface, strictly type-checked";
+    }
+    ''
+      set -euo pipefail
+      mkdir -p "$out"
+      ${findCdylib}
+      unibind-gen py --artifact "$cdylib" --package conformance --out "$out"
+      MYPYPATH="$out" MYPY_CACHE_DIR="$TMPDIR/mypy-cache" \
+        mypy --strict --no-color-output -p conformance
     '';
 in
   run.overrideAttrs (old: {
@@ -50,7 +80,7 @@ in
         tests =
           (old.passthru.tests or {})
           // {
-            inherit run;
+            inherit run stubs;
           };
       };
   })

--- a/packages/unibind/gen/src/py/mod.rs
+++ b/packages/unibind/gen/src/py/mod.rs
@@ -5,6 +5,7 @@
 //! and (unless skipped) the wrapper `__init__.py` re-exporting the module's
 //! public names.
 
+mod streams;
 mod stub;
 mod types;
 mod wrapper;
@@ -60,14 +61,6 @@ impl HostEmitter for PyEmitter {
 /// Refuse the IR surface the stub emitter does not render yet, with the
 /// same pointers the pyo3 backend gives.
 fn reject_unrendered_surface(interface: &Interface) -> Result<(), EmitError> {
-    if let Some(object) = interface.objects.first() {
-        return Err(EmitError {
-            message: format!(
-                "`{}` is a #[unibind::object]; class stubs are not rendered yet (issue #1991)",
-                object.name
-            ),
-        });
-    }
     if let Some(data_enum) = interface.enums.first() {
         return Err(EmitError {
             message: format!("`{}` is a data enum, which phase 1 does not render", data_enum.name),

--- a/packages/unibind/gen/src/py/streams.rs
+++ b/packages/unibind/gen/src/py/streams.rs
@@ -1,0 +1,71 @@
+//! Per-export stream classes: which exports return `UniStream` and what
+//! the pyo3 backend names the class it wraps each one in. The stub
+//! declares exactly those classes, so everything here mirrors
+//! `unibind-backend-py`'s `stream.rs`.
+
+use unibind_core::ir;
+
+/// One stream-returning export: the callable that produced it plus the
+/// item type its class yields.
+pub struct StreamExport<'a> {
+    /// `None` for free functions, the owning object's Rust name for
+    /// methods; scopes the class name.
+    pub owner: Option<&'a str>,
+    /// The stream-returning callable.
+    pub function: &'a ir::Function,
+    /// The yielded item type.
+    pub item: &'a ir::Type,
+}
+
+/// Every stream-returning export in the interface, in the backend's render
+/// order (free functions first, then each object's methods).
+pub fn collect(interface: &ir::Interface) -> Vec<StreamExport<'_>> {
+    let free = interface
+        .functions
+        .iter()
+        .filter_map(|function| stream_export(None, function));
+    let methods = interface.objects.iter().flat_map(|object| {
+        object
+            .methods
+            .iter()
+            .filter_map(|method| stream_export(Some(object.name.as_str()), method))
+    });
+    free.chain(methods).collect()
+}
+
+fn stream_export<'a>(
+    owner: Option<&'a str>,
+    function: &'a ir::Function,
+) -> Option<StreamExport<'a>> {
+    let Some(ir::Type::Stream(item)) = &function.ret else {
+        return None;
+    };
+    Some(StreamExport {
+        owner,
+        function,
+        item,
+    })
+}
+
+/// The Python-visible class name the backend registers for one export:
+/// `TailStream` for a free `tail`, `StoreWatchStream` for `Store::watch`.
+/// Built from the Rust names; renames never reach these classes.
+pub fn class_name(owner: Option<&str>, export: &str) -> String {
+    let export = pascal_case(export);
+    owner.map_or_else(
+        || format!("{export}Stream"),
+        |object| format!("{object}{export}Stream"),
+    )
+}
+
+/// `snake_case` -> `PascalCase` for export names.
+fn pascal_case(name: &str) -> String {
+    name.split('_')
+        .map(|segment| {
+            let mut chars = segment.chars();
+            chars.next().map_or_else(String::new, |first| {
+                first.to_ascii_uppercase().to_string() + chars.as_str()
+            })
+        })
+        .collect()
+}

--- a/packages/unibind/gen/src/py/stub.rs
+++ b/packages/unibind/gen/src/py/stub.rs
@@ -1,16 +1,16 @@
 //! Render the `.pyi` stub for one interface.
 //!
-//! Ordering is deterministic: module docstring, imports (`collections.abc`
-//! when a stream return needs it, `os` when an argument accepts a path),
-//! errors, records, functions, and the trailing
-//! `__version__` the generated `pymodule` sets. Everything keeps the
-//! interface's declaration order within its group, so the stub diffs the way
-//! the Rust module does.
+//! Ordering is deterministic: module docstring, imports (`os` when an
+//! argument accepts a path), errors, records, object classes, stream
+//! classes, functions, and the trailing `__version__` the generated
+//! `pymodule` sets. Everything keeps the interface's declaration order
+//! within its group, so the stub diffs the way the Rust module does.
 
 use std::fmt::Write as _;
 
 use unibind_core::ir;
 
+use crate::py::streams::{self, StreamExport};
 use crate::py::types::{self, Position};
 
 /// The complete `.pyi` text.
@@ -19,9 +19,8 @@ pub fn render(interface: &ir::Interface) -> String {
     if !interface.docs.is_empty() {
         blocks.push(docstring(&interface.docs, 0));
     }
-    let imports = imports(interface);
-    if !imports.is_empty() {
-        blocks.push(imports.join("\n"));
+    if needs_os_import(interface) {
+        blocks.push("import os".to_owned());
     }
     for error in &interface.errors {
         error_classes(error, &mut blocks);
@@ -29,8 +28,16 @@ pub fn render(interface: &ir::Interface) -> String {
     for record in &interface.records {
         blocks.push(record_class(interface, record));
     }
+    for object in &interface.objects {
+        blocks.push(object_class(interface, object));
+    }
+    // Forward references need no quoting in a stub, so stream classes can
+    // trail the objects whose methods return them.
+    for export in streams::collect(interface) {
+        blocks.push(stream_class(interface, &export));
+    }
     for function in &interface.functions {
-        blocks.push(function_def(interface, function));
+        blocks.push(callable_def(interface, function, &Receiver::Free));
     }
     blocks.push("__version__: str".to_owned());
     join_blocks(&blocks)
@@ -63,42 +70,30 @@ pub fn docstring(lines: &[String], indent: usize) -> String {
     out
 }
 
-/// The stub's imports, alphabetized: `collections.abc` exactly when a
-/// function returns a stream (its annotation is
-/// `collections.abc.AsyncIterator`), `os` exactly when a path can appear in
-/// argument position.
-fn imports(interface: &ir::Interface) -> Vec<String> {
-    let mut imports = Vec::new();
-    if needs_abc_import(interface) {
-        imports.push("import collections.abc".to_owned());
-    }
-    if needs_os_import(interface) {
-        imports.push("import os".to_owned());
-    }
-    imports
-}
-
-fn needs_abc_import(interface: &ir::Interface) -> bool {
-    interface
-        .functions
-        .iter()
-        .any(|function| matches!(function.ret, Some(ir::Type::Stream(_))))
-}
-
-/// A path in argument position: function arguments and record constructor
-/// arguments (fields).
+/// A path in argument position needs `import os` for the `os.PathLike`
+/// form: function, method, and constructor arguments, plus record
+/// constructor arguments (fields).
 fn needs_os_import(interface: &ir::Interface) -> bool {
     let function_args = interface
         .functions
         .iter()
         .flat_map(|function| function.args.iter())
         .map(|arg| &arg.ty);
-    let constructor_args = interface
+    let record_args = interface
         .records
         .iter()
         .flat_map(|record| record.fields.iter())
         .map(|field| &field.ty);
-    function_args.chain(constructor_args).any(types::mentions_path)
+    let object_args = interface
+        .objects
+        .iter()
+        .flat_map(|object| object.constructor.iter().chain(object.methods.iter()))
+        .flat_map(|function| function.args.iter())
+        .map(|arg| &arg.ty);
+    function_args
+        .chain(record_args)
+        .chain(object_args)
+        .any(types::mentions_path)
 }
 
 /// One class per error: the base (extending `py_base`, `Exception` when
@@ -119,6 +114,21 @@ fn class_block(header: &str, docs: &[String]) -> String {
         return format!("{header} ...");
     }
     format!("{header}\n{}", docstring(docs, 1))
+}
+
+/// A class whose body is a docstring plus member blocks separated by one
+/// blank line.
+fn class_with_members(header: &str, docs: &[String], members: &[String]) -> String {
+    if members.is_empty() {
+        return class_block(header, docs);
+    }
+    let mut out = format!("{header}\n");
+    if !docs.is_empty() {
+        out.push_str(&docstring(docs, 1));
+        out.push_str("\n\n");
+    }
+    out.push_str(&members.join("\n\n"));
+    out
 }
 
 /// A record: docstring, the positional `__init__` the generated `#[new]`
@@ -154,33 +164,174 @@ fn record_class(interface: &ir::Interface, record: &ir::Record) -> String {
         }
     }
 
-    let mut out = format!("class {name}:\n");
-    if !record.docs.is_empty() {
-        out.push_str(&docstring(&record.docs, 1));
-        out.push_str("\n\n");
-    }
-    out.push_str(&members.join("\n\n"));
-    out
+    class_with_members(&format!("class {name}:"), &record.docs, &members)
 }
 
-/// A function stub: literal defaults, `None` for undefaulted `Option`
-/// arguments, and a docstring that names the raised exception base when the
-/// function throws (stub signatures cannot express `raises`). Async functions
-/// render `async def`: the extension returns a coroutine resolving to the
-/// annotated type.
-fn function_def(interface: &ir::Interface, function: &ir::Function) -> String {
-    let name = types::py_name(&function.names, &function.name);
-    let params: Vec<String> = function.args.iter().map(|arg| parameter(interface, arg)).collect();
-    let ret = function.ret.as_ref().map_or_else(
-        || "None".to_owned(),
-        |ty| types::annotation(interface, ty, Position::Return),
+/// An object: docstring, the `__init__` its declared constructor exposes
+/// through `#[new]` (no constructor means the class cannot be instantiated
+/// from Python, so no `__init__` appears), its methods, and, for
+/// resources, the close/async-with surface the pyo3 backend generates.
+fn object_class(interface: &ir::Interface, object: &ir::Object) -> String {
+    let name = types::py_name(&object.names, &object.name);
+    let mut members = Vec::new();
+    if let Some(ctor) = &object.constructor {
+        members.push(constructor_def(interface, ctor));
+    }
+    let close = resource_close(object);
+    for method in &object.methods {
+        // The resource surface owns `close`; the backend skips the generic
+        // rendering for it, so the stub does too.
+        if close.is_some_and(|close| std::ptr::eq(close, method)) {
+            continue;
+        }
+        let receiver = Receiver::Method {
+            object: &object.name,
+        };
+        members.push(callable_def(interface, method, &receiver));
+    }
+    if let Some(close) = close {
+        members.push(close_def(interface, close));
+        members.push(aenter_def(name));
+        members.push(aexit_def());
+    }
+    class_with_members(&format!("class {name}:"), &object.docs, &members)
+}
+
+/// The user close method the resource surface wraps: named `close`, zero
+/// arguments, no success value (the shape lowering guarantees resources
+/// declare). `None` for plain objects.
+fn resource_close(object: &ir::Object) -> Option<&ir::Function> {
+    if !object.resource {
+        return None;
+    }
+    object
+        .methods
+        .iter()
+        .find(|method| method.name == "close" && method.args.is_empty() && method.ret.is_none())
+}
+
+/// The generated `close()`: idempotent in the runtime, async exactly when
+/// the user's close is.
+fn close_def(interface: &ir::Interface, close: &ir::Function) -> String {
+    let def = def_keyword(close.asyncness);
+    let header = format!("    {def} close(self) -> None:");
+    def_block(&header, &doc_lines_with_raises(interface, close), 1)
+}
+
+/// `__aenter__` resolves to the object itself; its docstring mirrors the
+/// generated method's.
+fn aenter_def(class: &str) -> String {
+    let docs = vec!["Enter `async with`: resolves to the object itself.".to_owned()];
+    def_block(&format!("    async def __aenter__(self) -> {class}:"), &docs, 1)
+}
+
+/// `__aexit__` closes and resolves to `False`; the generated method takes
+/// the exception triple as raw objects.
+fn aexit_def() -> String {
+    let docs =
+        vec!["Exit `async with`: closes the resource, never suppresses the exception.".to_owned()];
+    def_block(
+        "    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:",
+        &docs,
+        1,
+    )
+}
+
+/// The constructor stub: `#[new]` surfaces as `__init__`, with the same
+/// parameter surface as any callable.
+fn constructor_def(interface: &ir::Interface, ctor: &ir::Function) -> String {
+    let mut params = String::from("self");
+    for arg in &ctor.args {
+        params.push_str(", ");
+        params.push_str(&parameter(interface, arg));
+    }
+    let header = format!("    def __init__({params}) -> None:");
+    def_block(&header, &doc_lines_with_raises(interface, ctor), 1)
+}
+
+/// A per-export stream class, mirroring the pyo3 backend's generated
+/// async-iterator classes (`__aiter__` returns the class itself,
+/// `__anext__` resolves one item) and their synthesized docstrings.
+fn stream_class(interface: &ir::Interface, export: &StreamExport<'_>) -> String {
+    let class = streams::class_name(export.owner, &export.function.name);
+    let produced = export.owner.map_or_else(
+        || export.function.name.clone(),
+        |object| format!("{object}.{}", export.function.name),
     );
-    let def = match function.asyncness {
+    let docs = vec![
+        format!("Async iterator produced by `{produced}`."),
+        String::new(),
+        "Pull-based: each `__anext__` polls exactly one item, so the producer only runs as \
+         fast as the consumer awaits."
+            .to_owned(),
+    ];
+    let item = types::annotation(interface, export.item, Position::Return);
+    let members = vec![
+        format!("    def __aiter__(self) -> {class}: ..."),
+        format!("    async def __anext__(self) -> {item}: ..."),
+    ];
+    class_with_members(&format!("class {class}:"), &docs, &members)
+}
+
+/// Whose callable a stub renders: a module-level function, or a method
+/// (implicit `self`) of the named object. The receiver decides indentation
+/// and which per-export stream class a stream return names.
+enum Receiver<'a> {
+    Free,
+    Method { object: &'a str },
+}
+
+/// A function or method stub: literal defaults, `None` for undefaulted
+/// `Option` arguments, and a docstring that names the raised exception base
+/// when the callable throws (stub signatures cannot express `raises`).
+/// Async callables render `async def`: the extension returns a coroutine
+/// resolving to the annotated type.
+fn callable_def(
+    interface: &ir::Interface,
+    function: &ir::Function,
+    receiver: &Receiver<'_>,
+) -> String {
+    let (indent, owner) = match receiver {
+        Receiver::Free => (0, None),
+        Receiver::Method { object } => (1, Some(*object)),
+    };
+    let name = types::py_name(&function.names, &function.name);
+    let mut params = Vec::new();
+    if owner.is_some() {
+        params.push("self".to_owned());
+    }
+    params.extend(function.args.iter().map(|arg| parameter(interface, arg)));
+    let ret = match &function.ret {
+        None => "None".to_owned(),
+        // The runtime wraps a stream return in its per-export class; the
+        // annotation names that class rather than the abstract iterator.
+        Some(ir::Type::Stream(_)) => streams::class_name(owner, &function.name),
+        Some(ty) => types::annotation(interface, ty, Position::Return),
+    };
+    let def = def_keyword(function.asyncness);
+    let pad = "    ".repeat(indent);
+    let header = format!("{pad}{def} {name}({}) -> {ret}:", params.join(", "));
+    def_block(&header, &doc_lines_with_raises(interface, function), indent)
+}
+
+const fn def_keyword(asyncness: ir::Asyncness) -> &'static str {
+    match asyncness {
         ir::Asyncness::Async => "async def",
         ir::Asyncness::Sync => "def",
-    };
-    let header = format!("{def} {name}({}) -> {ret}:", params.join(", "));
+    }
+}
 
+/// A def whose body is its docstring, or `...` without one.
+fn def_block(header: &str, doc_lines: &[String], indent: usize) -> String {
+    if doc_lines.is_empty() {
+        return format!("{header} ...");
+    }
+    format!("{header}\n{}", docstring(doc_lines, indent + 1))
+}
+
+/// The callable's doc lines plus a trailing `Raises <base>.` naming the
+/// exception base class when it throws.
+fn doc_lines_with_raises(interface: &ir::Interface, function: &ir::Function) -> Vec<String> {
     let mut doc_lines = function.docs.clone();
     if let Some(throws) = &function.throws {
         let base = error_base_py_name(interface, throws);
@@ -189,10 +340,7 @@ fn function_def(interface: &ir::Interface, function: &ir::Function) -> String {
         }
         doc_lines.push(format!("Raises {base}."));
     }
-    if doc_lines.is_empty() {
-        return format!("{header} ...");
-    }
-    format!("{header}\n{}", docstring(&doc_lines, 1))
+    doc_lines
 }
 
 fn parameter(interface: &ir::Interface, arg: &ir::Arg) -> String {

--- a/packages/unibind/gen/src/py/types.rs
+++ b/packages/unibind/gen/src/py/types.rs
@@ -15,7 +15,7 @@ pub enum Position {
 }
 
 /// The Python annotation for `ty` at `position`. Named types resolve to the
-/// record's Python name through `interface`.
+/// record's or object's Python name through `interface`.
 pub fn annotation(interface: &ir::Interface, ty: &ir::Type, position: Position) -> String {
     match ty {
         ir::Type::Bool => "bool".to_owned(),
@@ -34,7 +34,7 @@ pub fn annotation(interface: &ir::Interface, ty: &ir::Type, position: Position) 
             annotation(interface, key, position),
             annotation(interface, value, position)
         ),
-        ir::Type::Named(name) => record_py_name(interface, name),
+        ir::Type::Named(name) => named_py_name(interface, name),
         // Stream items are always produced, never accepted, so the item
         // renders in return position regardless of where the stream sits.
         ir::Type::Stream(item) => format!(
@@ -82,12 +82,16 @@ pub fn py_name<'a>(names: &'a ir::Names, name: &'a str) -> &'a str {
     names.py.as_deref().unwrap_or(name)
 }
 
-fn record_py_name(interface: &ir::Interface, name: &str) -> String {
+/// Resolve a `Named` reference (a record or an object) to its Python name.
+fn named_py_name(interface: &ir::Interface, name: &str) -> String {
+    if let Some(record) = interface.records.iter().find(|record| record.name == name) {
+        return py_name(&record.names, &record.name).to_owned();
+    }
     interface
-        .records
+        .objects
         .iter()
-        .find(|record| record.name == name)
-        .map_or(name, |record| py_name(&record.names, &record.name))
+        .find(|object| object.name == name)
+        .map_or(name, |object| py_name(&object.names, &object.name))
         .to_owned()
 }
 

--- a/packages/unibind/gen/src/py/wrapper.rs
+++ b/packages/unibind/gen/src/py/wrapper.rs
@@ -9,6 +9,7 @@ use std::fmt::Write as _;
 
 use unibind_core::ir;
 
+use crate::py::streams;
 use crate::py::stub;
 use crate::py::types;
 
@@ -35,8 +36,9 @@ pub fn render(interface: &ir::Interface, module_name: &str) -> String {
     out
 }
 
-/// Every name the extension module registers: functions, record classes, and
-/// the error base plus its variant subclasses (Python names throughout).
+/// Every name the extension module registers: functions, record classes,
+/// object classes, per-export stream classes, and the error base plus its
+/// variant subclasses (Python names throughout).
 fn public_names(interface: &ir::Interface) -> Vec<String> {
     let mut names = Vec::new();
     for function in &interface.functions {
@@ -44,6 +46,12 @@ fn public_names(interface: &ir::Interface) -> Vec<String> {
     }
     for record in &interface.records {
         names.push(types::py_name(&record.names, &record.name).to_owned());
+    }
+    for object in &interface.objects {
+        names.push(types::py_name(&object.names, &object.name).to_owned());
+    }
+    for export in streams::collect(interface) {
+        names.push(streams::class_name(export.owner, &export.function.name));
     }
     for error in &interface.errors {
         names.push(types::py_name(&error.names, &error.name).to_owned());

--- a/packages/unibind/gen/tests/render.rs
+++ b/packages/unibind/gen/tests/render.rs
@@ -3,7 +3,8 @@
 //! review surface for what `unibind-gen py` writes; on drift the test prints
 //! the new content to copy over the snapshot file. The interface is built
 //! literally (every IR field is `pub`) so the fixture exercises renames,
-//! docs, defaults, and every boundary type without lowering Rust source.
+//! docs, defaults, objects (plain and resource), streams, and every
+//! boundary type without lowering Rust source.
 
 use unibind_core::ir;
 use unibind_gen::artifact::parse_ir_bytes;
@@ -183,6 +184,75 @@ fn sample_errors() -> Vec<ir::ErrorType> {
     }]
 }
 
+
+fn sample_objects() -> Vec<ir::Object> {
+    let constructor = ir::Function {
+        throws: Some("SampleError".to_owned()),
+        ..function(
+            "open",
+            None,
+            &["Open a store."],
+            vec![
+                arg("path", ir::Type::Path { owned: false }, None),
+                arg("create", ir::Type::Bool, Some(ir::Literal::Bool(true))),
+            ],
+        )
+    };
+    let head = ir::Function {
+        asyncness: ir::Asyncness::Async,
+        ret: Some(ir::Type::Named("Row".to_owned())),
+        throws: Some("SampleError".to_owned()),
+        ..function("head", None, &["The first row."], vec![])
+    };
+    let watch = ir::Function {
+        ret: Some(ir::Type::Stream(Box::new(ir::Type::Named("Row".to_owned())))),
+        ..function(
+            "watch",
+            None,
+            &["Watch rows as they land."],
+            vec![arg("prefix", owned_string(), Some(ir::Literal::Str(String::new())))],
+        )
+    };
+    let cursor = ir::Function {
+        ret: Some(ir::Type::Named("Cursor".to_owned())),
+        ..function("cursor", Some("open_cursor"), &["Open a cursor over the store."], vec![])
+    };
+    let store = ir::Object {
+        name: "Store".to_owned(),
+        names: names(None),
+        docs: docs(&["A stateful handle over one store."]),
+        resource: false,
+        constructor: Some(constructor),
+        methods: vec![head, watch, cursor],
+    };
+
+    let read = ir::Function {
+        asyncness: ir::Asyncness::Async,
+        ret: Some(owned_string()),
+        ..function(
+            "read",
+            None,
+            &["Read the next chunk."],
+            vec![arg("max_bytes", ir::Type::Int(ir::IntKind::U32), Some(ir::Literal::Int(4096)))],
+        )
+    };
+    let close = ir::Function {
+        asyncness: ir::Asyncness::Async,
+        throws: Some("SampleError".to_owned()),
+        ..function("close", None, &["Release the cursor."], vec![])
+    };
+    let cursor_object = ir::Object {
+        name: "Cursor".to_owned(),
+        names: names(Some("StoreCursor")),
+        docs: docs(&["A resource over one store; instances come from `Store.cursor`."]),
+        resource: true,
+        constructor: None,
+        methods: vec![read, close],
+    };
+
+    vec![store, cursor_object]
+}
+
 fn interface() -> ir::Interface {
     ir::Interface {
         version: ir::IR_VERSION,
@@ -191,13 +261,13 @@ fn interface() -> ir::Interface {
         docs: docs(&[
             "A sample boundary for the emitter tests.",
             "",
-            "Everything the phase 1 generator renders appears here once.",
+            "Everything the py generator renders appears here once.",
         ]),
         functions: sample_functions(),
         records: sample_records(),
         enums: vec![],
         errors: sample_errors(),
-        objects: vec![],
+        objects: sample_objects(),
     }
 }
 

--- a/packages/unibind/gen/tests/snapshots/sample.init.py
+++ b/packages/unibind/gen/tests/snapshots/sample.init.py
@@ -1,6 +1,6 @@
 """A sample boundary for the emitter tests.
 
-Everything the phase 1 generator renders appears here once.
+Everything the py generator renders appears here once.
 """
 
 from ._sample import (
@@ -9,6 +9,10 @@ from ._sample import (
     Row,
     SampleError,
     Source,
+    Store,
+    StoreCursor,
+    StoreWatchStream,
+    TailStream,
     __version__,
     find,
     greet,
@@ -24,6 +28,10 @@ __all__ = [
     "Row",
     "SampleError",
     "Source",
+    "Store",
+    "StoreCursor",
+    "StoreWatchStream",
+    "TailStream",
     "__version__",
     "find",
     "greet",
@@ -32,3 +40,4 @@ __all__ = [
     "tail",
     "write_file",
 ]
+

--- a/packages/unibind/gen/tests/snapshots/sample.pyi
+++ b/packages/unibind/gen/tests/snapshots/sample.pyi
@@ -1,10 +1,9 @@
 """A sample boundary for the emitter tests.
 
-Everything the phase 1 generator renders appears here once.
+Everything the py generator renders appears here once.
 """
 
 
-import collections.abc
 import os
 
 
@@ -46,6 +45,69 @@ class Source:
         """Where the row came from."""
 
 
+class Store:
+    """A stateful handle over one store."""
+
+    def __init__(self, path: str | os.PathLike[str], create: bool = True) -> None:
+        """Open a store.
+
+        Raises SampleError.
+        """
+
+    async def head(self) -> Row:
+        """The first row.
+
+        Raises SampleError.
+        """
+
+    def watch(self, prefix: str = "") -> StoreWatchStream:
+        """Watch rows as they land."""
+
+    def open_cursor(self) -> StoreCursor:
+        """Open a cursor over the store."""
+
+
+class StoreCursor:
+    """A resource over one store; instances come from `Store.cursor`."""
+
+    async def read(self, max_bytes: int = 4096) -> str:
+        """Read the next chunk."""
+
+    async def close(self) -> None:
+        """Release the cursor.
+
+        Raises SampleError.
+        """
+
+    async def __aenter__(self) -> StoreCursor:
+        """Enter `async with`: resolves to the object itself."""
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        """Exit `async with`: closes the resource, never suppresses the exception."""
+
+
+class TailStream:
+    """Async iterator produced by `tail`.
+
+    Pull-based: each `__anext__` polls exactly one item, so the producer only runs as fast as the consumer awaits.
+    """
+
+    def __aiter__(self) -> TailStream: ...
+
+    async def __anext__(self) -> str: ...
+
+
+class StoreWatchStream:
+    """Async iterator produced by `Store.watch`.
+
+    Pull-based: each `__anext__` polls exactly one item, so the producer only runs as fast as the consumer awaits.
+    """
+
+    def __aiter__(self) -> StoreWatchStream: ...
+
+    async def __anext__(self) -> Row: ...
+
+
 def rows(store: str, limit: int = 10) -> list[Row]:
     """Fetch rows.
 
@@ -66,7 +128,7 @@ def find(pattern: str, root: str | os.PathLike[str] | None = None) -> dict[str, 
 def greet(name: str = "hello \"world\"\n", ratio: float = 1.0, note: str | None = None) -> str: ...
 
 
-def tail(store: str) -> collections.abc.AsyncIterator[str]:
+def tail(store: str) -> TailStream:
     """Follow appended rows."""
 
 


### PR DESCRIPTION
`unibind-gen py` hard-errored on any interface exporting a `#[unibind::object]` and never learned the phase-2 surface (gap report: https://github.com/indexable-inc/index/issues/1996#issuecomment-4905721062). This renders the missing `.pyi` shapes by mirroring exactly what backend-py generates at runtime:

- **object classes**: `__init__` from the declared constructor (none declared means no `__init__`, matching the runtime's absent `#[new]`), `def`/`async def` methods with literal defaults and `Raises` docstrings, object returns typed as the class; py renames respected throughout.
- **resource objects**: idempotent `close()` (async exactly when the Rust close is async), plus `__aenter__`/`__aexit__` with the runtime's docstrings.
- **stream returns**: one class per stream-returning export (`TailStream`, `StoreWatchStream`) with `__aiter__`/`__anext__`; returns annotate the concrete class the runtime hands back instead of the abstract `collections.abc.AsyncIterator`.
- the wrapper `__init__.py` re-exports the new object and stream class names, mirroring module registration.

Validation: render fixture extended (object with constructor, async record-returning method, stream method, and a renamed non-constructible resource object); `sample.pyi`/`sample.init.py` regenerated; `cargo test -p unibind-gen` green (py, ts, ex snapshots untouched elsewhere); `mypy --strict` passes over a client exercising every new shape. A new `checks.<system>.unibind-conformance-stubs` gate runs `unibind-gen py` over the built conformance cdylib (objects + resource + streams, the exact repro from the issue) and strict-type-checks the result; verified end-to-end locally against the real cdylib.

Part of #1989. Unblocks the phase-6 port in #1996.

Authored by an AI agent (Claude Code) working indexable-inc/index#1996.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render object, resource, and stream class stubs in `unibind-gen py`
> - The Python stub generator in [`stub.rs`](https://github.com/indexable-inc/index/pull/2231/files#diff-af34165970c1801924487edd9626bf8bc8226406bfd03942b02d96c4fbbc5572) now emits object classes with constructors and methods, resource protocol methods (`close`, `__aenter__`, `__aexit__`), and concrete per-export async iterator stream classes.
> - A new [`streams.rs`](https://github.com/indexable-inc/index/pull/2231/files#diff-1437bc642972c2ae295d7496e1ff7fa0904090b8645f4073fb5f0f1bd46c9a00) module enumerates stream-returning exports and computes deterministic class names (e.g. `StoreWatchStream`, `TailStream`) used as return type annotations instead of `collections.abc.AsyncIterator`.
> - Named type annotations in [`types.rs`](https://github.com/indexable-inc/index/pull/2231/files#diff-b1b387a486c8ca6f494aa64d7d6065b740b66cbccb912d7d0712f04693efb821) now resolve object names in addition to records.
> - The generated `__init__.py` in [`wrapper.rs`](https://github.com/indexable-inc/index/pull/2231/files#diff-031f7e1b6f5877556c81aa7e40d5cc67f177d373eb1c5b90f490986740cbb58f) re-exports object and stream classes in `__all__`.
> - A new `stubs` derivation in [`conformance/default.nix`](https://github.com/indexable-inc/index/pull/2231/files#diff-a1ae77e8fb8404d5e7108bb51df56c17b95e72a2f509d91c750b488bd1fa9be6) generates stubs from the built cdylib and runs `mypy --strict` over them in CI.
> - Behavioral Change: stubs no longer import `collections.abc` at the module level; stream returns annotate to concrete per-export classes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9fe12f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->