### PR TITLE
mcp: skip arming pr_watch auto merge on an already-mergeable PR

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3053,7 +3053,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3093,6 +3093,8 @@
       cp ${./tests/test_builtin_shadow_restore.py} test_builtin_shadow_restore.py
       # Issue #2526: a failed cell's traceback names the bindings it never reached.
       cp ${./tests/test_unexecuted_note.py} test_unexecuted_note.py
+      # Issue #2532: watch_pr skips arming auto merge on an already-mergeable PR.
+      cp ${./tests/test_pr_watch_automerge.py} test_pr_watch_automerge.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
@@ -3107,6 +3109,7 @@
         test_kernel_trace_path.py \
         test_builtin_shadow_restore.py \
         test_unexecuted_note.py \
+        test_pr_watch_automerge.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -144,7 +144,9 @@ PR_WATCH = (
     "For pull requests, use `pr_watch` instead of a hand-written polling loop. It creates a "
     "live PR resource under the current task, shows each required check or action with elapsed "
     "time, enables auto merge by default, and notifies the CLI when the PR merges, fails, or "
-    "times out."
+    "times out. On an already-mergeable PR (no blocking required checks) it deliberately does "
+    "NOT arm auto merge, since arming would merge instantly before any watching; its result "
+    "says to merge explicitly once your own validation is green."
 )
 
 DISCOVER = (

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1926,6 +1926,16 @@ def _pr_resource_html(state: Mapping[str, Any]) -> str:
     )
 
 
