### PR TITLE
fzf: yield Ctrl+R to atuin in base profile

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -299,6 +299,12 @@ in {
           enableBashIntegration = true;
           enableZshIntegration = true;
           enableFishIntegration = true;
+          # Yield Ctrl+R to atuin (see above). fzf and atuin both bind
+          # Ctrl+R; atuin is sourced after fzf and wins, but Home Manager
+          # now warns on the double binding. Empty the history widget
+          # command to drop fzf's binding explicitly instead of relying on
+          # source order.
+          historyWidget.command = "";
         };
         # AST-aware merge driver. Parses 30+ languages (Nix, Rust,
         # Python, TS/JS, Go, Java, ...) and resolves structural conflicts


### PR DESCRIPTION
fzf and atuin both bind Ctrl+R. Home Manager now warns on the double binding during evaluation of the root profile. atuin is the intended owner (see the fzf block comment), so drop fzf's Ctrl+R binding explicitly with historyWidget.command = "" rather than relying on source order.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable fzf's Ctrl+R history widget to yield the binding to atuin
> Sets `historyWidget.command` to an empty string in the base profile's fzf config, removing fzf's default Ctrl+R shell binding so atuin can handle history search instead. Affects Bash, Zsh, and Fish integrations in [base/default.nix](https://github.com/indexable-inc/index/pull/2876/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f89f86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->