### PR TITLE
ci: align clone diff with checked-out merge

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # The clone diff gate compares against the event's base commit.
+          # The clone diff gate reads both parents of the checked-out merge.
           fetch-depth: 0
 
       # Underscore digit separators: every nix invocation that evaluates this
@@ -93,10 +93,18 @@ jobs:
         # limit across every PR). Fail fast and loudly instead.
         timeout-minutes: 15
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
         run: |
           set -euo pipefail
-          nix run .#clone -- . --diff "${BASE_SHA}" > /dev/null
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # index#3038: the event base can predate the synthetic merge that
+            # checkout regenerates after main advances. Its first parent is the
+            # base whose tree the checked-out PR contribution was merged into.
+            base_sha="$(git rev-parse --verify HEAD^1)"
+          else
+            base_sha="${EVENT_BASE_SHA}"
+          fi
+          nix run .#clone -- . --diff "${base_sha}" > /dev/null
 
       # Run the full gate through the repo-owned `check` app (lib/per-system.nix),
       # so CI and a local `nix run .#check` execute the same two commands from one

--- a/packages/code/clone-detect/cli/default.nix
+++ b/packages/code/clone-detect/cli/default.nix
@@ -1,14 +1,32 @@
 {
   ix,
   lib,
+  pkgs,
   ...
-}:
-ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
-  binary = "clone";
-  packageName = "clone-cli";
-  meta = {
-    description = "Code clone and duplication detector (Type-1/2/3) over tree-sitter ASTs";
-    license = lib.licenses.mit;
-    mainProgram = "clone";
-  };
-}
+}: let
+  workflowBase =
+    pkgs.runCommand "clone-workflow-base-test" {
+      nativeBuildInputs = [
+        pkgs.bash
+        pkgs.coreutils
+        pkgs.git
+        pkgs.yq-go
+      ];
+      strictDeps = true;
+    } ''
+      export HOME="$TMPDIR/home"
+      mkdir -p "$HOME"
+      bash ${./tests/workflow-base.sh} ${ix.paths.root + "/.github/workflows/check.yml"}
+      mkdir -p "$out"
+    '';
+in
+  ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+    binary = "clone";
+    packageName = "clone-cli";
+    passthru.tests.workflow-base = workflowBase;
+    meta = {
+      description = "Code clone and duplication detector (Type-1/2/3) over tree-sitter ASTs";
+      license = lib.licenses.mit;
+      mainProgram = "clone";
+    };
+  }

--- a/packages/code/clone-detect/cli/tests/workflow-base.sh
+++ b/packages/code/clone-detect/cli/tests/workflow-base.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=${1:?usage: workflow-base.sh CHECK_WORKFLOW}
+repo="$TMPDIR/repo"
+
+git -C "$TMPDIR" init --quiet --initial-branch=main repo
+git -C "$repo" config user.name test
+git -C "$repo" config user.email test@example.com
+
+printf 'event base\n' >"$repo/base"
+git -C "$repo" add base
+git -C "$repo" commit --quiet --message base
+event_base=$(git -C "$repo" rev-parse HEAD)
+
+git -C "$repo" switch --quiet --create pull-request
+printf 'pull request\n' >"$repo/contribution"
+git -C "$repo" add contribution
+git -C "$repo" commit --quiet --message contribution
+
+git -C "$repo" switch --quiet main
+printf 'new main\n' >"$repo/advanced"
+git -C "$repo" add advanced
+git -C "$repo" commit --quiet --message advance
+checkout_base=$(git -C "$repo" rev-parse HEAD)
+git -C "$repo" merge --quiet --no-ff --message synthetic-merge pull-request
+
+# Run the exact workflow body so the test covers its YAML wiring as well as the
+# git history. The nix stub observes which base reaches the clone CLI boundary.
+workflow_step=$(
+  yq '.jobs.flake-check.steps[] | select(.name == "Reject duplication on changed lines").run' "$workflow"
+)
+if [[ -z "$workflow_step" || "$workflow_step" == "null" ]]; then
+  printf 'clone diff workflow step is missing\n' >&2
+  exit 1
+fi
+
+nix() {
+  if [[ "$#" -ne 6 || "$1" != "run" || "$2" != ".#clone" || "$3" != "--" || "$4" != "." || "$5" != "--diff" ]]; then
+    printf 'unexpected clone invocation:' >&2
+    printf ' %q' "$@" >&2
+    printf '\n' >&2
+    return 1
+  fi
+  if [[ "$6" != "$EXPECTED_BASE_SHA" ]]; then
+    printf 'expected clone base %s, got %s\n' "$EXPECTED_BASE_SHA" "$6" >&2
+    return 1
+  fi
+}
+export -f nix
+
+(
+  cd "$repo"
+  export EVENT_BASE_SHA="$event_base"
+  export EXPECTED_BASE_SHA="$checkout_base"
+  export GITHUB_EVENT_NAME=pull_request
+  bash -c "$workflow_step"
+)
+
+printf 'clone workflow used checked-out merge parent %s\n' "$checkout_base"


### PR DESCRIPTION
## Problem

A `pull_request` event can retain an older base SHA while `actions/checkout` regenerates the synthetic merge against newer `main`. The clone gate then counts newly landed main code as part of the PR.

Run 29211425126 checked out merge `48836693` with first parent `13208d92`, but passed event base `fb3ba8c2` to clone. The stale base failed at 61 duplicated lines out of 1,512, all from main-only `retro.rs`; `HEAD^1` passed at 0 out of 790.

## Fix

For `pull_request`, derive the clone diff base from the checked-out synthetic merge's first parent. Preserve event-provided bases for `merge_group` and `push`.

Add a focused check that creates the main-advances-before-checkout history, extracts the literal workflow step from YAML, and verifies the clone invocation receives the synthetic merge's first parent.

## Validation

- `nix run .#lint`: 10 of 10 stages passed
- workflow race regression: passed with pinned `yq` invocation
- ShellCheck and `bash -n`: passed
- exact incident checkout: stale base fails 61/1,512; `HEAD^1` passes 0/790
- macOS passthru selection is blocked before this new derivation by existing #2927

Fixes #3038

(sent by an AI agent via Codex, GPT-5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI clone diff base to use first parent of checked-out synthetic merge on pull_request events
> - Changes the `EVENT_BASE_SHA` environment variable reference in the "Reject duplication on changed lines" step of [check.yml](.github/workflows/check.yml) so that on `pull_request` events, `base_sha` is resolved via `git rev-parse HEAD^1` (the first parent of the checked-out synthetic merge) rather than the raw event base SHA.
> - On non-`pull_request` events, the existing `EVENT_BASE_SHA` value is used unchanged.
> - Adds a `passthru.tests.workflow-base` derivation to the [clone-cli package](packages/code/clone-detect/cli/default.nix) backed by [workflow-base.sh](packages/code/clone-detect/cli/tests/workflow-base.sh), which creates a synthetic git repo and asserts the correct base SHA is passed to the clone detector.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee76a49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->