### PR TITLE
mcp: signal transport initialization with an event

### DIFF
--- a/packages/mcp/ix_notebook_mcp/transport.py
+++ b/packages/mcp/ix_notebook_mcp/transport.py
@@ -160,7 +160,9 @@ async def _run_with_channel_pump(server, read_stream, write_stream, init_options
         logger.warning("channel pump: SDK internals unavailable; running without the initialized gate")
         with _session_entity("stdio"):
             async with anyio.create_task_group() as tg:
-                tg.start_soon(pump_outbox, write_stream, None)
+                initialized = anyio.Event()
+                initialized.set()
+                tg.start_soon(pump_outbox, write_stream, initialized)
                 await server.run(read_stream, write_stream, init_options)
                 tg.cancel_scope.cancel()
         return
@@ -169,11 +171,14 @@ async def _run_with_channel_pump(server, read_stream, write_stream, init_options
         session = await stack.enter_async_context(
             ServerSession(read_stream, write_stream, init_options)
         )
+        initialized = anyio.Event()
         with _session_entity("stdio") as upgrade_client:
             async with anyio.create_task_group() as tg:
-                tg.start_soon(pump_outbox, write_stream, session)
-                tg.start_soon(_watch_client_name, session, upgrade_client)
+                tg.start_soon(pump_outbox, write_stream, initialized)
+                tg.start_soon(_watch_client_name, session, initialized, upgrade_client)
                 async for message in session.incoming_messages:
+                    if not initialized.is_set() and _session_initialized(session):
+                        initialized.set()
                     tg.start_soon(
                         functools.partial(
                             server._handle_message, message, session, lifespan_context, raise_exceptions=False
@@ -182,22 +187,21 @@ async def _run_with_channel_pump(server, read_stream, write_stream, init_options
                 tg.cancel_scope.cancel()
 
 
-def _session_initialized(session: ServerSession | None) -> bool:
-    """Whether the client has completed the initialize handshake. None session
-    (the fallback path) reports True: there is nothing to gate on there."""
-    if session is None:
-        return True
+def _session_initialized(session: ServerSession) -> bool:
+    """Whether the client has completed the initialize handshake."""
     return getattr(session, "_initialization_state", None) is InitializationState.Initialized
 
 
-async def _watch_client_name(session: ServerSession, upgrade: Callable[[str], None]) -> None:
+async def _watch_client_name(
+    session: ServerSession,
+    initialized: anyio.Event,
+    upgrade: Callable[[str], None],
+) -> None:
     """Upgrade the session entity's client fact from the transport kind to the
     name declared in the initialize handshake. ``client_params`` is set before
-    the session reports Initialized, so polling the same gate as the pump is
-    sufficient; a client that never completes the handshake keeps the kind."""
-    # ServerSession exposes no initialization event, only this private state.
-    while not _session_initialized(session):  # noqa: ASYNC110
-        await anyio.sleep(_OUTBOX_POLL_SECONDS)
+    session reports Initialized; a client that never completes the handshake
+    leaves this task waiting and keeps the transport kind."""
+    await initialized.wait()
     params = session.client_params
     if params is not None:
         upgrade(params.clientInfo.name)
@@ -205,7 +209,7 @@ async def _watch_client_name(session: ServerSession, upgrade: Callable[[str], No
 
 async def pump_outbox(
     write_stream: ObjectSendStream[SessionMessage],
-    session: ServerSession | None,
+    initialized: anyio.Event,
 ) -> None:
     """Drain this session's share of the in-process mailbox outbox into
     ``notifications/claude/channel`` events (broadcast rows plus rows addressed
@@ -214,18 +218,13 @@ async def pump_outbox(
     Custom notification methods are not in the SDK's typed ``ServerNotification``
     union, so the JSON-RPC message is built directly and sent on the transport's
     write stream -- the same bytes ``ServerSession.send_notification`` would
-    produce. Holds every send until the client is ``initialized`` (see
-    :func:`_session_initialized`), so a startup/replay ``notify()`` never emits a
-    notification before the handshake completes.
+    produce. Holds every send on the initialization event, so a startup/replay
+    ``notify()`` never emits a notification before the handshake completes.
     """
+    await initialized.wait()
     cfg = config()
     box = mailbox.get_mailbox()
     while True:
-        # Wait for the handshake before draining, so rows that accrue during
-        # startup are held (not dropped) until the client can receive them.
-        if not _session_initialized(session):
-            await anyio.sleep(_OUTBOX_POLL_SECONDS)
-            continue
         try:
             # Serve only this session's mail: broadcast rows (explicit
             # notify() -- pr_watch and friends) plus rows addressed to this

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -101,18 +101,20 @@ def test_dashboard_sse_streams_mailbox_event(tmp_path: Path) -> None:
     asyncio.run(run())
 
 
-def test_transport_pump_drains_mailbox() -> None:
+def test_transport_pump_waits_for_initialization_before_draining_mailbox() -> None:
     async def run() -> None:
         box = _box()
         box.add_outbox(content="hello", meta=json.dumps({"resource": "r"}), session="srv")
         set_config(Config(workdir=Path.cwd(), store_path=Path("x"), server_session_id="srv"))
 
-        class Session:
-            _initialization_state = transport.InitializationState.Initialized
-
+        initialized = anyio.Event()
         send, recv = anyio.create_memory_object_stream[SessionMessage](10)
         async with send, recv, anyio.create_task_group() as tg:
-            tg.start_soon(transport.pump_outbox, send, Session())
+            tg.start_soon(transport.pump_outbox, send, initialized)
+            with anyio.move_on_after(0.01) as scope:
+                await recv.receive()
+            assert scope.cancel_called
+            initialized.set()
             msg = await recv.receive()
             tg.cancel_scope.cancel()
         notification = msg.message.root


### PR DESCRIPTION
## Summary

- replace initialization-state polling with a shared `anyio.Event`
- gate both client-name upgrades and channel outbox draining on the exact handshake transition
- test that queued notifications remain blocked until initialization completes

## Validation

- `nix run .#lint -- --json`
- focused channel and transport session tests: 2 passed

Fixes #2582

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate MCP transport outbox pump and client-name watcher on an initialization event
> - Replaces polling loops in `pump_outbox` and `_watch_client_name` with a single `anyio.Event` (`initialized`) that is awaited before sending notifications or upgrading the client name.
> - `_run_with_channel_pump` creates the event unset in the held-session path and sets it once `_session_initialized` first returns true; in the SDK-fallback path the event is pre-set so behavior is unchanged.
> - `_session_initialized` now requires a non-`None` `ServerSession` and no longer treats `None` as initialized.
> - The test in [test_channel.py](https://github.com/indexable-inc/index/pull/2593/files#diff-f1684e518bfcf4f7df252a5c209b046a82ed7c2db27ff168d3e422b623323bbd) is updated to pass an `anyio.Event` to `pump_outbox` and assert no messages are sent before the event is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5e160d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->