### PR TITLE
mcp fsearch: find() auto-detects glob-shaped patterns like '*.py'

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3053,7 +3053,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3077,6 +3077,8 @@
       cp ${./tests/test_dashboard_autostart.py} test_dashboard_autostart.py
       cp ${./tests/test_fsearch_partial.py} test_fsearch_partial.py
       cp ${./tests/test_fsearch_glob.py} test_fsearch_glob.py
+      # Issue #2542: find('*.py') auto-detects a glob-shaped non-regex pattern.
+      cp ${./tests/test_fsearch_glob_pattern.py} test_fsearch_glob_pattern.py
       # Issue #2246: grep(files_only=True) -> path + match-count rows via rg --count-matches.
       cp ${./tests/test_fsearch_files_only.py} test_fsearch_files_only.py
       # Issue #2245: ranked per-session search over local Claude Code history.
@@ -3102,6 +3104,7 @@
         test_dashboard_autostart.py \
         test_fsearch_partial.py \
         test_fsearch_glob.py \
+        test_fsearch_glob_pattern.py \
         test_fsearch_files_only.py \
         test_claude_history.py \
         test_sh_module.py \

--- a/packages/mcp/src/fsearch/fsearch/__init__.py
+++ b/packages/mcp/src/fsearch/fsearch/__init__.py
@@ -29,6 +29,7 @@ import contextlib
 import fnmatch as _fnmatch
 import json as _json
 import os
+import re
 import signal
 import stat as _stat
 import sys
@@ -123,6 +124,23 @@ def _dir_root(pattern: str) -> str | None:
         return None
     path = Path(pattern).expanduser()
     return str(path) if path.is_dir() else None
+
+
+def _glob_shaped(pattern: str) -> bool:
+    """Whether a ``find`` pattern that is not a valid regex reads as a glob: it
+    contains a glob metacharacter (``*``/``?``/``[``) and fails to compile as a
+    regex, so ``find("*.py")`` flips to glob matching instead of surfacing fd's
+    regex parse error (#2542). A valid regex always keeps its regex reading,
+    even a glob-plausible one like ``[abc].py``. Python's ``re`` stands in for
+    fd's Rust regex dialect here; the two agree on the glob-shaped failures
+    (a bare leading repetition operator is invalid in both)."""
+    if not any(ch in pattern for ch in "*?["):
+        return False
+    try:
+        re.compile(pattern)
+    except re.error:
+        return True
+    return False
 
 
 async def _run(argv: list[str], *, timeout: float, ok_codes: tuple[int, ...] = (0,)) -> tuple[str, bool]:
