### PR TITLE
ci: preflight CA IFD before parallel evaluation

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -328,6 +328,7 @@
   check = ix.writeNushellApplication pkgs {
     name = "check";
     meta.description = "Run the full CI gate: build .#ciChecks.x86_64-linux and eval-validate .#packages.x86_64-linux";
+    runtimeInputs = [repoPackages.nix-eval-jobs.passthru.nix];
     text = ''
       # Patched nix-fast-build (packages/nix/nix-fast-build): stock --skip-cached
       # only skips a job whose nix-eval-jobs cacheStatus is `cached` (in a remote
@@ -345,6 +346,15 @@
       const eval_jobs = "${lib.getExe repoPackages.nix-eval-jobs}"
 
       def main [] {
+        # Realize the aggregate eval gate's IFD inputs sequentially before the
+        # parallel evaluator fans out. This also verifies the daemon-matched
+        # Nix client can complete CA realization before scheduling any builds.
+        ^nix eval ...[
+          "--raw" ".#ciChecks.x86_64-linux.eval.drvPath"
+          "--option" "accept-flake-config" "true"
+          "--option" "extra-experimental-features" "ca-derivations"
+        ] | ignore
+
         # ca-derivations: the rust workspace units default to
         # `contentAddressed = true` (lib/rust/cargo-unit.nix), so evaluating
         # `.#ciChecks.x86_64-linux` resolves floating content-addressed drvs. The

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -349,11 +349,38 @@
         # Realize the aggregate eval gate's IFD inputs sequentially before the
         # parallel evaluator fans out. This also verifies the daemon-matched
         # Nix client can complete CA realization before scheduling any builds.
-        ^nix eval ...[
-          "--raw" ".#ciChecks.x86_64-linux.eval.drvPath"
-          "--option" "accept-flake-config" "true"
-          "--option" "extra-experimental-features" "ca-derivations"
-        ] | ignore
+        mut pending_ifd = true
+        mut attempts = 0
+        while $pending_ifd {
+          let evaluated = (^nix eval ...[
+            "--raw" ".#ciChecks.x86_64-linux.eval.drvPath"
+            "--option" "accept-flake-config" "true"
+            "--option" "extra-experimental-features" "ca-derivations"
+          ] | complete)
+          if $evaluated.exit_code == 0 {
+            $pending_ifd = false
+          } else {
+            let drvs = (
+              $evaluated.stderr
+              | parse -r "(?<drv>/nix/store/[a-z0-9]{32}-[^' ]+\\.drv)"
+              | get --optional drv
+              | default []
+              | uniq
+            )
+            if ($drvs | is-empty) or $attempts >= 32 {
+              print --stderr $evaluated.stderr
+              error make {msg: "failed to realize aggregate eval IFD inputs"}
+            }
+            for drv in $drvs {
+              ^nix build $"($drv)^*" ...[
+                "--no-link"
+                "--option" "accept-flake-config" "true"
+                "--option" "extra-experimental-features" "ca-derivations"
+              ]
+            }
+            $attempts += 1
+          }
+        }
 
         # ca-derivations: the rust workspace units default to
         # `contentAddressed = true` (lib/rust/cargo-unit.nix), so evaluating


### PR DESCRIPTION
Realize the aggregate eval gate with the daemon-matched Nix client before nix-eval-jobs fans out. This prevents stale unbuilt CA manifests from aborting parallel evaluation after a runner daemon restart.

Validation: `nix run .#lint`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preflight CA IFD inputs before parallel evaluation in CI check CLI
> - Before running parallel evaluation, the check CLI now sequentially realizes IFD (Import From Derivation) inputs for the aggregate eval gate by evaluating `.#ciChecks.x86_64-linux.eval.drvPath` and building any referenced `.drv` paths on failure.
> - The loop retries up to 32 times, building each missing derivation with `nix build <drv>^* --no-link` before retrying the eval; it fails early if no `.drv` paths are found in stderr or attempts are exhausted.
> - Adds `nix` from `repoPackages.nix-eval-jobs.passthru.nix` to `runtimeInputs` of the check Nushell application so the binary is available on PATH during execution.
> - Behavioral Change: the check CLI now has a sequential preflight phase that must succeed before parallel evaluation begins, and will hard-fail after 32 unsuccessful attempts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 691098c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->