### PR TITLE
mcp: confine serve-side store SQLite to a worker thread off the event loop

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -5499,6 +5499,34 @@
       mkdir -p "$out"
     '';
 
+  # The store's async facade (packages/mcp/tests/test_store_async.py,
+  # index#2348): AsyncConn confines every store call to one worker thread off
+  # the shared event loop, and the pane bridge's `data_version` idle gate
+  # re-renders only on a foreign commit. Reuses the channel interpreter
+  # (ix_notebook_mcp + aiohttp + pytest).
+  storeAsyncTestSource = builtins.path {
+    name = "ix-mcp-store-async-test";
+    path = ./tests/test_store_async.py;
+  };
+  storeAsyncTests =
+    pkgs.runCommand "ix-mcp-store-async-tests"
+    {
+      nativeBuildInputs = [channelTestPython];
+      strictDeps = true;
+    }
+    ''
+      export HOME=$TMPDIR/home
+      mkdir -p "$HOME"
+      cp ${storeAsyncTestSource} "$TMPDIR/test_store_async.py"
+      ${lib.getExe channelTestPython} -m pytest "$TMPDIR/test_store_async.py" -q -p no:cacheprovider >stdout 2>stderr || {
+        echo "ix-mcp store-async tests failed:" >&2
+        cat stdout stderr >&2
+        exit 1
+      }
+      cat stdout
+      mkdir -p "$out"
+    '';
+
   # Background-task failure reporting (packages/mcp/tests/test_task_errors.py):
   # a fire-and-forget task that dies with an unretrieved exception must be
   # reported at completion into `task_errors` (asyncio's own warning only fires
@@ -6030,6 +6058,7 @@ in
               apiSmoke
               inputsTests
               channelTests
+              storeAsyncTests
               mcpUiTests
               taskErrorsTests
               readStatsTests

--- a/packages/mcp/ix_notebook_mcp/dashboard.py
+++ b/packages/mcp/ix_notebook_mcp/dashboard.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import hmac
 import json
-import sqlite3
 
 from aiohttp import web
 
@@ -77,12 +76,14 @@ def landing_html() -> str:
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", ""})
 
 
-def build_app(config: Config, conn: sqlite3.Connection) -> web.Application:
-    """Assemble the data API over an open store ``conn``.
+def build_app(config: Config, db: store.AsyncConn) -> web.Application:
+    """Assemble the data API over the store's async facade ``db``.
 
     Split out of :func:`start` so the routes (notably the token-gated
     ``/api/exec`` write path) are testable with an in-memory app and a fake
-    kernel, without binding a socket."""
+    kernel, without binding a socket. Every store read goes through ``db`` so a
+    slow read (a fat store's output blobs) costs latency on its request only,
+    never the shared event loop the MCP transport runs on (index#2348)."""
     app = web.Application()
 
     async def index(_request: web.Request) -> web.Response:
@@ -109,24 +110,24 @@ def build_app(config: Config, conn: sqlite3.Connection) -> web.Application:
         return web.Response(text=landing_html(), content_type="text/html")
 
     async def jobs(_request: web.Request) -> web.Response:
-        return web.json_response(store.recent(conn, limit=feed.JOBS_LIMIT))
+        return web.json_response(await db.run(store.recent, limit=feed.JOBS_LIMIT))
 
     async def resources(_request: web.Request) -> web.Response:
-        return web.json_response(store.live_resources(conn))
+        return web.json_response(await db.run(store.live_resources))
 
     async def cells(_request: web.Request) -> web.Response:
-        return web.json_response(store.cells(conn))
+        return web.json_response(await db.run(store.cells))
 
     async def snapshot(_request: web.Request) -> web.Response:
         # The whole presentation in one read, the embed contract an external
         # consumer (the room server) polls; `rev` lets it skip unchanged renders.
-        return web.json_response(feed.snapshot(conn))
+        return web.json_response(await db.run(feed.snapshot))
 
     async def job(request: web.Request) -> web.Response:
         # One execution by id: the rich outputs for the `jobs['<id>']` a
         # python_exec tool result already names, so an embedder renders that run's
         # tables/plots/HTML beside the tool call.