@@ -496,8 +514,9 @@ async def find(
     timeout: float = DEFAULT_TIMEOUT,
 ) -> pl.DataFrame:
     """Find files via fd, one row per path. ``pattern`` is a regex by default
-    (``glob=True`` for glob, ``fixed=True`` for a literal); ``kind`` ∈
-    file/dir/symlink; ``ext`` filters by extension. A *string* ``glob`` is a
+    (``glob=True`` for glob, ``fixed=True`` for a literal), but a glob-shaped
+    pattern that is not a valid regex — ``find("*.py")`` — is treated as a glob
+    automatically; ``kind`` ∈ file/dir/symlink; ``ext`` filters by extension. A *string* ``glob`` is a
     path filter, same meaning as on :func:`grep`: the pattern keeps its
     regex/literal reading and only paths matching the glob are returned (no
     ``/`` in the glob matches the file name; with ``/`` it matches the path
@@ -512,6 +531,12 @@ async def find(
     # default pattern), unless an explicit `root` already claims that slot.
     if root == "." and (dir_root := _dir_root(pattern)) is not None:
         pattern, root = ".", dir_root
+    # `find("*.py")` is a natural call shape but not a valid regex; instead of
+    # surfacing fd's regex parse error it flips to glob mode (#2542). Explicit
+    # modes are never second-guessed: glob=True/glob="..." and fixed=True keep
+    # their reading.
+    if glob is False and not fixed and _glob_shaped(pattern):
+        glob = True
     # `glob` is a mode flag (True: the pattern IS a glob) or, for parity with
     # grep's glob=, a filter string; without this split a string would truthily
     # flip the mode and silently glob-match `pattern` instead of filtering.
@@ -539,7 +564,15 @@ async def find(
         # `timeout` either way.
         argv += ["--max-results", str(limit)]
     argv += ["--", pattern, _expand(root)]
-    text, timed_out = await _run(argv, timeout=timeout)
+    try:
+        text, timed_out = await _run(argv, timeout=timeout)
+    except FsearchError as exc:
+        # The pattern was read as a regex and fd rejected it; name the escape
+        # hatches so the caller is steered before reaching for the fd docs.
+        if glob is not True and not fixed and "regex parse error" in str(exc):
+            msg = f"{exc}\n(find patterns are regexes by default; pass glob=True for a glob, or fixed=True for a literal)"
+            raise FsearchError(msg) from exc
+        raise
     return await _paths_frame(
         text,
         limit=limit,

--- a/packages/mcp/tests/test_fsearch_glob_pattern.py
+++ b/packages/mcp/tests/test_fsearch_glob_pattern.py
@@ -1,0 +1,64 @@
+"""``find("*.py")`` works: a glob-shaped pattern that is not a valid regex
+flips to fd's ``--glob`` mode instead of surfacing fd's regex parse error
+(issue #2542).
+
+The detector (`_glob_shaped`) is pure and exercised directly; the end-to-end
+paths run against real fd and skip cleanly when fd is not on PATH. A pattern
+fd still rejects as a regex must at least name the ``glob=``/``fixed=`` escape
+hatches in the error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+
+import pytest
+
+import fsearch
+
+
+def test_glob_shaped_detects_invalid_regex_with_glob_metachars() -> None:
+    assert fsearch._glob_shaped("*.py")
+    assert fsearch._glob_shaped("?.py")
+    # A valid regex keeps its regex reading, even a glob-plausible one.
+    assert not fsearch._glob_shaped(".*py")
+    assert not fsearch._glob_shaped("[abc].py")
+    # No glob metacharacter: never a glob, even when invalid as a regex.
+    assert not fsearch._glob_shaped("(ab")
+    assert not fsearch._glob_shaped("src")
+
+
+def test_find_star_pattern_matches_as_glob(tmp_path: object) -> None:
+    # The issue's exact call shape: find("*.py") used to raise
+    # "fd exited 1: regex parse error: repetition operator missing expression".
+    if shutil.which("fd") is None:
+        pytest.skip("fd not on PATH")
+    (tmp_path / "a.py").write_text("x")  # type: ignore[operator]
+    (tmp_path / "b.txt").write_text("x")  # type: ignore[operator]
+    (tmp_path / "sub").mkdir()  # type: ignore[operator]
+    (tmp_path / "sub" / "c.py").write_text("x")  # type: ignore[operator]
+
+    frame = asyncio.run(fsearch.find("*.py", root=str(tmp_path)))  # type: ignore[arg-type]
+    assert sorted(frame["name"].to_list()) == ["a.py", "c.py"], frame
+
+
+def test_find_valid_regex_keeps_regex_reading(tmp_path: object) -> None:
+    # `.*py` is a valid regex, so autodetect must not hijack it into glob mode
+    # (as a glob it would require a literal leading dot and match nothing here).
+    if shutil.which("fd") is None:
+        pytest.skip("fd not on PATH")
+    (tmp_path / "a.py").write_text("x")  # type: ignore[operator]
+    (tmp_path / "b.txt").write_text("x")  # type: ignore[operator]
+
+    frame = asyncio.run(fsearch.find(".*py", root=str(tmp_path)))  # type: ignore[arg-type]
+    assert frame["name"].to_list() == ["a.py"], frame
+
+
+def test_find_invalid_regex_error_names_the_escape_hatches(tmp_path: object) -> None:
+    # A pattern fd rejects that is NOT glob-shaped still errors, but the error
+    # must steer to glob=True / fixed=True instead of a bare fd passthrough.
+    if shutil.which("fd") is None:
+        pytest.skip("fd not on PATH")
+    with pytest.raises(fsearch.FsearchError, match="glob=True"):
+        asyncio.run(fsearch.find("(ab", root=str(tmp_path)))  # type: ignore[arg-type]


### PR DESCRIPTION
Fixes #2542.

`find('*.py')` used to surface fd's `regex parse error: repetition operator missing expression`. Now:

- **Glob autodetect**: a pattern containing a glob metacharacter (`*?[`) that fails to compile as a regex flips to `fd --glob` automatically, so `find('*.py')` just works. A valid regex (e.g. `.*py`, `[abc].py`) always keeps its regex reading, and explicit `glob=`/`fixed=` are never second-guessed.
- **Error steering**: a pattern fd still rejects as a regex (e.g. `(ab`) gets `pass glob=True for a glob, or fixed=True for a literal` appended to the `FsearchError`.
- Doc updated; tests in `packages/mcp/tests/test_fsearch_glob_pattern.py`, registered in `typecheckSmoke`.

Validated: `nix build .#mcp.tests.typecheckSmoke --no-link` passes (`/nix/store/g3v07wnvzjcpr58918w0yml1xhcpwf7r-ix-mcp-typecheck-smoke`).

(sent by an AI agent via Claude Code, model claude-opus-4-6)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-detect glob-shaped patterns in `fsearch.find()` to avoid regex parse errors
> - Adds a `_glob_shaped()` helper in [`__init__.py`](https://github.com/indexable-inc/index/pull/2543/files#diff-d49cbee7af25fcd8a29d12e63297e2d875f7609698886e1aec71033697a75bac) that detects patterns containing glob metacharacters (`*`, `?`, `[`) that are not valid regexes.
> - When `glob=False` and `fixed=False`, `find()` now calls `_glob_shaped()` and automatically sets `glob=True` for patterns like `*.py`, avoiding `fd` regex parse errors.
> - When a regex parse error still occurs for non-glob-shaped patterns, the raised `FsearchError` now suggests using `glob=True` or `fixed=True`.
> - Adds [`test_fsearch_glob_pattern.py`](https://github.com/indexable-inc/index/pull/2543/files#diff-7f0c8edab45ce3e7ad134f2b02d7ab30cee48e5cd159f3e7bb899b8f0f42920d) with unit and end-to-end tests covering autodetection, valid regex passthrough, and error messaging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2cf34e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->