### PR TITLE
guest platform: fall back to unsandboxed builds instead of dying

### DIFF
--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -559,6 +559,17 @@ in {
         ];
         allow-import-from-derivation = lib.mkDefault true;
         warn-dirty = false;
+        # nixpkgs' nix-daemon module bakes `sandbox-fallback = false` as a
+        # "legacy configuration conversion" (nixos/modules/services/system/
+        # nix-daemon.nix), which turns a build FATAL the moment the kernel
+        # lacks the namespaces sandboxing needs. ix guests deliberately run
+        # without user namespaces (hardening sets `allowNamespaces = false`)
+        # and the VM is itself the isolation boundary, so a build that cannot
+        # be sandboxed should degrade to an unsandboxed build with a warning,
+        # not kill `ix up`. Restore Nix's own upstream default of `true`.
+        # mkForce because the nixpkgs assignment is unconditional, not a
+        # default. See indexable-inc/index#2453.
+        sandbox-fallback = lib.mkForce true;
       };
       gc = {
         automatic = true;


### PR DESCRIPTION
Fixes #2453. Part of #2451.

## Problem

`ix up` on the default template dies with:

```
this system does not support the kernel namespaces that are required for sandboxing; use '--no-sandbox' to disable sandboxing
error: switch failed: nix build exited with status 1
```

This is the second, independent blocker behind #2451 (the first, the missing `cache.ix.dev` key, landed in #2454).

Root cause (ground truth confirmed by reading the baked guest nix.conf): the guest bakes `sandbox = true` + `sandbox-fallback = false`. The `false` is not a repo setting; nixpkgs' nix-daemon module assigns it unconditionally as a "legacy configuration conversion" (`nixos/modules/services/system/nix-daemon.nix:397`). ix guests deliberately run without user namespaces (hardening `allowNamespaces = false`), so any guest build that is not fully substituted cannot set up a sandbox, and with `sandbox-fallback = false` Nix's fatal branch fires (`src/libstore/unix/build/derivation-builder.cc`) instead of degrading.

## Change

Restore Nix's own upstream default `sandbox-fallback = true` in the guest platform `nix.settings` (`lib/image/platform.nix`). A build that cannot be sandboxed then degrades to an unsandboxed build with a warning rather than killing `ix up`. `sandbox = true` is untouched, so sandboxing still applies wherever the kernel supports it. `mkForce` because the nixpkgs assignment is unconditional.

## Verification

Eval of the `test` node with the `index` input overridden to this branch:

```
config.nix.settings.sandbox-fallback => true   (was false)
config.nix.settings.sandbox         => true   (unchanged)
```

The change can only relax a fatal throw into a warning, so it cannot break any build that succeeds today. End-to-end `ix up` confirmation on the live guest is in progress and will be posted to #2451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to unsandboxed builds instead of failing on guest platform
> Sets `sandbox-fallback = true` (via `lib.mkForce`) in `nix.settings` in [platform.nix](https://github.com/indexable-inc/index/pull/2459/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7). Previously, when sandboxing was unavailable, Nix would treat it as a fatal error; now it falls back to running builds without sandboxing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe97080.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->