### PR TITLE
claude-code: house settings defaults, typed features, version-aware statusline

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -30,14 +30,34 @@
   # `claude-code.override { dangerouslySkipPermissions = false; }`.
   dangerouslySkipPermissions ? true,
   # Extra settings.json keys to ship through the read-only flagSettings layer
-  # (the `--settings` file below), deep-merged UNDER the computed defaults so the
-  # keys this package controls always win on a conflict. Lets a consumer keep its whole
+  # (the `--settings` file below), deep-merged UNDER the controlled keys this
+  # package owns (so those always win on a conflict) and OVER the house posture
+  # defaults (`houseSettingsDefaults` in the let-block, so any of those can be
+  # overridden per consumer). Lets a consumer keep its whole
   # static Claude config (hooks, statusLine, enabledPlugins, marketplaces, ...)
   # in Nix and out of a hand-maintained ~/.claude/settings.json: flagSettings
   # merges per-key ABOVE user settings and is a separate read-only layer, so it
   # never occupies (or symlinks) the writable settings.json the CLI churns at
-  # runtime. `{ }` (default) ships only the computed defaults.
+  # runtime. `{ }` (default) ships the house defaults plus the controlled keys.
   extraSettings ? {},
+  # Typed Claude Code feature posture, rendered to the CLAUDE_CODE_* env vars
+  # so no consumer has to spell (or misspell) the raw names. Booleans gate
+  # features: false bakes the feature's CLAUDE_CODE_DISABLE_<NAME> var both as
+  # a soft launch-env default (export the var empty to re-enable for one
+  # session) and into settings `env` (read at CC startup even when the launch
+  # env is missing); true bakes nothing, i.e. stock behavior.
+  # `autoCompactWindow` is the token count baked as
+  # CLAUDE_CODE_AUTO_COMPACT_WINDOW into settings `env` (null bakes nothing).
+  # Unknown keys throw, like systemTools. Merged over `defaultFeatures` in the
+  # let-block:
+  #  - context1M = false: every 1M path in the CLI (the [1m] model suffix, the
+  #    silent auto-upgrade, the context-1m beta header) is ~5x input price;
+  #    past-the-window work belongs in subagents.
+  #  - cron = false: drops the scheduling/loop tools.
+  #  - autoCompactWindow = 300000: native-1M models (Fable 5, Sonnet 5,
+  #    Opus 4.8) otherwise autocompact near the 1M cliff; 300K matches the
+  #    standard (non-[1m]) working window the picker labels "300K High".
+  features ? {},
   # Claude Code built-in orchestration and hosted-service tool posture. True
   # means Claude sees the tool; false renders the bare tool name into settings
   # `permissions.deny`, which removes the tool from Claude's available
@@ -207,15 +227,37 @@
       }
     else null;
 
-  # `env_defaults` leaves caller-provided values alone: exporting the full
-  # CLAUDE_CODE_DISABLE_* name to empty re-enables that feature for one session.
-  claudeCodeDisabledFeatureDefaults = [
-    "1M_CONTEXT"
-    "CRON"
-  ];
-  wrapperEnvDefaults = lib.genAttrs (
-    map (name: "CLAUDE_CODE_DISABLE_${name}") claudeCodeDisabledFeatureDefaults
-  ) (_: 1);
+  # Typed feature table (see the `features` arg): one row per feature key,
+  # owning its CLAUDE_CODE_* env var name and default, so the raw strings
+  # exist exactly once. Toggle rows render DISABLE-style (feature off ⇒ var
+  # "1"); value rows render their scalar.
+  featureToggleEnvVars = {
+    context1M = "CLAUDE_CODE_DISABLE_1M_CONTEXT";
+    cron = "CLAUDE_CODE_DISABLE_CRON";
+  };
+  defaultFeatures = {
+    context1M = false;
+    cron = false;
+    autoCompactWindow = 300000;
+  };
+  unknownFeatures = lib.subtractLists (builtins.attrNames defaultFeatures) (builtins.attrNames features);
+  effectiveFeatures =
+    if unknownFeatures != []
+    then throw "claude-code.features: unknown feature(s): ${lib.concatStringsSep ", " unknownFeatures}"
+    else defaultFeatures // features;
+  disabledFeatureEnv =
+    lib.mapAttrs' (_: envVar: lib.nameValuePair envVar "1")
+    (lib.filterAttrs (name: _: !effectiveFeatures.${name}) featureToggleEnvVars);
+  # The full render, for settings `env` below. The launch layer gets only the
+  # toggles (as `env_defaults`, which leave caller-provided values alone:
+  # exporting the full CLAUDE_CODE_DISABLE_* name to empty re-enables that
+  # feature for one session).
+  featureSettingsEnv =
+    disabledFeatureEnv
+    // lib.optionalAttrs (effectiveFeatures.autoCompactWindow != null) {
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW = toString effectiveFeatures.autoCompactWindow;
+    };
+  wrapperEnvDefaults = disabledFeatureEnv;
 
   # Disabling a tool here puts its BARE name in `permissions.deny`, which
   # strips the tool's schema from the model context entirely; Claude Code has
