### PR TITLE
mcp: authenticate store writes with the weave session credential

### DIFF
--- a/packages/mcp/ix_notebook_mcp/store.py
+++ b/packages/mcp/ix_notebook_mcp/store.py
@@ -21,6 +21,7 @@ from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
+from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
@@ -44,13 +45,20 @@ _QUEUE_MAX = 10_000
 _BEAT_S = 60.0
 _WARNED_OFF = False
 
-def _http_json(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
-    headers: dict[str, str] = {}
+def _http_json(
+    method: str,
+    url: str,
+    *,
+    body: object = None,
+    content: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> object:
+    all_headers: dict[str, str] = dict(headers or {})
     data: bytes | None = content
     if body is not None:
         data = json.dumps(body).encode("utf-8")
-        headers["Content-Type"] = "application/json"
-    req = Request(url, data=data, headers=headers, method=method)  # noqa: S310 - configured local/Weave endpoint
+        all_headers["Content-Type"] = "application/json"
+    req = Request(url, data=data, headers=all_headers, method=method)  # noqa: S310 - configured local/Weave endpoint
     with urlopen(req, timeout=10.0) as resp:  # noqa: S310
         raw = resp.read()
     if not raw:
@@ -58,10 +66,16 @@ def _http_json(method: str, url: str, *, body: object = None, content: bytes | N
     return json.loads(raw.decode("utf-8"))
 
 
-def _http_bytes(method: str, url: str, *, content: bytes | None = None) -> bytes:
-    req = Request(url, data=content, method=method)  # noqa: S310 - configured local/Weave endpoint
+def _http_bytes(method: str, url: str, *, content: bytes | None = None, headers: dict[str, str] | None = None) -> bytes:
+    req = Request(url, data=content, headers=dict(headers or {}), method=method)  # noqa: S310 - configured local/Weave endpoint
     with urlopen(req, timeout=10.0) as resp:  # noqa: S310
         return resp.read()
+
+
+def _auth_denied(exc: Exception) -> bool:
+    """An authentication rejection is permanent for this process: the
+    credential (or its absence) will not change under retry."""
+    return isinstance(exc, HTTPError) and exc.code in (401, 403)
 
 
 def _now() -> float:
@@ -123,6 +137,11 @@ class WeaveStore:
         suffix = _stable8(path)
         self.weave_url = os.environ.get("WEAVE_URL", _DEFAULT_WEAVE_URL).rstrip("/")
         self.disabled = self.weave_url.lower() == "off"
+        # The per-session store credential (weave session_env). Sent as
+        # X-Api-Key on every weave request, the same header the sibling
+        # `weave` client module uses; absent on open-loopback dev servers.
+        # The mailbox/data API is a different trust domain: no token there.
+        self._token = os.environ.get("WEAVE_TOKEN") or ""
         self.agent = os.environ.get("IX_WEAVE_AGENT") or f"agent:{suffix}"
         self.kernel = f"kernel:{suffix}"
         self.mailbox_base = os.environ.get("IX_MCP_DATA_API_URL", _DEFAULT_DATA_API).rstrip("/")
@@ -159,6 +178,28 @@ class WeaveStore:
                 (self.kernel, "heartbeat_ms", now),
                 (self.agent, "on_kernel", self.kernel),
             ])
+
+    def _auth(self) -> dict[str, str]:
+        return {"X-Api-Key": self._token} if self._token else {}
+
+    def _disable_on_auth_denial(self, exc: Exception) -> None:
+        """Weave rejected the credential: retrying cannot help, so fail loudly
+        once and drop to the disabled mode instead of silently backing off
+        forever (the failure mode that hid a dead kernel-presence lane)."""
+        hint = "with credential" if self._token else "without WEAVE_TOKEN"
+        print(
+            f"ix-mcp store: weave rejected writes ({exc}) {hint}; persistence "
+            f"writes to {self.weave_url} are DISABLED for this process - the "
+            "kernel will not appear on the board (set WEAVE_TOKEN to a "
+            "credential the weave server accepts)",
+            file=sys.stderr,
+        )
+        with self._cv:
+            self.disabled = True
+            self._queue.clear()
+            self._inflight = False
+            self._closed = True
+            self._cv.notify_all()
 
     def close(self) -> None:
         # Best-effort drain so queued facts do not die with the process.
@@ -216,14 +257,14 @@ class WeaveStore:
         cached = self._blob_cache.get(digest)
         if cached:
             return _HashRef(cached)
-        h = str(_http_json("POST", f"{self.weave_url}/api/blob", content=data)["hash"])
+        h = str(_http_json("POST", f"{self.weave_url}/api/blob", content=data, headers=self._auth())["hash"])
         self._blob_cache[digest] = h
         return _HashRef(h)
 
     def get_blob(self, hash_: str) -> bytes:
         if self.disabled or not hash_:
             return b""
-        return _http_bytes("GET", f"{self.weave_url}/api/blob/{quote(hash_, safe='')}")
+        return _http_bytes("GET", f"{self.weave_url}/api/blob/{quote(hash_, safe='')}", headers=self._auth())
 
     def _resolve_blob_item(self, item: dict) -> dict:
         """blob_fact items defer their CAS put to the writer thread: PUT the
@@ -259,12 +300,15 @@ class WeaveStore:
                 self._inflight = True
             try:
                 body = [self._resolve_blob_item(item) for item in batch]
-                _http_json("POST", f"{self.weave_url}/api/facts", body=body if len(body) != 1 else body[0])
+                _http_json("POST", f"{self.weave_url}/api/facts", body=body if len(body) != 1 else body[0], headers=self._auth())
                 backoff = 0.25
                 with self._cv:
                     self._inflight = False
                     self._cv.notify_all()
             except Exception as exc:
+                if _auth_denied(exc):
+                    self._disable_on_auth_denial(exc)
+                    return
                 print(f"ix-mcp store: weave write failed, retrying: {exc}", file=sys.stderr)
                 with self._cv:
                     for item in reversed(batch):
@@ -285,7 +329,7 @@ class WeaveStore:
         payload: dict[str, Any] = {"program": program}
         if as_of is not None:
             payload["as_of"] = as_of
-        return _http_json("POST", f"{self.weave_url}/api/query", body=payload)
+        return _http_json("POST", f"{self.weave_url}/api/query", body=payload, headers=self._auth())
 
     def mailbox(self, method: str, path: str, *, json_body: object = None) -> object:
         try:

--- a/packages/mcp/tests/test_channel.py
+++ b/packages/mcp/tests/test_channel.py
@@ -146,7 +146,7 @@ def test_transport_pump_weave_chat_posts_instead_of_notifying(monkeypatch: pytes
         posts: list[tuple] = []
         posted = anyio.Event()
 
-        def fake_http(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+        def fake_http(method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None) -> object:
             posts.append((method, url, body))
             anyio.from_thread.run_sync(posted.set)
             return {"id": body["id"], "seq": 1}
@@ -183,7 +183,7 @@ def test_transport_pump_weave_chat_retries_failed_post_with_same_id(monkeypatch:
         attempts: list[str] = []
         retried = anyio.Event()
 
-        def fake_http(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+        def fake_http(method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None) -> object:
             attempts.append(body["id"])
             if len(attempts) == 1:
                 raise ConnectionError("weave down")

--- a/packages/mcp/tests/test_mcp_ui.py
+++ b/packages/mcp/tests/test_mcp_ui.py
@@ -297,7 +297,7 @@ def test_api_job_ui_serves_embedded_view(tmp_path: Path, monkeypatch: pytest.Mon
     facts: dict[tuple[str, str], object] = {}
     blobs: dict[str, bytes] = {}
 
-    def fake_json(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+    def fake_json(method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None) -> object:
         if url.endswith("/api/facts"):
             items = body if isinstance(body, list) else [body]
             for item in items:
@@ -324,7 +324,7 @@ def test_api_job_ui_serves_embedded_view(tmp_path: Path, monkeypatch: pytest.Mon
 
     monkeypatch.setenv("WEAVE_URL", "http://weave.stub")
     monkeypatch.setattr(store, "_http_json", fake_json)
-    monkeypatch.setattr(store, "_http_bytes", lambda method, url, content=None: blobs.get(url.rsplit("/", 1)[-1], b""))
+    monkeypatch.setattr(store, "_http_bytes", lambda method, url, content=None, headers=None: blobs.get(url.rsplit("/", 1)[-1], b""))
 
     db = tmp_path / "ui.db"
     conn = store.connect(db)

--- a/packages/mcp/tests/test_spawn_store_lifecycle.py
+++ b/packages/mcp/tests/test_spawn_store_lifecycle.py
@@ -15,7 +15,7 @@ def test_spawn_finish_updates_its_process_without_creating_a_run(
     calls: list[tuple[str, str, object]] = []
 
     def fake_json(
-        method: str, url: str, *, body: object = None, content: bytes | None = None
+        method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None
     ) -> object:
         calls.append((method, url, body if body is not None else content))
         if url.endswith("/api/blob"):
@@ -27,7 +27,7 @@ def test_spawn_finish_updates_its_process_without_creating_a_run(
     monkeypatch.setenv("WEAVE_URL", "http://weave.test")
     monkeypatch.setenv("IX_WEAVE_AGENT", "agent:test")
     monkeypatch.setattr(store, "_http_json", fake_json)
-    monkeypatch.setattr(store, "_http_bytes", lambda method, url, content=None: b"[]")
+    monkeypatch.setattr(store, "_http_bytes", lambda method, url, content=None, headers=None: b"[]")
 
     conn = store.connect(tmp_path / "spawn.ixnb")
     store.start(

--- a/packages/mcp/tests/test_store_async.py
+++ b/packages/mcp/tests/test_store_async.py
@@ -42,7 +42,7 @@ def test_async_conn_kwargs_and_store_functions(tmp_path: Path, monkeypatch: pyte
     monkeypatch.setenv("WEAVE_URL", "http://weave.test")
     monkeypatch.setenv("IX_WEAVE_AGENT", "agent:test")
 
-    def fake_json(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+    def fake_json(method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None) -> object:
         if url.endswith("/api/query"):
             # pivot rows for one finished run child of agent:test
             rows = [

--- a/packages/mcp/tests/test_store_auth.py
+++ b/packages/mcp/tests/test_store_auth.py
@@ -1,0 +1,149 @@
+"""Store credential handling against an authenticated Weave.
+
+Weave deployments behind ``--proxy-identity`` (or with API tokens) reject
+anonymous ``/api/facts`` writes with 401, which silently killed the whole
+kernel-presence lane: the write-behind writer backed off and retried
+forever, no kernel entity ever landed, and the board showed no kernel.
+
+Contract pinned here:
+- ``WEAVE_TOKEN`` rides every request against ``WEAVE_URL`` as ``X-Api-Key``
+  (the same header the sibling ``weave`` client module sends); no token
+  means no header, so open-loopback dev servers are untouched.
+- The mailbox/data API is a different trust domain: never send the token.
+- A 401/403 from Weave is permanent for the process: the writer logs one
+  loud line and drops to the disabled mode instead of retrying forever.
+- Any other failure keeps the existing retry-with-backoff behavior.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.error import HTTPError
+
+import pytest
+
+from ix_notebook_mcp import store
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, dict]]:
+    requests: list[tuple[str, str, dict]] = []
+
+    def fake_json(
+        method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None
+    ) -> object:
+        requests.append((method, url, dict(headers or {})))
+        if url.endswith("/api/blob"):
+            return {"hash": "0" * 64}
+        if url.endswith("/api/query"):
+            return {"vars": [], "rows": [], "as_of": 0}
+        return {"seq": 1, "id": "f1"}
+
+    def fake_bytes(method: str, url: str, *, content: bytes | None = None, headers: dict | None = None) -> bytes:
+        requests.append((method, url, dict(headers or {})))
+        return b""
+
+    monkeypatch.setattr(store, "_http_json", fake_json)
+    monkeypatch.setattr(store, "_http_bytes", fake_bytes)
+    return requests
+
+
+def test_weave_token_rides_every_weave_request(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WEAVE_URL", "http://weave.test")
+    monkeypatch.setenv("WEAVE_TOKEN", "s3cret")
+    requests = _capture(monkeypatch)
+
+    conn = store.WeaveStore(tmp_path / "s.ixnb")
+    try:
+        assert conn.flush(timeout=5.0)
+        conn.put_blob(b"payload")
+        conn.get_blob("0" * 64)
+        conn.query("?- latest(E, A, V).")
+    finally:
+        conn.close()
+
+    weave_requests = [r for r in requests if r[1].startswith("http://weave.test")]
+    assert weave_requests, "no weave traffic recorded"
+    for method, url, headers in weave_requests:
+        assert headers.get("X-Api-Key") == "s3cret", f"{method} {url} missing credential: {headers}"
+
+
+def test_without_token_no_auth_header_is_sent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WEAVE_URL", "http://weave.test")
+    monkeypatch.delenv("WEAVE_TOKEN", raising=False)
+    requests = _capture(monkeypatch)
+
+    conn = store.WeaveStore(tmp_path / "s.ixnb")
+    try:
+        assert conn.flush(timeout=5.0)
+    finally:
+        conn.close()
+
+    assert requests
+    for _, _, headers in requests:
+        assert "X-Api-Key" not in headers
+
+
+def _rejecting(monkeypatch: pytest.MonkeyPatch, code: int) -> list[str]:
+    urls: list[str] = []
+
+    def deny(
+        method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None
+    ) -> object:
+        urls.append(url)
+        raise HTTPError(url, code, "denied", None, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(store, "_http_json", deny)
+    return urls
+
+
+@pytest.mark.parametrize("code", [401, 403])
+def test_auth_rejection_disables_writes_permanently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], code: int
+) -> None:
+    monkeypatch.setenv("WEAVE_URL", "http://weave.test")
+    monkeypatch.delenv("WEAVE_TOKEN", raising=False)
+    attempts = _rejecting(monkeypatch, code)
+
+    conn = store.WeaveStore(tmp_path / "s.ixnb")
+    try:
+        assert conn.flush(timeout=10.0), "a permanent rejection must not wedge flush()"
+        assert conn.disabled, "an auth rejection must disable the store"
+        assert len(attempts) == 1, f"an auth rejection must not be retried: {attempts}"
+        # Disabled means later durable writes are dropped without touching
+        # the network, exactly like WEAVE_URL=off.
+        before = len(attempts)
+        store.start(conn, id="c1", name="probe", code="pass", started_at=0.0)
+        assert conn.flush(timeout=5.0)
+        assert len(attempts) == before
+    finally:
+        conn.close()
+
+    err = capsys.readouterr().err
+    assert "DISABLED" in err
+    assert "WEAVE_TOKEN" in err
+
+
+def test_transient_failures_still_retry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WEAVE_URL", "http://weave.test")
+    calls: list[str] = []
+
+    def flaky(
+        method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None
+    ) -> object:
+        calls.append(url)
+        if len(calls) == 1:
+            raise ConnectionError("weave not up yet")
+        return {"seq": 1, "id": "f1"}
+
+    monkeypatch.setattr(store, "_http_json", flaky)
+
+    conn = store.WeaveStore(tmp_path / "s.ixnb")
+    try:
+        assert conn.flush(timeout=10.0)
+        assert not conn.disabled
+        assert len(calls) >= 2, "a transient failure must be retried"
+    finally:
+        conn.close()

