### PR TITLE
claude-hooks: fix main flake-check red (clippy anonymous-tuple-return-type from #2941)

### DIFF
--- a/packages/agent/claude-hooks/src/retro.rs
+++ b/packages/agent/claude-hooks/src/retro.rs
@@ -592,6 +592,13 @@ struct McpClient {
     next_id: u64,
 }
 
+/// One HTTP exchange's outcome: the status code plus the raw body text
+/// (plain JSON or SSE, decoded later by [`parse_rpc_response`]).
+struct PostResponse {
+    status: u16,
+    text: String,
+}
+
 impl McpClient {
     fn connect(url: &str, key: &str) -> Option<Self> {
         let http = reqwest::blocking::Client::builder()
@@ -621,7 +628,7 @@ impl McpClient {
         Some(client)
     }
 
-    fn post(&mut self, body: &Value) -> Option<(u16, String)> {
+    fn post(&mut self, body: &Value) -> Option<PostResponse> {
         let mut req = self
             .http
             .post(&self.url)
@@ -649,7 +656,7 @@ impl McpClient {
         }
         let status = resp.status().as_u16();
         let text = resp.text().unwrap_or_default();
-        Some((status, text))
+        Some(PostResponse { status, text })
     }
 
     /// One JSON-RPC request; returns the `result` value or logs and None.
@@ -657,7 +664,7 @@ impl McpClient {
         let id = self.next_id;
         self.next_id += 1;
         let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
-        let (status, text) = self.post(&body)?;
+        let PostResponse { status, text } = self.post(&body)?;
         if !(200..300).contains(&status) {
             log(&format!(
                 "{method} -> HTTP {status}: {}",


### PR DESCRIPTION
Main's flake-check is red: `ciChecks.x86_64-linux.rust-claude-hooks.clippy` fails on `retro.rs:624` because `McpClient::post` returns `Option<(u16, String)>` and the toolchain runs with `-D clippy::anonymous_tuple_return_type`. Introduced by #2941; same class of main-red as #3006 fixed.

Fix: named `PostResponse { status, text }` struct, per the lint's guidance. Both call sites (`request`, `notify`) updated.

Validated locally: `nix build .#ciChecks.x86_64-linux.rust-claude-hooks.clippy` succeeds on this branch, fails on main.

This also unblocks flake-check on #2983 and #2984, which inherited the red via branch updates.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace anonymous tuple return type with `PostResponse` struct in `McpClient.post`
> Fixes a Clippy lint (`anonymous-tuple-return-type`) introduced in #2941 by replacing the `Option<(u16, String)>` return type of `McpClient.post` with a named `PostResponse` struct in [retro.rs](https://github.com/indexable-inc/index/pull/3044/files#diff-4819dd4460ea10e11838a63e273dbee2952e91ed014ae847fcea85a3ee3a0e8c). The struct holds the same status code and response body fields. Call sites destructure `PostResponse` instead of a tuple; no behavioral changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50cd936.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->