### PR TITLE
nwm: fold global why-chains into a collapsible derivation forest

### DIFF
--- a/packages/nix/nix-web-monitor/server/site/src/components/GlobalPanel.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/GlobalPanel.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import GlobalLogView from '$components/GlobalLogView.svelte';
+  import { SvelteSet } from 'svelte/reactivity';
+  import GlobalTreeRow from '$components/GlobalTreeRow.svelte';
   import PanelHeader from '$lib/PanelHeader.svelte';
-  import { formatDuration, splitDerivation } from '$lib/format';
+  import { buildGlobalForest } from '$lib/global-forest';
   import { useNow } from '$lib/now.svelte';
-  import type { GlobalBuild, GlobalBuildKind, GlobalBuilds } from '$lib/types';
+  import type { GlobalBuild, GlobalBuilds } from '$lib/types';
 
   type Props = {
     global: GlobalBuilds;
@@ -13,64 +14,28 @@
 
   const now = useNow();
 
-  /// Short badge per goal kind. The Rust side already folds unknown kinds into
-  /// `other`, so this record is total.
-  const BADGE: Record<GlobalBuildKind, string> = {
-    build: 'build',
-    substitution: 'sub',
-    other: 'other'
-  };
-
-  /// The store path a row identifies: the drv for a build, the store path for a
-  /// substitution. Either can be null on a drifted entry, so fall back to the
-  /// other and finally to a placeholder rather than rendering `null`.
-  function pathOf(build: GlobalBuild): string {
-    return build.drvPath ?? build.storePath ?? '(unknown)';
-  }
-
-  /// Stable row key. The status directory keys entries by `<path>-<pid>`: the
-  /// same derivation can appear once per daemon worker, so the path alone would
-  /// collide.
-  function rowKey(build: GlobalBuild): string {
-    return `${pathOf(build)}:${String(build.pid ?? 0)}`;
-  }
-
-  /// Builds grouped by the client user that requested them, so the panel
-  /// answers "who started this" before "what is it". Null users pool under one
-  /// unattributed group (a local store without a daemon records no client).
-  type UserGroup = Readonly<{
-    user: string | null;
-    label: string;
-    builds: readonly GlobalBuild[];
-  }>;
-
-  const groups = $derived(groupByUser(global.builds));
-
-  /// Group headers only earn their row when they attribute something: several
-  /// users, or one *known* user. A single anonymous group would just say
-  /// "unattributed" above every row.
-  const showGroups = $derived(groups.length > 1 || groups.some((group) => group.user !== null));
+  /// The why-chain forest: active goals hang under the derivations that
+  /// requested them, with skeleton nodes for the intermediate hops. Nodes are
+  /// keyed by store path, so row identity and expansion state survive the
+  /// two-second re-polls.
+  const forest = $derived(buildGlobalForest(global.builds));
 
   const meta = $derived(countsLabel(global.builds));
 
-  function groupByUser(builds: readonly GlobalBuild[]): UserGroup[] {
-    const buckets: { user: string | null; label: string; builds: GlobalBuild[] }[] = [];
-    for (const build of builds) {
-      const bucket = buckets.find((candidate) => candidate.user === build.user);
-      if (bucket === undefined) {
-        buckets.push({ user: build.user, label: build.user ?? 'unattributed', builds: [build] });
-      } else {
-        bucket.builds.push(build);
-      }
-    }
-    for (const bucket of buckets) {
-      // Oldest first within a group: long-running work floats to the top, and
-      // rows keep a stable order across the two-second re-polls.
-      bucket.builds.sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0));
-    }
-    return buckets.sort(
-      (a, b) => b.builds.length - a.builds.length || a.label.localeCompare(b.label)
-    );
+  /// The chains cover only active goals plus their ancestors, so the forest
+  /// under-reports: waiting or queued sibling derivations are invisible until
+  /// the status dir records the full goal graph. Surfaced as the meta tooltip
+  /// so the panel does not read as the whole plan.
+  const META_TITLE =
+    'active goals and their ancestor chains only; waiting or queued siblings are not recorded yet';
+
+  /// Collapsed forest nodes. Store-path keys stay stable while goals come and
+  /// go, so a fold survives updates to the underlying list.
+  const collapsed = new SvelteSet<string>();
+
+  function toggle(path: string): void {
+    if (collapsed.has(path)) collapsed.delete(path);
+    else collapsed.add(path);
   }
 
   /// Header meta splitting builds from substitutions, so the mix is readable
