### PR TITLE
nwm: attach headless when a sibling monitor owns the port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7045,6 +7045,7 @@ dependencies = [
  "clap",
  "ignore",
  "nix-web-monitor-parser",
+ "reqwest 0.12.28",
  "rmp-serde",
  "serde",
  "serde_json",

--- a/packages/nix/nix-web-monitor/server/Cargo.toml
+++ b/packages/nix/nix-web-monitor/server/Cargo.toml
@@ -17,6 +17,7 @@ bzip2.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 ignore.workspace = true
 nix-web-monitor-parser.workspace = true
+reqwest.workspace = true
 rmp-serde.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -43,6 +43,10 @@ const DELTA_CHANNEL_CAPACITY: usize = 1024;
 /// indefinitely; this bounds that to a drop instead of a permanent pin.
 const SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Bound on the loopback probe that classifies a busy port as a sibling
+/// monitor. The probe targets a local listener, so anything slower is not one.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
 #[derive(Parser)]
 #[command(about = "Run a Nix command with quiet terminal output and a live browser monitor.")]
 struct Args {
@@ -210,7 +214,13 @@ async fn main() -> Result<()> {
     // no command whose exit could end the run, so it serves until interrupted.
     if matches!(args.command, NwmCommand::Serve) {
         let monitor = Arc::new(RwLock::new(MonitorState::default()));
-        let ui = start_ui(&args.host, args.port, site_dir, monitor).await?;
+        let UiStart::Bound(ui) = start_ui(&args.host, args.port, site_dir, monitor).await? else {
+            bail!(
+                "port {} is already in use; a second serve daemon is a configuration error, \
+                 stop the other monitor or pass --port",
+                args.port
+            );
+        };
         eprintln!("nix-web-monitor: serving the machine view (no wrapped command); Ctrl-C to stop");
         tokio::signal::ctrl_c()
             .await
@@ -225,7 +235,35 @@ async fn main() -> Result<()> {
 
     let job = build_job(args.command).await.context("planning job")?;
     let monitor = Arc::new(RwLock::new(MonitorState::new(job.command_label.clone())));
-    let ui = start_ui(&args.host, args.port, site_dir, monitor).await?;
+    let ui = match start_ui(&args.host, args.port, site_dir, Arc::clone(&monitor)).await? {
+        UiStart::Bound(ui) => ui,
+        // A sibling monitor (an always-on `nwm serve`) already owns the port:
+        // run the job headless beside it instead of failing the switch. Its
+        // machine-builds panel shows this run's builds; the terminal keeps the
+        // summary stream.
+        UiStart::PortBusy => {
+            let url = format!("http://127.0.0.1:{}", args.port);
+            if !sibling_monitor(args.port).await {
+                bail!(
+                    "binding web monitor on {}:{}: address already in use, and {url}/api/state \
+                     is not a nix-web-monitor; stop the occupant or pass --port",
+                    args.host,
+                    args.port
+                );
+            }
+            eprintln!(
+                "nix-web-monitor: {url} already serves the monitor; running headless \
+                 (builds appear in its machine view)"
+            );
+            // No subscriber ever joins this channel; `broadcast_deltas`
+            // tolerates zero receivers.
+            let (deltas, _) = broadcast::channel::<Bytes>(DELTA_CHANNEL_CAPACITY);
+            let exit_code =
+                run_job(job, args.terminal_output, args.nix_verbose, monitor, deltas).await?;
+            // With no UI of our own to keep alive, `--exit-when-done` is moot.
+            std::process::exit(exit_code.unwrap_or(1));
+        }
+    };
 
     let build = tokio::spawn(run_job(
         job,
@@ -273,6 +311,15 @@ impl Ui {
     }
 }
 
+/// How [`start_ui`] came up: bound and serving, or the port already held
+/// (`AddrInUse`). The caller decides what a busy port means: fatal for `serve`
+/// mode (a second daemon is a configuration error), an attach for a wrapped
+/// command when [`sibling_monitor`] confirms the occupant.
+enum UiStart {
+    Bound(Ui),
+    PortBusy,
+}
+
 /// Bind the web server on `host:port` and start the machine-wide probes: the
 /// UI, the `/api/state` snapshot, and the `/ws` delta feed on one port, plus
 /// the two best-effort overlays that live for the whole life of the UI --
@@ -284,7 +331,7 @@ async fn start_ui(
     port: u16,
     site_dir: PathBuf,
     monitor: Arc<RwLock<MonitorState>>,
-) -> Result<Ui> {
+) -> Result<UiStart> {
     let index_html =
         Bytes::from(std::fs::read(site_dir.join("index.html")).context("reading index.html")?);
     let (deltas, _) = broadcast::channel::<Bytes>(DELTA_CHANNEL_CAPACITY);
@@ -293,42 +340,67 @@ async fn start_ui(
         .parse()
         .with_context(|| format!("invalid HTTP address {host}:{port}"))?;
 
+    let listener = match tokio::net::TcpListener::bind(http_addr).await {
+        Ok(listener) => listener,
+        Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+            return Ok(UiStart::PortBusy);
+        }
+        Err(error) => {
+            return Err(error).with_context(|| format!("binding web monitor on {http_addr}"));
+        }
+    };
+
     let state = AppState {
         monitor: Arc::clone(&monitor),
         deltas: deltas.clone(),
         index_html,
     };
-    let http_server = serve(http_addr, site_dir, state).await?;
+    let http_server = serve(listener, site_dir, state);
 
     eprintln!("nix-web-monitor: http://{http_addr}");
 
     let daemon_probe = tokio::spawn(run_daemon_probe(Arc::clone(&monitor), deltas.clone()));
     let global_probe = tokio::spawn(run_global_probe(Arc::clone(&monitor), deltas.clone()));
 
-    Ok(Ui {
+    Ok(UiStart::Bound(Ui {
         monitor,
         deltas,
         http_server,
         daemon_probe,
         global_probe,
-    })
+    }))
 }
 
-async fn serve(
-    addr: SocketAddr,
+/// Whether the busy port is held by another nix-web-monitor: loopback
+/// `GET /api/state` must answer with a decodable [`MonitorSnapshot`]. The
+/// probe targets loopback regardless of `--host`, since a bind that collided
+/// on the port is reachable there in every supported configuration.
+async fn sibling_monitor(port: u16) -> bool {
+    let Ok(client) = reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() else {
+        return false;
+    };
+    let Ok(response) = client
+        .get(format!("http://127.0.0.1:{port}/api/state"))
+        .send()
+        .await
+    else {
+        return false;
+    };
+    response.json::<MonitorSnapshot>().await.is_ok()
+}
+
+fn serve(
+    listener: tokio::net::TcpListener,
     site_dir: PathBuf,
     state: AppState,
-) -> Result<tokio::task::JoinHandle<()>> {
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .with_context(|| format!("binding web monitor on {addr}"))?;
+) -> tokio::task::JoinHandle<()> {
     let app = router(&site_dir, state);
 
-    Ok(tokio::spawn(async move {
+    tokio::spawn(async move {
         if let Err(error) = axum::serve(listener, app).await {
             eprintln!("nix-web-monitor: web server failed: {error}");
         }
-    }))
+    })
 }
 
 /// Build the HTTP router: the JSON snapshot, the WebSocket live feed, the
@@ -1393,6 +1465,38 @@ mod tests {
         assert!(matches!(args.command, NwmCommand::Serve));
         assert_eq!(args.host, "127.0.0.1");
         assert_eq!(args.port, 8080);
+    }
+
+    /// The attach path's classifier: a busy port counts as a sibling monitor
+    /// only when `/api/state` decodes as a snapshot; a listener without that
+    /// route (an empty router 404ing everything) must keep the bind failure
+    /// fatal.
+    #[tokio::test]
+    async fn sibling_probe_accepts_monitor_and_rejects_others() {
+        let sibling = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind sibling");
+        let sibling_port = sibling.local_addr().expect("sibling addr").port();
+        let sibling_router = router(Path::new("/nonexistent-site"), test_state());
+        tokio::spawn(async move {
+            axum::serve(sibling, sibling_router).await.expect("sibling serves");
+        });
+
+        let foreign = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind foreign");
+        let foreign_port = foreign.local_addr().expect("foreign addr").port();
+        tokio::spawn(async move {
+            axum::serve(foreign, axum::Router::new())
+                .await
+                .expect("foreign serves");
+        });
+
+        assert!(sibling_monitor(sibling_port).await, "monitor detected");
+        assert!(
+            !sibling_monitor(foreign_port).await,
+            "non-monitor listener rejected"
+        );
     }
 
     /// Adding the `serve` subcommand must not narrow the passthrough: any other

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -214,7 +214,7 @@ async fn main() -> Result<()> {
     // no command whose exit could end the run, so it serves until interrupted.
     if matches!(args.command, NwmCommand::Serve) {
         let monitor = Arc::new(RwLock::new(MonitorState::default()));
-        let UiStart::Bound(ui) = start_ui(&args.host, args.port, site_dir, monitor).await? else {
+        let UiStart::Bound(ui) = start_ui(&args.host, args.port, &site_dir, monitor).await? else {
             bail!(
                 "port {} is already in use; a second serve daemon is a configuration error, \
                  stop the other monitor or pass --port",
@@ -235,7 +235,7 @@ async fn main() -> Result<()> {
 
     let job = build_job(args.command).await.context("planning job")?;
     let monitor = Arc::new(RwLock::new(MonitorState::new(job.command_label.clone())));
-    let ui = match start_ui(&args.host, args.port, site_dir, Arc::clone(&monitor)).await? {
+    let ui = match start_ui(&args.host, args.port, &site_dir, Arc::clone(&monitor)).await? {
         UiStart::Bound(ui) => ui,
         // A sibling monitor (an always-on `nwm serve`) already owns the port:
         // run the job headless beside it instead of failing the switch. Its
@@ -329,7 +329,7 @@ enum UiStart {
 async fn start_ui(
     host: &str,
     port: u16,
-    site_dir: PathBuf,
+    site_dir: &Path,
     monitor: Arc<RwLock<MonitorState>>,
 ) -> Result<UiStart> {
     let index_html =
@@ -391,10 +391,10 @@ async fn sibling_monitor(port: u16) -> bool {
 
 fn serve(
     listener: tokio::net::TcpListener,
-    site_dir: PathBuf,
+    site_dir: &Path,
     state: AppState,
 ) -> tokio::task::JoinHandle<()> {
-    let app = router(&site_dir, state);
+    let app = router(site_dir, state);
 
     tokio::spawn(async move {
         if let Err(error) = axum::serve(listener, app).await {


### PR DESCRIPTION
Fixes #3170.

With the always-on `nwm serve` launchd agent (#2182) holding :7532, every wrapped command (`nwm home switch`, `nwm build .#x`, ...) died at startup with `Address already in use`.

## Change

- `start_ui` now returns a typed outcome: `Bound(Ui)` or `PortBusy` (bind hit `AddrInUse`; any other bind error stays fatal).
- A wrapped command on a busy port probes loopback `GET /api/state` (2s budget); when the occupant decodes as a `MonitorSnapshot`, the job runs headless beside the sibling monitor with one line pointing at its URL. The sibling's machine-builds panel (`nix store builds --json`) shows the run; the terminal keeps the summary stream. Exit code propagation unchanged.
- A foreign occupant keeps the hard bind error, naming the failed probe.
- `serve` on a busy port stays fatal: a second daemon is a configuration error.

## Validation

- `cargo test -p nix-web-monitor`: 28 passed, including a new probe classifier test (real loopback listeners: full router accepted, empty 404 router rejected).
- E2E with the debug binary: attach against a live `serve` daemon runs `nix eval` headless (exit 0, output intact); a failing command propagates exit 1; a second `serve` hard-fails; a raw non-HTTP occupant hard-fails with the probe message.

Follow-up (not in scope): session ingest so an attached run's build tree / activation steps / nvd diff render on the running server.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Attach nwm headless when a sibling monitor owns the port
> - When `nix-web-monitor` runs a wrapped command and the target port is already in use, it now probes `/api/state` on that port to detect a sibling monitor instance.
> - If a sibling is detected, the build runs headless (no UI binding), posting state to the existing monitor via a no-subscriber broadcast channel, then exits with the job's status.
> - If the port is occupied by a non-monitor process, the program exits with a clear error.
> - In serve-only mode, a busy port now exits with a targeted error message instead of surfacing a raw bind error.
> - Adds `sibling_monitor` function in [main.rs](https://github.com/indexable-inc/index/pull/3174/files#diff-5f7a5a3bf017bab11020325a81b81855b5999b26a72220162e9d5873d7cd5d6d) using `reqwest` with a 2s `PROBE_TIMEOUT` to classify the occupant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29593d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->