### PR TITLE
agent: reject zsh path assignments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tree-sitter",
+ "tree-sitter-bash",
  "xxhash-rust",
 ]
 

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -489,6 +489,15 @@
     pre_guard bash-habits-guard "quoted mention not a false positive" allow \
       "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo '2>/dev/null'\"}}"
 
+    pre_guard bash-habits-guard "zsh path assignment denied" deny \
+      '{"tool_name":"Bash","tool_input":{"command":"path=/private/tmp/worktree; git status"}}'
+    pre_guard bash-habits-guard "zsh local path assignment denied" deny \
+      '{"tool_name":"Bash","tool_input":{"command":"f() { local path=/private/tmp/worktree; git status; }; f"}}'
+    pre_guard bash-habits-guard "descriptive path variable allowed" allow \
+      '{"tool_name":"Bash","tool_input":{"command":"worktree_path=/private/tmp/worktree; git status"}}'
+    pre_guard bash-habits-guard "path argument allowed" allow \
+      '{"tool_name":"Bash","tool_input":{"command":"echo path=/private/tmp/worktree"}}'
+
     pre_guard search-guard "Search tool denied" deny '{"tool_name":"Search"}'
     pre_guard search-guard "WebSearch not denied" allow '{"tool_name":"WebSearch"}'
 

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -493,6 +493,12 @@
       '{"tool_name":"Bash","tool_input":{"command":"path=/private/tmp/worktree; git status"}}'
     pre_guard bash-habits-guard "zsh local path assignment denied" deny \
       '{"tool_name":"Bash","tool_input":{"command":"f() { local path=/private/tmp/worktree; git status; }; f"}}'
+    pre_guard bash-habits-guard "zsh path subscript assignment denied" deny \
+      '{"tool_name":"Bash","tool_input":{"command":"path[1]=/private/tmp/worktree; git status"}}'
+    pre_guard bash-habits-guard "zsh local path declaration denied" deny \
+      '{"tool_name":"Bash","tool_input":{"command":"f() { local path; git status; }; f"}}'
+    pre_guard bash-habits-guard "zsh path loop binding denied" deny \
+      '{"tool_name":"Bash","tool_input":{"command":"for path in /private/tmp/worktree /bin; do git status; done"}}'
     pre_guard bash-habits-guard "descriptive path variable allowed" allow \
       '{"tool_name":"Bash","tool_input":{"command":"worktree_path=/private/tmp/worktree; git status"}}'
     pre_guard bash-habits-guard "path argument allowed" allow \

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -503,6 +503,8 @@
       '{"tool_name":"Bash","tool_input":{"command":"worktree_path=/private/tmp/worktree; git status"}}'
     pre_guard bash-habits-guard "path argument allowed" allow \
       '{"tool_name":"Bash","tool_input":{"command":"echo path=/private/tmp/worktree"}}'
+    pre_guard bash-habits-guard "double quoted backticks denied" deny \
+      '{"tool_name":"Bash","tool_input":{"command":"rg -n \"literal `:ixvm` pattern\" ."}}'
 
     pre_guard search-guard "Search tool denied" deny '{"tool_name":"Search"}'
     pre_guard search-guard "WebSearch not denied" allow '{"tool_name":"WebSearch"}'

--- a/packages/agent/claude-hooks/Cargo.toml
+++ b/packages/agent/claude-hooks/Cargo.toml
@@ -22,6 +22,8 @@ libc.workspace = true
 regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tree-sitter.workspace = true
+tree-sitter-bash.workspace = true
 # friction-report routes the model child's stdout to a real temp file (not a
 # pipe), and the subagent-cache tests use it too.
 tempfile.workspace = true

--- a/packages/agent/claude-hooks/src/guards.rs
+++ b/packages/agent/claude-hooks/src/guards.rs
@@ -9,6 +9,7 @@
 //! returns with no output and the call proceeds.
 
 use serde_json::Value;
+use tree_sitter::{Node, Parser};
 
 use crate::DenyOutput;
 
@@ -109,15 +110,52 @@ fn grep_walks_tree(stage: &str) -> bool {
     false
 }
 
