### PR TITLE
zed: restore definition fallback

### DIFF
--- a/users/andrewgazelka/config/zed/settings.nix
+++ b/users/andrewgazelka/config/zed/settings.nix
@@ -106,7 +106,6 @@
   git_panel = {
     dock = "left";
   };
-  go_to_definition_fallback = "none";
   gutter = {
     bookmarks = false;
     breakpoints = false;


### PR DESCRIPTION
## Summary

Remove the explicit `go_to_definition_fallback` override, restoring Zed's default behavior.

## Validation

- `nix fmt -- --check users/andrewgazelka/config/zed/settings.nix`
- `nix eval --json --file users/andrewgazelka/config/zed/settings.nix | jq -e 'has("go_to_definition_fallback") | not'`
- `git diff --check`

Closes #2890.

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore default `go_to_definition_fallback` behavior in Zed settings
> Removes the explicit `go_to_definition_fallback` override from [settings.nix](https://github.com/indexable-inc/index/pull/2891/files#diff-ab09fc7f5bab958641754df125cfcc77298b8edbc57359f398cc3f0b1985b327), allowing Zed to use its built-in default for this setting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35a7c8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->