### PR TITLE
users: remove unused Bazel from workstation profile

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -524,7 +524,6 @@ in {
       # Development - Build tools
       cmake # cross-platform build system generator
       pkg-config # query compiler/linker flags for installed libs
-      bazel_8 # Google's hermetic, parallel build system (v8.x)
       # watchman  # commented 2026-05-22: upstream folly test (UninitializedMemoryHacksTest) fails to compile under current clang, blocking rebuilds. Re-enable when nixpkgs bumps folly.
       just # command runner (`justfile` — like make without the gotchas)
       capnproto # Cap'n Proto IDL + RPC (faster Protobuf alternative)


### PR DESCRIPTION
Closes #3088.

Removes `bazel_8` so personal Home Manager generations no longer build or install unused Bazel.

Validation: `nix run .#lint -- --json`

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `bazel_8` from workstation Nix profile
> Removes the `bazel_8` entry from the build tools section of [workstation.nix](https://github.com/indexable-inc/index/pull/3089/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962). Bazel v8 was unused and will no longer be installed by this profile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 625a155.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->