+fn node_text<'a>(node: Node<'_>, source: &'a str) -> Option<&'a str> {
+    source.get(node.byte_range())
+}
+
+fn is_zsh_path_assignment(node: Node<'_>, source: &str) -> bool {
+    node.kind() == "variable_assignment"
+        && node
+            .child_by_field_name("name")
+            .and_then(|name| node_text(name, source))
+            == Some("path")
+}
+
+fn syntax_tree_has_zsh_path_assignment(node: Node<'_>, source: &str) -> bool {
+    if is_zsh_path_assignment(node, source) {
+        return true;
+    }
+
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| syntax_tree_has_zsh_path_assignment(child, source))
+}
+
+fn has_zsh_path_assignment(command: &str) -> bool {
+    let mut parser = Parser::new();
+    if parser
+        .set_language(&tree_sitter_bash::LANGUAGE.into())
+        .is_err()
+    {
+        return false;
+    }
+    parser
+        .parse(command, None)
+        .is_some_and(|tree| syntax_tree_has_zsh_path_assignment(tree.root_node(), command))
+}
+
 /// `PreToolUse(Bash)`: block recurring bad command shapes (output-to-/dev/null,
-/// recursive `grep -r`, `--no-verify`). Quote/escape-aware so a literal mention
-/// inside a commit message or `echo` is not a false positive.
+/// recursive `grep -r`, `--no-verify`, lowercase zsh `path` assignments).
+/// Quote/escape-aware so a literal mention inside a commit message or `echo` is
+/// not a false positive.
 pub fn bash_habits_guard() {
     let Some(payload) = payload() else { return };
     if payload.get("tool_name").and_then(Value::as_str) != Some("Bash") {
         return;
     }
     let raw = command_of(&payload);
+    let zsh_path_assignment = has_zsh_path_assignment(&raw);
 
     // Match operators, not literal text inside a quoted string. Neutralize
     // escaped chars, then drop quoted substrings (a real `2>/dev/null` /
@@ -173,6 +211,18 @@ pub fn bash_habits_guard() {
              yourself outside the agent. (bash-habits-guard hook)"
                 .to_owned(),
         );
+        return;
+    }
+
+    // In zsh, lowercase `path` is tied to `PATH`. Parse assignment nodes so
+    // harmless arguments such as `echo path=/tmp` remain allowed.
+    if zsh_path_assignment {
+        deny(
+            "In zsh, lowercase `path` is tied to `PATH`, so assigning `path=...` \
+             replaces the command search path. Use a descriptive name such as \
+             `worktree_path` instead. (bash-habits-guard hook)"
+                .to_owned(),
+        );
     }
 }
 
