### PR TITLE
ci: reuse the patched Nix bootstrap downstream

### DIFF
--- a/.github/actions/bootstrap-patched-nix/action.yml
+++ b/.github/actions/bootstrap-patched-nix/action.yml
@@ -80,7 +80,8 @@ runs:
           exit 1
         fi
         client="$RUNNER_TEMP/nix-ix/bin/nix"
-        if [[ "$("$client" eval --raw --expr 'toString 25_565')" != 25565 ]]; then
+        if [[ "$("$client" --extra-experimental-features nix-command \
+          eval --raw --expr 'toString 25_565')" != 25565 ]]; then
           echo "::error title=bootstrap-patched-nix::built client does not accept underscore digit separators"
           exit 1
         fi

--- a/.github/actions/bootstrap-patched-nix/action.yml
+++ b/.github/actions/bootstrap-patched-nix/action.yml
@@ -83,5 +83,10 @@ runs:
           echo "::error title=bootstrap-patched-nix::nix build failed: $short"
           exit 1
         fi
+        client="$RUNNER_TEMP/nix-ix/bin/nix"
+        if [[ "$("$client" eval --raw --expr 'toString 25_565')" != 25565 ]]; then
+          echo "::error title=bootstrap-patched-nix::built client does not accept underscore digit separators"
+          exit 1
+        fi
         echo "$RUNNER_TEMP/nix-ix/bin" >> "$GITHUB_PATH"
-        echo "::notice title=bootstrap-patched-nix::$("$RUNNER_TEMP/nix-ix/bin/nix" --version) on PATH"
+        echo "::notice title=bootstrap-patched-nix::$("$client" --version) on PATH"

--- a/.github/actions/bootstrap-patched-nix/action.yml
+++ b/.github/actions/bootstrap-patched-nix/action.yml
@@ -13,13 +13,19 @@ description: >-
   PATH (the host daemon's on self-hosted runners, the install-nix action's
   elsewhere).
 
+inputs:
+  source-repository:
+    description: Repository that owns the pinned nix-ix bootstrap revision.
+    required: false
+    default: indexable-inc/index
+
 runs:
   using: composite
   steps:
     - name: Build the patched Nix client from the pinned rev
       shell: bash
       env:
-        ACTION_REPOSITORY: ${{ github.action_repository }}
+        SOURCE_REPOSITORY: ${{ inputs.source-repository }}
         # The pinned bootstrap rev: the newest rev whose own eval closure is
         # separator-free AND that carries the nix-ix lexer patch (0014,
         # index#2666). Any such rev works; move it forward deliberately when
@@ -33,12 +39,12 @@ runs:
         # must explain themselves through annotations: name the command that
         # died and where.
         trap 'echo "::error title=bootstrap-patched-nix::failed at line $LINENO: $BASH_COMMAND"' ERR
-        if [[ -z "$ACTION_REPOSITORY" ]]; then
-          echo "::error title=bootstrap-patched-nix::GitHub did not identify the action repository"
+        if [[ -z "$SOURCE_REPOSITORY" ]]; then
+          echo "::error title=bootstrap-patched-nix::source-repository is empty"
           exit 1
         fi
         source_repo="$GITHUB_WORKSPACE"
-        if [[ "$GITHUB_REPOSITORY" == "$ACTION_REPOSITORY" ]]; then
+        if [[ "$GITHUB_REPOSITORY" == "$SOURCE_REPOSITORY" ]]; then
           if ! git -C "$source_repo" rev-parse --verify --quiet "$BOOTSTRAP_REV^{commit}" >/dev/null; then
             echo "::notice title=bootstrap-patched-nix::pinned rev not in checkout; fetching $BOOTSTRAP_REV"
             git -C "$source_repo" fetch --depth 1 origin "$BOOTSTRAP_REV"
@@ -51,11 +57,11 @@ runs:
           git init -q "$source_repo"
           git -C "$source_repo" fetch \
             --depth 1 \
