### PR TITLE
codex: suppress the unstable-features startup warning

### DIFF
--- a/doc/codex/overview.md
+++ b/doc/codex/overview.md
@@ -47,6 +47,10 @@ Defaults bump multi-agent fan-out well above stock:
   the v2 feature because v2 rejects `agents.max_threads`.
 - `agents.max_depth = 3` (parent -> child -> grandchild -> great-grandchild),
   still read under v2.
+- `suppress_unstable_features_warning = true`: enabling `multi_agent_v2` is an
+  under-development-feature opt-in, which otherwise makes Codex print an
+  unstable-features warning on every startup. The wrapper silences the warning
+  it causes; a user's own value for the key still wins.
 
 ### Baked MCP servers (`default.nix:62-73`, `80`)
 

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -71,6 +71,11 @@
       max_concurrent_threads_per_session = 16;
     };
     agents.max_depth = 3;
+    # multi_agent_v2 is an under-development feature, so enabling it above
+    # makes Codex print an unstable-features warning on every startup. The
+    # wrapper opts into the feature deliberately, so it silences its own
+    # warning; a user who sets this key keeps their value.
+    suppress_unstable_features_warning = true;
   },
   # MCP servers rendered as soft Codex defaults. A user's own
   # `[mcp_servers.<name>]` config wins per-key through config-launch.

--- a/packages/agent/home-manager/codex.nix
+++ b/packages/agent/home-manager/codex.nix
@@ -96,6 +96,10 @@ in {
           max_concurrent_threads_per_session = 16;
         };
         agents.max_depth = 3;
+        # Enabling multi_agent_v2 above trips Codex's unstable-features
+        # startup warning; suppress it alongside the opt-in (mirrors the
+        # wrapper default in packages/agent/codex/default.nix).
+        suppress_unstable_features_warning = true;
       };
       description = ''
         Lower-priority Codex config rendered through the wrapper's default

--- a/packages/index-delta/src/diff.rs
+++ b/packages/index-delta/src/diff.rs
@@ -251,7 +251,12 @@ fn diff_arrays(
     }
 }
 
-fn indexed(items: &[Value], from: usize) -> impl DoubleEndedIterator<Item = (String, &Value)> {
+/// A rendered array-index segment paired with the element it addresses. A
+/// named alias (not a bare tuple) so `indexed`'s return type satisfies the
+/// workspace's `clippy::anonymous_tuple_return_type`.
+type IndexedItem<'v> = (String, &'v Value);
+
+fn indexed(items: &[Value], from: usize) -> impl DoubleEndedIterator<Item = IndexedItem<'_>> {
     items
         .iter()
         .enumerate()

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -199,6 +199,11 @@
     sandbox_mode = "danger-full-access";
     default_permissions = ":danger-full-access";
     commit_attribution = "";
+    # The features block below opts into under-development features
+    # (multi_agent_v2 et al.); without this Codex warns about them on every
+    # startup. Set here (not just the wrapper soft default) so the seeded
+    # config.toml stays quiet even under a stock codex binary.
+    suppress_unstable_features_warning = true;
     agents.max_depth = 3;
     mcp_servers = codexMcpServers;
     features = {


### PR DESCRIPTION
## Summary

The Codex wrapper and the seeded workstation config both opt into `features.multi_agent_v2`, an under-development feature, so Codex prints this on every startup:

```
⚠ Under-development features enabled: multi_agent_v2. Under-development features are incomplete and may behave
  unpredictably. To suppress this warning, set `suppress_unstable_features_warning = true` in ~/.codex/config.toml.
```

Set `suppress_unstable_features_warning = true` alongside each place that enables the feature:

- `packages/agent/codex/default.nix` — added to the wrapper's soft `settings` defaults, so the warning the wrapper itself causes is silenced while a user's own value for the key still wins (per-leaf detection via config-launch).
- `packages/agent/home-manager/codex.nix` — mirrored into the `programs.codex.defaults` option default, which duplicates the wrapper settings.
- `users/andrewgazelka/profiles/workstation.nix` — added to the seeded `config.toml` (`codexSettings`) so the config stays quiet even when read by a stock codex binary (e.g. the desktop app) rather than through the wrapper.
- `doc/codex/overview.md` — documented the new soft default.

## CI fix ridden along

`flake-check` has been red on main since #2629 landed: llm-clippy's `anonymous_tuple_return_type` (denied workspace-wide) walks the whole return type including impl-trait `Item` bindings, so `index-delta`'s `indexed()` returning `impl DoubleEndedIterator<Item = (String, &Value)>` fails the lint. Fixed here with a named type alias for the pair (the `edit-applier` precedent), since this PR can't go green without it. `cargo test -p index-delta` passes (28/28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B92tDoj1W6V9aq3nv7euB5

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress the unstable-features startup warning in Codex config defaults
> Sets `suppress_unstable_features_warning = true` in the Codex wrapper defaults ([default.nix](https://github.com/indexable-inc/index/pull/2641/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5)), the Home Manager module ([codex.nix](https://github.com/indexable-inc/index/pull/2641/files#diff-fa4eb9472b4a8e65174c3cc1db7317dbe279f7d3c22a5a688cdb437e2a6e6628)), and the workstation user profile. This silences the startup warning that `multi_agent_v2` triggers; user config can still override the key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4fd518.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->