### PR TITLE
run: expose Darwin libiconv link path

### DIFF
--- a/packages/tui/run/default.nix
+++ b/packages/tui/run/default.nix
@@ -7,6 +7,20 @@
     if pkgs.stdenv.hostPlatform.isLinux
     then lib.getExe' pkgs.util-linux "scriptreplay"
     else "scriptreplay";
+  # #2759: Rust links libiconv through the raw Darwin compiler, which does not
+  # consume NIX_LDFLAGS from the surrounding profile.
+  wrapperArgs =
+    [
+      "--set"
+      "IX_RUN_SCRIPTREPLAY"
+      scriptreplay
+    ]
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+      "--prefix"
+      "LIBRARY_PATH"
+      ":"
+      "${lib.getLib pkgs.libiconv}/lib"
+    ];
   unwrapped = ix.writePythonApplication pkgs {
     name = "run-unwrapped";
     src = ./run.py;
@@ -26,7 +40,7 @@
     ''
       mkdir -p $out/bin
       makeWrapper ${lib.getExe unwrapped} $out/bin/run \
-        --set IX_RUN_SCRIPTREPLAY ${lib.escapeShellArg scriptreplay}
+        ${lib.escapeShellArgs wrapperArgs}
     '';
   recordsSession =
     pkgs.runCommand "run-records-session"
@@ -180,13 +194,41 @@
 
       mkdir -p "$out"
     '';
+  darwinLibiconv =
+    pkgs.runCommand "run-darwin-libiconv"
+    {
+      nativeBuildInputs = [package];
+      strictDeps = true;
+    }
+    ''
+      cat >link-environment-probe <<'EOF'
+      #!${lib.getExe pkgs.bash}
+      IFS=:
+      for directory in $LIBRARY_PATH; do
+        if [ -f "$directory/libiconv.dylib" ]; then
+          exit 0
+        fi
+      done
+      echo "LIBRARY_PATH has no linkable libiconv" >&2
+      exit 1
+      EOF
+      chmod +x link-environment-probe
+
+      export IX_RUN_DIR="$TMPDIR/runs"
+      LIBRARY_PATH= run "$PWD/link-environment-probe"
+      mkdir -p "$out"
+    '';
 in
   package.overrideAttrs (old: {
     passthru =
       (old.passthru or {})
       // {
-        tests = {
-          inherit recordsSession;
-        };
+        tests =
+          {
+            inherit recordsSession;
+          }
+          // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+            inherit darwinLibiconv;
+          };
       };
   })

--- a/packages/tui/run/default.nix
+++ b/packages/tui/run/default.nix
@@ -197,25 +197,39 @@
   darwinLibiconv =
     pkgs.runCommand "run-darwin-libiconv"
     {
-      nativeBuildInputs = [package];
+      nativeBuildInputs = [
+        package
+        pkgs.darwin.binutils
+        pkgs.llvmPackages.clang-unwrapped
+      ];
       strictDeps = true;
     }
     ''
-      cat >link-environment-probe <<'EOF'
-      #!${lib.getExe pkgs.bash}
-      IFS=:
-      for directory in $LIBRARY_PATH; do
-        if [ -f "$directory/libiconv.dylib" ]; then
-          exit 0
-        fi
-      done
-      echo "LIBRARY_PATH has no linkable libiconv" >&2
-      exit 1
+      cat >main.c <<'EOF'
+      extern void *iconv_open(const char *, const char *);
+      void *probe(void) { return iconv_open("UTF-8", "UTF-8"); }
       EOF
-      chmod +x link-environment-probe
+
+      cat >link-iconv <<'EOF'
+      #!${lib.getExe pkgs.bash}
+      ${lib.getExe' pkgs.coreutils "env"} -i \
+        HOME="$TMPDIR" \
+        LIBRARY_PATH="$LIBRARY_PATH" \
+        PATH="$PATH" \
+        TMPDIR="$TMPDIR" \
+        ${lib.getExe pkgs.llvmPackages.clang-unwrapped} \
+          -shared -nostdlib main.c -liconv -o iconv-smoke.dylib \
+          2>"$TMPDIR/link-iconv.stderr"
+      EOF
+      chmod +x link-iconv
 
       export IX_RUN_DIR="$TMPDIR/runs"
-      LIBRARY_PATH= run "$PWD/link-environment-probe"
+      if ! LIBRARY_PATH= run "$PWD/link-iconv"; then
+        cat "$TMPDIR/link-iconv.stderr" >&2
+        exit 1
+      fi
+      ${lib.getExe' pkgs.darwin.cctools "otool"} -L iconv-smoke.dylib \
+        | ${lib.getExe' pkgs.gnugrep "grep"} -F ${lib.escapeShellArg "${lib.getLib pkgs.libiconv}/lib/libiconv.2.dylib"}
       mkdir -p "$out"
     '';
 in


### PR DESCRIPTION
## What

* Prefix Darwin `LIBRARY_PATH` for `.#run` with the pinned nixpkgs `libiconv` library directory.
* Render the wrapper arguments from one structured list.
* Add a Darwin-only passthru regression that proves a recorded child sees a linkable `libiconv.dylib`.

## Why

Rust tests link `-liconv` through the raw Darwin compiler. That compiler does not consume the surrounding profile's `NIX_LDFLAGS`, so the repository's sanctioned passthrough could compile a test and then fail at the final link.

## Validation

* `nix run .#run -- cargo test -p claude-hooks guards::tests -- --nocapture`: 2 passed
* `nix build .#run.tests.darwinLibiconv -L --print-out-paths`
* `nix run nixpkgs#alejandra -- --check packages/tui/run/default.nix`
* `nix run .#lint`: this file passes; the repository gate still reports unrelated failures already present on `origin/main`, including `lib/image/platform.nix` formatting and existing astlog findings

Fixes #2759

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose Darwin libiconv library path in the `run` wrapper
> - Adds a `wrapperArgs` list in [`default.nix`](https://github.com/indexable-inc/index/pull/2774/files#diff-8c1d8dd44a3d46bb720445bf7db75e65051dd9220cf473a6da0895e39980288b) that sets `IX_RUN_SCRIPTREPLAY` and, on Darwin, prefixes `LIBRARY_PATH` with the libiconv library path via `makeWrapper`.
> - Adds a Darwin-only test (`run-darwin-libiconv`) that compiles and links a small C program against iconv inside the `run` wrapper environment, verifying the resulting dylib links against `libiconv.2.dylib`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a5c164.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->