### PR TITLE
google gmail: name list page parts

### DIFF
--- a/packages/google/gmail/src/lib.rs
+++ b/packages/google/gmail/src/lib.rs
@@ -53,15 +53,16 @@ pub const USER_ME: &str = "me";
 /// `maxResults` at 500 per page; larger queries follow `nextPageToken`.
 pub(crate) const MAX_PAGE_SIZE: usize = 500;
 
-pub(crate) struct ListPageParts<T> {
+#[derive(Deserialize)]
+#[serde(
+    rename_all = "camelCase",
+    bound(deserialize = "T: serde::Deserialize<'de>"),
+)]
+struct ListPage<T> {
+    #[serde(default, alias = "messages", alias = "threads")]
     items: Vec<T>,
+    #[serde(default)]
     next_page_token: Option<String>,
-}
-
-pub(crate) trait ListPage: serde::de::DeserializeOwned {
-    type Item;
-
-    fn into_parts(self) -> ListPageParts<Self::Item>;
 }
 
 /// The Gmail / Google API error envelope:
@@ -149,13 +150,13 @@ impl Client {
         Ok(self.http.get(url).bearer_auth(token))
     }
 
-    pub(crate) async fn list_message_resources<P>(
+    pub(crate) async fn list_message_resources<T>(
         &self,
         resource: &str,
         query: &MessageQuery,
-    ) -> Result<Vec<P::Item>>
+    ) -> Result<Vec<T>>
     where
