### PR TITLE
ci: accept GitHub App approval principals

### DIFF
--- a/.github/scripts/approve-user-change-test.sh
+++ b/.github/scripts/approve-user-change-test.sh
@@ -25,8 +25,22 @@ expect_owned() {
 }
 
 expect_invalid_login() {
-  if valid_login "$1"; then
-    echo "expected invalid login: $1" >&2
+  local github_type="$1"
+  local login="$2"
+  if principal_kind "$login" "$github_type" >/dev/null; then
+    echo "expected invalid principal: $github_type $login" >&2
+    exit 1
+  fi
+}
+
+expect_principal() {
+  local expected_kind="$1"
+  local github_type="$2"
+  local login="$3"
+  local actual_kind
+  actual_kind="$(principal_kind "$login" "$github_type")"
+  if [ "$actual_kind" != "$expected_kind" ]; then
+    echo "expected $login to be a $expected_kind principal, got $actual_kind" >&2
     exit 1
   fi
 }
@@ -51,10 +65,16 @@ expect_rejected alice '[[{"filename":"users/alice-evil/home.nix"}]]'
 expect_rejected alice '[[{"filename":"users/alice/new.nix","previous_filename":"flake.nix"}]]'
 expect_rejected alice '[[{"filename":"users/alice/home.nix"},{"filename":"README.md"}]]'
 
-valid_login alice
-valid_login Alice-7
-expect_invalid_login --alice
-expect_invalid_login 'alice/bob'
-expect_invalid_login 'alice_'
+expect_principal user User alice
+expect_principal user User Alice-7
+expect_principal app Bot 'dependabot[bot]'
+expect_principal app Bot 'claude[bot]'
+expect_invalid_login User --alice
+expect_invalid_login User 'alice/bob'
+expect_invalid_login User 'alice_'
+expect_invalid_login Bot '[bot]'
+expect_invalid_login Bot 'alice_[bot]'
+expect_invalid_login User 'dependabot[bot]'
+expect_invalid_login Bot alice
 
 echo "approve-user-change tests passed"

--- a/.github/scripts/approve-user-change.sh
+++ b/.github/scripts/approve-user-change.sh
@@ -4,8 +4,25 @@ set -euo pipefail
 approval_tag="[approve-user-change:v1]"
 approval_body="${approval_tag} Every changed path belongs to the pull request author’s registered users directory."
 
-valid_login() {
+valid_user_login() {
   [[ "$1" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]
+}
+
+valid_app_login() {
+  [[ "$1" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?\[bot\]$ ]]
+}
+
+principal_kind() {
+  local login="$1"
+  local github_type="$2"
+
+  if [ "$github_type" = User ] && valid_user_login "$login"; then
+    echo user
+  elif [ "$github_type" = Bot ] && valid_app_login "$login"; then
+    echo app
+  else
+    return 1
+  fi
 }
 
 changes_belong_to_user() {
@@ -47,13 +64,19 @@ main() {
   : "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
   : "${PR_AUTHOR:?PR_AUTHOR is required}"
   : "${PR_AUTHOR_ID:?PR_AUTHOR_ID is required}"
+  : "${PR_AUTHOR_TYPE:?PR_AUTHOR_TYPE is required}"
   : "${PR_NUMBER:?PR_NUMBER is required}"
   : "${EXPECTED_BASE_SHA:?EXPECTED_BASE_SHA is required}"
   : "${EXPECTED_HEAD_SHA:?EXPECTED_HEAD_SHA is required}"
 
-  if ! valid_login "$PR_AUTHOR"; then
-    echo "Refusing invalid GitHub login: $PR_AUTHOR" >&2
+  local author_kind
+  author_kind="$(principal_kind "$PR_AUTHOR" "$PR_AUTHOR_TYPE")" || {
+    echo "Refusing invalid GitHub principal: ${PR_AUTHOR_TYPE} ${PR_AUTHOR}" >&2
     exit 1
+  }
+  if [ "$author_kind" = app ]; then
+    echo "GitHub App author ${PR_AUTHOR} requires human approval."
+    exit 0
   fi
 
   local login="${PR_AUTHOR,,}"
@@ -74,9 +97,11 @@ main() {
 
   jq -e \
     --arg author "$login" \
+    --arg author_type "$PR_AUTHOR_TYPE" \
     --arg base_sha "$EXPECTED_BASE_SHA" \
     --arg head_sha "$EXPECTED_HEAD_SHA" \
     '(.user.login | ascii_downcase) == $author
+      and .user.type == $author_type
       and .base.ref == "main"
       and .base.sha == $base_sha
       and .head.sha == $head_sha' \

--- a/.github/workflows/approve-user-change.yml
+++ b/.github/workflows/approve-user-change.yml
@@ -61,6 +61,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Fixes #3018.

Classifies pull request authors from GitHub's structured `user.type` plus a validated login shape. GitHub App PRs now pass the policy check without receiving the self-owner approval reserved for registered human users. Invalid type and login combinations still fail closed.

Validated with the approval policy tests, ShellCheck, Actionlint, and `nix run .#lint`.

(sent by an AI agent via Codex, GPT-5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept GitHub App principals in the PR auto-approval script
> - Adds `valid_app_login` and `principal_kind` helpers to [approve-user-change.sh](.github/scripts/approve-user-change.sh) to validate logins by GitHub type (`User` or `Bot`).
> - The script now requires `PR_AUTHOR_TYPE` (sourced from `github.event.pull_request.user.type` in the workflow) and rejects principals whose login and type don't match.
> - PRs authored by GitHub Apps are detected and skipped (no auto-approval) rather than rejected.
> - Test cases in [approve-user-change-test.sh](.github/scripts/approve-user-change-test.sh) are updated to cover user, app, and invalid principal combinations using the new type-aware assertions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f68cac2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->