### PR TITLE
provenance: whence backlinks from deployed files to nix source lines

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -419,6 +419,12 @@
       # services); import it from a darwin host to get the casks merged in. See
       # users/andrewgazelka/darwin.nix.
       andrewgazelka = ./users/andrewgazelka/darwin.nix;
+      # Per-generation provenance manifest for nix-darwin: bake deployed-path
+      # -> defining nix file:line backlinks (provenance.json) into the system
+      # closure so `whence </etc/...>` answers from /run/current-system with
+      # zero eval. Set `provenance.rev = self.rev or self.dirtyRev or null`
+      # in the consuming flake. See modules/darwin/provenance.nix.
+      provenance = import ./modules/darwin/provenance.nix {inherit (ix) provenance;};
     };
     homeModules = {
       # Workstation-facing home-manager module: declare a service once, get a
@@ -433,6 +439,12 @@
       # `programs.raycast.focus = { enable = true; ... }`. See
       # modules/home/raycast.nix.
       raycast = ./modules/home/raycast.nix;
+      # Per-generation provenance manifest: every home-manager generation
+      # carries provenance.json mapping deployed files back to the nix
+      # file:line that defined them, and `whence <path>` reads it with zero
+      # eval. Set `provenance.rev = self.rev or self.dirtyRev or null` in
+      # the consuming flake. See modules/home/provenance.nix.
+      provenance = import ./modules/home/provenance.nix {inherit (ix) provenance;};
       # Agent CLI modules: Home Manager is the user-facing configuration
       # surface, while the package wrappers remain the implementation detail.
       claude-code = import ./packages/agent/home-manager/claude-code.nix {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -206,6 +206,13 @@
   # one, so it stays outside `modules/`. Exposed as `homeModules.mutable-json`.
   mutableJson = import ./services/mutable-json.nix {inherit lib;};
 
+  # Eval-provenance walker (whence, #2413): map an evaluated home-manager /
+  # nix-darwin configuration's deployed files back to their defining nix
+  # sites via `definitionsWithLocations` + per-key `unsafeGetAttrPos`.
+  # Consumed by modules/home/provenance.nix and modules/darwin/provenance.nix
+  # and exposed so downstream tooling can render manifests for other configs.
+  provenance = import ./provenance.nix {inherit lib;};
+
   # Flat list of module paths from the auto-discovered registry under
   # `modules/`. Pulled in unconditionally so every option is in scope; each
   # module stays inert until its `enable` flag is set.
@@ -618,6 +625,7 @@
       patchedSrc
       patchedSrcFor
       pins
+      provenance
       publicArtifactsFor
       relativePath
       repoMetadata

--- a/lib/provenance.nix
+++ b/lib/provenance.nix
@@ -1,0 +1,266 @@
+# Eval-provenance walker: map every deployed config file of an evaluated
+# home-manager / nix-darwin configuration back to the nix expression that
+# defined it (#2414).
+#
+# The module system already records where every option definition came from
+# (`definitionsWithLocations`, the same machinery behind nixpkgs
+# `meta.position`); it just is not surfaced anywhere. This walker surfaces
+# it: for each file-materializing option (`home.file`, `xdg.configFile`,
+# `launchd.agents`/`daemons`, `environment.etc`) it emits one manifest entry
+# per deployed path:
+#
+#   { file, line, rev, drv, source, definitions, settings }
+#
+# `file:line` is the most specific definition site: per-key
+# `builtins.unsafeGetAttrPos` when the attrset was written literally,
+# degrading to the defining module file (line null) for computed attrs
+# (e.g. a `mapAttrs'` wiring hop). `definitions` keeps every site in
+# definition order, so a file wired through several modules shows the whole
+# chain.
+#
+# When a wiring module renders `programs.<x>.settings` into a file option
+# (home-manager's htop module materializing `xdg.configFile."htop/htoprc"`,
+# say), the entry additionally records the user's `programs.<x>.settings`
+# definition sites under `settings`. The link is exact, not heuristic: the
+# wiring module both declares the settings option and defines the file
+# entry, so a definition site that appears in the settings option's
+# `declarations` marks the hop.
+#
+# Pure eval, zero IFD. Store-path context is discarded from every recorded
+# string: the manifest names sources and drvs, it must not retain them.
+{lib}: let
+  discard = builtins.unsafeDiscardStringContext;
+
+  # A definition site: `pos` (from `builtins.unsafeGetAttrPos`) is trusted
+  # only when it lands in the module file that made the definition, i.e. the
+  # attr key was written literally there. Computed attrs (a `mapAttrs'`
+  # wiring hop, an imported attrset) carry positions pointing into whatever
+  # code constructed them (nixpkgs lib internals, another file), so they
+  # degrade to the defining module file with no line.
+  site = defFile: pos:
+    if pos != null && pos.file == defFile
+    then {
+      file = discard pos.file;
+      inherit (pos) line;
+    }
+    else {
+      file = discard defFile;
+      line = null;
+    };
+
+  # Definition sites of key `name` inside an attrsOf option: one
+  # {file, line} per module that defines the key.
+  keySites = option: name:
+    lib.concatMap (
+      def:
+        lib.optional (builtins.isAttrs def.value && def.value ? ${name})
+        (site def.file (builtins.unsafeGetAttrPos name def.value))
+    )
+    option.definitionsWithLocations;
+
+  sourcePayload = source:
+    if source == null
+    then {
+      source = null;
+      drv = null;
+    }
+    else {
+      source = discard (toString source);
+      drv =
+        if lib.isDerivation source
+        then discard source.drvPath
+        else null;
+    };
+
+  # Walk one attrsOf file option into raw entries. `path` maps a key plus
+  # its merged config value to the deployed path; `source` extracts the
+  # store payload backing it (null for options with no single payload,
+  # e.g. launchd plists rendered by the wiring module).
+  walkOption = {
+    options,
+    config,
+  }: {
+    optionPath,
+    path,
+    source ? _name: _value: null,
+    enabled ? value: value.enable or true,
+  }: let
+    option = lib.attrByPath optionPath null options;
+    cfg = lib.attrByPath optionPath {} config;
+  in
+    if !(builtins.isAttrs option) || !(option ? definitionsWithLocations)
+    then []
+    else
+      lib.concatMap (
+        name: let
+          value = cfg.${name};
+          sites = keySites option name;
+        in
+          if !(enabled value) || sites == []
+          then []
+          else [
+            ({
+                path = path name value;
+                inherit sites;
+              }
+              // sourcePayload (source name value))
+          ]
+      ) (builtins.attrNames cfg);
+
+  # Manifest keys are $HOME-relative for user files and absolute for system
+  # files, matching what `whence` reconstructs from its argument.
+  relativeTo = base: p:
+    lib.removePrefix "/" (lib.removePrefix (toString base) (toString p));
+
+  # Every `programs.<name>.settings`-style option that has definitions:
+  # the user's definition sites plus the option's declaration files (the
+  # wiring modules), used below to link settings onto file entries.
+  settingsIndex = options:
+    if !(options ? programs) || !(builtins.isAttrs options.programs)
+    then []
+    else
+      lib.concatMap (
+        name: let
+          group = options.programs.${name};
+          settings = group.settings or null;
+        in
+          if
+            lib.isOption group
+            || !(builtins.isAttrs settings)
+            || !(settings ? definitionsWithLocations)
+            || settings.definitionsWithLocations == []
+          then []
+          else [
+            {
+              option = "programs.${name}.settings";
+              declarations = map (decl: discard (toString decl)) settings.declarations;
+              definitions =
+                map (
+                  def: let
+                    names =
+                      if builtins.isAttrs def.value
+                      then builtins.attrNames def.value
+                      else [];
+                    pos =
+                      if names == []
+                      then null
+                      else builtins.unsafeGetAttrPos (builtins.head names) def.value;
+                  in
+                    site def.file pos
+                )
+                settings.definitionsWithLocations;
+            }
+          ]
+      ) (builtins.attrNames options.programs);
+
+  mergeEntry = prev: entry:
+    if prev == null
+    then entry
+    else
+      entry
+      // {
+        sites = lib.unique (prev.sites ++ entry.sites);
+        source =
+          if entry.source != null
+          then entry.source
+          else prev.source;
+        drv =
+          if entry.drv != null
+          then entry.drv
+          else prev.drv;
+      };
+in {
+  # File collectors for an evaluated home-manager configuration. Later
+  # collectors are more specific (an xdg entry re-walks the home.file entry
+  # the xdg module wired for it), so their sites land after the hop's in the
+  # merged chain and win the primary file:line slot.
+  homeCollectors = {
+    options,
+    config,
+  }: let
+    collect = walkOption {inherit options config;};
+    home = config.home.homeDirectory;
+  in
+    collect {
+      optionPath = ["home" "file"];
+      path = _name: value: relativeTo home value.target;
+      source = _name: value: value.source or null;
+    }
+    # xdg.configFile targets are already normalized relative to the home
+    # directory (home-manager's fileType anchors them at xdg.configHome and
+    # re-relativizes), so the entry merges with the home.file entry the xdg
+    # module wires for it: user site + wiring hop end up in one chain.
+    ++ collect {
+      optionPath = ["xdg" "configFile"];
+      path = _name: value: relativeTo home value.target;
+      source = _name: value: value.source or null;
+    }
+    # home-manager on darwin: agents are written per attr name under the
+    # user's LaunchAgents directory.
+    ++ collect {
+      optionPath = ["launchd" "agents"];
+      path = name: _value: "Library/LaunchAgents/${name}.plist";
+    };
+
+  # File collectors for an evaluated nix-darwin configuration.
+  darwinCollectors = {
+    options,
+    config,
+  }: let
+    collect = walkOption {inherit options config;};
+    label = name: value: value.serviceConfig.Label or "org.nixos.${name}";
+  in
+    collect {
+      optionPath = ["environment" "etc"];
+      path = _name: value: "/etc/${value.target}";
+      source = _name: value: value.source or null;
+    }
+    ++ collect {
+      optionPath = ["launchd" "agents"];
+      path = name: value: "/Library/LaunchAgents/${label name value}.plist";
+      enabled = _value: true;
+    }
+    ++ collect {
+      optionPath = ["launchd" "daemons"];
+      path = name: value: "/Library/LaunchDaemons/${label name value}.plist";
+      enabled = _value: true;
+    };
+
+  # Fold collector entries into the manifest attrset:
+  #   { version; files.<deployed path> = { file; line; rev; drv; source;
+  #     definitions; settings; }; }
+  # `rev` is the configuration flake's revision, copied onto every entry so
+  # `whence` prints which checkout defined a file.
+  manifestFor = {
+    options,
+    entries,
+    rev ? null,
+  }: let
+    settingsList = settingsIndex options;
+    byPath =
+      lib.foldl' (
+        acc: entry:
+          acc // {${entry.path} = mergeEntry (acc.${entry.path} or null) entry;}
+      ) {}
+      entries;
+    finish = entry: let
+      primary =
+        lib.findFirst (site: site.line != null) (lib.head entry.sites)
+        (lib.reverseList entry.sites);
+      linked =
+        lib.filter (
+          chain: lib.any (site: lib.elem site.file chain.declarations) entry.sites
+        )
+        settingsList;
+    in {
+      inherit (primary) file line;
+      inherit rev;
+      inherit (entry) source drv;
+      definitions = entry.sites;
+      settings = map (chain: {inherit (chain) option definitions;}) linked;
+    };
+  in {
+    version = 1;
+    files = lib.mapAttrs (_path: finish) byPath;
+  };
+}

--- a/modules/darwin/provenance.nix
+++ b/modules/darwin/provenance.nix
@@ -1,0 +1,63 @@
+# Per-generation eval-provenance manifest for nix-darwin (#2415): the
+# darwin counterpart of modules/home/provenance.nix, covering the system
+# surfaces (`environment.etc`, `launchd.agents`/`daemons`). The rendered
+# manifest is linked into the system derivation, so
+# `/run/current-system/provenance.json` always describes the running
+# generation and old generations keep theirs; `whence </etc/...>` reads it
+# with zero eval.
+# Callers inject the walker (`ix.provenance`, lib/provenance.nix) so this
+# file stays importable as a bare module argument set; see the flake's
+# homeModules/darwinModules wiring.
+{provenance}: {
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.provenance;
+in {
+  options.provenance = {
+    enable = lib.mkEnableOption "baking a provenance manifest (deployed path -> defining nix file:line) into each generation";
+
+    rev = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = lib.literalExpression "self.rev or self.dirtyRev or null";
+      description = ''
+        Configuration flake revision recorded on every manifest entry, so
+        `whence` can print which checkout defined a file. Pass
+        `self.rev or self.dirtyRev or null` from the consuming flake.
+      '';
+    };
+
+    entries = lib.mkOption {
+      type = lib.types.raw;
+      internal = true;
+      readOnly = true;
+      default = provenance.manifestFor {
+        inherit options;
+        inherit (cfg) rev;
+        entries = provenance.darwinCollectors {inherit options config;};
+      };
+      description = "Rendered manifest attrset (deployed path -> provenance).";
+    };
+
+    manifest = lib.mkOption {
+      type = lib.types.package;
+      internal = true;
+      readOnly = true;
+      default = (pkgs.formats.json {}).generate "provenance.json" cfg.entries;
+      description = "The provenance.json for this generation.";
+    };
+  };
+
+  # `system.systemBuilderCommands` (not `environment.etc`): the walker reads
+  # `environment.etc`, so materializing the manifest through it would make
+  # the manifest an input of itself.
+  config = lib.mkIf cfg.enable {
+    system.systemBuilderCommands = ''
+      ln -s ${cfg.manifest} $out/provenance.json
+    '';
+  };
+}

--- a/modules/home/provenance.nix
+++ b/modules/home/provenance.nix
@@ -1,0 +1,69 @@
+# Per-generation eval-provenance manifest for home-manager (#2415).
+#
+# A deployed config file (a `~/.config` symlink, a launchd plist) gives no
+# way back to the nix expression that generated it; xattrs cannot carry the
+# backlink (NAR has no xattr field, and Linux forbids `user.*` xattrs on the
+# symlinks home-manager deploys). This module bakes the backlink into the
+# generation itself: `lib/provenance.nix` walks the evaluated configuration
+# (`home.file`, `xdg.configFile`, `launchd.agents`, plus linked
+# `programs.*.settings` sites) and the rendered manifest is linked into the
+# activation package, so the live profile always carries
+# `~/.local/state/nix/profiles/home-manager/provenance.json` for its own
+# generation and old generations keep theirs. Query time is a JSON read
+# (`whence <path>`), zero eval.
+# Callers inject the walker (`ix.provenance`, lib/provenance.nix) so this
+# file stays importable as a bare module argument set; see the flake's
+# homeModules/darwinModules wiring.
+{provenance}: {
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.provenance;
+in {
+  options.provenance = {
+    enable = lib.mkEnableOption "baking a provenance manifest (deployed path -> defining nix file:line) into each generation";
+
+    rev = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = lib.literalExpression "self.rev or self.dirtyRev or null";
+      description = ''
+        Configuration flake revision recorded on every manifest entry, so
+        `whence` can print which checkout defined a file. Pass
+        `self.rev or self.dirtyRev or null` from the consuming flake.
+      '';
+    };
+
+    entries = lib.mkOption {
+      type = lib.types.raw;
+      internal = true;
+      readOnly = true;
+      default = provenance.manifestFor {
+        inherit options;
+        inherit (cfg) rev;
+        entries = provenance.homeCollectors {inherit options config;};
+      };
+      description = "Rendered manifest attrset (deployed path -> provenance).";
+    };
+
+    manifest = lib.mkOption {
+      type = lib.types.package;
+      internal = true;
+      readOnly = true;
+      default = (pkgs.formats.json {}).generate "provenance.json" cfg.entries;
+      description = "The provenance.json for this generation.";
+    };
+  };
+
+  # `home.extraBuilderCommands` (not `home.file`): the walker reads
+  # `home.file`, so materializing the manifest through it would make the
+  # manifest an input of itself.
+  config = lib.mkIf cfg.enable {
+    home.extraBuilderCommands = ''
+      ln -s ${cfg.manifest} $out/provenance.json
+    '';
+  };
+}

--- a/packages/nix/whence/default.nix
+++ b/packages/nix/whence/default.nix
@@ -1,0 +1,134 @@
+# `whence <path>`: deployed config file -> defining nix source line (#2416).
+#
+# Reads the provenance manifest that modules/home/provenance.nix and
+# modules/darwin/provenance.nix bake into each generation (deployed path ->
+# { file, line, rev, drv, source, definitions, settings }), so the answer
+# comes from the live profile with zero eval. A path no manifest knows about
+# falls back to `nix-store -q --deriver` on the resolved store path.
+{writeNushellApplication}:
+writeNushellApplication {
+  name = "whence";
+  meta = {
+    description = "Deployed config file -> defining nix source line, from the generation's provenance manifest";
+    mainProgram = "whence";
+  };
+  # No pinned nix in runtimeInputs: the fallback `nix-store -q --deriver`
+  # must speak the host daemon's protocol/experimental-feature set, so it
+  # uses the ambient nix, same as push-cache and the updaters.
+  text = ''
+    # nu
+
+    # Definition sites are store paths of the flake copy
+    # (/nix/store/<hash>-source/...); strip the copy prefix so sites print
+    # repo-relative.
+    def clean-site [file: string] {
+      $file | str replace -r '^/nix/store/[a-z0-9]{32}-[^/]+/' ""
+    }
+
+    def format-site [site: record] {
+      let line = $site.line?
+      if $line == null {
+        clean-site $site.file
+      } else {
+        $"(clean-site $site.file):($line)"
+      }
+    }
+
+    # Manifests of the live generations: the home-manager profile's and, on
+    # darwin, the running system's.
+    def manifests [] {
+      let state_home = ($env.XDG_STATE_HOME? | default ($env.HOME | path join ".local" "state"))
+      [
+        ($state_home | path join "nix" "profiles" "home-manager" "provenance.json")
+        "/run/current-system/provenance.json"
+      ] | where {|it| $it | path exists }
+    }
+
+    def print-entry [path: string, entry: record] {
+      let rev = ($entry.rev? | default "unknown rev")
+      let file = ($entry.file? | default "?")
+      let line = ($entry.line? | default "?")
+      print $"($path)"
+      print $"  (clean-site $file):($line) @ ($rev)"
+      let sites = ($entry.definitions? | default [])
+      if ($sites | length) > 1 {
+        print "  defined via:"
+        for site in $sites {
+          print $"    (format-site $site)"
+        }
+      }
+      for chain in ($entry.settings? | default []) {
+        print $"  ($chain.option):"
+        for site in ($chain.definitions? | default []) {
+          print $"    (format-site $site)"
+        }
+      }
+      if ($entry.source? | default null) != null {
+        print $"  source: ($entry.source)"
+      }
+      if ($entry.drv? | default null) != null {
+        print $"  drv: ($entry.drv)"
+      }
+    }
+
+    # Unmanifested store path: the store's own deriver link is the only
+    # provenance left.
+    def fallback [resolved: string] {
+      print $"no provenance manifest entry for ($resolved)"
+      let deriver = (do { ^nix-store -q --deriver $resolved } | complete)
+      let out = ($deriver.stdout | str trim)
+      if $deriver.exit_code == 0 and $out != "" and $out != "unknown-deriver" {
+        print $"  deriver: ($out)"
+      } else {
+        print "  no deriver recorded either (not built locally, or not a store path)"
+        exit 1
+      }
+    }
+
+    def main [path: string] {
+      let home = $env.HOME
+      # Logical absolute path (no symlink resolution): manifest keys are
+      # deployment targets, which are themselves symlinks into the store.
+      let logical = ($path | path expand --no-symlink)
+      # Fully resolved payload, for matching by store path and the fallback.
+      let resolved = (if ($logical | path exists) { $logical | path expand } else { $logical })
+
+      # Home-manager keys are $HOME-relative, system keys absolute.
+      let keys = (
+        [$logical $resolved]
+        | each {|it|
+            if ($it | str starts-with $"($home)/") {
+              [$it ($it | str replace $"($home)/" "")]
+            } else {
+              [$it]
+            }
+          }
+        | flatten
+        | uniq
+      )
+
+      for manifest_path in (manifests) {
+        let files = (open $manifest_path | get files? | default {} | transpose key entry)
+        let direct = ($files | where {|row| $row.key in $keys })
+        if ($direct | is-not-empty) {
+          let row = ($direct | first)
+          print-entry $row.key $row.entry
+          return
+        }
+        # No key match: the argument may be the store payload itself, or a
+        # file inside a directory-valued source.
+        let by_source = ($files | where {|row|
+          let src = ($row.entry.source? | default null)
+          $src != null and ($resolved == $src or ($resolved | str starts-with $"($src)/"))
+        })
+        if ($by_source | is-not-empty) {
+          let row = ($by_source | first)
+          print-entry $row.key $row.entry
+          return
+        }
+      }
+
+      fallback $resolved
+    }
+  '';
+}

--- a/packages/nix/whence/package.nix
+++ b/packages/nix/whence/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "whence";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -23,6 +23,18 @@
       paths
       ;
   };
