### PR TITLE
symphony: accept caller-selected run ids

### DIFF
--- a/doc/symphony/operations/overview.md
+++ b/doc/symphony/operations/overview.md
@@ -124,9 +124,14 @@ LiveView dashboard (`router.ex:25-40`):
 
 JSON API under `/api/v1` (`router.ex:42-61`):
 
-- `POST /runs` - manual-trigger enqueue: `{"workflow": "..", "input": {..}}`
-  starts that `.sym`; without `workflow` it fires every `on manual` workflow
-  (`controllers/api_controller.ex:1-29`).
+- `POST /runs`: manual-trigger enqueue. A body with `{"workflow": "..",
+  "input": {..}, "run_id": ".."}` starts that `.sym`. `run_id` is optional
+  and lets a caller record the id before sending, then cancel the run even if
+  the create response is lost. It is 1 to 128 lowercase ASCII letters, digits,
+  or hyphens, with a letter or digit at each end. Every replay of an owned id
+  returns 409, even when the workflow and input match. Without `workflow`, the
+  route fires every `on manual` workflow and rejects `run_id` because one id
+  cannot name the fan-out (`controllers/api_controller.ex:1-58`).
 - `GET /ir/schema` - the runtime enum vocabulary (drives form option lists).
 - `GET /ir/runs`, `POST /ir/runs`, `GET /ir/runs/:run_id` - list/create/read runs.
 - `POST /ir/runs/:run_id/{cancel,rerun,clear-failed}` and

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/ir/store.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/ir/store.ex
@@ -93,6 +93,34 @@ defmodule SymphonyElixir.IR.Store do
   end
 
   @doc """
+  Persist a new RunGraph only when its run id has no durable owner.
+
+  The completed temporary file is hard-linked into place, so the ownership
+  check and publication are one filesystem operation. A competing creator
+  receives {:error, :already_exists} and cannot replace the first graph.
+  """
+  @spec create(RunGraph.t(), keyword()) :: :ok | {:error, term()}
+  def create(%RunGraph{} = graph, opts \\ []) do
+    store_dir = dir(opts)
+    File.mkdir_p!(store_dir)
+    path = run_path(store_dir, graph.run_id)
+    tmp = path <> ".create-#{System.unique_integer([:positive, :monotonic])}.tmp"
+
+    try do
+      with {:ok, encoded} <- Jason.encode(encode(graph), pretty: true),
+           :ok <- File.write(tmp, encoded, [:exclusive]) do
+        case File.ln(tmp, path) do
+          :ok -> :ok
+          {:error, :eexist} -> {:error, :already_exists}
+          {:error, _} = error -> error
+        end
+      end
+    after
+      _ = File.rm(tmp)
+    end
+  end
+
+  @doc """
   Append a dynamic-expansion event and persist. A thin wrapper over
   `RunGraph.append_expansion/4` plus `persist/2`, so the append-only log
   that drives replay is never updated without hitting disk.

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime.ex
@@ -193,19 +193,25 @@ defmodule SymphonyElixir.Runtime do
     # An invalid dynamically-emitted envelope fails the run rather than
     # crashing init, so a bad child surfaces as a failed run, not a
     # supervisor restart loop.
-    case Materializer.expand_dynamic(state.graph) do
-      {:ok, expanded, _new_ids} ->
-        state = %{state | graph: expanded}
-        # Persist before the first scheduling pass so a producer that
-        # navigates to /ir/:run_id the moment start_run returns finds the
-        # run on disk, even while a slow placement acquire is still in
-        # flight. The run shows :running with :pending nodes; the broadcast
-        # also lands so the index row appears without a navigation.
-        persist(expanded, state)
-        {:ok, state, {:continue, :advance}}
+    case claim_run_id(state.graph, state, opts) do
+      :ok ->
+        case Materializer.expand_dynamic(state.graph) do
+          {:ok, expanded, _new_ids} ->
+            state = %{state | graph: expanded}
+            # Persist before the first scheduling pass so a producer that
+            # navigates to /ir/:run_id the moment start_run returns finds the
+            # run on disk, even while a slow placement acquire is still in
+            # flight. The run shows :running with :pending nodes; the broadcast
+            # also lands so the index row appears without a navigation.
+            persist(expanded, state)
+            {:ok, state, {:continue, :advance}}
+
+          {:error, reason} ->
+            {:ok, %{state | graph: fail_run(state.graph, reason, state.store_opts)}, {:continue, :advance}}
+        end
 
       {:error, reason} ->
-        {:ok, %{state | graph: fail_run(state.graph, reason, state.store_opts)}, {:continue, :advance}}
+        {:stop, reason}
     end
   end
 
@@ -744,6 +750,26 @@ defmodule SymphonyElixir.Runtime do
   end
 
   # --- helpers --------------------------------------------------------
+
+  # Ingress marks fresh runs for an exclusive durable claim. Claim before
+  # expansion so every init path, including an invalid expansion, either owns
+  # the id or stops without replacing another run's graph.
+  defp claim_run_id(%RunGraph{} = graph, state, opts) do
+    if Keyword.get(opts, :claim_run_id, false) do
+      case Store.create(graph, state.store_opts) do
+        :ok ->
+          :ok
+
+        {:error, :already_exists} ->
+          {:error, {:run_id_conflict, graph.run_id}}
+
+        {:error, reason} ->
+          {:error, {:run_store_create_failed, graph.run_id, reason}}
+      end
+    else
+      :ok
+    end
+  end
 
   # Dispatch one attempt by node kind. Only `:agent` nodes are engine
   # turns and go through the injected engine client; `:exec` runs a pack

--- a/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/ingress.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir/runtime/ingress.ex
@@ -23,30 +23,57 @@ defmodule SymphonyElixir.Runtime.Ingress do
   alias SymphonyElixir.Runtime.Trigger
   alias SymphonyElixir.WorkflowCatalog
 
+  @run_id_max_length 128
+  @run_id_pattern ~r/\A[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z/
+
   @typedoc "A started run: its generated id and the supervised runtime pid."
   @type started :: %{run_id: String.t(), pid: pid()}
 
   @doc """
   Materialize a catalog entry and start it. `trigger_context` is the event
