### PR TITLE
claude-code: use booleans for systemTools

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -120,7 +120,7 @@ wrapper injects its defaults file only `unless_present` a caller `--settings`
 - `permissions.deny` for `systemTools`: the `defaultSystemTools` table in
   `default.nix` is the source of truth for Claude Code orchestration and
   hosted-service tool posture. Override with
-  `systemTools.<ToolName> = "enabled"` when that surface earns its context cost.
+  `systemTools.<ToolName> = true` when that surface earns its context cost.
 - `hooks` (below).
 
 ### MCP servers (`--mcp-config`, `default.nix:90-94`, `295-297`)
@@ -176,7 +176,7 @@ and on Linux the sandbox helpers `bubblewrap` and `socat`.
 
 `default.nix` exposes these args: `binName` (default `claude`),
 `dangerouslySkipPermissions`, `extraSettings`, `systemTools`, `primaryCheckouts`,
-`mcpServers`, `systemPrompt`. Example: `claude-code.override { systemTools.AskUserQuestion = "enabled"; }`.
+`mcpServers`, `systemPrompt`. Example: `claude-code.override { systemTools.AskUserQuestion = true; }`.
 
 ## Build and wiring
 

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -38,11 +38,9 @@
   # never occupies (or symlinks) the writable settings.json the CLI churns at
   # runtime. `{ }` (default) ships only the computed defaults.
   extraSettings ? {},
-  # Claude Code built-in orchestration and hosted-service tool posture. Values
-  # are explicit strings, not booleans, so a review reads as "tool -> state" and
-  # adding a new controlled tool requires choosing `enabled` or `disabled` in
-  # `defaultSystemTools` below. Disabled entries render as bare tool names in
-  # settings `permissions.deny`, which removes the tool from Claude's available
+  # Claude Code built-in orchestration and hosted-service tool posture. True
+  # means Claude sees the tool; false renders the bare tool name into settings
+  # `permissions.deny`, which removes the tool from Claude's available
   # tool set. Core shell/file/search tools stay in sharedPermissions because
   # their defaults depend on which MCP replacements the wrapper bakes.
   systemTools ? {},
@@ -222,46 +220,39 @@
     map (name: "CLAUDE_CODE_DISABLE_${name}") claudeCodeDisabledFeatureDefaults
   ) (_: 1);
 
-  systemToolStates = [
-    "enabled"
-    "disabled"
-  ];
   defaultSystemTools = {
-    Agent = "enabled";
-    Artifact = "enabled";
-    AskUserQuestion = "disabled";
-    DesignSync = "disabled";
-    EnterPlanMode = "disabled";
-    EnterWorktree = "disabled";
-    ExitPlanMode = "disabled";
-    ExitWorktree = "disabled";
-    PushNotification = "disabled";
-    RemoteTrigger = "enabled";
-    ReportFindings = "disabled";
-    ScheduleWakeup = "enabled";
-    SendMessage = "enabled";
-    SendUserFile = "enabled";
-    ShareOnboardingGuide = "enabled";
-    Skill = "enabled";
-    TaskCreate = "enabled";
-    TaskGet = "enabled";
-    TaskList = "enabled";
-    TaskOutput = "enabled";
-    TaskStop = "enabled";
-    TaskUpdate = "enabled";
-    ToolSearch = "enabled";
-    WaitForMcpServers = "enabled";
-    Workflow = "enabled";
+    Agent = true;
+    Artifact = true;
+    AskUserQuestion = false;
+    DesignSync = false;
+    EnterPlanMode = false;
+    EnterWorktree = false;
+    ExitPlanMode = false;
+    ExitWorktree = false;
+    PushNotification = false;
+    RemoteTrigger = true;
+    ReportFindings = false;
+    ScheduleWakeup = true;
+    SendMessage = true;
+    SendUserFile = true;
+    ShareOnboardingGuide = true;
+    Skill = true;
+    TaskCreate = true;
+    TaskGet = true;
+    TaskList = true;
+    TaskOutput = true;
+    TaskStop = true;
+    TaskUpdate = true;
+    ToolSearch = true;
+    WaitForMcpServers = true;
+    Workflow = true;
   };
   unknownSystemTools = lib.subtractLists (builtins.attrNames defaultSystemTools) (builtins.attrNames systemTools);