@@ -266,6 +308,39 @@
   # Settings defaults are injected only when the caller passed no `--settings`;
   # Claude treats repeated settings flags as first-wins.
 
+  # House posture defaults every wrapped session starts from: agent-neutral
+  # preferences that used to live in per-machine extraSettings. They form the
+  # LOWEST-priority layer of the computed settings (under the caller's
+  # extraSettings, which sits under the controlled keys in settingsDefaults),
+  # so a consumer can override any of them without this package losing its
+  # invariants.
+  houseEffortLevel = "high";
+  houseSettingsDefaults = {
+    # No Claude attribution trailers on commits or PRs.
+    attribution = {
+      commit = "";
+      pr = "";
+    };
+    worktree.baseRef = "fresh";
+    autoMemoryEnabled = true;
+    effortLevel = houseEffortLevel;
+    fastMode = true;
+    theme = "auto";
+    verbose = false;
+    fileCheckpointingEnabled = false;
+    autoUpdatesChannel = "latest";
+    skipAutoPermissionPrompt = true;
+    # House statusline (./statusline.nu): context bar, model, effort, and the
+    # running CLI version with an update marker against Anthropic's `latest`
+    # release pointer. The house effortLevel rides argv because the script
+    # cannot read this read-only settings layer back from disk; the writable
+    # settings files still win when a user overrides per machine.
+    statusLine = {
+      type = "command";
+      command = "${lib.getExe pkgs.nushell} ${./statusline.nu} --default-effort ${houseEffortLevel}";
+    };
+  };
+
   # Build the hook runner once; shared policy renders it for each wrapper.
   hookRunner = import (ix.paths.packagesRoot + "/agent/policy/hook-runner.nix") {
     inherit
@@ -298,25 +373,16 @@
     exaSearchBaked = mcpServers ? exa;
   };
 
-  # Caller's extraSettings first, then the computed defaults recursively merged
-  # ON TOP, so the keys below always win a conflict while the caller's other
-  # keys (hooks, statusLine, ...) pass through.
-  settingsDefaults = ix.deepMerge.rhs extraSettings (
+  # Controlled keys this package always owns: the highest-priority settings
+  # layer, merged over the house defaults and the caller's extraSettings below.
+  controlledSettings =
     {
       # Keep transcripts and wrapper debug logs long enough for troubleshooting.
       cleanupPeriodDays = 365;
       # settings `env` is read at Claude Code startup (even when launch env is
-      # missing), so bake the 1M-disable + compact cap here as well as in
-      # wrapperEnvDefaults. Without DISABLE_1M, native-1M models (Fable 5,
-      # Sonnet 5, Opus 4.8) report `/context` as 1M and autocompact late.
-      env =
-        (extraSettings.env or {})
-        // {
-          CLAUDE_CODE_DISABLE_1M_CONTEXT = "1";
-          # Fable/Sonnet 5: compact well before the 1M cliff; 300K matches the
-          # standard (non-[1m]) working window the picker labels "300K High".
-          CLAUDE_CODE_AUTO_COMPACT_WINDOW = "300000";
-        };
+      # missing), so the typed feature render (see the `features` arg) bakes
+      # here as well as in the launch layer's env_defaults.
+      env = (extraSettings.env or {}) // featureSettingsEnv;
       permissions = {
         # Concatenate manually: deepMerge treats lists as leaves.
         deny = lib.unique (
@@ -331,8 +397,21 @@
     // lib.optionalAttrs dangerouslySkipPermissions {
       # Suppress the one-time warning that the skip flag alone still shows.
       skipDangerousModePermissionPrompt = true;
-    }
-  );
+    };
+
+  # Three layers, rhs winning at each leaf: house posture defaults, then the
+  # caller's extraSettings, then the controlled keys this package always owns.
+  # The caller's other keys (hooks aside — enabledPlugins, marketplaces, ...)
+  # pass through untouched.
+  settingsDefaults = ix.deepMerge.rhs (ix.deepMerge.rhs houseSettingsDefaults extraSettings) controlledSettings;
+
+  # What the installCheck expects the settings file to carry from the two
+  # lower layers: the merged house+extraSettings render, minus any top-level
+  # key the controlled layer shadows. Derived (not restated) so the check
+  # holds for overridden builds too.
+  houseSettingsRender =
+    builtins.removeAttrs (ix.deepMerge.rhs houseSettingsDefaults extraSettings)
+    (builtins.attrNames controlledSettings);
   settingsDefaultsFile =
     (formats.json {}).generate "claude-code-default-settings.json"
     settingsDefaults;
