### PR TITLE
cargo-unit: retain proc-macro Rust runtime

### DIFF
--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1280,12 +1280,12 @@ fn push_rustc_args(script: &mut String, unit: &Unit, hash: &str, driver: Driver)
         push_arg(script, "-C");
         push_arg(script, &format!("split-debuginfo={split_debuginfo}"));
     }
-    // Proc-macro targets use `prefer-dynamic`, including their libtest
-    // executables. Cargo normally supplies the rustc sysroot through the
-    // runner environment, but cargo-unit installs each output across a Nix
-    // derivation boundary. Embed rustc's library path so the installed output
-    // retains the toolchain closure and remains directly runnable.
-    if unit.profile.rpath || (driver == Driver::Rustc && unit.is_proc_macro()) {
+    // Proc-macro libtest executables inherit `prefer-dynamic`. Cargo normally
+    // supplies the rustc sysroot through the runner environment, but
+    // cargo-unit installs tests across a Nix derivation boundary. Embed rustc's
+    // library path so the installed test retains the toolchain closure and
+    // remains directly runnable.
+    if unit.profile.rpath || (driver == Driver::Rustc && unit.is_proc_macro() && unit.is_test()) {
         push_arg(script, "-C");
         push_arg(script, "rpath=yes");
     }

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1280,7 +1280,12 @@ fn push_rustc_args(script: &mut String, unit: &Unit, hash: &str, driver: Driver)
         push_arg(script, "-C");
         push_arg(script, &format!("split-debuginfo={split_debuginfo}"));
     }
-    if unit.profile.rpath {
+    // Proc-macro targets use `prefer-dynamic`, including their libtest
+    // executables. Cargo normally supplies the rustc sysroot through the
+    // runner environment, but cargo-unit installs each output across a Nix
+    // derivation boundary. Embed rustc's library path so the installed output
+    // retains the toolchain closure and remains directly runnable.
+    if unit.profile.rpath || (driver == Driver::Rustc && unit.is_proc_macro()) {
         push_arg(script, "-C");
         push_arg(script, "rpath=yes");
     }
@@ -3947,6 +3952,51 @@ mod tests {
         assert!(rendered.contains("testManifestDrv ="));
         assert!(rendered.contains("cargo-unit-test-manifest"));
         assert!(rendered.contains("failed to list tests for"));
+    }
+
+    #[test]
+    fn proc_macro_test_executable_embeds_rust_runtime_rpath() {
+        let graph: UnitGraph = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "units": [
+                {
+                  "pkg_id": "path+file:///workspace#fixture-macro@0.1.0",
+                  "target": {
+                    "kind": ["proc-macro"],
+                    "crate_types": ["proc-macro"],
+                    "name": "fixture_macro",
+                    "src_path": "/workspace/src/lib.rs",
+                    "edition": "2024",
+                    "test": true
+                  },
+                  "profile": { "name": "test", "opt_level": "0", "rpath": false },
+                  "features": [],
+                  "mode": "test",
+                  "dependencies": []
+                }
+              ],
+              "roots": [0]
+            }"#,
+        )
+        .unwrap();
+
+        let rendered = render_units_nix(
+            &graph,
+            &RenderOptions {
+                workspace_root: PathBuf::from("/workspace"),
+                vendor_root: None,
+                cargo_lock_sources: CargoLockSources::default(),
+                content_addressed: false,
+                toolchain_id: None,
+                deny_unused_crate_dependencies: false,
+                deny_panics: false,
+            },
+        )
+        .unwrap();
+
+        assert!(rendered.contains("'prefer-dynamic'"));
+        assert!(rendered.contains("'rpath=yes'"));
     }
 
     #[test]

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -3962,48 +3962,23 @@ mod tests {
 
     #[test]
     fn proc_macro_test_executable_embeds_rust_runtime_rpath() {
-        let graph: UnitGraph = serde_json::from_str(
-            r#"{
-              "version": 1,
-              "units": [
-                {
-                  "pkg_id": "path+file:///workspace#fixture-macro@0.1.0",
-                  "target": {
-                    "kind": ["proc-macro"],
-                    "crate_types": ["proc-macro"],
-                    "name": "fixture_macro",
-                    "src_path": "/workspace/src/lib.rs",
-                    "edition": "2024",
-                    "test": true
-                  },
-                  "profile": { "name": "test", "opt_level": "0", "rpath": false },
-                  "features": [],
-                  "mode": "test",
-                  "dependencies": []
-                }
-              ],
-              "roots": [0]
-            }"#,
-        )
-        .unwrap();
+        let mut graph = single_library_graph(
+            "path+file:///workspace#fixture-macro@0.1.0",
+            "fixture_macro",
+            "/workspace/src/lib.rs",
+            "2024",
+        );
+        let unit = &mut graph.units[0];
+        unit.target.kind = vec!["proc-macro".to_string()];
+        unit.target.crate_types = vec!["proc-macro".to_string()];
+        unit.mode = UnitMode::Test;
 
-        let rendered = render_units_nix(
-            &graph,
-            &RenderOptions {
-                workspace_root: PathBuf::from("/workspace"),
-                vendor_root: None,
-                cargo_lock_sources: CargoLockSources::default(),
-                content_addressed: false,
-                toolchain_id: None,
-                deny_unused_crate_dependencies: false,
-                deny_panics: false,
-            },
-        )
-        .unwrap();
+        let mut script = String::new();
+        push_rustc_args(&mut script, unit, "hash", Driver::Rustc);
 
-        assert!(rendered.contains("'prefer-dynamic'"));
+        assert!(script.contains("'prefer-dynamic'"));
         assert!(
-            rendered
+            script
                 .contains("link-arg=-Wl,-rpath,${rustToolchain}/lib/rustlib/${hostRustTarget}/lib")
         );
     }

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1280,14 +1280,20 @@ fn push_rustc_args(script: &mut String, unit: &Unit, hash: &str, driver: Driver)
         push_arg(script, "-C");
         push_arg(script, &format!("split-debuginfo={split_debuginfo}"));
     }
