### PR TITLE
fix(nu): expand ~ in cwd= before the directory check

### DIFF
--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -379,6 +379,22 @@ def test_nonexistent_explicit_cwd_is_rejected_at_the_boundary(tmp_path: pathlib.
         run(nu.value("2 + 2", cwd=tmp_path / "missing"))
 
 
+def test_tilde_cwd_expands_to_home(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Issue #3101: every shell expands `~` in a working-directory argument,
+    # so callers reach for it naturally; rejecting it as "not a directory"
+    # forced os.path.expanduser at every call site.
+    home = tmp_path / "home"
+    (home / "proj").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    try:
+        run(nu.value("2 + 2", cwd="~/proj"))
+        assert pathlib.Path(run(nu.value("$env.PWD"))).resolve() == (home / "proj").resolve()
+    finally:
+        nu.reset()
+
+
 def test_cwd_is_respected(tmp_path: pathlib.Path) -> None:
     (tmp_path / "hello.txt").write_text("hi")
     df = run(nu("ls | get name", cwd=tmp_path))

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -309,11 +309,13 @@ def _resolve_dir(cwd: str | os.PathLike) -> str:
 
     The engine persists PWD across calls, so a relative value would later be
     interpreted against an unrelated process directory and poison the session.
-    Resolve and validate it before the persistent engine sees it. This stays
-    synchronous on purpose: it is one local filesystem lookup, and keeping the
-    path method out of the async caller avoids ASYNC240.
+    Resolve and validate it before the persistent engine sees it (a leading
+    ``~`` expands first: every shell accepts one here, so callers reach for
+    it naturally, index#3101). This stays synchronous on purpose: it is one
+    local filesystem lookup, and keeping the path method out of the async
+    caller avoids ASYNC240.
     """
-    resolved = pathlib.Path(cwd).resolve()
+    resolved = pathlib.Path(cwd).expanduser().resolve()
     if not resolved.is_dir():
         raise ValueError(f"cwd is not a directory: {os.fspath(cwd)!r}")
     return os.fspath(resolved)


### PR DESCRIPTION
Fixes #3101.

`nu(cwd=...)` rejected tilde paths (`ValueError: cwd is not a directory: '~/...'`) because `_resolve_dir` never expanded `~` before the isdir check, forcing `os.path.expanduser` at every call site.

- `packages/nu-py/python/nu/__init__.py`: `_resolve_dir` now runs `Path(cwd).expanduser().resolve()`; a genuinely missing directory still raises the same `ValueError`.
- `packages/mcp/tests/test_nu.py`: `test_tilde_cwd_expands_to_home` pins the behavior against the real engine (HOME monkeypatched, hermetic).

Validated with `nix build .#mcp.tests.nuTests .#mcp.tests.typecheckSmoke`.

Authored by an AI agent (Claude Code, Claude Opus 4.5).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand `~` in `cwd` before directory validation in `_resolve_dir`
> Calls `.expanduser()` before `.resolve()` in [_resolve_dir](https://github.com/indexable-inc/index/pull/3105/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4) so that `cwd` values like `~/proj` are correctly resolved to the user's home directory before the `is_dir()` check. A new test in [test_nu.py](https://github.com/indexable-inc/index/pull/3105/files#diff-64ceabff54157dc4841671fdb42fdf6652de63656b70c2be5c4de568d0216ff2) verifies this behavior by setting `HOME` to a temp directory and asserting `$env.PWD` resolves to the expanded path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18cae2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->