### PR TITLE
darwin: move computed paths into config

### DIFF
--- a/modules/darwin/mutable-files.nix
+++ b/modules/darwin/mutable-files.nix
@@ -83,13 +83,14 @@
       _target = mkOption {
         type = types.str;
         internal = true;
-        default =
-          if lib.hasPrefix "/" name
-          then name
-          else "/${name}";
         description = "Resolved absolute target path.";
       };
     };
+
+    config._target =
+      if lib.hasPrefix "/" name
+      then name
+      else "/${name}";
   });
 
   files = lib.attrValues cfg.files;

--- a/modules/darwin/nfs.nix
+++ b/modules/darwin/nfs.nix
@@ -10,7 +10,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }: let
   inherit
@@ -57,13 +56,14 @@
       _mountpoint = mkOption {
         type = types.str;
         internal = true;
-        default =
-          if lib.hasPrefix "/" name
-          then name
-          else "/${name}";
         description = "Absolute local mount point (the attribute name).";
       };
     };
+
+    config._mountpoint =
+      if lib.hasPrefix "/" name
+      then name
+      else "/${name}";
   });
 
   mounts = lib.attrValues cfg.automounts;

--- a/packages/index-delta/src/diff.rs
+++ b/packages/index-delta/src/diff.rs
@@ -192,7 +192,10 @@ fn diff_values(
             let added = new_map
                 .iter()
                 .filter(|(key, _)| !old_map.contains_key(*key))
-                .map(|(key, item)| (key.clone(), item));
+                .map(|(key, value)| Leaf {
+                    segment: key.clone(),
+                    value,
+                });
             push_leaf_ops(addr, path, ops, added, |path, value| Op::Add {
                 path,
                 value,
@@ -251,12 +254,20 @@ fn diff_arrays(
     }
 }
 
-fn indexed(items: &[Value], from: usize) -> impl DoubleEndedIterator<Item = (String, &Value)> {
+struct Leaf<'v> {
+    segment: String,
+    value: &'v Value,
+}
+
+fn indexed(items: &[Value], from: usize) -> impl DoubleEndedIterator<Item = Leaf<'_>> {
     items
         .iter()
         .enumerate()
         .skip(from)
-        .map(|(index, item)| (index.to_string(), item))
+        .map(|(index, value)| Leaf {
+            segment: index.to_string(),
+            value,
+        })
 }
 
 /// Emit one leaf op per `(segment, value)` pair, each addressed one level
@@ -266,12 +277,12 @@ fn push_leaf_ops<'v>(
     addr: Addressing,
     path: &mut Vec<String>,
     ops: &mut Vec<Op>,
-    items: impl Iterator<Item = (String, &'v Value)>,
+    items: impl Iterator<Item = Leaf<'v>>,
     make: fn(String, Value) -> Op,
 ) {
-    for (segment, value) in items {
-        path.push(segment);
-        ops.push(make(render(addr, path), value.clone()));
+    for leaf in items {
+        path.push(leaf.segment);
+        ops.push(make(render(addr, path), leaf.value.clone()));
         path.pop();
     }
 }


### PR DESCRIPTION
## Summary

- move computed `_target` and `_mountpoint` values from conditional option defaults into submodule config
- remove the now-exposed unused `pkgs` argument from the NFS module
- replace the anonymous `index-delta` leaf tuple with a named type
- restore repository lint and `index-delta-clippy`

## Validation

- `nix run .#lint`
- `cargo test -p index-delta`

The host Cargo Clippy is older than the repository lint set, so the authoritative `index-delta-clippy` check is left to the Nix flake check and CI.

Closes #2638
Closes #2640

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move computed path resolution for darwin mutable files and NFS automounts into config assignments
> Moves the logic for computing `_target` (in [mutable-files.nix](https://github.com/indexable-inc/index/pull/2639/files#diff-8138811c3250ba97ceb05971140bf694aad1d713072d4193fe7e5e6887879268)) and `_mountpoint` (in [nfs.nix](https://github.com/indexable-inc/index/pull/2639/files#diff-2bb6df435ec5a186ad75732a7ba272d8c3c8cf2b060cf6396aa365043a6688ec)) from option `default` expressions into explicit `config` assignments. The resolved absolute path is now set unconditionally via config rather than as a default, which raises its merge priority. Also removes the unused `pkgs` parameter from the NFS module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3995d78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->