### PR TITLE
mcp: per-serve kernels behind a host seam; ray-hosted kernel actors

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2625,6 +2625,9 @@
       # The kernel host seam: local/ray selection, the actor's connection-info
       # plumbing (str HMAC key), offset-scoped trace reads.
       cp ${./tests/test_kernel_host.py} test_kernel_host.py
+      # The kernel's board lease: registration placement facts (kernel_host,
+      # node) and the writer's heartbeat_ms beat, agent idle-clock untouched.
+      cp ${./tests/test_store_kernel_lease.py} test_store_kernel_lease.py
       # Issue #2430: a cell rebinding/deleting a kernel builtin gets it restored.
       cp ${./tests/test_builtin_shadow_restore.py} test_builtin_shadow_restore.py
       # Issue #2526: a failed cell's traceback names the bindings it never reached.
@@ -2646,6 +2649,7 @@
         test_build_info.py \
         test_kernel_trace_path.py \
         test_kernel_host.py \
+        test_store_kernel_lease.py \
         test_builtin_shadow_restore.py \
         test_unexecuted_note.py \
         test_pr_watch_automerge.py \

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2586,7 +2586,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542) + nu input= routing past no-input statements (#2540)";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542) + nu input= routing past no-input statements (#2540) + kernel host seam: local child vs ray actor";
     }
     ''
       export HOME=$TMPDIR/home
@@ -2622,6 +2622,9 @@
       cp ${./tests/test_build_info.py} test_build_info.py
       # Issue #2355: per-serve kernel trace file + sweep of orphaned dumps.
       cp ${./tests/test_kernel_trace_path.py} test_kernel_trace_path.py
+      # The kernel host seam: local/ray selection, the actor's connection-info
+      # plumbing (str HMAC key), offset-scoped trace reads.
+      cp ${./tests/test_kernel_host.py} test_kernel_host.py
       # Issue #2430: a cell rebinding/deleting a kernel builtin gets it restored.
       cp ${./tests/test_builtin_shadow_restore.py} test_builtin_shadow_restore.py
       # Issue #2526: a failed cell's traceback names the bindings it never reached.
@@ -2642,6 +2645,7 @@
         test_sh_module.py \
         test_build_info.py \
         test_kernel_trace_path.py \
+        test_kernel_host.py \
         test_builtin_shadow_restore.py \
         test_unexecuted_note.py \
         test_pr_watch_automerge.py \

--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -508,6 +508,7 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
         exec_token=_exec_token(),
         exec_trust_network=_exec_trust_network(),
         server_session_id=server_session_id,
+        kernel_host=os.environ.get("IX_MCP_KERNEL", "local"),
     )
     set_config(cfg)
 

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -197,6 +197,11 @@ class Config:
     # restore (load the checkpoint, replay the gap) before running new cells.
     session_resume: bool = False
 
+    # Where the kernel process runs: "local" (a direct child of this serve, the
+    # default) or "ray" (a KernelActor on the fleet's Ray cluster, one per
+    # serve; see kernel_host.py). Wired from the IX_MCP_KERNEL env var by the CLI.
+    kernel_host: str = "local"
+
     # This machine's tailscale IPv4, resolved once by the CLI, or None when
     # tailscale is absent or its backend is down. The `/mesh` endpoint binds
     # ONLY this address (index#1787): the tailnet is the trust boundary, and

--- a/packages/mcp/ix_notebook_mcp/kernel.py
+++ b/packages/mcp/ix_notebook_mcp/kernel.py
@@ -22,24 +22,19 @@ from __future__ import annotations
 import ast
 import asyncio
 import contextlib
-import os
 import signal
 import sys
-from pathlib import Path
 
-from .config import Config, runtime_dir
+from .config import Config
+from .kernel_host import KernelHost, make_kernel_host
 from .outputs import job_summary, output_from_message
 
 _READY_TIMEOUT = 60.0
 
-# Env var carrying the path the kernel's faulthandler writes all-thread stacks to
-# on SIGUSR1. The server sets it before launching the kernel and reads it back in
-# ``dump_trace``; the kernel-side runtime registers the handler (``runtime``).
-TRACE_ENV = "IX_MCP_KERNEL_TRACE"
-
 # How often the death watch polls the kernel child (a waitpid(WNOHANG) via the
-# provisioner: cheap). Small enough that an external kill surfaces as the precise
-# death error within the same breath, not after a 35s transport timeout.
+# host's liveness primitive: cheap locally, one small actor call on ray). Small
+# enough that an external kill surfaces as the precise death error within the
+# same breath, not after a 35s transport timeout.
 _WATCH_INTERVAL = 0.5
 
 
@@ -60,31 +55,6 @@ def _describe_exit(returncode: int | None) -> str:
         except ValueError:
             return f"signal {-returncode}"
     return f"exit code {returncode}"
-
-
-def trace_path_for(server_pid: int) -> Path:
-    """The faulthandler dump target for the serve owning ``server_pid``. One
-    file per serve, not one machine-wide name: concurrent kernels sharing a
-    path truncate and interleave each other's dumps (index#2355)."""
-    return runtime_dir() / f"kernel-trace-{server_pid}.txt"
-
-
-def _sweep_stale_traces() -> None:
-    """Drop trace files orphaned by serves that are gone: a SIGKILLed serve
-    never reaches shutdown(), so its file would linger in runtime_dir()
-    forever. The legacy fixed-name ``kernel-trace.txt`` (no pid suffix) is
-    left alone for still-running older builds."""
-    for path in runtime_dir().glob("kernel-trace-*.txt"):
-        try:
-            pid = int(path.stem.rsplit("-", 1)[-1])
-        except ValueError:
-            continue
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            path.unlink(missing_ok=True)
-        except PermissionError:
-            continue  # a live process we cannot signal: not ours to sweep
 
 
 # What the wedge rescue actually achieved, verified rather than assumed
