### PR TITLE
nwm daemon panel: head-ellipsis for paths, label the other bucket

### DIFF
--- a/packages/nix/nix-web-monitor/parser/src/daemon.rs
+++ b/packages/nix/nix-web-monitor/parser/src/daemon.rs
@@ -29,12 +29,19 @@ pub enum OpClass {
     Fsync,
     Stat,
     Unlink,
+    /// Everything [`Self::classify`] does not group: syscalls with no class of
+    /// their own (`ioctl`, `mmap`, `getdirentries`, ...) and, on macOS, the
+    /// disk-I/O rows `fs_usage` interleaves with syscalls (`RdData`, `WrData`,
+    /// `PgIn`, ...), which is why this bucket dominates during heavy I/O.
     Other,
 }
 
 impl OpClass {
     /// Classify a syscall by name. Handles the `*at` and `p*`/`*64` variants the
     /// two tracers emit (`openat`, `pwrite`, `lstat64`, `fdatasync`, ...).
+    ///
+    /// The daemon panel restates this grouping in its per-row tooltips
+    /// (`DaemonPanel.svelte`, `OP_ORDER`); update both together.
     #[must_use]
     pub fn classify(syscall: &str) -> Self {
         // Strip a trailing `64`/`_nocancel` so `stat64` / `open_nocancel` match.

--- a/packages/nix/nix-web-monitor/server/site/src/components/DaemonPanel.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/DaemonPanel.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import PanelHeader from '$lib/PanelHeader.svelte';
-  import { middleTruncate } from '$lib/format';
   import type { DaemonInfo, DaemonOps } from '$lib/types';
 
   type Props = {
@@ -9,21 +8,28 @@
 
   const { daemon }: Props = $props();
 
-  /// Op classes in a fixed display order with a short label. Keyed by the
-  /// `DaemonOps` field so the row count joins by identity.
-  const OP_ORDER: ReadonlyArray<readonly [keyof DaemonOps, string]> = [
-    ['link', 'link'],
-    ['rename', 'rename'],
-    ['write', 'write'],
-    ['fsync', 'fsync'],
-    ['open', 'open'],
-    ['stat', 'stat'],
-    ['unlink', 'unlink'],
-    ['other', 'other']
+  /// Op classes in a fixed display order: the `DaemonOps` field (so the row
+  /// count joins by identity), a short label, and a tooltip spelling out what
+  /// the class counts. The syscall lists mirror `OpClass::classify` in
+  /// `parser/src/daemon.rs`; update both together.
+  const OP_ORDER: ReadonlyArray<readonly [keyof DaemonOps, string, string]> = [
+    ['link', 'link', 'link, linkat, clonefile: hard-linking, dominates store optimisation'],
+    ['rename', 'rename', 'rename, renameat: finished paths moving into place'],
+    ['write', 'write', 'write, pwrite, writev: file data being written'],
+    ['fsync', 'fsync', 'fsync, fdatasync: writes being flushed to disk'],
+    ['open', 'open', 'open, openat'],
+    ['stat', 'stat', 'stat, lstat, fstat, access, getattrlist, readlink: metadata reads'],
+    ['unlink', 'unlink', 'unlink, rmdir: paths being deleted'],
+    [
+      'other',
+      'other',
+      'everything else: syscalls with no class of their own (ioctl, mmap, getdirentries, …) ' +
+        'plus, on macOS, the disk-I/O rows fs_usage interleaves (RdData, WrData, PgIn, …)'
+    ]
   ];
 
   const rows = $derived(
-    OP_ORDER.map(([key, label]) => ({ label, count: daemon.ops[key] })).filter(
+    OP_ORDER.map(([key, label, detail]) => ({ label, detail, count: daemon.ops[key] })).filter(
       (row) => row.count > 0
     )
   );
@@ -53,7 +59,7 @@
     {:else}
       <div class="daemon-ops">
         {#each rows as row (row.label)}
-          <div class="daemon-op" title="{String(row.count)} {row.label}">
+          <div class="daemon-op" title="{String(row.count)} {row.label} &middot; {row.detail}">
             <span class="daemon-op-label">{row.label}</span>
             <span class="daemon-op-bar" aria-hidden="true"
               ><span class="daemon-op-fill" style="--p: {String(pct(row.count))}%"></span></span
@@ -63,16 +69,26 @@
         {/each}
       </div>
       {#if daemon.currentPath !== null}
-        <div class="daemon-path" title={daemon.currentPath}>
-          {middleTruncate(daemon.currentPath, 56)}
+        <!-- The most recent path any traced syscall touched: a "currently
+             working on" readout, not tied to the op-class rows above. The
+             &lrm; marks pin character order under the rtl ellipsis trick
+             (see .daemon-path-value in style.css). -->
+        <div class="daemon-path" title="most recently touched path: {daemon.currentPath}">
+          <span class="daemon-path-label">touching</span>
+          <span class="daemon-path-value">&lrm;{daemon.currentPath}&lrm;</span>
         </div>
       {/if}
       {#if daemon.hotPaths.length > 0}
         <div class="daemon-hot">
-          <div class="daemon-hot-title">hot paths</div>
+          <div
+            class="daemon-hot-title"
+            title="highest-traffic paths across all traced syscalls: rate this second, then total"
+          >
+            hot paths
+          </div>
           {#each daemon.hotPaths as hot (hot.path)}
             <div class="daemon-hot-row" title={hot.path}>
-              <span class="daemon-hot-path">{middleTruncate(hot.path, 48)}</span>
+              <span class="daemon-hot-path">&lrm;{hot.path}&lrm;</span>
               <span class="daemon-hot-rate">{hot.opsPerSec}/s</span>
               <span class="daemon-hot-count">{hot.count}</span>
             </div>

--- a/packages/nix/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix/nix-web-monitor/server/site/src/style.css
@@ -568,10 +568,34 @@ main.dragging-v .splitter-v::after {
 
 /* The store path the daemon last touched -- the "currently working on" line. */
 .daemon-path {
+  display: flex;
+  gap: 0.4rem;
   color: var(--faint);
   white-space: nowrap;
+}
+
+.daemon-path-label {
+  flex: none;
+  color: var(--muted);
+}
+
+/* Head-side ellipsis for path readouts: the leaf carries the identity, so
+ * overflow must eat the prefix, never the tail (#2487). `direction: rtl`
+ * moves the line's overflow edge (and its ellipsis) to the left; the &lrm;
+ * marks wrapping the text in the markup keep the characters themselves in
+ * left-to-right order, so nothing visually reorders. */
+.daemon-path-value,
+.daemon-hot-path {
+  min-width: 0;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
+  direction: rtl;
+  text-align: left;
+}
+
+.daemon-path-value {
+  flex: 1 1 auto;
 }
 
 .daemon-hot {
@@ -599,11 +623,7 @@ main.dragging-v .splitter-v::after {
 }
 
 .daemon-hot-path {
-  min-width: 0;
-  overflow: hidden;
   color: var(--ink);
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .daemon-hot-rate,


### PR DESCRIPTION
Fixes #2487, fixes #2488. Both are DaemonPanel readability bugs seen live on the :7532 dashboard.

**#2487, hot-path truncation hid the leaf.** The rows were truncated twice: `middleTruncate(path, 48)` in JS, then CSS `text-overflow: ellipsis` end-clipped whatever still overflowed, which is exactly how two distinct paths both rendered as `/private/var/folders/2z/…-mcp/sto…`. Truncation now clips the head: `direction: rtl` on the path span moves the CSS ellipsis to the left edge (with `&lrm;` marks pinning character order so nothing visually reorders), the leaf stays visible at any panel width, and the full path remains in the row tooltip. The JS truncation is gone since CSS now owns it at pixel accuracy.

**#2488, unlabeled `other` bucket.** Every op-class row gets a tooltip naming the syscalls it counts, mirroring `OpClass::classify` (cross-referenced comments both sides so they stay in sync). The `other` tooltip spells out that it also absorbs the disk-I/O rows `fs_usage` interleaves with syscalls (`RdData`/`WrData`/`PgIn` on `/dev/diskN`), which is why it dominates during heavy I/O and why `/dev/disk3s5` showed up under it. The sub-line under the histogram (the most recently touched path, not tied to any row) now carries a `touching` label plus an explanatory tooltip, and the `hot paths` header a tooltip for its rate/total columns.

Validated: `svelte-check` 0 errors, `eslint` clean, `vite build` ok; `nix build .#nix-web-monitor` + `.tests.package` + `.tests.site`.

🤖 Generated with Claude Code (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add head-side ellipsis for paths and tooltips for op-class rows in the daemon panel
> - Op-class rows in [DaemonPanel.svelte](https://github.com/indexable-inc/index/pull/2502/files#diff-3c97541a4919a0e7d73e88866532a75f06cd566f91dd548ba828cc6fc4d06536) now show tooltips describing the syscall groups they represent, including an expanded description for the 'other' bucket.
> - The current path line gains a muted 'touching' label and truncates from the head using CSS RTL ellipsis instead of JS `middleTruncate`.
> - Hot paths switch to the same CSS-based head ellipsis, removing the `middleTruncate` dependency entirely.
> - [style.css](https://github.com/indexable-inc/index/pull/2502/files#diff-cc4fc064f91df58680f5cfa2b46c3f8b17a80fca6cfe8c03205e2658ffdcd953) adds `.daemon-path-label`, `.daemon-path-value`, and RTL truncation rules to support the new layout.
> - Behavioral Change: path truncation now depends on CSS (`direction: rtl`, `text-overflow: ellipsis`) rather than JavaScript, so truncation behavior may differ in browsers or contexts where RTL rendering is non-standard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f47e3ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->