### PR TITLE
mcp: cancel the abandoned run by id, not the newest running job (Fixes #2406)

### DIFF
--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -231,7 +231,7 @@ class Kernel:
             try:
                 try:
                     await asyncio.shield(asyncio.wait({task, died}, return_when=asyncio.FIRST_COMPLETED))
-                except asyncio.CancelledError:
+                except asyncio.CancelledError as cancelled:
                     try:
                         await task
                     except TimeoutError:
@@ -245,6 +245,14 @@ class Kernel:
                         # Any other drain error: we only need the socket read to
                         # finish before releasing the lock.
                         pass
+                    # The drain above ran `on_iopub`, so `summary` now holds the
+                    # launched job's summary (with its id) when the reply arrived
+                    # before the cancel. Attach it to the exception so the caller
+                    # can cancel STRICTLY that job by id rather than guess which
+                    # background job the abandoned call started (index#2406). It
+                    # stays None when the cancel landed before any iopub, and the
+                    # by-id cancel then does nothing rather than guess.
+                    cancelled.ix_drained_summary = summary  # type: ignore[attr-defined]
                     raise
                 if not task.done():
                     # The kernel died with this request in flight: the reply can
@@ -296,6 +304,18 @@ class Kernel:
         deadline = float(budget) + grace
         try:
             return await self._execute(wrapper, timeout=deadline)
+        except asyncio.CancelledError as cancelled:
+            # The client abandoned this call. `_execute` drained the exec reply
+            # under the shell lock before re-raising, so its summary (with the
+            # launched job's id) rides on the exception. Lift that id to the
+            # attribute the server reads, so the cancel poke targets STRICTLY the
+            # run this call launched rather than guessing (index#2406). Absent
+            # when the cancel landed before any iopub -- the by-id cancel then
+            # does nothing rather than kill an unrelated background job.
+            summary = getattr(cancelled, "ix_drained_summary", None)
+            job_id = summary.get("id") if isinstance(summary, dict) else None
+            cancelled.ix_launched_job_id = job_id  # type: ignore[attr-defined]
+            raise
         except TimeoutError:
             # A dead kernel also never replies: if the death watch flagged one
             # while this request waited, report that precise cause, never a wedge.
@@ -333,25 +353,35 @@ class Kernel:
                     outcome = "restart_pending"
             return [], _wedged_summary(budget, grace, deadline, outcome=outcome)
 
-    async def cancel_running(self, session: str | None) -> list[str]:
-        """Cancel the run this ``session``'s abandoned ``python_exec`` launched.
+    async def cancel_running(
+        self, session: str | None, job_id: str | None = None
+    ) -> list[str]:
+        """Cancel the specific run this ``session``'s abandoned ``python_exec``
+        launched, identified by ``job_id``.
 
         The server calls this when a client cancels an in-flight ``python_exec``
         (``notifications/cancelled`` or a transport abort): the tool coroutine is
         cancelled server-side, but the job it started keeps running in the kernel
         as a background task, executing side effects the caller already abandoned
-        (index#2387). This pokes ``__ix_cancel_running`` on the raw shell channel
-        (no job/card, like ``set_client``), which cancels the same job an explicit
-        ``jobs['<id>'].cancel()`` would. Best-effort: a cancel arriving after the
-        run finished (the common race) cancels nothing, and a failure here must
-        never mask the original cancellation the caller is propagating. Returns
-        the ids cancelled (parsed from the raw reply; empty on any hiccup)."""
-        if self._pid is None:
+        (index#2387). ``job_id`` is that launched run's id, read off the drained
+        exec reply and passed through by the server (index#2406); this pokes
+        ``__ix_cancel_running`` on the raw shell channel (no job/card, like
+        ``set_client``), which cancels STRICTLY that job on the same path an
+        explicit ``jobs['<id>'].cancel()`` would -- never a heuristic guess.
+        ``job_id`` is None when the cancel landed before the launched job's
+        summary was drained; the poke then cancels nothing rather than kill an
+        unrelated background job. Best-effort: a cancel arriving after the run
+        finished (the common race) cancels nothing, and a failure here must never
+        mask the original cancellation the caller is propagating. Returns the ids
+        cancelled (parsed from the raw reply; empty on any hiccup)."""
+        if self._pid is None or job_id is None:
             return []
         session_arg = "None" if session is None else repr(session)
+        job_id_arg = repr(job_id)
         try:
             outputs, _ = await self._execute(
-                f"print(__ix_cancel_running(session={session_arg}))", timeout=10.0
+                f"print(__ix_cancel_running(session={session_arg}, job_id={job_id_arg}))",
+                timeout=10.0,
             )
         except BaseException:  # cancel is best-effort; never mask the caller's own cancellation
             return []

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -4374,9 +4374,13 @@ async def __ix_exec(
     _emit(job)
 
 
-def __ix_cancel_running(session: str | None = None, exclude: str | None = None) -> list[str]:
-    """Cancel the run this session's in-flight ``python_exec`` launched, so an
-    abandoned call stops instead of finishing in the background.
+def __ix_cancel_running(
+    session: str | None = None,
+    job_id: str | None = None,
+    exclude: str | None = None,
+) -> list[str]:
+    """Cancel the specific run this session's in-flight ``python_exec`` launched,
+    so an abandoned call stops instead of finishing in the background.
 
     The MCP server calls this when the client cancels an in-flight
     ``python_exec`` request (``notifications/cancelled`` or a transport abort):
@@ -4385,30 +4389,34 @@ def __ix_cancel_running(session: str | None = None, exclude: str | None = None) 
     already abandoned (index#2387). Cancelling that job here is the SAME path as
     an explicit ``jobs['<id>'].cancel()``, so it drains and records cleanly.
 
-    Only the single most recently started still-running ``python_exec`` run
-    (``kind == "cell"``) for ``session`` is cancelled: that is the one the
-    abandoned call launched. Crucially, jobs the call itself detached with
-    ``jobs.spawn`` (``kind == "spawn"``, newer-started than the parent run but
-    inheriting its session) are NOT candidates -- the user asked for those to
-    outlive the call, so cancelling the abandoned foreground run must leave them
-    running. Legitimate earlier runs the same session did not abandon also keep
-    running. ``exclude`` skips a job id -- the raw cancel request's own frame is
-    never a ``jobs`` entry, but the guard keeps the helper honest if that ever
-    changes. Returns the ids cancelled (empty when the run already finished, the
-    common race: a fast call completes before the cancellation lands)."""
-    candidates = [
-        job
-        for job in jobs.values()
-        if job.session == session
-        and job.kind == "cell"
-        and job.running()
-        and job.id != exclude
-    ]
-    if not candidates:
+    ``job_id`` is the id of the run the abandoned call launched, read off the
+    drained exec reply's summary and plumbed through by the server (index#2406).
+    We cancel STRICTLY that job: never a heuristic "newest running job for the
+    session", because the abandoned call's reply is drained under the shell lock
+    before this poke runs, so by the time we get here the launched run has either
+    backgrounded (still running -- cancel it) or finished within budget (nothing
+    to do). Guessing "newest" in the finished case would deterministically kill
+    an unrelated background job the same session started earlier and did NOT
+    abandon (the wrong-job kill in the issue). Targeting by id also inherently
+    spares jobs the call detached with ``jobs.spawn`` (index#2387): a spawned
+    child has its own id, so it is never the target. So:
+
+      - ``job_id`` absent (an old cancel path with no summary, e.g. a cancel that
+        landed before any iopub): cancel NOTHING rather than guess.
+      - the target is unknown, belongs to another session, or already finished:
+        cancel NOTHING (the common race is a fast call that completed in budget).
+      - otherwise cancel exactly that one job.
+
+    The ``session`` guard is kept so a stray/forged ``job_id`` can never reach
+    across sessions. ``exclude`` skips a job id -- the raw cancel request's own
+    frame is never a ``jobs`` entry, but the guard keeps the helper honest if
+    that ever changes. Returns the ids cancelled (empty when there was nothing to
+    cancel)."""
+    if job_id is None or job_id == exclude:
         return []
-    # Newest-started cell wins: `jobs` is insertion-ordered, and the abandoned
-    # call is the last foreground run this session launched.
-    target = max(candidates, key=lambda job: job.started)
+    target = jobs.get(job_id)
+    if target is None or target.session != session or not target.running():
+        return []
     target.cancel()
     return [target.id]
 

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -517,21 +517,28 @@ async def python_exec(
         cell_outputs, summary = await kernel.python_exec(
             code, effective_budget, intent, session=sid, topic=_session_topic(ctx)
         )
-    except asyncio.CancelledError:
+    except asyncio.CancelledError as cancelled:
         # The client cancelled this in-flight call (`notifications/cancelled` or a
         # transport abort; the MCP SDK cancels this handler's request scope, which
         # surfaces here as CancelledError). Without this the kernel job the call
         # launched keeps running in the background and executes its side effects
         # AFTER the caller abandoned it -- the permission-gate bypass in
-        # index#2387. Interrupt that job on the same path an explicit
-        # `jobs['<id>'].cancel()` takes, then re-raise so the cancellation still
-        # propagates. `shield` keeps the cancel poke itself from being torn down
-        # by the very cancellation we are handling. Note: Claude Code does not
-        # signal a USER REJECTION of an in-flight call, so this fires for
-        # spec-compliant cancels and Claude Code's own request timeout, not for a
-        # rejected prompt (documented in guide.CANCELLATION_NOTE).
+        # index#2387. Interrupt STRICTLY that job (its id rode out on the
+        # exception from `kernel.python_exec`, read off the drained exec reply --
+        # index#2406) on the same path an explicit `jobs['<id>'].cancel()` takes,
+        # then re-raise so the cancellation still propagates. Cancelling by id,
+        # not a "newest running job" heuristic, avoids killing an unrelated
+        # background job the same session started earlier (the wrong-job kill in
+        # index#2406); the id is None when the cancel landed before the launched
+        # job's summary was drained, and the poke then cancels nothing. `shield`
+        # keeps the cancel poke itself from being torn down by the very
+        # cancellation we are handling. Note: Claude Code does not signal a USER
+        # REJECTION of an in-flight call, so this fires for spec-compliant cancels
+        # and Claude Code's own request timeout, not for a rejected prompt
+        # (documented in guide.CANCELLATION_NOTE).
+        launched_job_id = getattr(cancelled, "ix_launched_job_id", None)
         with contextlib.suppress(Exception):  # best-effort: a cancel-time hiccup must not swallow the re-raise
-            await asyncio.shield(kernel.cancel_running(sid))
+            await asyncio.shield(kernel.cancel_running(sid, job_id=launched_job_id))
         raise
     rendered = outputs.to_mcp(cell_outputs)
     # The human view for an MCP Apps host: the same text/html fragments the

--- a/packages/mcp/tests/test_cancel_running.py
+++ b/packages/mcp/tests/test_cancel_running.py
@@ -1,18 +1,24 @@
 """A client that abandons an in-flight ``python_exec`` cancels the run it
-launched, instead of letting it finish in the background (issue #2387).
+launched, instead of letting it finish in the background (issue #2387), and
+cancels STRICTLY that run rather than a heuristic "newest running job" that
+would kill an unrelated background job the same session started (issue #2406).
 
 The MCP server dispatches a ``python_exec`` to the kernel, which runs the code
 as a background ``Job`` once its foreground budget elapses. If the client then
 cancels the request (``notifications/cancelled`` or a transport abort), the tool
 coroutine is cancelled server-side -- but the kernel job used to keep running,
 executing side effects the caller already abandoned (the permission-gate bypass
-in the issue: a rejected/abandoned ``home-manager switch`` still built).
+in #2387: a rejected/abandoned ``home-manager switch`` still built).
 
 ``__ix_cancel_running`` is what the server pokes on the raw shell channel when a
-call is cancelled: it cancels the single most-recently-started running job for
-that session, on the same path as an explicit ``jobs['<id>'].cancel()``. These
-tests exercise it directly against the runtime (no kernel process, no loopback
-bind -- so they pass under the darwin sandbox in nix checks).
+call is cancelled. It takes the launched run's ``job_id`` (read off the drained
+exec reply and plumbed through by the server) and cancels STRICTLY that job, on
+the same path as an explicit ``jobs['<id>'].cancel()``. It never falls back to
+"the newest running job for the session": that heuristic deterministically kills
+an unrelated background job whenever the abandoned call finished within budget
+(#2406). These tests exercise it directly against the runtime (no kernel
+process, no loopback bind -- so they pass under the darwin sandbox in nix
+checks).
 """
 
 from __future__ import annotations
@@ -34,8 +40,8 @@ def test_cancel_running_stops_the_abandoned_background_job(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # A session backgrounds a long side-effectful run (stand-in: a long sleep).
-    # The client abandons the call; the server cancels the run it launched, and
-    # the job must stop instead of finishing.
+    # The client abandons the call; the server cancels the run it launched by id,
+    # and the job must stop instead of finishing.
     _wire(monkeypatch, {"asyncio": asyncio})
 
     async def scenario() -> runtime.Job:
@@ -45,7 +51,7 @@ def test_cancel_running_stops_the_abandoned_background_job(
             session="agent-a",
         )
         assert job.running()
-        cancelled = runtime.__ix_cancel_running(session="agent-a")
+        cancelled = runtime.__ix_cancel_running(session="agent-a", job_id=job.id)
         assert cancelled == [job.id]
         await job.wait(10)
         return job
@@ -55,12 +61,14 @@ def test_cancel_running_stops_the_abandoned_background_job(
     assert "side effect ran" not in (job.text or "")
 
 
-def test_cancel_running_targets_only_the_newest_run_for_the_session(
+def test_cancel_running_targets_only_the_launched_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # A session may have an earlier legitimate background job still running. Only
-    # the most recently launched run (the abandoned call) is cancelled; the
-    # earlier one keeps running.
+    # the run named by ``job_id`` (the abandoned call) is cancelled; the earlier
+    # one keeps running -- even though it started FIRST, so a "newest wins"
+    # heuristic would have gotten this right too. The next test covers the case
+    # the heuristic gets wrong.
     _wire(monkeypatch, {"asyncio": asyncio})
 
     async def scenario() -> tuple[runtime.Job, runtime.Job]:
@@ -73,7 +81,7 @@ def test_cancel_running_targets_only_the_newest_run_for_the_session(
         )
         assert earlier.running()
         assert newest.running()
-        cancelled = runtime.__ix_cancel_running(session="agent-a")
+        cancelled = runtime.__ix_cancel_running(session="agent-a", job_id=newest.id)
         assert cancelled == [newest.id]
         await earlier.wait(10)
         return earlier, newest
@@ -84,11 +92,79 @@ def test_cancel_running_targets_only_the_newest_run_for_the_session(
     assert "earlier done" in (earlier.text or "")
 
 
+def test_cancel_running_does_not_kill_an_unrelated_job_when_the_abandoned_run_finished(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The wrong-job kill from #2406. The abandoned ``python_exec`` was a quick
+    # call that FINISHED within its foreground budget (so its summary is drained
+    # and its id is known), while an OLDER background job the same session
+    # started earlier is still running. The old heuristic ("cancel the newest
+    # still-running job for the session") had no running quick call left to find,
+    # so it fell through and cancelled the older long-running job -- a
+    # deterministic wrong-job kill. Cancelling strictly by the finished run's id
+    # is a no-op, and the older job keeps running.
+    _wire(monkeypatch, {"asyncio": asyncio})
+
+    async def scenario() -> tuple[runtime.Job, runtime.Job]:
+        older = await runtime.__ix_run(
+            "await asyncio.sleep(0.4)\n'older done'", budget=0.01, session="agent-a"
+        )
+        await asyncio.sleep(0.02)  # strictly later start for the quick call
+        quick = await runtime.__ix_run("1 + 1", budget=5.0, session="agent-a")
+        assert quick.status == "done"  # finished within budget
+        assert older.running()
+        # By-id cancel of the finished quick run: nothing to cancel, and the
+        # older running job is NOT touched (the newest-heuristic misfire).
+        assert runtime.__ix_cancel_running(session="agent-a", job_id=quick.id) == []
+        assert older.running()
+        # And the by-id cancel of an actually-abandoned running job still works:
+        running = await runtime.__ix_run(
+            "await asyncio.sleep(30)", budget=0.01, session="agent-a"
+        )
+        assert running.running()
+        assert runtime.__ix_cancel_running(session="agent-a", job_id=running.id) == [
+            running.id
+        ]
+        await running.wait(10)
+        await older.wait(10)
+        return older, running
+
+    older, running = asyncio.run(scenario())
+    assert older.status == "done"
+    assert "older done" in (older.text or "")
+    assert running.status == "cancelled"
+
+
+def test_cancel_running_without_a_job_id_cancels_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Some cancel paths have no summary to read the id from -- the cancel landed
+    # before any iopub carried the launched job's summary. With no id to target,
+    # the helper must cancel NOTHING rather than guess and risk the wrong-job
+    # kill; the running job is left alone.
+    _wire(monkeypatch, {"asyncio": asyncio})
+
+    async def scenario() -> runtime.Job:
+        job = await runtime.__ix_run(
+            "await asyncio.sleep(30)", budget=0.01, session="agent-a"
+        )
+        assert job.running()
+        assert runtime.__ix_cancel_running(session="agent-a", job_id=None) == []
+        assert job.running()
+        job.cancel()
+        await job.wait(10)
+        return job
+
+    job = asyncio.run(scenario())
+    assert job.status == "cancelled"
+
+
 def test_cancel_running_leaves_other_sessions_untouched(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Cancelling one session's abandoned run must never touch another session's
-    # job -- the same isolation issue #2104 protects.
+    # job -- the same isolation issue #2104 protects. Even a job_id that names
+    # another session's run is refused by the session guard.
     _wire(monkeypatch, {"asyncio": asyncio})
 
     async def scenario() -> tuple[runtime.Job, runtime.Job]:
@@ -98,7 +174,10 @@ def test_cancel_running_leaves_other_sessions_untouched(
         other = await runtime.__ix_run(
             "await asyncio.sleep(0.2)\n'other done'", budget=0.01, session="agent-b"
         )
-        cancelled = runtime.__ix_cancel_running(session="agent-a")
+        # A job_id from another session is refused by the session guard.
+        assert runtime.__ix_cancel_running(session="agent-a", job_id=other.id) == []
+        assert other.running()
+        cancelled = runtime.__ix_cancel_running(session="agent-a", job_id=mine.id)
         assert cancelled == [mine.id]
         await mine.wait(10)
         await other.wait(10)
@@ -114,12 +193,11 @@ def test_cancel_running_spares_a_job_the_call_deliberately_spawned(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # A python_exec call may detach work with ``jobs.spawn`` -- the user asked
-    # for that to outlive the call. The spawned child inherits the parent's
-    # session and starts LATER than the parent run, so a naive "cancel the
-    # newest running job for this session" would kill the child instead of the
-    # abandoned foreground run. Cancelling the abandoned call must cancel the
-    # foreground run (kind="cell") and leave the spawned child (kind="spawn")
-    # running.
+    # for that to outlive the call (index#2387/#2401). The spawned child inherits
+    # the parent's session and starts LATER than the parent run, so a naive
+    # "cancel the newest running job for this session" would kill the child
+    # instead of the abandoned foreground run. Cancelling by the foreground
+    # run's id spares the child by construction; this test pins that property.
     _wire(monkeypatch, {"asyncio": asyncio, "jobs": runtime.jobs})
 
     async def scenario() -> tuple[runtime.Job, runtime.Job]:
@@ -151,7 +229,9 @@ def test_cancel_running_spares_a_job_the_call_deliberately_spawned(
         assert children, "the cell's jobs.spawn child never registered"
         spawned = max(children, key=lambda j: j.started)
         assert spawned.started > foreground.started  # newest running is the child
-        cancelled = runtime.__ix_cancel_running(session="agent-a")
+        cancelled = runtime.__ix_cancel_running(
+            session="agent-a", job_id=foreground.id
+        )
         assert cancelled == [foreground.id]  # NOT the spawned child
         await foreground.wait(10)
         # Assert the child survives WHILE the loop is still live: `asyncio.run`
@@ -170,15 +250,15 @@ def test_cancel_running_spares_a_job_the_call_deliberately_spawned(
 def test_cancel_running_is_a_noop_when_the_run_already_finished(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # The common race: a fast call finishes before the cancellation lands. There
-    # is nothing to cancel, and the helper must return an empty list rather than
-    # touch an already-done job.
+    # The common race: a fast call finishes before the cancellation lands. Even
+    # with its id in hand there is nothing to cancel, and the helper must return
+    # an empty list rather than touch an already-done job.
     _wire(monkeypatch, {"asyncio": asyncio})
 
     async def scenario() -> runtime.Job:
         job = await runtime.__ix_run("1 + 1", budget=5.0, session="agent-a")
         assert job.status == "done"
-        assert runtime.__ix_cancel_running(session="agent-a") == []
+        assert runtime.__ix_cancel_running(session="agent-a", job_id=job.id) == []
         return job
 
     job = asyncio.run(scenario())


### PR DESCRIPTION
## What

`__ix_cancel_running` cancelled the *newest still-running* job for a session as a proxy for "the job the abandoned `python_exec` launched". But `Kernel._execute` drains the in-flight exec reply under the shell-channel lock **before** the cancel poke runs, so by the time the poke lands the launched run has either:

- **backgrounded** (still running) -> the right target, cancelled correctly; or
- **completed within budget** -> nothing to cancel, but the heuristic fell through and cancelled the session's newest *other* running job.

That second case is a deterministic wrong-job kill: background a long job, then cancel a quick call in the same session, and the long job dies.

## Fix: cancel by id

The drained exec reply carries the launched job's summary (with its `id`) through `_execute`'s `on_iopub`. Plumb that id out along the cancellation path:

- `_execute` attaches the drained `summary` to the `CancelledError` it re-raises.
- `Kernel.python_exec` lifts the launched job's `id` onto the exception (`ix_launched_job_id`).
- `tools.python_exec` reads it and passes it to `cancel_running(sid, job_id=...)`.
- `cancel_running` plumbs it to `__ix_cancel_running(job_id=...)`.

`__ix_cancel_running` now targets **strictly** that id: no-op when it is done, absent, or belongs to another session, and **never** a "newest running" fallback. When the summary is absent (cancel landed before any iopub), the id is `None` and it cancels nothing rather than guess. The session guard is kept.

## Tests

Extends `test_cancel_running.py`:

- **the misfire case (#2406):** newest run finished + older session job still running -> cancels **NOTHING**; a by-id cancel of an actually-running abandoned job still works.
- no `job_id` -> cancels nothing (the no-summary cancel path).
- existing #2387/#2104 cases reworked to pass the launched id explicitly.

Built `mcp.tests.typecheckSmoke` locally: `99 passed` (per-cell `ty` typecheck + all suites green).

Fixes #2406

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP kernel cancellation to target the abandoned run by job ID instead of the newest running job
> - Previously, cancelling an in-flight `python_exec` would guess the target by selecting the newest running job for the session, which could cancel the wrong job.
> - `__ix_cancel_running` in [runtime.py](https://github.com/indexable-inc/index/pull/2411/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now accepts a `job_id` and cancels only that specific job when it matches the session and is still running.
> - The job ID is threaded through the cancellation path: `Kernel._execute` attaches the drained job summary to the `CancelledError`, `python_exec` extracts the ID, and [tools.py](https://github.com/indexable-inc/index/pull/2411/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) passes it to `kernel.cancel_running`.
> - When no job ID is available, cancellation is a no-op rather than a guess.
> - Behavioral Change: cancellation now does nothing if the launched job ID is missing or the job already finished, instead of cancelling whatever job happens to be newest.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57ae85c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->