### PR TITLE
mcp: consume the channel outbox atomically so a row is delivered exactly once

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1824,6 +1824,14 @@ def _notify_job_finished(job: Job) -> None:
     server's session id (the stdio client), so the wake reaches the session
     that started the job and no other -- the dashboard still shows every job
     globally from the executions table (issue #2165).
+
+    Known limit (issue #2400): one Claude Code process multiplexes its parent
+    conversation and in-process subagents onto a single stdio MCP session, and
+    the client sends no per-agent identity on tool calls (only
+    ``claudecode/toolUseId``, see anthropics/claude-code#32514), so a
+    subagent's job wake still lands in the parent conversation. That split
+    needs the client to expose the caller; the addressing here is where it
+    will slot in.
     """
     if not job.backgrounded or job.kind == "replay":
         return

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -663,23 +663,22 @@ def take_outbox(conn: sqlite3.Connection, *, session: str = "") -> list[dict]:
     rows (``session = ''``) plus rows addressed to it -- oldest first, consuming
     exactly the rows returned. Rows addressed to OTHER sessions are left queued
     for their own pump (a job's lifecycle event reaches only the session that
-    started the job, issue #2165). Like ``_drain_inputs``: DELETE before
-    delivering, so an event can never be emitted twice; a crash between the
-    delete and the send loses at most one batch."""
+    started the job, issue #2165). Like ``_drain_inputs``: the rows are consumed
+    before delivering, so a crash between the delete and the send loses at most
+    one batch. The consume is a single ``DELETE ... RETURNING`` statement, not a
+    SELECT-then-DELETE: several pumps can share one store (serve processes
+    spawned with an inherited ``IX_MCP_STORE``/session file), and the statement
+    gap let two of them read the same row and each deliver it -- one session's
+    event waking every connected session (issue #2400). One statement means one
+    writer wins per row, so an event is emitted exactly once."""
     conn.row_factory = sqlite3.Row
     rows = conn.execute(
-        "SELECT seq, content, meta, session FROM outbox "
-        "WHERE session = '' OR session = ? ORDER BY seq ASC",
+        "DELETE FROM outbox WHERE session = '' OR session = ? "
+        "RETURNING seq, content, meta, session",
         (session,),
     ).fetchall()
-    if not rows:
-        return []
-    placeholders = ",".join("?" for _ in rows)
-    conn.execute(
-        f"DELETE FROM outbox WHERE seq IN ({placeholders})",  # noqa: S608 -- placeholders are bound params
-        [r["seq"] for r in rows],
-    )
-    return [dict(r) for r in rows]
+    # RETURNING order is unspecified; deliver oldest first, as the queue promises.
+    return sorted((dict(r) for r in rows), key=lambda row: row["seq"])
 
 
 def add_event(conn: sqlite3.Connection, *, resource: str, kind: str, body: str) -> None:

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import sqlite3
 import sys
+import threading
 from pathlib import Path
 
 import anyio
@@ -60,6 +61,44 @@ def test_take_outbox_default_serves_broadcast_only(tmp_path: Path) -> None:
     store.add_outbox(conn, content="addressed", meta="{}", session="s1")
     assert [r["content"] for r in store.take_outbox(conn)] == ["broadcast"]
     assert [r["content"] for r in store.take_outbox(conn, session="s1")] == ["addressed"]
+
+
+def test_take_outbox_delivers_each_row_exactly_once_across_connections(tmp_path: Path) -> None:
+    """The consume is atomic (issue #2400): several pumps can share one store
+    (serve processes spawned with an inherited store pin), and the old
+    SELECT-then-DELETE let two connections read the same rows and each deliver
+    them -- one session's event waking every connected session. Two connections
+    draining the same queue at once must partition it, never overlap."""
+    path = tmp_path / "race.db"
+    seed = store.connect(path)
+    for i in range(300):
+        store.add_outbox(seed, content=f"event {i}", meta="{}")
+    total = seed.execute("SELECT count(*) FROM outbox").fetchone()[0]
+
+    delivered: dict[str, list[int]] = {"a": [], "b": []}
+    barrier = threading.Barrier(2)
+
+    def drain(who: str) -> None:
+        conn = store.connect(path)  # its own connection, like a real pump
+        barrier.wait()  # maximize the overlap the old code raced on
+        while True:
+            rows = store.take_outbox(conn, session=who)
+            if not rows:
+                break
+            delivered[who].extend(r["seq"] for r in rows)
+
+    threads = [threading.Thread(target=drain, args=(who,)) for who in ("a", "b")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    seqs = delivered["a"] + delivered["b"]
+    assert len(seqs) == len(set(seqs)), "a row was delivered by both pumps"
+    assert len(seqs) == total, "a row was lost"
+    # Each drainer saw its share oldest-first.
+    assert delivered["a"] == sorted(delivered["a"])
+    assert delivered["b"] == sorted(delivered["b"])
 
 
 def test_add_outbox_prunes_rows_past_age_cap(tmp_path: Path) -> None:
@@ -477,6 +516,61 @@ def test_pump_outbox_delivers_own_session_and_skips_others(
         # The other session's row is still queued for its own pump.
         rows = store.take_outbox(conn, session="other")
         assert [r["content"] for r in rows] == ["for someone else"]
+
+    asyncio.run(run())
+
+
+def test_job_finished_wake_reaches_only_the_owning_sessions_pump(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end for issue #2400: session A starts a job and session B is
+    connected to the same store; when the backgrounded job finishes, the
+    kernel-side addressing (`_notify_job_finished`) plus each session's pump
+    deliver the completion channel event to A exactly once -- B's pump stays
+    silent and nothing is left queued."""
+
+    async def start_pump(
+        cfg: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[asyncio.Future, object]:
+        # pump_outbox reads config() once, before its first await, so patching,
+        # scheduling, and yielding one tick pins this pump to `cfg` even though
+        # the next pump repatches the same module attribute.
+        monkeypatch.setattr("ix_notebook_mcp.transport.config", lambda: cfg)
+        send, receive = anyio.create_memory_object_stream(8)
+        pump = asyncio.ensure_future(transport.pump_outbox(send, _FakeSession(initialized=True)))
+        await asyncio.sleep(0)
+        return pump, receive
+
+    async def run() -> None:
+        db = tmp_path / "p.db"
+        conn = store.connect(db)
+        _wire_runtime(monkeypatch, conn)
+
+        # Session A's backgrounded job reaches a terminal state.
+        job = _finished_job(session="sess-a")
+        runtime._notify_job_finished(job)
+
+        pump_a, receive_a = await start_pump(
+            Config(workdir=tmp_path, store_path=db, server_session_id="sess-a"), monkeypatch
+        )
+        pump_b, receive_b = await start_pump(
+            Config(workdir=tmp_path, store_path=db, server_session_id="sess-b"), monkeypatch
+        )
+        try:
+            message = await asyncio.wait_for(receive_a.receive(), timeout=5.0)
+            wire = message.message.root
+            assert wire.method == "notifications/claude/channel"
+            assert wire.params["content"] == "Background job poll ci finished with status done."
+            assert wire.params["meta"]["job_id"] == job.id
+            # B never sees A's wake -- not late, not at all.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(receive_b.receive(), timeout=1.0)
+        finally:
+            pump_a.cancel()
+            pump_b.cancel()
+        # The row was consumed by A's pump; nothing lingers for anyone.
+        assert store.take_outbox(conn, session="sess-a") == []
+        assert store.take_outbox(conn, session="sess-b") == []
 
     asyncio.run(run())
 


### PR DESCRIPTION
Fixes #2400.

## What the issue actually needed

The proposed mechanism (session-addressed job lifecycle events, `job.session` -> outbox `session` column -> per-session pump filter) already landed in #2190, the day before this issue was filed, with A/B routing tests at the store, source, and pump levels. Two residual gaps remained; this PR closes the in-repo one and documents the upstream one.

## In-repo fix: atomic outbox consume

`store.take_outbox` was a SELECT followed by a DELETE. Several serve pumps can share one store (serve processes spawned with an inherited `IX_MCP_STORE`/`--session` file), and the statement gap let two pumps both read the same row and each deliver it: one session's event waking every connected session, which is the literal issue title. The consume is now a single `DELETE ... RETURNING` (SQLite >= 3.35; WAL + busy_timeout serializes writers), so one writer wins per row and an event is emitted exactly once.

## Tests

- `test_take_outbox_delivers_each_row_exactly_once_across_connections`: two threads with independent connections drain 300 broadcast rows concurrently; no row is duplicated or lost, each drainer sees oldest-first.
- `test_job_finished_wake_reaches_only_the_owning_sessions_pump`: the issue's exact scenario end-to-end. Session A starts a job, sessions A and B both run `pump_outbox` against the shared store; only A's pump emits the `notifications/claude/channel` finish wake, B times out, and the outbox is fully consumed.

`nix build .#mcp.tests.channelTests`: 29 passed; the single failure is the pre-existing darwin-sandbox loopback-bind failure in `test_sse_streams_new_events_only`, which fails identically on main. `.#mcp.tests.strictTypecheck` passes. `nix run .#lint` fails only on pre-existing findings in files this PR does not touch (`lib/ruff-ann.nix` astlog, `tests/test_cancel_running.py` ruff), reproduced identically on pristine main `cd646249`.

## Upstream limit (documented in `_notify_job_finished`)

One Claude Code process multiplexes its parent conversation and in-process subagents onto a single stdio MCP session, and the client sends no per-agent identity on tool calls (only `claudecode/toolUseId`, anthropics/claude-code#32514) while channel notifications wake the main session only. So a subagent's job wake still lands in the parent conversation; that split needs the client to expose the caller, and the session addressing from #2190 is where it will slot in.

---

Written by Claude Code (Claude Fable 5).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `take_outbox` to consume channel outbox atomically for exactly-once delivery
> - Rewrites `take_outbox` in [store.py](https://github.com/indexable-inc/index/pull/2420/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976) to use a single `DELETE ... RETURNING` statement instead of a separate `SELECT` then `DELETE`, so each row is claimed by exactly one concurrent consumer.
> - Sorts returned rows by `seq` after the atomic delete to preserve oldest-first delivery order, since `RETURNING` does not guarantee ordering.
> - Adds concurrency tests in [test_channel.py](https://github.com/indexable-inc/index/pull/2420/files#diff-f1684e518bfcf4f7df252a5c209b046a82ed7c2db27ff168d3e422b623323bbd) covering 300 rows drained across two connections, asserting no duplicate delivery and monotonically increasing seqs per drainer.
> - Adds a docstring note in [runtime.py](https://github.com/indexable-inc/index/pull/2420/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) about a known limitation (issue #2400) with Claude Code multiplexing agents onto a single stdio MCP session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 497bf55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->