### PR TITLE
fix(slack): emit valid Weave operation IDs

### DIFF
--- a/packages/weave-slack-bot/tests/test_weave_slack_bot.py
+++ b/packages/weave-slack-bot/tests/test_weave_slack_bot.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib.util
 import pathlib
+import re
 import sys
 import unittest
 
@@ -78,6 +79,18 @@ class FailingSlack(FakeSlack):
     async def chat_postMessage(self, **kwargs):
         self.calls.append(("chat_postMessage", kwargs))
         raise FakeSlackApiError(self.code)
+
+
+class RecordingWeaveClient(bot_module.WeaveClient):
+    def __init__(self):
+        super().__init__("http://weave.invalid", "weave-slack-bot@ix.dev")
+        self.requests = []
+
+    async def _post(
+        self, path: str, body: dict[str, object]
+    ) -> dict[str, object]:
+        self.requests.append((path, body))
+        return {}
 
 
 def payload(event_type="app_mention", **event):
@@ -265,6 +278,32 @@ class EncodingTests(unittest.TestCase):
                 }
             },
         )
+
+
+class WeaveOperationIdTests(unittest.IsolatedAsyncioTestCase):
+    async def test_all_write_paths_emit_valid_operation_ids(self):
+        weave = RecordingWeaveClient()
+        item = event()
+
+        await weave.seed_agent("slack-bot", "fable", "system")
+        await weave.record(item)
+        await weave.dispatch(item, "slack-bot")
+        await weave.mark_sent(item, "200.1")
+
+        operation_ids = [
+            body["operation_id"]
+            for path, body in weave.requests
+            if path in {"/api/facts", "/api/chat"}
+        ]
+        self.assertEqual(len(operation_ids), 5)
+        for value in operation_ids:
+            self.assertIsNotNone(re.fullmatch(r"[A-Za-z0-9_-]{1,128}", value))
+
+    def test_operation_id_rejects_invalid_parts(self):
+        with self.assertRaisesRegex(  # noqa: PT027 -- this package uses unittest
+            ValueError, "invalid Weave operation id"
+        ):
+            bot_module.operation_id("slack", "invalid:key")
 
 
 if __name__ == "__main__":

--- a/packages/weave-slack-bot/weave_slack_bot.py
+++ b/packages/weave-slack-bot/weave_slack_bot.py
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import ssl
 import urllib.error
 import urllib.request
@@ -37,6 +38,7 @@ _TRANSIENT_SLACK_ERRORS = {
     "request_timeout",
     "service_unavailable",
 }
+_WEAVE_OPERATION_ID = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
 
 def slack_error_code(error: Exception) -> str | None:
@@ -57,6 +59,14 @@ class WeaveError(RuntimeError):
 
 class PermanentDeliveryError(RuntimeError):
     pass
+
+
+def operation_id(*parts: str) -> str:
+    """Build an identifier accepted by the Weave facts and chat APIs."""
+    value = "-".join(parts)
+    if _WEAVE_OPERATION_ID.fullmatch(value) is None:
+        raise ValueError(f"invalid Weave operation id: {value!r}")
+    return value
 
 
 @dataclasses.dataclass(frozen=True)
@@ -163,7 +173,7 @@ class WeaveClient:
         entity = f"agent:{agent}"
         digest = hashlib.sha256(f"{model}\0{system}".encode()).hexdigest()
         await self.operation(
-            f"slack-agent-config:{digest}",
+            operation_id("slack-agent-config", digest),
             [
                 fact(entity, "type", "agent"),
                 fact(entity, "name", agent),
@@ -174,7 +184,7 @@ class WeaveClient:
 
     async def record(self, event: SlackEvent) -> None:
         await self.operation(
-            f"slack-ingress-record:{event.key}",
+            operation_id("slack-ingress-record", event.key),
             [
                 fact(event.entity, "type", "slack_event"),
                 fact(event.entity, "event_id", event.event_id),
@@ -201,7 +211,7 @@ class WeaveClient:
         await self._post(
             "/api/chat",
             {
-                "operation_id": f"slack-ingress-chat:{event.key}",
+                "operation_id": operation_id("slack-ingress-chat", event.key),
                 "id": event.message_id,
                 "author": self.identity,
                 "from": f"slack:{event.user or 'unknown'}",
@@ -211,7 +221,7 @@ class WeaveClient:
             },
         )
         await self.operation(
-            f"slack-ingress-dispatched:{event.key}",
+            operation_id("slack-ingress-dispatched", event.key),
             [fact(event.entity, "state", "awaiting_reply")],
         )
 
@@ -224,7 +234,7 @@ class WeaveClient:
 
     async def mark_sent(self, event: SlackEvent, reply_ts: str) -> None:
         await self.operation(
-            f"slack-egress-sent:{event.key}",
+            operation_id("slack-egress-sent", event.key),
             [
                 fact(event.entity, "reply_ts", reply_ts),
                 fact(event.entity, "state", "sent"),


### PR DESCRIPTION
## What changed

- build every Slack bridge operation ID through one validated helper
- use hyphen-separated IDs accepted by Weave's facts and chat APIs
- cover all five write paths with a boundary test

## Root cause

The Slack bridge emitted colon-separated operation IDs. The deployed Weave API rejects those IDs because its operation ID contract permits only ASCII letters, digits, hyphens, and underscores, so the Nix-managed service failed during agent seeding.

## Validation

- `nix build .#weave-slack-bot --no-link`
- `nix run .#lint -- --output plain --only ruff`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `WeaveClient` to emit valid Weave operation IDs across all write paths
> Replaces bare f-string operation ID literals (e.g. `'slack-ingress-record:{event.key}'`) with a new `operation_id()` utility that joins parts with `-` and validates the result against the regex `[A-Za-z0-9_-]{1,128}`, raising `ValueError` for invalid identifiers. Affected methods are `seed_agent`, `record`, `dispatch`, and `mark_sent` in [`weave_slack_bot.py`](https://github.com/indexable-inc/index/pull/3155/files#diff-8cc5eb3df4dd11a24207a957ac03d2f600a9e111cbb06ff15a759488638ff7b3). Tests in [`test_weave_slack_bot.py`](https://github.com/indexable-inc/index/pull/3155/files#diff-23f02691788cea4be88059bc42af01c50b81fc1eb630eb4aaac2b6f35cd97890) cover all write paths and confirm rejection of invalid parts. Risk: any caller passing event keys containing `:` or other non-alphanumeric characters (beyond `_` and `-`) will now get a `ValueError` instead of silently emitting an invalid ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d1807e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->