-  payload (`nil` for an operator-started run); `opts` forwards `:engine`,
-  `:store_opts`, and an optional `:run_id` to the supervisor.
+  payload (`nil` for an operator-started run); `opts` forwards `:engine`
+  and `:store_opts` to the supervisor. An optional `:run_id` is validated
+  here, then claimed atomically by the runtime before the run starts. An id
+  already owned by a live or persisted run returns `{:run_id_conflict, id}`.
   """
   @spec start_workflow(WorkflowCatalog.entry(), map() | nil, keyword()) :: {:ok, started()} | {:error, term()}
   def start_workflow(entry, trigger_context \\ nil, opts \\ [])
 
   def start_workflow(%{ast: ast, hash: hash} = entry, trigger_context, opts) do
-    run_id = Keyword.get_lazy(opts, :run_id, fn -> generate_run_id(entry) end)
-    start_opts = Keyword.delete(opts, :run_id)
+    start_opts = opts |> Keyword.delete(:run_id) |> Keyword.put(:claim_run_id, true)
 
-    with {:ok, graph} <- Materializer.materialize(run_id, hash, ast) do
+    with {:ok, run_id} <- select_run_id(entry, opts),
+         {:ok, graph} <- Materializer.materialize(run_id, hash, ast) do
       graph = %{graph | trigger: trigger_context}
 
       case Runtime.Supervisor.start_run(graph, start_opts) do
         {:ok, pid} -> {:ok, %{run_id: run_id, pid: pid}}
+        {:error, {:already_started, _pid}} -> {:error, {:run_id_conflict, run_id}}
         {:error, _} = err -> err
       end
     end
   end
+
+  @doc """
+  Validate the run id grammar shared by generated and caller-supplied ids.
+
+  A run id is 1 to 128 lowercase ASCII letters, digits, or hyphens. It must
+  start and end with a letter or digit. This keeps the id safe as the shared
+  Store filename, workspace and state directory, git branch suffix, and URL
+  path component.
+  """
+  @spec validate_run_id(term()) :: {:ok, String.t()} | {:error, {:invalid_run_id, term()}}
+  def validate_run_id(run_id)
+
+  def validate_run_id(run_id) when is_binary(run_id) and byte_size(run_id) <= @run_id_max_length do
+    if Regex.match?(@run_id_pattern, run_id) do
+      {:ok, run_id}
+    else
+      {:error, {:invalid_run_id, run_id}}
+    end
+  end
+
+  def validate_run_id(run_id), do: {:error, {:invalid_run_id, run_id}}
 
   @doc """
   Resolve every `.sym` workflow that declared interest in this trigger
@@ -120,9 +147,15 @@ defmodule SymphonyElixir.Runtime.Ingress do
     |> Enum.any?(fn graph -> match_fun.({graph.status, graph.trigger}) end)
   end
 
