### PR TITLE
base profile: merge nix.settings into one attrset (fix statix on main)

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -46,19 +46,21 @@ in {
     # system closure from source, which then dies on the guest's no-namespace
     # sandbox and fails `ix up`. Both fields come from the one cache-identity
     # source of truth (lib/cache.nix), exposed here as `ix.cache`.
-    nix.settings.substituters = lib.mkBefore [ix.cache.url];
-    nix.settings.trusted-public-keys = lib.mkAfter [ix.cache.publicKey];
+    nix.settings = {
+      substituters = lib.mkBefore [ix.cache.url];
+      trusted-public-keys = lib.mkAfter [ix.cache.publicKey];
 
-    # The guest's writable layer (`/`, incl. `/nix/var/nix/db`) is a virtiofs
-    # FUSE mount with no DAX cache capability, so a memory-mapped file is served
-    # through FUSE writeback rather than a coherent shared window. SQLite's WAL
-    # mode needs exactly that: an mmap'd `*-shm` for cross-connection shared
-    # state plus strict WAL/main fsync ordering on checkpoint. Neither holds on
-    # this layer, so the nix DB's WAL silently corrupts and `nix` degrades to
-    # `database disk image is malformed`. Rollback-journal mode drops the `-shm`
-    # mmap dependency and keeps the DB intact. Mitigation for the VCFS layer bug
-    # tracked in indexable-inc/ix#6259; drop this once that layer honors mmap+fsync.
-    nix.settings.use-sqlite-wal = false;
+      # The guest's writable layer (`/`, incl. `/nix/var/nix/db`) is a virtiofs
+      # FUSE mount with no DAX cache capability, so a memory-mapped file is served
+      # through FUSE writeback rather than a coherent shared window. SQLite's WAL
+      # mode needs exactly that: an mmap'd `*-shm` for cross-connection shared
+      # state plus strict WAL/main fsync ordering on checkpoint. Neither holds on
+      # this layer, so the nix DB's WAL silently corrupts and `nix` degrades to
+      # `database disk image is malformed`. Rollback-journal mode drops the `-shm`
+      # mmap dependency and keeps the DB intact. Mitigation for the VCFS layer bug
+      # tracked in indexable-inc/ix#6259; drop this once that layer honors mmap+fsync.
+      use-sqlite-wal = false;
+    };
 
     # Install terminfo for every common terminal emulator so ncurses tools
     # (`clear`, `tmux`, `vim`, ...) work no matter what `$TERM` an operator's


### PR DESCRIPTION
Purely syntactic: folds the three `nix.settings.*` assignments from #2454 into one attrset so the statix repeated-keys warning clears and `nix run .#lint` is green on main again. `nix run .#lint`: 8/8 succeeded. Fixes #2457

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Merge `nix.settings` into a single attrset in base profile to fix statix lint
> Consolidates separate `nix.settings.<option>` assignments in [default.nix](https://github.com/indexable-inc/index/pull/2458/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) into a single `nix.settings = { ... }` block. No functional change — values and comments are preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86e0e04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->