+  # Provenance walker + home module (whence, #2413): asserts the manifest of
+  # a real home-manager eval links deployed paths to their defining sites,
+  # so it takes the home-manager flake input rather than option stubs.
+  provenanceTest = import ./provenance.nix {
+    inherit
+      lib
+      pkgs
+      ix
+      paths
+      home-manager
+      ;
+  };
   # VM boot smoke test for the minecraft-blocks Paper plugin (ENG-2186). Not
   # part of the `eval` aggregate: it boots a qemu VM, so it is its own check
   # (`checks.<system>.minecraft-blocks-vm`).
@@ -5836,6 +5848,7 @@ in {
   sdkPythonStrict = sdkPython.strictCheck;
   portableServices = portableServicesTest;
   symphonyHomeModule = symphonyHomeModuleTest;
+  provenance = provenanceTest;
   minecraftBlocksVm = minecraftBlocksVmTest;
   inherit baseImageNixDb;
 
@@ -5848,6 +5861,7 @@ in {
       helperTest
       portableServicesTest
       symphonyHomeModuleTest
+      provenanceTest
       cargoUnitPrebuiltTest
     ]
   );

--- a/tests/fixtures/provenance-home.nix
+++ b/tests/fixtures/provenance-home.nix
@@ -1,0 +1,22 @@
+# Fixture home-manager configuration for tests/provenance.nix. The walker
+# assertions match definition sites against THIS file's name and line
+# numbers, so it stays a separate file: inline modules would blur the
+# user-site vs wiring-hop distinction the test exercises.
+{
+  home = {
+    username = "test";
+    homeDirectory = "/home/test";
+    stateVersion = "25.05";
+    file."provenance-test.txt".text = "provenance eval fixture";
+  };
+
+  # Deployed through the xdg -> home.file wiring hop.
+  xdg.configFile."provenance-test/config.toml".text = "x = 1";
+
+  # Deployed through a settings-rendering program module: the manifest entry
+  # for htoprc must chain back to this settings definition site.
+  programs.htop = {
+    enable = true;
+    settings.color_scheme = 6;
+  };
+}