@@ -535,6 +614,8 @@ in
     # against a stub target; see ./install-check.nix for what each check guards.
     doInstallCheck = true;
     installCheckPhase = import ./install-check.nix {
+      inherit (pkgs) nushell;
+      statuslineCommand = houseSettingsDefaults.statusLine.command;
       inherit
         lib
         runtimeShell
@@ -546,6 +627,9 @@ in
         launchSpec
         settingsDefaultsFile
         wrapperFlags
+        wrapperEnvDefaults
+        featureSettingsEnv
+        houseSettingsRender
         disabledSystemTools
         python3
         binName

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -13,11 +13,16 @@
   ix,
   git,
   jq,
+  nushell,
   repoPackages,
   hookRunner,
   launchSpec,
   settingsDefaultsFile,
   wrapperFlags,
+  wrapperEnvDefaults,
+  featureSettingsEnv,
+  houseSettingsRender,
+  statuslineCommand,
   disabledSystemTools,
   python3,
   binName,
@@ -50,6 +55,9 @@
     fi
   ''}
 
+    # Every disabled typed feature (see the wrapper's `features` arg) must ride
+    # the launch spec as an env_default, never plain env, so a caller export
+    # can still re-enable it per session.
     check_env_default() {
       local key="$1" got
       got="$(${lib.getExe jq} -r --arg key "$key" \
@@ -61,8 +69,11 @@
         exit 1
       fi
     }
-    check_env_default CLAUDE_CODE_DISABLE_1M_CONTEXT
-    check_env_default CLAUDE_CODE_DISABLE_CRON
+    feature_envs=(${lib.escapeShellArgs (builtins.attrNames wrapperEnvDefaults)})
+    for feature_env in "''${feature_envs[@]}"
+    do
+      check_env_default "$feature_env"
+    done
 
     disabled_system_tools=(${lib.escapeShellArgs disabledSystemTools})
     for tool in "''${disabled_system_tools[@]}"
@@ -74,12 +85,13 @@
       fi
     done
 
-    if ${lib.getExe jq} -e \
-      '.env[] | select(.key == "CLAUDE_CODE_DISABLE_1M_CONTEXT" or .key == "CLAUDE_CODE_DISABLE_CRON")' \
+    if ${lib.getExe jq} -e --argjson names ${lib.escapeShellArg (builtins.toJSON (builtins.attrNames wrapperEnvDefaults))} \
+      '.env[] | select(.key as $k | $names | index($k))' \
       "$PWD/test-spec.json"; then
-      printf 'claude launcher env check failed: CLAUDE_CODE_DISABLE_* must be env_defaults, not env\n' >&2
+      printf 'claude launcher env check failed: disabled-feature vars must be env_defaults, not env\n' >&2
       exit 1
     fi
+    ${lib.optionalString (wrapperEnvDefaults ? CLAUDE_CODE_DISABLE_1M_CONTEXT) ''
     envstub="$PWD/envstub"
     printf '%s\n' '#!${runtimeShell}' 'printf "%s\n" "''${CLAUDE_CODE_DISABLE_1M_CONTEXT-unset}"' > "$envstub"
     chmod +x "$envstub"
@@ -94,23 +106,67 @@
       printf '1M-context guard check failed: caller re-enable (empty value) must win, got %s\n' "$got" >&2
       exit 1
     fi
+  ''}
 
