### PR TITLE
users/andrewgazelka: keep Signal on beta channel

### DIFF
--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -62,7 +62,7 @@ in {
       "raycast"
       "screen-studio"
       "setapp"
-      "signal"
+      "signal@beta"
       "skim"
       "slack"
       "spotify"


### PR DESCRIPTION
## Summary

- declare `signal@beta` as the managed cask
- keep the active Signal Beta profile as the source of truth

## Validation

- `git diff --check`
- `nix run .#lint -- --json`

Fixes #3156

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch Signal to beta channel in andrewgazelka's Darwin config
> Replaces `signal` with `signal@beta` in [darwin.nix](https://github.com/indexable-inc/index/pull/3157/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc) to keep Signal on the beta release channel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5ae74f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->