### PR TITLE
agents: give subagent kernels a non-colliding MCP server name (own-kernel)

### DIFF
--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -16,6 +16,9 @@
 # 2026-07-07 on 2.1.197). Subagents that need shell must bring their own
 # index kernel via `mcpServers` (see subagents.nix `executor` and
 # `index-action-runner`); do not rely on a declared Bash surviving the deny.
+# The inline server must carry a name the parent session does not already
+# bind: a same-named inline `index` is silently discarded and the parent's
+# connection shared instead (#2382), which is no isolation at all.
 {
   lib,
   # True when the wrapper bakes the `index` MCP server (the ix kernel,

--- a/packages/agent/subagents.nix
+++ b/packages/agent/subagents.nix
@@ -1,5 +1,14 @@
 # Declarative Claude subagents bundled by the agent package set. Each agent is
 # authored as Nix data: frontmatter fields plus markdown content.
+#
+# Inline `mcpServers` entries here must NOT reuse a server name the parent
+# session's wrapper already binds (`index`, `exa`): Claude Code silently
+# discards a same-named inline config and reuses the parent's existing
+# connection, so an "own kernel" declared as `index` actually shared the
+# spawning session's serve and inherited its wedges (#2382; probed 2026-07-07:
+# a same-named spawn ran on the parent's kernel pid, a fresh-named spawn got
+# its own serve process). The distinct name is what makes the isolation real;
+# the eval-time assert at the bottom keeps the trap from coming back.
 {
   ix,
   lib,
@@ -15,7 +24,7 @@
           + "the whole loop in its own index kernel and returns only the distilled "
           + "result, keeping screenshots and DOM dumps out of the main thread.";
         mcpServers = ix.mcp.toAgentMcpServers {
-          index = {
+          own-kernel = {
             transport = "stdio";
             command = lib.getExe repoPackages.mcp;
             args = ["serve"];
@@ -29,9 +38,12 @@
         dumps, and intermediate tool output it never needs again. Your whole value is
         that none of that crosses back. Only your final message reaches the parent.
 
-        You have your own `index` MCP: a fresh Python kernel (`python_exec`) with the
-        bundled helpers (`browser`, `view`, `grep`, `find`, `nu`, image `Read`, ...). Drive the
-        task to its outcome there, in this context, and return a small result.
+        You have your own kernel: the `own-kernel` MCP server, a fresh serve process
+        with a Python kernel (`python_exec`) and the bundled helpers (`browser`,
+        `view`, `grep`, `find`, `nu`, image `Read`, ...). Drive the task to its
+        outcome there, in this context, and return a small result. Use only the
+        `mcp__own-kernel__*` tools: any inherited `mcp__index__*` tools are the
+        spawning session's shared serve, not yours.
 
         ## You are the executor, not a planner
 
@@ -89,7 +101,7 @@
           + "repo-relative paths, keeping the search transcript out of your context. "
           + "Complements exact search (mgrep/rg), it does not replace it; read-only.";
         mcpServers = ix.mcp.toAgentMcpServers {
-          index = {
+          own-kernel = {
             transport = "stdio";
             command = lib.getExe repoPackages.mcp;
             args = ["serve"];
@@ -104,8 +116,9 @@
 
         ## Run the search
 
-        Cursor ships a semantic index of the repo; drive it headless (no TUI) from your
-        `index` kernel. In `python_exec`:
+        Cursor ships a semantic index of the repo; drive it headless (no TUI) from
+        your own kernel, the `own-kernel` MCP server (use its tools, not any
+        inherited `mcp__index__*` ones). In its `python_exec`:
 
         ```python
         res = await nu(
@@ -294,7 +307,7 @@
           + "spawns, or backgrounds work.";
         color = "green";
         mcpServers = ix.mcp.toAgentMcpServers {
-          index = {
+          own-kernel = {
             transport = "stdio";
             command = lib.getExe repoPackages.mcp;
             args = ["serve"];
@@ -308,8 +321,11 @@
         back the real outputs. Your whole value is fidelity: the parent needs
         verbatim stdout/stderr and exit codes, not a summary and not a plan.
 
-        You have no Bash tool. Your shell is the `index` MCP kernel: name the
-        session (`session_set_name`), then run each command via `python_exec`:
+        You have no Bash tool. Your shell is your OWN index kernel, connected as
+        the `own-kernel` MCP server: a fresh serve process spawned for this run,
+        so a wedged spawning session cannot reach you. Name the session
+        (`own-kernel`'s `session_set_name`), then run each command via its
+        `python_exec`:
 
         ```python
         r = await nu("^git -C /abs/path status --porcelain", check=False)
@@ -320,6 +336,10 @@
 
         - Run the commands verbatim, in order. Use absolute paths from the brief;
           never rely on cwd persisting between calls (`git -C <path>`, not `cd`).
+        - Use ONLY the `own-kernel` server's tools (`mcp__own-kernel__*`). Any
+          inherited `mcp__index__*` tools belong to the spawning session's shared
+          serve; touching them reintroduces the shared fate your dedicated
+          kernel exists to avoid (#2382).
         - NEVER delegate: no spawning agents, no background jobs, no relaying, no
           substitute execution paths through other MCP servers. If the kernel
           itself is unavailable, stop and report the exact failing tool call and
@@ -481,7 +501,28 @@
       '';
     };
   };
-in {
-  renderedAgents = agents;
-  rawFiles = [];
-}
+  # Server names the parent session's wrapper already binds. An inline
+  # subagent server reusing one of these is silently discarded by Claude Code
+  # and the parent's connection shared instead (#2382), so the isolated kernel
+  # the agent declares would not exist. Enforced at eval so the trap cannot
+  # come back.
+  reservedServerNames =
+    builtins.attrNames
+    (import ./mcp.nix {inherit lib ix repoPackages;}).defaultServers;
+  inlineServerNames = frontmatter:
+    lib.concatMap builtins.attrNames (lib.filter builtins.isAttrs (frontmatter.mcpServers or []));
+  serverNameCollisions =
+    lib.filterAttrs (
+      _: agent: lib.intersectLists reservedServerNames (inlineServerNames (agent.frontmatter or {})) != []
+    )
+    agents;
+in
+  assert lib.assertMsg (serverNameCollisions == {}) ''
+    subagents: an inline mcpServers entry reuses a wrapper-baked server name
+    (reserved: ${lib.concatStringsSep ", " reservedServerNames}). Claude Code
+    silently drops a same-named inline config and shares the parent session's
+    connection instead (#2382), so pick a distinct name.
+    Offending agent(s): ${lib.concatStringsSep ", " (builtins.attrNames serverNameCollisions)}''; {
+    renderedAgents = agents;
+    rawFiles = [];
+  }


### PR DESCRIPTION
Fixes #2382.

**Root cause**: Claude Code silently discards a subagent inline `mcpServers` entry whose name collides with a server the parent session already has, and reuses the parent's connection instead. `executor`, `index-action-runner`, and `cursor-search` all declared their "own" kernel under the name `index`, the exact name the wrapper bakes, so every spawn actually shared the spawning session's serve. That is why a wedged session kernel took both executor recovery spawns down with it (`session_set_name` timeouts at command 0, the issue's evidence).

**Fix**
- Rename the inline server to `own-kernel` in all three agents. A non-colliding name makes Claude Code actually spawn a fresh `ix-mcp serve` (own kernel process) per subagent run.
- Point each agent's prompt at the `mcp__own-kernel__*` tools explicitly and warn off the inherited `mcp__index__*` ones (still visible, still the parent's shared serve).
- Eval-time assert in `subagents.nix`: no inline agent server may reuse a wrapper-baked server name (`index`, `exa`), so the trap cannot come back.
- Document the constraint next to the kernel-first deny rationale in `policy/permissions.nix`.

**Validation** (live probes on the installed CLI, 2026-07-07)
- Same-named inline `index`: subagent tool calls ran on the parent's kernel pid (shared, reproducing the issue).
- Fresh-named inline server: subagent got its own kernel pid.
- End to end with the rendered `executor.md` from this branch (`nix build .#agents`): parent kernel pid 40212, executor's command ran under its own kernel pid 42648.

(by an AI agent, Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename subagent inline MCP server from `index` to `own-kernel` to avoid name collisions
> - Renames the inline MCP server key from `index` to `own-kernel` in three subagent definitions in [subagents.nix](https://github.com/indexable-inc/index/pull/2384/files#diff-45a91ccd89dc7a844cea2a6fca8aef743ce1cb606f0f101ed57304b99528d898), and updates agent instruction strings to reference `mcp__own-kernel__*` tools accordingly.
> - Adds a comment in [permissions.nix](https://github.com/indexable-inc/index/pull/2384/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) explaining that inline MCP server names must not collide with parent-session-bound names, since a same-named server is silently discarded and the parent's connection is reused instead.
> - Adds a Nix eval-time assertion in [subagents.nix](https://github.com/indexable-inc/index/pull/2384/files#diff-45a91ccd89dc7a844cea2a6fca8aef743ce1cb606f0f101ed57304b99528d898) that fails if any inline `mcpServers` key collides with a reserved name derived from `mcp.nix` defaultServers.
> - Behavioral Change: subagents previously connecting via an `mcp__index__*` tool will now use `mcp__own-kernel__*`; any config referencing the old name will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62f680a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->