### PR TITLE
rust: expose cargo-unit for external workspaces

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -312,6 +312,7 @@
     buildRustPackage
     ;
   cargoUnit = cargoUnitFor pkgs;
+  cargoUnitExternal = import ./rust/external.nix {repoRoot = paths.root;};
   # Default patched-source builder, bound to the top-level x86_64-linux pkgs for
   # image/module eval; `ixForPackages` / the overlay context rebind it to the
   # consuming pkgs so a patched source builds for its own system.
@@ -804,6 +805,7 @@
         appleSdkToolchain
         bunLockFor
         cargoUnitFor
+        cargoUnitExternal
         discoverModules
         discoverTree
         errors

--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -703,6 +703,7 @@
         testChecksByTarget
         testChecksAll
         ;
+      cargoConfigScript = context.configScript;
       targetSets = namedTargetSets;
       inherit (args) policy;
     };

--- a/lib/rust/external.nix
+++ b/lib/rust/external.nix
@@ -31,10 +31,7 @@
   checkedCargoUnit = rust.buildPackage {
     pname = manifest.package.name;
     inherit (manifest.package) version;
-    src = lib.fileset.toSource {
-      root = sourceRoot;
-      fileset = sourceRoot;
-    };
+    src = sourceRoot;
     policy = rust.policyPresets.pureBuild;
   };
   nixCargoUnit = checkedCargoUnit.passthru.unchecked;

--- a/lib/rust/external.nix
+++ b/lib/rust/external.nix
@@ -1,0 +1,49 @@
+{repoRoot}: {
+  pkgs,
+  rustToolchain,
+}: let
+  inherit (pkgs) lib;
+
+  lists = import (repoRoot + "/lib/util/lists.nix") {inherit lib;};
+  pins = import (repoRoot + "/lib/util/pins.nix") {inherit lib;};
+  ruffAnnArgs = import (repoRoot + "/lib/ruff-ann.nix") {
+    inherit lib;
+    ruffToml = repoRoot + "/ruff.toml";
+  };
+  writers = import (repoRoot + "/lib/util/writers.nix") {
+    inherit lib;
+    inherit (ruffAnnArgs) ruffAnnArgs;
+  };
+  rust = import (repoRoot + "/lib/rust/build.nix") {
+    inherit
+      lib
+      pkgs
+      rustToolchain
+      lists
+      pins
+      ;
+    writePythonApplication = writers.writePythonApplication pkgs;
+    evalTimeSubstitutable = import (repoRoot + "/lib/util/eval-time-substitutable.nix");
+  };
+
+  sourceRoot = repoRoot + "/packages/nix/nix-cargo-unit";
+  manifest = lib.importTOML (sourceRoot + "/Cargo.toml");
+  checkedCargoUnit = rust.buildPackage {
+    pname = manifest.package.name;
+    inherit (manifest.package) version;
+    src = lib.fileset.toSource {
+      root = sourceRoot;
+      fileset = sourceRoot;
+    };
+    policy = rust.policyPresets.pureBuild;
+  };
+  nixCargoUnit = checkedCargoUnit.passthru.unchecked;
+in
+  import (repoRoot + "/lib/rust/cargo-unit.nix") {
+    inherit
+      lib
+      pkgs
+      rust
+      nixCargoUnit
+      ;
+  }

--- a/lib/rust/external.nix
+++ b/lib/rust/external.nix
@@ -22,7 +22,10 @@
       lists
       pins
       ;
-    writePythonApplication = writers.writePythonApplication pkgs;
+    # The owner repository type-checks these scripts. Consumers should not
+    # rebuild that policy closure with their unrelated nixpkgs revision.
+    writePythonApplication = args:
+      writers.writePythonApplication pkgs (args // {check = false;});
     evalTimeSubstitutable = import (repoRoot + "/lib/util/eval-time-substitutable.nix");
   };
 

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1663,7 +1663,11 @@ fn render_build_script_run_phase(
         "build_script_manifest_dir_source={}",
         shell::double_quote(&manifest_dir)
     )?;
-    script.push_str("build_script_manifest_dir=$out/manifest-dir\n");
+    writeln!(
+        script,
+        "build_script_manifest_dir=$out/{}",
+        shell::quote(source.package_root())
+    )?;
     script.push_str("mkdir -p \"$build_script_manifest_dir\"\n");
     script.push_str(
         "cp -RL \"$build_script_manifest_dir_source\"/. \"$build_script_manifest_dir\"/\n",
@@ -5428,9 +5432,10 @@ links = "native_ffi"
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_or(0, |duration| duration.as_nanos())
         ));
