### PR TITLE
agents: upgrade GPT-5.5 references to GPT-5.6 Sol

### DIFF
--- a/doc/pi-harnesses/overview.md
+++ b/doc/pi-harnesses/overview.md
@@ -13,7 +13,7 @@ launcher.
 | `base/` | `pi-base` | base UX pack: live tok/s, git status widget, `/diff`, `/lg`. No agent behavior change. |
 | `prosecutor/` | `pi-prosecutor` | executor under a skeptical, context-isolated supervisor with earned-trust check-ins. |
 | `beam/` | `pi-beam` | executor that turns a hard decision into a bounded [beam search](beam.md) over isolated worktree branches. |
-| `fusion/` | `pi-fusion` | Fable primary agent delegating bounded work to a `gpt-5.5` low sidekick. |
+| `fusion/` | `pi-fusion` | Fable primary agent delegating bounded work to a `gpt-5.6-sol` low sidekick. |
 
 This is ONE component directory; each member package is documented here, with the
 beam-search executor on its own page ([beam.md](beam.md)).
@@ -46,8 +46,8 @@ template `wrapper.sh.in` resolves the model alias to `PI_PROVIDER`/`PI_MODEL`/
 
 One canonical table (`shared/models.nix`): `claude` = anthropic
 `claude-opus-4-8` (no thinking level; 4.8 is adaptive-only), `codex` = openai
-`gpt-5.5` at `thinking = medium`, `fable` = anthropic `fable-5`, and
-`codex-low` = openai `gpt-5.5` at `thinking = low`. Aliases map straight to
+`gpt-5.6-sol` at `thinking = medium`, `fable` = anthropic `fable-5`, and
+`codex-low` = openai `gpt-5.6-sol` at `thinking = low`. Aliases map straight to
 `pi --provider --model [--thinking]`. API keys are NOT stored here: each harness
 receives them from the caller's environment (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`)
 and Pi reads the named var itself. The harness owns model selection only, not
@@ -58,8 +58,8 @@ Select a model per run with `PI_HARNESS_MODEL`:
 
 ```
 nix run .#pi-prosecutor -- "your task"               # claude (opus-4-8)
-PI_HARNESS_MODEL=codex nix run .#pi-beam -- "..."    # gpt-5.5 medium
-nix run .#pi-fusion -- "your task"                   # fable primary + gpt-5.5 low sidekick
+PI_HARNESS_MODEL=codex nix run .#pi-beam -- "..."    # gpt-5.6-sol medium
+nix run .#pi-fusion -- "your task"                   # fable primary + gpt-5.6-sol low sidekick
 ```
 
 ## engine (`pi-harness`)
@@ -153,7 +153,7 @@ The bounded beam-search executor: see [beam.md](beam.md).
 
 Fusion-style primary/sidekick harness (`fusion/README.md`). The primary defaults
 to `fable` and gets a `delegate` tool for bounded sidekick work. The sidekick
-defaults to OpenAI `gpt-5.5` with `thinking=low`, runs headless in an isolated
+defaults to OpenAI `gpt-5.6-sol` with `thinking=low`, runs headless in an isolated
 worktree, and returns a summary plus patch for the primary to review/apply.
 
 ## Building

--- a/packages/agent/pi-harnesses/README.md
+++ b/packages/agent/pi-harnesses/README.md
@@ -21,7 +21,7 @@ pi-harnesses/
   base/                   # id: pi-base       - base UX pack: live tok/s, git widget, /diff, /lg
   prosecutor/             # id: pi-prosecutor - executor under a skeptical, earned-trust supervisor
   beam/                   # id: pi-beam       - executor with beam search over isolated worktree branches
-  fusion/                 # id: pi-fusion     - primary agent delegating to a gpt-5.5-low sidekick
+  fusion/                 # id: pi-fusion     - primary agent delegating to a gpt-5.6-sol sidekick at low reasoning
   omp/                    # id: omp           - oh-my-pi: pinned upstream release binary + Claude bridges (not mk-pi-harness)
 ```
 
@@ -51,8 +51,8 @@ work and the child agents must probe real state.
 ```sh
 nix run github:indexable-inc/index#pi-prosecutor -- "your task"   # opus-4-8 executor + prosecutor (same model)
 nix run github:indexable-inc/index#pi-beam       -- "your task"