@@ -86,72 +51,8 @@
     return parts.length === 0 ? 'idle' : parts.join(' · ');
   }
 
-  /// Live elapsed label from the goal's start. `startTime` is unix *seconds*
-  /// (unlike the rest of the monitor's ms timestamps), so scale to ms before
-  /// diffing against the reactive clock. Empty when the source gave no start.
-  function elapsed(startTimeSec: number | null): string {
-    if (startTimeSec === null) return '';
-    return formatDuration(now.value - startTimeSec * 1000);
-  }
-
-  /// One hop of the provenance trail: a derivation shown by name, full path
-  /// kept for the tooltip.
-  type TrailHop = Readonly<{ path: string; name: string }>;
-
-  /// The ancestors that wanted this goal: the requested root plus the
-  /// intermediate hops between it and this goal, in root -> leaf order. Null
-  /// when the goal *is* the root (nothing above it to attribute to).
-  type Trail = Readonly<{ root: TrailHop; via: readonly TrailHop[] }>;
-
-  function hop(path: string): TrailHop {
-    const name = splitDerivation(path).name;
-    return { path, name: name.length > 0 ? name : path };
-  }
-
-  function whyTrail(build: GlobalBuild): Trail | null {
-    // The why-chain is root-first and ends with the goal itself; drop that
-    // leaf so the trail is only the ancestors.
-    const chain = build.why.chain;
-    const ancestors =
-      chain.length > 0 && chain[chain.length - 1] === pathOf(build) ? chain.slice(0, -1) : chain;
-    const root = ancestors.length > 0 ? ancestors[0] : build.why.rootDrvPath;
-    if (root === null || root === pathOf(build)) return null;
-    return { root: hop(root), via: ancestors.slice(1).map(hop) };
-  }
-
-  /// Label when there is no ancestor trail. A top goal reads "requested
-  /// directly"; a sparse entry that still carries a cause shows it verbatim so
-  /// the row explains itself either way.
-  function noTrailLabel(build: GlobalBuild): string {
-    const cause = build.why.cause;
-    return cause === null || cause === 'requested' ? 'requested directly' : cause;
-  }
-
-  /// Row tooltip: the full store path plus the identity details (outputs,
-  /// worker pid, requesting user/uid, cause) that would crowd the row itself.
-  function rowTitle(build: GlobalBuild): string {
-    const lines = [pathOf(build)];
-    if (build.outputs.length > 0) lines.push(`outputs: ${build.outputs.join(', ')}`);
-    if (build.pid !== null) lines.push(`worker pid ${String(build.pid)}`);
-    if (build.user !== null) {
-      lines.push(
-        build.uid === null
-          ? `requested by ${build.user}`
-          : `requested by ${build.user} (uid ${String(build.uid)})`
-      );
-    }
-    if (build.why.cause !== null) lines.push(`cause: ${build.why.cause}`);
-    return lines.join('\n');
-  }
-
-  /// Trail tooltip: the full why-chain, one store path per line, root first.
-  function trailTitle(build: GlobalBuild): string {
-    if (build.why.chain.length > 0) return build.why.chain.join('\n→ ');
-    return build.why.rootDrvPath ?? '';
-  }
-
-  /// Which row's log drawer is open, by row key. One at a time keeps the panel
-  /// compact; clicking the open row's toggle closes it.
+  /// Which goal's log drawer is open, keyed `<path>:<pid>`. One at a time
+  /// keeps the panel compact; clicking the open row's toggle closes it.
   let openLog = $state<string | null>(null);
 
   function toggleLog(key: string): void {
@@ -162,62 +63,30 @@
 {#if global.detected}
   <section class="panel global-panel">
     <PanelHeader title="machine builds">
-      <span class="panel-meta">{meta}</span>
+      <span class="panel-meta" title={META_TITLE}>{meta}</span>
     </PanelHeader>
 
     <div class="global-body">
       {#if global.builds.length === 0}
         <div class="global-status">no machine builds right now</div>
       {:else}
-        {#each groups as group (group.label)}
-          {#if showGroups}
-            <div class="global-group">
-              <span class="global-group-user">{group.label}</span>
-              <span class="global-group-count">{group.builds.length}</span>
-            </div>
-          {/if}
-          {#each group.builds as build (rowKey(build))}
-            {@const parts = splitDerivation(pathOf(build))}
-            {@const trail = whyTrail(build)}
-            <div class="global-row">
-              <div class="global-row-head" title={rowTitle(build)}>
-                <span class="global-badge global-badge-{build.type}">{BADGE[build.type]}</span>
-                <span class="global-name">{parts.name.length > 0 ? parts.name : pathOf(build)}</span>
-                {#if parts.version.length > 0}<span class="global-version">{parts.version}</span>{/if}
-                {#if build.drvPath !== null && build.logFile !== null}
-                  <button
-                    type="button"
-                    class="global-log-toggle"
-                    class:open={openLog === rowKey(build)}
-                    aria-expanded={openLog === rowKey(build)}
-                    onclick={() => {
-                      toggleLog(rowKey(build));
-                    }}
-                  >
-                    log
-                  </button>
-                {/if}
-                <span class="global-elapsed">{elapsed(build.startTime)}</span>
-              </div>
-              <div class="global-why" title={trailTitle(build)}>
-                {#if trail === null}
-                  <span class="global-requested">{noTrailLabel(build)}</span>
-                {:else}
-                  <span class="global-why-label">for</span>
-                  <span class="global-why-root" title={trail.root.path}>{trail.root.name}</span>
-                  {#if trail.via.length > 0}
-                    <span class="global-why-via"
-                      >via {trail.via.map((step) => step.name).join(' → ')}</span
-                    >
-                  {/if}
-                {/if}
-              </div>
-              {#if build.drvPath !== null && openLog === rowKey(build)}
-                <GlobalLogView drvPath={build.drvPath} />
-              {/if}
-            </div>
+        <div class="global-tree">
+          {#each forest.roots as root, index (root)}
+            <GlobalTreeRow
+              path={root}
+              {forest}
+              {collapsed}
+              ontoggle={toggle}
+              now={now.value}
+              {openLog}
+              ontogglelog={toggleLog}
+              guideLines={[]}
+              isLast={index === forest.roots.length - 1}
+              isRoot={true}
+              ancestors={new Set()}
+            />
           {/each}
-        {/each}
+        </div>
       {/if}
     </div>
   </section>

--- a/packages/nix/nix-web-monitor/server/site/src/components/GlobalTreeRow.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/GlobalTreeRow.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import type { SvelteSet } from 'svelte/reactivity';
+  import Self from '$components/GlobalTreeRow.svelte';
+  import GlobalLogView from '$components/GlobalLogView.svelte';
+  import { formatDuration, shortHash, splitDerivation } from '$lib/format';
+  import { goalPath, type GlobalForest } from '$lib/global-forest';
+  import type { GlobalBuild, GlobalBuildKind } from '$lib/types';
+
+  type Props = {
+    path: string;
+    forest: GlobalForest;
+    collapsed: SvelteSet<string>;
+    ontoggle: (path: string) => void;
+    now: number;
+    /// Which goal's log drawer is open, keyed `<path>:<pid>`. One at a time
+    /// across the whole panel keeps it compact.
+    openLog: string | null;
+    ontogglelog: (key: string) => void;
+    /// Vertical-line flags for each ancestor column (true = ancestor has a
+    /// following sibling, so its column keeps a `│`). Empty for roots.
+    guideLines: boolean[];
+    /// Whether this node is the last among its siblings (picks `└` vs `├`).
+    isLast: boolean;
+    isRoot: boolean;
+    /// Paths from the root to here. Guards against re-entering a node already
+    /// above us, which contradictory why-chains could induce.
+    ancestors: ReadonlySet<string>;
+  };
+
+  const {
+    path,
+    forest,
+    collapsed,
+    ontoggle,
+    now,
+    openLog,
+    ontogglelog,
+    guideLines,
+    isLast,
+    isRoot,
+    ancestors
+  }: Props = $props();
+
+  /// Short badge per goal kind. The Rust side already folds unknown kinds into
+  /// `other`, so this record is total.
+  const BADGE: Record<GlobalBuildKind, string> = {
+    build: 'build',
+    substitution: 'sub',
+    other: 'other'
+  };
+
+  const goals = $derived(forest.goalsByPath.get(path) ?? []);
+  /// The goal whose affordances the row carries. The rare extra goals for the
+  /// same path (the status dir keys entries by `<path>-<pid>`, one per daemon
+  /// worker) fold into a ×N marker. Undefined on a skeleton ancestor.
+  const primary = $derived(goals.at(0));
+  const parts = $derived(splitDerivation(path));
+  const children = $derived(
+    (forest.childrenByPath.get(path) ?? []).filter((child) => !ancestors.has(child))
+  );
+  const isCollapsed = $derived(collapsed.has(path));
+  const childGuideLines = $derived(isRoot ? [] : [...guideLines, !isLast]);
+  const childAncestors = $derived(new Set([...ancestors, path]));
+
+  /// Stable per-goal key for the log drawer: the status dir keys entries by
+  /// `<path>-<pid>`, so the path alone would collide across workers.
+  function goalKey(goal: GlobalBuild): string {
+    return `${goalPath(goal)}:${String(goal.pid ?? 0)}`;
+  }
+
+  /// Live elapsed label from the goal's start. `startTime` is unix *seconds*
+  /// (unlike the rest of the monitor's ms timestamps), so scale to ms before
+  /// diffing against the reactive clock. Empty when the source gave no start.
+  function elapsed(goal: GlobalBuild): string {
+    if (goal.startTime === null) return '';
+    return formatDuration(now - goal.startTime * 1000);
+  }
+
+  /// Row tooltip: the full store path plus the identity details (outputs,
+  /// worker pid, requesting user/uid, cause) that would crowd the row itself.
+  /// A skeleton hop instead explains why it has no affordances.
+  function rowTitle(): string {
+    if (primary === undefined) {
+      return `${path}\nancestor of an active goal below, not itself active`;
+    }
+    const lines = [path];
+    if (primary.outputs.length > 0) lines.push(`outputs: ${primary.outputs.join(', ')}`);
+    if (primary.pid !== null) lines.push(`worker pid ${String(primary.pid)}`);
+    if (primary.user !== null) {
+      lines.push(
+        primary.uid === null
+          ? `requested by ${primary.user}`
+          : `requested by ${primary.user} (uid ${String(primary.uid)})`
+      );
+    }
+    if (primary.why.cause !== null) lines.push(`cause: ${primary.why.cause}`);
+    return lines.join('\n');
+  }
+</script>
+
+<div class="activity-row global-tree-row" class:skeleton={primary === undefined} title={rowTitle()}>
+  {#if !isRoot}
+    <span class="guides" aria-hidden="true"
+      >{#each guideLines as line, level (level)}<span class="guide">{line ? '│' : ' '}</span
+        >{/each}<span class="guide connector">{isLast ? '└' : '├'}</span></span
+    >
+  {/if}
+  <button
+    type="button"
+    class="twirl"
+    class:hidden={children.length === 0}
+    aria-label={isCollapsed ? 'expand' : 'collapse'}
+    aria-expanded={children.length === 0 ? undefined : !isCollapsed}
+    tabindex={children.length === 0 ? -1 : 0}
+    onclick={() => {
+      ontoggle(path);
+    }}
+  >
+    {children.length === 0 ? '' : isCollapsed ? '▸' : '▾'}
+  </button>
+  {#if primary !== undefined}
+    <span class="global-badge global-badge-{primary.type}">{BADGE[primary.type]}</span>
+  {/if}
+  <span class="drv activity-drv" title={path}>
+    <span class="drv-name">{parts.name.length > 0 ? parts.name : path}</span>{#if parts.version.length > 0}<span
+        class="drv-version">{parts.version}</span
+      >{/if}{#if parts.hash.length > 0}<span class="drv-hash">{shortHash(parts)}</span>{/if}
+  </span>
+  {#if goals.length > 1}
+    <span
+      class="group-count"
+      title="{String(goals.length)} active goals for this path, one per daemon worker"
+      >×{String(goals.length)}</span
+    >
+  {/if}
+  {#if primary !== undefined && primary.user !== null}
+    <span class="global-user" title="requested by {primary.user}">{primary.user}</span>
+  {/if}
+  {#if primary !== undefined && primary.drvPath !== null && primary.logFile !== null}
+    <button
+      type="button"
+      class="global-log-toggle"
+      class:open={openLog === goalKey(primary)}
+      aria-expanded={openLog === goalKey(primary)}
+      onclick={() => {
+        ontogglelog(goalKey(primary));
+      }}
+    >
+      log
+    </button>
+  {/if}
+  {#if isCollapsed && children.length > 0}
+    <span class="subtree-count">+{String(children.length)}</span>
+  {/if}
+  <span class="activity-dur">{primary === undefined ? '' : elapsed(primary)}</span>
+</div>
+
+{#if primary !== undefined && primary.drvPath !== null && openLog === goalKey(primary)}
+  <GlobalLogView drvPath={primary.drvPath} />
+{/if}
+
+{#if !isCollapsed}
+  {#each children as childPath, index (childPath)}
+    <Self
+      path={childPath}
+      {forest}
+      {collapsed}
+      {ontoggle}
+      {now}
+      {openLog}
+      {ontogglelog}
+      guideLines={childGuideLines}
+      isLast={index === children.length - 1}
+      isRoot={false}
+      ancestors={childAncestors}
+    />
+  {/each}
+{/if}

--- a/packages/nix/nix-web-monitor/server/site/src/lib/global-forest.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/global-forest.ts
@@ -1,0 +1,115 @@
+/// Reconstructs the machine-wide derivation forest from the flat active-goal
+/// list. Every active goal carries `why.chain` (root-first store paths ending
+/// at the goal itself), so the forest is rebuildable client-side with no
+/// protocol change: chains merge wherever they share a node, keyed by store
+/// path. Chain hops with no active goal of their own become skeleton nodes.
+///
+/// Known limitation: the status dir records only *active* goals plus their
+/// ancestor chains, so waiting/queued siblings are invisible until it records
+/// the full goal graph (sibling sub-issue of #2484).
+
+import { splitDerivation } from '$lib/format';
+import type { GlobalBuild } from '$lib/types';
+
+/// The store path a goal identifies: the drv for a build, the store path for a
+/// substitution. Either can be null on a drifted entry, so fall back to the
+/// other and finally to a placeholder rather than keying on `null`.
+export function goalPath(build: GlobalBuild): string {
+  return build.drvPath ?? build.storePath ?? '(unknown)';
+}
+
+export type GlobalForest = Readonly<{
+  /// Active goals per node, oldest first. A path with no entry here is a
+  /// skeleton ancestor: a chain hop nothing is actively building.
+  goalsByPath: ReadonlyMap<string, readonly GlobalBuild[]>;
+  /// Children per node. Name-ordered (not start-ordered) so rows keep a stable
+  /// order across the two-second re-polls as goals come and go.
+  childrenByPath: ReadonlyMap<string, readonly string[]>;
+  /// The requested derivations (chain heads nothing else wants), name-ordered.
+  roots: readonly string[];
+}>;
+
+/// Root-first chain from the requested derivation to this goal, normalized to
+/// end at the goal itself (the wire chain usually includes it, but a sparse
+/// entry may carry only `rootDrvPath`, or nothing).
+function chainTo(build: GlobalBuild): readonly string[] {
+  const path = goalPath(build);
+  const chain = build.why.chain;
+  if (chain.length > 0) {
+    return chain[chain.length - 1] === path ? chain : [...chain, path];
+  }
+  const root = build.why.rootDrvPath;
+  return root === null || root === path ? [path] : [root, path];
+}
+
+/// Display order: package name first, full path as the tiebreak, so identical
+/// names (different hashes) stay stably ordered.
+function byName(left: string, right: string): number {
+  return (
+    splitDerivation(left).name.localeCompare(splitDerivation(right).name) ||
+    left.localeCompare(right)
+  );
+}
+
+export function buildGlobalForest(builds: readonly GlobalBuild[]): GlobalForest {
+  const goalsByPath = new Map<string, GlobalBuild[]>();
+  const childSets = new Map<string, Set<string>>();
+  const isChild = new Set<string>();
+  const paths = new Set<string>();
+
+  for (const build of builds) {
+    const path = goalPath(build);
+    const goals = goalsByPath.get(path) ?? [];
+    goals.push(build);
+    goalsByPath.set(path, goals);
+
+    const chain = chainTo(build);
+    for (const hop of chain) paths.add(hop);
+    for (let i = 1; i < chain.length; i += 1) {
+      const parent = chain[i - 1];
+      const child = chain[i];
+      // A drifted self-hop would nest a node under itself forever.
+      if (parent === child) continue;
+      const children = childSets.get(parent) ?? new Set<string>();
+      children.add(child);
+      childSets.set(parent, children);
+      isChild.add(child);
+    }
+  }
+
+  // The status dir keys entries by `<path>-<pid>`, so one path can carry a
+  // goal per daemon worker; oldest first so the row leads with the
+  // longest-running one.
+  for (const goals of goalsByPath.values()) {
+    goals.sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0));
+  }
+
+  const childrenByPath = new Map<string, readonly string[]>();
+  for (const [parent, children] of childSets) {
+    childrenByPath.set(parent, [...children].sort(byName));
+  }
+
+  const roots = [...paths].filter((path) => !isChild.has(path)).sort(byName);
+
+  // Contradictory chains (A above B in one goal, B above A in another) mark
+  // both as children and orphan the whole component. Promote any active goal
+  // the roots cannot reach so a drifted entry stays visible; the renderer's
+  // ancestor guard breaks the cycle below it.
+  const reachable = new Set<string>();
+  const visit = (path: string): void => {
+    if (reachable.has(path)) return;
+    reachable.add(path);
+    for (const child of childrenByPath.get(path) ?? []) visit(child);
+  };
+  for (const root of roots) visit(root);
+  // Promote incrementally: the first orphan's subtree covers its cycle mates,
+  // so they are not promoted twice.
+  const orphans: string[] = [];
+  for (const path of [...goalsByPath.keys()].sort(byName)) {
+    if (reachable.has(path)) continue;
+    orphans.push(path);
+    visit(path);
+  }
+
+  return { goalsByPath, childrenByPath, roots: [...roots, ...orphans] };
+}

--- a/packages/nix/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix/nix-web-monitor/server/site/src/style.css
@@ -643,46 +643,39 @@ main.dragging-v .splitter-v::after {
   color: var(--muted);
 }
 
-/* One requesting user's header: name left, build count right. Rendered only
- * when attribution adds information (several users, or one known user). */
-.global-group {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  font-size: 0.72rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--muted);
-  margin-bottom: -0.3rem;
-}
-
-.global-group:not(:first-child) {
-  margin-top: 0.2rem;
-}
-
-.global-group-count {
-  color: var(--faint);
-}
-
-.global-row {
+/* The why-chain forest. Rows reuse the build-tree row language (guides,
+ * twirl, drv columns) at side-panel scale; the body already provides the
+ * horizontal padding, so rows drop their own. */
+.global-tree {
   display: flex;
   flex-direction: column;
-  gap: 0.1rem;
-  padding-bottom: 0.4rem;
-  border-bottom: 1px solid var(--line-soft);
 }
 
-.global-row:last-child {
+.global-tree .activity-row {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.global-tree .activity-row:last-child {
   border-bottom: none;
-  padding-bottom: 0;
 }
 
-/* badge | name | version | log | elapsed, name flexes and truncates. */
-.global-row-head {
-  display: flex;
-  align-items: baseline;
-  gap: 0.35rem;
-  font-variant-numeric: tabular-nums;
+/* Skeleton ancestors: chain hops nothing is actively building, kept only to
+ * show where the active leaves hang. Dimmed so live goals read as the
+ * foreground. */
+.global-tree .global-tree-row.skeleton .drv-name {
+  color: var(--muted);
+}
+
+/* Requesting user as a per-row annotation, now that rows nest by why-chain
+ * instead of grouping by user. */
+.global-user {
+  flex: 0 0 auto;
+  max-width: 7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.72rem;
+  color: var(--muted);
 }
 
 .global-badge {
@@ -699,25 +692,6 @@ main.dragging-v .splitter-v::after {
 .global-badge-substitution {
   color: var(--accent);
   border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
-}
-
-.global-name {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  color: var(--ink);
-}
-
-.global-version {
-  flex: 0 0 auto;
-  color: var(--faint);
-}
-
-.global-elapsed {
-  flex: 0 0 auto;
-  color: var(--muted);
 }
 
 /* Toggle for the row's inline log tail; styled as a quiet chip that fills with
@@ -744,31 +718,6 @@ main.dragging-v .splitter-v::after {
   background: var(--accent);
   border-color: var(--accent);
   color: var(--panel);
-}
-
-/* The provenance trail: "for <root> via <hop> → <hop>". Root-first so the
- * attribution survives the end-of-line truncation. */
-.global-why {
-  color: var(--faint);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 0.85rem;
-}
-
-.global-why-label,
-.global-requested {
-  color: var(--faint);
-}
-
-/* The top-level thing that wanted this build: the answer to "why is my fan
- * spinning", so it reads as ink rather than a dim afterthought. */
-.global-why-root {
-  color: var(--ink);
-}
-
-.global-why-via {
-  color: var(--faint);
 }
 
 /* Inline log tail under a row: a short fixed-height stream pinned to the


### PR DESCRIPTION
Folds the machine-builds panel's flat per-user rows into a collapsible derivation forest, per #2484.

- **`$lib/global-forest.ts`**: rebuilds the forest client-side from each active goal's root-first `why.chain` (no protocol change), merging chains at shared nodes keyed by store path. Contradictory/drifted chains stay visible via incremental orphan promotion; the renderer's ancestor guard breaks cycles.
- **`GlobalTreeRow.svelte`**: recursive rows reusing the wrapped-mode tree language (`guides`/`twirl`/drv columns from `BuildTree` / `ActivityTreeRow`). Active leaves keep the build/sub badge, elapsed, log drawer, and tooltip; intermediate hops render as dimmed skeleton nodes; user attribution moves from group headers to a per-row annotation.
- **Stability**: nodes keyed by store path and name-ordered children, so expansion state and row order survive the 2s re-poll.
- **Limitation** (noted on the panel meta tooltip and in code): chains cover only active goals plus their ancestors; waiting/queued siblings stay invisible until the status dir records the full goal graph.

Validated: `svelte-check` 0 errors, `eslint` clean, `vite build` ok, `nix build .#nix-web-monitor.site` green, plus node assertions over the forest builder (shared-prefix merge, chain normalization, sparse `rootDrvPath`, self-root, cycle promotion, per-worker goal fold, substitution keying, order determinism).

Fixes #2484

🤖 Generated with Claude Code (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace flat build list in global panel with collapsible why-chain derivation forest
> - Adds [`buildGlobalForest`](https://github.com/indexable-inc/index/pull/2493/files#diff-4ee84b57d8022adf5403d21c0cc0b64d65677ed806a4de20e86fdf5ba1197317) to aggregate active builds into a tree by merging why-chains on store-path nodes, sorting children by package name, and promoting orphaned or cyclic nodes to roots.
> - Replaces the flat, user-grouped list in [`GlobalPanel`](https://github.com/indexable-inc/index/pull/2493/files#diff-63da9d7b5d9bdbad3545513615466f2adc45a723a375562faf1fd67c98d7586d) with a recursive [`GlobalTreeRow`](https://github.com/indexable-inc/index/pull/2493/files#diff-2ef27da0d262fa238ed1a52ed00caa37d9daa5bb5bb65722137ba0f1b76e977c) that renders guide connectors, goal badges, per-row user chips, live elapsed time, and a log drawer toggle.
> - Nodes can be collapsed/expanded via a twirl button; collapsed state is tracked by store path in a `SvelteSet` and persists across re-polls.
> - Skeleton (ancestor-only) nodes with no active goals are visually dimmed and display an explanatory tooltip.
> - Behavioral Change: the previous group headers, provenance trail lines, and user-grouped layout are removed and replaced by the tree view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43e6908.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->