### PR TITLE
mcp: hide closed resources from the live listings by default

### DIFF
--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -469,7 +469,9 @@ def upsert_resource(
 
 
 def close_resource(conn: sqlite3.Connection, *, id: str, updated_at: float) -> None:
-    """Mark a resource closed while keeping its final pane visible."""
+    """Mark a resource closed so it drops out of the live listings. The row is
+    kept (final HTML included) so `resource_live` can refuse a late reply with a
+    precise error instead of a not-found."""
     conn.execute(
         "UPDATE resources SET status = 'closed', updated_at = ? WHERE id = ?",
         (updated_at, id),
@@ -754,10 +756,14 @@ def replayable(conn: sqlite3.Connection, since: float | None) -> list[dict]:
 
 
 def live_resources(conn: sqlite3.Connection) -> list[dict]:
-    """Every resource, oldest first, as plain dicts for the sidebar."""
+    """The not-yet-closed resources, oldest first, as plain dicts for the
+    sidebar. Closed rows stay in the table (see `close_resource`) but are not
+    listed: every consumer of this feed (`/api/resources`, the dashboard panes,
+    `feed.snapshot`) presents resources as live, self-updating views, and a
+    closed one can never update again."""
     conn.row_factory = sqlite3.Row
     rows = conn.execute(
         "SELECT id, title, kind, html, status, execution_id, created_at, updated_at "
-        "FROM resources ORDER BY created_at ASC"
+        "FROM resources WHERE status != 'closed' ORDER BY created_at ASC"
     ).fetchall()
     return [dict(r) for r in rows]

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -313,6 +313,9 @@ def test_closed_before_first_sweep_keeps_final_resource(tmp_path: Path, monkeypa
         assert row[1] == "<p>terminal</p>"
         assert row[2] == "closed"
         assert "blink" not in runtime.resources
+        # The row survives for the reply gate, but a closed resource is not
+        # listed: the sidebar/feed present live views only.
+        assert "blink" not in {r["id"] for r in store.live_resources(conn)}
 
     asyncio.run(run())
 


### PR DESCRIPTION
## What

`store.live_resources()` claimed to be the live view but selected every row, so closed resources leaked into `/api/resources`, the dashboard panes (`pane_bridge`), and `feed.snapshot`. This filters `status != 'closed'` in the query, so closed resources no longer show by default.

## Why the row (not the listing) keeps the closed state

- The row survives with its final HTML so the `reply` tool's `resource_live` gate can refuse a late reply with a precise error instead of a not-found.
- `room_event_mapper` is untouched: it reads the table directly because the closed *transition* is itself the event a room consumer needs.

## Notes

- `packages/mcp/tests/test_session.py` already asserted this behavior (closed resources vanish from `live_resources` after `mark_interrupted`) but that file is not wired into any nix check, so the mismatch never failed CI. This PR pins the behavior in the CI-wired `test_channel.py` instead.

## Validation

- `nix build .#mcp.tests.channelTests .#mcp.tests.feedSmoke .#mcp.tests.apiSmoke` all pass
- `nix run .#lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide closed resources from `live_resources` listings by default
> Adds a `WHERE status != 'closed'` filter to the `live_resources` SQL query in [store.py](https://github.com/indexable-inc/index/pull/2236/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976) so closed resources no longer appear in live listings. Closed rows are retained in the database so late replies can still be rejected. A new assertion in [test_channel.py](https://github.com/indexable-inc/index/pull/2236/files#diff-f1684e518bfcf4f7df252a5c209b046a82ed7c2db27ff168d3e422b623323bbd) verifies closed resource IDs are absent from `live_resources` output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c04170.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->