### PR TITLE
check: support plural checks command

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1539,7 +1539,12 @@
         gnutar
         ;
     }
-    // lib.optionalAttrs (system == "x86_64-linux") {inherit check;}
+    // lib.optionalAttrs (system == "x86_64-linux") {
+      inherit check;
+      # Keep the natural plural spelling runnable instead of letting Nix fall
+      # through to the non-runnable top-level `checks` schema output.
+      checks = check;
+    }
     // repoFlakePackages
     // examplePackages
     // nonNixExampleImages


### PR DESCRIPTION
## Summary
- expose `checks` as an alias of the existing Linux `check` package
- make `nix run .#checks` invoke the canonical CI gate instead of falling through to the non-runnable flake `checks` output

## Validation
- `nix fmt -- --check lib/per-system.nix`
- `git diff --check`
- `nix build .#checks --no-link`
- `nix run .#checks` (full gate started successfully; local uncached build in progress)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `checks` attribute alias for `check` in per-system outputs on x86_64-linux
> In [per-system.nix](https://github.com/indexable-inc/index/pull/2889/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683), the per-system attribute set on x86_64-linux now exposes both `check` and `checks` (set to the same value), supporting the plural `checks` command alongside the existing `check`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61c533e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->