### PR TITLE
claude-code: default off costly system tools

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -117,6 +117,10 @@ wrapper injects its defaults file only `unless_present` a caller `--settings`
 - `permissions.deny` `WebSearch` / `WebFetch`: one web surface, not two; use
   Exa MCP for live web research. Deny rules are enforced in every
   permission mode.
+- `permissions.deny` for `systemTools`: the `defaultSystemTools` table in
+  `default.nix` is the source of truth for Claude Code orchestration and
+  hosted-service tool posture. Override with
+  `systemTools.<ToolName> = "enabled"` when that surface earns its context cost.
 - `hooks` (below).
 
 ### MCP servers (`--mcp-config`, `default.nix:90-94`, `295-297`)
@@ -171,8 +175,8 @@ and on Linux the sandbox helpers `bubblewrap` and `socat`.
 ## Overrides
 
 `default.nix` exposes these args: `binName` (default `claude`),
-`dangerouslySkipPermissions`, `extraSettings`, `primaryCheckouts`, `mcpServers`,
-`systemPrompt`. Example: `claude-code.override { dangerouslySkipPermissions = false; }`.
+`dangerouslySkipPermissions`, `extraSettings`, `systemTools`, `primaryCheckouts`,
+`mcpServers`, `systemPrompt`. Example: `claude-code.override { systemTools.AskUserQuestion = "enabled"; }`.
 
 ## Build and wiring
 

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -38,6 +38,14 @@
   # never occupies (or symlinks) the writable settings.json the CLI churns at
   # runtime. `{ }` (default) ships only the computed defaults.
   extraSettings ? {},
+  # Claude Code built-in orchestration and hosted-service tool posture. Values
+  # are explicit strings, not booleans, so a review reads as "tool -> state" and
+  # adding a new controlled tool requires choosing `enabled` or `disabled` in
+  # `defaultSystemTools` below. Disabled entries render as bare tool names in
+  # settings `permissions.deny`, which removes the tool from Claude's available
+  # tool set. Core shell/file/search tools stay in sharedPermissions because
+  # their defaults depend on which MCP replacements the wrapper bakes.
+  systemTools ? {},
   # Directories baked into the wrapper as `--add-dir=<dir>` flags, one per entry.
   # `--add-dir` grants tool file-access to a directory, AND (the reason this arg
   # exists) Claude Code loads any `<dir>/.claude/skills/` and `<dir>/CLAUDE.md`
@@ -214,6 +222,47 @@
     map (name: "CLAUDE_CODE_DISABLE_${name}") claudeCodeDisabledFeatureDefaults
   ) (_: 1);
 
+  systemToolStates = [
+    "enabled"
+    "disabled"
+  ];
+  defaultSystemTools = {
+    Agent = "enabled";
+    Artifact = "enabled";
+    AskUserQuestion = "disabled";
+    DesignSync = "disabled";
+    EnterPlanMode = "disabled";
+    EnterWorktree = "disabled";
+    ExitPlanMode = "disabled";
+    ExitWorktree = "disabled";
+    PushNotification = "disabled";
+    RemoteTrigger = "enabled";
+    ReportFindings = "disabled";
+    ScheduleWakeup = "enabled";
+    SendMessage = "enabled";
+    SendUserFile = "enabled";
+    ShareOnboardingGuide = "enabled";
+    Skill = "enabled";
+    TaskCreate = "enabled";
+    TaskGet = "enabled";
+    TaskList = "enabled";
+    TaskOutput = "enabled";
+    TaskStop = "enabled";
+    TaskUpdate = "enabled";
+    ToolSearch = "enabled";
+    WaitForMcpServers = "enabled";
+    Workflow = "enabled";
+  };
+  unknownSystemTools = lib.subtractLists (builtins.attrNames defaultSystemTools) (builtins.attrNames systemTools);
+  invalidSystemTools = lib.filterAttrs (_: state: !(builtins.elem state systemToolStates)) systemTools;
+  effectiveSystemTools =
+    if unknownSystemTools != []
+    then throw "claude-code.systemTools: unknown tool(s): ${lib.concatStringsSep ", " unknownSystemTools}"
+    else if invalidSystemTools != {}
+    then throw "claude-code.systemTools: states must be one of ${lib.concatStringsSep ", " systemToolStates}"
+    else defaultSystemTools // systemTools;
+  disabledSystemTools = builtins.attrNames (lib.filterAttrs (_: state: state == "disabled") effectiveSystemTools);
+
   # Settings defaults are injected only when the caller passed no `--settings`;
   # Claude treats repeated settings flags as first-wins.
 
