### PR TITLE
claude_history: session search battery over local Claude Code transcripts

### DIFF
--- a/packages/agent/distiller/default.nix
+++ b/packages/agent/distiller/default.nix
@@ -151,6 +151,11 @@ in
       (old.passthru or {})
       // {
         python = distillerPython;
+        # The bare importable package and its source tree, for embedding the
+        # transcript reader into other interpreters without duplicating the
+        # recipe: packages/mcp bundles it for `claude_history` (issue #2245).
+        pythonModule = distillerModule;
+        pythonSource = distillerSource;
         tests =
           (old.passthru.tests or {})
           // {

--- a/packages/agent/distiller/src/distiller/transcripts.py
+++ b/packages/agent/distiller/src/distiller/transcripts.py
@@ -89,10 +89,23 @@ def _text_blocks(content: object) -> str:
     return ""
 
 
+# Box-drawing / block glyphs that dominate a pasted terminal (TUI) screen; a
+# handful of them early in a "user" message means a paste, not typed prose.
+_TUI_GLYPHS = frozenset("\u256d\u256e\u2570\u256f\u2502\u251c\u2524\u252c\u2534\u253c\u2500\u2550\u2551\u2554\u2557\u255a\u255d\u2590\u258c\u2588\u2580\u2584")
+
+
+def _is_pasted_tui_text(text: str) -> bool:
+    """A pasted terminal screen or paste placeholder, not typed prose."""
+    if text.startswith("[Pasted text"):
+        return True
+    head = text[:400]
+    return sum(1 for ch in head if ch in _TUI_GLYPHS) >= 8
+
+
 def _is_meta_user_text(text: str) -> bool:
-    """Harness-injected user content, not a human signal."""
+    """Harness-injected or pasted user content, not a human signal."""
     stripped = text.lstrip()
-    return stripped.startswith(("<", "Caveat:"))
+    return stripped.startswith(("<", "Caveat:")) or _is_pasted_tui_text(stripped)
 
 
 def parse_session(path: Path) -> Session | None:
@@ -158,7 +171,7 @@ def parse_session(path: Path) -> Session | None:
                     continue
                 if not isinstance(content, str) or not content.strip():
                     continue
-                if _is_meta_user_text(content):
+                if record.get("isMeta") or _is_meta_user_text(content):
                     continue
                 if not saw_user:
                     saw_user = True
@@ -217,8 +230,12 @@ _CONTAINER_DIRS = frozenset(
 )
 
 
-def _resolve_path(cwd: str | None, transcript_dir: str) -> str:
-    """The session's working dir: the recorded cwd, else the decoded dir name."""
+def resolve_cwd(cwd: str | None, transcript_dir: str) -> str:
+    """The session's working dir: the recorded cwd, else the decoded dir name.
+
+    Public: ``claude_history`` (packages/mcp) resolves the un-munged project
+    path of a search hit through this, so the decoding lives in one place.
+    """
     if cwd:
         return cwd
     # `-home-andrew-index` -> `/home/andrew/index` (lossy but stable).
