### PR TITLE
mcp: render nested command results safely

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2670,6 +2670,8 @@
       cp ${./tests/test_pr_watch_automerge.py} test_pr_watch_automerge.py
       # Issue #2540: input= routes past no-input statements (cd /tmp; ^cat) or raises.
       cp ${./tests/test_nu_input_routing.py} test_nu_input_routing.py
+      # Issue #3079: nested NuResult frames render as named structured data and finish the job.
+      cp ${./tests/test_nested_nu_results.py} test_nested_nu_results.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
@@ -2689,6 +2691,7 @@
         test_unexecuted_note.py \
         test_pr_watch_automerge.py \
         test_nu_input_routing.py \
+        test_nested_nu_results.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -66,6 +66,11 @@ _ix_current: contextvars.ContextVar = contextvars.ContextVar("ix_current_job", d
 # memory, store writes, and poll payloads all stay bounded.
 _MAX_OUTPUT_CHARS = 256_000
 
+# Model-facing result text carried inline by one call. Full results stay on the
+# Job for paging; nested leaf renders use the same ceiling before composition so
+# a container cannot multiply unbounded child strings in memory.
+_SUMMARY_CHARS = 50_000
+
 # n-pty chunk-stream flush policy: bulk job output rides CAS as ~1 chunk fact
 # per flush instead of per-character facts. Flush when either
 # _STREAM_FLUSH_BYTES accumulate (size cap, checked at feed time) or
@@ -698,6 +703,21 @@ def _nuon_key(value: Any) -> str:
     return text if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", text) else json.dumps(text, ensure_ascii=False)
 
 
+def _named_tuple_items(value: Any) -> list[tuple[str, Any]] | None:
+    """Return a named tuple's field/value pairs, or None for a plain tuple."""
+    if not isinstance(value, tuple):
+        return None
+    fields = getattr(type(value), "_fields", None)
+    if not isinstance(fields, tuple) or not all(isinstance(field, str) for field in fields):
+        return None
+    return [(field, getattr(value, field)) for field in fields]
+
+
+_NUON_MAX_DEPTH = 8
+_NESTED_RENDER_MAX_DEPTH = 8
+_NESTED_RENDER_MAX_ITEMS = 200
+
+
 def _nuon_table(columns: list[Any], rows: list[Mapping[Any, Any]], *, _depth: int = 0) -> str:
     header = ", ".join(_nuon_key(c) for c in columns)
     if not rows:
@@ -711,7 +731,7 @@ def _nuon_table(columns: list[Any], rows: list[Mapping[Any, Any]], *, _depth: in
 
 def _nuon(value: Any, *, _depth: int = 0) -> str:
     """A compact Nushell NUON subset for model-facing structured output."""
-    if _depth > 8:
+    if _depth > _NUON_MAX_DEPTH:
         return json.dumps(_safe_repr(value), ensure_ascii=False)
     if value is None:
         return "null"
@@ -1007,13 +1027,11 @@ class Result:
                 user_html=f'<pre class="ix-result">{_ansi_to_html(value)}</pre>',
                 llm_result=text_view,
             )
-        if _is_multi_rich(value):
-            # A tuple/list that carries a rich element (a DataFrame, a figure, a
-            # nested Result) is several things to SHOW, not one table: render each
-            # element with its own view, stacked, rather than stringifying the rich
-            # one into a `value` cell. `Result((repr_text, df))` thus shows the text
-            # and the real table, not a 2-row frame of two reprs.
-            return _result_from_values(list(value), llm_result=llm_result)
+        if _requires_nested_render(value):
+            # Generic Polars sequence coercion cannot represent rich values
+            # nested in named tuples or ordinary containers. Preserve each leaf's
+            # own bounded render and each container's structure instead.
+            return _result_from_nested(value, llm_result=llm_result)
         frame = _frame_view(value)
         if frame is not None:
             # A rich result type (anything with ``_ix_to_frame_``) that exposes a
@@ -1165,20 +1183,175 @@ def _as_frame_if_tabular(value: Any) -> Any:
     return value
 
 
-def _is_rich_element(value: Any) -> bool:
-    """True if ``value`` carries its own rich view (a DataFrame, a figure/image,
-    an htpy element, or a Result), so flattening it into a one-column frame would
-    throw that view away. Plain scalars and containers are not rich."""
-    return isinstance(value, Result) or _is_polars_df(value) or _is_displayable(value)
+def _contains_nested_view(
+    value: Any, *, _depth: int = 0, _seen: set[int] | None = None
+) -> bool:
+    """Whether a value must stay out of generic Polars container coercion.
+
+    Named tuples retain their fields. Rich leaves retain their own render. A
+    cycle or depth cutoff returns true conservatively because handing an
+    uninspected container to Polars can panic below Python's Exception boundary.
+    """
+    if _named_tuple_items(value) is not None:
+        return True
+    if isinstance(value, Result) or _is_polars_df(value) or _is_displayable(value):
+        return True
+    if not isinstance(value, (Mapping, list, tuple)):
+        return False
+    if _depth >= _NESTED_RENDER_MAX_DEPTH:
+        return True
+    seen = _seen if _seen is not None else set()
+    identity = id(value)
+    if identity in seen:
+        return True
+    seen.add(identity)
+    try:
+        children = value.values() if isinstance(value, Mapping) else value
+        return any(
+            _contains_nested_view(child, _depth=_depth + 1, _seen=seen)
+            for child in children
+        )
+    finally:
+        seen.remove(identity)
 
 
-def _is_multi_rich(value: Any) -> bool:
-    """True for a non-empty list/tuple that carries at least one rich element, so
-    ``Result.of`` should stack each element's view instead of coercing the whole
-    sequence to a single table. A list/tuple of plain scalars (or of mappings)
-    stays tabular -- only a sequence mixing in a DataFrame/figure/Result needs the
-    stacked treatment."""
-    return isinstance(value, (list, tuple)) and bool(value) and any(_is_rich_element(v) for v in value)
+def _requires_nested_render(value: Any) -> bool:
+    """Whether this container needs the bounded recursive renderer."""
+    return _named_tuple_items(value) is not None or (
+        isinstance(value, (Mapping, list, tuple)) and _contains_nested_view(value)
+    )
+
+
+@dataclasses.dataclass
+class _NestedRender:
+    user_html: str
+    model_value: Any
+    llm_images: list
+
+
+def _nested_marker(message: str) -> _NestedRender:
+    return _NestedRender(
+        user_html=f'<pre class="ix-result">{_escape_html(message)}</pre>',
+        model_value=message,
+        llm_images=[],
+    )
+
+
+def _nested_leaf_value(value: Any, rendered: Result) -> Any:
+    """Structured scalar value, or the leaf's already-bounded model render."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, bytes) and _image_bytes_mime(value) is None:
+        return value
+    iso = getattr(value, "isoformat", None)
+    if callable(iso):
+        with contextlib.suppress(Exception):
+            return iso()
+    text = rendered.llm_result
+    if len(text) <= _SUMMARY_CHARS:
+        return text
+    return (
+        text[:_SUMMARY_CHARS]
+        + f"\n... [nested value clipped to {_SUMMARY_CHARS} of {len(text)} chars]"
+    )
+
+
+def _render_nested(
+    value: Any, *, _depth: int = 0, _seen: set[int] | None = None
+) -> _NestedRender:
+    fields = _named_tuple_items(value)
+    is_mapping = isinstance(value, Mapping)
+    is_sequence = isinstance(value, (list, tuple))
+    if fields is None and not is_mapping and not is_sequence:
+        rendered = Result.of(value)
+        return _NestedRender(
+            user_html=rendered.user_html,
+            model_value=_nested_leaf_value(value, rendered),
+            llm_images=list(rendered.llm_images),
+        )
+    if _depth >= _NESTED_RENDER_MAX_DEPTH:
+        return _nested_marker(
+            f"<{type(value).__name__} omitted at nested render depth "
+            f"{_NESTED_RENDER_MAX_DEPTH}>"
+        )
+    seen = _seen if _seen is not None else set()
+    identity = id(value)
+    if identity in seen:
+        return _nested_marker(f"<cycle to {type(value).__name__}>")
+    seen.add(identity)
+    try:
+        if fields is not None:
+            rendered_fields = [
+                (name, _render_nested(field, _depth=_depth + 1, _seen=seen))
+                for name, field in fields
+            ]
+            user_html = '<dl class="ix-result-record">' + "".join(
+                f'<dt data-ix-field="{html_lib.escape(name, quote=True)}">'
+                f"{_escape_html(name)}</dt><dd>{field.user_html}</dd>"
+                for name, field in rendered_fields
+            ) + "</dl>"
+            return _NestedRender(
+                user_html=user_html,
+                model_value={name: field.model_value for name, field in rendered_fields},
+                llm_images=[
+                    image
+                    for _, field in rendered_fields
+                    for image in field.llm_images
+                ],
+            )
+        if is_mapping:
+            total = len(value)
+            rendered_entries: list[tuple[Any, _NestedRender]] = []
+            for index, (key, child) in enumerate(value.items()):
+                if index >= _NESTED_RENDER_MAX_ITEMS:
+                    break
+                rendered_entries.append(
+                    (key, _render_nested(child, _depth=_depth + 1, _seen=seen))
+                )
+            omitted = total - len(rendered_entries)
+            user_html = '<dl class="ix-result-record">' + "".join(
+                f'<dt>{_escape_html(str(key))}</dt><dd>{child.user_html}</dd>'
+                for key, child in rendered_entries
+            )
+            if omitted:
+                user_html += f"<dt>truncated</dt><dd>{omitted} more entries</dd>"
+            user_html += "</dl>"
+            model_value: Any = {
+                key: child.model_value for key, child in rendered_entries
+            }
+            if omitted:
+                model_value = {"items": model_value, "truncated": omitted}
+            return _NestedRender(
+                user_html=user_html,
+                model_value=model_value,
+                llm_images=[
+                    image
+                    for _, child in rendered_entries
+                    for image in child.llm_images
+                ],
+            )
+        total = len(value)
+        rendered_items = [
+            _render_nested(child, _depth=_depth + 1, _seen=seen)
+            for child in value[:_NESTED_RENDER_MAX_ITEMS]
+        ]
+        omitted = total - len(rendered_items)
+        user_html = "".join(
+            f'<div class="ix-result-item" data-ix-index="{index}">{item.user_html}</div>'
+            for index, item in enumerate(rendered_items)
+        )
+        if omitted:
+            user_html += f'<div class="ix-result-truncated">{omitted} more items</div>'
+        model_value = [item.model_value for item in rendered_items]
+        if omitted:
+            model_value.append({"truncated": omitted})
+        return _NestedRender(
+            user_html=user_html,
+            model_value=model_value,
+            llm_images=[image for item in rendered_items for image in item.llm_images],
+        )
+    finally:
+        seen.remove(identity)
 
 
 def _result_from_values(values: Any, *, llm_result: str | None = None) -> Result:
@@ -1195,6 +1368,16 @@ def _result_from_values(values: Any, *, llm_result: str | None = None) -> Result
     for item in items:
         images.extend(item.llm_images)
     return Result(user_html=user_html, llm_result=text, llm_images=images)
+
+
+def _result_from_nested(value: Any, *, llm_result: str | None = None) -> Result:
+    """Render nested containers once, preserving names, views, and model caps."""
+    rendered = _render_nested(value)
+    return Result(
+        user_html=rendered.user_html,
+        llm_result=llm_result if llm_result is not None else _nuon(rendered.model_value),
+        llm_images=rendered.llm_images,
+    )
 
 
 class Resource:
@@ -2838,12 +3021,11 @@ async def _runner(job: Job, ns: dict) -> None:
             job._exc = _kexc
         job._exc_tb = _kexc.__traceback__
         job._append(job.error)
-    except (Exception, SystemExit) as _exc:
+    except BaseException as _exc:
         # Isolate user code from the kernel: a job's SyntaxError, exception, or
-        # even sys.exit()/exit() becomes a failed job (traceback captured) instead
-        # of escaping the task and tearing down the shared kernel session.
-        # asyncio.CancelledError is BaseException, not caught here, so cooperative
-        # cancellation (handled above) still propagates.
+        # even a PyO3 PanicException becomes a failed job (traceback captured)
+        # instead of escaping the task and leaving the run marked running.
+        # Cancellation and KeyboardInterrupt retain their dedicated paths above.
         job.status = "error"
         # Trim the kernel's plumbing frames so the traceback starts at the cell,
         # and record the failing cell line for the dashboard's error highlight.
@@ -2948,10 +3130,10 @@ async def _spawn_runner(job: Job, aw: Awaitable[Any]) -> None:
         if isinstance(aw, asyncio.Future):
             aw.cancel()
         raise
-    except (Exception, KeyboardInterrupt, SystemExit) as _exc:
+    except BaseException as _exc:
         # Isolate like _runner: a failed awaitable becomes a failed job
-        # (traceback captured, `await jobs['<id>']` re-raises) instead of
-        # escaping the task and dying as an unretrieved background failure.
+        # (traceback captured, `await jobs['<id>']` re-raises), including a
+        # renderer PanicException. Cancellation retains its path above.
         job.status = "error"
         job.error = _user_traceback(_exc)
         job._exc = _exc
@@ -4266,13 +4448,6 @@ async def __ix_run(
     if not job.task.done():
         job.backgrounded = True
     return job
-
-
-# How many chars of a job's output/result the per-call summary carries inline.
-# The full output stays in the kernel as ``jobs[id]`` (paged via tail/head/slice/
-# grep/lines); the summary also reports the full sizes so the server can tell the
-# caller when a reply was truncated and point at the job to page.
-_SUMMARY_CHARS = 50_000
 
 
 def _result_text(job: Job) -> str:

--- a/packages/mcp/tests/test_nested_nu_results.py
+++ b/packages/mcp/tests/test_nested_nu_results.py
@@ -1,0 +1,185 @@
+"""Nested command results remain terminal, bounded, and structured (#3079)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import polars as pl
+import pytest
+
+import nu
+from ix_notebook_mcp import runtime
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict[str, object]) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+    monkeypatch.setattr(runtime, "_typecheck_enabled", lambda: False)
+
+
+async def _run_and_parse() -> tuple[runtime.Job, object]:
+    job = await runtime.__ix_run("results", budget=5.0)
+    parsed = await nu.value("from nuon", input=job.result.llm_result)
+    return job, parsed
+
+
+def _parse(text: str) -> object:
+    return asyncio.run(nu.value("from nuon", input=text))
+
+
+def test_nested_nu_dataframes_finish_with_named_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    results = [
+        nu.NuResult(pl.DataFrame({"number": [1], "title": ["one"]}), 0),
+        nu.NuResult(pl.DataFrame({"number": [2], "title": ["two"]}), 0),
+    ]
+    _wire(monkeypatch, {"results": results})
+
+    job, parsed = asyncio.run(_run_and_parse())
+
+    assert job.status == "done", (job.status, job.error)
+    assert job.result.value is results
+    assert [row["exit_code"] for row in parsed] == [0, 0]
+    assert '[[number, title]; [1, "one"]]' in parsed[0]["result"]
+    assert '[[number, title]; [2, "two"]]' in parsed[1]["result"]
+    assert job.result.user_html.count('data-ix-field="result"') == 2
+    assert job.result.user_html.count('data-ix-field="exit_code"') == 2
+
+
+def test_plain_nu_results_also_keep_their_named_structure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    results = [
+        nu.NuResult("hello", 0),
+        nu.NuResult({"nested": {"answer": 42}}, 3),
+    ]
+    _wire(monkeypatch, {"results": results})
+
+    job, parsed = asyncio.run(_run_and_parse())
+
+    assert job.status == "done", (job.status, job.error)
+    assert parsed == [
+        {"result": "hello", "exit_code": 0},
+        {"result": {"nested": {"answer": 42}}, "exit_code": 3},
+    ]
+
+
+def test_nested_dataframe_uses_its_bounded_render_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    extra_rows = 5
+    frame = pl.DataFrame(
+        {"number": list(range(runtime._DF_LLM_ROWS + extra_rows))}
+    )
+    results = [nu.NuResult(frame, 0)]
+    original = runtime._df_llm_text
+    calls = 0
+
+    def counted(value: object) -> str:
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(runtime, "_df_llm_text", counted)
+    _wire(monkeypatch, {"results": results})
+
+    job, parsed = asyncio.run(_run_and_parse())
+
+    assert job.status == "done", (job.status, job.error)
+    assert calls == 1
+    assert f"... ({extra_rows} more rows)" in parsed[0]["result"]
+    assert f"[{runtime._DF_LLM_ROWS - 1}]" in parsed[0]["result"]
+    assert f"[{runtime._DF_LLM_ROWS}]" not in parsed[0]["result"]
+
+
+class _RenderedOnly:
+    def __ix_html__(self) -> str:
+        return "<strong>bounded</strong>"
+
+    def __ix_llm__(self) -> str:
+        return "bounded"
+
+    def __repr__(self) -> str:
+        return "RAW_VALUE_MUST_NOT_RENDER"
+
+
+def test_nested_leaf_uses_its_render_instead_of_raw_repr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    results = [nu.NuResult(_RenderedOnly(), 0)]
+    _wire(monkeypatch, {"results": results})
+
+    job, parsed = asyncio.run(_run_and_parse())
+
+    assert job.status == "done", (job.status, job.error)
+    assert parsed == [{"result": "bounded", "exit_code": 0}]
+    assert "RAW_VALUE_MUST_NOT_RENDER" not in job.result.llm_result
+
+
+def test_nested_container_cycles_and_depth_are_bounded() -> None:
+    cycle: list[object] = []
+    cycle.append(cycle)
+    rendered_cycle = runtime.Result.of({"cycle": cycle, "result": nu.NuResult("ok", 0)})
+    assert "<cycle to list>" in rendered_cycle.llm_result
+
+    deep: list[object] = []
+    cursor = deep
+    for _ in range(runtime._NESTED_RENDER_MAX_DEPTH + 2):
+        child: list[object] = []
+        cursor.append(child)
+        cursor = child
+    cursor.append(nu.NuResult("too deep", 0))
+    rendered_deep = runtime.Result.of(deep)
+    assert (
+        f"omitted at nested render depth {runtime._NESTED_RENDER_MAX_DEPTH}"
+        in rendered_deep.llm_result
+    )
+
+
+def test_nested_sequence_and_mapping_caps_are_explicit() -> None:
+    limit = runtime._NESTED_RENDER_MAX_ITEMS
+    sequence: list[object] = [nu.NuResult("first", 0), *range(limit)]
+    rendered_sequence = runtime.Result.of(sequence)
+    parsed_sequence = _parse(rendered_sequence.llm_result)
+    assert len(parsed_sequence) == limit + 1
+    assert parsed_sequence[0] == {"result": "first", "exit_code": 0}
+    assert parsed_sequence[-1] == {"truncated": 1}
+    assert "1 more items" in rendered_sequence.user_html
+
+    mapping: dict[str, object] = {f"key_{index}": index for index in range(limit)}
+    mapping["rich_after_limit"] = nu.NuResult("omitted safely", 0)
+    rendered_mapping = runtime.Result.of(mapping)
+    parsed_mapping = _parse(rendered_mapping.llm_result)
+    assert parsed_mapping["truncated"] == 1
+    assert len(parsed_mapping["items"]) == limit
+    assert "rich_after_limit" not in parsed_mapping["items"]
+    assert "1 more entries" in rendered_mapping.user_html
+
+
+class _RendererPanic(BaseException):
+    pass
+
+
+class _PanickingValue:
+    def __ix_llm__(self) -> str:
+        raise _RendererPanic("renderer panic")
+
+
+def test_renderer_base_exception_terminalizes_the_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(monkeypatch, {"panic": _PanickingValue()})
+
+    job = asyncio.run(runtime.__ix_run("panic", budget=5.0))
+
+    assert job.status == "error"
+    assert job.done()
+    assert "renderer panic" in (job.error or "")
+
+    async def await_job() -> object:
+        return await job
+
+    with pytest.raises(_RendererPanic, match="renderer panic"):
+        asyncio.run(await_job())


### PR DESCRIPTION
## Summary

- Preserve named `NuResult` fields across nested lists, tuples, and mappings without sending rich Python objects into Polars container inference.
- Render rich leaves once, enforce row, item, text, cycle, and depth bounds, and keep model output valid NUON.
- Convert renderer `BaseException` failures, including PyO3 panic exceptions, into terminal job errors while retaining cancellation and keyboard interrupt behavior.

## Validation
- `nix build .#mcp .#mcp.passthru.tests.runtimeSmoke .#mcp.passthru.tests.nuTests .#mcp.passthru.tests.typecheckSmoke -L`
- `147 passed` in the MCP lifecycle suite and `44 passed` in the embedded Nushell suite.
- `nix run .#lint`, all 10 tasks passed.

- Correctness, security, performance, and maintainability reviews completed. All blockers were addressed; security was clean.

This touches renderer code that is line-disjoint from the `watch_pr` changes in #3061.
Fixes #3079. (sent by an AI agent via Codex, GPT-5)















<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render nested command results safely with cycle detection and depth/item bounds
> - Adds `_render_nested` in [runtime.py](https://github.com/indexable-inc/index/pull/3087/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95), a bounded recursive renderer for containers (named tuples, mappings, sequences) that preserves named structure, accumulates rich HTML and LLM images, and enforces `_NESTED_RENDER_MAX_DEPTH` (8) and `_NESTED_RENDER_MAX_ITEMS` (200) with explicit truncation markers.
> - Adds cycle detection via an id-based `seen` set; cycles and depth-limit hits emit a `_nested_marker` placeholder in both HTML and model output.
> - Broadens error capture in `_runner` and `_spawn_runner` from `except (Exception, SystemExit)` to `except BaseException`, so renderer exceptions (e.g. a custom `PanicException`) terminalize the job with a captured traceback instead of escaping.
> - Adds `tests/test_nested_nu_results.py` covering named-structure preservation, single bounded DataFrame render, leaf render precedence over `repr`, cycle/depth bounding, sequence/mapping truncation caps, and `BaseException` terminalization.
> - Behavioral Change: any uncaught `BaseException` from a renderer now marks the job as `error` and re-raises on `await job` rather than propagating uncaught.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46b32fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->