### PR TITLE
darwin: add localhost-proxy module (dnsmasq + Caddy vhost registry)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -544,6 +544,12 @@
       # direct-map line, /etc/auto_master gains the include idempotently, and
       # activation reloads automountd. See modules/darwin/nfs.nix.
       nfs = ./modules/darwin/nfs.nix;
+      # Loopback service naming: http://<name>.localhost -> 127.0.0.1:<port>,
+      # via a dnsmasq *.localhost wildcard resolver and a Caddy Host-header
+      # vhost registry whose Caddyfile is validated at build time. Optional
+      # Wi-Fi DNS takeover behind `setWifiDns`. See
+      # modules/darwin/localhost-proxy.nix.
+      localhost-proxy = ./modules/darwin/localhost-proxy.nix;
     };
     homeModules = {
       # Workstation-facing home-manager module: declare a service once, get a

--- a/flake.nix
+++ b/flake.nix
@@ -549,7 +549,7 @@
       # vhost registry whose Caddyfile is validated at build time. Optional
       # Wi-Fi DNS takeover behind `setWifiDns`. See
       # modules/darwin/localhost-proxy.nix.
-      localhost-proxy = ./modules/darwin/localhost-proxy.nix;
+      localhost-proxy = import ./modules/darwin/localhost-proxy.nix {inherit (ix) writeBashApplication;};
     };
     homeModules = {
       # Workstation-facing home-manager module: declare a service once, get a

--- a/modules/darwin/localhost-proxy.nix
+++ b/modules/darwin/localhost-proxy.nix
@@ -3,13 +3,61 @@
 # answers *.localhost with loopback addresses (RFC 6761 reserves .localhost
 # for exactly this) and Caddy on loopback :80 routes by Host header. Adding
 # a service is one line in `services.localhostProxy.services`.
-{
+{writeBashApplication}: {
   config,
   lib,
   pkgs,
   ...
 }: let
   cfg = config.services.localhostProxy;
+  dnsmasq = lib.getExe pkgs.dnsmasq;
+
+  # Keep the persistent networksetup mutation inside the launchd job that
+  # needs it. launchd sends SIGTERM when unloading a job, so disabling the
+  # option or removing the module restores automatic DNS as dnsmasq stops.
+  dnsmasqWithWifiDns = writeBashApplication pkgs {
+    name = "dnsmasq-with-wifi-dns";
+    runtimeInputs = [pkgs.dnsmasq];
+    text = ''
+      restore_dns() {
+        /usr/sbin/networksetup -setdnsservers Wi-Fi Empty
+      }
+
+      terminate() {
+        if [ -n "$dnsmasq_pid" ]; then
+          kill -TERM "$dnsmasq_pid"
+          wait "$dnsmasq_pid"
+        fi
+        exit 0
+      }
+
+      dnsmasq_pid=
+      trap restore_dns EXIT
+      trap terminate HUP INT TERM
+      /usr/sbin/networksetup -setdnsservers Wi-Fi 127.0.0.1 ::1
+      dnsmasq "$@" &
+      dnsmasq_pid=$!
+      wait "$dnsmasq_pid"
+    '';
+  };
+  dnsmasqWithWifiDnsExe = lib.getExe dnsmasqWithWifiDns;
+
+  dnsmasqArgs = [
+    "--keep-in-foreground"
+    "--listen-address=127.0.0.1"
+    "--listen-address=::1"
+    "--port=53"
+    "--no-resolv"
+    "--bogus-priv"
+    "--cache-size=1000"
+    "--server=100.100.100.100"
+    # Keep every RR type for *.localhost inside the local resolver. Since
+    # dnsmasq 2.86, --address alone forwards non-A/AAAA queries upstream:
+    # https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html
+    "--local=/localhost/"
+    "--address=/localhost/127.0.0.1"
+    "--address=/localhost/::1"
+  ];
 
   # Rendered and parse-checked at build time so a bad Caddyfile fails the
   # switch, not the running daemon. http:// + auto_https off keep Caddy from
@@ -30,7 +78,10 @@
       ${lib.concatStrings (lib.mapAttrsToList site cfg.services)}
     '';
   in
-    pkgs.runCommandLocal "Caddyfile" {nativeBuildInputs = [pkgs.caddy];} ''
+    pkgs.runCommandLocal "Caddyfile" {
+      strictDeps = true;
+      nativeBuildInputs = [pkgs.caddy];
+    } ''
       HOME=$TMPDIR caddy validate --config ${rendered} --adapter caddyfile
       cp ${rendered} $out
     '';
@@ -57,11 +108,12 @@ in {
       type = lib.types.bool;
       default = false;
       description = ''
-        Point Wi-Fi DNS at the local dnsmasq (127.0.0.1, ::1) at activation
-        time. Only safe AFTER setting global nameservers in the Tailscale
-        admin panel (DNS tab): otherwise Tailscale's MagicDNS forwards
-        non-tailnet queries through the system resolver, which is dnsmasq,
-        which sends them back to MagicDNS: loop.
+        Point Wi-Fi DNS at the local dnsmasq (127.0.0.1, ::1) while its
+        launchd job is running. Unloading the job restores automatic DNS.
+        Only safe AFTER setting global nameservers in the Tailscale admin
+        panel (DNS tab): otherwise Tailscale's MagicDNS forwards non-tailnet
+        queries through the system resolver, which sends them back to
+        MagicDNS in a loop.
 
         Prerequisite: Tailscale admin -> DNS -> add global nameservers
         (e.g. 1.1.1.1, 8.8.8.8) and enable "Override local DNS". This makes
@@ -87,21 +139,15 @@ in {
     launchd.daemons.dnsmasq = {
       serviceConfig = {
         Label = "org.nixos.dnsmasq";
-        ProgramArguments = [
-          "${pkgs.dnsmasq}/bin/dnsmasq"
-          "--keep-in-foreground"
-          "--listen-address=127.0.0.1"
-          "--listen-address=::1"
-          "--port=53"
-          "--no-resolv"
-          "--bogus-priv"
-          "--domain-needed"
-          "--cache-size=1000"
-          "--server=100.100.100.100"
-          # *.localhost -> loopback, for the Caddy vhosts (cfg.services).
-          "--address=/localhost/127.0.0.1"
-          "--address=/localhost/::1"
-        ];
+        ProgramArguments =
+          [
+            (
+              if cfg.setWifiDns
+              then dnsmasqWithWifiDnsExe
+              else dnsmasq
+            )
+          ]
+          ++ dnsmasqArgs;
         KeepAlive = true;
         RunAtLoad = true;
         StandardErrorPath = "/var/log/dnsmasq.log";
@@ -114,7 +160,7 @@ in {
       serviceConfig = {
         Label = "org.nixos.caddy";
         ProgramArguments = [
-          "${pkgs.caddy}/bin/caddy"
+          (lib.getExe pkgs.caddy)
           "run"
           "--config"
           "${caddyfile}"
@@ -129,12 +175,5 @@ in {
         StandardErrorPath = "/var/log/caddy.log";
       };
     };
-
-    # postActivation, not an arbitrary `system.activationScripts.<name>`:
-    # nix-darwin executes only its fixed set of activation hooks, so a
-    # freestanding name is declared but never runs.
-    system.activationScripts.postActivation.text = lib.mkIf cfg.setWifiDns (lib.mkAfter ''
-      /usr/sbin/networksetup -setdnsservers Wi-Fi 127.0.0.1 ::1
-    '');
   };
 }

--- a/modules/darwin/localhost-proxy.nix
+++ b/modules/darwin/localhost-proxy.nix
@@ -1,0 +1,140 @@
+# Loopback service naming (macOS): stable names (http://nwm.localhost)
+# for loopback services instead of memorized ports. dnsmasq on loopback :53
+# answers *.localhost with loopback addresses (RFC 6761 reserves .localhost
+# for exactly this) and Caddy on loopback :80 routes by Host header. Adding
+# a service is one line in `services.localhostProxy.services`.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.localhostProxy;
+
+  # Rendered and parse-checked at build time so a bad Caddyfile fails the
+  # switch, not the running daemon. http:// + auto_https off keep Caddy from
+  # minting TLS certs (no keychain trust prompts); default_bind keeps every
+  # listener loopback-only so nothing proxied leaks onto the LAN.
+  caddyfile = let
+    site = name: port: ''
+      http://${name}.localhost {
+        reverse_proxy 127.0.0.1:${toString port}
+      }
+    '';
+    rendered = pkgs.writeText "Caddyfile.in" ''
+      {
+        admin off
+        auto_https off
+        default_bind 127.0.0.1 ::1
+      }
+      ${lib.concatStrings (lib.mapAttrsToList site cfg.services)}
+    '';
+  in
+    pkgs.runCommandLocal "Caddyfile" {nativeBuildInputs = [pkgs.caddy];} ''
+      HOME=$TMPDIR caddy validate --config ${rendered} --adapter caddyfile
+      cp ${rendered} $out
+    '';
+in {
+  options.services.localhostProxy = {
+    enable = lib.mkEnableOption "the loopback localhost proxy (dnsmasq wildcard DNS + Caddy vhost registry)";
+
+    services = lib.mkOption {
+      type = lib.types.attrsOf lib.types.port;
+      default = {};
+      example = lib.literalExpression ''
+        {
+          nwm = 7532;
+          weave = 7677;
+        }
+      '';
+      description = ''
+        Loopback reverse proxy registry: `http://<name>.localhost` ->
+        `127.0.0.1:<port>`.
+      '';
+    };
+
+    setWifiDns = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Point Wi-Fi DNS at the local dnsmasq (127.0.0.1, ::1) at activation
+        time. Only safe AFTER setting global nameservers in the Tailscale
+        admin panel (DNS tab): otherwise Tailscale's MagicDNS forwards
+        non-tailnet queries through the system resolver, which is dnsmasq,
+        which sends them back to MagicDNS: loop.
+
+        Prerequisite: Tailscale admin -> DNS -> add global nameservers
+        (e.g. 1.1.1.1, 8.8.8.8) and enable "Override local DNS". This makes
+        MagicDNS use the tunnel for upstream resolution, breaking the cycle.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Local DNS resolver: dnsmasq on loopback, dual-stack.
+    #
+    # macOS's mDNSResponder wedges periodically on IPv4-only interfaces:
+    # en0 has no IPv6 default route, so resolver #2 gets "Request A records"
+    # only. AAAA queries fall through to mDNS resolvers with 5 s timeouts.
+    # When mDNSResponder's state gets stale (sleep/wake, VPN flap), every
+    # cold getaddrinfo pays a flat 5 s penalty.
+    #
+    # Running dnsmasq on 127.0.0.1 + ::1 and pointing Wi-Fi DNS there gives
+    # macOS both A and AAAA resolver flags. dnsmasq handles both query types,
+    # forwards everything to Tailscale's MagicDNS (100.100.100.100), which
+    # answers tailnet names itself and forwards the rest to the global
+    # nameservers configured in the Tailscale admin panel (see setWifiDns).
+    launchd.daemons.dnsmasq = {
+      serviceConfig = {
+        Label = "org.nixos.dnsmasq";
+        ProgramArguments = [
+          "${pkgs.dnsmasq}/bin/dnsmasq"
+          "--keep-in-foreground"
+          "--listen-address=127.0.0.1"
+          "--listen-address=::1"
+          "--port=53"
+          "--no-resolv"
+          "--bogus-priv"
+          "--domain-needed"
+          "--cache-size=1000"
+          "--server=100.100.100.100"
+          # *.localhost -> loopback, for the Caddy vhosts (cfg.services).
+          "--address=/localhost/127.0.0.1"
+          "--address=/localhost/::1"
+        ];
+        KeepAlive = true;
+        RunAtLoad = true;
+        StandardErrorPath = "/var/log/dnsmasq.log";
+      };
+    };
+
+    # Host-header reverse proxy for the cfg.services registry. Root daemon so
+    # it can bind :80; sockets stay loopback-only via default_bind.
+    launchd.daemons.caddy = {
+      serviceConfig = {
+        Label = "org.nixos.caddy";
+        ProgramArguments = [
+          "${pkgs.caddy}/bin/caddy"
+          "run"
+          "--config"
+          "${caddyfile}"
+          "--adapter"
+          "caddyfile"
+        ];
+        # launchd daemons get no HOME; Caddy refuses to start without one for
+        # its storage dir, even with TLS off. Root's home always exists.
+        EnvironmentVariables.HOME = "/var/root";
+        KeepAlive = true;
+        RunAtLoad = true;
+        StandardErrorPath = "/var/log/caddy.log";
+      };
+    };
+
+    # postActivation, not an arbitrary `system.activationScripts.<name>`:
+    # nix-darwin executes only its fixed set of activation hooks, so a
+    # freestanding name is declared but never runs.
+    system.activationScripts.postActivation.text = lib.mkIf cfg.setWifiDns (lib.mkAfter ''
+      /usr/sbin/networksetup -setdnsservers Wi-Fi 127.0.0.1 ::1
+    '');
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -44,6 +44,7 @@
       pkgs
       paths
       ;
+    inherit (ix) writeBashApplication;
   };
   # VM boot smoke test for the minecraft-blocks Paper plugin (ENG-2186). Not
   # part of the `eval` aggregate: it boots a qemu VM, so it is its own check

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -35,6 +35,16 @@
       home-manager
       ;
   };
+  # Darwin loopback localhost proxy (#2988): stub-option eval of
+  # modules/darwin/localhost-proxy.nix; its check builds the module's
+  # caddy-validated Caddyfile, so a rejected config fails CI.
+  localhostProxyTest = import ./localhost-proxy.nix {
+    inherit
+      lib
+      pkgs
+      paths
+      ;
+  };
   # VM boot smoke test for the minecraft-blocks Paper plugin (ENG-2186). Not
   # part of the `eval` aggregate: it boots a qemu VM, so it is its own check
   # (`checks.<system>.minecraft-blocks-vm`).
@@ -6204,6 +6214,7 @@ in {
   portableServices = portableServicesTest;
   symphonyHomeModule = symphonyHomeModuleTest;
   provenance = provenanceTest;
+  localhostProxy = localhostProxyTest;
   minecraftBlocksVm = minecraftBlocksVmTest;
   minestomSpleefVm = minestomSpleefVmTest;
   inherit baseImageNixDb;
@@ -6218,6 +6229,7 @@ in {
       portableServicesTest
       symphonyHomeModuleTest
       provenanceTest
+      localhostProxyTest
       cargoUnitPrebuiltTest
     ]
   );

--- a/tests/localhost-proxy.nix
+++ b/tests/localhost-proxy.nix
@@ -2,13 +2,14 @@
 # Evaluates modules/darwin/localhost-proxy.nix against stub nix-darwin
 # options and asserts the wiring: dnsmasq answers *.localhost on loopback and
 # forwards upstream to MagicDNS, Caddy serves the vhost registry from a
-# build-time-validated Caddyfile, and the Wi-Fi DNS hook lands in
-# postActivation only when opted in. The returned check derivation depends on
-# the rendered Caddyfile, so `caddy validate` genuinely gates CI.
+# build-time-validated Caddyfile, and the optional Wi-Fi DNS owner restores
+# automatic DNS when launchd unloads it. The returned check derivation depends
+# on the generated artifacts and checks their lifecycle commands.
 {
   lib,
   pkgs,
   paths,
+  writeBashApplication,
 }: let
   launchdDaemonType = lib.types.submodule {
     options.serviceConfig = lib.mkOption {
@@ -17,23 +18,10 @@
     };
   };
 
-  activationScriptType = lib.types.submodule {
-    options.text = lib.mkOption {
-      type = lib.types.lines;
-      default = "";
-    };
-  };
-
   optionStubs = {
-    options = {
-      launchd.daemons = lib.mkOption {
-        type = lib.types.attrsOf launchdDaemonType;
-        default = {};
-      };
-      system.activationScripts = lib.mkOption {
-        type = lib.types.attrsOf activationScriptType;
-        default = {};
-      };
+    options.launchd.daemons = lib.mkOption {
+      type = lib.types.attrsOf launchdDaemonType;
+      default = {};
     };
   };
 
@@ -41,7 +29,7 @@
     (lib.evalModules {
       modules = [
         optionStubs
-        (paths.root + "/modules/darwin/localhost-proxy.nix")
+        (import (paths.root + "/modules/darwin/localhost-proxy.nix") {inherit writeBashApplication;})
         {_module.args.pkgs = pkgs;}
         extraModule
       ];
@@ -66,19 +54,19 @@
   };
 
   dnsmasqArgs = enabled.launchd.daemons.dnsmasq.serviceConfig.ProgramArguments;
+  wifiDnsmasqArgs = wifiDns.launchd.daemons.dnsmasq.serviceConfig.ProgramArguments;
   caddyArgs = enabled.launchd.daemons.caddy.serviceConfig.ProgramArguments;
+  dnsmasqEntrypoint = builtins.head dnsmasqArgs;
+  wifiDnsmasqEntrypoint = builtins.head wifiDnsmasqArgs;
   # The element after `--config`: the validated Caddyfile store path. Built
   # by the check below so a Caddyfile `caddy validate` rejects fails CI.
   caddyfile = builtins.elemAt caddyArgs (
     1 + lib.lists.findFirstIndex (arg: arg == "--config") (-1) caddyArgs
   );
 
-  postActivationOf = config: (config.system.activationScripts.postActivation or {text = "";}).text;
-  setsWifiDns = config: lib.hasInfix "networksetup -setdnsservers Wi-Fi 127.0.0.1 ::1" (postActivationOf config);
-
   assertions = [
     {
-      assertion = disabled.launchd.daemons == {} && disabled.system.activationScripts == {};
+      assertion = disabled.launchd.daemons == {};
       message = "the module must stay inert until services.localhostProxy.enable is set";
     }
     {
@@ -86,10 +74,15 @@
         "--listen-address=127.0.0.1"
         "--listen-address=::1"
         "--server=100.100.100.100"
+        "--local=/localhost/"
         "--address=/localhost/127.0.0.1"
         "--address=/localhost/::1"
       ];
-      message = "dnsmasq must listen dual-stack on loopback, forward to MagicDNS, and wildcard *.localhost";
+      message = "dnsmasq must listen dual-stack, forward to MagicDNS, and keep every *.localhost RR local";
+    }
+    {
+      assertion = !lib.elem "--domain-needed" dnsmasqArgs;
+      message = "dnsmasq must forward single-label MagicDNS names";
     }
     {
       assertion = lib.isString caddyfile && lib.hasPrefix builtins.storeDir caddyfile;
@@ -100,12 +93,12 @@
       message = "caddy must get a HOME (launchd daemons have none and Caddy refuses to start without one)";
     }
     {
-      assertion = !setsWifiDns enabled;
-      message = "setWifiDns must be opt-in: it is only safe with Tailscale admin global nameservers set";
+      assertion = dnsmasqEntrypoint == lib.getExe pkgs.dnsmasq;
+      message = "setWifiDns must be opt-in";
     }
     {
-      assertion = setsWifiDns wifiDns;
-      message = "setWifiDns must point Wi-Fi DNS at the loopback dnsmasq via postActivation";
+      assertion = lib.isString wifiDnsmasqEntrypoint && wifiDnsmasqEntrypoint != dnsmasqEntrypoint;
+      message = "setWifiDns must run dnsmasq through the Wi-Fi DNS lifecycle owner";
     }
   ];
 
@@ -116,7 +109,14 @@ in
   );
     pkgs.runCommand "ix-test-localhost-proxy" {
       __structuredAttrs = true;
+      strictDeps = true;
       env.caddyfile = caddyfile;
+      env.wifiDnsmasqEntrypoint = wifiDnsmasqEntrypoint;
     } ''
+      grep -F '/usr/sbin/networksetup -setdnsservers Wi-Fi 127.0.0.1 ::1' "$wifiDnsmasqEntrypoint"
+      grep -F '/usr/sbin/networksetup -setdnsservers Wi-Fi Empty' "$wifiDnsmasqEntrypoint"
+      grep -F 'trap restore_dns EXIT' "$wifiDnsmasqEntrypoint"
+      grep -F 'trap terminate HUP INT TERM' "$wifiDnsmasqEntrypoint"
+      grep -F 'kill -TERM "$dnsmasq_pid"' "$wifiDnsmasqEntrypoint"
       mkdir -p "$out"
     ''

--- a/tests/localhost-proxy.nix
+++ b/tests/localhost-proxy.nix
@@ -1,0 +1,122 @@
+# Eval test for the darwin loopback localhost proxy module (#2988).
+# Evaluates modules/darwin/localhost-proxy.nix against stub nix-darwin
+# options and asserts the wiring: dnsmasq answers *.localhost on loopback and
+# forwards upstream to MagicDNS, Caddy serves the vhost registry from a
+# build-time-validated Caddyfile, and the Wi-Fi DNS hook lands in
+# postActivation only when opted in. The returned check derivation depends on
+# the rendered Caddyfile, so `caddy validate` genuinely gates CI.
+{
+  lib,
+  pkgs,
+  paths,
+}: let
+  launchdDaemonType = lib.types.submodule {
+    options.serviceConfig = lib.mkOption {
+      type = lib.types.attrsOf lib.types.raw;
+      default = {};
+    };
+  };
+
+  activationScriptType = lib.types.submodule {
+    options.text = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+    };
+  };
+
+  optionStubs = {
+    options = {
+      launchd.daemons = lib.mkOption {
+        type = lib.types.attrsOf launchdDaemonType;
+        default = {};
+      };
+      system.activationScripts = lib.mkOption {
+        type = lib.types.attrsOf activationScriptType;
+        default = {};
+      };
+    };
+  };
+
+  eval = extraModule:
+    (lib.evalModules {
+      modules = [
+        optionStubs
+        (paths.root + "/modules/darwin/localhost-proxy.nix")
+        {_module.args.pkgs = pkgs;}
+        extraModule
+      ];
+    }).config;
+
+  disabled = eval {};
+  enabled = eval {
+    services.localhostProxy = {
+      enable = true;
+      services = {
+        nwm = 7532;
+        weave = 7677;
+      };
+    };
+  };
+  wifiDns = eval {
+    services.localhostProxy = {
+      enable = true;
+      services.nwm = 7532;
+      setWifiDns = true;
+    };
+  };
+
+  dnsmasqArgs = enabled.launchd.daemons.dnsmasq.serviceConfig.ProgramArguments;
+  caddyArgs = enabled.launchd.daemons.caddy.serviceConfig.ProgramArguments;
+  # The element after `--config`: the validated Caddyfile store path. Built
+  # by the check below so a Caddyfile `caddy validate` rejects fails CI.
+  caddyfile = builtins.elemAt caddyArgs (
+    1 + lib.lists.findFirstIndex (arg: arg == "--config") (-1) caddyArgs
+  );
+
+  postActivationOf = config: (config.system.activationScripts.postActivation or {text = "";}).text;
+  setsWifiDns = config: lib.hasInfix "networksetup -setdnsservers Wi-Fi 127.0.0.1 ::1" (postActivationOf config);
+
+  assertions = [
+    {
+      assertion = disabled.launchd.daemons == {} && disabled.system.activationScripts == {};
+      message = "the module must stay inert until services.localhostProxy.enable is set";
+    }
+    {
+      assertion = lib.all (arg: lib.elem arg dnsmasqArgs) [
+        "--listen-address=127.0.0.1"
+        "--listen-address=::1"
+        "--server=100.100.100.100"
+        "--address=/localhost/127.0.0.1"
+        "--address=/localhost/::1"
+      ];
+      message = "dnsmasq must listen dual-stack on loopback, forward to MagicDNS, and wildcard *.localhost";
+    }
+    {
+      assertion = lib.isString caddyfile && lib.hasPrefix builtins.storeDir caddyfile;
+      message = "caddy must run from a store-rendered Caddyfile";
+    }
+    {
+      assertion = enabled.launchd.daemons.caddy.serviceConfig.EnvironmentVariables.HOME == "/var/root";
+      message = "caddy must get a HOME (launchd daemons have none and Caddy refuses to start without one)";
+    }
+    {
+      assertion = !setsWifiDns enabled;
+      message = "setWifiDns must be opt-in: it is only safe with Tailscale admin global nameservers set";
+    }
+    {
+      assertion = setsWifiDns wifiDns;
+      message = "setWifiDns must point Wi-Fi DNS at the loopback dnsmasq via postActivation";
+    }
+  ];
+
+  failures = map (a: a.message) (lib.filter (a: !a.assertion) assertions);
+in
+  assert lib.assertMsg (failures == []) (
+    "localhost-proxy:\n  " + lib.concatStringsSep "\n  " failures
+  );
+    pkgs.runCommand "ix-test-localhost-proxy" {
+      __structuredAttrs = true;
+      env.caddyfile = caddyfile;
+    } ''
+      mkdir -p "$out"
+    ''


### PR DESCRIPTION
Ports the hydra loopback localhost-proxy stack into a reusable nix-darwin module `services.localhostProxy` (enable / services / setWifiDns), registered as `darwinModules.localhost-proxy`.

Closes #2988 (parent #2987).

- dnsmasq on loopback :53 answers `*.localhost` dual-stack and forwards upstream to Tailscale MagicDNS (preserves the mDNSResponder AAAA-stall postmortem comments).
- Caddy root daemon on loopback :80 routes `http://<name>.localhost` by Host header; `admin off`, `auto_https off`, `default_bind 127.0.0.1 ::1`; Caddyfile is rendered and `caddy validate`d at build time.
- `setWifiDns` (default false, MagicDNS loop hazard documented) applies via `system.activationScripts.postActivation.text = lib.mkAfter ...` because the source's freestanding `system.activationScripts.setDns` is never executed by nix-darwin (root cause noted on the issue).
- `tests/localhost-proxy.nix`: stub-option `lib.evalModules` test; its check derivation depends on the module's validated Caddyfile, so a rejected config fails CI.

Validated locally: test derivation builds (caddy validate green), `nix eval .#darwinModules` lists `localhost-proxy`, pinned alejandra clean.

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `localhost-proxy` darwin module with dnsmasq wildcard DNS and Caddy reverse proxy
> - Adds a new nix-darwin module [`modules/darwin/localhost-proxy.nix`](https://github.com/indexable-inc/index/pull/2997/files#diff-a7faed6d08c355220a261599ede05d12744b45a9f62844971d9eac1ce521c7e7) with a `services.localhostProxy` options block, enabling a local `*.localhost` wildcard DNS resolver and HTTP reverse proxy registry.
> - Runs `dnsmasq` as a launchd daemon on loopback port 53, resolving `*.localhost` locally (A + AAAA) and forwarding other queries to `100.100.100.100`.
> - Runs `caddy` as a launchd daemon with a build-time validated Caddyfile, routing `http://<name>.localhost` to `127.0.0.1:<port>` per entries in `services.localhostProxy.services`.
> - When `setWifiDns` is enabled, a wrapper script temporarily sets Wi-Fi DNS to `127.0.0.1`/`::1` at daemon start and restores automatic DNS on exit.
> - Adds evaluation and artifact inspection tests in [`tests/localhost-proxy.nix`](https://github.com/indexable-inc/index/pull/2997/files#diff-006702f0404c12a67417719b15dc20537195e6c9b8b8ce7ffa7a4a44d1d7a400) covering disabled, enabled, and `setWifiDns` configurations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0ac09d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->