### PR TITLE
mcp: detect kernel death eagerly, report the precise cause, respawn

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3310,6 +3310,35 @@
       mkdir -p "$out"
     '';
 
+  # An externally killed kernel must be reported as `kernel died (pid N, signal
+  # S); respawning` -- never a generic 'wedged' timeout -- with kernel_trace
+  # naming the gone process and the death watch respawning it eagerly, not on
+  # the next execute (packages/mcp/tests/test_kernel_death.py, index#2339: a
+  # broad pkill SIGTERM'd a session's kernel and every symptom read as a wedge).
+  # Boots a real kernel, so it reuses the full interpreter plus pytest.
+  kernelDeathTestSource = builtins.path {
+    name = "ix-mcp-kernel-death-test";
+    path = ./tests/test_kernel_death.py;
+  };
+  kernelDeathSmoke =
+    pkgs.runCommand "ix-mcp-kernel-death-smoke"
+    {
+      nativeBuildInputs = [typecheckTestPython];
+      strictDeps = true;
+    }
+    ''
+      export HOME=$TMPDIR/home
+      mkdir -p "$HOME"
+      cp ${kernelDeathTestSource} "$TMPDIR/test_kernel_death.py"
+      ${lib.getExe typecheckTestPython} -m pytest "$TMPDIR/test_kernel_death.py" -q -p no:cacheprovider >stdout 2>stderr || {
+        echo "ix-mcp kernel-death smoke failed:" >&2
+        cat stdout stderr >&2
+        exit 1
+      }
+      cat stdout
+      mkdir -p "$out"
+    '';
+
   # Exercises the rich-output capture path: a DataFrame result is persisted to the
   # store with its text/html bundle (so the dashboard renders a table, not a repr),
   # a display() call made while a job runs is captured the same way, and a bytes
@@ -6008,6 +6037,7 @@ in
               svelteBundled
               svelteTests
               wedgeSmoke
+              kernelDeathSmoke
               richSmoke
               yieldSmoke
               bindingsSmoke

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -10,6 +10,11 @@ A single asyncio lock serializes the shell channel (a kernel processes one
 ``execute_request`` at a time): the *budget* keeps each request short by design,
 so backgrounded work never holds the channel, and a later ``python_exec`` that
 inspects ``jobs`` gets serviced promptly.
