### PR TITLE
mcp: wait for required check aggregate

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2048,7 +2048,7 @@ _FAILING_CHECK_STATES: frozenset[str] = frozenset(
 )
 _PASSING_CHECK_BUCKETS: frozenset[str] = frozenset({"pass", "skipping"})
 _FAILING_CHECK_BUCKETS: frozenset[str] = frozenset({"fail", "cancel"})
-_NO_REQUIRED_CHECKS = re.compile(r"^no required checks reported on the '.+' branch$")
+_NO_REQUIRED_CHECKS = re.compile(r"^no (?:required )?checks reported on the '.+' branch$")
 
 
 def _pr_check_state(check: Mapping[str, Any]) -> str:

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2040,6 +2040,40 @@ def _pr_resource_html(state: Mapping[str, Any]) -> str:
 _INSTANT_MERGE_STATES: frozenset[str] = frozenset({"CLEAN", "UNSTABLE", "HAS_HOOKS"})
 _MERGEABILITY_POLL_S: float = 2.0
 _MERGEABILITY_TIMEOUT_S: float = 30.0
+_PASSING_CHECK_STATES: frozenset[str] = frozenset({"SUCCESS", "NEUTRAL", "SKIPPED"})
+# Match gh v2.96 aggregateChecks: STALE remains pending because branch
+# protection still needs a fresh result, even though that CheckRun is complete.
+_FAILING_CHECK_STATES: frozenset[str] = frozenset(
+    {"ERROR", "FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "CANCELLED", "STARTUP_FAILURE"}
+)
+_PASSING_CHECK_BUCKETS: frozenset[str] = frozenset({"pass", "skipping"})
+_FAILING_CHECK_BUCKETS: frozenset[str] = frozenset({"fail", "cancel"})
+_NO_REQUIRED_CHECKS = re.compile(r"^no required checks reported on the '.+' branch$")
+
+
+def _pr_check_state(check: Mapping[str, Any]) -> str:
+    """Normalize CheckRun and legacy StatusContext outcomes."""
+    return str(check.get("conclusion") or check.get("state") or check.get("status") or "").upper()
+
+
+def _pr_check_is_terminal(check: Mapping[str, Any]) -> bool:
+    """Whether a CheckRun or legacy StatusContext has reached an outcome."""
+    check_state = _pr_check_state(check)
+    bucket = str(check.get("bucket") or "")
+    return (
+        check_state in _PASSING_CHECK_STATES
+        or check_state in _FAILING_CHECK_STATES
+        or bucket in _PASSING_CHECK_BUCKETS
+        or bucket in _FAILING_CHECK_BUCKETS
+    )
+
+
+def _pr_check_failed(check: Mapping[str, Any]) -> bool:
+    """Whether a terminal CheckRun or legacy StatusContext did not pass."""
+    return (
+        _pr_check_state(check) in _FAILING_CHECK_STATES
+        or str(check.get("bucket") or "") in _FAILING_CHECK_BUCKETS
+    )
 
 
 async def watch_pr(
@@ -2117,13 +2151,35 @@ async def watch_pr(
         )
         return row
 
+    async def required_checks() -> list[dict[str, Any]]:
+        # gh's JSON output omits isRequired, while `pr checks --required`
+        # evaluates GitHub's CheckRun.isRequired field and deduplicates reruns.
+        result: dict[str, Any] = await run_nu(
+            "gh pr checks $env.PR --required "
+            "--json bucket,completedAt,link,name,startedAt,state,workflow | complete"
+        )
+        stdout = str(result.get("stdout") or "").strip()
+        if stdout:
+            parsed = json.loads(stdout)
+            if not isinstance(parsed, list) or not all(isinstance(check, dict) for check in parsed):
+                raise RuntimeError("gh pr checks --required returned non-list JSON")
+            return parsed
+        stderr = str(result.get("stderr") or "").strip()
+        exit_code = int(result.get("exit_code") or 0)
+        # index#3059: cli/cli v2.96 reports an empty required set only as this
+        # stderr error. Keep that domain outcome distinct from API/auth failures.
+        if exit_code == 1 and _NO_REQUIRED_CHECKS.fullmatch(stderr):
+            print(f"pr_watch: {stderr}", flush=True)
+            return []
+        raise RuntimeError(
+            f"gh pr checks --required failed with exit code {exit_code}: {stderr or 'no error text'}"
+        )
+
     if auto_merge:
         # Arming auto merge on an already-mergeable PR merges it instantly,
-        # before any watching happens (#2532): branch-protection endpoints
-        # need admin and gh's statusCheckRollup carries no isRequired, so
-        # mergeStateStatus is the one read-accessible "would merge right now"
-        # signal. A fresh PR reports UNKNOWN while GitHub computes
-        # mergeability, so poll briefly for a real answer first.
+        # before any watching happens (#2532). mergeStateStatus accounts for
+        # every blocker, including checks, reviews, and conflicts. A fresh PR
+        # reports UNKNOWN while GitHub computes it, so poll briefly first.
         row = await refresh()
         deadline = time.time() + _MERGEABILITY_TIMEOUT_S
         while (
@@ -2164,27 +2220,48 @@ async def watch_pr(
     while True:
         last = await refresh()
         checks = last.get("statusCheckRollup") or []
-        failures = [
-            check
-            for check in checks
-            if check.get("conclusion") in {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}
-        ]
+        failures = [check for check in checks if _pr_check_failed(check)]
+        required: list[dict[str, Any]] | None = None
         if last.get("state") != "OPEN":
             state["status"] = "merged" if last.get("state") == "MERGED" else "closed"
             resource.close()
             await notify(f"PR {clean_pr} finished with state {last.get('state')}", resource=resource.id, pr=clean_pr)
             return finished({"state": last.get("state"), "url": last.get("url"), "checks": len(checks)})
         if failures:
-            state["status"] = "failed"
-            state["error"] = "One or more required actions failed."
-            resource.close()
-            await notify(f"PR {clean_pr} has failing checks", resource=resource.id, pr=clean_pr)
-            return finished({"state": "failed", "url": last.get("url"), "failures": failures})
+            required = await required_checks()
+            required_failures = [check for check in required if _pr_check_failed(check)]
+            required_pending = [check for check in required if not _pr_check_is_terminal(check)]
+            if required_failures and not required_pending:
+                state["status"] = "failed"
+                state["error"] = "One or more required actions failed."
+                resource.close()
+                await notify(f"PR {clean_pr} has failing checks", resource=resource.id, pr=clean_pr)
+                return finished(
+                    {"state": "failed", "url": last.get("url"), "failures": required_failures}
+                )
+            if required_failures:
+                state["status"] = "waiting for checks"
+                state["error"] = (
+                    f"{len(required_failures)} required action(s) failed; waiting for "
+                    f"{len(required_pending)} required action(s) still running."
+                )
         if time.time() - started > timeout:
+            if required is None:
+                required = await required_checks()
+            required_failures = [check for check in required if _pr_check_failed(check)]
+            required_pending = [check for check in required if not _pr_check_is_terminal(check)]
             state["status"] = "timed out"
             resource.close()
             await notify(f"PR {clean_pr} watch timed out", resource=resource.id, pr=clean_pr)
-            return finished({"state": "timed out", "url": last.get("url"), "checks": len(checks)})
+            return finished(
+                {
+                    "state": "timed out",
+                    "url": last.get("url"),
+                    "checks": len(checks),
+                    "failures": required_failures,
+                    "pending": required_pending,
+                }
+            )
         await asyncio.sleep(interval)
 
 

--- a/packages/mcp/tests/test_pr_watch_automerge.py
+++ b/packages/mcp/tests/test_pr_watch_automerge.py
@@ -25,11 +25,11 @@ class _ScriptedNu:
         views: list[dict[str, object]],
         required: list[list[dict[str, object]]] | None = None,
         *,
-        no_required: bool = False,
+        empty_error: str | None = None,
     ) -> None:
         self._views = list(views)
         self._required = list(required or [[]])
-        self._no_required = no_required
+        self._empty_error = empty_error
         self.merges: list[str] = []
         self.view_calls = 0
 
@@ -45,11 +45,11 @@ class _ScriptedNu:
             self.merges.append(code)
             return {"exit_code": 0, "stdout": "", "stderr": ""}
         if "gh pr checks" in code:
-            if self._no_required:
+            if self._empty_error is not None:
                 return {
                     "exit_code": 1,
                     "stdout": "",
-                    "stderr": "no required checks reported on the 'feature' branch",
+                    "stderr": self._empty_error,
                 }
             checks = self._required.pop(0) if len(self._required) > 1 else self._required[0]
             if any(check.get("bucket") == "pending" for check in checks):
@@ -88,9 +88,9 @@ def _watch(
     views: list[dict[str, object]],
     required: list[list[dict[str, object]]] | None = None,
     *,
-    no_required: bool = False,
+    empty_error: str | None = None,
 ) -> tuple[dict[str, object], _ScriptedNu, list[str]]:
-    fake = _ScriptedNu(views, required, no_required=no_required)
+    fake = _ScriptedNu(views, required, empty_error=empty_error)
     monkeypatch.setitem(sys.modules, "nu", fake)
     notified: list[str] = []
 
@@ -197,10 +197,17 @@ def test_startup_failure_is_terminal() -> None:
     assert runtime._pr_check_failed(check)
 
 
-def test_optional_failure_with_no_required_checks_keeps_watching(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    "empty_error",
+    [
+        "no checks reported on the 'feature' branch",
+        "no required checks reported on the 'feature' branch",
+    ],
+)
+def test_optional_failure_with_empty_required_set_keeps_watching(
+    monkeypatch: pytest.MonkeyPatch, empty_error: str
 ) -> None:
-    """gh reports an empty required set as stderr, not JSON (#3059)."""
+    """gh reports both empty check-set outcomes as stderr, not JSON (#3059)."""
     initial = _view(9106, "OPEN", "BLOCKED")
     failing = _view(9106, "OPEN", "BLOCKED")
     failing["statusCheckRollup"] = [
@@ -212,7 +219,7 @@ def test_optional_failure_with_no_required_checks_keeps_watching(
         monkeypatch,
         9106,
         [initial, failing, merged],
-        no_required=True,
+        empty_error=empty_error,
     )
 
     assert fake.view_calls == 3

--- a/packages/mcp/tests/test_pr_watch_automerge.py
+++ b/packages/mcp/tests/test_pr_watch_automerge.py
@@ -1,4 +1,4 @@
-"""`watch_pr` must not arm auto merge on an already-mergeable PR (#2532).
+"""`watch_pr` auto-merge and required-check terminal contracts (#2532, #3054).
 
 On a repo with no blocking required checks, GitHub merges a PR the moment
 `gh pr merge --auto` is armed, before any watching happens, so `watch_pr`
@@ -6,6 +6,7 @@ reads mergeStateStatus first and skips arming with a loud note instead.
 """
 
 import asyncio
+import json
 import sys
 
 import pytest
@@ -19,9 +20,18 @@ class _ScriptedNu:
     `__call__`. Serves scripted `gh pr view` rows (the last row repeats) and
     records every `gh pr merge` invocation."""
 
-    def __init__(self, views: list[dict[str, object]]) -> None:
+    def __init__(
+        self,
+        views: list[dict[str, object]],
+        required: list[list[dict[str, object]]] | None = None,
+        *,
+        no_required: bool = False,
+    ) -> None:
         self._views = list(views)
+        self._required = list(required or [[]])
+        self._no_required = no_required
         self.merges: list[str] = []
+        self.view_calls = 0
 
     async def __call__(
         self,
@@ -34,7 +44,23 @@ class _ScriptedNu:
         if "gh pr merge" in code:
             self.merges.append(code)
             return {"exit_code": 0, "stdout": "", "stderr": ""}
+        if "gh pr checks" in code:
+            if self._no_required:
+                return {
+                    "exit_code": 1,
+                    "stdout": "",
+                    "stderr": "no required checks reported on the 'feature' branch",
+                }
+            checks = self._required.pop(0) if len(self._required) > 1 else self._required[0]
+            if any(check.get("bucket") == "pending" for check in checks):
+                exit_code = 8
+            elif any(check.get("bucket") in {"fail", "cancel"} for check in checks):
+                exit_code = 1
+            else:
+                exit_code = 0
+            return {"exit_code": exit_code, "stdout": json.dumps(checks), "stderr": ""}
         assert "gh pr view" in code
+        self.view_calls += 1
         return self._views.pop(0) if len(self._views) > 1 else self._views[0]
 
 
@@ -52,10 +78,19 @@ def _view(pr: int, state: str, merge_state: str) -> dict[str, object]:
     }
 
 
+def _check(name: str, state: str, bucket: str) -> dict[str, object]:
+    return {"name": name, "state": state, "bucket": bucket}
+
+
 def _watch(
-    monkeypatch: pytest.MonkeyPatch, pr: int, views: list[dict[str, object]]
+    monkeypatch: pytest.MonkeyPatch,
+    pr: int,
+    views: list[dict[str, object]],
+    required: list[list[dict[str, object]]] | None = None,
+    *,
+    no_required: bool = False,
 ) -> tuple[dict[str, object], _ScriptedNu, list[str]]:
-    fake = _ScriptedNu(views)
+    fake = _ScriptedNu(views, required, no_required=no_required)
     monkeypatch.setitem(sys.modules, "nu", fake)
     notified: list[str] = []
 
@@ -107,3 +142,106 @@ def test_blocked_pr_still_arms_auto_merge(monkeypatch: pytest.MonkeyPatch) -> No
     assert len(fake.merges) == 1
     assert "--auto" in fake.merges[0]
     assert "auto_merge" not in result
+
+
+def test_optional_failure_waits_for_required_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An optional failure cannot terminate the watch while a required check
+    is still running (#3054)."""
+    initial = _view(9104, "OPEN", "BLOCKED")
+    failing = _view(9104, "OPEN", "BLOCKED")
+    failing["statusCheckRollup"] = [
+        {"name": "regression", "status": "COMPLETED", "conclusion": "FAILURE"},
+        {"name": "flake-check", "status": "IN_PROGRESS", "conclusion": None},
+    ]
+    terminal = _view(9104, "MERGED", "CLEAN")
+
+    result, fake, notified = _watch(
+        monkeypatch,
+        9104,
+        [initial, failing, terminal],
+        required=[[_check("flake-check", "IN_PROGRESS", "pending")]],
+    )
+
+    assert fake.view_calls == 3
+    assert result["state"] == "MERGED"
+    assert len(notified) == 1
+
+
+def test_required_failure_ignores_optional_pending_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An optional pending job cannot delay a terminal required failure."""
+    initial = _view(9105, "OPEN", "BLOCKED")
+    failing = _view(9105, "OPEN", "BLOCKED")
+    failing["statusCheckRollup"] = [
+        {"name": "flake-check", "status": "COMPLETED", "conclusion": "FAILURE"},
+        {"name": "regression", "status": "IN_PROGRESS", "conclusion": None},
+    ]
+
+    result, fake, notified = _watch(
+        monkeypatch,
+        9105,
+        [initial, failing],
+        required=[[_check("flake-check", "FAILURE", "fail")]],
+    )
+
+    assert fake.view_calls == 2
+    assert result["state"] == "failed"
+    assert [failure["name"] for failure in result["failures"]] == ["flake-check"]
+    assert len(notified) == 1
+
+
+def test_startup_failure_is_terminal() -> None:
+    """GitHub exposes STARTUP_FAILURE as a completed failure conclusion."""
+    check = _check("flake-check", "STARTUP_FAILURE", "pending")
+
+    assert runtime._pr_check_is_terminal(check)
+    assert runtime._pr_check_failed(check)
+
+
+def test_optional_failure_with_no_required_checks_keeps_watching(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gh reports an empty required set as stderr, not JSON (#3059)."""
+    initial = _view(9106, "OPEN", "BLOCKED")
+    failing = _view(9106, "OPEN", "BLOCKED")
+    failing["statusCheckRollup"] = [
+        {"name": "optional", "status": "COMPLETED", "conclusion": "FAILURE"}
+    ]
+    merged = _view(9106, "MERGED", "CLEAN")
+
+    result, fake, _notified = _watch(
+        monkeypatch,
+        9106,
+        [initial, failing, merged],
+        no_required=True,
+    )
+
+    assert fake.view_calls == 3
+    assert result["state"] == "MERGED"
+
+
+def test_failure_with_running_check_times_out_explicitly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The watch deadline remains active while failures wait for pending checks,
+    and its result preserves both sides of the incomplete aggregate."""
+    view = _view(9107, "OPEN", "BLOCKED")
+    view["statusCheckRollup"] = [
+        {"name": "regression", "status": "COMPLETED", "conclusion": "FAILURE"},
+        {"name": "flake-check", "status": "IN_PROGRESS", "conclusion": None},
+    ]
+    required = [
+        _check("regression", "FAILURE", "fail"),
+        _check("flake-check", "IN_PROGRESS", "pending"),
+    ]
+    fake = _ScriptedNu([view], [required])
+    monkeypatch.setitem(sys.modules, "nu", fake)
+
+    async def fake_notify(content: str, **meta: object) -> None:
+        return None
+
+    monkeypatch.setattr(runtime, "notify", fake_notify)
+    result = asyncio.run(
+        runtime.watch_pr(9107, auto_merge=False, interval=0.01, timeout=0.02)
+    )
+
+    assert result["state"] == "timed out"
+    assert [failure["name"] for failure in result["failures"]] == ["regression"]
+    assert [pending["name"] for pending in result["pending"]] == ["flake-check"]


### PR DESCRIPTION
## Problem

`pr_watch` closed on the first failed rollup entry even when a required sibling was still running. The result omitted that pending state and optional checks were indistinguishable from protected checks.

## Fix

- use `gh pr checks --required --json` as the terminal aggregate authority
- keep the full rollup for dashboard display
- wait while required failures and pending required checks coexist
- return required failures and pending checks when the watch times out
- keep optional failures from blocking a merge or optional pending jobs from delaying a required failure

## Validation

- `nix build .#mcp.tests.typecheckSmoke --no-link`: 145 tests passed
- `nix build .#mcp --no-link`
- `nix run .#lint`: 10 tasks passed
- adversarial correctness, security, performance, and maintainability review completed

Fixes #3054

(sent by an AI agent via Codex, GPT-5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wait for required checks before reporting terminal failure in `watch_pr`
> - `watch_pr` in [runtime.py](https://github.com/indexable-inc/index/pull/3061/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now defers a terminal failure until all required checks have reached a terminal state, avoiding false failures when only optional checks have failed.
> - Adds a `required_checks` inner function that runs `gh pr checks --required` and parses the result, treating gh's stderr-only empty-set messages as an empty required list rather than an error.
> - Introduces helper functions `_pr_check_state`, `_pr_check_is_terminal`, and `_pr_check_failed` to normalize and classify check states across `CheckRun` and legacy `StatusContext` types.
> - On timeout, the returned dict now includes counts and lists of `required_failures` and `required_pending`.
> - Behavioral Change: a PR with only optional failures no longer terminates as failed; it continues waiting until required checks complete or the timeout is reached.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 720ec35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->