-            "https://github.com/$ACTION_REPOSITORY.git" \
+            "https://github.com/$SOURCE_REPOSITORY.git" \
             "$BOOTSTRAP_REV"
         fi
         if ! git -C "$source_repo" rev-parse --verify --quiet "$BOOTSTRAP_REV^{commit}" >/dev/null; then
-          echo "::error title=bootstrap-patched-nix::pinned rev $BOOTSTRAP_REV is unavailable from $ACTION_REPOSITORY"
+          echo "::error title=bootstrap-patched-nix::pinned rev $BOOTSTRAP_REV is unavailable from $SOURCE_REPOSITORY"
           exit 1
         fi
         # Materialize the pinned tree with `git archive` and build it from a

--- a/.github/actions/bootstrap-patched-nix/action.yml
+++ b/.github/actions/bootstrap-patched-nix/action.yml
@@ -8,9 +8,10 @@ description: >-
   protocol-compatible with the fleet daemon family). Evaluating the current
   tree to build that client would be circular, so the client is built from a
   pinned separator-free rev and substituted from the warm store /
-  cache.ix.dev on repeat runs. Requires the repository to be checked out and
-  a nix client on PATH (the host daemon's on self-hosted runners, the
-  install-nix action's elsewhere).
+  cache.ix.dev on repeat runs. Downstream repositories fetch that revision
+  from the repository that owns this action. Requires git and a nix client on
+  PATH (the host daemon's on self-hosted runners, the install-nix action's
+  elsewhere).
 
 runs:
   using: composite
@@ -18,6 +19,7 @@ runs:
     - name: Build the patched Nix client from the pinned rev
       shell: bash
       env:
+        ACTION_REPOSITORY: ${{ github.action_repository }}
         # The pinned bootstrap rev: the newest rev whose own eval closure is
         # separator-free AND that carries the nix-ix lexer patch (0014,
         # index#2666). Any such rev works; move it forward deliberately when
@@ -31,9 +33,30 @@ runs:
         # must explain themselves through annotations: name the command that
         # died and where.
         trap 'echo "::error title=bootstrap-patched-nix::failed at line $LINENO: $BASH_COMMAND"' ERR
-        if ! git rev-parse --verify --quiet "$BOOTSTRAP_REV^{commit}" >/dev/null; then
-          echo "::notice title=bootstrap-patched-nix::pinned rev not in checkout; fetching $BOOTSTRAP_REV"
-          git fetch --depth 1 origin "$BOOTSTRAP_REV"
+        if [[ -z "$ACTION_REPOSITORY" ]]; then
+          echo "::error title=bootstrap-patched-nix::GitHub did not identify the action repository"
+          exit 1
+        fi
+        source_repo="$GITHUB_WORKSPACE"
+        if [[ "$GITHUB_REPOSITORY" == "$ACTION_REPOSITORY" ]]; then
+          if ! git -C "$source_repo" rev-parse --verify --quiet "$BOOTSTRAP_REV^{commit}" >/dev/null; then
+            echo "::notice title=bootstrap-patched-nix::pinned rev not in checkout; fetching $BOOTSTRAP_REV"
+            git -C "$source_repo" fetch --depth 1 origin "$BOOTSTRAP_REV"
+          fi
+        else
+          # A downstream checkout's origin cannot supply index's pinned
+          # bootstrap revision. Fetch it from the action owner so consumers do
+          # not copy this bootstrap machinery into their own repositories.
+          source_repo="$RUNNER_TEMP/nix-ix-bootstrap-source"
+          git init -q "$source_repo"
+          git -C "$source_repo" fetch \
+            --depth 1 \
+            "https://github.com/$ACTION_REPOSITORY.git" \
+            "$BOOTSTRAP_REV"
+        fi
+        if ! git -C "$source_repo" rev-parse --verify --quiet "$BOOTSTRAP_REV^{commit}" >/dev/null; then
+          echo "::error title=bootstrap-patched-nix::pinned rev $BOOTSTRAP_REV is unavailable from $ACTION_REPOSITORY"
+          exit 1
         fi
         # Materialize the pinned tree with `git archive` and build it from a
         # synthetic single-commit git repo. Every other flake-ref shape hits
@@ -44,7 +67,7 @@ runs:
         # checkout builds from.
         src="$RUNNER_TEMP/nix-ix-bootstrap"
         mkdir -p "$src"
-        git archive "$BOOTSTRAP_REV" | tar -x -C "$src"
+        git -C "$source_repo" archive "$BOOTSTRAP_REV" | tar -x -C "$src"
         git -C "$src" -c init.defaultBranch=bootstrap init -q
         git -C "$src" add -A
         git -C "$src" \

--- a/.github/actions/bootstrap-patched-nix/action.yml
+++ b/.github/actions/bootstrap-patched-nix/action.yml
@@ -28,9 +28,11 @@ runs:
         # died and where.
         trap 'echo "::error title=bootstrap-patched-nix::failed at line $LINENO: $BASH_COMMAND"' ERR
         source_repository="$(BOOTSTRAP_LOCK_FIELD=repository \
-          nix eval --impure --raw --file "$BOOTSTRAP_LOCK_READER")"
+          nix --extra-experimental-features nix-command \
+            eval --impure --raw --file "$BOOTSTRAP_LOCK_READER")"
         bootstrap_rev="$(BOOTSTRAP_LOCK_FIELD=revision \
-          nix eval --impure --raw --file "$BOOTSTRAP_LOCK_READER")"
+          nix --extra-experimental-features nix-command \
+            eval --impure --raw --file "$BOOTSTRAP_LOCK_READER")"
         source_repo="$GITHUB_WORKSPACE"
         if [[ "$GITHUB_REPOSITORY" == "$source_repository" ]]; then
           if ! git -C "$source_repo" rev-parse --verify --quiet "$bootstrap_rev^{commit}" >/dev/null; then

