### PR TITLE
fleet: source replacement images from the CAS manifest builder (ENG-6044)

### DIFF
--- a/doc/ix-fleet/overview.md
+++ b/doc/ix-fleet/overview.md
@@ -79,7 +79,9 @@ each node key matches its `name`; and that every `dependsOn` names a real node.
   direct `ix up` flake and `examples/dev/fleet/default.nix` for the mkDev
   wrapper).
 - **`ReplacementImage`** (`:34`): `imageName`, `destination`,
-  `source`, `sourceDrv` (the OCI image derivation to realise and push).
+  `sourceInstallable` (the `.#<node>` flake attr of the node's CAS-manifest
+  image, built at push time; the plan never carries the image's out/drv path
+  because instantiating the manifest builder forces the whole system closure).
 - **`HealthCheck`** (`:54`): `description`, `command` (argv), `timeoutSec`,
   `attempts`, `intervalSec`, `requiresIpv4`, and `from` (`guest`|`host`, stored
   as `from_` since `from` is a keyword).
@@ -98,8 +100,10 @@ uses. A node maps to an ix branch (`ix_sdk.BranchInfo`/`BranchStatus`:
 
 - create / delete / start a branch: `client().create(...)`, `branch.delete()`,
   `branch.start()` (`create_node` `:366`, `remove_node` `:509`).
-- image push: `client().image_push(source, destination, region)` after a
-  host-side `nix-store --realise` of `sourceDrv` (`push_replacement_image`, `:338`).
+- image push: a host-side `nix build` of `sourceInstallable`, then
+  `ix image push-manifest --locator <out>/locator.bin <out>/manifest.cas
+  <destination> --region <region>` (`push_replacement_image`, `:338`); the CLI
+  prints the pushed reference on stdout.
 - snapshot: `client().snapshot(name=...)` (`snapshot_node`, `:423`).
 - in-place switch: `client().switch_system(name, target, build_on)`
   (`switch_node`, `:430`).

--- a/doc/ix/images.md
+++ b/doc/ix/images.md
@@ -69,10 +69,10 @@ A fleet node carries two images (`lib/image/fleet.nix:291-300`):
   missing node. Defaults to the shared NixOS bootstrap image under
   `registry.ix.dev/...` (`lib/image/fleet.nix:48-49`,
   `lib/image/default.nix:104-107`).
-- **`replacementImage`** (`{ imageName, destination, source,
-  sourceDrv }`) - the image `up`/`replace` build and push from your config
-  (`lib/image/fleet.nix:311-316`). `destination` defaults to
-  `<imageName>:latest` (`lib/image/fleet.nix:269`).
+- **`replacementImage`** (`{ imageName, destination, sourceInstallable }`) -
+  the CAS-manifest image `up`/`replace` build (via the `.#<node>` flake attr)
+  and push from your config (`lib/image/fleet.nix:311-322`). `destination`
+  defaults to `<imageName>:latest` (`lib/image/fleet.nix:269`).
 
 See [fleet.md](fleet.md) for the authoring surface.
 

--- a/lib/image/cas-layer.nix
+++ b/lib/image/cas-layer.nix
@@ -1,0 +1,48 @@
+# CAS layer: the manifest-native image built from the NixOS system closure.
+#
+# Unlike the OCI layer, the builder itself does not live in this repo: the ix
+# repo owns manifest assembly (systemRoot, the baked nix store DB, init
+# config) and threads its builder in as a fleet/image module, e.g.
+#
+#   mkFleet {
+#     defaults = [{ix.build.casImageBuilder = ...;}];
+#     ...
+#   }
+#
+# `casImage` is deliberately lazy: nothing in this repo forces it during
+# fleet-plan evaluation (the plan carries only the `.#<node>` installable
+# string), so evaluating a fleet with no builder threaded stays valid.
+# Forcing `casImage` without a builder aborts evaluation with the module
+# system's "option `ix.build.casImageBuilder' ... used but not defined".
+{
+  config,
+  lib,
+  ...
+}: {
+  options.ix.build = {
+    /**
+    The ix-side manifest builder this repo codes against.
+
+    Called as `casImageBuilder { toplevel = <NixOS system closure>; }`.
+    Returns a derivation whose output directory contains `manifest.cas` (the
+    serialized CAS manifest) and `locator.bin` (the chunk locator table), the
+    pair `ix image push-manifest` consumes. The returned derivation must
+    carry `passthru.toplevel = toplevel` so CI can gate on the system closure
+    without building the manifest (the same property oci-layer.nix gives
+    `ociImage`).
+    */
+    casImageBuilder = lib.mkOption {
+      type = lib.types.functionTo lib.types.package;
+      internal = true;
+      description = "Builds the manifest-native CAS image for this node; provided by the ix repo (contract in the doc-comment above).";
+    };
+    casImage = lib.mkOption {
+      type = lib.types.package;
+      internal = true;
+    };
+  };
+
+  config.ix.build.casImage = config.ix.build.casImageBuilder {
+    inherit (config.system.build) toplevel;
+  };
+}

--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -146,6 +146,7 @@
         ++ [
           ./platform.nix
           ./oci-layer.nix
+          ./cas-layer.nix
           # Home Manager as a NixOS module. Per-tool XDG config (Nushell,
           # atuin, zoxide, starship, ...) is configured under
           # `home-manager.users.root` in the base profile; this module

--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -308,11 +308,16 @@ rendered fleet plan, image attrset, and wrapped CLI app.
             overrideInputs = deploy.switch.overrideInputs or {};
           };
           inherit (deploy) bootstrapImage;
+          # The plan carries only the `.#<node>` installable string (the
+          # fleet's `packages.<node>` attr, the node's CAS image): ix-fleet
+          # `nix build`s it at push time, mirroring `switch.sourceInstallable`.
+          # Never put the image's outPath/drvPath here: the CAS manifest
+          # builder reads its closure at eval (IFD), so forcing either would
+          # build every node's system closure just to render this plan.
           replacementImage = {
             inherit imageName;
             destination = replacementDestination;
-            source = unsafeDiscardStringContext "${config.ix.build.ociImage}";
-            sourceDrv = unsafeDiscardStringContext config.ix.build.ociImage.drvPath;
+            sourceInstallable = ".#${name}";
           };
           inherit (deploy) region;
           inherit (deploy) ipv4;
@@ -338,12 +343,12 @@ rendered fleet plan, image attrset, and wrapped CLI app.
 
   # Rename a fleet's external identities without re-evaluating any NixOS
   # closure: only plan data (node names, `dependsOn`, east-west `groups`, the
-  # registry `destination` the replacement image is pushed to, and the default
-  # `switch.sourceInstallable` attr) carries the prefix, while `system`/`switch`
-  # `target` and the OCI image `source`/`sourceDrv` keep pointing at the shared
-  # base closures. The prefixed `sourceInstallable` (`.#${prefix}${name}`) still
-  # resolves to the shared base closure because `nixosConfigurations.<external>`
-  # is a thin `{ config }` wrapper over the once-evaluated `nodeConfigs.<name>`
+  # registry `destination` the replacement image is pushed to, and the two
+  # installable attrs) carries the prefix, while `system`/`switch` `target`
+  # keep pointing at the shared base closures. The prefixed installables
+  # (`.#${prefix}${name}`) still resolve to the shared base closure because
+  # `nixosConfigurations.<external>` and `packages.<external>` are thin
+  # renames over the once-evaluated `nodeConfigs.<name>`
   # (see `resultFor`), so the native multi-VM `ix up` can name the prefixed VM
   # without a second eval. The health-check
   # runner relies on this so the 10 example fleets are evaluated once per
@@ -370,6 +375,10 @@ rendered fleet plan, image attrset, and wrapped CLI app.
                 node.replacementImage
                 // {
                   destination = prefixName node.replacementImage.destination;
+                  # Always re-derived: unlike `switch.sourceInstallable` there
+                  # is no user-facing override, the installable is defined as
+                  # this fleet's `packages.<external>` attr.
+                  sourceInstallable = ".#${prefixName name}";
                 };
               # Re-derive only the default installable to the prefixed attr, keyed
               # on whether the user set `switch.sourceInstallable` in the spec (not
