### PR TITLE
mcp: verify wedge rescue and escalate to kernel restart

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3373,6 +3373,35 @@
       mkdir -p "$out"
     '';
 
+  # python_exec's wedge escalation (index#2375): the SIGUSR2 rescue only helps a
+  # Python-level block; a main thread stuck inside native code never runs the
+  # handler, so after the interrupt the server must PROBE the kernel and, when
+  # the probe hangs too, kill and respawn only the kernel child (never claim
+  # "usable again" on mere signal delivery). Boots a real kernel, so it reuses
+  # the full interpreter plus pytest.
+  wedgeEscalationTestSource = builtins.path {
+    name = "ix-mcp-wedge-escalation-test";
+    path = ./tests/test_kernel_wedge_escalation.py;
+  };
+  wedgeEscalationSmoke =
+    pkgs.runCommand "ix-mcp-wedge-escalation-smoke"
+    {
+      nativeBuildInputs = [typecheckTestPython];
+      strictDeps = true;
+    }
+    ''
+      export HOME=$TMPDIR/home
+      mkdir -p "$HOME"
+      cp ${wedgeEscalationTestSource} "$TMPDIR/test_kernel_wedge_escalation.py"
+      ${lib.getExe typecheckTestPython} -m pytest "$TMPDIR/test_kernel_wedge_escalation.py" -q -p no:cacheprovider >stdout 2>stderr || {
+        echo "ix-mcp wedge-escalation smoke failed:" >&2
+        cat stdout stderr >&2
+        exit 1
+      }
+      cat stdout
+      mkdir -p "$out"
+    '';
+
   # Exercises the rich-output capture path: a DataFrame result is persisted to the
   # store with its text/html bundle (so the dashboard renders a table, not a repr),
   # a display() call made while a job runs is captured the same way, and a bytes
@@ -6102,6 +6131,7 @@ in
               wedgeSmoke
               kernelDeathSmoke
               kernelRestartSmoke
+              wedgeEscalationSmoke
               richSmoke
               yieldSmoke
               bindingsSmoke

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -368,6 +368,18 @@ class Kernel:
                 # and respawn just the kernel child instead (index#2375). Safe:
                 # session restore replays only SUCCESSFUL cells, so the wedged
                 # cell is not re-run.
