### PR TITLE
mcp: reap cancelled nix process trees

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2597,7 +2597,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542) + nu input= routing past no-input statements (#2540) + kernel host seam: local child vs ray actor";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + nix.eval process-tree cancellation (#2737) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542) + nu input= routing past no-input statements (#2540) + kernel host seam: local child vs ray actor";
     }
     ''
       export HOME=$TMPDIR/home
@@ -2615,6 +2615,8 @@
       # Issue #2387: a client that cancels an in-flight python_exec cancels the
       # backgrounded run it launched, instead of executing side effects after.
       cp ${./tests/test_cancel_running.py} test_cancel_running.py
+      # Issue #2737: cancelling nix.eval kills its process tree before the job settles.
+      cp ${./tests/test_nix_cancel.py} test_nix_cancel.py
       # Issue #2164: jobs.spawn registers an ad-hoc awaitable as a first-class job.
       cp ${./tests/test_jobs_spawn.py} test_jobs_spawn.py
       cp ${./tests/test_fsearch_partial.py} test_fsearch_partial.py
@@ -2650,6 +2652,7 @@
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
+        test_nix_cancel.py \
         test_jobs_spawn.py \
         test_fsearch_partial.py \
         test_fsearch_glob.py \

--- a/packages/mcp/src/nix/nix/__init__.py
+++ b/packages/mcp/src/nix/nix/__init__.py
@@ -40,11 +40,11 @@ while the dashboard pane shows the tree growing live as it builds.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import html as _html
 import json as _json
 import os
 import re
