### PR TITLE
workstation: disable unar, same ld64 hardening crash as vengi-tools (#3133)

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -719,7 +719,7 @@ in {
       termdown # countdown timer / stopwatch (duplicate also listed above)
       twurl # `curl` with built-in Twitter/X OAuth signing
       ugrep # fast grep with PDF/zip/tar/JSON support
-      unar # universal unarchiver (rar/7z/zip/tar/etc. via The Unarchiver)
+      # unar # universal unarchiver (rar/7z/zip/tar/etc. via The Unarchiver); disabled 2026-07-12: same ld64-957.1 libc++-hardening trap as vengi-tools (index#3133), crashes linking `unar` via xcodebuild, no cache.nixos.org aarch64-darwin build. Re-enable with vengi-tools once the pin carries NixOS/nixpkgs#536365.
       viddy # modern `watch` with diff highlighting and time-travel
       vivid # LS_COLORS theme generator (used by `eza`/`ls`)
       wabt # WebAssembly Binary Toolkit (`wasm2wat`, `wat2wasm`, `wasm-objdump`)


### PR DESCRIPTION
Same root cause as vengi-tools (#3133): the current nixpkgs pin's `ld64-957.1` is built without `hardeningDisable = ["libcxxhardeningfast"]` and traps (`Trace/BPT trap: 5`, exit 133) in the stubs pass. `unar` hits it linking its main binary via xcodebuild, deterministically, and cache.nixos.org has no aarch64-darwin build.

Found by a `--keep-going` census of the full home activation closure after #3134 merged: `unar` was the only remaining leaf failure, so this should be the last disable needed.

Re-enable with vengi-tools once the pin carries NixOS/nixpkgs#536365 (ld64: disable hardening again).

(sent by an AI agent via Claude Code, model Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable `unar` in workstation profile due to ld64 hardening crash
> Comments out `unar` in [workstation.nix](https://github.com/indexable-inc/index/pull/3146/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) to avoid a build failure caused by the same ld64 hardening crash seen in vengi-tools (#3133).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a803c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->