### PR TITLE
agent: route ix lint to its CI package

### DIFF
--- a/packages/agent/skills/linting/SKILL.md
+++ b/packages/agent/skills/linting/SKILL.md
@@ -1,26 +1,31 @@
 ---
 name: linting
-description: "Running the repo lint (nix run .#lint) and that the pre-commit hook and CI share the entry point. Use before committing or when a lint check fails."
+description: "Running each repository's authoritative lint gate. Use before committing or when a lint check fails."
 ---
 
 ## Linting
+
+In `index`, run:
 
 ```sh
 nix run .#lint
 ```
 
-The tracked pre-commit hook runs the same lint app. CI runs the same check
-through the flake. Keep one lint entry point so local and CI failures mean the
-same thing.
+Its tracked pre-commit hook and CI use the same lint app.
 
-For machine consumption (loading results as a dataframe rather than grepping
-the log), `nix run .#lint -- --json` prints one JSON array with a record per
-check — `{check, ok, output}`, where `output` carries the stage's diagnostics
-on failure — and still exits nonzero when any check fails.
+For machine consumption, `nix run .#lint -- --json` prints one JSON array with
+a `{check, ok, output}` record per check and still exits nonzero when any check
+fails. `output` carries each failed stage's diagnostics.
 
-Always lint through `nix run .#lint` (or build the package), never an ad-hoc
-`nix shell nixpkgs#ruff -c ruff check`. The flake pins ruff and passes a fixed
-`--target-version`; an ambient ruff is a different version with a different
-default target, so version-gated rules (e.g. `UP041`, `PERF203`) fire in one and
-not the other. A check that passes ad-hoc can still fail the gate, and vice
-versa.
+In `ix`, build the system-qualified Linux package that its CI lint phase uses:
+
+```sh
+nix build -L --no-link .#packages.x86_64-linux.ci-lint-checks
+```
+
+The explicit system is intentional on Darwin: the configured remote builder
+executes the Linux gate.
+
+Do not replace either gate with ambient tools such as
+`nix shell nixpkgs#ruff -c ruff check`. The flakes pin their tools and flags, so
+an ad hoc check can disagree with the repository gate.


### PR DESCRIPTION
Fixes #3055.

The shared linting skill now routes each repository to its authoritative gate:

* **index:** `nix run .#lint`
* **ix:** `nix build -L --no-link .#packages.x86_64-linux.ci-lint-checks`

The skill keeps the `index` JSON mode and explains why ambient lint tools are
not equivalent.

Validated with:

* `nix run .#skill-lint -- packages/agent/skills/linting`
* `nix run .#lint -- --json`
* The exact `ix` lint package on clean `origin/main`

(sent by an AI agent via Codex, GPT-5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route linting skill to the CI lint package for ix
> Updates [SKILL.md](https://github.com/indexable-inc/index/pull/3060/files#diff-860661f27e555fe1ccf4455b1f5e7ddcb4765014954bfe84b2de6e5c4756a8fb) to direct the linting skill to build and run `packages.x86_64-linux.ci-lint-checks` as the authoritative lint gate. Adds guidance for explicit system selection on Darwin with a remote Linux builder, and replaces prior ambient-tool warnings with a concise directive to avoid tools that may disagree with the repository gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb72f38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->