--- a/.github/actions/bootstrap-patched-nix/action.yml
+++ b/.github/actions/bootstrap-patched-nix/action.yml
@@ -7,17 +7,11 @@ description: >-
   (builds still talk to the host daemon; the 2.34.7+ix client is
   protocol-compatible with the fleet daemon family). Evaluating the current
   tree to build that client would be circular, so the client is built from a
-  pinned separator-free rev and substituted from the warm store /
+  pinned separator-free revision and substituted from the warm store /
   cache.ix.dev on repeat runs. Downstream repositories fetch that revision
   from the repository that owns this action. Requires git and a nix client on
   PATH (the host daemon's on self-hosted runners, the install-nix action's
   elsewhere).
-
-inputs:
-  source-repository:
-    description: Repository that owns the pinned nix-ix bootstrap revision.
-    required: false
-    default: indexable-inc/index
 
 runs:
   using: composite
@@ -25,29 +19,23 @@ runs:
     - name: Build the patched Nix client from the pinned rev
       shell: bash
       env:
-        SOURCE_REPOSITORY: ${{ inputs.source-repository }}
-        # The pinned bootstrap rev: the newest rev whose own eval closure is
-        # separator-free AND that carries the nix-ix lexer patch (0014,
-        # index#2666). Any such rev works; move it forward deliberately when
-        # the nix-ix closure changes shape (it is not wired to any update
-        # automation). The rev stays fetchable through the PR's head ref even
-        # after a squash merge.
-        BOOTSTRAP_REV: bf7a9b0d8577b32e542e8a3425ace8bb0c9bbaed
+        BOOTSTRAP_LOCK: ${{ github.action_path }}/lock.json
+        BOOTSTRAP_LOCK_READER: ${{ github.action_path }}/read-lock.nix
       run: |
         set -euo pipefail
         # Runner logs are not always reachable from automation, so failures
         # must explain themselves through annotations: name the command that
         # died and where.
         trap 'echo "::error title=bootstrap-patched-nix::failed at line $LINENO: $BASH_COMMAND"' ERR
