### PR TITLE
overseer: record the real dispatch handle, join fixer tracking on it

### DIFF
--- a/packages/agent/symphony/workflows/indexable/prompts/overseer.md
+++ b/packages/agent/symphony/workflows/indexable/prompts/overseer.md
@@ -66,3 +66,14 @@ earlier ticks appear as claude sessions whose user brief begins
 never re-diagnose their existence as a new problem. Likewise a
 session at age_min 0 with empty last text has just started; that is
 not evidence of a silent or stuck agent.
+
+Your notes may end with a DISPATCH LEDGER block. The runtime writes
+it, not you: every fixer dispatch is recorded there mechanically with
+its exact agent label and spawned session id, regenerated each tick
+from the runtime's own records. Track dispatched fixers ONLY by
+joining those handles against the snapshot. Never restate or invent a
+dispatch label in the notes you author (a restated label once diverged
+from the real one and the running fixer was declared "never
+materialized", triggering a duplicate dispatch), and never report a
+fixer missing while a session matching a ledger handle exists. Do not
+copy the ledger into your notes; the runtime re-appends it.

--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -223,16 +223,41 @@ while IFS=$'\t' read -r key title action; do
   # cwd (the pack dir), so their sessions showed up in later snapshots as
   # claude sessions inside workflows/indexable and the judge re-diagnosed
   # its own just-spawned fixers as a silent workflow agent (index#2188).
+  session=""
   if out="$(cd "$HOME" && "$HOME/.local/bin/claude" --bg -p "You are $agent_name, dispatched by the overseer. Problem: $title. Suggested action: $action. Investigate, fix it properly (worktree + PR when it is a repo change), and report." </dev/null 2>&1)"; then
-    note="dispatched $agent_name"
+    # `claude --bg` prints "backgrounded · <session-id>". That id plus the
+    # exact $agent_name label IS the dispatch handle; record it verbatim.
+    # Tick-time tracking joins on this recorded handle, never on a label
+    # the judge restates in its own notes: a self-invented label was
+    # declared "never materialized" for two ticks while the real fixer
+    # ran and finished, and a duplicate was dispatched (index#2288).
+    session="$(printf '%s\n' "$out" | awk '/backgrounded/ {print $NF; exit}')"
+    note="dispatched $agent_name session=${session:-unknown}"
   else
     note="dispatch failed: $(printf '%s' "$out" | head -c 120)"
   fi
   jq --arg k "$key" --argjson at "$now_epoch" --arg note "$note" \
-    '.[$k] = {at: $at, note: $note}' "$dispatched" > "$dispatched.tmp"
+    --arg agent "$agent_name" --arg session "$session" \
+    '.[$k] = {at: $at, note: $note, agent: $agent,
+              session: (if $session == "" then null else $session end)}' \
+    "$dispatched" > "$dispatched.tmp"
   mv "$dispatched.tmp" "$dispatched"
 done < <(jq -r '.attention[]? | select(.severity == "fix")
   | [(.title | ascii_downcase | gsub("[^a-z0-9]+"; "-")), .title, .action] | @tsv' "$report_file")
+
+# Append the dispatch ledger to the notes mechanically. The notes are
+# otherwise model-authored, and a restated label drifts (index#2288), so
+# the authoritative handles (exact label + spawned session id) are
+# re-derived from dispatched.json on every tick and appended after the
+# judge's own text; the next tick joins fixer tracking on these handles.
+ledger="$(jq -r --argjson now "$now_epoch" '
+  to_entries
+  | map(select($now - .value.at < 86400))
+  | sort_by(-.value.at)
+  | .[] | "- \(.value.at | todate) \(.value.note) [key: \(.key)]"' "$dispatched")"
+if [ -n "$ledger" ]; then
+  printf '\n\nDISPATCH LEDGER (machine-written by overseer.sh; the authoritative record of dispatched fixers -- do not restate):\n%s\n' "$ledger" >> "$notes"
+fi
 
 # fold the dispatch notes into the report the page renders
 jq --slurpfile d "$dispatched" '.attention = [.attention[]?


### PR DESCRIPTION
## Problem

The overseer tracked dispatched fixers by whatever label the judge restated in its own tick notes. On 2026-07-07 the real dispatch created session `6096b6b1` as `overseer-fix-nwm-serve-pa`, the notes said `DISPATCHED THIS TICK: overseer-fix-nwm-serve-resume`, and two ticks later the phantom label was declared "never materialized" and a duplicate fixer was dispatched. Fixes #2288.

## Change

- `overseer.sh`: parse the spawned session id from the `claude --bg` reply (`backgrounded · <id>`) and persist `{agent, session}` alongside the note in `dispatched.json`.
- `overseer.sh`: append a machine-written `DISPATCH LEDGER` block to the persisted notes on every tick, re-derived from `dispatched.json` (24h window), so the judge always sees the exact label + session id regardless of what it wrote itself.
- `prompts/overseer.md`: instruct the judge to join fixer tracking on the ledger handles, never author its own dispatch bookkeeping, and never report a fixer missing while a ledger handle matches a session.

## Validation

- `bash -n` + shellcheck (no new findings; only pre-existing info-level SC2012/SC2016).
- Simulated the loop end to end with a faked `--bg` reply: handle recorded (`agent`/`session` fields), legacy old-schema entries and the >24h window filtered, failure branch stores `session: null`, empty ledger appends nothing.
- `nix run .#lint`: 8/8 succeeded.

Filed and fixed by an AI agent (Claude Code) via the `issue-2288-dispatch-handle` background session.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record spawned session id per dispatch and append a machine-written DISPATCH LEDGER to overseer notes
> - The dispatch loop in [overseer.sh](https://github.com/indexable-inc/index/pull/2289/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) now captures the background session id from `claude --bg` output and stores it alongside the agent label in `dispatched.json`, extending the record from `{at, note}` to `{at, note, agent, session}`.
> - After the dispatch loop, the script appends a machine-written `DISPATCH LEDGER` block to the notes file, summarising recent dispatches (last 86400s) sorted by recency.
> - [overseer.md](https://github.com/indexable-inc/index/pull/2289/files#diff-a31238dc4da0ac6135c3a356d95617447fdd3dec34a3f7a3c6f51b07e0fa4fc0) instructs the overseer to track fixers by joining ledger handles against the snapshot rather than restating or inventing dispatch labels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f395f86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->