### PR TITLE
index-delta: fix symlink materialization, keyvalue header dup, unhex panic

### DIFF
--- a/packages/index-delta/src/apply.rs
+++ b/packages/index-delta/src/apply.rs
@@ -457,11 +457,10 @@ fn set_keyvalue(lines: &mut Vec<String>, path: &str, value: &Value) -> Result<()
         }
         return Ok(());
     }
-    if let Some(name) = &address.section
-        && section_body(lines, Some(name)).start >= lines.len()
-    {
-        lines.push(format!("[{name}]"));
-    }
+    // `parse_kv_address` only sets `address.section` when a matching header
+    // already exists, so the section is never missing here — an earlier
+    // `start >= lines.len()` guard "created" it, which duplicated the header
+    // whenever the section was the file's last line (empty trailing body).
     let body = section_body(lines, address.section.as_deref());
     let found = occurrences(lines, &body, &address.key);
     match (address.index, value) {
@@ -585,9 +584,14 @@ fn unhex(text: &str) -> Option<Vec<u8>> {
     if !text.len().is_multiple_of(2) || text.is_empty() {
         return None;
     }
+    // `get` (not a raw byte slice) so a multibyte char that straddles a pair
+    // boundary yields None instead of panicking; hex is ASCII anyway.
     (0..text.len())
         .step_by(2)
-        .map(|at| u8::from_str_radix(&text[at..at + 2], 16).ok())
+        .map(|at| {
+            text.get(at..at + 2)
+                .and_then(|pair| u8::from_str_radix(pair, 16).ok())
+        })
         .collect()
 }
 
@@ -702,6 +706,28 @@ mod tests {
         assert!(
             diff_bytes(Format::Keyvalue, out.as_bytes(), edited.as_bytes()).is_empty(),
             "not logically equal after apply: {out}"
+        );
+    }
+
+    #[test]
+    fn keyvalue_set_into_trailing_empty_section_keeps_one_header() {
+        // A section header as the file's last line (empty body) must not be
+        // duplicated when a key is written into it.
+        let mut lines: Vec<String> = "[sec]".lines().map(str::to_owned).collect();
+        set_keyvalue(&mut lines, "sec.k", &json!("v")).expect("set");
+        assert_eq!(lines, vec!["[sec]".to_owned(), "k = v".to_owned()]);
+    }
+
+    #[test]
+    fn unhex_rejects_multibyte_string_without_panic() {
+        // A "hex:" string carrying a multibyte char must fall back to a plain
+        // string, not panic slicing mid-codepoint.
+        assert_eq!(unhex("€x"), None);
+        let root = json!({ "blob": "hex:€x" });
+        let back = json_to_plist(&root).expect("convert");
+        assert_eq!(
+            back.as_dictionary().and_then(|dict| dict.get("blob")),
+            Some(&plist::Value::String("hex:€x".to_owned()))
         );
     }
 

--- a/packages/index-delta/src/cmd.rs
+++ b/packages/index-delta/src/cmd.rs
@@ -149,6 +149,15 @@ fn first_seed(store: &Store, meta: &Meta, incoming: &[u8]) -> Result<Outcome> {
                     "yourEdits": diff::diff_bytes(meta.format, incoming, &found),
                 })),
             )?;
