### PR TITLE
flake: stop evaluating deprecated platforms

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -379,7 +379,6 @@
       "x86_64-linux"
       "aarch64-linux"
       "aarch64-darwin"
-      "x86_64-darwin"
     ];
     perSystem = lib.genAttrs devSystems (
       system:
@@ -396,19 +395,18 @@
     );
     collect = key: lib.mapAttrs (_: out: out.${key}) perSystem;
     linuxDarwinAliases = perSystem.x86_64-linux.darwinPackageAliases or {};
-    # Graft the Linux->Darwin cross aliases over a collected per-system set, so
+    # Graft the Linux-to-Darwin cross aliases over a collected per-system set so
     # a Darwin namespace resolves an aliased attr to the cross-compiled
     # x86_64-linux derivation instead of a native rebuild. Applied to both
     # `packages` (the consumer surface) and `cachePushRoots` (what
-    # cache-push.yml publishes): the darwin cache lane realises the post-alias
+    # cache-push.yml publishes): the Darwin cache lane realises the post-alias
     # set filtered to native aarch64-darwin drvs, so an alias-shadowed native
-    # variant (e.g. dag-runner) is neither built nor published -- consumers can
+    # variant (e.g. dag-runner) is neither built nor published. Consumers can
     # never install it (#1890).
     withDarwinAliases = raw:
       raw
       // lib.genAttrs [
         "aarch64-darwin"
-        "x86_64-darwin"
       ] (system: raw.${system} // (linuxDarwinAliases.${system} or {}));
     packages = withDarwinAliases (collect "packages");
   in {

--- a/lib/languages/elixir.nix
+++ b/lib/languages/elixir.nix
@@ -14,7 +14,7 @@
     "1.16" = pkgs.elixir_1_16;
     "1.17" = pkgs.elixir_1_17;
     "1.18" = pkgs.elixir_1_18;
-    "1.19" = pkgs.elixir_1_19;
+    "1.19" = pkgs.beamPackages.elixir_1_19;
   };
 in {
   /**

--- a/lib/languages/erlang.nix
+++ b/lib/languages/erlang.nix
@@ -10,7 +10,7 @@
     "latest" = pkgs.erlang;
     "26" = pkgs.erlang_26;
     "27" = pkgs.erlang_27;
-    "28" = pkgs.erlang_28;
+    "28" = pkgs.beam28Packages.erlang;
   };
 in {
   /**


### PR DESCRIPTION
## Summary
- use the non-deprecated BEAM package-set attributes for Elixir 1.19 and Erlang 28
- stop exposing top-level x86_64-darwin flake outputs so downstream eval does not instantiate deprecated nixpkgs x86_64-darwin

## Validation
- `nix flake metadata --json . --no-eval-cache`
- `nix eval --raw --impure --no-eval-cache --file /tmp/index-elixir-toolchain.nix`
- `nix eval --raw --impure --no-eval-cache --file /tmp/index-erlang-toolchain.nix`
- `git diff --check`

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop evaluating deprecated `x86_64-darwin` platform in flake
> - Removes `x86_64-darwin` from `devSystems` in [flake.nix](https://github.com/indexable-inc/index/pull/2379/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0); only `aarch64-darwin` is now evaluated as a Darwin target.
> - Darwin alias grafting in `withDarwinAliases` is narrowed to `aarch64-darwin` only.
> - Updates Elixir `"1.19"` to resolve via `pkgs.beamPackages.elixir_1_19` and Erlang `"28"` to resolve via `pkgs.beam28Packages.erlang`, correcting package paths for these versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08e941b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->