### PR TITLE
agent: disable claude monitor tools

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -204,22 +204,15 @@
       }
     else null;
 
-  # Set only when the caller has not already provided an env value.
-  wrapperEnvDefaults = {
-    # Keep every session on the standard (~200K) context window, never 1M
-    # (~5x input price; past-the-window work belongs in subagents, and the
-    # smaller window makes auto-compaction trigger sooner). Verified against
-    # 2.1.197: this flag gates every 1M path in the CLI — the explicit `[1m]`
-    # model suffix, the silent auto-upgrade on eligible models, honoring a
-    # `context-1m` beta header, and the built-in `[1m]` /model rows. Server-
-    # pushed model options (`additionalModelOptionsCache` in ~/.claude.json,
-    # e.g. an org-offered row valued `claude-fable-5[1m]`) can still APPEAR in
-    # /model, but selecting one still runs at the standard window: the beta
-    # header is never sent and the window computation ignores the suffix.
-    # Model selection itself is untouched. Guarded by an install check.
-    # Re-enable 1M per machine: `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
-    CLAUDE_CODE_DISABLE_1M_CONTEXT = 1;
-  };
+  # `env_defaults` leaves caller-provided values alone: exporting the full
+  # CLAUDE_CODE_DISABLE_* name to empty re-enables that feature for one session.
+  claudeCodeDisabledFeatureDefaults = [
+    "1M_CONTEXT"
+    "CRON"
+  ];
+  wrapperEnvDefaults = lib.genAttrs (
+    map (name: "CLAUDE_CODE_DISABLE_${name}") claudeCodeDisabledFeatureDefaults
+  ) (_: 1);
 
   # Settings defaults are injected only when the caller passed no `--settings`;
   # Claude treats repeated settings flags as first-wins.

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -49,17 +49,24 @@
     fi
   ''}
 
-    # 1M-context guard (see wrapperEnvDefaults): sessions default to the
-    # standard context window, so the disable flag must ride env_defaults —
-    # baked in the spec, injected when the caller has it unset, and yielding
-    # to a caller value so the per-machine re-enable path
-    # (`export CLAUDE_CODE_DISABLE_1M_CONTEXT=`) keeps working.
-    one_m="$(${lib.getExe jq} -r \
-      '.env_defaults[] | select(.key == "CLAUDE_CODE_DISABLE_1M_CONTEXT") | .value' \
-      "$PWD/test-spec.json")"
-    if [ "$one_m" != 1 ]; then
-      printf 'claude launcher env check failed: CLAUDE_CODE_DISABLE_1M_CONTEXT env_default is %s, want 1\n' \
-        "$one_m" >&2
+    check_env_default() {
+      local key="$1" got
+      got="$(${lib.getExe jq} -r --arg key "$key" \
+        '.env_defaults[] | select(.key == $key) | .value' \
+        "$PWD/test-spec.json")"
+      if [ "$got" != 1 ]; then
+        printf 'claude launcher env check failed: %s env_default is %s, want 1\n' \
+          "$key" "$got" >&2
+        exit 1
+      fi
+    }
+    check_env_default CLAUDE_CODE_DISABLE_1M_CONTEXT
+    check_env_default CLAUDE_CODE_DISABLE_CRON
+
+    if ${lib.getExe jq} -e \
+      '.env[] | select(.key == "CLAUDE_CODE_DISABLE_1M_CONTEXT" or .key == "CLAUDE_CODE_DISABLE_CRON")' \
+      "$PWD/test-spec.json"; then
+      printf 'claude launcher env check failed: CLAUDE_CODE_DISABLE_* must be env_defaults, not env\n' >&2
       exit 1
     fi
     envstub="$PWD/envstub"

--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -90,12 +90,19 @@
     image_generation = false;
     in_app_browser = false;
   };
