### PR TITLE
mcp: deliver channel events to weave chat under weave-driven sessions

### DIFF
--- a/packages/mcp/ix_notebook_mcp/cli.py
+++ b/packages/mcp/ix_notebook_mcp/cli.py
@@ -360,6 +360,22 @@ def _exec_trust_network() -> bool:
     )
 
 
+def _channel_delivery() -> str:
+    """Where the transport pump delivers channel outbox events (see
+    ``Config.channel_delivery``). An unknown ``IX_MCP_CHANNEL_DELIVERY`` value
+    falls back loudly to "client" rather than silently swallowing events under
+    a mode this build does not know.
+    """
+    value = os.environ.get("IX_MCP_CHANNEL_DELIVERY", "client").strip() or "client"
+    if value not in ("client", "weave-chat"):
+        print(
+            f"ix-mcp: unknown IX_MCP_CHANNEL_DELIVERY {value!r}; using 'client'",
+            file=sys.stderr,
+        )
+        return "client"
+    return value
+
+
 def _auto_dashboard() -> bool:
     """Legacy flag retained for environment compatibility.
 
@@ -509,6 +525,7 @@ def _serve(args: argparse.Namespace, *, engine_only: bool = False) -> int:
         exec_trust_network=_exec_trust_network(),
         server_session_id=server_session_id,
         kernel_host=os.environ.get("IX_MCP_KERNEL", "local"),
+        channel_delivery=_channel_delivery(),
     )
     set_config(cfg)
 

--- a/packages/mcp/ix_notebook_mcp/config.py
+++ b/packages/mcp/ix_notebook_mcp/config.py
@@ -218,6 +218,18 @@ class Config:
     # every event is then a broadcast, the pre-#2165 behavior.
     server_session_id: str = ""
 
+    # Where the transport pump delivers channel outbox events. "client" (the
+    # default) emits notifications/claude/channel on the MCP transport, waking
+    # the connected client session. "weave-chat" instead posts each event as a
+    # chat message to the Weave agent (POST {WEAVE_URL}/api/chat, addressed to
+    # IX_WEAVE_AGENT): a Weave-driven Claude session must never be woken
+    # out-of-band (its turns are Weave-initiated; a self-woken turn's hook
+    # callbacks are rejected 401 and its work never reaches the journal), so
+    # Weave opens a normal run for the message and prompts the session itself.
+    # Sourced from IX_MCP_CHANNEL_DELIVERY by the CLI; Weave sets it in the
+    # env of every session it spawns (weave session_env).
+    channel_delivery: str = "client"
+
     # "stdio" (the default; what an MCP client launches), "http", or "none"
     # (the standalone notebook engine: kernel + dashboard, no MCP transport).
     transport: str = "stdio"

--- a/packages/mcp/ix_notebook_mcp/transport.py
+++ b/packages/mcp/ix_notebook_mcp/transport.py
@@ -13,6 +13,14 @@ stdio-only by contract (Claude Code spawns the channel server as a subprocess
 and a session opts in per-entry via ``--channels``), so the HTTP transport does
 not grow one. A client that did not opt in ignores both the capability and the
 notifications, so this costs nothing when unused.
+
+Under a Weave-driven session (``Config.channel_delivery == "weave-chat"``,
+set via IX_MCP_CHANNEL_DELIVERY by weave's session_env) the pump does NOT
+emit channel notifications: a self-woken Claude turn is out-of-band to Weave
+(its hook callbacks are rejected 401 and its work never reaches the journal).
+Each outbox row is instead posted to Weave's chat ingress (POST
+``{WEAVE_URL}/api/chat`` addressed to IX_WEAVE_AGENT), where Weave's observer
+opens a normal run and prompts the session itself.
 """
 
 from __future__ import annotations
@@ -26,6 +34,8 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable, Iterator, MutableMapping
 from contextlib import AsyncExitStack, contextmanager
+
+from xml.sax.saxutils import quoteattr
 
 import anyio
 from anyio.abc import ObjectSendStream