+  defp select_run_id(entry, opts) do
+    opts
+    |> Keyword.get_lazy(:run_id, fn -> generate_run_id(entry) end)
+    |> validate_run_id()
+  end
+
   # A readable, collision-resistant run id: the workflow slug, the wall
-  # clock, and a monotonic counter. Ids are opaque to the store; the slug is
-  # only there to make a runs listing scannable.
+  # clock, and a monotonic counter. Keep the suffix intact and bound only the
+  # display slug so generated ids obey the same public grammar as caller ids.
   defp generate_run_id(%{name: name}) do
     slug =
       name
@@ -131,7 +164,18 @@ defmodule SymphonyElixir.Runtime.Ingress do
       |> String.replace(~r/[^a-z0-9]+/, "-")
       |> String.trim("-")
 
-    slug = if slug == "", do: "workflow", else: slug
-    "#{slug}-#{System.system_time(:millisecond)}-#{System.unique_integer([:positive, :monotonic])}"
+    suffix = "#{System.system_time(:millisecond)}-#{System.unique_integer([:positive, :monotonic])}"
+    max_slug_length = @run_id_max_length - byte_size(suffix) - 1
+
+    slug =
+      slug
+      |> String.slice(0, max_slug_length)
+      |> String.trim("-")
+      |> case do
+        "" -> "workflow"
+        bounded -> bounded
+      end
+
+    "#{slug}-#{suffix}"
   end
 end

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/api_controller.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/api_controller.ex
@@ -3,11 +3,17 @@ defmodule SymphonyElixirWeb.ApiController do
   The manual-trigger enqueue producer onto the IR runtime.
 
       POST /api/v1/runs   start IR run(s) from a manual trigger;
-                          body: {"workflow": "...", "input": {...}}
+                          body: {"workflow": "...", "input": {...}, "run_id": "..."}
 
   A caller naming a `workflow` starts exactly that `.sym`; a caller without
   one fires every `on manual` workflow through the shared trigger matcher.
   Input rides on the trigger context so a node can read it as `<input>`.
