### PR TITLE
mcp: add per-session kernel_restart tool

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3339,6 +3339,36 @@
       mkdir -p "$out"
     '';
 
+  # An INTENTIONAL restart (the kernel_restart tool, index#2345) must be
+  # surgical: only this server's kernel child is bounced (old pid -> new pid,
+  # elapsed time reported), the namespace is rebuilt, the session name/topic the
+  # server pushed are re-applied, and stderr carries the requested-restart lines
+  # -- never the death watch's `kernel died` report, since the kill is on
+  # purpose (packages/mcp/tests/test_kernel_restart.py). Boots a real kernel,
+  # so it reuses the full interpreter plus pytest.
+  kernelRestartTestSource = builtins.path {
+    name = "ix-mcp-kernel-restart-test";
+    path = ./tests/test_kernel_restart.py;
+  };
+  kernelRestartSmoke =
+    pkgs.runCommand "ix-mcp-kernel-restart-smoke"
+    {
+      nativeBuildInputs = [typecheckTestPython];
+      strictDeps = true;
+    }
+    ''
+      export HOME=$TMPDIR/home
+      mkdir -p "$HOME"
+      cp ${kernelRestartTestSource} "$TMPDIR/test_kernel_restart.py"
+      ${lib.getExe typecheckTestPython} -m pytest "$TMPDIR/test_kernel_restart.py" -q -p no:cacheprovider >stdout 2>stderr || {
+        echo "ix-mcp kernel-restart smoke failed:" >&2
+        cat stdout stderr >&2
+        exit 1
+      }
+      cat stdout
+      mkdir -p "$out"
+    '';
+
   # Exercises the rich-output capture path: a DataFrame result is persisted to the
   # store with its text/html bundle (so the dashboard renders a table, not a repr),
   # a display() call made while a job runs is captured the same way, and a bytes
@@ -6038,6 +6068,7 @@ in
               svelteTests
               wedgeSmoke
               kernelDeathSmoke
+              kernelRestartSmoke
               richSmoke
               yieldSmoke
               bindingsSmoke

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -379,6 +379,18 @@ TRACE = (
     "background it)."
 )
 