-        one = feed.job(conn, request.match_info["id"])
+        one = await db.run(feed.job, request.match_info["id"])
         if one is None:
             return web.json_response({"error": "no such job"}, status=404)
         return web.json_response(one)
@@ -140,7 +141,7 @@ def build_app(config: Config, conn: sqlite3.Connection) -> web.Application:
         # entirely from the store, like every other GET here.
         from . import mcp_ui
 
-        one = feed.job(conn, request.match_info["id"])
+        one = await db.run(feed.job, request.match_info["id"])
         if one is None:
             return web.json_response({"error": "no such job"}, status=404)
         html = mcp_ui.embedded_html(mcp_ui.job_payload(one))
@@ -253,14 +254,14 @@ def build_app(config: Config, conn: sqlite3.Connection) -> web.Application:
             return web.json_response(
                 {"error": "missing 'payload'"}, status=400, headers=_CORS_HEADERS
             )
-        if not store.channel_open(conn, channel):
+        if not await db.run(store.channel_open, channel):
             # Unknown or already-closed channel: refuse rather than queue input no
             # awaiter will ever read (and so an attacker cannot grow the table by
             # posting to random ids).
             return web.json_response(
                 {"error": "no such open channel"}, status=404, headers=_CORS_HEADERS
             )
-        store.add_input(conn, channel=channel, payload=json.dumps(body["payload"]))
+        await db.run(store.add_input, channel=channel, payload=json.dumps(body["payload"]))
         return web.json_response({"ok": True}, headers=_CORS_HEADERS)
 
     async def resource_events(request: web.Request) -> web.StreamResponse:
@@ -282,10 +283,10 @@ def build_app(config: Config, conn: sqlite3.Connection) -> web.Application:
         await resp.prepare(request)
         # A comment frame so EventSource sees bytes immediately (open fires).
         await resp.write(b": connected\n\n")
-        last = store.latest_event_seq(conn, rid)
+        last = await db.run(store.latest_event_seq, rid)
         try:
             while True:
-                for row in store.events_after(conn, rid, last):
+                for row in await db.run(store.events_after, rid, last):
                     last = row["seq"]
                     try:
                         body = json.loads(row["body"])
@@ -317,8 +318,13 @@ async def start(config: Config) -> web.AppRunner:
     # `config.host` is resolved to a bindable address by the CLI before the
     # kernel spawns (see cli._serve), so the bind here is expected to succeed;
     # a failure is a genuine error worth surfacing.
-    conn = store.connect(config.store_path)
-    app = build_app(config, conn)
+    db = store.AsyncConn(config.store_path)
+    app = build_app(config, db)
+
+    async def _close_store(_app: web.Application) -> None:
+        await db.close()
+
+    app.on_cleanup.append(_close_store)
     runner = web.AppRunner(app)
     await runner.setup()
     await web.TCPSite(runner, config.host, config.dashboard_port).start()

--- a/packages/mcp/ix_notebook_mcp/pane_bridge.py
+++ b/packages/mcp/ix_notebook_mcp/pane_bridge.py
@@ -25,8 +25,10 @@ from . import store
 from .outputs import IX_VIEW_MIME
 from .produce import PaneProducer, data_pane, exec_pane, html_pane
 
-# How often to resample the store. Local SQLite in WAL mode, so a poll is cheap;
-# fast enough that a run appears promptly, slow enough to stay idle-quiet.
+# How often to resample the store: fast enough that a run appears promptly,
+# slow enough to stay idle-quiet. A tick is one `PRAGMA data_version` unless
+# another connection committed since the last tick (see `run`), so the rate is
+# safe even against a store carrying multi-MB output rows.
 _POLL_SECONDS = 0.25
 
 # Match the read-only API's window so the board and the API agree on which runs
@@ -206,24 +208,48 @@ def _panes(conn: sqlite3.Connection) -> list[dict]:
     return panes
 
 
