### PR TITLE
provenance: fix module dedup, launchd plist paths, whence lookup jank

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -437,6 +437,11 @@
       inherit indexPackages;
       portableServicesModule = ix.portableServices.homeModule;
     };
+    # One instance shared by every wiring site (the workstation profile and
+    # homeModules.provenance); the module's `key` also dedups the instances a
+    # consumer combines, but there is no reason to make them re-apply the
+    # walker.
+    provenanceHomeModule = import ./modules/home/provenance.nix {inherit (ix) provenance;};
     claudeCodeHomeModule = import ./packages/agent/home-manager/claude-code.nix {
       inherit indexPackages;
       promptModule = ./packages/agent/prompt;
@@ -458,7 +463,7 @@
       inherit indexPackages personalServicesModule ix;
       configRoot = personalConfigRoot;
       mutableFilesModule = mutableFilesHomeModule;
-      provenanceModule = import ./modules/home/provenance.nix {inherit (ix) provenance;};
+      provenanceModule = provenanceHomeModule;
       optionsModule = personalOptionsModule;
       indexSkillsSrc = paths.skills;
       tmuxModule = ./modules/home/tmux.nix;
@@ -577,7 +582,7 @@
       # file:line that defined them, and `whence <path>` reads it with zero
       # eval. Set `provenance.rev = self.rev or self.dirtyRev or null` in
       # the consuming flake. See modules/home/provenance.nix.
-      provenance = import ./modules/home/provenance.nix {inherit (ix) provenance;};
+      provenance = provenanceHomeModule;
       # Agent CLI modules: Home Manager is the user-facing configuration
       # surface, while the package wrappers remain the implementation detail.
       claude-code = claudeCodeHomeModule;

--- a/lib/provenance.nix
+++ b/lib/provenance.nix
@@ -130,27 +130,34 @@
             || !(settings ? definitionsWithLocations)
             || settings.definitionsWithLocations == []
           then []
-          else [
-            {
+          else let
+            declarations = map (decl: discard (toString decl)) settings.declarations;
+            definitions =
+              map (
+                def: let
+                  names =
+                    if builtins.isAttrs def.value
+                    then builtins.attrNames def.value
+                    else [];
+                  pos =
+                    if names == []
+                    then null
+                    else builtins.unsafeGetAttrPos (builtins.head names) def.value;
+                in
+                  site def.file pos
+              )
+              settings.definitionsWithLocations;
+            # A definition made by a declaring module is the wiring module
+            # populating its own option (programs.git filling settings from
+            # userName, say), not the user configuring it; a chain with only
+            # such definitions would claim a settings site the user never
+            # wrote.
+            userDefined = lib.any (def: !(lib.elem def.file declarations)) definitions;
+          in
+            lib.optional userDefined {
               option = "programs.${name}.settings";
-              declarations = map (decl: discard (toString decl)) settings.declarations;
-              definitions =
-                map (
-                  def: let
-                    names =
-                      if builtins.isAttrs def.value
-                      then builtins.attrNames def.value
-                      else [];
-                    pos =
-                      if names == []
-                      then null
-                      else builtins.unsafeGetAttrPos (builtins.head names) def.value;
-                  in
-                    site def.file pos
-                )
-                settings.definitionsWithLocations;
+              inherit declarations definitions;
             }
-          ]
       ) (builtins.attrNames options.programs);
 
   mergeEntry = prev: entry:
@@ -195,11 +202,12 @@ in {
       path = _name: value: relativeTo home value.target;
       source = _name: value: value.source or null;
     }
-    # home-manager on darwin: agents are written per attr name under the
-    # user's LaunchAgents directory.
+    # home-manager on darwin: the deployed plist is named after the agent's
+    # Label (default "org.nix-community.home.<name>"), not the attr name;
+    # keying by name would give entries no deployed file ever matches.
     ++ collect {
       optionPath = ["launchd" "agents"];
-      path = name: _value: "Library/LaunchAgents/${name}.plist";
+      path = _name: value: "Library/LaunchAgents/${value.config.Label}.plist";
     };
 
   # File collectors for an evaluated nix-darwin configuration.
@@ -208,7 +216,10 @@ in {
     config,
   }: let
     collect = walkOption {inherit options config;};
-    label = name: value: value.serviceConfig.Label or "org.nixos.${name}";
+    # nix-darwin always sets serviceConfig.Label (mkDefault
+    # "${labelPrefix}.${name}"), so read it directly: a hardcoded fallback
+    # would silently diverge from a consumer's launchd.labelPrefix.
+    label = value: value.serviceConfig.Label;
   in
     collect {
       optionPath = ["environment" "etc"];
@@ -217,12 +228,12 @@ in {
     }
     ++ collect {
       optionPath = ["launchd" "agents"];
-      path = name: value: "/Library/LaunchAgents/${label name value}.plist";
+      path = _name: value: "/Library/LaunchAgents/${label value}.plist";
       enabled = _value: true;
     }
     ++ collect {
       optionPath = ["launchd" "daemons"];
-      path = name: value: "/Library/LaunchDaemons/${label name value}.plist";
+      path = _name: value: "/Library/LaunchDaemons/${label value}.plist";
       enabled = _value: true;
     };
 

--- a/modules/darwin/provenance.nix
+++ b/modules/darwin/provenance.nix
@@ -9,55 +9,68 @@
 # file stays importable as a bare module argument set; see the flake's
 # homeModules/darwinModules wiring.
 {provenance}: {
-  config,
-  options,
-  lib,
-  pkgs,
-  ...
-}: let
-  cfg = config.provenance;
-in {
-  options.provenance = {
-    enable = lib.mkEnableOption "baking a provenance manifest (deployed path -> defining nix file:line) into each generation";
+  # Applying the walker makes every import site a distinct anonymous attrset,
+  # which the module system cannot deduplicate the way it dedups plain
+  # `imports = [ ./file.nix ]` by path. Two instances in one configuration
+  # then both declare `provenance.*` and eval dies with "already declared in
+  # `<unknown-file>'". The explicit `key` restores dedup; `_file` restores
+  # error attribution.
+  key = "index/modules/darwin/provenance.nix";
+  _file = "index/modules/darwin/provenance.nix";
 
-    rev = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      example = lib.literalExpression "self.rev or self.dirtyRev or null";
-      description = ''
-        Configuration flake revision recorded on every manifest entry, so
-        `whence` can print which checkout defined a file. Pass
-        `self.rev or self.dirtyRev or null` from the consuming flake.
-      '';
-    };
+  imports = [
+    ({
+      config,
+      options,
+      lib,
+      pkgs,
+      ...
+    }: let
+      cfg = config.provenance;
+    in {
+      options.provenance = {
+        enable = lib.mkEnableOption "baking a provenance manifest (deployed path -> defining nix file:line) into each generation";
 
-    entries = lib.mkOption {
-      type = lib.types.raw;
-      internal = true;
-      readOnly = true;
-      default = provenance.manifestFor {
-        inherit options;
-        inherit (cfg) rev;
-        entries = provenance.darwinCollectors {inherit options config;};
+        rev = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = lib.literalExpression "self.rev or self.dirtyRev or null";
+          description = ''
+            Configuration flake revision recorded on every manifest entry, so
+            `whence` can print which checkout defined a file. Pass
+            `self.rev or self.dirtyRev or null` from the consuming flake.
+          '';
+        };
+
+        entries = lib.mkOption {
+          type = lib.types.raw;
+          internal = true;
+          readOnly = true;
+          default = provenance.manifestFor {
+            inherit options;
+            inherit (cfg) rev;
+            entries = provenance.darwinCollectors {inherit options config;};
+          };
+          description = "Rendered manifest attrset (deployed path -> provenance).";
+        };
+
+        manifest = lib.mkOption {
+          type = lib.types.package;
+          internal = true;
+          readOnly = true;
+          default = (pkgs.formats.json {}).generate "provenance.json" cfg.entries;
+          description = "The provenance.json for this generation.";
+        };
       };
-      description = "Rendered manifest attrset (deployed path -> provenance).";
-    };
 
-    manifest = lib.mkOption {
-      type = lib.types.package;
-      internal = true;
-      readOnly = true;
-      default = (pkgs.formats.json {}).generate "provenance.json" cfg.entries;
-      description = "The provenance.json for this generation.";
-    };
-  };
-
-  # `system.systemBuilderCommands` (not `environment.etc`): the walker reads
-  # `environment.etc`, so materializing the manifest through it would make
-  # the manifest an input of itself.
-  config = lib.mkIf cfg.enable {
-    system.systemBuilderCommands = ''
-      ln -s ${cfg.manifest} $out/provenance.json
-    '';
-  };
+      # `system.systemBuilderCommands` (not `environment.etc`): the walker reads
+      # `environment.etc`, so materializing the manifest through it would make
+      # the manifest an input of itself.
+      config = lib.mkIf cfg.enable {
+        system.systemBuilderCommands = ''
+          ln -s ${cfg.manifest} $out/provenance.json
+        '';
+      };
+    })
+  ];
 }

--- a/modules/home/provenance.nix
+++ b/modules/home/provenance.nix
@@ -15,55 +15,68 @@
 # file stays importable as a bare module argument set; see the flake's
 # homeModules/darwinModules wiring.
 {provenance}: {
-  config,
-  options,
-  lib,
-  pkgs,
-  ...
-}: let
-  cfg = config.provenance;
-in {
-  options.provenance = {
-    enable = lib.mkEnableOption "baking a provenance manifest (deployed path -> defining nix file:line) into each generation";
+  # Applying the walker makes every import site a distinct anonymous attrset,
+  # which the module system cannot deduplicate the way it dedups plain
+  # `imports = [ ./file.nix ]` by path. Two instances in one configuration (a
+  # bundled profile plus homeModules.provenance, say) then both declare
+  # `provenance.*` and eval dies with "already declared in `<unknown-file>'".
+  # The explicit `key` restores dedup; `_file` restores error attribution.
+  key = "index/modules/home/provenance.nix";
+  _file = "index/modules/home/provenance.nix";
 
-    rev = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      example = lib.literalExpression "self.rev or self.dirtyRev or null";
-      description = ''
-        Configuration flake revision recorded on every manifest entry, so
-        `whence` can print which checkout defined a file. Pass
-        `self.rev or self.dirtyRev or null` from the consuming flake.
-      '';
-    };
+  imports = [
+    ({
+      config,
+      options,
+      lib,
+      pkgs,
+      ...
+    }: let
+      cfg = config.provenance;
+    in {
+      options.provenance = {
+        enable = lib.mkEnableOption "baking a provenance manifest (deployed path -> defining nix file:line) into each generation";
 
-    entries = lib.mkOption {
-      type = lib.types.raw;
-      internal = true;
-      readOnly = true;
-      default = provenance.manifestFor {
-        inherit options;
-        inherit (cfg) rev;
-        entries = provenance.homeCollectors {inherit options config;};
+        rev = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = lib.literalExpression "self.rev or self.dirtyRev or null";
+          description = ''
+            Configuration flake revision recorded on every manifest entry, so
+            `whence` can print which checkout defined a file. Pass
+            `self.rev or self.dirtyRev or null` from the consuming flake.
+          '';
+        };
+
+        entries = lib.mkOption {
+          type = lib.types.raw;
+          internal = true;
+          readOnly = true;
+          default = provenance.manifestFor {
+            inherit options;
+            inherit (cfg) rev;
+            entries = provenance.homeCollectors {inherit options config;};
+          };
+          description = "Rendered manifest attrset (deployed path -> provenance).";
+        };
+
+        manifest = lib.mkOption {
+          type = lib.types.package;
+          internal = true;
+          readOnly = true;
+          default = (pkgs.formats.json {}).generate "provenance.json" cfg.entries;
+          description = "The provenance.json for this generation.";
+        };
       };
-      description = "Rendered manifest attrset (deployed path -> provenance).";
-    };
 
-    manifest = lib.mkOption {
-      type = lib.types.package;
-      internal = true;
-      readOnly = true;
-      default = (pkgs.formats.json {}).generate "provenance.json" cfg.entries;
-      description = "The provenance.json for this generation.";
-    };
-  };
-
-  # `home.extraBuilderCommands` (not `home.file`): the walker reads
-  # `home.file`, so materializing the manifest through it would make the
-  # manifest an input of itself.
-  config = lib.mkIf cfg.enable {
-    home.extraBuilderCommands = ''
-      ln -s ${cfg.manifest} $out/provenance.json
-    '';
-  };
+      # `home.extraBuilderCommands` (not `home.file`): the walker reads
+      # `home.file`, so materializing the manifest through it would make the
+      # manifest an input of itself.
+      config = lib.mkIf cfg.enable {
+        home.extraBuilderCommands = ''
+          ln -s ${cfg.manifest} $out/provenance.json
+        '';
+      };
+    })
+  ];
 }

