### PR TITLE
claude-code: deny built-in agent/task/schedule/MCP-resource tool schemas; prune prompt guidance

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -217,8 +217,17 @@
     map (name: "CLAUDE_CODE_DISABLE_${name}") claudeCodeDisabledFeatureDefaults
   ) (_: 1);
 
+  # Disabling a tool here puts its BARE name in `permissions.deny`, which
+  # strips the tool's schema from the model context entirely; Claude Code has
+  # no lazy/deferred-description mode for built-in tools (scoped patterns
+  # like `Bash(...)` leave the schema loaded), so denying is the only way to
+  # reclaim their tokens. The orchestration surface (Agent, SendMessage,
+  # Task*, ScheduleWakeup) is off because delegation routes through the index
+  # kernel instead: coding agents spawned from `python_exec` as background
+  # jobs, completion notifying the session over the kernel channel (#2404).
+  # The MCP resource browsers are kernel-superseded the same way.
   defaultSystemTools = {
-    Agent = true;
+    Agent = false;
     Artifact = true;
     AskUserQuestion = false;
     DesignSync = false;
@@ -226,20 +235,23 @@
     EnterWorktree = false;
     ExitPlanMode = false;
     ExitWorktree = false;
+    ListMcpResourcesTool = false;
     PushNotification = false;
+    ReadMcpResourceDirTool = false;
+    ReadMcpResourceTool = false;
     RemoteTrigger = true;
     ReportFindings = false;
-    ScheduleWakeup = true;
-    SendMessage = true;
+    ScheduleWakeup = false;
+    SendMessage = false;
     SendUserFile = true;
     ShareOnboardingGuide = true;
     Skill = true;
-    TaskCreate = true;
-    TaskGet = true;
-    TaskList = true;
-    TaskOutput = true;
-    TaskStop = true;
-    TaskUpdate = true;
+    TaskCreate = false;
+    TaskGet = false;
+    TaskList = false;
+    TaskOutput = false;
+    TaskStop = false;
+    TaskUpdate = false;
     ToolSearch = true;
     WaitForMcpServers = true;
     Workflow = true;

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -659,22 +659,23 @@
   {
     backgroundSubagents = {
       text = ''
-        Delegate independent work to named subagents by default: split
+        Delegate independent work to agents spawned through the index kernel:
+        the harness subagent and task tools are absent by design, so
+        delegation means kernel-spawned coding agents (the how-to arrives
+        with the MCP instructions; `api('tui')` is the catalog entry),
+        launched as background jobs by default so the main thread stays free,
+        with completion notifying the session over the kernel channel. Split
         implementation by phase, fan independent questions (diagnostic
         differentials, research legs, per-component checks) out in parallel,
-        and give each editing subagent its own worktree. Keep the main agent on
-        orchestration, quick replies, and trivial one-step work. Match subagent model
-        strength to task difficulty: strongest for hard reasoning, planning, and
-        high-stakes decisions; cheaper tiers for mechanical edits, search, and
-        settled execution. For simple delegated questions, use the MCP subagent
-        tool to spawn Codex on `gpt-5.5` with low reasoning.
-        Subagents inherit the kernel-first tool denies: no Bash, Read, or
-        Edit, even when an agent definition declares them. Brief them to work
-        through their own index kernel, and for verbatim command execution
-        spawn the `executor` agent; never promise a subagent a Bash tool.
+        and give each editing agent its own worktree. Keep the main session
+        on orchestration, quick replies, and trivial one-step work. Match
+        agent model strength to task difficulty: strongest for hard
+        reasoning, planning, and high-stakes decisions; cheaper tiers (Codex
+        on `gpt-5.5` with low reasoning) for mechanical edits, search, and
+        settled execution.
         When a request branches off the current conversation (a side task,
         fix, or change that is not the thread's main line), dispatch it to a
-        named background subagent by default and keep the main thread
+        named background agent by default and keep the main thread
         conversational; do the work inline only when it is the conversation's
         actual subject or trivially quick.
       '';
@@ -682,12 +683,15 @@
         Serial main-thread editing wasted wall clock on independent work and bloated
         the orchestrating context. Simple lookup questions do not need expensive
         reasoning, but still benefit from separate context. Doing a mid-conversation
-        side task inline blocks the user's follow-ups; a background subagent keeps the
+        side task inline blocks the user's follow-ups; a background agent keeps the
         live conversation fluid.
-        Briefs that promised a default subagent "your Bash tool" (stripped by
-        the settings deny) produced relay swarms: in one session 130 subagents
-        reported the missing tool and improvised shell through Monitor and the
-        Blender MCP code runner (index#2153).
+        The harness Agent/Task tool schemas were denied to reclaim their
+        context tokens (bare-name deny is the only mechanism: built-in tools
+        have no lazy-description mode; #2404), and harness subagents
+        inherited the kernel-first denies anyway: briefs promising "your Bash
+        tool" produced relay swarms, 130 subagents in one session reporting
+        the missing tool and improvising shell through side channels
+        (index#2153).
       '';
     };
   }
@@ -742,10 +746,6 @@
         watch is actually alive: a harness-tracked background child running,
         its output growing. Receiving your own stop notification means no
         watch survived, so re-arm one or proceed synchronously.
-        An armed ScheduleWakeup is such a watch: pending wakeups live only
-        in harness memory and a session resume or user abort silently drops
-        them, so on any later turn that still counts on one, re-verify or
-        re-arm it before ending the turn.
       '';
       reason = ''
         Success-only watchers turn silent failures into indefinite waits. A
@@ -755,36 +755,6 @@
         watching the watcher. Separately, three background agents in one
         session ended turns "waiting for the monitor" with no live watch and
         stalled until a coordinator manually probed and nudged them (#1941).
-        An armed ScheduleWakeup vanished across intervening notification
-        turns and never fired, idling a background session 24h past its gate
-        (#2259).
-      '';
-    };
-  }
-  {
-    monitorHarnessKill = {
-      tags = ["claude-code"];
-      text = ''
-        A watch can also die without the watched thing ending: `script failed
-        (exit 144)` in a task-notification means the watch shell was SIGTERMed
-        from outside the session (144 is the harness sentinel for an external
-        SIGTERM; your own TaskStop renders "stopped" and a real timeout
-        "[Monitor timed out]"), often a deliberate nudge to wake a session
-        stuck behind a wedged watcher. No event accompanies it and the
-        output-file only exists if the script ever wrote output, so treat it
-        as "watched state unknown": re-probe the state directly, then re-arm.
-        Arm long poll loops with `trap 'echo <terminal line>; exit 0' TERM` so
-        an external kill surfaces as a clean terminal event instead.
-      '';
-      reason = ''
-        Two ssh poll-loop watchers wedged on a pgrep self-match were SIGTERMed
-        by the overseer to wake their session; each surfaced only as `script
-        failed (exit 144)` with zero events and no output file,
-        indistinguishable from a crash, and the watched builds went unprobed
-        until manual intervention (#2313). A trap-armed repro converted the
-        same external SIGTERM into a delivered terminal line and a clean
-        completion. Scoped to claude-code because it names the Monitor and
-        TaskStop tooling.
       '';
     };
   }


### PR DESCRIPTION
Closes #2404 (parent #2403).

**What**
- `packages/agent/claude-code/default.nix`: in the typed `defaultSystemTools` table, flip `Agent`, `SendMessage`, `TaskCreate/Get/List/Update/Output/Stop`, `ScheduleWakeup` to `false` and add `ListMcpResourcesTool`, `ReadMcpResourceDirTool`, `ReadMcpResourceTool` as `false`. Bare names in `permissions.deny` strip the tool schema from model context entirely; there is no lazy/deferred-description mode for built-in tools, so deny is the only token-saving mechanism (~3k tokens/session across the orchestration suite). The existing install-check deny assertion covers the new entries automatically.
- `packages/agent/prompt/rules.nix`: `backgroundSubagents` now routes delegation through kernel-spawned agents (background by default, completion notifies over the kernel channel); dropped the armed-ScheduleWakeup sentences from `monitorsCoverFailure`; removed `monitorHarnessKill` (it taught Monitor/TaskStop mechanics, both denied). Render verified via `nix eval`.

**Notes**
- The disable is unconditional (overlay build too): task/agent orchestration is off everywhere, matching house policy that delegation is kernel-owned.
- Follow-ups tracked: #2408 removes the now-inert ScheduleWakeup drop-detector hook; #2405 is the typed settings module this table grows into. Delivered agent *definitions* (`subagents.nix`) become unreachable from Claude sessions once `Agent` is denied; pruning their delivery can ride #2405.

(PR by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deny built-in agent, task, schedule, and MCP resource tool schemas in claude-code defaults
> - Sets `Agent`, `ScheduleWakeup`, `SendMessage`, all `Task*` tools, and the three MCP resource tools (`ListMcpResourcesTool`, `ReadMcpResourceDirTool`, `ReadMcpResourceTool`) to disabled by default in [default.nix](https://github.com/indexable-inc/index/pull/2409/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), which adds them to `permissions.deny` and strips their schemas from model context.
> - Updates the `backgroundSubagents` prompt rule in [rules.nix](https://github.com/indexable-inc/index/pull/2409/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to direct the model to delegate work via kernel-spawned agents rather than harness subagent or task tools.
> - Removes the `monitorHarnessKill` rule and watcher guidance around `ScheduleWakeup`, since those tools are now denied.
> - Behavioral Change: models using this config will no longer see task, scheduling, or MCP resource tool schemas, changing how delegation and background work are expressed by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3210b71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->