### PR TITLE
codex: pin importCargoLock git deps via outputHashes, not allowBuiltinFetchGit

### DIFF
--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -189,9 +189,25 @@
     # path, so no IFD), not the patched src: no patch touches Cargo.lock
     # today, and if one ever does, cargoSetupPostPatchHook's lock-consistency
     # check fails the build loudly rather than vendoring the wrong set.
+    #
+    # Git dependencies pinned in codex's Cargo.lock, keyed by "<name>-<version>"
+    # (rustPlatform.importCargoLock resolves the key to a locked commit SHA
+    # internally, so any one name-version sharing a SHA is enough; the
+    # rust-sdks monorepo contributes 4 crates from the same commit here).
+    # Refresh after a codex-src bump by rebuilding and copying the corrected
+    # hashes from the fetchgit mismatch errors; NOT allowBuiltinFetchGit,
+    # which would let builtins.fetchGit run at evaluation time (index#2255).
     cargoDeps = rustPlatform.importCargoLock {
       lockFile = ix.codexSrc + "/codex-rs/Cargo.lock";
-      allowBuiltinFetchGit = true;
+      outputHashes = {
+        "runfiles-0.1.0" = "sha256-uJpVLcQh8wWZA3GPv9D8Nt43EOirajfDJ7eq/FB+tek=";
+        "nucleo-0.5.0" = "sha256-Hm4SxtTSBrcWpXrtSqeO0TACbUxq3gizg1zD/6Yw/sI=";
+        "webrtc-sys-0.3.24" = "sha256-0HPuwaGcqpuG+Pp6z79bCuDu/DyE858VZSYr3DKZD9o=";
+        "crossterm-0.28.1" = "sha256-6qCtfSMuXACKFb9ATID39XyFDIEMFDmbx6SSmNe+728=";
+        "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
+        "tokio-tungstenite-0.28.0" = "sha256-V1xmnrfRWOcZZogelZEA4vvyMj2awCfHVA5/glQ6KAI=";
+        "tungstenite-0.27.0" = "sha256-VVHhk7l9J/sEmG3q/UuV/sQ3f+fGsmq5vumSy8vbMvw=";
+      };
     };
     postPatch = ''
       # shell


### PR DESCRIPTION
Closes #2255.

## Problem

`nix run .#lint` fails on `main` (`packages/agent/codex/default.nix:194:7:
error[no-allow-builtin-fetch-git]`), introduced by #2249 (9399d717). That
PR replaced codex's vendor FOD with `rustPlatform.importCargoLock` but set
`allowBuiltinFetchGit = true` for the git dependency graph, which the
lint bans: it lets `builtins.fetchGit` run at evaluation time (network
access + blocking clone) instead of through a fixed-output derivation.

## Fix

Replace `allowBuiltinFetchGit = true;` with `outputHashes`, pinning each
of the 7 distinct git commits reachable from codex's `Cargo.lock`
(`rust-sdks` alone contributes 4 crates - `libwebrtc`, `livekit-protocol`,
`livekit-runtime`, `webrtc-sys`/`webrtc-sys-build` - from one commit).
Keys are `"<name>-<version>"`, matching `rustPlatform.importCargoLock`'s
own convention (internally it resolves the key to the locked commit SHA,
so any one name-version per unique SHA is enough). This is the lint
rule's own documented remedy (`astlog-rules/nix.astlog`).

Hashes were harvested the same way `lib/rust/vendor.nix` documents for
the sibling snix package: placeholder hash, `nix build --keep-going`,
copy the corrected hashes from the fetchgit mismatches.

## Validation

- `nix run .#lint`: 8/8 tasks succeeded (astlog clean).
- `nix build .#codex --no-link`: succeeded,
  `/nix/store/55fc569p8y1hfh56c7l5nzy9i0r0pjhm-codex-0.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `importCargoLock` git dependencies via `outputHashes` in codex
> Replaces `allowBuiltinFetchGit = true` with explicit `outputHashes` entries in the `cargoDeps` attr of [default.nix](https://github.com/indexable-inc/index/pull/2261/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5). This shifts git dependency resolution from impure built-in fetching to fixed-output derivations, which is more reproducible and works in sandboxed Nix builds. Comments are added to document the git dependency refresh workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70846c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->