-    // Proc-macro libtest executables inherit `prefer-dynamic`. Cargo normally
-    // supplies the rustc sysroot through the runner environment, but
-    // cargo-unit installs tests across a Nix derivation boundary. Embed rustc's
-    // library path so the installed test retains the toolchain closure and
-    // remains directly runnable.
-    if unit.profile.rpath || (driver == Driver::Rustc && unit.is_proc_macro() && unit.is_test()) {
+    if unit.profile.rpath {
         push_arg(script, "-C");
         push_arg(script, "rpath=yes");
+    }
+    // Proc-macro libtest executables inherit `prefer-dynamic`. Cargo normally
+    // supplies the rustc sysroot through the runner environment, but
+    // cargo-unit installs tests across a Nix derivation boundary. An ordinary
+    // `-C rpath=yes` records a loader-relative path for `build/<test>` that is
+    // wrong after installation under `$out/bin`, so embed the store path.
+    if driver == Driver::Rustc && unit.is_proc_macro() && unit.is_test() {
+        push_arg(script, "-C");
+        script.push_str(
+            "rustc_args+=( \"link-arg=-Wl,-rpath,${rustToolchain}/lib/rustlib/${hostRustTarget}/lib\" )\n",
+        );
     }
     push_codegen(script, "metadata", hash);
     // rustc warns "ignoring -C extra-filename flag due to -o flag" when both
@@ -3996,7 +4002,10 @@ mod tests {
         .unwrap();
 
         assert!(rendered.contains("'prefer-dynamic'"));
-        assert!(rendered.contains("'rpath=yes'"));
+        assert!(
+            rendered
+                .contains("link-arg=-Wl,-rpath,${rustToolchain}/lib/rustlib/${hostRustTarget}/lib")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- embed the selected Rust toolchain's absolute runtime path in dynamically linked proc macro test executables
- retain the toolchain in each installed test's Nix closure without rebuilding ordinary proc macro libraries
- cover the libtest boundary with a focused renderer regression

## Validation

- `nix run .#run -- cargo test --manifest-path packages/nix/nix-cargo-unit/Cargo.toml proc_macro_test_executable_embeds_rust_runtime_rpath`
- Nix package check: 53 tests passed
- final `unibind --list --format terse`: exit 0
- final `cargo-unit-test-manifest`: built at `/nix/store/s17f6hfcwkcjjilz1zg0f526x41a9kv7-cargo-unit-test-manifest`
- `otool -l`: installed `unibind` contains the absolute rustc runtime `LC_RPATH`
- `nix-store -q --references`: installed `unibind` retains `rust-minimal-1.98.0-nightly-2026-05-27`
- `nix run .#lint -- --json`: unrelated pre-existing failures in `lib/image/platform.nix`, examples, user profiles, `packages/metal-httpd`, and `packages/mcp/tests/test_channel.py`; no finding touched this PR's file

Fixes #2927

(sent by an AI agent via Codex)
