### PR TITLE
ruff: check the lint policy in as ruff.toml so direct runs match the gates

### DIFF
--- a/lib/ruff-ann.nix
+++ b/lib/ruff-ann.nix
@@ -1,5 +1,7 @@
-# Single source of truth for the repo's ruff lint policy, consumed by every
-# Python gate so it never drifts across call sites:
+# The repo's ruff lint policy lives in the checked-in /ruff.toml (selector,
+# ignores, and the per-rule rationale); this module derives the inline-flag
+# form consumed by every Python gate so the policy never drifts across call
+# sites:
 #   lib/build/uv-application.nix   (all uv apps)
 #   lib/util/writers.nix          (writePythonApplication scripts)
 #   packages/mcp/default.nix      (bundled-module strict gate)
@@ -7,107 +9,22 @@
 #   packages/sdk/python/build.nix
 #   lib/per-system.nix            (the repo-wide `ruff` lint stage, over ALL .py)
 #
-# Philosophy: a high-signal "really good lints" set -- every rule family that
-# catches real bugs, security issues, or stale idioms -- and NOT the stylistic
-# rules that would only generate noqa noise. Highlights: B (bugbear, incl.
-# mutable-default args), ASYNC (blocking calls in async fns), S (bandit
-# security), PTH (pathlib), PT (pytest), UP (pyupgrade), plus the original
-# ANN (explicit annotations, ANN401 bans bare `typing.Any`) and TID251.
-#
-# `ignore` drops the contextual/noisy members of selected families so we never
-# need per-file ignores (the inline-config sandbox gate has no ruff.toml):
-#   S101 asserts (used in tests + runtime), S603/S607 deliberate fixed-arg
-#   subprocess calls, S311 non-crypto random, PLW0603 module-lifetime caches,
-#   ISC001 (formatter owns it), RUF001/2/3 ambiguous-unicode false positives.
-# Deliberately NOT selected (pure style): TRY003, EM, T201, N, ARG, D.
-#
-# TID251 bans `typing.cast`: it lies to the type checker at zero runtime cost, so
-# a wrong cast is a latent bug no checker can catch. Parse untrusted/JSON data
-# into a pydantic model at the boundary instead, or fix the real type; the rare
-# genuinely-unavoidable case (e.g. a test double) opts out with `# noqa: TID251`.
-#
-# Config is passed inline (`--config`/`--select`/`--ignore`) rather than via a
-# checked-in ruff.toml because per-package builds run ruff inside sandboxes that
-# do not contain the repo root, so an on-disk config would never be discovered.
+# Why flags AND a discovered toml: per-package builds run ruff inside sandboxes
+# that do not contain the repo root, so an on-disk config would never be found
+# there -- the gates take the policy inline (--select/--ignore/--config). A
+# direct `ruff check` in a checkout, meanwhile, discovers ruff.toml and applies
+# the same policy, so ad-hoc runs cannot diverge from the gates: ruff's default
+# E/F selection used to flag patterns the repo deliberately allows (e.g. the
+# importorskip-then-import pattern in tests -> E402), reading as "my change
+# broke lint" (#2393).
 {lib}: let
-  banMessage =
-    "typing.cast defeats the type checker (no runtime check), so a wrong cast "
-    + "is a latent bug. Parse untrusted/JSON data into a pydantic model at the "
-    + "boundary, or fix the real type. Only for an unavoidable case (e.g. a test "
-    + "double): add a `# noqa: TID251` with a reason.";
+  policy = builtins.fromTOML (builtins.readFile ../ruff.toml);
+  banMessage = policy.lint.flake8-tidy-imports.banned-api."typing.cast".msg;
   banConfig = ''lint.flake8-tidy-imports.banned-api."typing.cast".msg = "${banMessage}"'';
