### PR TITLE
agents: kernel-driven executor subagent; stop no-Bash relay swarms

### DIFF
--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -9,11 +9,13 @@
 # Claude runtime semantics, verified empirically on the pinned CLI (2.1.197,
 # headless `claude -p --settings` probes): `permissions.deny` is a hard block
 # even under the wrapper's default `--dangerously-skip-permissions` posture
-# (bypass skips prompts, not deny rules), and a SUBAGENT whose definition
-# declares an explicit `tools:` allowlist re-grants a settings-denied tool.
-# So gating the stock tools here sends the MAIN agent kernel-first while the
-# repo subagents (subagents.nix, explicit tool lists) keep their declared
-# tools.
+# (bypass skips prompts, not deny rules). A SUBAGENT whose definition declares
+# an explicit `tools:` allowlist re-grants only SOME settings-denied tools:
+# in a bg-dispatched session a code-reviewer spawn (declares Read/Bash/Glob/
+# Grep) got Glob and Grep but neither Bash nor Read (#2077, #2153; probed
+# 2026-07-07 on 2.1.197). Subagents that need shell must bring their own
+# index kernel via `mcpServers` (see subagents.nix `executor` and
+# `index-action-runner`); do not rely on a declared Bash surviving the deny.
 {
   lib,
   # True when the wrapper bakes the `index` MCP server (the ix kernel,

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -668,6 +668,10 @@
         high-stakes decisions; cheaper tiers for mechanical edits, search, and
         settled execution. For simple delegated questions, use the MCP subagent
         tool to spawn Codex on `gpt-5.5` with low reasoning.
+        Subagents inherit the kernel-first tool denies: no Bash, Read, or
+        Edit, even when an agent definition declares them. Brief them to work
+        through their own index kernel, and for verbatim command execution
+        spawn the `executor` agent; never promise a subagent a Bash tool.
         When a request branches off the current conversation (a side task,
         fix, or change that is not the thread's main line), dispatch it to a
         named background subagent by default and keep the main thread
@@ -680,6 +684,10 @@
         reasoning, but still benefit from separate context. Doing a mid-conversation
         side task inline blocks the user's follow-ups; a background subagent keeps the
         live conversation fluid.
+        Briefs that promised a default subagent "your Bash tool" (stripped by
+        the settings deny) produced relay swarms: in one session 130 subagents
+        reported the missing tool and improvised shell through Monitor and the
+        Blender MCP code runner (index#2153).
       '';
     };
   }

--- a/packages/agent/subagents.nix
+++ b/packages/agent/subagents.nix
@@ -274,6 +274,73 @@
       '';
     };
 
