### PR TITLE
rfcs: renumber git-fetcher-history RFC to 0011 (number collision)

### DIFF
--- a/packages/site/src/lib/rfcs/0011-git-fetcher-history.svx
+++ b/packages/site/src/lib/rfcs/0011-git-fetcher-history.svx
@@ -1,5 +1,5 @@
 ---
-id: 0010-git-fetcher-history
+id: 0011-git-fetcher-history
 number: '0010'
 title: Structured commit history from the Nix git fetcher
 status: Draft

--- a/packages/site/src/lib/rfcs/0011-git-fetcher-history.svx
+++ b/packages/site/src/lib/rfcs/0011-git-fetcher-history.svx
@@ -1,6 +1,6 @@
 ---
 id: 0011-git-fetcher-history
-number: '0010'
+number: '0011'
 title: Structured commit history from the Nix git fetcher
 status: Draft
 authors: andrewgazelka


### PR DESCRIPTION
Both 0010-fork-patch-series.svx (#2109, merged first, keeps 0010) and 0010-git-fetcher-history.svx (#2122) landed as RFC 0010. Renames the later one to 0011 and updates references. A duplicate-number guard is tracked separately.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Renumber git-fetcher-history RFC from 0010 to 0011 to resolve number collision
> Renames [0011-git-fetcher-history.svx](https://github.com/indexable-inc/index/pull/2263/files#diff-43ad224861ee1be2ebb4d5d775543a70af7900b17506baeef76fcc1b0933d746) from `0010-git-fetcher-history.svx` and updates the `id` and `number` frontmatter fields to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f5302e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->