### PR TITLE
fix(mcp): address delegated task completion

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -663,8 +663,10 @@
         the harness subagent and task tools are absent by design, so
         delegation means `await weave.delegate('prompt')` in a kernel cell
         (the weave app runs each task as a live, interruptible session),
-        launched as background jobs by default so the main thread stays free,
-        with completion notifying the session over the kernel channel. Split
+        then `jobs.spawn(weave.result(task), name='delegate: <name>')` by default
+        so the main thread stays free. The durable task result is authoritative;
+        its automatic addressed channel wake is best-effort, not exactly-once,
+        so do not add a manual notification. Split
         implementation by phase, fan independent questions (diagnostic
         differentials, research legs, per-component checks) out in parallel,
         and give each editing agent its own worktree. Keep the main session

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2617,6 +2617,8 @@
       cp ${./tests/test_cancel_running.py} test_cancel_running.py
       # Issue #2164: jobs.spawn registers an ad-hoc awaitable as a first-class job.
       cp ${./tests/test_jobs_spawn.py} test_jobs_spawn.py
+      # A spawned job starts and finishes the same proc entity; no detached run phantom.
+      cp ${./tests/test_spawn_store_lifecycle.py} test_spawn_store_lifecycle.py
       cp ${./tests/test_fsearch_partial.py} test_fsearch_partial.py
       cp ${./tests/test_fsearch_glob.py} test_fsearch_glob.py
       # Issue #2542: find('*.py') auto-detects a glob-shaped non-regex pattern.
@@ -2651,6 +2653,7 @@
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
         test_jobs_spawn.py \
