### PR TITLE
mcp: read fails loudly when the kernel cannot execute

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3402,6 +3402,36 @@
       mkdir -p "$out"
     '';
 
+  # The read tool's failure contract (index#2381): when the kernel bridge
+  # cannot execute the read (a wedge summary, a bridge returning neither
+  # output nor a completed job summary), the tool must raise a "kernel
+  # unavailable" error, never return empty content -- an empty reply is
+  # indistinguishable from reading an empty file, and was misread exactly that
+  # way. Pure unit tests over a stubbed kernel: no kernel boots, no sockets
+  # bind, so it runs in the sandbox on every platform.
+  readUnavailableTestSource = builtins.path {
+    name = "ix-mcp-read-unavailable-test";
+    path = ./tests/test_read_kernel_unavailable.py;
+  };
+  readUnavailableTests =
+    pkgs.runCommand "ix-mcp-read-unavailable-tests"
+    {
+      nativeBuildInputs = [typecheckTestPython];
+      strictDeps = true;
+    }
+    ''
+      export HOME=$TMPDIR/home
+      mkdir -p "$HOME"
+      cp ${readUnavailableTestSource} "$TMPDIR/test_read_kernel_unavailable.py"
+      ${lib.getExe typecheckTestPython} -m pytest "$TMPDIR/test_read_kernel_unavailable.py" -q -p no:cacheprovider >stdout 2>stderr || {
+        echo "ix-mcp read kernel-unavailable tests failed:" >&2
+        cat stdout stderr >&2
+        exit 1
+      }
+      cat stdout
+      mkdir -p "$out"
+    '';
+
   # Exercises the rich-output capture path: a DataFrame result is persisted to the
   # store with its text/html bundle (so the dashboard renders a table, not a repr),
   # a display() call made while a job runs is captured the same way, and a bytes
@@ -6132,6 +6162,7 @@ in
               kernelDeathSmoke
               kernelRestartSmoke
               wedgeEscalationSmoke
