### PR TITLE
mcp: per-serve kernel faulthandler trace file, sweep orphans

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1973,10 +1973,11 @@
   serverTools = importTest "server" (
     "import asyncio; from ix_notebook_mcp.tools import mcp; "
     + "names = sorted(t.name for t in asyncio.run(mcp.list_tools())); "
-    # session_set_name joined the surface in #1615 but this expected set was
-    # not updated with it; the stale drv kept passing from cache on main until
-    # this package's inputs changed and forced a rebuild.
-    + "expected = {'python_exec','pr_watch','read','kernel_trace','tui_act','session_set_name','topic_set','reply'}; "
+    # This set drifts silently: session_set_name (#1615) and kernel_restart
+    # (#2349) each joined the surface without updating it, and the stale drv
+    # kept passing from cache on main until this package's inputs changed and
+    # forced a rebuild. When adding a tool, add it here in the same change.
+    + "expected = {'python_exec','pr_watch','read','kernel_trace','kernel_restart','tui_act','session_set_name','topic_set','reply'}; "
     + "assert set(names) == expected, ('tool surface drifted: %r' % (names,)); "
     + "from ix_notebook_mcp import registry; instr = mcp._mcp_server.instructions; "
     + "assert 'root=' not in instr, 'a parameter/signature leaked into the instructions'; "

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3038,7 +3038,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3067,6 +3067,8 @@
       # In-band kernel build staleness (#2110): the api() header row and the
       # TypeError-hint build stamp; imports the site-packages ix_notebook_mcp.
       cp ${./tests/test_build_info.py} test_build_info.py
+      # Issue #2355: per-serve kernel trace file + sweep of orphaned dumps.
+      cp ${./tests/test_kernel_trace_path.py} test_kernel_trace_path.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_jobs_spawn.py \
@@ -3076,6 +3078,7 @@
         test_claude_history.py \
         test_sh_module.py \
         test_build_info.py \
+        test_kernel_trace_path.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -61,6 +61,31 @@ def _describe_exit(returncode: int | None) -> str:
     return f"exit code {returncode}"
 
 
+def trace_path_for(server_pid: int) -> Path:
+    """The faulthandler dump target for the serve owning ``server_pid``. One
+    file per serve, not one machine-wide name: concurrent kernels sharing a
+    path truncate and interleave each other's dumps (index#2355)."""
+    return runtime_dir() / f"kernel-trace-{server_pid}.txt"
+
+
+def _sweep_stale_traces() -> None:
+    """Drop trace files orphaned by serves that are gone: a SIGKILLed serve
+    never reaches shutdown(), so its file would linger in runtime_dir()
+    forever. The legacy fixed-name ``kernel-trace.txt`` (no pid suffix) is
+    left alone for still-running older builds."""
+    for path in runtime_dir().glob("kernel-trace-*.txt"):
+        try:
+            pid = int(path.stem.rsplit("-", 1)[-1])
+        except ValueError:
+            continue
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            path.unlink(missing_ok=True)
+        except PermissionError:
+            continue  # a live process we cannot signal: not ours to sweep
+
+
 def _wedged_summary(budget: float, grace: float, deadline: float, *, interrupted: bool) -> dict:
     """A per-call summary, shaped like ``runtime._job_summary``, returned when a
     cell blocks the kernel past ``deadline``. The server renders it like any
@@ -131,9 +156,14 @@ class Kernel:
         from jupyter_client.manager import AsyncKernelManager
 
         # Point the kernel's faulthandler at a private file before launch; the
-        # kernel inherits this env and registers the SIGUSR1 dump handler.
-        self._trace_path = runtime_dir() / "kernel-trace.txt"
+        # kernel inherits this env and registers the SIGUSR1 dump handler. The
+        # name carries this server's pid: every serve on the machine shares
+        # runtime_dir(), and one fixed name had concurrent kernels truncating
+        # and interleaving each other's dumps, so kernel_trace could return a
+        # different session's stacks (index#2355).
+        self._trace_path = trace_path_for(os.getpid())
         os.environ[TRACE_ENV] = str(self._trace_path)
+        _sweep_stale_traces()
 
         self._km = AsyncKernelManager(kernel_name="python3")
         await self._km.start_kernel(cwd=str(self._config.workdir))
@@ -565,6 +595,12 @@ class Kernel:
             self._kc.stop_channels()
         if self._km is not None:
             await self._km.shutdown_kernel(now=True)
+        # This serve owns its trace file (the name carries our pid): remove it
+        # so clean exits leave nothing behind; SIGKILLed serves are covered by
+        # the sweep at the next start().
+        if self._trace_path is not None:
+            self._trace_path.unlink(missing_ok=True)
+            self._trace_path = None
 
 
 _KERNEL: Kernel | None = None

--- a/packages/mcp/tests/test_kernel_trace_path.py
+++ b/packages/mcp/tests/test_kernel_trace_path.py
@@ -1,0 +1,48 @@
+"""index#2355: every serve pointed its kernel's faulthandler at one fixed
+``kernel-trace.txt``, so concurrent kernels truncated and interleaved each
+other's dumps and ``kernel_trace`` could return a different session's stacks.
+The dump target must be per-serve, and files orphaned by SIGKILLed serves
+must be swept at the next start."""
+
+import os
+import subprocess
+
+import pytest
+
+from ix_notebook_mcp.kernel import _sweep_stale_traces, trace_path_for
+
+
+@pytest.fixture
+def runtime(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory) -> str:
+    base = tmp_path_factory.mktemp("xdg")
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(base))
+    return str(base)
+
+
+def test_trace_path_is_per_server(runtime: str) -> None:
+    a, b = trace_path_for(111), trace_path_for(222)
+    assert a != b
+    assert a.parent == b.parent
+    assert str(a.parent).startswith(runtime)
+
+
+def test_sweep_removes_only_dead_owners(runtime: str) -> None:
+    dead = trace_path_for(_finished_pid())
+    alive = trace_path_for(os.getpid())
+    legacy = alive.parent / "kernel-trace.txt"  # older builds' fixed name
+    junk = alive.parent / "kernel-trace-abc.txt"  # no pid suffix
+    for p in (dead, alive, legacy, junk):
+        p.write_text("dump")
+
+    _sweep_stale_traces()
+
+    assert not dead.exists()
+    assert alive.exists()
+    assert legacy.exists()
+    assert junk.exists()
+
+
+def _finished_pid() -> int:
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    return proc.pid


### PR DESCRIPTION
Fixes #2355.

Every `ix_notebook_mcp serve` pointed `IX_MCP_KERNEL_TRACE` at the same fixed `runtime_dir()/kernel-trace.txt`, so all kernels on a machine shared one faulthandler dump file: `kernel_trace` could return a different session's stacks, and a concurrent kernel launch truncated the file mid-read (observed live: six kernels on one inode while diagnosing a wedge).

- name the trace file by the owning serve's pid (`kernel-trace-<pid>.txt`)
- remove it on clean `shutdown()`
- sweep files whose owning serve is gone at the next `start()` (a SIGKILLed serve never reaches shutdown)
- leave the legacy fixed name alone for still-running older builds

Validation: `nix build .#mcp.tests.typecheckSmoke .#mcp.tests.strictTypecheck` green locally (93 passed, includes the new `test_kernel_trace_path.py`). `kernelDeathSmoke`/`kernelRestartSmoke` fail on darwin sandbox socket-bind on unmodified main too (pre-existing, Linux CI runs them).

(PR by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-serve faulthandler trace files and sweep orphaned traces on kernel start
> - Each MCP server instance now writes kernel faulthandler dumps to a unique file (`kernel-trace-{pid}.txt`) instead of a shared fixed name, preventing collisions between concurrent servers.
> - On kernel start, `_sweep_stale_traces()` scans the runtime dir and removes trace files whose owning process no longer exists.
> - On clean shutdown, `Kernel.shutdown` unlinks the trace file owned by that server instance.
> - Tests in [test_kernel_trace_path.py](https://github.com/indexable-inc/index/pull/2360/files#diff-9995b2d32ce89ab33bf5a29fdd172ebda56f99f45e68289f809e401dc0518b8c) verify distinct path-per-pid naming and sweep semantics (live, legacy, and unparsable files are preserved).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76c89bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->