### PR TITLE
overseer: name every claude envelope shape, keep rejects as evidence

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -190,8 +190,16 @@ $(cat "$snap")" </dev/null > "$last_msg.envelope"
   # jq -e exit 1 with no message (the bare line-191 failures of
   # 2026-07-08); name the cause instead.
   [ -s "$last_msg.envelope" ] || { echo "claude -p produced no output" >&2; exit 5; }
-  jq -er 'if .is_error then error("claude -p errored: " + (.subtype // "unknown")) else .result end' \
-    "$last_msg.envelope" > "$last_msg"
+  # Name every envelope shape: is_error, and the null-result envelope the
+  # 12:30Z API-drop tick produced (jq -e exits 1 silently on null). Keep
+  # the envelope as evidence whenever the gate rejects it.
+  jq -er 'if (.is_error // false) then error("claude -p errored: " + (.subtype // "unknown"))
+          elif (.result // "") == "" then error("claude -p envelope has no result (subtype: " + (.subtype // "none") + ")")
+          else .result end' "$last_msg.envelope" > "$last_msg" || {
+    cp "$last_msg.envelope" "$HOME/.local/share/symphony/overseer/last-envelope.rejected"
+    echo "overseer: bad claude envelope; saved to last-envelope.rejected" >&2
+    exit 5
+  }
 )
 
 # The reply must be the {digest, attention, agents, notes} JSON object;


### PR DESCRIPTION
Follow-up to #2427: a valid `-p` envelope with `result: null` and `is_error: false` (12:30Z API-drop tick) still tripped `jq -e` silently. The gate now errors each shape by name and preserves the rejected envelope as `last-envelope.rejected`, mirroring the reply-evidence path. Part of #2139. (PR by an AI agent via Claude Code.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `overseer.sh` envelope validation and save rejected envelopes as evidence
> - Replaces the single `jq` `.result` extraction with a strict envelope validator in [overseer.sh](https://github.com/indexable-inc/index/pull/2442/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) that treats missing/falsey `.is_error` as false and explicitly errors on null or empty `.result`.
> - On validation failure, copies the offending envelope to `$HOME/.local/share/symphony/overseer/last-envelope.rejected` for post-mortem inspection and emits a descriptive stderr message.
> - Exits with status 5 on rejection instead of propagating `jq`'s exit code, giving callers a specific signal to detect envelope failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 934d83f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->