### PR TITLE
weave-slack-bot: mark shell phases for astlog

### DIFF
--- a/packages/weave-slack-bot/default.nix
+++ b/packages/weave-slack-bot/default.nix
@@ -28,12 +28,14 @@ in
     doCheck = true;
 
     checkPhase = ''
+      # shell
       runHook preCheck
       ${python}/bin/python3 -m unittest discover -s tests -p 'test_*.py'
       runHook postCheck
     '';
 
     installPhase = ''
+      # shell
       runHook preInstall
       install -Dm755 weave_slack_bot.py $out/libexec/weave-slack-bot.py
       makeWrapper ${python}/bin/python3 $out/bin/weave-slack-bot \


### PR DESCRIPTION
astlog blocks `phase-string-without-syntax-comment` on the two multiline phases #3152 added in `packages/weave-slack-bot/default.nix`. Main flake-check stayed green off a cached astlog result, so the findings surface on every PR branch that rebuilds the whole-tree lint (first hit: #3132 after update-branch, run 29277330775).

Adds the `# shell` first-line comment to both phases.

🤖 Filed by an AI agent (Claude Opus 4.6 via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark shell phases in weave-slack-bot derivation for astlog
> Adds `# shell` marker comments to the `checkPhase` and `installPhase` scripts in [default.nix](https://github.com/indexable-inc/index/pull/3154/files#diff-4c45c0f46f037a30f27c4f4265729e0923c12e958ac2975ca62ea2c3c2f64f0c) so that astlog can identify these blocks as shell code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84249e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->