-nix run github:indexable-inc/index#pi-fusion     -- "your task"   # fable-5 primary + gpt-5.5-low sidekick
-PI_HARNESS_MODEL=codex nix run github:indexable-inc/index#pi-prosecutor -- "..."   # gpt-5.5 medium
+nix run github:indexable-inc/index#pi-fusion     -- "your task"   # fable-5 primary + gpt-5.6-sol sidekick at low reasoning
+PI_HARNESS_MODEL=codex nix run github:indexable-inc/index#pi-prosecutor -- "..."   # gpt-5.6-sol medium
 ```
 
 API keys come from the caller's environment (`ANTHROPIC_API_KEY` /

--- a/packages/agent/pi-harnesses/engine/README.md
+++ b/packages/agent/pi-harnesses/engine/README.md
@@ -18,7 +18,7 @@ package, you get a `pi-harness` command that launches Pi already locked down.
 
 ```sh
 nix run github:indexable-inc/index#pi-harness -- "your prompt"      # claude (opus-4-8), JSON event stream
-PI_HARNESS_MODEL=codex pi-harness "..."                             # gpt-5.5 via OpenAI
+PI_HARNESS_MODEL=codex pi-harness "..."                             # gpt-5.6-sol via OpenAI
 ```
 
 ## How the lockdown works

--- a/packages/agent/pi-harnesses/engine/models.nix
+++ b/packages/agent/pi-harnesses/engine/models.nix
@@ -15,11 +15,11 @@
     apiKeyEnv = "ANTHROPIC_API_KEY";
   };
 
-  # GPT-5.5 (the model behind Codex) via the OpenAI API. `gpt-5.5` is the API
-  # model id - there is no separate `-codex` suffix on the API surface.
+  # GPT-5.6 Sol (the model behind Codex) via the OpenAI API.
+  # `gpt-5.6-sol` is the API model id; there is no separate `-codex` suffix.
   codex = {
     provider = "openai";
-    model = "gpt-5.5";
+    model = "gpt-5.6-sol";
     apiKeyEnv = "OPENAI_API_KEY";
   };
 }

--- a/packages/agent/pi-harnesses/engine/smoke/run.sh
+++ b/packages/agent/pi-harnesses/engine/smoke/run.sh
@@ -14,7 +14,7 @@
 #      run's executions into exactly that file and cell_update events flow.
 #
 # Needs network + an API key for the selected model (ANTHROPIC_API_KEY by
-# default; set PI_HARNESS_MODEL=codex + OPENAI_API_KEY for gpt-5.5). Run it
+# default; set PI_HARNESS_MODEL=codex + OPENAI_API_KEY for gpt-5.6-sol). Run it
 # yourself - first build can exceed a couple of minutes.
 #
 #   ANTHROPIC_API_KEY=... ./packages/agent/pi-harnesses/engine/smoke/run.sh

--- a/packages/agent/pi-harnesses/fusion/README.md
+++ b/packages/agent/pi-harnesses/fusion/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="assets/hero.svg" width="620" alt="a fable-5 primary delegates bounded work to a headless gpt-5.5-low sidekick in an isolated worktree, which returns a summary and a patch"></p>
+<p align="center"><img src="assets/hero.svg" width="620" alt="a fable-5 primary delegates bounded work to a headless gpt-5.6-sol sidekick at low reasoning in an isolated worktree, which returns a summary and a patch"></p>
 
 # pi-fusion
 
@@ -13,7 +13,7 @@ ambiguity-resolution, monitoring, and final review.
    `fable` (`fable-5`).
 2. The primary delegates bounded work with
    `delegate({ task, acceptance?, mode?, timeoutSec? })`.
-3. The sidekick runs as a headless Pi worker, defaulting to OpenAI `gpt-5.5`
+3. The sidekick runs as a headless Pi worker, defaulting to OpenAI `gpt-5.6-sol`
    with `thinking=low`.
 4. The sidekick works in an isolated git worktree off `HEAD`, returns a concise
    summary plus a patch, and the primary decides whether to apply or revise it.
@@ -25,7 +25,7 @@ inspection, mechanical edits, and test loops.
 ## Config
 
 - `PI_HARNESS_MODEL` - primary model alias; defaults to `fable`.
-- `PI_FUSION_SIDEKICK_MODEL` - sidekick model id; defaults to `gpt-5.5`.
+- `PI_FUSION_SIDEKICK_MODEL` - sidekick model id; defaults to `gpt-5.6-sol`.
 - `PI_FUSION_SIDEKICK_PROVIDER` - sidekick provider; defaults to `openai`.
 - `PI_FUSION_SIDEKICK_THINKING` - sidekick thinking level; defaults to `low`.
 - `PI_FUSION_GOAL` - optional explicit goal; otherwise captured from the first

--- a/packages/agent/pi-harnesses/fusion/assets/hero.svg
+++ b/packages/agent/pi-harnesses/fusion/assets/hero.svg
@@ -28,7 +28,7 @@
   <text x="289" y="42" text-anchor="middle" font-size="11" class="muted">delegate(task)</text>
 
   <rect class="box" x="390" y="28" width="210" height="64" rx="8"/>
-  <text x="495" y="54" text-anchor="middle" font-size="13" font-weight="600">sidekick · gpt-5.5 low</text>
+  <text x="495" y="54" text-anchor="middle" font-size="13" font-weight="600">sidekick · gpt-5.6-sol low</text>
   <text x="495" y="74" text-anchor="middle" font-size="11" class="muted">headless, isolated worktree</text>
 
   <line class="edge" x1="390" y1="112" x2="192" y2="106"/>

--- a/packages/agent/pi-harnesses/fusion/default.nix
+++ b/packages/agent/pi-harnesses/fusion/default.nix
@@ -13,7 +13,7 @@
 in
   mkPiHarness {
     name = "pi-fusion";
-    description = "Pi primary agent with a delegated gpt-5.5-low sidekick.";
+    description = "Pi primary agent with a delegated gpt-5.6-sol sidekick at low reasoning.";
 
     extensions = [./extension/fusion.ts];
     libFiles = [

--- a/packages/agent/pi-harnesses/fusion/extension/fusion.ts
+++ b/packages/agent/pi-harnesses/fusion/extension/fusion.ts
@@ -32,7 +32,7 @@ function sidekickSelection() {
   return {
     alias,
     provider: process.env.PI_FUSION_SIDEKICK_PROVIDER ?? "openai",
-    model: process.env.PI_FUSION_SIDEKICK_MODEL ?? "gpt-5.5",
+    model: process.env.PI_FUSION_SIDEKICK_MODEL ?? "gpt-5.6-sol",
     thinking: process.env.PI_FUSION_SIDEKICK_THINKING ?? "low",
   };
 }

--- a/packages/agent/pi-harnesses/prosecutor/README.md
+++ b/packages/agent/pi-harnesses/prosecutor/README.md
@@ -14,7 +14,7 @@ prosecutor verifies it against the real repo.
    claim: `claim({ statement, verify })`. Until it does, the `tool_call` gate
    blocks every other tool.
 3. The claim is handed to a **prosecutor**: a fresh `pi --print --no-session`
-   process on the same executor-class model (opus-4-8 / gpt-5.5 medium) with NO
+   process on the same executor-class model (opus-4-8 / gpt-5.6-sol medium) with NO
    access to the executor's transcript. It runs the suggested check plus its
    own probes and returns `VERDICT: UPHELD` or `VERDICT: BROKEN <evidence>`.
    The asymmetry that matters is context isolation, not a weaker model.
@@ -36,7 +36,7 @@ hallucinations: the supervisor only ever sees the claim and the repo.
 ## Config
 
 - `PI_HARNESS_MODEL` - executor model alias (default `claude` = opus-4-8;
-  `codex` = gpt-5.5 medium).
+  `codex` = gpt-5.6-sol medium).
 - `PI_PROSECUTOR_PROVIDER` / `PI_PROSECUTOR_MODEL` / `PI_PROSECUTOR_THINKING` -
   override the prosecutor model; defaults to the active executor model.
 - `PI_PROSECUTOR_GOAL` - objective for the prosecutor to judge against; if

--- a/packages/agent/pi-harnesses/prosecutor/default.nix
+++ b/packages/agent/pi-harnesses/prosecutor/default.nix
@@ -31,7 +31,7 @@ in
     lockdown = false;
     session = true;
 
-    # The prosecutor reuses the active executor model (opus-4-8 / gpt-5.5 medium)
+    # The prosecutor reuses the active executor model (opus-4-8 / gpt-5.6-sol medium)
     # by default - context isolation, not a weaker model, is what stops the two
     # agents laundering each other's hallucinations. Override per-run with
     # PI_PROSECUTOR_PROVIDER / PI_PROSECUTOR_MODEL / PI_PROSECUTOR_THINKING.

--- a/packages/agent/pi-harnesses/prosecutor/extension/prosecutor.ts
+++ b/packages/agent/pi-harnesses/prosecutor/extension/prosecutor.ts
@@ -112,7 +112,7 @@ export default function (pi: ExtensionAPI): void {
         const res = await runIsolatedPi({
           prompt,
           systemPrompt,
-          // The prosecutor reuses the executor's model (opus-4-8 / gpt-5.5
+          // The prosecutor reuses the executor's model (opus-4-8 / gpt-5.6-sol
           // medium) by default; the asymmetry that matters is context isolation,
           // not a weaker model. Override per-run with PI_PROSECUTOR_* if desired.
           provider: process.env.PI_PROSECUTOR_PROVIDER ?? process.env.PI_PROVIDER,

--- a/packages/agent/pi-harnesses/shared/models.nix
+++ b/packages/agent/pi-harnesses/shared/models.nix
@@ -14,12 +14,12 @@
     apiKeyEnv = "ANTHROPIC_API_KEY";
   };
 
-  # gpt-5.5 at medium reasoning effort. `thinking` is passed through as
+  # gpt-5.6-sol at medium reasoning effort. `thinking` is passed through as
   # `pi --thinking medium`. (opus-4-8 takes no thinking level: on 4.8 adaptive
   # thinking is the only mode, so `claude` omits it.)
   codex = {
     provider = "openai";
-    model = "gpt-5.5";
+    model = "gpt-5.6-sol";
     thinking = "medium";
     apiKeyEnv = "OPENAI_API_KEY";
   };
@@ -35,7 +35,7 @@
   # Cheap delegated worker for fusion-style harnesses.
   codex-low = {
     provider = "openai";
-    model = "gpt-5.5";
+    model = "gpt-5.6-sol";
     thinking = "low";
     apiKeyEnv = "OPENAI_API_KEY";
   };

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -671,7 +671,7 @@
         on orchestration, quick replies, and trivial one-step work. Match
         agent model strength to task difficulty: strongest for hard
         reasoning, planning, and high-stakes decisions; cheaper tiers (Codex
-        on `gpt-5.5` with low reasoning) for mechanical edits, search, and
+        on `gpt-5.6-sol` with low reasoning) for mechanical edits, search, and
         settled execution.
         When a request branches off the current conversation (a side task,
         fix, or change that is not the thread's main line), dispatch it to a

--- a/packages/agent/symphony/elixir/test/symphony_elixir_web/components/ir_graph_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir_web/components/ir_graph_test.exs
@@ -184,7 +184,7 @@ defmodule SymphonyElixirWeb.Components.IRGraphTest do
     test "agent node with full envelope produces engine/model, effort, permissions, location lines" do
       node =
         mk_agent("agent-0", "codex",
-          model: "gpt-5.5",
+          model: "gpt-5.6-sol",
           effort: "high",
           permissions: "danger_full_access",
           location: "ixvm",
@@ -193,7 +193,7 @@ defmodule SymphonyElixirWeb.Components.IRGraphTest do
 
       %{nodes: nodes} = IRGraph.layout([node])
       [n] = nodes
-      assert "codex gpt-5.5" in n.detail_lines
+      assert "codex gpt-5.6-sol" in n.detail_lines
       assert "high" in n.detail_lines
       assert "danger_full_access" in n.detail_lines
       assert "ixvm" in n.detail_lines
@@ -287,7 +287,7 @@ defmodule SymphonyElixirWeb.Components.IRGraphTest do
     test "node height grows to fit the full envelope block" do
       node =
         mk_agent("agent-0", "codex",
-          model: "gpt-5.5",
+          model: "gpt-5.6-sol",
           effort: "high",
           permissions: "danger_full_access",
           location: "ixvm",
@@ -363,7 +363,7 @@ defmodule SymphonyElixirWeb.Components.IRGraphTest do
     test "layout contains trigger label, skill name, engine+model, effort, permissions, location" do
       node =
         mk_agent("agent-0", "codex",
-          model: "gpt-5.5",
+          model: "gpt-5.6-sol",
           effort: "high",
           permissions: "danger_full_access",
           location: "ixvm",
@@ -384,7 +384,7 @@ defmodule SymphonyElixirWeb.Components.IRGraphTest do
       assert agent.id == "agent-0"
 
       # Envelope detail lines contain engine+model, effort, permissions, location
-      assert "codex gpt-5.5" in agent.detail_lines
+      assert "codex gpt-5.6-sol" in agent.detail_lines
       assert "high" in agent.detail_lines
       assert "danger_full_access" in agent.detail_lines
       assert "ixvm" in agent.detail_lines

--- a/packages/search/source/codex/tests/rollout.rs
+++ b/packages/search/source/codex/tests/rollout.rs
@@ -39,7 +39,7 @@ fn full_session_renders_messages_and_folded_tool_calls() {
     let temp = tempfile::tempdir().expect("tempdir");
     let lines = [
         session_meta("s-full", "/home/u/proj"),
-        r#"{"timestamp":"2026-05-31T10:00:01.000Z","type":"turn_context","payload":{"cwd":"/home/u/proj","model":"gpt-5.5"}}"#.to_owned(),
+        r#"{"timestamp":"2026-05-31T10:00:01.000Z","type":"turn_context","payload":{"cwd":"/home/u/proj","model":"gpt-5.6-sol"}}"#.to_owned(),
         // Developer boilerplate: never indexed.
         r#"{"timestamp":"2026-05-31T10:00:02.000Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"<permissions instructions>\nsandbox stuff\n</permissions instructions>"}]}}"#.to_owned(),
         // User prompt with an injected context block that must be dropped.
@@ -97,7 +97,7 @@ fn full_session_renders_messages_and_folded_tool_calls() {
     assert_eq!(call.meta_json["record_type"], "function_call");
     assert_eq!(call.meta_json["role"], "assistant");
     assert_eq!(call.meta_json["tool_name"], "exec_command");
-    assert_eq!(call.meta_json["model"], "gpt-5.5");
+    assert_eq!(call.meta_json["model"], "gpt-5.6-sol");
 
     let answer = &docs[2];
     assert_eq!(answer.meta_json["role"], "assistant");

--- a/packages/tui/tui-py/python/tui/harness.py
+++ b/packages/tui/tui-py/python/tui/harness.py
@@ -546,7 +546,7 @@ class Codex(Agent):
     ready = re.compile(r"[›❯>]\s*$", re.MULTILINE)
     busy_marker = None
     #: Defaults shared by the TUI constructor and the headless one-shot.
-    default_model: ClassVar[str] = "gpt-5.5"
+    default_model: ClassVar[str] = "gpt-5.6-sol"
     default_reasoning_effort: ClassVar[str] = "low"
     default_sandbox: ClassVar[str] = "danger-full-access"
 

--- a/users/andrewgazelka/config/zed/settings.nix
+++ b/users/andrewgazelka/config/zed/settings.nix
@@ -6,7 +6,7 @@
     default_model = {
       effort = "medium";
       enable_thinking = true;
-      model = "gpt-5.5";
+      model = "gpt-5.6-sol";
       provider = "openai";
     };
     dock = "right";

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -199,7 +199,7 @@
   codexSettings = {
     check_for_update_on_startup = false;
     bypass_hook_trust = true;
-    model = "gpt-5.5";
+    model = "gpt-5.6-sol";
     model_reasoning_effort = "low";
     personality = "pragmatic";
     service_tier = "fast";


### PR DESCRIPTION
## Summary

- move Pi harness, TUI, Zed, and workstation defaults from GPT-5.5 to canonical `gpt-5.6-sol`
- update directly coupled documentation, assets, and model-bearing fixtures

## Validation

- authenticated `codex exec --model gpt-5.6-sol` smoke
- `nix build .#pi-harness .#pi-fusion`
- `cargo test -p source-codex`
- changed Nix files pass Alejandra formatting

