### PR TITLE
panes: fire frame callbacks at send; acks become an in-flight cap

### DIFF
--- a/packages/vm/panes/README.md
+++ b/packages/vm/panes/README.md
@@ -14,7 +14,7 @@ issue: [index#1686](https://github.com/indexable-inc/index/issues/1686).
 - [`protocol/`](protocol/) (`panes-protocol`): the wire format. One duplex
   byte stream (guest vsock port 7100 to a host unix socket) carrying
   length-prefixed postcard frames: damage-tiled window contents up, input and
-  configure events down, ack-driven pacing genlocked to the host display. The
+  configure events down, acks up as backpressure on the in-flight window. The
   crate doc comments are the protocol spec. Minor 1 (v1.1) adds pointer lock
   for mouse-look apps (index#1724): `ToHost::PointerLock` when a surface's
   `zwp_locked_pointer_v1` (de)activates, `ToGuest::PointerRelative` for the

--- a/packages/vm/panes/compositor/README.md
+++ b/packages/vm/panes/compositor/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="assets/hero.svg" width="720" alt="client commits are diffed in a FrameStore, encoded as LZ4 band tiles, and shipped over vsock; the host's ack on present fires the clients' frame callbacks"></p>
+<p align="center"><img src="assets/hero.svg" width="720" alt="client commits are diffed in a FrameStore, encoded as LZ4 band tiles, and shipped over vsock; frame callbacks fire at send, host acks bound the in-flight window"></p>
 
 # panes-compositor
 
@@ -9,7 +9,7 @@ Apps connect to it as a completely ordinary Wayland compositor; every
 [`panes-host`](../host), which presents each one as a native NSWindow on the
 macOS side. It composites nothing and renders nothing: it only diffs, packs,
 and ships. The wire contract lives in [`../protocol`](../protocol) (postcard
-frames, damage tiles, ack pacing); context in
+frames, damage tiles, ack backpressure); context in
 [index#1686](https://github.com/indexable-inc/index/issues/1686).
 
 ## Install
@@ -67,24 +67,26 @@ because the host owns layout entirely.
 
 ## Pacing (no timer)
 
-The compositor never runs a frame timer. At most one `WindowFrame` per
-window is in flight; commits that land meanwhile only update the
-`FrameStore`. When the host presents a frame it sends `Ack{id, seq}`
-(cumulative: the host coalesces per display tick and acks only the newest
-presented seq, so any `seq >= awaited` satisfies the wait), and the
-compositor then (1) fires the window's wl_surface frame callbacks, which
-is the client's "draw again" signal, and (2) immediately sends the coalesced
-delta if more commits arrived. The guest is thereby genlocked to the host's
-CAMetalDisplayLink (ProMotion and all) with backpressure for free: a slow
-link degrades to fewer, bigger deltas instead of a growing queue.
+The compositor never runs a frame timer. A window's wl_surface frame
+callbacks (the client's "draw again" signal) fire when its `WindowFrame`
+goes onto the wire: the frame is a compositor-owned copy by then, and
+holding the callback to the host's ack quantized clients to `refresh/n`
+whenever the host's per-frame turnaround crossed one display tick (the
+index#1686 60-acks cap on a 120 Hz display). Acks are backpressure only:
+the host sends `Ack{id, seq}` when it presents (cumulative: it coalesces
+per display tick and acks only the newest presented seq), and at most
+`MAX_INFLIGHT_FRAMES` (2) frames per window may be on the wire unacked. At
+the cap, sends -- and the callbacks fired with them -- wait for an ack to
+free a slot, so a slow link degrades to fewer, bigger deltas instead of a
+growing queue; commits that land while capped only update the `FrameStore`.
 
 Three escape hatches keep clients from wedging when no ack can come: a
 commit that produces nothing to send fires its callbacks immediately (as do
 the commit paths that never reach a pump: popups, cursor surfaces, and the
 pre-configure commit), a 10 Hz fallback ticker fires callbacks for all
 windows while no host is connected (popup surfaces, which never carry wire
-frames, always tick), and a watchdog force-releases pacing after ~1s if an
-in-flight frame's ack never arrives (the mirror is invalidated so the next
+frames, always tick), and a watchdog force-releases pacing after ~1s if the
+in-flight frames' acks never arrive (the mirror is invalidated so the next
 frame ships full).
 
 ## GPU vs shm mode

--- a/packages/vm/panes/compositor/assets/hero.svg
+++ b/packages/vm/panes/compositor/assets/hero.svg
@@ -43,5 +43,5 @@
   <rect class="box" x="610" y="70" width="90" height="64" rx="6"/>
   <text class="mono" x="655" y="107" text-anchor="middle">host</text>
   <path class="back accent" d="M 640 134 C 600 200 160 200 100 136"/>
-  <text class="accent-t" x="370" y="205" text-anchor="middle" font-size="11">Ack{id, seq} on present &#8594; fires wl_surface frame callbacks (genlocked, no timer)</text>
+  <text class="accent-t" x="370" y="205" text-anchor="middle" font-size="11">frame callback fires at send; Ack{id, seq} on present frees an in-flight slot (cap 2)</text>
 </svg>

--- a/packages/vm/panes/compositor/src/compositor/handlers.rs
+++ b/packages/vm/panes/compositor/src/compositor/handlers.rs
@@ -240,7 +240,7 @@ impl App {
                     host.send(ToHost::WindowGone { id: pane.id });
                 }
                 pane.announced = false;
-                pane.inflight = None;
+                pane.acked = pane.seq;
                 pane.inflight_ticks = 0;
                 pane.store = crate::frame::FrameStore::default();
             }

