### PR TITLE
ci: stop duplicating site browser tests

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1521,9 +1521,6 @@
               test -f "$pkg/share/nix-web-monitor/index.html"
               mkdir -p "$out"
             '';
-          site-case-tests = pkgs.linkFarm "site-case-tests" (
-            lib.mapAttrsToList (name: path: {inherit name path;}) siteTests.cases
-          );
           site-test = siteTests.all;
         };
         checkNameCollisions = lib.intersectLists (lib.attrNames explicitChecks) (lib.attrNames rustChecks);


### PR DESCRIPTION
## Summary

The required check ran the full Vitest browser suite once and also forced every site test case through a separate Chromium derivation. Remove the duplicate per-case link farm and keep `site-test` as the single browser gate.

The generic per-case builder remains covered by its focused fixture in `tests/default.nix`.

## Evidence

On #3024, 96 concurrent builds left three Chromium workers asleep with zero CPU ticks and empty Nix logs. The same exact three derivations passed together in 19.135 seconds with three concurrent jobs.

- `nix build --no-link .#ciChecks.x86_64-linux.site-test`
- `nix run .#lint -- --json`
- Exact CI catalog evaluation confirms `site-test` is present and `site-case-tests` is absent

Closes #3057.

(sent by an AI agent via Codex, GPT-5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicate `site-case-tests` attribute from per-system outputs
> Removes the `site-case-tests` binding from [lib/per-system.nix](https://github.com/indexable-inc/index/pull/3058/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683), which duplicated browser test cases already covered by `site-test`. The `site-test = siteTests.all` binding remains unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40767fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->