+import signal
 import time
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
@@ -99,6 +99,83 @@ RESULT_TYPES = {
 }
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+async def _defer_cancellation[T](task: asyncio.Task[T]) -> T:
+    """Await ``task`` while deferring cancellation of the current task."""
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            continue
+    return task.result()
+
+
+def _kill_group(proc: asyncio.subprocess.Process) -> None:
+    """Kill the isolated process group led by ``proc``.
+
+    Every process this module owns starts a new session, so the stable group id
+    is the direct child's pid even if that child has already exited while one of
+    its descendants still holds a captured pipe open.
+    """
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        if proc.returncode is None:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            except PermissionError as exc:
+                raise RuntimeError(f"could not kill nix process {proc.pid}: {exc}") from exc
+    except PermissionError as exc:
+        raise RuntimeError(f"could not kill nix process group {proc.pid}: {exc}") from exc
+
+
+async def _kill_and_reap(proc: asyncio.subprocess.Process) -> int:
+    _kill_group(proc)
+    # communicate() drains captured pipes as it waits. A cancelled reader may
+    # have paused its transport at the high-water mark, in which case wait()
+    # alone cannot observe the subprocess transport closing even after SIGKILL.
+    await _defer_cancellation(asyncio.create_task(proc.communicate()))
+    if proc.returncode is None:
+        raise RuntimeError(f"nix process group {proc.pid} survived SIGKILL")
+    return proc.returncode
+
+
+async def _spawn(
+    *argv: str,
+    cwd: str | None,
+    stderr: int | None,
+) -> asyncio.subprocess.Process:
+    pending = asyncio.create_task(
+        asyncio.create_subprocess_exec(
+            *argv,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=stderr,
+            start_new_session=True,
+        )
+    )
+    try:
+        return await asyncio.shield(pending)
+    except asyncio.CancelledError:
+        # Process creation can yield after fork but before returning the handle.
+        # Recover that handle before propagating cancellation, then own its tree.
+        proc = await _defer_cancellation(pending)
+        await _kill_and_reap(proc)
+        raise
+
+
+async def _communicate(proc: asyncio.subprocess.Process) -> tuple[bytes, bytes]:
+    try:
+        out, err = await proc.communicate()
+    except BaseException:
+        await _kill_and_reap(proc)
+        raise
+    assert out is not None
+    assert err is not None
+    return out, err
 
 # Stable schema so `.events` is a well-typed frame even with zero rows.
 _EVENT_SCHEMA = {
@@ -542,14 +619,13 @@ async def run(
     """
     run_state = BuildRun(label=label or (args[1] if len(args) > 1 else args[0] if args else "nix"))
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await _spawn(
             _nix_web_monitor_bin(),
             "--emit",
             "ndjson",
             "--",
             *args,
             cwd=cwd,
-            stdout=asyncio.subprocess.PIPE,
             # The emitter routes nix's own stdout to its stderr; keep it out of our
             # NDJSON parse by draining it to the parent's stderr (not merged into
             # stdout, which carries the BuildView lines).
@@ -572,8 +648,8 @@ async def run(
     assert proc.stdout is not None
     # Read raw chunks and split on newlines ourselves: a build-log line folded
     # into a BuildView can exceed asyncio's default 64 KiB StreamReader limit,
-    # which would make `readline` raise and abort mid-stream. `finally` reaps the
-    # process and lets the live resource self-close (`alive` keys off `done`).
+    # which would make `readline` raise and abort mid-stream. The protected wait
+    # below reaps the process before `done` lets the live resource self-close.
     buf = b""
     try:
         while True:
@@ -586,15 +662,13 @@ async def run(
                 run_state.feed(line.decode(errors="replace"))
         if buf:
             run_state.feed(buf.decode(errors="replace"))
-    finally:
-        # On cancellation (or any early exit) the child must be signaled, not just
-        # awaited: a bare `await proc.wait()` would let a cancelled build keep
-        # running to completion while this coroutine parks in the finally. Kill it
-        # if it has not already exited, then reap.
-        if proc.returncode is None:
-            with contextlib.suppress(ProcessLookupError):
-                proc.terminate()
         run_state.returncode = await proc.wait()
+    except BaseException:
+        # The monitor owns the nix child beneath it. Kill their isolated group so
+        # cancellation cannot reap only the monitor and orphan the real build.
+        run_state.returncode = await _kill_and_reap(proc)
+        raise
+    finally:
         run_state.done = True
     return run_state
 
@@ -674,7 +748,7 @@ async def attrs(flake: str = ".", *, system: str | None = None, cwd: str | None 
     sub-attributes.
     """
     system = system or _current_system()
-    proc = await asyncio.create_subprocess_exec(
+    proc = await _spawn(
         "nix",
         "flake",
         "show",
@@ -682,10 +756,9 @@ async def attrs(flake: str = ".", *, system: str | None = None, cwd: str | None 
         "--no-warn-dirty",
         flake,
         cwd=cwd,
-        stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    out, err = await proc.communicate()
+    out, err = await _communicate(proc)
     if proc.returncode != 0:
         raise RuntimeError(f"nix flake show failed: {err.decode('utf-8', 'replace').strip()}")
     return pl.DataFrame(
@@ -741,14 +814,13 @@ async def eval(
     exit with nix's own stderr.
     """
     args = _eval_args(installable, apply=apply, system=system, raw=raw)
-    proc = await asyncio.create_subprocess_exec(
+    proc = await _spawn(
         "nix",
         *args,
         cwd=cwd,
-        stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    out, err = await proc.communicate()
+    out, err = await _communicate(proc)
     if proc.returncode != 0:
         raise RuntimeError(f"nix eval failed: {err.decode('utf-8', 'replace').strip()}")
     text = out.decode("utf-8", "replace")

--- a/packages/mcp/tests/test_nix_cancel.py
+++ b/packages/mcp/tests/test_nix_cancel.py
@@ -1,0 +1,269 @@
+"""Cancelling a kernel job must stop the process tree owned by ``nix.eval``.
+
+Issue #2737 exposed the gap between cancelling the Python task and cancelling
+the subprocess awaited by that task: the job became terminal while both `nix`
+and its child kept running. This test uses a fake `nix` executable whose child
+holds a file lock, so it proves both the direct process was reaped and the
+descendant stopped before the job reports cancellation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import fcntl
+import os
+import pathlib
+import signal
+import sys
+import time
+
+import pytest
+
+import nix
+from ix_notebook_mcp import runtime
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict[str, object]) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+    monkeypatch.setattr(runtime, "_typecheck_enabled", lambda: False)
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _wait_until_ready(pid_file: pathlib.Path, ready_file: pathlib.Path) -> None:
+    deadline = time.monotonic() + 10
+    while not (pid_file.exists() and ready_file.exists()):
+        if time.monotonic() >= deadline:
+            raise TimeoutError("fake nix process tree did not start")
+        time.sleep(0.01)
+
+
+def _wait_until_paused(stream: asyncio.StreamReader) -> None:
+    deadline = time.monotonic() + 10
+    while stream._transport.is_reading():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("subprocess stdout transport did not pause")
+        time.sleep(0.01)
+
+
+def _fake_tree(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> tuple[pathlib.Path, pathlib.Path, pathlib.Path, pathlib.Path]:
+    pid_file = tmp_path / "pids"
+    ready_file = tmp_path / "ready"
+    lock_file = tmp_path / "child.lock"
+    fake_nix = tmp_path / "nix"
+    fake_nix.write_text(
+        f"""#!{sys.executable}
+import fcntl
+import os
+import pathlib
+import time
+
+child = os.fork()
+if child == 0:
+    with open(os.environ["LOCK_FILE"], "w") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        pathlib.Path(os.environ["READY_FILE"]).write_text("ready")
+        while True:
+            time.sleep(60)
+
+pathlib.Path(os.environ["PID_FILE"]).write_text(f"{{os.getpid()}} {{child}}")
+os.waitpid(child, 0)
+"""
+    )
+    fake_nix.chmod(0o700)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("PID_FILE", str(pid_file))
+    monkeypatch.setenv("READY_FILE", str(ready_file))
+    monkeypatch.setenv("LOCK_FILE", str(lock_file))
+    return fake_nix, pid_file, ready_file, lock_file
+
+
+def _assert_tree_stopped(pid_file: pathlib.Path, lock_file: pathlib.Path) -> None:
+    parent = int(pid_file.read_text().split()[0])
+    assert not _pid_exists(parent), "the direct nix process was not reaped"
+    with lock_file.open("a") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _kill_tree(pid_file: pathlib.Path) -> None:
+    if pid_file.exists():
+        for value in reversed(pid_file.read_text().split()):
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(int(value), signal.SIGKILL)
+
+
+class _EofStream:
+    async def read(self, _size: int) -> bytes:
+        return b""
+
+
+class _WaitProcess:
+    def __init__(self) -> None:
+        self.pid = 424242
+        self.returncode: int | None = None
+        self.stdout = _EofStream()
+        self.wait_calls = 0
+        self.waiting = asyncio.Event()
+        self.reaping = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def wait(self) -> int:
+        self.wait_calls += 1
+        self.waiting.set()
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+    async def communicate(self) -> tuple[bytes, None]:
+        self.reaping.set()
+        await self.release.wait()
+        self.returncode = -signal.SIGKILL
+        return b"", None
+
+
+def test_job_cancel_kills_and_reaps_nix_eval_tree(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    _fake_nix, pid_file, ready_file, lock_file = _fake_tree(monkeypatch, tmp_path)
+    _wire(monkeypatch, {"nix": nix})
+
+    async def scenario() -> runtime.Job:
+        job = await runtime.__ix_run(
+            "await nix.eval('.#slow')",
+            budget=0.01,
+            session="agent-a",
+        )
+        await asyncio.to_thread(_wait_until_ready, pid_file, ready_file)
+        job.cancel()
+        await job.wait(10)
+        return job
+
+    try:
+        job = asyncio.run(scenario())
+        assert job.status == "cancelled"
+        _assert_tree_stopped(pid_file, lock_file)
+    finally:
+        _kill_tree(pid_file)
+
+
+def test_cancel_during_spawn_setup_recovers_and_kills_tree(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    fake_nix, pid_file, ready_file, lock_file = _fake_tree(monkeypatch, tmp_path)
+    original_spawn = asyncio.create_subprocess_exec
+
+    async def scenario() -> None:
+        created = asyncio.Event()
+        release = asyncio.Event()
+
+        async def delayed_spawn(*args: object, **kwargs: object) -> asyncio.subprocess.Process:
+            proc = await original_spawn(*args, **kwargs)
+            created.set()
+            await release.wait()
+            return proc
+
+        monkeypatch.setattr(nix.asyncio, "create_subprocess_exec", delayed_spawn)
+        task = asyncio.create_task(
+            nix._spawn(str(fake_nix), cwd=None, stderr=asyncio.subprocess.PIPE)
+        )
+        try:
+            await asyncio.wait_for(created.wait(), 5)
+            await asyncio.to_thread(_wait_until_ready, pid_file, ready_file)
+            task.cancel()
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            release.set()
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+    try:
+        asyncio.run(scenario())
+        _assert_tree_stopped(pid_file, lock_file)
+    finally:
+        _kill_tree(pid_file)
+
+
+def test_run_cancel_during_wait_reaps_despite_repeated_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def scenario() -> tuple[_WaitProcess, list[int]]:
+        proc = _WaitProcess()
+        killed: list[int] = []
+
+        async def spawn(*_args: object, **_kwargs: object) -> _WaitProcess:
+            return proc
+
+        def kill_group(target: _WaitProcess) -> None:
+            killed.append(target.pid)
+
+        monkeypatch.setattr(nix.asyncio, "create_subprocess_exec", spawn)
+        monkeypatch.setattr(nix, "_kill_group", kill_group)
+
+        task = asyncio.create_task(nix.run(["build", ".#slow"], live=False))
+        try:
+            await asyncio.wait_for(proc.waiting.wait(), 1)
+            task.cancel()
+            await asyncio.wait_for(proc.reaping.wait(), 1)
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done(), "a repeated cancel bypassed process reaping"
+            proc.release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            proc.release.set()
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        return proc, killed
+
+    proc, killed = asyncio.run(scenario())
+    assert killed == [proc.pid]
+    assert proc.returncode == -signal.SIGKILL
+
+
+def test_kill_and_reap_drains_a_paused_pipe() -> None:
+    async def scenario() -> int:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import os\nchunk = b'x' * 65536\nwhile True: os.write(1, chunk)",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        assert proc.stdout is not None
+        try:
+            await asyncio.to_thread(_wait_until_paused, proc.stdout)
+            cleanup = asyncio.create_task(nix._kill_and_reap(proc))
+            done, _ = await asyncio.wait({cleanup}, timeout=5)
+            if not done:
+                await proc.stdout.read()
+                await cleanup
+                raise AssertionError("reaping waited forever on the paused pipe")
+            return cleanup.result()
+        finally:
+            if proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(proc.pid, signal.SIGKILL)
+                await proc.communicate()
+
+    assert asyncio.run(scenario()) == -signal.SIGKILL


### PR DESCRIPTION
## What

- Give every `nix` module subprocess its own process group.
- Shield process creation so cancellation cannot lose a child between fork and handle return.
- On cancellation, kill the group, drain captured pipes, and reap the direct child before the kernel job becomes terminal.
- Apply the lifecycle to `nix.eval`, `nix.attrs`, and monitored `nix.run` builds.

## Root cause

`Job.cancel()` correctly cancelled the Python task, but `nix.eval()` awaited bare `proc.communicate()`. Asyncio task cancellation does not terminate that subprocess. Two further races mattered: cancellation can land while `create_subprocess_exec()` is still connecting pipes, and a cancelled pipe reader can pause at its high-water mark so `proc.wait()` alone never settles.

## Validation

- Authenticated `nix build --no-link .#mcp.tests.typecheckSmoke .#mcp.tests.nixSmoke --print-build-logs`: 141 tests passed, and `nixSmoke` built successfully.
- Regression coverage exercises a real process tree, cancellation during spawn setup, repeated cancellation during cleanup, and a paused large-output pipe.
- `ruff check`, `py_compile`, and `git diff --check` pass.
- Repo-wide lint reached every changed file cleanly. Its ruff stage passed; unrelated existing Nix, Cargo, and astlog findings elsewhere in the tree still make the aggregate lint command exit 2.

Closes #2737

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Kill and reap cancelled nix process trees to avoid orphaned child builds
> - Adds `_spawn`, `_communicate`, `_kill_group`, `_kill_and_reap`, and `_defer_cancellation` helpers in [`__init__.py`](https://github.com/indexable-inc/index/pull/2751/files#diff-b4bb27410b6cb969e2cdc750a71d049b0c52a3faecc2ca9709a4278184a20890) to manage subprocess lifecycle.
> - All nix subprocesses (`run`, `eval`, `attrs`) now use `start_new_session=True` to isolate a process group, enabling group-wide SIGKILL on cancellation or error.
> - Cancellation during spawn setup is handled by shielding the process creation awaitable, then killing and reaping before propagating.
> - Adds [`test_nix_cancel.py`](https://github.com/indexable-inc/index/pull/2751/files#diff-2031e616f76ee0dcd62fe61ab02631e868ff3763e6f6524d1914435d7acc122d) covering cancellation during eval, spawn, streaming, and stdout drain scenarios.
> - Behavioral Change: `nix.run` no longer attempts a graceful `terminate`+`wait`; it now sends SIGKILL to the entire process group immediately on any exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 205df33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->