+
+A death watch polls the kernel child for the server's lifetime: a kernel killed
+externally (SIGTERM/SIGKILL, OOM, crash) is reported as ``kernel died (pid N,
+signal S); respawning`` -- never as a generic wedge or transport timeout -- and
+is respawned immediately, not lazily on the next execute (index#2339).
 """
 
 from __future__ import annotations
@@ -18,6 +23,7 @@ import asyncio
 import contextlib
 import os
 import signal
+import sys
 from pathlib import Path
 
 from .config import Config, runtime_dir
@@ -29,6 +35,30 @@ _READY_TIMEOUT = 60.0
 # on SIGUSR1. The server sets it before launching the kernel and reads it back in
 # ``dump_trace``; the kernel-side runtime registers the handler (``runtime``).
 TRACE_ENV = "IX_MCP_KERNEL_TRACE"
+
+# How often the death watch polls the kernel child (a waitpid(WNOHANG) via the
+# provisioner: cheap). Small enough that an external kill surfaces as the precise
+# death error within the same breath, not after a 35s transport timeout.
+_WATCH_INTERVAL = 0.5
+
+
+class KernelDiedError(RuntimeError):
+    """The kernel process exited (killed externally, OOM, crashed) and the
+    server is respawning it. Raised by the tool entry points so the caller gets
+    the precise cause -- ``kernel died (pid N, signal S); respawning`` -- instead
+    of a generic wedge or timeout against a process that no longer exists."""
+
+
+def _describe_exit(returncode: int | None) -> str:
+    """Render a Popen returncode: negative is death by that signal, by name."""
+    if returncode is None:
+        return "unknown exit"
+    if returncode < 0:
+        try:
+            return f"signal {signal.Signals(-returncode).name}"
+        except ValueError:
+            return f"signal {-returncode}"
+    return f"exit code {returncode}"
 
 
 def _wedged_summary(budget: float, grace: float, deadline: float, *, interrupted: bool) -> dict:
@@ -79,6 +109,13 @@ class Kernel:
         self._trace_lock = asyncio.Lock()
         self._trace_path: Path | None = None
         self._pid: int | None = None
+        # Death-watch state: `_death` is the rendered cause while the kernel is
+        # down (entry guard), `_death_event` fails calls already in flight, and
+        # `_watch_task` is the poll loop itself (cancelled by shutdown()).
+        self._death: str | None = None
+        self._death_event = asyncio.Event()
+        self._watch_task: asyncio.Task | None = None
+        self._restore_task: asyncio.Task | None = None
 
     async def start(self) -> None:
         from jupyter_client.manager import AsyncKernelManager
@@ -94,6 +131,9 @@ class Kernel:
         self._kc = self._km.client()
         self._kc.start_channels()
         await self._kc.wait_for_ready(timeout=_READY_TIMEOUT)
+        # Watch the child we just spawned so an external kill is noticed the
+        # moment it happens, not at the next execute's timeout (index#2339).
+        self._watch_task = asyncio.ensure_future(self._watch())
 
     def _kernel_pid(self) -> int | None:
         """The kernel process's pid, so a trace signal targets that process alone
@@ -112,6 +152,8 @@ class Kernel:
         thread is still parked in the blocking call. Returns the newest dump."""
         if self._km is None or self._trace_path is None or self._pid is None:
             return "kernel is not running"
+        if self._death is not None:
+            return f"kernel process is gone: {self._death}"
         path = self._trace_path
         # Serialize dumps: two concurrent traces share the same `before` offset and
         # would each read both appended dumps. The lock keeps each dump clean.
@@ -125,10 +167,20 @@ class Kernel:
             deadline = loop.time() + timeout
             while loop.time() < deadline:
                 await asyncio.sleep(0.05)
+                # The signal may have gone to a zombie (a killed child not yet
+                # reaped): os.kill succeeds but nothing can ever dump. The death
+                # watch reaps and flags it within its poll interval; report the
+                # death instead of waiting out the deadline (index#2339).
+                if self._death is not None:
+                    return f"kernel process is gone: {self._death}"
                 if path.exists() and path.stat().st_size > before:
                     # A short settle so the whole multi-thread dump has flushed.
                     await asyncio.sleep(0.05)
                     return path.read_text()[before:].strip() or "(empty trace)"
+        # No dump and no flagged death: distinguish a gone process (say so
+        # plainly) from a live kernel that cannot service signals.
+        if self._death is not None or not await self._km.is_alive():
+            return "kernel process is gone: " + (self._death or f"kernel died (pid {self._pid})")
         return (
             f"No trace was produced within {timeout:.0f}s. The kernel may not have "
             "the faulthandler registered (older build) or cannot service signals."
@@ -169,23 +221,42 @@ class Kernel:
                     code, timeout=timeout, allow_stdin=False, output_hook=on_iopub, store_history=True
                 )
             )
+            # Race the reply against kernel death: a request to a process that
+            # exits mid-cell never gets a reply, so waiting out the full
+            # ``timeout`` would misreport an external kill as a wedge AND hold
+            # this lock against the respawn (index#2339). The death watch sets
+            # the event the moment the child exits.
+            died = asyncio.ensure_future(self._death_event.wait())
             try:
-                await asyncio.shield(task)
-            except asyncio.CancelledError:
                 try:
-                    await task
-                except TimeoutError:
-                    # The cell is synchronously wedging the loop, so the reply
-                    # never arrives within the deadline. The drain alone would
-                    # leave the kernel stuck behind the cancelled-but-still-running
-                    # cell, so fire the same SIGUSR2 watchdog the outer timeout
-                    # path uses to break the blocked frame and free the channel.
-                    await self._interrupt()
-                except BaseException:  # noqa: S110 -- any drain error is acceptable; we just need the socket read to finish before releasing the lock
-                    # Any other drain error: we only need the socket read to
-                    # finish before releasing the lock.
-                    pass
-                raise
+                    await asyncio.shield(asyncio.wait({task, died}, return_when=asyncio.FIRST_COMPLETED))
+                except asyncio.CancelledError:
+                    try:
+                        await task
+                    except TimeoutError:
+                        # The cell is synchronously wedging the loop, so the reply
+                        # never arrives within the deadline. The drain alone would
+                        # leave the kernel stuck behind the cancelled-but-still-running
+                        # cell, so fire the same SIGUSR2 watchdog the outer timeout
+                        # path uses to break the blocked frame and free the channel.
+                        await self._interrupt()
+                    except BaseException:  # noqa: S110 -- any drain error is acceptable; we just need the socket read to finish before releasing the lock
+                        # Any other drain error: we only need the socket read to
+                        # finish before releasing the lock.
+                        pass
+                    raise
+                if not task.done():
+                    # The kernel died with this request in flight: the reply can
+                    # never arrive. The process is gone and the respawn rebuilds
+                    # the channels, so there is no half-read reply to protect;
+                    # drop the read and surface the precise cause.
+                    task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await task
+                    raise KernelDiedError(self._death or "kernel died; respawning")
+                await task  # propagate the reply's own error (e.g. TimeoutError)
+            finally:
+                died.cancel()
             return outputs, summary
 
     async def python_exec(
@@ -216,11 +287,15 @@ class Kernel:
             f"await __ix_exec({code!r}, budget={float(budget)!r}, "
             f"name={name_arg}, session={session_arg}, topic={topic_arg})"
         )
+        self._check_alive()
         grace = self._config.wedge_grace
         deadline = float(budget) + grace
         try:
             return await self._execute(wrapper, timeout=deadline)
         except TimeoutError:
+            # A dead kernel also never replies: if the death watch flagged one
+            # while this request waited, report that precise cause, never a wedge.
+            self._check_alive()
             interrupted = await self._interrupt()
             return [], _wedged_summary(budget, grace, deadline, interrupted=interrupted)
 
@@ -238,10 +313,12 @@ class Kernel:
         This is the MCP-side naming handshake, not user code, so it uses the raw
         shell channel instead of ``__ix_exec``.
         """
+        self._check_alive()
         await self._execute(f"session.name = {name!r}\nsession._sync()", timeout=10.0)
 
     async def set_topic(self, topic: str) -> None:
         """Set the dashboard topic without creating an execution card."""
+        self._check_alive()
         await self._execute(f"session.topic = {topic!r}", timeout=10.0)
 
     async def _interrupt(self) -> bool:
@@ -285,16 +362,116 @@ class Kernel:
         with contextlib.suppress(Exception):  # shutdown must proceed even if the final flush fails
             await self._execute("__ix_emit_read_stats_final()", timeout=30.0)
 
+    def _check_alive(self) -> None:
+        """Fail a tool entry point with the precise death cause while the kernel
+        is down: `kernel died (pid N, signal S); respawning`, never a generic
+        wedge or transport timeout against a process that no longer exists."""
+        if self._death is not None:
+            raise KernelDiedError(self._death)
+
+    def _exit_code(self) -> int | None:
+        """The dead kernel's returncode (negative: killed by that signal), read
+        from the Popen the provisioner's liveness poll reaped."""
+        provisioner = getattr(self._km, "provisioner", None)
+        process = getattr(provisioner, "process", None)
+        code = getattr(process, "returncode", None)
+        return code if isinstance(code, int) else None
+
+    async def _watch(self) -> None:
+        """Notice the kernel child exiting the moment it happens.
+
+        Without this watch an externally killed kernel (a stray `pkill -f
+        ipykernel_launcher`, the OOM killer, a crash) presented as a generic
+        'wedged' timeout, `kernel_trace` signalled the zombie and blamed a
+        missing faulthandler, and the kernel only came back on the next execute
+        (index#2339). On death: record the precise cause, fail in-flight and
+        subsequent calls with it, say it loudly on stderr (which reaches
+        journald), and respawn immediately."""
+        while True:
+            await asyncio.sleep(_WATCH_INTERVAL)
+            km = self._km
+            if km is None:
+                return
+            try:
+                alive = await km.is_alive()
+            except Exception:  # noqa: S112 -- a transient introspection error must not end the lifetime watch
+                continue
+            if alive:
+                continue
+            pid = self._pid
+            cause = _describe_exit(self._exit_code())
+            self._death = f"kernel died (pid {pid}, {cause}); respawning"
+            self._death_event.set()
+            print(f"[ix-mcp] {self._death}", file=sys.stderr, flush=True)
+            delay = 1.0
+            while True:
+                try:
+                    await self.restart()
+                    break
+                except Exception as exc:
+                    # Still loud, still precise; keep trying so the server heals
+                    # without waiting for a client call.
+                    self._death = f"kernel died (pid {pid}, {cause}); respawn failed: {exc!r}, retrying in {delay:.0f}s"
+                    print(f"[ix-mcp] {self._death}", file=sys.stderr, flush=True)
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 30.0)
+            print(
+                f"[ix-mcp] kernel respawned (pid {self._pid}) after pid {pid} died ({cause})",
+                file=sys.stderr,
+                flush=True,
+            )
+
     async def restart(self) -> None:
-        if self._km is not None:
-            await self._km.restart_kernel(now=True)
-            # The restart launches a new process, so refresh the pid the trace and
-            # interrupt signals target; a stale pid would signal a dead or reused
-            # process. The new kernel re-runs install() and re-opens the trace file.
+        """Start a fresh kernel process; the death watch's respawn primitive.
+
+        Rebuilds everything the old process owned: the pid the trace/interrupt
+        signals target (a stale pid would signal a dead or reused process), the
+        client channels (the old sockets may hold a dead kernel's half-delivered
+        replies), and -- exactly as `serve` does at startup -- the session
+        checkpoint, restored while holding the shell channel so every call
+        admitted once the death flag clears queues behind the restored state.
+        The cwd is re-passed fresh so a respawn survives the original launch
+        directory having been deleted since (index#2120). The new kernel re-runs
+        install() and re-opens the trace file.
+        """
+        if self._km is None:
+            return
+        async with self._lock:
+            await self._km.restart_kernel(now=True, cwd=str(self._config.workdir))
             self._pid = self._kernel_pid()
+            if self._kc is not None:
+                self._kc.stop_channels()
+            self._kc = self._km.client()
+            self._kc.start_channels()
             await self._kc.wait_for_ready(timeout=_READY_TIMEOUT)
