### PR TITLE
mcp: self-heal a deleted kernel cwd instead of wedging every cell

### DIFF
--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -50,6 +50,7 @@ from .config import (
     is_tailnet_ipv4,
     live_hub,
     port_open,
+    process_cwd,
     runtime_dir,
     set_config,
 )
@@ -403,7 +404,7 @@ def _auto_dashboard() -> bool:
 
 def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
     wd = getattr(args, "workdir", None)
-    workdir = Path(wd).resolve() if wd else Path.cwd()
+    workdir = Path(wd).resolve() if wd else process_cwd()
     workdir.mkdir(parents=True, exist_ok=True)
 
     http = getattr(args, "http", None)

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -14,6 +14,7 @@ import json
 import os
 import socket
 import stat
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -46,6 +47,32 @@ def is_tailnet_ipv4(value: str) -> bool:
 # (ix_notebook_mcp.mesh) and the bundled `mesh` module's peer probes both read
 # it through :func:`mesh_port`, so the two sides cannot drift.
 DEFAULT_MESH_PORT = 8798
+
+
+def process_cwd() -> Path:
+    """The process working directory, self-healing a deleted one (index#2120).
+
+    A long-lived kernel can have its cwd removed under it (e.g. an auto-cleaned
+    ``.claude`` worktree a cell had ``os.chdir``'d into). From then on
+    ``Path.cwd()`` raises ``FileNotFoundError`` -- and because the per-cell type
+    checker resolves the cwd BEFORE user code runs, every subsequent cell
+    (including a repair ``os.chdir``) dies on that traceback until the server is
+    restarted. Every per-call cwd read goes through here instead: on a vanished
+    cwd the process moves itself to ``$HOME``, says so loudly on stderr (which
+    reaches journald), and carries on. One recovery, one warning; any other
+    error still propagates.
+    """
+    try:
+        return Path.cwd()
+    except FileNotFoundError:
+        home = Path.home()
+        os.chdir(home)
+        print(
+            f"[ix-mcp] working directory vanished (deleted under the process); moved to {home}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return home
 
 
 def mesh_port() -> int:

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -54,7 +54,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any, overload
 
 from . import readstats, registry, typecheck
-from .config import build_stamp
+from .config import build_stamp, process_cwd
 
 _ix_current: contextvars.ContextVar = contextvars.ContextVar("ix_current_job", default=None)
 
@@ -4468,7 +4468,7 @@ def install(user_ns: dict | None = None) -> None:
     # Seed the default session label with this kernel's working directory; the
     # connecting client's identity is folded in later (see Kernel.set_client).
     with contextlib.suppress(OSError):
-        session._workdir = pathlib.Path.cwd().name or ""
+        session._workdir = process_cwd().name or ""
         session._rev += 1  # ensure the first flush mirrors the default to the store
     target["resources"] = resources
     target["Resource"] = Resource

--- a/packages/mcp/ix_notebook_mcp/typecheck.py
+++ b/packages/mcp/ix_notebook_mcp/typecheck.py
@@ -41,6 +41,8 @@ import tempfile
 from collections.abc import Iterator
 from dataclasses import dataclass
 
+from .config import process_cwd
+
 # A name is stubbed with its real type only for these simple, always-importable
 # builtins; every other value (a module, a helper, an instance of some class) is
 # stubbed as ``Any``. Real types here are what make prior-cell scalars actually
@@ -399,9 +401,11 @@ async def check(code: str, namespace: dict, *, timeout: float = 10.0) -> TypeChe
             # with the kernel's working directory on sys.path: a first-party
             # module sitting next to the notebook (`import mymodule`) resolves at
             # runtime, so it must resolve for the checker too or a valid import
-            # would be flagged unresolved.
+            # would be flagged unresolved. process_cwd (not Path.cwd) because
+            # this runs BEFORE every cell: an unhandled FileNotFoundError from a
+            # deleted cwd here bricked the whole kernel (index#2120).
             "--extra-search-path",
-            str(pathlib.Path.cwd()),
+            str(process_cwd()),
             "--output-format",
             "concise",
             "--no-progress",

--- a/packages/mcp/tests/test_typecheck.py
+++ b/packages/mcp/tests/test_typecheck.py
@@ -216,6 +216,22 @@ def test_a_hung_checker_still_lets_the_cell_execute(tmp_path: Path, monkeypatch:
     assert ns.get("ran_anyway") is True
 
 
+def test_a_deleted_cwd_self_heals_instead_of_wedging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # index#2120: the kernel's cwd deleted under it (an auto-cleaned worktree)
+    # made the pre-cell cwd resolution raise FileNotFoundError, so EVERY later
+    # cell died before running -- even a repair os.chdir was blocked. The check
+    # must move the process somewhere real, warn loudly, and pass the cell.
+    doomed = tmp_path / "doomed"
+    doomed.mkdir()
+    monkeypatch.chdir(doomed)
+    doomed.rmdir()
+    assert _check("x = 1 + 2").ok
+    assert Path.cwd() == Path.home()  # the process recovered to a real directory
+    assert "working directory vanished" in capsys.readouterr().err
+
+
 # --------------------------------------------------------------------------- #
 # end to end through the runner: a type error blocks execution
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
A deleted cwd (e.g. an auto-cleaned `.claude` worktree a cell had chdir'd into) made the per-cell typechecker's `Path.cwd()` raise `FileNotFoundError` before ANY code ran, so every subsequent cell -- including a repair `os.chdir` -- died until the server was restarted. Two confirmed field hits (hydra + weave kernels).

- **one recovery helper**: `config.process_cwd()` catches `FileNotFoundError`, moves the process to `$HOME`, warns loudly on stderr (reaches journald), and continues; any other error still propagates
- **all cwd reads routed through it**: `typecheck.check` (the per-cell wedge), `runtime` session-label seed, `cli` startup workdir default
- **regression test**: delete the cwd under the checker, assert the cell still passes and the process recovered (runs in the nix `typecheckSmoke` gate)

Local gates: lint suite, `mcp.tests.typecheckSmoke` (91 passed), `mcp.tests.strictTypecheck`, `mcp.tests.sshAuthSockSmoke` all green.

Fixes #2120

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Self-heal a deleted kernel cwd instead of raising `FileNotFoundError` in notebook cells
> - Adds `process_cwd()` in [config.py](https://github.com/indexable-inc/index/pull/2341/files#diff-33f6f17aed79724ba72211bc8bf9dc1da1bbdb38de56be7ace76cc09837929ca): returns `Path.cwd()` normally, but on `FileNotFoundError` changes the process directory to `Path.home()`, emits a warning to stderr, and returns the home path.
> - Replaces direct `Path.cwd()` calls in [cli.py](https://github.com/indexable-inc/index/pull/2341/files#diff-7ce741e8223d63fdea11625cb78abad266299445db0213d2355bc93306df9ac5), [runtime.py](https://github.com/indexable-inc/index/pull/2341/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95), and [typecheck.py](https://github.com/indexable-inc/index/pull/2341/files#diff-cbfce87bcc71992ff78b6d76debfeb9900ee922abe1f35cddf31279031e73af7) with `process_cwd()` so all three sites recover gracefully.
> - Adds a test in [test_typecheck.py](https://github.com/indexable-inc/index/pull/2341/files#diff-a77a1523e315b67797fbb917515648504bc28666b2ea2007bed7241a9b9f284a) that deletes the cwd under the process and asserts recovery to `Path.home()` with a warning.
> - Behavioral Change: when the kernel cwd is deleted, the process silently relocates to `$HOME` instead of propagating a `FileNotFoundError` to every subsequent cell.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d215fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->