+def _data_version(conn: sqlite3.Connection) -> int:
+    """SQLite's cross-connection change counter: it moves between two calls on
+    the SAME connection iff another connection committed in between. This
+    connection never writes, so an unchanged value means an unchanged store."""
+    return int(conn.execute("PRAGMA data_version").fetchone()[0])
+
+
+def _snapshot(conn: sqlite3.Connection) -> tuple[list[dict], str]:
+    """The pane set plus its change fingerprint, computed together so both the
+    blob reads and the (large) JSON dump stay off the event loop."""
+    panes = _panes(conn)
+    return panes, json.dumps(panes, separators=(",", ":"), sort_keys=True)
+
+
 async def run(store_path: str | Path, *, interval: float = _POLL_SECONDS) -> None:
     """Publish the store as panes until cancelled. Mirrors the store on every tick
-    and pushes a new snapshot only when the rendered set changes."""
+    and pushes a new snapshot only when the rendered set changes.
+
+    Store access goes through :class:`store.AsyncConn`: reading a fat store's
+    output blobs inline used to block the shared event loop -- and with it the
+    MCP transport -- for the read's duration, 4x per second (index#2348)."""
     producer = await PaneProducer().start()
     if producer is None:
         return
-    conn = store.connect(store_path)
+    db = store.AsyncConn(store_path)
     last: str | None = None
+    version: int | None = None
     logged_error = False
     try:
         while True:
             try:
-                panes = _panes(conn)
-                # Cheap change check so an idle session never re-publishes.
-                fingerprint = json.dumps(panes, separators=(",", ":"), sort_keys=True)
-                if fingerprint != last:
-                    await producer.publish(panes)
-                    last = fingerprint
+                # Gate the full re-render on the store actually having changed;
+                # an idle session then costs one PRAGMA per tick instead of
+                # re-reading every output blob. `version` advances only after a
+                # successful pass, so a failed read or publish retries next tick.
+                seen = await db.run(_data_version)
+                if seen != version:
+                    panes, fingerprint = await db.run(_snapshot)
+                    if fingerprint != last:
+                        await producer.publish(panes)
+                        last = fingerprint
+                    version = seen
             except Exception as error:
                 # A transient read error must not kill the bridge; try next tick.
                 # Log the first one so a persistent failure (e.g. a schema
@@ -236,4 +262,4 @@ async def run(store_path: str | Path, *, interval: float = _POLL_SECONDS) -> Non
         pass
     finally:
         await producer.stop()
-        conn.close()
+        await db.close()

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -12,11 +12,22 @@ writer.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
+import functools
 import json
 import sqlite3
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Concatenate, ParamSpec
+
+    _P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 
 def _now() -> float:
@@ -173,6 +184,68 @@ def connect(path: str | Path) -> sqlite3.Connection:
     conn.executescript(_SCHEMA)
     _migrate(conn)
     return conn
+
+
+class AsyncConn:
+    """The store for an asyncio host: the same file, every call confined to one
+    worker thread.
+
+    Serve-side consumers (the data API, the pane bridge, the outbox pump, the
+    reply tool) share the MCP transport's event loop. A store call there is
+    synchronous SQLite, and once a session's store carries multi-MB output rows
+    the blob reads block the loop long enough to starve MCP stdio -- from the
+    client that is indistinguishable from a kernel wedge (index#2348). Confining
+    the connection to a private single-thread executor makes a slow read cost
+    latency on its own caller only, and serializes access exactly as the shared
+    loop used to. The connection opens lazily on the worker thread itself, so
+    sqlite3's ``check_same_thread`` guard keeps enforcing the confinement.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        # The connection opens lazily on the worker thread, so re-run connect()'s
+        # eager None guard here: a missing path must fail at construction (where
+        # `serve` startup surfaces it), not on the first request.
+        if path is None:
+            raise ValueError("store path is required (got None)")
+        self._path = path
+        self._pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ix-store")
+        self._conn: sqlite3.Connection | None = None
+
+    def _bound(self) -> sqlite3.Connection:
+        # Worker-thread only: the single-worker pool makes this race-free.
+        if self._conn is None:
+            self._conn = connect(self._path)
+        return self._conn
+
+    def _invoke(
+        self,
+        fn: Callable[Concatenate[sqlite3.Connection, _P], _T],
+        args: tuple,
+        kwargs: dict,
+    ) -> _T:
+        return fn(self._bound(), *args, **kwargs)
+
+    async def run(
+        self,
+        fn: Callable[Concatenate[sqlite3.Connection, _P], _T],
+        /,
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> _T:
+        """Run ``fn(conn, *args, **kwargs)`` on the store's worker thread."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._pool, functools.partial(self._invoke, fn, args, kwargs)
+        )
+
+    async def close(self) -> None:
+        def _close() -> None:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+        await asyncio.get_running_loop().run_in_executor(self._pool, _close)
+        self._pool.shutdown(wait=False)
 
 
 def _migrate(conn: sqlite3.Connection) -> None:

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -35,7 +35,6 @@ import json
 import logging
 import os
 import re