+
+  A named start may include a caller-selected run id. The caller can record
+  that id before sending the request and cancel the exact run even when the
+  create response is lost. Every replay of an owned id returns 409, including
+  an otherwise identical request. A run id without a workflow is rejected
+  because one id cannot identify a fan-out start.
   """
 
   use Phoenix.Controller, formats: [:json]
@@ -18,13 +24,18 @@ defmodule SymphonyElixirWeb.ApiController do
   def enqueue_run(conn, params) do
     input = Map.get(params, "input", %{})
 
-    case Map.get(params, "workflow") || Map.get(params, "dag") do
-      name when is_binary(name) and name != "" ->
+    case {Map.get(params, "workflow") || Map.get(params, "dag"), Map.fetch(params, "run_id")} do
+      {name, run_id} when is_binary(name) and name != "" ->
         name
-        |> Ingress.start_by_name(%{kind: :manual, input: input}, [])
+        |> Ingress.start_by_name(%{kind: :manual, input: input}, run_opts(run_id))
         |> respond_started(conn)
 
-      _ ->
+      {_name, {:ok, _run_id}} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "run_id requires a named workflow"})
+
+      {_name, :error} ->
         %{kind: :manual, input: input}
         |> Ingress.start_by_trigger([])
         |> respond_started(conn)
@@ -37,5 +48,10 @@ defmodule SymphonyElixirWeb.ApiController do
 
   defp respond_started({:error, {:workflow_not_found, _}} = reason, conn), do: conn |> put_status(:not_found) |> json(%{error: inspect(reason)})
 
+  defp respond_started({:error, {:run_id_conflict, run_id}}, conn), do: conn |> put_status(:conflict) |> json(%{error: "run id already exists: #{run_id}"})
+
   defp respond_started({:error, reason}, conn), do: conn |> put_status(:unprocessable_entity) |> json(%{error: inspect(reason)})
+
+  defp run_opts(:error), do: []
+  defp run_opts({:ok, run_id}), do: [run_id: run_id]
 end

--- a/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/ir_run_controller.ex
+++ b/packages/agent/symphony/elixir/lib/symphony_elixir_web/controllers/ir_run_controller.ex
@@ -56,6 +56,9 @@ defmodule SymphonyElixirWeb.IRRunController do
       {:error, {:workflow_not_found, _}} = reason ->
         conn |> put_status(:not_found) |> json(%{error: inspect(reason)})
 
+      {:error, {:run_id_conflict, run_id}} ->
+        conn |> put_status(:conflict) |> json(%{error: "run id already exists: #{run_id}"})
+
       {:error, reason} ->
         conn |> put_status(:unprocessable_entity) |> json(%{error: inspect(reason)})
     end

--- a/packages/agent/symphony/elixir/test/symphony_elixir/ir/store_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/ir/store_test.exs
@@ -111,6 +111,34 @@ defmodule SymphonyElixir.IR.StoreTest do
     assert {:error, :not_found} = Store.load("nope", dir: dir)
   end
 
+  test "create gives the first graph durable ownership of a run id", %{dir: dir} do
+    first = sample_graph()
+    second = %{first | trigger: %{kind: :manual, input: %{"owner" => "second"}}}
+
+    assert :ok = Store.create(first, dir: dir)
+    assert {:error, :already_exists} = Store.create(second, dir: dir)
+    assert {:ok, loaded} = Store.load(first.run_id, dir: dir)
+    assert loaded.trigger == first.trigger
+  end
+
+  test "concurrent creates publish exactly one owner", %{dir: dir} do
+    attempts =
+      ["first", "second"]
+      |> Task.async_stream(
+        fn owner ->
+          graph = %{sample_graph() | trigger: %{kind: :manual, input: %{"owner" => owner}}}
+          {owner, Store.create(graph, dir: dir)}
+        end,
+        ordered: false
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
+
+    assert Enum.sort(Enum.map(attempts, &elem(&1, 1))) == [:ok, {:error, :already_exists}]
+    {owner, :ok} = Enum.find(attempts, &(elem(&1, 1) == :ok))
+    assert {:ok, loaded} = Store.load("run-store-1", dir: dir)
+    assert loaded.trigger == %{kind: :manual, input: %{"owner" => owner}}
+  end
+
   test "round-trips a graph with a placement map (ixvm declared, host effective)", %{dir: dir} do
     graph =
       "run-placement"

--- a/packages/agent/symphony/elixir/test/symphony_elixir/runtime/ingress_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir/runtime/ingress_test.exs
@@ -98,6 +98,47 @@ defmodule SymphonyElixir.Runtime.IngressTest do
     assert wait_terminal("fixed-id", store_opts).status == :succeeded
   end
 
+  test "generated and caller-supplied ids share one path-safe grammar", %{store_opts: store_opts} do
+    long_name = String.duplicate("Long workflow ", 30)
+    e = entry(~s|workflow "#{long_name}" on manual { a <- agent { engine: codex, model: "m", prompt: inline "go" } }|)
+
+    assert {:ok, %{run_id: generated}} =
+             Ingress.start_workflow(e, nil, engine: FakeEngine, store_opts: store_opts)
+
+    assert {:ok, ^generated} = Ingress.validate_run_id(generated)
+    assert byte_size(generated) <= 128
+
+    for invalid <- ["", "-leading", "trailing-", "UPPER", "../escape", "has_underscore", String.duplicate("a", 129)] do
+      assert {:error, {:invalid_run_id, ^invalid}} = Ingress.validate_run_id(invalid)
+    end
+  end
+
+  test "a completed run keeps durable ownership of its explicit id", %{store_opts: store_opts} do
+    first = entry(~s|workflow "first" on manual { a <- agent { engine: codex, model: "m", prompt: inline "go" } }|)
+    second = entry(~s|workflow "second" on manual { b <- agent { engine: codex, model: "m", prompt: inline "go" } }|)
+    run_id = "durable-owner"
+
+    assert {:ok, %{run_id: ^run_id}} =
+             Ingress.start_workflow(first, %{kind: :manual, input: %{"owner" => "first"}},
+               run_id: run_id,
+               engine: FakeEngine,
+               store_opts: store_opts
+             )
+
+    assert wait_terminal(run_id, store_opts).status == :succeeded
+
+    assert {:error, {:run_id_conflict, ^run_id}} =
+             Ingress.start_workflow(second, %{kind: :manual, input: %{"owner" => "second"}},
+               run_id: run_id,
+               engine: FakeEngine,
+               store_opts: store_opts
+             )
+
+    assert {:ok, graph} = Store.load(run_id, store_opts)
+    assert graph.source_hash == first.hash
+    assert graph.trigger == %{kind: :manual, input: %{"owner" => "first"}}
+  end
+
   test "start_by_trigger fans out to every workflow matching the event", %{store_opts: store_opts, workflows_dir: dir} do
     write_sym!(dir, "label-a", ~s|workflow "label-a" on github_pr_label repo "acme/app" label "ship" { a <- agent { engine: codex, model: "m", prompt: inline "go" } }|)
     write_sym!(dir, "label-b", ~s|workflow "label-b" on github_pr_label repo "acme/app" label "ship" { b <- agent { engine: codex, model: "m", prompt: inline "go" } }|)

--- a/packages/agent/symphony/elixir/test/symphony_elixir_web/api_controller_test.exs
+++ b/packages/agent/symphony/elixir/test/symphony_elixir_web/api_controller_test.exs
@@ -1,0 +1,167 @@
+defmodule SymphonyElixirWeb.ApiControllerTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias SymphonyElixir.DSL.Parser
+  alias SymphonyElixir.IR.Store
+  alias SymphonyElixir.Runtime
+
+  @opts SymphonyElixirWeb.Endpoint.init([])
+
+  setup do
+    if !Process.whereis(SymphonyElixir.Runtime.Registry) do
+      start_supervised!({Registry, keys: :unique, name: SymphonyElixir.Runtime.Registry})
+    end
+
+    if !Process.whereis(SymphonyElixir.TaskSupervisor) do
+      start_supervised!({Task.Supervisor, name: SymphonyElixir.TaskSupervisor})
+    end
+
+    if !Process.whereis(SymphonyElixir.Runtime.Supervisor) do
+      start_supervised!(SymphonyElixir.Runtime.Supervisor)
+    end
+
+    ensure_workflow_catalog_table()
+
+    store_dir = Store.dir()
+    File.rm_rf!(store_dir)
+    File.mkdir_p!(store_dir)
+
+    script = Path.join(SymphonyElixir.Config.get().pack_dir, "scripts/api-controller-slow.sh")
+    File.mkdir_p!(Path.dirname(script))
+    File.write!(script, "#!/bin/sh\nsleep 30\n")
+    File.chmod!(script, 0o755)
+
+    on_exit(fn ->
+      File.rm_rf!(store_dir)
+      File.rm!(script)
+    end)
+
+    :ok
+  end
+
+  defp ensure_workflow_catalog_table do
+    table = :symphony_workflows
+
+    if :ets.whereis(table) == :undefined do
+      :ets.new(table, [:named_table, :public, read_concurrency: true])
+    else
+      :ets.delete_all_objects(table)
+    end
+  end
+
+  defp put_workflow(name, source) do
+    {:ok, ast} = Parser.parse(source)
+    entry = %{name: ast.name || name, ast: ast, trigger: ast.trigger, source: source, hash: :crypto.hash(:sha256, source)}
+    :ets.insert(:symphony_workflows, {name, entry})
+    entry
+  end
+
+  defp post(path, body) do
+    :post
+    |> conn(path, Jason.encode!(body))
+    |> put_req_header("content-type", "application/json")
+    |> SymphonyElixirWeb.Endpoint.call(@opts)
+  end
+
+  defp slow_workflow(name, node_id \\ "wait") do
+    ~s|workflow "#{name}" on manual { #{node_id} <- exec "./scripts/api-controller-slow.sh" timeout 60 }|
+  end
+
+  defp cancel_on_exit(run_id) do
+    on_exit(fn -> cancel_if_registered(Process.whereis(SymphonyElixir.Runtime.Registry), run_id) end)
+  end
+
+  defp cancel_if_registered(nil, _run_id), do: :ok
+
+  defp cancel_if_registered(_registry, run_id) do
+    case Registry.lookup(SymphonyElixir.Runtime.Registry, run_id) do
+      [{pid, _value}] -> Runtime.cancel(pid, :test_cleanup)
+      [] -> :ok
+    end
+  end
+
+  test "POST /api/v1/runs accepts a caller-supplied run id" do
+    put_workflow("slow", slow_workflow("slow"))
+    run_id = "caller-selected-create"
+    cancel_on_exit(run_id)
+
+    conn = post("/api/v1/runs", %{"workflow" => "slow", "run_id" => run_id, "input" => %{"proof" => "create"}})
+
+    assert conn.status == 201
+    assert Jason.decode!(conn.resp_body) == %{"run_ids" => [run_id]}
+    assert {:ok, graph} = Store.load(run_id)
+    assert graph.trigger == %{kind: :manual, input: %{"proof" => "create"}}
+  end
+
+  test "an identical caller-supplied run id replay is an explicit conflict" do
+    entry = put_workflow("slow", slow_workflow("slow"))
+    run_id = "caller-selected-replay"
+    cancel_on_exit(run_id)
+    request = %{"workflow" => "slow", "run_id" => run_id, "input" => %{"proof" => "same"}}
+
+    assert post("/api/v1/runs", request).status == 201
+    replay = post("/api/v1/runs", request)
+
+    assert replay.status == 409
+    assert Jason.decode!(replay.resp_body) == %{"error" => "run id already exists: #{run_id}"}
+    assert {:ok, graph} = Store.load(run_id)
+    assert graph.source_hash == entry.hash
+    assert graph.trigger == %{kind: :manual, input: %{"proof" => "same"}}
+  end
+
+  test "a duplicate run id cannot adopt a different workflow or input" do
+    first = put_workflow("first", slow_workflow("first"))
+    put_workflow("second", slow_workflow("second", "other"))
+    run_id = "caller-selected-mismatch"
+    cancel_on_exit(run_id)
+
+    assert post("/api/v1/runs", %{"workflow" => "first", "run_id" => run_id, "input" => %{"owner" => "first"}}).status == 201
+
+    duplicate = post("/api/v1/runs", %{"workflow" => "second", "run_id" => run_id, "input" => %{"owner" => "second"}})
+
+    assert duplicate.status == 409
+    assert Jason.decode!(duplicate.resp_body) == %{"error" => "run id already exists: #{run_id}"}
+    assert {:ok, graph} = Store.load(run_id)
+    assert graph.source_hash == first.hash
+    assert graph.trigger == %{kind: :manual, input: %{"owner" => "first"}}
+  end
+
+  test "a preselected run id cancels a run after its create response is lost" do
+    put_workflow("slow", slow_workflow("slow"))
+    run_id = "caller-selected-lost-response"
+    cancel_on_exit(run_id)
+
+    _dropped_response = post("/api/v1/runs", %{"workflow" => "slow", "run_id" => run_id})
+    cancelled = post("/api/v1/ir/runs/#{run_id}/cancel", %{})
+
+    assert cancelled.status == 200
+    assert Jason.decode!(cancelled.resp_body)["run_id"] == run_id
+    assert {:ok, %{status: :cancelled}} = Store.load(run_id)
+  end
+
+  test "caller-supplied run ids are validated at Ingress" do
+    put_workflow("slow", slow_workflow("slow"))
+
+    for invalid <- ["", "../escape", "UPPER", "trailing-", String.duplicate("a", 129), 42] do
+      conn = post("/api/v1/runs", %{"workflow" => "slow", "run_id" => invalid})
+
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["error"] =~ "invalid_run_id"
+    end
+
+    assert Store.load_all() == []
+  end
+
+  test "a caller-supplied run id requires one named workflow" do
+    put_workflow("slow", slow_workflow("slow"))
+
+    conn = post("/api/v1/runs", %{"run_id" => "fan-out-cannot-own-one-id"})
+
+    assert conn.status == 422
+    assert Jason.decode!(conn.resp_body) == %{"error" => "run_id requires a named workflow"}
+    assert Store.load_all() == []
+  end
+end


### PR DESCRIPTION
## Summary

- accept and centrally validate caller-selected `run_id` values on `POST /api/v1/runs`
- atomically grant durable ownership before a run starts, with every duplicate returning 409 without overwrite
- cover create, replay, mismatch, invalid input, concurrent ownership, and cancellation after a dropped response

## Validation

- `nix build .#checks.x86_64-linux.symphony-elixir`
- 460 tests, strict Credo clean
- `nix run .#lint` remains red only on unrelated current-main findings tracked by #2460

Fixes #2779

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add caller-selected run IDs with idempotent conflict handling to Symphony
> - `POST /api/v1/runs` now accepts an optional `run_id` for named workflow starts; supplying `run_id` without a workflow name returns 422.
> - `Ingress.start_workflow` validates caller-supplied IDs against a shared grammar (1–128 bytes, lowercase alphanumeric with interior hyphens) or generates a conforming ID if none is provided.
> - `Store.create/2` atomically claims durable ownership of a run ID via a temp file + hard link; concurrent creates return `{:error, :already_exists}` to the loser.
> - Both the API controller and IR run controller return HTTP 409 when a run ID conflict is detected, enabling safe replay of lost create responses.
> - Risk: runs with a caller-supplied `run_id` now fail at startup if the ID is already claimed on disk, rather than proceeding with a duplicate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a99002.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->