### PR TITLE
site: guard against duplicate RFC numbers

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -385,7 +385,7 @@
           upstream = "hold";
           reason = "Build-status series: engage on #15979 rather than open a competing PR.";
         };
-        # Structured git history export (RFC 0010). Designed to be
+        # Structured git history export (RFC 0011). Designed to be
         # upstreamable (deterministic, opt-in, experimental-feature gated,
         # never in lock files -- it dodges the objections that sank
         # leaveDotGit-for-flakes), but held: repo-wide upstreaming pause

--- a/packages/nix/nix/examples/history-changelog.nix
+++ b/packages/nix/nix/examples/history-changelog.nix
@@ -1,4 +1,4 @@
-# Demo for the `exportHistory` git-fetcher patch (RFC 0010): render a
+# Demo for the `exportHistory` git-fetcher patch (RFC 0011): render a
 # Markdown changelog for one subtree of an input, entirely from eval data.
 #
 # Run with the patched nix (the stock daemon/client lacks the feature):

--- a/packages/site/src/lib/rfcs.test.ts
+++ b/packages/site/src/lib/rfcs.test.ts
@@ -50,4 +50,9 @@ describe('rfcs', () => {
   test('findRfc returns undefined for an unknown id', () => {
     expect(findRfc('9999-does-not-exist')).toBeUndefined();
   });
+
+  test('rfc numbers are unique across every entry, including the template', () => {
+    const numbers = rfcEntries().map((e) => findRfc(e.id)?.number);
+    expect(new Set(numbers).size).toBe(numbers.length);
+  });
 });

--- a/packages/site/src/lib/rfcs.ts
+++ b/packages/site/src/lib/rfcs.ts
@@ -31,6 +31,33 @@ type SvxModule = {
 
 const modules = import.meta.glob<SvxModule>('./rfcs/*.svx', { eager: true });
 
+// RFC numbers derive from filenames (the digits before the first '-') and
+// must be unique and agree with frontmatter. Throwing at module scope makes
+// `vite build` — and so `nix build .#site` and CI — fail on a violation:
+// the glob is eager and every prerendered RFC route imports this module.
+// Two RFCs once merged as 0010 (#2154); this keeps that unrepresentable.
+const numberToPath = new Map<string, string>();
+for (const [path, mod] of Object.entries(modules)) {
+  const stem = path.slice(path.lastIndexOf('/') + 1).replace(/\.svx$/, '');
+  const number = stem.slice(0, stem.indexOf('-'));
+  if (!/^\d{4}$/.test(number)) {
+    throw new Error(`RFC ${path}: filename must start with a four-digit number and '-'`);
+  }
+  if (mod.metadata.number !== number) {
+    throw new Error(
+      `RFC ${path}: frontmatter number '${mod.metadata.number}' disagrees with filename-derived '${number}'`
+    );
+  }
+  if (mod.metadata.id !== stem) {
+    throw new Error(`RFC ${path}: frontmatter id '${mod.metadata.id}' disagrees with filename '${stem}'`);
+  }
+  const existing = numberToPath.get(number);
+  if (existing !== undefined) {
+    throw new Error(`Duplicate RFC number ${number}: ${existing} and ${path}`);
+  }
+  numberToPath.set(number, path);
+}
+
 const allRfcs: Rfc[] = Object.values(modules)
   .map((mod) => ({
     ...mod.metadata,


### PR DESCRIPTION
The site vitest suite only asserted RFC **id** uniqueness, not **number** uniqueness, which is how #2109 and #2122 both landed as RFC 0010 (renumbered in #2263, which deferred the guard).

- `rfcs.ts` now derives each RFC's number from its filename at module scope and throws on a duplicate number, a non-`NNNN-` filename, or frontmatter `number`/`id` disagreeing with the filename. Since the glob is eager and every prerendered RFC route imports the module, `vite build` / `nix build .#site` / CI all fail on a collision.
- Adds a vitest asserting number uniqueness.
- Repoints the two stale "RFC 0010" comments for the git-fetcher history export to RFC 0011 (`lib/fork-packages.nix`, `packages/nix/nix/examples/history-changelog.nix`).

Fixes #2154

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard against duplicate RFC numbers in the rfcs module
> - Adds module-scope validation in [rfcs.ts](https://github.com/indexable-inc/index/pull/2272/files#diff-216c8aece539bf6eee0aba1b4dde18fa95731b8f3e10e718f1181a4322ef257f) that checks each RFC file on import: filename must start with four digits, frontmatter `number` and `id` must match the filename, and RFC numbers must be unique across all entries.
> - Adds a test in [rfcs.test.ts](https://github.com/indexable-inc/index/pull/2272/files#diff-3b87613977533da1fa0b3114add7e032347b528d63df69fa07ca639ddea79a60) that asserts all RFC numbers (including the template) are unique.
> - Fixes two comments in [fork-packages.nix](https://github.com/indexable-inc/index/pull/2272/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4) and [history-changelog.nix](https://github.com/indexable-inc/index/pull/2272/files#diff-d2ab9fd7c7a848cbe81e828d770891cfc693ab00ce0e711071ee881e6139729a) that incorrectly referenced RFC 0010 instead of RFC 0011.
> - Risk: importing the rfcs module now throws at module scope for any malformed filename, mismatched frontmatter, or duplicate number, causing builds and tests to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 838b854.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->