### PR TITLE
ci: match evaluator to daemon protocol

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -300,8 +300,8 @@
   # each worker's eval bounded by the largest single crate. Both binaries are
   # nix-fast-build is the repo-built nixpkgs 1.5.0 package with a patch that
   # makes --skip-cached skip a `local` (warm-store) output, not just a remotely
-  # `cached` one. nix-eval-jobs is built against nixpkgs' Git Nix components so
-  # its CA-realisation protocol matches the fleet's rolling daemon. The eval
+  # `cached` one. nix-eval-jobs is built against the fleet daemon's exact Nix
+  # revision so its unstable CA-realisation protocol matches. The eval
   # cache is disabled for the parallel evaluator: all workers share one
   # per-flake SQLite database, so writes contend and can fail with "database is
   # busy" without providing useful hits on a fresh commit. See the $fast_build

--- a/packages/agent/distiller/default.nix
+++ b/packages/agent/distiller/default.nix
@@ -56,7 +56,7 @@
     mypy = {};
     # pyarrow's bundled stubs omit explicit top-level re-exports and leave its
     # writer/reader helpers untyped.
-    "mypy-pyarrow" = {
+    mypy-pyarrow = {
       implicit_reexport = true;
       disallow_untyped_calls = false;
     };

--- a/packages/nix/nix-eval-jobs/default.nix
+++ b/packages/nix/nix-eval-jobs/default.nix
@@ -1,10 +1,19 @@
 {pkgs}: let
-  # CA realisations changed wire format in Nix 2.35. Build the evaluator against
-  # nixpkgs' current Git components so it can communicate with the fleet's
-  # rolling daemon while the interactive client remains on the stable release.
-  package = pkgs.nix-eval-jobs.override {
-    nixComponents = pkgs.nixVersions.nixComponents_git;
+  daemonNixSrc = pkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nix";
+    rev = "ac94798c753e48fd0b36128a029ed8aecebe9b56";
+    hash = "sha256-lMvyBFy7jl8cnUI8efQuW8lxgIiwUhw6CHEmDpK0mfw=";
   };
+  # CA realisations are an unstable protocol. Build the evaluator from the
+  # exact Nix revision reported by the fleet daemon, while the interactive
+  # client remains on the stable release.
+  package =
+    (pkgs.nix-eval-jobs.override {
+      nixComponents = pkgs.nixVersions.nixComponents_git.overrideSource daemonNixSrc;
+    }).overrideAttrs (old: {
+      patches = (old.patches or []) ++ [./nix-master-api.patch];
+    });
 
   # The override's real risk is the C++ rebuild against nix's libstore linking
   # and the new symbols (staticOutputHashes, getDefaultSubstituters,

--- a/packages/nix/nix-eval-jobs/nix-master-api.patch
+++ b/packages/nix/nix-eval-jobs/nix-master-api.patch
@@ -1,0 +1,31 @@
+diff --git a/src/nix-eval-jobs.cc b/src/nix-eval-jobs.cc
+index 9d8c2a1..d714d91 100644
+--- a/src/nix-eval-jobs.cc
++++ b/src/nix-eval-jobs.cc
+@@ -540,9 +540 @@ int main(int argc, char **argv) {
+-            try {
+-                nix::saveMountNamespace();
+-                if (unshare(CLONE_NEWNS) == -1) {
+-                    throw nix::SysError("setting up a private mount namespace");
+-                }
+-            } catch (nix::Error &e) {
+-                nix::warn("failed to set up a private mount namespace: %s",
+-                          e.msg());
+-            }
++            nix::tryEnterPrivateMountNamespace();
+diff --git a/src/worker.cc b/src/worker.cc
+index c341f14..d94c0d7 100644
+--- a/src/worker.cc
++++ b/src/worker.cc
+@@ -59 +59 @@ namespace {
+-auto releaseExprTopLevelValue(nix::EvalState &state, nix::Bindings &autoArgs,
++auto releaseExprTopLevelValue(nix::EvalState &state, const nix::Bindings &autoArgs,
+@@ -283 +283 @@ auto initializeRootValue(const nix::ref<nix::EvalState> &state,
+-                         nix::Bindings &autoArgs, MyArgs &args)
++                         const nix::Bindings &autoArgs, MyArgs &args)
+@@ -320 +320 @@ auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
+-                       nix::AutoCloseFD &toParent, nix::Bindings &autoArgs,
++                       nix::AutoCloseFD &toParent, const nix::Bindings &autoArgs,
+@@ -407 +407 @@ void worker(
+-    nix::Bindings &autoArgs = *args.getAutoArgs(*state);
++    const nix::Bindings &autoArgs = *args.getAutoArgs(*state);

--- a/users/andrewgazelka/config/zellij/default.nix
+++ b/users/andrewgazelka/config/zellij/default.nix
@@ -223,14 +223,14 @@ in {
     };
 
     plugins = {
-      "tab-bar"._props.location = "zellij:tab-bar";
-      "status-bar"._props.location = "zellij:status-bar";
+      tab-bar._props.location = "zellij:tab-bar";
+      status-bar._props.location = "zellij:status-bar";
       strider._props.location = "zellij:strider";
-      "compact-bar" = {
+      compact-bar = {
         _props.location = "zellij:compact-bar";
         tooltip = "F1";
       };
-      "session-manager"._props.location = "zellij:session-manager";
+      session-manager._props.location = "zellij:session-manager";
       filepicker = {
         _props.location = "zellij:strider";
         cwd = "/";


### PR DESCRIPTION
Follow up #2578 after the fleet daemon advanced its unstable content-addressed realisation protocol.

- build nix-eval-jobs against the daemon exact Nix revision
- adapt nix-eval-jobs to the current Nix API
- fix bare-attribute lint findings exposed after #2591

Validation:
- `nix build .#packages.x86_64-linux.nix-eval-jobs --no-link`
- `nix run .#lint`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build nix-eval-jobs against the fleet daemon's pinned Nix revision
> - Pins `nix-eval-jobs` to a specific NixOS/nix revision (`ac94798`) via `fetchFromGitHub`, matching the exact Nix version used by the fleet daemon to ensure protocol compatibility.
> - Applies [nix-master-api.patch](https://github.com/indexable-inc/index/pull/2603/files#diff-8d8fc96afd71b97a8b5ec70866d3ecfe88b67022b15ff556d2cf7a66ae3fb0fb) during build, replacing manual mount namespace setup with `nix::tryEnterPrivateMountNamespace()` and updating `nix::Bindings` signatures to `const` in the evaluator sources.
> - Updates comments in [per-system.nix](https://github.com/indexable-inc/index/pull/2603/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) to document that the CA-realisation protocol is unstable and that `nix-eval-jobs` tracks the daemon's exact Nix revision.
> - Risk: the evaluator binary now diverges from upstream `nix-eval-jobs` and must be kept in sync with daemon Nix updates manually.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf12af3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->