-  # Bug-catchers + security + pathlib + pytest + the original explicit-annotation
-  # and no-cast gates. TID251 here is redundant with the banned-api config below
-  # but makes the ban explicit in the selector.
-  select = [
-    "ANN"
-    "TID251"
-    "B"
-    "ASYNC"
-    "C4"
-    "SIM"
-    "RET"
-    "PIE"
-    "UP"
-    "RUF"
-    "PERF"
-    "FURB"
-    "PLE"
-    "PLW"
-    "LOG"
-    "G"
-    "DTZ"
-    "FLY"
-    "ISC"
-    "S"
-    "PTH"
-    "PT"
-    "FBT"
-  ];
-  ignore = [
-    "S101"
-    "S603"
-    "S607"
-    "S311"
-    "PLW0603"
-    "ISC001"
-    "RUF001"
-    "RUF002"
-    "RUF003"
-    # PERF203 (try-except in a loop) is a minor perf hint AND version-volatile
-    # across ruff releases: the per-package buildUvApplication gate and the
-    # repo-wide lint stage can resolve to different ruff builds, so a
-    # `# noqa: PERF203` one gate needs the other flags as RUF100 (unused). Drop
-    # it -- the flagged loops (retry/drain/collect-failures) genuinely need the
-    # per-iteration try; hoisting it would change behavior.
-    "PERF203"
-    # ASYNC109: async function that takes a `timeout` parameter. The codebase's
-    # pervasive, deliberate pattern is to accept a timeout and forward it to the
-    # underlying library (httpx/asyncssh/subprocess/wait_for), which the rule
-    # cannot see; it fires ~38 times with no bug behind any. Not a helpful lint here.
-    "ASYNC109"
-    # PEP-695 modernization (UP040 `type X =`, UP047 `def f[T]`, UP049 private
-    # type params) is churn, not bug-catching, and it fights the type checker:
-    # zuban rejects PEP-695 generics ("type parameter not declared"). Keep the
-    # classic `TypeAlias` / `TypeVar` forms.
-    "UP040"
-    "UP047"
-    "UP049"
-  ];
 in {
-  inherit
-    banMessage
-    banConfig
-    select
-    ignore
-    ;
+  inherit (policy.lint) select ignore;
+  inherit banMessage banConfig;
   # Drop-in replacement for the old bare `--select ANN`:
   #   ruff check ${ruffAnnArgs} <targets>
-  #
-  # `--target-version py313` is pinned so every gate (per-package and the repo-wide
-  # lint stage) evaluates target-version-gated rules (UP041 aliased errors, UP017
-  # datetime.UTC, ...) identically -- the whole repo is Python 3.13, and without
-  # this the lint stage's per-file pyproject discovery diverged from the package
-  # gates, flagging rules in one place but not the other.
-  ruffAnnArgs = "--target-version py313 --select ${lib.concatStringsSep "," select} --ignore ${lib.concatStringsSep "," ignore} --config ${lib.escapeShellArg banConfig}";
+  ruffAnnArgs = "--target-version ${policy.target-version} --select ${lib.concatStringsSep "," policy.lint.select} --ignore ${lib.concatStringsSep "," policy.lint.ignore} --config ${lib.escapeShellArg banConfig}";
 }

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,104 @@
+# The repo's ruff lint policy -- single source of truth, consumed two ways:
+#
+#   1. Discovered: a direct `ruff check <path>` in a checkout picks this file
+#      up, so ad-hoc runs apply the same policy as the nix gates instead of
+#      ruff's default E/F selection, which flags patterns the repo deliberately
+#      allows (e.g. the importorskip-then-import pattern in tests -> E402).
+#   2. Derived: lib/ruff-ann.nix reads this file (builtins.fromTOML) to build
+#      the inline `ruffAnnArgs` flags used by every nix gate; per-package
+#      builds run ruff inside sandboxes that do not contain the repo root, so
+#      this file is never discovered there and the policy must travel as flags.
+#
+# Philosophy: a high-signal "really good lints" set -- every rule family that
+# catches real bugs, security issues, or stale idioms -- and NOT the stylistic
+# rules that would only generate noqa noise. Highlights: B (bugbear, incl.
+# mutable-default args), ASYNC (blocking calls in async fns), S (bandit
+# security), PTH (pathlib), PT (pytest), UP (pyupgrade), plus the original
+# ANN (explicit annotations, ANN401 bans bare `typing.Any`) and TID251.
+# Deliberately NOT selected (pure style): TRY003, EM, T201, N, ARG, D.
+
+# Pinned so every gate (per-package and the repo-wide lint stage) evaluates
+# target-version-gated rules (UP041 aliased errors, UP017 datetime.UTC, ...)
+# identically -- the whole repo is Python 3.13, and without this the lint
+# stage's per-file pyproject discovery diverged from the package gates,
+# flagging rules in one place but not the other.
+target-version = "py313"
+
+# Agent worktrees and assets. Mirrors the explicit `.claude` filter in the
+# repo-wide lint stage (lib/per-system.nix); the gates' explicit file lists
+# are unaffected either way (force-exclude defaults to false).
+extend-exclude = [".claude"]
+
+[lint]
+# Bug-catchers + security + pathlib + pytest + the original explicit-annotation
+# and no-cast gates. TID251 here is redundant with the banned-api config below
+# but makes the ban explicit in the selector.
+select = [
+  "ANN",
+  "TID251",
+  "B",
+  "ASYNC",
+  "C4",
+  "SIM",
+  "RET",
+  "PIE",
+  "UP",
+  "RUF",
+  "PERF",
+  "FURB",
+  "PLE",
+  "PLW",
+  "LOG",
+  "G",
+  "DTZ",
+  "FLY",
+  "ISC",
+  "S",
+  "PTH",
+  "PT",
+  "FBT",
+]
+
+# `ignore` drops the contextual/noisy members of selected families so we never
+# need per-file ignores:
+#   S101 asserts (used in tests + runtime), S603/S607 deliberate fixed-arg
+#   subprocess calls, S311 non-crypto random, PLW0603 module-lifetime caches,
+#   ISC001 (formatter owns it), RUF001/2/3 ambiguous-unicode false positives.
+ignore = [
+  "S101",
+  "S603",
+  "S607",
+  "S311",
+  "PLW0603",
+  "ISC001",
+  "RUF001",
+  "RUF002",
+  "RUF003",
+  # PERF203 (try-except in a loop) is a minor perf hint AND version-volatile
+  # across ruff releases: the per-package buildUvApplication gate and the
+  # repo-wide lint stage can resolve to different ruff builds, so a
+  # `# noqa: PERF203` one gate needs the other flags as RUF100 (unused). Drop
+  # it -- the flagged loops (retry/drain/collect-failures) genuinely need the
+  # per-iteration try; hoisting it would change behavior.
+  "PERF203",
+  # ASYNC109: async function that takes a `timeout` parameter. The codebase's
+  # pervasive, deliberate pattern is to accept a timeout and forward it to the
+  # underlying library (httpx/asyncssh/subprocess/wait_for), which the rule
+  # cannot see; it fires ~38 times with no bug behind any. Not a helpful lint here.
+  "ASYNC109",
+  # PEP-695 modernization (UP040 `type X =`, UP047 `def f[T]`, UP049 private
+  # type params) is churn, not bug-catching, and it fights the type checker:
+  # zuban rejects PEP-695 generics ("type parameter not declared"). Keep the
+  # classic `TypeAlias` / `TypeVar` forms.
+  "UP040",
+  "UP047",
+  "UP049",
+]
+
+# TID251 bans `typing.cast`: it lies to the type checker at zero runtime cost,
+# so a wrong cast is a latent bug no checker can catch. Parse untrusted/JSON
+# data into a pydantic model at the boundary instead, or fix the real type; the
+# rare genuinely-unavoidable case (e.g. a test double) opts out with
+# `# noqa: TID251`.
+[lint.flake8-tidy-imports.banned-api."typing.cast"]
+msg = "typing.cast defeats the type checker (no runtime check), so a wrong cast is a latent bug. Parse untrusted/JSON data into a pydantic model at the boundary, or fix the real type. Only for an unavoidable case (e.g. a test double): add a `# noqa: TID251` with a reason."


