### PR TITLE
nu: route input= past no-input statements or fail loudly

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -3053,7 +3053,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542) + nu input= routing past no-input statements (#2540)";
     }
     ''
       export HOME=$TMPDIR/home
@@ -3097,6 +3097,8 @@
       cp ${./tests/test_unexecuted_note.py} test_unexecuted_note.py
       # Issue #2532: watch_pr skips arming auto merge on an already-mergeable PR.
       cp ${./tests/test_pr_watch_automerge.py} test_pr_watch_automerge.py
+      # Issue #2540: input= routes past no-input statements (cd /tmp; ^cat) or raises.
+      cp ${./tests/test_nu_input_routing.py} test_nu_input_routing.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
@@ -3113,6 +3115,7 @@
         test_builtin_shadow_restore.py \
         test_unexecuted_note.py \
         test_pr_watch_automerge.py \
+        test_nu_input_routing.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/tests/test_nu_input_routing.py
+++ b/packages/mcp/tests/test_nu_input_routing.py
@@ -1,0 +1,79 @@
+"""Issue #2540 regressions: `input=` reaches the pipeline in multi-statement
+code, or the call fails loudly -- never a silent drop.
+
+`nu("cd /tmp; ^cat | complete", input="hi")` used to return empty stdout with
+exit code 0: nushell block semantics feed input to the FIRST top-level
+pipeline, and `cd` (declared `nothing` input) drained the payload. Real
+casualties: `gh issue comment --body-file -` posted "Body cannot be blank"
+and `git commit --file -` aborted on an empty message. Drives the real
+embedded engine (the `nu._nu` PyO3 cdylib), like test_nu.py.
+"""
+
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+import nu
+
+# An external that echoes its stdin, using the interpreter binary the sandbox
+# certainly has (the pattern test_nu.py uses for external-command coverage).
+STDIN_ECHO = f'^{sys.executable} -c "import sys; sys.stdout.write(sys.stdin.read())"'
+
+
+def run(coro: object) -> object:
+    return asyncio.run(coro)
+
+
+def test_input_reaches_external_stdin_after_cd(tmp_path: pathlib.Path) -> None:
+    # The issue's literal shape: a `cd` prefix must not eat the external's stdin.
+    try:
+        rec = run(nu(f"cd {tmp_path}; {STDIN_ECHO} | complete", input="hi"))
+        assert isinstance(rec, dict)
+        assert rec["exit_code"] == 0
+        assert rec["stdout"] == "hi"
+    finally:
+        nu.reset()
+
+
+def test_input_routes_to_mid_block_external_not_the_last_pipeline(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Routing targets the first ACCEPTING pipeline, not blindly the final one:
+    # the mid-block external gets the payload, its output prints as an
+    # intermediate (issue #2391), and the final statement's value returns.
+    # (An INTERNAL command that cannot take `nothing` input is already a parse
+    # error mid-block, so externals are the consumers this routing serves.)
+    try:
+        assert run(nu(f"cd {tmp_path}; {STDIN_ECHO}; 'done'", input="hi")) == "done"
+        assert "hi" in capsys.readouterr().out
+    finally:
+        nu.reset()
+
+
+def test_first_accepting_pipeline_still_receives_input(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Unchanged pre-#2540 behavior when the first pipeline CAN consume: input
+    # feeds it (nushell block semantics) and its output prints as an
+    # intermediate (issue #2391) while the final value is returned.
+    assert run(nu("str upcase; 'done'", input="hi")) == "done"
+    assert "HI" in capsys.readouterr().out
+
+
+def test_undeliverable_input_raises_instead_of_dropping(tmp_path: pathlib.Path) -> None:
+    try:
+        with pytest.raises(nu.NuError, match="input="):
+            run(nu(f"cd {tmp_path}; cd {tmp_path}", input="hi"))
+    finally:
+        nu.reset()
+
+
+def test_single_no_input_statement_raises(tmp_path: pathlib.Path) -> None:
+    try:
+        with pytest.raises(nu.NuError, match="input="):
+            run(nu(f"cd {tmp_path}", input="hi"))
+    finally:
+        nu.reset()

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -31,6 +31,12 @@ A DataFrame (or list/dict/scalar) can be piped THROUGH a pipeline: pass
 
     df = await nu("where size > 1kb | sort-by size", input=df)
 
+In multi-statement source the input is delivered to the first statement that
+can accept pipeline input, so a leading ``cd``/``def`` (declared ``nothing``
+input) never drains it (``cd /tmp; ^cat | complete`` still feeds cat); when
+no statement can accept it, the call raises instead of silently dropping the
+payload (issue #2540).
+
 ``nu()`` is the single shell-out path: side-effectful commands
 (``git``/``gh`` writes) run as externals with ``^cmd``, and a CLI with a native
 ``--json`` mode decodes end to end (``^gh ... --json | from json``). For a nix
@@ -513,7 +519,10 @@ async def nu(
     being silently dropped (issue #2391), and ``let``/``def``/``cd`` persist
     to later calls (REPL semantics; the engine is per session, so another
     session's ``cd`` can never move this one's PWD). ``input`` pipes a value in as ``$in`` -- a polars DataFrame,
-    list, dict, or scalar (datetimes must be tz-aware). ``cwd`` sets ``PWD``
+    list, dict, or scalar (datetimes must be tz-aware) -- delivered to the
+    first statement that accepts pipeline input (a leading ``cd``/``def``
+    declares none and is skipped); when nothing can accept it the call
+    raises instead of dropping the payload (issue #2540). ``cwd`` sets ``PWD``
     and persists like ``cd``; if the remembered directory no longer exists
     the call raises with the remedy instead of silently running elsewhere.
     ``env`` adds environment variables;

--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -23,11 +23,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, FixedOffset, TimeDelta, Utc};
-use nu_protocol::ast::{Block, Expr, Expression, ListItem, RecordItem};
+use nu_protocol::ast::{Block, Expr, Expression, ListItem, Pipeline, RecordItem};
 use nu_protocol::debugger::WithoutDebug;
 use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
 use nu_protocol::{
-    ByteStreamSource, ErrorStyle, PipelineData, Record, ShellError, Signals, Span, Value,
+    ByteStreamSource, ErrorStyle, PipelineData, Record, ShellError, Signals, Span, Type, Value,
     report_error::format_cli_error,
 };
 use pyo3::create_exception;
@@ -237,6 +237,30 @@ fn run_block(
     input: Option<Value>,
     check: bool,
 ) -> Result<(Vec<Value>, Value, i64), String> {
+    // input= routing (issue #2540): deliver the input to the FIRST pipeline
+    // that can accept pipeline input. Nushell's own block semantics feed the
+    // first pipeline unconditionally, so a leading no-input statement (`cd
+    // /tmp; ^cat` -- cd declares `nothing` input) drained the payload
+    // silently and the external read empty stdin with exit code 0 (`gh
+    // ... --body-file -` then failed on a blank body). When NO pipeline can
+    // accept it, fail loudly instead of dropping it.
+    let deliver_to = match input {
+        None => None,
+        Some(_) => Some(
+            block
+                .pipelines
+                .iter()
+                .position(|pipeline| pipeline_accepts_input(engine_state, pipeline))
+                .ok_or_else(|| {
+                    "input= was provided but no statement in this source accepts pipeline \
+                     input (each one, like `cd` or `def`, declares `nothing` input), so \
+                     the input cannot be delivered; consume it (e.g. `$in | ...`) or drop \
+                     input="
+                        .to_owned()
+                })?,
+        ),
+    };
+
     // One pipeline: evaluate the parse-compiled block as-is (the historical
     // fast path; nothing intermediate exists to surface).
     if block.pipelines.len() <= 1 {
@@ -280,7 +304,7 @@ fn run_block(
 
     let last_index = sub_blocks.len() - 1;
     let mut intermediates = Vec::with_capacity(last_index);
-    let mut input = input; // `$in` feeds the FIRST pipeline, like block IR.
+    let mut input = input;
     for (index, sub) in sub_blocks.iter().enumerate() {
         let is_last = index == last_index;
         if index > 0 {
@@ -291,17 +315,47 @@ fn run_block(
                 .check(&span)
                 .map_err(|error| render_shell_error(engine_state, stack, &error))?;
         }
+        let pipeline_input = if deliver_to == Some(index) {
+            input.take()
+        } else {
+            None
+        };
         // `check` governs only the final pipeline's trailing external
         // (documented NuResult semantics); an intermediate external that
         // fails aborts the eval either way.
         let (value, exit_code) =
-            run_pipeline(engine_state, stack, sub, input.take(), if is_last { check } else { true })?;
+            run_pipeline(engine_state, stack, sub, pipeline_input, if is_last { check } else { true })?;
         if is_last {
             return Ok((intermediates, value, exit_code));
         }
         intermediates.push(value);
     }
     unreachable!("the loop returns at the last pipeline and the block is non-empty");
+}
+
+/// True when `pipeline` can receive pipeline input: its head is an external
+/// (stdin), a plain expression (a `$in`-referencing element arrives
+/// collect-wrapped, never as a bare call), or a call whose declared input
+/// types include something other than `nothing`. `cd` and `def` declare
+/// `(nothing, nothing)`, so [`run_block`]'s input routing skips them (issue
+/// #2540); `let`/`mut` declare `any` and keep receiving input (their RHS may
+/// read `$in`). An empty declaration list is treated as accepting: dropping
+/// input on an unknown signature would be the very bug being fixed.
+fn pipeline_accepts_input(engine_state: &EngineState, pipeline: &Pipeline) -> bool {
+    let Some(element) = pipeline.elements.first() else {
+        return false;
+    };
+    match &element.expr.expr {
+        Expr::Call(call) => {
+            let signature = engine_state.get_decl(call.decl_id).signature();
+            signature.input_output_types.is_empty()
+                || signature
+                    .input_output_types
+                    .iter()
+                    .any(|(input, _)| !matches!(input, Type::Nothing))
+        }
+        _ => true,
+    }
 }
 
 /// Evaluate one compiled block (a whole single-pipeline eval, or one
@@ -701,7 +755,10 @@ impl Engine {
     /// the wrapper to print, issue #2391) and `value` is the final
     /// pipeline's output; `handle.interrupt()` stops this eval (and only
     /// this eval) the way ctrl-c would. `input` becomes the
-    /// pipeline's `$in`; `cwd`/`env` set `PWD` / environment variables for
+    /// pipeline's `$in`, delivered to the first pipeline that can accept
+    /// pipeline input (a leading `cd`/`def` declares `nothing` input and is
+    /// skipped; undeliverable input raises instead of dropping, issue
+    /// #2540); `cwd`/`env` set `PWD` / environment variables for
     /// this and later calls (the stack is persistent). When `cwd` is omitted
     /// the persistent PWD is validated first: a directory that no longer
     /// exists raises with the remedy instead of running somewhere unintended.
@@ -940,7 +997,7 @@ mod tests {
     }
 
     #[test]
-    fn input_feeds_the_first_pipeline_only() {
+    fn input_feeds_the_first_accepting_pipeline() {
         let (mut inner, interrupt) = test_inner();
         let (intermediates, value, _) = inner
             .eval(
@@ -954,6 +1011,62 @@ mod tests {
             .expect("input piped into the first pipeline");
         assert!(matches!(&intermediates[0], Value::String { val, .. } if val == "HI"));
         assert!(matches!(&value, Value::String { val, .. } if val == "done"));
+    }
+
+    #[test]
+    fn input_routes_past_no_input_statements_to_the_consumer() {
+        // Issue #2540's shape: `cd /tmp; ^cat` fed the input to `cd`
+        // (declared `nothing` input), which drained it, and the external
+        // read empty stdin with exit 0. Routing must skip `cd` and deliver.
+        // The consumer is an external on purpose: nushell's parser already
+        // rejects an internal command mid-block unless it accepts `nothing`
+        // input (nu::parser::input_type_mismatch), so externals are the
+        // consumers this routing exists for.
+        let (mut inner, interrupt) = test_inner();
+        let (intermediates, value, _) = inner
+            .eval(
+                &format!("cd {}; ^cat", std::env::temp_dir().display()),
+                Some(Value::string("hi", Span::unknown())),
+                None,
+                None,
+                &interrupt,
+                true,
+            )
+            .expect("input routed past cd (issue #2540)");
+        assert!(matches!(&intermediates[0], Value::Nothing { .. }));
+        assert!(matches!(&value, Value::String { val, .. } if val == "hi"));
+    }
+
+    #[test]
+    fn undeliverable_input_fails_loudly() {
+        let (mut inner, interrupt) = test_inner();
+        let diagnostic = inner
+            .eval(
+                "def noop [] {}; def still-no-input [] {}",
+                Some(Value::string("hi", Span::unknown())),
+                None,
+                None,
+                &interrupt,
+                true,
+            )
+            .expect_err("input nothing can consume must error, not drop (issue #2540)");
+        assert!(diagnostic.contains("input="), "diagnostic: {diagnostic}");
+    }
+
+    #[test]
+    fn undeliverable_input_fails_loudly_for_a_single_statement() {
+        let (mut inner, interrupt) = test_inner();
+        let diagnostic = inner
+            .eval(
+                "def noop [] {}",
+                Some(Value::string("hi", Span::unknown())),
+                None,
+                None,
+                &interrupt,
+                true,
+            )
+            .expect_err("single-statement undeliverable input must error too");
+        assert!(diagnostic.contains("input="), "diagnostic: {diagnostic}");
     }
 
     /// A statement whose FIRST element references `$in` makes the parser


### PR DESCRIPTION
Fixes #2540.

`nu()`'s `run_block` fed `input=` to the FIRST top-level pipeline unconditionally (nushell block semantics), so `cd /tmp; ^cat | complete` handed the payload to `cd`, which declares `(nothing, nothing)` input and drained it: the external read empty stdin and exited 0. Production casualties: `gh issue comment --body-file -` failed with "Body cannot be blank", `git commit --file -` aborted on an empty message.

**Fix** (`packages/nu-py/src/lib.rs`): route `input=` to the first pipeline whose head can accept pipeline input: an external (stdin), a plain expression, or a call whose declared input types include more than `nothing`. When no statement can accept it, raise a clear `NuError` instead of dropping the payload. `let`/`mut` declare `any`, so `let x = $in` keeps working. (Internal commands that can't take `nothing` input are already a parse error mid-block, so externals are the consumers this routing serves.)

**Tests**: 4 new Rust unit tests in nu-py (route past `cd`, undeliverable input errors for multi- and single-statement source, first-accepting-pipeline behavior pinned), plus `packages/mcp/tests/test_nu_input_routing.py` registered in typecheckSmoke.

**Validated**: `nix build .#mcp.tests.typecheckSmoke --no-link` (green, 127 passed) and `cargo test -p nu-py` (16 passed).

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route `input=` to the first accepting pipeline in `nu` and raise on undeliverable input
> - Previously, `input=` was unconditionally delivered to the first pipeline in a block; now [lib.rs](https://github.com/indexable-inc/index/pull/2547/files#diff-424ce210c45fc8f162c45814067651d48d245471a2e86b63c39b71c370ffe7fe) uses a new `pipeline_accepts_input` helper to find the first pipeline that can consume input, skipping `cd`/`def` and other `Nothing`-input commands.
> - If no pipeline in the block can accept input, evaluation now returns an error diagnostic mentioning `input=` instead of silently dropping the value.
> - New Rust unit tests and a [Python integration test module](https://github.com/indexable-inc/index/pull/2547/files#diff-eb53554d1063b22e62d3dd1979ef2908f9c004c47040b56d472ad0cf8c15e5d5) cover the routing and error-on-undeliverable cases.
> - Behavioral Change: code that previously passed `input=` to blocks where no pipeline accepted it will now raise `NuError` instead of silently succeeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82e76f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->