### PR TITLE
ci: disable the parallel evaluator cache

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -246,8 +246,11 @@
   # outputs so they report a real cacheStatus instead of always-uncached, and the
   # patched nix-fast-build makes --skip-cached skip a `local` (warm-store) output,
   # not just a remotely-`cached` one. Without both, --skip-cached re-realizes every
-  # floating-CA rust unit and image closure (~1450) on every warm run. See the
-  # $fast_build and $eval_jobs comments below.
+  # floating-CA rust unit and image closure (~1450) on every warm run. The eval
+  # cache is disabled for this parallel evaluator too: all workers share one
+  # per-flake SQLite database, so writes contend and can fail with "database is
+  # busy" without providing useful hits on a fresh commit. See the $fast_build
+  # and $eval_jobs comments below.
   #
   # Step 2 (nix-eval-jobs) is the schema/eval gate over the package outputs,
   # broader than the `checks` set step 1 built. nix-eval-jobs is the same
@@ -339,6 +342,7 @@
               "--result-format" "json"
               "--result-file" "check-results.json"
               "--option" "accept-flake-config" "true"
+              "--option" "eval-cache" "false"
               "--option" "extra-experimental-features" "ca-derivations"
             ]
             false


### PR DESCRIPTION
## Summary

- disable Nix's eval cache in the nix-fast-build evaluator, matching the schema evaluator
- document why parallel workers must not share the per-flake SQLite cache

## Root cause

The `check` wrapper said the eval cache was disabled, but only passed `eval-cache=false` to its second, schema-only nix-eval-jobs invocation. The first nix-fast-build invocation still launched 16 evaluators against the same per-flake SQLite database, producing repeated `database is busy` warnings.

The unbuilt floating-CA manifest failures observed at the same time had a separate live-host cause: `vc1` was running an experimental Nix 2.36 daemon from `/tmp/nix-fixed` after the system 2.34.7 daemon was stopped. That protocol mismatch is tracked by #2592.

## Validation

- `nix run .#lint`
- built `.#packages.x86_64-linux.check`
- verified both evaluator invocations in the rendered script contain `--option eval-cache false`

Fixes #2598

Authored by Codex, an AI coding agent.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable the eval cache in the parallel evaluator to avoid SQLite contention
> Passes `--option eval-cache false` to the parallel evaluator invocation in [per-system.nix](https://github.com/indexable-inc/index/pull/2600/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683). The shared SQLite database used by the Nix eval cache causes contention when multiple evaluators run in parallel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8874a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->