### PR TITLE
cargo-unit: stabilize generated source paths

### DIFF
--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -4284,31 +4284,31 @@ version = "0.1.0"
         assert_eq!(rendered.matches("\"beta\" = mkDoctestEntry").count(), 2);
     }
 
-    #[test]
-    fn doctest_commands_match_cargo_rustdoc_contract() {
-        let workspace = tempfile::tempdir().unwrap();
-        fs::create_dir_all(workspace.path().join("src")).unwrap();
+    fn write_doctest_contract_sources(workspace: &Path) -> [String; 4] {
+        fs::create_dir_all(workspace.join("src")).unwrap();
         fs::write(
-            workspace.path().join("Cargo.toml"),
+            workspace.join("Cargo.toml"),
             r#"[package]
 name = "native"
 version = "0.1.0"
 "#,
         )
         .unwrap();
-        let build_rs = workspace.path().join("build.rs");
-        let leaf_rs = workspace.path().join("src/leaf.rs");
-        let lib_rs = workspace.path().join("src/lib.rs");
-        let middle_rs = workspace.path().join("src/middle.rs");
+        let build_rs = workspace.join("build.rs");
+        let leaf_rs = workspace.join("src/leaf.rs");
+        let lib_rs = workspace.join("src/lib.rs");
+        let middle_rs = workspace.join("src/middle.rs");
         fs::write(&build_rs, "fn main() {}\n").unwrap();
         fs::write(&leaf_rs, "pub fn leaf() {}\n").unwrap();
         fs::write(&lib_rs, "pub fn native() {}\n").unwrap();
         fs::write(&middle_rs, "pub fn middle() {}\n").unwrap();
-        let build_rs = build_rs.to_string_lossy();
-        let leaf_rs = leaf_rs.to_string_lossy();
-        let lib_rs = lib_rs.to_string_lossy();
-        let middle_rs = middle_rs.to_string_lossy();
-        let pkg_id = format!("path+file://{}#native@0.1.0", workspace.path().display());
+
+        [build_rs, leaf_rs, lib_rs, middle_rs].map(|path| path.to_string_lossy().into_owned())
+    }
+
+    fn doctest_contract_graph(workspace: &Path) -> UnitGraph {
+        let [build_rs, leaf_rs, lib_rs, middle_rs] = write_doctest_contract_sources(workspace);
+        let pkg_id = format!("path+file://{}#native@0.1.0", workspace.display());
 
         let graph: UnitGraph = serde_json::from_value(serde_json::json!({
           "version": 1,
@@ -4396,6 +4396,14 @@ version = "0.1.0"
           "roots": [4]
         }))
         .unwrap();
+
+        graph
+    }
+
+    #[test]
+    fn doctest_commands_match_cargo_rustdoc_contract() {
+        let workspace = tempfile::tempdir().unwrap();
+        let graph = doctest_contract_graph(workspace.path());
 
         let rendered = render_units_nix(
             &graph,

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -1433,9 +1433,11 @@ fn append_build_script_flag_reader(script: &mut String, run_ref: &str, unit: &Un
         script,
         "if [ -f {quoted_run_ref}/cargo-metadata ]; then\n  cp {quoted_run_ref}/cargo-metadata build/cargo-metadata\nfi",
     );
+    // Generated source paths enter crate metadata, so mktemp entropy makes
+    // separately realized content-addressed dependencies byte-incompatible.
     let _ = writeln!(
         script,
-        "compile_out_dir=$(mktemp -d)\nif [ -d {quoted_run_ref}/out-dir ]; then\n  cp -R {quoted_run_ref}/out-dir/. \"$compile_out_dir\"/\nfi\nrustc_env+=( OUT_DIR=\"$compile_out_dir\" )\n"
+        "compile_out_dir=$NIX_BUILD_TOP/cargo-unit-build-script-out\nmkdir -p \"$compile_out_dir\"\nif [ -d {quoted_run_ref}/out-dir ]; then\n  cp -R {quoted_run_ref}/out-dir/. \"$compile_out_dir\"/\nfi\nrustc_args+=( --remap-path-prefix \"$compile_out_dir=/cargo-unit-build-script-out\" )\nrustc_env+=( OUT_DIR=\"$compile_out_dir\" )\n"
     );
 }
 
@@ -4295,11 +4297,17 @@ version = "0.1.0"
         )
         .unwrap();
         let build_rs = workspace.path().join("build.rs");
+        let leaf_rs = workspace.path().join("src/leaf.rs");
         let lib_rs = workspace.path().join("src/lib.rs");
+        let middle_rs = workspace.path().join("src/middle.rs");
         fs::write(&build_rs, "fn main() {}\n").unwrap();
+        fs::write(&leaf_rs, "pub fn leaf() {}\n").unwrap();
         fs::write(&lib_rs, "pub fn native() {}\n").unwrap();
+        fs::write(&middle_rs, "pub fn middle() {}\n").unwrap();
         let build_rs = build_rs.to_string_lossy();
+        let leaf_rs = leaf_rs.to_string_lossy();
         let lib_rs = lib_rs.to_string_lossy();
+        let middle_rs = middle_rs.to_string_lossy();
         let pkg_id = format!("path+file://{}#native@0.1.0", workspace.path().display());
 
         let graph: UnitGraph = serde_json::from_value(serde_json::json!({
@@ -4340,6 +4348,36 @@ version = "0.1.0"
               "target": {
                 "kind": ["lib"],
                 "crate_types": ["lib"],
+                "name": "leaf",
+                "src_path": leaf_rs,
+                "edition": "2024"
+              },
+              "profile": { "name": "release", "opt_level": "3" },
+              "features": [],
+              "mode": "build",
+              "dependencies": []
+            },
+            {
+              "pkg_id": pkg_id,
+              "target": {
+                "kind": ["lib"],
+                "crate_types": ["lib"],
+                "name": "middle",
+                "src_path": middle_rs,
+                "edition": "2024"
+              },
+              "profile": { "name": "release", "opt_level": "3" },
+              "features": [],
+              "mode": "build",
+              "dependencies": [
+                { "index": 2, "extern_crate_name": "leaf" }
+              ]
+            },
+            {
+              "pkg_id": pkg_id,
+              "target": {
+                "kind": ["lib"],
+                "crate_types": ["lib"],
                 "name": "native",
                 "src_path": lib_rs,
                 "edition": "2024"
@@ -4350,11 +4388,12 @@ version = "0.1.0"
               "features": [],
               "mode": "build",
               "dependencies": [
-                { "index": 1, "extern_crate_name": "build_script_build" }
+                { "index": 1, "extern_crate_name": "build_script_build" },
+                { "index": 3, "extern_crate_name": "middle" }
               ]
             }
           ],
-          "roots": [2]
+          "roots": [4]
         }))
         .unwrap();
 
