### PR TITLE
nix: accept opaque temporary root filenames

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -163,6 +163,12 @@
   # Exposed so a downstream consumer passes it straight through to `mkForkChecks`
   # rather than reaching into index's package layout by path.
   forkDagCheckSrc = paths.packagesRoot + "/rebase-patches";
+  # Public patch data for consumers whose system Nix is not `nix-ix`. Keep the
+  # patch bytes owned by index so fleet configurations consume one source of
+  # truth instead of copying the fix into each repository.
+  nixPatches = {
+    opaqueTemporaryRootFilenames = paths.packagesRoot + "/nix/nix/patches/0016-fix-libstore-accept-opaque-temporary-root-filenames.patch";
+  };
   secretRefs = import ./util/secret-refs.nix {inherit lib;};
   selfVersionFor = self: import ./util/self-version.nix {inherit lib self;};
   checks = import ./checks.nix {inherit lib;};
@@ -693,6 +699,7 @@
       mkMinecraftSyncManaged
       mutableJson
       netCidr
+      nixPatches
       paths
       patchedSrc
       patchedSrcFor

--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -481,6 +481,15 @@
           upstream = "hold";
           reason = "Fixes repeated installables multiplying `nix build --json` results (indexable-inc/index#2633). Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
         };
+        # 0016: a newer Nix uses opaque per-instance temporary-root filenames.
+        # The 2.34 collector parsed every entry as a decimal PID, so one newer
+        # file disabled both scheduled and reactive GC until the store filled
+        # (index#3031). Upstream master already treats the name as opaque in
+        # NixOS/nix#15992; this is the reader-side backport for mixed versions.
+        "0016-fix-libstore-accept-opaque-temporary-root-filenames.patch" = {
+          upstream = "hold";
+          reason = "Backports the mixed-version temporary-root reader from NixOS/nix#15992 (indexable-inc/index#3031). Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
       };
     }
   ];

--- a/packages/nix/nix/patches/0016-fix-libstore-accept-opaque-temporary-root-filenames.patch
+++ b/packages/nix/nix/patches/0016-fix-libstore-accept-opaque-temporary-root-filenames.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew.gazelka@gmail.com>
+Date: Sun, 12 Jul 2026 15:23:02 -0700
+Subject: [PATCH] fix(libstore): accept opaque temporary root filenames
+
+Newer Nix processes can share a store with 2.34 and create per-instance
+temporary root files named temproots-<pid>-<random>. Treat the filename
+as opaque diagnostic data so one such entry cannot abort every garbage
+collection with std::invalid_argument and exhaust the store.
+
+Refs indexable-inc/index#3031
+
+Assisted-by: Codex <noreply@openai.com>
+
+diff --git a/src/libstore/gc.cc b/src/libstore/gc.cc
+index 16b81abf2..12f492a5e 100644
+--- a/src/libstore/gc.cc
++++ b/src/libstore/gc.cc
+@@ -168,8 +168,6 @@ void LocalStore::findTempRoots(Roots & tempRoots, bool censor)
+         }
+         auto path = i.path();
+ 
+-        pid_t pid = std::stoi(name);
+-
+         debug("reading temporary root file %1%", PathFmt(path));
+         AutoCloseFD fd(toDescriptor(open(
+             path.string().c_str(),
+@@ -204,7 +202,7 @@ void LocalStore::findTempRoots(Roots & tempRoots, bool censor)
+         while ((end = contents.find((char) 0, pos)) != std::string::npos) {
+             auto root = std::string_view(contents).substr(pos, end - pos);
+             debug("got temporary root '%s'", root);
+-            tempRoots[parseStorePath(root)].emplace(censor ? censored : fmt("{temp:%d}", pid));
++            tempRoots[parseStorePath(root)].emplace(censor ? censored : fmt("{temp:%s}", name));
+             pos = end + 1;
+         }
+     }
+diff --git a/tests/functional/gc.sh b/tests/functional/gc.sh
+index c58f47021..576bb546c 100755
+--- a/tests/functional/gc.sh
++++ b/tests/functional/gc.sh
+@@ -6,6 +6,14 @@ TODO_NixOS
+ 
+ clearStore
+ 
++# A newer Nix may share this store and use an opaque, per-instance temporary
++# root filename. GC must treat the filename as diagnostic data rather than
++# assuming that every non-hidden entry is a decimal PID.
++futureTempRoot="$NIX_STATE_DIR/temproots/temproots-123-456"
++touch "$futureTempRoot"
++nix-store --gc --print-roots
++test ! -e "$futureTempRoot"
++
+ drvPath=$(nix-instantiate dependencies.nix)
+ outPath=$(nix-store -rvv "$drvPath")
+ 

--- a/packages/nix/nix/patches/0016-fix-libstore-accept-opaque-temporary-root-filenames.patch
+++ b/packages/nix/nix/patches/0016-fix-libstore-accept-opaque-temporary-root-filenames.patch
@@ -38,13 +38,14 @@ diff --git a/tests/functional/gc.sh b/tests/functional/gc.sh
 index c58f47021..576bb546c 100755
 --- a/tests/functional/gc.sh
 +++ b/tests/functional/gc.sh
-@@ -6,6 +6,14 @@ TODO_NixOS
+@@ -6,6 +6,15 @@ TODO_NixOS
  
  clearStore
  
 +# A newer Nix may share this store and use an opaque, per-instance temporary
 +# root filename. GC must treat the filename as diagnostic data rather than
 +# assuming that every non-hidden entry is a decimal PID.
++mkdir -p "$NIX_STATE_DIR/temproots"
 +futureTempRoot="$NIX_STATE_DIR/temproots/temproots-123-456"
 +touch "$futureTempRoot"
 +nix-store --gc --print-roots

--- a/packages/nix/nix/patches/dag.json
+++ b/packages/nix/nix/patches/dag.json
@@ -65,6 +65,10 @@
     {
       "patch": "0015-fix-libcmd-preserve-repeated-installable-cardinality.patch",
       "deps": []
+    },
+    {
+      "patch": "0016-fix-libstore-accept-opaque-temporary-root-filenames.patch",
+      "deps": []
     }
   ]
 }


