### PR TITLE
codex: derive vendor deps from Cargo.lock via importCargoLock

### DIFF
--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -2,6 +2,7 @@
   lib,
   ix,
   codex,
+  rustPlatform,
   makeBinaryWrapper,
   runCommand,
   git,
@@ -172,7 +173,7 @@
           ;
       }).codex;
   };
-  codexWithNotifications = codex.overrideAttrs (finalAttrs: previousAttrs: {
+  codexWithNotifications = codex.overrideAttrs (previousAttrs: {
     version = "0.0.0";
     src = codexSrc;
     # `unpackPhase` names the unpacked dir after the src store path. The old
@@ -180,18 +181,26 @@
     # its own name (`codex-patched`), so derive the sourceRoot from the src's
     # name rather than hardcoding `source/`.
     sourceRoot = "${codexSrc.name}/codex-rs";
-    cargoHash = "sha256-mLpfLi5Wu/t/D8il/5xkDqCTHIeaJZ2OYMZmMIsg7E0=";
-    # buildRustPackage carries cargoDeps through overrideAttrs, so retarget the
-    # nested fixed-output staging derivation when swapping the upstream source.
-    cargoDeps = previousAttrs.cargoDeps.overrideAttrs (_: previousCargoAttrs: {
-      vendorStaging = previousCargoAttrs.vendorStaging.overrideAttrs (_: {
-        inherit (finalAttrs) src sourceRoot;
-        outputHash = finalAttrs.cargoHash;
-      });
-    });
+    # No cargoHash: an inlined vendor FOD hash goes stale on every codex-src
+    # bump the flake-update bot makes (index #2233 broke every ix deploy this
+    # way). importCargoLock needs no aggregate hash: crates.io checksums come
+    # from Cargo.lock itself and git deps are fetched by their locked revs.
+    # The lockfile is read from the RAW codex-src input (an eval-time store
+    # path, so no IFD), not the patched src: no patch touches Cargo.lock
+    # today, and if one ever does, cargoSetupPostPatchHook's lock-consistency
+    # check fails the build loudly rather than vendoring the wrong set.
+    cargoDeps = rustPlatform.importCargoLock {
+      lockFile = ix.codexSrc + "/codex-rs/Cargo.lock";
+      allowBuiltinFetchGit = true;
+    };
     postPatch = ''
       # shell
-      substituteInPlace $cargoDepsCopy/*/webrtc-sys-*/build.rs \
+      # importCargoLock vendors one top-level dir per crate (name-version),
+      # unlike fetchCargoVendor's extra nesting level. Version-anchor the glob
+      # so the sibling crate webrtc-sys-build-* can never match if a future
+      # rust-sdks rev gives it a build.rs (that would break --replace-fail on
+      # the next codex-src bump, the breakage class this file just eliminated).
+      substituteInPlace $cargoDepsCopy/webrtc-sys-[0-9]*/build.rs \
         --replace-fail "cargo:rustc-link-lib=static=webrtc" "cargo:rustc-link-lib=dylib=webrtc"
       substituteInPlace Cargo.toml \
         --replace-fail 'lto = "thin"' "" \


### PR DESCRIPTION
Closes #2233.

## Problem

`codexWithNotifications` pinned an aggregate `cargoHash` for the vendor FOD. Every codex-src bump by the flake-update bot desyncs that hash, and because index CI does not build `#codex` per-PR, the stale hash lands on main and breaks every downstream ix deploy (#2233; latest occurrence unbroken by pinning codex-src in ix#6637).

## Fix

Replace the FOD with `rustPlatform.importCargoLock`: no aggregate hash exists to go stale. Crates.io checksums come from `Cargo.lock` itself; git deps fetch by their locked revs (`allowBuiltinFetchGit`, deterministic fetch-by-rev, no new trust surface vs the prior FOD). The lockfile is read from the raw `codex-src` input (eval-time store path, no IFD); if a patch ever edits `Cargo.lock`, `cargoSetupPostPatchHook`'s lock-consistency diff fails the build loudly.

The `webrtc-sys` build.rs substitution moves to importCargoLock's flat vendor layout, version-anchored (`webrtc-sys-[0-9]*`) so the sibling `webrtc-sys-build-*` crate can never collide on a future rust-sdks rev.

## On #2233 item 3 (CI building codex)

Already covered at the right cost point: `patched-src-codex` and `patch-dag-codex` gate every PR (seconds-fast series-apply checks via lib/mk-fork-checks.nix); full-package builds are deliberately not flake checks (lib/fork-closure-gates.nix posture, flat per-PR cost). With importCargoLock the hash-desync class is eliminated by construction, so the remaining per-PR exposure is patch-apply, which is gated.

## Validation

- x86_64-linux: full `nix build .#codex` at this rev green (`/nix/store/9vlmla269s2fxwgficlgkkzq109lmzvx-codex-0.0.0`).
- aarch64-darwin: vendor layer (importCargoLock + cargo-vendor-dir + lock-consistency + webrtc-sys substitution) built green; full-package build in flight, past all prior failure points (which were unrelated store orphans, index#2247).
- Adversarial review (correctness/security): approve, no blockers; its one hardening suggestion (version-anchored glob) is applied.

🤖 Opened by an AI agent via Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive vendor deps for codex from Cargo.lock via `rustPlatform.importCargoLock`
> - Replaces the fixed `cargoHash` and manual `cargoDeps` override in [default.nix](https://github.com/indexable-inc/index/pull/2249/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5) with `rustPlatform.importCargoLock`, pointing at `ix.codexSrc/codex-rs/Cargo.lock` with `allowBuiltinFetchGit` enabled.
> - Updates the `postPatch` glob for `webrtc-sys` from a two-level wildcard to a version-anchored single-level pattern (`webrtc-sys-[0-9]*/build.rs`) to match the directory layout that `importCargoLock` produces.
> - Adds `rustPlatform` to the top-level Nix file arguments so `importCargoLock` is accessible.
> - Behavioral Change: callers must now pass `rustPlatform`; the vendored dependency tree is derived from the lockfile at build time rather than a pinned hash.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcb68cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->