### PR TITLE
flake: update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783550008,
-        "narHash": "sha256-qbbZUk9IG9dLNwCPwdPBs6I5clxwugRpP+1YU+GPK20=",
+        "lastModified": 1783711151,
+        "narHash": "sha256-232L3Nku2nLch/TQHsJEIhiZJKr+VTehnVUs1NZ0SNc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f4d01c1d87c7c2ec909549165d5a8338f1bd3315",
+        "rev": "f938277527aa084929261879d50d9832b9eab6d3",
         "type": "github"
       },
       "original": {
@@ -248,11 +248,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -474,11 +474,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783614422,
-        "narHash": "sha256-zSX553aXiIKJHWzUF6nrDKgeNRlfNK/SdyNYSbs2nkM=",
+        "lastModified": 1783663825,
+        "narHash": "sha256-TTrNVoFdEw8j0Hn+shP1KAsimTmszTWBIIUliTaAuY0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e8e9d70b96113fd49ccde6c3e08fb260b6ef5dd6",
+        "rev": "072adf9b18936c1062c48123a9b77891d5968f2c",
         "type": "github"
       },
       "original": {
@@ -548,10 +548,10 @@
     "snix-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1783373906,
-        "narHash": "sha256-PPooXg6H/MbFdquSz9okE2Jbqrhglk8/GoeeUskIyCc=",
+        "lastModified": 1783715473,
+        "narHash": "sha256-SL8JVtk07E9Cm/B6373pDM8AWg6aPPjUSYtLVQr8jgI=",
         "ref": "canon",
-        "rev": "ff8db41cdc01b72f2614c2b2c60ffe3cae5449c6",
+        "rev": "fe6aa2c677f6aa8829cae3c8104fc98db2ca21fa",
         "shallow": true,
         "type": "git",
         "url": "https://git.snix.dev/snix/snix"


### PR DESCRIPTION
Closes #2732.
Related to indexable-inc/ix#6959.
Supersedes the stale bot PR #2550.

Refreshes the four auto-managed inputs on current `main`: `home-manager`, `nixpkgs`, `rust-overlay`, and `snix-src`. Deliberately pinned sources such as `codex-src` and `nix-src` remain unchanged and continue through their owning update paths.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update flake inputs
> Updates the [flake.lock](https://github.com/indexable-inc/index/pull/2736/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) file to pull in the latest versions of all Nix flake dependencies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72b1e13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->