### PR TITLE
fix(cve-scan): drop --force-recurse from nixpkgs index eval

### DIFF
--- a/packages/cve-scan/src/identity.rs
+++ b/packages/cve-scan/src/identity.rs
@@ -31,11 +31,19 @@ pub struct IndexDiagnostic {
 pub fn export_nixpkgs_index(executable: &Path, flake: &str, system: &str) -> Result<NixpkgsIndex> {
     let revision = nixpkgs_revision(flake)?;
     let selector = format!("flake: flake.inputs.nixpkgs.legacyPackages.{system}");
+    // No `--force-recurse`: it ignores nixpkgs' `recurseForDerivations` markers and
+    // descends into the unmarked splice/cross machinery (`__splicedPackages`,
+    // `pkgsBuildHost`, `pkgsCross.<system>`, `pkgsStatic`, ...). That machinery is
+    // self-referential and re-emits ~80 full cross/variant package sets, driving the
+    // evaluator to tens of GiB and OOM-killing it. Default recursion follows the
+    // markers, which emit every package's output path once via its canonical
+    // attribute (aliases like `python3Packages` are `dontRecurseIntoAttrs` precisely
+    // because `python313Packages` already carries the marker), so a native closure's
+    // routable coverage is preserved while the memory blowup is removed.
     let output = Command::new(executable)
         .args([
             "--flake",
             "--meta",
-            "--force-recurse",
             "--apply",
             "p: { pname = p.pname or null; version = p.version or null; }",
             "--select",


### PR DESCRIPTION
export_nixpkgs_index ran nix-eval-jobs with --force-recurse, which ignores nixpkgs' recurseForDerivations markers and descends into the unmarked splice and cross machinery (__splicedPackages, pkgsBuildHost, pkgsCross.<system>, pkgsStatic, ...). That machinery is self-referential and re-emits ~80 full cross/variant package sets, so a single evaluator worker climbs to tens of GiB and gets OOM-killed on the CI dispatcher.

Default recursion follows nixpkgs' own curation: every package's output path is emitted once via its canonical marked attribute (friendly aliases such as python3Packages are dontRecurseIntoAttrs precisely because python313Packages already carries the marker). On a native x86_64-linux eval everything --force-recurse added was either the same output paths already emitted (splice and alias duplicates) or non-native cross/static/musl/32-bit paths that never enter an x86_64-linux production closure. Dropping the flag removes the memory blowup while preserving the routable CVE coverage the scan depends on.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `--force-recurse` from nixpkgs index evaluation in `export_nixpkgs_index`
> Removes the `--force-recurse` flag from the `nix` command spawned in [`identity.rs`](https://github.com/indexable-inc/index/pull/2865/files#diff-2a716b6ec72ba81ca4066419c9376761af2a2de2bce4ac498421c7b599784f09). An explanatory comment is added describing the default recursion behavior. Risk: the evaluated nixpkgs attribute set and resulting JSONL output may differ from previous runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3d26fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->