### PR TITLE
mcp: signal transport initialization

### DIFF
--- a/packages/mcp/ix_notebook_mcp/transport.py
+++ b/packages/mcp/ix_notebook_mcp/transport.py
@@ -159,8 +159,10 @@ async def _run_with_channel_pump(server, read_stream, write_stream, init_options
     if not _can_hold_session(server):
         logger.warning("channel pump: SDK internals unavailable; running without the initialized gate")
         with _session_entity("stdio"):
+            initialized = anyio.Event()
+            initialized.set()
             async with anyio.create_task_group() as tg:
-                tg.start_soon(pump_outbox, write_stream, None)
+                tg.start_soon(pump_outbox, write_stream, initialized)
                 await server.run(read_stream, write_stream, init_options)
                 tg.cancel_scope.cancel()
         return
@@ -170,15 +172,18 @@ async def _run_with_channel_pump(server, read_stream, write_stream, init_options
             ServerSession(read_stream, write_stream, init_options)
         )
         with _session_entity("stdio") as upgrade_client:
+            initialized = anyio.Event()
+
+            async def handle_message(message) -> None:  # noqa: ANN001 -- SDK message type is internal
+                await server._handle_message(message, session, lifespan_context, raise_exceptions=False)
+                if _session_initialized(session):
+                    initialized.set()
+
             async with anyio.create_task_group() as tg:
-                tg.start_soon(pump_outbox, write_stream, session)
-                tg.start_soon(_watch_client_name, session, upgrade_client)
+                tg.start_soon(pump_outbox, write_stream, initialized)
+                tg.start_soon(_watch_client_name, session, upgrade_client, initialized)
                 async for message in session.incoming_messages:
-                    tg.start_soon(
-                        functools.partial(
-                            server._handle_message, message, session, lifespan_context, raise_exceptions=False
-                        )
-                    )
+                    tg.start_soon(handle_message, message)
                 tg.cancel_scope.cancel()
 
 
@@ -190,14 +195,13 @@ def _session_initialized(session: ServerSession | None) -> bool:
     return getattr(session, "_initialization_state", None) is InitializationState.Initialized
 
 
-async def _watch_client_name(session: ServerSession, upgrade: Callable[[str], None]) -> None:
-    """Upgrade the session entity's client fact from the transport kind to the
-    name declared in the initialize handshake. ``client_params`` is set before
-    the session reports Initialized, so polling the same gate as the pump is
-    sufficient; a client that never completes the handshake keeps the kind."""
-    # ServerSession exposes no initialization event, only this private state.
-    while not _session_initialized(session):  # noqa: ASYNC110
-        await anyio.sleep(_OUTBOX_POLL_SECONDS)
+async def _watch_client_name(
+    session: ServerSession,
+    upgrade: Callable[[str], None],
+    initialized: anyio.Event,
+) -> None:
+    """Upgrade the session entity after the initialize handler completes."""
+    await initialized.wait()
     params = session.client_params
     if params is not None:
         upgrade(params.clientInfo.name)
@@ -205,7 +209,7 @@ async def _watch_client_name(session: ServerSession, upgrade: Callable[[str], No
 
 async def pump_outbox(
     write_stream: ObjectSendStream[SessionMessage],
-    session: ServerSession | None,
+    initialized: anyio.Event,
 ) -> None:
     """Drain this session's share of the in-process mailbox outbox into
     ``notifications/claude/channel`` events (broadcast rows plus rows addressed
@@ -220,12 +224,10 @@ async def pump_outbox(
     """
     cfg = config()
     box = mailbox.get_mailbox()
+    # Rows that accrue during startup stay queued until the client can receive
+    # them. The initialize handler sets the event after the SDK changes state.
+    await initialized.wait()
     while True:
-        # Wait for the handshake before draining, so rows that accrue during
-        # startup are held (not dropped) until the client can receive them.
-        if not _session_initialized(session):
-            await anyio.sleep(_OUTBOX_POLL_SECONDS)
-            continue
         try:
             # Serve only this session's mail: broadcast rows (explicit
             # notify() -- pr_watch and friends) plus rows addressed to this

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -107,12 +107,11 @@ def test_transport_pump_drains_mailbox() -> None:
         box.add_outbox(content="hello", meta=json.dumps({"resource": "r"}), session="srv")
         set_config(Config(workdir=Path.cwd(), store_path=Path("x"), server_session_id="srv"))
 
-        class Session:
-            _initialization_state = transport.InitializationState.Initialized
-
+        initialized = anyio.Event()
+        initialized.set()
         send, recv = anyio.create_memory_object_stream[SessionMessage](10)
         async with send, recv, anyio.create_task_group() as tg:
-            tg.start_soon(transport.pump_outbox, send, Session())
+            tg.start_soon(transport.pump_outbox, send, initialized)
             msg = await recv.receive()
             tg.cancel_scope.cancel()
         notification = msg.message.root


### PR DESCRIPTION
Fixes #2582.

- signal initialization after the SDK handler completes
- make the outbox pump and client-name upgrade await that event
- remove the polling-loop suppression added on `main`

Validation: `nix run .#lint -- --json` passes. The channel derivation reached 6 passing tests; its unrelated SSE test cannot bind a loopback socket inside the Nix build sandbox.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace session polling with event-based signaling for MCP transport initialization
> - Replaces per-iteration polling loops in `pump_outbox` and `_watch_client_name` with an `anyio.Event` named `initialized` that is awaited once, in [transport.py](https://github.com/indexable-inc/index/pull/2588/files#diff-39ae84714e8a966882f8856c976f1ebce9f5fd42dac02f22e89e4cbc672e1675).
> - Introduces a `handle_message` coroutine in the held-session path that sets `initialized` after the first successful `_session_initialized` check, gating both the outbox pump and client-name upgrade.
> - In the fallback path (no held session), the event is created and immediately set so downstream behavior is unchanged.
> - Updates [test_channel.py](https://github.com/indexable-inc/index/pull/2588/files#diff-f1684e518bfcf4f7df252a5c209b046a82ed7c2db27ff168d3e422b623323bbd) to pass a pre-set `anyio.Event` instead of a dummy `Session` object to `pump_outbox`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f407ea3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->