+        # The new process is alive: in-flight racing stops now (fresh event); the
+        # entry guard (`_death`) stays up until the restore holds the channel.
+        self._death_event = asyncio.Event()
+        if self._config.session_resume:
+            locked = asyncio.Event()
+
+            async def _restore() -> None:
+                try:
+                    summary = await self.restore_session(on_locked=locked.set)
+                    if summary:
+                        print(f"[ix-mcp] {summary}", file=sys.stderr, flush=True)
+                except Exception as exc:
+                    print(f"[ix-mcp] session restore after respawn failed: {exc!r}", file=sys.stderr, flush=True)
+                finally:
+                    locked.set()  # a restore that died before locking must not hold the death flag forever
+
+            self._restore_task = asyncio.ensure_future(_restore())
+            await locked.wait()
+        self._death = None
 
     async def shutdown(self) -> None:
+        # Stop the death watch first: shutdown kills the kernel on purpose, and
+        # the watch must not report that as a death or respawn over it.
+        if self._watch_task is not None:
+            self._watch_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._watch_task
+            self._watch_task = None
         if self._kc is not None:
             self._kc.stop_channels()
         if self._km is not None:

--- a/packages/mcp/tests/test_kernel_death.py
+++ b/packages/mcp/tests/test_kernel_death.py
@@ -1,0 +1,92 @@
+"""An externally killed kernel must be loud and precise, then heal itself.
+
+index#2339: a broad ``pkill -f ipykernel_launcher`` SIGTERM'd a session's kernel
+child and the server presented it as a generic ``status: wedged`` timeout,
+``kernel_trace`` signalled the zombie and blamed a missing faulthandler, and the
+kernel only came back on the next execute. The death watch must instead report
+``kernel died (pid N, signal S); respawning`` (in-flight and subsequent calls
+alike), say the process is gone in ``kernel_trace``, log the death to stderr
+(which reaches journald), and respawn without waiting for a client call.
+"""
+
+import asyncio
+import os
+import signal
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ix_notebook_mcp import cli
+from ix_notebook_mcp.config import Config
+from ix_notebook_mcp.kernel import Kernel, KernelDiedError
+
+
+def test_killed_kernel_reports_death_and_respawns(capsys: pytest.CaptureFixture[str]) -> None:
+    # Install the shipped IPython startup so the in-kernel runtime (__ix_exec,
+    # Result, the signal handlers) loads in the booted kernel, as the CLI wires it.
+    os.environ["IPYTHONDIR"] = str(cli._prepare_ipython_startup(0))
+    config = Config(workdir=Path(tempfile.mkdtemp()), wedge_grace=1.0, max_budget=5.0)
+
+    async def main() -> None:
+        kernel = Kernel(config)
+        await kernel.start()
+        try:
+            loop = asyncio.get_running_loop()
+            _, up = await kernel.python_exec("Result.ok('up')", budget=15.0, name="up")
+            assert up is not None, up
+            assert up["status"] == "done", up
+            pid = kernel._pid
+            assert pid is not None
+
+            # Kill the kernel child with a request in flight: the call must fail
+            # promptly with the precise cause, not sit out budget+grace and
+            # come back as a generic 'wedged' summary.
+            inflight = asyncio.ensure_future(
+                kernel.python_exec("await asyncio.sleep(60)\nResult.ok('nope')", budget=30.0, name="inflight")
+            )
+            await asyncio.sleep(1.0)  # the execute request is on the wire
+            started = loop.time()
+            os.kill(pid, signal.SIGTERM)
+            with pytest.raises(KernelDiedError) as err:
+                await inflight
+            elapsed = loop.time() - started
+            assert f"kernel died (pid {pid}, signal SIGTERM); respawning" in str(err.value), str(err.value)
+            assert elapsed < 15, ("death was reported at the wedge timeout, not eagerly", elapsed)
+
+            # While the respawn is still in progress a NEW call gets the same
+            # precise error (the respawn needs a fresh process + ready handshake,
+            # so it cannot have finished within this same event-loop breath) ...
+            with pytest.raises(KernelDiedError) as during:
+                await kernel.python_exec("Result.ok('during')", budget=5.0, name="during")
+            assert f"pid {pid}" in str(during.value), str(during.value)
+
+            # ... and kernel_trace says the process is gone, instead of signalling
+            # the corpse and blaming a missing faulthandler.
+            trace = await kernel.dump_trace()
+            assert "kernel process is gone" in trace, trace
+            assert f"pid {pid}" in trace, trace
+
+            # The watch respawns on its own: the death flag clears and the pid
+            # changes WITHOUT this test issuing any execute.
+            for _ in range(1200):  # up to ~120s; a fresh kernel boots in a few
+                if kernel._death is None:
+                    break
+                await asyncio.sleep(0.1)
+            assert kernel._death is None, kernel._death
+            assert kernel._pid is not None, kernel._pid
+            assert kernel._pid != pid, (kernel._pid, pid)
+
+            # The respawned kernel serves cells again.
+            _, back = await kernel.python_exec("Result.ok('back')", budget=15.0, name="back")
+            assert back is not None, back
+            assert back["status"] == "done", back
+        finally:
+            await kernel.shutdown()
+
+    asyncio.run(main())
+    # The death must be loud: both the death and the respawn reach stderr (journald).
+    err_text = capsys.readouterr().err
+    assert "kernel died (pid" in err_text, err_text
+    assert "signal SIGTERM" in err_text, err_text
+    assert "kernel respawned (pid" in err_text, err_text


