### PR TITLE
nwm: render the machine-build goal graph as a per-coordinator forest

### DIFF
--- a/packages/nix/nix-web-monitor/parser/src/global.rs
+++ b/packages/nix/nix-web-monitor/parser/src/global.rs
@@ -9,6 +9,15 @@
 //! and lists every active build/substitution goal on the host, with the
 //! why-chain (root derivation -> ... -> this goal) and the cause that forced it.
 //!
+//! The patched nix keeps one `graph-<pid>.json` per coordinating process, and
+//! `nix store builds --graph --json` dumps those documents verbatim: every goal
+//! the coordinator knows (waiting, running, done, failed) with its dependency
+//! edges. The probe prefers that graph view and derives the flat build list
+//! from it via [`flatten_graph`], the same flattening the patched nix itself
+//! applies for plain `--json`; on a graph-capable nix the flat subcommand is
+//! never polled. An older patched nix without `--graph` still answers the flat
+//! form, so both parsers live here.
+//!
 //! The subcommand is only present on a patched nix, so the whole view degrades
 //! gracefully: on stock nix the probe cannot parse a build list, marks the view
 //! undetected, and the UI hides the panel. The server owns polling the
@@ -55,6 +64,78 @@ pub enum GlobalBuildKind {
     /// A kind this build of the monitor does not know; surfaced, not dropped.
     #[serde(other)]
     Other,
+}
+
+/// Lifecycle state of one goal in a coordinator's graph.
+///
+/// `waiting` and `running` are live goals; `done` and `failed` are the
+/// session-local record of goals that already completed (the coordinator keeps
+/// them so the forest shows finished work draining, not vanishing).
+/// `#[serde(other)]` keeps an unknown future state from failing the parse.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GlobalGoalStatus {
+    /// Scheduled, with unfinished dependencies (or queued for a build slot).
+    #[default]
+    Waiting,
+    /// Actively building or downloading right now.
+    Running,
+    /// Completed successfully this session.
+    Done,
+    /// Completed unsuccessfully this session.
+    Failed,
+    /// A status this build of the monitor does not know; surfaced, not dropped.
+    #[serde(other)]
+    Other,
+}
+
+/// One goal in a coordinator's graph, as recorded in `graph-<pid>.json` and
+/// reported by `nix store builds --graph --json`.
+///
+/// `id` is the derivation path for a build and the store path for a
+/// substitution; `waiters` names the goal ids that *want* this goal (edges
+/// point upward, so inverting them yields the dependency forest). The running
+/// extras (`start_time`, `log_file`, `builder_pid`) are null on any goal that
+/// is not running. Tolerant like the flat row: unknown fields are ignored and
+/// missing ones default.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct GlobalGoal {
+    /// The goal's stable identity: drv path (build) or store path (substitution).
+    /// Empty when the source omitted it; such a goal is dropped from the forest.
+    pub id: String,
+    /// Build or substitution.
+    pub kind: GlobalBuildKind,
+    /// Where the goal is in its lifecycle.
+    pub status: GlobalGoalStatus,
+    /// Ids of the goals that want this one (dependents, edges pointing up).
+    pub waiters: Vec<String>,
+    /// Wanted outputs (`out`, `dev`, ...). May be empty.
+    pub outputs: Vec<String>,
+    /// Unix epoch seconds the goal started running. `None` unless running.
+    pub start_time: Option<i64>,
+    /// The build log path, once a running build opened one.
+    pub log_file: Option<String>,
+    /// The builder child pid of a running local build.
+    pub builder_pid: Option<i64>,
+}
+
+/// One coordinating nix process and everything it is working on: the whole
+/// goal graph behind one `graph-<pid>.json`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct GlobalCoordinator {
+    /// The coordinator process (the `nix build` / daemon worker), whose
+    /// liveness scopes the file: the reader prunes files of dead pids.
+    pub pid: Option<i64>,
+    /// The client user that requested the work, when attributable.
+    pub user: Option<String>,
+    /// The client uid, when attributable.
+    pub uid: Option<i64>,
+    /// Goal ids the client asked for directly: the roots of the forest.
+    pub roots: Vec<String>,
+    /// Every goal this coordinator knows, live and session-completed.
+    pub goals: Vec<GlobalGoal>,
 }
 
 /// One active build or substitution goal on the machine.
