### PR TITLE
mcp: name the bindings a failed cell never updated

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3051,7 +3051,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + stale-binding note on failed cells (#2526)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3089,6 +3089,8 @@
       cp ${./tests/test_kernel_trace_path.py} test_kernel_trace_path.py
       # Issue #2430: a cell rebinding/deleting a kernel builtin gets it restored.
       cp ${./tests/test_builtin_shadow_restore.py} test_builtin_shadow_restore.py
+      # Issue #2526: a failed cell's traceback names the bindings it never updated.
+      cp ${./tests/test_stale_binding_note.py} test_stale_binding_note.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
@@ -3102,6 +3104,7 @@
         test_build_info.py \
         test_kernel_trace_path.py \
         test_builtin_shadow_restore.py \
+        test_stale_binding_note.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/ix_notebook_mcp/introspect.py
+++ b/packages/mcp/ix_notebook_mcp/introspect.py
@@ -22,6 +22,7 @@ import inspect
 import reprlib
 import sys
 import types
+from collections.abc import Iterator
 from itertools import islice
 from typing import Any
 
@@ -140,6 +141,186 @@ def binding_names(code: str) -> tuple[set[str], set[str]]:
             # Store ``Name`` node, so ``ast.walk`` would otherwise miss it.
             assigned.add(node.name)
     return assigned, used
+
+
+def unreached_bindings(code: str, fail_line: int) -> list[str]:
+    """The cell-level names ``code`` provably never (re)bound in a run whose
+    exception left the cell's top-level frame at ``fail_line``, in source order.
+
+    The static half of the stale-binding trap (index#2526): a cell that raises
+    partway leaves every later assignment unexecuted while the namespace keeps
+    each name's old value, so a retry cell that reads one silently operates on
+    stale state. This walk names those bindings so the runner can say so right
+    in the traceback (``runtime._stale_binding_note``).
+
+    Only provable claims are made. A statement binds its targets when it
+    *completes*, so any binding statement ending at or after ``fail_line``
+    never bound -- including the failing statement itself (its right side
+    raised first). Bindings that happen mid-statement (a ``for``/``with``/
+    ``except as`` target, a walrus) qualify only strictly after the failing
+    line, and regions an interrupted run may still have executed are excluded
+    entirely: the span of any loop enclosing the failing line (an earlier
+    iteration ran its body) and the handlers/finally of any ``try`` enclosing
+    it (they run during the unwind). Nested ``def``/``class``/lambda scopes
+    bind locals, not cell names, so only the ``def``/``class`` name itself
+    counts. Returns [] for code that does not parse."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+    spans = _maybe_ran_spans(tree, fail_line)
+    names: list[str] = []
+    seen: set[str] = set()
+
+    def emit(name: str, line: int) -> None:
+        if name in seen or any(a <= line <= b for a, b in spans):
+            return
+        seen.add(name)
+        names.append(name)
+
+    def point(node: ast.AST) -> None:
+        # A walrus binds the moment it evaluates; only one strictly after the
+        # failing line is provably unexecuted (same-line order is unknowable
+        # without column info).
+        for name, line in _walrus_targets(node):
+            if line > fail_line:
+                emit(name, line)
+
+    def visit(body: list[ast.stmt]) -> None:
+        for stmt in body:
+            end = stmt.end_lineno or stmt.lineno
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                # The name binds when the whole statement (decorators, bases,
+                # defaults, class body) completes; the body's own assignments
+                # bind locals or class attributes when called, never cell
+                # names, so don't descend.
+                if end >= fail_line:
+                    emit(stmt.name, stmt.lineno)
+            elif isinstance(stmt, (ast.For, ast.AsyncFor)):
+                if stmt.lineno > fail_line:
+                    for name, line in _name_targets(stmt.target):
+                        emit(name, line)
+                point(stmt.iter)
+                visit(stmt.body)
+                visit(stmt.orelse)
+            elif isinstance(stmt, (ast.While, ast.If)):
+                point(stmt.test)
+                visit(stmt.body)
+                visit(stmt.orelse)
+            elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+                for item in stmt.items:
+                    point(item.context_expr)
+                    if item.optional_vars is not None and stmt.lineno > fail_line:
+                        for name, line in _name_targets(item.optional_vars):
+                            emit(name, line)
+                visit(stmt.body)
+            elif isinstance(stmt, (ast.Try, ast.TryStar)):
+                visit(stmt.body)
+                for handler in stmt.handlers:
+                    if handler.name and handler.lineno > fail_line:
+                        emit(handler.name, handler.lineno)
+                    visit(handler.body)
+                visit(stmt.orelse)
+                visit(stmt.finalbody)
+            elif isinstance(stmt, ast.Match):
+                point(stmt.subject)
+                for case in stmt.cases:
+                    for name, line in _pattern_targets(case.pattern):
+                        if line > fail_line:
+                            emit(name, line)
+                    if case.guard is not None:
+                        point(case.guard)
+                    visit(case.body)
+            else:
+                # A simple statement binds at completion: one that never
+                # completed (it ends at/after the failing line) never bound.
+                if end >= fail_line:
+                    for name, line in _completion_targets(stmt):
+                        emit(name, line)
+                point(stmt)
+
+    visit(tree.body)
+    return names
+
+
+def _maybe_ran_spans(tree: ast.Module, fail_line: int) -> list[tuple[int, int]]:
+    """Line spans at/after ``fail_line`` that may nonetheless have executed,
+    so :func:`unreached_bindings` must not claim anything inside them: the
+    whole span of any loop enclosing the failing line (an earlier iteration
+    ran its body) and the handlers/finally of any ``try`` enclosing it (a
+    ``finally`` runs during the unwind; a handler may have run and re-raised)."""
+    spans: list[tuple[int, int]] = []
+    for node in ast.walk(tree):
+        lineno = getattr(node, "lineno", None)
+        end = getattr(node, "end_lineno", None)
+        if lineno is None or end is None or not (lineno <= fail_line <= end):
+            continue
+        if isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+            spans.append((lineno, end))
+        elif isinstance(node, (ast.Try, ast.TryStar)):
+            spans.extend((h.lineno, h.end_lineno or h.lineno) for h in node.handlers)
+            if node.finalbody:
+                last = node.finalbody[-1]
+                spans.append((node.finalbody[0].lineno, last.end_lineno or last.lineno))
+    return spans
+
+
+def _completion_targets(stmt: ast.stmt) -> Iterator[tuple[str, int]]:
+    """``(name, line)`` for each name a simple statement binds when it
+    completes: assignment targets, import heads, ``del`` targets (a ``del``
+    that never ran leaves the old value bound, the same stale trap)."""
+    if isinstance(stmt, ast.Assign):
+        for target in stmt.targets:
+            yield from _name_targets(target)
+    elif isinstance(stmt, ast.AugAssign) or (isinstance(stmt, ast.AnnAssign) and stmt.value is not None):
+        yield from _name_targets(stmt.target)
+    elif isinstance(stmt, ast.Delete):
+        for target in stmt.targets:
+            yield from _name_targets(target)
+    elif isinstance(stmt, (ast.Import, ast.ImportFrom)):
+        for alias in stmt.names:
+            name = alias.asname or alias.name.split(".", 1)[0]
+            if name != "*":
+                yield name, alias.lineno
+
+
+def _name_targets(target: ast.expr) -> Iterator[tuple[str, int]]:
+    """``(name, line)`` for each plain name a target expression binds.
+    Attribute and subscript targets mutate an existing object rather than bind
+    a cell name, so they are skipped."""
+    if isinstance(target, ast.Name):
+        yield target.id, target.lineno
+    elif isinstance(target, ast.Starred):
+        yield from _name_targets(target.value)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            yield from _name_targets(elt)
+
+
+def _walrus_targets(node: ast.AST) -> Iterator[tuple[str, int]]:
+    """``(name, line)`` for each walrus under ``node`` that binds the enclosing
+    scope. Nested ``def``/``class``/lambda are skipped (their walruses bind
+    locals); a comprehension's walrus deliberately counts (PEP 572 binds it
+    outward), while its ``for`` targets are plain names, never ``NamedExpr``,
+    so they need no special casing."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+        return
+    if isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
+        yield node.target.id, node.target.lineno
+    for child in ast.iter_child_nodes(node):
+        yield from _walrus_targets(child)
+
+
+def _pattern_targets(pattern: ast.pattern) -> Iterator[tuple[str, int]]:
+    """``(name, line)`` for each capture a match pattern binds."""
+    if isinstance(pattern, (ast.MatchAs, ast.MatchStar)):
+        if pattern.name:
+            yield pattern.name, pattern.lineno
+    elif isinstance(pattern, ast.MatchMapping) and pattern.rest:
+        yield pattern.rest, pattern.lineno
+    for child in ast.iter_child_nodes(pattern):
+        if isinstance(child, ast.pattern):
+            yield from _pattern_targets(child)
 
 
 def describe(value: Any) -> dict:

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2485,6 +2485,45 @@ def _error_line(exc: BaseException, job: Job) -> int | None:
     return line
 
 