-import sqlite3
 import uuid
 import weakref
 from typing import Annotated
@@ -47,7 +46,7 @@ from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData
 from pydantic import AnyUrl, Field
 
-from . import guide, mcp_ui, outputs, resources_bridge
+from . import guide, mcp_ui, outputs, resources_bridge, store
 from .config import config, server_version
 from .kernel import current_kernel
 
@@ -692,13 +691,14 @@ async def kernel_trace(ctx: Context | None = None) -> str:
 
 # The reply tool's store connection, opened lazily on first reply. The tool runs
 # in the server process (the kernel's `events` writes come from its own
-# connection), so it needs its own handle on the shared WAL store.
-_reply_conn: sqlite3.Connection | None = None
+# connection), so it needs its own handle on the shared WAL store. The async
+# facade keeps its writes off the shared event loop (index#2348).
+_reply_db: store.AsyncConn | None = None
 
 
-def _reply_store() -> sqlite3.Connection:
-    global _reply_conn
-    if _reply_conn is None:
+def _reply_store() -> store.AsyncConn:
+    global _reply_db
+    if _reply_db is None:
         # `store_path` is None outside `serve` (e.g. an embedder driving the
         # tools directly), which needs the same error as having no config at all.
         try:
@@ -709,10 +709,8 @@ def _reply_store() -> sqlite3.Connection:
             raise McpError(
                 ErrorData(code=types.INTERNAL_ERROR, message="no store configured; reply needs `ix-mcp serve`")
             )
-        from . import store
-
-        _reply_conn = store.connect(path)
-    return _reply_conn
+        _reply_db = store.AsyncConn(path)
+    return _reply_db
 
 
 @mcp.tool(structured_output=False, description=guide.REPLY)