### PR DESCRIPTION
## Summary

* Treat shared-store temporary root filenames as opaque diagnostic data.
* Backport the compatible reader already merged in NixOS/nix#15992.
* Add a functional regression for `temproots-123-456` and register the patch lifecycle metadata.

## Root cause

A Nix 2.36 client left opaque temporary root filenames in the shared store. The deployed Nix 2.34 collector parsed every entry with `std::stoi`, so scheduled and reactive GC both failed until the CI worker reached ENOSPC.

## Validation

* Isolated Nix 2.34 store reproduces `error: stoi: no conversion` before the patch.
* Patched source and patch DAG checks pass.
* `nix run .#lint -- --json` passes every check.
* Independent correctness, security, performance, and maintainability reviews found no blockers.

Refs #3031.

(sent by an AI agent via Codex, GPT-5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Nix garbage collector to accept opaque temporary root filenames
> - Adds [0016-fix-libstore-accept-opaque-temporary-root-filenames.patch](https://github.com/indexable-inc/index/pull/3050/files#diff-9d705e279f5c4eddc41bd763d6cbf66da43ff23c32e78fa76e06113b5dab66bb) to the forked Nix patch set, fixing a crash in `gc.cc` where `std::stoi(name)` throws `std::invalid_argument` when a temp root filename is not a decimal PID.
> - The patch replaces PID parsing with opaque filename handling, embedding the raw filename in the temp root tag via `fmt("{temp:%s}", name)`.
> - Registers the patch in the DAG ([dag.json](https://github.com/indexable-inc/index/pull/3050/files#diff-bb8cabe3c8aca5a21a04124e99377308810f2ffd5701104ed528dd747207dc2d)) and exposes a `nixPatches` attribute in [lib/default.nix](https://github.com/indexable-inc/index/pull/3050/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) for downstream consumers.
> - Behavioral Change: temp root annotations now display the full filename string instead of a numeric PID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da25170.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->