### PR TITLE
users: import the codex home module into the workstation profile

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -446,6 +446,10 @@
       inherit indexPackages;
       promptModule = ./packages/agent/prompt;
     };
+    codexHomeModule = import ./packages/agent/home-manager/codex.nix {
+      inherit indexPackages;
+      promptModule = ./packages/agent/prompt;
+    };
     personalServicesModule = import ./users/andrewgazelka/home.nix {
       inherit indexPackages ix;
       claudeCodeModule = claudeCodeHomeModule;
@@ -461,6 +465,7 @@
     };
     personalWorkstationModule = import ./users/andrewgazelka/profiles/workstation.nix {
       inherit indexPackages personalServicesModule ix;
+      codexModule = codexHomeModule;
       configRoot = personalConfigRoot;
       mutableFilesModule = mutableFilesHomeModule;
       provenanceModule = provenanceHomeModule;
@@ -586,10 +591,7 @@
       # Agent CLI modules: Home Manager is the user-facing configuration
       # surface, while the package wrappers remain the implementation detail.
       claude-code = claudeCodeHomeModule;
-      codex = import ./packages/agent/home-manager/codex.nix {
-        indexPackages = system: packages.${system};
-        promptModule = ./packages/agent/prompt;
-      };
+      codex = codexHomeModule;
       # Personal-but-shareable workstation module for github:andrewgazelka: the
       # ix.dev downtime watcher + boss bar overlay + the shared say-detached
       # sound helper, all as portable services. Closed over the per-system

--- a/packages/agent/home-manager/codex.nix
+++ b/packages/agent/home-manager/codex.nix
@@ -74,6 +74,14 @@
     // optionalOverride (cfg.systemPrompt.source == "house") "omitRules" cfg.systemPrompt.omitRules;
   finalPackage = cfg.basePackage.override packageOverrides;
 in {
+  # Stable module-system identity: this module is anonymous (imported as a
+  # value, not a path), and it reaches configs through two routes — the
+  # `homeModules.codex` flake export and the workstation profile's nested
+  # import. Without a key, the module system assigns each route a distinct
+  # fallback key and then rejects the doubled `programs.codex.*` option
+  # declarations; with one, the copies deduplicate.
+  key = "indexable-inc/index#homeModules.codex";
+
   options.programs.codex = {
     basePackage = lib.mkOption {
       type = lib.types.package;

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -1066,6 +1066,12 @@ in {
     # AGENTS.md rides the module's default house context render plus the same
     # personal appendix Claude gets, so the two agents cannot drift.
     houseContext.extraText = personalContext;
+    # hooks.json stays owned by the manual home.file declaration below (from
+    # `codexBase.passthru.hooksJson`, matching the package on PATH). Without
+    # this the imported codex module also claims ~/.codex/hooks.json with
+    # `finalPackage.hooksJson`, and the two sources conflict as soon as any
+    # hook-affecting option diverges from the wrapper defaults.
+    installHooks = false;
   };
 
   # Both agents edit their own config at runtime, so neither file can be a
@@ -1119,7 +1125,8 @@ in {
     ''
   );
 
-  # Codex hooks (the one thing the programs.codex module above does NOT deliver;
+  # Codex hooks, delivered manually (the module's own delivery is switched off
+  # via `installHooks = false` above so this stays the single owner;
   # config.toml/AGENTS.md/skills rationale lives there). Rendered from the SAME
   # declaration list as Claude's, owned by the index repo
   # (packages/agent/hooks.nix) and exposed as the codex package's

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -1,6 +1,7 @@
 # Full personal workstation profile. Index-owned dependencies are closed over
 # by the flake export; host-owned values arrive through typed options.nix.
 {
+  codexModule,
   configRoot,
   indexPackages,
   ix,
@@ -274,6 +275,12 @@ in {
   imports = [
     optionsModule
     personalServicesModule
+    # Declares `programs.codex.houseContext` (and the rest of the index codex
+    # options) that this profile sets below; home-manager's stock
+    # programs.codex module only carries enable/package/skills/context, so
+    # without this import the houseContext definitions fail eval (#2653
+    # regression).
+    codexModule
     # Per-generation provenance manifest: each HM generation carries
     # provenance.json mapping deployed files back to the nix file:line that
     # defined them; `whence <path>` (below) reads it with zero eval.


### PR DESCRIPTION
Fixes #2713.

#2653 switched the workstation profile to `programs.codex.houseContext.extraText`, an option declared only by `packages/agent/home-manager/codex.nix`, which the profile chain never imported. `programs.codex.*` had been resolving against home-manager upstream's stock codex module (`enable`/`package`/`skills`/`context`) by accident, so every consumer of `homeModules.andrewgazelka-workstation` fails eval:

```
error: The option `programs.codex.houseContext' does not exist.
Did you mean `programs.codex.context', `programs.codex.hooks' or `programs.codex.enable'?
```

Change: hoist the codex home module into a single `codexHomeModule` binding (shared with the `homeModules.codex` export, replacing the inline second instantiation) and thread it into the workstation profile's imports.

Validation: `nix eval '<consumer>#homeConfigurations."andrewgazelka@hydra".activationPackage.drvPath' --override-input index git+file://<this branch>` succeeds; it reproduces the error at d151dca9.

Not addressed here: `personal-light-profile` covers only portable + development, so no check evaluates workstation.nix (tracked in #2713).

(opened by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Import the codex home module into the workstation profile
> - Defines a shared `codexHomeModule` in [flake.nix](https://github.com/indexable-inc/index/pull/2715/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) by importing [codex.nix](https://github.com/indexable-inc/index/pull/2715/files#diff-fa4eb9472b4a8e65174c3cc1db7317dbe279f7d3c22a5a688cdb437e2a6e6628), then passes it into the workstation profile instead of using separate inline imports.
> - Adds a `key` attribute to [codex.nix](https://github.com/indexable-inc/index/pull/2715/files#diff-fa4eb9472b4a8e65174c3cc1db7317dbe279f7d3c22a5a688cdb437e2a6e6628) so the module deduplicates correctly when included via multiple paths, preventing duplicate option declaration conflicts.
> - Sets `programs.codex.installHooks = false` in [workstation.nix](https://github.com/indexable-inc/index/pull/2715/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) so `~/.codex/hooks.json` remains managed by the existing manual `home.file` declaration rather than the codex module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9fef33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->