@@ -449,7 +458,11 @@ rendered fleet plan, image attrset, and wrapped CLI app.
     planValue = planValueFor;
     nodes = externalKeyed nodeConfigs;
     meta = externalKeyed checkedNodeSpecs;
-    packages = externalKeyed (lib.mapAttrs (_: config: config.ix.build.ociImage) nodeConfigs);
+    # Each node's CAS-manifest image, the target of the plan's
+    # `replacementImage.sourceInstallable`; merge into a flake's top-level
+    # `packages` so `nix build .#<node>` resolves it. Lazy: forcing one
+    # requires the ix-side `ix.build.casImageBuilder` module (cas-layer.nix).
+    packages = externalKeyed (lib.mapAttrs (_: config: config.ix.build.casImage) nodeConfigs);
     systemPackages =
       lib.mapAttrs' (
         name: config: lib.nameValuePair "${externalName name}-system" config.system.build.toplevel

--- a/lib/image/health-checks.nix
+++ b/lib/image/health-checks.nix
@@ -65,14 +65,18 @@ Returns an attrset with two front-ends over the same lifecycle scripts:
   '';
 
   mkLifecycle = name: fleet: let
-    # Pin each node's OCI image as a build-time dep of the lifecycle script
-    # so `nix run .#health-checks` realises every image before the runner
-    # starts. Without this, `ix-fleet up` calls `nix-store --realise` on the
-    # image .drv at runtime, which then triggers an x86_64-linux build chain
-    # on whatever host launched the runner. Surfacing the realise step as a
-    # normal Nix build fails fast at one well-known boundary instead of five
+    # Pin each node's NixOS system closure as a build-time dep of the
+    # lifecycle script so `nix run .#health-checks` realises every closure
+    # before the runner starts. Without this, `ix-fleet up`'s runtime
+    # `nix build` of the replacement image triggers an x86_64-linux build
+    # chain on whatever host launched the runner. Surfacing the build as a
+    # normal Nix dep fails fast at one well-known boundary instead of five
     # parallel runners independently rediscovering a broken remote builder.
