### PR TITLE
symphony: disable the overseer cron, keep it manually runnable

### DIFF
--- a/packages/agent/symphony/workflows/indexable/workflows/overseer.sym
+++ b/packages/agent/symphony/workflows/indexable/workflows/overseer.sym
@@ -1,9 +1,13 @@
-# Overseer: every 10 minutes, snapshot what every agent on this machine is
-# doing (agent processes, claude sessions, symphony runs, hot or stalled
-# processes), have a headless codex write a terse digest, and maintain a
-# minimal HTML report at ~/.local/share/symphony/overseer/index.html.
-# Not Slack-notified: it is a local page. Timeout stays under the cadence
-# so runs cannot overlap.
-workflow "overseer" on cron "*/10 * * * *" tz "America/Los_Angeles" {
+# Overseer: snapshot what every agent on this machine is doing (agent
+# processes, claude sessions, symphony runs, hot or stalled processes),
+# have a headless codex write a terse digest, and maintain a minimal HTML
+# report at ~/.local/share/symphony/overseer/index.html.
+#
+# DISABLED for now (was `on cron "*/10 * * * *" tz "America/Los_Angeles"`,
+# timeout 480 under the cadence so runs cannot overlap): every failed tick
+# posted to Slack #general via IR.RunNotifier's cron-failure default
+# (SYMPHONY_SLACK_NOTIFY_CRON_FAILURES). Manual trigger keeps it runnable
+# from the enqueue UI; restore the cron clause to re-enable.
+workflow "overseer" on manual {
   overseer <- exec "./scripts/overseer.sh" timeout 480
 }


### PR DESCRIPTION
Disables the overseer workflow's schedule for now: every failed 10-minute tick posted a cron-failure notification to Slack #general via IR.RunNotifier (`SYMPHONY_SLACK_NOTIFY_CRON_FAILURES` defaults to true, `SYMPHONY_SLACK_NOTIFY_CHANNEL=C0A4TD9G7HR`).

- Trigger flips from `cron "*/10 * * * *" tz "America/Los_Angeles"` to `manual`: `Triggers.Cron` only walks `trigger.kind = :cron` workflows, so the scheduler never fires it, while the workflow stays in the catalog for manual runs from the enqueue UI.
- Header comment records the original schedule so re-enabling is a one-line revert.
- Verified: all three indexable pack workflows parse through `SymphonyElixir.DSL.Parser`; overseer now yields `trigger=%{kind: :manual}`. No test asserts the overseer trigger (catalog_assets_test covers insights/triage only).

Deployments hot-reload `.sym` files from their packDir checkout, so this takes effect on the next pack pull without a runtime restart.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable automatic cron trigger for the symphony overseer workflow
> Changes the overseer workflow trigger in [overseer.sym](https://github.com/indexable-inc/index/pull/2482/files#diff-61a96082caf72c2fa50846c45c0d7e244ad3c62f8563d350bacc7d737d5cc85a) from `on cron "*/10 * * * *" tz "America/Los_Angeles"` to `on manual`. The workflow no longer runs automatically every 10 minutes and must be triggered manually.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e717bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->