--- a/tests/provenance.nix
+++ b/tests/provenance.nix
@@ -1,0 +1,106 @@
+# Eval test for the provenance walker + home module (whence, #2413).
+# Evaluates a real home-manager configuration through
+# modules/home/provenance.nix and asserts the manifest links deployed paths
+# back to their defining nix sites: a literal `home.file` entry carries the
+# fixture's file:line, an `xdg.configFile` entry records both the user site
+# and the home-manager wiring hop, and a `programs.htop.settings`-driven
+# file records the settings chain. Eval-only: nothing from the evaluated
+# configuration is built.
+{
+  lib,
+  pkgs,
+  ix,
+  paths,
+  home-manager,
+}: let
+  testRev = "0000000000000000000000000000000000000000";
+
+  hmConfig =
+    (home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        (import (paths.root + "/modules/home/provenance.nix") {inherit (ix) provenance;})
+        ./fixtures/provenance-home.nix
+        {
+          provenance = {
+            enable = true;
+            rev = testRev;
+          };
+        }
+      ];
+    }).config;
+
+  inherit (hmConfig.provenance.entries) files;
+
+  fixtureSuffix = "fixtures/provenance-home.nix";
+  siteInFixture = site: lib.hasSuffix fixtureSuffix site.file && site.line != null;
+
+  fileEntry = files."provenance-test.txt" or null;
+  xdgEntry = files.".config/provenance-test/config.toml" or null;
+  # Current home-manager deploys htop's config as `.config/htop` (a
+  # directory source); older revisions wrote `.config/htop/htoprc`. Scan by
+  # prefix so the assertion tracks the settings chain, not HM's layout.
+  htopEntry = let
+    keys = lib.filter (key: lib.hasPrefix ".config/htop" key) (builtins.attrNames files);
+  in
+    if keys == []
+    then null
+    else files.${builtins.head keys};
+
+  assertions = [
+    {
+      assertion = fileEntry != null && siteInFixture fileEntry;
+      message = "home.file entry should resolve to its literal fixture site (file:line)";
+    }
+    {
+      assertion = fileEntry != null && fileEntry.rev == testRev;
+      message = "manifest entries should carry the configured flake rev";
+    }
+    {
+      assertion =
+        fileEntry != null && fileEntry.source != null && lib.hasPrefix builtins.storeDir fileEntry.source;
+      message = "home.file entry should record its store source";
+    }
+    {
+      assertion = fileEntry != null && fileEntry.drv != null && lib.hasSuffix ".drv" fileEntry.drv;
+      message = "a text-generated home.file entry should record its deriver";
+    }
+    {
+      assertion = xdgEntry != null && siteInFixture xdgEntry;
+      message = "the xdg entry's primary site should be the user's literal definition";
+    }
+    {
+      assertion = xdgEntry != null && lib.any (site: !(lib.hasSuffix fixtureSuffix site.file)) xdgEntry.definitions;
+      message = "the xdg entry should also record the home-manager wiring hop";
+    }
+    {
+      assertion =
+        htopEntry
+        != null
+        && lib.any (
+          chain:
+            chain.option
+            == "programs.htop.settings"
+            && lib.any siteInFixture chain.definitions
+        )
+        htopEntry.settings;
+      message = "settings-driven files should chain back to the user's programs.*.settings site";
+    }
+    {
+      assertion = htopEntry != null && !(siteInFixture htopEntry);
+      message = "the settings-driven file's own definition should be the wiring module, not the fixture";
+    }
+    {
+      assertion = lib.hasInfix "provenance.json" hmConfig.home.extraBuilderCommands;
+      message = "enabling provenance should link provenance.json into the generation builder";
+    }
+  ];
+
+  failures = map (a: a.message) (lib.filter (a: !a.assertion) assertions);
+in
+  assert lib.assertMsg (failures == []) (
+    "provenance:\n  " + lib.concatStringsSep "\n  " failures
+  );
+    pkgs.runCommand "ix-test-provenance" {__structuredAttrs = true;} ''
+      mkdir -p "$out"
+    ''