-    # Same policy via the baked --settings env layer (read at CC startup even
-    # when process env is missing). Keeps `/context` off 1M for Fable 5 et al.
-    disable_1m="$(${lib.getExe jq} -r '.env.CLAUDE_CODE_DISABLE_1M_CONTEXT // empty' \
-      ${settingsDefaultsFile})"
-    compact_win="$(${lib.getExe jq} -r '.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW // empty' \
-      ${settingsDefaultsFile})"
-    if [ "$disable_1m" != 1 ]; then
-      printf '1M-context guard check failed: settings env CLAUDE_CODE_DISABLE_1M_CONTEXT is %s, want 1\n' \
-        "$disable_1m" >&2
+    # The typed feature render must land verbatim in the baked settings env
+    # (read at CC startup even when the launch env is missing), and the house
+    # posture layer (post-extraSettings merge, minus controlled keys) must
+    # land key-for-key in the settings file. Both expectations are derived
+    # from the same nix values that build the file, so they hold for
+    # overridden builds too.
+    if ! ${lib.getExe jq} -e --argjson want ${lib.escapeShellArg (builtins.toJSON featureSettingsEnv)} \
+      '.env as $env | $want | to_entries | all($env[.key] == .value)' \
+      ${settingsDefaultsFile} >/dev/null; then
+      printf 'feature settings env check failed: want %s within .env of %s\n' \
+        ${lib.escapeShellArg (builtins.toJSON featureSettingsEnv)} ${settingsDefaultsFile} >&2
       exit 1
     fi
-    if [ "$compact_win" != 300000 ]; then
-      printf '1M-context guard check failed: settings env CLAUDE_CODE_AUTO_COMPACT_WINDOW is %s, want 300000\n' \
-        "$compact_win" >&2
+    if ! ${lib.getExe jq} -e --argjson want ${lib.escapeShellArg (builtins.toJSON houseSettingsRender)} \
+      '. as $doc | $want | to_entries | all($doc[.key] == .value)' \
+      ${settingsDefaultsFile} >/dev/null; then
+      printf 'house settings default check failed: want %s within %s\n' \
+        ${lib.escapeShellArg (builtins.toJSON houseSettingsRender)} ${settingsDefaultsFile} >&2
       exit 1
     fi