### PR DESCRIPTION
## Problem

#2339: a session's kernel child was SIGTERM'd externally (a broad `pkill -f ipykernel_launcher`) and the server presented every symptom as a generic kernel wedge:

- `python_exec` / `topic_set` timed out with `status: wedged` against a process that no longer existed
- `kernel_trace` signalled the zombie (the kill succeeds, nothing can dump) and blamed a missing faulthandler
- the kernel only came back lazily on a later execute, which the session never issued

## Fix

`Kernel` now runs a death watch for the server's lifetime (a 0.5s `is_alive` poll via the provisioner, which also reaps the zombie):

- **precise, loud**: on exit it records `kernel died (pid N, signal S); respawning` (signal by name, exit code otherwise) and prints it to stderr, which reaches journald
- **in-flight calls fail fast**: `_execute` races the shell reply against the death event, so a call caught mid-request gets the death error promptly instead of holding the lock until the wedge timeout
- **subsequent calls**: `python_exec` / `set_session_name` / `set_topic` raise `KernelDiedError` with the same message while the kernel is down
- **kernel_trace**: says `kernel process is gone: ...` at entry, mid-wait (zombie case), and in the no-dump fallback, instead of guessing about faulthandler
- **eager respawn**: the watch respawns immediately (fresh pid, fresh channels, cwd re-passed so a deleted launch dir does not brick the respawn, session checkpoint restored exactly as at startup), retrying with backoff and staying loud if the respawn itself fails