@@ -4421,7 +4460,18 @@ version = "0.1.0"
         assert!(!rendered.contains("rustdoc_args+=( \"''${build_script_flags[@]}\" )"));
         assert!(rendered.contains("done < \"${units."));
         assert!(rendered.contains("/rustc-env"));
-        assert!(rendered.contains("compile_out_dir=$(mktemp -d)"));
+        assert!(
+            rendered.contains("compile_out_dir=$NIX_BUILD_TOP/cargo-unit-build-script-out")
+        );
+        assert!(rendered.contains(
+            "rustc_args+=( --remap-path-prefix \"$compile_out_dir=/cargo-unit-build-script-out\" )"
+        ));
+        assert!(rendered.contains(
+            "rustdoc_args+=( -L \"dependency=${units.\"middle-0.1.0-"
+        ));
+        assert!(rendered.contains(
+            "rustdoc_args+=( -L \"dependency=${units.\"leaf-0.1.0-"
+        ));
         assert!(rendered.contains("/out-dir/. \"$compile_out_dir\"/"));
         assert!(rendered.contains("rustc_env+=( OUT_DIR=\"$compile_out_dir\" )"));
         assert!(!rendered.contains("--test-args --exact"));


### PR DESCRIPTION
## Summary

* Keep compile-time build-script output at a stable build-top path.
* Remap generated source paths before rustc records crate metadata.
* Cover direct and transitive doctest dependency search paths in the renderer regression.

## Root cause

`mktemp -d` put a random `OUT_DIR` path into generated Rust source metadata. Independent content-addressed realizations could therefore publish incompatible crate metadata under the same logical unit hash. A doctest manifest could mix those realizations and fail with E0463 despite having the expected externs and dependency search paths.

## Validation

* All 52 `nix-cargo-unit` tests pass.
* `nix run .#lint -- --json` reports every check green.
* Independent hc1 and hc2 builds converge on identical tantivy, code_tokenizer, and file_search store paths plus rlib/rmeta hashes.
* The exact shared `ast_merge_matcher` doctest manifest evaluation completes with exit 0 and no E0463.

Fixes #3070

(sent by an AI agent via Codex, GPT-5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize generated build script source paths using deterministic OUT_DIR
> - Replaces `mktemp`-based `OUT_DIR` with a deterministic path under `$NIX_BUILD_TOP/cargo-unit-build-script-out` in [`render.rs`](https://github.com/indexable-inc/index/pull/3076/files#diff-91be6a053ea25b59c072a514f469215dbbfeb6abbba3ddb8d77ad99ffa244e7f)
> - Adds `--remap-path-prefix "$compile_out_dir=/cargo-unit-build-script-out"` to `rustc_args` so compiled artifacts have stable embedded paths
> - Updates the doctest contract test to assert deterministic `OUT_DIR` handling, path remapping, and `-L dependency` flags for transitive library dependencies
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 961ea00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->