### PR TITLE
symphony: document exact elixir check command

### DIFF
--- a/packages/agent/symphony/docs/quality.md
+++ b/packages/agent/symphony/docs/quality.md
@@ -39,6 +39,16 @@ check); the advisory lane is a local `make quality` run. Sobelow, deps.audit,
 Dialyzer, and coveralls all want network access or large mutable caches, so a
 sandboxed derivation is a bad fit for them today.
 
+Build the required lane explicitly from the repository root:
+
+```sh
+nix build .#checks.x86_64-linux.symphony-elixir --no-link -L
+```
+
+The canonical flake-check attribute is under `checks.x86_64-linux`, regardless
+of the caller's host system. Building it from another system requires access to
+an `x86_64-linux` builder.
+
 ## Phased rollout
 
 The gate ships in two phases so it never blocks PRs while the codebase is still


### PR DESCRIPTION
## Summary

- document the canonical `checks.x86_64-linux.symphony-elixir` build command
- clarify that the attribute is host independent and needs access to an `x86_64-linux` builder when built elsewhere

## Validation

- `nix build .#checks.x86_64-linux.symphony-elixir --no-link -L`
- `git diff --check`
- `nix run .#lint -- --json` reports only current-main findings outside the changed Markdown file

Fixes #2790

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document exact Nix command for running the symphony Elixir check
> Updates [quality.md](https://github.com/indexable-inc/index/pull/2810/files#diff-e0eaff8e9e6233d09df056d4ef32db9723926033ccd4b282281b2887a4c5eed9) with a dedicated subsection showing the exact `nix build .#checks.x86_64-linux.symphony-elixir --no-link -L` command. Clarifies that the canonical flake-check attribute is always under `checks.x86_64-linux` regardless of the caller's host system, and notes that running from a non-Linux host requires access to an `x86_64-linux` builder.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b00ca0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->