## Validation

- new regression smoke `mcp.tests.kernelDeathSmoke` (`tests/test_kernel_death.py`): boots a real kernel, SIGTERMs the child, asserts the precise in-flight error (<15s, not the wedge timeout), the precise error during respawn, the gone-message from `kernel_trace`, an unprompted respawn (pid changes with no execute issued), a working cell afterwards, and both stderr lines
- the same scenario run live un-sandboxed on darwin: in-flight error in 0.46s, respawn 96022 -> 96072, all assertions green (the sandboxed smoke needs the Linux builder, same as the existing `wedgeSmoke`: darwin's sandbox denies the kernel's loopback bind)
- `nix build .#mcp.tests.typecheckSmoke .#mcp.tests.strictTypecheck` green, repo lint green

Closes #2339

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect kernel process death eagerly, report precise cause, and respawn automatically
> - Adds a `_watch` loop in [kernel.py](https://github.com/indexable-inc/index/pull/2344/files#diff-ced4fbbdf05b4f126e987804d73fdc2d811511b346e4985a9996ae7903683d1c) that polls `km.is_alive()` every 0.5 s; on death it records the cause via `_describe_exit` (e.g. `signal SIGTERM` or `exit code N`), sets a `_death_event`, logs to stderr, and respawns with exponential backoff.
> - In-flight `_execute` calls race against `_death_event` and raise the new `KernelDiedError` immediately instead of waiting for the full timeout and misreporting as a wedge.
> - `dump_trace` now checks for a recorded death first and returns a precise "kernel process is gone" message rather than timing out.
> - `shutdown` cancels the watch task before tearing down the kernel to prevent spurious respawn activity during intentional termination.
> - Adds a pytest smoke test in [test_kernel_death.py](https://github.com/indexable-inc/index/pull/2344/files#diff-a5d82486967fc180923b74c95e0df24bce84676ebd0eeb28f9bf2806e30e8a2f) (wired into the Nix build) that SIGTERMs a live kernel and asserts fast `KernelDiedError`, correct death/respawn log lines, and successful execution after respawn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d3c13f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->