### PR TITLE
agent: reject double-quoted backticks

### DIFF
--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -503,6 +503,8 @@
       '{"tool_name":"Bash","tool_input":{"command":"worktree_path=/private/tmp/worktree; git status"}}'
     pre_guard bash-habits-guard "path argument allowed" allow \
       '{"tool_name":"Bash","tool_input":{"command":"echo path=/private/tmp/worktree"}}'
+    pre_guard bash-habits-guard "double quoted backticks denied" deny \
+      '{"tool_name":"Bash","tool_input":{"command":"rg -n \"literal `:ixvm` pattern\" ."}}'
 
     pre_guard search-guard "Search tool denied" deny '{"tool_name":"Search"}'
     pre_guard search-guard "WebSearch not denied" allow '{"tool_name":"WebSearch"}'

--- a/packages/agent/claude-hooks/src/guards.rs
+++ b/packages/agent/claude-hooks/src/guards.rs
@@ -189,8 +189,30 @@ fn has_zsh_path_binding(command: &str) -> bool {
     bash_syntax_matches(command, is_zsh_path_binding)
 }
 
+fn is_double_quoted_backtick_substitution(node: Node<'_>, source: &str) -> bool {
+    if node.kind() != "command_substitution"
+        || !node_text(node, source).is_some_and(|text| text.starts_with('`'))
+    {
+        return false;
+    }
+
+    let mut ancestor = node.parent();
+    while let Some(node) = ancestor {
+        if node.kind() == "string" {
+            return true;
+        }
+        ancestor = node.parent();
+    }
+    false
+}
+
+fn has_double_quoted_backtick_substitution(command: &str) -> bool {
+    bash_syntax_matches(command, is_double_quoted_backtick_substitution)
+}
+
 /// `PreToolUse(Bash)`: block recurring bad command shapes (output-to-/dev/null,
-/// recursive `grep -r`, `--no-verify`, lowercase zsh `path` bindings).
+/// recursive `grep -r`, `--no-verify`, lowercase zsh `path` bindings, and
+/// double-quoted backticks).
 /// Quote/escape-aware so a literal mention inside a commit message or `echo` is
 /// not a false positive.
 pub fn bash_habits_guard() {
@@ -200,6 +222,7 @@ pub fn bash_habits_guard() {
     }
     let raw = command_of(&payload);
     let zsh_path_binding = has_zsh_path_binding(&raw);
+    let double_quoted_backticks = has_double_quoted_backtick_substitution(&raw);
 
     // Match operators, not literal text inside a quoted string. Neutralize
     // escaped chars, then drop quoted substrings (a real `2>/dev/null` /
@@ -267,6 +290,17 @@ pub fn bash_habits_guard() {
              as `worktree_path` instead. (bash-habits-guard hook)"
                 .to_owned(),
         );
+        return;
+    }
+
+    if double_quoted_backticks {
+        deny(
+            "Backticks inside double quotes trigger shell command substitution, so literal \
+             text can execute and disappear before the command runs. Use single quotes for \
+             literal text and search patterns, escape each backtick when interpolation is \
+             required, or use `$()` for intentional substitution. (bash-habits-guard hook)"
+                .to_owned(),
+        );
     }
 }
 
@@ -289,7 +323,10 @@ pub fn search_guard() {
 
 #[cfg(test)]
 mod tests {
-    use super::{grep_walks_tree, has_zsh_path_binding, is_recursive_flag};
+    use super::{
+        grep_walks_tree, has_double_quoted_backtick_substitution, has_zsh_path_binding,
+        is_recursive_flag,
+    };
 
     #[test]
     fn recursive_flag_detection() {
@@ -342,6 +379,34 @@ mod tests {
             "typeset -p path",
         ] {
             assert!(!has_zsh_path_binding(command), "{command:?}");
+        }
+    }
+
+    #[test]
+    fn double_quoted_backtick_substitution_detection() {
+        for command in [
+            r#"rg -n "literal `:ixvm` pattern" ."#,
+            r#"query="`printf literal`"; rg "$query" ."#,
+            "printf '%s\\n' \"first line\\n`printf second`\\nthird line\"",
+        ] {
+            assert!(
+                has_double_quoted_backtick_substitution(command),
+                "{command:?}"
+            );
+        }
+
+        for command in [
+            r"rg -n 'literal `:ixvm` pattern' .",
+            r#"rg -n "literal \`:ixvm\` pattern" ."#,
+            r#"printf '%s\n' "$(pwd)""#,
+            r"printf '%s\n' `pwd`",
+            "# Markdown `code` in a comment",
+            "cat <<'EOF'\\nMarkdown `code`\\nEOF",
+        ] {
+            assert!(
+                !has_double_quoted_backtick_substitution(command),
+                "{command:?}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Problem

zsh treats backticks inside double-quoted arguments as command substitution. A literal search pattern can therefore execute text, remove it from the pattern, print only a non-fatal diagnostic, and let the enclosing command return success. The safe reproduction emitted `command not found: :ixvm`, changed `prefix `:ixvm` suffix` to `prefix  suffix`, and still exited 0.

The same shape also corrupted GitHub review replies while this fix was under review, which confirmed the failure is not limited to searches.

## Change

- Reuse the tree-sitter Bash traversal added by #2792.
- Deny legacy backtick command-substitution nodes under double-quoted strings.
- Tell the caller to use single quotes for literal text and search patterns, escape literal backticks when interpolation is required, or use `$()` for intentional substitution.
- Preserve safe single-quoted, escaped, quoted-heredoc, unquoted substitution, and `$()` forms.

## Validation

- `nix build .#ciChecks.x86_64-linux.rust-claude-hooks.claude-hooks-all`
- `nix build .#ciChecks.x86_64-linux.rust-claude-hooks.clippy`
- `nix build .#ciChecks.x86_64-linux.rust-claude-hooks.unusedCrateDependencies`
- `nix build .#ciChecks.x86_64-linux.rust-claude-hooks.package`
- `nix build .#claude-code -L`

All 42 hook tests passed. The full Claude Code package install check passed at `/nix/store/rw81977a6g6yq5irpmylkw24rrb0rpwn-claude-code-2.1.206`.

## Stack

This PR targets `codex/2784-zsh-path-guard` and depends on #2792. After #2792 lands, it will be rebased onto `origin/main`, retargeted to `main`, and revalidated before merge.

Fixes #2788

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deny backtick command substitution inside double-quoted strings in bash-habits-guard
> - Adds `is_double_quoted_backtick_substitution` and `has_double_quoted_backtick_substitution` helpers in [guards.rs](https://github.com/indexable-inc/index/pull/2806/files#diff-ceb0330ee49cd3262b2725de9a02359c6b0bd30c5d75062ed1e6fdf7a7552551) that use tree-sitter AST inspection to detect backtick-style command substitution nodes nested inside double-quoted strings.
> - Updates `bash_habits_guard` to deny commands matching this pattern, with a message recommending single quotes, escaped backticks, or `$()` substitution.
> - Adds an install-check test case in [install-check.nix](https://github.com/indexable-inc/index/pull/2806/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) asserting that commands with backticks inside double-quoted strings are denied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fccdee5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->