### PR TITLE
agents: keep read-only flake evals immutable

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -138,6 +138,9 @@
         change your confidence; gather it if it can affect the answer, and skip
         probes that are intrusive, noisy, or unlikely to change the decision.
 
+        Pass `--no-write-lock-file` for diagnostic and other read-only flake
+        evaluations. Update lock files only as an explicit task outcome.
+
         Success at an intermediate layer is not the outcome. A wrapper's zero
         exit, an upstream job reporting done, a cache reporting populated, or
         a green pipeline stage says only that that layer finished; every hop
@@ -154,7 +157,9 @@
         file, host, or log; checking the strongest source first is cheaper than a
         wrong conclusion. Separately, a config switch was declared good because
         an upstream cache publish finished, inferring the end state through
-        untested hops instead of reading the live generation.
+        untested hops instead of reading the live generation. A diagnostic flake
+        evaluation created and staged a lock file because the read-only intent was
+        not expressed to Nix.
       '';
     };
   }


### PR DESCRIPTION
## Summary

- require `--no-write-lock-file` for diagnostic and read-only flake evaluations
- reserve lock-file updates for explicit task outcomes

## Validation

- rendered and reread Claude system prompt
- rendered and reread Codex context
- `nix fmt -- --check packages/agent/prompt/rules.nix`
- `git diff --check`
- `nix run .#lint -- --json` (fails only on pre-existing findings outside this change)

Fixes #2904

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--no-write-lock-file` guidance for read-only flake evaluations in agent rules
> Updates [rules.nix](https://github.com/indexable-inc/index/pull/2907/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to instruct the agent to pass `--no-write-lock-file` when performing diagnostic or read-only flake evaluations. Without this flag, Nix may create and stage a lock file even when the intent is read-only, causing unintended side effects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5155543.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->