### PR TITLE
agent: detect dropped ScheduleWakeup wakeups at Stop (#2259)

### DIFF
--- a/packages/agent/claude-hooks/src/main.rs
+++ b/packages/agent/claude-hooks/src/main.rs
@@ -15,6 +15,7 @@ mod guards;
 mod retro;
 mod review;
 mod session_banner;
+mod wakeup;
 
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
@@ -81,6 +82,8 @@ fn main() -> ExitCode {
         Some("review-log-edit") => review::review_log_edit(),
         Some("review-gate") => review::review_gate(),
         Some("retro-gate") => retro::retro_gate(),
+        Some("wakeup-log") => wakeup::wakeup_log(),
+        Some("wakeup-gate") => wakeup::wakeup_gate(),
         Some("cargo-guard") => guards::cargo_guard(),
         Some("bash-habits-guard") => guards::bash_habits_guard(),
         Some("search-guard") => guards::search_guard(),
@@ -110,6 +113,28 @@ pub(crate) fn read_stdin() -> Option<String> {
     let mut buf = String::new();
     std::io::stdin().read_to_string(&mut buf).ok()?;
     Some(buf)
+}
+
+/// `session_id` is interpolated into state-file paths; accept only a plain
+/// filename component so a crafted value cannot escape a state dir.
+pub(crate) fn safe_session(payload: &Value) -> Option<String> {
+    let session = payload.get("session_id").and_then(Value::as_str)?;
+    if session.is_empty() || session == "." || session == ".." || session.contains('/') {
+        return None;
+    }
+    Some(session.to_owned())
+}
+
+/// True when a hook payload fired inside a subagent (Task tool) rather than
+/// the main thread. Claude Code populates `agent_id` ONLY inside a subagent
+/// call (`PostToolUse` carries it; the docs call it the way to "distinguish
+/// subagent hook calls from main-thread calls"), so its presence is the
+/// authoritative author signal while `session_id` stays the parent's.
+pub(crate) fn is_subagent(payload: &Value) -> bool {
+    payload
+        .get("agent_id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.is_empty())
 }
 
 fn cap_chars(s: &str, max: usize) -> String {

--- a/packages/agent/claude-hooks/src/retro.rs
+++ b/packages/agent/claude-hooks/src/retro.rs
@@ -38,17 +38,6 @@ fn min_tool_calls() -> usize {
         .unwrap_or(DEFAULT_MIN_TOOL_CALLS)
 }
 
-/// `session_id` is interpolated into a file path; accept only a plain filename
-/// component so a crafted value cannot escape the state dir. Same contract as
-/// `review::safe_session`.
-fn safe_session(payload: &Value) -> Option<String> {
-    let session = payload.get("session_id").and_then(Value::as_str)?;
-    if session.is_empty() || session == "." || session == ".." || session.contains('/') {
-        return None;
-    }
-    Some(session.to_owned())
-}
-
 /// One `<session>.retro-done` marker per session: its presence means the retro
 /// gate already fired, so a later Stop must not fire again.
 fn marker_path(session: &str) -> PathBuf {
@@ -145,7 +134,7 @@ pub fn retro_gate() {
     let Ok(payload) = serde_json::from_str::<Value>(&input) else {
         return;
     };
-    let Some(session) = safe_session(&payload) else {
+    let Some(session) = crate::safe_session(&payload) else {
         return;
     };
 
@@ -212,23 +201,8 @@ pub fn retro_gate() {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        GateAction, count_tool_calls, gate_action, is_substantive, safe_session,
-    };
+    use super::{GateAction, count_tool_calls, gate_action, is_substantive};
     use serde_json::json;
-
-    #[test]
-    fn session_rejects_path_escapes() {
-        assert_eq!(
-            safe_session(&json!({"session_id": "abc-123"})).as_deref(),
-            Some("abc-123")
-        );
-        assert!(safe_session(&json!({"session_id": "../escape"})).is_none());
-        assert!(safe_session(&json!({"session_id": "a/b"})).is_none());
-        assert!(safe_session(&json!({"session_id": "."})).is_none());
-        assert!(safe_session(&json!({"session_id": ""})).is_none());
-        assert!(safe_session(&json!({})).is_none());
-    }
 
     #[test]
     fn gate_evaluates_a_plain_main_session_stop() {

--- a/packages/agent/claude-hooks/src/review.rs
+++ b/packages/agent/claude-hooks/src/review.rs
@@ -20,32 +20,8 @@ fn state_dir() -> PathBuf {
         .map_or_else(|| crate::home().join(".claude/.review-state"), PathBuf::from)
 }
 
-/// `session_id` is interpolated into a file path; accept only a plain filename
-/// component so a crafted value cannot escape the state dir.
-fn safe_session(payload: &Value) -> Option<String> {
-    let session = payload.get("session_id").and_then(Value::as_str)?;
-    if session.is_empty() || session == "." || session == ".." || session.contains('/') {
-        return None;
-    }
-    Some(session.to_owned())
-}
-
 fn marker_path(session: &str) -> PathBuf {
     state_dir().join(format!("{session}.changed"))
-}
-
-/// True when this hook payload fired inside a subagent (Task tool) rather than
-/// the main thread. Claude Code populates `agent_id` ONLY inside a subagent call
-/// (`PostToolUse` carries it; the docs call it the way to "distinguish subagent
-/// hook calls from main-thread calls"), so its presence is the authoritative
-/// author signal. A subagent's `PostToolUse` reuses the PARENT `session_id`, so
-/// without this check its work-in-progress lands in the parent's marker and the
-/// Stop gate blames the main session for edits it never made.
-fn is_subagent(payload: &Value) -> bool {
-    payload
-        .get("agent_id")
-        .and_then(Value::as_str)
-        .is_some_and(|id| !id.is_empty())
 }
 
 /// `PostToolUse(Write|Edit|MultiEdit|NotebookEdit)`: record the edited path.
@@ -62,10 +38,10 @@ pub fn review_log_edit() {
     // its own diff, and a still-running background subagent's WIP must not arm the
     // parent's gate. Drop subagent-authored edits here so the gate counts only the
     // main session's own tool calls.
-    if is_subagent(&payload) {
+    if crate::is_subagent(&payload) {
         return;
     }
-    let Some(session) = safe_session(&payload) else {
+    let Some(session) = crate::safe_session(&payload) else {
         return;
     };
     // Write/Edit/MultiEdit use file_path; NotebookEdit uses notebook_path.
@@ -152,7 +128,7 @@ pub fn review_gate() {
     let Ok(payload) = serde_json::from_str::<Value>(&input) else {
         return;
     };
-    let Some(session) = safe_session(&payload) else {
+    let Some(session) = crate::safe_session(&payload) else {
         return;
     };
     let marker = marker_path(&session);
@@ -220,7 +196,8 @@ pub fn review_gate() {
 
 #[cfg(test)]
 mod tests {
-    use super::{GateAction, gate_action, is_subagent, safe_session};
+    use super::{GateAction, gate_action};
+    use crate::{is_subagent, safe_session};
     use serde_json::json;
 
     #[test]

--- a/packages/agent/claude-hooks/src/wakeup.rs
+++ b/packages/agent/claude-hooks/src/wakeup.rs
@@ -1,0 +1,283 @@
+//! `ScheduleWakeup` drop detector: the `wakeup-log` (`PostToolUse`) and
+//! `wakeup-gate` (Stop) pair.
+//!
+//! A pending `ScheduleWakeup` lives only in harness process memory (it is never
+//! written to `scheduled_tasks.json`), a session resume or user abort clears the
+//! whole pending list, and the missed-task recovery path covers persisted tasks
+//! only. A dropped wakeup therefore silently never fires: in
+//! indexable-inc/index#2259 a background session armed a wakeup, four
+//! notification-driven turns intervened, the fire time passed with nothing
+//! scheduled, and the session idled 24h until nudged.
+//!
+//! `wakeup-log` records each armed fire time (the tool's `scheduledFor` epoch
+//! ms) in a per-session marker. `wakeup-gate` compares that marker against the
+//! Stop payload's `session_crons` (present since Claude Code 2.1.x; lists
+//! pending `ScheduleWakeup`/`CronCreate`/loop crons): if the recorded fire time is
+//! still ahead but no one-shot cron remains pending, the wakeup was dropped and
+//! the gate blocks ONCE with a re-arm nudge, turning a silent stall into a loud
+//! correction. Like every hook in this crate both fail OPEN and SILENT: missing
+//! input, parse errors, an absent `session_crons` field (older harness), or a
+//! marker already nagged all allow the Stop.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Per-session marker dir; overridable so the hooks can be tested against a
+/// temp dir, matching the `review-gate` `CLAUDE_REVIEW_STATE_DIR` convention.
+fn state_dir() -> PathBuf {
+    std::env::var_os("CLAUDE_WAKEUP_STATE_DIR")
+        .filter(|v| !v.is_empty())
+        .map_or_else(|| crate::home().join(".claude/.wakeup-state"), PathBuf::from)
+}
+
+fn marker_path(session: &str) -> PathBuf {
+    state_dir().join(format!("{session}.wakeup.json"))
+}
+
+/// The armed wakeup this session is counting on. `nagged` caps the gate at one
+/// block per armed wakeup so a model that deliberately ends the loop is never
+/// wedged into a permanent block.
+#[derive(Serialize, Deserialize)]
+struct Marker {
+    scheduled_for_ms: i64,
+    armed_at_ms: i64,
+    nagged: bool,
+}
+
+fn read_marker(session: &str) -> Option<Marker> {
+    let text = std::fs::read_to_string(marker_path(session)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn write_marker(session: &str, marker: &Marker) {
+    let dir = state_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    if let Ok(s) = serde_json::to_string(marker) {
+        let _ = std::fs::write(marker_path(session), s);
+    }
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+/// `PostToolUse(ScheduleWakeup)`: record the armed fire time. The tool's
+/// structured response carries `scheduledFor` (epoch ms of the registered fire
+/// target, already clamped and minute-rounded by the harness); `0` means the
+/// loop runtime declined to schedule (gate off or loop over), which clears any
+/// stale marker. Side effect only, never blocks.
+pub fn wakeup_log() {
+    let Some(input) = crate::read_stdin() else {
+        return;
+    };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    // ScheduleWakeup is main-thread /loop machinery; a subagent's call (parent
+    // session_id reused, `agent_id` set) must not arm the parent's gate.
+    if crate::is_subagent(&payload) {
+        return;
+    }
+    let Some(session) = crate::safe_session(&payload) else {
+        return;
+    };
+    let Some(scheduled_for) = payload
+        .get("tool_response")
+        .and_then(|r| r.get("scheduledFor"))
+        .and_then(Value::as_i64)
+    else {
+        return;
+    };
+    if scheduled_for <= 0 {
+        let _ = std::fs::remove_file(marker_path(&session));
+        return;
+    }
+    write_marker(
+        &session,
+        &Marker {
+            scheduled_for_ms: scheduled_for,
+            armed_at_ms: now_ms(),
+            nagged: false,
+        },
+    );
+}
+
+/// What the Stop gate should do this turn, decided from payload + marker + the
+/// clock alone (no I/O), so the policy is testable like `review::gate_action`.
+#[derive(Debug, PartialEq, Eq)]
+enum GateAction {
+    /// Nothing to say; leave any marker in place.
+    Allow,
+    /// The marker is spent (fire time reached, or already nagged): remove it
+    /// and allow.
+    ClearAndAllow,
+    /// The armed wakeup vanished before its fire time: block once with a
+    /// re-arm nudge and remember the nag.
+    Block,
+}
+
+fn gate_action(payload: &Value, marker: &Marker, now_ms: i64) -> GateAction {
+    // At or past the fire target the Stop cannot distinguish "fired" (the fire
+    // starts its own turn) from "dropped", so the marker is spent: fail open.
+    if now_ms >= marker.scheduled_for_ms {
+        return GateAction::ClearAndAllow;
+    }
+    // `session_crons` absent (or malformed) means this harness predates the
+    // field; there is nothing to verify against, so fail open.
+    let Some(crons) = payload.get("session_crons").and_then(Value::as_array) else {
+        return GateAction::Allow;
+    };
+    // Any pending one-shot counts as the wakeup being alive. A distinct
+    // one-shot CronCreate task could mask a dropped wakeup here, but that
+    // false negative only fails open, and prompts are clipped in the payload,
+    // so exact matching would be fragile.
+    let alive = crons
+        .iter()
+        .any(|c| c.get("recurring").and_then(Value::as_bool) == Some(false));
+    if alive {
+        return GateAction::Allow;
+    }
+    if marker.nagged {
+        return GateAction::ClearAndAllow;
+    }
+    GateAction::Block
+}
+
+#[derive(Serialize)]
+struct StopBlock {
+    decision: &'static str,
+    reason: String,
+}
+
+fn fmt_local(ms: i64) -> String {
+    chrono::DateTime::from_timestamp_millis(ms).map_or_else(
+        || format!("epoch+{ms}ms"),
+        |t| {
+            t.with_timezone(&chrono::Local)
+                .format("%H:%M:%S")
+                .to_string()
+        },
+    )
+}
+
+/// Stop: block once when the armed wakeup is gone before its fire time.
+pub fn wakeup_gate() {
+    let Some(input) = crate::read_stdin() else {
+        return;
+    };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    let Some(session) = crate::safe_session(&payload) else {
+        return;
+    };
+    let Some(marker) = read_marker(&session) else {
+        return;
+    };
+    let now = now_ms();
+    match gate_action(&payload, &marker, now) {
+        GateAction::Allow => return,
+        GateAction::ClearAndAllow => {
+            let _ = std::fs::remove_file(marker_path(&session));
+            return;
+        }
+        GateAction::Block => {}
+    }
+    write_marker(&session, &Marker { nagged: true, ..marker });
+    let reason = format!(
+        "An armed ScheduleWakeup was dropped before firing: this session armed a wakeup at {} \
+         to fire at {} (in {}s), but the harness now reports no pending one-shot wakeup in \
+         `session_crons`, so nothing will re-invoke this session \
+         (indexable-inc/index#2259: session resume and user abort silently clear pending \
+         wakeups). If the loop should continue, call ScheduleWakeup again now to re-arm. If \
+         the loop is deliberately over, or the user cancelled it, finish the turn without one.",
+        fmt_local(marker.armed_at_ms),
+        fmt_local(marker.scheduled_for_ms),
+        (marker.scheduled_for_ms - now) / 1000,
+    );
+    // Stop hook contract: a top-level {"decision":"block","reason":...}, NOT the
+    // hookSpecificOutput wrapper the PreToolUse/SessionStart hooks use.
+    if let Ok(s) = serde_json::to_string(&StopBlock {
+        decision: "block",
+        reason,
+    }) {
+        println!("{s}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GateAction, Marker, gate_action};
+    use serde_json::json;
+
+    fn marker(scheduled_for_ms: i64, nagged: bool) -> Marker {
+        Marker {
+            scheduled_for_ms,
+            armed_at_ms: scheduled_for_ms - 3_000_000,
+            nagged,
+        }
+    }
+
+    // The #2259 shape: fire time still ahead, but the pending wakeup vanished
+    // from `session_crons` after intervening turns. Must block.
+    #[test]
+    fn blocks_when_pending_wakeup_vanished_before_fire_time() {
+        assert_eq!(
+            gate_action(&json!({"session_crons": []}), &marker(2_000_000, false), 1_000_000),
+            GateAction::Block,
+        );
+    }
+
+    #[test]
+    fn allows_while_wakeup_still_pending() {
+        let payload = json!({"session_crons": [
+            {"id": "ab12", "schedule": "20 19 * * *", "recurring": false, "prompt": "/loop ..."},
+        ]});
+        assert_eq!(gate_action(&payload, &marker(2_000_000, false), 1_000_000), GateAction::Allow);
+    }
+
+    // A recurring cron (CronCreate autonomous loop) is not the one-shot wakeup;
+    // its presence must not mask a dropped ScheduleWakeup.
+    #[test]
+    fn recurring_cron_does_not_count_as_alive() {
+        let payload = json!({"session_crons": [
+            {"id": "cd34", "schedule": "0 9 * * *", "recurring": true, "prompt": "daily"},
+        ]});
+        assert_eq!(gate_action(&payload, &marker(2_000_000, false), 1_000_000), GateAction::Block);
+    }
+
+    // At or past the fire target the fire itself starts a turn, so the Stop
+    // cannot distinguish fired from dropped: the marker is spent.
+    #[test]
+    fn clears_once_fire_time_passed() {
+        assert_eq!(
+            gate_action(&json!({"session_crons": []}), &marker(2_000_000, false), 2_000_000),
+            GateAction::ClearAndAllow,
+        );
+    }
+
+    // Loop guard: one nag per armed wakeup. A model that deliberately ends the
+    // loop after the nudge must not be wedged into a permanent block.
+    #[test]
+    fn blocks_at_most_once_per_armed_wakeup() {
+        assert_eq!(
+            gate_action(&json!({"session_crons": []}), &marker(2_000_000, true), 1_000_000),
+            GateAction::ClearAndAllow,
+        );
+    }
+
+    // An older harness without `session_crons` gives nothing to verify: fail
+    // open and keep the marker (it clears itself once the fire time passes).
+    #[test]
+    fn missing_session_crons_fails_open() {
+        assert_eq!(gate_action(&json!({}), &marker(2_000_000, false), 1_000_000), GateAction::Allow);
+        assert_eq!(
+            gate_action(&json!({"session_crons": "notanarray"}), &marker(2_000_000, false), 1_000_000),
+            GateAction::Allow,
+        );
+    }
+}

--- a/packages/agent/policy/hooks.nix
+++ b/packages/agent/policy/hooks.nix
@@ -23,6 +23,8 @@
     reviewEditLogger = hookRunnerSubcommand "review-log-edit";
     stopReviewGate = hookRunnerSubcommand "review-gate";
     stopRetroGate = hookRunnerSubcommand "retro-gate";
+    wakeupArmLogger = hookRunnerSubcommand "wakeup-log";
+    stopWakeupGate = hookRunnerSubcommand "wakeup-gate";
     frictionIssueReporter = hookRunnerSubcommand "friction-report";
     subagentCachePopulate = hookRunnerSubcommand "subagent-cache-populate";
   };
@@ -93,6 +95,13 @@
         command = hookCommands.reviewEditLogger;
         agents = ["claude"];
       }
+      # Records each armed ScheduleWakeup fire time so the Stop gate below can
+      # tell a dropped wakeup from a fired one (index#2259).
+      {
+        matcher = "ScheduleWakeup";
+        command = hookCommands.wakeupArmLogger;
+        agents = ["claude"];
+      }
     ];
 
     Stop = [
@@ -104,6 +113,13 @@
       # improvable, once per session (own marker), like the review gate above.
       {
         command = hookCommands.stopRetroGate;
+        agents = ["claude"];
+      }
+      # Blocks once when an armed ScheduleWakeup vanished before its fire time
+      # (index#2259: pending wakeups are in-memory only and cleared by session
+      # resume or user abort, so a drop is otherwise a silent stall).
+      {
+        command = hookCommands.stopWakeupGate;
         agents = ["claude"];
       }
       {

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -760,6 +760,10 @@ let
           watch is actually alive: a harness-tracked background child or Monitor
           running, its output growing. Receiving your own stop notification
           means no watch survived, so re-arm one or proceed synchronously.
+          An armed ScheduleWakeup is such a watch: pending wakeups live only
+          in harness memory and a session resume or user abort silently drops
+          them, so on any later turn that still counts on one, re-verify or
+          re-arm it before ending the turn.
         '';
         reason = ''
           Success-only watchers turn silent failures into indefinite waits. A
@@ -769,6 +773,9 @@ let
           watching the watcher. Separately, three background agents in one
           session ended turns "waiting for the monitor" with no live watch and
           stalled until a coordinator manually probed and nudged them (#1941).
+          An armed ScheduleWakeup vanished across intervening notification
+          turns and never fired, idling a background session 24h past its gate
+          (#2259).
         '';
       };
     }


### PR DESCRIPTION
Fixes #2259.

## Root cause

Reverse-engineered from the Claude Code 2.1.197 binary: a pending `ScheduleWakeup` lives only in process memory (`sessionCronTasks`), never in `scheduled_tasks.json`. Session resume clears all session crons and a user abort cancels pending loop wakeups, and the missed-task recovery path only covers persisted tasks. So a wakeup dropped by an intervening turn silently never fires; in #2259 that idled a background session 24h past its gate.

## Fix (at the layer we own)

The scheduler is upstream and closed, but the Stop hook payload already reports `session_crons`. This adds a marker-based detector to `claude-hooks`:

- `wakeup-log` (PostToolUse on `ScheduleWakeup`): records `{scheduled_for_ms, armed_at_ms}` per session from the tool's structured response; `scheduledFor <= 0` clears the marker. Subagents ignored.
- `wakeup-gate` (Stop): if the marker says a wakeup should still be pending but `session_crons` has no one-shot entry, block once with a reason telling the agent to re-arm (or finish deliberately). Nags at most once per armed wakeup, clears past fire time, and fails open on any missing/malformed input, so it can never wedge a session.
- `system-prompt.nix`: monitors section now names dropped wakeups explicitly.

Also consolidates the previously triplicated `safe_session`/`is_subagent` helpers into the crate root.

## Validation

- `nix build .#claude-hooks` passes; 6 unit tests on the pure `gate_action` run in CI.
- End-to-end against the built binary: arm writes marker; pending wakeup silent; the #2259 drop shape blocks with the re-arm nudge; second Stop allows (single nag); `scheduledFor=0` and past-fire clear; subagent arms ignored.

🤖 Generated with Claude Code (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect dropped ScheduleWakeup wakeups at agent Stop
> - Adds a `wakeup_log` PostToolUse hook that records a JSON marker (scheduled fire time, arm time) to `~/.claude/.wakeup-state` when a `ScheduleWakeup` tool fires.
> - Adds a `wakeup_gate` Stop hook that checks if a previously armed one-shot wakeup has disappeared before its scheduled fire time, blocking the Stop exactly once to prompt re-arming, then failing open.
> - Promotes `safe_session` and `is_subagent` helpers to crate-level in [main.rs](https://github.com/indexable-inc/index/pull/2264/files#diff-2d219c1873e0f6f8db7cbd30aeabac405d384c224e26f89100fa1eafed6c62eb), removing duplicated copies from [retro.rs](https://github.com/indexable-inc/index/pull/2264/files#diff-4819dd4460ea10e11838a63e273dbee2952e91ed014ae847fcea85a3ee3a0e8c) and [review.rs](https://github.com/indexable-inc/index/pull/2264/files#diff-b892a9dba25aeb82bdceef845e2ecb1e6e7ada74c3b6a3b95add2de3b8e2b3a6).
> - Updates the system prompt to instruct the model to verify or re-arm `ScheduleWakeup` before ending a turn.
> - Behavioral Change: Stop events may now be blocked once by `wakeup_gate` if a required wakeup is missing, after which the gate clears and subsequent Stops proceed normally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 067efae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->