+              readUnavailableTests
               richSmoke
               yieldSmoke
               bindingsSmoke

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -367,7 +367,9 @@ READ = (
     "as a file when it names an existing file, otherwise it is evaluated as a Python expression "
     "in the kernel namespace (e.g. `jobs['ab12'].output` to page a job, or a variable you bound "
     "earlier); an expression whose value is a string naming an existing file reads that file "
-    "too. Pass `start` / `end` for a 1-based inclusive line range."
+    "too. Pass `start` / `end` for a 1-based inclusive line range. When the kernel cannot execute "
+    "the read (wedged or dead), the tool ERRORS with 'kernel unavailable' rather than returning "
+    "empty output, so empty content always means the file or value is genuinely empty."
 )
 
 TRACE = (

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -674,11 +674,58 @@ async def read(
     span = f":{start}-{end}" if start is not None and end is not None else (f":{start}" if start is not None else "")
     name = f"read {target}{span}"
     cell_outputs, summary = await current_kernel().python_exec(code, budget=30.0, name=name, session=sid)
-    if summary is not None and summary.get("status") == "error" and summary.get("error"):
+    status = summary.get("status") if summary is not None else None
+    if summary is not None and status == "error" and summary.get("error"):
+        # The in-kernel read itself raised (bad expression, unreadable path):
+        # the traceback is the useful answer, so return it as the content.
         return [outputs.text(summary["error"])]
+    if summary is not None and status == "wedged":
+        # The kernel bridge could not execute the read: a wedged cell holds the
+        # kernel's one event loop, so nothing was read. Fail loudly -- a quiet
+        # empty reply here is indistinguishable from reading an empty file, and
+        # was misread exactly that way (index#2381).
+        raise McpError(
+            ErrorData(
+                code=types.INTERNAL_ERROR,
+                message=(
+                    f"read {target}: kernel unavailable, nothing was read. "
+                    + str(summary.get("error") or "The kernel did not respond.")
+                ),
+            )
+        )
     rendered = outputs.to_mcp(cell_outputs)
     content = [item for item in rendered if getattr(item, "text", None) != "(no output)"]
-    return content or rendered
+    if content:
+        return content
+    if status == "done":
+        # The read COMPLETED and produced no text: the file or value is
+        # genuinely empty. Only this state may report emptiness (index#2381).
+        return rendered
+    if status == "running" and summary is not None and summary.get("id"):
+        # The kernel is healthy but the read outlived its foreground budget
+        # (a slow expression, a giant file): point at the live job instead of
+        # posing as empty output.
+        job_id = summary["id"]
+        return [
+            outputs.text(
+                f"[read {target} is still running as jobs[{job_id!r}] after its 30s "
+                f"foreground budget; await or page it via python_exec.]"
+            )
+        ]
+    # No output and no completed job summary: the in-kernel runtime never ran
+    # the read (dead bridge, cancelled run, stale build). Never report this as
+    # empty success (index#2381).
+    raise McpError(
+        ErrorData(
+            code=types.INTERNAL_ERROR,
+            message=(
+                f"read {target}: kernel unavailable, nothing was read "
+                "(the read produced no output and no completed job summary"
+                + (f"; status {status!r}" if status is not None else "")
+                + ")."
+            ),
+        )
+    )
 
 
 @mcp.tool(structured_output=False, description=guide.TRACE)

--- a/packages/mcp/tests/test_kernel_wedge_escalation.py
+++ b/packages/mcp/tests/test_kernel_wedge_escalation.py
@@ -45,19 +45,23 @@ def test_unrescuable_block_escalates_to_kernel_restart() -> None:
                 budget=15.0,
                 name="arm",
             )
-            assert armed is not None and armed["status"] == "done", armed
+            assert armed is not None
+            assert armed["status"] == "done", armed
             old_pid = kernel._pid
             assert old_pid is not None
 
             _, summary = await kernel.python_exec("import time\ntime.sleep(120)", budget=0.5, name="block")
-            assert summary is not None and summary["status"] == "wedged", summary
+            assert summary is not None
+            assert summary["status"] == "wedged", summary
             assert "killed and respawned" in summary["error"], summary
             # The escalation bounced only this kernel child; the fresh pid proves it.
-            assert kernel._pid is not None and kernel._pid != old_pid, (old_pid, kernel._pid)
+            assert kernel._pid is not None
+            assert kernel._pid != old_pid, (old_pid, kernel._pid)
             assert kernel._death is None, kernel._death
 
             _, after = await kernel.python_exec("Result.text('alive')", budget=10.0, name="after")
-            assert after is not None and after["status"] == "done", after
+            assert after is not None
+            assert after["status"] == "done", after
         finally:
             await kernel.shutdown()
 
@@ -75,13 +79,15 @@ def test_rescued_block_reports_verified_recovery() -> None:
             # A plain Python-level block: SIGUSR2 interrupts it, the probe
             # confirms the kernel answered, and NO restart happens.
             _, summary = await kernel.python_exec("import time\ntime.sleep(120)", budget=0.5, name="block")
-            assert summary is not None and summary["status"] == "wedged", summary
+            assert summary is not None
+            assert summary["status"] == "wedged", summary
             assert "usable again" in summary["error"], summary
             assert "asyncio.to_thread" in summary["error"], summary
             assert kernel._pid == old_pid, (old_pid, kernel._pid)
 
             _, after = await kernel.python_exec("Result.text('alive')", budget=10.0, name="after")
-            assert after is not None and after["status"] == "done", after
+            assert after is not None
+            assert after["status"] == "done", after
         finally:
             await kernel.shutdown()
 

--- a/packages/mcp/tests/test_read_kernel_unavailable.py
+++ b/packages/mcp/tests/test_read_kernel_unavailable.py
@@ -1,0 +1,138 @@
+"""The read tool must fail loudly when the kernel cannot execute (index#2381).
+
+A wedged or dead kernel used to make `read` return empty content,
+indistinguishable from reading an empty file: agents in one session twice
+misread a known non-empty file as empty exactly that way. Any state in which
+the in-kernel `__ix_read` did not complete must raise `McpError` ("kernel
+unavailable"), never pose as empty success; only a COMPLETED read may report
+emptiness, because an empty file is a real answer.
+
+Pure unit tests over a stubbed kernel bridge: no kernel boots, no sockets bind
+(the darwin sandbox denies loopback binds), so this runs anywhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pytest
+from mcp.shared.exceptions import McpError
+
+from ix_notebook_mcp import tools
+from ix_notebook_mcp.kernel import _wedged_summary
+
+
+class _StubKernel:
+    """Stands in for the kernel bridge: `read` only calls `python_exec` on it."""
+
+    def __init__(self, outputs: list[dict], summary: dict | None) -> None:
+        self._outputs = outputs
+        self._summary = summary
+        self.code: str | None = None
+
+    async def python_exec(
+        self,
+        code: str,
+        budget: float,
+        name: str | None = None,
+        session: str | None = None,
+        topic: str | None = None,
+    ) -> tuple[list[dict], dict | None]:
+        self.code = code
+        return self._outputs, self._summary
+
+
+def _wire(
+    monkeypatch: pytest.MonkeyPatch, outputs: list[dict], summary: dict | None
+) -> _StubKernel:
+    """Point the read tool at a stub kernel and disarm the per-call gates."""
+    stub = _StubKernel(outputs, summary)
+
+    async def gate(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(tools, "_start_dashboard_once", gate)
+    monkeypatch.setattr(tools, "_identify_client_once", gate)
+    monkeypatch.setattr(tools, "_require_session_name", gate)
+    monkeypatch.setattr(tools, "current_kernel", lambda: stub)
+    return stub
+
+
+def test_wedged_kernel_errors_instead_of_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The regression itself: a wedge summary (the kernel's event loop is held
+    by a blocked cell, so `__ix_read` never ran) must raise, not return []."""
+    summary = _wedged_summary(30.0, 5.0, 35.0, outcome="restart_pending")
+    _wire(monkeypatch, [], summary)
+
+    with pytest.raises(McpError, match="kernel unavailable") as excinfo:
+        asyncio.run(tools.read("~/notes.md"))
+    message = str(excinfo.value)
+    assert "nothing was read" in message
+    # The wedge summary's own diagnosis rides along so the caller sees WHY.
+    assert "blocked the kernel's event loop" in message
+
+
+def test_no_summary_and_no_output_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bridge that returns neither output nor a job summary (dead kernel on
+    an older build, stale runtime without `__ix_read`) must also raise."""
+    _wire(monkeypatch, [], None)
+
+    with pytest.raises(McpError, match="kernel unavailable"):
+        asyncio.run(tools.read("~/notes.md"))
+
+
+def test_cancelled_read_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A terminal-but-incomplete state (cancelled) produced no text either;
+    it must not read as an empty file."""
+    _wire(monkeypatch, [], {"id": "ab12", "status": "cancelled", "running": False})
+
+    with pytest.raises(McpError, match="cancelled"):
+        asyncio.run(tools.read("~/notes.md"))
+
+
+def test_completed_empty_read_still_reports_no_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty file is a real answer: a COMPLETED read with no text keeps the
+    quiet '(no output)' placeholder and does NOT raise."""
+    _wire(monkeypatch, [], {"id": "ab12", "status": "done", "running": False})
+
+    content = asyncio.run(tools.read("empty-file.txt"))
+    assert [item.text for item in content] == ["(no output)"]
+
+
+def test_running_read_points_at_its_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A read that outlives its foreground budget on a healthy kernel names
+    the live job instead of posing as empty output."""
+    _wire(monkeypatch, [], {"id": "ab12", "status": "running", "running": True})
+
+    content = asyncio.run(tools.read("big.expression"))
+    assert len(content) == 1
+    assert "jobs['ab12']" in content[0].text
+    assert "still running" in content[0].text
+
+
+def test_in_kernel_error_returns_traceback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An error raised BY the read (bad expression, unreadable path) is the
+    useful answer: it comes back as content, unchanged behavior."""
+    _wire(monkeypatch, [], {"id": "ab12", "status": "error", "error": "NameError: name 'nope' is not defined"})
+
+    content = asyncio.run(tools.read("nope"))
+    assert len(content) == 1
+    assert "NameError" in content[0].text
+
+
+def test_successful_read_returns_its_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The happy path is untouched: a completed read's text is the content."""
+    outputs = [
+        {
+            "output_type": "execute_result",
+            "data": {"text/plain": "line one"},
+            "metadata": {},
+            "execution_count": 1,
+        }
+    ]
+    stub = _wire(monkeypatch, outputs, {"id": "ab12", "status": "done", "running": False})
+
+    content = asyncio.run(tools.read("notes.md", start=1, end=1))
+    assert [item.text for item in content] == ["line one"]
+    # The tool routed through the in-kernel __ix_read helper.
+    assert stub.code is not None
+    assert "__ix_read" in stub.code


### PR DESCRIPTION
Fixes #2381.

When the kernel bridge could not execute a read, the `read` tool returned empty content: a wedged kernel's summary carries `status: "wedged"`, which the tool ignored (it only surfaced `status: "error"`), so the reply collapsed to the filtered-out `(no output)` placeholder, indistinguishable from reading an empty file. Session defe2bc3 misread a known non-empty file as empty twice this way.

## Changes

- `read` now raises `McpError` ("kernel unavailable, nothing was read", carrying the wedge summary's own diagnosis) for a wedge summary, and for any reply with no output and no completed job summary (dead bridge, cancelled run, stale runtime without `__ix_read`).
- A read that outlives its 30s foreground budget on a healthy kernel names its live job (`jobs['<id>']`) instead of posing as empty output.
- Only a COMPLETED read may report emptiness: an empty file is a real answer, and the guide's `read` description now states that contract.
- Regression tests in `packages/mcp/tests/test_read_kernel_unavailable.py`, wired as the `readUnavailableTests` nix check: pure unit tests over a stubbed kernel bridge, no kernel boots and no sockets bind, so they run in the darwin sandbox too.
- Breaks down the wedge escalation test's composite asserts (pre-existing ruff PT018 findings the whole-tree lint hook flags).

## Validation

- `nix build .#mcp.tests.readUnavailableTests` (7 passed)
- `nix build .#mcp.tests.strictTypecheck` (zuban strict + ruff ANN: clean)
- pre-commit whole-tree lint hook: 8/8 tasks green

(by an AI agent, Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `McpError` in the MCP `read` tool when the kernel is unavailable
> - The `read` tool in [tools.py](https://github.com/indexable-inc/index/pull/2386/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) previously returned empty content when the kernel was wedged or failed to produce a job summary; it now raises `McpError(INTERNAL_ERROR)` with a `'kernel unavailable'` message including diagnostics.
> - Empty content (`'(no output)'`) is now reserved for completed reads that genuinely produced no text; in-progress reads return a pointer to the live job instead.
> - The updated failure contract is documented in the `guide.READ` constant and covered by a new pure unit-test suite in [test_read_kernel_unavailable.py](https://github.com/indexable-inc/index/pull/2386/files#diff-73788b26d26848cd0b9e5fb69910ef2e373d1237d4536969e7113b3156b5a29e) using a stubbed kernel bridge.
> - Behavioral Change: callers that previously received empty output on kernel failure will now receive an MCP error response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d7f9b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->