+        test_spawn_store_lifecycle.py \
         test_fsearch_partial.py \
         test_fsearch_glob.py \
         test_fsearch_glob_pattern.py \

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -69,7 +69,8 @@ JOBS = (
     "Each call runs as an async task and waits up to `budget` seconds; if the work is still going "
     "it keeps running in the background and the call returns a job handle. Background jobs live "
     "in the `jobs` dict, so manage them with more python_exec: `jobs['ab12']` to inspect, `await "
-    "jobs['ab12']` to wait (it yields the run's value), `jobs['ab12'].cancel()` to stop, "
+    "jobs['ab12']` to wait (it yields a `Result`: use `.text` for rendered text or `.value` "
+    "for the original Python value), `jobs['ab12'].cancel()` to stop, "
     "`jobs['ab12'].done()` to test if it has finished, `[j for j in jobs.values() if "
     "j.running()]` to list. `budget` is how long the run holds the one shared shell channel "
     "before it backgrounds, so keep it small and poll: do NOT pass a huge budget to sit on a "
@@ -77,7 +78,7 @@ JOBS = (
     "time and is capped server-side anyway. Let the work background, then re-await or poll "
     "`.done()` in a later cell. `jobs.spawn(coro, name=...)` registers an awaitable you created "
     "yourself as a first-class job with the same lifecycle (appears in `jobs`, notifies on "
-    "completion, result via `await jobs['<id>']`)."
+    "completion, result text via `(await jobs['<id>']).text`)."
 )
 
 PAGING = (
@@ -218,10 +219,14 @@ DELEGATE = (
     "Delegate work to coding agents with the weave verbs. `task = await "
     "weave.delegate('prompt', name='reviewer', model=..., system=...)` appends task facts to "
     "the shared journal; the weave app fulfills them as a live interactive Claude session - "
-    "visible and interruptible in the Constellation - and the outcome folds back to "
-    "agent:main automatically. `await weave.result(task)` blocks until the task finishes and "
-    "returns its result text (`timeout=` to bound the wait). Run a long delegation as a "
-    "background job and push a channel event with `await notify(...)` when it finishes."
+    "visible and interruptible in the Constellation - and publishes the terminal outcome to "
+    "the journal. `await weave.result(task)` blocks until the task finishes and "
+    "returns its result text or raises its failed/cancelled outcome (`timeout=` to bound the "
+    "wait). Keep the main thread free with `job = jobs.spawn(weave.result(task), "
+    "name='delegate: reviewer')`; the durable task result is authoritative and the automatic "
+    "addressed channel wake is best-effort, not exactly-once, so do not add a manual "
+    "`notify(...)`. Once done, read `job.result.text` (or `(await job).text`); `job.result` is "
+    "a `Result` wrapper, not a string."
 )
 
 NIX = (

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -1545,7 +1545,7 @@ class Jobs(dict[str, Job]):
     run, keyed by job id. Beyond the dict surface, :meth:`spawn` registers an
     ad-hoc awaitable as a first-class background job, so work an agent started
     itself (a coroutine, a Task) gets the same lifecycle as a backgrounded cell:
-    a dashboard card, a completion notification, and a pageable/awaitable
+    a dashboard card, a best-effort completion wake, and a pageable/awaitable
     ``jobs['<id>']`` handle (issue #2164)."""
 
     def spawn(self, aw: Awaitable[Any], *, name: str | None = None, topic: str | None = None) -> Job:
@@ -1554,7 +1554,7 @@ class Jobs(dict[str, Job]):
 
         The awaitable gets the full job lifecycle: it appears in ``jobs`` /
         ``history()`` and on the dashboard, its completion pushes a channel
-        notification exactly like a backgrounded cell, and its value is
+        notification addressed to the session that spawned it, and its value is
         retrieved with ``await jobs['<id>']`` (or ``.result`` once done; a
         failure re-raises there, like any other job). ``name`` labels the job
         (defaults to the coroutine's qualname); ``topic`` files it under a
@@ -2882,6 +2882,7 @@ def _persist_final(job: Job) -> None:
         _store.finish(
             _store_conn,
             id=job.id,
+            kind=job.kind,
             status=job.status,
             ended_at=job.ended or time.time(),
             output=job.output,
@@ -2961,17 +2962,11 @@ async def _spawn_runner(job: Job, aw: Awaitable[Any]) -> None:
         _ix_current.reset(token)
         _persist_final(job)
         _mark_snapshot_dirty()
-        # Spawned jobs are backgrounded by construction, so completion always
-        # notifies (the suppress mirrors _runner: a session without the channel
-        # has nothing to deliver to, and that must not fail the job's cleanup).
+        # The durable job row above is the completion authority. The addressed
+        # channel wake is intentionally best-effort, not exactly-once: it may be
+        # lost, but must never be broadcast elsewhere or fail job cleanup.
         with contextlib.suppress(Exception):
-            await notify(
-                f"Background job {job.name} finished with status {job.status}.",
-                job_id=job.id,
-                job_name=job.name,
-                status=job.status,
-                topic=job.topic,
-            )
+            _notify_job_finished(job)
 
 
 def _cell_bindings(job: Job) -> dict:

--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -504,8 +504,11 @@ def stream_snapshot(conn: WeaveStore, stream: str, data: bytes) -> None:
         conn._enqueue_blob_fact(stream, "snapshot", data)
 
 
-def finish(conn: WeaveStore, *, id: str, status: str, ended_at: float, output: str, result: str | None, error: str | None, error_line: int | None = None, outputs: list | None = None, bindings: dict | None = None, namespace: list | None = None) -> None:
-    ent = _entity("run", id)
+def finish(conn: WeaveStore, *, id: str, kind: str, status: str, ended_at: float, output: str, result: str | None, error: str | None, error_line: int | None = None, outputs: list | None = None, bindings: dict | None = None, namespace: list | None = None) -> None:
+    # This must select the same entity as start(): spawned awaitables are
+    # processes, not runs. Finishing a spawn under run:<id> leaves proc:<id>
+    # permanently running and creates a detached phantom run.
+    ent = _entity("proc", id) if kind == "spawn" else _entity("run", id)
     ended = _ms(ended_at)
     facts: list[tuple[str, str, Any]] = [(ent, "status", status), (ent, "ended_ms", ended), (ent, "last_output", (output or "")[-200:]), (conn.agent, "last_output", (output or "")[-200:])]
     if result is not None:

--- a/packages/mcp/src/weave/test_weave.py
+++ b/packages/mcp/src/weave/test_weave.py
@@ -172,6 +172,38 @@ def test_result_returns_on_done(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    ("state", "attr", "detail", "error"),
+    [
+        ("failed", "error", "worker process exited", weave.TaskFailedError),
+        ("cancelled", "result", "stopped by user", weave.TaskCancelledError),
+    ],
+)
+def test_result_raises_terminal_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    state: str,
+    attr: str,
+    detail: str,
+    error: type[RuntimeError],
+) -> None:
+    programs: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        program = weave.json.loads(req.read())["program"]
+        programs.append(program)
+        value = state if ", state, " in program else detail
+        variable = "S" if ", state, " in program else "R"
+        return httpx.Response(200, json={"vars": [variable], "rows": [[{"t": "str", "v": value}]], "as_of": 1})
+
+    install_transport(monkeypatch, handler)
+    with pytest.raises(error, match=rf"task {state}: task-abcd1234: {detail}"):
+        run(weave.result("task-abcd1234"))
+    assert programs == [
+        '?- latest("task-abcd1234", state, S).',
+        f'?- latest("task-abcd1234", {attr}, R).',
+    ]
+
+
 def test_result_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
     def handler(req: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"vars": ["S"], "rows": [[{"t": "str", "v": "pending"}]], "as_of": 1})

--- a/packages/mcp/src/weave/weave/__init__.py
+++ b/packages/mcp/src/weave/weave/__init__.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 __all__ = [
     "HashRef",
     "QueryResult",
+    "TaskCancelledError",
+    "TaskFailedError",
     "Weave",
     "assert_fact",
     "assert_facts",
@@ -52,6 +54,14 @@ class HashRef:
     """Explicit marker for a Weave hash value."""
 
     value: str
+
+
+class TaskFailedError(RuntimeError):
+    """A delegated Weave task published the terminal ``failed`` state."""
+
+
+class TaskCancelledError(RuntimeError):
+    """A delegated Weave task published the terminal ``cancelled`` state."""
 
 
 def hashref(h: str) -> HashRef:
@@ -283,18 +293,31 @@ class Weave:
     async def result(self, task: str, *, timeout: float | None = None) -> str:
         """Block until ``task`` finishes; return its ``result`` fact text.
 
-        Polls ``latest(task, state)`` every 0.5s until it reaches done,
-        failed, or cancelled, then returns the task's ``result`` fact text
-        ("" when the fulfiller wrote none). Raises TimeoutError once
-        ``timeout`` seconds pass without a terminal state.
+        Polls ``latest(task, state)`` every 0.5s. ``done`` returns the durable
+        ``result`` fact ("" when the fulfiller wrote none); ``failed`` and
+        ``cancelled`` raise :class:`TaskFailedError` and
+        :class:`TaskCancelledError` with the published terminal detail.
+        Raises TimeoutError once ``timeout`` seconds pass without a terminal
+        state. This journal read is completion authority; any channel wake is
+        only a best-effort hint to inspect the durable result.
         """
 
         deadline = None if timeout is None else time.monotonic() + timeout
         while True:
             rows = (await self.query(f'?- latest("{task}", state, S).'))["rows"]
-            if rows and rows[0][0] in ("done", "failed", "cancelled"):
-                out = (await self.query(f'?- latest("{task}", result, R).'))["rows"]
-                return out[0][0] if out else ""
+            if rows:
+                state = rows[0][0]
+                if state == "done":
+                    out = (await self.query(f'?- latest("{task}", result, R).'))["rows"]
+                    return out[0][0] if out else ""
+                if state == "failed":
+                    out = (await self.query(f'?- latest("{task}", error, R).'))["rows"]
+                    detail = out[0][0] if out else ""
+                    raise TaskFailedError(f"task failed: {task}" + (f": {detail}" if detail else ""))
+                if state == "cancelled":
+                    out = (await self.query(f'?- latest("{task}", result, R).'))["rows"]
+                    detail = out[0][0] if out else ""
+                    raise TaskCancelledError(f"task cancelled: {task}" + (f": {detail}" if detail else ""))
             if deadline is not None and time.monotonic() >= deadline:
                 raise TimeoutError(f"task not finished after {timeout}s: {task}")
             await asyncio.sleep(0.5)

--- a/packages/mcp/tests/test_jobs_spawn.py
+++ b/packages/mcp/tests/test_jobs_spawn.py
@@ -1,12 +1,12 @@
 """``jobs.spawn`` registers an ad-hoc awaitable as a first-class background job
 (issue #2164).
 
-The kernel's job lifecycle (dashboard card, completion notification, pageable
+The kernel's job lifecycle (dashboard card, best-effort addressed completion wake, pageable
 ``jobs['<id>']`` handle, ``await`` yields the value / re-raises the failure) used
 to be reachable only through ``python_exec`` cells; an awaitable an agent created
 itself (a coroutine, a Task) had none of it. ``jobs.spawn(coro, name=...)`` gives
-any awaitable the same lifecycle: it appears in ``jobs``, its completion sends
-the same channel notification a backgrounded cell sends, and its result follows
+any awaitable the same lifecycle: it appears in ``jobs``, its completion queues
+the same addressed channel wake a backgrounded cell sends, and its result follows
 the existing Job contract (``.result`` raises while running, a failure re-raises
 on ``await``, cancel works).
 """
@@ -160,14 +160,19 @@ def test_cancelling_a_spawned_task_shape_cancels_the_work(monkeypatch: pytest.Mo
     asyncio.run(drive())
 
 
-def test_completion_sends_the_backgrounded_job_notification(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_completion_sends_the_addressed_backgrounded_job_notification(monkeypatch: pytest.MonkeyPatch) -> None:
     _wire(monkeypatch, {})
-    sent: list[tuple[str, dict]] = []
+    sent: list[runtime.Job] = []
+    broadcasts: list[str] = []
 
-    async def fake_notify(content: str, **meta: object) -> None:
-        sent.append((content, meta))
+    def fake_notify(job: runtime.Job) -> None:
+        sent.append(job)
 
-    monkeypatch.setattr(runtime, "notify", fake_notify)
+    async def fake_broadcast(content: str, **_meta: object) -> None:
+        broadcasts.append(content)
+
+    monkeypatch.setattr(runtime, "_notify_job_finished", fake_notify)
+    monkeypatch.setattr(runtime, "notify", fake_broadcast)
 
     async def work() -> int:
         return 7
@@ -179,12 +184,8 @@ def test_completion_sends_the_backgrounded_job_notification(monkeypatch: pytest.
 
     job = asyncio.run(drive())
     assert job.status == "done"
-    assert len(sent) == 1
-    content, meta = sent[0]
-    assert "notified" in content
-    assert "done" in content
-    assert meta["job_id"] == job.id
-    assert meta["status"] == "done"
+    assert sent == [job]
+    assert broadcasts == []
 
 
 def test_spawn_rejects_a_non_awaitable(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/mcp/tests/test_live_lines.py
+++ b/packages/mcp/tests/test_live_lines.py
@@ -130,6 +130,7 @@ def test_store_round_trips_line_and_error_line(tmp_path: Path, fake_weave: objec
     store.finish(
         conn,
         id="j1",
+        kind="cell",
         status="error",
         ended_at=1.0,
         output="out",

--- a/packages/mcp/tests/test_mcp_ui.py
+++ b/packages/mcp/tests/test_mcp_ui.py
@@ -332,6 +332,7 @@ def test_api_job_ui_serves_embedded_view(tmp_path: Path, monkeypatch: pytest.Mon
     store.finish(
         conn,
         id="ab12",
+        kind="cell",
         status="done",
         ended_at=2.0,
         output="",

--- a/packages/mcp/tests/test_session.py
+++ b/packages/mcp/tests/test_session.py
@@ -26,11 +26,11 @@ def test_latest_namespace_is_not_stale_after_clear(tmp_path: Path, fake_weave: o
     conn = store.connect(tmp_path / "ns.db")
     x = [{"name": "x", "type": "int", "kind": "scalar", "repr": "4", "size": 28, "shape": ""}]
     store.start(conn, id="j1", name="", code="x = 4", started_at=100.0)
-    store.finish(conn, id="j1", status="done", ended_at=100.1, output="", result="4", error=None, namespace=x)
+    store.finish(conn, id="j1", kind="cell", status="done", ended_at=100.1, output="", result="4", error=None, namespace=x)
     assert store.latest_namespace(conn) == x
     # A later run clears the namespace: the pane must go empty, not stay on `x`.
     store.start(conn, id="j2", name="", code="reset", started_at=101.0)
-    store.finish(conn, id="j2", status="done", ended_at=101.1, output="", result=None, error=None, namespace=[])
+    store.finish(conn, id="j2", kind="cell", status="done", ended_at=101.1, output="", result=None, error=None, namespace=[])
     assert store.latest_namespace(conn) == []
     # A running job (no ended_at) is excluded; the last finished value still holds.
     store.start(conn, id="j3", name="", code="while True:\n    pass", started_at=102.0)
@@ -62,7 +62,7 @@ def test_mark_interrupted_closes_running_rows_and_live_resources(tmp_path: Path,
     conn = store.connect(tmp_path / "s.ixnb")
     store.start(conn, id="dead", name="dead", code="x", started_at=1.0)
     store.start(conn, id="fine", name="fine", code="y", started_at=1.0)
-    store.finish(conn, id="fine", status="done", ended_at=2.0, output="", result=None, error=None)
+    store.finish(conn, id="fine", kind="cell", status="done", ended_at=2.0, output="", result=None, error=None)
     store.upsert_resource(
         conn, id="r1", title="t", kind="tui", html="", status="live", created_at=1.0, updated_at=1.0
     )
@@ -77,19 +77,19 @@ def test_replayable_anchors_on_ended_at_and_excludes_replays(tmp_path: Path, fak
     conn = store.connect(tmp_path / "s.ixnb")
     # Finished before the checkpoint: captured by it, not replayed.
     store.start(conn, id="old", name="old", code="a = 1", started_at=1.0)
-    store.finish(conn, id="old", status="done", ended_at=2.0, output="", result=None, error=None)
+    store.finish(conn, id="old", kind="cell", status="done", ended_at=2.0, output="", result=None, error=None)
     # Started before but FINISHED after the checkpoint: partial effects in the
     # checkpoint, so it must replay.
     store.start(conn, id="straddle", name="straddle", code="b = 2", started_at=1.5)
-    store.finish(conn, id="straddle", status="done", ended_at=6.0, output="", result=None, error=None)
+    store.finish(conn, id="straddle", kind="cell", status="done", ended_at=6.0, output="", result=None, error=None)
     # Finished after the checkpoint: replays.
     store.start(conn, id="new", name="new", code="c = 3", started_at=7.0)
-    store.finish(conn, id="new", status="done", ended_at=8.0, output="", result=None, error=None)
+    store.finish(conn, id="new", kind="cell", status="done", ended_at=8.0, output="", result=None, error=None)
     # Failed and replay-kind rows never replay.
     store.start(conn, id="bad", name="bad", code="boom", started_at=7.0)
-    store.finish(conn, id="bad", status="error", ended_at=8.0, output="", result=None, error="x")
+    store.finish(conn, id="bad", kind="cell", status="error", ended_at=8.0, output="", result=None, error="x")
     store.start(conn, id="rep", name="rep", code="d = 4", started_at=7.0, kind="replay")
-    store.finish(conn, id="rep", status="done", ended_at=8.0, output="", result=None, error=None)
+    store.finish(conn, id="rep", kind="replay", status="done", ended_at=8.0, output="", result=None, error=None)
 
     assert [r["id"] for r in store.replayable(conn, since=5.0)] == ["straddle", "new"]
     # No checkpoint at all: the whole successful original log, oldest first.

--- a/packages/mcp/tests/test_spawn_store_lifecycle.py
+++ b/packages/mcp/tests/test_spawn_store_lifecycle.py
@@ -1,0 +1,72 @@
+"""A spawned job starts and finishes one process entity, never a phantom run."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ix_notebook_mcp import store
+
+
+def test_spawn_finish_updates_its_process_without_creating_a_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[str, str, object]] = []
+
+    def fake_json(
+        method: str, url: str, *, body: object = None, content: bytes | None = None
+    ) -> object:
+        calls.append((method, url, body if body is not None else content))
+        if url.endswith("/api/blob"):
+            return {"hash": f"h{len(calls):063d}"}
+        if url.endswith("/api/query"):
+            return {"vars": [], "rows": [], "as_of": 0}
+        return [] if isinstance(body, list) else {"seq": 1, "id": "f1"}
+
+    monkeypatch.setenv("WEAVE_URL", "http://weave.test")
+    monkeypatch.setenv("IX_WEAVE_AGENT", "agent:test")
+    monkeypatch.setattr(store, "_http_json", fake_json)
+    monkeypatch.setattr(store, "_http_bytes", lambda method, url, content=None: b"[]")
+
+    conn = store.connect(tmp_path / "spawn.ixnb")
+    store.start(
+        conn,
+        id="job-1",
+        name="delegation",
+        code="await work()",
+        started_at=10.0,
+        kind="spawn",
+    )
+    store.finish(
+        conn,
+        id="job-1",
+        kind="spawn",
+        status="done",
+        ended_at=12.0,
+        output="",
+        result="finished",
+        error=None,
+    )
+    assert conn.flush(timeout=2.0)
+    conn.close()
+
+    fact_batches = [body for _method, url, body in calls if url.endswith("/api/facts")]
+    facts = [
+        item["fact"]
+        for body in fact_batches
+        for item in (body if isinstance(body, list) else [body])
+    ]
+    entities = [fact["entity"]["v"] for fact in facts]
+    assert "proc:job-1" in entities
+    assert "run:job-1" not in entities
+    assert any(
+        fact["entity"]["v"] == "proc:job-1"
+        and fact["attr"] == "status"
+        and fact["value"] == {"t": "str", "v": "done"}
+        for fact in facts
+    )
+    assert any(
+        fact["entity"]["v"] == "proc:job-1" and fact["attr"] == "ended_ms"
+        for fact in facts
+    )

--- a/packages/mcp/tests/test_store_facts.py
+++ b/packages/mcp/tests/test_store_facts.py
@@ -37,7 +37,7 @@ def test_start_finish_set_session_and_snapshot_emit_fact_shapes(tmp_path: Path, 
     calls = _capture(monkeypatch)
     conn = store.connect(tmp_path / "session.ixnb")
     store.start(conn, id="abc", name="Example", code="x = 1", started_at=10.0, budget=3.0, topic="t")
-    store.finish(conn, id="abc", status="done", ended_at=12.0, output="hello", result="1", error=None, outputs=[{"text": "hello"}], bindings={"x": 1}, namespace=[])
+    store.finish(conn, id="abc", kind="cell", status="done", ended_at=12.0, output="hello", result="1", error=None, outputs=[{"text": "hello"}], bindings={"x": 1}, namespace=[])
     store.set_session(conn, name="Demo", client="claude")
     store.save_snapshot(conn, created_at=13.0, blob=b"state", names=["x"], skipped=[])
     _drain(conn)

--- a/packages/mcp/tests/test_toolusage.py
+++ b/packages/mcp/tests/test_toolusage.py
@@ -31,6 +31,7 @@ def _run(
         store.finish(
             conn,
             id=id,
+            kind="cell",
             status="done",
             ended_at=started_at + 1,
             output="",

--- a/packages/mcp/tests/test_weave_integration.py
+++ b/packages/mcp/tests/test_weave_integration.py
@@ -75,11 +75,14 @@ def test_phase0_store_roundtrip_against_real_weave(weave_server: str, tmp_path: 
     store.start(ws, id="run-1", name="smoke import", code="print('hello weave')",
                 started_at=now, budget=15.0, kind="cell", topic="swap-e2e")
     store.update_output(ws, "run-1", "hello weave\n", line=1)
-    store.finish(ws, id="run-1", status="done", ended_at=now + 2.5,
+    store.finish(ws, id="run-1", kind="cell", status="done", ended_at=now + 2.5,
                  output="hello weave\n", result="'ok'", error=None,
                  outputs=[], bindings={}, namespace=[])
     store.start(ws, id="job-1", name="background watcher", code="watch()",
                 started_at=now, budget=0.0, kind="spawn", topic="swap-e2e")
+    store.finish(ws, id="job-1", kind="spawn", status="done", ended_at=now + 3.0,
+                 output="", result="'finished'", error=None,
+                 outputs=[], bindings={}, namespace=[])
     store.save_snapshot(ws, created_at=now, blob=b"snapshot-bytes" * 10,
                         names=["x", "y"], skipped=[])
     assert ws.flush(timeout=15.0), "write queue failed to drain"
@@ -87,6 +90,7 @@ def test_phase0_store_roundtrip_against_real_weave(weave_server: str, tmp_path: 
     got = {r["id"]: r for r in store.recent(ws, limit=10)}
     assert got["run-1"]["status"] == "done"
     assert got["run-1"]["code"] == "print('hello weave')"
+    assert got["job-1"]["status"] == "done"
     assert store.get_session(ws)["name"] == "e2e demo session"
     snap = store.latest_snapshot(ws)
     assert snap is not None
@@ -104,6 +108,7 @@ def test_phase0_store_roundtrip_against_real_weave(weave_server: str, tmp_path: 
         kinds = {tuple(r) for r in (await weave_mod.query('?- child_of(R, "agent:e2e"), type(R, T).'))["rows"]}
         assert ("run:run-1", "run") in kinds
         assert ("proc:job-1", "process") in kinds
+        assert not (await weave_mod.query('?- latest("run:job-1", A, V).'))["rows"]
 
     asyncio.run(check())
 


### PR DESCRIPTION
## Summary
- route spawned-job completion through the existing session-addressed outbox instead of broadcast notify
- make weave.result return done results and raise truthful failed/cancelled outcomes
- teach the canonical prompt and MCP guide to use jobs.spawn(weave.result(task)) without manual notifications

## Verification
- MCP typecheck smoke and channel tests
- Weave client tests: 9 passed
- full .#mcp package build
- .#system-prompt-eval build
- Ruff, Alejandra, and diff checks

The journal remains completion authority. Channel wakeups are addressed and best-effort, not claimed as exactly-once.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix delegated task completion to write spawn job facts to proc entities
> - `store.finish` now accepts a `kind` parameter; when `kind='spawn'`, facts are written to `proc:<id>` instead of `run:<id>`, preventing a permanently-running proc entity and a detached phantom run.
> - `weave.result()` now raises `TaskFailedError` or `TaskCancelledError` for terminal failed/cancelled states instead of returning a string.
> - Completion notification in `_spawn_runner` is replaced with a best-effort call to `_notify_job_finished(job)`; broadcast channel notifications are no longer sent from this path.
> - Delegation and job guidance in prompts and the guide module is updated to reflect that the durable job row is the completion authority and addressed channel wake is best-effort.
> - Risk: all existing callers of `store.finish` must now pass `kind='cell'`; tests are updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e31f20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->