### PR TITLE
nu: recover after persistent cwd is removed

### DIFF
--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -324,9 +324,12 @@ def test_removed_cwd_fails_loudly_and_cwd_recovers(tmp_path: pathlib.Path) -> No
     try:
         run(nu(f"cd {target}"))
         target.rmdir()
-        with pytest.raises(nu.NuError, match="no longer exists"):
+        with pytest.raises(nu.NuCwdError, match="no longer exists"):
             run(nu.value("2 + 2"))
-        # An explicit cwd= both runs the call and repairs the engine.
+        # The typed failure discards only the stale engine, so a retry works
+        # without manual reset and never silently redirects the failed call.
+        assert run(nu.value("2 + 2")) == 4
+        # An explicit cwd= still selects and persists a deliberate directory.
         keep = tmp_path / "keep"
         keep.mkdir()
         assert run(nu.value("2 + 2", cwd=keep)) == 4
@@ -339,6 +342,34 @@ def test_explicit_cwd_persists_like_cd(tmp_path: pathlib.Path) -> None:
     try:
         run(nu.value("2 + 2", cwd=tmp_path))
         assert pathlib.Path(run(nu.value("$env.PWD"))).resolve() == tmp_path.resolve()
+    finally:
+        nu.reset()
+
+
+def test_relative_explicit_cwd_persists_as_absolute(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    monkeypatch.chdir(tmp_path)
+    try:
+        run(nu.value("2 + 2", cwd="target"))
+        assert run(nu.value("$env.PWD")) == str(target)
+    finally:
+        nu.reset()
+
+
+def test_setup_failure_preserves_cwd_and_env(tmp_path: pathlib.Path) -> None:
+    keep = tmp_path / "keep"
+    rejected = tmp_path / "rejected"
+    keep.mkdir()
+    rejected.mkdir()
+    try:
+        run(nu.value("2 + 2", cwd=keep))
+        with pytest.raises(nu.NuError):
+            run(nu.value("let =", cwd=rejected, env={"NU_SETUP_POISON": "yes"}))
+        assert run(nu.value("$env.PWD")) == str(keep)
+        assert run(nu.value("$env.NU_SETUP_POISON? == null")) is True
     finally:
         nu.reset()
 

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -20,8 +20,8 @@ or a ``cd`` in one call is visible to the next. Each kernel session has its
 own engine, so a ``cd`` here never moves another session's PWD (issue #2089:
 the per-call re-sync to the shared process cwd silently redirected bare git
 commands into other agents' worktrees). If the remembered directory has been
-deleted, the next call fails loudly until you pass ``cwd=`` or ``nu.reset()``
-(issue #1986)::
+deleted, the next call fails loudly and discards that engine; retrying starts
+fresh, while an explicit ``cwd=`` recovers in the same call (issue #2587)::
 
     await nu("let prs = (http get $url)")
     await nu("$prs | where author.login == 'andrewgazelka'")
@@ -119,12 +119,12 @@ import re
 import time
 from typing import TYPE_CHECKING, Literal, NamedTuple, overload
 
-from ._nu import Engine, NuError
+from ._nu import Engine, NuCwdError, NuError
 
 if TYPE_CHECKING:
     import polars as pl
 
-__all__ = ["Engine", "NuError", "NuResult", "nu", "reset", "value"]
+__all__ = ["Engine", "NuCwdError", "NuError", "NuResult", "nu", "reset", "value"]
 
 __version__ = "0.1.0"
 
@@ -304,14 +304,19 @@ class NuResult(NamedTuple):
     exit_code: int
 
 
-def _require_dir(cwd: str | os.PathLike) -> None:
-    """Reject an explicit ``cwd=`` that is not an existing directory. A bad
-    cwd would be written into the persistent stack and wedge every later call
-    (issue #1986's failure mode, self-inflicted); reject it at the boundary
-    instead. Sync on purpose: one local ``stat``, and keeping the path method
-    out of the ``async`` caller keeps it free of path methods (ASYNC240)."""
-    if not pathlib.Path(cwd).is_dir():
+def _resolve_dir(cwd: str | os.PathLike) -> str:
+    """Return an existing directory as an absolute path.
+
+    The engine persists PWD across calls, so a relative value would later be
+    interpreted against an unrelated process directory and poison the session.
+    Resolve and validate it before the persistent engine sees it. This stays
+    synchronous on purpose: it is one local filesystem lookup, and keeping the
+    path method out of the async caller avoids ASYNC240.
+    """
+    resolved = pathlib.Path(cwd).resolve()
+    if not resolved.is_dir():
         raise ValueError(f"cwd is not a directory: {os.fspath(cwd)!r}")
+    return os.fspath(resolved)
 
 
 async def _run(
@@ -329,8 +334,7 @@ async def _run(
     With ``check=True`` a non-zero trailing external raises inside the engine,
     so the exit code of anything that returns is 0.
     """
-    if cwd is not None:
-        _require_dir(cwd)
+    resolved_cwd = _resolve_dir(cwd) if cwd is not None else None
     if name is not None and _rename_current_job is not None and (
         _ix_current is not None and _ix_current.get() is not None
     ):
@@ -340,7 +344,7 @@ async def _run(
     loop = asyncio.get_running_loop()
     state: dict[str, object] = {
         "code": code,
-        "cwd": os.fspath(cwd) if cwd is not None else None,
+        "cwd": resolved_cwd,
         "status": "running",
         "result": None,
         "error": None,
@@ -351,7 +355,7 @@ async def _run(
     coroutine, handle = engine.eval(
         code,
         input=_serialize_input(input) if input is not None else None,
-        cwd=os.fspath(cwd) if cwd is not None else None,
+        cwd=resolved_cwd,
         env=env,
         check=check,
     )
@@ -385,6 +389,8 @@ async def _run(
             close()
         raise
     except Exception as exc:
+        if isinstance(exc, NuCwdError):
+            _discard_engine(engine)
         state["status"] = "failed"
         state["error"] = str(exc)
         state["ended"] = loop.time()
@@ -523,8 +529,9 @@ async def nu(
     first statement that accepts pipeline input (a leading ``cd``/``def``
     declares none and is skipped); when nothing can accept it the call
     raises instead of dropping the payload (issue #2540). ``cwd`` sets ``PWD``
-    and persists like ``cd``; if the remembered directory no longer exists
-    the call raises with the remedy instead of silently running elsewhere.
+    and persists like ``cd``; if the remembered directory no longer exists,
+    the call raises :class:`NuCwdError` instead of silently running elsewhere
+    and discards the stale engine so a retry starts fresh.
     ``env`` adds environment variables;
     ``timeout`` interrupts the evaluation and discards the engine state (see
     the module docstring); ``name`` labels the running job in the dashboard.

--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -207,7 +207,7 @@ impl EngineInner {
             )));
         }
 
-        let block = {
+        let block = (|| -> Result<Arc<Block>, String> {
             let mut working_set = StateWorkingSet::new(engine_state);
             let block = nu_parser::parse(&mut working_set, Some("nu()"), code.as_bytes(), false);
             if let Some(error) = working_set.parse_errors.first() {
@@ -216,8 +216,7 @@ impl EngineInner {
                     &working_set,
                     error,
                     Some("nu::parser::error"),
-                )
-                .into());
+                ));
             }
             if let Some(error) = working_set.compile_errors.first() {
                 return Err(format_cli_error(
@@ -225,15 +224,14 @@ impl EngineInner {
                     &working_set,
                     error,
                     Some("nu::compile::error"),
-                )
-                .into());
+                ));
             }
             let delta = working_set.render();
             engine_state
                 .merge_delta(delta)
                 .map_err(|error| render_shell_error(engine_state, stack, &error))?;
-            block
-        };
+            Ok(block)
+        })()?;
 
         // Parse and compile before changing the persistent environment. A
         // setup error must leave the previous PWD and variables intact so the

--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -19,6 +19,8 @@
 //! `list`. The `nu` Python package turns those into polars frames.
 
 use std::collections::HashMap;
+use std::fmt;
+use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -41,6 +43,46 @@ create_exception!(
     pyo3::exceptions::PyException,
     "A nushell pipeline failed; the message is nushell's own rendered diagnostic."
 );
+create_exception!(
+    _nu,
+    NuCwdError,
+    NuError,
+    "The persistent engine's working directory was removed."
+);
+
+#[derive(Debug)]
+enum EvalError {
+    Diagnostic(String),
+    RemovedCwd(String),
+}
+
+impl EvalError {
+    fn diagnostic(&self) -> &str {
+        match self {
+            Self::Diagnostic(diagnostic) | Self::RemovedCwd(diagnostic) => diagnostic,
+        }
+    }
+}
+
+impl Deref for EvalError {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.diagnostic()
+    }
+}
+
+impl fmt::Display for EvalError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.diagnostic())
+    }
+}
+
+impl From<String> for EvalError {
+    fn from(diagnostic: String) -> Self {
+        Self::Diagnostic(diagnostic)
+    }
+}
 
 /// The engine state a fresh [`Engine`] starts from: the full shell command
 /// set, the host environment, and REPL-free configuration.
@@ -134,7 +176,7 @@ impl EngineInner {
         env: Option<HashMap<String, String>>,
         interrupt: &Arc<AtomicBool>,
         check: bool,
-    ) -> Result<(Vec<Value>, Value, i64), String> {
+    ) -> Result<(Vec<Value>, Value, i64), EvalError> {
         let Self {
             engine_state,
             stack,
@@ -146,9 +188,8 @@ impl EngineInner {
         // receive a signal aimed at the one currently running.
         engine_state.set_signals(Signals::new(Arc::clone(interrupt)));
 
-        if let Some(dir) = cwd {
-            stack.add_env_var("PWD".into(), Value::string(dir, Span::unknown()));
-        } else if let Some(pwd) = stack.get_env_var(engine_state, "PWD")
+        if cwd.is_none()
+            && let Some(pwd) = stack.get_env_var(engine_state, "PWD")
             && let Ok(pwd) = pwd.as_str()
             && !std::path::Path::new(pwd).is_dir()
         {
@@ -159,15 +200,11 @@ impl EngineInner {
             // across worktrees). A `cd` target that has since been removed
             // (issue #1986) must fail loudly with the remedy, not be silently
             // redirected somewhere else.
-            return Err(format!(
+            return Err(EvalError::RemovedCwd(format!(
                 "the engine's working directory `{pwd}` no longer exists \
-                 (a previous `cd` target was removed); pass cwd= to run \
-                 somewhere real (it persists like `cd`), or nu.reset() \
-                 for a fresh engine"
-            ));
-        }
-        for (key, value) in env.into_iter().flatten() {
-            stack.add_env_var(key, Value::string(value, Span::unknown()));
+                 (a previous `cd` target was removed); this engine was \
+                 discarded, so retry the call or pass cwd= explicitly"
+            )));
         }
 
         let block = {
@@ -179,7 +216,8 @@ impl EngineInner {
                     &working_set,
                     error,
                     Some("nu::parser::error"),
-                ));
+                )
+                .into());
             }
             if let Some(error) = working_set.compile_errors.first() {
                 return Err(format_cli_error(
@@ -187,7 +225,8 @@ impl EngineInner {
                     &working_set,
                     error,
                     Some("nu::compile::error"),
-                ));
+                )
+                .into());
             }
             let delta = working_set.render();
             engine_state
@@ -195,6 +234,16 @@ impl EngineInner {
                 .map_err(|error| render_shell_error(engine_state, stack, &error))?;
             block
         };
+
+        // Parse and compile before changing the persistent environment. A
+        // setup error must leave the previous PWD and variables intact so the
+        // next call starts from the last successfully configured state.
+        if let Some(dir) = cwd {
+            stack.add_env_var("PWD".into(), Value::string(dir, Span::unknown()));
+        }
+        for (key, value) in env.into_iter().flatten() {
+            stack.add_env_var(key, Value::string(value, Span::unknown()));
+        }
 
         // Bash redirection tokens the parser handed to an external as literal
         // argv (`2>/dev/null` and friends), detected up front and reported
@@ -209,7 +258,7 @@ impl EngineInner {
             diagnostic.push('\n');
             diagnostic.push_str(&bash_redirection_hint(token));
         }
-        result
+        result.map_err(EvalError::from)
     }
 }
 
@@ -805,7 +854,8 @@ impl Engine {
                         .unbind()
                         .into_any())
                 }),
-                Err(diagnostic) => Err(NuError::new_err(diagnostic)),
+                Err(EvalError::Diagnostic(diagnostic)) => Err(NuError::new_err(diagnostic)),
+                Err(EvalError::RemovedCwd(diagnostic)) => Err(NuCwdError::new_err(diagnostic)),
             }
         })?;
         Ok((future, EvalHandle { flag }))
@@ -835,6 +885,7 @@ fn _nu(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<Engine>()?;
     module.add_class::<EvalHandle>()?;
     module.add("NuError", module.py().get_type::<NuError>())?;
+    module.add("NuCwdError", module.py().get_type::<NuCwdError>())?;
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- raise a typed `NuCwdError` when the persistent engine retains a deleted directory
- discard that stale engine after the loud failure so the failed call never redirects and the next call starts fresh
- resolve explicit relative `cwd=` values to absolute paths and commit cwd/env changes only after parsing succeeds

Supersedes #2573 and includes its fix for #2567.

## Validation

- `cargo check -p nu-py`
- `cargo test -p nu-py` (16 passed)
- `nix build .#mcp.tests.nuTests`
- `nix run .#lint -- --json`

Fixes #2587
Fixes #2567

Authored by Codex, an AI coding agent.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover Nu engine after persistent working directory is removed
> - Introduces `NuCwdError`, a new Python exception (subclass of `NuError`) raised when the engine's persistent working directory no longer exists on disk.
> - When a `NuCwdError` occurs, the stale engine is discarded in [`__init__.py`](https://github.com/indexable-inc/index/pull/2596/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4) so the next call automatically uses a fresh engine without requiring a manual reset.
> - The `cwd` resolver in [`__init__.py`](https://github.com/indexable-inc/index/pull/2596/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4) now converts relative paths to absolute paths before storing them in state and passing them to the engine.
> - Detection logic in [`lib.rs`](https://github.com/indexable-inc/index/pull/2596/files#diff-424ce210c45fc8f162c45814067651d48d245471a2e86b63c39b71c370ffe7fe) compares the engine's stored PWD against the filesystem and returns `EvalError::RemovedCwd` when the directory is missing.
> - Behavioral Change: callers that previously caught `NuError` for removed-cwd failures must now also handle `NuCwdError` (which is a subclass, so existing broad catches still work).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52253e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->