### PR TITLE
mcp: allow top-level await in the read tool's target expression

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2638,7 +2638,7 @@
         pkgs.fd
       ];
       strictDeps = true;
-      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542) + nu input= routing past no-input statements (#2540) + kernel host seam: local child vs ray actor";
+      meta.description = "per-cell type check (ty) + issue #1754 bug 1-3 regressions + sh exit surfacing (#1766) + Result.value reachability (#2068) + find glob= filter (#1366) + in-band build stamp (#2110) + session-scoped job cancellation (#2104) + client-cancel interrupts in-flight run (#2387) + jobs.spawn ad-hoc awaitables (#2164) + grep files_only (#2246) + claude-history session search (#2245) + per-serve kernel trace file (#2355) + builtin shadow restore (#2430) + failed-cell stale-binding note (#2526) + pr_watch instant-merge guard (#2532) + find glob-pattern autodetect (#2542) + nu input= routing past no-input statements (#2540) + read target top-level await (#3139) + kernel host seam: local child vs ray actor";
     }
     ''
       export HOME=$TMPDIR/home
@@ -2690,6 +2690,8 @@
       cp ${./tests/test_pr_watch_automerge.py} test_pr_watch_automerge.py
       # Issue #2540: input= routes past no-input statements (cd /tmp; ^cat) or raises.
       cp ${./tests/test_nu_input_routing.py} test_nu_input_routing.py
+      # Issue #3139: the read tool's target expression allows top-level await.
+      cp ${./tests/test_read_await.py} test_read_await.py
       ${lib.getExe typecheckTestPython} -m pytest \
         test_typecheck.py test_job_await_errors.py test_job_cancel_scope.py \
         test_cancel_running.py \
@@ -2709,6 +2711,7 @@
         test_unexecuted_note.py \
         test_pr_watch_automerge.py \
         test_nu_input_routing.py \
+        test_read_await.py \
         -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp typecheck smoke failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -427,9 +427,10 @@ READ = (
     "python_exec whenever the content is for you to read, not for the human to look at — a normal "
     "cell's result streams to BOTH audiences, so it would flood the dashboard. `target` is read "
     "as a file when it names an existing file, otherwise it is evaluated as a Python expression "
-    "in the kernel namespace (e.g. `jobs['ab12'].output` to page a job, or a variable you bound "
-    "earlier); an expression whose value is a string naming an existing file reads that file "
-    "too. Pass `start` / `end` for a 1-based inclusive line range. When the kernel cannot execute "
+    "in the kernel namespace with top-level await allowed, exactly as in a cell (e.g. "
+    "`jobs['ab12'].output` to page a job, `await jobs['ab12']` to wait for one, or a variable "
+    "you bound earlier); an expression whose value is a string naming an existing file reads "
+    "that file too. Pass `start` / `end` for a 1-based inclusive line range. When the kernel cannot execute "
     "the read (wedged or dead), the tool ERRORS with 'kernel unavailable' rather than returning "
     "empty output, so empty content always means the file or value is genuinely empty."
 )

--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -4493,7 +4493,8 @@ async def __ix_read(target: Any, start: int | None = None, end: int | None = Non
     natively (highlighted card with the read span), so a large read informs the
     model without flooding the dashboard. ``target`` is read as a file when it
     names an existing file, otherwise evaluated as a Python expression in the user
-    namespace (e.g. ``jobs['ab12'].output``, a variable you bound). ``start`` and
+    namespace (e.g. ``jobs['ab12'].output``, a variable you bound); top-level
+    ``await`` is allowed, exactly as in a cell. ``start`` and
     ``end`` select a 1-based inclusive line range. ``session`` evaluates the
     expression in that MCP session's namespace (the same one its ``python_exec``
     cells run in), so a variable bound there resolves. Backs the ``read`` MCP tool.