-        P: ListPage,
+        T: serde::de::DeserializeOwned,
     {
         let mut items = Vec::new();
         let mut page_token: Option<String> = None;
@@ -181,10 +182,10 @@ impl Client {
             }
 
             let response = self.get(url).await?.send().await.context(HttpSnafu)?;
-            let ListPageParts {
+            let ListPage {
                 items: page_items,
                 next_page_token,
-            } = decode::<P>(response).await?.into_parts();
+            } = decode::<ListPage<T>>(response).await?;
             items.extend(page_items);
             match next_page_token {
                 Some(next) if items.len() < query.max_results => page_token = Some(next),

--- a/packages/google/gmail/src/lib.rs
+++ b/packages/google/gmail/src/lib.rs
@@ -53,10 +53,15 @@ pub const USER_ME: &str = "me";
 /// `maxResults` at 500 per page; larger queries follow `nextPageToken`.
 pub(crate) const MAX_PAGE_SIZE: usize = 500;
 
+pub(crate) struct ListPageParts<T> {
+    items: Vec<T>,
+    next_page_token: Option<String>,
+}
+
 pub(crate) trait ListPage: serde::de::DeserializeOwned {
     type Item;
 
-    fn into_parts(self) -> (Vec<Self::Item>, Option<String>);
+    fn into_parts(self) -> ListPageParts<Self::Item>;
 }
 
 /// The Gmail / Google API error envelope:
@@ -176,7 +181,10 @@ impl Client {
             }
 
             let response = self.get(url).await?.send().await.context(HttpSnafu)?;
-            let (page_items, next_page_token) = decode::<P>(response).await?.into_parts();
+            let ListPageParts {
+                items: page_items,
+                next_page_token,
+            } = decode::<P>(response).await?.into_parts();
             items.extend(page_items);
             match next_page_token {
                 Some(next) if items.len() < query.max_results => page_token = Some(next),

--- a/packages/google/gmail/src/messages.rs
+++ b/packages/google/gmail/src/messages.rs
@@ -75,27 +75,6 @@ impl std::str::FromStr for MessageFormat {
     }
 }
 
-/// One page of `users.messages.list`.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct MessagesPage {
-    #[serde(default)]
-    messages: Vec<MessageStub>,
-    #[serde(default)]
-    next_page_token: Option<String>,
-}
-
-impl crate::ListPage for MessagesPage {
-    type Item = MessageStub;
-
-    fn into_parts(self) -> crate::ListPageParts<Self::Item> {
-        crate::ListPageParts {
-            items: self.messages,
-            next_page_token: self.next_page_token,
-        }
-    }
-}
-
 /// `messages.list` returns only ids and thread ids on the page; the caller
 /// fetches each one's payload through `get_message`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -127,7 +106,7 @@ impl Client {
     /// # Errors
     /// Returns auth, transport, or API errors.
     pub async fn list_messages(&self, query: &MessageQuery) -> Result<Vec<MessageStub>> {
-        self.list_message_resources::<MessagesPage>("messages", query)
+        self.list_message_resources::<MessageStub>("messages", query)
             .await
     }
 

--- a/packages/google/gmail/src/messages.rs
+++ b/packages/google/gmail/src/messages.rs
@@ -88,8 +88,11 @@ struct MessagesPage {
 impl crate::ListPage for MessagesPage {
     type Item = MessageStub;
 
-    fn into_parts(self) -> (Vec<Self::Item>, Option<String>) {
-        (self.messages, self.next_page_token)
+    fn into_parts(self) -> crate::ListPageParts<Self::Item> {
+        crate::ListPageParts {
+            items: self.messages,
+            next_page_token: self.next_page_token,
+        }
     }
 }
 

--- a/packages/google/gmail/src/threads.rs
+++ b/packages/google/gmail/src/threads.rs
@@ -21,8 +21,11 @@ struct ThreadsPage {
 impl crate::ListPage for ThreadsPage {
     type Item = ThreadStub;
 
-    fn into_parts(self) -> (Vec<Self::Item>, Option<String>) {
-        (self.threads, self.next_page_token)
+    fn into_parts(self) -> crate::ListPageParts<Self::Item> {
+        crate::ListPageParts {
+            items: self.threads,
+            next_page_token: self.next_page_token,
+        }
     }
 }
 

--- a/packages/google/gmail/src/threads.rs
+++ b/packages/google/gmail/src/threads.rs
@@ -8,27 +8,6 @@ use crate::messages::MessageFormat;
 use crate::model::{MessageQuery, Thread};
 use crate::{Client, Result, decode};
 
-/// One page of `users.threads.list`.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ThreadsPage {
-    #[serde(default)]
-    threads: Vec<ThreadStub>,
-    #[serde(default)]
-    next_page_token: Option<String>,
-}
-
-impl crate::ListPage for ThreadsPage {
-    type Item = ThreadStub;
-
-    fn into_parts(self) -> crate::ListPageParts<Self::Item> {
-        crate::ListPageParts {
-            items: self.threads,
-            next_page_token: self.next_page_token,
-        }
-    }
-}
-
 /// `threads.list` returns only thread ids and snippets on the page; the
 /// caller fetches messages by calling `get_thread`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -50,7 +29,7 @@ impl Client {
     /// # Errors
     /// Returns auth, transport, or API errors.
     pub async fn list_threads(&self, query: &MessageQuery) -> Result<Vec<ThreadStub>> {
-        self.list_message_resources::<ThreadsPage>("threads", query)
+        self.list_message_resources::<ThreadStub>("threads", query)
             .await
     }
 


### PR DESCRIPTION
## Summary
- replace the Gmail list-page tuple transport with named `ListPageParts<T>`
- update message and thread page implementations to return the named type

## Validation
- `nix build .#ciChecks.x86_64-linux.rust-google-gmail.clippy --no-link -L`
- `cargo test -p google-gmail` (23 tests passed)
- `nix run .#lint -- --json` (fails on pre-existing findings in `users/andrewgazelka/config/zellij/default.nix` and `packages/mcp/tests/test_linear_triage.py`)

Fixes #2607

(sent by Codex, an AI coding agent)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace per-endpoint page structs with a generic `ListPage<T>` in the Gmail crate
> - Removes the `ListPage` trait and the per-endpoint `MessagesPage`/`ThreadsPage` structs, replacing them with a single generic `ListPage<T>` struct in [lib.rs](https://github.com/indexable-inc/index/pull/2608/files#diff-2471193b89033699d7b73b74ca60119959c5c826cd0facf98c89bf23e78e42a2).
> - `ListPage<T>` uses serde field aliases (`messages`, `threads`) to deserialize both message and thread list responses into a unified `items` vector.
> - `list_message_resources` now takes a `T: DeserializeOwned` type parameter directly (e.g. `MessageStub`, `ThreadStub`) instead of a page-level generic, simplifying call sites in [messages.rs](https://github.com/indexable-inc/index/pull/2608/files#diff-74f3ae45fd6353c5bc8a19857334cc061ef1f1f21426fa7cd0eb92c46ac34dd5) and [threads.rs](https://github.com/indexable-inc/index/pull/2608/files#diff-557d60221c35724d02bed08a922c7d663a993ca94be821005e5296178e6f85b6).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52902c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->