### PR TITLE
Revert "darwin: consume the cross unit graph on the cache lane" (#2463)

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -301,17 +301,14 @@ jobs:
           eval_jobs="$(nix build --inputs-from . nixpkgs#nix-eval-jobs --no-link --print-out-paths)/bin/nix-eval-jobs"
           phase tools "$tools_t"
 
-          # The eval IFDs the input-addressed cross cargo unit graph (vendor
-          # dir, unit graph JSON, rendered cargo-units.nix): the darwin
-          # workspace is bound to the cross graph (lib/packages.nix), so these
-          # substitute from the `push` lane's `crossIfdRoots` instead of
-          # re-rendering here. The realised residual is codex, btop,
-          # nix-output-monitor, libkrun-efi, and the config-launch launcher
-          # units. Non-darwin rows are the `push` lane's responsibility and
-          # drop out. Eval errors surface as warnings, not failures: an attr
-          # can legitimately refuse to instantiate on darwin (linux-only module
-          # assertions), and the error row does not say which system the attr
-          # would have been.
+          # The eval IFDs the native darwin cargo unit graph (vendor dir, unit
+          # graph JSON, rendered cargo-units.nix); those realise here -- this is
+          # a mac -- and are published as explicit roots (lib/per-system.nix
+          # `nativeIfdRoots`) because consumer evals force them too. Non-darwin
+          # rows are the `push` lane's responsibility and drop out. Eval errors
+          # surface as warnings, not failures: an attr can legitimately refuse
+          # to instantiate on darwin (linux-only module assertions), and the
+          # error row does not say which system the attr would have been.
           #
           # `--gc-roots-dir` roots every instantiated drv for the realise
           # loop below: its per-root `nix store gc` otherwise deletes the

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -19,19 +19,7 @@
       # is bound to.
       cargoUnit = cargoUnitFor pkgs;
       goUnit = goUnitFor pkgs;
-      # On aarch64-darwin swap the workspace's native unit graph for the
-      # input-addressed cross graph the linux `push` lane already publishes
-      # (`unitsFor` re-roots the DAG at the target, same shape as `units`).
-      # The native graph is floating content-addressed, so a Mac can't
-      # substitute it from cache.ix.dev (atticd serves narinfos only, no
-      # `/realisations`) and re-renders it locally every eval (#1755); the
-      # cross graph carries eval-time paths and substitutes via plain narinfo.
-      rustWorkspace = let
-        ws = rustWorkspaceFor pkgs;
-      in
-        if packageSystem == "aarch64-darwin"
-        then ws // {units = ws.unitsFor {target = "aarch64-apple-darwin";};}
-        else ws;
+      rustWorkspace = rustWorkspaceFor pkgs;
       # unibind build glue bound to the caller's pkgs, for the same reason as
       # rustWorkspace above.
       unibind = ixSpecialArgs.unibindFor pkgs;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1464,11 +1464,13 @@ in {
   #      forces at eval when it substitutes a Darwin cross output. These are
   #      build-time deps of the cross packages, so they are absent from those
   #      packages' runtime closures; adding them as roots is the fix for #1687.
-  #      A Darwin consumer forces these same drvs too: `ixForPackages` binds
-  #      its `rustWorkspace` to this cross graph on aarch64-darwin (see
-  #      lib/packages.nix), so evaluating any darwin wrapper (codex,
-  #      claude-code) reaches the cross unit-graph outputs, which substitute
-  #      via plain narinfo instead of re-rendering locally (#1755, #1890).
+  #   4. On Darwin hosts, the native lane's eval-time IFD outputs
+  #      (`nativeIfdRoots`): the same three unit-graph artifacts as (3) but for
+  #      the host's own target, which a Darwin consumer forces at eval when it
+  #      evaluates any native wrapper (codex, claude-code) against the workspace
+  #      unit graph. Runtime closures never carry them, so without explicit
+  #      roots every Darwin consumer re-vendors and re-renders the graph at
+  #      eval -- the same trap as (3), for the darwin cache lane (#1890).
   cachePushRoots = let
     # Per-node `health-check-*` lifecycle packages and the two
     # `health-checks{,-zellij}` runners all share the `health-check` prefix.
@@ -1487,6 +1489,14 @@ in {
           fleet.systemPackages
       )
       exampleFleets;
+    # Native analog of `crossIfdRoots` (adjustment 4). `crossWorkspace` with no
+    # target override IS the host workspace, so these are exactly the drvs a
+    # Darwin consumer's eval of the native wrappers imports.
+    nativeIfdRoots = lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+      native-ifd-units-nix = crossWorkspace.units.unitsNix;
+      native-ifd-unit-graph = crossWorkspace.units.unitGraphJson;
+      native-ifd-vendor-dir = crossWorkspace.units.vendorDir;
+    };
   in
     # Fleet node toplevels are NixOS closures: on Darwin they can only
     # eval-error (every `<fleet>-<node>` row in the first darwin lane run was
@@ -1494,14 +1504,8 @@ in {
     # Alias-shadowed natives (dag-runner, nix-web-monitor) need no exclusion
     # here: the flake grafts `linuxDarwinAliases` over this set, so the darwin
     # lane sees the cross drvs and its system filter drops them.
-    #
-    # The darwin lane needs no explicit IFD roots: `ixForPackages` binds its
-    # `rustWorkspace` to the input-addressed cross graph on aarch64-darwin
-    # (see lib/packages.nix), so every darwin wrapper's eval forces the cross
-    # unit-graph drvs the linux lane already publishes as `crossIfdRoots`,
-    # which substitute via plain narinfo.
     if pkgs.stdenv.hostPlatform.isDarwin
-    then imagesAsClosures
+    then imagesAsClosures // nativeIfdRoots
     else imagesAsClosures // exampleNodeToplevels // crossIfdRoots;
 
   inherit darwinPackageAliases;


### PR DESCRIPTION
Reverts #2463 (commit 1bbf332f).

## Why

#2463 did not achieve its goal and is net-negative on `main`. Measured on the first cache-push run after merge (28979626387) vs the baseline (28944386598):

| phase | baseline | after #2463 |
|---|---|---|
| eval | 1192s (~20m) | **946s (~16m)** |
| realise | 3570s (~59m) | 3853s (~64m) |

The goal was to make the darwin `eval` phase *substitute* the cross unit graph (→ seconds) instead of rebuilding it. It still rebuilds for ~16 min.

## Root cause

The rebind bound `ix.rustWorkspace` to `rustWorkspaceFor pkgs` where `pkgs` is the **aarch64-darwin** pkgs. The IFD roots (`unitsNix`/`unitGraphJson`/`vendorDir`) are `pkgs.runCommand`, so they became **aarch64-darwin-platform** derivations — a different drv hash than the **x86_64-linux** `crossIfdRoots` the `push` lane publishes. Different hash → no cache hit → rebuild.

Proof from the CI behavior: an x86_64-linux derivation cannot be built on a Mac (platform mismatch → hard error). The eval *succeeded by building* for ~16 min, so what it built were Mac-native derivations — not the published x86_64-linux roots — confirming no substitution occurred. The change also routed *all* darwin workspace binaries through a darwin-rooted cross graph (build-only confidence, RFC 0009) for zero benefit.

## Follow-up

A robust fix must root the darwin package eval at the **x86_64-linux** `crossWorkspace` (byte-identical to the published `crossIfdRoots`), the way `darwinPackageAliases`/`crossIxFor` already do for dag-runner/nix-web-monitor — and be verified by comparing drvPaths across systems *before* merge, not on CI. Deferred to a separate PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert cross unit graph on Darwin cache lane and restore native workspace roots
> - Reverts a previous change that replaced the native `rustWorkspace` with a cross-compiled unit graph on `aarch64-darwin`; `rustWorkspace` now always resolves directly from `rustWorkspaceFor pkgs`.
> - On Darwin, `cachePushRoots` now includes `nativeIfdRoots` (native IFD units, unit graph, and vendor dir from `crossWorkspace`) merged alongside `imagesAsClosures`.
> - Updates the [cache-push workflow](https://github.com/indexable-inc/index/pull/2475/files#diff-56c6f531ecd11b28cb14d6aa2ec8abf63b2cb701d82ce2f772c5a324c3bbbfb8) comment to reflect that the eval step targets the native darwin cargo unit graph rather than a cross graph.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 780c55a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->