+            // The pre-existing target can still be a read-only store symlink
+            // (a home-manager link left by a `home.file` -> `mutable.files`
+            // migration). Keeping its content as day-one drift is pointless
+            // unless the file is writable, so materialize the symlink into a
+            // plain file holding the same bytes — the one seeding path that
+            // otherwise skips write_creating_parents' symlink replacement.
+            if fs::symlink_metadata(target).is_ok_and(|md| md.file_type().is_symlink()) {
+                write_creating_parents(target, &found)?;
+            }
             Ok(Outcome::DriftKept)
         }
         (_, pre_existing) => {
@@ -751,6 +760,34 @@ mod tests {
         fs::write(&fixture.target, r#"{"handmade": true}"#).expect("pre-existing");
         fixture.set_base(r#"{"a": 1}"#);
         fixture.activate();
+        assert_eq!(fixture.target_contents(), r#"{"handmade": true}"#);
+        assert_eq!(fixture.entry().state, State::Drifted);
+    }
+
+    #[test]
+    fn pre_existing_durable_symlink_is_materialized_writable() {
+        // Migrating `home.file` -> `mutable.files` can leave the target as a
+        // read-only store symlink. Day-one drift must still be writable.
+        let fixture = Fixture::new("durable");
+        let target = Path::new(&fixture.target);
+        fs::create_dir_all(target.parent().expect("parent")).expect("mkdir");
+        let old_render = fixture
+            .source
+            .parent()
+            .expect("store dir")
+            .join("old-render.json");
+        fs::write(&old_render, r#"{"handmade": true}"#).expect("old render");
+        std::os::unix::fs::symlink(&old_render, target).expect("symlink");
+        fixture.set_base(r#"{"a": 1}"#);
+        fixture.activate();
+        // The symlink is replaced by a writable regular file with its content.
+        assert!(
+            fs::symlink_metadata(target)
+                .expect("meta")
+                .file_type()
+                .is_file(),
+            "target should be a regular file, not a symlink"
+        );
         assert_eq!(fixture.target_contents(), r#"{"handmade": true}"#);
         assert_eq!(fixture.entry().state, State::Drifted);
     }


### PR DESCRIPTION
Follow-up to #2629 (`mutable-files`). Three bugs the post-merge review confirmed, each with a regression test.

### 1. `first_seed` durable "kept-existing" leaves a read-only store symlink
`write_creating_parents` deliberately replaces a leftover `home.file` -> `mutable.files` store symlink with a plain file (regular-file invariant). The one seeding path that bypassed it was the durable "kept-existing" branch: a pre-existing target that differs logically from the incoming base is kept as day-one drift, but if that target is still a home-manager symlink into the read-only store, keeping it is pointless: the user can't edit it, and the next store GC breaks it. Materialize the symlink into a regular file holding the same bytes before recording the drift. (`cmd.rs`)

### 2. keyvalue `set` duplicates the header on a trailing empty section
`parse_kv_address` only sets `address.section` when a matching `[header]` physically exists in the file, so by the time `set_keyvalue` runs the section is guaranteed present. The `start >= lines.len()` guard that "created" it was dead for every real address and actively wrong for one case: a section that is the file's last line with an empty body, where it pushed a second `[header]`. Removed the dead guard. (`apply.rs`)

### 3. `unhex` panics on a multibyte string
`unhex` byte-sliced `text[at..at + 2]`, which panics when a multibyte UTF-8 char straddles a pair boundary (e.g. a plist Data value of `hex:EUR x`). Switched to `str::get`, which returns `None` on a non-char-boundary slice instead of panicking; hex is ASCII so valid input is unaffected. (`apply.rs`)

### Verification
`nix build .#index-delta.passthru.tests.{index-delta-all,clippy,unusedCrateDependencies}` on an x86_64 compute node: `test result: ok. 31 passed` (28 -> 31), clippy clean under the workspace `pedantic`/`nursery` deny lints, unused-deps clean.

### Out of scope (deferred)
The review also flagged lower-severity items left for follow-ups: `apply_to_file` re-sniffing format per op, `kv_line` value escaping, the `json_to_plist` `hex:` sentinel collision, an orphaned nfs `auto_master` entry, and darwin-home import coupling.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix symlink materialization, duplicate section headers, and `unhex` panic in index-delta
> - Replaces symlinked targets with regular files when durable content is kept as day-one drift in `first_seed`, ensuring the result is writable.
> - Removes a conditional in `set_keyvalue` that incorrectly appended a section header when the section was the last line with an empty body, preventing duplicate headers.
> - Replaces unsafe byte-slice indexing in `unhex` with `text.get(at..at + 2)` to return `None` instead of panicking on multibyte character boundaries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60e6bdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->