--- a/packages/vm/panes/compositor/src/compositor/mod.rs
+++ b/packages/vm/panes/compositor/src/compositor/mod.rs
@@ -4,7 +4,8 @@
 //! There is no rendering and no output device here. Client pixels are copied
 //! out of their buffers on commit, diffed, and shipped as damage tiles; the
 //! only pacing signal clients see is the `wl_surface` frame callback, fired
-//! when the host acks the frame it presented (see `pump` and `on_host_msg`).
+//! when a frame goes onto the wire (see `pump`). Host acks are backpressure
+//! only: they free slots under the [`crate::pacing::MAX_INFLIGHT_FRAMES`] cap.
 
 mod handlers;
 mod input;
@@ -48,6 +49,7 @@ use tracing::{info, warn};
 
 use crate::cli::Cli;
 use crate::frame::FrameStore;
+use crate::pacing::{apply_ack, under_inflight_cap};
 use transport::{HostEvent, HostLink, ListenSpec};
 
 /// The advertised `wl_output` mode. The output is virtual (windows are exported
@@ -60,11 +62,11 @@ const VIRTUAL_SIZE: (i32, i32) = (3840, 2160);
 /// wedging forever on a callback that would never come.
 const FALLBACK_TICK: Duration = Duration::from_millis(100);
 
-/// Watchdog: ticks (of `FALLBACK_TICK`) an in-flight frame may go unacked
-/// before pacing is force-released (~1s). Pacing is one-frame-in-flight, so a
-/// host that drops a single ack (e.g. the window is removed host-side between
-/// `set_frame` and its next display tick) would otherwise wedge that client
-/// permanently.
+/// Watchdog: ticks (of `FALLBACK_TICK`) in-flight frames may go unacked
+/// before pacing is force-released (~1s). A host that drops its acks (e.g.
+/// the window is removed host-side between `set_frame` and its next display
+/// tick) would otherwise pin the window at the in-flight cap and wedge that
+/// client permanently.
 const INFLIGHT_WATCHDOG_TICKS: u32 = 10;
 
 /// Ceiling for the watchdog's exponential backoff (~8s of `FALLBACK_TICK`s).
