### PR TITLE
nu: preserve cwd across setup failures

### DIFF
--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -343,6 +343,34 @@ def test_explicit_cwd_persists_like_cd(tmp_path: pathlib.Path) -> None:
         nu.reset()
 
 
+def test_relative_explicit_cwd_persists_as_absolute(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    monkeypatch.chdir(tmp_path)
+    try:
+        run(nu.value("2 + 2", cwd="target"))
+        assert run(nu.value("$env.PWD")) == str(target)
+    finally:
+        nu.reset()
+
+
+def test_setup_failure_preserves_cwd_and_env(tmp_path: pathlib.Path) -> None:
+    keep = tmp_path / "keep"
+    rejected = tmp_path / "rejected"
+    keep.mkdir()
+    rejected.mkdir()
+    try:
+        run(nu.value("2 + 2", cwd=keep))
+        with pytest.raises(nu.NuError):
+            run(nu.value("let =", cwd=rejected, env={"NU_SETUP_POISON": "yes"}))
+        assert run(nu.value("$env.PWD")) == str(keep)
+        assert run(nu.value("$env.NU_SETUP_POISON? == null")) is True
+    finally:
+        nu.reset()
+
+
 def test_nonexistent_explicit_cwd_is_rejected_at_the_boundary(tmp_path: pathlib.Path) -> None:
     with pytest.raises(ValueError, match="not a directory"):
         run(nu.value("2 + 2", cwd=tmp_path / "missing"))

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -304,14 +304,19 @@ class NuResult(NamedTuple):
     exit_code: int
 
 
-def _require_dir(cwd: str | os.PathLike) -> None:
-    """Reject an explicit ``cwd=`` that is not an existing directory. A bad
-    cwd would be written into the persistent stack and wedge every later call
-    (issue #1986's failure mode, self-inflicted); reject it at the boundary
-    instead. Sync on purpose: one local ``stat``, and keeping the path method
-    out of the ``async`` caller keeps it free of path methods (ASYNC240)."""
-    if not pathlib.Path(cwd).is_dir():
+def _resolve_dir(cwd: str | os.PathLike) -> str:
+    """Return an existing directory as an absolute path.
+
+    The engine persists PWD across calls, so a relative value would later be
+    interpreted against an unrelated process directory and poison the session.
+    Resolve and validate it before the persistent engine sees it. This stays
+    synchronous on purpose: it is one local filesystem lookup, and keeping the
+    path method out of the async caller avoids ASYNC240.
+    """
+    resolved = pathlib.Path(cwd).resolve()
+    if not resolved.is_dir():
         raise ValueError(f"cwd is not a directory: {os.fspath(cwd)!r}")
+    return os.fspath(resolved)
 
 
 async def _run(
@@ -329,8 +334,7 @@ async def _run(
     With ``check=True`` a non-zero trailing external raises inside the engine,
     so the exit code of anything that returns is 0.
     """
-    if cwd is not None:
-        _require_dir(cwd)
+    resolved_cwd = _resolve_dir(cwd) if cwd is not None else None
     if name is not None and _rename_current_job is not None and (
         _ix_current is not None and _ix_current.get() is not None
     ):
@@ -340,7 +344,7 @@ async def _run(
     loop = asyncio.get_running_loop()
     state: dict[str, object] = {
         "code": code,
-        "cwd": os.fspath(cwd) if cwd is not None else None,
+        "cwd": resolved_cwd,
         "status": "running",
         "result": None,
         "error": None,
@@ -351,7 +355,7 @@ async def _run(
     coroutine, handle = engine.eval(
         code,
         input=_serialize_input(input) if input is not None else None,
-        cwd=os.fspath(cwd) if cwd is not None else None,
+        cwd=resolved_cwd,
         env=env,
         check=check,
     )

--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -146,9 +146,8 @@ impl EngineInner {
         // receive a signal aimed at the one currently running.
         engine_state.set_signals(Signals::new(Arc::clone(interrupt)));
 
-        if let Some(dir) = cwd {
-            stack.add_env_var("PWD".into(), Value::string(dir, Span::unknown()));
-        } else if let Some(pwd) = stack.get_env_var(engine_state, "PWD")
+        if cwd.is_none()
+            && let Some(pwd) = stack.get_env_var(engine_state, "PWD")
             && let Ok(pwd) = pwd.as_str()
             && !std::path::Path::new(pwd).is_dir()
         {
@@ -165,9 +164,6 @@ impl EngineInner {
                  somewhere real (it persists like `cd`), or nu.reset() \
                  for a fresh engine"
             ));
-        }
-        for (key, value) in env.into_iter().flatten() {
-            stack.add_env_var(key, Value::string(value, Span::unknown()));
         }
 
         let block = {
@@ -195,6 +191,16 @@ impl EngineInner {
                 .map_err(|error| render_shell_error(engine_state, stack, &error))?;
             block
         };
+
+        // Parse and compile before changing the persistent environment. A
+        // setup error must leave the previous PWD and variables intact so the
+        // next call starts from the last successfully configured state.
+        if let Some(dir) = cwd {
+            stack.add_env_var("PWD".into(), Value::string(dir, Span::unknown()));
+        }
+        for (key, value) in env.into_iter().flatten() {
+            stack.add_env_var(key, Value::string(value, Span::unknown()));
+        }
 
         // Bash redirection tokens the parser handed to an external as literal
         // argv (`2>/dev/null` and friends), detected up front and reported


### PR DESCRIPTION
## Summary

- resolve explicit `cwd` values before they reach the persistent Nushell engine
- apply PWD and environment changes only after parsing and compilation succeed
- cover relative cwd persistence and setup-failure rollback with end-to-end engine tests

## Validation

- `nix run .#lint`
- `nix build .#packages.aarch64-darwin.mcp.passthru.tests.strictTypecheck`
- `nix build .#packages.aarch64-darwin.mcp.passthru.tests.nuTests .#packages.aarch64-darwin.mcp`
- `nuTests`: 44 passed

Fixes #2567

(sent by Codex, an AI coding agent)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve cwd and env vars across setup failures in nu engine eval
> - In [lib.rs](https://github.com/indexable-inc/index/pull/2573/files#diff-424ce210c45fc8f162c45814067651d48d245471a2e86b63c39b71c370ffe7fe), PWD and env vars are now applied to the engine state only after parse/compile succeed, so a bad script no longer mutates the persistent environment.
> - A new `_resolve_dir` helper in [__init__.py](https://github.com/indexable-inc/index/pull/2573/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4) resolves relative `cwd` values to absolute paths before passing them to the engine, so `$env.PWD` is always stored as an absolute path.
> - The stale-PWD check is now skipped when an explicit `cwd` is provided, avoiding a spurious error in that case.
> - New tests cover both the absolute-path persistence of a relative `cwd` and the invariant that a failing eval leaves prior PWD and env vars unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5de9fd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->