+# GitHub mergeStateStatus values under which `gh pr merge --auto` merges the
+# PR the moment it is armed (#2532): nothing blocking remains, either because
+# the repo has no required checks or because they already passed, so "arm,
+# then watch, then merge" silently degrades to "merge now". UNSTABLE is
+# mergeable with failing or pending NON-required checks; those never block.
+_INSTANT_MERGE_STATES: frozenset[str] = frozenset({"CLEAN", "UNSTABLE", "HAS_HOOKS"})
+_MERGEABILITY_POLL_S: float = 2.0
+_MERGEABILITY_TIMEOUT_S: float = 30.0
+
+
 async def watch_pr(
     pr: str | int,
     *,
@@ -1955,6 +1965,7 @@ async def watch_pr(
         "elapsed": "",
     }
     started = time.time()
+    auto_merge_note = ""
     resource = register_resource(
         render=lambda: _pr_resource_html(state),
         id=f"pr-{safe_id}",
@@ -1989,7 +2000,11 @@ async def watch_pr(
                 "status": str(row.get("state") or "").lower(),
                 "merge_state": row.get("mergeStateStatus") or "",
                 "checks": checks,
-                "auto_merge": "auto merge on" if row.get("autoMergeRequest") else "auto merge off",
+                "auto_merge": (
+                    "auto merge skipped: already mergeable"
+                    if auto_merge_note
+                    else ("auto merge on" if row.get("autoMergeRequest") else "auto merge off")
+                ),
                 "elapsed": _format_duration(time.time() - started),
                 "error": "",
             }
@@ -1997,15 +2012,47 @@ async def watch_pr(
         return row
 
     if auto_merge:
-        flag = f"--{merge_method}"
-        delete = "--delete-branch" if delete_branch else ""
-        # `| complete` yields a nu record: a plain dict, not a 1-row frame
-        # (issue #2390).
-        merge: dict[str, Any] = await run_nu(
-            f"gh pr merge $env.PR --auto {flag} {delete} | complete"
-        )
-        if int(merge["exit_code"]) != 0:
-            state["error"] = str(merge["stderr"] or merge["stdout"])
+        # Arming auto merge on an already-mergeable PR merges it instantly,
+        # before any watching happens (#2532): branch-protection endpoints
+        # need admin and gh's statusCheckRollup carries no isRequired, so
+        # mergeStateStatus is the one read-accessible "would merge right now"
+        # signal. A fresh PR reports UNKNOWN while GitHub computes
+        # mergeability, so poll briefly for a real answer first.
+        row = await refresh()
+        deadline = time.time() + _MERGEABILITY_TIMEOUT_S
+        while (
+            row.get("state") == "OPEN"
+            and str(row.get("mergeStateStatus") or "UNKNOWN") == "UNKNOWN"
+            and time.time() < deadline
+        ):
+            await asyncio.sleep(_MERGEABILITY_POLL_S)
+            row = await refresh()
+        if str(row.get("mergeStateStatus") or "") in _INSTANT_MERGE_STATES:
+            auto_merge_note = (
+                f"auto merge NOT armed: PR {clean_pr} is already mergeable "
+                f"(mergeStateStatus={row.get('mergeStateStatus')}: no blocking "
+                f"required checks remain), so arming would merge it immediately, "
+                f"before any watching. Merge explicitly "
+                f"(gh pr merge {clean_pr} --{merge_method}) once your own gate is green."
+            )
+            print(auto_merge_note, flush=True)
+            await notify(auto_merge_note, resource=resource.id, pr=clean_pr)
+        else:
+            flag = f"--{merge_method}"
+            delete = "--delete-branch" if delete_branch else ""
+            # `| complete` yields a nu record: a plain dict, not a 1-row frame
+            # (issue #2390).
+            merge: dict[str, Any] = await run_nu(
+                f"gh pr merge $env.PR --auto {flag} {delete} | complete"
+            )
+            if int(merge["exit_code"]) != 0:
+                state["error"] = str(merge["stderr"] or merge["stdout"])
+
+    def finished(result: dict[str, Any]) -> dict[str, Any]:
+        """Carry the skipped-auto-merge note onto the returned summary."""
+        if auto_merge_note:
+            result["auto_merge"] = auto_merge_note
+        return result
 
     last: dict[str, Any] = {}
     while True:
@@ -2020,18 +2067,18 @@ async def watch_pr(
             state["status"] = "merged" if last.get("state") == "MERGED" else "closed"
             resource.close()
             await notify(f"PR {clean_pr} finished with state {last.get('state')}", resource=resource.id, pr=clean_pr)
-            return {"state": last.get("state"), "url": last.get("url"), "checks": len(checks)}
+            return finished({"state": last.get("state"), "url": last.get("url"), "checks": len(checks)})
         if failures:
             state["status"] = "failed"
             state["error"] = "One or more required actions failed."
             resource.close()
             await notify(f"PR {clean_pr} has failing checks", resource=resource.id, pr=clean_pr)
-            return {"state": "failed", "url": last.get("url"), "failures": failures}
+            return finished({"state": "failed", "url": last.get("url"), "failures": failures})
         if time.time() - started > timeout:
             state["status"] = "timed out"
             resource.close()
             await notify(f"PR {clean_pr} watch timed out", resource=resource.id, pr=clean_pr)
-            return {"state": "timed out", "url": last.get("url"), "checks": len(checks)}
+            return finished({"state": "timed out", "url": last.get("url"), "checks": len(checks)})
         await asyncio.sleep(interval)
 
 

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -606,7 +606,11 @@ async def python_exec(
         "Watch a GitHub pull request in the dashboard. Creates a live PR resource "
         "nested under this task, lists required checks and actions with elapsed "
         "time, enables auto merge by default, and notifies the CLI when the PR "
-        "merges, fails, or times out. Use this instead of hand-written PR polling."
+        "merges, fails, or times out. When the PR is already mergeable (no "
+        "blocking required checks), auto merge is NOT armed, since arming would "
+        "merge instantly before any watching: the result says so, and the caller "
+        "merges explicitly once its own validation is green. Use this instead of "
+        "hand-written PR polling."
     ),
 )
 async def pr_watch(

--- a/packages/mcp/tests/test_pr_watch_automerge.py
+++ b/packages/mcp/tests/test_pr_watch_automerge.py
@@ -1,0 +1,109 @@
+"""`watch_pr` must not arm auto merge on an already-mergeable PR (#2532).
+
+On a repo with no blocking required checks, GitHub merges a PR the moment
+`gh pr merge --auto` is armed, before any watching happens, so `watch_pr`
+reads mergeStateStatus first and skips arming with a loud note instead.
+"""
+
+import asyncio
+import sys
+
+import pytest
+
+from ix_notebook_mcp import runtime
+
+
+class _ScriptedNu:
+    """Stand-in for the bundled `nu` module: `watch_pr` does `import nu as
+    nu_call` then calls the module object itself, so the TYPE must define
+    `__call__`. Serves scripted `gh pr view` rows (the last row repeats) and
+    records every `gh pr merge` invocation."""
+
+    def __init__(self, views: list[dict[str, object]]) -> None:
+        self._views = list(views)
+        self.merges: list[str] = []
+
+    async def __call__(
+        self,
+        code: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float = 60,
+    ) -> dict[str, object]:
+        if "gh pr merge" in code:
+            self.merges.append(code)
+            return {"exit_code": 0, "stdout": "", "stderr": ""}
+        assert "gh pr view" in code
+        return self._views.pop(0) if len(self._views) > 1 else self._views[0]
+
+
+def _view(pr: int, state: str, merge_state: str) -> dict[str, object]:
+    return {
+        "number": pr,
+        "title": "fix: guard",
+        "state": state,
+        "mergeStateStatus": merge_state,
+        "statusCheckRollup": [],
+        "url": f"https://github.com/o/r/pull/{pr}",
+        "autoMergeRequest": None,
+        "isDraft": False,
+        "reviewDecision": "",
+    }
+
+
+def _watch(
+    monkeypatch: pytest.MonkeyPatch, pr: int, views: list[dict[str, object]]
+) -> tuple[dict[str, object], _ScriptedNu, list[str]]:
+    fake = _ScriptedNu(views)
+    monkeypatch.setitem(sys.modules, "nu", fake)
+    notified: list[str] = []
+
+    async def fake_notify(content: str, **meta: object) -> None:
+        notified.append(content)
+
+    monkeypatch.setattr(runtime, "notify", fake_notify)
+    result = asyncio.run(runtime.watch_pr(pr, auto_merge=True, interval=0.01))
+    return result, fake, notified
+
+
+def test_already_mergeable_pr_skips_arming_with_loud_note(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLEAN at arm time: no `gh pr merge --auto`, and the note reaches both
+    the returned summary and the notify stream."""
+    result, fake, notified = _watch(
+        monkeypatch, 9101, [_view(9101, "OPEN", "CLEAN"), _view(9101, "MERGED", "CLEAN")]
+    )
+    assert fake.merges == []
+    assert result["state"] == "MERGED"
+    note = str(result["auto_merge"])
+    assert "NOT armed" in note
+    assert "gh pr merge 9101 --squash" in note
+    assert any("NOT armed" in text for text in notified)
+
+
+def test_unknown_mergeability_polls_until_it_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fresh PR reports UNKNOWN while GitHub computes mergeability; the guard
+    polls past it and still catches the instant-merge case (#2532's repro: the
+    PR that merged 8 seconds after creation)."""
+    monkeypatch.setattr(runtime, "_MERGEABILITY_POLL_S", 0.01)
+    result, fake, _notified = _watch(
+        monkeypatch,
+        9102,
+        [
+            _view(9102, "OPEN", "UNKNOWN"),
+            _view(9102, "OPEN", "CLEAN"),
+            _view(9102, "MERGED", "CLEAN"),
+        ],
+    )
+    assert fake.merges == []
+    assert "NOT armed" in str(result["auto_merge"])
+
+
+def test_blocked_pr_still_arms_auto_merge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BLOCKED (required checks pending) keeps the old behavior: arm and watch."""
+    result, fake, _notified = _watch(
+        monkeypatch, 9103, [_view(9103, "OPEN", "BLOCKED"), _view(9103, "MERGED", "BLOCKED")]
+    )
+    assert len(fake.merges) == 1
+    assert "--auto" in fake.merges[0]
+    assert "auto_merge" not in result


### PR DESCRIPTION
Fixes #2532.

`pr_watch` arms auto merge by default; on a repo with no blocking required checks (index since the merge queue was dropped) GitHub merges the PR the moment it is armed, before any watching happens (#2528 merged 8s after creation while the local gate was still running).

`watch_pr` now checks mergeability before arming:

- reads `mergeStateStatus` from the `gh pr view` refresh it already does (branch-protection endpoints need admin; gh's `statusCheckRollup` carries no `isRequired`), polling briefly past `UNKNOWN` while GitHub computes it
- when the PR is already mergeable (`CLEAN`/`UNSTABLE`/`HAS_HOOKS`), it does NOT arm auto merge and says so loudly: job output, `notify()` stream, the PR resource meta, and the returned summary, telling the caller to merge explicitly (`gh pr merge <pr> --squash`) once its own gate is green
- blocked PRs (required checks pending, review required) keep the old arm-and-watch behavior
- tool + guide descriptions updated to match

Tests: `packages/mcp/tests/test_pr_watch_automerge.py` (skip on CLEAN, poll past UNKNOWN, still-arms on BLOCKED), registered in `typecheckSmoke`.

Validated locally: `nix build .#mcp.tests.typecheckSmoke .#mcp.tests.strictTypecheck .#mcp.tests.channelTests` all green (122 passed / 29 passed).

(sent by an AI agent via Claude Code, model claude-opus-4-6)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip arming auto merge in `watch_pr` when a PR is already mergeable
> - `watch_pr` in [runtime.py](https://github.com/indexable-inc/index/pull/2539/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now checks `mergeStateStatus` before arming auto merge. If the status is `CLEAN`, `UNSTABLE`, or `HAS_HOOKS`, it skips `gh pr merge --auto` and emits a notification instructing explicit merge instead.
> - When `mergeStateStatus` is `UNKNOWN`, `watch_pr` polls up to 30s (at 2s intervals) before deciding whether to arm or skip.
> - The returned summary includes an `auto_merge_note` field when the arm is skipped, and the tool/guide descriptions are updated to document this behavior.
> - Three new tests in [test_pr_watch_automerge.py](https://github.com/indexable-inc/index/pull/2539/files#diff-d243930ff12d7f05a5b5592577c7a8444edb1403b703fecd4f559c185cc67ca3) cover the skip-on-mergeable, poll-through-UNKNOWN, and arm-on-BLOCKED cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbf6491.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->