@@ -270,7 +319,11 @@
         };
       permissions = {
         # Concatenate manually: deepMerge treats lists as leaves.
-        deny = (extraSettings.permissions.deny or []) ++ sharedPermissions.claude.deniedToolPatterns;
+        deny = lib.unique (
+          (extraSettings.permissions.deny or [])
+          ++ disabledSystemTools
+          ++ sharedPermissions.claude.deniedToolPatterns
+        );
       };
       # Full Claude hook set rendered from shared agent policy.
       hooks = sharedHooks.claude;
@@ -482,6 +535,7 @@ in
         launchSpec
         settingsDefaultsFile
         wrapperFlags
+        disabledSystemTools
         python3
         binName
         ;

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -18,6 +18,7 @@
   launchSpec,
   settingsDefaultsFile,
   wrapperFlags,
+  disabledSystemTools,
   python3,
   binName,
 }: ''
@@ -62,6 +63,16 @@
     }
     check_env_default CLAUDE_CODE_DISABLE_1M_CONTEXT
     check_env_default CLAUDE_CODE_DISABLE_CRON
+
+    disabled_system_tools=(${lib.escapeShellArgs disabledSystemTools})
+    for tool in "''${disabled_system_tools[@]}"
+    do
+      if ! ${lib.getExe jq} -e --arg tool "$tool" '.permissions.deny | index($tool)' \
+        ${settingsDefaultsFile} >/dev/null; then
+        printf 'system tool deny check failed: %s is not denied in settings defaults\n' "$tool" >&2
+        exit 1
+      fi
+    done
 
     if ${lib.getExe jq} -e \
       '.env[] | select(.key == "CLAUDE_CODE_DISABLE_1M_CONTEXT" or .key == "CLAUDE_CODE_DISABLE_CRON")' \

--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -38,6 +38,7 @@
         dangerouslySkipPermissions
         personalStartupContext
         primaryCheckouts
+        systemTools
         ;
       # The index plugin (skills as `/index:<skill>`) rides the wrapper's
       # `--plugin-dir` layer ahead of any user-specified plugin dirs.
@@ -74,6 +75,23 @@ in {
       type = lib.types.bool;
       default = true;
       description = "Bake Claude Code's bypass-permissions flag into the wrapper.";
+    };
+
+    systemTools = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.enum [
+        "enabled"
+        "disabled"
+      ]);
+      default = {};
+      example = {
+        AskUserQuestion = "enabled";
+        DesignSync = "enabled";
+      };
+      description = ''
+        Overrides for Claude Code built-in orchestration and hosted-service
+        tools. Tool names must be present in the wrapper's defaultSystemTools
+        table, and values must be `enabled` or `disabled`.
+      '';
     };
 
     addDirs = lib.mkOption {


### PR DESCRIPTION
## Summary
- Add explicit `systemTools` posture for Claude Code orchestration and hosted-service tools.
- Default off `AskUserQuestion`, `DesignSync`, plan mode, worktree switching, `PushNotification`, and `ReportFindings` by rendering them into `permissions.deny`.
- Expose the same override through the Home Manager module and validate the generated settings in the package install check.

## Validation
- `nix build .#claude-code`
- built `claude-code-default-settings.json` contains the disabled tools in `permissions.deny`
- `nix run .#lint`

Refs #2322

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default costly system tools to disabled in claude-code derivation
> - Introduces a `systemTools` argument to the [claude-code derivation](https://github.com/indexable-inc/index/pull/2330/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) and [home-manager module](https://github.com/indexable-inc/index/pull/2330/files#diff-b941f4c92dd8de3d70290f80abe17e83e8710287c6a7430cad3d5f1c81cdbdab) for controlling built-in tool states (enabled/disabled), with a `defaultSystemTools` table as the source of truth.
> - Tools resolved as disabled are automatically added to `permissions.deny` in the generated settings; duplicate deny entries are de-duplicated via `lib.unique`.
> - Build fails with an error if `systemTools` contains unknown tool names or invalid state values.
> - Adds a validation loop in [install-check.nix](https://github.com/indexable-inc/index/pull/2330/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) that asserts every disabled tool appears in the settings file's `permissions.deny`.
> - Behavioral Change: system tools that are off by default will now be denied in settings without any explicit user configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61b8a28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->