### PR TITLE
nix: gate darwin flaky-test-skip patch on existence in consumer nixpkgs

### DIFF
--- a/packages/nix/nix/default.nix
+++ b/packages/nix/nix/default.nix
@@ -42,10 +42,16 @@ let
   # nixpkgs' own whole-source patches for this version: currently just the
   # aarch64-darwin flaky-test skip (empty on every other system). `overrideSource`
   # resets the scope's `patches` to `[]`, so re-apply them here to match a stock
-  # `nix_2_34` build; our own delta rides in `patchedSrc`, not here.
-  patchesCommon = lib.optional pkgs.stdenv.hostPlatform.isDarwin (
-    pkgs.path + "/pkgs/tools/package-management/nix/patches/skip-flaky-darwin-tests.patch"
-  );
+  # `nix_2_34` build; our own delta rides in `patchedSrc`, not here. Gated on
+  # existence because the patch lives in the consumer's nixpkgs tree, not ours:
+  # nixpkgs 26.11pre dropped it, and a flake that instantiates this package
+  # with such a nixpkgs must still evaluate (we already skip test suites on
+  # darwin, so losing the flaky-test skip changes nothing we run).
+  flakySkipPatch = pkgs.path + "/pkgs/tools/package-management/nix/patches/skip-flaky-darwin-tests.patch";
+  patchesCommon =
+    lib.optional
+    (pkgs.stdenv.hostPlatform.isDarwin && builtins.pathExists flakySkipPatch)
+    flakySkipPatch;
 
   # The whole patched pipeline as a function of the applied series, so the
   # per-attempt-patch closure gates below rebuild the SAME logic with a


### PR DESCRIPTION
`packages/nix/nix/default.nix` re-applies nixpkgs' `skip-flaky-darwin-tests.patch` via `pkgs.path`, which resolves against the consumer's nixpkgs, not our pin. nixpkgs 26.11pre removed that patch, so any downstream flake instantiating `nix-ix` on that channel fails eval with a missing-path error (hit in my home config after a nixpkgs bump).

Gate it on `builtins.pathExists`: when present, identical build; when absent, we only lose a flaky-test mute for test suites we already drop from the darwin build (#1970).

Verified: `nix eval .#nix-ix.outPath` unchanged with the repo's pinned nixpkgs; `pathExists` confirmed false at nixpkgs d407951 (26.11pre).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate Darwin flaky-test skip patch on file existence in nixpkgs
> In [default.nix](https://github.com/indexable-inc/index/pull/2450/files#diff-4332ad9feb37626c0ac4a68155597b10c261c0e0460cfcbca84f88d3d6125c6e), the Darwin flaky-test skip patch is now only applied when the patch file actually exists in the nixpkgs tree. A new `flakySkipPatch` let-binding captures the path, and `patchesCommon` checks for file existence before including it, preventing failures when the patch is absent from the consumer's nixpkgs version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28a867a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->