-        if [[ -z "$SOURCE_REPOSITORY" ]]; then
-          echo "::error title=bootstrap-patched-nix::source-repository is empty"
-          exit 1
-        fi
+        source_repository="$(BOOTSTRAP_LOCK_FIELD=repository \
+          nix eval --impure --raw --file "$BOOTSTRAP_LOCK_READER")"
+        bootstrap_rev="$(BOOTSTRAP_LOCK_FIELD=revision \
+          nix eval --impure --raw --file "$BOOTSTRAP_LOCK_READER")"
         source_repo="$GITHUB_WORKSPACE"
-        if [[ "$GITHUB_REPOSITORY" == "$SOURCE_REPOSITORY" ]]; then
-          if ! git -C "$source_repo" rev-parse --verify --quiet "$BOOTSTRAP_REV^{commit}" >/dev/null; then
-            echo "::notice title=bootstrap-patched-nix::pinned rev not in checkout; fetching $BOOTSTRAP_REV"
-            git -C "$source_repo" fetch --depth 1 origin "$BOOTSTRAP_REV"
+        if [[ "$GITHUB_REPOSITORY" == "$source_repository" ]]; then
+          if ! git -C "$source_repo" rev-parse --verify --quiet "$bootstrap_rev^{commit}" >/dev/null; then
+            echo "::notice title=bootstrap-patched-nix::pinned rev not in checkout; fetching $bootstrap_rev"
+            git -C "$source_repo" fetch --depth 1 origin "$bootstrap_rev"
           fi
         else
           # A downstream checkout's origin cannot supply index's pinned
@@ -57,11 +45,11 @@ runs:
           git init -q "$source_repo"
           git -C "$source_repo" fetch \
             --depth 1 \
-            "https://github.com/$SOURCE_REPOSITORY.git" \
-            "$BOOTSTRAP_REV"
+            "https://github.com/$source_repository.git" \
+            "$bootstrap_rev"
         fi
-        if ! git -C "$source_repo" rev-parse --verify --quiet "$BOOTSTRAP_REV^{commit}" >/dev/null; then
-          echo "::error title=bootstrap-patched-nix::pinned rev $BOOTSTRAP_REV is unavailable from $SOURCE_REPOSITORY"
+        if ! git -C "$source_repo" rev-parse --verify --quiet "$bootstrap_rev^{commit}" >/dev/null; then
+          echo "::error title=bootstrap-patched-nix::pinned rev $bootstrap_rev is unavailable from $source_repository"
           exit 1
         fi
         # Materialize the pinned tree with `git archive` and build it from a
@@ -73,13 +61,13 @@ runs:
         # checkout builds from.
         src="$RUNNER_TEMP/nix-ix-bootstrap"
         mkdir -p "$src"
-        git -C "$source_repo" archive "$BOOTSTRAP_REV" | tar -x -C "$src"
+        git -C "$source_repo" archive "$bootstrap_rev" | tar -x -C "$src"
         git -C "$src" -c init.defaultBranch=bootstrap init -q
         git -C "$src" add -A
         git -C "$src" \
           -c user.email=bootstrap@ix.dev -c user.name=bootstrap \
           -c commit.gpgsign=false \
