### PR TITLE
zed: jump directly to a single reference

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -719,11 +719,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1783828526,
-        "narHash": "sha256-NKM2SkrjmyrfsoRZRt3oHWA/QY8zE3QWspA8LOuAzDc=",
+        "lastModified": 1783845838,
+        "narHash": "sha256-KEHzrBRiB5CQ/qsy2MWMZxgV4MF0FqsQO/iUmqyi+/8=",
         "owner": "indexable-inc",
         "repo": "zed",
-        "rev": "74f546aabcec8d885da8e7f223f1d9246a9e82f6",
+        "rev": "78f14e412e4197a799e4232963e1be0226b811ac",
         "type": "github"
       },
       "original": {

--- a/packages/zed/patches/0003-editor-navigate-directly-to-a-single-reference.patch
+++ b/packages/zed/patches/0003-editor-navigate-directly-to-a-single-reference.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew.gazelka@gmail.com>
+Date: Sun, 12 Jul 2026 01:42:40 -0700
+Subject: [PATCH] editor: navigate directly to a single reference
+
+Make the default Find All References action use the existing single-location navigation path. Callers can still request a multibuffer explicitly.
+
+Fixes indexable-inc/index#2976
+
+(authored by an AI agent via Codex)
+
+diff --git a/crates/editor/src/actions.rs b/crates/editor/src/actions.rs
+index f0b9cfb4f5d..de52cc72547 100644
+--- a/crates/editor/src/actions.rs
++++ b/crates/editor/src/actions.rs
+@@ -959,7 +959,7 @@ pub struct FindAllReferences {
+ impl Default for FindAllReferences {
+     fn default() -> Self {
+         Self {
+-            always_open_multibuffer: true,
++            always_open_multibuffer: false,
+         }
+     }
+ }
+diff --git a/crates/editor/src/editor_tests.rs b/crates/editor/src/editor_tests.rs
+index b08c9865d16..a8b493e5f0a 100644
+--- a/crates/editor/src/editor_tests.rs
++++ b/crates/editor/src/editor_tests.rs
+@@ -35378,12 +35378,10 @@ async fn test_find_references_single_case(cx: &mut TestAppContext) {
+ 
+     cx.set_state(before);
+ 
+-    let action = FindAllReferences {
+-        always_open_multibuffer: false,
+-    };
+-
+     let navigated = cx
+-        .update_editor(|editor, window, cx| editor.find_all_references(&action, window, cx))
++        .update_editor(|editor, window, cx| {
++            editor.find_all_references(&FindAllReferences::default(), window, cx)
++        })
+         .expect("should have spawned a task")
+         .await
+         .unwrap();

--- a/packages/zed/patches/dag.json
+++ b/packages/zed/patches/dag.json
@@ -9,6 +9,10 @@
     {
       "patch": "0002-nix-expose-stable-application-package.patch",
       "deps": []
+    },
+    {
+      "patch": "0003-editor-navigate-directly-to-a-single-reference.patch",
+      "deps": []
     }
   ]
 }


### PR DESCRIPTION
## Summary

- make the default Find All References action navigate directly when one location remains
- retain the explicit `always_open_multibuffer` action argument for callers that want a references view
- advance the maintained fork and reviewed patch series

## Validation

- `cargo test -p editor test_find_references_single_case` passes
- `patched-src-zed` and `patch-dag-zed` checks pass
- full Nix Zed build is running locally

Fixes #2976

(authored by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Jump directly to a single reference in Zed instead of opening a multibuffer
> Sets `always_open_multibuffer` to `false` by default in `FindAllReferences` so that when only one reference exists, Zed navigates directly to it instead of opening a multibuffer view. The patch is registered in [`dag.json`](https://github.com/indexable-inc/index/pull/2977/files#diff-a5e77eb96a5d226b205c38aec07c9f8134350289f01e47875e7e287e7789a820) and applied during the Zed package build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 599ccca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->