### PR TITLE
mcp: send appInfo in app handshake

### DIFF
--- a/packages/mcp/ix_notebook_mcp/mcp_ui.py
+++ b/packages/mcp/ix_notebook_mcp/mcp_ui.py
@@ -587,7 +587,7 @@ _VIEWER_HTML = (
   }
   request("ui/initialize", {
     protocolVersion: "2026-01-26",
-    clientInfo: { name: "ix-mcp tool result viewer", version: "1.0.0" },
+    appInfo: { name: "ix-mcp tool result viewer", version: "1.0.0" },
     capabilities: {},
     appCapabilities: { availableDisplayModes: ["inline"] }
   }).then(function (result) {

--- a/packages/mcp/tests/test_mcp_ui.py
+++ b/packages/mcp/tests/test_mcp_ui.py
@@ -73,6 +73,11 @@ def test_register_viewer_declares_ui_resource() -> None:
     # restrictive default CSP applies without any csp metadata.
     assert "http://" not in document
     assert "https://" not in document
+    # The MCP Apps initialize schema uses appInfo, not the core MCP
+    # initialize field clientInfo. Hosts reject the view before rendering when
+    # this field is missing.
+    assert 'appInfo: { name: "ix-mcp tool result viewer", version: "1.0.0" }' in document
+    assert "clientInfo" not in document
     # The JS reads the same _meta key the Python side writes.
     assert mcp_ui.RESULT_META_KEY in document
 
@@ -400,4 +405,3 @@ async def _wire_roundtrip(server: FastMCP) -> None:
         # relays to the iframe as `ui/notifications/tool-result` params.
         assert result.meta is not None
         assert result.meta[mcp_ui.RESULT_META_KEY] == {"title": "show", "html": ["<p>hi</p>"]}
-


### PR DESCRIPTION
## Summary
- send MCP Apps ui/initialize metadata as appInfo instead of clientInfo
- add a regression assertion for the viewer handshake payload

## Validation
- nix build --option sandbox false .#mcp.passthru.tests.mcpUiTests
- nix run .#lint

Note: plain sandboxed nix build .#mcp.passthru.tests.mcpUiTests reaches this change's assertions, then fails an existing aiohttp localhost bind test with PermissionError: [Errno 1] Operation not permitted; rerun with sandbox false passes the full focused suite.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send `appInfo` instead of `clientInfo` in MCP viewer `ui/initialize` handshake
> Fixes the field name in the `ui/initialize` request payload sent by the embedded viewer in [mcp_ui.py](https://github.com/indexable-inc/index/pull/2634/files#diff-b4a22204eb2ac244f22ade1f151289bbc2ff58e9442b7a6a3e36ae95b512f2bf), replacing `clientInfo` with `appInfo` to match the expected app handshake format. A test is added to assert the correct field name is present and `clientInfo` does not appear.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d9a37e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->