### PR TITLE
claude-code: use development channel flag

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -84,8 +84,9 @@ positional). Both rules are learned from real breakage; see the long comment at
 - `--debug`: writes operational telemetry to `~/.claude/debug/` (pruned on the
   `cleanupPeriodDays` sweep). It is an optional-value flag, so it cannot take
   `=`; it is safe only because `--thinking-display` follows it.
-- `--channels server:index`: lets the baked `index` MCP server push channel
-  events into the running session without Claude's development-channel warning.
+- `--dangerously-load-development-channels server:index`: lets the baked
+  `index` MCP server push channel events into the running session without
+  Claude's approved-channel allowlist error.
 - `--thinking-display=summarized`: forces visible reasoning. The API default
   flipped to "omitted" on Opus 4.7/4.8, hiding thinking in the UI and
   transcript; this hidden flag is the only lever that restores it (verified on

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -146,7 +146,9 @@
   # is our OWN stdio server, baked into this package from the same trusted
   # registry as `mcpServers`. Each entry is a channel spec:
   # `server:<mcpServersKey>` or `plugin:<name>@<marketplace>`; baked as
-  # `--channels <spec>...`. Defaults to the `index`
+  # `--dangerously-load-development-channels <spec>...` because the bundled
+  # `index` server is local development channel code, not an Anthropic allowlist
+  # entry. Defaults to the `index`
   # server WHEN it is baked (so notify()/interactive resources reach a session
   # with no per-launch flag), and to nothing otherwise (the overlay build has no
   # `index` server, so referencing it would be a dead flag). A session whose org
@@ -441,13 +443,13 @@
       # Write ~/.claude/debug telemetry; cleanupPeriodDays controls retention.
       "--debug"
     ]
-    # Load our own MCP servers as channels (research preview). This flag is
-    # VARIADIC (it consumes every following non-`--` token as a spec), so it must
-    # be followed by a `--`-prefixed flag — never placed last, where it would
-    # swallow the user's argv (a prompt, a subcommand). It sits here so the always-
-    # present `--thinking-display=` below terminates the spec list.
+    # Load our own MCP servers as local development channels (research preview).
+    # This flag is VARIADIC (it consumes every following non-`--` token as a spec),
+    # so it must be followed by a `--`-prefixed flag, never placed last, where it
+    # would swallow the user's argv (a prompt, a subcommand). It sits here so the
+    # always-present `--thinking-display=` below terminates the spec list.
     ++ lib.optionals (developmentChannels != []) (
-      ["--channels"] ++ developmentChannels
+      ["--dangerously-load-development-channels"] ++ developmentChannels
     )
     ++ [
       # Opus 4.7+ otherwise omits thinking from the UI/transcript.


### PR DESCRIPTION
Fixes #2478.

## Summary
- pass baked local channel specs through `--dangerously-load-development-channels`
- update the Claude Code wrapper overview to match

## Validation
- `nix build .#claude-code --out-link result-claude-code`
- built `share/claude-code-launch-spec.json` contains `--dangerously-load-development-channels server:index` and no `--channels`
- `./result-claude-code/bin/claude --help`
- `nix build .#lint`

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `--channels` with `--dangerously-load-development-channels` flag in claude-code
> Updates the CLI flag passed to the Claude CLI when `developmentChannels` are present, in both [default.nix](https://github.com/indexable-inc/index/pull/2480/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) and [overview.md](https://github.com/indexable-inc/index/pull/2480/files#diff-559790f4098fd36e6c2b388e089f9728a89e74720ef2cc2511f7e77794ad6916). Also updates the docs to reflect the renamed error/warning from 'development-channel warning' to 'approved-channel allowlist error'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5454b96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->