+RESTART = (
+    "Restart THIS server's kernel process on purpose: shut the child down, respawn it, restore "
+    "the session checkpoint (when serving a session file), and report the old pid, new pid, and "
+    "elapsed seconds. Scoped to your own connection's server -- other sessions' kernels on the "
+    "machine are untouched, so NEVER reach for `pkill -f ipykernel_launcher` (it kills every "
+    "session's kernel at once). Use it when the kernel is truly wedged (kernel_trace shows a "
+    "stuck frame and an interrupt cannot break it) or to adopt a fixed/updated kernel build "
+    "without restarting the MCP server (index#2209). It is disruptive: the namespace is rebuilt "
+    "(the checkpoint restore covers a session file's names; without one every variable is lost) "
+    "and running background jobs die with the process."
+)
+
 REPLY = (
     "Send a message to the page behind an interactive resource. Use it to answer a channel event "
     "that carries a resource attribute (<channel resource=\"...\">): pass that resource id and "

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -116,6 +116,16 @@ class Kernel:
         self._death_event = asyncio.Event()
         self._watch_task: asyncio.Task | None = None
         self._restore_task: asyncio.Task | None = None
+        # The session identity the server last pushed (client label, session
+        # name, topic), re-applied by restart() so a respawned kernel keeps the
+        # dashboard grouping the client already chose instead of resetting to
+        # the default label.
+        self._client_label: str | None = None
+        self._session_name: str | None = None
+        self._session_topic: str | None = None
+        # Entry guard for restart_now(): two concurrent intentional restarts
+        # would cancel each other's death watch and double-respawn.
+        self._restarting = False
 
     async def start(self) -> None:
         from jupyter_client.manager import AsyncKernelManager
@@ -304,6 +314,7 @@ class Kernel:
         default to it. Runs as a raw shell request (not ``__ix_exec``), so it
         leaves no job/card behind — it only pokes ``session._set_client``. The
         server calls this once, when the client identifies itself."""
+        self._client_label = client
         with contextlib.suppress(Exception):  # session label is a convenience; must not break the tool call
             await self._execute(f"session._set_client({client!r})", timeout=10.0)
 
@@ -315,11 +326,28 @@ class Kernel:
         """
         self._check_alive()
         await self._execute(f"session.name = {name!r}\nsession._sync()", timeout=10.0)
+        self._session_name = name
 
     async def set_topic(self, topic: str) -> None:
         """Set the dashboard topic without creating an execution card."""
         self._check_alive()
         await self._execute(f"session.topic = {topic!r}", timeout=10.0)
+        self._session_topic = topic
+
+    async def _reapply_session(self) -> None:
+        """Re-push the session identity the server already set (client label,
+        session name, topic) into a fresh kernel process. The respawned kernel
+        boots with a default ``Session`` and nothing else replays these -- the
+        checkpoint covers user-bound names only -- so without this a restart
+        silently resets the dashboard grouping the client already chose.
+        Best-effort, like ``set_client``: a label must never fail a restart."""
+        with contextlib.suppress(Exception):  # labels are a convenience; the restart must proceed without them
+            if self._client_label is not None:
+                await self._execute(f"session._set_client({self._client_label!r})", timeout=10.0)
+            if self._session_name is not None:
+                await self._execute(f"session.name = {self._session_name!r}\nsession._sync()", timeout=10.0)
+            if self._session_topic is not None:
+                await self._execute(f"session.topic = {self._session_topic!r}", timeout=10.0)
 
     async def _interrupt(self) -> bool:
         """Break a synchronous call wedging the kernel's event loop. ipykernel's
@@ -347,11 +375,13 @@ class Kernel:
         texts = [o.get("text", "") for o in outputs if isinstance(o, dict)]
         return "".join(t for t in texts if isinstance(t, str)).strip()
 
-    async def snapshot_session(self) -> None:
-        """Best-effort final checkpoint at shutdown, so the last cells' state is
-        in the file even if the debounced checkpoint had not fired yet."""
-        with contextlib.suppress(Exception):  # shutdown must proceed; periodic checkpoint plus replay guarantee a correct reopen
-            await self._execute("await __ix_snapshot()", timeout=60.0)
+    async def snapshot_session(self, timeout: float = 60.0) -> None:
+        """Best-effort final checkpoint (shutdown, or just before an intentional
+        restart), so the last cells' state is in the file even if the debounced
+        checkpoint had not fired yet. ``timeout`` bounds the wait: a caller
+        about to kill a possibly-wedged kernel keeps it short."""
+        with contextlib.suppress(Exception):  # the caller must proceed; periodic checkpoint plus replay guarantee a correct reopen
+            await self._execute("await __ix_snapshot()", timeout=timeout)
 
     async def emit_read_stats_final(self) -> None:
         """Flush the final ``mcp_read_stats`` line per session at shutdown, so the
@@ -447,6 +477,9 @@ class Kernel:
         # The new process is alive: in-flight racing stops now (fresh event); the
         # entry guard (`_death`) stays up until the restore holds the channel.
         self._death_event = asyncio.Event()
+        # Re-push the session identity the server already set, BEFORE the
+        # restore, so replayed cells group under the label the client chose.
+        await self._reapply_session()
         if self._config.session_resume:
             locked = asyncio.Event()
 
@@ -463,6 +496,62 @@ class Kernel:
             self._restore_task = asyncio.ensure_future(_restore())
             await locked.wait()
         self._death = None
+
+    async def restart_now(self) -> dict[str, int | float | None]:
+        """An intentional restart of this server's kernel: the `kernel_restart`
+        tool's primitive (index#2345).
+
+        Reuses the death watch's respawn machinery (``restart()``: fresh
+        process, rebuilt channels, checkpoint restore, session labels
+        re-applied) but for a kill made ON PURPOSE, so the watch is cancelled
+        first -- exactly the order ``shutdown()`` uses -- and must neither
+        report this as a death nor race its own respawn against it; it is
+        re-armed for the new process afterwards. Loud on stderr (which reaches
+        journald), like the death watch, so an operator can see who bounced a
+        kernel and when. Returns the old pid, the new pid, and the elapsed
+        seconds.
+        """
+        if self._km is None:
+            raise RuntimeError("the kernel is not running")
+        if self._restarting:
+            raise RuntimeError("a kernel restart is already in progress")
+        self._restarting = True
+        try:
+            loop = asyncio.get_running_loop()
+            started = loop.time()
+            old_pid = self._pid
+            print(f"[ix-mcp] kernel restart requested (pid {old_pid})", file=sys.stderr, flush=True)
+            # Stop the death watch FIRST, exactly as shutdown() does: the kill
+            # below is intentional.
+            if self._watch_task is not None:
+                self._watch_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._watch_task
+                self._watch_task = None
+            # Freshen the checkpoint so the restore replays (i.e. RE-EXECUTES)
+            # as little as possible -- but on a short leash: the kernel may be
+            # wedged, the very reason for this restart, and the periodic
+            # checkpoint plus replay already guarantee a correct reopen.
+            if self._death is None and self._config.session_resume:
+                with contextlib.suppress(Exception):  # best-effort freshness; a timeout here means a wedged kernel, which the restart below fixes
+                    await asyncio.wait_for(self.snapshot_session(timeout=10.0), timeout=15.0)
+            # Fail calls already in flight (a wedged cell would otherwise hold
+            # the shell lock against the respawn for its whole budget) and guard
+            # new ones until the restore holds the channel -- the death watch's
+            # own mechanism, with the honest cause instead of a death report.
+            self._death = f"kernel is restarting (requested via kernel_restart; was pid {old_pid}); retry shortly"
+            self._death_event.set()
+            await self.restart()
+            self._watch_task = asyncio.ensure_future(self._watch())
+            elapsed = loop.time() - started
+            print(
+                f"[ix-mcp] kernel restarted on request (pid {old_pid} -> {self._pid}) in {elapsed:.1f}s",
+                file=sys.stderr,
+                flush=True,
+            )
+            return {"old_pid": old_pid, "new_pid": self._pid, "elapsed_s": round(elapsed, 2)}
+        finally:
+            self._restarting = False
 
     async def shutdown(self) -> None:
         # Stop the death watch first: shutdown kills the kernel on purpose, and

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -690,6 +690,14 @@ async def kernel_trace(ctx: Context | None = None) -> str:
     return await current_kernel().dump_trace()
 
 
+@mcp.tool(structured_output=False, description=guide.RESTART)
+async def kernel_restart(ctx: Context | None = None) -> str:
+    await _start_dashboard_once()
+    await _identify_client_once(ctx)
+    await _require_session_name(ctx, intent="kernel restart")
+    return json.dumps(await current_kernel().restart_now())
+
+
 # The reply tool's store connection, opened lazily on first reply. The tool runs
 # in the server process (the kernel's `events` writes come from its own
 # connection), so it needs its own handle on the shared WAL store.

--- a/packages/mcp/tests/test_kernel_restart.py
+++ b/packages/mcp/tests/test_kernel_restart.py
@@ -1,0 +1,92 @@
+"""kernel_restart: an intentional, per-server kernel restart must be surgical.
+
+index#2345: recovering ONE wedged kernel required `pkill -f ipykernel_launcher`,
+which SIGTERM'd every session's kernel on the machine. The `kernel_restart`
+tool's primitive (``Kernel.restart_now``) must instead bounce only this server's
+kernel child: the pid changes, the namespace is rebuilt, the session name/topic
+the server had pushed are re-applied to the fresh process, stderr carries the
+requested-restart lines (which reach journald) and NEVER the death watch's
+``kernel died`` report (the kill is intentional, so the watch from index#2344
+is cancelled around it, exactly as ``shutdown()`` does), and the watch is
+re-armed for the new process afterwards.
+"""
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ix_notebook_mcp import cli
+from ix_notebook_mcp.config import Config
+from ix_notebook_mcp.kernel import Kernel
+
+
+def test_restart_now_is_intentional_and_scoped(capsys: pytest.CaptureFixture[str]) -> None:
+    # Install the shipped IPython startup so the in-kernel runtime (__ix_exec,
+    # Result, session) loads in the booted kernel, as the CLI wires it.
+    os.environ["IPYTHONDIR"] = str(cli._prepare_ipython_startup(0))
+    config = Config(workdir=Path(tempfile.mkdtemp()), wedge_grace=1.0, max_budget=5.0)
+
+    async def main() -> None:
+        kernel = Kernel(config)
+        await kernel.start()
+        try:
+            await kernel.set_session_name("restart smoke")
+            await kernel.set_topic("restart topic")
+            _, up = await kernel.python_exec("marker = 41\nResult.ok('up')", budget=15.0, name="up")
+            assert up is not None, up
+            assert up["status"] == "done", up
+            old_pid = kernel._pid
+            assert old_pid is not None
+
+            info = await kernel.restart_now()
+
+            # The restart is reported precisely: old pid, new pid, elapsed time.
+            assert info["old_pid"] == old_pid, info
+            assert info["new_pid"] == kernel._pid, info
+            assert info["new_pid"] != old_pid, info
+            assert isinstance(info["elapsed_s"], float), info
+            assert info["elapsed_s"] >= 0, info
+            # Usable immediately: no lingering death flag, and the death watch is
+            # re-armed for the new process.
+            assert kernel._death is None, kernel._death
+            assert kernel._watch_task is not None
+            assert not kernel._watch_task.done()
+
+            # Give a mis-cancelled death watch several poll intervals to
+            # (wrongly) report the intentional kill; the stderr assertions at the
+            # end then catch it.
+            await asyncio.sleep(2.0)
+
+            # The namespace was rebuilt (no session file, so nothing restores
+            # `marker`), but the session name/topic the server pushed survive.
+            _, after = await kernel.python_exec(
+                "try:\n"
+                "    marker\n"
+                "    found = True\n"
+                "except NameError:\n"
+                "    found = False\n"
+                "print(f'found={found} name={session.name} topic={session.topic}')\n"
+                "Result.ok('after')",
+                budget=15.0,
+                name="after",
+            )
+            assert after is not None, after
+            assert after["status"] == "done", after
+            text = f"{after.get('output') or ''}\n{after.get('result') or ''}"
+            assert "found=False" in text, text
+            assert "name=restart smoke" in text, text
+            assert "topic=restart topic" in text, text
+        finally:
+            await kernel.shutdown()
+
+    asyncio.run(main())
+    err_text = capsys.readouterr().err
+    # Loud and intentional on stderr (journald): the requested-restart lines ...
+    assert "kernel restart requested (pid" in err_text, err_text
+    assert "kernel restarted on request (pid" in err_text, err_text
+    # ... and never the death watch's unexpected-death report or respawn line.
+    assert "kernel died" not in err_text, err_text
+    assert "kernel respawned" not in err_text, err_text


### PR DESCRIPTION
## Problem

Recovering one wedged kernel (#2120) required `pkill -f ipykernel_launcher`, which SIGTERM'd all ~30 sessions' kernels on hydra and produced a misdiagnosed wedge report (#2339). The MCP surface had `kernel_trace` but no restart.

## Change

- `Kernel.restart_now()`: intentional restart reusing #2344's respawn machinery. Cancels the death watch first (the `shutdown()` pattern, so the kill is never reported as a death), takes a short-leash best-effort checkpoint, fails in-flight calls with an honest "kernel is restarting" cause (a wedged cell would otherwise hold the shell lock for its whole budget), respawns + restores the checkpoint via `restart()`, re-arms the watch, and returns old pid, new pid, elapsed seconds. Loud on stderr (reaches journald).
- `kernel_restart` MCP tool (registered like `kernel_trace`), with guidance on when to use it: truly wedged kernel, or adopting a fixed build without restarting the server (#2209) -- and never `pkill`.
- `restart()` now re-applies the session identity (client label, session name, topic) to the fresh kernel, so both intentional restarts and death-watch respawns keep the dashboard grouping instead of resetting to the default label.
- Regression test `packages/mcp/tests/test_kernel_restart.py`, wired as `mcp.tests.kernelRestartSmoke` alongside `kernelDeathSmoke`: pid changes, namespace resets, session name/topic restored, no spurious `kernel died` report.

## Validation

- `nix build .#mcp.tests.typecheckSmoke .#mcp.tests.strictTypecheck .#mcp.tests.kernelRestartSmoke`
- `kernelRestartSmoke` also run on vin-compute-1 (linux)
- repo lint (pre-commit suite) green

Closes #2345

*Opened by an AI agent via Claude Code.*


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-session `kernel_restart` MCP tool to intentionally restart the current kernel
> - Adds a `kernel_restart` MCP tool in [`tools.py`](https://github.com/indexable-inc/index/pull/2349/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) that calls `Kernel.restart_now()` and returns old/new PIDs and elapsed seconds as JSON.
> - `restart_now()` in [`kernel.py`](https://github.com/indexable-inc/index/pull/2349/files#diff-ced4fbbdf05b4f126e987804d73fdc2d811511b346e4985a9996ae7903683d1c) rejects concurrent restarts, fails in-flight calls with a clear 'kernel is restarting' message, re-arms the death watch, and reapplies session identity (client label, session name, topic) to the new kernel process.
> - Session identity fields are now cached on `Kernel` via updated `set_client`, `set_session_name`, and `set_topic` methods, and a new `_reapply_session` helper pushes them back after restart.
> - A smoke test in [`tests/test_kernel_restart.py`](https://github.com/indexable-inc/index/pull/2349/files#diff-5f943a0ae5f23a203c295d63afd0ba7aaf738d608d3757b9257dd0dc68713e70) verifies pid changes, session persistence, namespace reset, and absence of spurious death-watch log messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77f3a33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->