### PR TITLE
mcp: return terminal results before weave persistence

### DIFF
--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dataclasses
 import functools
 import hashlib
 import json
@@ -90,6 +91,14 @@ def _entity(prefix: str, id: str) -> str:
 
 class _HashRef(str):
     """Marks a value as a CAS blob reference so it rides as a typed hash."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _PendingBlob:
+    """Blob bytes whose CAS put belongs to the write-behind thread."""
+
+    data: bytes
+    digest: str
 
 
 def _api_value(value: object) -> dict:
@@ -192,12 +201,26 @@ class WeaveStore:
         facts = [*facts, (self.agent, "last_active_ms", _ms())]
         for entity, attr, value in facts:
             key = (entity, attr)
-            if self._last_values.get(key) == value:
+            dedupe_value = ("blob", value.digest) if isinstance(value, _PendingBlob) else value
+            if self._last_values.get(key) == dedupe_value:
                 continue
-            self._last_values[key] = value
-            self._enqueue({"fact": {"entity": _api_value(entity), "attr": attr, "value": _api_value(value)}})
+            self._last_values[key] = dedupe_value
+            if isinstance(value, _PendingBlob):
+                self._enqueue_blob_fact(entity, attr, value.data, digest=value.digest)
+            else:
+                self._enqueue(
+                    {
+                        "fact": {
+                            "entity": _api_value(entity),
+                            "attr": attr,
+                            "value": _api_value(value),
+                        }
+                    }
+                )
 
-    def _enqueue_blob_fact(self, entity: str, attr: str, data: bytes) -> None:
+    def _enqueue_blob_fact(
+        self, entity: str, attr: str, data: bytes, *, digest: str | None = None
+    ) -> None:
         """Queue one (entity, attr, <hash of data>) fact whose CAS put is
         deferred to the writer thread (see _resolve_blob_item). The enqueue is
         a plain list append, so bulk payloads (pty chunks) never block the