@@ -108,8 +189,14 @@ pub struct GlobalBuilds {
     /// Whether `nix store builds --json` is available and produced a build list.
     /// False on stock nix (no such subcommand); the UI hides the panel.
     pub detected: bool,
-    /// Active build/substitution goals on the machine, as last polled.
+    /// Active build/substitution goals on the machine, as last polled. Always
+    /// populated: derived from `coordinators` via [`flatten_graph`] when the
+    /// graph view is available, polled flat otherwise.
     pub builds: Vec<GlobalBuild>,
+    /// Full per-coordinator goal graphs, from `nix store builds --graph
+    /// --json`. Empty on a patched nix that predates `--graph` (the panel then
+    /// falls back to the flat rows).
+    pub coordinators: Vec<GlobalCoordinator>,
     /// Human state line, like [`DaemonInfo.status`](crate::DaemonInfo::status):
     /// the availability note, the active count, or an error.
     pub status: String,
@@ -120,6 +207,7 @@ impl Default for GlobalBuilds {
         Self {
             detected: false,
             builds: Vec::new(),
+            coordinators: Vec::new(),
             status: "not available (stock nix)".to_owned(),
         }
     }
@@ -138,6 +226,116 @@ impl Default for GlobalBuilds {
 /// "unknown command" error, not a build array, on the first poll.
 pub fn parse_builds(json: &str) -> Result<Vec<GlobalBuild>, serde_json::Error> {
     serde_json::from_str(json)
+}
+
+/// The document `nix store builds --graph --json` prints: coordinators wrapped
+/// in one object, so the top level can grow siblings without breaking readers.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct GraphDocument {
+    coordinators: Vec<GlobalCoordinator>,
+}
+
+/// Parse the JSON object `nix store builds --graph --json` prints into the
+/// per-coordinator goal graphs. Tolerant like [`parse_builds`].
+///
+/// # Errors
+///
+/// Returns a [`serde_json::Error`] when the payload is not an object of the
+/// expected shape. The server treats that as "no graph support": a patched nix
+/// without `--graph` prints a flag error, not a JSON object, and the probe
+/// falls back to the flat form.
+pub fn parse_graph(json: &str) -> Result<Vec<GlobalCoordinator>, serde_json::Error> {
+    let value: serde_json::Value = serde_json::from_str(json)?;
+    // Require the wrapper object explicitly: serde would happily read a struct
+    // from a JSON *array* (fields in order), so a flat `[]` payload would
+    // otherwise pass as "no coordinators" and mask a probe wiring bug.
+    if !value.is_object() {
+        return Err(serde::de::Error::custom("graph payload is not a JSON object"));
+    }
+    let document: GraphDocument = serde_json::from_value(value)?;
+    Ok(document.coordinators)
+}
+
+/// Derive the flat running-goal list from the coordinator graphs.
+///
+/// Mirrors the flattening the patched nix itself applies for plain
+/// `nix store builds --json` (`flattenCoordinator` in `store-builds.cc`), so a
+/// graph-capable nix is polled once and both views stay consistent: only
+/// `running` goals appear, and each row's why-chain is recomputed by walking
+/// `waiters` edges up to a root.
+pub fn flatten_graph(coordinators: &[GlobalCoordinator]) -> Vec<GlobalBuild> {
+    coordinators.iter().flat_map(flatten_coordinator).collect()
+}
+
+fn flatten_coordinator(coordinator: &GlobalCoordinator) -> Vec<GlobalBuild> {
+    let goals_by_id: std::collections::HashMap<&str, &GlobalGoal> = coordinator
+        .goals
+        .iter()
+        .filter(|goal| !goal.id.is_empty())
+        .map(|goal| (goal.id.as_str(), goal))
+        .collect();
+
+    coordinator
+        .goals
+        .iter()
+        .filter(|goal| goal.status == GlobalGoalStatus::Running && !goal.id.is_empty())
+        .map(|goal| {
+            let substitution = goal.kind == GlobalBuildKind::Substitution;
+            let chain = why_chain(&goals_by_id, &goal.id);
+            // A chain of one is the goal itself: a root the client asked for.
+            // Deeper chains carry the same fixed causes the C++ flattening
+            // emits (nix does not record the scheduler's actual reason in the
+            // graph; these are the two reasons a non-root goal exists).
+            let cause = if chain.len() == 1 {
+                "requested"
+            } else if substitution {
+                "outputInvalid"
+            } else {
+                "outputsMissing"
+            };
+            GlobalBuild {
+                drv_path: (!substitution).then(|| goal.id.clone()),
+                store_path: substitution.then(|| goal.id.clone()),
+                outputs: goal.outputs.clone(),
+                kind: goal.kind,
+                pid: coordinator.pid,
+                start_time: goal.start_time,
+                user: coordinator.user.clone(),
+                uid: coordinator.uid,
+                log_file: goal.log_file.clone(),
+                why: GlobalWhy {
+                    root_drv_path: chain.first().cloned(),
+                    chain,
+                    cause: Some(cause.to_owned()),
+                },
+            }
+        })
+        .collect()
+}
+
+/// Walk `waiters` edges from `id` up to a root, returned root-first and ending
+/// with `id` itself. Any waiter leads to a root, so following the first is
+/// enough for a why-chain; the visited set guards against a cyclic document.
+fn why_chain(
+    goals_by_id: &std::collections::HashMap<&str, &GlobalGoal>,
+    id: &str,
+) -> Vec<String> {
+    let mut chain_leaf_first = Vec::new();
+    let mut visited = std::collections::HashSet::new();
+    let mut current = id;
+    while visited.insert(current) {
+        chain_leaf_first.push(current.to_owned());
+        let Some(first_waiter) = goals_by_id
+            .get(current)
+            .and_then(|goal| goal.waiters.first())
+        else {
+            break;
+        };
+        current = first_waiter;
+    }
+    chain_leaf_first.reverse();
+    chain_leaf_first
 }
 
 #[cfg(test)]
@@ -301,6 +499,201 @@ mod tests {
         let default = GlobalBuilds::default();
         assert!(!default.detected);
         assert!(default.builds.is_empty());
+        assert!(default.coordinators.is_empty());
         assert!(!default.status.is_empty());
+    }
+
+    /// A representative graph document: one coordinator building a root whose
+    /// dependency is running while the root waits, plus a substitution that
+    /// already finished. Field-for-field what the patched nix emits.
+    const GRAPH_FIXTURE: &str = r#"{
+        "coordinators": [
+            {
+                "pid": 4242,
+                "user": "alice",
+                "uid": 1000,
+                "roots": ["/nix/store/aaa-app.drv"],
+                "goals": [
+                    {
+                        "id": "/nix/store/aaa-app.drv",
+                        "kind": "build",
+                        "status": "waiting",
+                        "waiters": [],
+                        "outputs": ["out"],
+                        "startTime": null,
+                        "logFile": null,
+                        "builderPid": null
+                    },
+                    {
+                        "id": "/nix/store/bbb-dep.drv",
+                        "kind": "build",
+                        "status": "running",
+                        "waiters": ["/nix/store/aaa-app.drv"],
+                        "outputs": ["out"],
+                        "startTime": 1720200000,
+                        "logFile": "/nix/var/log/nix/drvs/bb/b-dep.drv.bz2",
+                        "builderPid": 777
+                    },
+                    {
+                        "id": "/nix/store/ccc-src",
+                        "kind": "substitution",
+                        "status": "done",
+                        "waiters": ["/nix/store/bbb-dep.drv"],
+                        "outputs": [],
+                        "startTime": null,
+                        "logFile": null,
+                        "builderPid": null
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn parses_graph_document() {
+        let coordinators = parse_graph(GRAPH_FIXTURE).expect("graph document parses");
+        assert_eq!(coordinators.len(), 1);
+        let coordinator = &coordinators[0];
+        assert_eq!(coordinator.pid, Some(4242));
+        assert_eq!(coordinator.user.as_deref(), Some("alice"));
+        assert_eq!(coordinator.roots, vec!["/nix/store/aaa-app.drv".to_owned()]);
+        assert_eq!(coordinator.goals.len(), 3);
+
+        let root = &coordinator.goals[0];
+        assert_eq!(root.status, GlobalGoalStatus::Waiting);
+        assert!(root.waiters.is_empty());
+        assert_eq!(root.start_time, None);
+
+        let dep = &coordinator.goals[1];
+        assert_eq!(dep.status, GlobalGoalStatus::Running);
+        assert_eq!(dep.waiters, vec!["/nix/store/aaa-app.drv".to_owned()]);
+        assert_eq!(dep.start_time, Some(1_720_200_000));
+        assert_eq!(dep.builder_pid, Some(777));
+
+        let src = &coordinator.goals[2];
+        assert_eq!(src.kind, GlobalBuildKind::Substitution);
+        assert_eq!(src.status, GlobalGoalStatus::Done);
+    }
+
+    /// The flat derivation of the graph: only the running dep appears, with the
+    /// coordinator's identity and a why-chain recomputed from `waiters`. This
+    /// mirrors `flattenCoordinator` in the patched nix, so the flat rows look
+    /// the same whichever side flattened.
+    #[test]
+    fn flatten_graph_yields_running_goals_with_why_chain() {
+        let coordinators = parse_graph(GRAPH_FIXTURE).expect("graph document parses");
+        let builds = flatten_graph(&coordinators);
+        assert_eq!(builds.len(), 1, "only the running goal flattens");
+        let build = &builds[0];
+        assert_eq!(build.drv_path.as_deref(), Some("/nix/store/bbb-dep.drv"));
+        assert_eq!(build.kind, GlobalBuildKind::Build);
+        assert_eq!(build.pid, Some(4242));
+        assert_eq!(build.user.as_deref(), Some("alice"));
+        assert_eq!(build.uid, Some(1000));
+        assert_eq!(build.start_time, Some(1_720_200_000));
+        assert_eq!(
+            build.log_file.as_deref(),
+            Some("/nix/var/log/nix/drvs/bb/b-dep.drv.bz2")
+        );
+        assert_eq!(
+            build.why.chain,
+            vec![
+                "/nix/store/aaa-app.drv".to_owned(),
+                "/nix/store/bbb-dep.drv".to_owned()
+            ]
+        );
+        assert_eq!(
+            build.why.root_drv_path.as_deref(),
+            Some("/nix/store/aaa-app.drv")
+        );
+        assert_eq!(build.why.cause.as_deref(), Some("outputsMissing"));
+    }
+
+    /// A running root (nothing above it) flattens to `requested`, and a running
+    /// substitution names `storePath` with cause `outputInvalid`: the exact
+    /// labels the C++ flattening emits.
+    #[test]
+    fn flatten_graph_labels_roots_and_substitutions() {
+        let json = r#"{
+            "coordinators": [
+                {
+                    "pid": 1,
+                    "roots": ["/nix/store/aaa-app.drv"],
+                    "goals": [
+                        {
+                            "id": "/nix/store/aaa-app.drv",
+                            "kind": "build",
+                            "status": "running",
+                            "waiters": [],
+                            "startTime": 1720200000
+                        },
+                        {
+                            "id": "/nix/store/bbb-src",
+                            "kind": "substitution",
+                            "status": "running",
+                            "waiters": ["/nix/store/aaa-app.drv"]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+        let builds = flatten_graph(&parse_graph(json).expect("graph parses"));
+        assert_eq!(builds.len(), 2);
+        assert_eq!(builds[0].why.cause.as_deref(), Some("requested"));
+        assert_eq!(builds[0].why.chain.len(), 1);
+        assert_eq!(builds[1].store_path.as_deref(), Some("/nix/store/bbb-src"));
+        assert_eq!(builds[1].drv_path, None);
+        assert_eq!(builds[1].why.cause.as_deref(), Some("outputInvalid"));
+        assert_eq!(
+            builds[1].why.root_drv_path.as_deref(),
+            Some("/nix/store/aaa-app.drv")
+        );
+    }
+
+    /// A cyclic `waiters` document (which a healthy nix never writes) must not
+    /// hang the chain walk: the visited guard cuts the loop.
+    #[test]
+    fn flatten_graph_survives_waiter_cycles() {
+        let json = r#"{
+            "coordinators": [
+                {
+                    "pid": 1,
+                    "goals": [
+                        { "id": "a", "status": "running", "waiters": ["b"] },
+                        { "id": "b", "status": "waiting", "waiters": ["a"] }
+                    ]
+                }
+            ]
+        }"#;
+        let builds = flatten_graph(&parse_graph(json).expect("graph parses"));
+        assert_eq!(builds.len(), 1);
+        assert_eq!(builds[0].why.chain, vec!["b".to_owned(), "a".to_owned()]);
+    }
+
+    /// A goal with an unknown status or a missing id degrades quietly: the
+    /// status parses as `Other` and the id-less goal never flattens.
+    #[test]
+    fn graph_tolerates_unknown_status_and_missing_id() {
+        let json = r#"{
+            "coordinators": [
+                {
+                    "goals": [
+                        { "id": "a", "status": "paused" },
+                        { "status": "running" }
+                    ]
+                }
+            ]
+        }"#;
+        let coordinators = parse_graph(json).expect("graph parses");
+        assert_eq!(coordinators[0].goals[0].status, GlobalGoalStatus::Other);
+        assert!(flatten_graph(&coordinators).is_empty());
+    }
+
+    /// A patched nix without `--graph` prints a flag error, not a JSON object;
+    /// the server relies on the parse error to fall back to the flat form.
+    #[test]
+    fn non_object_graph_payload_errors() {
+        assert!(parse_graph("error: unrecognised flag '--graph'").is_err());
+        assert!(parse_graph("[]").is_err());
     }
 }

--- a/packages/nix/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix/nix-web-monitor/parser/src/lib.rs
@@ -14,7 +14,10 @@ pub mod global;
 pub use activation::{Activation, ActivationStatus, ActivationStep};
 pub use build_view::{ActivityRow, BuildCounts, BuildRow, BuildView};
 pub use daemon::{DaemonInfo, DaemonOps, OpClass};
-pub use global::{GlobalBuild, GlobalBuildKind, GlobalBuilds, GlobalWhy};
+pub use global::{
+    GlobalBuild, GlobalBuildKind, GlobalBuilds, GlobalCoordinator, GlobalGoal, GlobalGoalStatus,
+    GlobalWhy,
+};
 
 const NIX_JSON_PREFIX: &str = "@nix ";
 

--- a/packages/nix/nix-web-monitor/server/site/src/components/GlobalPanel.svelte
+++ b/packages/nix/nix-web-monitor/server/site/src/components/GlobalPanel.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
+  import { SvelteSet } from 'svelte/reactivity';
+
   import GlobalLogView from '$components/GlobalLogView.svelte';
   import PanelHeader from '$lib/PanelHeader.svelte';
   import { formatDuration, splitDerivation } from '$lib/format';
+  import { buildGoalForest, flattenGoalForest, type GoalForest, type GoalRow } from '$lib/global-tree';
   import { useNow } from '$lib/now.svelte';
-  import type { GlobalBuild, GlobalBuildKind, GlobalBuilds } from '$lib/types';
+  import type {
+    GlobalBuild,
+    GlobalBuildKind,
+    GlobalBuilds,
+    GlobalCoordinator,
+    GlobalGoal,
+    GlobalGoalStatus
+  } from '$lib/types';
 
   type Props = {
     global: GlobalBuilds;
@@ -21,57 +31,7 @@
     other: 'other'
   };
 
-  /// The store path a row identifies: the drv for a build, the store path for a
-  /// substitution. Either can be null on a drifted entry, so fall back to the
-  /// other and finally to a placeholder rather than rendering `null`.
-  function pathOf(build: GlobalBuild): string {
-    return build.drvPath ?? build.storePath ?? '(unknown)';
-  }
-
-  /// Stable row key. The status directory keys entries by `<path>-<pid>`: the
-  /// same derivation can appear once per daemon worker, so the path alone would
-  /// collide.
-  function rowKey(build: GlobalBuild): string {
-    return `${pathOf(build)}:${String(build.pid ?? 0)}`;
-  }
-
-  /// Builds grouped by the client user that requested them, so the panel
-  /// answers "who started this" before "what is it". Null users pool under one
-  /// unattributed group (a local store without a daemon records no client).
-  type UserGroup = Readonly<{
-    user: string | null;
-    label: string;
-    builds: readonly GlobalBuild[];
-  }>;
-
-  const groups = $derived(groupByUser(global.builds));
-
-  /// Group headers only earn their row when they attribute something: several
-  /// users, or one *known* user. A single anonymous group would just say
-  /// "unattributed" above every row.
-  const showGroups = $derived(groups.length > 1 || groups.some((group) => group.user !== null));
-
   const meta = $derived(countsLabel(global.builds));
-
-  function groupByUser(builds: readonly GlobalBuild[]): UserGroup[] {
-    const buckets: { user: string | null; label: string; builds: GlobalBuild[] }[] = [];
-    for (const build of builds) {
-      const bucket = buckets.find((candidate) => candidate.user === build.user);
-      if (bucket === undefined) {
-        buckets.push({ user: build.user, label: build.user ?? 'unattributed', builds: [build] });
-      } else {
-        bucket.builds.push(build);
-      }
-    }
-    for (const bucket of buckets) {
-      // Oldest first within a group: long-running work floats to the top, and
-      // rows keep a stable order across the two-second re-polls.
-      bucket.builds.sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0));
-    }
-    return buckets.sort(
-      (a, b) => b.builds.length - a.builds.length || a.label.localeCompare(b.label)
-    );
-  }
 
   /// Header meta splitting builds from substitutions, so the mix is readable
   /// without scanning badges ("3 building · 2 fetching").
@@ -92,6 +52,130 @@
   function elapsed(startTimeSec: number | null): string {
     if (startTimeSec === null) return '';
     return formatDuration(now.value - startTimeSec * 1000);
+  }
+
+  // ---------- goal-graph forest (graph-capable patched nix) ----------
+
+  /// One coordinator's forest plus the label bits its header shows.
+  type CoordinatorView = Readonly<{
+    coordinator: GlobalCoordinator;
+    key: string;
+    label: string;
+    forest: GoalForest;
+    rows: readonly GoalRow[];
+  }>;
+
+  /// Collapsed goals, keyed `<coordinator>:<goal id>` so the same derivation
+  /// folding under one coordinator leaves it open under another.
+  const collapsed = new SvelteSet<string>();
+
+  const coordinators = $derived(global.coordinators.map(coordinatorView));
+
+  function coordinatorKey(coordinator: GlobalCoordinator): string {
+    return `pid:${String(coordinator.pid ?? 0)}`;
+  }
+
+  function coordinatorView(coordinator: GlobalCoordinator): CoordinatorView {
+    const key = coordinatorKey(coordinator);
+    const forest = buildGoalForest(coordinator);
+    const user = coordinator.user ?? 'unattributed';
+    const pid = coordinator.pid === null ? '' : ` · pid ${String(coordinator.pid)}`;
+    return {
+      coordinator,
+      key,
+      label: `${user}${pid}`,
+      forest,
+      rows: flattenGoalForest(forest, (id) => collapsed.has(`${key}:${id}`))
+    };
+  }
+
+  /// Header counts for one coordinator: live work first, then the session's
+  /// completed record ("2 running · 3 waiting · 5 done").
+  function forestCounts(forest: GoalForest): string {
+    const order: readonly GlobalGoalStatus[] = ['running', 'waiting', 'done', 'failed', 'other'];
+    const parts = order
+      .filter((status) => forest.counts[status] > 0)
+      .map((status) => `${String(forest.counts[status])} ${status}`);
+    return parts.length === 0 ? 'idle' : parts.join(' · ');
+  }
+
+  /// The `.state` dot palette is shared with the invocation build tree, whose
+  /// statuses differ; map goal states onto it (waiting renders as the hollow
+  /// "pending" ring, done as the success fill).
+  const DOT_STATE: Record<GlobalGoalStatus, string> = {
+    waiting: 'planned',
+    running: 'running',
+    done: 'succeeded',
+    failed: 'failed',
+    other: 'other'
+  };
+
+  function goalKey(view: CoordinatorView, goal: GlobalGoal): string {
+    return `${view.key}:${goal.id}`;
+  }
+
+  /// Goal row tooltip: the full id plus the details that would crowd the row.
+  function goalTitle(goal: GlobalGoal): string {
+    const lines = [goal.id, goal.status];
+    if (goal.outputs.length > 0) lines.push(`outputs: ${goal.outputs.join(', ')}`);
+    if (goal.builderPid !== null) lines.push(`builder pid ${String(goal.builderPid)}`);
+    return lines.join('\n');
+  }
+
+  function toggleCollapse(key: string): void {
+    if (collapsed.has(key)) collapsed.delete(key);
+    else collapsed.add(key);
+  }
+
+  // ---------- flat rows (patched nix without --graph) ----------
+
+  /// The store path a row identifies: the drv for a build, the store path for a
+  /// substitution. Either can be null on a drifted entry, so fall back to the
+  /// other and finally to a placeholder rather than rendering `null`.
+  function pathOf(build: GlobalBuild): string {
+    return build.drvPath ?? build.storePath ?? '(unknown)';
+  }
+
+  /// Stable row key. The same derivation can be running under two
+  /// coordinators, so the path alone would collide.
+  function rowKey(build: GlobalBuild): string {
+    return `${pathOf(build)}:${String(build.pid ?? 0)}`;
+  }
+
+  /// Builds grouped by the client user that requested them, so the panel
+  /// answers "who started this" before "what is it". Null users pool under one
+  /// unattributed group (a local store without a daemon records no client).
+  type UserGroup = Readonly<{
+    user: string | null;
+    label: string;
+    builds: readonly GlobalBuild[];
+  }>;
+
+  const groups = $derived(groupByUser(global.builds));
+
+  /// Group headers only earn their row when they attribute something: several
+  /// users, or one *known* user. A single anonymous group would just say
+  /// "unattributed" above every row.
+  const showGroups = $derived(groups.length > 1 || groups.some((group) => group.user !== null));
+
+  function groupByUser(builds: readonly GlobalBuild[]): UserGroup[] {
+    const buckets: { user: string | null; label: string; builds: GlobalBuild[] }[] = [];
+    for (const build of builds) {
+      const bucket = buckets.find((candidate) => candidate.user === build.user);
+      if (bucket === undefined) {
+        buckets.push({ user: build.user, label: build.user ?? 'unattributed', builds: [build] });
+      } else {
+        bucket.builds.push(build);
+      }
+    }
+    for (const bucket of buckets) {
+      // Oldest first within a group: long-running work floats to the top, and
+      // rows keep a stable order across the two-second re-polls.
+      bucket.builds.sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0));
+    }
+    return buckets.sort(
+      (a, b) => b.builds.length - a.builds.length || a.label.localeCompare(b.label)
+    );
   }
 
   /// One hop of the provenance trail: a derivation shown by name, full path
@@ -166,7 +250,69 @@
     </PanelHeader>
 
     <div class="global-body">
-      {#if global.builds.length === 0}
+      {#if global.coordinators.length > 0}
+        {#each coordinators as view (view.key)}
+          <div class="global-group">
+            <span class="global-group-user">{view.label}</span>
+            <span class="global-group-count">{forestCounts(view.forest)}</span>
+          </div>
+          {#each view.rows as row, index (`${goalKey(view, row.goal)}#${String(index)}`)}
+            {@const goal = row.goal}
+            {@const key = goalKey(view, goal)}
+            {@const parts = splitDerivation(goal.id)}
+            {@const running = goal.status === 'running'}
+            <div
+              class="global-goal"
+              class:settled={goal.status === 'done' || goal.status === 'failed'}
+              style:--goal-depth={row.depth}
+            >
+              <div class="global-row-head" title={goalTitle(goal)}>
+                <button
+                  type="button"
+                  class="twirl"
+                  class:hidden={!row.hasChildren || row.repeat}
+                  aria-label={collapsed.has(key) ? 'expand' : 'collapse'}
+                  aria-expanded={row.hasChildren && !row.repeat ? !collapsed.has(key) : undefined}
+                  tabindex={row.hasChildren && !row.repeat ? 0 : -1}
+                  onclick={() => {
+                    toggleCollapse(key);
+                  }}
+                >
+                  {!row.hasChildren || row.repeat ? '' : collapsed.has(key) ? '▸' : '▾'}
+                </button>
+                <span class="state" data-state={DOT_STATE[goal.status]} title={goal.status}></span>
+                {#if goal.kind === 'substitution'}
+                  <span class="global-badge global-badge-substitution">{BADGE[goal.kind]}</span>
+                {/if}
+                <span class="global-name">{parts.name.length > 0 ? parts.name : goal.id}</span>
+                {#if parts.version.length > 0}<span class="global-version">{parts.version}</span>{/if}
+                {#if row.repeat}
+                  <span class="global-repeat" title="also shown above under another dependent">↩</span>
+                {/if}
+                {#if running && goal.kind === 'build' && goal.logFile !== null}
+                  <button
+                    type="button"
+                    class="global-log-toggle"
+                    class:open={openLog === key}
+                    aria-expanded={openLog === key}
+                    onclick={() => {
+                      toggleLog(key);
+                    }}
+                  >
+                    log
+                  </button>
+                {/if}
+                {#if running}
+                  <span class="global-elapsed">{elapsed(goal.startTime)}</span>
+                {/if}
+              </div>
+              {#if running && goal.kind === 'build' && openLog === key}
+                <GlobalLogView drvPath={goal.id} />
+              {/if}
+            </div>
+          {/each}
+        {/each}
+      {:else if global.builds.length === 0}
         <div class="global-status">no machine builds right now</div>
       {:else}
         {#each groups as group (group.label)}

--- a/packages/nix/nix-web-monitor/server/site/src/lib/global-tree.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/global-tree.ts
@@ -1,0 +1,125 @@
+/// Turns one coordinator's goal list (from `nix store builds --graph --json`)
+/// into a renderable dependency forest. Each goal's `waiters` names the goals
+/// that *want* it (edges point upward), so inverting them yields parent ->
+/// children, and the coordinator's `roots` are the goals the client asked for.
+///
+/// Mirrors `build-tree.ts` in spirit but stays a forest: a coordinator can
+/// request several roots, and unlike the invocation tree there is no synthetic
+/// command root to hang them under (the coordinator header plays that role).
+///
+/// A goal wanted by several parents (a diamond) appears under each of them,
+/// but only its first appearance expands its subtree; later appearances render
+/// as leaf references. That bounds the walk on any document, including a
+/// cyclic one a healthy nix never writes.
+
+import type { GlobalCoordinator, GlobalGoal, GlobalGoalStatus } from '$lib/types';
+
+export type GoalForest = Readonly<{
+  goalById: ReadonlyMap<string, GlobalGoal>;
+  /// Direct dependencies per goal id, in display order (running work first).
+  childrenById: ReadonlyMap<string, readonly string[]>;
+  /// The forest's top-level goal ids: the coordinator's requested roots, plus
+  /// any goal nothing waits on (so a drifted or missing roots list still
+  /// renders every goal somewhere).
+  roots: readonly string[];
+  /// Goal count per status, for the coordinator header.
+  counts: Readonly<Record<GlobalGoalStatus, number>>;
+}>;
+
+/// One visible row of the flattened forest, in render order.
+export type GoalRow = Readonly<{
+  goal: GlobalGoal;
+  depth: number;
+  /// Whether the row has children (an expand/collapse toggle earns its spot).
+  hasChildren: boolean;
+  /// A repeat appearance of a goal already expanded above (a diamond); the row
+  /// renders without descendants and without a toggle.
+  repeat: boolean;
+}>;
+
+/// Display order within one parent: live work first, then queued, then the
+/// session's completed record; name for a stable tie-break.
+const STATUS_ORDER: Record<GlobalGoalStatus, number> = {
+  running: 0,
+  waiting: 1,
+  other: 2,
+  done: 3,
+  failed: 3
+};
+
+export function buildGoalForest(coordinator: GlobalCoordinator): GoalForest {
+  const goalById = new Map<string, GlobalGoal>();
+  const counts: Record<GlobalGoalStatus, number> = {
+    waiting: 0,
+    running: 0,
+    done: 0,
+    failed: 0,
+    other: 0
+  };
+  for (const goal of coordinator.goals) {
+    // An id-less goal (a drifted document) cannot join the forest.
+    if (goal.id.length === 0) continue;
+    goalById.set(goal.id, goal);
+    counts[goal.status] += 1;
+  }
+
+  const children = new Map<string, string[]>();
+  const hasParent = new Set<string>();
+  for (const goal of goalById.values()) {
+    for (const waiter of goal.waiters) {
+      // Ignore edges into goals the document does not list; the writer only
+      // emits known ids, but this keeps the view honest if that ever drifts.
+      if (!goalById.has(waiter)) continue;
+      const deps = children.get(waiter) ?? [];
+      deps.push(goal.id);
+      children.set(waiter, deps);
+      hasParent.add(goal.id);
+    }
+  }
+
+  const order = (ids: string[]): string[] =>
+    ids.sort((left, right) => {
+      const a = goalById.get(left);
+      const b = goalById.get(right);
+      if (a === undefined || b === undefined) return left.localeCompare(right);
+      return STATUS_ORDER[a.status] - STATUS_ORDER[b.status] || left.localeCompare(right);
+    });
+
+  const childrenById = new Map<string, readonly string[]>();
+  for (const [parent, deps] of children) childrenById.set(parent, order(deps));
+
+  // Requested roots first (in the coordinator's order), then any orphan goal
+  // nothing waits on, so the forest always covers every listed goal.
+  const roots = coordinator.roots.filter((root) => goalById.has(root));
+  const inRoots = new Set(roots);
+  const orphans = order(
+    [...goalById.keys()].filter((id) => !hasParent.has(id) && !inRoots.has(id))
+  );
+  return { goalById, childrenById, roots: [...roots, ...orphans], counts };
+}
+
+/// Pre-order walk of the rows the forest currently shows. `isCollapsed`
+/// answers per goal id (a collapsed goal keeps its own row but hides its
+/// descendants); a predicate rather than a set because the caller keys its
+/// collapse state per coordinator. A goal already expanded earlier in the walk
+/// is not re-entered (diamond/cycle guard), matching the patched nix's own
+/// human forest rendering.
+export function flattenGoalForest(
+  forest: GoalForest,
+  isCollapsed: (id: string) => boolean
+): readonly GoalRow[] {
+  const rows: GoalRow[] = [];
+  const expanded = new Set<string>();
+  const walk = (id: string, depth: number): void => {
+    const goal = forest.goalById.get(id);
+    if (goal === undefined) return;
+    const childIds = forest.childrenById.get(id) ?? [];
+    const repeat = expanded.has(id);
+    rows.push({ goal, depth, hasChildren: childIds.length > 0, repeat });
+    if (repeat || isCollapsed(id)) return;
+    expanded.add(id);
+    for (const child of childIds) walk(child, depth + 1);
+  };
+  for (const root of forest.roots) walk(root, 0);
+  return rows;
+}

--- a/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/monitor-transport.ts
@@ -68,7 +68,7 @@ function createWorking(): Working {
       currentPath: null,
       hotPaths: []
     },
-    global: { detected: false, builds: [], status: '' },
+    global: { detected: false, builds: [], coordinators: [], status: '' },
     activation: { active: false, command: '', steps: [], status: '' },
     diff: null,
     expected: {},

--- a/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
+++ b/packages/nix/nix-web-monitor/server/site/src/lib/types.ts
@@ -87,6 +87,38 @@ export const globalWhySchema = v.object({
 /// reaches the wire, so the wire value is a closed set.
 export const globalBuildKindSchema = v.picklist(['build', 'substitution', 'other']);
 
+/// Lifecycle state of one goal in a coordinator's graph. Mirrors the Rust
+/// `GlobalGoalStatus`, which folds unknown future states into `other`.
+export const globalGoalStatusSchema = v.picklist(['waiting', 'running', 'done', 'failed', 'other']);
+
+/// One goal in a coordinator's graph, from `nix store builds --graph --json`.
+/// `id` is the drv path (build) or store path (substitution); `waiters` names
+/// the goals that want this one (edges point upward, so the panel inverts them
+/// into the dependency forest). The running extras (`startTime` in unix
+/// *seconds*, `logFile`, `builderPid`) are null on non-running goals. Mirrors
+/// the Rust `GlobalGoal`.
+export const globalGoalSchema = v.object({
+  id: v.string(),
+  kind: globalBuildKindSchema,
+  status: globalGoalStatusSchema,
+  waiters: v.array(v.string()),
+  outputs: v.array(v.string()),
+  startTime: v.nullable(v.number()),
+  logFile: v.nullable(v.string()),
+  builderPid: v.nullable(v.number())
+});
+
+/// One coordinating nix process and its whole goal graph: the requested roots
+/// plus every goal it knows (waiting, running, and session-completed). Mirrors
+/// the Rust `GlobalCoordinator`.
+export const globalCoordinatorSchema = v.object({
+  pid: v.nullable(v.number()),
+  user: v.nullable(v.string()),
+  uid: v.nullable(v.number()),
+  roots: v.array(v.string()),
+  goals: v.array(globalGoalSchema)
+});
+
 /// One active build or substitution goal on the machine, from the patched-nix
 /// `nix store builds --json` subcommand. Mirrors the Rust `GlobalBuild`; a
 /// substitution has a null `drvPath` and sets `storePath`. `startTime` is unix
@@ -111,6 +143,9 @@ export const globalBuildSchema = v.object({
 export const globalBuildsSchema = v.object({
   detected: v.boolean(),
   builds: v.array(globalBuildSchema),
+  /// Per-coordinator goal graphs; empty on a patched nix without `--graph`,
+  /// in which case the panel falls back to the flat `builds` rows.
+  coordinators: v.array(globalCoordinatorSchema),
   status: v.string()
 });
 
@@ -246,6 +281,9 @@ export type DaemonHotPath = v.InferOutput<typeof daemonHotPathSchema>;
 export type DaemonInfo = v.InferOutput<typeof daemonInfoSchema>;
 export type GlobalWhy = v.InferOutput<typeof globalWhySchema>;
 export type GlobalBuildKind = v.InferOutput<typeof globalBuildKindSchema>;
+export type GlobalGoalStatus = v.InferOutput<typeof globalGoalStatusSchema>;
+export type GlobalGoal = v.InferOutput<typeof globalGoalSchema>;
+export type GlobalCoordinator = v.InferOutput<typeof globalCoordinatorSchema>;
 export type GlobalBuild = v.InferOutput<typeof globalBuildSchema>;
 export type GlobalBuilds = v.InferOutput<typeof globalBuildsSchema>;
 export type ActivationStep = v.InferOutput<typeof activationStepSchema>;
@@ -288,7 +326,7 @@ export const EMPTY_SNAPSHOT: MonitorSnapshot = Object.freeze({
       currentPath: null,
       hotPaths: []
     },
-  global: { detected: false, builds: [], status: '' },
+  global: { detected: false, builds: [], coordinators: [], status: '' },
   activation: { active: false, command: '', steps: [], status: '' },
   diff: null,
   expected: {},

--- a/packages/nix/nix-web-monitor/server/site/src/style.css
+++ b/packages/nix/nix-web-monitor/server/site/src/style.css
@@ -746,6 +746,29 @@ main.dragging-v .splitter-v::after {
   color: var(--panel);
 }
 
+/* One goal row of a coordinator's dependency forest (graph-capable patched
+ * nix). Indented by tree depth; tighter than the flat `.global-row` since a
+ * forest shows many more rows and position already carries the why. */
+.global-goal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding-left: calc(var(--goal-depth, 0) * 0.9rem);
+}
+
+/* Session-completed goals are the record, not the live work: keep them
+ * legible but recessive, like the invocation tree's planned rows. */
+.global-goal.settled {
+  opacity: 0.55;
+}
+
+/* A diamond's repeat appearance: the goal already expanded above under
+ * another dependent, so this row is a reference, not a subtree. */
+.global-repeat {
+  flex: 0 0 auto;
+  color: var(--faint);
+}
+
 /* The provenance trail: "for <root> via <hop> → <hop>". Root-first so the
  * attribution survives the end-of-line truncation. */
 .global-why {

--- a/packages/nix/nix-web-monitor/server/src/global.rs
+++ b/packages/nix/nix-web-monitor/server/src/global.rs
@@ -26,8 +26,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
-use nix_web_monitor_parser::global::parse_builds;
-use nix_web_monitor_parser::{GlobalBuild, GlobalBuilds, MonitorState};
+use nix_web_monitor_parser::global::{flatten_graph, parse_builds, parse_graph};
+use nix_web_monitor_parser::{GlobalBuild, GlobalBuilds, GlobalCoordinator, MonitorState};
 use tokio::process::Command;
 use tokio::sync::{RwLock, broadcast};
 
@@ -56,7 +56,7 @@ const LOG_TAIL_BYTES: usize = 64 * 1024;
 /// panel shows (or a hidden panel) and the loop retries.
 pub async fn run_global_probe(monitor: Arc<RwLock<MonitorState>>, deltas: broadcast::Sender<Bytes>) {
     loop {
-        let Some(builds) = poll_builds().await else {
+        let Some(global) = poll_view().await else {
             // Undetected: publish the undetected view once (its `Default` carries
             // the "not available" status) so a later detection can flip the panel
             // on, then back off before re-probing.
@@ -64,59 +64,88 @@ pub async fn run_global_probe(monitor: Arc<RwLock<MonitorState>>, deltas: broadc
             tokio::time::sleep(RETRY_INTERVAL).await;
             continue;
         };
-        let status = format!("{} active", builds.len());
-        let global = GlobalBuilds {
-            detected: true,
-            builds,
-            status,
-        };
         publish(&monitor, &deltas, global).await;
         tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
 
-/// Run `nix store builds --json` and parse its output into a build list, or
-/// `None` when the subcommand is unavailable (stock nix) or errored.
+/// The invocation variants per view. The patched command is gated behind the
+/// `build-status-dir` experimental feature, so the feature-enabling form is the
+/// one that normally succeeds and goes first (one subprocess per tick on a
+/// patched nix). The plain form is the fallback for a nix that rejects the
+/// unknown feature name but has the command ungated or the feature enabled via
+/// nix.conf.
+const FEATURE_VARIANTS: [&[&str]; 2] = [
+    &["--extra-experimental-features", "nix-command build-status-dir"],
+    &["--extra-experimental-features", "nix-command"],
+];
+
+/// Poll the machine-wide view, preferring the goal-graph form.
 ///
-/// Detection is by *result*, not by exit-code text-matching: whatever variant of
-/// the invocation yields a parseable JSON array wins. A stock nix prints an
-/// "unknown command" / "unknown experimental feature" error to stderr (not a
-/// JSON array), so every variant fails to parse and this returns `None` ->
-/// undetected.
-async fn poll_builds() -> Option<Vec<GlobalBuild>> {
-    // The patched command is gated behind the `build-status-dir` experimental
-    // feature, so the feature-enabling form is the one that normally succeeds
-    // and goes first (one subprocess per tick on a patched nix). The plain form
-    // is the fallback for a nix that rejects the unknown feature name but has
-    // the command ungated or the feature enabled via nix.conf.
-    const ATTEMPTS: [&[&str]; 2] = [
-        &[
-            "store",
-            "builds",
-            "--json",
-            "--extra-experimental-features",
-            "nix-command build-status-dir",
-        ],
-        &["store", "builds", "--json", "--extra-experimental-features", "nix-command"],
-    ];
-    for args in ATTEMPTS {
-        if let Some(builds) = try_builds(args).await {
-            return Some(builds);
+/// `--graph --json` carries strictly more (every coordinator's waiting,
+/// running and completed goals with dependency edges), and the flat build list
+/// is derived from it with [`flatten_graph`], the same flattening the patched
+/// nix applies for plain `--json`, so one subprocess feeds both the forest and
+/// the flat rows. A patched nix that predates `--graph` rejects the flag; the
+/// probe then falls back to the flat form and leaves `coordinators` empty.
+/// `None` when nothing answers (stock nix): undetected.
+///
+/// Detection is by *result*, not by exit-code text-matching: whatever variant
+/// of the invocation yields a parseable payload wins. A stock nix prints an
+/// "unknown command" / "unknown experimental feature" error to stderr (not
+/// JSON), so every variant fails to parse.
+async fn poll_view() -> Option<GlobalBuilds> {
+    for feature_args in FEATURE_VARIANTS {
+        if let Some(coordinators) = try_graph(feature_args).await {
+            let builds = flatten_graph(&coordinators);
+            return Some(GlobalBuilds {
+                detected: true,
+                status: format!("{} active", builds.len()),
+                builds,
+                coordinators,
+            });
+        }
+    }
+    for feature_args in FEATURE_VARIANTS {
+        if let Some(builds) = try_builds(feature_args).await {
+            return Some(GlobalBuilds {
+                detected: true,
+                status: format!("{} active", builds.len()),
+                builds,
+                coordinators: Vec::new(),
+            });
         }
     }
     None
 }
 
-/// Run one `nix` argument variant and return the parsed builds if its stdout is
-/// a JSON build array. Any spawn failure, or output that is not a build array,
-/// yields `None` so the caller falls through to the next variant / undetected.
-async fn try_builds(args: &[&str]) -> Option<Vec<GlobalBuild>> {
-    let output = Command::new("nix").args(args).output().await.ok()?;
-    // Parse stdout regardless of exit status: a patched nix might print the array
-    // and still exit nonzero on some warning, and a stock nix prints its error to
-    // stderr with empty stdout, so the parse is the real detector.
-    let stdout = String::from_utf8_lossy(&output.stdout);
+/// Run `nix store builds --graph --json` with one feature variant and return
+/// the parsed coordinators if its stdout is a graph document.
+async fn try_graph(feature_args: &[&str]) -> Option<Vec<GlobalCoordinator>> {
+    let stdout = run_nix(&["store", "builds", "--graph", "--json"], feature_args).await?;
+    parse_graph(stdout.trim()).ok()
+}
+
+/// Run `nix store builds --json` with one feature variant and return the parsed
+/// builds if its stdout is a JSON build array.
+async fn try_builds(feature_args: &[&str]) -> Option<Vec<GlobalBuild>> {
+    let stdout = run_nix(&["store", "builds", "--json"], feature_args).await?;
     parse_builds(stdout.trim()).ok()
+}
+
+/// Spawn one `nix` invocation and capture its stdout. Any spawn failure yields
+/// `None` so the caller falls through to the next variant / undetected.
+async fn run_nix(args: &[&str], feature_args: &[&str]) -> Option<String> {
+    let output = Command::new("nix")
+        .args(args)
+        .args(feature_args)
+        .output()
+        .await
+        .ok()?;
+    // Return stdout regardless of exit status: a patched nix might print the
+    // payload and still exit nonzero on some warning, and a stock nix prints
+    // its error to stderr with empty stdout, so the parse is the real detector.
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 /// Push a machine-wide build view to the monitor and broadcast the change.
@@ -294,6 +323,7 @@ mod tests {
             detected: true,
             status: format!("{} active", builds.len()),
             builds,
+            coordinators: Vec::new(),
         };
 
         assert_eq!(global.builds.len(), 2);
@@ -423,6 +453,7 @@ mod tests {
         state.set_global(GlobalBuilds {
             detected: true,
             builds: vec![with_log, without_log],
+            coordinators: Vec::new(),
             status: "2 active".to_owned(),
         });
         let monitor = Arc::new(RwLock::new(state));

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -1428,6 +1428,7 @@ mod tests {
                     log_file: Some(log_path.to_string_lossy().into_owned()),
                     ..nix_web_monitor_parser::GlobalBuild::default()
                 }],
+                coordinators: Vec::new(),
                 status: "1 active".to_owned(),
             },
         );


### PR DESCRIPTION
Stacked on #2507 (lands after it merges; will be retargeted/rebased onto `main` then).

Renders the new per-coordinator goal graph from `nix store builds --graph --json` (#2485) in nix-web-monitor.

## Parser (`nix-web-monitor-parser`)
- Tolerant serde types for the graph document: `GlobalCoordinator`, `GlobalGoal`, `GlobalGoalStatus` (unknown statuses fold into `Other`).
- `parse_graph` (with an explicit is-object guard: serde otherwise accepts `[]` as an all-default struct) and `flatten_graph`, a pure mirror of the C++ `flattenCoordinator`, so the flat `GlobalBuild` rows stay available from graph input. 6 new tests.

## Server
- The probe prefers `nix store builds --graph --json` and falls back to the flat `--json` shape on older nix (detection by result, no version sniffing).

## UI
- When coordinators are present, the panel renders a collapsible forest per coordinator (user · pid header with status counts): waiting/running/done/failed dots, elapsed clocks and a log drawer on running builds, substitution badges, and a `↩` marker on diamond re-visits. Collapse state is keyed per coordinator.
- The flat rows remain the fallback rendering for older nix.

## Validation
- `cargo nextest run -p nix-web-monitor-parser -p nix-web-monitor`: 98/98 pass.
- `svelte-check` 0 errors, eslint clean, vite build green.
- e2e against hand-written `graph-<pid>.json` fixtures under a scratch `NIX_STATE_DIR` (pid-1 liveness trick): both coordinators render, collapse hides subtrees (8 -> 6 -> 2 rows), log drawer streams, dead-pid files are pruned.

Refs #2485.

Assisted-by: Claude (Claude Code, model claude-opus-4-6)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render the nix-web-monitor machine-build goal graph as a per-coordinator forest
> - Adds server-side parsing of `nix store builds --graph --json` payloads via `parse_graph` and `flatten_graph` in [parser/src/global.rs](https://github.com/indexable-inc/index/pull/2515/files#diff-a8aef52744a31d4a9a38106f9fae9b6fc0cbf10a6842b15bce0d8b5fb81c8085), producing a `GlobalCoordinator`/`GlobalGoal` type hierarchy.
> - The server in [server/src/global.rs](https://github.com/indexable-inc/index/pull/2515/files#diff-4820d587d4c1c1d078b1a44dc5322acedb592ec373035bd38ff4634e02411c8e) now prefers the graph endpoint and falls back to flat `nix store builds --json` when graph is unsupported.
> - The frontend in [GlobalPanel.svelte](https://github.com/indexable-inc/index/pull/2515/files#diff-63da9d7b5d9bdbad3545513615466f2adc45a723a375562faf1fd67c98d7586d) renders a per-coordinator dependency forest with indentation, expand/collapse for shared dependencies, state dots, substitution badges, elapsed time, and log controls when coordinators are present; falls back to flat rows otherwise.
> - New [global-tree.ts](https://github.com/indexable-inc/index/pull/2515/files#diff-41ad4aba25ebbbffe6083c50aaf571035a62c0b3aa2137b36518ca5979c5f20e) module handles forest construction and pre-order flattening with cycle/diamond safety.
> - Behavioral Change: `GlobalBuilds` now always includes a `coordinators` field (empty array when graph is unavailable); clients consuming the wire schema must handle the new field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4798ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->