+# How many never-updated names a stale-binding note lists before eliding.
+_STALE_NOTE_NAMES = 12
+
+
+def _stale_binding_note(exc: BaseException, job: Job) -> str:
+    """A traceback addendum naming the bindings the failed cell provably never
+    updated (issue #2526). The namespace keeps each such name's old value, so a
+    retry cell that reads one silently operates on stale state (the incident: a
+    retry rebuilt an email from a ``body`` the failed cell never reassigned and
+    re-sent the previous one). The static walk lives in
+    :func:`introspect.unreached_bindings`; the failing line is read off the
+    FIRST frame in the cell's pseudo-file -- the cell's top level, where
+    execution actually stopped -- not the deepest (which can sit inside a
+    helper the cell defined, whose lines interleave the module's). Empty when
+    the exception never entered the cell (a SyntaxError, kernel plumbing) or
+    when nothing qualifies; best-effort, never raises."""
+    try:
+        target = f"<job {job.id}>"
+        tb = exc.__traceback__
+        while tb is not None and tb.tb_frame.f_code.co_filename != target:
+            tb = tb.tb_next
+        if tb is None:
+            return ""
+        from .introspect import unreached_bindings
+
+        names = unreached_bindings(job.code, tb.tb_lineno)
+        if not names:
+            return ""
+        shown = ", ".join(names[:_STALE_NOTE_NAMES])
+        if len(names) > _STALE_NOTE_NAMES:
+            shown += f", +{len(names) - _STALE_NOTE_NAMES} more"
+        return (
+            f"\nNOTE: this cell failed before updating: {shown} -- a retry "
+            "that reads these names gets values from before this run."
+        )
+    except Exception:
+        return ""
+
+
 def _typecheck_enabled() -> bool:
     """Whether per-cell type checking runs. Default ON; the escape hatch is the
     ``IX_MCP_TYPECHECK`` env var (``0``/``false``/``no``/``off`` disables it) or,
@@ -2618,6 +2657,9 @@ async def _runner(job: Job, ns: dict) -> None:
         raise
     except KeyboardInterrupt as _kexc:
         job.status = "error"
+        # An interrupt stops the cell mid-run exactly like an exception does,
+        # so the stale-binding note (issue #2526) applies to both branches.
+        stale = _stale_binding_note(_kexc, job)
         if job.interrupted_by_watchdog:
             # The server's wedge watchdog (SIGUSR2, fired after config.wedge_grace)
             # raised this: a synchronous call blocked the event loop past the
@@ -2628,7 +2670,7 @@ async def _runner(job: Job, ns: dict) -> None:
                 "time.sleep, requests, a long CPU op), which freezes every job. Wrap "
                 "it in `await asyncio.to_thread(...)` or use an async API, and run "
                 "anything slow as a background job."
-            )
+            ) + stale
             # Keep the interrupt as the job's exception (with the actionable
             # message) so `await jobs['<id>']` re-raises rather than yielding None.
             job._exc = _kexc
@@ -2636,7 +2678,7 @@ async def _runner(job: Job, ns: dict) -> None:
         else:
             # The user's own code raised KeyboardInterrupt; keep its real
             # traceback (trimmed to the cell's frames) and the failing line.
-            job.error = _user_traceback(_kexc)
+            job.error = _user_traceback(_kexc) + stale
             job.error_line = _error_line(_kexc, job)
             job._exc = _kexc
         job._exc_tb = _kexc.__traceback__
@@ -2653,7 +2695,7 @@ async def _runner(job: Job, ns: dict) -> None:
         tb = _user_traceback(_exc)
         job.error_line = _error_line(_exc, job)
         hint = _type_error_hint(_exc) if isinstance(_exc, TypeError) else ""
-        job.error = tb + hint
+        job.error = tb + hint + _stale_binding_note(_exc, job)
         # Keep the exception object itself, so `await jobs['<id>']` re-raises it
         # (type + message + the cell's own traceback) instead of yielding None.
         job._exc = _exc

--- a/packages/mcp/tests/test_stale_binding_note.py
+++ b/packages/mcp/tests/test_stale_binding_note.py
@@ -1,0 +1,182 @@
+"""A failed cell's traceback names the bindings it never updated (issue #2526).
+
+A cell that raises partway leaves every assignment at/after the failing line
+unexecuted while the namespace keeps each name's old value, so a retry cell
+that reads those names silently operates on stale state (the incident: a retry
+rebuilt an email from a ``body`` the failed cell never reassigned and re-sent
+the previous one). The runner now appends ``NOTE: this cell failed before
+updating: ...`` to the traceback; ``introspect.unreached_bindings`` supplies
+the names and makes only provable claims.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ix_notebook_mcp import runtime
+from ix_notebook_mcp.introspect import unreached_bindings
+
+
+class TestUnreachedBindings:
+    """The static walk: which bindings provably never ran."""
+
+    def test_linear_cell_names_the_assignments_at_and_after_the_failing_line(self) -> None:
+        # The incident shape: line 2 raises, so `mid` (the failing statement's
+        # own target: its right side raised first), `body`, and `msg` never
+        # (re)bound.
+        code = (
+            "meta = fetch()\n"
+            "mid = meta['Message-ID']\n"
+            "body = 'Following up'\n"
+            "msg = build(body)\n"
+        )
+        assert unreached_bindings(code, 2) == ["mid", "body", "msg"]
+
+    def test_bindings_before_the_failing_line_are_not_claimed(self) -> None:
+        assert unreached_bindings("meta = 1\nboom()\nx = 2\n", 2) == ["x"]
+
+    def test_multiline_statement_containing_the_failure_is_claimed(self) -> None:
+        # The statement starts before the failing line but binds only at
+        # completion, which it never reached.
+        code = "x = build(\n    boom(),\n)\ny = 1\n"
+        assert unreached_bindings(code, 2) == ["x", "y"]
+
+    def test_enclosing_loop_body_is_not_claimed(self) -> None:
+        # An earlier iteration may have bound `x`, `y`, and the loop target;
+        # only `z`, outside the loop, is provable.
+        code = "for i in gen():\n    x = step(i)\n    boom()\n    y = 2\nz = 3\n"
+        assert unreached_bindings(code, 3) == ["z"]
+
+    def test_loops_entirely_after_the_failing_line_are_claimed(self) -> None:
+        code = "boom()\nfor i in gen():\n    x = step(i)\n"
+        assert unreached_bindings(code, 1) == ["i", "x"]
+
+    def test_handlers_and_finally_of_the_enclosing_try_are_not_claimed(self) -> None:
+        # The unwind runs `finally` (and a handler may have run and re-raised),
+        # so only the try body's `a` and the post-try `d` are provable.
+        code = (
+            "try:\n"
+            "    boom()\n"
+            "    a = 1\n"
+            "except ValueError:\n"
+            "    b = 2\n"
+            "finally:\n"
+            "    c = 3\n"
+            "d = 4\n"
+        )
+        assert unreached_bindings(code, 2) == ["a", "d"]
+
+    def test_nested_function_locals_are_not_claimed_but_the_def_name_is(self) -> None:
+        code = "boom()\ndef helper():\n    local = 1\n"
+        assert unreached_bindings(code, 1) == ["helper"]
+
+    def test_import_and_unpack_targets_count(self) -> None:
+        code = "boom()\nimport json as j\na, (b, *rest) = f()\n"
+        assert unreached_bindings(code, 1) == ["j", "a", "b", "rest"]
+
+    def test_walrus_after_the_failing_line_counts_same_line_does_not(self) -> None:
+        # `n` may have bound before `boom()` raised on the same line (order
+        # within a line is unknowable), so only `total` (statement completion)
+        # and `m` (strictly after) are claimed.
+        code = "total = (n := count()) + boom()\nif (m := match()):\n    pass\n"
+        assert unreached_bindings(code, 1) == ["total", "m"]
+
+    def test_attribute_and_subscript_targets_are_not_names(self) -> None:
+        assert unreached_bindings("boom()\nobj.attr = 1\nd['k'] = 2\n", 1) == []
+
+    def test_unparseable_code_yields_nothing(self) -> None:
+        assert unreached_bindings("def (", 1) == []
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+
+
+def _run(code: str) -> runtime.Job:
+    return asyncio.run(runtime.__ix_run(code, budget=5.0))
+
+
+def _note(job: runtime.Job) -> str:
+    """The NOTE line of a failed job's error, or ''."""
+    for line in (job.error or "").splitlines():
+        if line.startswith("NOTE:"):
+            return line
+    return ""
+
+
+class TestStaleBindingNote:
+    """End to end: the note rides the failed cell's recorded traceback."""
+
+    def test_failed_cell_traceback_names_unreached_assignments(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _wire(monkeypatch, {})
+        job = _run("meta = {}\nmid = meta['Message-ID']\nbody = 'x'\nmsg = body\n")
+        assert job.status == "error"
+        assert "KeyError" in (job.error or "")
+        assert "NOTE: this cell failed before updating: mid, body, msg" in (job.error or "")
+
+    def test_failure_on_the_last_line_has_no_note(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _wire(monkeypatch, {})
+        job = _run("x = 1\nraise ValueError('boom')\n")
+        assert job.status == "error"
+        assert _note(job) == ""
+
+    def test_syntax_error_has_no_note(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Nothing ran at all; the SyntaxError already says so.
+        _wire(monkeypatch, {})
+        job = _run("x = 1\ndef (\n")
+        assert job.status == "error"
+        assert _note(job) == ""
+
+    def test_raise_inside_a_cell_defined_helper_uses_the_toplevel_line(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The deepest cell frame is line 2 (inside helper); the note must key
+        # off the top-level call at line 4, so `x` (already bound) is not
+        # claimed and `y` is.
+        _wire(monkeypatch, {})
+        code = (
+            "def helper():\n"
+            "    raise ValueError('boom')\n"
+            "x = 1\n"
+            "helper()\n"
+            "y = 2\n"
+        )
+        job = _run(code)
+        assert job.status == "error"
+        assert _note(job) == (
+            "NOTE: this cell failed before updating: y -- a retry "
+            "that reads these names gets values from before this run."
+        )
+
+    def test_yielding_cell_gets_the_note_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Gen-mode cells run inside __ix_cell__, whose frame keeps the
+        # original line numbers.
+        _wire(monkeypatch, {})
+        job = _run("yield 1\nint('nope')\nz = 5\n")
+        assert job.status == "error"
+        assert "NOTE: this cell failed before updating: z" in (job.error or "")
+
+    def test_user_keyboard_interrupt_gets_the_note(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An interrupt stops the cell mid-run exactly like an exception.
+        _wire(monkeypatch, {})
+        job = _run("raise KeyboardInterrupt()\nx = 1\n")
+        assert job.status == "error"
+        assert "NOTE: this cell failed before updating: x" in (job.error or "")
+
+    def test_successful_cell_has_no_note(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _wire(monkeypatch, {})
+        job = _run("x = 1\ny = 2\n")
+        assert job.status == "done"
+        assert job.error is None
+
+    def test_many_names_are_elided(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _wire(monkeypatch, {})
+        lines = "int('nope')\n" + "".join(f"v{i} = {i}\n" for i in range(15))
+        job = _run(lines)
+        assert job.status == "error"
+        note = _note(job)
+        assert "v11" in note
+        assert "v12" not in note
+        assert "+3 more" in note


### PR DESCRIPTION
Fixes #2526.

A cell that raises partway leaves every assignment at/after the failing line unexecuted while the namespace keeps each name's old value, so a retry cell that reads those names silently operates on stale state (the incident: a retry rebuilt an email from a `body` the failed cell never reassigned and re-sent a vendor rep a duplicate).

**What changed**

- `introspect.unreached_bindings(code, fail_line)`: static AST walk naming the cell-level bindings that provably never ran. Conservative by design: statement-completion bindings (assignments, imports, def/class names) count when the statement ends at/after the failing top-level line; mid-statement bindings (`for`/`with`/`except as` targets, walrus) only strictly after it; the span of any loop enclosing the failure and the handlers/finally of any enclosing `try` are excluded (they may have executed anyway); nested scopes bind locals, not cell names.
- `runtime._stale_binding_note`: reads the failing line off the FIRST frame in the cell's pseudo-file (the cell's top level, not a helper's line) and appends to the failed job's traceback:

  ```
  NOTE: this cell failed before updating: body, msg -- a retry that reads these names gets values from before this run.
  ```

  Wired into the generic exception path and both KeyboardInterrupt paths (watchdog + user). Best-effort, never raises; empty for SyntaxError (nothing ran).

**Tests**: `tests/test_stale_binding_note.py` (19 cases: the incident shape, loop/try/finally/nested-scope exclusions, walrus/import/unpack targets, gen-mode cells, interrupt path, elision), wired into the `typecheckSmoke` check. All pass locally alongside the neighboring runtime suites (60 tests).

*(PR by an AI agent, Claude Opus 4.5 via Claude Code.)*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add stale-binding note to failed cell errors naming variables not updated before the failure
> - Adds `introspect.unreached_bindings` in [introspect.py](https://github.com/indexable-inc/index/pull/2531/files#diff-006579eb39a5fc5841047297950ecbb104d7094d82bdaec8fe1b9a4eeeda9cad), which statically analyzes cell source via `ast.parse` to determine which variable names were provably not assigned before the failing line.
> - Adds `runtime._stale_binding_note` in [runtime.py](https://github.com/indexable-inc/index/pull/2531/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95), which calls `unreached_bindings` and formats a `NOTE:` string listing up to 12 names (with `+N more` elision) appended to `job.error` on both exception and `KeyboardInterrupt` failures.
> - Adds unit and end-to-end tests in [test_stale_binding_note.py](https://github.com/indexable-inc/index/pull/2531/files#diff-2a12f4d7ad49007ca0618566d5503d5344512b3440f3b019f00f8260050274e1) covering AST edge cases and the elision behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32402c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->