### PR TITLE
index-delta tui: model diffs for structured formats, list all managed files

### DIFF
--- a/modules/darwin/mutable-files.nix
+++ b/modules/darwin/mutable-files.nix
@@ -141,6 +141,10 @@ in {
   };
 
   config = mkIf (cfg.files != {}) {
+    # The resolution CLI rides the module: anyone whose files it tracks can
+    # run `index-delta status`/`tui` without wiring the package themselves.
+    environment.systemPackages = [cfg.package];
+
     assertions =
       map (file: {
         assertion = (file.source == null) != (file.text == null);

--- a/modules/home/mutable-files.nix
+++ b/modules/home/mutable-files.nix
@@ -194,6 +194,10 @@ in {
   };
 
   config = mkIf (cfg.files != {}) {
+    # The resolution CLI rides the module: anyone whose files it tracks can
+    # run `index-delta status`/`tui` without wiring the package themselves.
+    home.packages = [cfg.package];
+
     assertions =
       map (file: {
         assertion = (file.source == null) != (file.text == null);

--- a/packages/index-delta/src/cmd.rs
+++ b/packages/index-delta/src/cmd.rs
@@ -285,20 +285,24 @@ pub enum State {
     Snoozed,
 }
 
-/// One side of a pending file's diff. Text sides get a line diff; when
-/// either side is not UTF-8 (a binary plist, say) a lossy line diff would be
-/// gibberish, so the logical ops the differ computes stand in instead.
+/// One side of a pending file's diff, in the representation its format is
+/// modeled in. Structured formats diff as logical ops: object key order is
+/// not significant (RFC 8259 §4, and likewise toml/yaml/plist tables), so a
+/// byte-level line diff would bury one real edit under an app rewriting the
+/// file in its own key order. Only true text files diff as lines.
 pub enum TuiDiff {
     Text { old: String, new: String },
     Ops(Vec<Op>),
 }
 
 fn tui_diff(format: Format, old: &[u8], new: &[u8]) -> TuiDiff {
-    match (str::from_utf8(old), str::from_utf8(new)) {
-        (Ok(old), Ok(new)) => TuiDiff::Text {
+    match (format, str::from_utf8(old), str::from_utf8(new)) {
+        (Format::Text, Ok(old), Ok(new)) => TuiDiff::Text {
             old: old.to_owned(),
             new: new.to_owned(),
         },
+        // Structured formats, plus non-UTF-8 text sides (a binary plist,
+        // say) where a lossy line diff would be gibberish.
         _ => TuiDiff::Ops(diff::diff_bytes(format, old, new)),
     }
 }
@@ -323,9 +327,6 @@ pub fn tui_entries(store: &Store) -> Result<Vec<TuiEntry>> {
     let mut entries = Vec::new();
     for meta in store.all_metas()? {
         let entry = status_entry(store, &meta)?;
-        if entry.state == State::Clean {
-            continue;
-        }
         let base = store.base_bytes(&meta.path)?;
         let upper = fs::read(&meta.path).unwrap_or_default();
         let staged = store.staged_bytes(&meta.path)?;
@@ -340,7 +341,20 @@ pub fn tui_entries(store: &Store) -> Result<Vec<TuiEntry>> {
             overlap: entry.overlap,
         });
     }
+    // Every managed file is listed; the ones needing attention sort first
+    // and clean files sink to the bottom (stable, so store order holds
+    // within a state).
+    entries.sort_by_key(|entry| attention_rank(entry.state));
     Ok(entries)
+}
+
+const fn attention_rank(state: State) -> u8 {
+    match state {
+        State::Conflict => 0,
+        State::Drifted => 1,
+        State::Snoozed => 2,
+        State::Clean => 3,
+    }
 }
 
 #[derive(Serialize)]
@@ -875,8 +889,68 @@ mod tests {
             }]
         );
         assert!(matches!(
-            tui_diff(Format::Json, b"{}", b"{}"),
+            tui_diff(Format::Text, b"a\n", b"b\n"),
             TuiDiff::Text { .. }
         ));
+    }
+
+    #[test]
+    fn tui_lists_clean_files_after_pending() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let store = Store::open(root.join("state")).expect("open");
+        // "a" sorts before "b" by path; only attention rank may reorder them.
+        let clean = root.join("home/a.json");
+        let drifted = root.join("home/b.json");
+        let source = root.join("store/base.json");
+        fs::create_dir_all(source.parent().expect("parent")).expect("mkdir");
+        fs::write(&source, r#"{"a": 1}"#).expect("write source");
+        let manifest = root.join("manifest.json");
+        let files: Vec<_> = [&clean, &drifted]
+            .into_iter()
+            .map(|path| {
+                serde_json::json!({
+                    "path": path, "source": source, "persistence": "durable",
+                })
+            })
+            .collect();
+        fs::write(
+            &manifest,
+            serde_json::json!({ "files": files }).to_string(),
+        )
+        .expect("write manifest");
+        activate(&store, &manifest).expect("activate");
+        fs::write(&drifted, r#"{"a": 2}"#).expect("drift");
+
+        let entries = tui_entries(&store).expect("entries");
+        let states: Vec<_> = entries
+            .iter()
+            .map(|entry| (entry.state, entry.path.clone()))
+            .collect();
+        assert_eq!(
+            states,
+            vec![
+                (State::Drifted, drifted.to_string_lossy().into_owned()),
+                (State::Clean, clean.to_string_lossy().into_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn tui_diff_hides_key_reorder_noise_in_structured_formats() {
+        // An app rewriting a json file in its own key order must not drown
+        // the one real edit: the model diff shows exactly that edit.
+        let old = br#"{"a": 1, "src": {"repo": "r", "source": "github"}}"#;
+        let new = br#"{"src": {"source": "github", "repo": "r"}, "a": 1, "model": "m"}"#;
+        let TuiDiff::Ops(ops) = tui_diff(Format::Json, old, new) else {
+            panic!("structured formats must diff as logical ops");
+        };
+        assert_eq!(
+            ops,
+            vec![Op::Add {
+                path: "/model".to_owned(),
+                value: "m".into(),
+            }]
+        );
     }
 }

--- a/packages/index-delta/src/tui.rs
+++ b/packages/index-delta/src/tui.rs
@@ -1,8 +1,9 @@
 //! `index-delta tui`: an interactive drift browser. The sidebar lists every
-//! pending file; the detail pane renders the real unified diff (base vs the
-//! file on disk, plus base vs the staged incoming base for conflicts). Enter
-//! suspends into `$VISUAL`/`$EDITOR` on the selected file and re-diffs on
-//! return.
+//! pending file; the detail pane renders each side's diff (base vs the file
+//! on disk, plus base vs the staged incoming base for conflicts) in its
+//! format's model: logical ops for structured formats, a unified line diff
+//! for text. Enter suspends into `$VISUAL`/`$EDITOR` on the selected file
+//! and re-diffs on return.
 
 use std::env;
 use std::io::{self, Stdout};
@@ -289,7 +290,11 @@ fn render_header(frame: &mut ratatui::Frame, area: Rect, app: &App) {
             Style::new().fg(badge.color).bold(),
         ));
     }
-    if app.entries.is_empty() {
+    if app
+        .entries
+        .iter()
+        .all(|entry| entry.state == State::Clean)
+    {
         spans.push(Span::styled(
             "  ✓ all clean",
             Style::new().fg(Color::Green).bold(),
@@ -310,7 +315,7 @@ fn render_sidebar(frame: &mut ratatui::Frame, area: Rect, app: &App) {
         ]))
     });
     let list = List::new(items)
-        .block(pane_block(&format!("pending · {}", app.entries.len())))
+        .block(pane_block(&format!("files · {}", app.entries.len())))
         .highlight_symbol("▌")
         .highlight_style(Style::new().bg(Color::DarkGray).bold());
     let mut state = ListState::default();
@@ -321,8 +326,8 @@ fn render_sidebar(frame: &mut ratatui::Frame, area: Rect, app: &App) {
 fn render_detail(frame: &mut ratatui::Frame, area: Rect, app: &App) {
     let Some(entry) = app.entries.get(app.selected) else {
         let empty = Paragraph::new(Line::styled(
-            "✓ nothing to resolve",
-            Style::new().fg(Color::Green).bold(),
+            "no managed files",
+            Style::new().fg(DIM).bold(),
         ))
         .block(pane_block("diff"));
         frame.render_widget(empty, area);
@@ -401,6 +406,13 @@ fn detail_lines(entry: &TuiEntry) -> Vec<Line<'static>> {
         ));
     }
     lines.push(Line::default());
+    if entry.state == State::Clean {
+        lines.push(Line::styled(
+            "✓ matches the declared base",
+            Style::new().fg(Color::Green),
+        ));
+        return lines;
+    }
     match &entry.incoming {
         Some(incoming) => {
             lines.push(section("your edits · base → file"));
@@ -434,26 +446,33 @@ fn diff_lines(diff: &TuiDiff) -> Vec<Line<'static>> {
     }
 }
 
-/// Logical ops as styled lines: the diff view for sides a line diff cannot
-/// render, e.g. binary plists.
+/// Logical ops as styled lines: the model diff for structured formats.
+/// Values render for reading, not re-parsing — strings shed their quotes,
+/// containers pretty-print — so one real edit reads as one line instead of
+/// a raw-file hunk.
 fn ops_lines(ops: &[Op]) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     for op in ops {
         match op {
-            Op::Add { path, value } => lines.push(Line::styled(
-                format!("+ {path} = {value}"),
-                Style::new().fg(Color::Green),
-            )),
-            Op::Remove { path, from } => lines.push(Line::styled(
-                format!("- {path} = {from}"),
-                Style::new().fg(Color::Red),
-            )),
-            Op::Replace { path, from, to } => lines.push(Line::from(vec![
-                Span::styled(format!("~ {path}  "), Style::new().fg(Color::Yellow)),
-                Span::styled(from.to_string(), Style::new().fg(Color::Red)),
-                Span::styled(" → ", Style::new().fg(DIM)),
-                Span::styled(to.to_string(), Style::new().fg(Color::Green)),
-            ])),
+            Op::Add { path, value } => entry_lines(&mut lines, '+', Color::Green, path, value),
+            Op::Remove { path, from } => entry_lines(&mut lines, '-', Color::Red, path, from),
+            Op::Replace { path, from, to } => {
+                if let (Some(from), Some(to)) = (scalar(from), scalar(to)) {
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("~ {path}  "), Style::new().fg(Color::Yellow)),
+                        Span::styled(from, Style::new().fg(Color::Red)),
+                        Span::styled(" → ", Style::new().fg(DIM)),
+                        Span::styled(to, Style::new().fg(Color::Green)),
+                    ]));
+                } else {
+                    lines.push(Line::styled(
+                        format!("~ {path}"),
+                        Style::new().fg(Color::Yellow),
+                    ));
+                    block_lines(&mut lines, '-', Color::Red, from);
+                    block_lines(&mut lines, '+', Color::Green, to);
+                }
+            }
             Op::Text { diff } => lines.extend(diff.lines().map(patch_line)),
             Op::Binary => lines.push(Line::styled(
                 "(binary contents differ)",
@@ -468,6 +487,70 @@ fn ops_lines(ops: &[Op]) -> Vec<Line<'static>> {
         ));
     }
     lines
+}
+
+/// `<mark> path  value` on one line for scalars, or `<mark> path` above the
+/// container's pretty-printed block.
+fn entry_lines(
+    lines: &mut Vec<Line<'static>>,
+    mark: char,
+    color: Color,
+    path: &str,
+    value: &serde_json::Value,
+) {
+    if let Some(text) = scalar(value) {
+        lines.push(Line::styled(
+            format!("{mark} {path}  {text}"),
+            Style::new().fg(color),
+        ));
+    } else {
+        lines.push(Line::styled(
+            format!("{mark} {path}"),
+            Style::new().fg(color),
+        ));
+        block_lines(lines, mark, color, value);
+    }
+}
+
+fn block_lines(
+    lines: &mut Vec<Line<'static>>,
+    mark: char,
+    color: Color,
+    value: &serde_json::Value,
+) {
+    for text in pretty(value) {
+        lines.push(Line::styled(
+            format!("{mark}   {text}"),
+            Style::new().fg(color),
+        ));
+    }
+}
+
+/// A scalar rendered bare when its spelling is unambiguous; strings keep
+/// their JSON quoting only where dropping it would lie (empty, multi-line,
+/// or whitespace-trimmed). Containers return `None` and pretty-print.
+fn scalar(value: &serde_json::Value) -> Option<String> {
+    use serde_json::Value;
+    match value {
+        Value::String(text) => {
+            let ambiguous = text.is_empty() || text.contains('\n') || text.trim() != text;
+            Some(if ambiguous {
+                value.to_string()
+            } else {
+                text.clone()
+            })
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => Some(value.to_string()),
+        Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+fn pretty(value: &serde_json::Value) -> Vec<String> {
+    serde_json::to_string_pretty(value)
+        .expect("a Value has no non-string keys, so pretty-printing cannot fail")
+        .lines()
+        .map(str::to_owned)
+        .collect()
 }
 
 /// Style one line of an already-rendered unified diff by its marker.
@@ -598,6 +681,14 @@ mod tests {
     }
 
     #[test]
+    fn clean_detail_reports_in_sync_without_a_diff() {
+        let entry = entry(State::Clean, None, Vec::new());
+        let text = rendered(&detail_lines(&entry)).join("\n");
+        assert!(text.contains("✓ matches the declared base"));
+        assert!(!text.contains("@@"), "clean entries must not render a diff");
+    }
+
+    #[test]
     fn conflict_detail_shows_both_sides_and_overlap() {
         let entry = entry(
             State::Conflict,
@@ -645,14 +736,42 @@ mod tests {
             Op::Binary,
         ];
         let lines = rendered(&ops_lines(&ops));
-        assert_eq!(lines[0], "+ /a = 1");
-        assert_eq!(lines[1], "- /b = 2");
+        assert_eq!(lines[0], "+ /a  1");
+        assert_eq!(lines[1], "- /b  2");
         assert_eq!(lines[2], "~ /c  3 → 4");
         assert_eq!(lines[3], "(binary contents differ)");
         assert_eq!(
             rendered(&ops_lines(&[]))[0],
             "(no logical changes; drift is formatting- or key-order-only)"
         );
+    }
+
+    #[test]
+    fn ops_render_strings_bare_and_containers_pretty() {
+        use serde_json::json;
+        let ops = vec![
+            Op::Add {
+                path: "/model".to_owned(),
+                value: json!("claude-fable-5[1m]"),
+            },
+            Op::Replace {
+                path: "/mode".to_owned(),
+                from: json!("auto"),
+                to: json!(" padded"),
+            },
+            Op::Add {
+                path: "/rules".to_owned(),
+                value: json!({"deep": true}),
+            },
+        ];
+        let lines = rendered(&ops_lines(&ops));
+        assert_eq!(lines[0], "+ /model  claude-fable-5[1m]");
+        // Ambiguous strings keep their quotes.
+        assert_eq!(lines[1], "~ /mode  auto → \" padded\"");
+        assert_eq!(lines[2], "+ /rules");
+        assert_eq!(lines[3], "+   {");
+        assert_eq!(lines[4], "+     \"deep\": true");
+        assert_eq!(lines[5], "+   }");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3161.

**Before** (the screenshot in the issue): a drifted `~/.claude/settings.json` showed a screenful of `-`/`+` pairs because Claude Code rewrote the file in its own key order, burying the single real edit.

**After**, the detail pane renders the format's model, not its bytes:

```
~ drifted  json  durable
declared at users/andrewgazelka/profiles/workstation.nix

+ /model  claude-fable-5[1m]
```

- **Model diffs for structured formats**: `TuiDiff` routes json/toml/yaml/plist/keyvalue to the logical ops the differ already computes (key order is insignificant per RFC 8259 §4 and the equivalents for the other formats); only `Format::Text` keeps the unified line diff.
- **Readable ops**: strings render bare (quotes kept only when dropping them would lie: empty, multi-line, whitespace-trimmed), scalar replaces as `old → new`, containers as pretty-printed marked blocks.
- **All files listed**: the sidebar shows every managed file, attention-ranked (conflict → drifted → snoozed → clean), clean at the bottom with a `✓ matches the declared base` detail.
- **CLI on PATH**: both `mutable-files` modules add `cfg.package` to packages, so any `mutable.files` consumer gets `index-delta` as a default tool.

Validated live against the real store on hydra (screens above are from the built binary driving the actual drift queue). 42 unit tests pass, including new coverage for reorder-noise suppression, bare/pretty rendering, and clean-last ordering.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render structured format diffs as logical ops and list all managed files in index-delta TUI
> - `tui_diff` in [cmd.rs](https://github.com/indexable-inc/index/pull/3163/files#diff-5b1601d88066a1a85132a3907d154df23498afcb396c4ca0907337a99c089184) now uses logical op diffs for structured formats (JSON/TOML/YAML/plist) instead of text diffs, avoiding noise from key-ordering changes.
> - `tui_entries` now includes clean files in the TUI list (previously skipped), sorted by a new `attention_rank`: conflicts first, then drifted, snoozed, and clean last.
> - In [tui.rs](https://github.com/indexable-inc/index/pull/3163/files#diff-9e28663c66b17176ed7be38adae16684fb4e3c040983c72aa14534571a2575ec), `ops_lines` rendering is improved: scalars display bare without JSON quotes, containers render as pretty-printed blocks, and replace ops show inline `from → to` for scalar-to-scalar changes.
> - Clean entries show a `✓ matches the declared base` confirmation instead of diff content; the sidebar title changes from `pending · N` to `files · N`.
> - Both darwin and home `mutable-files.nix` modules now add `cfg.package` to system/home packages when any files are tracked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 233e0a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->