### PR TITLE
overseer: name a nonzero claude exit instead of a bare subshell abort

### DIFF
--- a/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
+++ b/packages/agent/symphony/workflows/indexable/scripts/overseer.sh
@@ -185,7 +185,14 @@ Your notes from previous ticks:
 $(cat "$notes")
 
 Snapshot ($now_iso):
-$(cat "$snap")" </dev/null > "$last_msg.envelope"
+$(cat "$snap")" </dev/null > "$last_msg.envelope" || claude_status=$?
+  # set -e must not abort the subshell on a nonzero claude exit (the
+  # bare line-203 failures: no ERR trap inside a subshell); a nonzero
+  # exit that still wrote an envelope proceeds to the shape gate.
+  [ "${claude_status:-0}" -eq 0 ] || [ -s "$last_msg.envelope" ] || {
+    echo "claude -p exited ${claude_status} with no output (API unreachable?)" >&2
+    exit 5
+  }
   # An empty envelope (claude killed mid-run, e.g. host slept) makes
   # jq -e exit 1 with no message (the bare line-191 failures of
   # 2026-07-08); name the cause instead.


### PR DESCRIPTION
Last unnamed failure path (bare "failed at line 203", 12:50Z): `claude -p` exiting nonzero on a dropped API connection aborts the judge subshell before any named check (ERR traps do not reach subshells). Capture the exit code, proceed to the shape gate when an envelope exists anyway, and name the no-output case. With this, every observed tick-failure mode self-describes. Part of #2139. (PR by an AI agent via Claude Code.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle nonzero `claude -p` exit with a named error in `overseer.sh`
> Previously, a nonzero exit from `claude -p` would abort the subshell via `set -e` with no useful diagnostic. Now, the exit status is captured explicitly.
>
> - If `claude -p` exits nonzero but still produced a non-empty envelope, execution continues normally.
> - If `claude -p` exits nonzero and produced no output, the script emits `claude -p exited <status> with no output (API unreachable?)` to stderr and exits with code 5.
> - Comments in [overseer.sh](https://github.com/indexable-inc/index/pull/2444/files#diff-c3e92c62a4b2ac12446f41a8649e9d9bf1671b9834941ed463fdbebc80ed0b26) explain why `set -e` must not abort within this block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d58775.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->