### PR TITLE
zed: remove user-specific repository settings

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,25 +1,12 @@
 {
   // astlog rules are S-expressions (no dedicated grammar/LSP yet, #1703):
-  // Scheme gives paren matching + sexp highlighting via the auto-installed extension.
-  "auto_install_extensions": {
-    "scheme": true
-  },
+  // The Scheme extension gives paren matching + sexp highlighting.
   "file_types": {
     "Nu": ["nu"],
     "JSONC": ["common.json", "*-mods.json"],
     "Scheme": ["astlog"]
   },
   "languages": {
-    "Nix": {
-      "language_servers": ["nixd", "!nil"],
-      "formatter": {
-        "external": {
-          "command": "nixfmt",
-          "arguments": []
-        }
-      },
-      "format_on_save": "on"
-    },
     "Rust": {
       "formatter": "language_server",
       "format_on_save": "on"


### PR DESCRIPTION
## Summary

Remove user-specific Zed extension installation and Nix editor preferences from the repository settings. The personal Zed configuration remains the owner of those choices.

Fixes #2894

## Validation

- `.zed/settings.json` parses as JSON5
- `git diff --check`
- `nix run .#lint` reports existing failures outside `.zed/settings.json`, including `lib/image/platform.nix` formatting and repository-wide astlog findings

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove user-specific Scheme and Nix settings from Zed editor config
> Removes personal editor preferences from [.zed/settings.json](https://github.com/indexable-inc/index/pull/2895/files#diff-abb804d570c3104a261c81b34f0ad1c1d5edb2f62e1318fa5030dbe6ffbdf3d4) that should not be tracked in the repository. Deletes the `auto_install_extensions` entry for the Scheme extension and the entire Nix language block, which configured `nixd`/`nil` language servers, `nixfmt` as an external formatter, and format-on-save.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 989b1b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->