### PR TITLE
kernel: restore clobbered builtins after each cell

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3039,7 +3039,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3073,6 +3073,8 @@
       cp ${./tests/test_build_info.py} test_build_info.py
       # Issue #2355: per-serve kernel trace file + sweep of orphaned dumps.
       cp ${./tests/test_kernel_trace_path.py} test_kernel_trace_path.py
+      # Issue #2430: a cell rebinding/deleting a kernel builtin gets it restored.
+      cp ${./tests/test_builtin_shadow_restore.py} test_builtin_shadow_restore.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
@@ -3084,6 +3086,7 @@
         test_sh_module.py \
         test_build_info.py \
         test_kernel_trace_path.py \
+        test_builtin_shadow_restore.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2502,6 +2502,26 @@ def _typecheck_enabled() -> bool:
         return True
 
 
+def _restore_clobbered_builtins(ns: dict, job: Job) -> None:
+    """Re-inject every kernel builtin the finished cell rebound or deleted
+    (issue #2430). A cell that assigned to a builtin name (``api = ...``,
+    ``json = json.loads(...)``) used to silently destroy that helper for every
+    later cell in the session -- and ``del`` could not bring it back, because
+    the injected binding was gone rather than shadowed. Called from the
+    runner's ``finally`` so error and cancel paths restore too; the warning
+    lands in the job's output, naming the builtin so the author picks a
+    different name on the retry."""
+    for name, canonical in _protected_builtins.items():
+        if ns.get(name, _ABSENT) is canonical:
+            continue
+        ns[name] = canonical
+        job._append(
+            f"[ix] '{name}' is a kernel builtin; this cell rebound or deleted "
+            f"it, so the builtin was restored (the cell's own '{name}' value "
+            "was discarded) -- use a different name\n"
+        )
+
+
 async def _runner(job: Job, ns: dict) -> None:
     token = _ix_current.set(job)
     # (Re-)arm the task-failure watch on the loop actually running jobs.
@@ -2641,6 +2661,10 @@ async def _runner(job: Job, ns: dict) -> None:
         job._append(job.error)
     finally:
         job.ended = time.time()
+        # Before persisting: the restore warning must ride the job's stored
+        # output, and the namespace snapshot must see the restored builtin,
+        # not the clobbered value.
+        _restore_clobbered_builtins(ns, job)
         _ix_current.reset(token)
         _persist_final(job)
         _mark_snapshot_dirty()
@@ -4393,6 +4417,17 @@ def _register_rich_formatters(shell: Any) -> None:
 
 _user_ns: dict | None = None
 