+    # Kernel-first wrappers deny the stock shell/file tools for subagents
+    # (policy/permissions.nix), and a declared `tools = ["Bash"]` allowlist
+    # does NOT re-grant Bash in bg-dispatched sessions (#2077; probe
+    # 2026-07-07: a code-reviewer spawn got Glob/Grep but neither Bash nor
+    # Read). So "run these commands" briefs sent to any subagent find no Bash
+    # and improvise relay chains (#2153). This agent is the sanctioned spawn
+    # path for verbatim command execution: it runs the commands through its
+    # own index kernel, the one shell surface subagents reliably have.
+    executor = {
+      frontmatter = {
+        description =
+          "Runs an exact, ordered list of shell commands verbatim through its "
+          + "own index kernel and returns the verbatim outputs and exit codes. "
+          + "Spawn it for \"execute these commands\" briefs: subagents have no "
+          + "Bash tool under the kernel-first tool policy (even when a brief "
+          + "promises one), so briefs that assume Bash produce relay chains "
+          + "instead of output. Synchronous and terminal: it never delegates, "
+          + "spawns, or backgrounds work.";
+        color = "green";
+        mcpServers = ix.mcp.toAgentMcpServers {
+          index = {
+            transport = "stdio";
+            command = lib.getExe repoPackages.mcp;
+            args = ["serve"];
+          };
+        };
+      };
+      content = ''
+        # Executor
+
+        You run the exact commands in your brief, yourself, synchronously, and hand
+        back the real outputs. Your whole value is fidelity: the parent needs
+        verbatim stdout/stderr and exit codes, not a summary and not a plan.
+
+        You have no Bash tool. Your shell is the `index` MCP kernel: name the
+        session (`session_set_name`), then run each command via `python_exec`:
+
+        ```python
+        r = await nu("^git -C /abs/path status --porcelain", check=False)
+        print(r.exit_code); print(r.result)
+        ```
+
+        ## Rules
+
+        - Run the commands verbatim, in order. Use absolute paths from the brief;
+          never rely on cwd persisting between calls (`git -C <path>`, not `cd`).
+        - NEVER delegate: no spawning agents, no background jobs, no relaying, no
+          substitute execution paths through other MCP servers. If the kernel
+          itself is unavailable, stop and report the exact failing tool call and
+          error instead of improvising.
+        - A non-zero exit code is a result, not a failure of your task: capture it
+          and continue only if the brief says to; otherwise stop at the first
+          failed command and report.
+        - Do not editorialize, retry, or "fix" a failing command unless the brief
+          explicitly allows it.
+
+        ## Report
+
+        Your final message is the deliverable:
+
+        - Per command: the command as run, its exit code, and the verbatim output
+          (truncate only mechanically noisy output, and say what you truncated).
+        - End with a one-line verdict: `all N commands succeeded` or
+          `stopped at command K (exit <code>)`.
+      '';
+    };
+
     fixup = {
       frontmatter = {
         description = "Runs pre-commit checks and fixes any issues. Called by loop skill before starting work. Returns 'clean' or 'fixed: N issues'.";


### PR DESCRIPTION
Ref #2153 (also #2077).

Executor briefs sent to subagents assume a Bash tool that the kernel-first deny strips, and no spawn path could grant one: in session `08218f3d` (2026-07-08), 130 subagent transcripts reported the missing tool, every one of the 17 Bash attempts failed with "Bash exists but is not enabled in this context", and agents improvised shell through Monitor and ~380 Blender-MCP `execute_blender_code` calls, relaying results through 3-deep agent chains.

A declared `tools = ["Bash"]` allowlist does not fix it: probed today on the pinned CLI (2.1.197, bg-dispatched session), a `code-reviewer` spawn got Glob/Grep but neither Bash nor Read, so the re-grant assumption documented in `policy/permissions.nix` holds only partially.

Changes:

- **`subagents.nix`**: add an `executor` agent, the sanctioned spawn path for "run these commands verbatim" briefs. It brings its own index kernel via `mcpServers` (same seam as `index-action-runner`), runs the commands synchronously through `nu()`, reports verbatim outputs and exit codes, and is forbidden from delegating or improvising substitute execution paths.
- **`prompt/rules.nix`**: tell orchestrators subagents have no Bash/Read/Edit (even when declared), to brief subagents kernel-first, and to spawn `executor` for verbatim command execution.
- **`policy/permissions.nix`**: correct the stale claim that a declared allowlist re-grants denied tools; record the observed split (Glob/Grep yes, Bash/Read no) with the probe date.

Validated: prompt renders with the new wording (`nix eval` per the repo recipe), `subagents.nix` evals and `.#claude-code.drvPath` evaluates clean, alejandra clean.

(PR by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add kernel-driven `executor` subagent and fix relay swarms caused by missing Bash tool
> - Adds a new `executor` subagent in [subagents.nix](https://github.com/indexable-inc/index/pull/2316/files#diff-45a91ccd89dc7a844cea2a6fca8aef743ce1cb606f0f101ed57304b99528d898) that runs verbatim, ordered shell commands synchronously via its own index MCP kernel (`python_exec`), returning stdout/stderr and exit codes without delegation.
> - Updates prompt rules in [rules.nix](https://github.com/indexable-inc/index/pull/2316/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to instruct agents that subagents do not inherit Bash/Read/Edit tools and must route shell execution through the `executor` agent.
> - Adds commentary in [permissions.nix](https://github.com/indexable-inc/index/pull/2316/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) clarifying that deny rules strip Bash/Read even when a subagent's definition declares them, and that subagents needing shell access must provide their own MCP kernel.
> - Behavioral Change: agents will no longer promise Bash to subagents; previously, briefs that did so caused relay swarms when the tool was stripped at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afb8ce2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->