### PR TITLE
fix image runtime DNS ownership

### DIFF
--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -616,6 +616,12 @@ in {
       # pending and blocks services such as minecraft.
       useDHCP = false;
 
+      # ix-vm-guest writes the runtime-provided nameservers to /etc/resolv.conf
+      # before starting the image. NixOS 26.05 enables resolvconf by default;
+      # with no NixOS-owned nameservers, stage 2 then replaces that file with an
+      # empty one and breaks DNS in an otherwise connected VM.
+      resolvconf.enable = lib.mkDefault false;
+
       # In-guest firewall is the NixOS nftables backend, enforcing each
       # module's `services.*.openFirewall` and `networking.firewall.allowed*`
       # declarations. ix VMs are `boot.isContainer = true` and share the

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3376,6 +3376,10 @@
         message = "base image should publish from the ix/base repository";
       }
       {
+        assertion = !base.config.networking.resolvconf.enable;
+        message = "image platform should preserve the runtime DNS configuration written by ix-vm-guest";
+      }
+      {
         assertion = lib.elemAt base.config.nix.settings.substituters 0 == "https://cache.ix.dev";
         message = "base profile should route Nix through cache.ix.dev before fallback substituters";
       }


### PR DESCRIPTION
## What changed

- disable NixOS `resolvconf` by default for ix images
- assert the shared image platform preserves runtime DNS ownership

## Root cause

`ix-vm-guest` writes the orchestrator-provided nameservers to `/etc/resolv.conf` before starting the image. NixOS 26.05 enables `networking.resolvconf.enable` by default, and stage 2 subsequently regenerated the file from an empty NixOS nameserver set. The VM retained working routes but lost DNS.

The platform already disables DHCP because ix owns guest network configuration. This change applies the same ownership boundary to DNS while retaining a one-line override for images that deliberately manage `resolv.conf` themselves.

## Impact

Newly published index images keep the DNS configuration supplied by ix, so commands such as `nix run nixpkgs#fastfetch` resolve hosts after systemd reaches normal startup.

## Validation

- `git diff --check`
- repository eval and lint deferred to CI at operator request


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable resolvconf in image platform to preserve runtime DNS nameservers
> Sets `networking.resolvconf.enable` to `false` by default in [lib/image/platform.nix](https://github.com/indexable-inc/index/pull/3158/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7), preventing NixOS stage 2 from overwriting `/etc/resolv.conf` with its own nameservers. A corresponding assertion is added in [tests/default.nix](https://github.com/indexable-inc/index/pull/3158/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to verify this setting holds in the base image profile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e088da6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->