+
+    # House statusline, driven through the exact command string the house
+    # defaults bake (so the store paths inside it are exercised; the render
+    # check above proves the settings file carries it, extraSettings aside).
+    # Offline by construction: the seeded run finds a fresh cache and never
+    # fetches; the cold run's fetch fails in the sandbox and must degrade to a
+    # plain version segment. The seeded latest (1.2.10 vs current 1.2.3) also
+    # guards the numeric per-segment compare a string compare would get
+    # backwards.
+    statusline_cmd=${lib.escapeShellArg statuslineCommand}
+    if [ "$(${lib.getExe nushell} --no-config-file -c "nu-check '${./statusline.nu}'")" != true ]; then
+      printf 'statusline check failed: nu-check rejected statusline.nu\n' >&2
+      exit 1
+    fi
+    statusline_payload='{"version":"1.2.3","model":{"display_name":"TestModel"},"context_window":{"context_window_size":200000,"current_usage":{"input_tokens":100000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}'
+    mkdir -p sl-home/.cache/ix-claude-statusline sl-cold-home
+    printf '1.2.10' > sl-home/.cache/ix-claude-statusline/latest
+    got="$(printf '%s' "$statusline_payload" \
+      | HOME="$PWD/sl-home" XDG_CACHE_HOME="$PWD/sl-home/.cache" ${runtimeShell} -c "$statusline_cmd")"
+    case "$got" in
+    *'█████░░░░░ | TestModel | high | v1.2.3 '*'↑1.2.10'*) : ;;
+    *)
+      printf 'statusline check failed (seeded cache): want bar/model/effort/version/update marker, got:\n%s\n' "$got" >&2
+      exit 1
+      ;;
+    esac
+    got="$(printf '%s' "$statusline_payload" \
+      | HOME="$PWD/sl-cold-home" XDG_CACHE_HOME="$PWD/sl-cold-home/.cache" ${runtimeShell} -c "$statusline_cmd")"
+    case "$got" in
+    *'↑'*)
+      printf 'statusline check failed (cold cache): update marker must not render offline, got:\n%s\n' "$got" >&2
+      exit 1
+      ;;
+    *'█████░░░░░ | TestModel | high | v1.2.3'*) : ;;
+    *)
+      printf 'statusline check failed (cold cache): want plain version segment, got:\n%s\n' "$got" >&2
+      exit 1
+      ;;
+    esac
 
     check() {
       local desc="$1" expected="$2"

--- a/packages/agent/claude-code/statusline.nu
+++ b/packages/agent/claude-code/statusline.nu
@@ -1,0 +1,113 @@
+# House Claude Code statusline (settings `statusLine.command`, baked by
+# package.nix into the wrapper's read-only settings layer). Renders one
+# dark-gray line: context-window bar, model, effort level, and the running CLI
+# version with an "↑<latest>" marker when Anthropic has published a newer
+# release than the wrapper pins.
+#
+# Claude Code pipes a JSON status payload on stdin and re-runs this on every
+# render, so everything here must be fast and fail-soft: the one network call
+# (the `latest` version pointer) is cached for hours and swallowed on error.
+
+# Anthropic's release bucket: `<base>/latest` is a plain-text version string,
+# the same pointer update.nix tracks when bumping manifest.json.
+const release_base = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+const cache_ttl = 6hr
+
+# Newest published version, from a small mtime-TTL cache so at most one
+# render per TTL window pays the (2s-capped) fetch. Null when offline with a
+# cold cache: the caller then renders the plain version, no marker.
+def latest-version [] {
+  let cache_root = ($env.XDG_CACHE_HOME? | default $"($env.HOME)/.cache")
+  let cache_dir = $"($cache_root)/ix-claude-statusline"
+  let cache_file = $"($cache_dir)/latest"
+
+  let cached_fresh = (try {
+    ((date now) - (ls $cache_file | first | get modified)) < $cache_ttl
+  } catch { false })
+  if $cached_fresh {
+    return (open --raw $cache_file | str trim)
+  }
+
+  let fetched = (try {
+    http get --max-time 2sec $"($release_base)/latest" | str trim
+  } catch { "" })
+  if ($fetched | is-not-empty) {
+    mkdir $cache_dir
+    $fetched | save --force $cache_file
+    return $fetched
+  }
+  # Stale cache beats nothing while the network is away.
+  try { open --raw $cache_file | str trim } catch { null }
+}
+
+# Numeric per-segment compare, so a pinned-ahead `next` build (local > latest)
+# is not flagged as outdated the way plain string inequality would.
+def is-newer [latest: string, current: string] {
+  try {
+    let l = ($latest | split row "." | each {|p| $p | into int })
+    let c = ($current | split row "." | each {|p| $p | into int })
+    let n = ([($l | length) ($c | length)] | math max)
+    for i in 0..<$n {
+      let a = (if $i < ($l | length) { $l | get $i } else { 0 })
+      let b = (if $i < ($c | length) { $c | get $i } else { 0 })
+      if $a > $b { return true }
+      if $a < $b { return false }
+    }
+    false
+  } catch { false }
+}
+
+# `--default-effort` carries the house `effortLevel` baked into the wrapper's
+# read-only settings layer, which this script cannot read back from disk; the
+# writable settings files below still win when the user overrides per-machine.
+def main [--default-effort: string = ""] {
+  let input = (open --raw /dev/stdin | from json)
+
+  let model = ($input.model?.display_name? | default "?")
+
+  # Effort cascade: settings.local.json > settings.json > baked default.
+  let effort = (try {
+    let local_settings = $"($env.HOME)/.claude/settings.local.json"
+    let user_settings = $"($env.HOME)/.claude/settings.json"
+    let from_local = (if ($local_settings | path exists) {
+      open $local_settings | get effortLevel?
+    } else { null })
+    let from_user = (if ($user_settings | path exists) {
+      open $user_settings | get effortLevel?
+    } else { null })
+    $from_local | default $from_user | default $default_effort
+  } catch { $default_effort })
+
+  # Context bar.
+  let context_size = ($input.context_window?.context_window_size? | default 200000)
+  let usage = $input.context_window?.current_usage?
+  let ctx_pct = (if $usage != null {
+    let total = (
+      ($usage.input_tokens? | default 0)
+      + ($usage.cache_creation_input_tokens? | default 0)
+      + ($usage.cache_read_input_tokens? | default 0)
+    )
+    $total * 100 // $context_size
+  } else { 0 })
+  let bar_width = 10
+  let filled = ($ctx_pct * $bar_width // 100 | [$in $bar_width] | math min)
+  let empty = $bar_width - $filled
+  let filled_str = (if $filled > 0 { 1..$filled | each { "█" } | str join } else { "" })
+  let empty_str = (if $empty > 0 { 1..$empty | each { "░" } | str join } else { "" })
+  let bar = $filled_str + $empty_str
+
+  # Version, with an update marker when upstream has moved past this build.
+  let current = ($input.version? | default "" | str trim)
+  let version_segment = (if ($current | is-not-empty) {
+    let latest = (latest-version)
+    if $latest != null and (is-newer $latest $current) {
+      $" | v($current) (ansi yellow)↑($latest)(ansi reset)(ansi dark_gray)"
+    } else {
+      $" | v($current)"
+    }
+  } else { "" })
+
+  let effort_segment = (if ($effort | is-not-empty) { $" | ($effort)" } else { "" })
+
+  print $"(ansi dark_gray)($bar) | ($model)($effort_segment)($version_segment)(ansi reset)"
+}

--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -36,6 +36,7 @@
         (cfg)
         addDirs
         dangerouslySkipPermissions
+        features
         personalStartupContext
         primaryCheckouts
         systemTools
@@ -78,6 +79,23 @@ in {
       type = lib.types.bool;
       default = true;
       description = "Bake Claude Code's bypass-permissions flag into the wrapper.";
+    };
+
+    features = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.nullOr (lib.types.either lib.types.bool lib.types.int));
+      default = {};
+      example = {
+        context1M = true;
+        autoCompactWindow = null;
+      };
+      description = ''
+        Typed Claude Code feature posture forwarded to the wrapper's
+        `features` argument: booleans gate features (false bakes the
+        feature's CLAUDE_CODE_DISABLE_* env var into both the launch layer
+        and the settings env), `autoCompactWindow` is a token count for
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW (null bakes nothing). Keys must
+        exist in the wrapper's defaultFeatures table.
+      '';
     };
 
     systemTools = lib.mkOption {


### PR DESCRIPTION
Moves house-posture Claude Code settings out of personal home-manager config into the index wrapper as an overridable defaults layer, and ships a house statusline.

- **House defaults layer**: attribution, worktree.baseRef, autoMemoryEnabled, effortLevel, fastMode, theme, verbose, fileCheckpointingEnabled, autoUpdatesChannel, skipAutoPermissionPrompt, statusLine — merged below `extraSettings`, which stays below the controlled keys (env clamps, permissions.deny, hooks).
- **Typed `features` argument**: `context1M` / `cron` booleans and `autoCompactWindow` token count replace stringly `CLAUDE_CODE_DISABLE_*` env attrsets; unknown keys throw (same pattern as `systemTools`). Exposed through the HM module as `programs.claude-code.features`.
- **Statusline** (`statusline.nu`): context bar, model, effort (cascade: settings.local.json > settings.json > baked default via argv), and running CLI version with a yellow `↑<latest>` marker when Anthropic's release bucket `latest` pointer is newer. 6h mtime-TTL cache, 2s timeout, fail-soft when offline; numeric per-segment semver compare.
- **Install checks derive from the build's own nix values** (wrapperEnvDefaults, featureSettingsEnv, houseSettingsRender, statuslineCommand), so `claude-code.override { features.cron = true; }` still passes its own installCheck. Statusline gets nu-check plus seeded-cache and cold-cache behavioral tests.

Verified locally: default and overridden (`features.cron = true; extraSettings.theme = "dark"`) builds pass install checks; `--which-settings` renders as expected; lint clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed feature flags, house settings defaults, and version-aware statusline to claude-code wrapper
> - Introduces a typed `features` argument in [default.nix](https://github.com/indexable-inc/index/pull/2449/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) that maps feature keys (e.g. `context1M`, `cron`, `autoCompactWindow`) to `CLAUDE_CODE_DISABLE_*` env vars; builds throw on unrecognized feature keys.
> - Adds a house-posture settings layer (`houseSettingsDefaults`) that is always present at the lowest priority, with `extraSettings` overlaying it and package-controlled keys (env, permissions, cleanupPeriodDays) winning last.
> - Adds [statusline.nu](https://github.com/indexable-inc/index/pull/2449/files#diff-9e4486732397a9fae41a08dcfcf45652a13511e403aa1a82aa5caa1c161b7b0d), a Nushell script that renders a one-line status bar with context window usage, model, effort level, and a version update marker (cached, non-blocking).
> - Exposes a `features` option in the [Home Manager module](https://github.com/indexable-inc/index/pull/2449/files#diff-b941f4c92dd8de3d70290f80abe17e83e8710287c6a7430cad3d5f1c81cdbdab) so consumers can configure feature posture.
> - Extends [install-check.nix](https://github.com/indexable-inc/index/pull/2449/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) to validate feature env-defaults, baked settings content, and statusline runtime behavior.
> - Behavioral Change: settings file composition order changes — house defaults are now always present as the base layer, which may override previously unset defaults in consumer `extraSettings`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a26ea3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->