@@ -83,11 +85,12 @@ struct Pane {
     /// `WindowNew` sent on the *current* host connection.
     announced: bool,
     seq: u64,
-    /// Frame seq on the wire, unacked. At most one frame is in flight per
-    /// window: that is the whole pacing mechanism.
-    inflight: Option<u64>,
-    /// Fallback ticks the current in-flight frame has gone unacked; drives
-    /// the `INFLIGHT_WATCHDOG_TICKS` rescue in `on_tick`.
+    /// Newest seq the host acked. Frames in `acked+1..=seq` are on the wire
+    /// unacked; `pump` stops sending (and thus firing frame callbacks) at
+    /// `MAX_INFLIGHT_FRAMES` of them.
+    acked: u64,
+    /// Fallback ticks the in-flight frames have gone unacked since the last
+    /// send; drives the `INFLIGHT_WATCHDOG_TICKS` rescue in `on_tick`.
     inflight_ticks: u32,
     /// Ticks the watchdog currently waits before firing. Doubles on each
     /// consecutive fire (see `INFLIGHT_WATCHDOG_MAX_TICKS`); reset by a
@@ -121,7 +124,8 @@ struct Pane {
     /// hundreds of frames a second, and a per-commit readback of a 2x buffer
     /// saturates the event-loop thread -- measured live with Minecraft
     /// (index#1686): internal render at ~347fps, wire cadence collapsed to a
-    /// tick-quantized ~30 acks/s. Held unreleased so the client cannot write
+    /// tick-quantized ~30 acks/s. The readback runs in `pump`, once per WIRE
+    /// frame under the in-flight cap. Held unreleased so the client cannot write
     /// into it while a readback may still happen; a superseding commit
     /// releases it untouched (that frame is simply never sent, which is
     /// mailbox semantics).
@@ -147,7 +151,7 @@ impl Pane {
             store: FrameStore::default(),
             announced: false,
             seq: 0,
-            inflight: None,
+            acked: 0,
             inflight_ticks: 0,
             watchdog_ticks: INFLIGHT_WATCHDOG_TICKS,
             title: String::new(),
@@ -533,21 +537,24 @@ impl App {
     fn absorb_pending_gpu(&mut self, _idx: usize) {}
 
     /// Try to move one frame onto the wire for `panes[idx]`, announcing the
-    /// window first if this connection has not seen it. When there is
-    /// nothing to send, release the window's frame callbacks instead: no
-    /// frame means no ack, and without this the client would stall. The only
-    /// path that leaves callbacks pending is a frame actually in flight
-    /// (that is the throttle; the ack or its watchdog releases them).
+    /// window first if this connection has not seen it. Frame callbacks fire
+    /// here, at send (or immediately when there is nothing to send): the
+    /// host's ack never gates the client's next frame, it only frees an
+    /// in-flight slot. The only path that leaves callbacks pending is the
+    /// `MAX_INFLIGHT_FRAMES` cap (an ack or its watchdog releases it and
+    /// re-pumps).
     fn pump(&mut self, idx: usize) {
         let now = self.now_ms();
         if self.host.as_ref().is_none_or(|h| !h.ready) {
             // No ready host: the 10Hz fallback tick paces this pane.
             return;
         }
-        if self.panes[idx].inflight.is_some() {
-            // A frame is pacing the wire. Any held dmabuf stays held (and
-            // keeps being superseded by newer commits) so the readback below
-            // captures the newest content once the ack lands.
+        if !under_inflight_cap(self.panes[idx].seq, self.panes[idx].acked) {
+            // At the in-flight cap: this is the one place callbacks are
+            // withheld, so a stalled host stops the client instead of
+            // letting it run unboundedly ahead. Any held dmabuf stays held
+            // (and keeps being superseded by newer commits) so the readback
+            // below captures the newest content once an ack frees a slot.
             return;
         }
         // Pacing allows a send: absorb the newest held dmabuf now.
@@ -559,7 +566,7 @@ impl App {
         };
         if !pane.store.has_content() {
             // Content-less commits (initial pre-map commit, commit after
-            // unmap) never turn into wire frames, so nothing would ever ack
+            // unmap) never turn into wire frames, so no send would ever fire
             // their callbacks; the fallback tick only runs host-less.
             fire_frame_callbacks(pane.toplevel.wl_surface(), now);
             return;
@@ -599,12 +606,14 @@ impl App {
                 full: frame.full,
                 tiles: frame.tiles,
             });
-            pane.inflight = Some(pane.seq);
             pane.inflight_ticks = 0;
             tracing::debug!(id = pane.id, seq = pane.seq, "frame sent");
-        } else {
-            fire_frame_callbacks(pane.toplevel.wl_surface(), now);
         }
+        // Sent or nothing to send, the client may draw again now: the wire
+        // frame is a copy the store owns (shm copied at commit, dmabuf read
+        // back in absorb_pending_gpu above), so the ack it will produce is
+        // pure backpressure, not a "buffer free" signal.
+        fire_frame_callbacks(pane.toplevel.wl_surface(), now);
     }
 
     fn on_host_event(&mut self, event: HostEvent) {
@@ -637,7 +646,7 @@ impl App {
                     // sync_pointer_lock call in on_hello.
                     self.locked_pane = None;
                     for pane in &mut self.panes {
-                        pane.inflight = None;
+                        pane.acked = pane.seq;
                         pane.inflight_ticks = 0;
                         // A reconnect is a fresh link; backoff earned on the
                         // old one says nothing about it.
@@ -731,8 +740,8 @@ impl App {
         }
         info!(major, minor, refresh_mhz, scale, "host hello");
         // Advertise the host's real refresh so clients that pace themselves
-        // by wl_output pick the right budget (the actual genlock is the
-        // ack-driven frame callback, not this number).
+        // by wl_output pick the right budget (actual pacing is the frame
+        // callback fired at send under the in-flight cap, not this number).
         self.output.change_current_state(
             Some(Mode {
                 size: VIRTUAL_SIZE.into(),
@@ -777,26 +786,21 @@ impl App {
     }
 
     fn on_ack(&mut self, id: WindowId, seq: u64) {
-        let now = self.now_ms();
         let Some(idx) = self.pane_index(id) else {
             return;
         };
-        // Acks are cumulative: the host coalesces per display tick and acks
-        // only the newest presented seq, so any seq >= the awaited one
-        // satisfies the wait (an exact-match test would stall forever under
-        // coalescing). Older seqs are stale and ignored.
-        match self.panes[idx].inflight {
-            Some(awaited) if seq >= awaited => {}
-            _ => return,
-        }
-        self.panes[idx].inflight = None;
-        self.panes[idx].inflight_ticks = 0;
+        let pane = &mut self.panes[idx];
+        let Some(acked) = apply_ack(pane.seq, pane.acked, seq) else {
+            // Stale: already covered by a newer cumulative ack.
+            return;
+        };
+        pane.acked = acked;
+        pane.inflight_ticks = 0;
         // A live ack ends any backoff: the link is moving again.
-        self.panes[idx].watchdog_ticks = INFLIGHT_WATCHDOG_TICKS;
-        // The host presented: let the client draw the next frame.
-        fire_frame_callbacks(self.panes[idx].toplevel.wl_surface(), now);
-        // And if commits accumulated while this frame was in flight, send
-        // the coalesced delta immediately.
+        pane.watchdog_ticks = INFLIGHT_WATCHDOG_TICKS;
+        // Callbacks fired at send; the ack only frees in-flight slots. If
+        // commits piled up at the cap, send the coalesced delta now (pump
+        // fires the withheld callbacks with it).
         self.pump(idx);
     }
 
@@ -960,7 +964,7 @@ impl App {
         if host_ready {
             for idx in 0..self.panes.len() {
                 let pane = &mut self.panes[idx];
-                if pane.inflight.is_none() {
+                if pane.acked == pane.seq {
                     continue;
                 }
                 pane.inflight_ticks += 1;
@@ -974,14 +978,16 @@ impl App {
                     (pane.watchdog_ticks * 2).min(INFLIGHT_WATCHDOG_MAX_TICKS);
                 warn!(
                     id = pane.id,
-                    seq = pane.inflight,
+                    seq = pane.seq,
+                    acked = pane.acked,
                     next_wait_ticks = pane.watchdog_ticks,
                     "ack never arrived; releasing pacing and resending full"
                 );
-                pane.inflight = None;
+                pane.acked = pane.seq;
                 pane.inflight_ticks = 0;
                 pane.store.invalidate();
-                fire_frame_callbacks(pane.toplevel.wl_surface(), now);
+                // pump fires the callbacks: pacing is released, so it either
+                // sends the full frame or takes the nothing-to-send path.
                 self.pump(idx);
             }
             // smithay 0.7's PointerConstraintsHandler has no

--- a/packages/vm/panes/compositor/src/main.rs
+++ b/packages/vm/panes/compositor/src/main.rs
@@ -1,14 +1,17 @@
 //! Guest-side headless Wayland compositor: exports each `xdg_toplevel` over
 //! vsock (or a unix/TCP socket for off-VM development) to `panes-host` on the
 //! macOS side. The wire contract lives in `packages/vm/panes/protocol`; the
-//! design constraints (ack-paced frame callbacks, damage tiles, host-side
-//! resize) are documented there and in index#1686.
+//! design constraints (send-paced frame callbacks with ack backpressure,
+//! damage tiles, host-side resize) are documented there and in index#1686.
 
 mod cli;
-// The pure damage/tile logic compiles everywhere so its unit tests run on any
-// development host; outside Linux nothing calls it, hence the dead_code allow.
+// The pure damage/tile and pacing logic compiles everywhere so its unit tests
+// run on any development host; outside Linux nothing calls it, hence the
+// dead_code allows.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 mod frame;
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+mod pacing;
 
 #[cfg(target_os = "linux")]
 mod compositor;

--- a/packages/vm/panes/compositor/src/pacing.rs
+++ b/packages/vm/panes/compositor/src/pacing.rs
@@ -1,0 +1,70 @@
+//! Wire pacing, the pure core: frame callbacks fire at SEND, host acks are
+//! backpressure only. Kept smithay-free (like [`crate::frame`]) so the
+//! arithmetic that decides whether a client may draw is unit-tested on any
+//! development host; the event-loop plumbing lives in `compositor`.
+
+/// Backpressure cap on unacked wire frames per window. Frame callbacks fire
+/// at SEND, not at ack: a callback held to the ack quantizes the client to
+/// `display_hz / n` whenever the host's per-frame turnaround exceeds one
+/// display tick (the index#1686 60-acks cap on a 120Hz display). This cap is
+/// what still bounds the client when the host stalls: at the cap, sends (and
+/// the callbacks fired with them) wait for an ack to free a slot.
+pub const MAX_INFLIGHT_FRAMES: u64 = 2;
+
+/// May another frame go onto the wire? Frames in `acked+1..=sent` are in
+/// flight; `acked <= sent` is an invariant ([`apply_ack`] clamps).
+pub const fn under_inflight_cap(sent: u64, acked: u64) -> bool {
+    sent - acked < MAX_INFLIGHT_FRAMES
+}
+
+/// Apply a cumulative ack (the host coalesces per display tick and acks only
+/// the newest presented seq, so one ack may cover several in-flight frames):
+/// the new acked watermark, or `None` for a stale ack. Clamped to `sent` so
+/// a buggy host acking a seq it never received cannot widen the in-flight
+/// window past [`MAX_INFLIGHT_FRAMES`].
+pub const fn apply_ack(sent: u64, acked: u64, ack_seq: u64) -> Option<u64> {
+    if ack_seq <= acked {
+        return None;
+    }
+    Some(if ack_seq < sent { ack_seq } else { sent })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cap_gates_sends() {
+        // (sent, acked, may send another frame)
+        let table = [
+            (0, 0, true),  // nothing in flight
+            (1, 0, true),  // one slot free
+            (2, 0, false), // at the cap: callbacks wait for an ack
+            (3, 1, false), // still at the cap after a partial ack
+            (3, 2, true),
+            (3, 3, true), // fully drained
+        ];
+        for (sent, acked, open) in table {
+            assert_eq!(under_inflight_cap(sent, acked), open, "sent={sent} acked={acked}");
+        }
+    }
+
+    #[test]
+    fn acks_are_cumulative_stale_ignored_future_clamped() {
+        // (sent, acked, ack_seq, new watermark)
+        let table = [
+            (2, 0, 1, Some(1)), // partial ack frees one slot
+            (2, 0, 2, Some(2)), // coalesced ack drains both
+            (2, 1, 1, None),    // stale: already covered
+            (2, 2, 1, None),    // stale after a watchdog release
+            (2, 0, 5, Some(2)), // buggy host acking the future: clamped
+        ];
+        for (sent, acked, ack_seq, expect) in table {
+            assert_eq!(
+                apply_ack(sent, acked, ack_seq),
+                expect,
+                "sent={sent} acked={acked} ack_seq={ack_seq}"
+            );
+        }
+    }
+}

--- a/packages/vm/panes/guest-image/apps.nix
+++ b/packages/vm/panes/guest-image/apps.nix
@@ -211,15 +211,15 @@ in {
       #
       # Beyond the Vulkan backend, these are latency-opinionated defaults
       # (index#1686): MC's frames reach glass through the compositor's
-      # ack-paced stream plus the host's display link, so anything that adds
+      # ack-backpressured stream plus the host's display link, so anything that adds
       # in-game frame time or a second pacing loop stacks straight onto
       # mouse-look latency.
       # - enableVsync:false -- the dominant term, validated live by A/B:
       #   MC's vsync waits on the swapchain, stacking a second frame of
-      #   pacing on top of the compositor's ack genlock (double vsync).
+      #   pacing on top of the compositor's frame pacing (double vsync).
       # - maxFps:260 -- the slider's "Unlimited" stop (valid range 10-260).
       #   Uncapped, the frame the compositor ships is always the freshest
-      #   sample; the ack pacing is what actually bounds the shipped rate.
+      #   sample; the in-flight cap is what actually bounds the shipped rate.
       # - rawMouseInput:true -- GLFW raw relative motion (the default,
       #   pinned against stale instance state): pairs with
       #   zwp_relative_pointer fed by the host's uncoalesced deltas.

--- a/packages/vm/panes/host/README.md
+++ b/packages/vm/panes/host/README.md
@@ -67,13 +67,14 @@ the window is dirty we encode one fullscreen-triangle pass sampling the
 texture into the drawable (a render pass, not a blit, because
 `framebufferOnly` drawables are render-target-only, and sampling stretches
 stale content for free during resize), present, and only then send
-`ToGuest::Ack { id, seq }`. The compositor fires Wayland frame callbacks off
-that ack, so guest rendering is genlocked to ProMotion instead of running an
-open-loop timer. Coalescing: if several frames land between ticks, only the
-newest is presented and acked; guests should treat an ack as "presented up
-to seq". A frame the host cannot take at all (zero-size, texture allocation
-failure) is still acked immediately so the guest's one-in-flight loop never
-wedges on it. The link starts paused, unpauses on content/resize, and
+`ToGuest::Ack { id, seq }`. The compositor uses acks as backpressure for its
+in-flight frame cap (frame callbacks fire guest-side at send), so a slow
+host bounds how far a client runs ahead instead of quantizing its frame
+rate. Coalescing: if several frames land between ticks, every frame's tiles
+are applied but only the newest is presented and acked; guests should treat
+an ack as "presented up to seq". A frame the host cannot take at all
+(zero-size, texture allocation failure) is still acked immediately so the
+guest's in-flight window never wedges on it. The link starts paused, unpauses on content/resize, and
 re-pauses after ~250ms of idle ticks so a quiet window stops costing CPU.
 
 `PANES_TRACE=1` emits one parseable stderr line per input event, frame
@@ -167,7 +168,7 @@ compositor).
 connects to it: one 800x600-point toplevel with a moving gradient and a
 blocky frame counter, full-damage-tiled in 256px tiles, LZ4 when the host
 advertises it. It renders the next frame when the previous seq is acked
-(exactly one frame in flight, like the real compositor) and logs every input
+(exactly one frame in flight) and logs every input
 event plus a once-a-second ack rate. A right-click into the window toggles
 `ToHost::PointerLock`, exercising the host's cursor capture without a VM:
 the cursor hides and freezes, motion arrives in the log as `PointerRelative`

--- a/packages/vm/panes/host/src/app.rs
+++ b/packages/vm/panes/host/src/app.rs
@@ -430,7 +430,7 @@ fn handle_msg(app: &mut App, msg: ToHost, recv: f64) -> Deferred {
             }
             if !applied {
                 // Frame the host could not take (zero-size / texture alloc
-                // failure): ack immediately anyway. With one-frame-in-flight
+                // failure): ack immediately anyway. With capped-in-flight
                 // guest pacing, an ack held hostage to a texture we never
                 // made would wedge that window's frame loop forever.
                 if let Some(out) = &app.out {

--- a/packages/vm/panes/host/src/mock.rs
+++ b/packages/vm/panes/host/src/mock.rs
@@ -7,7 +7,7 @@
 //! capture end to end; the `PointerRelative` deltas it produces land in the
 //! same input log as everything else.
 //!
-//! Pacing mirrors the real compositor: exactly one frame in flight, the next
+//! Pacing keeps exactly one frame in flight, the next
 //! render starts when the host acks the previous seq. On a `ProMotion` panel
 //! the ack loop should settle at ~120 acks/s; the rate is logged every
 //! second.

--- a/packages/vm/panes/host/src/window.rs
+++ b/packages/vm/panes/host/src/window.rs
@@ -4,8 +4,9 @@
 //! Presentation pacing: the display link ticks at the panel's rate (up to
 //! 120Hz on `ProMotion`) and hands us the drawable; we only encode/present when
 //! a new guest frame (or a resize) made the window dirty, and the frame's
-//! `seq` is acked right after the present is scheduled. The guest renders its
-//! next frame off that ack, genlocking it to the display. A fully occluded
+//! `seq` is acked right after the present is scheduled. The guest paces its
+//! sends off that ack (a capped in-flight window; its clients render on
+//! send-time frame callbacks). A fully occluded
 //! window downshifts to slow ack-only ticks instead (see
 //! [`PaneWindow::set_occluded`]): presents would be invisible, but a
 //! withheld ack would wedge the guest.
@@ -493,7 +494,7 @@ impl PaneWindow {
     /// Returns true when the frame will be presented (its ack rides the next
     /// display-link tick). Returns false when the host cannot take the frame
     /// at all (zero size, texture allocation failure): the caller must ack
-    /// `seq` immediately, because with one-frame-in-flight guest pacing a
+    /// `seq` immediately, because with capped-in-flight guest pacing a
     /// withheld ack wedges that window's frame loop forever. Malformed tiles
     /// inside an otherwise valid frame are logged and skipped, never stall.
     pub fn apply_frame(
@@ -619,7 +620,7 @@ impl PaneWindow {
     }
 
     /// Occlusion change from the window delegate. The link must never be
-    /// paused here outright: with one-frame-in-flight guest pacing the tick
+    /// paused here outright: with capped-in-flight guest pacing the tick
     /// is what releases the pending ack, and a withheld ack wedges the guest
     /// window (its compositor watchdog then resends full frames forever). So
     /// occlusion only downshifts the tick rate; the occluded branch of

--- a/packages/vm/panes/protocol/src/lib.rs
+++ b/packages/vm/panes/protocol/src/lib.rs
@@ -8,10 +8,12 @@
 //! - Frames are damage-driven: [`WindowFrame`] carries only damaged tiles, the
 //!   host keeps the previous contents. `Lz4` per-tile because raw 1080p120 is
 //!   ~1 GB/s, at the edge of the libkrun vsock budget.
-//! - Pacing is ack-driven: the host sends [`ToGuest::Ack`] when a frame is
-//!   presented (`CAMetalDisplayLink`), and the compositor fires Wayland frame
-//!   callbacks off that ack, genlocking guest rendering to `ProMotion` instead
-//!   of running an open-loop 120Hz timer.
+//! - Acks are backpressure: the host sends [`ToGuest::Ack`] when a frame is
+//!   presented (`CAMetalDisplayLink`), and the compositor caps how many
+//!   unacked frames a window may have on the wire. Wayland frame callbacks
+//!   fire at frame SEND (holding them to the ack quantizes clients to
+//!   `refresh/n` once per-frame host cost crosses a display tick), so the
+//!   ack bounds a client only when the host falls behind.
 //! - Windows are `xdg_toplevels`: title/`app_id`/min-max map onto `NSWindow`
 //!   properties; interactive resize is host-side (`WSLg` lesson) and lands as
 //!   [`ToGuest::Configure`].
@@ -206,7 +208,7 @@ pub enum ToGuest {
     /// Presented up to `seq` for window `id` (cumulative: the host coalesces
     /// and acks only the newest frame it presented per display tick, so a
     /// guest must treat any `seq >= awaited` as satisfying the wait).
-    /// Compositor fires frame callbacks off this.
+    /// Backpressure for the compositor's in-flight frame cap.
     Ack {
         id: WindowId,
         seq: u64,


### PR DESCRIPTION
Guest clients were stuck at exactly 60 acks/s on a 120Hz panel: the compositor held each `wl_surface` frame callback until the host acked the presented frame, so any host turnaround over one display tick halved the client rate (follow-up to #1846).

Frame callbacks now fire when the frame goes onto the wire (`pump`); acks are backpressure only. A per-window `acked` watermark caps unacked frames at 2 (`compositor/src/pacing.rs`), and at the cap `pump` withholds the send and the callback until an ack frees a slot, so a stalled host still bounds the client instead of quantizing it. Safe to fire at send because wire frames are compositor-owned copies by then (shm copied at commit, dmabuf read back in `absorb_pending_gpu`); buffer release timing is unchanged. The host applies every frame's tiles regardless of present coalescing, so two frames in flight can't corrupt the delta chain.

Validated: `cargo test -p panes-compositor` (11 pass, incl. new table-driven pacing tests), `cargo check --target aarch64-unknown-linux-gnu --all-targets` clean, `nix build .#packages.aarch64-linux.panes-compositor` green.

Leaving auto-merge off: want a local e2e run from this branch's guest image first.

Implemented by Claude (AI agent).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fire Wayland frame callbacks at send time and replace in-flight tracking with ack backpressure
> - Replaces the single-frame-in-flight ack-paced loop with a 2-frame in-flight window (`MAX_INFLIGHT_FRAMES=2`) in the new [`pacing.rs`](https://github.com/indexable-inc/index/pull/2529/files#diff-8d73653a8a78d5f31cba03f647f333784373090064fce2fd34c46970f0730047) module, which provides `under_inflight_cap` and `apply_ack` helpers.
> - `wl_surface` frame callbacks now fire immediately at send time (in `pump`) instead of waiting for a host ack; acks advance a cumulative `acked` watermark and unblock sends when the window is full.
> - Replaces the `inflight: Option<u64>` field on `Pane` with `acked: u64`; teardown and disconnect advance `acked = seq` to collapse the in-flight window cleanly.
> - Watchdog logic in `on_tick` now detects stalls via `acked != seq` and recovers by resetting the window and calling `pump`, which fires callbacks under the new rules.
> - Behavioral Change: clients now receive frame callbacks one RTT earlier (at send, not at ack), and up to 2 frames per window can be in-flight simultaneously.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2d0916.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->