### PR TITLE
mcp: cancel in-flight python_exec when the client abandons the call (#2387)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3039,7 +3039,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3054,6 +3054,9 @@
       cp ${./tests/test_job_await_errors.py} test_job_await_errors.py
       # Issue #2104: one session's wait must never cancel another session's job.
       cp ${./tests/test_job_cancel_scope.py} test_job_cancel_scope.py
+      # Issue #2387: a client that cancels an in-flight python_exec cancels the
+      # backgrounded run it launched, instead of executing side effects after.
+      cp ${./tests/test_cancel_running.py} test_cancel_running.py
       # Issue #2164: jobs.spawn registers an ad-hoc awaitable as a first-class job.
       cp ${./tests/test_jobs_spawn.py} test_jobs_spawn.py
       cp ${./tests/test_fsearch_partial.py} test_fsearch_partial.py
@@ -3072,6 +3075,7 @@
       cp ${./tests/test_kernel_trace_path.py} test_kernel_trace_path.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
+        test_cancel_running.py \
         test_jobs_spawn.py \
         test_fsearch_partial.py \
         test_fsearch_glob.py \

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -353,6 +353,32 @@ PYEXEC_INTRO = (
     "(inspect / await / cancel it via more python_exec on the `jobs` dict)."
 )
 
+# Developer note (NOT part of any tool description or the model-facing
+# instructions -- it documents server behavior for maintainers). When an MCP
+# client cancels an in-flight `python_exec` request -- MCP `notifications/cancelled`
+# for the request id, or a transport-level abort -- the SDK cancels this handler's
+# request scope, and `tools.python_exec` catches that cancellation and interrupts
+# the kernel job the call launched (the same path as `jobs['<id>'].cancel()`),
+# rather than leaving it to finish in the background and run its side effects after
+# the caller abandoned it (index#2387).
+#
+# LIMITATION: Claude Code does NOT send `notifications/cancelled` when a USER
+# REJECTS an in-flight tool call (clicks "No" on the permission prompt). Its
+# permission verdict is a client-local decision that never reaches the server, so
+# the server has nothing to cancel in that specific case: a call that was already
+# dispatched to the kernel before the (racing) rejection landed still runs to
+# completion. The cancellation wiring above therefore fires for spec-compliant MCP
+# clients and for Claude Code's own request-timeout cancellation, but not for a
+# rejected permission prompt. Fully closing the rejection gap needs a client-side
+# fix (Claude Code sending `notifications/cancelled` on rejection, or gating
+# dispatch behind the permission verdict); see index#2387.
+CANCELLATION_NOTE = (
+    "An MCP client that cancels an in-flight python_exec (notifications/cancelled "
+    "or transport abort) interrupts the kernel job it launched, on the same path as "
+    "jobs['<id>'].cancel(). Claude Code does not signal a user's REJECTION of an "
+    "in-flight call, so a rejected prompt is not covered (index#2387)."
+)
+
 SEE_INSTRUCTIONS = (
     "The server instructions cover the rest — the bundled tooling (grep / find / view / nix / "
     "fleet / polars / htpy), how to find and read things, and how to curate the dashboard's cells."

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -19,6 +19,7 @@ is respawned immediately, not lazily on the next execute (index#2339).
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import contextlib
 import os
@@ -388,6 +389,39 @@ class Kernel:
                     # already owns the respawn; its restore will serve us too.
                     outcome = "restart_pending"
             return [], _wedged_summary(budget, grace, deadline, outcome=outcome)
+
+    async def cancel_running(self, session: str | None) -> list[str]:
+        """Cancel the run this ``session``'s abandoned ``python_exec`` launched.
+
+        The server calls this when a client cancels an in-flight ``python_exec``
+        (``notifications/cancelled`` or a transport abort): the tool coroutine is
+        cancelled server-side, but the job it started keeps running in the kernel
+        as a background task, executing side effects the caller already abandoned
+        (index#2387). This pokes ``__ix_cancel_running`` on the raw shell channel
+        (no job/card, like ``set_client``), which cancels the same job an explicit
+        ``jobs['<id>'].cancel()`` would. Best-effort: a cancel arriving after the
+        run finished (the common race) cancels nothing, and a failure here must
+        never mask the original cancellation the caller is propagating. Returns
+        the ids cancelled (parsed from the raw reply; empty on any hiccup)."""
+        if self._pid is None:
+            return []
+        session_arg = "None" if session is None else repr(session)
+        try:
+            outputs, _ = await self._execute(
+                f"print(__ix_cancel_running(session={session_arg}))", timeout=10.0
+            )
+        except BaseException:  # noqa: BLE001 -- cancel is best-effort; never mask the caller's own cancellation
+            return []
+        text = "".join(
+            o.get("text", "") for o in outputs if isinstance(o, dict)
+        ).strip()
+        # `print(list)` renders `['ab12']`; parse it back defensively so a
+        # malformed reply degrades to "cancelled nothing" rather than raising.
+        with contextlib.suppress(Exception):
+            value = ast.literal_eval(text)
+            if isinstance(value, list):
+                return [str(item) for item in value]
+        return []
 
     async def set_client(self, client: str) -> None:
         """Tell the kernel which MCP client connected, so the session label can

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -4125,6 +4125,38 @@ async def __ix_exec(
     _emit(job)
 
 
+def __ix_cancel_running(session: str | None = None, exclude: str | None = None) -> list[str]:
+    """Cancel the run this session's in-flight ``python_exec`` launched, so an
+    abandoned call stops instead of finishing in the background.
+
+    The MCP server calls this when the client cancels an in-flight
+    ``python_exec`` request (``notifications/cancelled`` or a transport abort):
+    the tool coroutine is cancelled server-side, but the kernel job it started
+    keeps running as a background task -- executing side effects the caller
+    already abandoned (index#2387). Cancelling that job here is the SAME path as
+    an explicit ``jobs['<id>'].cancel()``, so it drains and records cleanly.
+
+    Only the single most recently started still-running job for ``session`` is
+    cancelled: that is the one the abandoned call launched. Other background jobs
+    the same session started earlier (and did not abandon) keep running.
+    ``exclude`` skips a job id -- the raw cancel request's own frame is never a
+    ``jobs`` entry, but the guard keeps the helper honest if that ever changes.
+    Returns the ids cancelled (empty when the run already finished, the common
+    race: a fast call completes before the cancellation lands)."""
+    candidates = [
+        job
+        for job in jobs.values()
+        if job.session == session and job.running() and job.id != exclude
+    ]
+    if not candidates:
+        return []
+    # Newest-started wins: `jobs` is insertion-ordered, and the abandoned call is
+    # the last run this session launched.
+    target = max(candidates, key=lambda job: job.started)
+    target.cancel()
+    return [target.id]
+
+
 def __ix_emit_read_stats_final() -> None:
     """Emit every session's final ``mcp_read_stats`` line. The server calls this
     in-kernel from its shutdown ``finally`` block, BEFORE it kills the kernel with
@@ -4480,6 +4512,7 @@ def install(user_ns: dict | None = None) -> None:
     target["input_channels"] = input_channels
     target["__ix_run"] = __ix_run
     target["__ix_exec"] = __ix_exec
+    target["__ix_cancel_running"] = __ix_cancel_running
     target["__ix_read"] = __ix_read
     target["__ix_emit_read_stats_final"] = __ix_emit_read_stats_final
     target["__ix_snapshot"] = __ix_snapshot

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -510,9 +510,28 @@ async def python_exec(
     effective_budget = min(budget, cap)
     # `intent` is the run's human label (the dashboard feed's title); it flows to
     # the kernel as the job name and lands in the store's `name` column.
-    cell_outputs, summary = await current_kernel().python_exec(
-        code, effective_budget, intent, session=_session_id(ctx), topic=_session_topic(ctx)
-    )
+    sid = _session_id(ctx)
+    kernel = current_kernel()
+    try:
+        cell_outputs, summary = await kernel.python_exec(
+            code, effective_budget, intent, session=sid, topic=_session_topic(ctx)
+        )
+    except asyncio.CancelledError:
+        # The client cancelled this in-flight call (`notifications/cancelled` or a
+        # transport abort; the MCP SDK cancels this handler's request scope, which
+        # surfaces here as CancelledError). Without this the kernel job the call
+        # launched keeps running in the background and executes its side effects
+        # AFTER the caller abandoned it -- the permission-gate bypass in
+        # index#2387. Interrupt that job on the same path an explicit
+        # `jobs['<id>'].cancel()` takes, then re-raise so the cancellation still
+        # propagates. `shield` keeps the cancel poke itself from being torn down
+        # by the very cancellation we are handling. Note: Claude Code does not
+        # signal a USER REJECTION of an in-flight call, so this fires for
+        # spec-compliant cancels and Claude Code's own request timeout, not for a
+        # rejected prompt (documented in guide.CANCELLATION_NOTE).
+        with contextlib.suppress(Exception):  # best-effort: a cancel-time hiccup must not swallow the re-raise
+            await asyncio.shield(kernel.cancel_running(sid))
+        raise
     rendered = outputs.to_mcp(cell_outputs)
     # The human view for an MCP Apps host: the same text/html fragments the
     # dashboard and room render for this run, carried on the reply's `_meta`

--- a/packages/mcp/tests/test_cancel_running.py
+++ b/packages/mcp/tests/test_cancel_running.py
@@ -1,0 +1,127 @@
+"""A client that abandons an in-flight ``python_exec`` cancels the run it
+launched, instead of letting it finish in the background (issue #2387).
+
+The MCP server dispatches a ``python_exec`` to the kernel, which runs the code
+as a background ``Job`` once its foreground budget elapses. If the client then
+cancels the request (``notifications/cancelled`` or a transport abort), the tool
+coroutine is cancelled server-side -- but the kernel job used to keep running,
+executing side effects the caller already abandoned (the permission-gate bypass
+in the issue: a rejected/abandoned ``home-manager switch`` still built).
+
+``__ix_cancel_running`` is what the server pokes on the raw shell channel when a
+call is cancelled: it cancels the single most-recently-started running job for
+that session, on the same path as an explicit ``jobs['<id>'].cancel()``. These
+tests exercise it directly against the runtime (no kernel process, no loopback
+bind -- so they pass under the darwin sandbox in nix checks).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ix_notebook_mcp import runtime
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+
+
+def test_cancel_running_stops_the_abandoned_background_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A session backgrounds a long side-effectful run (stand-in: a long sleep).
+    # The client abandons the call; the server cancels the run it launched, and
+    # the job must stop instead of finishing.
+    _wire(monkeypatch, {"asyncio": asyncio})
+
+    async def scenario() -> runtime.Job:
+        job = await runtime.__ix_run(
+            "await asyncio.sleep(30)\n'side effect ran'",
+            budget=0.01,
+            session="agent-a",
+        )
+        assert job.running()
+        cancelled = runtime.__ix_cancel_running(session="agent-a")
+        assert cancelled == [job.id]
+        await job.wait(10)
+        return job
+
+    job = asyncio.run(scenario())
+    assert job.status == "cancelled"
+    assert "side effect ran" not in (job.text or "")
+
+
+def test_cancel_running_targets_only_the_newest_run_for_the_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A session may have an earlier legitimate background job still running. Only
+    # the most recently launched run (the abandoned call) is cancelled; the
+    # earlier one keeps running.
+    _wire(monkeypatch, {"asyncio": asyncio})
+
+    async def scenario() -> tuple[runtime.Job, runtime.Job]:
+        earlier = await runtime.__ix_run(
+            "await asyncio.sleep(0.3)\n'earlier done'", budget=0.01, session="agent-a"
+        )
+        await asyncio.sleep(0.02)  # ensure a strictly later start time
+        newest = await runtime.__ix_run(
+            "await asyncio.sleep(30)", budget=0.01, session="agent-a"
+        )
+        assert earlier.running() and newest.running()
+        cancelled = runtime.__ix_cancel_running(session="agent-a")
+        assert cancelled == [newest.id]
+        await earlier.wait(10)
+        return earlier, newest
+
+    earlier, newest = asyncio.run(scenario())
+    assert newest.status == "cancelled"
+    assert earlier.status == "done"
+    assert "earlier done" in (earlier.text or "")
+
+
+def test_cancel_running_leaves_other_sessions_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Cancelling one session's abandoned run must never touch another session's
+    # job -- the same isolation issue #2104 protects.
+    _wire(monkeypatch, {"asyncio": asyncio})
+
+    async def scenario() -> tuple[runtime.Job, runtime.Job]:
+        mine = await runtime.__ix_run(
+            "await asyncio.sleep(30)", budget=0.01, session="agent-a"
+        )
+        other = await runtime.__ix_run(
+            "await asyncio.sleep(0.2)\n'other done'", budget=0.01, session="agent-b"
+        )
+        cancelled = runtime.__ix_cancel_running(session="agent-a")
+        assert cancelled == [mine.id]
+        await mine.wait(10)
+        await other.wait(10)
+        return mine, other
+
+    mine, other = asyncio.run(scenario())
+    assert mine.status == "cancelled"
+    assert other.status == "done"
+    assert "other done" in (other.text or "")
+
+
+def test_cancel_running_is_a_noop_when_the_run_already_finished(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The common race: a fast call finishes before the cancellation lands. There
+    # is nothing to cancel, and the helper must return an empty list rather than
+    # touch an already-done job.
+    _wire(monkeypatch, {"asyncio": asyncio})
+
+    async def scenario() -> runtime.Job:
+        job = await runtime.__ix_run("1 + 1", budget=5.0, session="agent-a")
+        assert job.status == "done"
+        assert runtime.__ix_cancel_running(session="agent-a") == []
+        return job
+
+    job = asyncio.run(scenario())
+    assert job.status == "done"


### PR DESCRIPTION
## What

A `python_exec` the MCP client cancels (`notifications/cancelled` or a transport abort) used to keep running in the kernel as a background job, executing side effects **after the caller had abandoned the call**. This defeats the permission gate for side-effectful operations: the evidence in #2387 is a rejected `home-manager switch` that still built for minutes.

## Fix

- **`tools.python_exec`** now catches the `CancelledError` the MCP SDK raises when it tears down the request scope on cancellation, and interrupts the job the call launched before re-raising. The cancel poke is `shield`ed so it isn't torn down by the very cancellation it's handling, and best-effort so it never masks the propagating cancel.
- **`Kernel.cancel_running` -> `runtime.__ix_cancel_running`** cancels the single **newest** running job for that session -- the one the abandoned call launched -- on the exact same path as `jobs['<id>'].cancel()`. Earlier legitimate background jobs for the same session keep running (respects the #2104 session-isolation contract), and other sessions are never touched.

## Limitation (documented, needs a client-side fix)

Claude Code does **not** send `notifications/cancelled` when a user *rejects* an in-flight tool call (clicks "No" on the permission prompt) -- that verdict is client-local and never reaches the server. So a call already dispatched to the kernel before a racing rejection still runs. This PR closes the gap for spec-compliant MCP clients and for Claude Code's own request-timeout cancellation; fully closing the rejection race needs Claude Code to emit `notifications/cancelled` on rejection (or to gate dispatch behind the verdict). Documented in `guide.py` (`CANCELLATION_NOTE` + maintainer note).

## Test

`packages/mcp/tests/test_cancel_running.py` exercises the runtime directly (no kernel process, no loopback bind -- sandbox-safe on darwin), covering: cancel stops the abandoned job; only the newest run for the session is cancelled; other sessions untouched; no-op when the run already finished. Wired into `typecheckSmoke` -- full suite is **97 passed** locally.

Closes #2387

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel in-flight `python_exec` kernel jobs when the MCP client abandons the call
> - When a client cancels an in-flight `python_exec` tool call, the server now issues an in-kernel cancellation via a new `cancel_running` method on `Kernel` and re-raises the `CancelledError`, instead of leaving the job running in the background.
> - A new `__ix_cancel_running(session, exclude)` helper is injected into the kernel's user namespace via [runtime.py](https://github.com/indexable-inc/index/pull/2396/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95); it finds the newest running job for the session, cancels it, and returns its id.
> - `Kernel.cancel_running` in [kernel.py](https://github.com/indexable-inc/index/pull/2396/files#diff-ced4fbbdf05b4f126e987804d73fdc2d811511b346e4985a9996ae7903683d1c) calls this helper inside the kernel with a timeout, parsing the result defensively and returning `[]` on any failure.
> - Four tests in [test_cancel_running.py](https://github.com/indexable-inc/index/pull/2396/files#diff-b074cccb19bab2c8c10a5f5b731522b35750542088559a7a4cec3dcab9212687) cover session isolation, no-op on already-finished jobs, and preservation of background jobs from other sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2ced2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->