### PR TITLE
base profile: trust the cache.ix.dev signing key

### DIFF
--- a/lib/cache.nix
+++ b/lib/cache.nix
@@ -1,0 +1,20 @@
+# Single source of truth for the ix public binary cache identity.
+#
+# `cache.ix.dev` is the ix pull-through cache: ncps fronting the `ix-public`
+# atticd cache, falling through to cache.nixos.org for generic nixpkgs paths so
+# one substituter covers both. atticd signs every narinfo it serves server-side
+# under `ix-workspace:`, so this one trusted key verifies both ix's builds and
+# index's published packages.
+#
+# Any module that adds `url` as a substituter MUST also trust `publicKey`.
+# `require-sigs` is on in the guests, so an untrusted substituter is rejected
+# narinfo-by-narinfo as unsigned and the daemon silently falls back to building
+# the whole closure from source.
+#
+# Consumed through `specialArgs.ix.cache` and the public `index.lib.cache`. The
+# flake's own `nixConfig` (flake.nix) has to repeat these as literals because
+# Nix reads `nixConfig` before the flake's lib exists; keep the two in sync.
+{
+  url = "https://cache.ix.dev";
+  publicKey = "ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI=";
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -587,6 +587,10 @@
   */
   appleSdkToolchain = import ./darwin/apple-sdk-toolchain.nix;
 
+  # Single source of truth for the ix public binary cache identity (URL + the
+  # `ix-workspace:` trusted key that verifies its narinfos). See ./cache.nix.
+  cache = import ./cache.nix;
+
   /**
   Helper surface shared by both the per-module `specialArgs.ix`
   (`ixSpecialArgs`) and the public `index.lib` (`ixReturn`). Listed once
@@ -611,6 +615,7 @@
       buildSvelteSite
       buildUvApplication
       buildZigPackage
+      cache
       cargoUnit
       checks
       claudePlugin

--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -38,9 +38,16 @@ in {
     # `cache.ix.dev` is the ix pull-through cache for guest Nix operations. Put
     # it in the auto-enabled base profile so every image gets the same warm
     # binary-cache path unless an image explicitly disables the profile.
-    nix.settings.substituters = lib.mkBefore [
-      "https://cache.ix.dev"
-    ];
+    #
+    # The matching `ix-workspace:` key has to be trusted alongside it. The
+    # guests keep `require-sigs` on, so without the key the daemon rejects every
+    # `cache.ix.dev` narinfo as unsigned ("ignoring substitute ... not signed by
+    # any of the keys in 'trusted-public-keys'") and silently rebuilds the whole
+    # system closure from source, which then dies on the guest's no-namespace
+    # sandbox and fails `ix up`. Both fields come from the one cache-identity
+    # source of truth (lib/cache.nix), exposed here as `ix.cache`.
+    nix.settings.substituters = lib.mkBefore [ix.cache.url];
+    nix.settings.trusted-public-keys = lib.mkAfter [ix.cache.publicKey];
 
     # The guest's writable layer (`/`, incl. `/nix/var/nix/db`) is a virtiofs
     # FUSE mount with no DAX cache capability, so a memory-mapped file is served


### PR DESCRIPTION
Fixes #2452. Part of #2451.

## Problem

The auto-enabled guest base profile (`modules/profiles/base/default.nix`) lists `cache.ix.dev` as a substituter but never trusts its `ix-workspace:` key. Guests keep `require-sigs = true`, so the daemon rejects every `cache.ix.dev` narinfo as unsigned and rebuilds the whole system closure from source. On a fresh default-template project this shows up as 38 `ignoring substitute ... not signed by any of the keys in 'trusted-public-keys'` warnings on `ix up`.

## Change

- New `lib/cache.nix`: single source of truth for the ix public cache identity (URL plus the `ix-workspace:` key).
- Exposed on the `ix` module bundle as `ix.cache` (via `sharedHelpers`, so it also reaches `index.lib.cache`).
- Base profile now trusts the key (`nix.settings.trusted-public-keys`, `mkAfter`) and routes the existing substituter URL through `ix.cache.url`. No new inline copy of the key or URL.

## Verification

Evaluated the `test` node with the `index` input overridden to this branch:

```
$ nix eval --json --override-input index path:<worktree> \
    path:/…/test#nixosConfigurations.test.config.nix.settings.trusted-public-keys
["cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=","ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI="]
```

The nixpkgs default is preserved (list-merge) and `ix-workspace:` is appended. On a live `ix up` with only this key added, the 38 substitute-rejection warnings drop to 0.

## Scope

This removes the substitute-rejection half of #2451. A second, independent blocker (guest `sandbox=true` with no namespaces, #2453) still fails `ix up` on its own and is tracked separately; its fix is not in this profile.

## Follow-up

`ci-runner` and `flake.nix` still inline the same key. `ci-runner` has no `ix` module arg and flake `nixConfig` must be a literal, so consolidating those onto `lib/cache.nix` is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trust the cache.ix.dev signing key in the base NixOS profile
> - Adds a [`cache` attrset](https://github.com/indexable-inc/index/pull/2454/files#diff-3ecba895cc128d245dcde8356a558489b3a905247448633105bb4200090dd356) to the shared lib surface with the `cache.ix.dev` URL and its `ix-workspace:` public key.
> - Updates the [base profile](https://github.com/indexable-inc/index/pull/2454/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) to use `lib.mkBefore` for the substituter and adds `nix.settings.trusted-public-keys` via `lib.mkAfter` so signed narinfos from the cache are accepted by the nix daemon.
> - Behavioral Change: the nix daemon will now trust the `ix-workspace:` key; previously, substitutions from `cache.ix.dev` could be rejected if the narinfo signature was not already trusted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afa4fa3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->