### PR TITLE
zed: disable definition fallback

### DIFF
--- a/users/andrewgazelka/config/zed/settings.nix
+++ b/users/andrewgazelka/config/zed/settings.nix
@@ -106,6 +106,7 @@
   git_panel = {
     dock = "left";
   };
+  go_to_definition_fallback = "none";
   gutter = {
     bookmarks = false;
     breakpoints = false;


### PR DESCRIPTION
## Summary

Set Zed's `go_to_definition_fallback` to `none`, so a failed definition lookup does not open all references.

## Validation

- `nix eval --json --file users/andrewgazelka/config/zed/settings.nix | jq '{go_to_definition_fallback}'`
- `git diff --check`

Closes #2877.

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable go-to-definition fallback in Zed editor settings
> Sets `go_to_definition_fallback` to `"none"` in [settings.nix](https://github.com/indexable-inc/index/pull/2878/files#diff-ab09fc7f5bab958641754df125cfcc77298b8edbc57359f398cc3f0b1985b327), so Zed no longer performs any fallback behavior when a definition cannot be resolved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acf884a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->