@@ -195,7 +245,7 @@ pub fn search_guard() {
 
 #[cfg(test)]
 mod tests {
-    use super::{grep_walks_tree, is_recursive_flag};
+    use super::{grep_walks_tree, has_zsh_path_assignment, is_recursive_flag};
 
     #[test]
     fn recursive_flag_detection() {
@@ -219,5 +269,29 @@ mod tests {
         assert!(!grep_walks_tree("grep foo"));
         // -- ends flags
         assert!(!grep_walks_tree("grep -- -r"));
+    }
+
+    #[test]
+    fn zsh_path_assignment_detection() {
+        for command in [
+            "path=/private/tmp/worktree; git status",
+            "path=(/private/tmp/worktree /bin); git status",
+            "f() { local path=/private/tmp/worktree; git status; }; f",
+            "FOO=bar path=/private/tmp/worktree git status",
+            "result=$(path=/private/tmp/worktree; git status)",
+        ] {
+            assert!(has_zsh_path_assignment(command), "{command:?}");
+        }
+
+        for command in [
+            "worktree_path=/private/tmp/worktree; git status",
+            "PATH=/private/tmp/worktree git status",
+            "echo path=/private/tmp/worktree",
+            "env path=/private/tmp/worktree git status",
+            "bash -c 'path=/private/tmp/worktree; git status'",
+            "cat <<'EOF'\npath=/private/tmp/worktree\nEOF",
+        ] {
+            assert!(!has_zsh_path_assignment(command), "{command:?}");
+        }
     }
 }

--- a/packages/agent/claude-hooks/src/guards.rs
+++ b/packages/agent/claude-hooks/src/guards.rs
@@ -189,8 +189,30 @@ fn has_zsh_path_binding(command: &str) -> bool {
     bash_syntax_matches(command, is_zsh_path_binding)
 }
 
+fn is_double_quoted_backtick_substitution(node: Node<'_>, source: &str) -> bool {
+    if node.kind() != "command_substitution"
+        || !node_text(node, source).is_some_and(|text| text.starts_with('`'))
+    {
+        return false;
+    }
+
+    let mut ancestor = node.parent();
+    while let Some(node) = ancestor {
+        if node.kind() == "string" {
+            return true;
+        }
+        ancestor = node.parent();
+    }
+    false
+}
+
+fn has_double_quoted_backtick_substitution(command: &str) -> bool {
+    bash_syntax_matches(command, is_double_quoted_backtick_substitution)
+}
+
 /// `PreToolUse(Bash)`: block recurring bad command shapes (output-to-/dev/null,
-/// recursive `grep -r`, `--no-verify`, lowercase zsh `path` bindings).
+/// recursive `grep -r`, `--no-verify`, lowercase zsh `path` bindings, and
+/// double-quoted backticks).
 /// Quote/escape-aware so a literal mention inside a commit message or `echo` is
 /// not a false positive.
 pub fn bash_habits_guard() {
@@ -200,6 +222,7 @@ pub fn bash_habits_guard() {
     }
     let raw = command_of(&payload);
     let zsh_path_binding = has_zsh_path_binding(&raw);
+    let double_quoted_backticks = has_double_quoted_backtick_substitution(&raw);
 
     // Match operators, not literal text inside a quoted string. Neutralize
     // escaped chars, then drop quoted substrings (a real `2>/dev/null` /
@@ -267,6 +290,17 @@ pub fn bash_habits_guard() {
              as `worktree_path` instead. (bash-habits-guard hook)"
                 .to_owned(),
         );
+        return;
+    }
+
+    if double_quoted_backticks {
+        deny(
+            "Backticks inside double quotes trigger shell command substitution, so literal \
+             text can execute and disappear before the command runs. Use single quotes for \
+             literal text and search patterns, escape each backtick when interpolation is \
+             required, or use `$()` for intentional substitution. (bash-habits-guard hook)"
+                .to_owned(),
+        );
     }
 }
 
@@ -289,7 +323,10 @@ pub fn search_guard() {
 
 #[cfg(test)]
 mod tests {
-    use super::{grep_walks_tree, has_zsh_path_binding, is_recursive_flag};
+    use super::{
+        grep_walks_tree, has_double_quoted_backtick_substitution, has_zsh_path_binding,
+        is_recursive_flag,
+    };
 
     #[test]
     fn recursive_flag_detection() {
@@ -342,6 +379,34 @@ mod tests {
             "typeset -p path",
         ] {
             assert!(!has_zsh_path_binding(command), "{command:?}");
+        }
+    }
+
+    #[test]
+    fn double_quoted_backtick_substitution_detection() {
+        for command in [
+            r#"rg -n "literal `:ixvm` pattern" ."#,
+            r#"query="`printf literal`"; rg "$query" ."#,
+            "printf '%s\\n' \"first line\\n`printf second`\\nthird line\"",
+        ] {
+            assert!(
+                has_double_quoted_backtick_substitution(command),
+                "{command:?}"
+            );
+        }
+
+        for command in [
+            r"rg -n 'literal `:ixvm` pattern' .",
+            r#"rg -n "literal \`:ixvm\` pattern" ."#,
+            r#"printf '%s\n' "$(pwd)""#,
+            r"printf '%s\n' `pwd`",
+            "# Markdown `code` in a comment",
+            "cat <<'EOF'\\nMarkdown `code`\\nEOF",
+        ] {
+            assert!(
+                !has_double_quoted_backtick_substitution(command),
+                "{command:?}"
+            );
         }
     }
 }

--- a/packages/agent/claude-hooks/src/guards.rs
+++ b/packages/agent/claude-hooks/src/guards.rs
@@ -114,25 +114,65 @@ fn node_text<'a>(node: Node<'_>, source: &'a str) -> Option<&'a str> {
     source.get(node.byte_range())
 }
 
-fn is_zsh_path_assignment(node: Node<'_>, source: &str) -> bool {
-    node.kind() == "variable_assignment"
-        && node
+type SyntaxPredicate = for<'tree> fn(Node<'tree>, &str) -> bool;
+
+fn variable_target_is_path(node: Node<'_>, source: &str) -> bool {
+    match node.kind() {
+        "variable_name" => node_text(node, source) == Some("path"),
+        "subscript" => node
             .child_by_field_name("name")
-            .and_then(|name| node_text(name, source))
-            == Some("path")
+            .is_some_and(|name| variable_target_is_path(name, source)),
+        _ => false,
+    }
 }
 
-fn syntax_tree_has_zsh_path_assignment(node: Node<'_>, source: &str) -> bool {
-    if is_zsh_path_assignment(node, source) {
+fn declaration_binds_path(node: Node<'_>, source: &str) -> bool {
+    // Attribute-only export and `-p` inspection preserve the tied parameter.
+    if node_text(node, source).and_then(|text| text.split_ascii_whitespace().next())
+        == Some("export")
+    {
+        return false;
+    }
+
+    let mut cursor = node.walk();
+    let children: Vec<_> = node.named_children(&mut cursor).collect();
+    let prints_declaration = children.iter().any(|child| {
+        child.kind() == "word"
+            && node_text(*child, source).is_some_and(|word| {
+                word.strip_prefix('-')
+                    .is_some_and(|flags| flags.contains('p'))
+            })
+    });
+    !prints_declaration
+        && children
+            .into_iter()
+            .any(|child| variable_target_is_path(child, source))
+}
+
+fn is_zsh_path_binding(node: Node<'_>, source: &str) -> bool {
+    match node.kind() {
+        "variable_assignment" => node
+            .child_by_field_name("name")
+            .is_some_and(|name| variable_target_is_path(name, source)),
+        "declaration_command" => declaration_binds_path(node, source),
+        "for_statement" => node
+            .child_by_field_name("variable")
+            .is_some_and(|variable| variable_target_is_path(variable, source)),
+        _ => false,
+    }
+}
+
+fn syntax_tree_matches(node: Node<'_>, source: &str, predicate: SyntaxPredicate) -> bool {
+    if predicate(node, source) {
         return true;
     }
 
     let mut cursor = node.walk();
     node.named_children(&mut cursor)
-        .any(|child| syntax_tree_has_zsh_path_assignment(child, source))
+        .any(|child| syntax_tree_matches(child, source, predicate))
 }
 
-fn has_zsh_path_assignment(command: &str) -> bool {
+fn bash_syntax_matches(command: &str, predicate: SyntaxPredicate) -> bool {
     let mut parser = Parser::new();
     if parser
         .set_language(&tree_sitter_bash::LANGUAGE.into())
@@ -142,11 +182,15 @@ fn has_zsh_path_assignment(command: &str) -> bool {
     }
     parser
         .parse(command, None)
-        .is_some_and(|tree| syntax_tree_has_zsh_path_assignment(tree.root_node(), command))
+        .is_some_and(|tree| syntax_tree_matches(tree.root_node(), command, predicate))
+}
+
+fn has_zsh_path_binding(command: &str) -> bool {
+    bash_syntax_matches(command, is_zsh_path_binding)
 }
 
 /// `PreToolUse(Bash)`: block recurring bad command shapes (output-to-/dev/null,
-/// recursive `grep -r`, `--no-verify`, lowercase zsh `path` assignments).
+/// recursive `grep -r`, `--no-verify`, lowercase zsh `path` bindings).
 /// Quote/escape-aware so a literal mention inside a commit message or `echo` is
 /// not a false positive.
 pub fn bash_habits_guard() {
@@ -155,7 +199,7 @@ pub fn bash_habits_guard() {
         return;
     }
     let raw = command_of(&payload);
-    let zsh_path_assignment = has_zsh_path_assignment(&raw);
+    let zsh_path_binding = has_zsh_path_binding(&raw);
 
     // Match operators, not literal text inside a quoted string. Neutralize
     // escaped chars, then drop quoted substrings (a real `2>/dev/null` /
@@ -214,13 +258,13 @@ pub fn bash_habits_guard() {
         return;
     }
 
-    // In zsh, lowercase `path` is tied to `PATH`. Parse assignment nodes so
+    // In zsh, lowercase `path` is tied to `PATH`. Parse binding nodes so
     // harmless arguments such as `echo path=/tmp` remain allowed.
-    if zsh_path_assignment {
+    if zsh_path_binding {
         deny(
-            "In zsh, lowercase `path` is tied to `PATH`, so assigning `path=...` \
-             replaces the command search path. Use a descriptive name such as \
-             `worktree_path` instead. (bash-habits-guard hook)"
+            "In zsh, lowercase `path` is tied to `PATH`, so binding or assigning \
+             it changes the command search path. Use a descriptive name such \
+             as `worktree_path` instead. (bash-habits-guard hook)"
                 .to_owned(),
         );
     }
@@ -245,7 +289,7 @@ pub fn search_guard() {
 
 #[cfg(test)]
 mod tests {
-    use super::{grep_walks_tree, has_zsh_path_assignment, is_recursive_flag};
+    use super::{grep_walks_tree, has_zsh_path_binding, is_recursive_flag};
 
     #[test]
     fn recursive_flag_detection() {
@@ -272,15 +316,19 @@ mod tests {
     }
 
     #[test]
-    fn zsh_path_assignment_detection() {
+    fn zsh_path_binding_detection() {
         for command in [
             "path=/private/tmp/worktree; git status",
             "path=(/private/tmp/worktree /bin); git status",
+            "path[1]=/private/tmp/worktree; git status",
             "f() { local path=/private/tmp/worktree; git status; }; f",
+            "f() { local path; git status; }; f",
+            "f() { typeset path; git status; }; f",
             "FOO=bar path=/private/tmp/worktree git status",
             "result=$(path=/private/tmp/worktree; git status)",
+            "for path in /private/tmp/worktree /bin; do git status; done",
         ] {
-            assert!(has_zsh_path_assignment(command), "{command:?}");
+            assert!(has_zsh_path_binding(command), "{command:?}");
         }
 
         for command in [
@@ -290,8 +338,10 @@ mod tests {
             "env path=/private/tmp/worktree git status",
             "bash -c 'path=/private/tmp/worktree; git status'",
             "cat <<'EOF'\npath=/private/tmp/worktree\nEOF",
+            "export path",
+            "typeset -p path",
         ] {
-            assert!(!has_zsh_path_assignment(command), "{command:?}");
+            assert!(!has_zsh_path_binding(command), "{command:?}");
         }
     }
 }


### PR DESCRIPTION
## Summary

* Parse Bash tool commands and reject lowercase `path` assignments, indexed writes, declarations, and loop bindings before zsh changes `PATH`.
* Keep descriptive variables, ordinary arguments, heredocs, declaration inspection, exports, and explicit Bash child scripts allowed.
* Cover the guard in Rust unit tests and the installed Claude Code hook check.

## Validation

* `nix build .#ciChecks.x86_64-linux.rust-claude-hooks.clippy .#ciChecks.x86_64-linux.rust-claude-hooks.unusedCrateDependencies .#ciChecks.x86_64-linux.rust-claude-hooks.claude-hooks-all .#ciChecks.x86_64-linux.rust-claude-hooks.package -L`
* `nix build .#claude-code -L`
* `nix build .#claude-hooks -L`
* `nix fmt -- --check packages/agent/claude-code/install-check.nix`
* `git diff --check`

`nix run .#lint -- --json` still reports current-main findings outside this diff. No failing diagnostic names a changed file.

Fixes #2784

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject zsh `path` variable bindings in the `bash_habits_guard`
> - Adds tree-sitter-based AST parsing to [`guards.rs`](https://github.com/indexable-inc/index/pull/2792/files#diff-ceb0330ee49cd3262b2725de9a02359c6b0bd30c5d75062ed1e6fdf7a7552551) to detect zsh-style lowercase `path` bindings (assignments, `local`, subscripts, declarations, and loop bindings) and deny them in the `PreToolUse(Bash)` hook.
> - Also denies backtick command substitution inside double-quoted strings, which is a common zsh-compat anti-pattern in bash.
> - Adds an early return after the existing `--no-verify` denial to prevent further checks from running.
> - Extends [`install-check.nix`](https://github.com/indexable-inc/index/pull/2792/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) with test cases covering all new denial and allow scenarios.
> - Risk: the guard now depends on tree-sitter parsing; if parsing fails, the zsh and backtick checks silently return `false` (no denial).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7286fa6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
