### PR TITLE
workstation: disable vengi-tools while darwin ld64 crashes building it

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -743,7 +743,7 @@ in {
       protoc-gen-swift # Swift codegen plugin for protoc
       # sif                                             # Singularity Image Format tooling
       swiftformat # Swift source code formatter
-      vengi-tools # voxel/mesh conversion toolkit; `vengi-voxconvert` supports binvox without x86_64-darwin nixpkgs
+      # vengi-tools # voxel/mesh conversion toolkit (`vengi-voxconvert` for binvox); disabled 2026-07-12: current nixpkgs crashes cctools ld64 (EXC_BREAKPOINT in ld::passes::stubs::Pass::process) linking its first executable, deterministically, and cache.nixos.org has no aarch64-darwin build. Re-enable via index#3133 once the toolchain regression is resolved.
       # wezterm # GPU terminal emulator; disabled 2026-07-01: aarch64-darwin output was absent from cache.nixos.org and rebuilt locally for ~46m during a routine flake update. Use Alacritty or `nix run nixpkgs#wezterm -- ...` when needed.
       cfg.packages.mercuryCli # Mercury CLI (custom flake input)
       indexPkgs.elevenlabs-say # ElevenLabs say-style TTS CLI (-r/-v, streaming); key via ELEVENLABS_API_KEY


### PR DESCRIPTION
Part of #3133 (kept open to re-enable).

`vengi-tools` no longer builds on aarch64-darwin with current nixpkgs: cctools ld64 crashes (EXC_BREAKPOINT in `ld::passes::stubs::Pass::process`) linking the first executable. Deterministic (4/4 failures across two drv variants on the new nixpkgs; the same source builds fine on the previous pin). cache.nixos.org has no build either: Hydra last succeeded June 23 and the two newer attempts aborted.

An earlier revision of this PR raised `CMAKE_OSX_DEPLOYMENT_TARGET` to 14.0; that was a wrong lead. The flag reaches cmake but vengi forces 11.0 at link time regardless, and the previously working build shows the same 11.0-vs-14.0 warnings, so the mismatch is not the trigger.

This disables the package with a dated comment (same pattern as the `wezterm` line in this list) so Home Manager switches build again. Root-cause forensics (old vs new ld64 on the identical link invocation) continue on #3133.

(sent by an AI agent via Claude Code, model Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable vengi-tools in workstation profile due to darwin ld64 crash
> Comments out `vengi-tools` in [workstation.nix](https://github.com/indexable-inc/index/pull/3134/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) to work around a toolchain regression where the darwin ld64 linker crashes when building it. A comment is left in place with guidance for re-enabling once the regression is fixed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7b62e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->