### PR TITLE
mcp: default SSL_CERT_FILE/CURL_CA_BUNDLE on kernel wrappers

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1372,6 +1372,14 @@
   # cell importing a bundled module resolves that module's real types.
   tyBin = lib.getExe pkgs.ty;
 
+  # TLS trust for every shelled-out client in the kernel (issue #2429): the
+  # nix-built curl/git carry no baked-in system CA path on darwin and the
+  # launchd/user environment provides none, so `^curl https://...` inside nu()
+  # failed verification (exit 60) while httpx in the same kernel worked
+  # (Python carries certifi). set-default, not set: an operator-provided
+  # bundle (a corporate CA) must still win.
+  caBundle = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+
   package =
     pkgs.runCommand "ix-mcp"
     {
@@ -1396,6 +1404,8 @@
         --set IX_MCP_TY_BIN ${lib.escapeShellArg tyBin} \
         --set IX_MCP_TY_PYTHON ${lib.escapeShellArg mcpPython.interpreter} \
         --set IX_NIX_WEB_MONITOR_BIN ${lib.escapeShellArg (lib.getExe nixWebMonitorBin)} \
+        --set-default SSL_CERT_FILE ${lib.escapeShellArg caBundle} \
+        --set-default CURL_CA_BUNDLE ${lib.escapeShellArg caBundle} \
         --prefix PATH : ${
         lib.makeBinPath [
           pkgs.ripgrep
@@ -1418,6 +1428,8 @@
         --set IX_MCP_TY_BIN ${lib.escapeShellArg tyBin} \
         --set IX_MCP_TY_PYTHON ${lib.escapeShellArg mcpPython.interpreter} \
         --set IX_NIX_WEB_MONITOR_BIN ${lib.escapeShellArg (lib.getExe nixWebMonitorBin)} \
+        --set-default SSL_CERT_FILE ${lib.escapeShellArg caBundle} \
+        --set-default CURL_CA_BUNDLE ${lib.escapeShellArg caBundle} \
         --prefix PATH : ${
         lib.makeBinPath [
           pkgs.ripgrep


### PR DESCRIPTION
Fixes #2429.

`^curl https://...` inside the kernel's `nu()` failed TLS verification (exit 60, `CURLE_PEER_FAILED_VERIFICATION`): the nu subprocess environment set neither `SSL_CERT_FILE` nor `CURL_CA_BUNDLE`, and the nix-built curl has no baked-in system CA path on darwin. `httpx` in the same kernel worked because Python carries certifi.

Fix: both kernel wrappers (`ix-mcp`, `ix-notebook`) now `--set-default SSL_CERT_FILE` and `CURL_CA_BUNDLE` to `${cacert}/etc/ssl/certs/ca-bundle.crt`, so every shelled-out TLS client (curl, git over https, ...) verifies out of the box. `set-default`, not `set`: an operator-provided bundle still wins.

Validated:
- built `.#mcp`; both wrappers export the vars (`export SSL_CERT_FILE=''${SSL_CERT_FILE-'/nix/store/...-nss-cacert-3.123/etc/ssl/certs/ca-bundle.crt'}`)
- reproduced in a live kernel: bare `^curl -s -o /dev/null -w '%{http_code}' https://playbook.ix.dev/` exits 60; the same call with exactly this env returns 200

(PR by an AI agent, Claude Code / Opus 4.5.)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default SSL_CERT_FILE and CURL_CA_BUNDLE on ix-mcp kernel wrapper binaries
> Sets `SSL_CERT_FILE` and `CURL_CA_BUNDLE` to the `pkgs.cacert` bundle path in the `ix-mcp` wrapper derivations in [default.nix](https://github.com/indexable-inc/index/pull/2436/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db). Uses `--set-default` so existing values in the environment are not overridden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23bb8da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->