### PR TITLE
claude-hooks: restore pinned Clippy after retro gate

### DIFF
--- a/packages/agent/claude-hooks/src/retro.rs
+++ b/packages/agent/claude-hooks/src/retro.rs
@@ -592,6 +592,11 @@ struct McpClient {
     next_id: u64,
 }
 
+struct HttpReply {
+    status: u16,
+    text: String,
+}
+
 impl McpClient {
     fn connect(url: &str, key: &str) -> Option<Self> {
         let http = reqwest::blocking::Client::builder()
@@ -621,7 +626,7 @@ impl McpClient {
         Some(client)
     }
 
-    fn post(&mut self, body: &Value) -> Option<(u16, String)> {
+    fn post(&mut self, body: &Value) -> Option<HttpReply> {
         let mut req = self
             .http
             .post(&self.url)
@@ -649,7 +654,7 @@ impl McpClient {
         }
         let status = resp.status().as_u16();
         let text = resp.text().unwrap_or_default();
-        Some((status, text))
+        Some(HttpReply { status, text })
     }
 
     /// One JSON-RPC request; returns the `result` value or logs and None.
@@ -657,7 +662,7 @@ impl McpClient {
         let id = self.next_id;
         self.next_id += 1;
         let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
-        let (status, text) = self.post(&body)?;
+        let HttpReply { status, text } = self.post(&body)?;
         if !(200..300).contains(&status) {
             log(&format!(
                 "{method} -> HTTP {status}: {}",


### PR DESCRIPTION
Fixes #3039.

`ServerState::post` now returns a named `HttpReply`, preserving behavior while satisfying the pinned `anonymous_tuple_return_type` lint introduced by #2677.

Validated with 48 claude-hooks tests, repository lint, the 0/8 changed-lines clone gate, and `nix build .#ciChecks.x86_64-linux.rust-claude-hooks.clippy`.

(sent by an AI agent via Codex, GPT-5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor `McpClient.post` return type to use `HttpReply` struct in claude-hooks
> Introduces a dedicated `HttpReply` struct in [retro.rs](https://github.com/indexable-inc/index/pull/3043/files#diff-4819dd4460ea10e11838a63e273dbee2952e91ed014ae847fcea85a3ee3a0e8c) to replace the anonymous `(u16, String)` tuple returned by `McpClient.post`. Destructuring in `McpClient.request` is updated to match the new named fields. No behavioral changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c15282.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->