+
+  claudeHouseDeniedTools = [
+    "Monitor"
+    "CronCreate"
+    "CronDelete"
+    "CronList"
+  ];
 in {
   claude = {
     deniedToolPatterns =
       map (pattern: "Bash(${pattern})") protectedMergeCommandPatterns
       ++ lib.optionals exaSearchBaked exaSuperseded.claudeTools
-      ++ lib.optionals indexKernelBaked kernelClaudeTools;
+      ++ lib.optionals indexKernelBaked (kernelClaudeTools ++ claudeHouseDeniedTools);
   };
 
   codex = {

--- a/packages/agent/skills/merge-pr/SKILL.md
+++ b/packages/agent/skills/merge-pr/SKILL.md
@@ -18,7 +18,7 @@ Hand a PR's whole "watch CI → fix failures → merge" loop to a **background s
 
 3. **On the completion notification**, relay the outcome: merged (with commit), or stopped-stuck (with the failure it could not fix and why), or blocked (needs a human decision).
 
-Keep all CI watching inside the fork, and even there make it event-driven (see below). A foreground `gh pr checks --watch` / `gh run watch` in the main thread holds a Bash slot up to the 600s timeout and freezes the session, so route it through `run_in_background` + `Monitor` instead.
+Keep all CI watching inside the fork, and even there make it event-driven (see below). A foreground `gh pr checks --watch` / `gh run watch` in the main thread holds a Bash slot up to the 600s timeout and freezes the session, so route it through a harness-tracked background job instead.
 
 ## The fork's charter (paste into the subagent prompt)
 

--- a/packages/agent/system-prompt.nix
+++ b/packages/agent/system-prompt.nix
@@ -716,7 +716,8 @@ let
           Treat wall time as a first-class cost. Before launching an operation
           expected to run longer than about a minute, state its expected
           duration, and when other work can proceed meanwhile, run it in the
-          background with a monitor instead of foreground-blocking a tool slot.
+          background with a harness-tracked job instead of foreground-blocking a
+          tool slot.
           A blocking critical-path operation with nothing to parallelize may run
           foreground. Among strategies of equal rigor, pick the one that yields
           signal soonest.
@@ -724,7 +725,7 @@ let
         reason = ''
           Foreground-blocking on long operations idles the whole session. An
           agent foreground-waited a 600s Bash timeout on a long build instead of
-          backgrounding it with a log-tail monitor.
+          backgrounding it with an observable log-tail job.
         '';
       };
     }
@@ -757,9 +758,9 @@ let
           terminal state: success, failure, and disappearance of the thing
           watched, and must carry its own heartbeat or deadline so a stalled
           watcher is itself detected. Before ending a turn to wait, verify the
-          watch is actually alive: a harness-tracked background child or Monitor
-          running, its output growing. Receiving your own stop notification
-          means no watch survived, so re-arm one or proceed synchronously.
+          watch is actually alive: a harness-tracked background child running,
+          its output growing. Receiving your own stop notification means no
+          watch survived, so re-arm one or proceed synchronously.
           An armed ScheduleWakeup is such a watch: pending wakeups live only
           in harness memory and a session resume or user abort silently drops
           them, so on any later turn that still counts on one, re-verify or

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3904,6 +3904,10 @@
             "NotebookEdit"
             "Glob"
             "Grep"
+            "Monitor"
+            "CronCreate"
+            "CronDelete"
+            "CronList"
             "WebSearch"
             "WebFetch"
           ]


### PR DESCRIPTION
## Summary
- default Claude Code DISABLE feature envs from a feature-name list
- deny Monitor/Cron tools from Claude's managed tool surface
- remove Monitor guidance from agent prompt text

## Tests
- nix run nixpkgs#alejandra -- packages/agent/claude-code/default.nix packages/agent/claude-code/install-check.nix packages/agent/policy/permissions.nix packages/agent/system-prompt.nix
- nix build .#claude-code (running locally)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable Monitor and Cron tools in the Claude agent policy
> - Adds `Monitor`, `CronCreate`, `CronDelete`, and `CronList` to the denied tool patterns in [permissions.nix](https://github.com/indexable-inc/index/pull/2274/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) when `indexKernelBaked` is enabled.
> - Sets `CLAUDE_CODE_DISABLE_CRON=1` as a default env var alongside the existing `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` in [default.nix](https://github.com/indexable-inc/index/pull/2274/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), using a generated list to keep both consistent.
> - Replaces references to `Monitor` in the system prompt and merge-pr skill docs with guidance to use a harness-tracked background job instead.
> - Extends the install-check script to assert `CLAUDE_CODE_DISABLE_CRON` is present in `env_defaults` and that no `CLAUDE_CODE_DISABLE_*` keys appear under `env`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cd88a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->