### PR TITLE
doc: fix stale packages/nix-web-monitor path references

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -88,7 +88,7 @@ User-facing guides for the hosted `ix` platform. Start at
 | [mynoise](mynoise/overview.md) | `packages/mynoise` plays myNoise.net generators from the CLI by streaming and mixing their band loops locally. |
 | [nix-cargo-unit](nix-cargo-unit/overview.md) | `packages/nix-cargo-unit` renders a Cargo unit graph into composable Nix derivations: one `stdenv.mkDerivation` per rustc invocation, wired into a graph that mirrors Cargo's own. |
 | [nix-output-monitor](nix-output-monitor/overview.md) | `packages/nix-output-monitor` is the upstream `nix-output-monitor` (`nom`), re-packaged with one patch so it parses content-addressed derivations. |
-| [nix-web-monitor](nix-web-monitor/overview.md) | `packages/nix-web-monitor` runs a Nix command with quiet terminal output and a live browser monitor: a build tree, log tail, activity DAG, store-optimisation totals, and a `nix-daemon` sy... |
+| [nix-web-monitor](nix-web-monitor/overview.md) | `packages/nix/nix-web-monitor` runs a Nix command with quiet terminal output and a live browser monitor: a build tree, log tail, activity DAG, store-optimisation totals, and a `nix-daemon` sy... |
 | [oci-image-builder](oci-image-builder/overview.md) | `packages/oci-image-builder` turns a `dockerTools.streamLayeredImage` layer plan into an OCI image. |
 | [pi-harnesses](pi-harnesses/overview.md) | `packages/pi-harnesses` is a collection of Pi-based agent harnesses. |
 | [polars-mixedbread](polars-mixedbread/overview.md) | `packages/polars-mixedbread` is a Polars IO source backed by Mixedbread store search. |

--- a/doc/nix-web-monitor/overview.md
+++ b/doc/nix-web-monitor/overview.md
@@ -1,6 +1,6 @@
 # nix-web-monitor
 
-`packages/nix-web-monitor` runs a Nix command with quiet terminal output and a
+`packages/nix/nix-web-monitor` runs a Nix command with quiet terminal output and a
 live browser monitor: a build tree, log tail, activity DAG, store-optimisation
 totals, and a `nix-daemon` syscall panel, all on one HTTP port. It is two Rust
 workspace crates:

--- a/packages/site/src/lib/updates/nix-web-monitor-dependency-tree.svx
+++ b/packages/site/src/lib/updates/nix-web-monitor-dependency-tree.svx
@@ -5,7 +5,7 @@ title: "`nix-web-monitor` builds panel can nest derivations by dependency"
 tags: [nix, tooling, observability]
 links:
   - label: nix-web-monitor
-    href: https://github.com/indexable-inc/index/tree/main/packages/nix-web-monitor
+    href: https://github.com/indexable-inc/index/tree/main/packages/nix/nix-web-monitor
 ---
 
 The builds panel now has a `flat` / `tree` toggle. Tree mode nests each built derivation under the derivation that depends on it, so you can read which build is waiting on which instead of scanning a flat list.

--- a/packages/site/src/lib/updates/nix-web-monitor-full-tree.svx
+++ b/packages/site/src/lib/updates/nix-web-monitor-full-tree.svx
@@ -5,7 +5,7 @@ title: "`nix-web-monitor` shows the whole build tree from the start"
 tags: [nix, tooling, observability]
 links:
   - label: nix-web-monitor
-    href: https://github.com/indexable-inc/index/tree/main/packages/nix-web-monitor
+    href: https://github.com/indexable-inc/index/tree/main/packages/nix/nix-web-monitor
 ---
 
 The builds panel now seeds the entire tree the moment Nix prints its plan, so `nix build .#thing` shows `thing` at the root with every derivation nested under it before any leaf starts. Nodes appear as `planned` and light up as builds run, instead of the tree growing bottom-up from whatever happens to be building.


### PR DESCRIPTION
Update stale `packages/nix-web-monitor` path references to `packages/nix/nix-web-monitor` (the crates moved there):

- `doc/index.md:91`
- `doc/nix-web-monitor/overview.md:3`
- `packages/site/src/lib/updates/nix-web-monitor-dependency-tree.svx` (GitHub tree link)
- `packages/site/src/lib/updates/nix-web-monitor-full-tree.svx` (GitHub tree link)

Repo-wide `git grep 'packages/nix-web-monitor'` now only matches the new path.

Fixes #2486

Authored by an AI agent (Claude Opus 4.6 via Claude Code).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale `packages/nix-web-monitor` path references in docs
> Updates four files to replace the old path `packages/nix-web-monitor` with the correct `packages/nix/nix-web-monitor`, covering the main docs index, the nix-web-monitor overview, and two Svelte content files with GitHub links.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28d29f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->