### PR TITLE
mcp: add files_only= to the kernel grep() helper

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3001,7 +3001,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + jobs.spawn ad-hoc awaitables (#2164)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3020,6 +3020,8 @@
       cp ${./tests/test_jobs_spawn.py} test_jobs_spawn.py
       cp ${./tests/test_fsearch_partial.py} test_fsearch_partial.py
       cp ${./tests/test_fsearch_glob.py} test_fsearch_glob.py
+      # Issue #2246: grep(files_only=True) -> path + match-count rows via rg --count-matches.
+      cp ${./tests/test_fsearch_files_only.py} test_fsearch_files_only.py
       # sh Output rendering regressions (issue #1766: a failed build must not
       # read as success/still-running); imports the site-packages sh module.
       cp ${./tests/test_sh_module.py} test_sh_module.py
@@ -3031,6 +3033,7 @@
         test_jobs_spawn.py \
         test_fsearch_partial.py \
         test_fsearch_glob.py \
+        test_fsearch_files_only.py \
         test_sh_module.py \
         test_build_info.py \
         -q -p no:cacheprovider >stdout 2>stderr || {

--- a/packages/mcp/src/fsearch/fsearch/__init__.py
+++ b/packages/mcp/src/fsearch/fsearch/__init__.py
@@ -6,6 +6,7 @@ separate process through the async :mod:`sh` helper, and each returns a
 table while you get a frame to ``.filter`` / ``.sort`` / ``.group_by`` / ``.head``.
 
     rows = await grep("TODO", "src")           # ripgrep -> path, line_number, col, match, line, abs_offset
+    hits = await grep("TODO", files_only=True) # ripgrep -> path, count (one row per matching file)
     files = await find(ext="py", root="src")   # fd       -> path, name, type, size, mtime
     docs = await spotlight("invoice", "~")     # mdfind   -> path, name, type, size, mtime (macOS only)
 
@@ -56,6 +57,10 @@ _GREP_SCHEMA = {
     "match": pl.Utf8,
     "line": pl.Utf8,
     "abs_offset": pl.Int64,
+}
+_GREP_FILES_SCHEMA = {
+    "path": pl.Utf8,
+    "count": pl.Int64,
 }
 _FIND_SCHEMA = {
     "path": pl.Utf8,
@@ -215,14 +220,20 @@ async def grep(
     multiline: bool = False,
     hidden: bool = False,
     no_ignore: bool = False,
+    files_only: bool = False,
     limit: int = DEFAULT_LIMIT,
     timeout: float = DEFAULT_TIMEOUT,
 ) -> pl.DataFrame:
     """Content search via ripgrep, one row per match. Respects ``.gitignore`` by
     default (``no_ignore=True`` to override) and searches ``root`` (cwd by
     default). Columns: ``path, line_number, col, match, line, abs_offset``.
-    ``col``/``abs_offset`` are byte offsets. ``fixed`` = literal (no regex)."""
-    argv = ["rg", "--json"]
+    ``col``/``abs_offset`` are byte offsets. ``fixed`` = literal (no regex).
+    ``files_only=True`` lists the matching *files* instead (``rg
+    --count-matches``): columns ``path, count``, one row per file, where
+    ``count`` is that file's number of individual matches -- so listing which
+    files match never materializes every match row, and ``limit`` caps files,
+    not matches."""
+    argv = ["rg", "--count-matches", "--null"] if files_only else ["rg", "--json"]
     if ignore_case:
         argv.append("-i")
     if fixed:
@@ -236,6 +247,8 @@ async def grep(
     if glob:
         argv += ["-g", glob]
     argv += ["--", pattern, _expand(root)]
+    if files_only:
+        return await _grep_files_only(argv, limit=limit, timeout=timeout)
     rows, timed_out, hit_limit = await _stream_rg(argv, limit=limit, timeout=timeout)
     if timed_out:
         return PartialFrame(
@@ -253,6 +266,49 @@ async def grep(
             reason=f"stopped at limit={limit}; raise limit= to scan further",
         )
     return pl.DataFrame(rows, schema=_GREP_SCHEMA)
+
+
+def _count_rows(text: str) -> list[dict[str, Any]]:
+    """Parse ``rg --count-matches --null`` output (one ``<path>NUL<count>`` line
+    per matching file) into files-only rows. ``--null`` makes the path/count
+    separator a NUL byte, so a ``:`` in a path cannot corrupt the split; a line
+    without a NUL (e.g. a stderr warning ``sh`` merged into the stream) is
+    skipped, which drops the noise without losing hits."""
+    rows: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        path, sep, num = line.rpartition("\0")
+        if not sep:
+            continue  # no NUL separator: a stderr line, not a count line
+        try:
+            count = int(num)
+        except ValueError:
+            continue  # NUL but no trailing integer: also not a count line
+        rows.append({"path": path, "count": count})
+    return rows
+
+
+async def _grep_files_only(argv: list[str], *, limit: int, timeout: float) -> pl.DataFrame:
+    """The ``files_only=True`` tail of :func:`grep`: run ``rg --count-matches``
+    to completion and parse the per-file counts. Counting inherently scans every
+    file (there is no early limit-kill like :func:`_stream_rg`; the output is
+    one line per matching file, so it stays small either way), and the
+    ``timeout`` process-group kill still bounds a runaway scan. rg exits 1 on
+    "no matches" -- a legitimate empty frame, not a failure."""
+    text, timed_out = await _run(argv, timeout=timeout, ok_codes=(0, 1))
+    rows = _count_rows(text)
+    hit_limit = len(rows) > limit
+    frame = pl.DataFrame(rows[:limit], schema=_GREP_FILES_SCHEMA)
+    if timed_out:
+        return PartialFrame(
+            frame,
+            reason=f"rg timed out after {timeout}s; {frame.height} file(s) counted before the deadline",
+        )
+    if hit_limit:
+        return PartialFrame(
+            frame,
+            reason=f"stopped at limit={limit}; raise limit= to see every matching file",
+        )
+    return frame
 
 
 def _parse_rg_match(event: dict[str, Any]) -> list[dict[str, Any]]:

--- a/packages/mcp/tests/test_fsearch_files_only.py
+++ b/packages/mcp/tests/test_fsearch_files_only.py
@@ -1,0 +1,72 @@
+"""``grep(files_only=True)`` returns one row per matching *file* (path +
+match count) instead of per-line match rows (issue #2246).
+
+Before, listing which files match forced materializing every match row and
+deduping paths client-side (``df["path"].unique()`` over the row limit). The
+count-line parser (``_count_rows``) is pure and exercised directly — the NUL
+path/count separator means a ``:`` in a path cannot corrupt the split, and a
+stderr line merged into the stream is dropped; the end-to-end path runs against
+real ripgrep and skips cleanly when rg is not on PATH.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+
+import pytest
+
+import fsearch
+
+
+def test_count_rows_splits_on_nul_not_colon() -> None:
+    text = "/r/a:b.txt\x002\n/r/c.txt\x001\n"
+    assert fsearch._count_rows(text) == [
+        {"path": "/r/a:b.txt", "count": 2},
+        {"path": "/r/c.txt", "count": 1},
+    ]
+
+
+def test_count_rows_skips_stderr_noise() -> None:
+    text = "rg: /r/denied: Permission denied (os error 13)\n/r/a.txt\x003\n"
+    assert fsearch._count_rows(text) == [{"path": "/r/a.txt", "count": 3}]
+
+
+def test_grep_files_only_counts_matches_per_file(tmp_path: object) -> None:
+    if shutil.which("rg") is None:
+        pytest.skip("rg not on PATH")
+    (tmp_path / "two.txt").write_text("needle needle\n")  # type: ignore[operator]
+    (tmp_path / "one.txt").write_text("a needle\n")  # type: ignore[operator]
+    (tmp_path / "none.txt").write_text("hay\n")  # type: ignore[operator]
+
+    frame = asyncio.run(fsearch.grep("needle", str(tmp_path), files_only=True))
+    assert frame.columns == ["path", "count"]
+    got = {row["path"].rsplit("/", 1)[-1]: row["count"] for row in frame.to_dicts()}
+    # --count-matches counts individual matches (two.txt has one line, two hits);
+    # a file with no match contributes no row.
+    assert got == {"two.txt": 2, "one.txt": 1}, frame
+    assert not isinstance(frame, fsearch.PartialFrame)
+
+
+def test_grep_files_only_no_matches_is_an_empty_frame(tmp_path: object) -> None:
+    # rg exits 1 on "no matches"; that is a legitimate empty frame, not an error.
+    if shutil.which("rg") is None:
+        pytest.skip("rg not on PATH")
+    (tmp_path / "a.txt").write_text("hay\n")  # type: ignore[operator]
+    frame = asyncio.run(fsearch.grep("needle", str(tmp_path), files_only=True))
+    assert frame.height == 0
+    assert frame.columns == ["path", "count"]
+
+
+def test_grep_files_only_limit_caps_files_and_flags_partial(tmp_path: object) -> None:
+    # In files-only mode `limit` counts files, and a capped result is flagged as
+    # partial so a caller cannot mistake it for the complete file list.
+    if shutil.which("rg") is None:
+        pytest.skip("rg not on PATH")
+    for i in range(10):
+        (tmp_path / f"f{i}.txt").write_text("needle\n")  # type: ignore[operator]
+    frame = asyncio.run(fsearch.grep("needle", str(tmp_path), files_only=True, limit=3))
+    assert frame.height == 3
+    assert isinstance(frame, fsearch.PartialFrame)
+    assert frame.truncated
+    assert "limit=3" in frame.reason


### PR DESCRIPTION
Resolves #2246.

`grep()` (the kernel fsearch helper) gains `files_only: bool = False`. When true it runs `rg --count-matches --null` and returns a `path, count` DataFrame (one row per matching file, `count` = individual matches in that file) instead of per-line match rows, so listing which files match no longer materializes every match row up to the 10k limit and dedupes paths client-side.

- `--null` makes the path/count separator a NUL byte, so a `:` in a path cannot corrupt the split; stderr lines merged into the stream are dropped by the parser.
- In this mode `limit` caps files (not matches); a capped or timed-out scan comes back as a `PartialFrame` with a reason, same contract as the per-match mode.
- rg exit 1 ("no matches") is an empty frame, not an error; exit >= 2 still raises `FsearchError`.
- Docstrings updated (module header + `grep`), so `api()` / `help(grep)` stay accurate.
- Tests: `tests/test_fsearch_files_only.py` (pure parser tests + end-to-end against real rg), wired into the `typecheckSmoke` nix check.

Validated locally: `nix run .#lint` and `nix build .#mcp.tests.typecheckSmoke .#mcp.tests.fsearchBundled` both green (86 tests passed).

The `include=` alias floated in the issue is left out to keep this focused; happy to follow up if wanted.

Authored by an AI agent (Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `files_only=` parameter to `fsearch.grep()` for per-file match counts
> - Adds a `files_only: bool = False` parameter to `grep()` in [fsearch/__init__.py](https://github.com/indexable-inc/index/pull/2250/files#diff-d49cbee7af25fcd8a29d12e63297e2d875f7609698886e1aec71033697a75bac); when `True`, runs `rg --count-matches` instead of `rg --json` and returns one row per matching file with `path` and `count` columns.
> - Parses NUL-separated ripgrep output via a new `_count_rows` helper that tolerates paths containing `:` and skips non-conforming lines.
> - The new `_grep_files_only` async helper enforces `limit` on file count, treats exit code 1 (no matches) as an empty frame, and returns a `PartialFrame` when capped or timed out.
> - Adds a [test_fsearch_files_only.py](https://github.com/indexable-inc/index/pull/2250/files#diff-16dbb7a27b88440cc15a52374722a706e9940fb0564050b4af0f0a018bf3e6c9) covering NUL parsing, noise skipping, end-to-end counting, empty frames, and limit behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a421870.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->