### PR TITLE
nushell profile: survive login on index-free hosts

### DIFF
--- a/users/andrewgazelka/config/nushell/functions/secrets.nu
+++ b/users/andrewgazelka/config/nushell/functions/secrets.nu
@@ -63,10 +63,15 @@ def resolve-secret-line [line: string] {
 
 # Generate secrets cache from template.
 def generate-secrets-cache [] {
+    # Hosts without the private config repo (e.g. the builder VM) have no
+    # secrets template; leave the cache absent (indexable-inc/index#3165).
+    let private_dir = $env.NIX_PRIVATE_CONFIG_DIR?
+    if $private_dir == null { return }
+
     let cache_path = $SECRETS_CACHE | path expand
     mkdir ($cache_path | path dirname)
 
-    let template_path = $env.NIX_PRIVATE_CONFIG_DIR | path join "nushell" "secrets.template.nu"
+    let template_path = $private_dir | path join "nushell" "secrets.template.nu"
 
     open $template_path
     | lines

--- a/users/andrewgazelka/profiles/development.nix
+++ b/users/andrewgazelka/profiles/development.nix
@@ -18,10 +18,11 @@
 in {
   xdg.configFile."nvim/lua".source = nvimLua;
 
+  # theme.nu in the shared nushell config calls vivid at every login; ship
+  # it with the config so index-free hosts (builder VM) get it too (#3165).
+  home.packages = [pkgs.vivid];
+
   home.file = {
-    ".config/nushell" = lib.mkIf pkgs.stdenv.isLinux {
-      source = configRoot + "/nushell";
-    };
     ".config/nushell-hm-session-vars.nu".text =
       lib.concatStringsSep "\n" (
         lib.mapAttrsToList (
@@ -30,7 +31,18 @@ in {
         config.home.sessionVariables
       )
       + "\n";
-  };
+  }
+  # Link nushell config children individually rather than the whole dir:
+  # nushell creates history.sqlite3 inside its config dir on Linux, so a
+  # single read-only store symlink breaks interactive login (#3165).
+  // lib.optionalAttrs pkgs.stdenv.isLinux (
+    lib.mapAttrs' (
+      name: _:
+        lib.nameValuePair ".config/nushell/${name}" {
+          source = configRoot + "/nushell/${name}";
+        }
+    ) (builtins.readDir (configRoot + "/nushell"))
+  );
 
   programs = {
     bash.enable = true;

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -721,7 +721,6 @@ in {
       ugrep # fast grep with PDF/zip/tar/JSON support
       # unar # universal unarchiver (rar/7z/zip/tar/etc. via The Unarchiver); disabled 2026-07-12: same ld64-957.1 libc++-hardening trap as vengi-tools (index#3133), crashes linking `unar` via xcodebuild, no cache.nixos.org aarch64-darwin build. Re-enable with vengi-tools once the pin carries NixOS/nixpkgs#536365.
       viddy # modern `watch` with diff highlighting and time-travel
-      vivid # LS_COLORS theme generator (used by `eza`/`ls`)
       wabt # WebAssembly Binary Toolkit (`wasm2wat`, `wat2wasm`, `wasm-objdump`)
       wasmtime # standalone WebAssembly runtime
       watch # rerun a command periodically and show output


### PR DESCRIPTION
Closes #3165. Interactive nushell login on the builder VM failed three ways: secrets cache generation hard-required NIX_PRIVATE_CONFIG_DIR, theme.nu called vivid that only workstation shipped, and the whole-dir ~/.config/nushell store symlink blocked history.sqlite3 creation (Read-only file system). Fix: guard secrets on the env var, ship vivid from the development profile (workstation imports it; dup dropped), and link nushell config children individually so the dir stays writable. Note: hosts with the old whole-dir symlink need a one-time rm ~/.config/nushell before HM activation (done on the builder VM). Validated live on the VM: script -qec nu -l login now zero errors, history.sqlite3 created. (opened by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nushell profile to survive login on hosts without a nix index
> - `generate-secrets-cache` in [secrets.nu](https://github.com/indexable-inc/index/pull/3167/files#diff-6043ee6c811546b4e2126e98bf533390e3e9b94be415fa41ffb064f0680e0d24) now returns early when `NIX_PRIVATE_CONFIG_DIR` is unset, skipping cache generation on hosts where it is absent.
> - On Linux, [development.nix](https://github.com/indexable-inc/index/pull/3167/files#diff-b28e7d27c0f08f00752dc4e8b7627c43c3d2d3a6a11814e5fdba9e9b89f2ffd4) replaces the whole-directory `.config/nushell` symlink with per-file symlinks using `builtins.readDir`, allowing home-manager to coexist with other files in that directory.
> - `pkgs.vivid` is moved from [workstation.nix](https://github.com/indexable-inc/index/pull/3167/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) to [development.nix](https://github.com/indexable-inc/index/pull/3167/files#diff-b28e7d27c0f08f00752dc4e8b7627c43c3d2d3a6a11814e5fdba9e9b89f2ffd4) so it is available across all development environments.
> - Behavioral Change: hosts without `NIX_PRIVATE_CONFIG_DIR` will no longer have a secrets cache generated; the `.config/nushell` directory is no longer a single symlink on Linux.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b5e502.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->