### PR DESCRIPTION
Adds source-line provenance for deployed files, per #2413.

- `lib/provenance.nix`: options-tree walker that maps each deployed path (home.file, xdg.configFile, launchd agents/daemons, environment.etc) to its definition sites (`file`, `line`, `rev`, `drv`, `source`), using `definitionsWithLocations` plus per-key `unsafeGetAttrPos` (trusted only when the pos file matches the definition file). `programs.*.settings` chains are linked exactly by matching a definition site against the settings option's `declarations`.
- `modules/home/provenance.nix` / `modules/darwin/provenance.nix`: bake the manifest into the generation as `provenance.json` via `home.extraBuilderCommands` / `system.systemBuilderCommands` (avoids manifest self-reference recursion).
- `packages/nix/whence`: `whence <path>` CLI (writeNushellApplication) that resolves a path against the HM and darwin manifests and prints file:line @ rev, the definition chain, settings chains, source, and drv; falls back to `nix-store -q --deriver` for bare store paths.
- `tests/provenance.nix` + fixture: evaluates a real HM configuration through the module and asserts fixture file:line, rev, xdg chain, and the htop settings-chain link; wired into the `eval` check aggregate.

Deviations from the issue text: the modules take a `{provenance}:` injection argument instead of importing `../../lib` (repo no-parent-path lint), and each entry's `rev` comes from the single configured `provenance.rev` rather than per-definition git archaeology.