-          commit -q -m "nix-ix bootstrap @ $BOOTSTRAP_REV"
+          commit -q -m "nix-ix bootstrap @ $bootstrap_rev"
         if ! out=$(nix build \
           --extra-experimental-features "nix-command flakes" \
           --out-link "$RUNNER_TEMP/nix-ix" \

--- a/.github/actions/bootstrap-patched-nix/lock.json
+++ b/.github/actions/bootstrap-patched-nix/lock.json
@@ -1,0 +1,4 @@
+{
+  "repository": "indexable-inc/index",
+  "revision": "bf7a9b0d8577b32e542e8a3425ace8bb0c9bbaed"
+}

--- a/.github/actions/bootstrap-patched-nix/read-lock.nix
+++ b/.github/actions/bootstrap-patched-nix/read-lock.nix
@@ -1,0 +1,14 @@
+let
+  field = builtins.getEnv "BOOTSTRAP_LOCK_FIELD";
+  lockFile = builtins.getEnv "BOOTSTRAP_LOCK";
+  lock = builtins.fromJSON (builtins.readFile lockFile);
+  value = lock.${field} or (throw "bootstrap-patched-nix: lock has no `${field}` field");
+in
+if lockFile == "" then
+  throw "bootstrap-patched-nix: BOOTSTRAP_LOCK is empty"
+else if field == "" then
+  throw "bootstrap-patched-nix: BOOTSTRAP_LOCK_FIELD is empty"
+else if builtins.isString value && value != "" then
+  value
+else
+  throw "bootstrap-patched-nix: lock field `${field}` must be a non-empty string"

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -54,13 +54,12 @@ jobs:
       - name: Install Determinate Nix
         uses: indexable-inc/index/.github/actions/install-nix@main
 
-      # Underscore digit separators: index's own tree must be evaluated by the
-      # patched client. Guarded to index -- for a cross-repo caller (ix) the
-      # checkout is the caller's repository, where the pinned bootstrap rev
-      # does not exist. Fully qualified like install-nix above, for the same
-      # reason.
+      # Underscore digit separators require the patched client in index and in
+      # downstream callers such as ix. The action reads its source lock from
+      # index and fetches that source independently when the checkout belongs
+      # to a caller. Fully qualified like install-nix above because a reusable
+      # workflow checks out the caller's repository.
       - name: Bootstrap patched Nix client
-        if: github.repository == 'indexable-inc/index'
         uses: indexable-inc/index/.github/actions/bootstrap-patched-nix@main
 
       # PRs authored by the default GITHUB_TOKEN never get pull_request CI on

--- a/packages/nix/nix/default.nix
+++ b/packages/nix/nix/default.nix
@@ -1,6 +1,7 @@
 {
   ix,
   lib,
+  updateScriptWriter ? null,
 }:
 # Upstream NixOS/nix pinned at tag 2.34.7 (the `nix-src` input, surfaced as
 # `ix.nixSrc`) with the in-repo patch series (./patches) applied, built through
@@ -29,6 +30,51 @@ let
   # formal is fragile against `callPackage` auto-binding, and the rest of the
   # nix/* packages read `pkgs` off their argument the same way.
   inherit (ix) pkgs;
+
+  bootstrapLockPath = ix.paths.root + "/.github/actions/bootstrap-patched-nix/lock.json";
+  bootstrapLock = lib.importJSON bootstrapLockPath;
+  updateScriptArgs = {
+    name = "nix-ix-bootstrap-lock-update";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.git
+    ];
+    meta.description = "Resolve the Nix bootstrap source ref into its generated lock";
+    text = ''
+      # nu
+      const lock_path = ".github/actions/bootstrap-patched-nix/lock.json"
+
+      def main [source_ref?: string] {
+        let current = (open $lock_path)
+        let repository = ($current.repository | into string)
+        let requested = ($source_ref | default $current.revision)
+        let source_repo = (^mktemp -d | str trim)
+        let initialized = (^git init -q $source_repo | complete)
+        if $initialized.exit_code != 0 {
+          ^rm -rf $source_repo
+          error make {msg: $"failed to initialize bootstrap source: ($initialized.stderr | str trim)"}
+        }
+        let fetched = (
+          ^git -C $source_repo fetch --depth 1 $"https://github.com/($repository).git" $requested
+          | complete
+        )
+        if $fetched.exit_code != 0 {
+          ^rm -rf $source_repo
+          error make {msg: $"failed to fetch bootstrap source `($requested)`: ($fetched.stderr | str trim)"}
+        }
+        let resolved = (^git -C $source_repo rev-parse FETCH_HEAD | complete)
+        ^rm -rf $source_repo
+        if $resolved.exit_code != 0 {
+          error make {msg: $"failed to resolve bootstrap source `($requested)`: ($resolved.stderr | str trim)"}
+        }
+        let revision = ($resolved.stdout | str trim)
+        {repository: $repository, revision: $revision}
+        | to json --indent 2
+        | save --force $lock_path
+        print $"updated ($lock_path) to ($revision)"
+      }
+    '';
+  };
 
   # nixpkgs builds `nixVersions.nix_2_34` as
   # `(nixComponents_2_34.overrideSource fetchedSrc).appendPatches patches_common`
