### PR TITLE
minecraft: make the Spleef example production ready

### DIFF
--- a/packages/minecraft/minestom/servers/spleef/README.md
+++ b/packages/minecraft/minestom/servers/spleef/README.md
@@ -1,0 +1,51 @@
+# Minestom Spleef
+
+A complete Minecraft 26.2 server example built directly on Minestom. Players
+wait in a protected lobby, move into a fresh snow arena for each round, and
+return to the lobby after the last player standing wins.
+
+## Run
+
+From the repository root:
+
+```console
+nix build .#minestom-spleef-server-jar
+java -jar result
+```
+
+The server listens on `0.0.0.0:25565` and uses Mojang authentication by
+default. Connect with a Minecraft 26.2 client.
+
+## Configure
+
+Configuration is read once from the process environment at startup. Invalid
+values stop startup with a precise error.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SPLEEF_BIND_ADDRESS` | `0.0.0.0` | Address on which to listen |
+| `SPLEEF_PORT` | `25565` | Client port |
+| `SPLEEF_AUTH` | `online` | `online` for Mojang authentication or `offline` for isolated tests |
+| `SPLEEF_MIN_PLAYERS` | `2` | Players required to start a round |
+| `SPLEEF_MAX_PLAYERS` | `20` | Advertised server capacity |
+| `SPLEEF_COUNTDOWN_SECONDS` | `10` | Lobby countdown after enough players join |
+
+Offline authentication lets clients impersonate any username. Use it only on
+an isolated development network or behind an authenticated proxy.
+
+```console
+SPLEEF_PORT=25570 SPLEEF_COUNTDOWN_SECONDS=5 java -jar result
+```
+
+## Structure
+
+* `Main.java` owns process configuration, authentication, server status, and
+  connection admission.
+* `Lobby.java` owns the persistent waiting room and starts rounds from a stable
+  snapshot of its current players.
+* `Game.java` owns one disposable arena, including its listeners, timers, and
+  player state. Unregistering the instance tears down the round.
+
+The NixOS VM test at `tests/minestom-spleef-vm.nix` builds the fat jar, boots it
+through `services.minestom`, checks its server-list response, joins a real
+protocol client, and exports a ReplayMod recording.

--- a/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Game.java
+++ b/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Game.java
@@ -3,7 +3,9 @@ package dev.ix.minestom.spleef;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -61,17 +63,25 @@ final class Game {
     private final Lobby lobby;
     private final InstanceContainer arena;
     private final Set<Player> alive = new HashSet<>();
+    private final int startingPlayers;
+    private final BossBar status;
     private Phase phase = Phase.FREEZE;
     private int freezeLeft = FREEZE_SECONDS;
 
     static void start(Lobby lobby, Collection<Player> players) {
-        new Game(lobby, players);
+        new Game(lobby, List.copyOf(players));
     }
 
     private Game(Lobby lobby, Collection<Player> players) {
         this.lobby = lobby;
         this.arena = createArena();
         this.alive.addAll(players);
+        this.startingPlayers = players.size();
+        this.status = BossBar.bossBar(
+            Component.text("Snow arena: get ready", NamedTextColor.YELLOW),
+            1f,
+            BossBar.Color.YELLOW,
+            BossBar.Overlay.PROGRESS);
 
         var events = arena.eventNode();
         events.addListener(PlayerStartDiggingEvent.class, this::onStartDigging);
@@ -96,8 +106,15 @@ final class Game {
             double z = Math.sin(angle) * SPAWN_RADIUS;
             float yaw = (float) Math.toDegrees(Math.atan2(x, -z));
             Pos spawn = new Pos(x, FLOOR_Y + 1, z, yaw, 0f);
+            player.setGameMode(GameMode.ADVENTURE);
+            player.setInvulnerable(true);
+            player.getInventory().clear();
             player.setRespawnPoint(spawn);
             player.setInstance(arena, spawn);
+            player.showBossBar(status);
+            player.sendPlayerListHeaderAndFooter(
+                Component.text("IX SPLEEF", NamedTextColor.AQUA, TextDecoration.BOLD),
+                Component.text("Snow arena | %d players".formatted(startingPlayers), NamedTextColor.GRAY));
         }
 
         arena.scheduler().submitTask(() -> {
@@ -142,6 +159,8 @@ final class Game {
 
     private void release() {
         phase = Phase.RUNNING;
+        status.name(Component.text("Snow arena: %d alive".formatted(alive.size()), NamedTextColor.GREEN));
+        status.color(BossBar.Color.GREEN);
         for (Player player : alive) {
             player.setGameMode(GameMode.SURVIVAL);
             player.getInventory().setItemStack(0, SHOVEL);
@@ -182,6 +201,14 @@ final class Game {
 
     private void eliminate(Player player) {
         if (!alive.remove(player)) return;
+        status.name(Component.text("Snow arena: %d alive".formatted(alive.size()), NamedTextColor.RED));
+        status.progress((float) alive.size() / startingPlayers);
+        for (Player survivor : alive) {
+            survivor.sendActionBar(Component.text(
+                "%s fell | %d player%s left"
+                    .formatted(player.getUsername(), alive.size(), alive.size() == 1 ? "" : "s"),
+                NamedTextColor.YELLOW));
+        }
         if (player.getInstance() == arena) {
             // Still connected: park them as a spectator hovering over the arena.
             player.setGameMode(GameMode.SPECTATOR);
@@ -201,8 +228,13 @@ final class Game {
         phase = Phase.ENDING;
         Player winner = alive.isEmpty() ? null : alive.iterator().next();
         if (winner == null) {
+            status.name(Component.text("Round over: no survivors", NamedTextColor.GRAY));
+            status.color(BossBar.Color.WHITE);
             arena.sendMessage(Component.text("Nobody survived the round.", NamedTextColor.GRAY));
         } else {
+            status.name(Component.text("%s wins!".formatted(winner.getUsername()), NamedTextColor.GOLD));
+            status.color(BossBar.Color.YELLOW);
+            status.progress(1f);
             arena.showTitle(Title.title(
                 Component.text("%s wins!".formatted(winner.getUsername()), NamedTextColor.GOLD, TextDecoration.BOLD),
                 Component.empty(),
@@ -214,6 +246,7 @@ final class Game {
 
     private void close() {
         for (Player player : Set.copyOf(arena.getPlayers())) {
+            player.hideBossBar(status);
             player.setInstance(lobby.instance(), Lobby.SPAWN);
         }
         // Instance switches complete asynchronously; unregister the arena (and

--- a/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Game.java
+++ b/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Game.java
@@ -105,7 +105,7 @@ final class Game {
             if (freezeLeft > 0) {
                 arena.showTitle(Title.title(
                     Component.text(freezeLeft, NamedTextColor.RED),
-                    Component.text("Get ready…", NamedTextColor.GRAY),
+                    Component.text("Snow arena: get ready", NamedTextColor.GRAY),
                     Title.Times.times(Duration.ZERO, Duration.ofMillis(900), Duration.ofMillis(100))));
                 arena.playSound(Sound.sound(SoundEvent.BLOCK_NOTE_BLOCK_PLING, Sound.Source.MASTER, 1f, 1f));
                 freezeLeft--;
@@ -148,8 +148,8 @@ final class Game {
             player.setHeldItemSlot((byte) 0);
         }
         arena.showTitle(Title.title(
-            Component.text("DIG!", NamedTextColor.GREEN, TextDecoration.BOLD),
-            Component.empty(),
+            Component.text("DIG THE SNOW!", NamedTextColor.GREEN, TextDecoration.BOLD),
+            Component.text("Last player standing wins", NamedTextColor.GRAY),
             Title.Times.times(Duration.ZERO, Duration.ofMillis(700), Duration.ofMillis(300))));
         arena.playSound(Sound.sound(SoundEvent.BLOCK_NOTE_BLOCK_PLING, Sound.Source.MASTER, 1f, 2f));
     }

--- a/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Lobby.java
+++ b/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Lobby.java
@@ -5,6 +5,7 @@ import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.title.Title;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
@@ -36,7 +37,7 @@ final class Lobby {
 
     private final InstanceContainer instance;
     private final BossBar status =
-        BossBar.bossBar(Component.text("Waiting for players…"), 1f, BossBar.Color.WHITE, BossBar.Overlay.PROGRESS);
+        BossBar.bossBar(Component.text("Lobby: waiting for players"), 1f, BossBar.Color.WHITE, BossBar.Overlay.PROGRESS);
     private int secondsLeft = COUNTDOWN_SECONDS;
 
     Lobby() {
@@ -80,15 +81,25 @@ final class Lobby {
         player.setGameMode(GameMode.ADVENTURE);
         player.getInventory().clear();
         player.showBossBar(status);
+        player.showTitle(Title.title(
+            Component.text("SPLEEF LOBBY", NamedTextColor.AQUA, TextDecoration.BOLD),
+            Component.text("Adventure mode protects this waiting platform", NamedTextColor.GRAY),
+            Title.Times.times(Duration.ofMillis(200), Duration.ofSeconds(3), Duration.ofMillis(500))));
+        player.sendMessage(Component.text("Lobby: ", NamedTextColor.AQUA, TextDecoration.BOLD)
+            .append(Component.text(
+                "wait for 2 players, then you will move to the snow arena. Adventure mode protects this platform.",
+                NamedTextColor.GRAY)));
         player.sendMessage(Component.text(
-            "Dig the snow out from under the other players — last one standing wins.", NamedTextColor.GRAY));
+            "In the arena, dig the snow out from under the other player. Last one standing wins.",
+            NamedTextColor.GRAY));
     }
 
     private void tick() {
         var players = instance.getPlayers();
         if (players.size() < MIN_PLAYERS) {
             secondsLeft = COUNTDOWN_SECONDS;
-            status.name(Component.text("Waiting for players (%d/%d)".formatted(players.size(), MIN_PLAYERS)));
+            status.name(Component.text(
+                "Lobby: waiting for players (%d/%d)".formatted(players.size(), MIN_PLAYERS)));
             status.progress(1f);
             status.color(BossBar.Color.WHITE);
             return;
@@ -101,13 +112,13 @@ final class Lobby {
             return;
         }
 
-        status.name(Component.text("Starting in %ds".formatted(secondsLeft)));
+        status.name(Component.text("Lobby: snow arena starts in %ds".formatted(secondsLeft)));
         status.progress((float) secondsLeft / COUNTDOWN_SECONDS);
         status.color(BossBar.Color.GREEN);
         if (secondsLeft <= 5) {
             instance.showTitle(Title.title(
                 Component.text(secondsLeft, NamedTextColor.GOLD),
-                Component.empty(),
+                Component.text("Entering the snow arena", NamedTextColor.GRAY),
                 Title.Times.times(Duration.ZERO, Duration.ofMillis(900), Duration.ofMillis(100))));
             instance.playSound(Sound.sound(SoundEvent.BLOCK_NOTE_BLOCK_PLING, Sound.Source.MASTER, 1f, 1f));
         }

--- a/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Lobby.java
+++ b/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Lobby.java
@@ -12,8 +12,10 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.entity.Player;
+import net.minestom.server.event.entity.EntityDamageEvent;
 import net.minestom.server.event.instance.AddEntityToInstanceEvent;
 import net.minestom.server.event.instance.RemoveEntityFromInstanceEvent;
+import net.minestom.server.event.player.PlayerMoveEvent;
 import net.minestom.server.instance.InstanceContainer;
 import net.minestom.server.instance.LightingChunk;
 import net.minestom.server.instance.block.Block;
@@ -30,17 +32,21 @@ import net.minestom.server.timer.TaskSchedule;
 final class Lobby {
     private static final int PLATFORM_Y = 64;
     private static final int PLATFORM_HALF_SIZE = 12;
-    private static final int MIN_PLAYERS = 2;
-    private static final int COUNTDOWN_SECONDS = 10;
+    private static final int RESCUE_Y = PLATFORM_Y - 6;
 
     static final Pos SPAWN = new Pos(0.5, PLATFORM_Y + 1, 0.5);
 
     private final InstanceContainer instance;
+    private final int minPlayers;
+    private final int countdownSeconds;
     private final BossBar status =
         BossBar.bossBar(Component.text("Lobby: waiting for players"), 1f, BossBar.Color.WHITE, BossBar.Overlay.PROGRESS);
-    private int secondsLeft = COUNTDOWN_SECONDS;
+    private int secondsLeft;
 
-    Lobby() {
+    Lobby(int minPlayers, int countdownSeconds) {
+        this.minPlayers = minPlayers;
+        this.countdownSeconds = countdownSeconds;
+        this.secondsLeft = countdownSeconds;
         instance = MinecraftServer.getInstanceManager().createInstanceContainer();
         instance.setChunkSupplier(LightingChunk::new);
         // Generate only where a chunk overlaps the platform square; the rest of
@@ -54,7 +60,10 @@ final class Lobby {
             int maxZ = (int) Math.min(end.z(), PLATFORM_HALF_SIZE + 1);
             for (int x = minX; x < maxX; x++) {
                 for (int z = minZ; z < maxZ; z++) {
-                    unit.modifier().setBlock(x, PLATFORM_Y, z, Block.SMOOTH_QUARTZ);
+                    boolean border = Math.abs(x) == PLATFORM_HALF_SIZE || Math.abs(z) == PLATFORM_HALF_SIZE;
+                    boolean lamp = border && Math.floorMod(x + z, 4) == 0;
+                    Block block = lamp ? Block.SEA_LANTERN : border ? Block.CYAN_CONCRETE : Block.SMOOTH_QUARTZ;
+                    unit.modifier().setBlock(x, PLATFORM_Y, z, block);
                 }
             }
         });
@@ -68,6 +77,10 @@ final class Lobby {
         events.addListener(RemoveEntityFromInstanceEvent.class, event -> {
             if (event.getEntity() instanceof Player player) player.hideBossBar(status);
         });
+        events.addListener(EntityDamageEvent.class, event -> event.setCancelled(true));
+        events.addListener(PlayerMoveEvent.class, event -> {
+            if (event.getNewPosition().y() < RESCUE_Y) event.getPlayer().teleport(SPAWN);
+        });
 
         instance.scheduler().buildTask(this::tick).repeat(TaskSchedule.seconds(1)).schedule();
     }
@@ -79,8 +92,17 @@ final class Lobby {
     private void onEnter(Player player) {
         player.setRespawnPoint(SPAWN);
         player.setGameMode(GameMode.ADVENTURE);
+        player.setInvulnerable(true);
+        player.setHealth(20f);
+        player.setFood(20);
+        player.setFoodSaturation(20f);
+        player.setExp(0f);
+        player.setLevel(0);
         player.getInventory().clear();
         player.showBossBar(status);
+        player.sendPlayerListHeaderAndFooter(
+            Component.text("IX SPLEEF", NamedTextColor.AQUA, TextDecoration.BOLD),
+            Component.text("Lobby | Minecraft 26.2", NamedTextColor.GRAY));
         player.showTitle(Title.title(
             Component.text("SPLEEF LOBBY", NamedTextColor.AQUA, TextDecoration.BOLD),
             Component.text("Adventure mode protects this waiting platform", NamedTextColor.GRAY),
@@ -96,25 +118,35 @@ final class Lobby {
 
     private void tick() {
         var players = instance.getPlayers();
-        if (players.size() < MIN_PLAYERS) {
-            secondsLeft = COUNTDOWN_SECONDS;
+        if (players.size() < minPlayers) {
+            secondsLeft = countdownSeconds;
             status.name(Component.text(
-                "Lobby: waiting for players (%d/%d)".formatted(players.size(), MIN_PLAYERS)));
-            status.progress(1f);
+                "Lobby: waiting for players (%d/%d)".formatted(players.size(), minPlayers)));
+            status.progress(Math.min(1f, (float) players.size() / minPlayers));
             status.color(BossBar.Color.WHITE);
+            for (Player player : players) {
+                player.sendActionBar(Component.text(
+                    "Waiting for %d more player%s"
+                        .formatted(minPlayers - players.size(), minPlayers - players.size() == 1 ? "" : "s"),
+                    NamedTextColor.YELLOW));
+            }
             return;
         }
 
         secondsLeft--;
         if (secondsLeft <= 0) {
-            secondsLeft = COUNTDOWN_SECONDS;
+            secondsLeft = countdownSeconds;
             Game.start(this, players);
             return;
         }
 
         status.name(Component.text("Lobby: snow arena starts in %ds".formatted(secondsLeft)));
-        status.progress((float) secondsLeft / COUNTDOWN_SECONDS);
+        status.progress((float) secondsLeft / countdownSeconds);
         status.color(BossBar.Color.GREEN);
+        for (Player player : players) {
+            player.sendActionBar(Component.text(
+                "Snow arena starts in %ds".formatted(secondsLeft), NamedTextColor.GREEN));
+        }
         if (secondsLeft <= 5) {
             instance.showTitle(Title.title(
                 Component.text(secondsLeft, NamedTextColor.GOLD),

--- a/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Main.java
+++ b/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/Main.java
@@ -1,7 +1,13 @@
 package dev.ix.minestom.spleef;
 
+import java.util.Locale;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.event.player.AsyncPlayerConfigurationEvent;
+import net.minestom.server.event.server.ServerListPingEvent;
+import net.minestom.server.ping.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,17 +22,35 @@ public final class Main {
     private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
     public static void main(String[] args) {
-        MinecraftServer server = MinecraftServer.init();
+        ServerConfig config = ServerConfig.fromEnvironment(System.getenv());
+        MinecraftServer server = MinecraftServer.init(config.authentication().minestomAuth());
+        MinecraftServer.setBrandName("ix Spleef");
 
-        Lobby lobby = new Lobby();
+        Lobby lobby = new Lobby(config.minPlayers(), config.countdownSeconds());
         // Every connection lands in the lobby; Game moves players out and back.
         MinecraftServer.getGlobalEventHandler().addListener(AsyncPlayerConfigurationEvent.class, event -> {
+            int playerCount = MinecraftServer.getConnectionManager().getOnlinePlayerCount();
+            if (playerCount >= config.maxPlayers()) {
+                event.getPlayer().kick(Component.text("The Spleef server is full.", NamedTextColor.RED));
+                return;
+            }
             event.setSpawningInstance(lobby.instance());
             event.getPlayer().setRespawnPoint(Lobby.SPAWN);
         });
+        MinecraftServer.getGlobalEventHandler().addListener(ServerListPingEvent.class, event -> event.setStatus(
+            Status.builder()
+                .description(Component.text("Spleef", NamedTextColor.AQUA, TextDecoration.BOLD)
+                    .append(Component.text(" | Fast rounds on Minecraft 26.2", NamedTextColor.GRAY)))
+                .playerInfo(MinecraftServer.getConnectionManager().getOnlinePlayerCount(), config.maxPlayers())
+                .enforcesSecureChat(config.authentication() == ServerConfig.Authentication.ONLINE)
+                .build()));
 
-        server.start("0.0.0.0", 25565);
-        LOGGER.info("spleef server listening on :25565");
+        server.start(config.bindAddress(), config.port());
+        LOGGER.info(
+            "spleef server listening on {}:{} with {} authentication",
+            config.bindAddress(),
+            config.port(),
+            config.authentication().name().toLowerCase(Locale.ROOT));
     }
 
     private Main() {}

--- a/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/ServerConfig.java
+++ b/packages/minecraft/minestom/servers/spleef/src/main/java/dev/ix/minestom/spleef/ServerConfig.java
@@ -1,0 +1,66 @@
+package dev.ix.minestom.spleef;
+
+import java.util.Locale;
+import java.util.Map;
+import net.minestom.server.Auth;
+
+record ServerConfig(
+    String bindAddress,
+    int port,
+    Authentication authentication,
+    int minPlayers,
+    int maxPlayers,
+    int countdownSeconds
+) {
+    private static final int DEFAULT_PORT = 25565;
+    private static final int DEFAULT_MIN_PLAYERS = 2;
+    private static final int DEFAULT_MAX_PLAYERS = 20;
+    private static final int DEFAULT_COUNTDOWN_SECONDS = 10;
+
+    enum Authentication {
+        ONLINE,
+        OFFLINE;
+
+        Auth minestomAuth() {
+            return switch (this) {
+                case ONLINE -> new Auth.Online();
+                case OFFLINE -> new Auth.Offline();
+            };
+        }
+    }
+
+    static ServerConfig fromEnvironment(Map<String, String> environment) {
+        String bindAddress = environment.getOrDefault("SPLEEF_BIND_ADDRESS", "0.0.0.0");
+        int port = integer(environment, "SPLEEF_PORT", DEFAULT_PORT, 1, 65535);
+        int minPlayers = integer(environment, "SPLEEF_MIN_PLAYERS", DEFAULT_MIN_PLAYERS, 2, 64);
+        int maxPlayers = integer(environment, "SPLEEF_MAX_PLAYERS", DEFAULT_MAX_PLAYERS, minPlayers, 64);
+        int countdownSeconds =
+            integer(environment, "SPLEEF_COUNTDOWN_SECONDS", DEFAULT_COUNTDOWN_SECONDS, 1, 300);
+        Authentication authentication = authentication(environment.getOrDefault("SPLEEF_AUTH", "online"));
+        return new ServerConfig(bindAddress, port, authentication, minPlayers, maxPlayers, countdownSeconds);
+    }
+
+    private static Authentication authentication(String value) {
+        try {
+            return Authentication.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException("SPLEEF_AUTH must be 'online' or 'offline', got: " + value, exception);
+        }
+    }
+
+    private static int integer(Map<String, String> environment, String name, int defaultValue, int min, int max) {
+        String value = environment.get(name);
+        if (value == null) return defaultValue;
+
+        final int parsed;
+        try {
+            parsed = Integer.parseInt(value);
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(name + " must be an integer, got: " + value, exception);
+        }
+        if (parsed < min || parsed > max) {
+            throw new IllegalArgumentException(name + " must be between " + min + " and " + max + ", got: " + parsed);
+        }
+        return parsed;
+    }
+}

--- a/playbook/src/routes/minestom-spleef-26-2/+page.svx
+++ b/playbook/src/routes/minestom-spleef-26-2/+page.svx
@@ -1,0 +1,45 @@
+---
+title: "A production-ready Minestom Spleef server for Minecraft 26.2"
+date: 2026-07-11
+---
+
+The Minestom example is now a complete Spleef server for Minecraft 26.2. A
+protected lobby gathers players, a visible countdown moves a stable snapshot of
+them into a disposable snow arena, and the last player standing wins. Each
+round owns its instance, event listeners, timers, boss bar, and player state, so
+unregistering the instance tears the round down as one unit.
+
+## Player experience
+
+The waiting platform is deliberately distinct from the arena. Players arrive
+in Adventure mode on illuminated quartz and cyan concrete, see the live player
+requirement, and get a direct explanation that the platform is protected. The
+countdown names the upcoming snow arena. During a round, titles, action bars,
+the player list, sounds, and a boss bar communicate each phase and elimination.
+
+Lobby damage is disabled, and anyone who falls is returned to spawn. Entering
+the lobby resets health, food, experience, inventory, game mode, and status UI.
+Round startup copies the lobby player collection before moving anyone, avoiding
+mutation during iteration.
+
+## Deployment contract
+
+Mojang authentication is the default. Offline authentication must be selected
+explicitly for isolated tests or an authenticated proxy. Environment variables
+configure the bind address, port, authentication mode, capacity, minimum player
+count, and countdown duration. Invalid values stop startup with a named error.
+
+Server-list pings advertise the game, Minecraft 26.2 support, live player
+count, configured capacity, and secure-chat policy. The example README keeps
+the complete build, run, security, and configuration contract beside the code.
+
+## Evidence
+
+The fat jar compiled on Linux from the pinned Minestom snapshot. The NixOS VM
+test then booted it through `services.minestom`, asserted protocol 776, checked
+the Spleef MOTD and configured capacity, completed an offline protocol login,
+and produced a 42,899-byte ReplayMod recording of the client session.
+
+Issue #2872. PR #2873.
+
+*Written by Codex, an AI coding agent.*

--- a/tests/minestom-spleef-vm.nix
+++ b/tests/minestom-spleef-vm.nix
@@ -71,6 +71,13 @@ in
         enable = true;
         serverJar = spleefJar;
       };
+
+      # Production defaults to Mojang authentication. The protocol bot has no
+      # account session, so this isolated VM explicitly selects offline mode.
+      systemd.services.minestom.environment = {
+        SPLEEF_AUTH = "offline";
+        SPLEEF_MAX_PLAYERS = "8";
+      };
     };
 
     testScript = ''
@@ -80,7 +87,7 @@ in
       # Main's readiness line: MinecraftServer.start() returned, so the
       # network stack is bound and the lobby instance is registered.
       server.wait_until_succeeds(
-          "journalctl -u minestom.service --grep 'spleef server listening on :25565' --quiet",
+          "journalctl -u minestom.service --grep 'spleef server listening on 0.0.0.0:25565 with offline authentication' --quiet",
           timeout=300,
       )
       server.wait_for_open_port(25565)
@@ -91,7 +98,10 @@ in
       # there moves these assertions too. Both probes run so both unibind
       # renderings of mc-protocol (Python/pyo3, Kotlin/FFM) are proven
       # against a live server, not just their conformance fixtures.
-      server.succeed("${mcProbe} 127.0.0.1:25565 --protocol-version 776 --timeout 30")
+      server.succeed(
+          "${mcProbe} 127.0.0.1:25565 --protocol-version 776"
+          + " --motd-contains Spleef --min-max-players 8 --timeout 30"
+      )
       server.succeed("${mcProbeKt} 127.0.0.1:25565 --protocol-version 776 --timeout 30")
 
       # Join as a real player and record the session. mc-bot walks the whole


### PR DESCRIPTION
## Summary

- make the protected lobby, countdown, snow arena, and winner states visually distinct
- snapshot lobby players before moving them into a round and rescue lobby falls
- add secure-by-default authentication, validated environment configuration, capacity admission, and server-list metadata
- document local and production configuration next to the example
- extend the Linux VM test to verify offline test configuration, MOTD, capacity, a 26.2 login, and the replay artifact

## Validation

- `javac --release 25` across all Spleef sources
- configuration boundary checks for defaults, overrides, and invalid values
- `nix build .#minestom-spleef-server-jar` on `hc1`
- `nix build .#checks.x86_64-linux.minestom-spleef-vm` on `hc1`
- terminal VM artifact: `spleef.mcpr`, 42,899 bytes
- `nix run .#lint -- --json` (fails on existing repository findings outside this diff; all filename, directory, Ruff, clone, and Elixir checks pass)

Fixes #2872

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the Minestom Spleef example production-ready with environment-based config and polished gameplay
> - Adds [ServerConfig.java](https://github.com/indexable-inc/index/pull/2873/files#diff-49c19bf791e58674705ddc63afc42d624715cbe2bf813a6051b8fa081d52b970) to read bind address, port, auth mode, min/max players, and countdown from environment variables, failing fast on invalid values.
> - Server now enforces a player capacity limit (kicking excess connections), sets a custom MOTD with player counts, and reports secure-chat policy based on auth mode.
> - Lobby gains damage immunity, fall rescue (teleport back to spawn), illuminated platform borders, and parameterized min-players/countdown driven by config.
> - Game rounds display a BossBar tracking phase and remaining players; players receive cleared inventories, ADVENTURE mode, and invulnerability during the freeze phase.
> - VM test updated to run in offline mode with capacity 8 and assert the new MOTD and player count in the server-list response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c367001.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->