### PR TITLE
friction-report: stop mining meta-sessions (extractor recursion, overseer ticks)

### DIFF
--- a/packages/agent/claude-hooks/src/friction.rs
+++ b/packages/agent/claude-hooks/src/friction.rs
@@ -344,6 +344,15 @@ fn ask_model(delta: &str, cwd: Option<&str>) -> Vec<Item> {
         "",
         "--setting-sources",
         "",
+        // The index claude-code wrapper injects `--settings <default-settings>`
+        // (Stop hooks included) whenever the caller passes no --settings, and
+        // --setting-sources does not filter that injected file. Without this
+        // override every extractor run is itself sliced by the Stop hooks and
+        // spawns another extractor: 84k recursive transcripts on hydra
+        // (index#2275). An explicit empty hooks object keeps the extractor
+        // session hook-free.
+        "--settings",
+        "{\"hooks\":{}}",
         "--strict-mcp-config",
         "--mcp-config",
         "{\"mcpServers\":{}}",
@@ -786,6 +795,18 @@ pub fn friction_report() {
     }
     let _ = fs::create_dir_all(state_dir());
 
+    // Meta-session filter (index#2275): headless judges run in mktemp scratch
+    // cwds (the symphony overseer tick, one-off summarizers). Their transcripts
+    // are role prompts and reports, not agent work, and mining them burned a
+    // model call per tick and filed noise. Deterministic skip, logged so the
+    // exclusion stays visible in friction.log.
+    if let Some(cwd) = payload.get("cwd").and_then(Value::as_str)
+        && is_scratch_cwd(cwd)
+    {
+        log(&format!("{session}: scratch cwd {cwd}, skipping meta-session"));
+        return;
+    }
+
     if std::env::var_os("FRICTION_FOREGROUND").is_some_and(|v| !v.is_empty()) {
         analyze(&payload);
         return;
@@ -804,6 +825,18 @@ fn read_stdin() -> Option<String> {
 /// component with no path separators, matching `os.path.basename(s) == s`.
 fn is_plain_component(s: &str) -> bool {
     Path::new(s).file_name().map(OsString::from) == Some(OsString::from(s))
+}
+
+/// True when the session's cwd lives in a throwaway temp location: `/tmp`, or
+/// the macOS per-user temp tree `/var/folders/<xx>/<hash>/T` (`$TMPDIR`).
+/// macOS aliases these under `/private`, and payloads carry either spelling,
+/// so the optional `/private` prefix is stripped before matching. Sessions
+/// there are headless meta-calls by construction, never mined for friction.
+fn is_scratch_cwd(cwd: &str) -> bool {
+    let path = cwd.strip_prefix("/private").unwrap_or(cwd);
+    path == "/tmp"
+        || path.starts_with("/tmp/")
+        || path.starts_with("/var/folders/")
 }
 
 /// Re-spawn THIS binary as `friction-report --analyze`, detached (new session,
@@ -862,7 +895,7 @@ fn set_new_session(cmd: &mut Command) {
 
 #[cfg(test)]
 mod tests {
-    use super::{compose_prompt, condense, normalize_title, parse_items};
+    use super::{compose_prompt, condense, is_scratch_cwd, normalize_title, parse_items};
 
     #[test]
     fn condense_claude_dialect() {
@@ -949,5 +982,24 @@ mod tests {
     fn parse_items_no_array() {
         assert!(parse_items("no brackets here").is_empty());
         assert!(parse_items("]backwards[").is_empty());
+    }
+
+    #[test]
+    fn scratch_cwd_detection() {
+        // overseer tick judge (index#2275): mktemp -d under the macOS user T dir
+        assert!(is_scratch_cwd(
+            "/private/var/folders/2z/yxvv26350y7cnj7w0q3p66mc0000gn/T/tmp.KGYPUmQMiV"
+        ));
+        assert!(is_scratch_cwd("/var/folders/2z/abc/T/tmp.x"));
+        assert!(is_scratch_cwd("/tmp"));
+        assert!(is_scratch_cwd("/tmp/scratch"));
+        assert!(is_scratch_cwd("/private/tmp/scratch"));
+        // real work cwds are never scratch
+        assert!(!is_scratch_cwd("/Users/andrewgazelka"));
+        assert!(!is_scratch_cwd("/Users/x/Projects/indexable-inc/index"));
+        assert!(!is_scratch_cwd("/home/user/tmp/repo"));
+        // similarly-named but distinct roots
+        assert!(!is_scratch_cwd("/tmpfs/work"));
+        assert!(!is_scratch_cwd("/var/folderstuff"));
     }
 }

--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -166,6 +166,10 @@ jq -n \
 # sandbox. The -p JSON envelope is checked before the reply is trusted:
 # an is_error envelope carries a partial .result (the 04:30Z truncation),
 # which must fail the tick with the envelope's own error.
+# --settings '{"hooks":{}}': the tick judge is a pure function call, not an
+# agent session. Without it the nix claude wrapper injects the default
+# settings (Stop hooks included), so every tick's meta-transcript was sliced
+# by the friction-report hook and fed to the extractor (index#2275).
 (
   cd "$workdir"
   env -u SLACK_BOT_OAUTH_TOKEN -u SLACK_SIGNING_SECRET \
@@ -174,6 +178,7 @@ jq -n \
     -u SYMPHONY_GITHUB_APP_PRIVATE_KEY_BASE64 -u SYMPHONY_ROOM_REGISTRY_TOKEN \
     claude -p --model fable --effort high \
     --allowedTools "" --output-format json \
+    --settings '{"hooks":{}}' \
     "$(cat "$prompt_file")
 
 Your notes from previous ticks:


### PR DESCRIPTION
Fixes #2275.

The friction-report extractor was mining meta-sessions:

- **Extractor recursion**: the extractor's own `claude -p` run inherited the wrapper-injected `--settings` (Stop hooks included), so every extractor session was itself sliced and spawned another extractor; 84,008 of 84,025 transcripts in the hydra `$HOME` project dir are extractor sessions. `--setting-sources ""` cannot filter the injected flag file, so the spawn now passes an explicit `--settings '{"hooks":{}}'` (the wrapper injects only `unless_present: --settings`).
- **Scratch-cwd meta sessions**: the symphony overseer tick judge runs in a `mktemp -d` cwd; its transcript is a role prompt plus digest and produced one wasted extractor call per 10-minute tick (22 confused refusals on 2026-07-07 alone, pre-#2240 fence). `friction_report` now skips payloads whose cwd is under `/tmp` or the macOS per-user `T` dir, logging each skip to `friction.log`, and `overseer.sh` gives the judge the same empty-hooks `--settings` so tick sessions never run Stop hooks at all.

Unit test added for the scratch-cwd matcher; `bash -n` passes on `overseer.sh`.

_Authored by an AI agent via Claude Code (Opus 4.5), dispatched by the overseer._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop friction reports from running during scratch-dir sessions and hook-spawned processes
> - Adds an `is_scratch_cwd` check in [`friction.rs`](https://github.com/indexable-inc/index/pull/2282/files#diff-fe250a9c7871a0c5ed6f2d35c985d21db58b58e112c24e1cbaddf0c55c90900b) that returns early when the payload `cwd` is a temp directory (`/tmp`, `/var/folders/`, etc.), preventing analysis of extractor recursion and other meta-sessions.
> - Passes `--settings '{"hooks":{}}'` to claude invocations in both [`friction.rs`](https://github.com/indexable-inc/index/pull/2282/files#diff-fe250a9c7871a0c5ed6f2d35c985d21db58b58e112c24e1cbaddf0c55c90900b) and [`overseer.sh`](https://github.com/indexable-inc/index/pull/2282/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) to suppress injected default hooks for these internal calls.
> - Behavioral Change: friction reports are now silently skipped for any session running from a scratch temp directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4fb4c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->