### PR TITLE
mcp: name the bindings a failed cell never reached

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3051,7 +3051,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3089,6 +3089,8 @@
       cp ${./tests/test_kernel_trace_path.py} test_kernel_trace_path.py
       # Issue #2430: a cell rebinding/deleting a kernel builtin gets it restored.
       cp ${./tests/test_builtin_shadow_restore.py} test_builtin_shadow_restore.py
+      # Issue #2526: a failed cell's traceback names the bindings it never reached.
+      cp ${./tests/test_unexecuted_note.py} test_unexecuted_note.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
@@ -3102,6 +3104,7 @@
         test_build_info.py \
         test_kernel_trace_path.py \
         test_builtin_shadow_restore.py \
+        test_unexecuted_note.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/ix_notebook_mcp/introspect.py
+++ b/packages/mcp/ix_notebook_mcp/introspect.py
@@ -142,6 +142,164 @@ def binding_names(code: str) -> tuple[set[str], set[str]]:
     return assigned, used
 
 
+
+def unexecuted_bindings(code: str, stop_line: int) -> list[str]:
+    """The names ``code`` binds at module scope that a run stopped on
+    ``stop_line`` never (re)bound, in source order (issue #2526).
+
+    ``stop_line`` is the top-level cell line that was executing when the cell's
+    exception escaped. Every statement that completed strictly before it did its
+    binding; the statement in flight and everything after it did not, so those
+    targets keep whatever value an earlier run left -- the stale-state trap the
+    failure note warns about. The walk is static and best-effort:
+
+    - A statement counts once its extent reaches ``stop_line``
+      (``end_lineno >= stop_line``), so a multi-line assignment that failed
+      inside its value expression still reports its target.
+    - Compound statements recurse into their blocks; their header bindings (a
+      ``for`` target, ``with ... as``) count only when the header itself is the
+      stop line, because a failure inside the body means the header already
+      bound this iteration's value.
+    - ``def``/``class`` bodies never contribute (those are locals); the
+      def/class *name* is the module-scope binding and counts like any other.
+    - Untaken branches are indistinguishable statically, so an ``if``/``except``
+      arm past the stop line is included even when the run would have skipped
+      it: over-warning beats silently missing a stale name.
+
+    Returns ``[]`` for code that does not parse (a SyntaxError's traceback
+    already shows the offending line, and nothing at all ran)."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+    out: list[str] = []
+    _unexecuted_in(tree.body, stop_line, out)
+    return out
+
+
+def _unexecuted_in(stmts: list[ast.stmt], stop_line: int, out: list[str]) -> None:
+    """Collect into ``out`` the bindings in ``stmts`` execution stopped before;
+    see :func:`unexecuted_bindings` for the rules."""
+    for stmt in stmts:
+        if (stmt.end_lineno or stmt.lineno) < stop_line:
+            continue  # completed before execution reached the stop line
+        if isinstance(stmt, (ast.For, ast.AsyncFor)):
+            if stmt.lineno >= stop_line:
+                # Stopped on the header: this pass never bound the target. A
+                # failure in the body (below) means the header did bind.
+                _bindings_in(stmt.target, out)
+                _bindings_in(stmt.iter, out)  # a walrus in the iterable
+            _unexecuted_in(stmt.body, stop_line, out)
+            _unexecuted_in(stmt.orelse, stop_line, out)
+        elif isinstance(stmt, (ast.While, ast.If)):
+            if stmt.lineno >= stop_line:
+                _bindings_in(stmt.test, out)  # a walrus in the condition
+            _unexecuted_in(stmt.body, stop_line, out)
+            _unexecuted_in(stmt.orelse, stop_line, out)
+        elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+            if stmt.lineno >= stop_line:
+                for item in stmt.items:
+                    _bindings_in(item.context_expr, out)
+                    if item.optional_vars is not None:
+                        _bindings_in(item.optional_vars, out)
+            _unexecuted_in(stmt.body, stop_line, out)
+        elif isinstance(stmt, (ast.Try, ast.TryStar)):
+            _unexecuted_in(stmt.body, stop_line, out)
+            for handler in stmt.handlers:
+                if handler.name and handler.lineno >= stop_line:
+                    _note(handler.name, out)
+                _unexecuted_in(handler.body, stop_line, out)
+            _unexecuted_in(stmt.orelse, stop_line, out)
+            _unexecuted_in(stmt.finalbody, stop_line, out)
+        elif isinstance(stmt, ast.Match):
+            for case in stmt.cases:
+                if case.pattern.lineno >= stop_line:
+                    _bindings_in(case.pattern, out)  # capture patterns bind
+                _unexecuted_in(case.body, stop_line, out)
+        elif isinstance(stmt, ast.AnnAssign) and stmt.value is None:
+            continue  # a bare `x: T` annotates without binding
+        else:
+            # A simple statement (or a def/class) whose extent reaches the stop
+            # line: in flight or never reached, so none of its bindings landed.
+            _bindings_in(stmt, out)
+
+
+def _note(name: str, out: list[str]) -> None:
+    if name not in out:
+        out.append(name)
+
+
+def _bindings_in(node: ast.AST, out: list[str]) -> None:
+    _Bindings(out).visit(node)
+
+
+class _Bindings(ast.NodeVisitor):
+    """Every module-scope name a node binds, appended to ``out`` in source
+    order. Function/class/lambda bodies are private scopes and are not entered
+    (the def/class *name* is the enclosing scope's binding). Comprehension
+    targets do not leak either, but a walrus inside one binds the enclosing
+    scope (PEP 572), so comprehensions are entered minus their targets."""
+
+    def __init__(self, out: list[str]) -> None:
+        self.out = out
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            _note(node.id, self.out)
+
+    def visit_alias(self, node: ast.alias) -> None:
+        _note(node.asname or node.name.split(".", 1)[0], self.out)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        _note(node.name, self.out)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        _note(node.name, self.out)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        _note(node.name, self.out)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        """A lambda body is its own scope; nothing in it binds ours."""
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.name:
+            _note(node.name, self.out)
+        self.generic_visit(node)
+
+    def visit_MatchAs(self, node: ast.MatchAs) -> None:
+        if node.name:
+            _note(node.name, self.out)
+        self.generic_visit(node)
+
+    def visit_MatchStar(self, node: ast.MatchStar) -> None:
+        if node.name:
+            _note(node.name, self.out)
+
+    def visit_MatchMapping(self, node: ast.MatchMapping) -> None:
+        if node.rest:
+            _note(node.rest, self.out)
+        self.generic_visit(node)
+
+    def _visit_comprehension(
+        self, node: ast.ListComp | ast.SetComp | ast.GeneratorExp | ast.DictComp
+    ) -> None:
+        if isinstance(node, ast.DictComp):
+            self.visit(node.key)
+            self.visit(node.value)
+        else:
+            self.visit(node.elt)
+        for gen in node.generators:
+            self.visit(gen.iter)
+            for cond in gen.ifs:
+                self.visit(cond)
+
+    visit_ListComp = _visit_comprehension
+    visit_SetComp = _visit_comprehension
+    visit_GeneratorExp = _visit_comprehension
+    visit_DictComp = _visit_comprehension
+
+
 def describe(value: Any) -> dict:
     """A compact descriptor for one live value.
 

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2485,6 +2485,50 @@ def _error_line(exc: BaseException, job: Job) -> int | None:
     return line
 
 
+def _cell_stop_line(exc: BaseException, job: Job) -> int | None:
+    """The top-level cell line executing when ``exc`` escaped: the shallowest
+    traceback frame in this job's pseudo-file. Distinct from :func:`_error_line`
+    (the deepest cell frame, for the dashboard's highlight): a failure inside a
+    function the cell defined stops the cell at the call site, and it is the
+    call site that decides which later top-level statements never ran."""
+    target = f"<job {job.id}>"
+    tb = exc.__traceback__
+    while tb is not None:
+        if tb.tb_frame.f_code.co_filename == target:
+            return tb.tb_lineno
+        tb = tb.tb_next
+    return None
+
+
+def _unexecuted_note(exc: BaseException, job: Job) -> str:
+    """A one-line warning naming the bindings the failed cell never reached
+    (issue #2526). A cell that raises partway through leaves every assignment
+    at/after the failing statement unexecuted while the namespace keeps the old
+    values, so a retry cell that reuses those names silently operates on stale
+    state (the incident: a rebuilt email reused the previous run's ``body`` and
+    sent a duplicate). Static and best-effort (see
+    :func:`introspect.unexecuted_bindings`); empty when nothing at/after the
+    failure binds a name."""
+    line = _cell_stop_line(exc, job)
+    if line is None:
+        return ""
+    try:
+        from .introspect import unexecuted_bindings
+
+        names = unexecuted_bindings(job.code, line)
+    except Exception:
+        # Best-effort: a failure here just means no note.
+        return ""
+    if not names:
+        return ""
+    return (
+        "\nNOTE: this cell failed before updating: "
+        + ", ".join(names)
+        + " (their current values, if any, predate this cell; rebuild them "
+        + "before reuse)."
+    )
+
+
 def _typecheck_enabled() -> bool:
     """Whether per-cell type checking runs. Default ON; the escape hatch is the
     ``IX_MCP_TYPECHECK`` env var (``0``/``false``/``no``/``off`` disables it) or,
@@ -2636,7 +2680,7 @@ async def _runner(job: Job, ns: dict) -> None:
         else:
             # The user's own code raised KeyboardInterrupt; keep its real
             # traceback (trimmed to the cell's frames) and the failing line.
-            job.error = _user_traceback(_kexc)
+            job.error = _user_traceback(_kexc) + _unexecuted_note(_kexc, job)
             job.error_line = _error_line(_kexc, job)
             job._exc = _kexc
         job._exc_tb = _kexc.__traceback__
@@ -2653,7 +2697,7 @@ async def _runner(job: Job, ns: dict) -> None:
         tb = _user_traceback(_exc)
         job.error_line = _error_line(_exc, job)
         hint = _type_error_hint(_exc) if isinstance(_exc, TypeError) else ""
-        job.error = tb + hint
+        job.error = tb + hint + _unexecuted_note(_exc, job)
         # Keep the exception object itself, so `await jobs['<id>']` re-raises it
         # (type + message + the cell's own traceback) instead of yielding None.
         job._exc = _exc

--- a/packages/mcp/tests/test_unexecuted_note.py
+++ b/packages/mcp/tests/test_unexecuted_note.py
@@ -1,0 +1,141 @@
+"""A failed cell names the bindings it never reached (issue #2526).
+
+A cell that raises partway through leaves every assignment at/after the failing
+statement unexecuted while the namespace keeps the old values; a retry cell that
+reuses those names silently operates on stale state (the incident: a rebuilt
+email reused the previous run's ``body`` and sent a vendor rep a duplicate).
+The runner now appends ``NOTE: this cell failed before updating: ...`` to the
+traceback, computed statically by :func:`introspect.unexecuted_bindings` from
+the top-level line execution stopped on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ix_notebook_mcp import runtime
+from ix_notebook_mcp.introspect import unexecuted_bindings
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict) -> None:
+    # The note is an execution-time diagnostic; disable the per-cell type check
+    # so deliberately type-wrong cells (the TypeError-hint case) still run.
+    monkeypatch.setenv("IX_MCP_TYPECHECK", "0")
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+
+
+def _run(code: str) -> runtime.Job:
+    return asyncio.run(runtime.__ix_run(code, budget=5.0))
+
+
+class TestUnexecutedBindings:
+    """The static walk: which names a run stopped on a line never (re)bound."""
+
+    def test_names_at_and_after_the_stop_line(self) -> None:
+        code = "existing = 'old'\nraise KeyError('Message-ID')\nbody = 'x'\nmsg = body\n"
+        assert unexecuted_bindings(code, 2) == ["body", "msg"]
+
+    def test_multiline_assignment_straddling_the_failure_reports_its_target(self) -> None:
+        # The target's own lineno is BEFORE the failing expression line; the
+        # statement extent is what decides.
+        code = "x = (\n    1 / 0\n)\ny = 2\n"
+        assert unexecuted_bindings(code, 1) == ["x", "y"]
+
+    def test_def_bodies_are_locals_not_cell_bindings(self) -> None:
+        code = "def f():\n    inner = 1\n    raise ValueError\nx = 1\ny = f()\nz = 2\n"
+        # Stop line 5 is the call site; f and x already bound, inner is a local.
+        assert unexecuted_bindings(code, 5) == ["y", "z"]
+
+    def test_loop_target_bound_when_the_body_fails(self) -> None:
+        # A failure inside the body means the header bound this iteration.
+        assert unexecuted_bindings("for i in range(3):\n    acc = 1 / 0\ndone = True\n", 2) == [
+            "acc",
+            "done",
+        ]
+        # Stopping on the header itself means the target never (re)bound.
+        assert unexecuted_bindings("for i in bad():\n    acc = i\ndone = True\n", 1) == [
+            "i",
+            "acc",
+            "done",
+        ]
+
+    def test_comprehension_targets_do_not_leak_but_walrus_does(self) -> None:
+        code = "raise ValueError\nrows = [r for r in data]\ntotal = (t := sum(rows))\n"
+        assert unexecuted_bindings(code, 1) == ["rows", "total", "t"]
+
+    def test_import_def_and_class_names_count(self) -> None:
+        code = "raise ValueError\nimport json as j\ndef g(): pass\nclass C: pass\n"
+        assert unexecuted_bindings(code, 1) == ["j", "g", "C"]
+
+    def test_unparseable_code_yields_nothing(self) -> None:
+        assert unexecuted_bindings("def broken(:\n", 1) == []
+
+
+class TestFailureNote:
+    """The runner appends the note to the traceback of a failed cell."""
+
+    def test_incident_shape_names_the_stale_bindings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The 2026-07-08 incident: a raise before `body = ...` left the previous
+        # run's body in the namespace and the retry sent a duplicate email.
+        _wire(monkeypatch, {})
+        job = _run(
+            "existing = 'old'\n"
+            "raise KeyError('Message-ID')\n"
+            "body = 'Following up'\n"
+            "msg = body\n"
+        )
+        assert job.status == "error"
+        assert job.error is not None
+        assert "NOTE: this cell failed before updating: body, msg" in job.error
+
+    def test_failure_inside_a_cell_defined_function_stops_at_the_call_site(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The deepest cell frame is inside f's body; the note must key off the
+        # top-level call site, not list f's locals or already-run assignments.
+        _wire(monkeypatch, {})
+        job = _run(
+            "def f():\n"
+            "    inner = 1\n"
+            "    raise ValueError('boom')\n"
+            "x = 1\n"
+            "y = f()\n"
+            "z = 2\n"
+        )
+        assert job.status == "error"
+        assert job.error is not None
+        assert "NOTE: this cell failed before updating: y, z" in job.error
+        assert "inner" not in job.error.split("NOTE:")[1]
+
+    def test_no_note_when_nothing_after_the_failure_binds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _wire(monkeypatch, {})
+        job = _run("x = 1\nraise ValueError('boom')\n")
+        assert job.status == "error"
+        assert job.error is not None
+        assert "NOTE:" not in job.error
+
+    def test_note_rides_after_the_typeerror_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Both diagnostics apply: the signature hint, then the stale-binding note.
+        def kw_target(*, query: str) -> None:
+            pass
+
+        _wire(monkeypatch, {"kw_target": kw_target})
+        job = _run("out = kw_target(bad_kwarg=1)\nsent = out\n")
+        assert job.status == "error"
+        assert job.error is not None
+        assert "NOTE: this cell failed before updating: out, sent" in job.error
+        if "Hint:" in job.error:
+            assert job.error.index("Hint:") < job.error.index("NOTE:")
+
+    def test_generator_cell_gets_the_note_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A yielding cell runs as __ix_cell__ with original line numbers; the
+        # note must work through that frame as well.
+        _wire(monkeypatch, {})
+        job = _run("yield 1\nraise ValueError('boom')\nlater = 2\n")
+        assert job.status == "error"
+        assert job.error is not None
+        assert "NOTE: this cell failed before updating: later" in job.error


### PR DESCRIPTION
A cell that raises partway through leaves every assignment at/after the failing statement unexecuted while the namespace keeps the old bindings; a retry cell that reuses those names silently operates on stale state (the 2026-07-08 incident: a `KeyError` before `body = ...` left the previous email in `body` and the retry sent a vendor rep a duplicate).

On a cell exception the runner now appends a note to the traceback:

```
NOTE: this cell failed before updating: body, msg (their current values, if any, predate this cell; rebuild them before reuse).
```

- `introspect.unexecuted_bindings(code, stop_line)`: static walk of the cell AST for the module-scope names not (re)bound once execution stopped on `stop_line`. Statement extent decides (a multi-line assignment failing in its value still reports its target); compound statements recurse with header bindings charged only when the header itself is the stop line; def/class bodies are locals and never contribute; comprehension targets do not leak but a walrus does.
- The stop line is the shallowest cell frame (new `_cell_stop_line`), not the deepest (`_error_line`, kept for the dashboard highlight): a failure inside a cell-defined function is charged to its call site.
- Wired into both the generic exception path (after the TypeError signature hint) and the user-raised KeyboardInterrupt path. Best-effort: unparseable code or no cell frame means no note.
- Tests: static-walk cases + runner integration (incident shape, call-site attribution, no-op when nothing follows the failure, generator cells), registered in the `typecheckSmoke` gate.

Resolves #2526

🤖 Generated with Claude Code (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add names of bindings a failed cell never reached to job error output
> - Adds `unexecuted_bindings(code, stop_line)` in [introspect.py](https://github.com/indexable-inc/index/pull/2528/files#diff-006579eb39a5fc5841047297950ecbb104d7094d82bdaec8fe1b9a4eeeda9cad) that parses cell code and returns binding names whose statements were not reached before execution stopped.
> - Adds `_cell_stop_line` in [runtime.py](https://github.com/indexable-inc/index/pull/2528/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) to extract the failure line from a traceback, and `_unexecuted_note` to format a NOTE listing stale bindings.
> - Appends the NOTE to `job.error` for both `KeyboardInterrupt` and `Exception`/`SystemExit` failures in the `_runner` coroutine.
> - Covers control flow (for/while/if/with/try/match), imports, def/class, comprehensions with walrus, and annotation assignments in the static analysis.
> - New test module [test_unexecuted_note.py](https://github.com/indexable-inc/index/pull/2528/files#diff-fb2cbd386bdbd9ed31dbd19f16d8c83e71ee8d907e7d4199a9e47dd2f178e0e1) covers both the static analysis and the runtime NOTE integration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ef4ac7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->