### PR TITLE
mutable-files: writable Nix-declared files with a logical drift queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4967,6 +4967,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
+name = "index-delta"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "plist",
+ "serde",
+ "serde_json",
+ "serde_norway",
+ "sha2 0.11.0",
+ "similar",
+ "tempfile",
+ "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
+]
+
+[[package]]
 name = "indexbench"
 version = "0.1.0"
 dependencies = [
@@ -8318,6 +8335,19 @@ checksum = "9368d62437c8cbb7c31ee37fd8c08a7d390e09a3ff75698a674953f46705ffcb"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap 2.14.0",
+ "quick-xml 0.41.0",
+ "serde",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
   "packages/google/gmail/cli",
   "packages/google/mcp",
   "packages/google/py",
+  "packages/index-delta",
   "packages/indexbench",
   "packages/ix-dev-diagnose",
   "packages/ix-windows",
@@ -266,6 +267,10 @@ panes-guest-transport = { path = "packages/vm/panes/guest-transport" }
 parking_lot = "0.12"
 parquet = { version = "59", features = ["arrow"] }
 percent-encoding = "2"
+# Apple property lists for index-delta's logical-diff engines: macOS `defaults`
+# domains and LaunchAgents are plists (XML and binary), so drift in them must be
+# diffed as parsed values, not bytes.
+plist = "1"
 prettyplease = "0.2"
 proc-macro2 = "1"
 progress-style = { path = "packages/progress-style" }

--- a/flake.nix
+++ b/flake.nix
@@ -490,6 +490,17 @@
       # zero eval. Set `provenance.rev = self.rev or self.dirtyRev or null`
       # in the consuming flake. See modules/darwin/provenance.nix.
       provenance = import ./modules/darwin/provenance.nix {inherit (ix) provenance;};
+      # System-level (root, /etc) adapter for declarative-but-writable files:
+      # same model as homeModules.mutable-files, state under
+      # /var/db/index-delta, boot-time reseed daemon. See
+      # modules/darwin/mutable-files.nix.
+      mutable-files = import ./modules/darwin/mutable-files.nix {
+        indexPackages = system: packages.${system};
+      };
+      # Declarative NFS automounts via macOS autofs: each entry renders a
+      # direct-map line, /etc/auto_master gains the include idempotently, and
+      # activation reloads automountd. See modules/darwin/nfs.nix.
+      nfs = ./modules/darwin/nfs.nix;
     };
     homeModules = {
       # Workstation-facing home-manager module: declare a service once, get a
@@ -499,6 +510,17 @@
       # Declarative-but-writable JSON config files (last-applied 3-way merge),
       # for config an app rewrites at runtime. See lib/mutable-json.nix.
       mutable-json = ix.mutableJson.homeModule;
+      # Declarative-but-writable files with logical (format-aware) drift
+      # tracking and a model-oriented resolution queue — no auto-merge.
+      # Declared content seeds a plain writable file; ephemeral files reset
+      # at login (drift journaled), durable files queue base-vs-drift
+      # conflicts in `index-delta status --json` for discard / adopt /
+      # absorb-into-Nix via `index-delta apply-ops`. See
+      # modules/home/mutable-files.nix and packages/index-delta.
+      mutable-files = import ./modules/home/mutable-files.nix {
+        indexPackages = system: packages.${system};
+        portableServicesModule = ix.portableServices.homeModule;
+      };
       # Reusable workstation module (macOS): declare Raycast Focus session
       # defaults (title, filter mode, duration) and have them written to the
       # com.raycast.macos defaults domain at switch time. Import it and set

--- a/flake.nix
+++ b/flake.nix
@@ -412,6 +412,10 @@
     indexPackages = system: packages.${system};
     personalConfigRoot = ./users/andrewgazelka/config;
     personalOptionsModule = ./users/andrewgazelka/options.nix;
+    mutableFilesHomeModule = import ./modules/home/mutable-files.nix {
+      inherit indexPackages;
+      portableServicesModule = ix.portableServices.homeModule;
+    };
     claudeCodeHomeModule = import ./packages/agent/home-manager/claude-code.nix {
       inherit indexPackages;
       promptModule = ./packages/agent/prompt;
@@ -432,7 +436,7 @@
     personalWorkstationModule = import ./users/andrewgazelka/profiles/workstation.nix {
       inherit indexPackages personalServicesModule ix;
       configRoot = personalConfigRoot;
-      mutableJsonModule = ix.mutableJson.homeModule;
+      mutableFilesModule = mutableFilesHomeModule;
       provenanceModule = import ./modules/home/provenance.nix {inherit (ix) provenance;};
       optionsModule = personalOptionsModule;
       indexSkillsSrc = paths.skills;
@@ -509,6 +513,8 @@
       tmux = ./modules/home/tmux.nix;
       # Declarative-but-writable JSON config files (last-applied 3-way merge),
       # for config an app rewrites at runtime. See lib/mutable-json.nix.
+      # Prefer `mutable-files` below for new config: it never auto-merges,
+      # covers more formats, and queues drift for explicit resolution.
       mutable-json = ix.mutableJson.homeModule;
       # Declarative-but-writable files with logical (format-aware) drift
       # tracking and a model-oriented resolution queue — no auto-merge.
@@ -517,10 +523,7 @@
       # conflicts in `index-delta status --json` for discard / adopt /
       # absorb-into-Nix via `index-delta apply-ops`. See
       # modules/home/mutable-files.nix and packages/index-delta.
-      mutable-files = import ./modules/home/mutable-files.nix {
-        indexPackages = system: packages.${system};
-        portableServicesModule = ix.portableServices.homeModule;
-      };
+      mutable-files = mutableFilesHomeModule;
       # Reusable workstation module (macOS): declare Raycast Focus session
       # defaults (title, filter mode, duration) and have them written to the
       # com.raycast.macos defaults domain at switch time. Import it and set

--- a/modules/darwin/mutable-files.nix
+++ b/modules/darwin/mutable-files.nix
@@ -1,0 +1,170 @@
+# System-level (nix-darwin) adapter for declarative-but-writable files: the
+# /etc counterpart of modules/home/mutable-files.nix. Same model, run as root
+# at activation — a declared file is deployed as a plain regular file (no
+# read-only store symlink), seeded from its Nix-declared base, with local
+# edits tracked as logical, format-aware diffs by `index-delta`
+# (packages/index-delta).
+#
+# Persistence per file: `ephemeral` (default) resets from the base at every
+# activation and boot after archiving the drift's diff to the journal;
+# `durable` keeps edits and stages base changes under drift as conflicts in
+# `index-delta status` instead of touching the file.
+#
+# State lives at /var/db/index-delta (the macOS convention for system state),
+# so `sudo index-delta --state-dir /var/db/index-delta status` inspects the
+# system queue without clashing with any per-user state.
+{indexPackages}: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit
+    (lib)
+    mkOption
+    mkIf
+    types
+    ;
+
+  cfg = config.mutable;
+
+  stateDir = "/var/db/index-delta";
+
+  defaultPackage = (indexPackages pkgs.stdenv.hostPlatform.system).index-delta;
+
+  fileType = types.submodule ({name, ...}: {
+    options = {
+      source = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "File holding the declared content. Exactly one of `source` and `text` must be set.";
+      };
+
+      text = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = "Inline declared content. Exactly one of `source` and `text` must be set.";
+      };
+
+      format = mkOption {
+        type = types.nullOr (types.enum [
+          "json"
+          "toml"
+          "yaml"
+          "plist"
+          "keyvalue"
+          "text"
+        ]);
+        default = null;
+        description = "Logical-diff format; null auto-detects from extension then content and sticks.";
+      };
+
+      persistence = mkOption {
+        type = types.enum [
+          "ephemeral"
+          "durable"
+        ];
+        default = "ephemeral";
+        description = "`ephemeral`: reset from base each activation/boot (drift journaled). `durable`: edits survive; base changes under drift queue as conflicts.";
+      };
+
+      sourceFile = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Repo path of the declared content, so `index-delta status` can point `apply-ops` at it. Informational.";
+      };
+
+      declaredAt = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Nix file (and line) that declared this entry. Informational.";
+      };
+
+      _target = mkOption {
+        type = types.str;
+        internal = true;
+        default =
+          if lib.hasPrefix "/" name
+          then name
+          else "/${name}";
+        description = "Resolved absolute target path.";
+      };
+    };
+  });
+
+  files = lib.attrValues cfg.files;
+
+  contentFor = file:
+    if file.text != null
+    then pkgs.writeText (baseNameOf file._target) file.text
+    else file.source;
+
+  manifest = (pkgs.formats.json {}).generate "index-delta-system-manifest.json" {
+    files =
+      map (
+        file:
+          {
+            path = file._target;
+            source = "${contentFor file}";
+            inherit (file) persistence;
+          }
+          // lib.optionalAttrs (file.format != null) {inherit (file) format;}
+          // lib.optionalAttrs (file.sourceFile != null) {inherit (file) sourceFile;}
+          // lib.optionalAttrs (file.declaredAt != null) {inherit (file) declaredAt;}
+      )
+      files;
+  };
+in {
+  options.mutable = {
+    package = mkOption {
+      type = types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "index.packages.\${system}.index-delta";
+      description = "The `index-delta` package that seeds and tracks the files.";
+    };
+
+    files = mkOption {
+      type = types.attrsOf fileType;
+      default = {};
+      example = lib.literalExpression ''
+        {
+          "etc/pf.anchors/dev".text = "...";
+        }
+      '';
+      description = ''
+        System files declared in Nix but deployed as plain writable files,
+        seeded and tracked by `index-delta` as root. Attribute names are
+        absolute paths (a leading `/` is implied).
+      '';
+    };
+  };
+
+  config = mkIf (cfg.files != {}) {
+    assertions =
+      map (file: {
+        assertion = (file.source == null) != (file.text == null);
+        message = "mutable.files.\"${file._target}\": set exactly one of `source` and `text`.";
+      })
+      files;
+
+    system.activationScripts.postActivation.text = lib.mkAfter ''
+      echo "seeding mutable files (index-delta)..."
+      ${cfg.package}/bin/index-delta --state-dir ${stateDir} activate --manifest ${manifest}
+    '';
+
+    # Boot-time reseed: ephemeral system files start every boot from their
+    # declared base. `reseed` works off snapshotted bases, so no manifest.
+    launchd.daemons.index-delta-reseed = {
+      serviceConfig = {
+        Label = "org.nixos.index-delta-reseed";
+        ProgramArguments = [
+          "${cfg.package}/bin/index-delta"
+          "--state-dir"
+          stateDir
+          "reseed"
+        ];
+        RunAtLoad = true;
+      };
+    };
+  };
+}

--- a/modules/darwin/nfs.nix
+++ b/modules/darwin/nfs.nix
@@ -1,0 +1,110 @@
+# Declarative NFS automounts for nix-darwin, via the autofs machinery macOS
+# ships (automountd). Each entry renders one line of a direct map
+# (/etc/auto_index), the include line is added to /etc/auto_master
+# idempotently at activation, and `automount -vc` reloads the maps — no
+# daemons, no kexts, and mounts appear on first access like any autofs mount.
+#
+# macOS never got FSKit-based NFS (FSKit ships with only msdos in practice)
+# and nix-darwin has no mount module, so autofs is the supported, native path
+# for "declared network mounts" on Darwin.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit
+    (lib)
+    mkOption
+    mkIf
+    types
+    ;
+
+  cfg = config.services.nfs;
+
+  mountType = types.submodule ({name, ...}: {
+    options = {
+      server = mkOption {
+        type = types.str;
+        example = "nas.local";
+        description = "NFS server host.";
+      };
+
+      remotePath = mkOption {
+        type = types.str;
+        example = "/export/media";
+        description = "Exported path on the server.";
+      };
+
+      options = mkOption {
+        type = types.listOf types.str;
+        default = [
+          "resvport"
+          "nfc"
+        ];
+        example = [
+          "resvport"
+          "nfsvers=4"
+          "soft"
+        ];
+        description = ''
+          Mount options for the map entry. `resvport` is required by most
+          Linux NFS servers' default export policy; `nfc` normalizes unicode
+          filenames. Add `nfsvers=4`/`soft`/`intr` etc. as the server needs.
+        '';
+      };
+
+      _mountpoint = mkOption {
+        type = types.str;
+        internal = true;
+        default =
+          if lib.hasPrefix "/" name
+          then name
+          else "/${name}";
+        description = "Absolute local mount point (the attribute name).";
+      };
+    };
+  });
+
+  mounts = lib.attrValues cfg.automounts;
+
+  mapLine = mount: "${mount._mountpoint} -${lib.concatStringsSep "," mount.options} ${mount.server}:${mount.remotePath}";
+
+  mapFile = "auto_index";
+in {
+  options.services.nfs.automounts = mkOption {
+    type = types.attrsOf mountType;
+    default = {};
+    example = lib.literalExpression ''
+      {
+        "/Volumes/media" = {
+          server = "nas.local";
+          remotePath = "/export/media";
+          options = [ "resvport" "nfsvers=4" ];
+        };
+      }
+    '';
+    description = ''
+      Declarative NFS automounts (macOS autofs). Attribute names are local
+      mount points; each renders a direct-map entry in /etc/${mapFile}, and
+      activation reloads automountd. Mounts attach lazily on first access
+      and detach when idle, like any autofs mount.
+    '';
+  };
+
+  config = mkIf (cfg.automounts != {}) {
+    environment.etc.${mapFile}.text =
+      lib.concatMapStrings (mount: mapLine mount + "\n") mounts;
+
+    # /etc/auto_master is Apple-owned and may gain entries across OS updates,
+    # so it is amended in place (idempotently) rather than replaced through
+    # environment.etc.
+    system.activationScripts.postActivation.text = lib.mkAfter ''
+      if ! /usr/bin/grep -q '^/-[[:space:]]\{1,\}${mapFile}' /etc/auto_master 2>/dev/null; then
+        printf '/-\t${mapFile}\t-nosuid\n' >> /etc/auto_master
+        echo "added ${mapFile} direct map to /etc/auto_master"
+      fi
+      /usr/sbin/automount -vc
+    '';
+  };
+}

--- a/modules/home/mutable-files.nix
+++ b/modules/home/mutable-files.nix
@@ -1,0 +1,225 @@
+# Declarative-but-writable files: `mutable.files.<path>` declares content in
+# Nix, but the deployed file is a plain regular file the owning app can edit
+# freely — no read-only store symlink. `index-delta` (packages/index-delta)
+# seeds each file from its declared base at activation and tracks local edits
+# as *logical*, format-aware diffs (JSON diffed as JSON, TOML as TOML, ...).
+#
+# There is deliberately no auto-merge. Persistence is per file:
+#
+#   * `ephemeral` (the default): edits are scratch. Every activation and every
+#     login rewrites the file from its base; the drift's logical diff is
+#     archived to `index-delta journal` first, so nothing is silently lost.
+#   * `durable`: edits survive. When the declared base changes under local
+#     drift, the incoming base is parked as *staged* and the file queues in
+#     `index-delta status` for resolution (discard / adopt / absorb via
+#     `apply-ops` / snooze) — the file itself is never touched.
+#
+# The resolution queue (`index-delta status --json`) is designed for a model
+# to read: both diffs (yours + incoming) as addressed ops, plus the overlap
+# between them. `index-delta apply-ops <repo-file> <ops.json>` replays chosen
+# ops onto the Nix source, so drift can be absorbed into the repo instead of
+# resolved by hand.
+#
+# Closed over the per-system flake package set (for the `index-delta` binary)
+# and the portable-services home module (for the login reseed agent: native
+# launchd on macOS, systemd user unit on Linux). See flake.nix homeModules.
+{
+  indexPackages,
+  portableServicesModule,
+}: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit
+    (lib)
+    mkOption
+    mkIf
+    types
+    ;
+
+  cfg = config.mutable;
+
+  defaultPackage = (indexPackages pkgs.stdenv.hostPlatform.system).index-delta;
+
+  # Attribute names are target paths: absolute and `~/`-prefixed pass
+  # through; anything else is relative to home.
+  targetPath = name:
+    if lib.hasPrefix "/" name || lib.hasPrefix "~" name
+    then name
+    else "~/${name}";
+
+  fileType = types.submodule ({name, ...}: {
+    options = {
+      source = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "File holding the declared content. Exactly one of `source` and `text` must be set.";
+      };
+
+      text = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = "Inline declared content. Exactly one of `source` and `text` must be set.";
+      };
+
+      format = mkOption {
+        type = types.nullOr (types.enum [
+          "json"
+          "toml"
+          "yaml"
+          "plist"
+          "keyvalue"
+          "text"
+        ]);
+        default = null;
+        description = ''
+          Logical-diff format. Null (the default) auto-detects from the
+          target's extension, then the base's content; the detected format is
+          recorded in the file's state so it can never flip under an existing
+          diff. Set it only to override detection (e.g. an extensionless
+          ghostty config that should diff as `keyvalue`).
+        '';
+      };
+
+      persistence = mkOption {
+        type = types.enum [
+          "ephemeral"
+          "durable"
+        ];
+        default = "ephemeral";
+        description = ''
+          `ephemeral` (default): edits are scratch — reset from the base at
+          every activation and login, with the drift's logical diff archived
+          to the journal first. `durable`: edits survive; a base change under
+          drift stages a conflict in `index-delta status` instead of touching
+          the file.
+        '';
+      };
+
+      sourceFile = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "modules/profiles/ghostty/config";
+        description = ''
+          Repo path of the file holding the declared content, recorded in the
+          file's state so `index-delta status` can point "absorb this drift
+          into Nix" edits (`index-delta apply-ops`) at the right file. Purely
+          informational — omitting it only means status cannot suggest where
+          to apply ops.
+        '';
+      };
+
+      declaredAt = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "users/alice/home.nix:42";
+        description = "Nix file (and line) that declared this entry, surfaced by `index-delta status`. Informational.";
+      };
+
+      _target = mkOption {
+        type = types.str;
+        internal = true;
+        default = targetPath name;
+        description = "Resolved target path handed to the manifest.";
+      };
+    };
+  });
+
+  files = lib.attrValues cfg.files;
+
+  contentFor = file:
+    if file.text != null
+    then pkgs.writeText (baseNameOf file._target) file.text
+    else file.source;
+
+  manifest = (pkgs.formats.json {}).generate "index-delta-manifest.json" {
+    files =
+      map (
+        file:
+          {
+            path = file._target;
+            source = "${contentFor file}";
+            inherit (file) persistence;
+          }
+          // lib.optionalAttrs (file.format != null) {inherit (file) format;}
+          // lib.optionalAttrs (file.sourceFile != null) {inherit (file) sourceFile;}
+          // lib.optionalAttrs (file.declaredAt != null) {inherit (file) declaredAt;}
+      )
+      files;
+  };
+in {
+  imports = [portableServicesModule];
+
+  options.mutable = {
+    package = mkOption {
+      type = types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "index.packages.\${system}.index-delta";
+      description = "The `index-delta` package that seeds and tracks the files.";
+    };
+
+    loginReseed = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Run `index-delta reseed` at login so ephemeral files start every
+        session from their declared base (drift is archived to the journal
+        first). Durable files are never touched by reseed.
+      '';
+    };
+
+    files = mkOption {
+      type = types.attrsOf fileType;
+      default = {};
+      example = lib.literalExpression ''
+        {
+          ".config/ghostty/config" = {
+            source = ./ghostty-config;
+            format = "keyvalue";
+          };
+          ".config/lazygit/config.yml" = {
+            text = "gui:\n  theme: dark\n";
+            persistence = "durable";
+          };
+        }
+      '';
+      description = ''
+        Files declared in Nix but deployed as plain writable files, seeded and
+        tracked by `index-delta`. Attribute names are target paths (relative
+        to home unless absolute or `~/`-prefixed).
+      '';
+    };
+  };
+
+  config = mkIf (cfg.files != {}) {
+    assertions =
+      map (file: {
+        assertion = (file.source == null) != (file.text == null);
+        message = "mutable.files.\"${file._target}\": set exactly one of `source` and `text`.";
+      })
+      files;
+
+    # After writeBoundary so activation ordering matches home.file targets;
+    # `activate` seeds new files, reseeds ephemeral ones, and gates durable
+    # ones (staging conflicts rather than touching drifted files), then prints
+    # one line per file.
+    home.activation.mutableFiles = config.lib.dag.entryAfter ["writeBoundary"] ''
+      $DRY_RUN_CMD ${cfg.package}/bin/index-delta activate --manifest ${manifest}
+    '';
+
+    # Login reseed: ephemeral files reset every session, not just at switch
+    # time. `reseed` works off the snapshotted bases, so it needs no manifest
+    # and never blocks on the repo being checked out.
+    services.portable.index-delta-reseed = {
+      enable = cfg.loginReseed;
+      description = "Reset ephemeral mutable files to their declared base";
+      command = [
+        "${cfg.package}/bin/index-delta"
+        "reseed"
+      ];
+      runAtLoad = true;
+    };
+  };
+}

