### PR TITLE
astlog/nix: flag escapeShellArgs-fed for loops (SC2043 deploy trap)

### DIFF
--- a/astlog-rules/nix-lints.md
+++ b/astlog-rules/nix-lints.md
@@ -2,7 +2,7 @@
 
 Complete reference for every house-style lint ASTLog enforces on Nix source in this
 repo. Generated from [`astlog-rules/nix.astlog`](./nix.astlog), the single source of
-truth. **94 lints total: 90 `error`, 4 `warning`.**
+truth. **99 lints total: 95 `error`, 4 `warning`.**
 
 ## How it works
 
@@ -1298,6 +1298,46 @@ xs: xs ++ [ ]
 
 ```nix
 xs: ys: xs ++ ys
+```
+
+</td></tr></table>
+
+### no-escapeshellargs-for-loop
+
+**🔴 error**
+
+`for <var> in ${lib.escapeShellArgs xs}` in a nix-rendered bash string iterates a
+nix-computed word list. When the list dedups/filters to a single element the loop
+renders as `for v in one-word`, which shellcheck flags SC2043 ("loop only runs
+once") and `writeBashApplication` treats as a fatal build error. Because the
+toplevel is only built by the deploy job, never PR CI, a single-element render
+turns `main` red after merge (ix#6688). Materialize the list into a bash array and
+iterate it: `xs=(${lib.escapeShellArgs xs}); for v in "${xs[@]}"` renders zero,
+one, or many elements uniformly and never trips SC2043.
+
+*Matches:* `string_expression` / `indented_string_expression` · *predicates:* `text-match` · *2 pattern variants*
+
+<table><tr><th>flagged</th><th>ok</th></tr><tr><td>
+
+```nix
+{ lib, names }:
+''
+  for name in ${lib.escapeShellArgs names}; do
+    echo "$name"
+  done
+''
+```
+
+</td><td>
+
+```nix
+{ lib, names }:
+''
+  script_names=(${lib.escapeShellArgs names})
+  for name in "${script_names[@]}"; do
+    echo "$name"
+  done
+''
 ```
 
 </td></tr></table>

--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -255,6 +255,40 @@
 (lint no-empty-list-concat error
   "`[ ] ++ X` and `X ++ [ ]` are no-ops; drop the empty operand")
 
+;; no-escapeshellargs-for-loop: `for <var> in ${lib.escapeShellArgs xs}` in a
+;; nix-rendered bash string iterates a word list that is nix-computed, so when
+;; the list dedups/filters to a single element the loop renders as
+;; `for v in one-word`, which shellcheck flags SC2043 ("loop only runs once")
+;; and `writeBashApplication` treats as a fatal build error. This surfaces only
+;; when the toplevel is built (deploy job), never in PR CI, so a single-element
+;; render turns main red after merge (ix#6688). Materialize the list into a bash
+;; array and iterate it: `xs=(${lib.escapeShellArgs xs}); for v in "''${xs[@]}"`
+;; renders zero, one, or many elements uniformly and never trips SC2043. The
+;; preceding string fragment is the `... for <var> in ` text; the interpolation
+;; is the escapeShellArgs call.
+(rule (no-escapeshellargs-for-loop n frag f)
+  (match nix "
+    (string_expression
+      (string_fragment) @frag
+      .
+      (interpolation
+        expression: (apply_expression
+          function: [(variable_expression) (select_expression)] @f)) @n)")
+  (text-match f "^(lib\\.)?escapeShellArgs$")
+  (text-match frag "(^|[^A-Za-z0-9_])for[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]+in[ \t]*$"))
+(rule (no-escapeshellargs-for-loop n frag f)
+  (match nix "
+    (indented_string_expression
+      (string_fragment) @frag
+      .
+      (interpolation
+        expression: (apply_expression
+          function: [(variable_expression) (select_expression)] @f)) @n)")
+  (text-match f "^(lib\\.)?escapeShellArgs$")
+  (text-match frag "(^|[^A-Za-z0-9_])for[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]+in[ \t]*$"))
+(lint no-escapeshellargs-for-loop error
+  "`for <var> in ${{lib.escapeShellArgs xs}}` trips shellcheck SC2043 when the nix-computed list renders single-element, failing writeBashApplication only at deploy time; materialize a bash array (`xs=(${{lib.escapeShellArgs xs}}); for v in \"${{xs[@]}}\"`) so zero/one/many elements iterate uniformly")
+
 ;; no-fake-hash: Fake hashes are banned. Compute the real SRI hash before
 ;; editing tracked Nix files.
 (rule (no-fake-hash n)

--- a/astlog-rules/tests/no-escapeshellargs-for-loop/bad.fixture
+++ b/astlog-rules/tests/no-escapeshellargs-for-loop/bad.fixture
@@ -1,0 +1,6 @@
+{ lib, names }:
+''
+  for name in ${lib.escapeShellArgs names}; do
+    echo "$name"
+  done
+''

--- a/astlog-rules/tests/no-escapeshellargs-for-loop/good.fixture
+++ b/astlog-rules/tests/no-escapeshellargs-for-loop/good.fixture
@@ -1,0 +1,7 @@
+{ lib, names }:
+''
+  script_names=(${lib.escapeShellArgs names})
+  for name in "''${script_names[@]}"; do
+    echo "$name"
+  done
+''


### PR DESCRIPTION
## What

Adds the `no-escapeshellargs-for-loop` astlog rule to `astlog-rules/nix.astlog`, flagging `for <var> in ${lib.escapeShellArgs xs}` inside nix-rendered bash strings.

## Why

Consumed by ix ([indexable-inc/ix#6688](https://github.com/indexable-inc/ix/issues/6688)). Such a loop iterates a nix-computed word list. When the list dedups/filters to a single element it renders as `for v in one-word`, which shellcheck flags SC2043 ("loop only runs once") and `writeBashApplication` treats as a fatal build error. The colmenaHive toplevels carrying these scripts are only built by the deploy job, never PR CI, so a single-element render turns `main` red *after merge* — ix#6688 documents regional-status going red for ~2h until the array idiom fix landed. The array idiom (`xs=(${lib.escapeShellArgs xs}); for v in "${xs[@]}"`) iterates zero/one/many uniformly and never trips SC2043.

## How

The rule binds the interpolation together with the preceding `for <var> in ` string fragment via tree-sitter's sibling anchor (same technique as `no-root-string-interp`), across both `string_expression` and `indented_string_expression`. The array idiom does not match (its preceding fragment ends in `xs=(`), so it is the clean suggested fix.

Verified against the ix tree, the rule catches exactly the 5 remaining `escapeShellArgs`-fed `for` loops there (including a sibling loop in the very file the ix#6688 point-fix touched), with no false positives on array-idiom or `while`/`until` loops.

## Validation

- `nix run .#lint` passes clean (`astlog succeeded`, `alejandra succeeded`) — the rule loads and flags nothing in this repo.
- astlog-rules self-test logic passes: `bad.fixture` fires 1 finding, `good.fixture` fires 0, fixture dir backs the lint.
- Ships the required `astlog-rules/tests/no-escapeshellargs-for-loop/{good,bad}.fixture` pair and a `nix-lints.md` entry.

Filed and implemented by an AI agent (Claude Code, Opus 4.8).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `no-escapeshellargs-for-loop` lint to flag `for x in ${lib.escapeShellArgs ...}` in Nix strings
> Adds a new error-level lint rule to [nix.astlog](https://github.com/indexable-inc/index/pull/2287/files#diff-de5bc8426aac324b41bb80bf1cfa277c527b5423c78e6e4767189c3b0330cc60) that detects the SC2043-style trap where `lib.escapeShellArgs` is used directly in a Bash `for` loop interpolation inside a Nix string. The fix pattern is to materialize a Bash array first and iterate with `"${array[@]}"`.
>
> - Covers both `string_expression` and `indented_string_expression` forms.
> - Adds test fixtures for both the flagged and accepted patterns.
> - Brings the total lint count from 94 to 99.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17666c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->