Full `nix run .#lint` remains blocked by pre-existing current-main findings in unrelated files.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade `gpt-5.5` model references to `gpt-5.6-sol` across agents and TUI
> - Updates the `codex` and `codex-low` alias mappings in [shared/models.nix](https://github.com/indexable-inc/index/pull/2776/files#diff-8c3ff77bd3f53b8d36106cb062322084e095b604e1669ca5308a7816154b1c8e) and [engine/models.nix](https://github.com/indexable-inc/index/pull/2776/files#diff-6ff211314e7acb200b9e4eb4a2650dce0e4e158f1ac6d150f38db452a735660c) to target `gpt-5.6-sol` instead of `gpt-5.5`.
> - Changes the default model in [fusion.ts](https://github.com/indexable-inc/index/pull/2776/files#diff-a0f1128b3058a0e72f08de3b04acc82ebdff97a1b9ebad72a88dc27bebcd87b7) and [harness.py](https://github.com/indexable-inc/index/pull/2776/files#diff-2fc410689b430c18113770dec5a98ea57e4cb0602d8df3e9c95ad810425242bf) so unset model configurations resolve to `gpt-5.6-sol`.
> - Updates prompt rules text, test fixtures, and documentation to reference `gpt-5.6-sol`.
> - Behavioral Change: any agent, harness, or TUI invocation that previously defaulted to `gpt-5.5` will now use `gpt-5.6-sol`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e26fac6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->