@@ -207,12 +230,21 @@ class WeaveStore:
         needs every flush."""
         if self.disabled:
             return
-        self._enqueue({"blob_fact": {"entity": entity, "attr": attr, "data": data}})
+        self._enqueue(
+            {
+                "blob_fact": {
+                    "entity": entity,
+                    "attr": attr,
+                    "data": data,
+                    "digest": digest,
+                }
+            }
+        )
 
-    def put_blob(self, data: bytes) -> _HashRef:
+    def put_blob(self, data: bytes, *, digest: str | None = None) -> _HashRef:
         if self.disabled:
-            return _HashRef(hashlib.sha256(data).hexdigest())
-        digest = hashlib.sha256(data).hexdigest()
+            return _HashRef(digest or hashlib.sha256(data).hexdigest())
+        digest = digest or hashlib.sha256(data).hexdigest()
         cached = self._blob_cache.get(digest)
         if cached:
             return _HashRef(cached)
@@ -234,7 +266,7 @@ class WeaveStore:
         blob = item.get("blob_fact")
         if blob is None:
             return item
-        h = self.put_blob(blob["data"])
+        h = self.put_blob(blob["data"], digest=blob["digest"])
         return {"fact": {"entity": _api_value(blob["entity"]), "attr": blob["attr"], "value": _api_value(h)}}
 
     def _writer(self) -> None:
@@ -265,7 +297,15 @@ class WeaveStore:
                     self._inflight = False
                     self._cv.notify_all()
             except Exception as exc:
-                print(f"ix-mcp store: weave write failed, retrying: {exc}", file=sys.stderr)
+                pending = ", ".join(_item_label(item) for item in batch[:8])
+                if len(batch) > 8:
+                    pending += f", +{len(batch) - 8} more"
+                print(
+                    "ix-mcp store: weave persistence failed; "
+                    f"queued facts will retry in {backoff:g}s; pending={pending}; "
+                    f"error={type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
                 with self._cv:
                     for item in reversed(batch):
                         self._queue.appendleft(item)
@@ -360,12 +400,25 @@ class AsyncConn:
         self._pool.shutdown(wait=False)
 
 
-def _blob(conn: WeaveStore, value: object) -> _HashRef:
-    return conn.put_blob(_json_blob(value))
+def _item_label(item: dict) -> str:
+    """Compact entity.attr handle for a failed write batch."""
+    blob = item.get("blob_fact")
+    if blob is not None:
+        return f"{blob['entity']}.{blob['attr']}"
+    fact = item["fact"]
+    return f"{_unwrap(fact['entity'])}.{fact['attr']}"
 
 
-def _blob_text(conn: WeaveStore, text: str) -> _HashRef:
-    return conn.put_blob(text.encode("utf-8"))
+def _blob(value: object) -> _PendingBlob:
+    return _pending_blob(_json_blob(value))
+
+
+def _blob_text(text: str) -> _PendingBlob:
+    return _pending_blob(text.encode("utf-8"))
+
+
+def _pending_blob(data: bytes) -> _PendingBlob:
+    return _PendingBlob(data=data, digest=hashlib.sha256(data).hexdigest())
 
 
 def _load_json_blob(conn: WeaveStore, hash_: str, default: object) -> object:
@@ -456,7 +509,7 @@ def start(conn: WeaveStore, *, id: str, name: str, code: str, started_at: float,
         (ent, "verb", "python_exec"),
         (ent, "desc", name),
         (ent, "topic", topic),
-        (ent, "code", _blob_text(conn, code)),
+        (ent, "code", _blob_text(code)),
         (ent, "status", "running"),
         (ent, "started_ms", _ms(started_at)),
         (ent, "budget", budget),
@@ -474,7 +527,7 @@ def update_output(conn: WeaveStore, id: str, output: str, outputs: list | None =
     if line is not None:
         facts.append((_entity("run", id), "line", line))
     if outputs is not None:
-        facts.append((_entity("run", id), "outputs", _blob(conn, outputs)))
+        facts.append((_entity("run", id), "outputs", _blob(outputs)))
     conn._enqueue_facts(facts)
 
 
@@ -509,17 +562,17 @@ def finish(conn: WeaveStore, *, id: str, status: str, ended_at: float, output: s
     ended = _ms(ended_at)
     facts: list[tuple[str, str, Any]] = [(ent, "status", status), (ent, "ended_ms", ended), (ent, "last_output", (output or "")[-200:]), (conn.agent, "last_output", (output or "")[-200:])]
     if result is not None:
-        facts.append((ent, "result", _blob_text(conn, result)))
+        facts.append((ent, "result", _blob_text(result)))
     if error is not None:
         facts.append((ent, "error", error))
     if error_line is not None:
         facts.append((ent, "error_line", error_line))
     if outputs is not None:
-        facts.append((ent, "outputs", _blob(conn, outputs)))
+        facts.append((ent, "outputs", _blob(outputs)))
     if bindings is not None:
-        facts.append((ent, "bindings", _blob(conn, bindings)))
+        facts.append((ent, "bindings", _blob(bindings)))
     if namespace is not None:
-        facts.append((ent, "namespace", _blob(conn, namespace)))
+        facts.append((ent, "namespace", _blob(namespace)))
     conn._enqueue_facts(facts)
 
 
@@ -539,7 +592,7 @@ def save_tool_view(conn: WeaveStore, *, id: str, html: str, label: str) -> str |
     conn._enqueue_facts([
         (ent, "type", "view"),
         (ent, "renderer", "cas-html"),
-        (ent, "body", _blob_text(conn, html)),
+        (ent, "body", _blob_text(html)),
         (ent, "label", label),
         (ent, "child_of", _entity("run", id)),
     ])
@@ -616,13 +669,13 @@ def cells(conn: WeaveStore) -> list[dict]:
 
 
 def replace_cells(conn: WeaveStore, items: list[dict]) -> None:
-    conn._enqueue_facts([(conn.agent, "cells", _blob(conn, items))])
+    conn._enqueue_facts([(conn.agent, "cells", _blob(items))])
 
 
 
 def upsert_resource(conn: WeaveStore, *, id: str, title: str, kind: str, html: str, status: str, created_at: float, updated_at: float, execution_id: str = "") -> None:
     ent = _entity("resource", id)
-    facts = [(ent, "type", "resource"), (ent, "child_of", conn.agent), (ent, "verb", kind), (ent, "label", title), (ent, "html", _blob_text(conn, html)), (ent, "status", status), (ent, "started_ms", _ms(created_at)), (ent, "last_active_ms", _ms(updated_at))]
+    facts = [(ent, "type", "resource"), (ent, "child_of", conn.agent), (ent, "verb", kind), (ent, "label", title), (ent, "html", _blob_text(html)), (ent, "status", status), (ent, "started_ms", _ms(created_at)), (ent, "last_active_ms", _ms(updated_at))]
     if execution_id:
         facts.append((ent, "of_run", _entity("run", execution_id)))
     conn._enqueue_facts(facts)
@@ -691,10 +744,27 @@ def resource_live(conn: WeaveStore, id: str) -> bool:
     return bool(rows and rows[0].get("S") != "closed")
 
 
-def save_snapshot(conn: WeaveStore, *, created_at: float, blob: bytes, names: list[str], skipped: list[dict]) -> None:
-    h = conn.put_blob(blob)
-    ent = f"snapshot:{h[:16]}"
-    conn._enqueue_facts([(ent, "type", "snapshot"), (ent, "child_of", conn.agent), (ent, "created_ms", _ms(created_at)), (ent, "blob", h), (ent, "names", _blob(conn, names)), (ent, "skipped", _blob(conn, skipped)), (conn.agent, "snapshot", h)])
+def save_snapshot(
+    conn: WeaveStore,
+    *,
+    created_at: float,
+    blob: bytes,
+    names: list[str],
+    skipped: list[dict],
+) -> None:
+    pending = _pending_blob(blob)
+    ent = f"snapshot:{pending.digest[:16]}"
+    conn._enqueue_facts(
+        [
+            (ent, "type", "snapshot"),
+            (ent, "child_of", conn.agent),
+            (ent, "created_ms", _ms(created_at)),
+            (ent, "blob", pending),
+            (ent, "names", _blob(names)),
+            (ent, "skipped", _blob(skipped)),
+            (conn.agent, "snapshot", pending),
+        ]
+    )
 
 
 def latest_snapshot(conn: WeaveStore) -> dict | None:

--- a/packages/mcp/tests/test_store_kernel_lease.py
+++ b/packages/mcp/tests/test_store_kernel_lease.py
@@ -10,12 +10,15 @@ un-idling the agent (no last_active_ms ride-along).
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import threading
 import time
 from pathlib import Path
 
 import pytest
 
-from ix_notebook_mcp import store
+from ix_notebook_mcp import runtime, store
 
 
 def _capture(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
@@ -91,3 +94,88 @@ def test_writer_beats_the_lease_without_unidling_the_agent(
     # A beat is process liveness, not agent activity: the idle-styling
     # clock (agent last_active_ms) must not advance with it.
     assert all(attr != "last_active_ms" for _, attr, _ in tail), tail
+
+
+def test_terminal_result_does_not_wait_for_weave_blob_persistence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("WEAVE_URL", "http://weave.test")
+    code = "land()\nResult.ok('terminal-result')"
+    action_landed = threading.Event()
+    persistence_blocked = threading.Event()
+    release_persistence = threading.Event()
+    persistence_failed = threading.Event()
+    runner_done = threading.Event()
+    summaries: list[dict] = []
+    failures: list[BaseException] = []
+
+    def land() -> None:
+        action_landed.set()
+
+    def fake_json(
+        method: str, url: str, *, body: object = None, content: bytes | None = None
+    ) -> object:
+        if url.endswith("/api/blob"):
+            data = content or b""
+            if data != code.encode():
+                persistence_blocked.set()
+                if not release_persistence.wait(timeout=5.0):
+                    raise TimeoutError("test did not release the blocked journal write")
+                if not persistence_failed.is_set():
+                    persistence_failed.set()
+                    raise TimeoutError("weave journal timed out")
+            return {"hash": hashlib.sha256(data).hexdigest()}
+        if url.endswith("/api/facts"):
+            return {"seq": 1, "id": "f1"}
+        raise AssertionError(url)
+
+    monkeypatch.setattr(store, "_http_json", fake_json)
+    conn = store.connect(tmp_path / "terminal.ixnb")
+    assert conn.flush(timeout=2.0)
+    monkeypatch.setattr(runtime, "_store", store)
+    monkeypatch.setattr(runtime, "_store_conn", conn)
+    monkeypatch.setattr(runtime, "_typecheck_enabled", lambda: False)
+    monkeypatch.setattr(runtime, "_protected_builtins", {})
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset({"land", "Result"}))
+    ns = {"land": land, "Result": runtime.Result}
+    job = runtime.Job(code, name="issue-2795-regression")
+    job._ns = ns
+
+    def run_job() -> None:
+        async def run() -> None:
+            job.task = asyncio.create_task(runtime._runner(job, ns))
+            await job.task
+            summaries.append(runtime._job_summary(job))
+
+        # Preserve a worker-thread failure for the main test thread's assertion.
+        try:
+            asyncio.run(run())
+        except BaseException as exc:
+            failures.append(exc)
+        finally:
+            runner_done.set()
+
+    thread = threading.Thread(target=run_job, name="issue-2795-runner")
+    thread.start()
+    completed_while_blocked = False
+    try:
+        assert action_landed.wait(timeout=2.0)
+        assert persistence_blocked.wait(timeout=2.0)
+        completed_while_blocked = runner_done.wait(timeout=1.0)
+    finally:
+        release_persistence.set()
+        thread.join(timeout=5.0)
+        conn.close()
+
+    assert not thread.is_alive()
+    assert completed_while_blocked, (
+        "the terminal result waited behind weave persistence"
+    )
+    assert failures == []
+    assert summaries[0]["status"] == "done"
+    assert summaries[0]["running"] is False
+    assert summaries[0]["result"] == "terminal-result"
+    warning = capsys.readouterr().err
+    assert "weave persistence failed" in warning
+    assert f"run:{job.id}" in warning
+    assert "queued facts will retry" in warning


### PR DESCRIPTION
## Summary

- defer run, view, resource, and snapshot CAS uploads to the existing Weave writer thread
- keep blob deduplication memory-bounded and include pending entity handles in persistence failure warnings
- prove a completed acting cell returns its terminal result while the journal write is blocked and retrying

## Validation

- regression fails on `38469f5d` with `the terminal result waited behind weave persistence`
- focused store suites: 33 passed
- MCP UI suite outside the Nix sandbox: 17 passed
- typecheck smoke: 138 passed
- strict MCP typecheck and targeted Ruff checks passed

The Darwin `mcpUiTests` derivation has an independent current-main loopback sandbox failure, tracked in #2803.

Fixes #2795

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return terminal results before weave blob persistence in MCP store
> - Blob uploads in [store.py](https://github.com/indexable-inc/index/pull/2807/files#diff-a4763dded9f44ec2a563e568a62d900b996c6a956b6de36462468f1d2b03b976) are now deferred to a background writer thread via a new `_PendingBlob` sentinel dataclass, so callers like `finish`, `start`, and `save_snapshot` return immediately without blocking on CAS uploads.
> - `_enqueue_facts` detects `_PendingBlob` values and routes them as `blob_fact` items carrying data and digest; the writer thread resolves uploads and reuses the precomputed sha256 to avoid redundant hashing.
> - Writer thread error logging now includes a structured warning with up to eight pending `entity.attr` labels, backoff duration, and exception details.
> - A new test in [test_store_kernel_lease.py](https://github.com/indexable-inc/index/pull/2807/files#diff-f3623d87ec68ea00a90feaba57e4d0d7c518589b59bf4e7246208d1ca24cf8bb) verifies that a job completes while blob persistence is blocked, confirming the non-blocking behavior.
> - Behavioral Change: blob persistence errors no longer surface synchronously to callers; failures are retried silently in the background writer with a warning log.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc1de16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->