Closes #2414
Closes #2415
Closes #2416
Refs #2413

Generated via Claude Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `whence` CLI and provenance manifest modules to trace deployed files back to Nix source lines
> - Adds [lib/provenance.nix](https://github.com/indexable-inc/index/pull/2423/files#diff-9e0941e276a1dea7fd8e358a5c357e27313aa14cb971df51a1f690a1bc04aad7) with walkers that inspect `options.definitionsWithLocations` and `builtins.unsafeGetAttrPos` to map deployed file paths to `{file, line}` definition sites without runtime evaluation.
> - Adds nix-darwin and home-manager modules ([modules/darwin/provenance.nix](https://github.com/indexable-inc/index/pull/2423/files#diff-179eea52238df67eb7e27dc0ba6fc908d263c1d4f8cea8f2f5f4523f88788c95), [modules/home/provenance.nix](https://github.com/indexable-inc/index/pull/2423/files#diff-40ac76caab7f7d53cb712be6b64a9d8068c15ab4bab93b52d250cb4d549febf8)) that, when `provenance.enable = true`, emit a `provenance.json` manifest into each generation (at `/run/current-system/provenance.json` or `~/.local/state/nix/profiles/home-manager/provenance.json`).
> - Adds the [`whence` CLI](https://github.com/indexable-inc/index/pull/2423/files#diff-c889f8e07851ddd496bb5244bfbfb05322270ff2aec6c8bd34b1d01340092f84), a Nushell script that reads the live provenance manifest to print the defining file/line for a given deployed path, falling back to `nix-store -q --deriver` when no manifest entry exists.
> - Manifest entries include primary site, full definition chain, linked `programs.*.settings` chains, and source/drv store paths; entries for the same deployed path are merged across collectors.
> - Eval-only tests in [tests/provenance.nix](https://github.com/indexable-inc/index/pull/2423/files#diff-4af13059190bddcb8f0e863cd3c505fde360577fce278ae0509a458a0ef1f030) assert correctness of site selection, rev propagation, settings chains, and `home.extraBuilderCommands` injection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51ba58e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->