### PR DESCRIPTION
Fixes #2393.

**Problem**: the repo has no discoverable ruff config, so a direct `ruff check` applies ruff's *default* E/F selection and flags patterns the repo deliberately allows -- the importorskip-then-import pattern in `packages/mcp/tests/test_vdom_properties.py` fails E402 (and under defaults `packages/mcp` has 54 findings total: 24 E402, 19 F401, 4 E741, 4 F841, 2 F811, 1 F821). Meanwhile every gate is green because the enforced policy (`lib/ruff-ann.nix`) selects bug-catcher families and never pycodestyle E / pyflakes F. Not the lint-cache mask: it's a policy-discovery divergence.

**Fix**: check the policy in as a root `ruff.toml` (target-version, select, ignore, typing.cast ban, per-rule rationale) and make `lib/ruff-ann.nix` derive the gates' inline `ruffAnnArgs` from it via `builtins.fromTOML`. One source of truth: direct runs discover the toml, sandboxed gates (which can't see the repo root) keep getting the same policy as flags.

**No gate behavior change**: the derived `ruffAnnArgs` string is byte-identical to main's (verified by `nix eval` of old vs new).

**Verified**:
- `ruff check packages/mcp` with repo-pinned ruff 0.15.20: 54 findings -> `All checks passed!`
- repo-wide lint stage simulation (`fd --extension py` + gate args, as `lib/per-system.nix` does): green
- alejandra / statix / deadnix clean on `lib/ruff-ann.nix`

**Surfaced, out of scope here**: the lint stage's `fd` skips hidden dirs, so `.github/scripts/bump-rust-nightly.py` carries 4 violations of the enforced rules (3x PTH123, 1x S310) CI never checks. Noted on #2393.

---
*Authored by an AI agent (Claude Code, session issue-2393-mcp-ruff-e402).*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Check in `ruff.toml` so direct `ruff check` runs use the same lint policy as Nix gates
> - Adds [ruff.toml](https://github.com/indexable-inc/index/pull/2397/files#diff-26f436cb29eecc7bb4f9066747b43df8da81ac808955ce95c109f5d7aa778989) with `target-version = "py313"`, select/ignore rule sets, and a banned-api message for `typing.cast`.
> - Updates [lib/ruff-ann.nix](https://github.com/indexable-inc/index/pull/2397/files#diff-01487ef35550c07143c37258d91313e9322477979c117eb1dc6dcbe38f93360b) to load policy values from `ruff.toml` via `builtins.fromTOML` instead of hardcoded lists, so both sources stay in sync.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e29d2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->