### PR TITLE
mcp: spare a jobs.spawn child when cancelling an abandoned python_exec (#2387)

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -4141,22 +4141,29 @@ def __ix_cancel_running(session: str | None = None, exclude: str | None = None) 
     already abandoned (index#2387). Cancelling that job here is the SAME path as
     an explicit ``jobs['<id>'].cancel()``, so it drains and records cleanly.
 
-    Only the single most recently started still-running job for ``session`` is
-    cancelled: that is the one the abandoned call launched. Other background jobs
-    the same session started earlier (and did not abandon) keep running.
-    ``exclude`` skips a job id -- the raw cancel request's own frame is never a
-    ``jobs`` entry, but the guard keeps the helper honest if that ever changes.
-    Returns the ids cancelled (empty when the run already finished, the common
-    race: a fast call completes before the cancellation lands)."""
+    Only the single most recently started still-running ``python_exec`` run
+    (``kind == "cell"``) for ``session`` is cancelled: that is the one the
+    abandoned call launched. Crucially, jobs the call itself detached with
+    ``jobs.spawn`` (``kind == "spawn"``, newer-started than the parent run but
+    inheriting its session) are NOT candidates -- the user asked for those to
+    outlive the call, so cancelling the abandoned foreground run must leave them
+    running. Legitimate earlier runs the same session did not abandon also keep
+    running. ``exclude`` skips a job id -- the raw cancel request's own frame is
+    never a ``jobs`` entry, but the guard keeps the helper honest if that ever
+    changes. Returns the ids cancelled (empty when the run already finished, the
+    common race: a fast call completes before the cancellation lands)."""
     candidates = [
         job
         for job in jobs.values()
-        if job.session == session and job.running() and job.id != exclude
+        if job.session == session
+        and job.kind == "cell"
+        and job.running()
+        and job.id != exclude
     ]
     if not candidates:
         return []
-    # Newest-started wins: `jobs` is insertion-ordered, and the abandoned call is
-    # the last run this session launched.
+    # Newest-started cell wins: `jobs` is insertion-ordered, and the abandoned
+    # call is the last foreground run this session launched.
     target = max(candidates, key=lambda job: job.started)
     target.cancel()
     return [target.id]

--- a/packages/mcp/tests/test_cancel_running.py
+++ b/packages/mcp/tests/test_cancel_running.py
@@ -109,6 +109,63 @@ def test_cancel_running_leaves_other_sessions_untouched(
     assert "other done" in (other.text or "")
 
 
+def test_cancel_running_spares_a_job_the_call_deliberately_spawned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A python_exec call may detach work with ``jobs.spawn`` -- the user asked
+    # for that to outlive the call. The spawned child inherits the parent's
+    # session and starts LATER than the parent run, so a naive "cancel the
+    # newest running job for this session" would kill the child instead of the
+    # abandoned foreground run. Cancelling the abandoned call must cancel the
+    # foreground run (kind="cell") and leave the spawned child (kind="spawn")
+    # running.
+    _wire(monkeypatch, {"asyncio": asyncio, "jobs": runtime.jobs})
+
+    async def scenario() -> tuple[runtime.Job, runtime.Job]:
+        foreground = await runtime.__ix_run(
+            "child = jobs.spawn(asyncio.sleep(30))\n"
+            "await asyncio.sleep(30)\n"
+            "'foreground side effect ran'",
+            budget=0.05,
+            session="agent-a",
+        )
+        assert foreground.running()
+
+        # The cell spawns the child on its FIRST line, but the foreground run may
+        # background (budget elapsed) before the cell task has run that far --
+        # more likely under a loaded, single-core CI runner. Wait for the child
+        # to actually register rather than assuming it is there already.
+        def _spawned() -> list[runtime.Job]:
+            return [
+                j
+                for j in runtime.jobs.values()
+                if j.session == "agent-a" and j.kind == "spawn"
+            ]
+
+        for _ in range(1000):
+            if _spawned():
+                break
+            await asyncio.sleep(0.005)
+        children = _spawned()
+        assert children, "the cell's jobs.spawn child never registered"
+        spawned = max(children, key=lambda j: j.started)
+        assert spawned.started > foreground.started  # newest running is the child
+        cancelled = runtime.__ix_cancel_running(session="agent-a")
+        assert cancelled == [foreground.id]  # NOT the spawned child
+        await foreground.wait(10)
+        # Assert the child survives WHILE the loop is still live: `asyncio.run`
+        # cancels every outstanding task at teardown, so a check after it
+        # returned would see the child cancelled by the shutdown, not by us.
+        assert foreground.status == "cancelled"
+        assert spawned.running()  # the deliberately-detached job was spared
+        spawned.cancel()  # cleanup before the loop closes
+        return foreground, spawned
+
+    foreground, spawned = asyncio.run(scenario())
+    assert foreground.status == "cancelled"
+    assert "foreground side effect ran" not in (foreground.text or "")
+
+
 def test_cancel_running_is_a_noop_when_the_run_already_finished(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What

Follow-up to #2396 (which landed the #2387 fix). While reviewing, I found a wrong-job edge case in the cancellation logic.

`__ix_cancel_running` cancelled the **newest-started** running job for the session. But a job the call itself detached with `jobs.spawn(...)` **inherits the parent run's session** and starts **later** than the foreground run. So an abandoned `python_exec` that had spawned a background job would cancel the *spawned child* -- which the user explicitly asked to outlive the call -- instead of the foreground run it actually abandoned.

## Fix

Restrict cancellation candidates to `kind == "cell"` (a `python_exec` foreground run). Spawned jobs (`kind == "spawn"`) are never targeted. This still cancels exactly the abandoned foreground run in the common case (no children), and now correctly spares deliberately-detached work.

## Test

Adds `test_cancel_running_spares_a_job_the_call_deliberately_spawned`: a call spawns a child then is cancelled; asserts the foreground run (`kind="cell"`) is cancelled and the spawned child (`kind="spawn"`) keeps running. The survival check runs **inside** the event loop, before `asyncio.run` tears down (which would otherwise cancel every outstanding task). Full suite: **98 passed** locally.

Refs #2387.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `__ix_cancel_running` to spare spawned child jobs when cancelling a `python_exec` run
> When a `python_exec` cell spawns a child job via `jobs.spawn`, `__ix_cancel_running` previously could cancel those spawned jobs instead of (or in addition to) the foreground cell run.
>
> - Restricts cancellation candidates in `__ix_cancel_running` to jobs with `kind == "cell"`, excluding `kind == "spawn"` jobs from eligibility.
> - Adds a test in [test_cancel_running.py](https://github.com/indexable-inc/index/pull/2401/files#diff-b074cccb19bab2c8c10a5f5b731522b35750542088559a7a4cec3dcab9212687) that spawns a child job, invokes `__ix_cancel_running`, and asserts the foreground run is cancelled while the spawned child continues running.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62dcc44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->