-    pinnedImages = lib.attrValues fleet.packages;
+    # Deliberately the toplevels, NOT `fleet.packages`: the CAS images those
+    # hold need the ix-side `casImageBuilder` threaded in (cas-layer.nix),
+    # which this repo's example fleets do not have, and even referencing
+    # their outPaths here would force that eval during `nix flake check`.
+    pinnedSystems = lib.attrValues fleet.systemPackages;
   in
     writeNushellApplication pkgs {
       name = "health-check-${name}";
@@ -96,11 +100,11 @@ Returns an attrset with two front-ends over the same lifecycle scripts:
 
           ${ixTokenCheck}
 
-          let pinned_images = ${builtins.toJSON pinnedImages}
+          let pinned_systems = ${builtins.toJSON pinnedSystems}
           let plan_data = (open ${fleet.plan})
           let nodes = $plan_data.order
 
-          print $"[${name}] ($pinned_images | length) image\(s) pinned in store; removing any pre-existing VMs: ($nodes | str join ', ')"
+          print $"[${name}] ($pinned_systems | length) system closure\(s) pinned in store; removing any pre-existing VMs: ($nodes | str join ', ')"
           for node_name in $nodes {
             do --ignore-errors { ^ix rm --force $node_name } | ignore
           }

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1455,10 +1455,10 @@ in {
   #      streamLayeredImage). Non-image packages, and non-NixOS OCI images (which
   #      expose no `toplevel`), pass through unchanged. See lib/image/oci-layer.nix.
   #   2. The `health-check-*` packages (and the `health-checks{,-zellij}` runners)
-  #      pin every fleet node's OCI *tar* as a build dep (lib/image/health-checks.nix),
-  #      so realising them would rebuild ~all the archives. Drop them and add the
-  #      fleet node `toplevel` closures directly, so the closures those checks used
-  #      to drag in stay cached without ever building a tar.
+  #      pin every fleet node's `toplevel` closure as a build dep
+  #      (lib/image/health-checks.nix). Drop the wrapper scripts and add the
+  #      fleet node `toplevel` closures directly, so the closures those checks
+  #      drag in stay cached without pushing the per-fleet script derivations.
   #   3. The cross lane's eval-time IFD outputs (`crossIfdRoots`): the rendered
   #      `cargo-units.nix`, its `cargo-unit-graph.json`, and the vendor dir a Mac
   #      forces at eval when it substitutes a Darwin cross output. These are

--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -30,8 +30,7 @@
       replacementImage = {
         imageName = "api";
         destination = "registry.ix.dev/example/api:latest";
-        source = "/nix/store/api-image.tar";
-        sourceDrv = "/nix/store/api-image.drv";
+        sourceInstallable = ".#api";
       };
       region = "us-west-1";
       ipv4 = false;
@@ -89,8 +88,7 @@
       replacementImage = {
         imageName = name;
         destination = "registry.ix.dev/example/${name}:latest";
-        source = "/nix/store/${name}-image.tar";
-        sourceDrv = "/nix/store/${name}-image.drv";
+        sourceInstallable = ".#${name}";
       };
       region = "us-west-1";
       ipv4 = false;

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -36,8 +36,11 @@ class ReplacementImage(BaseModel):
 
     imageName: str = Field(min_length=1)
     destination: str = Field(min_length=1)
-    source: str = Field(min_length=1)
-    sourceDrv: str = Field(min_length=1)
+    # The flake attr of the node's CAS-manifest image (`.#<node>`), built at
+    # push time. The plan deliberately carries no out/drv path: instantiating
+    # the manifest builder evaluates the node's whole system closure (IFD), so
+    # plan rendering must never force it.
+    sourceInstallable: str = Field(min_length=1)
 
 
 class SwitchSpec(BaseModel):
@@ -340,21 +343,47 @@ async def wait_node_ready(node: FleetNode, *, dry_run: bool) -> None:
 async def push_replacement_image(node: FleetNode, *, dry_run: bool) -> str:
     image = node.replacementImage
     if dry_run:
-        step(f"+ realise {image.sourceDrv} and image push -> {image.destination}")
+        step(f"+ build {image.sourceInstallable} and image push-manifest -> {image.destination}")
         return image.destination
 
-    # Realising the OCI image is host-side nix work; the push itself goes through
-    # the SDK (sdk-core owns the chunk/dedup/upload pipeline).
-    source = image.source
-    out = await run_cli(["nix-store", "--realise", image.sourceDrv], dry_run=False)
-    realised = [line.strip() for line in out.splitlines() if line.strip()]
-    if realised:
-        source = realised[-1]
-    if not await asyncio.to_thread(Path(source).exists):
-        raise RuntimeError(f"OCI image derivation did not realise to an existing path: {source}")
+    # Building the CAS image is host-side nix work; the push goes through the
+    # ix CLI: `push-manifest` streams data chunks straight from the origin
+    # /nix/store files the locator names, so nothing is staged host-side.
+    out = await run_cli(
+        ["nix", "build", "--no-link", "--print-out-paths", image.sourceInstallable],
+        dry_run=False,
+    )
+    built = [line.strip() for line in out.splitlines() if line.strip()]
+    if not built:
+        raise RuntimeError(f"nix build printed no out path for {image.sourceInstallable}")
+    image_dir = Path(built[-1])
+    manifest = image_dir / "manifest.cas"
+    locator = image_dir / "locator.bin"
+    for required in (manifest, locator):
+        if not await asyncio.to_thread(required.exists):
+            raise RuntimeError(f"CAS image {image_dir} is missing {required.name}")
 
-    step(f"pushing {image.destination} from {source}")
-    return await client().image_push(source, image.destination, region=node.region)
+    step(f"pushing {image.destination} from {image_dir}")
+    out = await run_cli(
+        [
+            "ix",
+            "image",
+            "push-manifest",
+            "--locator",
+            str(locator),
+            str(manifest),
+            image.destination,
+            "--region",
+            node.region,
+        ],
+        dry_run=False,
+    )
+    # The pushed reference is the only stdout line (phase progress renders on
+    # stderr), the same normalized reference the SDK's image_push returned.
+    pushed = [line.strip() for line in out.splitlines() if line.strip()]
+    if not pushed:
+        raise RuntimeError(f"ix image push-manifest printed no reference for {image.destination}")
+    return pushed[-1]
 
 
 async def list_nodes() -> list[ix_sdk.BranchInfo]:

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -27,8 +27,7 @@ def fleet_node(name: str, *, depends_on: list[str] | None = None) -> dict[str, t
         "replacementImage": {
             "imageName": name,
             "destination": f"registry.ix.dev/example/{name}:latest",
-            "source": f"/nix/store/{name}-image.tar",
-            "sourceDrv": f"/nix/store/{name}-image.drv",
+            "sourceInstallable": f".#{name}",
         },
         "region": "us-west-1",
         "ipv4": False,
@@ -154,50 +153,81 @@ class VerifySecretsAvailableTests(unittest.TestCase):
 
 
 class PushReplacementImageTests(unittest.TestCase):
-    def test_uses_image_subcommand(self) -> None:
+    @staticmethod
+    def _node(destination: str) -> ix_fleet.FleetNode:
+        return ix_fleet.FleetNode.model_validate(
+            {
+                "name": "health-check-nginx",
+                "baseName": "nginx",
+                "system": "/nix/store/example-system",
+                "switch": {
+                    "target": "/nix/store/example-system.drv",
+                    "sourceInstallable": ".#health-check-nginx-system",
+                },
+                "bootstrapImage": "registry.ix.dev/ix/base:latest",
+                "replacementImage": {
+                    "imageName": "health-check-nginx",
+                    "destination": destination,
+                    "sourceInstallable": ".#health-check-nginx",
+                },
+                "region": "us-west-1",
+                "ipv4": False,
+                "snapshot": True,
+            }
+        )
+
+    def test_builds_installable_and_pushes_manifest(self) -> None:
         with TemporaryDirectory() as temporary_directory:
-            source = Path(temporary_directory) / "image.tar"
-            source.write_text("")
+            image_dir = Path(temporary_directory)
+            (image_dir / "manifest.cas").write_text("")
+            (image_dir / "locator.bin").write_text("")
             calls: list[list[str]] = []
 
             async def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
                 del timeout
-                calls.append(command)
-                if command[0] == "nix-store":
-                    return f"{source}\n"
                 assert not dry_run
+                calls.append(command)
+                if command[0] == "nix":
+                    return f"{image_dir}\n"
                 return "registry.ix.dev/example/health-check-nginx:nginx-lifecycle\n"
 
-            node = ix_fleet.FleetNode.model_validate(
-                {
-                    "name": "health-check-nginx",
-                    "baseName": "nginx",
-                    "system": "/nix/store/example-system",
-                    "switch": {
-                        "target": "/nix/store/example-system.drv",
-                        "sourceInstallable": ".#health-check-nginx-system",
-                    },
-                    "bootstrapImage": "registry.ix.dev/ix/base:latest",
-                    "replacementImage": {
-                        "imageName": "health-check-nginx",
-                        "destination": "health-check-nginx:nginx-lifecycle",
-                        "source": str(source),
-                        "sourceDrv": "/nix/store/example-image.drv",
-                    },
-                    "region": "us-west-1",
-                    "ipv4": False,
-                    "snapshot": True,
-                }
-            )
+            node = self._node("health-check-nginx:nginx-lifecycle")
 
             with patch.object(ix_fleet, "run_cli", fake_run_cli):
                 image = asyncio.run(ix_fleet.push_replacement_image(node, dry_run=False))
 
             assert calls == [
-                ["nix-store", "--realise", "/nix/store/example-image.drv"],
-                ["ix", "image", "push", str(source), "health-check-nginx:nginx-lifecycle"],
+                ["nix", "build", "--no-link", "--print-out-paths", ".#health-check-nginx"],
+                [
+                    "ix",
+                    "image",
+                    "push-manifest",
+                    "--locator",
+                    str(image_dir / "locator.bin"),
+                    str(image_dir / "manifest.cas"),
+                    "health-check-nginx:nginx-lifecycle",
+                    "--region",
+                    "us-west-1",
+                ],
             ]
             assert image == "registry.ix.dev/example/health-check-nginx:nginx-lifecycle"
+
+    def test_rejects_build_output_missing_manifest_files(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            image_dir = Path(temporary_directory)
+
+            async def fake_run_cli(command: list[str], *, dry_run: bool, timeout: int | None = None) -> str:
+                del dry_run, timeout
+                assert command[0] == "nix", "must fail before any push attempt"
+                return f"{image_dir}\n"
+
+            node = self._node("health-check-nginx:nginx-lifecycle")
+
+            with (
+                patch.object(ix_fleet, "run_cli", fake_run_cli),
+                pytest.raises(RuntimeError, match=r"missing manifest\.cas"),
+            ):
+                asyncio.run(ix_fleet.push_replacement_image(node, dry_run=False))
 
 
 class UpNodeTests(unittest.TestCase):

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1710,6 +1710,22 @@
   mcpPackage = (ix.packageSetFor pkgs).mcp;
 
   fleet = ix.mkFleet {
+    # Stand-in for the ix-side CAS manifest builder (the cas-layer.nix
+    # contract): a directory with manifest.cas + locator.bin, carrying
+    # passthru.toplevel. Only this fixture threads a builder; the other fleet
+    # fixtures deliberately leave it unset, proving plan eval never forces
+    # `casImage`.
+    defaults = [
+      (
+        {pkgs, ...}: {
+          ix.build.casImageBuilder = {toplevel}:
+            pkgs.runCommand "cas-image-stub" {passthru = {inherit toplevel;};} ''
+              mkdir -p "$out"
+              touch "$out/manifest.cas" "$out/locator.bin"
+            '';
+        }
+      )
+    ];
     deployment.region = "us-west-1";
     # Fleet-wide per-VM user-store secret attachment; merges with per-node refs.
     deployment.secrets = {
@@ -1775,6 +1791,11 @@
   };
 
   prefixedFleet = prefixedFleetBase.withNodePrefix "tprefix-";
+
+  # No casImageBuilder is threaded into prefixedFleetBase, so forcing a CAS
+  # image must abort with the module system's "used but not defined" error
+  # rather than falling back to anything.
+  fleetMissingCasBuilderEval = builtins.tryEval (builtins.seq prefixedFleetBase.packages.api true);
 
   # A local-build node: its source switch runs a plain `nix build`, so the
   # default installable must be the `.#<node>-system` package alias, not the
@@ -5198,8 +5219,8 @@
         message = "fleet should expose nixosConfigurations.<node> so `ix up .#<node>` (native multi-VM switch) resolves the node toplevel";
       }
       {
-        assertion = fleet.packages.web == fleet.nodes.web.ix.build.ociImage;
-        message = "fleet replacement package outputs should keep node names";
+        assertion = fleet.packages.web == fleet.nodes.web.ix.build.casImage;
+        message = "fleet replacement package outputs should keep node names and resolve to the CAS image";
       }
       {
         assertion =
@@ -5214,10 +5235,12 @@
         message = "fleet plans should default to local eval and remote build switch metadata";
       }
       {
-        assertion =
-          fleetPlan.web.replacementImage.sourceDrv
-          == builtins.unsafeDiscardStringContext fleet.nodes.web.ix.build.ociImage.drvPath;
-        message = "fleet plans should expose replacement image derivations without forcing local image builds";
+        assertion = fleetPlan.web.replacementImage.sourceInstallable == ".#web";
+        message = "fleet plans should reference the replacement image only by flake installable; forcing the CAS image at plan eval would IFD-build every node's system closure";
+      }
+      {
+        assertion = !fleetMissingCasBuilderEval.success;
+        message = "forcing a node's CAS image without the ix-side casImageBuilder must abort eval, never fall back";
       }
       {
         assertion = fleetPlan.web.region == "us-west-1";
@@ -5343,9 +5366,9 @@
         assertion =
           prefixedFleet.planValue.nodes."tprefix-api".system
           == prefixedFleetBase.planValue.nodes.api.system
-          && prefixedFleet.planValue.nodes."tprefix-api".replacementImage.source
-          == prefixedFleetBase.planValue.nodes.api.replacementImage.source;
-        message = "withNodePrefix must reuse the base fleet's system closure and image source, not re-evaluate them";
+          && prefixedFleet.planValue.nodes."tprefix-api".replacementImage.sourceInstallable
+          == ".#tprefix-api";
+        message = "withNodePrefix must reuse the base fleet's system closure while re-deriving the replacement installable to the prefixed packages attr";
       }
       {
         assertion = prefixedFleet.nodes."tprefix-worker".environment.etc."api-host".text == "api";


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge before the ix-side builder threading lands.** This PR makes `fleet.packages.<node>` (and the plan's `replacementImage.sourceInstallable`) resolve to a CAS-manifest image that only exists once the ix repo threads its manifest builder in via the module option below. Fleet plan *evaluation* is unaffected either way (nothing here forces the image), but a fleet operator running `ix-fleet up` against a flake without the builder would fail at push time. Landing order: ix threading first (it only references the `mkFleet` API that already exists on index main plus the option added here), then this PR.

Closes ENG-6044 (phase 6.2, index side).

## What

Fleet nodes now expose a CAS-manifest image and the fleet replacement-image path pushes it, replacing the OCI-archive source:

- **`lib/image/cas-layer.nix` (new)**: defines `ix.build.casImage`, built by the new internal option `ix.build.casImageBuilder` (`functionTo package`, no default). The builder is owned by the ix repo and threaded per fleet/image, e.g. `mkFleet { defaults = [{ix.build.casImageBuilder = ...;}]; ... }`. Contract: `casImageBuilder { toplevel }` returns a derivation whose output contains `manifest.cas` + `locator.bin` (what `ix image push-manifest` consumes) and carries `passthru.toplevel = toplevel`.
- **`lib/image/fleet.nix`**: the plan's `replacementImage` is now `{ imageName, destination, sourceInstallable }` with `sourceInstallable = ".#<node>"`, replacing the embedded OCI `source`/`sourceDrv` store paths. `fleet.packages.<node>` now maps to `casImage` (was `ociImage`); `withNodePrefix` re-derives the installable to the prefixed attr while still sharing the base closures.
- **`packages/ix-fleet`**: `push_replacement_image` now `nix build`s the installable and pushes with `ix image push-manifest --locator <out>/locator.bin <out>/manifest.cas <destination> --region <region>`, returning the pushed reference the CLI prints on stdout (same return semantics as the old SDK `image_push`). Plan schema, dry-run fixtures, and the pytest suite updated to match.
- **`lib/image/health-checks.nix`**: lifecycle scripts pin the node *system closures* (`fleet.systemPackages`) instead of `fleet.packages`, since the CAS images need the ix-side builder this repo's example fleets don't have.

`ociImage`/`oci-layer.nix` are untouched and still build (phase 7 deletes them); `base-image-nix-db` still gates the baked store DB.

## Why an option, not `ix.mkCasImage` in specialArgs

The originally sketched contract was an `ix.mkCasImage` helper in `ixSpecialArgs`. A module option is strictly better here:

- Threading uses the **existing** `mkFleet`/`mkImage` surface (`defaults`/modules); no new specialArgs plumbing in either repo.
- Forcing `casImage` with no builder threaded aborts eval with the module system's `option 'ix.build.casImageBuilder' ... used but not defined` — a hard, typed failure instead of a silent fallback or an `ix ? mkCasImage` guard.
- Per-fleet/per-node override semantics come for free.

The ix-side threading should be written against this option.

## Never force the CAS image at plan eval

The ix manifest builder reads its closure via IFD, so forcing `casImage`'s outPath/drvPath at eval builds the node's entire system. The plan therefore carries only the installable string, and this is enforced structurally: no builder exists anywhere in this repo, so *any* plan-eval path that touched `casImage` would abort every fleet eval in CI with the undefined-option error. Guarded by:

- `tests/default.nix`: `fleetMissingCasBuilderEval` asserts forcing a builder-less fleet's package throws (no fallback); the plan assertions pin `replacementImage.sourceInstallable == ".#web"` / `".#tprefix-api"`; the `fleet` fixture threads a stub builder so `packages.<node> == casImage` stays covered.
- `packages/ix-fleet`: pydantic `extra="forbid"` on `ReplacementImage` rejects any plan that still carries `source`/`sourceDrv` paths (the nix dry-run checks run this in CI).

## Verification

- `checks.x86_64-linux.eval` instantiated on a linux builder (assertion gate; all fleet asserts run at eval).
- `nix build .#checks.x86_64-linux.base-image-nix-db` green on a linux builder: `ociImage` still evaluates and builds and its baked nix-db invariant holds. (A byte-for-byte drv compare against main is impossible by construction: the check bakes the flake source itself into the image's store DB, so any tree change shifts the drv. `lib/image/oci-layer.nix` is untouched by this diff.)
- `ix-fleet` `dryRunUp`/`dryRunSwitch` nix checks green on linux.
- `ix-fleet` pytest on linux: 33 passed, 7 failed. All 7 failures pre-exist at the base commit: pristine main (b44ab6fd) fails the identical 7 plus an 8th (the old drifted push test this PR rewrites), so this PR is net +2 passing / 0 new failures. The 7 live in up/down/bootstrap flows this diff does not touch: 4 construct a live `ix_sdk.Client()` without a token (the tests only fake `run_cli`, but the code now calls the SDK), 2 hit `find_node` expecting SDK `BranchInfo` objects where the fakes return dicts, 1 is `up_node` dry-run step-list drift.
- `nix run .#lint` green.
- Note: index main is currently unevaluable for `checks` on a clean lock (#1779 pinned nightly 2026-07-09; locked rust-overlay is 2026-07-08). Verification used a local, uncommitted `nix flake update rust-overlay`; this PR does not bump the lock.

## Open items / follow-ups

- The example fleets in this repo can never thread the real builder (ix depends on index; the input would be circular), so `nix run .#health-checks`' runtime push path needs the caller's flake to provide it once ix lands the threading.
- Fleet flakes must merge `fleet.packages` into their top-level `packages` output for `.#<node>` to resolve at push time (mirrors the existing `nixosConfigurations` guidance in `doc/ix-fleet/overview.md`).
- The pytest suite is not wired into CI (no pytest in `buildUvApplication`); the old push test had already drifted from the SDK-based implementation at HEAD.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace OCI image push with CAS-manifest workflow in fleet replacement images
> - Replaces `source`/`sourceDrv` fields on `ReplacementImage` with a single `sourceInstallable` flake attr (e.g. `.#<node>`), avoiding forced system closure evaluation at plan time.
> - `push_replacement_image` now runs `nix build --no-link --print-out-paths <sourceInstallable>` to get the CAS image output dir, then calls `ix image push-manifest` with the resulting `manifest.cas` and `locator.bin` files.
> - Fleet `packages` output exposes each node's `ix.build.casImage` (from the new [cas-layer.nix](https://github.com/indexable-inc/index/pull/2552/files#diff-1e0ccbece635ddc155752049bee290476fc359978d43b8636c6fd636ede49860) module) instead of OCI tar images; health-check scripts now pin system closures (`fleet.systemPackages`) instead of image outputs.
> - Risk: incoming plan JSON must provide `sourceInstallable` instead of `source`/`sourceDrv`; old plan payloads will fail validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 157d9bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->