### PR TITLE
profile(andrewgazelka): adopt nox-lsp as the Nix language server

### DIFF
--- a/users/andrewgazelka/config/zed/settings.nix
+++ b/users/andrewgazelka/config/zed/settings.nix
@@ -139,7 +139,10 @@
         };
       };
       language_servers = [
-        "nixd"
+        # nox-lsp (nox docs/lsp.md): eval-backed Nix LSP. typenix stays
+        # installed behind the nixd slot below; revert by swapping this list.
+        "nox-lsp"
+        "!nixd"
         "!nil"
       ];
     };
@@ -198,6 +201,22 @@
       binary = {
         arguments = [];
         path = "typenix-lsp";
+      };
+    };
+    nox-lsp = {
+      binary = {
+        arguments = [];
+        path = "nox-lsp";
+      };
+      initialization_options = {
+        embedded = {
+          commands = {
+            bash = [
+              "bash-language-server"
+              "start"
+            ];
+          };
+        };
       };
     };
     rust-analyzer = {

--- a/users/andrewgazelka/config/zed/settings.nix
+++ b/users/andrewgazelka/config/zed/settings.nix
@@ -139,11 +139,13 @@
         };
       };
       language_servers = [
-        # nox-lsp (nox docs/lsp.md): eval-backed Nix LSP. typenix stays
-        # installed behind the nixd slot below; revert by swapping this list.
-        "nox-lsp"
+        # nox-lsp (nox docs/lsp.md): eval-backed Nix LSP, run through the
+        # registered nil adapter slot (Zed's Nix extension only registers
+        # nil/nixd; an lsp entry alone can't add a new adapter). typenix
+        # stays installed behind the nixd slot below; revert by swapping
+        # this list.
+        "nil"
         "!nixd"
-        "!nil"
       ];
     };
     Nu = {
@@ -197,13 +199,8 @@
         };
       };
     };
-    nixd = {
-      binary = {
-        arguments = [];
-        path = "typenix-lsp";
-      };
-    };
-    nox-lsp = {
+    # nil adapter slot repointed at nox-lsp (see languages.Nix above).
+    nil = {
       binary = {
         arguments = [];
         path = "nox-lsp";
@@ -217,6 +214,12 @@
             ];
           };
         };
+      };
+    };
+    nixd = {
+      binary = {
+        arguments = [];
+        path = "typenix-lsp";
       };
     };
     rust-analyzer = {

--- a/users/andrewgazelka/options.nix
+++ b/users/andrewgazelka/options.nix
@@ -40,6 +40,11 @@ in {
         default = null;
         description = "Host-native Mercury CLI supplied by the consuming flake.";
       };
+      noxLsp = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        description = "Host-native nox-lsp (Nix language server) supplied by the consuming flake.";
+      };
       typenix = lib.mkOption {
         type = lib.types.nullOr lib.types.package;
         default = null;

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -301,6 +301,10 @@ in {
       message = "users.andrewgazelka.packages.typenix must be set for the workstation profile.";
     }
     {
+      assertion = cfg.packages.noxLsp != null;
+      message = "users.andrewgazelka.packages.noxLsp must be set for the workstation profile.";
+    }
+    {
       assertion = cfg.paths.vscodeIslands != null;
       message = "users.andrewgazelka.paths.vscodeIslands must be set for the workstation profile.";
     }
@@ -651,6 +655,13 @@ in {
           exec ${cfg.packages.typenix}/bin/typenix --lsp --stdio "$@"
         '';
       })
+      # nox-lsp: Nix language server over the nox arena evaluator (nox
+      # docs/lsp.md) — eval-backed hovers/completions, embedded-language
+      # delegation, provenance jumps. Zed's Nix language points at it
+      # (config/zed/settings.nix); supplied host-native by the consuming
+      # flake like typenix above.
+      cfg.packages.noxLsp
+      bash-language-server # nox-lsp delegates embedded bash strings to it (must be on PATH)
       # Experimental: MLsub/SimpleSub type checker LSP for Nix (Nix-native).
       # https://github.com/JRMurr/tix — Cursor/Zed point at tix-lsp.
       # inputs.tix.packages.${pkgs.stdenv.hostPlatform.system}.default


### PR DESCRIPTION
Add a `packages.noxLsp` option (host-native, supplied by the consuming
flake like typenix), install it plus bash-language-server (embedded bash
delegation) in the workstation profile, and point Zed's Nix language at
nox-lsp. typenix-lsp stays installed behind the nixd slot for easy revert.

Closes #2712


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adopt nox-lsp as the Nix language server in andrewgazelka's Zed config
> - Switches Zed's Nix `language_servers` from `nixd` to `nil` in [settings.nix](https://github.com/indexable-inc/index/pull/2714/files#diff-ab09fc7f5bab958641754df125cfcc77298b8edbc57359f398cc3f0b1985b327), routing nox-lsp through the nil adapter slot.
> - Configures the `nil` LSP adapter to execute the `nox-lsp` binary with embedded bash handling via `bash-language-server start`.
> - Adds a `noxLsp` option in [options.nix](https://github.com/indexable-inc/index/pull/2714/files#diff-e2d6dc3bb070a114e9baae9f4b8c329946568b5e444d9ef00ed7e63453e0ab02) and installs `nox-lsp` and `bash-language-server` in the workstation profile.
> - Risk: the workstation profile now asserts that `packages.noxLsp` is non-null, so evaluation fails if the package is not provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49a16a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->