+# Every name install() binds into the namespace (jobs, nu, api, ...), keyed to
+# its canonical object. A cell that rebound or deleted one (``api = ...``,
+# ``del nu``) used to silently brick that helper for the rest of the session,
+# and ``del`` could not bring it back (issue #2430): the runner re-injects
+# these after every cell (see _restore_clobbered_builtins).
+_protected_builtins: dict[str, Any] = {}
+
+# Sentinel distinguishing "name deleted" from any real value (None included)
+# when checking the namespace for clobbered builtins.
+_ABSENT: Any = object()
+
 
 def _install_signal_handlers() -> None:
     """Wire the two operator signals the MCP server uses to inspect or rescue a
@@ -4509,35 +4544,44 @@ def install(user_ns: dict | None = None) -> None:
             _store_conn = None
 
     target = user_ns if user_ns is not None else globals()
-    target["jobs"] = jobs
-    target["history"] = history
-    target["doc"] = doc
-    target["Job"] = Job
-    target["Result"] = Result
-    target["cells"] = cells
-    target["Cells"] = Cells
-    target["session"] = session
+
+    def _bind(name: str, value: Any) -> None:
+        """Bind one runtime builtin and register it for post-cell restore: every
+        name bound through here is re-injected by the runner when a cell rebinds
+        or deletes it (issue #2430)."""
+        target[name] = value
+        _protected_builtins[name] = value
+
+    _protected_builtins.clear()
+    _bind("jobs", jobs)
+    _bind("history", history)
+    _bind("doc", doc)
+    _bind("Job", Job)
+    _bind("Result", Result)
+    _bind("cells", cells)
+    _bind("Cells", Cells)
+    _bind("session", session)
     # Seed the default session label with this kernel's working directory; the
     # connecting client's identity is folded in later (see Kernel.set_client).
     with contextlib.suppress(OSError):
         session._workdir = process_cwd().name or ""
         session._rev += 1  # ensure the first flush mirrors the default to the store
-    target["resources"] = resources
-    target["Resource"] = Resource
-    target["register_resource"] = register_resource
-    target["Input"] = Input
-    target["ask"] = ask
-    target["notify"] = notify
-    target["watch_pr"] = watch_pr
-    target["input_channels"] = input_channels
-    target["__ix_run"] = __ix_run
-    target["__ix_exec"] = __ix_exec
-    target["__ix_cancel_running"] = __ix_cancel_running
-    target["__ix_read"] = __ix_read
-    target["__ix_emit_read_stats_final"] = __ix_emit_read_stats_final
-    target["__ix_snapshot"] = __ix_snapshot
-    target["__ix_restore"] = __ix_restore
-    target["DASHBOARD_URL"] = os.environ.get("IX_MCP_DASHBOARD_URL", "")
+    _bind("resources", resources)
+    _bind("Resource", Resource)
+    _bind("register_resource", register_resource)
+    _bind("Input", Input)
+    _bind("ask", ask)
+    _bind("notify", notify)
+    _bind("watch_pr", watch_pr)
+    _bind("input_channels", input_channels)
+    _bind("__ix_run", __ix_run)
+    _bind("__ix_exec", __ix_exec)
+    _bind("__ix_cancel_running", __ix_cancel_running)
+    _bind("__ix_read", __ix_read)
+    _bind("__ix_emit_read_stats_final", __ix_emit_read_stats_final)
+    _bind("__ix_snapshot", __ix_snapshot)
+    _bind("__ix_restore", __ix_restore)
+    _bind("DASHBOARD_URL", os.environ.get("IX_MCP_DASHBOARD_URL", ""))
     # `sh`/`zsh` are RETIRED (agents shell out through `await nu(...)`; the sh
     # module's public entry points now raise a migration hint). Bind them anyway
     # so a stale `await sh(cmd)` in an old transcript fails LOUDLY with that hint
@@ -4546,8 +4590,8 @@ def install(user_ns: dict | None = None) -> None:
     with contextlib.suppress(Exception):  # sh may be absent outside the bundled interpreter; skip it
         import sh as _sh_module
 
-        target["sh"] = _sh_module
-        target["zsh"] = _sh_module.zsh
+        _bind("sh", _sh_module)
+        _bind("zsh", _sh_module.zsh)
     # Bind the filesystem-search helpers as top-level callables (`await grep(...)`
     # / `find(...)` / `spotlight(...)`) the way `sh` is bound, so the most common
     # search/listing actions need no import. They live in the bundled `fsearch`
@@ -4556,9 +4600,9 @@ def install(user_ns: dict | None = None) -> None:
     with contextlib.suppress(Exception):  # fsearch may be absent outside the bundled interpreter; skip it
         import fsearch as _fsearch_module
 
-        target["grep"] = _fsearch_module.grep
-        target["find"] = _fsearch_module.find
-        target["spotlight"] = _fsearch_module.spotlight
+        _bind("grep", _fsearch_module.grep)
+        _bind("find", _fsearch_module.find)
+        _bind("spotlight", _fsearch_module.spotlight)
     # Pre-bind the most-reached-for bundled module so `view.ls(...)` works with no
     # import, the way Result/cells/jobs/sh do (an explicit `import view` returns
     # the same object). It is already imported at startup (01-ix-polars installs
@@ -4566,24 +4610,24 @@ def install(user_ns: dict | None = None) -> None:
     # fleet, search) stay import-on-demand to keep the namespace lean.
     for _mod_name in registry.preimport_names():
         with contextlib.suppress(Exception):  # best-effort per-module import; continue on missing modules
-            target[_mod_name] = __import__(_mod_name)
+            _bind(_mod_name, __import__(_mod_name))
     # The kernel is async-first and polars-first: nearly every session reaches
     # for asyncio (ensure_future / sleep), json (every CLI's --json output), and
     # pl within its first cells, and a NameError on `asyncio` in an async kernel
     # is pure friction (observed twice in one 2026-06-10 session). Bound like
     # sh/view; an explicit import returns the same module.
-    target["asyncio"] = asyncio
-    target["json"] = json
+    _bind("asyncio", asyncio)
+    _bind("json", json)
     with contextlib.suppress(Exception):  # polars may be absent; skip binding pl
         import polars as _polars_mod
 
-        target["pl"] = _polars_mod
-    target["api"] = api
-    target["read_stats"] = read_stats
+        _bind("pl", _polars_mod)
+    _bind("api", api)
+    _bind("read_stats", read_stats)
     # Failures of fire-and-forget tasks, newest last (see the deque's comment).
     # A report also lands in the spawning job's output, tagged `[task_errors]`,
     # which is how the name advertises itself.
-    target["task_errors"] = task_errors
+    _bind("task_errors", task_errors)
 
     # Everything in the namespace up to here is the runtime's own surface plus
     # the kernel preamble -- not user state. Session checkpoints cover only the

--- a/packages/mcp/tests/test_builtin_shadow_restore.py
+++ b/packages/mcp/tests/test_builtin_shadow_restore.py
@@ -1,0 +1,91 @@
+"""A cell that rebinds or deletes a kernel builtin gets it restored (issue #2430).
+
+``api = await nu(...)`` used to silently destroy the ``api`` catalog helper for
+the rest of the session, and ``del api`` afterwards raised NameError instead of
+bringing the builtin back (the injected binding was gone, not shadowed), so the
+failure surfaced cells later and looked like a broken kernel. The runner now
+re-injects every install()-bound builtin after each cell and drops a one-line
+warning naming the clobbered name into the job's output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ix_notebook_mcp import runtime
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict, protected: dict) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+    monkeypatch.setattr(runtime, "_protected_builtins", protected)
+
+
+def _run(code: str) -> runtime.Job:
+    return asyncio.run(runtime.__ix_run(code, budget=5.0))
+
+
+def test_rebinding_a_builtin_restores_it_and_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    ns = {"api": runtime.api}
+    _wire(monkeypatch, ns, {"api": runtime.api})
+    job = _run("api = 'clobbered'")
+    assert job.status == "done"
+    assert ns["api"] is runtime.api, "the builtin must be re-injected after the cell"
+    assert "'api' is a kernel builtin" in job.output
+
+
+def test_deleting_a_builtin_restores_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    ns = {"api": runtime.api}
+    _wire(monkeypatch, ns, {"api": runtime.api})
+    job = _run("del api")
+    assert job.status == "done"
+    assert ns["api"] is runtime.api
+    assert "'api' is a kernel builtin" in job.output
+
+
+def test_error_cells_restore_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The restore runs in the runner's finally, so a cell that clobbers a builtin
+    # and then blows up still leaves the surface intact for the next cell.
+    ns = {"api": runtime.api}
+    _wire(monkeypatch, ns, {"api": runtime.api})
+    job = _run("api = 42\nraise ValueError('boom')")
+    assert job.status == "error"
+    assert ns["api"] is runtime.api
+    assert "'api' is a kernel builtin" in job.output
+
+
+def test_untouched_builtins_stay_silent(monkeypatch: pytest.MonkeyPatch) -> None:
+    ns = {"api": runtime.api}
+    _wire(monkeypatch, ns, {"api": runtime.api})
+    job = _run("x = 1")
+    assert job.status == "done"
+    assert "kernel builtin" not in job.output
+    assert ns["x"] == 1, "ordinary user bindings are untouched"
+
+
+def test_reimporting_the_same_module_is_not_a_clobber(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `import json` rebinds the name to the same module object install() bound;
+    # identity comparison keeps that silent.
+    import json as json_mod
+
+    ns = {"json": json_mod}
+    _wire(monkeypatch, ns, {"json": json_mod})
+    job = _run("import json")
+    assert job.status == "done"
+    assert "kernel builtin" not in job.output
+
+
+def test_install_registers_builtins_but_not_lazy_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    # End-to-end against the real install(): the helper surface (api, jobs, and
+    # the preimported modules) is protected; lazy-proxied module names are NOT --
+    # a user variable shadowing one (a temp `x`, say) deliberately stays user
+    # state (see the lazy-binding comment in install()).
+    ns: dict = {}
+    runtime.install(ns)
+    assert runtime._protected_builtins["api"] is runtime.api
+    assert "jobs" in runtime._protected_builtins
+    for lazy_name in runtime._lazy_module_names:
+        assert lazy_name not in runtime._protected_builtins


### PR DESCRIPTION
Fixes #2430.

A cell that assigns to a kernel builtin name (`api = ...`, `json = json.loads(...)`) silently destroyed the builtin for the rest of the session, and `del` afterwards raised NameError instead of bringing it back: the injected binding was gone, not shadowed, so the failure surfaced cells later and looked like a broken kernel. Recovery required knowing the private home (`from ix_notebook_mcp.runtime import api`).

Fix (issue option 1):
- `install()` now binds every runtime builtin through a recording `_bind()` helper, so the protected set is derived from the bindings themselves (`_protected_builtins`), never a hand-kept list. Lazy-proxied module names stay unprotected on purpose: a user variable shadowing one (a temp `x`) is deliberately user state.
- the runner's `finally` re-injects any clobbered builtin after every cell (success, error, and cancel paths) and drops a one-line warning naming it into the job's output, before persistence so the stored output and namespace snapshot see the restored state.

Identity comparison keeps benign rebinding silent: `import json` rebinds the same module object and does not warn.

Validated: `.#mcp.tests.typecheckSmoke` green (104 passed; 6 new tests in `test_builtin_shadow_restore.py` covering rebind, del, error-path restore, untouched silence, same-object reimport, and install() registration).

(PR by an AI agent, Claude Code / Opus 4.5.)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore clobbered kernel builtins after each notebook cell execution
> - Adds `_restore_clobbered_builtins` in [runtime.py](https://github.com/indexable-inc/index/pull/2437/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) that scans the notebook namespace after each cell and resets any protected builtin name that was rebound or deleted by user code.
> - `install()` now tracks all initially bound helper names (e.g. `jobs`, `ask`, `notify`, `sh`, preimported modules) in a `_protected_builtins` dict via a new `_bind` helper.
> - After each cell (success or error), the runner calls `_restore_clobbered_builtins` and appends a warning to the job output for any name that was restored.
> - Lazy-proxied modules bound after baseline capture are not protected.
> - Adds [test_builtin_shadow_restore.py](https://github.com/indexable-inc/index/pull/2437/files#diff-30f2e133555207411b0056844369f4be7fca23becd2b4865af26de6cd5135a2f) covering rebind, delete, error-path, no-op, and re-import scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ed1100.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->