### PR TITLE
fix(nu): render NuResult as the command's own output text

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2653,7 +2653,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542) + nu input= routing past no-input statements (#2540) + read target top-level await (#3139) + kernel host seam: local child vs ray actor";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542) + nu input= routing past no-input statements (#2540) + read target top-level await (#3139) + nu-job line paging (#3131) + kernel host seam: local child vs ray actor";
     }
     ''
       export HOME=$TMPDIR/home
@@ -2707,6 +2707,8 @@
       cp ${./tests/test_nu_input_routing.py} test_nu_input_routing.py
       # Issue #3139: the read tool's target expression allows top-level await.
       cp ${./tests/test_read_await.py} test_read_await.py
+      # Issue #3131: a job wrapping nu(check=False) pages real stdout lines.
+      cp ${./tests/test_nu_job_output.py} test_nu_job_output.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
@@ -2727,6 +2729,7 @@
         test_pr_watch_automerge.py \
         test_nu_input_routing.py \
         test_read_await.py \
+        test_nu_job_output.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -522,3 +522,47 @@ def test_externals_run_color_free_even_when_host_forces_color(
         # The forced-color engine (and the env= override, which persists on
         # the stack) must not leak into later tests.
         nu.reset()
+
+
+# --------------------------------------------------------------------------- #
+# Issue #3131: NuResult renders as the command's own output text, so a job
+# wrapping `nu(..., check=False)` pages real lines instead of a NUON frame
+# with every newline escaped.
+# --------------------------------------------------------------------------- #
+
+
+def test_nuresult_llm_text_is_the_output_plus_exit_marker() -> None:
+    assert nu.NuResult("line one\nline two", 3).__ix_llm__() == "line one\nline two\n[exit 3]"
+
+
+def test_nuresult_llm_text_zero_exit_is_verbatim() -> None:
+    # A clean exit needs no marker: the text reads exactly like a check=True
+    # lone-string result.
+    assert nu.NuResult("hi\nthere", 0).__ix_llm__() == "hi\nthere"
+
+
+def test_nuresult_llm_text_empty_output_is_the_marker_alone() -> None:
+    assert nu.NuResult("", 1).__ix_llm__() == "[exit 1]"
+    assert nu.NuResult("", 0).__ix_llm__() == "[exit 0]"
+
+
+def test_nuresult_llm_text_record_result_is_its_repr() -> None:
+    assert nu.NuResult({"stdout": "x"}, 0).__ix_llm__() == "{'stdout': 'x'}"
+
+
+def test_nuresult_llm_text_frame_result_defers_to_rich_rendering() -> None:
+    # None tells the kernel to keep its rich DataFrame rendering (styled table
+    # for the human, compact NUON for the model).
+    assert nu.NuResult(pl.DataFrame({"a": [1]}), 0).__ix_llm__() is None
+
+
+def test_check_false_multiline_external_llm_text_keeps_real_newlines() -> None:
+    # The issue's shape end to end: a failing multi-line external under
+    # check=False must render its stdout as lines, not as escaped fragments.
+    import sys
+
+    script = "print('alpha'); print('beta'); raise SystemExit(3)"
+    res = run(nu(f'^{sys.executable} -c "{script}"', check=False))
+    assert isinstance(res, nu.NuResult)
+    assert res.exit_code == 3
+    assert res.__ix_llm__() == "alpha\nbeta\n[exit 3]"

--- a/packages/mcp/tests/test_nu_job_output.py
+++ b/packages/mcp/tests/test_nu_job_output.py
@@ -1,0 +1,65 @@
+"""Issue #3131: a background job wrapping ``nu(...)`` pages as real lines.
+
+``jobs.spawn(nu('...', check=False), name=...)`` used to have no readable
+output surface: ``.output`` is empty by design (the text is the job's VALUE,
+not its stdout), and the pageable fallback -- the result's model text -- was
+the generic tuple rendering, a mixed one-column NUON frame with every newline
+escaped (``[[value]; ["..."], ["0"]]``). ``NuResult.__ix_llm__`` now renders
+the command's own output (plus a trailing ``[exit N]`` marker on failure), so
+``.tail()`` / ``.grep()`` / ``.lines()`` / ``.text`` page the stdout lines.
+Drives the real embedded engine (the ``nu._nu`` PyO3 cdylib), like test_nu.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+import nu
+from ix_notebook_mcp import runtime
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict) -> None:
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+
+
+# A failing multi-line external: the issue's `bash -c "nix build ... | tail"`
+# shape, using the interpreter binary the sandbox certainly has.
+_SCRIPT = "print('alpha'); print('beta'); raise SystemExit(3)"
+
+
+def test_spawned_nu_job_pages_stdout_lines(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {})
+
+    async def drive() -> runtime.Job:
+        job = runtime.jobs.spawn(
+            nu(f'^{sys.executable} -c "{_SCRIPT}"', check=False), name="nu-build"
+        )
+        await job
+        return job
+
+    try:
+        job = asyncio.run(drive())
+    finally:
+        nu.reset()
+    assert job.status == "done", job.error
+
+    # The paging helpers operate on the command's real stdout lines.
+    tail = job.tail()
+    assert "alpha\nbeta" in tail, tail
+    assert "\\n" not in tail, tail  # no escaped newlines (the issue's symptom)
+    assert "[exit 3]" in tail
+    assert "0: alpha" in job.grep("alpha")
+    assert "1: beta" in job.lines(1, 2)
+
+    # The rendered result text is the same unescaped view, and the original
+    # NuResult stays reachable for structured reads.
+    assert job.text == "alpha\nbeta\n[exit 3]"
+    result = job.result
+    assert result is not None
+    assert result.value.exit_code == 3
+    assert result.value.result == "alpha\nbeta"

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -303,6 +303,28 @@ class NuResult(NamedTuple):
     result: pl.DataFrame | dict[str, object] | str
     exit_code: int
 
+    def __ix_llm__(self) -> str | None:
+        """Model-facing text for the kernel's Result rendering (issue #3131).
+
+        The generic tuple rendering coerced ``(text, exit_code)`` into a mixed
+        one-column frame whose NUON escaped every newline, so a background job
+        wrapping ``nu(..., check=False)`` had no readable lines to page
+        (``jobs['<id>'].tail()`` returned frame fragments). Render the
+        command's own output verbatim instead, with ``sh``-style trailing
+        ``[exit N]`` marker on a non-zero exit; a frame result returns None so
+        the kernel's rich table rendering still applies.
+        """
+        if isinstance(self.result, str):
+            body = self.result
+        elif isinstance(self.result, dict):
+            body = repr(self.result)
+        else:
+            return None
+        marker = f"[exit {self.exit_code}]"
+        if not body:
+            return marker
+        return body if self.exit_code == 0 else f"{body}\n{marker}"
+
 
 def _resolve_dir(cwd: str | os.PathLike) -> str:
     """Return an existing directory as an absolute path.


### PR DESCRIPTION
Fixes #3131.

**Problem:** a background job wrapping `nu(..., check=False)` had no readable output surface: `jobs['<id>'].tail(15)` returned serialized NUON frame fragments (`[[value]; ["..."], ["0"]]`), `.output` was empty, and the result text arrived with every newline escaped.

**Root cause:** `nu()` is the embedded engine, so the command's text is the job's VALUE, not its stdout; `.output` being empty is by design. The pageable fallback is the result's model text, and `NuResult` (a NamedTuple) fell through to the generic tuple rendering: a mixed one-column frame whose NUON escapes newlines. The issue's proposed "stream stdout into `.output`" is the wrong layer; the fix is at the renderer.

**Fix:** give `NuResult` an `__ix_llm__` hook (the kernel's existing `Result` rendering seam) that returns the command's own output verbatim, with an `sh`-style trailing `[exit N]` marker on non-zero exit. A DataFrame result returns `None` so the rich table rendering still applies. With that, `.tail()` / `.grep()` / `.lines()` / `.text` all page real stdout lines.

**Tests:**
- `test_nu.py`: 6 unit tests over `__ix_llm__` (multiline + marker, zero-exit verbatim, empty output, record repr, frame defers, end-to-end failing external).
- `test_nu_job_output.py` (new, wired into typecheckSmoke): spawns a real `jobs.spawn(nu(...))` job against the embedded engine and asserts line paging, grep, lines, text, and structured `.result.value` access.

**Validation:** `nix build .#mcp.tests.nuTests .#mcp.tests.typecheckSmoke` green; local pytest 51+1 passed.

Note: line-disjoint from #3087 (nested-container rendering in `runtime.py`); only `default.nix` test wiring is adjacent.

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render `NuResult.__ix_llm__` as command stdout with an `[exit N]` marker for non-zero exits
> - Adds `__ix_llm__` to `NuResult` in [__init__.py](https://github.com/indexable-inc/index/pull/3136/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4): for string output, returns the text verbatim on zero exit, or appends `[exit N]` on a new line for non-zero exits; empty output returns only the marker.
> - Dict results return `repr(dict)`; polars DataFrame results return `None` to defer to rich table rendering.
> - Adds unit tests in [test_nu.py](https://github.com/indexable-inc/index/pull/3136/files#diff-64ceabff54157dc4841671fdb42fdf6652de63656b70c2be5c4de568d0216ff2) and a new async integration test in [test_nu_job_output.py](https://github.com/indexable-inc/index/pull/3136/files#diff-21d80b76de848e1863df1febec87beb9efeec1308575bc55ac63731f86a774d2) covering spawned jobs with `check=False`.
> - Behavioral Change: previously `NuResult` had no model-facing text representation; frame results now produce no string output instead of falling back to a default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83d929c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->