### PR TITLE
playbook: document API catalog DataFrame migration

### DIFF
--- a/playbook/src/routes/api-catalog-dataframe/+page.svx
+++ b/playbook/src/routes/api-catalog-dataframe/+page.svx
@@ -1,0 +1,47 @@
+---
+title: "API discovery as a DataFrame"
+date: 2026-07-10
+---
+
+The index notebook API catalog now has one discovery surface: `api()` returns
+the complete Polars DataFrame. Callers inspect and filter structured columns
+instead of passing a hidden string selector such as `api("beeper")`.
+
+## Usage
+
+```python
+catalog = api()
+catalog.filter(pl.col("where") == "beeper")
+catalog.filter(pl.col("name").str.contains("send|search"))
+```
+
+The catalog exposes `where`, `name`, `kind`, `sig`, and `summary`. This makes
+capability discovery visible in the notebook, supports normal DataFrame
+operations, and avoids a second selector language maintained inside `api`.
+An unknown integration is an empty filter result, not a special fallback path.
+
+## Shipped contract
+
+- `api()` accepts no arguments and always returns `pl.DataFrame`.
+- Polars is a required runtime dependency.
+- Runtime guidance, shell hints, smoke tests, type checks, and personal agent
+  instructions use DataFrame filtering.
+- The package build, runtime smoke, typecheck smoke, repository lint, and full
+  flake check passed before merge.
+
+## CI evidence
+
+Landing exposed two unrelated main-branch regressions in Darwin module option
+defaults and `index-delta` Clippy policy. PR #2639 repaired both before PR #2631
+merged.
+
+The remaining delay came from the self-hosted CI dispatcher. Read-only service
+and journal checks showed a healthy dispatcher at its eight-runner limit. Later,
+five systemd runner units were still active after GitHub had marked their runs
+terminal. Stopping only those terminal units released capacity and allowed the
+required flake check to start and pass. Queue fairness and terminal unit cleanup
+remain tracked in issue #2644.
+
+Issues #2627 and #2644. PRs #2631 and #2639.
+
+*Written by Codex, an AI coding agent.*


### PR DESCRIPTION
Closes #2648

Documents the shipped `api()` DataFrame contract and the CI runner evidence that unblocked #2631.

Validation: `nix run .#lint`

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add documentation page for API catalog DataFrame migration
> Adds a new mdsvex page at `/api-catalog-dataframe` in the playbook documenting the `api()` function that returns a Polars DataFrame. The page includes usage examples with Polars filtering, the shipped contract, and CI evidence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 559cca5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->