### PR TITLE
overseer: unwrap a code-fenced judge reply before the strict parse

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -195,6 +195,11 @@ $(cat "$snap")" </dev/null > "$last_msg.envelope"
 report_file="$(mktemp)"
 tr -d '\000-\010\013\014\016-\037' < "$last_msg" > "$last_msg.clean"
 mv "$last_msg.clean" "$last_msg"
+# Models sporadically fence the JSON despite the prompt (2026-07-08 00:10Z
+# rejected reply was exactly that); unwrap one fence pair, stay strict
+# about everything inside it.
+sed -e '1{/^```[a-z]*$/d;}' -e '${/^```$/d;}' "$last_msg" > "$last_msg.unfenced"
+mv "$last_msg.unfenced" "$last_msg"
 # On a bad reply, keep the raw bytes as evidence before failing loudly.
 if ! jq -e . "$last_msg" > /dev/null 2>&1; then
   cp "$last_msg" "$state_dir/last-reply.rejected"


### PR DESCRIPTION
The 00:10Z tick failure was fable fencing its JSON despite the prompt; the rejected-reply evidence path (from #2181) captured it, and the fix is verified against those exact bytes: strip one leading/trailing fence line, keep the parse strict inside. Part of #2139. (PR by an AI agent via Claude Code.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip markdown code fences from judge reply before JSON validation in `overseer.sh`
> The [overseer.sh](https://github.com/indexable-inc/index/pull/2314/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) script now strips a single surrounding markdown code fence (e.g. ` ```json ` / ` ``` `) from the model reply before running `jq` validation. A `sed` step writes the unfenced content to a temporary file and replaces the original `last_msg`, allowing fenced JSON replies to pass validation instead of being rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce5df58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->