### PR TITLE
mcp: return dashboard URL from connection

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2024,6 +2024,9 @@
     + "from ix_notebook_mcp import registry; instr = mcp._mcp_server.instructions; "
     + "assert 'root=' not in instr, 'a parameter/signature leaked into the instructions'; "
     + "assert '(query:' not in instr and '(path:' not in instr, 'a signature leaked into the instructions'; "
+    + "from ix_notebook_mcp import tools; tools.set_dashboard_url('http://127.0.0.1:58430/'); "
+    + "assert mcp._mcp_server.instructions == instr, 'connection URL mutated reusable instructions'; "
+    + "assert '58430' not in instr, 'connection URL leaked into reusable instructions'; "
     + "missing = [m.name for m in registry.MODULES if ('`' + m.name + '`') not in instr]; "
     + "assert not missing, ('registry modules missing from instructions: %r' % (missing,)); "
     + "print('server-ok', len(names))"
@@ -2872,8 +2875,12 @@
             else:
                 raise AssertionError("python_exec ran before the session was named")
 
+            tools.set_dashboard_url("http://127.0.0.1:7677/")
             named = await tools.session_set_name("wedge smoke")
-            assert "wedge smoke" in " ".join(getattr(c, "text", "") or "" for c in named), named
+            named_text = " ".join(getattr(c, "text", "") or "" for c in named)
+            assert "wedge smoke" in named_text, named
+            assert "http://127.0.0.1:7677/" in named_text, named
+            assert "58430" not in named_text, named
             topic = await tools.topic_set("wedge validation")
             assert "wedge validation" in " ".join(getattr(c, "text", "") or "" for c in topic), topic
 

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -361,7 +361,9 @@ CELLS = (
     "Three dashboard panes show the session live: every running/finished run under executions, "
     "every live view (a terminal, a widget) under resources, and your curated highlight reel "
     "under cells; its address is the `DASHBOARD_URL` value in the namespace (read the variable — "
-    "there is no `dashboard()` function to call). Answer THROUGH cells by default: the cells pane "
+    "there is no `dashboard()` function to call). The required `session_set_name` call returns "
+    "this connection's live dashboard URL. Give the human that link in your first reply so they "
+    "can watch the work live. Answer THROUGH cells by default: the cells pane "
     "is what the human reads as the answer, so put any result worth seeing there with "
     "`cells.add(value, title=...)` (a DataFrame, a figure, a `view` render, an htpy "
     "element) rather than leaving it only in your tool text. Treat cells as the FINAL "
@@ -454,19 +456,3 @@ REPLY = (
     "reads the page, not this session — anything you want them to see must go through this tool; "
     "your transcript output never reaches them. Fails when the resource is closed or unknown."
 )
-
-
-# --- appended once the dashboard has bound a port ---
-
-_DASHBOARD_URL_NOTE = (
-    "This session's live dashboard (every running job, its output, and your curated cells) is at "
-    "{url} -- ALWAYS give the human this link in your very first reply of the session, before or "
-    "alongside your first answer, so they can watch the work unfold live; never make them ask for "
-    "it. It is also the `DASHBOARD_URL` variable in the kernel namespace."
-)
-
-
-def dashboard_note(url: str) -> str:
-    """The live-dashboard sentence the CLI folds into the instructions once the
-    dashboard has a URL (see tools.set_dashboard_url)."""
-    return _DASHBOARD_URL_NOTE.format(url=url)

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -21,10 +21,9 @@ cell has wedged the event loop, which is exactly when ``python_exec`` cannot hel
 
 The server ``instructions`` a client reads at ``initialize`` are composed, not
 hand-listed: :func:`_compose_instructions` joins the authored ``_KERNEL_GUIDE``
-with a tool overview derived from the registry (:func:`_tools_overview`) and,
-once the dashboard has a port, its live URL. So each ``@mcp.tool`` describes
-itself once and lists itself in the instructions automatically -- nothing here
-restates a tool by hand.
+with a tool overview derived from the registry (:func:`_tools_overview`). So
+each ``@mcp.tool`` describes itself once and lists itself in the instructions
+automatically. Nothing here restates a tool by hand.
 """
 
 from __future__ import annotations
@@ -360,29 +359,16 @@ def _tools_overview() -> str:
     return "\n".join(lines)
 
 
-def _compose_instructions(dashboard_url: str | None = None) -> str:
-    """The full server instructions: the kernel guide, then the registry-derived
-    tool overview, then (once the dashboard has bound a port) its live URL. Called
-    at import to seed the instructions and again by `set_dashboard_url` to fold the
-    URL in before the transport serves ``initialize``."""
-    parts = [_KERNEL_GUIDE, _tools_overview()]
-    if dashboard_url:
-        parts.append(guide.dashboard_note(dashboard_url))
-    return "\n\n".join(parts)
+def _compose_instructions() -> str:
+    """The full reusable server instructions: the kernel guide followed by the
+    registry-derived tool overview."""
+    return f"{_KERNEL_GUIDE}\n\n{_tools_overview()}"
 
 
 def set_dashboard_url(url: str) -> None:
-    """Bake the live dashboard URL into the server instructions so a client reads
-    it straight out of the ``initialize`` response -- the agent has the URL from
-    the first message, with no tool call to look it up. The CLI calls this once
-    the dashboard has bound its port, before the transport serves ``initialize``.
-    The URL is stashed so a tool call can surface it, never auto-popped in a
-    browser. The human-facing UI is the standalone aggregator (`nix run
-    .#dashboard`), which renders every server at once.
-    """
+    """Store the live URL returned by this connection's required naming call."""
     global _dashboard_url
     _dashboard_url = url
-    mcp._mcp_server.instructions = _compose_instructions(url)
 
 
 # The live dashboard URL (set by `set_dashboard_url`). Module-level because the
@@ -403,7 +389,8 @@ Content = list[outputs.Content]
     description=(
         "Name this MCP connection's dashboard session. Call this before acting "
         "tools such as python_exec, read, kernel_trace, or tui_act; the name "
-        "should be a short human task label, not code or secrets."
+        "should be a short human task label, not code or secrets. The result "
+        "contains this connection's live dashboard URL."
     ),
 )
 async def session_set_name(
@@ -420,6 +407,13 @@ async def session_set_name(
 ) -> Content:
     await _start_dashboard_once()
     await _identify_client_once(ctx)
+    if _dashboard_url is None:
+        raise McpError(
+            ErrorData(
+                code=types.INTERNAL_ERROR,
+                message="Dashboard URL was not initialized before the MCP connection started.",
+            )
+        )
     clean = " ".join((name or "").split())
     if not 3 <= len(clean) <= 80:
         raise McpError(
@@ -430,7 +424,7 @@ async def session_set_name(
         )
     await current_kernel().set_session_name(clean)
     _set_session_label(ctx, clean)
-    return [outputs.text(f"dashboard session named: {clean}")]
+    return [outputs.text(f"dashboard session named: {clean}\ndashboard: {_dashboard_url}")]
 
 
 @mcp.tool(
@@ -949,5 +943,4 @@ async def tui_act(
 
 # Seed the server instructions now that every `@mcp.tool` above is registered, so
 # the tool overview is derived from the registry rather than maintained by hand.
-# `set_dashboard_url` re-composes them with the live dashboard URL before serving.
 mcp._mcp_server.instructions = _compose_instructions()


### PR DESCRIPTION
## Summary

- stop embedding connection-specific dashboard URLs in reusable MCP server instructions
- return the live URL from the required `session_set_name` call for that connection
- fail clearly if the server did not initialize its dashboard URL
- cover instruction immutability and the connection result

## Validation

- `nix build .#packages.aarch64-darwin.mcp.passthru.tests.serverTools`
- focused async regression against the changed source: `dashboard-url-ok`
- `ruff check packages/mcp/ix_notebook_mcp/guide.py packages/mcp/ix_notebook_mcp/tools.py`
- `python3 -m py_compile packages/mcp/ix_notebook_mcp/guide.py packages/mcp/ix_notebook_mcp/tools.py`
- `git diff --check`
- `nix run .#lint` reports unrelated existing failures; its one finding in this change was fixed
- `wedgeSmoke` was cancelled after spinning for more than seven minutes without its expected kernel child

Fixes #2911

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return dashboard URL from `session_set_name` MCP tool
> - Moves the dashboard URL out of server instructions and into the `session_set_name` tool's return value, so each connection surfaces its own live dashboard URL directly to the agent.
> - `set_dashboard_url` now only stores the URL; it no longer mutates `mcp._mcp_server.instructions` at runtime, making instructions static.
> - `session_set_name` raises an MCP `INTERNAL_ERROR` if the dashboard URL was not set before the connection started.
> - Guide text in [guide.py](https://github.com/indexable-inc/index/pull/2920/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) is updated to tell agents to share the URL returned by `session_set_name` with the user in the first reply.
> - Behavioral Change: `mcp._mcp_server.instructions` no longer contains the dashboard URL; agents must read it from the `session_set_name` response instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44c0bbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->