--- a/packages/index-delta/Cargo.toml
+++ b/packages/index-delta/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "index-delta"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Drift tracker for Nix-declared mutable files: seed writable overlays from store bases, report logical (format-aware) diffs, and resolve them with explicit verbs instead of auto-merge"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+plist.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
+serde_norway.workspace = true
+sha2.workspace = true
+similar.workspace = true
+toml = { workspace = true, features = ["parse", "serde"] }
+toml_edit.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[[bin]]
+name = "index-delta"
+path = "src/main.rs"

--- a/packages/index-delta/default.nix
+++ b/packages/index-delta/default.nix
@@ -1,0 +1,13 @@
+{
+  ix,
+  lib,
+  ...
+}:
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "index-delta";
+  meta = {
+    description = "Mutable files over Nix: seed declared files as plain writable files, track drift as logical format-aware diffs (json/toml/yaml/plist/keyvalue), and queue base-vs-drift conflicts for model-driven resolution instead of auto-merging";
+    license = lib.licenses.mit;
+    mainProgram = "index-delta";
+  };
+}

--- a/packages/index-delta/package.nix
+++ b/packages/index-delta/package.nix
@@ -1,0 +1,8 @@
+{
+  id = "index-delta";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/index-delta/src/apply.rs
+++ b/packages/index-delta/src/apply.rs
@@ -1,0 +1,718 @@
+//! `apply-ops`: replay chosen logical ops onto a file, going through each
+//! format's own writer so the edit is format-preserving where the format
+//! allows it (`toml_edit` keeps comments and layout; keyvalue is edited
+//! line-by-line; json/yaml/plist re-serialize). The model decides *which*
+//! ops to keep — this module is only the mechanical half.
+
+use std::fs;
+use std::io::Cursor;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+
+use crate::diff::{Op, parse_address};
+use crate::store;
+use crate::value::{self, Format};
+
+/// Apply ops onto a file in place, returning the format that was used
+/// (detected from the file unless overridden).
+pub fn apply_to_file(path: &Path, format_override: Option<Format>, ops: &[Op]) -> Result<Format> {
+    let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    let format = format_override.unwrap_or_else(|| value::detect(path, &bytes));
+    let output = render_applied(format, path, &bytes, ops)?;
+    store::write_creating_parents(path, &output)?;
+    Ok(format)
+}
+
+fn render_applied(format: Format, path: &Path, bytes: &[u8], ops: &[Op]) -> Result<Vec<u8>> {
+    match format {
+        Format::Json => {
+            let text = std::str::from_utf8(bytes).context("file is not UTF-8")?;
+            let mut root: Value = serde_json::from_str(text)
+                .with_context(|| format!("parsing {} as JSON", path.display()))?;
+            apply_structured(&mut root, format, ops)?;
+            let mut out = serde_json::to_string_pretty(&root).context("serializing JSON")?;
+            out.push('\n');
+            Ok(out.into_bytes())
+        }
+        Format::Yaml => {
+            let text = std::str::from_utf8(bytes).context("file is not UTF-8")?;
+            let yaml: serde_norway::Value = serde_norway::from_str(text)
+                .with_context(|| format!("parsing {} as YAML", path.display()))?;
+            let mut root = serde_json::to_value(yaml).context("normalizing YAML")?;
+            apply_structured(&mut root, format, ops)?;
+            let out = serde_norway::to_string(&root).context("serializing YAML")?;
+            Ok(out.into_bytes())
+        }
+        Format::Toml => {
+            let text = std::str::from_utf8(bytes).context("file is not UTF-8")?;
+            let out = apply_toml(text, ops)
+                .with_context(|| format!("applying ops to {}", path.display()))?;
+            Ok(out.into_bytes())
+        }
+        Format::Plist => {
+            let plist_value = plist::Value::from_reader(Cursor::new(bytes))
+                .with_context(|| format!("parsing {} as plist", path.display()))?;
+            let mut root = value::plist_to_json(plist_value);
+            apply_structured(&mut root, format, ops)?;
+            let back = json_to_plist(&root)?;
+            let mut out = Vec::new();
+            if bytes.starts_with(b"bplist") {
+                back.to_writer_binary(&mut out)
+                    .context("writing binary plist")?;
+            } else {
+                back.to_writer_xml(&mut out).context("writing XML plist")?;
+                out.push(b'\n');
+            }
+            Ok(out)
+        }
+        Format::Keyvalue => {
+            let text = std::str::from_utf8(bytes).context("file is not UTF-8")?;
+            let out = apply_keyvalue(text, ops)
+                .with_context(|| format!("applying ops to {}", path.display()))?;
+            Ok(out.into_bytes())
+        }
+        Format::Text => bail!(
+            "{} is tracked as text: it has no addressed ops — edit the file directly",
+            path.display()
+        ),
+    }
+}
+
+// --- structured (json/yaml/plist, via serde_json::Value) ---
+
+pub fn apply_structured(root: &mut Value, format: Format, ops: &[Op]) -> Result<()> {
+    for op in ops {
+        match op {
+            Op::Add { path, value } => set_value(root, format, path, value.clone())?,
+            Op::Replace { path, to, .. } => set_value(root, format, path, to.clone())?,
+            Op::Remove { path, .. } => remove_value(root, format, path)?,
+            Op::Text { .. } | Op::Binary => {
+                bail!("unaddressed op cannot be applied; resolve text diffs by hand")
+            }
+        }
+    }
+    Ok(())
+}
+
+fn set_value(root: &mut Value, format: Format, path: &str, new: Value) -> Result<()> {
+    let segments = parse_address(format, path);
+    let Some((last, parents)) = segments.split_last() else {
+        *root = new;
+        return Ok(());
+    };
+    match navigate(root, parents, path)? {
+        Value::Object(map) => {
+            map.insert(last.clone(), new);
+        }
+        Value::Array(items) => {
+            let index: usize = last
+                .parse()
+                .with_context(|| format!("path {path}: {last} is not an array index"))?;
+            if index == items.len() {
+                items.push(new);
+            } else {
+                *items
+                    .get_mut(index)
+                    .with_context(|| format!("path {path}: index {index} out of range"))? = new;
+            }
+        }
+        _ => bail!("path {path}: parent is not a container"),
+    }
+    Ok(())
+}
+
+fn remove_value(root: &mut Value, format: Format, path: &str) -> Result<()> {
+    let segments = parse_address(format, path);
+    let Some((last, parents)) = segments.split_last() else {
+        bail!("cannot remove the document root");
+    };
+    match navigate(root, parents, path)? {
+        Value::Object(map) => {
+            map.shift_remove(last)
+                .with_context(|| format!("path {path}: key {last} not present"))?;
+        }
+        Value::Array(items) => {
+            let index: usize = last
+                .parse()
+                .with_context(|| format!("path {path}: {last} is not an array index"))?;
+            if index >= items.len() {
+                bail!("path {path}: index {index} out of range");
+            }
+            items.remove(index);
+        }
+        _ => bail!("path {path}: parent is not a container"),
+    }
+    Ok(())
+}
+
+fn navigate<'root>(
+    root: &'root mut Value,
+    segments: &[String],
+    full: &str,
+) -> Result<&'root mut Value> {
+    let mut current = root;
+    for segment in segments {
+        current = match current {
+            Value::Object(map) => map.get_mut(segment),
+            Value::Array(items) => segment
+                .parse::<usize>()
+                .ok()
+                .and_then(|index| items.get_mut(index)),
+            _ => None,
+        }
+        .with_context(|| format!("path {full}: segment {segment} not found"))?;
+    }
+    Ok(current)
+}
+
+// --- toml (format-preserving via toml_edit) ---
+
+fn apply_toml(text: &str, ops: &[Op]) -> Result<String> {
+    let mut doc: toml_edit::DocumentMut = text.parse().context("parsing TOML")?;
+    for op in ops {
+        match op {
+            Op::Add { path, value }
+            | Op::Replace {
+                path, to: value, ..
+            } => {
+                let segments = parse_address(Format::Toml, path);
+                set_toml(doc.as_item_mut(), &segments, value)
+                    .with_context(|| format!("setting {path}"))?;
+            }
+            Op::Remove { path, .. } => {
+                let segments = parse_address(Format::Toml, path);
+                remove_toml(doc.as_item_mut(), &segments)
+                    .with_context(|| format!("removing {path}"))?;
+            }
+            Op::Text { .. } | Op::Binary => {
+                bail!("unaddressed op cannot be applied; resolve text diffs by hand")
+            }
+        }
+    }
+    Ok(doc.to_string())
+}
+
+fn set_toml(item: &mut toml_edit::Item, segments: &[String], value: &Value) -> Result<()> {
+    let Some((head, rest)) = segments.split_first() else {
+        *item = toml_edit::Item::Value(json_to_toml(value)?);
+        return Ok(());
+    };
+    if rest.is_empty()
+        && let Ok(index) = head.parse::<usize>()
+    {
+        return set_toml_index(item, index, value);
+    }
+    let child = toml_child(item, head).with_context(|| format!("segment {head} not reachable"))?;
+    set_toml(child, rest, value)
+}
+
+/// Final numeric segment: replace an element in place or append at `len`.
+fn set_toml_index(item: &mut toml_edit::Item, index: usize, value: &Value) -> Result<()> {
+    if let Some(tables) = item.as_array_of_tables_mut() {
+        let table = json_to_toml_table(value)?;
+        if index == tables.len() {
+            tables.push(table);
+        } else if let Some(slot) = tables.get_mut(index) {
+            *slot = table;
+        } else {
+            bail!("index {index} out of range");
+        }
+        return Ok(());
+    }
+    let array = item.as_array_mut().context("not an array")?;
+    let new = json_to_toml(value)?;
+    if index == array.len() {
+        array.push(new);
+    } else if let Some(slot) = array.get_mut(index) {
+        *slot = new;
+    } else {
+        bail!("index {index} out of range");
+    }
+    Ok(())
+}
+
+fn remove_toml(item: &mut toml_edit::Item, segments: &[String]) -> Result<()> {
+    let Some((last, parents)) = segments.split_last() else {
+        bail!("cannot remove the document root");
+    };
+    let mut current = item;
+    for segment in parents {
+        // Probe immutably first: `get_mut` with a string key auto-creates
+        // missing entries, which a remove must not do.
+        let exists = current.get(segment.as_str()).is_some()
+            || segment
+                .parse::<usize>()
+                .ok()
+                .is_some_and(|index| current.get(index).is_some());
+        if !exists {
+            bail!("segment {segment} not found");
+        }
+        current = toml_child(current, segment)
+            .with_context(|| format!("segment {segment} not reachable"))?;
+    }
+    if let Ok(index) = last.parse::<usize>() {
+        if let Some(tables) = current.as_array_of_tables_mut() {
+            if index >= tables.len() {
+                bail!("index {index} out of range");
+            }
+            tables.remove(index);
+            return Ok(());
+        }
+        if let Some(array) = current.as_array_mut() {
+            if index >= array.len() {
+                bail!("index {index} out of range");
+            }
+            array.remove(index);
+            return Ok(());
+        }
+    }
+    let table = current
+        .as_table_like_mut()
+        .with_context(|| format!("parent of {last} is not a table"))?;
+    table
+        .remove(last)
+        .with_context(|| format!("key {last} not present"))?;
+    Ok(())
+}
+
+fn toml_child<'item>(
+    item: &'item mut toml_edit::Item,
+    segment: &str,
+) -> Option<&'item mut toml_edit::Item> {
+    if let Ok(index) = segment.parse::<usize>()
+        && (item.is_array() || item.is_array_of_tables())
+    {
+        return item.get_mut(index);
+    }
+    item.get_mut(segment)
+}
+
+fn json_to_toml(value: &Value) -> Result<toml_edit::Value> {
+    Ok(match value {
+        Value::Null => bail!("TOML cannot represent null"),
+        Value::Bool(flag) => (*flag).into(),
+        Value::Number(number) => number
+            .as_i64()
+            .map(toml_edit::Value::from)
+            .or_else(|| number.as_f64().map(toml_edit::Value::from))
+            .context("number not representable in TOML")?,
+        Value::String(text) => text.as_str().into(),
+        Value::Array(items) => {
+            let mut array = toml_edit::Array::new();
+            for item in items {
+                array.push(json_to_toml(item)?);
+            }
+            array.into()
+        }
+        Value::Object(map) => {
+            let mut table = toml_edit::InlineTable::new();
+            for (key, item) in map {
+                table.insert(key, json_to_toml(item)?);
+            }
+            table.into()
+        }
+    })
+}
+
+fn json_to_toml_table(value: &Value) -> Result<toml_edit::Table> {
+    let Value::Object(map) = value else {
+        bail!("array-of-tables element must be an object");
+    };
+    let mut table = toml_edit::Table::new();
+    for (key, item) in map {
+        table.insert(key, toml_edit::Item::Value(json_to_toml(item)?));
+    }
+    Ok(table)
+}
+
+// --- keyvalue (line-oriented, preserves comments and unknown lines) ---
+
+fn apply_keyvalue(text: &str, ops: &[Op]) -> Result<String> {
+    let mut lines: Vec<String> = text.lines().map(str::to_owned).collect();
+    for op in ops {
+        match op {
+            Op::Add { path, value }
+            | Op::Replace {
+                path, to: value, ..
+            } => {
+                set_keyvalue(&mut lines, path, value)?;
+            }
+            Op::Remove { path, .. } => remove_keyvalue(&mut lines, path)?,
+            Op::Text { .. } | Op::Binary => {
+                bail!("unaddressed op cannot be applied; resolve text diffs by hand")
+            }
+        }
+    }
+    let mut out = lines.join("\n");
+    out.push('\n');
+    Ok(out)
+}
+
+/// A keyvalue address resolved against the actual file: dotted paths are
+/// ambiguous (`a.b` is section `a` key `b`, or root key `a.b`), so the
+/// section part is only split off when a matching `[header]` exists.
+struct KvAddress {
+    section: Option<String>,
+    key: String,
+    /// Occurrence index for repeated keys (`keybind.1`).
+    index: Option<usize>,
+}
+
+fn parse_kv_address(lines: &[String], path: &str) -> KvAddress {
+    let segments: Vec<&str> = path.split('.').collect();
+    let has_header = |name: &str| {
+        lines
+            .iter()
+            .any(|line| value::header_name(line.trim()) == Some(name.to_owned()))
+    };
+    let (section, rest) = match segments.split_first() {
+        Some((first, rest)) if !rest.is_empty() && has_header(first) => {
+            (Some((*first).to_owned()), rest)
+        }
+        _ => (None, segments.as_slice()),
+    };
+    let (index, key_segments) = match rest.split_last() {
+        Some((last, key_segments)) if !key_segments.is_empty() => last
+            .parse::<usize>()
+            .map_or((None, rest), |occurrence| (Some(occurrence), key_segments)),
+        _ => (None, rest),
+    };
+    KvAddress {
+        section,
+        key: key_segments.join("."),
+        index,
+    }
+}
+
+/// Line range of a section's body (header excluded), or of the root section.
+fn section_body(lines: &[String], section: Option<&str>) -> std::ops::Range<usize> {
+    let is_header = |line: &String| value::header_name(line.trim()).is_some();
+    section.map_or_else(
+        || {
+            let end = lines.iter().position(is_header).unwrap_or(lines.len());
+            0..end
+        },
+        |name| {
+            let start = lines
+                .iter()
+                .position(|line| value::header_name(line.trim()) == Some(name.to_owned()))
+                .map_or(lines.len(), |header| header + 1);
+            let end = lines[start..]
+                .iter()
+                .position(is_header)
+                .map_or(lines.len(), |offset| start + offset);
+            start..end
+        },
+    )
+}
+
+fn occurrences(lines: &[String], body: &std::ops::Range<usize>, key: &str) -> Vec<usize> {
+    body.clone()
+        .filter(|&line_number| {
+            let trimmed = lines[line_number].trim();
+            !trimmed.is_empty()
+                && !trimmed.starts_with('#')
+                && !trimmed.starts_with(';')
+                && value::split_entry(trimmed).key == key
+        })
+        .collect()
+}
+
+/// Where to insert a new entry: after the last non-blank line of the body,
+/// so blank separators before the next section stay put.
+fn insertion_point(lines: &[String], body: &std::ops::Range<usize>) -> usize {
+    lines[body.clone()]
+        .iter()
+        .rposition(|line| !line.trim().is_empty())
+        .map_or(body.start, |offset| body.start + offset + 1)
+}
+
+fn kv_line(key: &str, value: &Value) -> Result<String> {
+    let rendered = match value {
+        Value::String(text) => text.clone(),
+        Value::Bool(_) | Value::Number(_) => value.to_string(),
+        Value::Null | Value::Array(_) | Value::Object(_) => {
+            bail!("value for {key} is not a keyvalue scalar")
+        }
+    };
+    if rendered.is_empty() {
+        Ok(key.to_owned())
+    } else {
+        Ok(format!("{key} = {rendered}"))
+    }
+}
+
+fn set_keyvalue(lines: &mut Vec<String>, path: &str, value: &Value) -> Result<()> {
+    let address = parse_kv_address(lines, path);
+    // A one-segment object write is a whole new `[section]` block.
+    if let (None, Value::Object(map)) = (&address.section, value)
+        && address.index.is_none()
+    {
+        lines.push(format!("[{}]", address.key));
+        for (key, item) in map {
+            let line = kv_line(key, item)?;
+            lines.push(line);
+        }
+        return Ok(());
+    }
+    if let Some(name) = &address.section
+        && section_body(lines, Some(name)).start >= lines.len()
+    {
+        lines.push(format!("[{name}]"));
+    }
+    let body = section_body(lines, address.section.as_deref());
+    let found = occurrences(lines, &body, &address.key);
+    match (address.index, value) {
+        (Some(occurrence), _) => {
+            let line = kv_line(&address.key, value)?;
+            if let Some(&line_number) = found.get(occurrence) {
+                lines[line_number] = line;
+            } else if occurrence == found.len() {
+                let at = found
+                    .last()
+                    .map_or_else(|| insertion_point(lines, &body), |&last| last + 1);
+                lines.insert(at, line);
+            } else {
+                bail!("occurrence {occurrence} of {} out of range", address.key);
+            }
+        }
+        (None, Value::Array(items)) => {
+            let at = found
+                .first()
+                .copied()
+                .unwrap_or_else(|| insertion_point(lines, &body));
+            for &line_number in found.iter().rev() {
+                lines.remove(line_number);
+            }
+            for (offset, item) in items.iter().enumerate() {
+                let line = kv_line(&address.key, item)?;
+                lines.insert(at + offset, line);
+            }
+        }
+        (None, _) => {
+            let line = kv_line(&address.key, value)?;
+            if let Some((&first, extra)) = found.split_first() {
+                for &line_number in extra.iter().rev() {
+                    lines.remove(line_number);
+                }
+                lines[first] = line;
+            } else {
+                lines.insert(insertion_point(lines, &body), line);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn remove_keyvalue(lines: &mut Vec<String>, path: &str) -> Result<()> {
+    let address = parse_kv_address(lines, path);
+    // Removing a whole section: the path is just the header name.
+    if address.key.is_empty() || (address.section.is_none() && address.index.is_none()) {
+        let name = if address.key.is_empty() {
+            address.section.clone()
+        } else {
+            Some(address.key.clone())
+        };
+        if let Some(name) = name
+            && lines
+                .iter()
+                .any(|line| value::header_name(line.trim()) == Some(name.clone()))
+        {
+            let body = section_body(lines, Some(&name));
+            let header = body.start.saturating_sub(1);
+            lines.drain(header..body.end);
+            return Ok(());
+        }
+    }
+    let body = section_body(lines, address.section.as_deref());
+    let found = occurrences(lines, &body, &address.key);
+    if found.is_empty() {
+        bail!("{} not present", address.key);
+    }
+    match address.index {
+        Some(occurrence) => {
+            let &line_number = found.get(occurrence).with_context(|| {
+                format!("occurrence {occurrence} of {} out of range", address.key)
+            })?;
+            lines.remove(line_number);
+        }
+        None => {
+            for &line_number in found.iter().rev() {
+                lines.remove(line_number);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn json_to_plist(value: &Value) -> Result<plist::Value> {
+    Ok(match value {
+        Value::Null => bail!("plist cannot represent null"),
+        Value::Bool(flag) => plist::Value::Boolean(*flag),
+        Value::Number(number) => number
+            .as_i64()
+            .map(|int| plist::Value::Integer(int.into()))
+            .or_else(|| number.as_u64().map(|int| plist::Value::Integer(int.into())))
+            .or_else(|| number.as_f64().map(plist::Value::Real))
+            .context("number not representable in plist")?,
+        Value::String(text) => text.strip_prefix("hex:").map_or_else(
+            || plist::Value::String(text.clone()),
+            |encoded| {
+                unhex(encoded)
+                    .map_or_else(|| plist::Value::String(text.clone()), plist::Value::Data)
+            },
+        ),
+        Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(json_to_plist(item)?);
+            }
+            plist::Value::Array(out)
+        }
+        Value::Object(map) => {
+            let mut dict = plist::Dictionary::new();
+            for (key, item) in map {
+                dict.insert(key.clone(), json_to_plist(item)?);
+            }
+            plist::Value::Dictionary(dict)
+        }
+    })
+}
+
+fn unhex(text: &str) -> Option<Vec<u8>> {
+    if !text.len().is_multiple_of(2) || text.is_empty() {
+        return None;
+    }
+    (0..text.len())
+        .step_by(2)
+        .map(|at| u8::from_str_radix(&text[at..at + 2], 16).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::diff::diff_bytes;
+
+    #[test]
+    fn json_apply_round_trips_a_diff() {
+        let base = br#"{"a": 1, "list": [1, 2], "drop": true}"#;
+        let edited = br#"{"a": 2, "list": [1, 2, 3], "new": {"deep": "x"}}"#;
+        let ops = diff_bytes(Format::Json, base, edited);
+        let mut root: Value = serde_json::from_slice(base).expect("parse");
+        apply_structured(&mut root, Format::Json, &ops).expect("apply");
+        let expected: Value = serde_json::from_slice(edited).expect("parse");
+        assert_eq!(root, expected);
+    }
+
+    #[test]
+    fn toml_apply_preserves_comments() {
+        let base = "# heading comment\ntitle = \"old\" # trailing\n\n[server]\nport = 80\n";
+        let ops = vec![
+            Op::Replace {
+                path: "server.port".to_owned(),
+                from: json!(80),
+                to: json!(8080),
+            },
+            Op::Add {
+                path: "server.host".to_owned(),
+                value: json!("localhost"),
+            },
+        ];
+        let out = apply_toml(base, &ops).expect("apply");
+        assert!(out.contains("# heading comment"), "out: {out}");
+        assert!(out.contains("# trailing"), "out: {out}");
+        assert!(out.contains("port = 8080"), "out: {out}");
+        assert!(out.contains("host = \"localhost\""), "out: {out}");
+    }
+
+    #[test]
+    fn toml_remove_does_not_create_missing_paths() {
+        let base = "a = 1\n";
+        let err = apply_toml(
+            base,
+            &[Op::Remove {
+                path: "missing.key".to_owned(),
+                from: json!(1),
+            }],
+        )
+        .expect_err("should fail");
+        assert!(
+            err.to_string().contains("removing missing.key"),
+            "err: {err}"
+        );
+        let untouched = apply_toml(base, &[]).expect("no ops");
+        assert_eq!(untouched, base);
+    }
+
+    #[test]
+    fn keyvalue_apply_preserves_comments_and_repeats() {
+        let base = "# ghostty\nfont-size = 13\nkeybind = a\nkeybind = b\n\n[sec]\nk = v\n";
+        let ops = vec![
+            Op::Replace {
+                path: "font-size".to_owned(),
+                from: json!("13"),
+                to: json!("14"),
+            },
+            Op::Add {
+                path: "keybind.2".to_owned(),
+                value: json!("c"),
+            },
+            Op::Replace {
+                path: "sec.k".to_owned(),
+                from: json!("v"),
+                to: json!("w"),
+            },
+        ];
+        let mut lines: Vec<String> = base.lines().map(str::to_owned).collect();
+        for op in &ops {
+            match op {
+                Op::Add { path, value }
+                | Op::Replace {
+                    path, to: value, ..
+                } => {
+                    set_keyvalue(&mut lines, path, value).expect("set");
+                }
+                _ => unreachable!(),
+            }
+        }
+        let out = lines.join("\n");
+        assert!(out.contains("# ghostty"), "out: {out}");
+        assert!(out.contains("font-size = 14"), "out: {out}");
+        assert!(out.contains("keybind = c"), "out: {out}");
+        assert!(out.contains("k = w"), "out: {out}");
+        // The new keybind lands right after the existing ones.
+        let keybinds: Vec<&str> = out
+            .lines()
+            .filter(|line| line.starts_with("keybind"))
+            .collect();
+        assert_eq!(keybinds, vec!["keybind = a", "keybind = b", "keybind = c"]);
+    }
+
+    #[test]
+    fn keyvalue_diff_round_trips_through_apply() {
+        let base = "font-size = 13\n[sec]\nk = v\n";
+        let edited = "font-size = 14\nnew-key = yes\n[sec]\nk = v\n";
+        let ops = diff_bytes(Format::Keyvalue, base.as_bytes(), edited.as_bytes());
+        let out = apply_keyvalue(base, &ops).expect("apply");
+        assert!(
+            diff_bytes(Format::Keyvalue, out.as_bytes(), edited.as_bytes()).is_empty(),
+            "not logically equal after apply: {out}"
+        );
+    }
+
+    #[test]
+    fn plist_data_round_trips_through_hex() {
+        let root = json!({"blob": "hex:00ff10", "name": "x"});
+        let back = json_to_plist(&root).expect("convert");
+        let dict = back.as_dictionary().expect("dict");
+        assert_eq!(
+            dict.get("blob"),
+            Some(&plist::Value::Data(vec![0x00, 0xff, 0x10]))
+        );
+    }
+}

--- a/packages/index-delta/src/cmd.rs
+++ b/packages/index-delta/src/cmd.rs
@@ -1,0 +1,757 @@
+//! The verbs. Activation is a pure function of manifest + recorded state:
+//! ephemeral files are reseeded (drift archived to the journal first),
+//! durable files fast-forward when clean and *stage* the incoming base when
+//! drifted — nothing is ever auto-merged and nothing is ever lost. The rest
+//! of the verbs operate on the queue that gating produces.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::diff::{self, Op};
+use crate::store::{Meta, Persistence, Store, write_creating_parents};
+use crate::value::{self, Format};
+
+/// What `activate` receives from the nix module: the full set of declared
+/// mutable files for this generation.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Manifest {
+    pub files: Vec<ManifestEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestEntry {
+    /// Target path; `~/` is expanded against `HOME`.
+    pub path: String,
+    /// Store path holding the declared content (the incoming base).
+    pub source: String,
+    /// Omitted ⇒ auto-detected from the target name and base contents,
+    /// then sticky for the file's lifetime.
+    #[serde(default)]
+    pub format: Option<Format>,
+    /// Omitted ⇒ ephemeral: edits are scratch and reset at activation/login.
+    #[serde(default)]
+    pub persistence: Option<Persistence>,
+    #[serde(default)]
+    pub declared_at: Option<String>,
+    #[serde(default)]
+    pub source_file: Option<String>,
+}
+
+/// Reconciliation outcome for one file, printed as the activation log line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    Seeded,
+    Reseeded,
+    FastForwarded,
+    AlreadyClean,
+    DriftKept,
+    Staged,
+    Adopted,
+}
+
+impl Outcome {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Seeded => "seeded",
+            Self::Reseeded => "reseeded (drift archived to journal)",
+            Self::FastForwarded => "updated",
+            Self::AlreadyClean => "clean",
+            Self::DriftKept => "drifted (base unchanged, edits kept)",
+            Self::Staged => "conflict (incoming base staged, edits kept)",
+            Self::Adopted => "clean (your edits match the incoming base)",
+        }
+    }
+}
+
+pub fn activate(store: &Store, manifest_path: &Path) -> Result<()> {
+    let text = fs::read_to_string(manifest_path)
+        .with_context(|| format!("reading manifest {}", manifest_path.display()))?;
+    let manifest: Manifest = serde_json::from_str(&text)
+        .with_context(|| format!("parsing manifest {}", manifest_path.display()))?;
+
+    let mut declared = Vec::new();
+    for entry in &manifest.files {
+        let target = expand_tilde(&entry.path)?;
+        declared.push(target.clone());
+        let outcome =
+            reconcile(store, entry, &target).with_context(|| format!("reconciling {target}"))?;
+        println!("{} {target}", outcome.label());
+    }
+
+    // Files no longer declared: forget their state, leave them on disk.
+    for meta in store.all_metas()? {
+        if !declared.contains(&meta.path) {
+            store.journal(&meta.path, "unmanaged", None)?;
+            store.forget(&meta.path)?;
+            println!("unmanaged {} (file left on disk)", meta.path);
+        }
+    }
+    Ok(())
+}
+
+fn reconcile(store: &Store, entry: &ManifestEntry, target: &str) -> Result<Outcome> {
+    let incoming =
+        fs::read(&entry.source).with_context(|| format!("reading source {}", entry.source))?;
+    let existing = store.meta(target)?;
+
+    // Format is sticky once recorded so detection can never flip under an
+    // existing diff; an explicit manifest format always wins.
+    let format = entry
+        .format
+        .or_else(|| existing.as_ref().map(|meta| meta.format));
+    let format = format.unwrap_or_else(|| value::detect(Path::new(target), &incoming));
+    let persistence = entry.persistence.unwrap_or(Persistence::Ephemeral);
+
+    let mut meta = Meta {
+        path: target.to_owned(),
+        source: entry.source.clone(),
+        staged_source: existing
+            .as_ref()
+            .and_then(|meta| meta.staged_source.clone()),
+        source_file: entry.source_file.clone(),
+        declared_at: entry.declared_at.clone(),
+        format,
+        persistence,
+        snoozed: existing.as_ref().and_then(|meta| meta.snoozed.clone()),
+    };
+
+    let outcome = match existing {
+        None => first_seed(store, &meta, &incoming)?,
+        Some(_) => match persistence {
+            Persistence::Ephemeral => reseed(store, &mut meta, &incoming, "activate")?,
+            Persistence::Durable => gate(store, &mut meta, &incoming)?,
+        },
+    };
+    store.save_meta(&meta)?;
+    Ok(outcome)
+}
+
+fn first_seed(store: &Store, meta: &Meta, incoming: &[u8]) -> Result<Outcome> {
+    let target = Path::new(&meta.path);
+    let pre_existing = fs::read(target).ok();
+    store.write_base(&meta.path, incoming)?;
+    store.journal(&meta.path, "managed", None)?;
+    match (meta.persistence, pre_existing) {
+        // A durable target that already had content keeps it: the existing
+        // file becomes day-one drift instead of being clobbered.
+        (Persistence::Durable, Some(found))
+            if !diff::logically_equal(meta.format, incoming, &found) =>
+        {
+            store.journal(
+                &meta.path,
+                "kept-existing",
+                Some(serde_json::json!({
+                    "yourEdits": diff::diff_bytes(meta.format, incoming, &found),
+                })),
+            )?;
+            Ok(Outcome::DriftKept)
+        }
+        (_, pre_existing) => {
+            // Ephemeral (or logically-equal) pre-existing content is about
+            // to be overwritten: archive its diff first so nothing is lost.
+            if let Some(found) = pre_existing {
+                let archived = diff::diff_bytes(meta.format, incoming, &found);
+                if !archived.is_empty() {
+                    store.journal(
+                        &meta.path,
+                        "reseeded",
+                        Some(serde_json::json!({ "cause": "first-seed", "archived": archived })),
+                    )?;
+                }
+            }
+            write_creating_parents(target, incoming)?;
+            Ok(Outcome::Seeded)
+        }
+    }
+}
+
+/// Ephemeral files: archive any drift's logical diff, then Nix wins.
+fn reseed(store: &Store, meta: &mut Meta, incoming: &[u8], cause: &str) -> Result<Outcome> {
+    let target = Path::new(&meta.path);
+    let base = store.base_bytes(&meta.path)?;
+    let upper = fs::read(target).unwrap_or_default();
+    let drift = diff::diff_bytes(meta.format, &base, &upper);
+    if drift.is_empty() && incoming == base.as_slice() && target.exists() {
+        return Ok(Outcome::AlreadyClean);
+    }
+    if !drift.is_empty() {
+        store.journal(
+            &meta.path,
+            "reseeded",
+            Some(serde_json::json!({ "cause": cause, "archived": drift })),
+        )?;
+        meta.snoozed = None;
+    }
+    write_creating_parents(target, incoming)?;
+    store.write_base(&meta.path, incoming)?;
+    store.clear_staged(&meta.path)?;
+    meta.staged_source = None;
+    if drift.is_empty() {
+        Ok(Outcome::FastForwarded)
+    } else {
+        Ok(Outcome::Reseeded)
+    }
+}
+
+/// Durable files: the gated switch.
+fn gate(store: &Store, meta: &mut Meta, incoming: &[u8]) -> Result<Outcome> {
+    let target = Path::new(&meta.path);
+    let base = store.base_bytes(&meta.path)?;
+    // A deleted target is almost always accidental for a declared file:
+    // recreate rather than treating deletion as drift.
+    let Ok(upper) = fs::read(target) else {
+        write_creating_parents(target, incoming)?;
+        adopt_base(store, meta, incoming)?;
+        store.journal(&meta.path, "seeded", None)?;
+        return Ok(Outcome::Seeded);
+    };
+
+    if diff::logically_equal(meta.format, incoming, &upper) {
+        // Your edits already match the incoming content (typically because
+        // drift was absorbed into the repo). The diff being empty IS the
+        // resolution — keep the upper's bytes, adopt the base.
+        let outcome = if diff::logically_equal(meta.format, &base, &upper) {
+            Outcome::AlreadyClean
+        } else {
+            Outcome::Adopted
+        };
+        adopt_base(store, meta, incoming)?;
+        return Ok(outcome);
+    }
+    if diff::logically_equal(meta.format, &base, &upper) {
+        // Clean under the old base: fast-forward to the new one.
+        write_creating_parents(target, incoming)?;
+        adopt_base(store, meta, incoming)?;
+        store.journal(&meta.path, "base-updated", None)?;
+        return Ok(Outcome::FastForwarded);
+    }
+    if diff::logically_equal(meta.format, &base, incoming) {
+        // Base unchanged; your drift simply persists.
+        return Ok(Outcome::DriftKept);
+    }
+    // Drifted AND the base moved: stage the incoming base, touch nothing.
+    store.write_staged(&meta.path, incoming)?;
+    meta.staged_source = Some(meta.source.clone());
+    store.journal(&meta.path, "staged", None)?;
+    Ok(Outcome::Staged)
+}
+
+fn adopt_base(store: &Store, meta: &mut Meta, incoming: &[u8]) -> Result<()> {
+    store.write_base(&meta.path, incoming)?;
+    store.clear_staged(&meta.path)?;
+    meta.staged_source = None;
+    meta.snoozed = None;
+    Ok(())
+}
+
+/// The login/boot reseed for ephemeral files. Needs no manifest: bases are
+/// already snapshotted in the store.
+pub fn reseed_ephemeral(store: &Store) -> Result<()> {
+    for mut meta in store.all_metas()? {
+        if meta.persistence != Persistence::Ephemeral {
+            continue;
+        }
+        let base = store.base_bytes(&meta.path)?;
+        let outcome = reseed(store, &mut meta, &base, "reseed")?;
+        store.save_meta(&meta)?;
+        println!("{} {}", outcome.label(), meta.path);
+    }
+    Ok(())
+}
+
+// --- status ---
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum State {
+    Clean,
+    Drifted,
+    Conflict,
+    Snoozed,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusEntry {
+    path: String,
+    state: State,
+    persistence: Persistence,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resets_at: Option<&'static str>,
+    format: Format,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    declared_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_file: Option<String>,
+    base: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    staged_base: Option<String>,
+    upper: String,
+    your_edits: Vec<Op>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    incoming_edits: Vec<Op>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    overlap: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusReport {
+    pending: Vec<StatusEntry>,
+    clean: Vec<String>,
+    snoozed: Vec<String>,
+}
+
+fn status_entry(store: &Store, meta: &Meta) -> Result<StatusEntry> {
+    let base = store.base_bytes(&meta.path)?;
+    let upper = fs::read(&meta.path).unwrap_or_default();
+    let staged = store.staged_bytes(&meta.path)?;
+    let your_edits = diff::diff_bytes(meta.format, &base, &upper);
+    let incoming_edits = staged.as_ref().map_or_else(Vec::new, |bytes| {
+        diff::diff_bytes(meta.format, &base, bytes)
+    });
+    let overlap = diff::overlap(meta.format, &your_edits, &incoming_edits);
+    let state = if staged.is_some() {
+        State::Conflict
+    } else if your_edits.is_empty() {
+        State::Clean
+    } else if meta.snoozed.as_deref() == Some(diff::fingerprint(&your_edits).as_str()) {
+        State::Snoozed
+    } else {
+        State::Drifted
+    };
+    Ok(StatusEntry {
+        path: meta.path.clone(),
+        state,
+        persistence: meta.persistence,
+        resets_at: matches!(meta.persistence, Persistence::Ephemeral).then_some("next-login"),
+        format: meta.format,
+        declared_at: meta.declared_at.clone(),
+        source_file: meta.source_file.clone(),
+        base: meta.source.clone(),
+        staged_base: meta.staged_source.clone(),
+        upper: meta.path.clone(),
+        your_edits,
+        incoming_edits,
+        overlap,
+    })
+}
+
+pub fn status(store: &Store, json: bool) -> Result<()> {
+    let mut pending = Vec::new();
+    let mut clean = Vec::new();
+    let mut snoozed = Vec::new();
+    for meta in store.all_metas()? {
+        let entry = status_entry(store, &meta)?;
+        match entry.state {
+            State::Clean => clean.push(entry.path),
+            State::Snoozed => snoozed.push(entry.path),
+            State::Drifted | State::Conflict => pending.push(entry),
+        }
+    }
+    if json {
+        let report = StatusReport {
+            pending,
+            clean,
+            snoozed,
+        };
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+    for entry in &pending {
+        let mark = if entry.state == State::Conflict {
+            "✗ conflict"
+        } else {
+            "~ drifted "
+        };
+        println!(
+            "{mark} {} ({} ops, {})",
+            entry.path,
+            entry.your_edits.len(),
+            entry.format
+        );
+    }
+    for path in &snoozed {
+        println!("· snoozed  {path}");
+    }
+    for path in &clean {
+        println!("✓ clean    {path}");
+    }
+    if pending.is_empty() {
+        println!("nothing to resolve");
+    }
+    Ok(())
+}
+
+// --- per-file verbs ---
+
+fn require_meta(store: &Store, path: &str) -> Result<Meta> {
+    let target = expand_tilde(path)?;
+    store
+        .meta(&target)?
+        .with_context(|| format!("{target} is not a managed mutable file"))
+}
+
+pub fn print_diff(store: &Store, path: &str, raw: bool) -> Result<()> {
+    let meta = require_meta(store, path)?;
+    let base = store.base_bytes(&meta.path)?;
+    let upper = fs::read(&meta.path).unwrap_or_default();
+    if raw {
+        let old = String::from_utf8_lossy(&base);
+        let new = String::from_utf8_lossy(&upper);
+        print!(
+            "{}",
+            similar::TextDiff::from_lines(old.as_ref(), new.as_ref())
+                .unified_diff()
+                .context_radius(3)
+                .header("base", "upper")
+        );
+        return Ok(());
+    }
+    let ops = diff::diff_bytes(meta.format, &base, &upper);
+    println!("{}", serde_json::to_string_pretty(&ops)?);
+    Ok(())
+}
+
+/// Drop your edits: the (staged, if any) base wins and the file goes clean.
+pub fn discard(store: &Store, path: &str) -> Result<()> {
+    let mut meta = require_meta(store, path)?;
+    let winning = match store.staged_bytes(&meta.path)? {
+        Some(staged) => {
+            meta.source = meta
+                .staged_source
+                .take()
+                .unwrap_or_else(|| meta.source.clone());
+            staged
+        }
+        None => store.base_bytes(&meta.path)?,
+    };
+    let upper = fs::read(&meta.path).unwrap_or_default();
+    let dropped = diff::diff_bytes(meta.format, &store.base_bytes(&meta.path)?, &upper);
+    store.journal(
+        &meta.path,
+        "discarded",
+        Some(serde_json::json!({ "dropped": dropped })),
+    )?;
+    write_creating_parents(Path::new(&meta.path), &winning)?;
+    adopt_base(store, &mut meta, &winning)?;
+    store.save_meta(&meta)?;
+    println!("discarded edits to {}", meta.path);
+    Ok(())
+}
+
+/// Accept the staged base as the new base but keep your upper: the conflict
+/// becomes plain drift, re-diffed against what the config now declares.
+pub fn adopt(store: &Store, path: &str) -> Result<()> {
+    let mut meta = require_meta(store, path)?;
+    let staged = store
+        .staged_bytes(&meta.path)?
+        .with_context(|| format!("{} has no staged base (not in conflict)", meta.path))?;
+    meta.source = meta
+        .staged_source
+        .take()
+        .unwrap_or_else(|| meta.source.clone());
+    store.write_base(&meta.path, &staged)?;
+    store.clear_staged(&meta.path)?;
+    meta.snoozed = None;
+    store.journal(&meta.path, "adopted", None)?;
+    store.save_meta(&meta)?;
+    println!("adopted staged base for {} (your edits kept)", meta.path);
+    Ok(())
+}
+
+/// Silence a drifted file until its diff changes.
+pub fn snooze(store: &Store, path: &str) -> Result<()> {
+    let mut meta = require_meta(store, path)?;
+    let base = store.base_bytes(&meta.path)?;
+    let upper = fs::read(&meta.path).unwrap_or_default();
+    let ops = diff::diff_bytes(meta.format, &base, &upper);
+    if ops.is_empty() {
+        bail!("{} is clean; nothing to snooze", meta.path);
+    }
+    if store.staged_bytes(&meta.path)?.is_some() {
+        bail!(
+            "{} is in conflict; resolve it (discard/adopt) instead of snoozing",
+            meta.path
+        );
+    }
+    meta.snoozed = Some(diff::fingerprint(&ops));
+    store.journal(&meta.path, "snoozed", None)?;
+    store.save_meta(&meta)?;
+    println!("snoozed {} until its diff changes", meta.path);
+    Ok(())
+}
+
+pub fn apply_ops(path: &str, ops_source: &str, format: Option<Format>) -> Result<()> {
+    let text = if ops_source == "-" {
+        std::io::read_to_string(std::io::stdin()).context("reading ops from stdin")?
+    } else {
+        fs::read_to_string(ops_source).with_context(|| format!("reading ops file {ops_source}"))?
+    };
+    let ops: Vec<Op> = serde_json::from_str(&text).context("parsing ops JSON")?;
+    let target = expand_tilde(path)?;
+    let used = crate::apply::apply_to_file(Path::new(&target), format, &ops)?;
+    println!("applied {} ops to {target} ({used})", ops.len());
+    Ok(())
+}
+
+pub fn journal(store: &Store, path: Option<&str>, json: bool) -> Result<()> {
+    let filter = path.map(expand_tilde).transpose()?;
+    let entries: Vec<_> = store
+        .journal_entries()?
+        .into_iter()
+        .filter(|entry| filter.as_ref().is_none_or(|wanted| &entry.path == wanted))
+        .collect();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+        return Ok(());
+    }
+    for entry in &entries {
+        let detail = entry
+            .detail
+            .as_ref()
+            .map_or_else(String::new, |extra| format!(" {extra}"));
+        println!("{} {} {}{detail}", entry.ts, entry.event, entry.path);
+    }
+    if entries.is_empty() {
+        println!("journal is empty");
+    }
+    Ok(())
+}
+
+pub fn expand_tilde(path: &str) -> Result<String> {
+    if let Some(rest) = path.strip_prefix("~/") {
+        let home = std::env::var("HOME").context("HOME is not set; cannot expand ~")?;
+        return Ok(format!("{home}/{rest}"));
+    }
+    Ok(path.to_owned())
+}
+
+/// Exit code for `status --check`: 0 when nothing is pending, 1 otherwise.
+pub fn pending_count(store: &Store) -> Result<usize> {
+    let mut count = 0;
+    for meta in store.all_metas()? {
+        let entry = status_entry(store, &meta)?;
+        if matches!(entry.state, State::Drifted | State::Conflict) {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Fixture {
+        _dir: tempfile::TempDir,
+        store: Store,
+        target: String,
+        source: std::path::PathBuf,
+        manifest: std::path::PathBuf,
+    }
+
+    impl Fixture {
+        fn new(persistence: &str) -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let root = dir.path();
+            let target = root.join("home/config.json");
+            let source = root.join("store/config.json");
+            fs::create_dir_all(source.parent().expect("parent")).expect("mkdir");
+            let manifest = root.join("manifest.json");
+            let store = Store::open(root.join("state")).expect("open");
+            let fixture = Self {
+                target: target.to_string_lossy().into_owned(),
+                source,
+                manifest,
+                store,
+                _dir: dir,
+            };
+            fixture.write_manifest(persistence);
+            fixture
+        }
+
+        fn write_manifest(&self, persistence: &str) {
+            let manifest = serde_json::json!({
+                "files": [{
+                    "path": self.target,
+                    "source": self.source,
+                    "persistence": persistence,
+                    "declaredAt": "home/test.nix:1",
+                }],
+            });
+            fs::write(&self.manifest, manifest.to_string()).expect("write manifest");
+        }
+
+        fn set_base(&self, contents: &str) {
+            fs::write(&self.source, contents).expect("write source");
+        }
+
+        fn activate(&self) {
+            activate(&self.store, &self.manifest).expect("activate");
+        }
+
+        fn target_contents(&self) -> String {
+            fs::read_to_string(&self.target).expect("read target")
+        }
+
+        fn entry(&self) -> StatusEntry {
+            let meta = self
+                .store
+                .meta(&self.target)
+                .expect("meta")
+                .expect("managed");
+            status_entry(&self.store, &meta).expect("status")
+        }
+    }
+
+    #[test]
+    fn ephemeral_reseed_archives_drift() {
+        let fixture = Fixture::new("ephemeral");
+        fixture.set_base(r#"{"a": 1}"#);
+        fixture.activate();
+        assert_eq!(fixture.entry().state, State::Clean);
+
+        fs::write(&fixture.target, r#"{"a": 2}"#).expect("drift");
+        assert_eq!(fixture.entry().state, State::Drifted);
+
+        fixture.activate();
+        assert_eq!(fixture.target_contents(), r#"{"a": 1}"#);
+        assert_eq!(fixture.entry().state, State::Clean);
+        let archived = fixture
+            .store
+            .journal_entries()
+            .expect("journal")
+            .into_iter()
+            .find(|entry| entry.event == "reseeded")
+            .expect("reseed archived");
+        let detail = archived.detail.expect("detail");
+        assert!(
+            detail["archived"]
+                .as_array()
+                .is_some_and(|ops| !ops.is_empty())
+        );
+    }
+
+    #[test]
+    fn durable_gate_matrix() {
+        let fixture = Fixture::new("durable");
+        fixture.set_base(r#"{"a": 1}"#);
+        fixture.activate();
+        assert_eq!(fixture.entry().state, State::Clean);
+
+        // Base unchanged + local drift → drift persists across activation.
+        fs::write(&fixture.target, r#"{"a": 1, "mine": true}"#).expect("drift");
+        fixture.activate();
+        assert_eq!(fixture.entry().state, State::Drifted);
+        assert_eq!(fixture.target_contents(), r#"{"a": 1, "mine": true}"#);
+
+        // Base changed + local drift → conflict with both diffs and no overlap.
+        fixture.set_base(r#"{"a": 2}"#);
+        fixture.activate();
+        let entry = fixture.entry();
+        assert_eq!(entry.state, State::Conflict);
+        assert_eq!(fixture.target_contents(), r#"{"a": 1, "mine": true}"#);
+        assert_eq!(entry.your_edits.len(), 1);
+        assert_eq!(entry.incoming_edits.len(), 1);
+        assert!(entry.overlap.is_empty());
+
+        // adopt: staged base becomes base, drift remains vs the new base.
+        adopt(&fixture.store, &fixture.target).expect("adopt");
+        let entry = fixture.entry();
+        assert_eq!(entry.state, State::Drifted);
+
+        // discard: base wins, file is clean.
+        discard(&fixture.store, &fixture.target).expect("discard");
+        assert_eq!(fixture.entry().state, State::Clean);
+        assert_eq!(fixture.target_contents(), r#"{"a": 2}"#);
+    }
+
+    #[test]
+    fn durable_clean_fast_forwards() {
+        let fixture = Fixture::new("durable");
+        fixture.set_base(r#"{"a": 1}"#);
+        fixture.activate();
+        fixture.set_base(r#"{"a": 2}"#);
+        fixture.activate();
+        assert_eq!(fixture.target_contents(), r#"{"a": 2}"#);
+        assert_eq!(fixture.entry().state, State::Clean);
+    }
+
+    #[test]
+    fn absorbing_drift_into_the_repo_resolves_on_switch() {
+        let fixture = Fixture::new("durable");
+        fixture.set_base(r#"{"a": 1}"#);
+        fixture.activate();
+        fs::write(&fixture.target, r#"{"a": 1, "mine": true}"#).expect("drift");
+        // The model absorbs the edit into the repo; the next generation's
+        // base is logically equal to the upper → clean, no bookkeeping.
+        fixture.set_base(r#"{"a": 1, "mine": true}"#);
+        fixture.activate();
+        assert_eq!(fixture.entry().state, State::Clean);
+        // Upper bytes were kept, not rewritten.
+        assert_eq!(fixture.target_contents(), r#"{"a": 1, "mine": true}"#);
+    }
+
+    #[test]
+    fn formatting_only_drift_is_clean() {
+        let fixture = Fixture::new("durable");
+        fixture.set_base(r#"{"a": 1, "b": 2}"#);
+        fixture.activate();
+        fs::write(&fixture.target, "{\n  \"a\": 1,\n  \"b\": 2\n}\n").expect("reformat");
+        assert_eq!(fixture.entry().state, State::Clean);
+    }
+
+    #[test]
+    fn snooze_holds_until_diff_changes() {
+        let fixture = Fixture::new("durable");
+        fixture.set_base(r#"{"a": 1}"#);
+        fixture.activate();
+        fs::write(&fixture.target, r#"{"a": 3}"#).expect("drift");
+        snooze(&fixture.store, &fixture.target).expect("snooze");
+        assert_eq!(fixture.entry().state, State::Snoozed);
+        fs::write(&fixture.target, r#"{"a": 4}"#).expect("more drift");
+        assert_eq!(fixture.entry().state, State::Drifted);
+    }
+
+    #[test]
+    fn deleted_durable_target_is_recreated() {
+        let fixture = Fixture::new("durable");
+        fixture.set_base(r#"{"a": 1}"#);
+        fixture.activate();
+        fs::remove_file(&fixture.target).expect("delete");
+        fixture.activate();
+        assert_eq!(fixture.target_contents(), r#"{"a": 1}"#);
+    }
+
+    #[test]
+    fn undeclared_files_are_forgotten_but_kept_on_disk() {
+        let fixture = Fixture::new("durable");
+        fixture.set_base(r#"{"a": 1}"#);
+        fixture.activate();
+        fs::write(
+            &fixture.manifest,
+            serde_json::json!({ "files": [] }).to_string(),
+        )
+        .expect("empty manifest");
+        fixture.activate();
+        assert!(fixture.store.meta(&fixture.target).expect("meta").is_none());
+        assert_eq!(fixture.target_contents(), r#"{"a": 1}"#);
+    }
+
+    #[test]
+    fn pre_existing_durable_content_becomes_day_one_drift() {
+        let fixture = Fixture::new("durable");
+        fs::create_dir_all(Path::new(&fixture.target).parent().expect("parent")).expect("mkdir");
+        fs::write(&fixture.target, r#"{"handmade": true}"#).expect("pre-existing");
+        fixture.set_base(r#"{"a": 1}"#);
+        fixture.activate();
+        assert_eq!(fixture.target_contents(), r#"{"handmade": true}"#);
+        assert_eq!(fixture.entry().state, State::Drifted);
+    }
+}

--- a/packages/index-delta/src/diff.rs
+++ b/packages/index-delta/src/diff.rs
@@ -1,0 +1,420 @@
+//! The logical differ: one algorithm over `serde_json::Value` serves every
+//! structured format; only the *addressing* differs (JSON Pointer for
+//! json/yaml/plist, dotted paths for toml/keyvalue). Text files fall back to
+//! a single unified-diff op — still queued, never auto-merged.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::store;
+use crate::value::{self, Doc, Format};
+
+/// One logical edit. `Add`/`Remove`/`Replace` are addressed ops a model can
+/// reason about (and `apply-ops` can replay onto a repo source file);
+/// `Text`/`Binary` are the unaddressed fallbacks.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "lowercase")]
+pub enum Op {
+    Add {
+        path: String,
+        value: Value,
+    },
+    Remove {
+        path: String,
+        from: Value,
+    },
+    Replace {
+        path: String,
+        from: Value,
+        to: Value,
+    },
+    /// Unified diff of the whole file — the fallback for `text` format and
+    /// for structured files whose upper failed to parse.
+    Text {
+        diff: String,
+    },
+    /// Contents differ and at least one side is not UTF-8.
+    Binary,
+}
+
+impl Op {
+    /// The address an op touches, when it has one.
+    pub fn address(&self) -> Option<&str> {
+        match self {
+            Self::Add { path, .. } | Self::Remove { path, .. } | Self::Replace { path, .. } => {
+                Some(path)
+            }
+            Self::Text { .. } | Self::Binary => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Addressing {
+    /// RFC 6901 JSON Pointer (`/profiles/0/name`).
+    Pointer,
+    /// Dotted key paths (`section.key`), matching how toml/keyvalue files
+    /// are actually written and edited.
+    Dotted,
+}
+
+const fn addressing(format: Format) -> Addressing {
+    match format {
+        Format::Toml | Format::Keyvalue => Addressing::Dotted,
+        Format::Json | Format::Yaml | Format::Plist | Format::Text => Addressing::Pointer,
+    }
+}
+
+const fn separator(format: Format) -> char {
+    match addressing(format) {
+        Addressing::Pointer => '/',
+        Addressing::Dotted => '.',
+    }
+}
+
+/// Diff two byte snapshots of a file under its recorded format. An empty
+/// result means *logically equal* — formatting-only changes (reordered JSON
+/// whitespace, requoted YAML) produce no ops and count as clean.
+pub fn diff_bytes(format: Format, old: &[u8], new: &[u8]) -> Vec<Op> {
+    if old == new {
+        return Vec::new();
+    }
+    match (value::load(format, old), value::load(format, new)) {
+        (Doc::Structured(old_value), Doc::Structured(new_value)) => {
+            let mut ops = Vec::new();
+            let mut path = Vec::new();
+            diff_values(
+                addressing(format),
+                &mut path,
+                &old_value,
+                &new_value,
+                &mut ops,
+            );
+            ops
+        }
+        (Doc::Text(old_text), Doc::Text(new_text)) => text_ops(&old_text, &new_text),
+        (Doc::Binary(old_bytes), Doc::Binary(new_bytes)) if old_bytes == new_bytes => Vec::new(),
+        _ => fallback_ops(old, new),
+    }
+}
+
+/// Two snapshots are logically equal when their diff is empty.
+pub fn logically_equal(format: Format, old: &[u8], new: &[u8]) -> bool {
+    diff_bytes(format, old, new).is_empty()
+}
+
+/// Stable fingerprint of a set of ops, used by `snooze`: the file stays
+/// silenced until its diff changes.
+pub fn fingerprint(ops: &[Op]) -> String {
+    let text = serde_json::to_string(ops).unwrap_or_default();
+    store::hex(&Sha256::digest(text.as_bytes()))
+}
+
+/// Addresses touched by both sides of a conflict — equal paths or one being
+/// a prefix of the other. Empty overlap means the two diffs are disjoint and
+/// trivially resolvable; non-empty is where judgment is needed. Two text
+/// diffs always overlap (there is no addressing to prove them disjoint).
+pub fn overlap(format: Format, yours: &[Op], incoming: &[Op]) -> Vec<String> {
+    let unaddressed = |ops: &[Op]| ops.iter().any(|op| op.address().is_none());
+    if !yours.is_empty() && !incoming.is_empty() && (unaddressed(yours) || unaddressed(incoming)) {
+        return vec!["(entire file)".to_owned()];
+    }
+    let sep = separator(format);
+    let mut hits: Vec<String> = yours
+        .iter()
+        .filter_map(Op::address)
+        .filter(|yours_path| {
+            incoming
+                .iter()
+                .filter_map(Op::address)
+                .any(|incoming_path| related(sep, yours_path, incoming_path))
+        })
+        .map(str::to_owned)
+        .collect();
+    hits.dedup();
+    hits
+}
+
+fn related(sep: char, a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    let prefixed = |longer: &str, shorter: &str| {
+        longer
+            .strip_prefix(shorter)
+            .is_some_and(|rest| rest.starts_with(sep))
+    };
+    prefixed(a, b) || prefixed(b, a)
+}
+
+fn fallback_ops(old: &[u8], new: &[u8]) -> Vec<Op> {
+    match (std::str::from_utf8(old), std::str::from_utf8(new)) {
+        (Ok(old_text), Ok(new_text)) => text_ops(old_text, new_text),
+        _ => vec![Op::Binary],
+    }
+}
+
+fn text_ops(old: &str, new: &str) -> Vec<Op> {
+    if old == new {
+        return Vec::new();
+    }
+    let diff = similar::TextDiff::from_lines(old, new)
+        .unified_diff()
+        .context_radius(2)
+        .to_string();
+    vec![Op::Text { diff }]
+}
+
+fn diff_values(
+    addr: Addressing,
+    path: &mut Vec<String>,
+    old: &Value,
+    new: &Value,
+    ops: &mut Vec<Op>,
+) {
+    if old == new {
+        return;
+    }
+    match (old, new) {
+        (Value::Object(old_map), Value::Object(new_map)) => {
+            for (key, old_item) in old_map {
+                path.push(key.clone());
+                match new_map.get(key) {
+                    Some(new_item) => diff_values(addr, path, old_item, new_item, ops),
+                    None => ops.push(Op::Remove {
+                        path: render(addr, path),
+                        from: old_item.clone(),
+                    }),
+                }
+                path.pop();
+            }
+            for (key, new_item) in new_map {
+                if !old_map.contains_key(key) {
+                    path.push(key.clone());
+                    ops.push(Op::Add {
+                        path: render(addr, path),
+                        value: new_item.clone(),
+                    });
+                    path.pop();
+                }
+            }
+        }
+        (Value::Array(old_items), Value::Array(new_items)) => {
+            diff_arrays(addr, path, old_items, new_items, ops);
+        }
+        _ => ops.push(Op::Replace {
+            path: render(addr, path),
+            from: old.clone(),
+            to: new.clone(),
+        }),
+    }
+}
+
+/// Arrays are diffed positionally: same length recurses per index, a pure
+/// append/truncate becomes tail adds/removes (the common "added a rule"
+/// case), anything else replaces the whole array. Deliberately no LCS —
+/// deterministic, and a model resolving the queue prefers one honest
+/// replace over clever-but-wrong moves.
+fn diff_arrays(
+    addr: Addressing,
+    path: &mut Vec<String>,
+    old_items: &[Value],
+    new_items: &[Value],
+    ops: &mut Vec<Op>,
+) {
+    let shared = old_items.len().min(new_items.len());
+    let prefix_equal = old_items[..shared] == new_items[..shared];
+    if old_items.len() == new_items.len() {
+        for (index, (old_item, new_item)) in old_items.iter().zip(new_items).enumerate() {
+            path.push(index.to_string());
+            diff_values(addr, path, old_item, new_item, ops);
+            path.pop();
+        }
+    } else if prefix_equal && new_items.len() > old_items.len() {
+        for (index, new_item) in new_items.iter().enumerate().skip(old_items.len()) {
+            path.push(index.to_string());
+            ops.push(Op::Add {
+                path: render(addr, path),
+                value: new_item.clone(),
+            });
+            path.pop();
+        }
+    } else if prefix_equal {
+        // Descending so the ops stay valid when applied in order.
+        for (index, old_item) in old_items.iter().enumerate().skip(new_items.len()).rev() {
+            path.push(index.to_string());
+            ops.push(Op::Remove {
+                path: render(addr, path),
+                from: old_item.clone(),
+            });
+            path.pop();
+        }
+    } else {
+        ops.push(Op::Replace {
+            path: render(addr, path),
+            from: Value::Array(old_items.to_vec()),
+            to: Value::Array(new_items.to_vec()),
+        });
+    }
+}
+
+fn render(addr: Addressing, segments: &[String]) -> String {
+    match addr {
+        Addressing::Pointer => {
+            let mut out = String::new();
+            for segment in segments {
+                out.push('/');
+                out.push_str(&segment.replace('~', "~0").replace('/', "~1"));
+            }
+            out
+        }
+        Addressing::Dotted => segments.join("."),
+    }
+}
+
+/// Parse a rendered address back into segments, for `apply-ops`.
+pub fn parse_address(format: Format, path: &str) -> Vec<String> {
+    match addressing(format) {
+        Addressing::Pointer => path
+            .split('/')
+            .skip(1)
+            .map(|segment| segment.replace("~1", "/").replace("~0", "~"))
+            .collect(),
+        Addressing::Dotted => path.split('.').map(str::to_owned).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn ops(format: Format, old: &str, new: &str) -> Vec<Op> {
+        diff_bytes(format, old.as_bytes(), new.as_bytes())
+    }
+
+    #[test]
+    fn formatting_only_changes_are_clean() {
+        assert!(
+            ops(
+                Format::Json,
+                "{\"a\":1,\"b\":2}",
+                "{\n  \"a\": 1,\n  \"b\": 2\n}"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn object_add_remove_replace() {
+        let found = ops(
+            Format::Json,
+            r#"{"keep": 1, "drop": 2, "change": {"deep": true}}"#,
+            r#"{"keep": 1, "change": {"deep": false}, "new": [1]}"#,
+        );
+        assert_eq!(
+            found,
+            vec![
+                Op::Remove {
+                    path: "/drop".to_owned(),
+                    from: json!(2)
+                },
+                Op::Replace {
+                    path: "/change/deep".to_owned(),
+                    from: json!(true),
+                    to: json!(false)
+                },
+                Op::Add {
+                    path: "/new".to_owned(),
+                    value: json!([1])
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn array_append_and_rewrite() {
+        let appended = ops(
+            Format::Json,
+            r#"{"rules": [1, 2]}"#,
+            r#"{"rules": [1, 2, 3]}"#,
+        );
+        assert_eq!(
+            appended,
+            vec![Op::Add {
+                path: "/rules/2".to_owned(),
+                value: json!(3)
+            }]
+        );
+        let rewritten = ops(Format::Json, r#"{"rules": [1, 2]}"#, r#"{"rules": [2]}"#);
+        assert_eq!(
+            rewritten,
+            vec![Op::Replace {
+                path: "/rules".to_owned(),
+                from: json!([1, 2]),
+                to: json!([2])
+            }]
+        );
+    }
+
+    #[test]
+    fn keyvalue_uses_dotted_addresses() {
+        let found = ops(
+            Format::Keyvalue,
+            "font-size = 13\n[sec]\nk = v\n",
+            "font-size = 14\n[sec]\nk = v\n",
+        );
+        assert_eq!(
+            found,
+            vec![Op::Replace {
+                path: "font-size".to_owned(),
+                from: json!("13"),
+                to: json!("14")
+            }]
+        );
+    }
+
+    #[test]
+    fn text_falls_back_to_unified_diff() {
+        let found = ops(Format::Text, "a\nb\n", "a\nc\n");
+        let [Op::Text { diff }] = found.as_slice() else {
+            panic!("expected one text op, got {found:?}");
+        };
+        assert!(diff.contains("-b"), "diff was: {diff}");
+        assert!(diff.contains("+c"), "diff was: {diff}");
+    }
+
+    #[test]
+    fn overlap_matches_prefixes_only() {
+        let yours = vec![Op::Replace {
+            path: "/profiles/0/name".to_owned(),
+            from: json!("a"),
+            to: json!("b"),
+        }];
+        let disjoint = vec![Op::Replace {
+            path: "/profiles/1".to_owned(),
+            from: json!(1),
+            to: json!(2),
+        }];
+        let ancestor = vec![Op::Remove {
+            path: "/profiles/0".to_owned(),
+            from: json!({}),
+        }];
+        assert!(overlap(Format::Json, &yours, &disjoint).is_empty());
+        assert_eq!(
+            overlap(Format::Json, &yours, &ancestor),
+            vec!["/profiles/0/name".to_owned()]
+        );
+    }
+
+    #[test]
+    fn pointer_round_trips_through_parse() {
+        let segments = parse_address(Format::Json, "/a~1b/c~0d/0");
+        assert_eq!(
+            segments,
+            vec!["a/b".to_owned(), "c~d".to_owned(), "0".to_owned()]
+        );
+    }
+}

--- a/packages/index-delta/src/diff.rs
+++ b/packages/index-delta/src/diff.rs
@@ -189,16 +189,14 @@ fn diff_values(
                 }
                 path.pop();
             }
-            for (key, new_item) in new_map {
-                if !old_map.contains_key(key) {
-                    path.push(key.clone());
-                    ops.push(Op::Add {
-                        path: render(addr, path),
-                        value: new_item.clone(),
-                    });
-                    path.pop();
-                }
-            }
+            let added = new_map
+                .iter()
+                .filter(|(key, _)| !old_map.contains_key(*key))
+                .map(|(key, item)| (key.clone(), item));
+            push_leaf_ops(addr, path, ops, added, |path, value| Op::Add {
+                path,
+                value,
+            });
         }
         (Value::Array(old_items), Value::Array(new_items)) => {
             diff_arrays(addr, path, old_items, new_items, ops);
@@ -232,30 +230,49 @@ fn diff_arrays(
             path.pop();
         }
     } else if prefix_equal && new_items.len() > old_items.len() {
-        for (index, new_item) in new_items.iter().enumerate().skip(old_items.len()) {
-            path.push(index.to_string());
-            ops.push(Op::Add {
-                path: render(addr, path),
-                value: new_item.clone(),
-            });
-            path.pop();
-        }
+        let appended = indexed(new_items, old_items.len());
+        push_leaf_ops(addr, path, ops, appended, |path, value| Op::Add {
+            path,
+            value,
+        });
     } else if prefix_equal {
         // Descending so the ops stay valid when applied in order.
-        for (index, old_item) in old_items.iter().enumerate().skip(new_items.len()).rev() {
-            path.push(index.to_string());
-            ops.push(Op::Remove {
-                path: render(addr, path),
-                from: old_item.clone(),
-            });
-            path.pop();
-        }
+        let truncated = indexed(old_items, new_items.len()).rev();
+        push_leaf_ops(addr, path, ops, truncated, |path, from| Op::Remove {
+            path,
+            from,
+        });
     } else {
         ops.push(Op::Replace {
             path: render(addr, path),
             from: Value::Array(old_items.to_vec()),
             to: Value::Array(new_items.to_vec()),
         });
+    }
+}
+
+fn indexed(items: &[Value], from: usize) -> impl DoubleEndedIterator<Item = (String, &Value)> {
+    items
+        .iter()
+        .enumerate()
+        .skip(from)
+        .map(|(index, item)| (index.to_string(), item))
+}
+
+/// Emit one leaf op per `(segment, value)` pair, each addressed one level
+/// below the current `path`. Shared by object-key adds and array tail
+/// adds/removes so the push/render/pop dance lives in exactly one place.
+fn push_leaf_ops<'v>(
+    addr: Addressing,
+    path: &mut Vec<String>,
+    ops: &mut Vec<Op>,
+    items: impl Iterator<Item = (String, &'v Value)>,
+    make: fn(String, Value) -> Op,
+) {
+    for (segment, value) in items {
+        path.push(segment);
+        ops.push(make(render(addr, path), value.clone()));
+        path.pop();
     }
 }
 

--- a/packages/index-delta/src/main.rs
+++ b/packages/index-delta/src/main.rs
@@ -1,0 +1,127 @@
+//! index-delta: drift tracker for Nix-declared mutable files.
+//!
+//! Nix declares a file's content (the *base*); the file on disk stays a
+//! plain writable file (the *upper*). Activation seeds the upper from the
+//! base and gates every later switch: ephemeral files (the default) are
+//! reseeded with their drift archived to the journal, durable files keep
+//! your edits and *stage* an incoming base change as a conflict instead of
+//! merging. `status --json` is the resolution queue — logical, format-aware
+//! diffs in both directions, geared toward a model deciding what to absorb
+//! into the Nix config (`apply-ops`), discard, adopt, or snooze.
+
+mod apply;
+mod cmd;
+mod diff;
+mod store;
+mod value;
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use crate::store::Store;
+use crate::value::Format;
+
+#[derive(Parser)]
+#[command(name = "index-delta", version, about)]
+struct Cli {
+    /// State directory (default: `$INDEX_DELTA_STATE_DIR`, then
+    /// `$XDG_STATE_HOME/index-delta`, then `~/.local/state/index-delta`).
+    #[arg(long, global = true, value_name = "DIR")]
+    state_dir: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Reconcile every file declared in a manifest (called by the nix
+    /// module's activation step). Ephemeral files are reseeded, durable
+    /// files fast-forward when clean and stage conflicts when not.
+    Activate {
+        /// Manifest JSON: {"files": [{"path", "source", "format"?,
+        /// "persistence"?, "declaredAt"?, "sourceFile"?}]}.
+        #[arg(long, value_name = "FILE")]
+        manifest: PathBuf,
+    },
+    /// Rewrite every ephemeral file from its recorded base, archiving any
+    /// drift to the journal first (called by the login agent; needs no
+    /// manifest).
+    Reseed,
+    /// The resolution queue: every managed file's state with logical diffs
+    /// in both directions.
+    Status {
+        /// Emit the machine contract instead of the human summary.
+        #[arg(long)]
+        json: bool,
+        /// Exit 1 when anything is drifted or in conflict (for scripts).
+        #[arg(long)]
+        check: bool,
+    },
+    /// One file's logical diff (upper vs base).
+    Diff {
+        path: String,
+        /// Unified text diff instead of logical ops.
+        #[arg(long)]
+        raw: bool,
+    },
+    /// Drop your edits: the (staged, if any) base wins.
+    Discard { path: String },
+    /// Accept the staged base as the new base but keep your edits — the
+    /// conflict becomes plain drift.
+    Adopt { path: String },
+    /// Apply logical ops onto a file, format-preserving where the format
+    /// allows. The mechanical half of absorbing drift into the repo.
+    ApplyOps {
+        /// File to edit (typically the repo copy of a config).
+        file: String,
+        /// Ops JSON (array of {op, path, ...}); `-` reads stdin.
+        ops: String,
+        /// Override format detection.
+        #[arg(long, value_enum)]
+        format: Option<Format>,
+    },
+    /// Silence a drifted file until its diff changes.
+    Snooze { path: String },
+    /// Archived state transitions — including the logical diffs of edits
+    /// wiped by past ephemeral reseeds.
+    Journal {
+        path: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+fn run(cli: Cli) -> Result<ExitCode> {
+    let store = Store::open(Store::resolve_root(cli.state_dir)?)?;
+    match cli.command {
+        Command::Activate { manifest } => cmd::activate(&store, &manifest)?,
+        Command::Reseed => cmd::reseed_ephemeral(&store)?,
+        Command::Status { json, check } => {
+            cmd::status(&store, json)?;
+            if check && cmd::pending_count(&store)? > 0 {
+                return Ok(ExitCode::FAILURE);
+            }
+        }
+        Command::Diff { path, raw } => cmd::print_diff(&store, &path, raw)?,
+        Command::Discard { path } => cmd::discard(&store, &path)?,
+        Command::Adopt { path } => cmd::adopt(&store, &path)?,
+        Command::ApplyOps { file, ops, format } => cmd::apply_ops(&file, &ops, format)?,
+        Command::Snooze { path } => cmd::snooze(&store, &path)?,
+        Command::Journal { path, json } => cmd::journal(&store, path.as_deref(), json)?,
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn main() -> ExitCode {
+    match run(Cli::parse()) {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("index-delta: {error:#}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/packages/index-delta/src/store.rs
+++ b/packages/index-delta/src/store.rs
@@ -1,0 +1,301 @@
+//! On-disk state: one directory per managed file (keyed by a hash of its
+//! absolute target path), holding the last-adopted base snapshot, the staged
+//! incoming base while a conflict is unresolved, and a `meta.json` record.
+//! An append-only journal at the root archives every state transition —
+//! including the logical diff of edits an ephemeral reseed wiped, so a tweak
+//! lost to a reboot is recoverable.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::value::Format;
+
+/// Whether edits to a managed file survive the next activation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum Persistence {
+    /// The default: edits are scratch. Every activation (and the login
+    /// reseed) rewrites the file from its base after archiving the drift's
+    /// logical diff to the journal. Nix always wins; conflicts cannot exist.
+    Ephemeral,
+    /// Edits survive activations. A base change under local drift parks the
+    /// incoming base as *staged* and queues the file for resolution instead
+    /// of touching it.
+    Durable,
+}
+
+/// Per-file record. Everything `status` reports that isn't computed from
+/// file contents lives here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Meta {
+    /// Absolute target path (tilde already expanded).
+    pub path: String,
+    /// Store path the current base was adopted from, for display.
+    pub source: String,
+    /// Store path parked during a conflict, for display.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub staged_source: Option<String>,
+    /// Repo file holding the declared content — where "absorb into Nix"
+    /// edits go.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_file: Option<String>,
+    /// Nix file (and line, when known) that declared this entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_at: Option<String>,
+    pub format: Format,
+    pub persistence: Persistence,
+    /// Fingerprint of the drift being deliberately ignored; the file
+    /// resurfaces as soon as its diff changes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snoozed: Option<String>,
+}
+
+/// One archived state transition.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JournalEntry {
+    /// Unix seconds.
+    pub ts: u64,
+    pub path: String,
+    pub event: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<Value>,
+}
+
+pub struct Store {
+    root: PathBuf,
+}
+
+impl Store {
+    pub fn open(root: PathBuf) -> Result<Self> {
+        fs::create_dir_all(root.join("files"))
+            .with_context(|| format!("creating state dir {}", root.display()))?;
+        Ok(Self { root })
+    }
+
+    /// Resolve the state root: explicit flag, then `INDEX_DELTA_STATE_DIR`,
+    /// then `$XDG_STATE_HOME/index-delta`, then `~/.local/state/index-delta`.
+    pub fn resolve_root(flag: Option<PathBuf>) -> Result<PathBuf> {
+        if let Some(dir) = flag {
+            return Ok(dir);
+        }
+        if let Some(dir) = env_dir("INDEX_DELTA_STATE_DIR") {
+            return Ok(dir);
+        }
+        if let Some(dir) = env_dir("XDG_STATE_HOME") {
+            return Ok(dir.join("index-delta"));
+        }
+        let home = env_dir("HOME").context("HOME is not set; pass --state-dir")?;
+        Ok(home.join(".local/state/index-delta"))
+    }
+
+    fn dir_for(&self, target: &str) -> PathBuf {
+        let digest = Sha256::digest(target.as_bytes());
+        self.root.join("files").join(&hex(&digest)[..16])
+    }
+
+    pub fn meta(&self, target: &str) -> Result<Option<Meta>> {
+        let path = self.dir_for(target).join("meta.json");
+        if !path.exists() {
+            return Ok(None);
+        }
+        let text =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        let meta =
+            serde_json::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
+        Ok(Some(meta))
+    }
+
+    pub fn save_meta(&self, meta: &Meta) -> Result<()> {
+        let dir = self.dir_for(&meta.path);
+        fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        let text = serde_json::to_string_pretty(meta).context("serializing meta")?;
+        fs::write(dir.join("meta.json"), text + "\n").context("writing meta.json")?;
+        Ok(())
+    }
+
+    /// Every managed file's record, sorted by target path for stable output.
+    pub fn all_metas(&self) -> Result<Vec<Meta>> {
+        let files = self.root.join("files");
+        let mut metas = Vec::new();
+        for entry in fs::read_dir(&files).with_context(|| format!("listing {}", files.display()))? {
+            let meta_path = entry?.path().join("meta.json");
+            if !meta_path.exists() {
+                continue;
+            }
+            let text = fs::read_to_string(&meta_path)
+                .with_context(|| format!("reading {}", meta_path.display()))?;
+            metas.push(
+                serde_json::from_str(&text)
+                    .with_context(|| format!("parsing {}", meta_path.display()))?,
+            );
+        }
+        metas.sort_by(|a: &Meta, b: &Meta| a.path.cmp(&b.path));
+        Ok(metas)
+    }
+
+    pub fn base_bytes(&self, target: &str) -> Result<Vec<u8>> {
+        let path = self.dir_for(target).join("base");
+        fs::read(&path).with_context(|| format!("reading base snapshot {}", path.display()))
+    }
+
+    pub fn write_base(&self, target: &str, bytes: &[u8]) -> Result<()> {
+        let dir = self.dir_for(target);
+        fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        fs::write(dir.join("base"), bytes).context("writing base snapshot")?;
+        Ok(())
+    }
+
+    pub fn staged_bytes(&self, target: &str) -> Result<Option<Vec<u8>>> {
+        let path = self.dir_for(target).join("staged");
+        if !path.exists() {
+            return Ok(None);
+        }
+        let bytes =
+            fs::read(&path).with_context(|| format!("reading staged base {}", path.display()))?;
+        Ok(Some(bytes))
+    }
+
+    pub fn write_staged(&self, target: &str, bytes: &[u8]) -> Result<()> {
+        fs::write(self.dir_for(target).join("staged"), bytes).context("writing staged base")?;
+        Ok(())
+    }
+
+    pub fn clear_staged(&self, target: &str) -> Result<()> {
+        let path = self.dir_for(target).join("staged");
+        if path.exists() {
+            fs::remove_file(&path).with_context(|| format!("removing {}", path.display()))?;
+        }
+        Ok(())
+    }
+
+    /// Forget a file: drop its state directory. The file itself is left on
+    /// disk — unmanaging is not deletion.
+    pub fn forget(&self, target: &str) -> Result<()> {
+        let dir = self.dir_for(target);
+        if dir.exists() {
+            fs::remove_dir_all(&dir).with_context(|| format!("removing {}", dir.display()))?;
+        }
+        Ok(())
+    }
+
+    pub fn journal(&self, path: &str, event: &str, detail: Option<Value>) -> Result<()> {
+        let entry = JournalEntry {
+            ts: now_secs(),
+            path: path.to_owned(),
+            event: event.to_owned(),
+            detail,
+        };
+        let mut line = serde_json::to_string(&entry).context("serializing journal entry")?;
+        line.push('\n');
+        let journal = self.root.join("journal.jsonl");
+        let mut file = fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&journal)
+            .with_context(|| format!("opening {}", journal.display()))?;
+        std::io::Write::write_all(&mut file, line.as_bytes())
+            .with_context(|| format!("appending to {}", journal.display()))?;
+        Ok(())
+    }
+
+    pub fn journal_entries(&self) -> Result<Vec<JournalEntry>> {
+        let journal = self.root.join("journal.jsonl");
+        if !journal.exists() {
+            return Ok(Vec::new());
+        }
+        let text = fs::read_to_string(&journal)
+            .with_context(|| format!("reading {}", journal.display()))?;
+        text.lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| {
+                serde_json::from_str(line).with_context(|| format!("parsing journal line {line}"))
+            })
+            .collect()
+    }
+}
+
+fn env_dir(name: &str) -> Option<PathBuf> {
+    std::env::var(name)
+        .ok()
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from)
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_secs())
+}
+
+pub fn hex(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut out, byte| {
+            let _ = write!(out, "{byte:02x}");
+            out
+        })
+}
+
+/// Write a file, creating parent directories. Used for both seeding targets
+/// and `apply-ops` output.
+pub fn write_creating_parents(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent dirs for {}", path.display()))?;
+    }
+    fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_encodes() {
+        assert_eq!(hex(&[0x00, 0xff, 0x10]), "00ff10");
+    }
+
+    #[test]
+    fn meta_round_trips_and_journal_appends() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path().to_path_buf()).expect("open");
+        let meta = Meta {
+            path: "/tmp/x/config.json".to_owned(),
+            source: "/nix/store/abc".to_owned(),
+            staged_source: None,
+            source_file: None,
+            declared_at: Some("home/x.nix:3".to_owned()),
+            format: Format::Json,
+            persistence: Persistence::Ephemeral,
+            snoozed: None,
+        };
+        store.save_meta(&meta).expect("save");
+        let loaded = store.meta(&meta.path).expect("load").expect("present");
+        assert_eq!(loaded.source, meta.source);
+        assert!(store.meta("/tmp/other").expect("load").is_none());
+
+        store.journal(&meta.path, "managed", None).expect("journal");
+        store
+            .journal(
+                &meta.path,
+                "reseeded",
+                Some(serde_json::json!({"archived": []})),
+            )
+            .expect("journal");
+        let entries = store.journal_entries().expect("entries");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[1].event, "reseeded");
+
+        store.forget(&meta.path).expect("forget");
+        assert!(store.meta(&meta.path).expect("load").is_none());
+    }
+}

--- a/packages/index-delta/src/store.rs
+++ b/packages/index-delta/src/store.rs
@@ -251,6 +251,13 @@ pub fn write_creating_parents(path: &Path, bytes: &[u8]) -> Result<()> {
         fs::create_dir_all(parent)
             .with_context(|| format!("creating parent dirs for {}", path.display()))?;
     }
+    // The upper must be a plain regular file. A target that is still a
+    // symlink (typically a leftover home-manager link into the read-only
+    // store, from a config migrating `home.file` -> `mutable.files`) is
+    // replaced, never written through.
+    if fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        fs::remove_file(path).with_context(|| format!("unlinking symlink {}", path.display()))?;
+    }
     fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))?;
     Ok(())
 }
@@ -297,5 +304,22 @@ mod tests {
 
         store.forget(&meta.path).expect("forget");
         assert!(store.meta(&meta.path).expect("load").is_none());
+    }
+
+    #[test]
+    fn write_replaces_symlink_instead_of_writing_through() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let linked = dir.path().join("generation-file");
+        fs::write(&linked, b"old").expect("write link target");
+        let target = dir.path().join("config");
+        std::os::unix::fs::symlink(&linked, &target).expect("symlink");
+
+        write_creating_parents(&target, b"new").expect("write");
+
+        let meta = fs::symlink_metadata(&target).expect("meta");
+        assert!(meta.file_type().is_file());
+        assert_eq!(fs::read(&target).expect("read"), b"new");
+        // The old link destination is untouched.
+        assert_eq!(fs::read(&linked).expect("read linked"), b"old");
     }
 }

--- a/packages/index-delta/src/value.rs
+++ b/packages/index-delta/src/value.rs
@@ -1,0 +1,305 @@
+//! Format detection and parsing: every structured format is lifted to a
+//! `serde_json::Value` so a single differ (`diff.rs`) serves all of them.
+//! Parsing is lossy where a format has types JSON lacks (TOML datetimes,
+//! plist data/dates become strings); that is fine for *diffing* — `apply.rs`
+//! goes back through each format's own writer, not through this
+//! normalization.
+
+use std::fmt;
+use std::io::Cursor;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// File formats the logical-diff engines understand. `Text` is the fallback:
+/// still tracked and journaled, but diffed as unified hunks rather than
+/// addressed ops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum Format {
+    Json,
+    Toml,
+    Yaml,
+    Plist,
+    /// Line-oriented `key = value` files with optional `[section]` headers
+    /// (ghostty, git config, INI). Unlike TOML it tolerates repeated keys,
+    /// which become arrays.
+    Keyvalue,
+    Text,
+}
+
+impl fmt::Display for Format {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Json => "json",
+            Self::Toml => "toml",
+            Self::Yaml => "yaml",
+            Self::Plist => "plist",
+            Self::Keyvalue => "keyvalue",
+            Self::Text => "text",
+        };
+        f.write_str(name)
+    }
+}
+
+/// A file's contents lifted to the representation its format is diffed in.
+pub enum Doc {
+    Structured(Value),
+    Text(String),
+    Binary(Vec<u8>),
+}
+
+/// Pick a format for a file: extension first, then content sniffing on the
+/// base. Runs once when a file is first managed; the result is recorded in
+/// its meta so detection can never flip under an existing diff.
+pub fn detect(path: &Path, contents: &[u8]) -> Format {
+    by_extension(path).unwrap_or_else(|| sniff(contents))
+}
+
+fn by_extension(path: &Path) -> Option<Format> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "json" => Some(Format::Json),
+        "toml" => Some(Format::Toml),
+        "yaml" | "yml" => Some(Format::Yaml),
+        "plist" => Some(Format::Plist),
+        "ini" => Some(Format::Keyvalue),
+        _ => None,
+    }
+}
+
+fn sniff(contents: &[u8]) -> Format {
+    if contents.starts_with(b"bplist") {
+        return Format::Plist;
+    }
+    let Ok(text) = std::str::from_utf8(contents) else {
+        return Format::Text;
+    };
+    let first = text.trim_start().chars().next();
+    if matches!(first, Some('{' | '[')) && serde_json::from_str::<Value>(text).is_ok() {
+        return Format::Json;
+    }
+    if text.contains("<plist") {
+        return Format::Plist;
+    }
+    // TOML before the keyvalue heuristic: a file that parses as TOML gets the
+    // format-preserving toml_edit writer for `apply-ops`. Files TOML rejects
+    // but that still look line-oriented (repeated keys, `key: value`) fall
+    // through to keyvalue.
+    if text.contains('=') && toml::from_str::<toml::Value>(text).is_ok() {
+        return Format::Toml;
+    }
+    if looks_keyvalue(text) {
+        return Format::Keyvalue;
+    }
+    Format::Text
+}
+
+fn looks_keyvalue(text: &str) -> bool {
+    let mut entries = 0usize;
+    let mut other = 0usize;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+            continue;
+        }
+        let is_header = trimmed.starts_with('[') && trimmed.ends_with(']');
+        if is_header || trimmed.contains('=') {
+            entries += 1;
+        } else {
+            other += 1;
+        }
+    }
+    entries > 0 && entries >= other
+}
+
+/// Parse contents under a format, degrading gracefully: a structured file
+/// that fails to parse (e.g. an app saved mid-edit garbage) is treated as
+/// text so drift is still visible instead of erroring the whole run.
+pub fn load(format: Format, contents: &[u8]) -> Doc {
+    let structured = match format {
+        Format::Json => std::str::from_utf8(contents)
+            .ok()
+            .and_then(|text| serde_json::from_str(text).ok()),
+        Format::Toml => std::str::from_utf8(contents)
+            .ok()
+            .and_then(|text| toml::from_str::<toml::Value>(text).ok())
+            .map(toml_to_json),
+        Format::Yaml => std::str::from_utf8(contents)
+            .ok()
+            .and_then(|text| serde_norway::from_str::<serde_norway::Value>(text).ok())
+            .and_then(|yaml| serde_json::to_value(yaml).ok()),
+        Format::Plist => plist::Value::from_reader(Cursor::new(contents))
+            .ok()
+            .map(plist_to_json),
+        Format::Keyvalue => std::str::from_utf8(contents).ok().map(parse_keyvalue),
+        Format::Text => None,
+    };
+    structured.map_or_else(|| text_or_binary(contents), Doc::Structured)
+}
+
+fn text_or_binary(contents: &[u8]) -> Doc {
+    std::str::from_utf8(contents).map_or_else(
+        |_| Doc::Binary(contents.to_vec()),
+        |text| Doc::Text(text.to_owned()),
+    )
+}
+
+fn toml_to_json(value: toml::Value) -> Value {
+    match value {
+        toml::Value::String(s) => Value::String(s),
+        toml::Value::Integer(i) => Value::from(i),
+        toml::Value::Float(f) => serde_json::Number::from_f64(f)
+            .map_or_else(|| Value::String(f.to_string()), Value::Number),
+        toml::Value::Boolean(b) => Value::from(b),
+        toml::Value::Datetime(d) => Value::String(d.to_string()),
+        toml::Value::Array(items) => Value::Array(items.into_iter().map(toml_to_json).collect()),
+        toml::Value::Table(table) => Value::Object(
+            table
+                .into_iter()
+                .map(|(key, item)| (key, toml_to_json(item)))
+                .collect(),
+        ),
+    }
+}
+
+pub fn plist_to_json(value: plist::Value) -> Value {
+    match value {
+        plist::Value::String(s) => Value::String(s),
+        plist::Value::Boolean(b) => Value::from(b),
+        plist::Value::Integer(i) => i
+            .as_signed()
+            .map(Value::from)
+            .or_else(|| i.as_unsigned().map(Value::from))
+            .unwrap_or(Value::Null),
+        plist::Value::Real(f) => serde_json::Number::from_f64(f)
+            .map_or_else(|| Value::String(f.to_string()), Value::Number),
+        plist::Value::Date(d) => Value::String(d.to_xml_format()),
+        plist::Value::Data(bytes) => Value::String(format!("hex:{}", crate::store::hex(&bytes))),
+        plist::Value::Uid(uid) => Value::from(uid.get()),
+        plist::Value::Array(items) => Value::Array(items.into_iter().map(plist_to_json).collect()),
+        plist::Value::Dictionary(dict) => Value::Object(
+            dict.into_iter()
+                .map(|(key, item)| (key, plist_to_json(item)))
+                .collect(),
+        ),
+        _ => Value::Null,
+    }
+}
+
+pub fn parse_keyvalue(text: &str) -> Value {
+    let mut root = Map::new();
+    let mut section: Option<String> = None;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+            continue;
+        }
+        if let Some(name) = header_name(trimmed) {
+            root.entry(name.clone())
+                .or_insert_with(|| Value::Object(Map::new()));
+            section = Some(name);
+            continue;
+        }
+        let entry = split_entry(trimmed);
+        let map = match &section {
+            None => &mut root,
+            Some(name) => {
+                let slot = root
+                    .entry(name.clone())
+                    .or_insert_with(|| Value::Object(Map::new()));
+                // A bare key earlier claimed this name; entries after the
+                // header win and the scalar is dropped.
+                if !slot.is_object() {
+                    *slot = Value::Object(Map::new());
+                }
+                slot.as_object_mut().expect("just ensured an object")
+            }
+        };
+        insert_multi(map, entry.key, entry.value);
+    }
+    Value::Object(root)
+}
+
+pub fn header_name(trimmed: &str) -> Option<String> {
+    trimmed
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .map(|name| name.trim().to_owned())
+}
+
+/// A parsed keyvalue entry line.
+pub struct Entry<'line> {
+    pub key: &'line str,
+    pub value: &'line str,
+}
+
+/// Split a keyvalue entry line. Lines without `=` are flag-style bare keys
+/// with an empty value.
+pub fn split_entry(trimmed: &str) -> Entry<'_> {
+    trimmed.split_once('=').map_or(
+        Entry {
+            key: trimmed,
+            value: "",
+        },
+        |(key, value)| Entry {
+            key: key.trim_end(),
+            value: value.trim_start(),
+        },
+    )
+}
+
+fn insert_multi(map: &mut Map<String, Value>, key: &str, value: &str) {
+    let new = Value::String(value.to_owned());
+    match map.get_mut(key) {
+        None => {
+            map.insert(key.to_owned(), new);
+        }
+        Some(Value::Array(items)) => items.push(new),
+        Some(existing) => {
+            let first = existing.take();
+            *existing = Value::Array(vec![first, new]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_by_extension_then_content() {
+        assert_eq!(detect(Path::new("a.json"), b"whatever"), Format::Json);
+        assert_eq!(detect(Path::new("config"), b"{\"a\": 1}"), Format::Json);
+        assert_eq!(
+            detect(Path::new("config"), b"a = 1\n[table]\nb = 2\n"),
+            Format::Toml
+        );
+        assert_eq!(
+            detect(Path::new("config"), b"keybind = a\nkeybind = b\n"),
+            Format::Keyvalue
+        );
+        assert_eq!(detect(Path::new("notes"), b"just prose\n"), Format::Text);
+        assert_eq!(detect(Path::new("d"), b"bplist00garbage"), Format::Plist);
+    }
+
+    #[test]
+    fn keyvalue_sections_and_repeats() {
+        let parsed = parse_keyvalue("top = 1\nkeybind = a\nkeybind = b\n[sec]\nk = v\n");
+        assert_eq!(
+            parsed,
+            serde_json::json!({
+                "top": "1",
+                "keybind": ["a", "b"],
+                "sec": {"k": "v"},
+            })
+        );
+    }
+
+    #[test]
+    fn corrupt_structured_falls_back_to_text() {
+        let doc = load(Format::Json, b"{not json");
+        assert!(matches!(doc, Doc::Text(_)));
+    }
+}

--- a/packages/index-delta/src/value.rs
+++ b/packages/index-delta/src/value.rs
@@ -31,15 +31,11 @@ pub enum Format {
 
 impl fmt::Display for Format {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = match self {
-            Self::Json => "json",
-            Self::Toml => "toml",
-            Self::Yaml => "yaml",
-            Self::Plist => "plist",
-            Self::Keyvalue => "keyvalue",
-            Self::Text => "text",
-        };
-        f.write_str(name)
+        // Single source of truth for the lowercase names: the ValueEnum
+        // derive (which also keeps Display in sync with the CLI's accepted
+        // `--format` spellings and the serde rename above).
+        let value = clap::ValueEnum::to_possible_value(self).expect("no skipped variants");
+        f.write_str(value.get_name())
     }
 }
 

--- a/users/andrewgazelka/config/home/ghostty.nix
+++ b/users/andrewgazelka/config/home/ghostty.nix
@@ -2,8 +2,10 @@
 #
 # Single source of truth: the `settings` attrset below. It is rendered in-store
 # by pkgs.formats.keyValue (the same generator home-manager's programs.ghostty
-# uses) and written to the macOS config path with an in-store source, so there
-# is no out-of-store symlink back into the repo. Edit Nix, switch, done.
+# uses) and seeded to the macOS config path as a plain writable file
+# (`mutable.files`, ephemeral): tweak the live file to experiment, and every
+# switch/login resets it to this render with the drift journaled. Edit Nix,
+# switch, done — or scribble on the deployed file and lift the keepers here.
 #
 # Repeated keybind/shader families (repo `cd` shortcuts, directional split
 # focus, shader stack) are built algebraically by mapping over data, so adding
@@ -146,12 +148,22 @@
     "ghostty-config"
     settings;
 in {
-  # In-store source (no mkOutOfStoreSymlink). Written to the macOS
-  # Application Support path Ghostty already loads; shaders/themes stay under
-  # ~/.config/ghostty (linked in profiles/workstation.nix). Only one config path is
-  # written so cumulative settings (e.g. custom-shader) are not double-applied.
-  home.file."Library/Application Support/com.mitchellh.ghostty/config" = {
+  # Written to the macOS Application Support path Ghostty already loads;
+  # shaders/themes stay under ~/.config/ghostty (linked in
+  # profiles/workstation.nix). Only one config path is written so cumulative
+  # settings (e.g. custom-shader) are not double-applied.
+  #
+  # Deployed as a writable mutable file (module imported in
+  # profiles/workstation.nix), NOT a store symlink: edit the live config to
+  # experiment (`cmd+shift+r` reloads it in place), and every activation and
+  # login resets it to this declared render — ephemeral, with the drift's
+  # logical keyvalue diff archived to `index-delta journal` first, so a tweak
+  # worth keeping can be lifted back into this file instead of being lost.
+  mutable.files."Library/Application Support/com.mitchellh.ghostty/config" = {
     source = configFile;
-    force = true;
+    format = "keyvalue";
+    # No `sourceFile`: the declaration is Nix, not raw keyvalue, so
+    # `apply-ops` cannot absorb drift mechanically — lift keepers by hand.
+    declaredAt = "users/andrewgazelka/config/home/ghostty.nix";
   };
 }

--- a/users/andrewgazelka/profiles/darwin-home.nix
+++ b/users/andrewgazelka/profiles/darwin-home.nix
@@ -352,9 +352,11 @@ in {
 
   # Ghostty main config: generated from Nix in home/ghostty.nix (imported above).
 
-  # Claude Desktop rewrites this file and carries a runtime Authorization
-  # header. Reconcile only public keys; mutable-json preserves the unmanaged
-  # credential without ever copying it into the Nix store.
+  # Claude Desktop rewrites its config file and carries a runtime
+  # Authorization header. The `mutable.files` declaration below seeds only
+  # public keys; the app-added credential stays on disk as tracked drift
+  # (durable, so never reset) without ever being copied into the Nix store —
+  # only the declared base lives in the store.
   # BlenderMCP addon auto-load: the in-Blender half of the MCP bridge, from the
   # SAME pinned rev as the `blender-mcp` server binary (index packages/blender-mcp
   # passthru.addon), so the :9876 socket protocol cannot drift between them.
@@ -447,12 +449,16 @@ in {
       bpy.app.timers.register(_blender_lab_mcp_setup, first_interval=0.5)
     '';
 
-  # Cursor and VS Code rewrite settings during UI changes. Keep the files
-  # writable while reconciling the Nix-owned keys on activation.
-  home.mutableJsonFiles = {
-    claude-desktop = {
-      target = "Library/Application Support/Claude/claude_desktop_config.json";
-      value = {
+  # Apps that rewrite their own config at runtime (Cursor and VS Code save
+  # settings/keybindings on UI changes, Claude Desktop persists preferences,
+  # rbw rewrites its config on `rbw config set`): seeded writable and
+  # drift-tracked by index-delta (module imported in profiles/workstation.nix;
+  # replaces the old mutable-json last-applied merge). Durable — app edits
+  # survive, base-vs-drift conflicts queue in `index-delta status` — and a
+  # pre-existing file is kept as day-one drift, never clobbered.
+  mutable.files = {
+    "Library/Application Support/Claude/claude_desktop_config.json" = {
+      source = jsonFormat.generate "andrewgazelka-claude-desktop.json" {
         globalShortcut = "";
         mcpServers.ix = {
           type = "http";
@@ -473,35 +479,51 @@ in {
           dispatchCodeTasksPermissionMode = "bypassPermissions";
         };
       };
+      persistence = "durable";
+      declaredAt = "users/andrewgazelka/profiles/darwin-home.nix";
     };
-    cursor-settings = {
-      target = "Library/Application Support/Cursor/User/settings.json";
-      value = cursorSettings;
+    "Library/Application Support/Cursor/User/settings.json" = {
+      source = jsonFormat.generate "andrewgazelka-cursor-settings.json" cursorSettings;
+      persistence = "durable";
+      declaredAt = "users/andrewgazelka/config/settings/structured.nix";
     };
-    vscode-settings = {
-      target = "Library/Application Support/Code/User/settings.json";
-      value = cursorSettings;
+    "Library/Application Support/Code/User/settings.json" = {
+      source = jsonFormat.generate "andrewgazelka-vscode-settings.json" cursorSettings;
+      persistence = "durable";
+      declaredAt = "users/andrewgazelka/config/settings/structured.nix";
     };
-    rbw = {
-      target = "Library/Application Support/rbw/config.json";
-      value = {
+    "Library/Application Support/rbw/config.json" = {
+      source = jsonFormat.generate "andrewgazelka-rbw-config.json" {
         email = cfg.rbw.email;
         base_url = cfg.rbw.baseUrl;
         pinentry = "${cfg.paths.privateConfigDirectory}/rbw/op-pinentry.sh";
         lock_timeout = 3600;
         sync_interval = 3600;
       };
+      persistence = "durable";
+      declaredAt = "users/andrewgazelka/profiles/darwin-home.nix";
+    };
+    "Library/Application Support/Cursor/User/keybindings.json" = {
+      source =
+        jsonFormat.generate "andrewgazelka-cursor-keybindings.json"
+        (import (configRoot + "/cursor/keybindings.nix"));
+      persistence = "durable";
+      declaredAt = "users/andrewgazelka/config/cursor/keybindings.nix";
+    };
+    "Library/Application Support/Code/User/keybindings.json" = {
+      source =
+        jsonFormat.generate "andrewgazelka-vscode-keybindings.json"
+        (import (configRoot + "/cursor/keybindings.nix"));
+      persistence = "durable";
+      declaredAt = "users/andrewgazelka/config/cursor/keybindings.nix";
+    };
+    # Bacon persists preference edits (`bacon --prefs`) into this file.
+    "Library/Application Support/org.dystroy.bacon/prefs.toml" = {
+      source = tomlFormat.generate "andrewgazelka-bacon-prefs.toml" structured.bacon-prefs.value;
+      persistence = "durable";
+      declaredAt = "users/andrewgazelka/config/settings/structured.nix";
     };
   };
-
-  home.file."Library/Application Support/Cursor/User/keybindings.json".source =
-    jsonFormat.generate "andrewgazelka-cursor-keybindings.json" (import (configRoot + "/cursor/keybindings.nix"));
-  home.file."Library/Application Support/Code/User/keybindings.json".source =
-    jsonFormat.generate "andrewgazelka-vscode-keybindings.json" (import (configRoot + "/cursor/keybindings.nix"));
-
-  # Bacon
-  home.file."Library/Application Support/org.dystroy.bacon/prefs.toml".source =
-    tomlFormat.generate "andrewgazelka-bacon-prefs.toml" structured.bacon-prefs.value;
 
   # Zen browser
   home.file."Library/Application Support/zen/Profiles/nu2gused.Default (release)/chrome".source =

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -4,7 +4,7 @@
   configRoot,
   indexPackages,
   ix,
-  mutableJsonModule,
+  mutableFilesModule,
   optionsModule,
   personalServicesModule,
   provenanceModule,
@@ -91,8 +91,10 @@
     doCheck = false;
   });
 
-  # Personal-only Claude config. Home Manager renders this into
-  # ~/.claude/settings.json, the application's native default layer.
+  # Personal-only Claude config, seeded into ~/.claude/settings.json as a
+  # writable mutable file (see `mutable.files` below): the app's native
+  # default layer, which Claude itself edits at runtime (/config, plugin
+  # toggles), so it must not be a read-only store symlink.
   # House posture lives in the index wrapper itself now: attribution, worktree
   # baseRef, effort/fast/theme runtime-toggle defaults, auto-updates channel,
   # the version-aware statusline, the 1M/cron/autocompact clamps (typed
@@ -183,6 +185,44 @@
     })
   agentMcpServers;
 
+  # Native Codex settings, seeded into ~/.codex/config.toml as a writable
+  # mutable file (see `mutable.files` below): Codex appends per-project trust
+  # decisions and runtime toggles to config.toml, which a read-only store
+  # symlink would reject.
+  codexSettings = {
+    check_for_update_on_startup = false;
+    bypass_hook_trust = true;
+    model = "gpt-5.5";
+    model_reasoning_effort = "low";
+    personality = "pragmatic";
+    service_tier = "fast";
+    sandbox_mode = "danger-full-access";
+    default_permissions = ":danger-full-access";
+    commit_attribution = "";
+    agents.max_depth = 3;
+    mcp_servers = codexMcpServers;
+    features = {
+      steer = true;
+      multi_agent = true;
+      multi_agent_v2 = {
+        enabled = true;
+        max_concurrent_threads_per_session = 16;
+      };
+      apps = false;
+      plugins = false;
+      terminal_resize_reflow = true;
+      goals = true;
+      # Prevent Codex from recreating stale externally discovered MCP entries.
+      external_migration = false;
+      js_repl = false;
+    };
+    shell_environment_policy = {
+      "inherit" = "all";
+      ignore_default_excludes = true;
+      set.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+    };
+  };
+
   # Shared skill source: the index repo's SKILL.md bundles (open Agent-Skills
   # standard, `packages/agent/skills`). ONE directory, delivered to BOTH agents
   # bare (no plugin namespace, so `/<skill>` on Claude and `$<skill>` / implicit
@@ -227,7 +267,11 @@ in {
     # defined them; `whence <path>` (below) reads it with zero eval.
     # indexable-inc/index#2418.
     provenanceModule
-    mutableJsonModule
+    # Declarative-but-writable files (index-delta): apps edit their config
+    # freely, drift is tracked as logical diffs and resolved explicitly.
+    # darwin-home.nix uses `mutable.files` too and relies on this import,
+    # the same way it always rode this profile's other shared modules.
+    mutableFilesModule
     tmuxModule
   ];
 
@@ -798,12 +842,24 @@ in {
     renderLines "andrewgazelka-gitattributes" (import (configRoot + "/git/attributes.nix"));
 
   # Zed (the macOS-only icon overrides live under ~/Library/Application Support).
-  home.file.".config/zed/keymap.json".source = jsonFormat.generate "andrewgazelka-zed-keymap.json" (
-    import (configRoot + "/zed/keymap.nix")
-  );
-  home.file.".config/zed/settings.json".source =
-    jsonFormat.generate "andrewgazelka-zed-settings.json"
-    (import (configRoot + "/zed/settings.nix"));
+  # Zed's settings UI rewrites both files in place, so they are declared as
+  # writable mutable files: the Nix render seeds them, in-app edits survive
+  # (durable) and queue as logical diffs in `index-delta status` when the
+  # declared base moves.
+  mutable.files.".config/zed/keymap.json" = {
+    source = jsonFormat.generate "andrewgazelka-zed-keymap.json" (
+      import (configRoot + "/zed/keymap.nix")
+    );
+    persistence = "durable";
+    declaredAt = "users/andrewgazelka/config/zed/keymap.nix";
+  };
+  mutable.files.".config/zed/settings.json" = {
+    source =
+      jsonFormat.generate "andrewgazelka-zed-settings.json"
+      (import (configRoot + "/zed/settings.nix"));
+    persistence = "durable";
+    declaredAt = "users/andrewgazelka/config/zed/settings.nix";
+  };
   home.file."Library/Application Support/Zed/extensions/installed/jetbrains-new-ui-icons/icons/andrew-folder-test-green.svg" = lib.mkIf pkgs.stdenv.isDarwin {
     source = repoFile "zed/icons/andrew-folder-test-green.svg";
   };
@@ -947,14 +1003,15 @@ in {
   # dir), delivered bare to ~/.claude/skills/<name> and invoked as `/<skill>`
   # (no `index:` namespace): the same source Codex gets via programs.codex
   # below. This replaces the old baked `--plugin-dir` plugin.
-  # settings.json is generation-owned from claudeSettings. .claude.json remains
-  # app-owned runtime state because Claude stores account and session metadata
-  # beside user choices there. CLAUDE.md is generation-owned from its tracked
-  # source because the app never rewrites it.
+  # settings.json is NOT declared here (the module would render it as a
+  # read-only store symlink): it is seeded writable from claudeSettings via
+  # `mutable.files` below, because Claude edits it at runtime. .claude.json
+  # remains app-owned runtime state because Claude stores account and session
+  # metadata beside user choices there. CLAUDE.md is generation-owned from its
+  # tracked source because the app never rewrites it.
   programs.claude-code = {
     enable = true;
     package = claudeCode;
-    settings = claudeSettings;
     houseContext.enable = false;
     # All agents, BARE, sourced straight from the index repo (index's agents
     # package now holds my former personal agents too). Bare (not plugin) so
@@ -973,44 +1030,31 @@ in {
   # Codex, via Home Manager. Static policy and defaults live in config.toml,
   # where Codex and its desktop app can inspect the same source of truth. The
   # wrapper carries only behavior without a native config-file representation.
+  # `settings` is deliberately NOT set here: the module would render
+  # config.toml as a read-only store symlink, and Codex writes to it at
+  # runtime (project trust, model switches). The same values are seeded
+  # writable from `codexSettings` via `mutable.files` below.
   programs.codex = {
     enable = true;
     package = codex;
-    settings = {
-      check_for_update_on_startup = false;
-      bypass_hook_trust = true;
-      model = "gpt-5.5";
-      model_reasoning_effort = "low";
-      personality = "pragmatic";
-      service_tier = "fast";
-      sandbox_mode = "danger-full-access";
-      default_permissions = ":danger-full-access";
-      commit_attribution = "";
-      agents.max_depth = 3;
-      mcp_servers = codexMcpServers;
-      features = {
-        steer = true;
-        multi_agent = true;
-        multi_agent_v2 = {
-          enabled = true;
-          max_concurrent_threads_per_session = 16;
-        };
-        apps = false;
-        plugins = false;
-        terminal_resize_reflow = true;
-        goals = true;
-        # Prevent Codex from recreating stale externally discovered MCP entries.
-        external_migration = false;
-        js_repl = false;
-      };
-      shell_environment_policy = {
-        "inherit" = "all";
-        ignore_default_excludes = true;
-        set.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
-      };
-    };
     skills = skillsSrc;
     context = repoFile "claude/global/CLAUDE.md";
+  };
+
+  # Both agents edit their own config at runtime, so neither file can be a
+  # read-only store render. Durable: in-app changes survive activation and
+  # login; when the declared base moves under local edits, the file queues in
+  # `index-delta status --json` (both diffs as addressed ops) for an explicit
+  # discard / adopt / absorb-into-Nix via `index-delta apply-ops`.
+  mutable.files.".claude/settings.json" = {
+    source = jsonFormat.generate "andrewgazelka-claude-settings.json" claudeSettings;
+    persistence = "durable";
+    declaredAt = "users/andrewgazelka/profiles/workstation.nix";
+  };
+  mutable.files.".codex/config.toml" = {
+    source = tomlFormat.generate "andrewgazelka-codex-config.toml" codexSettings;
+    persistence = "durable";
+    declaredAt = "users/andrewgazelka/profiles/workstation.nix";
   };
 
   # CLAUDE.md is read-only and generation-owned. `force` replaces any stale
@@ -1067,31 +1111,45 @@ in {
     force = true;
   };
 
-  # Writable application configuration with declarative field ownership. The
-  # mutable-json module preserves application-added keys while reconciling the
-  # tracked declaration on activation.
-  home.mutableJsonFiles = {
-    claude-keybindings = {
-      target = ".claude/keybindings.json";
-      value = structured.claude-global-keybindings.value;
-    };
-    cursor-mcp = {
-      target = ".cursor/mcp.json";
-      value = builtins.fromJSON (
+  # Writable application configuration, seeded and drift-tracked by
+  # index-delta (replaces the old mutable-json last-applied merge, which
+  # silently auto-merged). Durable: the apps rewrite these files at runtime
+  # and those edits survive; base-vs-drift conflicts queue in
+  # `index-delta status`. A pre-existing file (including one previously
+  # managed by mutable-json, with app-added keys) is kept as day-one drift,
+  # never clobbered.
+  mutable.files.".claude/keybindings.json" = {
+    source =
+      jsonFormat.generate "andrewgazelka-claude-keybindings.json"
+      structured.claude-global-keybindings.value;
+    persistence = "durable";
+    declaredAt = "users/andrewgazelka/config/settings/structured.nix";
+  };
+  mutable.files.".cursor/mcp.json" = {
+    source = jsonFormat.generate "andrewgazelka-cursor-mcp.json" (
+      builtins.fromJSON (
         builtins.replaceStrings
         ["/Users/andrewgazelka"]
         [config.home.homeDirectory]
         (builtins.toJSON structured.cursor-mcp.value)
-      );
-    };
-    cursor-cli = {
-      target = ".cursor/cli-config.json";
-      value = structured.cursor-cli-config.value;
-    };
-    amp = {
-      target = ".config/amp/settings.json";
-      value = structured.amp-settings.value;
-    };
+      )
+    );
+    persistence = "durable";
+    declaredAt = "users/andrewgazelka/config/settings/structured.nix";
+  };
+  mutable.files.".cursor/cli-config.json" = {
+    source =
+      jsonFormat.generate "andrewgazelka-cursor-cli-config.json"
+      structured.cursor-cli-config.value;
+    persistence = "durable";
+    declaredAt = "users/andrewgazelka/config/settings/structured.nix";
+  };
+  mutable.files.".config/amp/settings.json" = {
+    source =
+      jsonFormat.generate "andrewgazelka-amp-settings.json"
+      structured.amp-settings.value;
+    persistence = "durable";
+    declaredAt = "users/andrewgazelka/config/settings/structured.nix";
   };
 
   # Cursor extensions sourced from github flake inputs. Dir name must match


### PR DESCRIPTION
## What

A Nix-declared file stays a **plain writable file** on disk — no read-only store symlink. A new `index-delta` CLI seeds it from its declared base and tracks local edits as **logical, format-aware diffs** (JSON diffed as JSON, TOML as TOML, YAML/plist/keyvalue likewise; unified text as the fallback). **Nothing is ever auto-merged**: base-vs-drift tension queues in `index-delta status --json` for explicit resolution, in a shape geared for a model to read and act on.

### `packages/index-delta` (Rust)

- **Persistence per file.** `ephemeral` (the default) means edits are scratch: every activation and every login rewrites the file from its base, archiving the drift's logical diff to an append-only journal first — a lost tweak is always recoverable, and conflicts cannot exist. `durable` means edits survive: a base change under drift parks the incoming base as *staged* and queues the file instead of touching it.
- **The gated switch (durable).** Upper ≡ incoming (logically) → adopt, keep your bytes — the diff being empty *is* the resolution. Upper ≡ base → fast-forward. Incoming ≡ base → drift persists untouched. Both moved → stage the conflict, touch nothing.
- **Model-oriented queue.** `status --json` reports `yourEdits` (upper vs base) and `incomingEdits` (staged vs base) as addressed ops (`add`/`remove`/`replace` with JSON Pointer or dotted paths), plus the `overlap` between them — empty overlap means trivially resolvable. Resolution verbs: `discard`, `adopt`, `snooze` (until the diff changes), and `apply-ops`, which replays chosen ops onto a repo source file — format-preserving via `toml_edit` for TOML and a line editor for keyvalue — so drift can be **absorbed into the Nix repo** instead of resolved by hand.
- **Formats auto-detect** from extension, then content, and stick per file (recorded in state so detection can never flip under an existing diff). Formatting-only changes are logically clean. Positional array diffing (per-index / tail append / tail truncate / honest whole-array replace — deliberately no LCS).
- **Migration-safe seeding.** A target that is still a symlink (a leftover home-manager link into the store, from a config moving `home.file` → `mutable.files`) is replaced, never written through.
- 28 unit/integration tests covering the gate matrix, absorb-into-repo round-trips per format, snooze fingerprints, day-one drift for pre-existing durable targets, symlink replacement, and unmanaged-file forgetting.

### Nix modules

- **`homeModules.mutable-files`** — `mutable.files.` with `source`/`text`, optional `format` override, per-file `persistence`. Renders the manifest, runs `index-delta activate` after `writeBoundary`, and installs a login reseed agent through portable-services (native launchd agent on macOS, systemd user unit on Linux).
- **`darwinModules.mutable-files`** — the `/etc` adapter: same model as root, state under `/var/db/index-delta`, boot-time reseed daemon.
- **`darwinModules.nfs`** — declarative NFS automounts via the autofs machinery macOS ships: each entry renders a direct-map line in `/etc/auto_index`, the `auto_master` include is added idempotently at activation, and `automount -vc` reloads. (macOS never got FSKit-based NFS; autofs is the supported native path.)

### `users/andrewgazelka` adopts it end-to-end

Everything an app rewrites at runtime moves onto `mutable.files`, so runtime edits become tracked drift instead of write failures or silent auto-merges:

- `programs.claude-code` / `programs.codex` no longer render read-only settings files; `~/.claude/settings.json` and `~/.codex/config.toml` are seeded as **durable** mutable files from the same Nix attrsets (Claude edits its settings in place; Codex writes project trust and model switches back to `config.toml`). The index wrapper modules (baked defaults, house plugin) are unaffected.
- Zed keymap/settings, Cursor + VS Code settings and keybindings, Claude Desktop, Claude keybindings, Cursor MCP/CLI config, Amp, rbw, and bacon migrate from `home.file` / `home.mutableJsonFiles` to **durable** `mutable.files`. Pre-existing files (including app-added keys like Claude Desktop's runtime credential) are kept as day-one drift — only the declared base ever enters the store.
- ghostty is the flagship **ephemeral** case: scribble on the live config to experiment (`cmd+shift+r` reloads), and every activation/login resets it to the declared render with the keyvalue diff journaled first.
- `flake.nix` hoists the mutable-files home module and threads it into the personal workstation module in place of mutable-json; `homeModules.mutable-json` stays exported for existing users but points newcomers here.

## Why

Deploying config as store symlinks fights every app that writes its own config; deploying with `home.file` + writable copies loses the declared/actual relationship entirely. This keeps both: the file is honestly writable, and the *relationship* (base, drift, incoming) is tracked as logical ops a model can reason about — pull the diff into the repo, discard it, or let ephemeral semantics wipe it on schedule.

## Verified

- `cargo test -p index-delta`: 28 passed.
- `cargo clippy -p index-delta --all-targets`: clean apart from the two fork-only lint names stock clippy doesn't know (CI's clippy fork defines them) and pre-existing cargo-metadata findings in unrelated packages.
- Clone gates: global 0.4308% ≤ 0.44%, changed-lines 0/3476 duplicated (0.0000%).
- End-to-end smoke run of the full lifecycle: seed → drift → base change → staged conflict with both diffs + overlap in `status --json` → `apply-ops` absorbing `yourEdits` into the source → re-activate → `discard` → clean; ephemeral drift archived to the journal and reseeded.
- All edited Nix files parse; identifier/wiring cross-checks pass (no `mutableJsonFiles` references remain under `users/`, all `structured.nix` keys referenced exist). Full flake eval runs in CI (this sandbox can't fetch flake inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pypw5VDpK5xD1fVA2tdRxe

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `index-delta` tool for writable Nix-declared files with logical drift tracking
> - Introduces a new `index-delta` Rust binary ([packages/index-delta](https://github.com/indexable-inc/index/pull/2629/files#diff-42caef7efbf663bb15ac75680b54ef54320ea91de7815ddedafda3e81853c019)) that seeds files from Nix declarations while keeping them writable, tracking the diff between the declared base and the live file as "drift".
> - Files can be `ephemeral` (reset to base at login/boot) or `durable` (user edits persist; base changes are surfaced as conflicts to resolve via `adopt`, `discard`, or `snooze`).
> - Adds Home Manager ([modules/home/mutable-files.nix](https://github.com/indexable-inc/index/pull/2629/files#diff-9f11e0e687ccf708454832748366cf04048fc36d62c91dcd25f64663fb104c70)) and nix-darwin ([modules/darwin/mutable-files.nix](https://github.com/indexable-inc/index/pull/2629/files#diff-8138811c3250ba97ceb05971140bf694aad1d713072d4193fe7e5e6887879268)) modules exposing a `mutable.files` option that generates a JSON manifest and wires activation hooks and login/boot reseed services.
> - Logical diffs and applies are format-aware across JSON, TOML, YAML, plist, and key-value files, preserving comments and layout; a JSONL journal records state transitions with timestamps.
> - Migrates several user config files (Zed, Claude, Cursor, Codex, Amp, Ghostty, VS Code, rbw, Bacon) from read-only symlinks or `mutableJsonFiles` to durable `mutable.files` entries.
> - Risk: files previously deployed as read-only symlinks are now writable regular files; on first activation, `index-delta` breaks the symlink and seeds a base snapshot, and any pre-existing durable content is recorded as day-one drift rather than being overwritten.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa36f63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->