-        fs::create_dir_all(workspace.join("builder")).unwrap();
+        let package_root = workspace.join("crates/nested-native");
+        fs::create_dir_all(package_root.join("builder")).unwrap();
         fs::write(
-            workspace.join("Cargo.toml"),
+            package_root.join("Cargo.toml"),
             r#"[package]
 name = "nested-native"
 version = "0.1.0"
@@ -5438,10 +5443,10 @@ links = "nested_native"
 "#,
         )
         .unwrap();
-        let build_rs = workspace.join("builder").join("main.rs");
+        let build_rs = package_root.join("builder").join("main.rs");
         fs::write(&build_rs, "fn main() {}\n").unwrap();
         let build_rs_path = build_rs.to_string_lossy();
-        let pkg_id = format!("path+file://{}#nested-native@0.1.0", workspace.display());
+        let pkg_id = format!("path+file://{}#nested-native@0.1.0", package_root.display());
         let graph: UnitGraph = serde_json::from_value(serde_json::json!({
             "version": 1,
             "units": [
@@ -5493,7 +5498,7 @@ links = "nested_native"
         .unwrap();
 
         assert!(rendered.contains("build_script_manifest_dir_source=\"$src\""));
-        assert!(rendered.contains("build_script_manifest_dir=$out/manifest-dir"));
+        assert!(rendered.contains("build_script_manifest_dir=$out/'crates/nested-native'"));
         assert!(rendered.contains(
             "cp -RL \"$build_script_manifest_dir_source\"/. \"$build_script_manifest_dir\"/"
         ));

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1713,7 +1713,7 @@ fn render_build_script_run_phase(
         "${{renderCargoEncodedRustflags {package_name} {platform}}}"
     )?;
     script.push_str(
-        "export CARGO_ENCODED_RUSTFLAGS=\"$(IFS=$'\\x1f'; printf '%s' \"${cargo_encoded_rustflags[*]}\")\"\n",
+        "export CARGO_ENCODED_RUSTFLAGS=\"$(IFS=$'\\x1f'; printf '%s' \"''${cargo_encoded_rustflags[*]}\")\"\n",
     );
     writeln!(
         script,

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1692,6 +1692,29 @@ fn render_build_script_run_phase(
         "export OPT_LEVEL={}",
         shell::quote(&run_unit.profile.opt_level)
     )?;
+    let package_name = nix_attr(&run_unit.package_name());
+    let platform = run_unit
+        .platform
+        .as_ref()
+        .map_or_else(|| "null".to_string(), |platform| nix_attr(platform));
+    writeln!(
+        script,
+        "cargo_encoded_rustflags=( {} )",
+        run_unit
+            .profile
+            .rustflags
+            .iter()
+            .map(|flag| shell::quote(flag))
+            .collect::<Vec<_>>()
+            .join(" ")
+    )?;
+    writeln!(
+        script,
+        "${{renderCargoEncodedRustflags {package_name} {platform}}}"
+    )?;
+    script.push_str(
+        "export CARGO_ENCODED_RUSTFLAGS=\"$(IFS=$'\\x1f'; printf '%s' \"${cargo_encoded_rustflags[*]}\")\"\n",
+    );
     writeln!(
         script,
         "export DEBUG={}",
@@ -5328,7 +5351,7 @@ links = "native_ffi"
                         "src_path": build_rs_path,
                         "edition": "2024"
                     },
-                    "profile": { "name": "release", "opt_level": "3" },
+                    "profile": { "name": "release", "opt_level": "3", "rustflags": ["-C", "target-cpu=native"] },
                     "features": ["arch", "simd-support"],
                     "mode": "build",
                     "dependencies": []
@@ -5342,7 +5365,7 @@ links = "native_ffi"
                         "src_path": build_rs_path,
                         "edition": "2024"
                     },
-                    "profile": { "name": "release", "opt_level": "3" },
+                    "profile": { "name": "release", "opt_level": "3", "rustflags": ["-C", "target-cpu=native"] },
                     "features": ["arch", "simd-support"],
                     "mode": "run-custom-build",
                     "platform": "x86_64-unknown-linux-gnu",
@@ -5383,6 +5406,12 @@ links = "native_ffi"
         assert!(rendered.contains("export CARGO_MANIFEST_LINKS=\"native_ffi\""));
         assert!(rendered.contains("export CARGO_FEATURE_ARCH=1"));
         assert!(rendered.contains("export CARGO_FEATURE_SIMD_SUPPORT=1"));
+        assert!(rendered.contains("cargo_encoded_rustflags=( '-C' 'target-cpu=native' )"));
+        assert!(
+            rendered
+                .contains("${renderCargoEncodedRustflags \"native\" \"x86_64-unknown-linux-gnu\"}")
+        );
+        assert!(rendered.contains("export CARGO_ENCODED_RUSTFLAGS="));
         assert!(rendered.contains("\"$RUSTC\" --print cfg --target \"$TARGET\""));
         assert!(rendered.contains("cargo_cfg_env=\"CARGO_CFG_$(printf '%s' \"$cargo_cfg_key\""));
         assert!(

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1679,6 +1679,7 @@ fn render_build_script_run_phase(
     ensure_source_contains_unit(source, run_unit)?;
     script.push_str("export CARGO_MANIFEST_DIR=$build_script_manifest_dir\n");
     script.push_str("export RUSTC=\"$(type -p rustc)\"\n");
+    script.push_str("export RUSTDOC=\"$(type -p rustdoc)\"\n");
     script.push_str("HOST_TRIPLE=\"$($RUSTC -vV | sed -n 's/^host: //p')\"\n");
     script.push_str("export HOST=\"$HOST_TRIPLE\"\n");
     if let Some(platform) = &run_unit.platform {
@@ -5408,6 +5409,7 @@ links = "native_ffi"
         assert!(rendered.contains("export CARGO_PKG_LICENSE_FILE=\"LICENSE\""));
         assert!(rendered.contains("export CARGO_PKG_RUST_VERSION=\"1.85\""));
         assert!(rendered.contains("export CARGO_MANIFEST_LINKS=\"native_ffi\""));
+        assert!(rendered.contains("export RUSTDOC=\"$(type -p rustdoc)\""));
         assert!(rendered.contains("export CARGO_FEATURE_ARCH=1"));
         assert!(rendered.contains("export CARGO_FEATURE_SIMD_SUPPORT=1"));
         assert!(rendered.contains("cargo_encoded_rustflags=( '-C' 'target-cpu=native' )"));

--- a/packages/nix/nix-cargo-unit/templates/units.nix.in
+++ b/packages/nix/nix-cargo-unit/templates/units.nix.in
@@ -72,6 +72,14 @@ let
       )
     );
 
+  renderCargoEncodedRustflags =
+    packageName: platform:
+    "cargo_encoded_rustflags+=( ${pkgs.lib.escapeShellArgs (
+      extraRustcArgs
+      ++ (packageRustcArgs.${packageName} or [ ])
+      ++ extraRustcArgsForPlatform platform
+    )} )";
+
   renderExtraLinkRustcArgs =
     platform:
     pkgs.lib.concatStringsSep "\n" (map renderRustcArg (extraLinkRustcArgsForPlatform platform));


### PR DESCRIPTION
## Summary

- expose a source-importable `cargoUnitExternal` factory
- bootstrap `nix-cargo-unit` from the owner repository while accepting a consumer-owned Rust toolchain
- expose the resolved Cargo config script for consumer-owned companion derivations
- keep owner-only Python policy checks out of unrelated consumer nixpkgs closures

Closes #2978 only together with the follow-up Zed consumer change.

## Validation

- `nix eval --json .#lib.cargoUnitExternal --apply 'f: builtins.isFunction f'`\n- built `tests/fixtures/cargo-unit-hello` through `cargoUnitExternal`\n- evaluated the maintained Zed fork to a 1,980-derivation cargo-unit graph using this source seam\n- `nix fmt lib/rust/external.nix lib/rust/cargo-unit.nix lib/default.nix`\n\n(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `cargoUnitExternal` for use in external workspaces
> - Adds [external.nix](https://github.com/indexable-inc/index/pull/2979/files#diff-4d409c05b5ec77d4a2528315e4e8658adad992910b01c463e7e05aee152e3d0a), a new module that wires up a cargo-unit factory for external workspaces using the owner repository's scripts and `nix-cargo-unit` binary without rebuilding the policy closure.
> - Exports `cargoUnitExternal` from [lib/default.nix](https://github.com/indexable-inc/index/pull/2979/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) alongside the existing `cargoUnitFor`.
> - Exposes `cargoConfigScript` from [cargo-unit.nix](https://github.com/indexable-inc/index/pull/2979/files#diff-82054df1a7d1648a5be88265641a7ae5d3b9e4ec4cdea72c518359ea4ae3f804) context exports so downstream consumers can access it.
> - Build script run phases in [render.rs](https://github.com/indexable-inc/index/pull/2979/files#diff-91be6a053ea25b59c072a514f469215dbbfeb6abbba3ddb8d77ad99ffa244e7f) now write the crate manifest directory into `$out/<package_root>`, export `RUSTDOC`, and populate `CARGO_ENCODED_RUSTFLAGS` from profile rustflags plus injected extra args.
> - Adds `renderCargoEncodedRustflags` to [units.nix.in](https://github.com/indexable-inc/index/pull/2979/files#diff-22a77df39c2977097bc5e357af36873052c0aad50ca302d915b95ee50fdecc94) to append per-package and per-platform extra rustc args into the `cargo_encoded_rustflags` array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe36036.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->