@@ -146,11 +116,10 @@ def _wedged_summary(budget: float, grace: float, deadline: float, *, outcome: st
 class Kernel:
     def __init__(self, config: Config) -> None:
         self._config = config
-        self._km = None
+        self._host: KernelHost = make_kernel_host(config.kernel_host)
         self._kc = None
         self._lock = asyncio.Lock()
         self._trace_lock = asyncio.Lock()
-        self._trace_path: Path | None = None
         self._pid: int | None = None
         # Death-watch state: `_death` is the rendered cause while the kernel is
         # down (entry guard), `_death_event` fails calls already in flight, and
@@ -171,73 +140,47 @@ class Kernel:
         self._restarting = False
 
     async def start(self) -> None:
-        from jupyter_client.manager import AsyncKernelManager
-
-        # Point the kernel's faulthandler at a private file before launch; the
-        # kernel inherits this env and registers the SIGUSR1 dump handler. The
-        # name carries this server's pid: every serve on the machine shares
-        # runtime_dir(), and one fixed name had concurrent kernels truncating
-        # and interleaving each other's dumps, so kernel_trace could return a
-        # different session's stacks (index#2355).
-        self._trace_path = trace_path_for(os.getpid())
-        os.environ[TRACE_ENV] = str(self._trace_path)
-        _sweep_stale_traces()
-
-        self._km = AsyncKernelManager(kernel_name="python3")
-        await self._km.start_kernel(cwd=str(self._config.workdir))
-        self._pid = self._kernel_pid()
-        self._kc = self._km.client()
+        await self._host.start(self._config.workdir)
+        self._pid = self._host.pid
+        self._kc = self._host.client()
         self._kc.start_channels()
         await self._kc.wait_for_ready(timeout=_READY_TIMEOUT)
         # Watch the child we just spawned so an external kill is noticed the
         # moment it happens, not at the next execute's timeout (index#2339).
         self._watch_task = asyncio.ensure_future(self._watch())
 
-    def _kernel_pid(self) -> int | None:
-        """The kernel process's pid, so a trace signal targets that process alone
-        (not the kernel's process group, whose default SIGUSR1 would terminate
-        user-launched subprocesses)."""
-        provisioner = getattr(self._km, "provisioner", None)
-        pid = getattr(provisioner, "pid", None)
-        if pid is None:
-            pid = getattr(getattr(self._km, "kernel", None), "pid", None)
-        return pid
-
     async def dump_trace(self, timeout: float = 5.0) -> str:
         """All-thread Python stack of the kernel, captured via faulthandler on
         SIGUSR1. Works even when a synchronous call has wedged the event loop:
         the C-level handler runs in signal context, so it dumps while the main
         thread is still parked in the blocking call. Returns the newest dump."""
-        if self._km is None or self._trace_path is None or self._pid is None:
+        if not self._host.running or self._pid is None:
             return "kernel is not running"
         if self._death is not None:
             return f"kernel process is gone: {self._death}"
-        path = self._trace_path
         # Serialize dumps: two concurrent traces share the same `before` offset and
         # would each read both appended dumps. The lock keeps each dump clean.
         async with self._trace_lock:
-            before = path.stat().st_size if path.exists() else 0
-            try:
-                os.kill(self._pid, signal.SIGUSR1)
-            except ProcessLookupError:
+            before = await self._host.trace_size()
+            if not await self._host.send_signal(signal.SIGUSR1):
                 return "kernel process is not alive"
             loop = asyncio.get_running_loop()
             deadline = loop.time() + timeout
             while loop.time() < deadline:
                 await asyncio.sleep(0.05)
                 # The signal may have gone to a zombie (a killed child not yet
-                # reaped): os.kill succeeds but nothing can ever dump. The death
+                # reaped): delivery succeeds but nothing can ever dump. The death
                 # watch reaps and flags it within its poll interval; report the
                 # death instead of waiting out the deadline (index#2339).
                 if self._death is not None:
                     return f"kernel process is gone: {self._death}"
-                if path.exists() and path.stat().st_size > before:
+                if await self._host.trace_size() > before:
                     # A short settle so the whole multi-thread dump has flushed.
                     await asyncio.sleep(0.05)
-                    return path.read_text()[before:].strip() or "(empty trace)"
+                    return (await self._host.trace_read(before)).strip() or "(empty trace)"
         # No dump and no flagged death: distinguish a gone process (say so
         # plainly) from a live kernel that cannot service signals.
-        if self._death is not None or not await self._km.is_alive():
+        if self._death is not None or not await self._host.is_alive():
             return "kernel process is gone: " + (self._death or f"kernel died (pid {self._pid})")
         return (
             f"No trace was produced within {timeout:.0f}s. The kernel may not have "
@@ -475,11 +418,7 @@ class Kernel:
         (index#2375). Callers must verify with :meth:`_probe_idle`."""
         if self._pid is None:
             return False
-        try:
-            os.kill(self._pid, signal.SIGUSR2)
-        except ProcessLookupError:
-            return False
-        return True
+        return await self._host.send_signal(signal.SIGUSR2)
 
     async def _probe_idle(self, timeout: float | None = None) -> bool:
         """Whether the kernel answers a trivial execute, i.e. a rescue attempt
@@ -527,14 +466,6 @@ class Kernel:
         if self._death is not None:
             raise KernelDiedError(self._death)
 
-    def _exit_code(self) -> int | None:
-        """The dead kernel's returncode (negative: killed by that signal), read
-        from the Popen the provisioner's liveness poll reaped."""
-        provisioner = getattr(self._km, "provisioner", None)
-        process = getattr(provisioner, "process", None)
-        code = getattr(process, "returncode", None)
-        return code if isinstance(code, int) else None
-
     async def _watch(self) -> None:
         """Notice the kernel child exiting the moment it happens.
 
@@ -547,17 +478,16 @@ class Kernel:
         journald), and respawn immediately."""
         while True:
             await asyncio.sleep(_WATCH_INTERVAL)
-            km = self._km
-            if km is None:
+            if not self._host.running:
                 return
             try:
-                alive = await km.is_alive()
+                alive = await self._host.is_alive()
             except Exception:  # noqa: S112 -- a transient introspection error must not end the lifetime watch
                 continue
             if alive:
                 continue
             pid = self._pid
-            cause = _describe_exit(self._exit_code())
+            cause = _describe_exit(await self._host.exit_code())
             self._death = f"kernel died (pid {pid}, {cause}); respawning"
             self._death_event.set()
             print(f"[ix-mcp] {self._death}", file=sys.stderr, flush=True)
@@ -592,14 +522,14 @@ class Kernel:
         directory having been deleted since (index#2120). The new kernel re-runs
         install() and re-opens the trace file.
         """
-        if self._km is None:
+        if not self._host.running:
             return
         async with self._lock:
-            await self._km.restart_kernel(now=True, cwd=str(self._config.workdir))
-            self._pid = self._kernel_pid()
+            await self._host.restart(self._config.workdir)
+            self._pid = self._host.pid
             if self._kc is not None:
                 self._kc.stop_channels()
-            self._kc = self._km.client()
+            self._kc = self._host.client()
             self._kc.start_channels()
             await self._kc.wait_for_ready(timeout=_READY_TIMEOUT)
         # The new process is alive: in-flight racing stops now (fresh event); the
@@ -634,7 +564,7 @@ class Kernel:
         blocked, where the snapshot attempt would only burn its timeout.
         Returns the old pid, the new pid, and the elapsed seconds.
         """
-        if self._km is None:
+        if not self._host.running:
             raise RuntimeError("the kernel is not running")
         if self._restarting:
             raise RuntimeError("a kernel restart is already in progress")
@@ -686,14 +616,7 @@ class Kernel:
             self._watch_task = None
         if self._kc is not None:
             self._kc.stop_channels()
-        if self._km is not None:
-            await self._km.shutdown_kernel(now=True)
-        # This serve owns its trace file (the name carries our pid): remove it
-        # so clean exits leave nothing behind; SIGKILLed serves are covered by
-        # the sweep at the next start().
-        if self._trace_path is not None:
-            self._trace_path.unlink(missing_ok=True)
-            self._trace_path = None
+        await self._host.shutdown()
 
 
 async def restore_with_lock(kernel: Kernel, locked: asyncio.Event, context: str) -> None:

--- a/packages/mcp/ix_notebook_mcp/kernel_host.py
+++ b/packages/mcp/ix_notebook_mcp/kernel_host.py
@@ -162,7 +162,7 @@ class LocalKernelHost(KernelHost):
     def running(self) -> bool:
         return self._km is not None
 
-    async def start(self, workdir: Path) -> None:
+    async def start(self, workdir: Path, *, ip: str | None = None) -> None:
         from jupyter_client.manager import AsyncKernelManager
 
         # Point the kernel's faulthandler at a private file before launch; the
@@ -176,11 +176,18 @@ class LocalKernelHost(KernelHost):
         _sweep_stale_traces()
 
         self._km = AsyncKernelManager(kernel_name="python3")
+        if ip is not None:
+            self._km.ip = ip
         await self._km.start_kernel(cwd=str(workdir))
         self._pid = _child_pid(self._km)
 
     def client(self) -> AsyncKernelClient:
         return self._km.client()
+
+    def connection_info(self) -> dict:
+        """The kernel's ZMQ connection info as a plain dict (the key stays
+        bytes here; :class:`KernelActor` ships it back to the serve)."""
+        return dict(self._km.get_connection_info(session=False))
 
     async def is_alive(self) -> bool:
         return self._km is not None and bool(await self._km.is_alive())
@@ -229,17 +236,16 @@ class KernelActor:
     """Runs on a fleet node; supervises one ipykernel child there.
 
     Decorated with ``ray.remote`` at spawn time (``RayKernelHost``), never at
-    import, so importing this module costs no Ray. Async methods make it an
-    async actor; each does node-local work the server cannot do remotely:
-    signals, trace-file reads, spawn/restart against the local jupyter
-    provisioner. The connection info it returns carries the node's routable
-    IP, so the server's ZMQ channels reach the kernel directly.
+    import, so importing this module costs no Ray. A thin shell over the same
+    :class:`LocalKernelHost` the serve uses directly -- "local" here means the
+    RAY NODE -- adding only what remoteness demands: env replay, an IPYTHONDIR
+    that exists on this node, a routable bind IP so the serve's ZMQ channels
+    reach the kernel directly, and the connection info shipped back as a
+    plain dict.
     """
 
     def __init__(self) -> None:
-        self._km: Any = None
-        self._pid: int | None = None
-        self._trace_path: Path | None = None
+        self._core = LocalKernelHost()
 
     async def launch(self, workdir: str, env: dict[str, str]) -> dict:
         """Start the kernel on this node; return pid + ZMQ connection info.
@@ -248,82 +254,56 @@ class KernelActor:
         exactly that, so the actor replays it for parity (IX_MCP_STORE, the
         weave/session vars, SSH_AUTH_SOCK). Two entries are node-local and
         re-derived here: the trace path (this actor's pid, this node's
-        runtime_dir) and IPYTHONDIR when the inherited path does not exist on
-        this node (the serve materialized it under ITS runtime_dir).
+        runtime_dir; core.start owns it) and IPYTHONDIR when the inherited
+        path does not exist on this node (the serve materialized it under
+        ITS runtime_dir).
         """
         import ray
 
         os.environ.update(env)
-        self._trace_path = trace_path_for(os.getpid())
-        os.environ[TRACE_ENV] = str(self._trace_path)
-        _sweep_stale_traces()
         ipythondir = env.get("IPYTHONDIR")
         if not ipythondir or not await asyncio.to_thread(Path(ipythondir).exists):
             from .cli import _prepare_ipython_startup
 
             os.environ["IPYTHONDIR"] = str(_prepare_ipython_startup(os.getpid()))
-
-        from jupyter_client.manager import AsyncKernelManager
-
         await asyncio.to_thread(lambda: Path(workdir).mkdir(parents=True, exist_ok=True))
-        self._km = AsyncKernelManager(kernel_name="python3")
         # Bind the kernel's ZMQ sockets on this node's routable IP (the one
         # Ray knows peers reach it by), not loopback: the serve driving this
         # kernel may sit on another node.
-        self._km.ip = ray.util.get_node_ip_address()
-        await self._km.start_kernel(cwd=workdir)
-        self._pid = _child_pid(self._km)
+        await self._core.start(Path(workdir), ip=ray.util.get_node_ip_address())
         return self._info()
 
     def _info(self) -> dict:
-        info = dict(self._km.get_connection_info(session=False))
+        info = self._core.connection_info()
         key = info.get("key", b"")
         # Plain-str payload: bytes round-trip through Ray fine, but a str key
         # keeps the dict JSON-safe for logs/facts; load_connection_info
         # re-encodes it.
         info["key"] = key.decode("ascii") if isinstance(key, bytes) else key
-        return {"pid": self._pid, "connection": info, "node_ip": self._km.ip}
+        return {"pid": self._core.pid, "connection": info, "node_ip": info.get("ip")}
 
     async def relaunch(self, workdir: str) -> dict:
         """A fresh kernel child from the same actor (the respawn primitive)."""
-        await self._km.restart_kernel(now=True, cwd=workdir)
-        self._pid = _child_pid(self._km)
+        await self._core.restart(Path(workdir))
         return self._info()
 
     async def is_alive(self) -> bool:
-        return self._km is not None and bool(await self._km.is_alive())
+        return await self._core.is_alive()
 
     async def exit_code(self) -> int | None:
-        provisioner = getattr(self._km, "provisioner", None)
-        process = getattr(provisioner, "process", None)
-        code = getattr(process, "returncode", None)
-        return code if isinstance(code, int) else None
+        return await self._core.exit_code()
 
     async def send_signal(self, signum: int) -> bool:
-        if self._pid is None:
-            return False
-        try:
-            os.kill(self._pid, signum)
-        except ProcessLookupError:
-            return False
-        return True
+        return await self._core.send_signal(signum)
 
     async def trace_size(self) -> int:
-        path = self._trace_path
-        return path.stat().st_size if path is not None and path.exists() else 0
+        return await self._core.trace_size()
 
     async def trace_read(self, offset: int) -> str:
-        if self._trace_path is None:
-            return ""
-        return self._trace_path.read_text()[offset:]
+        return await self._core.trace_read(offset)
 
     async def shutdown(self) -> None:
-        if self._km is not None:
-            await self._km.shutdown_kernel(now=True)
-            self._km = None
-        if self._trace_path is not None:
-            self._trace_path.unlink(missing_ok=True)
-            self._trace_path = None
+        await self._core.shutdown()
 
 
 class RayKernelHost(KernelHost):

--- a/packages/mcp/ix_notebook_mcp/kernel_host.py
+++ b/packages/mcp/ix_notebook_mcp/kernel_host.py
@@ -1,0 +1,471 @@
+"""Where the kernel process lives: a local child (default) or a Ray actor.
+
+``Kernel`` (kernel.py) drives one ipykernel over jupyter ZMQ and needs a
+handful of process-level primitives around it: spawn, liveness, exit code,
+signals (SIGUSR1 trace / SIGUSR2 interrupt), the faulthandler trace file,
+restart, shutdown. Every one of those is a same-host operation WITH THE
+KERNEL, so they live behind :class:`KernelHost` with two implementations:
+
+- :class:`LocalKernelHost` -- today's shape: the kernel as a direct child of
+  this serve (``AsyncKernelManager``), signals via ``os.kill``, the trace
+  file read off local disk.
+- :class:`RayKernelHost` -- the kernel as the child of a small Ray actor
+  (:class:`KernelActor`) scheduled on the fleet's Ray cluster, one actor per
+  serve. Exec traffic still flows over jupyter ZMQ DIRECTLY from this server
+  to the kernel (the connection file binds the node's routable IP, HMAC key
+  shipped back through the actor); Ray carries only the control plane --
+  spawn/restart/shutdown, liveness, signals, trace reads -- as actor calls.
+
+Selection: ``Config.kernel_host`` (``"local"`` | ``"ray"``), wired from the
+``IX_MCP_KERNEL`` env var by the CLI. Ray mode connects through
+``fleet.connect()`` -- the fleet module's own resolution chain
+(``IX_FLEET_RAY_ADDRESS`` / ``RAY_ADDRESS`` / tailnet probe, loud private
+fallback) -- so ONE convention decides which cluster this machine belongs to.
+
+Lifecycle: the actor handle is OWNED by this server process, never detached,
+so Ray's ownership GC kills the actor -- and with it the kernel child -- the
+moment the serve exits, crashes included. No pidfiles, no orphan reaping.
+The actor reserves no CPU (``num_cpus=0``): an interactive kernel is mostly
+idle, and N claude sessions must not eat N cores of fleet capacity; heavy
+work inside cells fans out as ordinary Ray tasks, which do reserve.
+
+Placement: soft node affinity to THIS node, so the kernel stays next to the
+workdir and the node-local channels it inherits (``IX_MCP_STORE``, loopback
+``WEAVE_URL``, ``IPYTHONDIR`` under runtime_dir). Cross-node placement only
+becomes safe once those channels are network-addressed; the actor already
+regenerates ``IPYTHONDIR`` when the inherited path is absent on its node, and
+soft (not hard) affinity lets a respawn heal onto another node when this one
+cannot host it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import sys
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .config import runtime_dir
+
+if TYPE_CHECKING:
+    from jupyter_client.asynchronous.client import AsyncKernelClient
+
+# Env var carrying the path the kernel's faulthandler writes all-thread stacks
+# to on SIGUSR1. The host sets it before launching the kernel and reads the
+# file back for ``Kernel.dump_trace``; the kernel-side runtime registers the
+# handler (``runtime``).
+TRACE_ENV = "IX_MCP_KERNEL_TRACE"
+
+
+def trace_path_for(server_pid: int) -> Path:
+    """The faulthandler dump target for the serve owning ``server_pid``. One
+    file per serve, not one machine-wide name: concurrent kernels sharing a
+    path truncate and interleave each other's dumps (index#2355)."""
+    return runtime_dir() / f"kernel-trace-{server_pid}.txt"
+
+
+def _sweep_stale_traces() -> None:
+    """Drop trace files orphaned by serves that are gone: a SIGKILLed serve
+    never reaches shutdown(), so its file would linger in runtime_dir()
+    forever. The legacy fixed-name ``kernel-trace.txt`` (no pid suffix) is
+    left alone for still-running older builds."""
+    for path in runtime_dir().glob("kernel-trace-*.txt"):
+        try:
+            pid = int(path.stem.rsplit("-", 1)[-1])
+        except ValueError:
+            continue
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            path.unlink(missing_ok=True)
+        except PermissionError:
+            continue  # a live process we cannot signal: not ours to sweep
+
+
+def _child_pid(km: Any) -> int | None:  # noqa: ANN401 -- jupyter_client's manager has no useful static type here
+    """The kernel process's pid, so a trace signal targets that process alone
+    (not the kernel's process group, whose default SIGUSR1 would terminate
+    user-launched subprocesses)."""
+    provisioner = getattr(km, "provisioner", None)
+    pid = getattr(provisioner, "pid", None)
+    if pid is None:
+        pid = getattr(getattr(km, "kernel", None), "pid", None)
+    return pid
+
+
+class KernelHost(ABC):
+    """Process-level supervision of one ipykernel, wherever it runs."""
+
+    @property
+    @abstractmethod
+    def pid(self) -> int | None:
+        """The kernel process's pid (on the node it runs on)."""
+
+    @property
+    @abstractmethod
+    def running(self) -> bool:
+        """Started and not shut down (says nothing about liveness)."""
+
+    @abstractmethod
+    async def start(self, workdir: Path) -> None:
+        """Launch the kernel; ready to hand out connected clients after."""
+
+    @abstractmethod
+    def client(self) -> AsyncKernelClient:
+        """A fresh client wired to the kernel; caller starts the channels."""
+
+    @abstractmethod
+    async def is_alive(self) -> bool:
+        """Whether the kernel process (and its supervisor) is alive."""
+
+    @abstractmethod
+    async def exit_code(self) -> int | None:
+        """The dead kernel's returncode (negative: killed by that signal)."""
+
+    @abstractmethod
+    async def send_signal(self, signum: int) -> bool:
+        """Deliver ``signum`` to the kernel process; False when it is gone."""
+
+    @abstractmethod
+    async def trace_size(self) -> int:
+        """Current size of the faulthandler trace file (0 when absent)."""
+
+    @abstractmethod
+    async def trace_read(self, offset: int) -> str:
+        """Trace file text past ``offset``."""
+
+    @abstractmethod
+    async def restart(self, workdir: Path) -> None:
+        """A fresh kernel process; ``client()`` reflects it afterwards."""
+
+    @abstractmethod
+    async def shutdown(self) -> None:
+        """Kill the kernel and release everything the host owns."""
+
+
+class LocalKernelHost(KernelHost):
+    """The kernel as a direct child of this serve (the default)."""
+
+    def __init__(self) -> None:
+        self._km: Any = None
+        self._pid: int | None = None
+        self._trace_path: Path | None = None
+
+    @property
+    def pid(self) -> int | None:
+        return self._pid
+
+    @property
+    def running(self) -> bool:
+        return self._km is not None
+
+    async def start(self, workdir: Path) -> None:
+        from jupyter_client.manager import AsyncKernelManager
+
+        # Point the kernel's faulthandler at a private file before launch; the
+        # kernel inherits this env and registers the SIGUSR1 dump handler. The
+        # name carries this server's pid: every serve on the machine shares
+        # runtime_dir(), and one fixed name had concurrent kernels truncating
+        # and interleaving each other's dumps, so kernel_trace could return a
+        # different session's stacks (index#2355).
+        self._trace_path = trace_path_for(os.getpid())
+        os.environ[TRACE_ENV] = str(self._trace_path)
+        _sweep_stale_traces()
+
+        self._km = AsyncKernelManager(kernel_name="python3")
+        await self._km.start_kernel(cwd=str(workdir))
+        self._pid = _child_pid(self._km)
+
+    def client(self) -> AsyncKernelClient:
+        return self._km.client()
+
+    async def is_alive(self) -> bool:
+        return self._km is not None and bool(await self._km.is_alive())
+
+    async def exit_code(self) -> int | None:
+        provisioner = getattr(self._km, "provisioner", None)
+        process = getattr(provisioner, "process", None)
+        code = getattr(process, "returncode", None)
+        return code if isinstance(code, int) else None
+
+    async def send_signal(self, signum: int) -> bool:
+        if self._pid is None:
+            return False
+        try:
+            os.kill(self._pid, signum)
+        except ProcessLookupError:
+            return False
+        return True
+
+    async def trace_size(self) -> int:
+        path = self._trace_path
+        return path.stat().st_size if path is not None and path.exists() else 0
+
+    async def trace_read(self, offset: int) -> str:
+        if self._trace_path is None:
+            return ""
+        return self._trace_path.read_text()[offset:]
+
+    async def restart(self, workdir: Path) -> None:
+        await self._km.restart_kernel(now=True, cwd=str(workdir))
+        self._pid = _child_pid(self._km)
+
+    async def shutdown(self) -> None:
+        if self._km is not None:
+            await self._km.shutdown_kernel(now=True)
+            self._km = None
+        # This serve owns its trace file (the name carries our pid): remove it
+        # so clean exits leave nothing behind; SIGKILLed serves are covered by
+        # the sweep at the next start().
+        if self._trace_path is not None:
+            self._trace_path.unlink(missing_ok=True)
+            self._trace_path = None
+
+
+class KernelActor:
+    """Runs on a fleet node; supervises one ipykernel child there.
+
+    Decorated with ``ray.remote`` at spawn time (``RayKernelHost``), never at
+    import, so importing this module costs no Ray. Async methods make it an
+    async actor; each does node-local work the server cannot do remotely:
+    signals, trace-file reads, spawn/restart against the local jupyter
+    provisioner. The connection info it returns carries the node's routable
+    IP, so the server's ZMQ channels reach the kernel directly.
+    """
+
+    def __init__(self) -> None:
+        self._km: Any = None
+        self._pid: int | None = None
+        self._trace_path: Path | None = None
+
+    async def launch(self, workdir: str, env: dict[str, str]) -> dict:
+        """Start the kernel on this node; return pid + ZMQ connection info.
+
+        ``env`` is the serve's environment: a local kernel child would inherit
+        exactly that, so the actor replays it for parity (IX_MCP_STORE, the
+        weave/session vars, SSH_AUTH_SOCK). Two entries are node-local and
+        re-derived here: the trace path (this actor's pid, this node's
+        runtime_dir) and IPYTHONDIR when the inherited path does not exist on
+        this node (the serve materialized it under ITS runtime_dir).
+        """
+        import ray
+
+        os.environ.update(env)
+        self._trace_path = trace_path_for(os.getpid())
+        os.environ[TRACE_ENV] = str(self._trace_path)
+        _sweep_stale_traces()
+        ipythondir = env.get("IPYTHONDIR")
+        if not ipythondir or not await asyncio.to_thread(Path(ipythondir).exists):
+            from .cli import _prepare_ipython_startup
+
+            os.environ["IPYTHONDIR"] = str(_prepare_ipython_startup(os.getpid()))
+
+        from jupyter_client.manager import AsyncKernelManager
+
+        await asyncio.to_thread(lambda: Path(workdir).mkdir(parents=True, exist_ok=True))
+        self._km = AsyncKernelManager(kernel_name="python3")
+        # Bind the kernel's ZMQ sockets on this node's routable IP (the one
+        # Ray knows peers reach it by), not loopback: the serve driving this
+        # kernel may sit on another node.
+        self._km.ip = ray.util.get_node_ip_address()
+        await self._km.start_kernel(cwd=workdir)
+        self._pid = _child_pid(self._km)
+        return self._info()
+
+    def _info(self) -> dict:
+        info = dict(self._km.get_connection_info(session=False))
+        key = info.get("key", b"")
+        # Plain-str payload: bytes round-trip through Ray fine, but a str key
+        # keeps the dict JSON-safe for logs/facts; load_connection_info
+        # re-encodes it.
+        info["key"] = key.decode("ascii") if isinstance(key, bytes) else key
+        return {"pid": self._pid, "connection": info, "node_ip": self._km.ip}
+
+    async def relaunch(self, workdir: str) -> dict:
+        """A fresh kernel child from the same actor (the respawn primitive)."""
+        await self._km.restart_kernel(now=True, cwd=workdir)
+        self._pid = _child_pid(self._km)
+        return self._info()
+
+    async def is_alive(self) -> bool:
+        return self._km is not None and bool(await self._km.is_alive())
+
+    async def exit_code(self) -> int | None:
+        provisioner = getattr(self._km, "provisioner", None)
+        process = getattr(provisioner, "process", None)
+        code = getattr(process, "returncode", None)
+        return code if isinstance(code, int) else None
+
+    async def send_signal(self, signum: int) -> bool:
+        if self._pid is None:
+            return False
+        try:
+            os.kill(self._pid, signum)
+        except ProcessLookupError:
+            return False
+        return True
+
+    async def trace_size(self) -> int:
+        path = self._trace_path
+        return path.stat().st_size if path is not None and path.exists() else 0
+
+    async def trace_read(self, offset: int) -> str:
+        if self._trace_path is None:
+            return ""
+        return self._trace_path.read_text()[offset:]
+
+    async def shutdown(self) -> None:
+        if self._km is not None:
+            await self._km.shutdown_kernel(now=True)
+            self._km = None
+        if self._trace_path is not None:
+            self._trace_path.unlink(missing_ok=True)
+            self._trace_path = None
+
+
+class RayKernelHost(KernelHost):
+    """The kernel behind a :class:`KernelActor` on the fleet's Ray cluster."""
+
+    def __init__(self) -> None:
+        self._actor: Any = None
+        self._connection: dict | None = None
+        self._pid: int | None = None
+        self._node_ip: str | None = None
+
+    @property
+    def pid(self) -> int | None:
+        return self._pid
+
+    @property
+    def running(self) -> bool:
+        return self._actor is not None
+
+    async def start(self, workdir: Path) -> None:
+        # fleet.connect() blocks (probe + ray.init): keep it off the loop. Ray
+        # state is process-global, so initializing from a worker thread is fine.
+        actor = await asyncio.to_thread(self._spawn_actor)
+        try:
+            info = await actor.launch.remote(str(workdir), dict(os.environ))
+        except BaseException:
+            # A launch that failed (worker env missing a dep, workdir refused)
+            # must not leak a live actor.
+            import ray
+
+            with contextlib.suppress(Exception):
+                ray.kill(actor)
+            raise
+        self._actor = actor
+        self._apply(info)
+        print(
+            f"[ix-mcp] kernel hosted on ray (node {self._node_ip}, pid {self._pid})",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    def _spawn_actor(self) -> Any:  # noqa: ANN401 -- a ray actor handle has no importable static type
+        import ray
+        from fleet.cluster import connect
+        from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+        connect()
+        remote_cls = ray.remote(num_cpus=0, max_restarts=0)(KernelActor)
+        return remote_cls.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                node_id=ray.get_runtime_context().get_node_id(), soft=True
+            ),
+        ).remote()
+
+    def _apply(self, info: dict) -> None:
+        self._connection = dict(info["connection"])
+        self._pid = info["pid"]
+        self._node_ip = info.get("node_ip")
+
+    def client(self) -> AsyncKernelClient:
+        from jupyter_client.asynchronous.client import AsyncKernelClient
+
+        kc = AsyncKernelClient()
+        kc.load_connection_info(self._connection or {})
+        return kc
+
+    async def is_alive(self) -> bool:
+        if self._actor is None:
+            return False
+        try:
+            return bool(await self._actor.is_alive.remote())
+        except Exception:
+            # The actor itself is gone (killed, node lost, cluster down): the
+            # kernel died with it. restart() below respawns actor and kernel.
+            return False
+
+    async def exit_code(self) -> int | None:
+        if self._actor is None:
+            return None
+        try:
+            return await self._actor.exit_code.remote()
+        except Exception:
+            return None
+
+    async def send_signal(self, signum: int) -> bool:
+        if self._actor is None:
+            return False
+        try:
+            return bool(await self._actor.send_signal.remote(signum))
+        except Exception:
+            return False
+
+    async def trace_size(self) -> int:
+        if self._actor is None:
+            return 0
+        try:
+            return int(await self._actor.trace_size.remote())
+        except Exception:
+            return 0
+
+    async def trace_read(self, offset: int) -> str:
+        if self._actor is None:
+            return ""
+        try:
+            return str(await self._actor.trace_read.remote(offset))
+        except Exception:
+            return ""
+
+    async def restart(self, workdir: Path) -> None:
+        if self._actor is not None:
+            try:
+                self._apply(await self._actor.relaunch.remote(str(workdir)))
+                return
+            except Exception as exc:
+                # The actor died with its node (or the kernel manager inside it
+                # is unusable): respawn both. Soft affinity lets the fresh actor
+                # land wherever the cluster can host it.
+                print(
+                    f"[ix-mcp] kernel actor lost ({type(exc).__name__}); respawning actor",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                await self.shutdown()
+        await self.start(workdir)
+
+    async def shutdown(self) -> None:
+        actor, self._actor = self._actor, None
+        self._connection = None
+        if actor is None:
+            return
+        with contextlib.suppress(Exception):
+            await actor.shutdown.remote()
+        import ray
+
+        with contextlib.suppress(Exception):
+            ray.kill(actor)
+
+
+def make_kernel_host(kind: str) -> KernelHost:
+    """The host ``Config.kernel_host`` names; unknown values fail loudly."""
+    if kind == "local":
+        return LocalKernelHost()
+    if kind == "ray":
+        return RayKernelHost()
+    raise ValueError(f"unknown kernel host {kind!r} (expected 'local' or 'ray')")

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -4646,7 +4646,7 @@ def _install_signal_handlers() -> None:
     kernel whose event loop is blocked by a synchronous call.
 
     SIGUSR1: faulthandler dumps every thread's Python stack to the file named by
-    ``IX_MCP_KERNEL_TRACE`` (kept by ``kernel.TRACE_ENV``). The handler is C-level
+    ``IX_MCP_KERNEL_TRACE`` (kept by ``kernel_host.TRACE_ENV``). The handler is C-level
     so it runs even while the main thread is parked in a blocking call; the
     ``kernel_trace`` tool reads the file back.
 

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -13,6 +13,7 @@ import functools
 import hashlib
 import json
 import os
+import socket
 import sys
 import threading
 import time
@@ -34,6 +35,13 @@ _DEFAULT_WEAVE_URL = "http://127.0.0.1:7677"
 _DEFAULT_DATA_API = "http://127.0.0.1:8765"
 _BATCH = 500
 _QUEUE_MAX = 10_000
+# How often the writer thread renews the kernel's board lease while this
+# process lives (weave prelude.dl: three missed beats, ~3 min, expire the
+# kernel entity and its sessions). The store rides INSIDE the kernel
+# process, so a beat is honest liveness: a crashed kernel, a reaped ray
+# actor, or a SIGKILLed serve's child all stop beating with no shutdown
+# hook needed.
+_BEAT_S = 60.0
 _WARNED_OFF = False
 
 def _http_json(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
@@ -143,6 +151,12 @@ class WeaveStore:
                 (self.kernel, "type", "kernel"),
                 (self.kernel, "transport", "mcp"),
                 (self.kernel, "pid", os.getpid()),
+                # Where this kernel process runs: the host kind the serve chose
+                # (ix-mcp Config.kernel_host via IX_MCP_KERNEL: "ray" = a
+                # KernelActor on the fleet cluster) and the node it landed on.
+                (self.kernel, "kernel_host", os.environ.get("IX_MCP_KERNEL", "local")),
+                (self.kernel, "node", socket.gethostname()),
+                (self.kernel, "heartbeat_ms", now),
                 (self.agent, "on_kernel", self.kernel),
             ])
 
@@ -225,12 +239,22 @@ class WeaveStore:
 
     def _writer(self) -> None:
         backoff = 0.25
+        next_beat = time.monotonic() + _BEAT_S
         while True:
             with self._cv:
-                while not self._queue and not self._closed:
+                while not self._queue and not self._closed and time.monotonic() < next_beat:
                     self._cv.wait(timeout=1.0)
                 if not self._queue and self._closed:
                     return
+                if time.monotonic() >= next_beat:
+                    # Renew the kernel's board lease. Enqueued directly, NOT via
+                    # _enqueue_facts: a beat is process liveness, and its agent
+                    # last_active_ms ride-along would un-idle an agent that has
+                    # not done anything.
+                    next_beat = time.monotonic() + _BEAT_S
+                    self._queue.append(
+                        {"fact": {"entity": _api_value(self.kernel), "attr": "heartbeat_ms", "value": _api_value(_ms())}}
+                    )
                 batch = [self._queue.popleft() for _ in range(min(_BATCH, len(self._queue)))]
                 self._inflight = True
             try:

--- a/packages/mcp/tests/test_kernel_host.py
+++ b/packages/mcp/tests/test_kernel_host.py
@@ -1,0 +1,114 @@
+"""The kernel host seam: where the kernel process lives (kernel_host.py).
+
+Selection must be explicit (``Config.kernel_host`` -> ``make_kernel_host``,
+unknown values loud), and the Ray host must rebuild a working ZMQ client from
+the plain-dict connection info the actor ships back (str HMAC key, node-IP
+endpoints) -- the piece that lets exec traffic flow server -> kernel directly
+and keeps Ray as control plane only. None of this needs a running Ray: the
+Ray-touching paths import ray lazily, inside actor spawn.
+"""
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ix_notebook_mcp.config import Config
+from ix_notebook_mcp.kernel import Kernel
+from ix_notebook_mcp.kernel_host import (
+    KernelActor,
+    LocalKernelHost,
+    RayKernelHost,
+    make_kernel_host,
+)
+
+
+def test_selection_is_explicit_and_unknown_is_loud() -> None:
+    assert isinstance(make_kernel_host("local"), LocalKernelHost)
+    assert isinstance(make_kernel_host("ray"), RayKernelHost)
+    with pytest.raises(ValueError, match="unknown kernel host"):
+        make_kernel_host("k8s")
+
+
+def test_config_defaults_to_local_child() -> None:
+    # An embedder building Config directly (the tests, the notebook engine)
+    # must keep today's behavior with no Ray anywhere near the process.
+    config = Config(workdir=Path(tempfile.gettempdir()))
+    assert config.kernel_host == "local"
+    assert isinstance(Kernel(config)._host, LocalKernelHost)
+
+
+def test_kernel_binds_the_configured_host_without_importing_ray() -> None:
+    # Constructing a ray-hosted Kernel must be side-effect free: ray connects
+    # at start(), never at __init__ (the CLI builds Config long before serve).
+    config = Config(workdir=Path(tempfile.gettempdir()), kernel_host="ray")
+    assert isinstance(Kernel(config)._host, RayKernelHost)
+
+
+def test_ray_client_rebuilds_from_shipped_connection_info() -> None:
+    # The actor ships a plain dict (str key); the server-side client must come
+    # back HMAC-keyed and pointed at the kernel node's routable endpoints, or
+    # every execute would silently talk to nothing.
+    host = RayKernelHost()
+    host._apply(
+        {
+            "pid": 4242,
+            "node_ip": "100.64.0.7",
+            "connection": {
+                "transport": "tcp",
+                "ip": "100.64.0.7",
+                "shell_port": 51001,
+                "iopub_port": 51002,
+                "stdin_port": 51003,
+                "hb_port": 51004,
+                "control_port": 51005,
+                "signature_scheme": "hmac-sha256",
+                "key": "5ecret",
+            },
+        }
+    )
+    kc = host.client()
+    assert host.pid == 4242
+    assert kc.ip == "100.64.0.7"
+    assert kc.session.key == b"5ecret"
+    assert kc.session.signature_scheme == "hmac-sha256"
+    assert (kc.shell_port, kc.iopub_port, kc.control_port) == (51001, 51002, 51005)
+
+
+def test_actor_info_ships_a_json_safe_key() -> None:
+    # jupyter's get_connection_info returns the HMAC key as bytes; the actor
+    # payload keeps it a str so the dict stays JSON-safe for logs/facts, and
+    # load_connection_info on the server side re-encodes it (pinned above).
+    class FakeKM:
+        ip = "100.64.0.7"
+
+        def get_connection_info(self, *, session: bool = False) -> dict:
+            assert session is False
+            return {"transport": "tcp", "ip": self.ip, "key": b"5ecret"}
+
+    actor = KernelActor()
+    actor._km = FakeKM()
+    actor._pid = 7
+    info = actor._info()
+    assert info == {
+        "pid": 7,
+        "node_ip": "100.64.0.7",
+        "connection": {"transport": "tcp", "ip": "100.64.0.7", "key": "5ecret"},
+    }
+
+
+def test_local_trace_reads_are_offset_scoped(tmp_path: Path) -> None:
+    # dump_trace's contract: mark the size, signal, read only what was appended
+    # past the mark. The host primitives carry that offset arithmetic.
+    host = LocalKernelHost()
+    host._trace_path = tmp_path / "kernel-trace-1.txt"
+
+    async def main() -> None:
+        assert await host.trace_size() == 0  # absent file reads as empty
+        host._trace_path.write_text("first dump\n")
+        mark = await host.trace_size()
+        host._trace_path.write_text("first dump\nsecond dump\n")
+        assert await host.trace_read(mark) == "second dump\n"
+
+    asyncio.run(main())

--- a/packages/mcp/tests/test_kernel_host.py
+++ b/packages/mcp/tests/test_kernel_host.py
@@ -88,8 +88,8 @@ def test_actor_info_ships_a_json_safe_key() -> None:
             return {"transport": "tcp", "ip": self.ip, "key": b"5ecret"}
 
     actor = KernelActor()
-    actor._km = FakeKM()
-    actor._pid = 7
+    actor._core._km = FakeKM()
+    actor._core._pid = 7
     info = actor._info()
     assert info == {
         "pid": 7,

--- a/packages/mcp/tests/test_kernel_trace_path.py
+++ b/packages/mcp/tests/test_kernel_trace_path.py
@@ -9,7 +9,7 @@ import subprocess
 
 import pytest
 
-from ix_notebook_mcp.kernel import _sweep_stale_traces, trace_path_for
+from ix_notebook_mcp.kernel_host import _sweep_stale_traces, trace_path_for
 
 
 @pytest.fixture

--- a/packages/mcp/tests/test_store_kernel_lease.py
+++ b/packages/mcp/tests/test_store_kernel_lease.py
@@ -1,0 +1,93 @@
+"""The kernel's board lease: registration facts and the writer's heartbeat.
+
+Weave expires a kernel entity (and its sessions) three missed beats after
+its last write (prelude.dl kernel_seen_ms/kernel_expired), so the store --
+which rides inside the kernel process -- must (a) register the kernel with
+its placement facts (kernel_host from IX_MCP_KERNEL, node, pid) and (b)
+keep beating heartbeat_ms while the process lives, WITHOUT the beat
+un-idling the agent (no last_active_ms ride-along).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from ix_notebook_mcp import store
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    posted: list[dict] = []
+
+    def fake_json(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+        if url.endswith("/api/facts"):
+            posted.extend(body if isinstance(body, list) else [body])
+        return {"seq": 1, "id": "f1"}
+
+    monkeypatch.setattr(store, "_http_json", fake_json)
+    return posted
+
+
+def _facts(posted: list[dict]) -> list[tuple[str, str, object]]:
+    out = []
+    for item in posted:
+        fact = item.get("fact") or {}
+        out.append((fact["entity"]["v"], fact["attr"], fact["value"]["v"]))
+    return out
+
+
+def test_registration_carries_placement_and_a_first_beat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WEAVE_URL", "http://weave.test")
+    monkeypatch.setenv("IX_MCP_KERNEL", "ray")
+    monkeypatch.delenv("IX_WEAVE_AGENT", raising=False)
+    posted = _capture(monkeypatch)
+
+    conn = store.WeaveStore(tmp_path / "s.ixnb")
+    try:
+        assert conn.flush(timeout=5.0)
+    finally:
+        conn.close()
+
+    facts = _facts(posted)
+    kernel = conn.kernel
+    by_attr = {attr: value for entity, attr, value in facts if entity == kernel}
+    assert by_attr["type"] == "kernel"
+    assert by_attr["kernel_host"] == "ray"
+    assert isinstance(by_attr["node"], str)
+    assert by_attr["node"]
+    assert isinstance(by_attr["heartbeat_ms"], int)
+    assert (conn.agent, "on_kernel", kernel) in facts
+
+
+def test_writer_beats_the_lease_without_unidling_the_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WEAVE_URL", "http://weave.test")
+    monkeypatch.delenv("IX_MCP_KERNEL", raising=False)
+    posted = _capture(monkeypatch)
+    monkeypatch.setattr(store, "_BEAT_S", 0.15)
+
+    conn = store.WeaveStore(tmp_path / "s.ixnb")
+    try:
+        conn.flush(timeout=5.0)
+        registered = len(posted)
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            beats = [f for f in _facts(posted[registered:]) if f[1] == "heartbeat_ms"]
+            if len(beats) >= 2:
+                break
+            time.sleep(0.05)
+    finally:
+        conn.close()
+
+    tail = _facts(posted[registered:])
+    beats = [f for f in tail if f[1] == "heartbeat_ms"]
+    assert len(beats) >= 2, f"writer never beat the lease: {tail}"
+    assert all(entity == conn.kernel for entity, _, _ in beats)
+    # A beat is process liveness, not agent activity: the idle-styling
+    # clock (agent last_active_ms) must not advance with it.
+    assert all(attr != "last_active_ms" for _, attr, _ in tail), tail


### PR DESCRIPTION
## Why

Weave is moving to per-claude-code MCP servers whose kernels are scheduled on one Ray cluster (weave#116 reverted the one-shared-kernel-per-host design). The kernel process needs to be spawnable away from the serve without touching the exec protocol.

## What

- **`kernel_host.py` (new):** `KernelHost` seam owning every process-level primitive (`spawn`/`liveness`/`exit code`/`signals`/`trace reads`/`restart`/`shutdown`). `LocalKernelHost` = today's direct child, behavior unchanged. `RayKernelHost` = kernel as child of an owned `KernelActor` on the fleet's Ray cluster (via `fleet.connect()`, one convention). Exec traffic stays direct server->kernel ZMQ (node-IP-bound connection file, HMAC key shipped back); Ray is control plane only. Ray ownership GC reaps actor+kernel when the serve dies - no pidfiles. Soft node affinity pins the kernel to the serve's node (workdir + node-local env channels); `num_cpus=0` so idle kernels reserve no fleet cores.
- **`kernel.py`:** drives the host instead of AsyncKernelManager directly; SIGUSR1/SIGUSR2, trace offset reads, death watch, and restart_now all go through host primitives. Messages and semantics unchanged.
- **Selection:** `Config.kernel_host` ("local" default | "ray"), wired from `IX_MCP_KERNEL` by the CLI.
- The actor regenerates IPYTHONDIR when the serve's path is absent on its node; multi-node caveats (sqlite store path, loopback WEAVE_URL) documented in the module docstring - soft same-node affinity keeps parity today.

## Verification

- `nix build .#mcp.tests.typecheckSmoke` (135 passed, incl. 6 new kernel-host tests), `.#mcp.tests.kernelDeathSmoke`, `.#mcp.tests.kernelRestartSmoke`, `.#mcp.tests.serverTools` - all green on the final tree.
- ruff check clean on all touched files.
- **Live smoke** (private Ray, worktree code): actor spawn -> ZMQ exec through shipped connection info -> SIGUSR1 trace via actor -> intentional restart (0.9s, fresh kernel pid, same actor) -> external SIGTERM -> death watch respawn through the actor -> shutdown reaps the actor (`is_alive` false after).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pluggable kernel host abstraction with Ray-hosted kernel actor support
> - Introduces `KernelHost` as an abstract interface in [`kernel_host.py`](https://github.com/indexable-inc/index/pull/2668/files#diff-86b600cdd1f71949be447f80bf4ac07fa136f7e541c8f63e99fdcb991bb1dce6), with `LocalKernelHost` (existing behavior) and `RayKernelHost` (kernel runs inside a Ray actor) as implementations.
> - `Kernel` in [`kernel.py`](https://github.com/indexable-inc/index/pull/2668/files#diff-ced4fbbdf05b4f126e987804d73fdc2d811511b346e4985a9996ae7903683d1c) delegates all process lifecycle, trace collection, liveness checks, and signal delivery to the selected host instead of managing them directly.
> - `KernelActor` wraps `LocalKernelHost` as a Ray actor, shipping JSON-safe connection info so a remote `RayKernelHost` can reconstruct an `AsyncKernelClient` on the server side.
> - Host selection is controlled by the `IX_MCP_KERNEL` env var (`"local"` or `"ray"`), wired through `Config.kernel_host` and a `make_kernel_host` factory.
> - `WeaveStore` now records `kernel_host`, `node`, and an initial `heartbeat_ms` on writer startup to track kernel placement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8be2c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

## Addendum (second commit)

**store.py: the kernel's board lease.** The store rides inside the kernel process, so its writer thread now beats `heartbeat_ms` on the kernel entity every 60s - honest liveness (crashed kernels, reaped ray actors, SIGKILLed serves all stop beating, no shutdown hook). Registration gains `kernel_host` (from `IX_MCP_KERNEL`) and `node` (hostname) placement facts. Beats bypass `_enqueue_facts` so the agent's idle clock (`last_active_ms`) does not advance with them. Weave-side lease rules + board rendering: weave#120.

Verification: typecheckSmoke now 137 passed (adds `test_store_kernel_lease.py`: registration placement facts; the writer beats at least twice without touching agent `last_active_ms`). Live smoke against a real weave server: kernel visible with `kernel_host=ray, node=spark`, heartbeat renews.