### PR TITLE
overseer: name the empty-envelope failure

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -186,6 +186,10 @@ $(cat "$notes")
 
 Snapshot ($now_iso):
 $(cat "$snap")" </dev/null > "$last_msg.envelope"
+  # An empty envelope (claude killed mid-run, e.g. host slept) makes
+  # jq -e exit 1 with no message (the bare line-191 failures of
+  # 2026-07-08); name the cause instead.
+  [ -s "$last_msg.envelope" ] || { echo "claude -p produced no output" >&2; exit 5; }
   jq -er 'if .is_error then error("claude -p errored: " + (.subtype // "unknown")) else .result end' \
     "$last_msg.envelope" > "$last_msg"
 )


### PR DESCRIPTION
The bare "failed at line 191" ticks (2026-07-08 02:20Z-03:00Z) were an empty claude -p envelope (process killed mid-sleep) hitting `jq -er`, which exits 1 with no message. Guard the envelope with a named error so the run output states the cause. Part of #2139. (PR by an AI agent via Claude Code.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add named error and exit code 5 to `overseer.sh` when Claude produces no output
> Previously, when `claude -p` produced no output, the script silently passed an empty file to `jq`, which exited with code 1 and no message. The script now checks that `$last_msg.envelope` is non-empty after writing, prints `claude -p produced no output` to stderr, and exits with code 5 if the file is empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 916733c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->