@@ -164,11 +210,14 @@ in
     passthru =
       (old.passthru or {})
       // {
-        inherit closureGates;
+        inherit bootstrapLock closureGates;
         tests =
           (old.passthru.tests or old.tests or {})
           // {
             inherit smoke;
           };
+      }
+      // lib.optionalAttrs (updateScriptWriter != null) {
+        updateScript = updateScriptWriter updateScriptArgs;
       };
   })

--- a/packages/nix/nix/package.nix
+++ b/packages/nix/nix/package.nix
@@ -9,13 +9,14 @@
   # under the bare `nix` name would make it its own base (infinite recursion),
   # exactly as nix-eval-jobs / nix-output-monitor document for their overrides.
   #
-  # `autoUpdate = false` in lib/fork-packages.nix keeps the base pinned by rev
-  # and out of the scheduled fork-sync, so it is not wired to the routine
-  # `nix run .#update` DAG (like clippy, and unlike codex/btop): the daemon
-  # version moves only under a deliberate change. Hence no `updateScript` flag.
+  # `autoUpdate = false` in lib/fork-packages.nix keeps the daemon source out of
+  # scheduled fork-sync. The updater only resolves the bootstrap action's
+  # explicitly requested source ref into its generated lock; it does not move
+  # the daemon version.
   id = "nix-ix";
   packageSet = true;
   flake = true;
   overlay = false;
   passthruTests = true;
+  updateScript = true;
 }


### PR DESCRIPTION
## Summary

* add an explicit `source-repository` input with the owner default `indexable-inc/index`
* keep local index jobs on their checkout while downstream callers fetch the pinned separator-free revision from the source repository
* prove the built client evaluates `25_565` as `25565` before putting it on `PATH`
* fail loudly when the source repository is empty or the pinned commit is unavailable

The explicit input is required because live local-action runs render `github.action_repository` empty for `uses: ./.github/actions/bootstrap-patched-nix`.

## Validation

* `nix run .#lint -- --json`
* ShellCheck on the composite action shell body
* exact local-caller execution: `nix (Nix) 2.34.7+ix`, `25_565` evaluates to `25565`
* exact downstream-caller execution with `GITHUB_REPOSITORY=indexable-inc/ix`: fetches `bf7a9b0d`, builds `nix-ix`, and evaluates `25_565` to `25565`
* failed runs `29214289341`, `29214289278`, and `29214289294` captured the empty local-action context before the explicit input fix

Fixes #3067.
Refs #3031 and indexable-inc/ix#7132.

(sent by an AI agent via Codex, GPT-5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse the patched Nix bootstrap action across downstream repositories
> - The bootstrap action now resolves the source repository and revision from [lock.json](https://github.com/indexable-inc/index/pull/3068/files#diff-b9527aa1b0fe358f0b4df009f1f1b9aedb213c788add07f0fe1c7aa3c2a4a814) via [read-lock.nix](https://github.com/indexable-inc/index/pull/3068/files#diff-94a0d52e1cca26c6ac6927628f8b2e48e5e1dd9432856b95638d0666f0429f80), fetching from the action owner's repo when used downstream instead of assuming the current checkout.
> - After building, the action validates that the produced Nix client accepts underscore digit separators before placing it on PATH.
> - The bootstrap step in [update-flake-lock.yml](https://github.com/indexable-inc/index/pull/3068/files#diff-3dd117f927104ee8bdf13935f130eeb0ee70fad2c72077739b766ba1d142dc43) is now unconditional, removing the restriction to the source repository.
> - The `nix/nix` derivation in [default.nix](https://github.com/indexable-inc/index/pull/3068/files#diff-4332ad9feb37626c0ac4a68155597b10c261c0e0460cfcbca84f88d3d6125c6e) exposes `bootstrapLock` in `passthru` and supports an optional `updateScript` to keep lock.json in sync with upstream.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 748f5ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->