### PR TITLE
mcp: fix two ruff gate violations that raced past #2396

### DIFF
--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -410,7 +410,7 @@ class Kernel:
             outputs, _ = await self._execute(
                 f"print(__ix_cancel_running(session={session_arg}))", timeout=10.0
             )
-        except BaseException:  # noqa: BLE001 -- cancel is best-effort; never mask the caller's own cancellation
+        except BaseException:  # cancel is best-effort; never mask the caller's own cancellation
             return []
         text = "".join(
             o.get("text", "") for o in outputs if isinstance(o, dict)

--- a/packages/mcp/tests/test_cancel_running.py
+++ b/packages/mcp/tests/test_cancel_running.py
@@ -71,7 +71,8 @@ def test_cancel_running_targets_only_the_newest_run_for_the_session(
         newest = await runtime.__ix_run(
             "await asyncio.sleep(30)", budget=0.01, session="agent-a"
         )
-        assert earlier.running() and newest.running()
+        assert earlier.running()
+        assert newest.running()
         cancelled = runtime.__ix_cancel_running(session="agent-a")
         assert cancelled == [newest.id]
         await earlier.wait(10)


### PR DESCRIPTION
Current main fails the repo's enforced ruff policy on two spots introduced by #2396 (its flake-check passed on the same tree, see the note on #2393 about the gate gap):

- `ix_notebook_mcp/kernel.py:413`: RUF100, `# noqa: BLE001` is unused because BLE is not an enabled family. Dropped the directive, kept the rationale as a plain comment.
- `tests/test_cancel_running.py:74`: PT018 compound assertion, split into two asserts (identical pass/fail semantics).

Verified: gate-args sweep over every `.py` in the tree and default `ruff check packages/mcp` (discovers `ruff.toml` since #2397) both pass.

---
*Authored by an AI agent (Claude Code, session issue-2393-mcp-ruff-e402).*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix two ruff linting violations in MCP kernel and cancel-running tests
> Removes a stray `noqa: BLE001` directive from the `except BaseException` clause in [`kernel.py`](https://github.com/indexable-inc/index/pull/2402/files#diff-ced4fbbdf05b4f126e987804d73fdc2d811511b346e4985a9996ae7903683d1c) and splits a compound `assert` into two separate assertions in [`test_cancel_running.py`](https://github.com/indexable-inc/index/pull/2402/files#diff-b074cccb19bab2c8c10a5f5b731522b35750542088559a7a4cec3dcab9212687). No logic or behavior changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36fcdc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->