@@ -728,17 +726,15 @@ async def reply(
     await _identify_client_once(ctx)
     # Deliberately not gated on session_set_name: a reply answers a channel event
     # (often the session's very first act) and creates no dashboard run to label.
-    from . import store
-
-    conn = _reply_store()
-    if not store.resource_live(conn, resource):
+    db = _reply_store()
+    if not await db.run(store.resource_live, resource):
         raise McpError(
             ErrorData(
                 code=types.INVALID_PARAMS,
                 message=f"no live resource {resource!r}; pass the id from the <channel resource=...> attribute",
             )
         )
-    store.add_event(conn, resource=resource, kind="reply", body=json.dumps({"text": text}))
+    await db.run(store.add_event, resource=resource, kind="reply", body=json.dumps({"text": text}))
     return [outputs.text("sent")]
 
 

--- a/packages/mcp/ix_notebook_mcp/transport.py
+++ b/packages/mcp/ix_notebook_mcp/transport.py
@@ -150,7 +150,9 @@ async def pump_outbox(
     cfg = config()
     if not cfg.store_path:
         return
-    conn = store.connect(cfg.store_path)
+    # Through the async facade: `take_outbox` deletes as it reads, and on a fat
+    # store that write used to run inline on the shared event loop (index#2348).
+    db = store.AsyncConn(cfg.store_path)
     try:
         while True:
             # Wait for the handshake before draining, so rows that accrue during
@@ -164,7 +166,7 @@ async def pump_outbox(
                 # server's own session id. A job lifecycle event addressed to
                 # another session stays queued for its own pump instead of
                 # waking this client (issue #2165).
-                rows = store.take_outbox(conn, session=cfg.server_session_id)
+                rows = await db.run(store.take_outbox, session=cfg.server_session_id)
             except Exception:
                 rows = []  # best-effort: a read error this tick just retries next tick
             for row in rows:
@@ -186,7 +188,7 @@ async def pump_outbox(
                     return
             await anyio.sleep(_OUTBOX_POLL_SECONDS)
     finally:
-        conn.close()
+        await db.close()
 
 
 # ASGI plumbing types for the HTTP transport's auth gate. `object` values (not

--- a/packages/mcp/tests/fleet_cluster_check.py
+++ b/packages/mcp/tests/fleet_cluster_check.py
@@ -133,7 +133,7 @@ def check_exec_auth() -> None:
             exec_token=token,
             exec_trust_network=trust,
         )
-        app = dashboard.build_app(cfg, conn)
+        app = dashboard.build_app(cfg, store.AsyncConn(cfg.store_path))
         async with TestClient(TestServer(app)) as client:
             headers = {"Authorization": auth} if auth else {}
             resp = await client.post("/api/exec", json=payload, headers=headers)

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -516,7 +516,7 @@ def test_sse_streams_new_events_only(tmp_path: Path) -> None:
         cfg = Config(workdir=tmp_path, store_path=db)
         # History from before the subscription must not replay.
         store.add_event(conn, resource="panel", kind="reply", body=json.dumps({"text": "old"}))
-        client = TestClient(TestServer(dashboard.build_app(cfg, conn)))
+        client = TestClient(TestServer(dashboard.build_app(cfg, store.AsyncConn(cfg.store_path))))
         await client.start_server()
         try:
             async with client.get("/api/resources/panel/events") as resp:
@@ -555,7 +555,7 @@ def test_reply_tool_appends_event_for_live_resource(tmp_path: Path, monkeypatch:
         conn = store.connect(db)
         cfg = Config(workdir=tmp_path, store_path=db)
         monkeypatch.setattr("ix_notebook_mcp.tools.config", lambda: cfg)
-        monkeypatch.setattr(tools, "_reply_conn", None)
+        monkeypatch.setattr(tools, "_reply_db", None)
         monkeypatch.setattr(tools, "_dashboard_started", True)
 
         # An unknown/closed resource is refused loudly, and nothing is written.

--- a/packages/mcp/tests/test_input_browser.py
+++ b/packages/mcp/tests/test_input_browser.py
@@ -41,7 +41,7 @@ def test_sandboxed_iframe_fetch_delivers_input(tmp_path: Path, monkeypatch: pyte
         port = _free_port()
         base = f"http://127.0.0.1:{port}"
         cfg = Config(workdir=tmp_path, store_path=db, host="127.0.0.1", dashboard_port=port)
-        runner = web.AppRunner(dashboard.build_app(cfg, conn))
+        runner = web.AppRunner(dashboard.build_app(cfg, store.AsyncConn(cfg.store_path)))
         await runner.setup()
         await web.TCPSite(runner, "127.0.0.1", port).start()
 

--- a/packages/mcp/tests/test_inputs.py
+++ b/packages/mcp/tests/test_inputs.py
@@ -73,8 +73,8 @@ def _app(tmp_path: Path) -> tuple[Config, sqlite3.Connection]:
     return cfg, conn
 
 
-async def _client(cfg: Config, conn: sqlite3.Connection) -> TestClient:
-    client = TestClient(TestServer(dashboard.build_app(cfg, conn)))
+async def _client(cfg: Config) -> TestClient:
+    client = TestClient(TestServer(dashboard.build_app(cfg, store.AsyncConn(cfg.store_path))))
     await client.start_server()
     return client
 
@@ -89,7 +89,7 @@ def test_api_input_network_gate(tmp_path: Path) -> None:
         # rides in HTML the read endpoints serve, so it is not a secret -- input is
         # authorized by the network boundary, like /api/exec.
         untrusted = Config(workdir=tmp_path, store_path=db, host="100.64.0.1")
-        client = await _client(untrusted, conn)
+        client = await _client(untrusted)
         try:
             resp = await client.post("/api/input", data=body)
             assert resp.status == 403
@@ -98,7 +98,7 @@ def test_api_input_network_gate(tmp_path: Path) -> None:
             await client.close()
         # Trusting the tailnet (what the fleet sets) accepts it.
         trusted = Config(workdir=tmp_path, store_path=db, host="100.64.0.1", exec_trust_network=True)
-        client = await _client(trusted, conn)
+        client = await _client(trusted)
         try:
             resp = await client.post("/api/input", data=body)
             assert resp.status == 200
@@ -113,7 +113,7 @@ def test_api_input_accepts_open_channel_and_queues(tmp_path: Path) -> None:
     async def run() -> None:
         cfg, conn = _app(tmp_path)
         store.open_channel(conn, id="cap", title="t")
-        client = await _client(cfg, conn)
+        client = await _client(cfg)
         try:
             resp = await client.post(
                 "/api/input", data=json.dumps({"channel": "cap", "payload": {"value": "hi"}})
@@ -135,7 +135,7 @@ def test_api_input_accepts_open_channel_and_queues(tmp_path: Path) -> None:
 def test_api_input_rejects_unknown_and_closed_channel(tmp_path: Path) -> None:
     async def run() -> None:
         cfg, conn = _app(tmp_path)
-        client = await _client(cfg, conn)
+        client = await _client(cfg)
         try:
             resp = await client.post(
                 "/api/input", data=json.dumps({"channel": "ghost", "payload": 1})
@@ -152,7 +152,7 @@ def test_api_input_validation_and_size_cap(tmp_path: Path) -> None:
     async def run() -> None:
         cfg, conn = _app(tmp_path)
         store.open_channel(conn, id="cap", title="t")
-        client = await _client(cfg, conn)
+        client = await _client(cfg)
         try:
             # Missing payload key is a 400 (distinct from a closed channel's 404).
             resp = await client.post("/api/input", data=json.dumps({"channel": "cap"}))
@@ -174,7 +174,7 @@ def test_api_input_validation_and_size_cap(tmp_path: Path) -> None:
 def test_api_input_preflight_returns_cors(tmp_path: Path) -> None:
     async def run() -> None:
         cfg, conn = _app(tmp_path)
-        client = await _client(cfg, conn)
+        client = await _client(cfg)
         try:
             resp = await client.options("/api/input")
             assert resp.status == 204

--- a/packages/mcp/tests/test_mcp_ui.py
+++ b/packages/mcp/tests/test_mcp_ui.py
@@ -272,7 +272,7 @@ def test_api_job_ui_serves_embedded_view(tmp_path: Path) -> None:
     cfg = Config(workdir=tmp_path, store_path=db)
 
     async def run() -> None:
-        client = TestClient(TestServer(dashboard.build_app(cfg, conn)))
+        client = TestClient(TestServer(dashboard.build_app(cfg, store.AsyncConn(cfg.store_path))))
         await client.start_server()
         try:
             resp = await client.get("/api/jobs/ab12/ui")

--- a/packages/mcp/tests/test_store_async.py
+++ b/packages/mcp/tests/test_store_async.py
@@ -1,0 +1,73 @@
+"""The store's async facade: every call runs on one private worker thread, off
+the caller's event loop, and the cheap `data_version` change gate the pane
+bridge polls with (index#2348: inline blob reads on the shared loop starved MCP
+stdio and presented as a kernel wedge)."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import threading
+from pathlib import Path
+
+import pytest
+
+from ix_notebook_mcp import store
+from ix_notebook_mcp.pane_bridge import _data_version
+
+
+def test_async_conn_runs_off_loop_on_one_thread(tmp_path: Path) -> None:
+    async def run() -> None:
+        db = store.AsyncConn(tmp_path / "a.db")
+        seen: set[int] = set()
+
+        def probe(conn: sqlite3.Connection, value: int) -> int:
+            seen.add(threading.get_ident())
+            # The connection is live and usable where the call runs.
+            assert conn.execute("SELECT ?", (value,)).fetchone()[0] == value
+            return value
+
+        try:
+            assert [await db.run(probe, n) for n in range(3)] == [0, 1, 2]
+        finally:
+            await db.close()
+        # Confined: every call landed on the same worker thread, never the loop's.
+        assert seen != {threading.get_ident()}
+        assert len(seen) == 1
+
+    asyncio.run(run())
+
+
+def test_async_conn_kwargs_and_store_functions(tmp_path: Path) -> None:
+    async def run() -> None:
+        path = tmp_path / "s.db"
+        writer = store.connect(path)
+        store.start(writer, id="j1", name="n", code="1+1", started_at=1.0)
+        db = store.AsyncConn(path)
+        try:
+            rows = await db.run(store.recent, limit=5)
+        finally:
+            await db.close()
+        assert [r["id"] for r in rows] == ["j1"]
+
+    asyncio.run(run())
+
+
+def test_async_conn_requires_a_path() -> None:
+    # Eager, like store.connect: `serve` must fail at startup, not first request.
+    with pytest.raises(ValueError):
+        store.AsyncConn(None)  # type: ignore[arg-type]
+
+
+def test_data_version_moves_only_on_foreign_commit(tmp_path: Path) -> None:
+    # The pane bridge's idle gate: reads on the polling connection leave the
+    # version unchanged; a commit by ANY other connection (the kernel writing a
+    # run) moves it, triggering exactly one re-render.
+    path = tmp_path / "v.db"
+    poller = store.connect(path)
+    before = _data_version(poller)
+    store.recent(poller, limit=5)  # own reads never move it
+    assert _data_version(poller) == before
+    writer = store.connect(path)
+    store.start(writer, id="j1", name="", code="1", started_at=1.0)
+    assert _data_version(poller) != before

--- a/packages/mcp/tests/test_svelte.py
+++ b/packages/mcp/tests/test_svelte.py
@@ -131,7 +131,7 @@ def test_component_click_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         port = _free_port()
         base = f"http://127.0.0.1:{port}"
         cfg = Config(workdir=tmp_path, store_path=db, host="127.0.0.1", dashboard_port=port)
-        runner = web.AppRunner(dashboard.build_app(cfg, conn))
+        runner = web.AppRunner(dashboard.build_app(cfg, store.AsyncConn(cfg.store_path)))
         await runner.setup()
         await web.TCPSite(runner, "127.0.0.1", port).start()
 


### PR DESCRIPTION
Fixes #2348.

`ix_notebook_mcp serve` ran every store SQLite call synchronously on its single asyncio event loop (shared by MCP stdio transport, the aiohttp data API, and the pane bridge). Against a large per-session store (225MB observed; pane_bridge re-read 100 executions with full multi-MB blobs 4x/sec even when idle), blob I/O starved MCP stdio and the session presented as a wedged kernel.

Changes:
- `store.AsyncConn`: the store connection confined to a private single-worker thread pool; the connection is opened lazily on the worker thread so `check_same_thread` enforces confinement. `await db.run(store.fn, ...)` keeps the existing free-function store API.
- pane_bridge: gate each poll on `PRAGMA data_version` (one cheap query per tick) instead of re-reading all pane blobs; snapshot + publish only when another connection actually committed.
- dashboard, transport `pump_outbox`, tools `reply`: migrated to `AsyncConn`.
- New `storeAsyncTests` derivation (thread confinement, kwargs passthrough, eager None-path failure, data_version semantics).

Validation: `nix build .#mcp.tests.{storeAsyncTests,channelTests,inputsTests,mcpUiTests,strictTypecheck,serverTools}` on darwin; failure set identical to origin/main's darwin baseline (loopback-bind `PermissionError` in the nix sandbox, pre-existing), strictTypecheck green.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Confine server-side SQLite store calls to a worker thread off the event loop
> - Introduces `AsyncConn` in [`store.py`](https://github.com/indexable-inc/index/pull/2353/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976), a facade that routes all synchronous store calls through a single-threaded `ThreadPoolExecutor`, exposing an `async run(fn, ...)` interface for use in async contexts.
> - Updates `dashboard.py`, `pane_bridge.py`, `tools.py`, and `transport.py` to replace direct `sqlite3` connections with `AsyncConn`, so all store I/O runs off the event loop.
> - The pane bridge additionally gates snapshot recomputation on `PRAGMA data_version` changes, so it only re-renders when another connection has committed.
> - Adds `tests/test_store_async.py` to verify thread confinement and `data_version` behavior, and wires it into the Nix `checks`.
> - Behavioral Change: all async entry points that previously blocked the event loop on SQLite reads/writes now delegate to a background thread; connection lifecycle (open, close) also moves to that thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 412d80b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->