### PR TITLE
mcp: add google_auth.send mail helper with reply threading and readback

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1752,6 +1752,8 @@
 
     assert _asyncio.iscoroutinefunction(google_auth.login)
     assert callable(google_auth.status) and callable(google_auth.logout)
+    # The mail sender (issue #2523): awaitable, so it never blocks the loop.
+    assert _asyncio.iscoroutinefunction(google_auth.send)
 
     # In a shared (multiplayer) room (IX_MCP_SHARED set) Gmail/Calendar are
     # refused before minting ever looks for the grant, so a personal mailbox
@@ -6048,6 +6050,39 @@
       mkdir -p "$out"
     '';
 
+  # Network-free unit tests for the `google_auth` mail sender (issue #2523):
+  # MIME assembly, reply threading (threadId + In-Reply-To/References), and the
+  # delivered-body readback, driven against a stub Gmail Resource. Only the
+  # module's import-time deps are needed: googleapiclient itself is stubbed.
+  googleAuthTestPython = pkgs.python3.withPackages (ps: [
+    ps.pytest
+    ps.pydantic
+    ps.google-auth
+    googleAuthModule
+  ]);
+  googleAuthTestSource = builtins.path {
+    name = "ix-mcp-google-auth-send-test";
+    path = ./tests/test_google_auth_send.py;
+  };
+  googleAuthTests =
+    pkgs.runCommand "ix-mcp-google-auth-tests"
+    {
+      nativeBuildInputs = [googleAuthTestPython];
+      strictDeps = true;
+    }
+    ''
+      export HOME=$TMPDIR/home
+      mkdir -p "$HOME"
+      cp ${googleAuthTestSource} "$TMPDIR/test_google_auth_send.py"
+      ${lib.getExe googleAuthTestPython} -m pytest "$TMPDIR/test_google_auth_send.py" -q -p no:cacheprovider >stdout 2>stderr || {
+        echo "ix-mcp google_auth tests failed:" >&2
+        cat stdout stderr >&2
+        exit 1
+      }
+      cat stdout
+      mkdir -p "$out"
+    '';
+
   # Network-free unit tests for the federated-resources bridge: every path of
   # `resources_bridge` (list/read/act, peer-flag assembly, not-found -> -32002,
   # graceful empty/clear-error when `ix-resource-cli` is absent) driven against a
@@ -6154,6 +6189,7 @@ in
               exaBundled
               cursorSdkBundled
               googleAuthBundled