-  invalidSystemTools = lib.filterAttrs (_: state: !(builtins.elem state systemToolStates)) systemTools;
   effectiveSystemTools =
     if unknownSystemTools != []
     then throw "claude-code.systemTools: unknown tool(s): ${lib.concatStringsSep ", " unknownSystemTools}"
-    else if invalidSystemTools != {}
-    then throw "claude-code.systemTools: states must be one of ${lib.concatStringsSep ", " systemToolStates}"
     else defaultSystemTools // systemTools;
-  disabledSystemTools = builtins.attrNames (lib.filterAttrs (_: state: state == "disabled") effectiveSystemTools);
+  disabledSystemTools = builtins.attrNames (lib.filterAttrs (_: enabled: !enabled) effectiveSystemTools);
 
   # Settings defaults are injected only when the caller passed no `--settings`;
   # Claude treats repeated settings flags as first-wins.

--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -78,19 +78,16 @@ in {
     };
 
     systemTools = lib.mkOption {
-      type = lib.types.attrsOf (lib.types.enum [
-        "enabled"
-        "disabled"
-      ]);
+      type = lib.types.attrsOf lib.types.bool;
       default = {};
       example = {
-        AskUserQuestion = "enabled";
-        DesignSync = "enabled";
+        AskUserQuestion = true;
+        DesignSync = true;
       };
       description = ''
         Overrides for Claude Code built-in orchestration and hosted-service
         tools. Tool names must be present in the wrapper's defaultSystemTools
-        table, and values must be `enabled` or `disabled`.
+        table. True enables the tool; false denies it.
       '';
     };
 
@@ -147,15 +144,16 @@ in {
     houseContext = {
       enable = lib.mkOption {
         type = lib.types.bool;
-        default = true;
+        default = false;
         description = ''
           Write the house context render (the tagged prompt rules minus the
           `system`-only basics, see packages/agent/prompt) to
           {file}`~/.claude/CLAUDE.md` through the native
           {option}`programs.claude-code.context` option, so sessions whose
           runtime keeps its stock system prompt (claude.ai desktop, unwrapped
-          CLIs) still ride the house rules. An explicit `context` value
-          overrides this default entirely.
+          CLIs) still ride the house rules. Keep this off when the consuming
+          Home Manager configuration already manages {file}`.claude/CLAUDE.md`
+          through {option}`home.file`.
         '';
       };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -206,6 +206,7 @@
           programs.claude-code = {
             enable = true;
             systemPrompt.omitRules = ["reportToPlaybook"];
+            houseContext.enable = true;
             personalStartupContext = true;
           };
           programs.codex = {
@@ -4013,7 +4014,7 @@
         message = "Codex Home Manager module should thread systemPrompt.omitRules into the package wrapper";
       }
       {
-        # houseContext defaults on: the native `context` option carries the
+        # When explicitly enabled, the native `context` option carries the
         # context render (house rules without the system-tagged basics).
         assertion =
           lib.hasInfix "shokunin" homeAgentConfig.programs.claude-code.context


### PR DESCRIPTION
## Summary
- Change Claude Code `systemTools` overrides from string states to Nix booleans.
- `true` keeps a tool enabled; `false` renders it into `permissions.deny`.
- Update Home Manager option type and docs examples.
- Avoid the Home Manager `.claude/CLAUDE.md` target conflict by making `houseContext.enable` opt-in.

## Validation
- `nix build .#claude-code`
- built `claude-code-default-settings.json` contains the default-disabled tools in `permissions.deny`
- `nix run .#lint`
- `nix eval ~/.config/nix#homeConfigurations."andrewgazelka@darwin".activationPackage.drvPath --override-input index git+file://<worktree> --raw`

Refs #2331
Refs #2333

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use booleans for `systemTools` configuration in claude-code
> - Replaces string values (`"enabled"`/`"disabled"`) with booleans (`true`/`false`) for `systemTools` in [default.nix](https://github.com/indexable-inc/index/pull/2332/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) and the Home Manager option in [claude-code.nix](https://github.com/indexable-inc/index/pull/2332/files#diff-b941f4c92dd8de3d70290f80abe17e83e8710287c6a7430cad3d5f1c81cdbdab).
> - `disabledSystemTools` is now derived by filtering tools with value `false` instead of matching the string `"disabled"`; validation for invalid string states is removed.
> - `programs.claude-code.houseContext.enable` now defaults to `false`; tests are updated to opt in explicitly.
> - Risk: passing non-boolean values to `systemTools` will cause a type error at evaluation time rather than a validation warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fce85cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->