--- a/packages/nix/whence/default.nix
+++ b/packages/nix/whence/default.nix
@@ -34,12 +34,14 @@ writeNushellApplication {
       }
     }
 
-    # Manifests of the live generations: the home-manager profile's and, on
-    # darwin, the running system's.
+    # Manifests of the live generations: the home-manager profile's (XDG
+    # location, plus the pre-XDG per-user profile older installs still use)
+    # and, on darwin, the running system's.
     def manifests [] {
       let state_home = ($env.XDG_STATE_HOME? | default ($env.HOME | path join ".local" "state"))
       [
         ($state_home | path join "nix" "profiles" "home-manager" "provenance.json")
+        $"/nix/var/nix/profiles/per-user/($env.USER)/home-manager/provenance.json"
         "/run/current-system/provenance.json"
       ] | where {|it| $it | path exists }
     }
@@ -86,7 +88,9 @@ writeNushellApplication {
     }
 
     def main [path: string] {
-      let home = $env.HOME
+      # A trailing slash on HOME would make the ($home)/ prefix tests below
+      # miss every home file.
+      let home = ($env.HOME | str trim --right --char '/')
       # Logical absolute path (no symlink resolution): manifest keys are
       # deployment targets, which are themselves symlinks into the store.
       let logical = ($path | path expand --no-symlink)

--- a/tests/provenance.nix
+++ b/tests/provenance.nix
@@ -20,6 +20,11 @@
       inherit pkgs;
       modules = [
         (import (paths.root + "/modules/home/provenance.nix") {inherit (ix) provenance;})
+        # Second distinct instance (a bundled profile plus homeModules.provenance,
+        # say): each application of the walker is an anonymous attrset the module
+        # system cannot dedup by path, so without the module's explicit `key`
+        # this eval dies with "provenance.enable already declared".
+        (import (paths.root + "/modules/home/provenance.nix") {inherit (ix) provenance;})
         ./fixtures/provenance-home.nix
         {
           provenance = {


### PR DESCRIPTION
Closes ENG-6624

Review of the `whence` eval-provenance stack (lib/provenance.nix + the two
`provenance.nix` modules + `packages/nix/whence`, shipped in #2423/#2426).
Ran an adversarial pass; found and fixed real jank in five places. All the
eval assertions and the four Nix lint stages (alejandra, astlog, deadnix,
statix) pass.

## Fixes

**Module dedup (correctness).** `modules/{home,darwin}/provenance.nix` are
functors `{provenance}: { ... }`. Applying the walker turns every import site
into a distinct *anonymous* attrset, which the module system cannot
deduplicate the way it dedups `imports = [ ./file.nix ]` by path. Combine a
bundled profile that pulls the module with `homeModules.provenance` (exactly
what a consumer does) and both instances declare `provenance.*`, so eval dies
with `The option 'provenance.enable' ... has already been declared`. Fix: an
explicit `key` restores dedup and `_file` restores error attribution; the
flake also shares a single `provenanceHomeModule` instance across its own
wiring sites. Regression test added (`tests/provenance.nix` now imports the
module twice).

**home-manager launchd plist path (correctness).** The home collector keyed
launchd agents as `Library/LaunchAgents/<attr-name>.plist`, but home-manager
deploys the plist named after the agent's `Label`
(default `org.nix-community.home.<name>`). The manifest key matched no
deployed file, so `whence ~/Library/LaunchAgents/...plist` on any agent fell
through to the deriver fallback. Now keys by `value.config.Label`.

**nix-darwin label guess (fail-loud).** The darwin collector hardcoded a
`org.nixos.<name>` fallback label. nix-darwin always sets
`serviceConfig.Label` (`mkDefault "${labelPrefix}.${name}"`), so the code now
reads it directly rather than silently diverging from a consumer's
`launchd.labelPrefix`.

**whence lookup (robustness).** `manifests` now also reads the pre-XDG
per-user profile manifest that older installs still use, and `main` trims a
trailing slash from `$HOME` so the `($home)/` prefix tests cannot miss every
home file.

**spurious settings chains.** A `programs.<x>.settings` chain whose only
definitions come from the declaring (wiring) module is the module populating
its own option, not the user configuring it. Such chains no longer claim a
settings site the user never wrote.

## Left alone (with reasons)

- **cwd-relative `whence` arg** - `path expand` resolving against cwd is
  standard shell semantics, not a bug.
- **`relativeTo` empty-base branch** - latent only; no current collector
  reaches it.
- **options.json cosmetic warning** - not worth a diff.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix module dedup, launchd plist paths, and manifest lookup in provenance
> - Adds explicit `key` and `_file` attributes to [modules/home/provenance.nix](https://github.com/indexable-inc/index/pull/2663/files#diff-40ac76caab7f7d53cb712be6b64a9d8068c15ab4bab93b52d250cb4d549febf8) and [modules/darwin/provenance.nix](https://github.com/indexable-inc/index/pull/2663/files#diff-179eea52238df67eb7e27dc0ba6fc908d263c1d4f8cea8f2f5f4523f88788c95) so the module system deduplicates instances and avoids "already declared" errors on repeated imports.
> - Fixes launchd plist manifest keys to use the configured `Label` (e.g. `value.config.Label` for Home Manager, `value.serviceConfig.Label` for nix-darwin) instead of the attribute name, so keys match deployed filenames.
> - Fixes `programs.*.settings` entries in `provenance.manifestFor` to only appear when the value is defined outside the declaring module, filtering out self-defined defaults.
> - Extends `whence` manifest discovery to include pre-XDG Home Manager profile paths and trims trailing slashes from `$HOME` during path comparisons.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bc0856.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->