### PR TITLE
ci: fail the clone duplication gate fast on a wedged daemon

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,6 +83,10 @@ jobs:
       # in the checkout so a PR cannot add duplication while staying under the
       # repository-wide percentage ratchet.
       - name: Reject duplication on changed lines
+        # Warm runs finish in minutes; the only way this step reaches double
+        # digits is a wedged nix daemon (index#2750 ate the whole 60-minute job
+        # limit across every PR). Fail fast and loudly instead.
+        timeout-minutes: 15
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
         run: |


### PR DESCRIPTION
Item 1 of #2750: give the "Reject duplication on changed lines" step a `timeout-minutes: 15` so a wedged nix daemon fails the job fast instead of silently eating the 60-minute job limit (which took down every flake-check in the fleet for ~2h tonight).

Leaves #2750 open for the daemon-side root causes (ssh-ng localhost builder protocol deadlock, hold-and-wait crate-lock acquisition).

Authored by an AI agent (Claude Code, Opus 4.5) as part of the #2750 incident response.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 15-minute timeout to the clone duplication CI gate to fail fast on a wedged nix daemon
> Adds `timeout-minutes: 15` to the 'Reject duplication on changed lines' step in [check.yml](https://github.com/indexable-inc/index/pull/2775/files#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428). Without this, a wedged nix daemon could cause the step to hang until the job-level timeout expires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92f93c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->