### PR TITLE
codex: forward Google OAuth credentials to index MCP

### DIFF
--- a/lib/util/mcp/servers.nix
+++ b/lib/util/mcp/servers.nix
@@ -12,6 +12,8 @@
   indexApiEnvVars = [
     "GH_TOKEN"
     "GITHUB_TOKEN"
+    "GOOGLE_OAUTH_CLIENT_ID"
+    "GOOGLE_OAUTH_CLIENT_SECRET"
     "IX_TOKEN"
     "LINEAR_API_KEY"
     "NOTION_API_KEY"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -189,16 +189,15 @@
   # ix guest sidecars are opened by the shared platform base config.
   baseFirewallTcpPorts = [5001];
   baseFirewallUdpPorts = [8443];
-  sampleCodexMcpEntries = ix.mcp.toCodexEntries (
-    ix.mcp.defaultServers {
-      indexCommand = "/bin/ix-mcp";
-    }
-  );
-  sampleClaudeMcpServers = ix.mcp.toClaudeJson (
-    ix.mcp.defaultServers {
-      indexCommand = "/bin/ix-mcp";
-    }
-  );
+  googleOauthEnvVars = [
+    "GOOGLE_OAUTH_CLIENT_ID"
+    "GOOGLE_OAUTH_CLIENT_SECRET"
+  ];
+  sampleMcpServers = ix.mcp.defaultServers {
+    indexCommand = "/bin/ix-mcp";
+  };
+  sampleCodexMcpEntries = ix.mcp.toCodexEntries sampleMcpServers;
+  sampleClaudeMcpServers = ix.mcp.toClaudeJson sampleMcpServers;
   sampleCodexMcpEntriesWithoutIndex = ix.mcp.toCodexEntries (ix.mcp.defaultServers {});
   sampleCodexMcpEntry = key: lib.findFirst (entry: entry.key == key) null sampleCodexMcpEntries;
   sampleCodexMcpEntryWithoutIndex = key: lib.findFirst (entry: entry.key == key) null sampleCodexMcpEntriesWithoutIndex;
@@ -2836,16 +2835,25 @@
       }
       {
         assertion =
-          sampleCodexMcpEntry "mcp_servers.index.env_vars"
-          == {
-            key = "mcp_servers.index.env_vars";
-            value = ''[ "GH_TOKEN", "GITHUB_TOKEN", "IX_TOKEN", "LINEAR_API_KEY", "NOTION_API_KEY", "SLACK_TOKEN", "SLACK_USER_TOKEN" ]'';
-          };
-        message = "Codex MCP entries should explicitly forward API environment variables to index MCP";
+          lib.all (name: builtins.elem name sampleMcpServers.index.envVars) googleOauthEnvVars;
+        message = "index MCP should declare the Google OAuth client environment variables";
       }
       {
-        assertion = sampleClaudeMcpServers.index.env.LINEAR_API_KEY == "\${LINEAR_API_KEY:-}";
-        message = "Claude MCP config should forward API environment variables to index MCP";
+        assertion = let
+          entry = sampleCodexMcpEntry "mcp_servers.index.env_vars";
+        in
+          entry
+          != null
+          && lib.all (name: lib.hasInfix (builtins.toJSON name) entry.value) googleOauthEnvVars;
+        message = "Codex MCP config should forward the Google OAuth client environment variables";
+      }
+      {
+        assertion =
+          lib.all (
+            name: sampleClaudeMcpServers.index.env.${name} == "\${${name}:-}"
+          )
+          googleOauthEnvVars;
+        message = "Claude MCP config should forward the Google OAuth client environment variables";
       }
       {
         assertion =


### PR DESCRIPTION
Fixes #2635.

The index MCP registry now forwards the Google OAuth client ID and secret through both generated Codex and Claude configurations. Tests use the neutral server definition as structured data and verify both rendered consumers without maintaining a hand-written TOML array.

Validation:
- repository formatter
- production registry evaluation
- Linux assertion aggregate evaluation

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward Google OAuth credentials to the index MCP server
> Adds `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` to the environment variables forwarded to the index MCP server in [servers.nix](https://github.com/indexable-inc/index/pull/2636/files#diff-a74190c62a3086f0b0e05489808b80559c743c45cb2f5d09e9734aa712b7604b). Tests in [tests/default.nix](https://github.com/indexable-inc/index/pull/2636/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) are updated to assert that both variables are present in the declared `envVars` and are correctly forwarded in both Codex and Claude MCP config output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6efd225.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->