### PR TITLE
fix(nu): probe SSH_AUTH_SOCK liveness per call, unset a dead socket loudly

### DIFF
--- a/packages/mcp/tests/test_nu.py
+++ b/packages/mcp/tests/test_nu.py
@@ -10,7 +10,11 @@ crossing, the df -> nu -> df roundtrip, the NuError diagnostic surface,
 import asyncio
 import datetime
 import inspect
+import os
 import pathlib
+import shutil
+import socket
+import tempfile
 
 import polars as pl
 import pytest
@@ -521,4 +525,90 @@ def test_externals_run_color_free_even_when_host_forces_color(
     finally:
         # The forced-color engine (and the env= override, which persists on
         # the stack) must not leak into later tests.
+        nu.reset()
+
+
+def _short_socket_path() -> pathlib.Path:
+    # AF_UNIX sun_path caps at ~104 bytes on macOS; pytest's tmp_path nests
+    # too deep under the sandbox TMPDIR to bind reliably, so carve a
+    # short-named dir instead (the caller removes it).
+    return pathlib.Path(tempfile.mkdtemp(prefix="nu-sock-")) / "a.sock"
+
+
+def test_dead_ssh_auth_sock_is_unset_everywhere_and_logged(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Issue #3140: the long-lived kernel outlives the ssh agent it inherited
+    # SSH_AUTH_SOCK from, and git commit signing then fails mid-session with
+    # 'agent refused operation'. A socket file with no listener is exactly
+    # that shape (connect -> ECONNREFUSED); the probe must unset the variable
+    # in the process env AND the engine's own env copy, and say so loudly.
+    sock_path = _short_socket_path()
+    holder = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    holder.bind(str(sock_path))
+    holder.close()  # the file stays; nothing accepts connections
+    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock_path))
+    nu.reset()  # the engine copies the host env at construction
+    try:
+        assert run(nu.value("2 + 2")) == 4
+        assert "SSH_AUTH_SOCK" not in os.environ
+        assert run(nu.value("'SSH_AUTH_SOCK' in $env")) is False
+        # The sentinel carrying the dead path must not persist into $env.
+        assert run(nu.value("$env | columns | where $it =~ 'ix_nu_dead' | length")) == 0
+        logged = capsys.readouterr().out
+        assert str(sock_path) in logged
+        assert "3140" in logged
+    finally:
+        shutil.rmtree(sock_path.parent)
+        nu.reset()
+
+
+def test_missing_ssh_auth_sock_path_counts_as_dead(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The other stale shape: the launchd/agent directory is gone entirely
+    # (connect -> ENOENT).
+    monkeypatch.setenv("SSH_AUTH_SOCK", "/nonexistent/ix-3140/agent.sock")
+    nu.reset()
+    try:
+        assert run(nu.value("2 + 2")) == 4
+        assert "SSH_AUTH_SOCK" not in os.environ
+        assert "/nonexistent/ix-3140/agent.sock" in capsys.readouterr().out
+    finally:
+        nu.reset()
+
+
+def test_live_ssh_auth_sock_is_left_alone(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sock_path = _short_socket_path()
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(str(sock_path))
+    server.listen(1)
+    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock_path))
+    nu.reset()
+    try:
+        assert run(nu.value("$env.SSH_AUTH_SOCK")) == str(sock_path)
+        assert os.environ["SSH_AUTH_SOCK"] == str(sock_path)
+        assert capsys.readouterr().out == ""
+    finally:
+        server.close()
+        shutil.rmtree(sock_path.parent)
+        nu.reset()
+
+
+def test_deliberate_env_override_survives_host_sock_death(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # env= persists on the engine's stack; only an engine value EQUAL to the
+    # dead host path is hidden, so a caller's own override is never
+    # clobbered even while the process env copy gets unset.
+    monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
+    nu.reset()
+    try:
+        run(nu.value("2 + 2", env={"SSH_AUTH_SOCK": "/deliberate/override.sock"}))
+        monkeypatch.setenv("SSH_AUTH_SOCK", "/nonexistent/ix-3140/dead.sock")
+        assert run(nu.value("$env.SSH_AUTH_SOCK")) == "/deliberate/override.sock"
+        assert "SSH_AUTH_SOCK" not in os.environ
+    finally:
         nu.reset()

--- a/packages/nu-py/python/nu/__init__.py
+++ b/packages/nu-py/python/nu/__init__.py
@@ -75,6 +75,12 @@ Contract:
   to prompt into a captured pipe. A call
   that wants ANSI re-enables it with ``env={"NO_COLOR": "",
   "CLICOLOR_FORCE": "1"}`` (or ``with-env`` inside the pipeline).
+- ``SSH_AUTH_SOCK`` is probed once per call: the long-lived kernel
+  outlives the ssh agent it inherited the socket from, so when the path no
+  longer accepts connections it is unset (process env and this engine) with
+  a loud log line instead of letting ``git commit`` signing fail
+  mid-session with ``agent refused operation`` (issue #3140). A live
+  socket, and a deliberate ``env=`` override, are never touched.
 - Each kernel session gets its OWN engine (stored in the session's
   namespace), so one agent's ``let``/``cd``/``def`` never leaks into or
   clobbers another session's pipelines.
@@ -116,6 +122,7 @@ import inspect as _inspect
 import os
 import pathlib
 import re
+import socket
 import time
 from typing import TYPE_CHECKING, Literal, NamedTuple, overload
 
@@ -321,6 +328,76 @@ def _resolve_dir(cwd: str | os.PathLike) -> str:
     return os.fspath(resolved)
 
 
+# The engine keeps its own env copy (seeded from the host env at
+# construction), so a dead SSH_AUTH_SOCK must be hidden there too, not just
+# in os.environ. One eval, atomic under the engine lock: compare-and-hide
+# only while the engine still holds the dead path (a deliberate env=
+# override is the caller's business, never clobbered). The dead path crosses
+# as a per-eval env var instead of a source literal, so no hand-rendered
+# nushell string quoting; the sentinel hides itself in the same eval so it
+# never persists into `$env`.
+_DEAD_SOCK_VAR = "__ix_nu_dead_ssh_auth_sock"
+_HIDE_DEAD_SOCK = (
+    f"if ($env.SSH_AUTH_SOCK? == $env.{_DEAD_SOCK_VAR}) {{ hide-env SSH_AUTH_SOCK }}; "
+    f"hide-env -i {_DEAD_SOCK_VAR}"
+)
+
+
+def _dead_ssh_auth_sock() -> str | None:
+    """The dead socket ``SSH_AUTH_SOCK`` points at, or ``None`` when the
+    variable is unset or the socket accepts connections.
+
+    The long-lived kernel inherits ``SSH_AUTH_SOCK`` once at startup while
+    the agent behind it (1Password, launchd) restarts independently, so
+    hours into a session the path goes dead and ``git commit`` signing fails
+    with ``agent refused operation`` with no hint that the env is the
+    culprit (issue #3140). One connect(2) per call catches that before the
+    pipeline runs. Synchronous on purpose, like :func:`_resolve_dir`: a
+    local unix socket connect succeeds or fails immediately.
+    """
+    path = os.environ.get("SSH_AUTH_SOCK")
+    if not path:
+        return None
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+            probe.settimeout(1.0)
+            probe.connect(path)
+    except OSError:
+        return path
+    return None
+
+
+async def _drop_dead_ssh_auth_sock(engine: Engine, cwd: str | None) -> None:
+    """Unset ``SSH_AUTH_SOCK`` everywhere when its socket is dead, loudly.
+
+    Unsetting reproduces the manual ``hide-env -i SSH_AUTH_SOCK`` workaround
+    (issue #3140): with no agent socket in the env, git's signing program
+    resolves the live agent itself. No refresh is attempted: a replacement
+    socket at the same path would have passed the probe. ``cwd`` mirrors the
+    caller's resolved directory so an explicit ``cwd=`` still recovers a
+    deleted remembered PWD in the same call (issue #2587).
+    """
+    dead = _dead_ssh_auth_sock()
+    if dead is None:
+        return
+    del os.environ["SSH_AUTH_SOCK"]
+    coroutine, _handle = engine.eval(
+        _HIDE_DEAD_SOCK, input=None, cwd=cwd, env={_DEAD_SOCK_VAR: dead}, check=True
+    )
+    try:
+        await coroutine
+    except NuCwdError:
+        # The main eval's recovery contract (issue #2587) must survive this
+        # pre-eval: discard the stale engine so a retry starts fresh.
+        _discard_engine(engine)
+        raise
+    print(
+        f"[nu] SSH_AUTH_SOCK pointed at a dead agent socket ({dead}); "
+        "unset it (process env and this engine) so commit signing stops "
+        "failing with 'agent refused operation' (issue #3140)"
+    )
+
+
 async def _run(
     code: str,
     *,
@@ -343,6 +420,7 @@ async def _run(
         _rename_current_job(name)
 
     engine = _default_engine()
+    await _drop_dead_ssh_auth_sock(engine, resolved_cwd)
     loop = asyncio.get_running_loop()
     state: dict[str, object] = {
         "code": code,


### PR DESCRIPTION
Fixes #3140.

**Problem:** the long-lived kernel inherits `SSH_AUTH_SOCK` once at startup while the agent behind it (1Password, launchd) restarts independently, so hours into a session `git commit` in a `nu()` cell fails signing with `agent refused operation` / `failed to write commit object`, with no hint that the env is the culprit. The manual workaround (`hide-env -i SSH_AUTH_SOCK; git commit ...`) lived only in auto-memory.

**Change** (`packages/nu-py/python/nu/__init__.py`, Python seam only, no Rust changes):

- `nu()` probes `SSH_AUTH_SOCK` liveness once per call: one `connect(2)` to the unix socket before the pipeline runs.
- When the socket is dead (ENOENT or ECONNREFUSED), the variable is unset in `os.environ` AND hidden in the engine's own env copy (the engine seeds its env from the host at construction). The hide is a compare-and-hide in one atomic eval, so a deliberate `env=` override never gets clobbered; the dead path crosses as a per-eval env var (no hand-rendered nushell quoting) and the sentinel hides itself in the same eval.
- The refresh logs loudly into the calling job's stdout: `[nu] SSH_AUTH_SOCK pointed at a dead agent socket (...)`.
- A live socket is never touched; once unset, later probes are no-ops.
- No re-pointing is attempted: with the variable unset, git's signing program (op-ssh-sign) resolves the live agent itself, and a replacement socket at the same path would have passed the probe. The pre-eval mirrors the caller's resolved `cwd`, so the deleted-PWD recovery contract (#2587) is preserved.

**Tests** (`packages/mcp/tests/test_nu.py`, runs in CI via `mcp.tests.nuTests`): dead socket file with no listener (ECONNREFUSED), missing path (ENOENT), live listener left untouched, and a deliberate `env=` override surviving host-sock death. The two dead-sock tests fail against unfixed `nu` (verified).

(sent by an AI agent via Claude Code, model Claude Opus 4.6)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Probe `SSH_AUTH_SOCK` liveness on each `nu` call and unset dead sockets with a log message
> - Adds `_dead_ssh_auth_sock` in [`nu/__init__.py`](https://github.com/indexable-inc/index/pull/3143/files#diff-1b1b715fd290d16b51363424dc714ebeb7b9a942d93a9bce548fb3d83d610fe4) that attempts a 1-second AF_UNIX connect to detect dead or missing socket paths.
> - Adds `_drop_dead_ssh_auth_sock`, called at the start of every `nu._run`, which removes a dead socket from both process env and the nushell engine env, then logs the path and issue number 3140.
> - Explicit `env` overrides passed via `nu.value` are preserved even when the host `SSH_AUTH_SOCK` is dead.
> - Adds four tests covering dead socket, missing path, live socket, and override-survives-dead-host-socket scenarios.
> - Behavioral Change: `SSH_AUTH_SOCK` is now silently removed from the engine and process env on every pipeline run when the socket is unreachable, rather than passing a stale path through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44aa5f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->