### PR TITLE
claude-code: use approved channels flag

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -84,6 +84,8 @@ positional). Both rules are learned from real breakage; see the long comment at
 - `--debug`: writes operational telemetry to `~/.claude/debug/` (pruned on the
   `cleanupPeriodDays` sweep). It is an optional-value flag, so it cannot take
   `=`; it is safe only because `--thinking-display` follows it.
+- `--channels server:index`: lets the baked `index` MCP server push channel
+  events into the running session without Claude's development-channel warning.
 - `--thinking-display=summarized`: forces visible reasoning. The API default
   flipped to "omitted" on Opus 4.7/4.8, hiding thinking in the UI and
   transcript; this hidden flag is the only lever that restores it (verified on

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -123,13 +123,10 @@
   # things that happen while you are away. Our `index` server (baked above via
   # `mcpServers`, packages/mcp) is a channel: kernel `notify(...)` and
   # interactive-resource actions emit `notifications/claude/channel` events. It
-  # is our OWN stdio server, not on Anthropic's curated preview allowlist, so it
-  # loads with `--dangerously-load-development-channels` rather than `--channels`
-  # (the "dangerous" name is because a channel injects text into the session's
-  # context — a trust decision; here the source is our own baked server). Each
-  # entry is a channel spec: `server:<mcpServersKey>` or
-  # `plugin:<name>@<marketplace>`; baked as
-  # `--dangerously-load-development-channels <spec>...`. Defaults to the `index`
+  # is our OWN stdio server, baked into this package from the same trusted
+  # registry as `mcpServers`. Each entry is a channel spec:
+  # `server:<mcpServersKey>` or `plugin:<name>@<marketplace>`; baked as
+  # `--channels <spec>...`. Defaults to the `index`
   # server WHEN it is baked (so notify()/interactive resources reach a session
   # with no per-launch flag), and to nothing otherwise (the overlay build has no
   # `index` server, so referencing it would be a dead flag). A session whose org
@@ -359,7 +356,7 @@
     # swallow the user's argv (a prompt, a subcommand). It sits here so the always-
     # present `--thinking-display=` below terminates the spec list.
     ++ lib.optionals (developmentChannels != []) (
-      ["--dangerously-load-development-channels"] ++ developmentChannels
+      ["--channels"] ++ developmentChannels
     )
     ++ [
       # Opus 4.7+ otherwise omits thinking from the UI/transcript.

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -308,7 +308,7 @@ READABLE = (
 
 CHANNEL = (
     "This server is also a Claude Code channel (research preview). When the client session was "
-    "launched with the channel enabled (`claude --dangerously-load-development-channels "
+    "launched with the channel enabled (`claude --channels "
     "server:<name>`), kernel code can push events into the running agent session with `await "
     "notify(content, **meta)`: each event arrives in the session as <channel source=\"...\" "
     "key=\"val\">content</channel>, with each meta kwarg a tag attribute (identifier keys only). "

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1748,7 +1748,7 @@ async def notify(content: str, **meta: Any) -> None:
 
     This server is a Claude Code channel (research preview): when the client
     session was launched with the channel enabled (``claude
-    --dangerously-load-development-channels server:<name>``), the event lands in
+    --channels server:<name>``), the event lands in
     the agent's context as ``<channel source="<name>" key="val">content</channel>``
     and wakes it. Each keyword becomes a tag attribute (values are stringified)::
 

--- a/packages/mcp/ix_notebook_mcp/transport.py
+++ b/packages/mcp/ix_notebook_mcp/transport.py
@@ -10,9 +10,8 @@ https://code.claude.com/docs/en/channels-reference): it advertises the
 (what the kernel's ``notify()`` writes) as ``notifications/claude/channel``
 events, so kernel code can push into the running agent session. Channels are
 stdio-only by contract (Claude Code spawns the channel server as a subprocess
-and a session opts in per-entry via ``--channels`` /
-``--dangerously-load-development-channels``), so the HTTP transport does not
-grow one. A client that did not opt in ignores both the capability and the
+and a session opts in per-entry via ``--channels``), so the HTTP transport does
+not grow one. A client that did not opt in ignores both the capability and the
 notifications, so this costs nothing when unused.
 """
 

--- a/packages/mcp/tests/test_inputs.py
+++ b/packages/mcp/tests/test_inputs.py
@@ -173,7 +173,7 @@ def test_api_input_validation_and_size_cap(tmp_path: Path) -> None:
 
 def test_api_input_preflight_returns_cors(tmp_path: Path) -> None:
     async def run() -> None:
-        cfg, conn = _app(tmp_path)
+        cfg, _conn = _app(tmp_path)
         client = await _client(cfg)
         try:
             resp = await client.options("/api/input")

--- a/packages/mcp/tests/test_store_async.py
+++ b/packages/mcp/tests/test_store_async.py
@@ -55,7 +55,7 @@ def test_async_conn_kwargs_and_store_functions(tmp_path: Path) -> None:
 
 def test_async_conn_requires_a_path() -> None:
     # Eager, like store.connect: `serve` must fail at startup, not first request.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="store path is required"):
         store.AsyncConn(None)  # type: ignore[arg-type]
 
 


### PR DESCRIPTION
## Summary
- load the baked index Claude channel with `--channels` instead of the development-channel flag
- update MCP channel docs to show the approved flag
- fix two ruff nits so the repo lint gate is green

## Validation
- built `.#claude-code`
- inspected the built launch spec: `--channels` present, old development-channel flag absent
- `nix run .#lint`

Fixes #2373

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `--dangerously-load-development-channels` with `--channels` flag in claude-code
> - Updates [default.nix](https://github.com/indexable-inc/index/pull/2374/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) to pass `--channels <spec>` instead of `--dangerously-load-development-channels <spec>` when launching Claude Code with configured channels.
> - Updates documentation and MCP package guidance in [guide.py](https://github.com/indexable-inc/index/pull/2374/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76), [runtime.py](https://github.com/indexable-inc/index/pull/2374/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95), and [transport.py](https://github.com/indexable-inc/index/pull/2374/files#diff-39ae84714e8a966882f8856c976f1ebce9f5fd42dac02f22e89e4cbc672e1675) to reference the new flag name.
> - Behavioral Change: Claude Code sessions now launch with the approved `--channels` flag, removing development-channel warnings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef421e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->