+                #
+                # First preserve the evidence the kill would destroy: faulthandler's
+                # SIGUSR1 dump is C-level, so it fires even mid-native-block and
+                # names the frame that called into it -- exactly the stack #2095
+                # needs from a live occurrence. Best-effort, to stderr/journald.
+                with contextlib.suppress(Exception):  # evidence capture must never block the escalation
+                    trace = await self.dump_trace()
+                    print(
+                        f"[ix-mcp] wedged kernel stack before escalation kill (pid {self._pid}):\n{trace}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
                 try:
                     await self.restart_now(freshen=False, reason="wedge escalation, index#2375")
                     outcome = "restarted"

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -86,28 +86,45 @@ def _sweep_stale_traces() -> None:
             continue  # a live process we cannot signal: not ours to sweep
 
 
-def _wedged_summary(budget: float, grace: float, deadline: float, *, interrupted: bool) -> dict:
+# What the wedge rescue actually achieved, verified rather than assumed
+# (index#2375): "recovered" means the kernel answered a probe after the
+# interrupt; "restarted" means it did not (a block inside native code never
+# reaches the Python-level rescue handler) and the kernel child was killed and
+# respawned; "restart_pending" means another call already owns that respawn.
+_RECOVERY = {
+    "recovered": "The kernel was interrupted, answered a follow-up probe, and is usable again.",
+    "restarted": (
+        "The interrupt did not unblock it (a block inside native code never "
+        "reaches the Python-level rescue handler), so the kernel child was "
+        "killed and respawned: the session namespace was restored from its "
+        "checkpoint and this cell's work was lost."
+    ),
+    "restart_pending": (
+        "The interrupt did not unblock it and a kernel restart is already in "
+        "progress; retry shortly."
+    ),
+}
+
+
+def _wedged_summary(budget: float, grace: float, deadline: float, *, outcome: str) -> dict:
     """A per-call summary, shaped like ``runtime._job_summary``, returned when a
     cell blocks the kernel past ``deadline``. The server renders it like any
     other summary, so the caller gets a clear, actionable message rather than an
-    opaque transport timeout. ``interrupted`` reports whether the rescue signal
-    was actually sent, so the message does not claim a recovery that did not
-    happen when the kernel pid is unknown."""
-    recovery = (
-        "The kernel was interrupted and is usable again."
-        if interrupted
-        else "The kernel could NOT be interrupted (its pid is unknown); it is still "
-        "blocked and likely needs a restart."
-    )
+    opaque transport timeout. ``outcome`` (a ``_RECOVERY`` key) reports what the
+    rescue verifiably achieved, so the message never claims a recovery that did
+    not happen (index#2375: SIGUSR2 delivery alone proves nothing when the block
+    is in native code)."""
     message = (
         f"Cell blocked the kernel's event loop for over {deadline:.0f}s "
         f"(budget {budget:.0f}s + {grace:.0f}s grace) with a synchronous "
-        f"call, so the budget could not background it. {recovery} "
+        f"call, so the budget could not background it. {_RECOVERY[outcome]} "
         "Wrap blocking calls (subprocess.run, time.sleep, "
         "requests, heavy CPU) in `await asyncio.to_thread(...)` or use an async "
-        "API, and run anything slow as a background job. The interrupted run is "
-        "recoverable in this kernel via history() / jobs['<id>']."
+        "API, and run anything slow as a background job."
     )
+    if outcome == "recovered":
+        # Only a surviving kernel still holds the interrupted run's job row.
+        message += " The interrupted run is recoverable in this kernel via history() / jobs['<id>']."
     return {
         "id": None,
         "name": None,
@@ -317,8 +334,11 @@ class Kernel:
         the job and returns the summary right after the budget elapses). If the
         kernel does not report idle within ``budget + wedge_grace`` the cell is
         blocking the kernel's single event loop with a synchronous call: interrupt
-        the kernel so it is usable again and return an actionable summary instead
-        of letting an opaque ``Timeout waiting for output`` escape to the caller.
+        the kernel, verify with a probe that the interrupt actually landed, and
+        escalate to a kernel restart when it did not (index#2375: a block inside
+        native code never reaches the Python-level rescue handler, so delivery
+        alone recovers nothing) -- then return an actionable summary instead of
+        letting an opaque ``Timeout waiting for output`` escape to the caller.
         """
         name_arg = "None" if name is None else repr(name)
         session_arg = "None" if session is None else repr(session)
@@ -337,7 +357,25 @@ class Kernel:
             # while this request waited, report that precise cause, never a wedge.
             self._check_alive()
             interrupted = await self._interrupt()
-            return [], _wedged_summary(budget, grace, deadline, interrupted=interrupted)
+            if interrupted and await self._probe_idle():
+                outcome = "recovered"
+            else:
+                # Delivery is not recovery: the SIGUSR2 rescue is a Python-level
+                # handler that only runs at a bytecode boundary, so a main thread
+                # blocked inside native code (the embedded nu engine, index#2095;
+                # any C extension) never executes it. Left alone the kernel wedges
+                # until the client SIGTERMs the whole serve (index#2365), so kill
+                # and respawn just the kernel child instead (index#2375). Safe:
+                # session restore replays only SUCCESSFUL cells, so the wedged
+                # cell is not re-run.
+                try:
+                    await self.restart_now(freshen=False, reason="wedge escalation, index#2375")
+                    outcome = "restarted"
+                except RuntimeError:
+                    # Another call's escalation (or an operator's kernel_restart)
+                    # already owns the respawn; its restore will serve us too.
+                    outcome = "restart_pending"
+            return [], _wedged_summary(budget, grace, deadline, outcome=outcome)
 
     async def set_client(self, client: str) -> None:
         """Tell the kernel which MCP client connected, so the session label can
@@ -386,13 +424,27 @@ class Kernel:
         the kernel's runtime handler instead: it raises ``KeyboardInterrupt`` inline
         at the blocked frame, which ``_runner`` records as a failed job so the
         kernel returns to idle and the next call runs. Returns whether the signal
-        was actually delivered, so the caller's summary does not claim a recovery
-        that did not happen."""
+        was DELIVERED -- not whether it recovered anything: the handler is
+        Python-level, so a main thread blocked inside native code never runs it
+        (index#2375). Callers must verify with :meth:`_probe_idle`."""
         if self._pid is None:
             return False
         try:
             os.kill(self._pid, signal.SIGUSR2)
         except ProcessLookupError:
+            return False
+        return True
+
+    async def _probe_idle(self, timeout: float | None = None) -> bool:
+        """Whether the kernel answers a trivial execute, i.e. a rescue attempt
+        actually returned it to idle. ``wait_for`` also bounds the wait for the
+        shell lock itself, which an unrescued kernel's earlier request may still
+        hold; cancelling ``_execute`` there is safe (its cancel path drains the
+        socket under the lock before re-raising)."""
+        budget = timeout if timeout is not None else max(5.0, self._config.wedge_grace)
+        try:
+            await asyncio.wait_for(self._execute("pass", timeout=budget), timeout=budget + 5.0)
+        except TimeoutError:
             return False
         return True
 
@@ -527,9 +579,11 @@ class Kernel:
             await locked.wait()
         self._death = None
 
-    async def restart_now(self) -> dict[str, int | float | None]:
+    async def restart_now(
+        self, *, freshen: bool = True, reason: str = "requested via kernel_restart"
+    ) -> dict[str, int | float | None]:
         """An intentional restart of this server's kernel: the `kernel_restart`
-        tool's primitive (index#2345).
+        tool's primitive (index#2345) and the wedge escalation's (index#2375).
 
         Reuses the death watch's respawn machinery (``restart()``: fresh
         process, rebuilt channels, checkpoint restore, session labels
@@ -538,8 +592,10 @@ class Kernel:
         report this as a death nor race its own respawn against it; it is
         re-armed for the new process afterwards. Loud on stderr (which reaches
         journald), like the death watch, so an operator can see who bounced a
-        kernel and when. Returns the old pid, the new pid, and the elapsed
-        seconds.
+        kernel and when. ``freshen=False`` skips the pre-kill checkpoint
+        freshening: the wedge escalation calls this against a kernel known to be
+        blocked, where the snapshot attempt would only burn its timeout.
+        Returns the old pid, the new pid, and the elapsed seconds.
         """
         if self._km is None:
             raise RuntimeError("the kernel is not running")
@@ -550,7 +606,7 @@ class Kernel:
             loop = asyncio.get_running_loop()
             started = loop.time()
             old_pid = self._pid
-            print(f"[ix-mcp] kernel restart requested (pid {old_pid})", file=sys.stderr, flush=True)
+            print(f"[ix-mcp] kernel restart requested (pid {old_pid}; {reason})", file=sys.stderr, flush=True)
             # Stop the death watch FIRST, exactly as shutdown() does: the kill
             # below is intentional.
             if self._watch_task is not None:
@@ -562,14 +618,14 @@ class Kernel:
             # as little as possible -- but on a short leash: the kernel may be
             # wedged, the very reason for this restart, and the periodic
             # checkpoint plus replay already guarantee a correct reopen.
-            if self._death is None and self._config.session_resume:
+            if freshen and self._death is None and self._config.session_resume:
                 with contextlib.suppress(Exception):  # best-effort freshness; a timeout here means a wedged kernel, which the restart below fixes
                     await asyncio.wait_for(self.snapshot_session(timeout=10.0), timeout=15.0)
             # Fail calls already in flight (a wedged cell would otherwise hold
             # the shell lock against the respawn for its whole budget) and guard
             # new ones until the restore holds the channel -- the death watch's
             # own mechanism, with the honest cause instead of a death report.
-            self._death = f"kernel is restarting (requested via kernel_restart; was pid {old_pid}); retry shortly"
+            self._death = f"kernel is restarting ({reason}; was pid {old_pid}); retry shortly"
             self._death_event.set()
             await self.restart()
             self._watch_task = asyncio.ensure_future(self._watch())

--- a/packages/mcp/tests/test_kernel_wedge_escalation.py
+++ b/packages/mcp/tests/test_kernel_wedge_escalation.py
@@ -1,0 +1,88 @@
+"""python_exec wedge escalation: interrupt delivery is not recovery.
+
+index#2375: a cell that blocks the kernel's main thread inside native code
+(the embedded nu engine, index#2095; any C extension) never reaches a bytecode
+boundary, so the Python-level SIGUSR2 rescue handler cannot run. The old path
+still reported "interrupted and is usable again" on mere signal delivery and
+left the kernel wedged until the client SIGTERMed the whole serve
+(index#2365). python_exec must instead verify the rescue with a probe and,
+when the probe also hangs, kill and respawn only the kernel child
+(``restart_now``) so the next call runs.
+"""
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+
+from ix_notebook_mcp import cli
+from ix_notebook_mcp.config import Config
+from ix_notebook_mcp.kernel import Kernel
+
+
+def _config() -> Config:
+    # Install the shipped IPython startup so the in-kernel runtime (__ix_exec,
+    # Result, the SIGUSR1/SIGUSR2 handlers) loads in the booted kernel, as the
+    # CLI wires it.
+    os.environ["IPYTHONDIR"] = str(cli._prepare_ipython_startup(0))
+    return Config(workdir=Path(tempfile.mkdtemp()), wedge_grace=1.0, max_budget=5.0)
+
+
+def test_unrescuable_block_escalates_to_kernel_restart() -> None:
+    config = _config()
+
+    async def main() -> None:
+        kernel = Kernel(config)
+        await kernel.start()
+        try:
+            # Stand in for a native-code block: SIG_IGN makes the process drop
+            # SIGUSR2 at the C level, exactly like a main thread stuck inside a
+            # Rust call that never reaches a bytecode boundary -- the signal is
+            # delivered but the Python-level rescue never runs, so the sleep
+            # holds the loop for its full duration.
+            _, armed = await kernel.python_exec(
+                "import signal\nsignal.signal(signal.SIGUSR2, signal.SIG_IGN)\nResult.ok('armed')",
+                budget=15.0,
+                name="arm",
+            )
+            assert armed is not None and armed["status"] == "done", armed
+            old_pid = kernel._pid
+            assert old_pid is not None
+
+            _, summary = await kernel.python_exec("import time\ntime.sleep(120)", budget=0.5, name="block")
+            assert summary is not None and summary["status"] == "wedged", summary
+            assert "killed and respawned" in summary["error"], summary
+            # The escalation bounced only this kernel child; the fresh pid proves it.
+            assert kernel._pid is not None and kernel._pid != old_pid, (old_pid, kernel._pid)
+            assert kernel._death is None, kernel._death
+
+            _, after = await kernel.python_exec("Result.text('alive')", budget=10.0, name="after")
+            assert after is not None and after["status"] == "done", after
+        finally:
+            await kernel.shutdown()
+
+    asyncio.run(main())
+
+
+def test_rescued_block_reports_verified_recovery() -> None:
+    config = _config()
+
+    async def main() -> None:
+        kernel = Kernel(config)
+        await kernel.start()
+        try:
+            old_pid = kernel._pid
+            # A plain Python-level block: SIGUSR2 interrupts it, the probe
+            # confirms the kernel answered, and NO restart happens.
+            _, summary = await kernel.python_exec("import time\ntime.sleep(120)", budget=0.5, name="block")
+            assert summary is not None and summary["status"] == "wedged", summary
+            assert "usable again" in summary["error"], summary
+            assert "asyncio.to_thread" in summary["error"], summary
+            assert kernel._pid == old_pid, (old_pid, kernel._pid)
+
+            _, after = await kernel.python_exec("Result.text('alive')", budget=10.0, name="after")
+            assert after is not None and after["status"] == "done", after
+        finally:
+            await kernel.shutdown()
+
+    asyncio.run(main())


### PR DESCRIPTION
Fixes #2375. Context: #2365 (incident timeline), #2095 (the nu-engine native hang that triggered it).

**Problem**: `python_exec`'s timeout path fired SIGUSR2 and reported "The kernel was interrupted and is usable again" on mere signal *delivery*. The rescue handler is Python-level (runs only at a bytecode boundary), so a main thread blocked inside native code never executes it. The kernel stayed wedged (observed live 2026-07-08: ~2.5h) until the client SIGTERMed the whole serve, landing the session in #2365's dead-serve state.

**Fix**:
- after `_interrupt()`, probe the kernel with a short raw execute (`_probe_idle`);
- if the probe hangs too, escalate to the existing `restart_now()` (#2345) with `freshen=False` (no point snapshotting a known-blocked kernel) and a `reason` that lands in stderr/journald;
- the wedged summary now reports the verified outcome: recovered / restarted / restart pending.

Safe wrt state: session restore replays only *successful* cells, so the wedged cell is never re-run after the respawn.

**Tests**: `test_kernel_wedge_escalation.py` (wired as `wedgeEscalationSmoke`):
- unrescuable block (SIG_IGN stands in for a native-code block) → kernel child killed and respawned (fresh pid), summary says so, next cell runs;
- plain Python-level block → SIGUSR2 rescue verified by the probe, same pid, "usable again" + `asyncio.to_thread` advice preserved (keeps `wedgeSmoke` green).

Both pass locally against the worktree source (escalation restart in 1.1s).

🤖 Authored by an AI agent (Claude Code, Opus 4.5) during incident response for #2365.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Escalate wedged kernel executes to kernel restart after failed interrupt rescue
> - When `python_exec` times out, it now sends an interrupt and probes the kernel with a trivial `pass` execute via the new `_probe_idle` helper; if the probe fails, it dumps a native stack trace and calls `restart_now(freshen=False)` to kill and respawn only the kernel child process.
> - `_wedged_summary` now selects user-facing text from a `_RECOVERY` map keyed by outcome (`'recovered'`, `'restarted'`, `'restart_pending'`), and only promises job recovery via `history()`/`jobs[...]` when the kernel actually responded to the probe.
> - Adds two smoke tests in [test_kernel_wedge_escalation.py](https://github.com/indexable-inc/index/pull/2378/files#diff-2c331b65a197cbb4ea4f3e5f4b452891574e3ee91530b1e2646010de006d3b30): one simulates an unrescuable block (via `SIGUSR2 → SIG_IGN`) and asserts the kernel pid changes and the summary reports 'killed and respawned'; the other exercises a pure Python sleep and asserts 'usable again' with no restart.
> - Behavioral Change: wedge handling now kills and respawns the kernel process when an interrupt does not restore idle, rather than leaving the kernel in an unresponsive state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2669f38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->