@@ -236,7 +253,7 @@ def repo_identity(cwd: str | None, transcript_dir: str) -> str | None:
     take the project-root basename. It cannot collapse two clones whose
     basenames differ, but it fixes the common clone and worktree cases.
     """
-    path = _resolve_path(cwd, transcript_dir).rstrip("/")
+    path = resolve_cwd(cwd, transcript_dir).rstrip("/")
     if not path or _SCRATCH_RE.search(path) or _HOME_RE.match(path):
         return None
     # A git worktree lives at ``<repo>/.claude/worktrees/<name>``; the repo root
@@ -262,7 +279,7 @@ def legacy_state_slugs(sessions: list[Session]) -> list[str]:
     slug(s) for a repo's sessions lets ``load`` migrate the old file forward
     (newest cwd first, so the most recent silo wins on collision).
 
-    The old key used ``_resolve_path`` -- the recorded ``cwd`` when present, else
+    The old key used ``resolve_cwd`` -- the recorded ``cwd`` when present, else
     the decoded transcript-dir name -- so a session that never recorded a ``cwd``
     still wrote a legacy file under that decoded path. Use the same fallback here
     so those transcripts migrate too instead of starting from empty state.
@@ -270,7 +287,7 @@ def legacy_state_slugs(sessions: list[Session]) -> list[str]:
     seen: set[str] = set()
     slugs: list[str] = []
     for session in sorted(sessions, key=lambda s: s.last_ts or 0, reverse=True):
-        raw = _resolve_path(session.cwd, Path(session.path).parent.name)
+        raw = resolve_cwd(session.cwd, Path(session.path).parent.name)
         slug = project_slug(raw)
         if slug == "unknown" or slug in seen:
             continue

--- a/packages/agent/distiller/tests/test_merge.py
+++ b/packages/agent/distiller/tests/test_merge.py
@@ -225,7 +225,7 @@ def test_legacy_state_slugs_falls_back_to_transcript_dir() -> None:
     """A cwd-less session keyed off the decoded transcript dir, like old scan()."""
     from distiller.transcripts import Session, legacy_state_slugs
 
-    # No recorded cwd: old _resolve_path used the decoded `-home-u-repo` dir name.
+    # No recorded cwd: old resolve_cwd used the decoded `-home-u-repo` dir name.
     sessions = [
         Session(
             session_id="a",

--- a/packages/agent/distiller/tests/test_transcripts.py
+++ b/packages/agent/distiller/tests/test_transcripts.py
@@ -124,3 +124,27 @@ def test_repo_identity_heuristics() -> None:
     # dir-name fallback when cwd is absent
     assert transcripts.repo_identity(None, "-home-u-my-repo") == "repo"
     assert transcripts.project_slug("/home/u/my repo!") == "home-u-my-repo"
+
+
+def test_is_meta_records_and_pasted_noise_never_become_the_goal(tmp_path: Path) -> None:
+    # Records flagged isMeta (even plain-looking prose), pasted-TUI screens,
+    # and paste placeholders all precede the typed request; none may win.
+    path = tmp_path / "proj" / "s.jsonl"
+    write_transcript(
+        path,
+        [
+            rec("user", "Caveat: injected by the harness", isMeta=True),
+            rec("user", "plain-looking but harness-flagged", isMeta=True),
+            rec("user", "\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e\n\u2502 TUI \u2502\n\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f"),
+            rec("user", "[Pasted text #1 +120 lines]"),
+            rec("user", "real goal"),
+        ],
+    )
+    session = transcripts.parse_session(path)
+    assert session is not None
+    assert session.goal == "real goal"
+
+
+def test_resolve_cwd_prefers_the_recorded_cwd() -> None:
+    assert transcripts.resolve_cwd("/home/u/repo", "-home-u-other") == "/home/u/repo"
+    assert transcripts.resolve_cwd(None, "-home-u-repo") == "/home/u/repo"

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -610,6 +610,37 @@
       cp -r ${worktreePythonSource}/worktree/. "$site/"
     ''
   );
+
+  # Local Claude Code history search (issue #2245): `await
+  # claude_history.search(pattern)` returns one polars row per matching session
+  # under ~/.claude/projects -- session id, un-munged cwd, start/end
+  # timestamps, hit count, first real user message -- ranked by hit count. Pure
+  # Python: ripgrep matching rides the bundled `fsearch`, transcript parsing
+  # reuses the distiller's reader (below), so the transcript schema stays owned
+  # in one place on the Python side.
+  claudeHistoryPythonSource = builtins.path {
+    name = "ix-mcp-claude-history-python-source";
+    path = ./src/claude_history;
+  };
+  claudeHistoryModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-claude-history-python-module"
+    {
+      strictDeps = true;
+      meta.description = "Local Claude Code history search bundled into the ix-mcp interpreter";
+    }
+    ''
+      site="$out/${pkgs.python3.sitePackages}/claude_history"
+      mkdir -p "$site"
+      cp -r ${claudeHistoryPythonSource}/claude_history/. "$site/"
+    ''
+  );
+  # The distiller's transcript reader (packages/agent/distiller), the single
+  # Python-side owner of the Claude transcript schema, bundled from that
+  # package's own passthru so the module recipe is not duplicated here.
+  # `claude_history` imports `distiller.transcripts` (stdlib-only); the
+  # distiller's optional deps (pyarrow/boto3) stay out of this interpreter.
+  distillerModule = pkgs.ix-distiller.passthru.pythonModule;
+  distillerPythonSource = pkgs.ix-distiller.passthru.pythonSource;
   # Example task-dependency graphs generated in Python and stored in SQLite:
   # `import tasks`, then `tasks.seed("tasks.sqlite")` writes a ~100-node DAG and
   # `tasks.load(...)` / `tasks.frame(...)` read it back. The task-graph demo site
@@ -1289,6 +1320,8 @@
       shModule
       svelteModule
       worktreeModule
+      claudeHistoryModule
+      distillerModule
       browserModule
       xModule
       slackModule
@@ -1446,6 +1479,7 @@
     "view"
     "worktree"
     "mesh"
+    "claude_history"
   ];
   # The `ix_notebook_mcp` server package is migrated file-by-file (the package
   # as a whole is still ~200 errors from strict-clean, index#1902): each file
@@ -1460,7 +1494,9 @@
     # All src module package dirs go on MYPYPATH so first-party cross-imports
     # resolve; the green subset are the actual check targets.
     allSrcModules = builtins.attrNames (builtins.readDir ./src);
-    mypypath = lib.concatMapStringsSep ":" (m: "src/${m}") allSrcModules;
+    # `claude_history` imports the distiller's transcript reader, so the
+    # distiller source rides MYPYPATH alongside the src module dirs.
+    mypypath = lib.concatMapStringsSep ":" (m: "src/${m}") allSrcModules + ":distiller-src";
     targets = lib.concatStringsSep " " (
       map (m: "src/${m}/${m}") strictGreenModules
       ++ map (f: "ix_notebook_mcp/${f}") strictGreenServerFiles
@@ -1479,8 +1515,9 @@
     ''
       cp -r ${ixNotebookMcpSource} ix_notebook_mcp
       cp -r ${./src} src
+      cp -r ${distillerPythonSource} distiller-src
       cp ${./zuban.ini} zuban.ini
-      chmod -R u+w ix_notebook_mcp src
+      chmod -R u+w ix_notebook_mcp src distiller-src
 
       export MYPYPATH=${lib.escapeShellArg mypypath}:.
       echo "zuban check --strict over: ${toString strictGreenModules} + ix_notebook_mcp: ${toString strictGreenServerFiles}"
@@ -3001,7 +3038,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3022,6 +3059,8 @@
       cp ${./tests/test_fsearch_glob.py} test_fsearch_glob.py
       # Issue #2246: grep(files_only=True) -> path + match-count rows via rg --count-matches.
       cp ${./tests/test_fsearch_files_only.py} test_fsearch_files_only.py
+      # Issue #2245: ranked per-session search over local Claude Code history.
+      cp ${./tests/test_claude_history.py} test_claude_history.py
       # sh Output rendering regressions (issue #1766: a failed build must not
       # read as success/still-running); imports the site-packages sh module.
       cp ${./tests/test_sh_module.py} test_sh_module.py
@@ -3034,6 +3073,7 @@
         test_fsearch_partial.py \
         test_fsearch_glob.py \
         test_fsearch_files_only.py \
+        test_claude_history.py \
         test_sh_module.py \
         test_build_info.py \
         -q -p no:cacheprovider >stdout 2>stderr || {

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -121,6 +121,13 @@ MODULES: tuple[Module, ...] = (
         ),
     ),
     Module(
+        "claude_history",
+        "find past local Claude Code sessions by content: `await claude_history.search(pattern)` "
+        "greps every transcript under ~/.claude/projects and returns one polars row per matching "
+        "session (session id, un-munged project cwd, start/end timestamps, hit count, first real "
+        "user message with meta / tool-result / pasted-TUI noise skipped), ranked by hit count",
+    ),
+    Module(
         "astlog",
         "Datalog over tree-sitter ASTs: tree-sitter query matches become relations, rules join "
         "them (position, text, recursion), `(lint ...)` rows become findings, rewrites turn rows "

--- a/packages/mcp/src/claude_history/claude_history/__init__.py
+++ b/packages/mcp/src/claude_history/claude_history/__init__.py
@@ -1,0 +1,145 @@
+"""Search local Claude Code history: one ranked row per matching session.
+
+``await claude_history.search(pattern)`` greps every transcript under
+``~/.claude/projects`` (ripgrep, via the bundled :mod:`fsearch`) and returns a
+``polars.DataFrame`` with one row per matching *session*, ranked by hit count::
+
+    df = await claude_history.search("golden snapshot")
+    # session_id | cwd | hits | first_user_message | started_at | ended_at | ...
+
+The per-session columns answer "which past conversation was that": the session
+id, the un-munged project ``cwd``, first/last message timestamps, how many
+transcript lines matched, and the first *real* user message -- harness-injected
+meta records (``isMeta``, ``<...>``/``Caveat:`` prefixes), tool-result-only
+entries, and pasted-TUI noise are all skipped (issue #2245).
+
+The transcript schema is deliberately NOT re-implemented here: parsing reuses
+:func:`distiller.transcripts.parse_session` (packages/agent/distiller), the
+same reader the transcript distiller runs, so the schema knowledge stays owned
+in one place on the Python side (the Rust owner is
+``packages/search/source/claude``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import polars as pl
+from polars.datatypes import DataType, DataTypeClass
+from distiller.transcripts import Session, parse_session, resolve_cwd
+
+import fsearch
+
+__all__ = ["DEFAULT_ROOT", "search"]
+
+__version__ = "0.1.0"
+
+DEFAULT_ROOT = "~/.claude/projects"
+
+_SCHEMA: dict[str, DataTypeClass | DataType] = {
+    "session_id": pl.Utf8,
+    "cwd": pl.Utf8,
+    "hits": pl.Int64,
+    "first_user_message": pl.Utf8,
+    "started_at": pl.Datetime(time_zone="UTC"),
+    "ended_at": pl.Datetime(time_zone="UTC"),
+    "messages": pl.Int64,
+    "git_branch": pl.Utf8,
+    "path": pl.Utf8,
+}
+
+
+def _when(epoch: float | None) -> datetime | None:
+    """Epoch seconds (the distiller's timestamp shape) to an aware datetime."""
+    return None if epoch is None else datetime.fromtimestamp(epoch, tz=UTC)
+
+
+def _sessions(paths: list[str]) -> dict[str, Session]:
+    """Parse each matching transcript once, keyed by path.
+
+    A file that yields no session (marker/snapshot-only, or no real user
+    message) is dropped: it has no session identity worth ranking.
+    """
+    out: dict[str, Session] = {}
+    for path in paths:
+        session = parse_session(Path(path))
+        if session is not None:
+            out[path] = session
+    return out
+
+
+async def search(
+    pattern: str,
+    root: str | os.PathLike[str] = DEFAULT_ROOT,
+    *,
+    ignore_case: bool = True,
+    fixed: bool = False,
+    limit: int = 100,
+    max_matches: int = 100_000,
+    timeout: float = 60.0,
+    include_subagents: bool = False,
+) -> pl.DataFrame:
+    """One ranked row per session whose transcript matches ``pattern``.
+
+    ``pattern`` is a regex (``fixed=True`` for a literal), case-insensitive by
+    default. ``root`` is the Claude projects directory. ``limit`` caps the
+    returned *sessions*; ``max_matches`` caps the underlying grep rows (the
+    safety bound on a very broad pattern) and ``timeout`` bounds the scan.
+    Subagent transcripts (``.../subagents/*.jsonl``) are folded out unless
+    ``include_subagents=True`` -- the parent session carries the outcome.
+
+    Columns: ``session_id, cwd, hits, first_user_message, started_at,
+    ended_at, messages, git_branch, path``, sorted by ``hits`` descending.
+    ``cwd`` is the session's recorded working directory (the un-munged project
+    path), falling back to the path decoded from the transcript directory
+    name. When the scan was cut short (timeout, or ``max_matches``) the frame
+    comes back as :class:`fsearch.PartialFrame` with ``.truncated`` /
+    ``.reason`` set, so a capped scan is never mistaken for a complete one.
+    """
+    matches = await fsearch.grep(
+        pattern,
+        root,
+        ignore_case=ignore_case,
+        fixed=fixed,
+        glob="*.jsonl",
+        hidden=True,
+        no_ignore=True,
+        limit=max_matches,
+        timeout=timeout,
+    )
+    truncated = bool(getattr(matches, "truncated", False))
+    reason = str(getattr(matches, "reason", "")) or "the underlying scan was cut short"
+    if not include_subagents:
+        matches = matches.filter(~pl.col("path").str.contains("/subagents/", literal=True))
+    if matches.is_empty():
+        empty = pl.DataFrame(schema=_SCHEMA)
+        return fsearch.PartialFrame(empty, schema=_SCHEMA, reason=reason) if truncated else empty
+
+    counts: dict[str, int] = {
+        str(path): int(hits)
+        for path, hits in matches.group_by("path").len(name="hits").iter_rows()
+    }
+    sessions = await asyncio.to_thread(_sessions, sorted(counts))
+    rows: list[dict[str, object]] = [
+        {
+            "session_id": session.session_id,
+            "cwd": resolve_cwd(session.cwd, Path(path).parent.name),
+            "hits": counts[path],
+            "first_user_message": session.goal,
+            "started_at": _when(session.first_ts),
+            "ended_at": _when(session.last_ts),
+            "messages": session.message_count,
+            "git_branch": session.git_branch,
+            "path": path,
+        }
+        for path, session in sessions.items()
+    ]
+    frame = (
+        pl.DataFrame(rows, schema=_SCHEMA)
+        .sort("hits", "ended_at", descending=True, nulls_last=True)
+        .head(limit)
+    )
+    return fsearch.PartialFrame(frame, schema=_SCHEMA, reason=reason) if truncated else frame

--- a/packages/mcp/tests/test_claude_history.py
+++ b/packages/mcp/tests/test_claude_history.py
@@ -1,0 +1,143 @@
+"""``claude_history.search`` over a fixture transcript tree (issue #2245).
+
+One ranked row per matching session: id, un-munged cwd, start/end timestamps,
+hit count, and the first *real* user message. Harness-injected meta records
+(``isMeta`` / ``<...>`` / ``Caveat:``), tool-result-only entries, and
+pasted-TUI noise still count as grep hits, but must never surface as the
+opening message. Runs against real ripgrep (the fsearch backend) and skips
+cleanly when ``rg`` is not on PATH.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import claude_history
+
+pytestmark = pytest.mark.skipif(shutil.which("rg") is None, reason="rg not on PATH")
+
+NEEDLE = "golden snapshot"
+
+
+def _line(
+    rtype: str,
+    content: object,
+    ts: str,
+    session: str,
+    cwd: str = "/home/u/proj",
+    **extra: object,
+) -> str:
+    return json.dumps(
+        {
+            "type": rtype,
+            "uuid": f"{session}:{ts}",
+            "sessionId": session,
+            "timestamp": ts,
+            "cwd": cwd,
+            "gitBranch": "main",
+            "message": {"role": rtype, "content": content},
+            **extra,
+        }
+    )
+
+
+def _fixture_root(tmp_path: Path) -> Path:
+    """Two sessions matching NEEDLE (5 hits vs 1) plus a subagent transcript."""
+    root = tmp_path / "projects"
+    proj = root / "-home-u-proj"
+    proj.mkdir(parents=True)
+    tui_paste = (
+        "\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e\n"
+        f"\u2502 {NEEDLE} \u2502\n"
+        "\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f"
+    )
+    (proj / "sess-a.jsonl").write_text(
+        "\n".join(
+            [
+                # A hit inside harness-injected meta: counted, never the goal.
+                _line("user", f"Caveat: harness noise about the {NEEDLE}", "2026-06-10T10:00:00Z", "sess-a", isMeta=True),
+                # Tool-result-only user line: not a real user message.
+                _line(
+                    "user",
+                    [{"type": "tool_result", "tool_use_id": "t1", "content": f"{NEEDLE} in tool output"}],
+                    "2026-06-10T10:00:30Z",
+                    "sess-a",
+                ),
+                # Pasted-TUI noise carrying the needle: counted, never the goal.
+                _line("user", tui_paste, "2026-06-10T10:01:00Z", "sess-a"),
+                _line("user", f"please fix the {NEEDLE} test", "2026-06-10T10:02:00Z", "sess-a"),
+                _line(
+                    "assistant",
+                    [{"type": "text", "text": f"Looking at the {NEEDLE} fixture now."}],
+                    "2026-06-10T11:00:00Z",
+                    "sess-a",
+                ),
+            ]
+        )
+    )
+    other = root / "-home-u-other"
+    other.mkdir()
+    (other / "sess-b.jsonl").write_text(
+        "\n".join(
+            [
+                _line("user", "unrelated question", "2026-06-11T09:00:00Z", "sess-b", cwd="/home/u/other"),
+                _line(
+                    "assistant",
+                    [{"type": "text", "text": f"that reminds me of the {NEEDLE}"}],
+                    "2026-06-11T09:05:00Z",
+                    "sess-b",
+                    cwd="/home/u/other",
+                ),
+            ]
+        )
+    )
+    sub = proj / "sess-a" / "subagents"
+    sub.mkdir(parents=True)
+    (sub / "agent-1.jsonl").write_text(
+        _line("user", f"subagent chatter about the {NEEDLE}", "2026-06-10T10:30:00Z", "agent-1")
+    )
+    return root
+
+
+def test_ranked_sessions_with_first_real_user_message(tmp_path: Path) -> None:
+    frame = asyncio.run(claude_history.search(NEEDLE, _fixture_root(tmp_path)))
+    assert frame["session_id"].to_list() == ["sess-a", "sess-b"], frame
+    assert frame["hits"].to_list() == [5, 1]
+
+    top = frame.row(0, named=True)
+    # Meta, tool-result-only, and pasted-TUI lines all matched, yet the first
+    # REAL user message is the typed request.
+    assert top["first_user_message"] == f"please fix the {NEEDLE} test"
+    assert top["cwd"] == "/home/u/proj"  # un-munged, from the records
+    assert top["started_at"] == datetime(2026, 6, 10, 10, 0, tzinfo=UTC)
+    assert top["ended_at"] == datetime(2026, 6, 10, 11, 0, tzinfo=UTC)
+    assert top["git_branch"] == "main"
+    assert top["path"].endswith("sess-a.jsonl")
+    assert frame.row(1, named=True)["cwd"] == "/home/u/other"
+
+
+def test_subagent_transcripts_are_folded_out_by_default(tmp_path: Path) -> None:
+    root = _fixture_root(tmp_path)
+    default = asyncio.run(claude_history.search(NEEDLE, root))
+    assert "agent-1" not in default["session_id"].to_list()
+
+    included = asyncio.run(claude_history.search(NEEDLE, root, include_subagents=True))
+    assert "agent-1" in included["session_id"].to_list()
+
+
+def test_no_match_returns_an_empty_typed_frame(tmp_path: Path) -> None:
+    frame = asyncio.run(claude_history.search("no-such-needle-xyz", _fixture_root(tmp_path)))
+    assert frame.is_empty()
+    assert frame.columns == list(claude_history._SCHEMA)
+    assert not getattr(frame, "truncated", False)
+
+
+def test_limit_caps_returned_sessions(tmp_path: Path) -> None:
+    frame = asyncio.run(claude_history.search(NEEDLE, _fixture_root(tmp_path), limit=1))
+    assert frame["session_id"].to_list() == ["sess-a"]


### PR DESCRIPTION
Resolves #2245.

## What

A new `claude_history` MCP kernel battery: `await claude_history.search(pattern)` greps every transcript under `~/.claude/projects` and returns one polars row per matching session, ranked by hit count:

| column | |
|---|---|
| `session_id` | transcript stem |
| `cwd` | un-munged project cwd (recorded `cwd`, falling back to decoding the munged dir name) |
| `hits` | ripgrep match count in that session, sort key |
| `first_user_message` | first real user message: `isMeta` records, tool_result-only entries, `[Pasted text` placeholders, and pasted-TUI box-drawing noise all skipped |
| `started_at` / `ended_at` | UTC timestamps |
| `messages`, `git_branch`, `path` | extras |

`root=`, `ignore_case=`, `fixed=`, `limit=`, `max_matches=`, `timeout=`, `include_subagents=` knobs; truncated scans come back as `fsearch.PartialFrame` with a `.reason`.

## How (reuse, not duplication)

- Transcript parsing is `distiller.transcripts.parse_session` — the existing Python owner of the transcript schema. The distiller nix package now exports `passthru.pythonModule` / `pythonSource` so packages/mcp bundles it without re-declaring the build.
- The grep is `fsearch.grep` (bounded ripgrep --json), so no hand-rolled JSONL scanning.
- The shared meta filter in distiller gained the `isMeta` / pasted-TUI / paste-placeholder skips, so distiller session goals improve too; `_resolve_path` is now public `resolve_cwd`.

## Validation

- `nix build .#mcp.tests.strictTypecheck` (zuban --strict + ruff ANN, `claude_history` added to strictGreenModules) — pass
- `nix build .#mcp.tests.typecheckSmoke` (85 pytest tests incl. 4 new fixture-transcript tests: ranking + first-message + cwd + timestamps, subagent fold-out, empty typed frame, limit cap) — pass
- `nix build .#distiller.tests.typecheck` — pass (`.tests.pytest` fails identically on plain main on darwin: sandbox `/nix/.Trashes` stat, pre-existing; two new transcript tests validated directly)
- `nix run .#lint` — 8/8 succeeded
- Registered in the `api()` catalog (`ix_notebook_mcp/registry.py`)

---

Authored by Claude Code (AI), issue #2245 handoff.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `claude_history.search` for ranked search over local Claude Code transcripts
> - Adds a new `claude_history` package to the MCP interpreter that exposes `await claude_history.search(...)`, returning a polars DataFrame of matching sessions ranked by hit count.
> - Uses `fsearch.grep` over JSONL transcripts, groups matches by path, and enriches results with session metadata (goal, cwd, timestamps, git branch, message count).
> - Subagent transcripts are excluded by default; a `include_subagents` flag opts them back in.
> - Extends `distiller.transcripts` to filter out `isMeta` records and pasted TUI content when determining the session goal, and renames `_resolve_path` to `resolve_cwd` for external use.
> - Wires `distiller` sources into the MCP build and type-check pipeline via new `passthru.pythonModule` / `passthru.pythonSource` attributes on the distiller derivation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a23634.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->