+              googleAuthTests
               ixGoogleBundled
               slackBundled
               slackTests

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -58,7 +58,10 @@ NAMESPACE = (
     "define stay defined and are reusable by every later call: define a helper once and call it "
     "again next turn. Bind expensive or large outputs to names (`df = await nu(...)`, "
     "`df = ...`) instead of only printing or returning them, so later calls can inspect, filter, "
-    "or pass that same object to `read` without recomputing."
+    "or pass that same object to `read` without recomputing. Persistence cuts both ways: a "
+    "failed cell stops at the raise, so names its later lines would have rebound keep their old "
+    "values -- re-run those assignments before reusing them, never retry from possibly-stale "
+    "bindings."
 )
 
 JOBS = (

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -210,7 +210,9 @@ MODULES: tuple[Module, ...] = (
     Module(
         "google_auth",
         "Google for your own account: read and send Gmail, and manage Calendar, over the "
-        "official googleapiclient (`google_auth.gmail()` / `.calendar()`); "
+        "official googleapiclient (`google_auth.gmail()` / `.calendar()`); `await "
+        "google_auth.send(to, subject, body)` sends mail (MIME assembly, reply threading via "
+        "`reply_to_message_id=`, and delivered-body readback handled for you); "
         "`await google_auth.login()` signs in through your browser and `status()` / `logout()` "
         "manage the grant. Incognito sessions only (a personal mailbox never reaches a shared room)",
         # The bundled `gcal` binary owns the grant; the stored refresh token

--- a/packages/mcp/src/google_auth/google_auth/__init__.py
+++ b/packages/mcp/src/google_auth/google_auth/__init__.py
@@ -9,7 +9,7 @@ session can read and send mail and manage a calendar with no setup file:
 
     await google_auth.login()            # sign in: opens your browser (once)
     gmail = google_auth.gmail()          # googleapiclient Resource for Gmail
-    gmail.users().messages().send(userId="me", body=...).execute()
+    await google_auth.send("a@b.com", "subject", "body")  # MIME + threading handled
     cal = google_auth.calendar()         # ... and Calendar
 
     google_auth.status()                 # {"signed_in", "email", "scopes"}
@@ -45,11 +45,13 @@ people.
 from __future__ import annotations
 
 import asyncio
+import base64
 import datetime
 import json
 import os
 import subprocess
 import webbrowser
+from email.message import EmailMessage
 from typing import Any
 
 from google.oauth2.credentials import Credentials
@@ -62,6 +64,7 @@ __all__ = [
     "gmail",
     "login",
     "logout",
+    "send",
     "service",
     "status",
 ]
@@ -257,6 +260,107 @@ def calendar(version: str = "v3") -> Any:  # noqa: ANN401 -- googleapiclient Res
     Run `await login()` first if not signed in.
     """
     return service("calendar", version)
+
+
+def _payload_text(payload: dict[str, Any]) -> str:
+    """The first text/plain content in a Gmail payload tree, decoded.
+
+    Gmail returns the body base64url-encoded either directly on
+    ``payload.body`` (a simple message) or nested under ``payload.parts``
+    (multipart); recurse until a text/plain part with data appears.
+    """
+    if payload.get("mimeType", "text/plain").startswith("text/plain"):
+        data = payload.get("body", {}).get("data")
+        if data:
+            return base64.urlsafe_b64decode(data).decode("utf-8", errors="replace")
+    for part in payload.get("parts") or []:
+        text = _payload_text(part)
+        if text:
+            return text
+    return ""
+
+
+def _send_blocking(
+    to: str,
+    subject: str,
+    body: str,
+    cc: str | None,
+    reply_to_message_id: str | None,
+) -> dict[str, Any]:
+    """Assemble, send, and read back one message (blocking; see `send`)."""
+    messages = gmail().users().messages()
+
+    msg = EmailMessage()
+    msg["To"] = to
+    msg["Subject"] = subject
+    if cc:
+        msg["Cc"] = cc
+    msg.set_content(body)
+
+    request: dict[str, Any] = {}
+    if reply_to_message_id:
+        original = messages.get(
+            userId="me",
+            id=reply_to_message_id,
+            format="metadata",
+            metadataHeaders=["Message-ID", "References"],
+        ).execute()
+        headers = {
+            h["name"].lower(): h["value"] for h in original.get("payload", {}).get("headers", [])
+        }
+        # Gmail threads a reply only when the requested threadId is accompanied
+        # by the RFC 5322 reply headers: In-Reply-To names the parent, and
+        # References extends the parent's own chain with the parent itself.
+        message_id = headers.get("message-id")
+        if message_id:
+            msg["In-Reply-To"] = message_id
+            references = headers.get("references")
+            msg["References"] = f"{references} {message_id}" if references else message_id
+        request["threadId"] = original["threadId"]
+
+    request["raw"] = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
+    sent = messages.send(userId="me", body=request).execute()
+
+    # Read the delivered message back and return its body: the caller verifies
+    # content from the return value instead of trusting that the arguments made
+    # it out (issue #2523: a stale-namespace retry once resent an old body while
+    # `labelIds: SENT` still read as success).
+    delivered = messages.get(userId="me", id=sent["id"], format="full").execute()
+    return {
+        "id": sent["id"],
+        "thread_id": delivered.get("threadId") or sent.get("threadId", ""),
+        "body": _payload_text(delivered.get("payload") or {}),
+    }
+
+
+async def send(
+    to: str,
+    subject: str,
+    body: str,
+    *,
+    cc: str | None = None,
+    reply_to_message_id: str | None = None,
+) -> dict[str, Any]:
+    """Send plain-text mail as the signed-in account; return what was delivered.
+
+    Owns the whole fiddly path so no session hand-rolls it: assembles the MIME
+    message, base64url-encodes it for ``messages().send``, and, for a reply,
+    threads it properly -- pass ``reply_to_message_id`` (the Gmail message
+    ``id`` of the message being answered, from ``messages().list()`` /
+    ``.get()``) and the helper fetches that message and sets ``threadId``,
+    ``In-Reply-To``, and ``References``. Give a reply the thread's subject
+    (``Re: <original>``), which Gmail also requires for threading.
+
+    Returns ``{"id", "thread_id", "body"}`` where ``body`` is read back from
+    the message Gmail actually stored, so verifying the delivered content is
+    free: check the returned body, not just that the call succeeded.
+
+    Raises `GoogleAuthError` when not signed in (run `await login()`) or in a
+    shared room.
+    """
+    _require_incognito()
+    # googleapiclient is blocking (httplib2); keep the kernel's loop free.
+    return await asyncio.to_thread(_send_blocking, to, subject, body, cc, reply_to_message_id)
 
 
 def status() -> dict[str, Any]:

--- a/packages/mcp/tests/test_google_auth_send.py
+++ b/packages/mcp/tests/test_google_auth_send.py
@@ -1,0 +1,187 @@
+"""Network-free tests for `google_auth.send` (issue #2523).
+
+These never reach Gmail: they stub the one network primitive (`gmail()`) with a
+fake googleapiclient Resource and check that `send` assembles the MIME message
+correctly, threads replies (threadId + In-Reply-To/References), and returns the
+body read back from the message the API stored, not an echo of the arguments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import email
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Prefer the bundled module (nix check); fall back to the source tree (dev run).
+GOOGLE_AUTH_SRC = Path(__file__).resolve().parents[1] / "src" / "google_auth"
+if GOOGLE_AUTH_SRC.is_dir() and str(GOOGLE_AUTH_SRC) not in sys.path:
+    sys.path.insert(0, str(GOOGLE_AUTH_SRC))
+
+import google_auth
+
+_ORIGINAL_ID = "18f0deadbeef0001"
+_ORIGINAL_THREAD = "18f0deadbeef0000"
+_ORIGINAL_MESSAGE_ID = "<orig@mail.example.com>"
+_SENT_ID = "18f0deadbeef0002"
+
+
+def _b64(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode()).decode("ascii")
+
+
+class _Request:
+    """A googleapiclient HttpRequest stand-in: `.execute()` yields the response."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self._response = response
+
+    def execute(self) -> dict[str, Any]:
+        return self._response
+
+
+class FakeGmail:
+    """The slice of the Gmail Resource `send` uses, with call capture.
+
+    `send` stores the raw MIME; a later `get` of the sent id answers with a
+    payload rebuilt from what was actually "stored", so the readback assertion
+    is real (the returned body comes from the API, not the arguments).
+    """
+
+    def __init__(self, *, original_headers: list[dict[str, str]] | None = None) -> None:
+        self.sent_bodies: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+        self._original_headers = original_headers or [
+            {"name": "Message-ID", "value": _ORIGINAL_MESSAGE_ID}
+        ]
+
+    # The chained Resource shape: users().messages().<verb>(...)
+    def users(self) -> FakeGmail:
+        return self
+
+    def messages(self) -> FakeGmail:
+        return self
+
+    def send(self, userId: str, body: dict[str, Any]) -> _Request:
+        assert userId == "me"
+        self.sent_bodies.append(body)
+        return _Request({"id": _SENT_ID, "threadId": body.get("threadId", _SENT_ID)})
+
+    def get(self, userId: str, id: str, **kwargs: str | list[str]) -> _Request:
+        assert userId == "me"
+        self.get_calls.append({"id": id, **kwargs})
+        if id == _ORIGINAL_ID:
+            return _Request(
+                {
+                    "id": _ORIGINAL_ID,
+                    "threadId": _ORIGINAL_THREAD,
+                    "payload": {"headers": self._original_headers},
+                }
+            )
+        # The sent message read back: body rebuilt from the stored raw MIME.
+        assert id == _SENT_ID, f"unexpected get({id})"
+        raw = self.sent_bodies[-1]["raw"]
+        stored = email.message_from_bytes(base64.urlsafe_b64decode(raw))
+        text = stored.get_payload(decode=True).decode()
+        return _Request(
+            {
+                "id": _SENT_ID,
+                "threadId": self.sent_bodies[-1].get("threadId", _SENT_ID),
+                "payload": {"mimeType": "text/plain", "body": {"data": _b64(text)}},
+            }
+        )
+
+
+@pytest.fixture
+def fake_gmail(monkeypatch: pytest.MonkeyPatch) -> FakeGmail:
+    monkeypatch.delenv(google_auth.SHARED_ENV, raising=False)
+    fake = FakeGmail()
+    monkeypatch.setattr(google_auth, "gmail", lambda: fake)
+    return fake
+
+
+def _sent_mime(fake: FakeGmail) -> email.message.Message:
+    return email.message_from_bytes(base64.urlsafe_b64decode(fake.sent_bodies[-1]["raw"]))
+
+
+def test_send_assembles_mime(fake_gmail: FakeGmail) -> None:
+    out = asyncio.run(
+        google_auth.send("to@example.com", "hello", "the body\n", cc="cc@example.com")
+    )
+    mime = _sent_mime(fake_gmail)
+    assert mime["To"] == "to@example.com"
+    assert mime["Subject"] == "hello"
+    assert mime["Cc"] == "cc@example.com"
+    assert mime.get_payload(decode=True).decode() == "the body\n"
+    # A fresh message carries no reply headers and no threadId.
+    assert mime["In-Reply-To"] is None
+    assert mime["References"] is None
+    assert "threadId" not in fake_gmail.sent_bodies[-1]
+    assert out["id"] == _SENT_ID
+
+
+def test_send_omits_cc_by_default(fake_gmail: FakeGmail) -> None:
+    asyncio.run(google_auth.send("to@example.com", "s", "b"))
+    assert _sent_mime(fake_gmail)["Cc"] is None
+
+
+def test_reply_threads(fake_gmail: FakeGmail) -> None:
+    out = asyncio.run(
+        google_auth.send(
+            "to@example.com", "Re: hello", "reply body", reply_to_message_id=_ORIGINAL_ID
+        )
+    )
+    # The original was fetched as metadata with the reply headers requested.
+    lookup = fake_gmail.get_calls[0]
+    assert lookup["id"] == _ORIGINAL_ID
+    assert lookup["format"] == "metadata"
+    assert set(lookup["metadataHeaders"]) == {"Message-ID", "References"}
+
+    mime = _sent_mime(fake_gmail)
+    assert mime["In-Reply-To"] == _ORIGINAL_MESSAGE_ID
+    assert mime["References"] == _ORIGINAL_MESSAGE_ID
+    assert fake_gmail.sent_bodies[-1]["threadId"] == _ORIGINAL_THREAD
+    assert out["thread_id"] == _ORIGINAL_THREAD
+
+
+def test_reply_extends_references_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(google_auth.SHARED_ENV, raising=False)
+    fake = FakeGmail(
+        original_headers=[
+            {"name": "Message-ID", "value": _ORIGINAL_MESSAGE_ID},
+            {"name": "References", "value": "<root@mail.example.com>"},
+        ]
+    )
+    monkeypatch.setattr(google_auth, "gmail", lambda: fake)
+    asyncio.run(google_auth.send("to@example.com", "Re: s", "b", reply_to_message_id=_ORIGINAL_ID))
+    assert _sent_mime(fake)["References"] == f"<root@mail.example.com> {_ORIGINAL_MESSAGE_ID}"
+
+
+def test_returns_body_read_back(fake_gmail: FakeGmail) -> None:
+    out = asyncio.run(google_auth.send("to@example.com", "s", "verify me"))
+    # The body comes from the stored message via get(), not from the argument:
+    # the second get call targets the sent id.
+    assert fake_gmail.get_calls[-1]["id"] == _SENT_ID
+    assert fake_gmail.get_calls[-1]["format"] == "full"
+    assert out["body"].rstrip("\n") == "verify me"
+
+
+def test_payload_text_recurses_multipart() -> None:
+    payload = {
+        "mimeType": "multipart/alternative",
+        "parts": [
+            {"mimeType": "text/html", "body": {"data": _b64("<b>nope</b>")}},
+            {"mimeType": "text/plain", "body": {"data": _b64("plain wins")}},
+        ],
+    }
+    assert google_auth._payload_text(payload) == "plain wins"
+
+
+def test_shared_room_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(google_auth.SHARED_ENV, "1")
+    with pytest.raises(google_auth.GoogleAuthError, match="shared"):
+        asyncio.run(google_auth.send("to@example.com", "s", "b"))


### PR DESCRIPTION
Adds `await google_auth.send(to, subject, body, *, cc=None, reply_to_message_id=None)` to the bundled kernel module so sessions stop hand-rolling MIMEText + base64url (issue #2523).

- **MIME assembly** owned by the helper (`EmailMessage` -> base64url raw), `cc=` optional.
- **Reply threading**: `reply_to_message_id=` (Gmail message id) fetches the original and sets `threadId`, `In-Reply-To`, and `References` (extending the original's chain), the part agents most often skip.
- **Delivered-body readback**: the sent message is read back (`format="full"`) and its decoded text/plain body returned as `{"id", "thread_id", "body"}`, so content verification is free (per the 2026-07-08 stale-namespace duplicate-send incident on the issue).
- **Guide**: one warning in the kernel guide's namespace section that a failed cell leaves bindings after the failing line stale, the failure mode behind that incident.
- **Registry**: google_auth module summary mentions the helper.

Tests: `packages/mcp/tests/test_google_auth_send.py` (network-free, stub Gmail Resource) wired as `googleAuthTests` in `passthru.tests`, plus a `send` coroutine assertion in the existing `googleAuthBundled` import check.

Local gates: repo lint green, pytest 7/7 green, `nix build .#mcp.tests.googleAuthTests` green, zuban `--strict` over `google_auth` green. (`googleAuthBundled` locally raced a concurrent CA build of the same closure during the cache.ix.dev outage; CI will build it cleanly.)

Closes #2523

🤖 Generated with Claude Code (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `google_auth.send` async helper with reply threading and message readback
> - Adds `google_auth.send(to, subject, body, *, cc=None, reply_to_message_id=None)` in [`__init__.py`](https://github.com/indexable-inc/index/pull/2530/files#diff-a31e9489e608de89bdd19aa1fb80b8fc8d42366733c8d9c7dd260771bec32bd9), an awaitable that offloads blocking Gmail API calls to a thread via `asyncio.to_thread`.
> - Reply threading works by fetching the original message metadata (`Message-ID`, `References`) to set `In-Reply-To`/`References` headers and preserve `threadId` on send.
> - After sending, the helper reads back the delivered message from the API and returns `id`, `thread_id`, and decoded body — rather than trusting the input arguments.
> - Raises an error when called in shared (non-incognito) sessions.
> - A network-free pytest suite in [`test_google_auth_send.py`](https://github.com/indexable-inc/index/pull/2530/files#diff-83d86fcf15033997f57a850ca8f44c6c912fbeb8e7549c3a2b20f42845e773c6) is wired into the Nix build and will fail the derivation if any test fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0695a91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->