### PR TITLE
agent: preserve stderr in shell commands

### DIFF
--- a/users/andrewgazelka/config/claude/global/CLAUDE.md
+++ b/users/andrewgazelka/config/claude/global/CLAUDE.md
@@ -16,6 +16,8 @@ End with 🎉🎉🏁 only at genuine 100% completion (never a partial or blocke
 
 ## Tools
 
+Preserve stderr in shell commands. Never redirect stderr or combined output to `/dev/null`; filter only a named noisy pattern, or redirect stderr to a file and read it. Plain stdout-only `>/dev/null` is allowed.
+
 Check the index kernel `api()` catalog (via `python_exec`) before declaring you can't do something: it exposes already-authorized capabilities the standalone MCP connectors gate behind a separate OAuth handshake (Gmail/Calendar via `google_auth`, search, file/shell helpers). Live internet: `exa` web search + `web_fetch` for arbitrary URLs, but read/research only: you cannot log into the user's accounts or drive a live chat/checkout/form, so say that specifically when a task needs it. Search is triage: `exa` ~5 results; code via `mgrep search -a --agentic` (locations then `Read`), `rg` only for an exact literal, never recursive-grep a tree. Ad hoc tools via `nix run nixpkgs#<pkg>`. `sudo` works on hydra via Touch ID. Drive interactive or long-running processes with the kernel's `tui` module (`api().filter(pl.col('where') == 'tui')`): `Tui` spawns the process in a real PTY driven Playwright-style (`wait_for` a pattern, snapshot, send keys, never sleep-and-scrape), and `tui.serve()`/`publish()` mirror every live terminal to the dashboard for the human. Reach for tmux only when the process must outlive the kernel process itself. Some programs hard-require a real tty (termios raw-mode setup EINTRs or ENOTTYs otherwise, e.g. vfkit's stdio console): prefer their file/log output mode for daemons, and a PTY only for genuinely interactive use.
 
 ## Working style


### PR DESCRIPTION
## Summary

Add the active `bash-habits-guard` constraint and its actionable alternatives to the personal shell-tool guidance rendered into both `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`.

Closes andrewgazelka/nix#82

## Validation

- Rendered the Codex context with the real prompt module and personal appendix
- Verified the guidance appears exactly once under `## Tools`
- `git diff --check`
- `nix run .#lint` remains red on unrelated existing findings, including `lib/image/platform.nix` formatting and 21 `astlog` findings outside this change

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve stderr in shell commands per agent guidelines
> Updates [CLAUDE.md](https://github.com/indexable-inc/index/pull/2879/files#diff-7a499180ca508010968eada9afc4197aee8dfc5c9d54c03f52b31ebe6b29eea7) to prohibit redirecting stderr or combined output to `/dev/null` in shell commands. Filtering a specific noisy pattern or redirecting stderr to a file (and reading it) are the allowed alternatives. Plain stdout-only redirection (`>/dev/null`) remains permitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6c502d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->