@@ -220,10 +230,18 @@ async def pump_outbox(
     write stream -- the same bytes ``ServerSession.send_notification`` would
     produce. Holds every send on the initialization event, so a startup/replay
     ``notify()`` never emits a notification before the handshake completes.
+
+    Under ``channel_delivery == "weave-chat"`` rows go to Weave's chat ingress
+    instead of the client (see the module docstring): ``take_outbox`` is
+    destructive, so undelivered rows ride a local ``pending`` buffer until a
+    2xx acknowledges them, each keeping the one message id minted for it so a
+    retry after an ambiguous failure lands on the same message entity.
     """
     await initialized.wait()
     cfg = config()
     box = mailbox.get_mailbox()
+    weave_chat = _weave_chat_target() if cfg.channel_delivery == "weave-chat" else None
+    pending: list[dict] = []
     while True:
         try:
             # Serve only this session's mail: broadcast rows (explicit
@@ -234,6 +252,11 @@ async def pump_outbox(
             rows = box.take_outbox(session=cfg.server_session_id)
         except Exception:
             rows = []  # best-effort: a read error this tick just retries next tick
+        if weave_chat is not None:
+            pending.extend({**row, "msg_id": f"msg-ixch-{uuid.uuid4().hex[:12]}"} for row in rows)
+            pending = await _deliver_weave_chat(weave_chat, pending)
+            await anyio.sleep(_OUTBOX_POLL_SECONDS)
+            continue
         for row in rows:
             try:
                 meta = json.loads(row["meta"] or "{}")
@@ -252,6 +275,73 @@ async def pump_outbox(
             except (anyio.ClosedResourceError, anyio.BrokenResourceError):
                 return
         await anyio.sleep(_OUTBOX_POLL_SECONDS)
+
+
+def _weave_chat_target() -> tuple[str, str] | None:
+    """The (weave_url, agent) a weave-chat pump posts to, or None when the
+    environment cannot support the mode -- the pump then falls back loudly to
+    client notifications rather than silently dropping events."""
+    url = os.environ.get("WEAVE_URL", "").rstrip("/")
+    agent = os.environ.get("IX_WEAVE_AGENT", "")
+    if not url or url.lower() == "off" or not agent:
+        logger.warning(
+            "channel_delivery=weave-chat needs WEAVE_URL and IX_WEAVE_AGENT; "
+            "falling back to client notifications"
+        )
+        return None
+    return url, agent
+
+
+def _channel_chat_text(row: dict) -> str:
+    """Render one outbox row in the same ``<channel ...>content</channel>``
+    shape Claude Code gives channel notifications, so the agent reads identical
+    provenance whichever way the event reached it."""
+    try:
+        meta = json.loads(row["meta"] or "{}")
+    except ValueError:
+        meta = {}
+    attrs = "".join(f" {key}={quoteattr(str(value))}" for key, value in meta.items())
+    return f'<channel source="ix-mcp"{attrs}>{row["content"]}</channel>'
+
+
+async def _deliver_weave_chat(target: tuple[str, str], pending: list[dict]) -> list[dict]:
+    """POST pending rows to Weave's chat ingress, oldest first, in order.
+
+    Returns the rows still undelivered: the first failure keeps its row and
+    everything behind it queued for the next tick, preserving order. Weave's
+    /api/chat ``id`` is idempotent (one message entity per id; an answered or
+    claimed message never re-dispatches), so retrying a POST whose response
+    was lost cannot double-run the agent. Rows older than the outbox TTL are
+    dropped with an error line -- the same bound the mailbox itself enforces
+    -- so a long Weave outage cannot grow the buffer without limit."""
+    url, agent = target
+    cutoff = time.time() - mailbox._OUTBOX_MAX_AGE_SECONDS
+    expired = [row for row in pending if row["created_at"] < cutoff]
+    if expired:
+        logger.error(
+            "dropping %d channel event(s) undelivered to weave past the outbox TTL",
+            len(expired),
+        )
+    kept = [row for row in pending if row["created_at"] >= cutoff]
+    for index, row in enumerate(kept):
+        body = {
+            "author": "ix-mcp",
+            "to": agent,
+            "role": "user",
+            "id": row["msg_id"],
+            "text": _channel_chat_text(row),
+        }
+        try:
+            # store._http_json is the one seam every Weave HTTP call in this
+            # process goes through (and what tests stub); blocking stdlib
+            # urllib, so run it off the event loop.
+            await anyio.to_thread.run_sync(
+                functools.partial(store._http_json, "POST", f"{url}/api/chat", body=body)
+            )
+        except Exception as exc:
+            logger.warning("weave chat delivery failed, retrying next tick: %s", exc)
+            return kept[index:]
+    return []
 
 # ASGI plumbing types for the HTTP transport's auth gate. `object` values (not
 # Any) keep the wrapper honestly typed; only our own literal dicts flow through.

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -124,6 +124,86 @@ def test_transport_pump_waits_for_initialization_before_draining_mailbox() -> No
     anyio.run(run)
 
 
+def _weave_chat_pump_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    set_config(
+        Config(
+            workdir=Path.cwd(),
+            store_path=Path("x"),
+            server_session_id="srv",
+            channel_delivery="weave-chat",
+        )
+    )
+    monkeypatch.setenv("WEAVE_URL", "http://weave.test")
+    monkeypatch.setenv("IX_WEAVE_AGENT", "agent:main")
+    monkeypatch.setattr(transport, "_OUTBOX_POLL_SECONDS", 0.01)
+
+
+def test_transport_pump_weave_chat_posts_instead_of_notifying(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        box = _box()
+        box.add_outbox(content="job done", meta=json.dumps({"job_id": "42"}), session="srv")
+        _weave_chat_pump_config(monkeypatch)
+        posts: list[tuple] = []
+
+        def fake_http(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+            posts.append((method, url, body))
+            return {"id": body["id"], "seq": 1}
+
+        monkeypatch.setattr(store, "_http_json", fake_http)
+        initialized = anyio.Event()
+        initialized.set()
+        send, recv = anyio.create_memory_object_stream[SessionMessage](10)
+        async with send, recv, anyio.create_task_group() as tg:
+            tg.start_soon(transport.pump_outbox, send, initialized)
+            with anyio.fail_after(2):
+                while not posts:
+                    await anyio.sleep(0.01)
+            # The client is never woken: no channel notification is emitted.
+            with anyio.move_on_after(0.05) as scope:
+                await recv.receive()
+            assert scope.cancel_called
+            tg.cancel_scope.cancel()
+        method, url, body = posts[0]
+        assert (method, url) == ("POST", "http://weave.test/api/chat")
+        assert body["to"] == "agent:main"
+        assert body["role"] == "user"
+        assert body["author"] == "ix-mcp"
+        assert body["id"].startswith("msg-ixch-")
+        assert body["text"] == '<channel source="ix-mcp" job_id="42">job done</channel>'
+
+    anyio.run(run)
+
+
+def test_transport_pump_weave_chat_retries_failed_post_with_same_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        box = _box()
+        box.add_outbox(content="flaky", meta="{}", session="srv")
+        _weave_chat_pump_config(monkeypatch)
+        attempts: list[str] = []
+
+        def fake_http(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+            attempts.append(body["id"])
+            if len(attempts) == 1:
+                raise ConnectionError("weave down")
+            return {"id": body["id"], "seq": 1}
+
+        monkeypatch.setattr(store, "_http_json", fake_http)
+        initialized = anyio.Event()
+        initialized.set()
+        send, recv = anyio.create_memory_object_stream[SessionMessage](10)
+        async with send, recv, anyio.create_task_group() as tg:
+            tg.start_soon(transport.pump_outbox, send, initialized)
+            with anyio.fail_after(2):
+                while len(attempts) < 2:
+                    await anyio.sleep(0.01)
+            tg.cancel_scope.cancel()
+        # The retry reuses the id minted for the row, so an ambiguous failure
+        # (response lost after the write landed) cannot double-deliver.
+        assert attempts[0] == attempts[1]
+
+    anyio.run(run)
+
+
 def test_reply_tool_appends_event(monkeypatch: pytest.MonkeyPatch) -> None:
     async def run() -> None:
         box = _box()


### PR DESCRIPTION
## Problem

A Claude Code session driven by weave must never be woken out-of-band. Weave arms per-turn hook credentials before injecting each prompt; a turn started by a `notifications/claude/channel` wake (e.g. a background `python_exec` job finishing after the parent turn ended) has its hook callbacks rejected with 401 and its work never reaches the journal.

## Change

New `Config.channel_delivery` (`IX_MCP_CHANNEL_DELIVERY`, default `client` = current behavior, standalone sessions untouched).

Under `weave-chat`, `pump_outbox` posts each outbox row to weave's existing chat ingress (`POST {WEAVE_URL}/api/chat`, addressed to `IX_WEAVE_AGENT`) instead of emitting the channel notification. The message lands in the journal, weave's observer (`NEEDS_REPLY`) opens a normal run, queues it behind any in-flight turn, and drives a fully authenticated weave-initiated turn. No new delivery infrastructure: the outbox, the pump, and weave's chat pipeline all already exist; this switches the pump's last hop.

Delivery details:
- `take_outbox` is destructive, so undelivered rows ride a local pending buffer until a 2xx acknowledges them; the first failure preserves order for the next tick.
- Each row keeps the one message id minted for it and `/api/chat` ids are idempotent, so retrying an ambiguous failure cannot double-run the agent.
- Rows undelivered past the outbox TTL are dropped with an error line (same bound the mailbox enforces).
- Message text uses the same `<channel source=... k=v>content</channel>` shape Claude sees from native channel notifications.
- Unsupported env (WEAVE_URL=off / missing agent) falls back loudly to client notifications.

## Testing

`nix build .#mcp.tests.channelTests`: 9 passed (2 new: weave-chat posts instead of notifying; failed POST retries with the same message id).

Companion weave PR sets the env var in `session_env`. Either lands safely alone: this is inert until the var is set, and the var is ignored by older builds.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deliver channel events to Weave chat via POST in weave-driven MCP sessions
> - Adds a `channel_delivery` config field (sourced from `IX_MCP_CHANNEL_DELIVERY`) with two modes: `'client'` (existing behavior, emits `notifications/claude/channel` over MCP transport) and `'weave-chat'` (POSTs each outbox row to `{WEAVE_URL}/api/chat` addressed to `IX_WEAVE_AGENT`).
> - In `weave-chat` mode, `pump_outbox` in [transport.py](https://github.com/indexable-inc/index/pull/2886/files#diff-39ae84714e8a966882f8856c976f1ebce9f5fd42dac02f22e89e4cbc672e1675) assigns each row a stable `msg_id`, retries failed POSTs with the same ID to avoid double-delivery, and drops rows that exceed the outbox TTL.
> - Message bodies include a structured XML-like text payload embedding meta fields as quoted attributes.
> - Two new tests cover the no-notification guarantee and retry ID stability.
> - Behavioral Change: sessions configured with `IX_MCP_CHANNEL_DELIVERY=weave-chat` no longer emit MCP channel notifications; if `WEAVE_URL` or `IX_WEAVE_AGENT` are missing or set to `'off'`, the transport logs a warning and falls back to client mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3269792.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->