### PR TITLE
beamvm: warn instead of failing switch when reload finds the VM down

### DIFF
--- a/packages/beamvm/home-module.nix
+++ b/packages/beamvm/home-module.nix
@@ -255,9 +255,9 @@ in {
 
     # After home-manager rewrites the manifest symlinks (and after the
     # platform's unit-management step handled any unit-definition changes),
-    # poke each running VM to converge on the new manifest. "Not running"
-    # (exit 2) is fine -- the next start reads the same stable path -- but a
-    # running VM that fails to reload fails the switch loudly.
+    # poke each running VM to converge on the new manifest. "Not running" is
+    # a loud no-op -- the next start reads the same stable path -- and only a
+    # reload attempted against a live VM that then fails fails the switch.
     # VM names reach systemd/launchd unit names, socket paths, and this
     # activation script; constrain them once here rather than letting a
     # metacharacter render an invalid unit or script.
@@ -287,15 +287,31 @@ in {
             # Plain statements, no name-derived shell identifiers: the VM
             # name appears only inside quoted strings.
             lib.hm.dag.entryAfter ["linkGeneration" "reloadSystemd" "setupLaunchAgents"] ''
-              beamvmReloadRc=0
-              run ${getExe' cfg.package "beamvm-ctl"} \
+              # Probe liveness before reloading: a dead VM can leave a stale
+              # socket file behind, and then `reload` fails with socat's
+              # connection-refused (exit 1), indistinguishable by exit code
+              # from a live VM whose reload failed. "Not running" must not
+              # fail the switch -- activation already succeeded and the next
+              # start reads the same stable manifest path -- so warn and move
+              # on instead (#2389).
+              if run --silence ${getExe' cfg.package "beamvm-ctl"} \
                 --socket ${lib.escapeShellArg "${stateDirFor name vm}/control.sock"} \
-                reload || beamvmReloadRc=$?
-              if [ "$beamvmReloadRc" -eq 2 ]; then
-                verboseEcho ${lib.escapeShellArg "beamvm ${name}: not running; next start reads the current manifest"}
-              elif [ "$beamvmReloadRc" -ne 0 ]; then
-                echo ${lib.escapeShellArg "beamvm ${name}: hot reload failed"} "(exit $beamvmReloadRc)" >&2
-                exit "$beamvmReloadRc"
+                ping; then
+                beamvmReloadRc=0
+                run ${getExe' cfg.package "beamvm-ctl"} \
+                  --socket ${lib.escapeShellArg "${stateDirFor name vm}/control.sock"} \
+                  reload || beamvmReloadRc=$?
+                if [ "$beamvmReloadRc" -eq 2 ]; then
+                  # Went down between the ping and the reload: same no-op.
+                  warnEcho ${lib.escapeShellArg "beamvm ${name}: stopped before reload; next start reads the current manifest"}
+                elif [ "$beamvmReloadRc" -ne 0 ]; then
+                  # The VM answered ping, so this is a live reload that
+                  # failed: the one case that must fail the switch.
+                  echo ${lib.escapeShellArg "beamvm ${name}: hot reload failed"} "(exit $beamvmReloadRc)" >&2
+                  exit "$beamvmReloadRc"
+                fi
+              else
+                warnEcho ${lib.escapeShellArg "beamvm ${name}: not running; skipping hot reload (next start reads the current manifest)"}
               fi
             ''
           )


### PR DESCRIPTION
Fixes #2389.

`beamvm-ctl` only exits 2 when the control socket *file* is absent; a dead VM that left a stale socket behind gets socat's connection-refused (exit 1), which the `beamvmReload-<name>` activation hook treated as a live-reload failure, failing an otherwise successful `home-manager switch`.

The hook now probes liveness with `ping` before reloading:

- **VM not running** (no socket, or stale socket / connection refused): `warnEcho` + continue, exit 0. The next start reads the same stable manifest path, so nothing is lost.
- **Live VM whose reload fails** (it answered ping): unchanged, loud error and nonzero exit — the one case that must fail the switch.
- **Race** (VM answered ping then stopped before reload, ctl exit 2): same warn-and-continue no-op.

Validated by rendering the activation script through `hm.lib.homeManagerConfiguration` and exercising it with a stubbed `run`/`warnEcho` and a fake ctl across all four scenarios (exit 0/0/0/1 as above), plus reproducing the premise: real `beamvm-ctl ping` against a bound-then-closed socket exits 1 with socat connection-refused. `nix run .#lint` nix gates all pass (the ruff failure in `packages/mcp/tests/test_kernel_wedge_escalation.py` is pre-existing on main, untouched here).

*PR by an AI agent (Claude Code).*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn instead of failing switch when `beamvm reload` finds the VM down
> Previously, the activation script ran `reload` directly and failed the switch on any nonzero exit except code 2 (VM not running). Now it pings the VM first via `beamvm-ctl --socket <sock> ping` and only attempts `reload` if the VM is live.
>
> - If ping fails, a warning is emitted and reload is skipped — the switch succeeds.
> - If ping succeeds but reload returns exit code 2, a warning is emitted (race condition) and the switch succeeds.
> - Any other nonzero exit from `reload` still fails the switch.
> - Behavioral Change: non-running VMs no longer cause the activation switch to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a551d19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->