--- a/packages/mcp/tests/test_store_facts.py
+++ b/packages/mcp/tests/test_store_facts.py
@@ -9,7 +9,7 @@ from ix_notebook_mcp import store
 def _capture(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, object]]:
     calls: list[tuple[str, str, object]] = []
 
-    def fake_json(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+    def fake_json(method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None) -> object:
         calls.append((method, url, body if body is not None else content))
         if url.endswith("/api/blob"):
             return {"hash": f"h{len(calls):063d}"}
@@ -18,7 +18,7 @@ def _capture(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, object]]:
         return [] if isinstance(body, list) else {"seq": 1, "id": "f1"}
 
     monkeypatch.setattr(store, "_http_json", fake_json)
-    monkeypatch.setattr(store, "_http_bytes", lambda method, url, content=None: b"[]")
+    monkeypatch.setattr(store, "_http_bytes", lambda method, url, content=None, headers=None: b"[]")
     return calls
 
 

--- a/packages/mcp/tests/test_store_kernel_lease.py
+++ b/packages/mcp/tests/test_store_kernel_lease.py
@@ -21,7 +21,7 @@ from ix_notebook_mcp import store
 def _capture(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
     posted: list[dict] = []
 
-    def fake_json(method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+    def fake_json(method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None) -> object:
         if url.endswith("/api/facts"):
             posted.extend(body if isinstance(body, list) else [body])
         return {"seq": 1, "id": "f1"}

--- a/packages/mcp/tests/weave_stub.py
+++ b/packages/mcp/tests/weave_stub.py
@@ -91,7 +91,7 @@ class FakeWeave:
         raise AssertionError(f"weave_stub: unhandled query shape: {program!r}")
 
     # -- transport hooks ------------------------------------------------------
-    def http_json(self, method: str, url: str, *, body: object = None, content: bytes | None = None) -> object:
+    def http_json(self, method: str, url: str, *, body: object = None, content: bytes | None = None, headers: dict | None = None) -> object:
         if url.endswith("/api/facts"):
             items = body if isinstance(body, list) else [body]
             acks = [self._apply(item) for item in items]
@@ -106,7 +106,7 @@ class FakeWeave:
             raise ConnectionError("no data api in unit tests (mailbox falls back in-process)")
         raise AssertionError(f"weave_stub: unhandled url {url}")
 
-    def http_bytes(self, method: str, url: str, *, content: bytes | None = None) -> bytes:
+    def http_bytes(self, method: str, url: str, *, content: bytes | None = None, headers: dict | None = None) -> bytes:
         digest = url.rsplit("/", 1)[-1]
         return self.blobs.get(digest, b"")
 


### PR DESCRIPTION
## Problem

Weave servers that require authentication (`--proxy-identity` or API tokens) reject anonymous `POST /api/facts` with 401. `ix_notebook_mcp/store.py`'s write-behind writer sends no credentials and treats 401 as retryable, so it backs off and retries forever. Net effect, diagnosed live on hil-compute-1: the whole kernel-presence lane dies invisibly - no `type=kernel` entity, no `heartbeat_ms`, no python_exec satellites, no pty streams - and the weave board shows no kernel while the kernel itself works fine.

## Change

- `WeaveStore` reads `WEAVE_TOKEN` (injected per session by weave's supervisor; already the convention of the sibling `weave` client module) and sends it as `X-Api-Key` on every request against `WEAVE_URL`: `/api/facts`, `/api/blob` put/get, `/api/query`. The mailbox/data API is a different trust domain and never sees the token. No token, no header: open-loopback dev servers unchanged.
- 401/403 is permanent, not retryable: one loud stderr line naming the fix, then the store drops to the existing `disabled` mode (like `WEAVE_URL=off`). Transient failures keep the retry-with-backoff path.

This is the ix-mcp side of weave's new `store-auth-v1` runtime capability (weave PR: indexable-inc/weave - per-session store credentials; merge this first, then weave bumps its index pin).

## Validation

- New `tests/test_store_auth.py`: token on every weave request, no header without token, 401 and 403 disable permanently after exactly one attempt with the loud message, transient errors still retry. Existing store/kernel-lease/channel/mcp-ui/tool-view suites updated for the new `headers` kwarg and green (45 tests).
- End-to-end against a real weave built from the companion branch, serving with `--token`: with `WEAVE_TOKEN` the kernel entity lands and `latest(K, type, \"kernel\")` returns it; without, one DISABLED line in 0.01s and no retry loop.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate WeaveStore HTTP requests with session credentials from `WEAVE_TOKEN`
> - Adds `_auth()` method to `WeaveStore` that returns an `X-Api-Key` header when `WEAVE_TOKEN` is set, and threads those headers into all blob, fact, and query requests.
> - Adds `_disable_on_auth_denial()` to permanently disable the store on 401/403 responses, clearing the queue and unblocking waiting threads.
> - Updates `_http_json` and `_http_bytes` utilities to accept an optional `headers` dict, and ensures `Content-Type` is set on JSON POST bodies.
> - Adds [test_store_auth.py](https://github.com/indexable-inc/index/pull/3125/files#diff-0163f19a6a1e8d37072d09257c54dc939bbb3361f264e14866286682f5cb7629) covering header inclusion, absence when token is unset, permanent disabling on auth denial, and retry behavior on transient failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0202e66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->