@@ -4502,11 +4503,20 @@ async def __ix_read(target: Any, start: int | None = None, end: int | None = Non
     value = None
     path = _existing_file(target)
     if path is None:
-        # Not a file on disk: evaluate the expression. If the VALUE is a string
-        # naming an existing file (`os.path.join(...)`, a variable holding a
-        # path), the same file rule applies to it -- an expression yielding a
+        # Not a file on disk: evaluate the expression. Compiled with top-level
+        # await allowed, matching cells (_compile), so `await jobs['ab12']` is a
+        # valid target instead of a SyntaxError (index#3139); an awaited target's
+        # coroutine resolves right here on the kernel loop. If the VALUE is a
+        # string naming an existing file (`os.path.join(...)`, a variable holding
+        # a path), the same file rule applies to it -- an expression yielding a
         # path reads the file, never echoes the path string back.
-        value = eval(target, ns) if isinstance(target, str) else target  # noqa: S307 -- intentional: evaluating user-provided expression in kernel namespace
+        if isinstance(target, str):
+            code_obj = compile(target, "<read>", "eval", flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+            value = eval(code_obj, ns)  # noqa: S307 -- intentional: evaluating user-provided expression in kernel namespace
+            if inspect.iscoroutine(value):
+                value = await value
+        else:
+            value = target
         path = _existing_file(value)
     if path is not None:
         # Off the loop: a large file read is blocking I/O, the one thing that

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -690,8 +690,9 @@ async def read(
         str,
         Field(
             description=(
-                "A file path, or a Python expression evaluated in the kernel "
-                "(e.g. jobs['ab12'].output, or a variable you bound earlier)"
+                "A file path, or a Python expression evaluated in the kernel; "
+                "top-level await is allowed (e.g. jobs['ab12'].output, "
+                "await jobs['ab12'], or a variable you bound earlier)"
             )
         ),
     ],

--- a/packages/mcp/tests/test_read_await.py
+++ b/packages/mcp/tests/test_read_await.py
@@ -1,0 +1,55 @@
+"""The read tool's target expression supports top-level await (index#3139).
+
+``__ix_read`` evaluated its target with plain ``eval()``, so an ``await ...``
+target (e.g. ``await jobs['ab12']``) died with ``SyntaxError: 'await' outside
+function``. The expression now compiles with ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT``
+and its coroutine is awaited on the kernel loop, matching how cells support
+top-level await (``_compile``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ix_notebook_mcp import runtime
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ns: dict[str, Any]) -> None:
+    """A controlled shared namespace, mirroring what install() leaves behind."""
+    monkeypatch.setattr(runtime, "_user_ns", ns)
+    monkeypatch.setattr(runtime, "_baseline_names", frozenset(ns))
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+
+
+def test_await_target_evaluates(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def answer() -> int:
+        await asyncio.sleep(0)
+        return 41
+
+    _wire(monkeypatch, {"answer": answer})
+    result = asyncio.run(runtime.__ix_read("await answer() + 1"))
+    assert result.llm_result == "42"
+
+
+def test_awaited_value_naming_a_file_reads_the_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # The path rule applies to the RESOLVED value: an awaited expression whose
+    # value names an existing file reads that file, never echoes the path.
+    note = tmp_path / "note.txt"
+    note.write_text("hello from disk\n")
+
+    async def where() -> str:
+        return str(note)
+
+    _wire(monkeypatch, {"where": where})
+    result = asyncio.run(runtime.__ix_read("await where()"))
+    assert "hello from disk" in result.llm_result
+
+
+def test_plain_expression_target_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {"answer": 41})
+    result = asyncio.run(runtime.__ix_read("answer + 1"))
+    assert result.llm_result == "42"


### PR DESCRIPTION
Fixes #3139.

The `read` MCP tool's target expression was evaluated with plain `eval()`, so an `await ...` target failed:

```
File ".../ix_notebook_mcp/runtime.py", line 4509, in __ix_read
    value = eval(target, ns) if isinstance(target, str) else target
File "<string>", line 1
SyntaxError: 'await' outside function
```

(reproduced live against the installed server before this change.)

- `__ix_read` now compiles a string target with `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` and awaits the resulting coroutine on the kernel loop, matching how cells support top-level await (`_compile`).
- Tool descriptions (`guide.READ`, the `target` field) now say top-level await is allowed.
- Regression tests in `packages/mcp/tests/test_read_await.py`, wired into `typecheckSmoke`: an `await` target evaluates, an awaited value naming a file reads the file, plain expressions unchanged.

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow top-level await in the MCP read tool's target expression
> The `__ix_read` helper in [runtime.py](https://github.com/indexable-inc/index/pull/3141/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) now compiles target expressions with `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` and awaits any resulting coroutine before processing the value. This matches cell compilation semantics and lets callers write expressions like `await jobs['ab12']` as the read target. Tool descriptions and parameter docs in [guide.py](https://github.com/indexable-inc/index/pull/3141/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) and [tools.py](https://github.com/indexable-inc/index/pull/3141/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) are updated accordingly, and new tests in [test_read_await.py](https://github.com/indexable-inc/index/pull/3141/files#diff-0eedd2a94c0a577a3968612972d446380b31f4e1f3489b83e897e45fd5153367) cover the await path, file-path resolution after awaiting, and unchanged plain-expression behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de2e96e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->