### PR TITLE
ci: securely approve self-owned user changes

### DIFF
--- a/.github/scripts/approve-user-change-test.sh
+++ b/.github/scripts/approve-user-change-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=.github/scripts/approve-user-change.sh
+source "$(dirname "$0")/approve-user-change.sh"
+
+manifest=.github/user-owners.json
+jq -e '
+  type == "object"
+    and all(keys[]; test("^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$") )
+    and all(.[]; type == "number" and . > 0 and floor == .)
+' "$manifest" >/dev/null
+
+mapfile -t directories < <(find users -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+mapfile -t registered < <(jq -r 'keys[]' "$manifest" | sort)
+if [ "${directories[*]}" != "${registered[*]}" ]; then
+  echo "Every users directory must have exactly one immutable owner in $manifest." >&2
+  exit 1
+fi
+
+expect_owned() {
+  local login="$1"
+  local files="$2"
+  changes_belong_to_user "$login" <<<"$files"
+}
+
+expect_invalid_login() {
+  if valid_login "$1"; then
+    echo "expected invalid login: $1" >&2
+    exit 1
+  fi
+}
+
+expect_rejected() {
+  local login="$1"
+  local files="$2"
+  if changes_belong_to_user "$login" <<<"$files"; then
+    echo "expected changed files to be rejected: $files" >&2
+    exit 1
+  fi
+}
+
+expect_owned alice '[[{"filename":"users/alice/home.nix"}]]'
+expect_owned alice '[[{"filename":"users/alice/new.nix","previous_filename":"users/alice/old.nix"}]]'
+expect_owned alice '[[{"filename":"users/alice/a"}],[{"filename":"users/alice/b"}]]'
+
+expect_rejected alice '[]'
+expect_rejected alice '[[]]'
+expect_rejected alice '[[{"filename":"flake.nix"}]]'
+expect_rejected alice '[[{"filename":"users/alice-evil/home.nix"}]]'
+expect_rejected alice '[[{"filename":"users/alice/new.nix","previous_filename":"flake.nix"}]]'
+expect_rejected alice '[[{"filename":"users/alice/home.nix"},{"filename":"README.md"}]]'
+
+valid_login alice
+valid_login Alice-7
+expect_invalid_login --alice
+expect_invalid_login 'alice/bob'
+expect_invalid_login 'alice_'
+
+echo "approve-user-change tests passed"

--- a/.github/scripts/approve-user-change.sh
+++ b/.github/scripts/approve-user-change.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+approval_tag="[approve-user-change:v1]"
+approval_body="${approval_tag} Every changed path belongs to the pull request author’s registered users directory."
+
+valid_login() {
+  [[ "$1" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]
+}
+
+changes_belong_to_user() {
+  local login="$1"
+  local prefix="users/${login}/"
+
+  jq -e --arg prefix "$prefix" '
+    [ .[][] ] as $files
+    | ($files | length) > 0
+      and all(
+        $files[];
+        (.filename | startswith($prefix))
+          and (
+            (has("previous_filename") | not)
+              or (.previous_filename | startswith($prefix))
+          )
+      )
+  ' >/dev/null
+}
+
+api_pages() {
+  local endpoint="$1"
+  gh api --method GET --paginate --slurp -f per_page=100 "$endpoint"
+}
+
+dismiss_review() {
+  local reviews_endpoint="$1"
+  local review_id="$2"
+  gh api --method PUT \
+    "${reviews_endpoint}/${review_id}/dismissals" \
+    -f message="Revalidating the current pull request commit." \
+    -f event=DISMISS \
+    >/dev/null
+}
+
+main() {
+  : "${GH_TOKEN:?GH_TOKEN is required}"
+  : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+  : "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+  : "${PR_AUTHOR:?PR_AUTHOR is required}"
+  : "${PR_AUTHOR_ID:?PR_AUTHOR_ID is required}"
+  : "${PR_NUMBER:?PR_NUMBER is required}"
+  : "${EXPECTED_BASE_SHA:?EXPECTED_BASE_SHA is required}"
+  : "${EXPECTED_HEAD_SHA:?EXPECTED_HEAD_SHA is required}"
+
+  if ! valid_login "$PR_AUTHOR"; then
+    echo "Refusing invalid GitHub login: $PR_AUTHOR" >&2
+    exit 1
+  fi
+
+  local login="${PR_AUTHOR,,}"
+  local registered_id
+  registered_id="$(jq -er --arg login "$login" '.[$login]' "${GITHUB_WORKSPACE}/.github/user-owners.json")" || {
+    echo "No immutable owner registered for users/${login}; not approving."
+    exit 0
+  }
+  if [ "$registered_id" != "$PR_AUTHOR_ID" ]; then
+    echo "GitHub user id ${PR_AUTHOR_ID} does not own users/${login}; not approving."
+    exit 0
+  fi
+
+  local pr_endpoint="repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"
+  local reviews_endpoint="${pr_endpoint}/reviews"
+  local pr
+  pr="$(gh api "$pr_endpoint")"
+
+  jq -e \
+    --arg author "$login" \
+    --arg base_sha "$EXPECTED_BASE_SHA" \
+    --arg head_sha "$EXPECTED_HEAD_SHA" \
+    '(.user.login | ascii_downcase) == $author
+      and .base.ref == "main"
+      and .base.sha == $base_sha
+      and .head.sha == $head_sha' \
+    <<<"$pr" >/dev/null || {
+      echo "Pull request identity, base, or head changed before validation." >&2
+      exit 1
+    }
+
+  local reviews review_id
+  reviews="$(api_pages "$reviews_endpoint")"
+  while IFS= read -r review_id; do
+    dismiss_review "$reviews_endpoint" "$review_id"
+  done < <(
+    jq -r --arg tag "$approval_tag" '
+      .[][]
+      | select(
+          .user.login == "github-actions[bot]"
+            and .state == "APPROVED"
+            and (.body | startswith($tag))
+        )
+      | .id
+    ' <<<"$reviews"
+  )
+
+  if [ "$(jq -r '.draft' <<<"$pr")" = true ]; then
+    echo "Draft pull requests are not approved."
+    exit 0
+  fi
+
+  local user_dir="${GITHUB_WORKSPACE}/users/${login}"
+  if [ ! -d "$user_dir" ] || [ -L "$user_dir" ]; then
+    echo "No existing trusted directory at users/${login}; not approving."
+    exit 0
+  fi
+
+  local files expected_file_count actual_file_count
+  files="$(api_pages "${pr_endpoint}/files")"
+  expected_file_count="$(jq -r '.changed_files' <<<"$pr")"
+  actual_file_count="$(jq '[.[][]] | length' <<<"$files")"
+  if [ "$actual_file_count" != "$expected_file_count" ]; then
+    echo "GitHub returned ${actual_file_count} of ${expected_file_count} changed files; not approving." >&2
+    exit 1
+  fi
+  if ! changes_belong_to_user "$login" <<<"$files"; then
+    echo "At least one changed or renamed path is outside users/${login}/; not approving."
+    exit 0
+  fi
+
+  local current_base_sha current_head_sha
+  read -r current_base_sha current_head_sha < <(gh api --jq '[.base.sha, .head.sha] | @tsv' "$pr_endpoint")
+  if [ "$current_base_sha" != "$EXPECTED_BASE_SHA" ] || [ "$current_head_sha" != "$EXPECTED_HEAD_SHA" ]; then
+    echo "Pull request base or head changed during validation; a newer run must decide." >&2
+    exit 1
+  fi
+
+  local review review_id_after
+  review="$(
+    gh api --method POST "$reviews_endpoint" \
+      -f event=APPROVE \
+      -f commit_id="$EXPECTED_HEAD_SHA" \
+      -f body="$approval_body"
+  )"
+  review_id_after="$(jq -r '.id' <<<"$review")"
+
+  read -r current_base_sha current_head_sha < <(gh api --jq '[.base.sha, .head.sha] | @tsv' "$pr_endpoint")
+  if [ "$current_base_sha" != "$EXPECTED_BASE_SHA" ] || [ "$current_head_sha" != "$EXPECTED_HEAD_SHA" ]; then
+    dismiss_review "$reviews_endpoint" "$review_id_after"
+    echo "Pull request base or head changed after approval; dismissed the stale review." >&2
+    exit 1
+  fi
+
+  echo "Approved ${PR_AUTHOR}'s current commit for users/${login}/."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/user-owners.json
+++ b/.github/user-owners.json
@@ -1,0 +1,3 @@
+{
+  "andrewgazelka": 7644264
+}

--- a/.github/workflows/approve-user-change.yml
+++ b/.github/workflows/approve-user-change.yml
@@ -1,0 +1,67 @@
+name: Approve self-owned user changes
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/approve-user-change.sh
+      - .github/scripts/approve-user-change-test.sh
+      - .github/user-owners.json
+      - .github/workflows/approve-user-change.yml
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: approve-user-change-${{ github.event.pull_request.number }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Test approval policy
+        run: |
+          bash -n \
+            .github/scripts/approve-user-change.sh \
+            .github/scripts/approve-user-change-test.sh
+          shellcheck -x \
+            .github/scripts/approve-user-change.sh \
+            .github/scripts/approve-user-change-test.sh
+          .github/scripts/approve-user-change-test.sh
+
+  approve:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      (github.event.action != 'edited' || github.event.changes.base != null)
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # pull_request_target supplies a write token, so only trusted base-branch
+      # code may run. Never change this ref to the pull request head.
+      - name: Checkout trusted policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Approve current commit when the author owns every path
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: .github/scripts/approve-user-change.sh


### PR DESCRIPTION
## Summary

- approve pull requests only when every changed path belongs to the author’s registered `users/<login>/` directory
- bind ownership to immutable GitHub user IDs and approval to the exact base and head commits
- fail closed on rename sources, incomplete GitHub file enumeration, drafts, races, and unregistered users
- test the policy with `bash -n`, ShellCheck, fixtures, Actionlint, and the repo lint

## Validation

- `nix run .#lint`
- `nix run nixpkgs#actionlint -- .github/workflows/approve-user-change.yml`
- `nix run nixpkgs#shellcheck -- -x .github/scripts/approve-user-change.sh .github/scripts/approve-user-change-test.sh`
- `.github/scripts/approve-user-change-test.sh`

Fixes #2554

Authored by Codex (OpenAI gpt-5.5).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI workflow to securely auto-approve self-owned user directory changes
> - Adds [approve-user-change.sh](.github/scripts/approve-user-change.sh) which automatically approves PRs where the author is the registered owner of their `users/<login>/` directory, enforcing login format, branch target, SHA immutability, non-draft status, and file scope.
> - Adds [approve-user-change.yml](.github/workflows/approve-user-change.yml) with two triggers: `pull_request` for linting/testing and `pull_request_target` for the actual approval step, which runs from the trusted base ref.
> - Adds [user-owners.json](.github/user-owners.json) mapping GitHub logins to numeric IDs to prevent login-spoofing attacks.
> - Adds a test harness in [approve-user-change-test.sh](.github/scripts/approve-user-change-test.sh) that validates login regex and file-ownership logic with positive and negative cases.
> - Risk: the `pull_request_target` trigger executes with write permissions; the workflow mitigates this by checking out only the base ref as trusted code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e38d2c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->