### PR TITLE
claude-code: brand statusline as ix

### DIFF
--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -148,7 +148,7 @@
     got="$(printf '%s' "$statusline_payload" \
       | HOME="$PWD/sl-home" XDG_CACHE_HOME="$PWD/sl-home/.cache" ${runtimeShell} -c "$statusline_cmd")"
     case "$got" in
-    *'█████░░░░░ | TestModel | high | v1.2.3 '*'↑1.2.10'*) : ;;
+    *'⟡ 𝒊𝒙 | █████░░░░░ | TestModel | high | v1.2.3 '*'↑1.2.10'*) : ;;
     *)
       printf 'statusline check failed (seeded cache): want bar/model/effort/version/update marker, got:\n%s\n' "$got" >&2
       exit 1
@@ -161,7 +161,7 @@
       printf 'statusline check failed (cold cache): update marker must not render offline, got:\n%s\n' "$got" >&2
       exit 1
       ;;
-    *'█████░░░░░ | TestModel | high | v1.2.3'*) : ;;
+    *'⟡ 𝒊𝒙 | █████░░░░░ | TestModel | high | v1.2.3'*) : ;;
     *)
       printf 'statusline check failed (cold cache): want plain version segment, got:\n%s\n' "$got" >&2
       exit 1

--- a/packages/agent/claude-code/statusline.nu
+++ b/packages/agent/claude-code/statusline.nu
@@ -1,8 +1,8 @@
 # House Claude Code statusline (settings `statusLine.command`, baked by
 # package.nix into the wrapper's read-only settings layer). Renders one
-# dark-gray line: context-window bar, model, effort level, and the running CLI
-# version with an "↑<latest>" marker when Anthropic has published a newer
-# release than the wrapper pins.
+# dark-gray line: the ix identity mark, context-window bar, model, effort
+# level, and the running CLI version with an "↑<latest>" marker when
+# Anthropic has published a newer release than the wrapper pins.
 #
 # Claude Code pipes a JSON status payload on stdin and re-runs this on every
 # render, so everything here must be fast and fail-soft: the one network call
@@ -108,6 +108,7 @@ def main [--default-effort: string = ""] {
   } else { "" })
 
   let effort_segment = (if ($effort | is-not-empty) { $" | ($effort)" } else { "" })
+  let identity_segment = "⟡ 𝒊𝒙"
 
-  print $"(ansi dark_gray)($bar) | ($model)($effort_segment)($version_segment)(ansi reset)"
+  print $"(ansi dark_gray)($identity_segment) | ($bar) | ($model)($effort_segment)($version_segment)(ansi reset)"
 }


### PR DESCRIPTION
## Summary
- Prefix the Claude Code statusline with `⟡ 𝒊𝒙`.
- Update the install check fixture to assert the ix mark renders with the rest of the status line.

## Validation
- `nu --no-config-file -c "nu-check packages/agent/claude-code/statusline.nu"`
- Rendered fixture: `⟡ 𝒊𝒙 | █████░░░░░ | TestModel | high | v1.2.3 ↑1.2.10`
- `nix build .#claude-code`
- `nix run .#lint`

Fixes #2479

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Brand claude-code statusline with '⟡ 𝒊𝒙' identity segment
> Prepends `⟡ 𝒊𝒙 | ` to the statusline output in [statusline.nu](https://github.com/indexable-inc/index/pull/2481/files#diff-9e4486732397a9fae41a08dcfcf45652a13511e403aa1a82aa5caa1c161b7b0d) before the existing context-window bar, model, effort, and version segments. Updates [install-check.nix](https://github.com/indexable-inc/index/pull/2481/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) to expect the new identity prefix in both seeded-cache and cold-cache output checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aea787c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->