### PR TITLE
mcp: normalize watch_pr nu records at the boundary

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2042,6 +2042,25 @@ _MERGEABILITY_POLL_S: float = 2.0
 _MERGEABILITY_TIMEOUT_S: float = 30.0
 
 
+def _nu_record(value: Any, *, source: str) -> dict[str, Any]:
+    """One nu pipeline result as a plain record dict.
+
+    nu() hands a single record back as a plain dict (#2394), but a kernel
+    running a pre-#2394 nu build returns a 1-row polars DataFrame instead,
+    and `.get` on a frame killed the watch with AttributeError (#3175).
+    Normalize at the boundary; anything else fails loudly.
+    """
+    if isinstance(value, dict):
+        return value
+    to_dicts = getattr(value, "to_dicts", None)
+    if callable(to_dicts):
+        rows = to_dicts()
+        if len(rows) == 1:
+            return dict(rows[0])
+        raise TypeError(f"{source}: expected one record, got a {len(rows)}-row frame")
+    raise TypeError(f"{source}: expected a record, got {type(value).__name__}")
+
+
 async def watch_pr(
     pr: str | int,
     *,
@@ -2090,11 +2109,12 @@ async def watch_pr(
         )
 
     async def refresh() -> dict[str, Any]:
-        # `from json` on a gh object yields a nu record, which nu() returns as
-        # a plain dict (issue #2390).
-        row: dict[str, Any] = await run_nu(
-            'gh pr view $env.PR --json number,title,state,mergeStateStatus,statusCheckRollup,'
-            'url,autoMergeRequest,isDraft,reviewDecision | complete | get stdout | from json'
+        row = _nu_record(
+            await run_nu(
+                'gh pr view $env.PR --json number,title,state,mergeStateStatus,statusCheckRollup,'
+                'url,autoMergeRequest,isDraft,reviewDecision | complete | get stdout | from json'
+            ),
+            source="gh pr view",
         )
         checks = row.get("statusCheckRollup") or []
         title = row.get("title") or f"PR {row.get('number') or clean_pr}"
@@ -2146,10 +2166,9 @@ async def watch_pr(
         else:
             flag = f"--{merge_method}"
             delete = "--delete-branch" if delete_branch else ""
-            # `| complete` yields a nu record: a plain dict, not a 1-row frame
-            # (issue #2390).
-            merge: dict[str, Any] = await run_nu(
-                f"gh pr merge $env.PR --auto {flag} {delete} | complete"
+            merge = _nu_record(
+                await run_nu(f"gh pr merge $env.PR --auto {flag} {delete} | complete"),
+                source="gh pr merge",
             )
             if int(merge["exit_code"]) != 0:
                 state["error"] = str(merge["stderr"] or merge["stdout"])

--- a/packages/mcp/tests/test_pr_watch_automerge.py
+++ b/packages/mcp/tests/test_pr_watch_automerge.py
@@ -107,3 +107,41 @@ def test_blocked_pr_still_arms_auto_merge(monkeypatch: pytest.MonkeyPatch) -> No
     assert len(fake.merges) == 1
     assert "--auto" in fake.merges[0]
     assert "auto_merge" not in result
+
+
+class _FrameNu(_ScriptedNu):
+    """A pre-#2394 nu build: a single record arrives as a 1-row polars
+    DataFrame instead of a plain dict (#3175)."""
+
+    async def __call__(self, code: str, **kwargs: object) -> object:
+        import polars as pl
+
+        value = await super().__call__(code, **kwargs)
+        return pl.DataFrame([value])
+
+
+def test_one_row_frame_from_stale_nu_still_watches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#3175: `refresh()` died with AttributeError DataFrame.get when nu
+    returned a 1-row frame for the gh pr view record; the boundary now
+    normalizes it and the watch survives to the terminal state."""
+    fake = _FrameNu([_view(9104, "OPEN", "BLOCKED"), _view(9104, "MERGED", "BLOCKED")])
+    monkeypatch.setitem(sys.modules, "nu", fake)
+
+    async def fake_notify(content: str, **meta: object) -> None:
+        pass
+
+    monkeypatch.setattr(runtime, "notify", fake_notify)
+    result = asyncio.run(runtime.watch_pr(9104, auto_merge=True, interval=0.01))
+    assert result["state"] == "MERGED"
+    assert len(fake.merges) == 1
+
+
+def test_nu_record_rejects_unexpected_shapes() -> None:
+    import polars as pl
+
+    assert runtime._nu_record({"a": 1}, source="t") == {"a": 1}
+    assert runtime._nu_record(pl.DataFrame([{"a": 1}]), source="t") == {"a": 1}
+    with pytest.raises(TypeError, match="2-row frame"):
+        runtime._nu_record(pl.DataFrame([{"a": 1}, {"a": 2}]), source="t")
+    with pytest.raises(TypeError, match="expected a record"):
+        runtime._nu_record("text", source="t")

--- a/users/andrewgazelka/profiles/development.nix
+++ b/users/andrewgazelka/profiles/development.nix
@@ -22,27 +22,28 @@ in {
   # it with the config so index-free hosts (builder VM) get it too (#3165).
   home.packages = [pkgs.vivid];
 
-  home.file = {
-    ".config/nushell-hm-session-vars.nu".text =
-      lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (
-          name: value: "$env.${name} = ${builtins.toJSON (toString value)}"
+  home.file =
+    {
+      ".config/nushell-hm-session-vars.nu".text =
+        lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (
+            name: value: "$env.${name} = ${builtins.toJSON (toString value)}"
+          )
+          config.home.sessionVariables
         )
-        config.home.sessionVariables
-      )
-      + "\n";
-  }
-  # Link nushell config children individually rather than the whole dir:
-  # nushell creates history.sqlite3 inside its config dir on Linux, so a
-  # single read-only store symlink breaks interactive login (#3165).
-  // lib.optionalAttrs pkgs.stdenv.isLinux (
-    lib.mapAttrs' (
-      name: _:
-        lib.nameValuePair ".config/nushell/${name}" {
-          source = configRoot + "/nushell/${name}";
-        }
-    ) (builtins.readDir (configRoot + "/nushell"))
-  );
+        + "\n";
+    }
+    # Link nushell config children individually rather than the whole dir:
+    # nushell creates history.sqlite3 inside its config dir on Linux, so a
+    # single read-only store symlink breaks interactive login (#3165).
+    // lib.optionalAttrs pkgs.stdenv.isLinux (
+      lib.mapAttrs' (
+        name: _:
+          lib.nameValuePair ".config/nushell/${name}" {
+            source = configRoot + "/nushell/${name}";
+          }
+      ) (builtins.readDir (configRoot + "/nushell"))
+    );
 
   programs = {
     bash.enable = true;


### PR DESCRIPTION
Fixes #3175.

- **Bug**: `pr_watch` died on its first `refresh()` with `AttributeError: 'DataFrame' object has no attribute 'get'`: the `gh pr view ... | from json` record arrived as a 1-row polars DataFrame instead of the plain dict `nu()` documents (#2394). A kernel running a pre-#2394 nu build returns the old frame shape, so the MCP server and nu can skew in deployment.
- **Fix**: `_nu_record` normalizes both `run_nu` record results (`gh pr view`, `gh pr merge`) to a plain dict at the boundary; a dict passes through, a 1-row frame is converted, anything else raises `TypeError` loudly. Audited the other `.get` consumers in `watch_pr`: all downstream reads (`row`, `last`, per-check dicts) now flow from the normalized dict.
- **Tests**: regression test drives `watch_pr` with a nu stand-in returning 1-row frames (the #3175 shape) end to end, plus `_nu_record` shape unit tests. Local `pytest tests/test_pr_watch_automerge.py`: 5 passed.
- **Drive-by**: `users/andrewgazelka/profiles/development.nix` landed unformatted in #3167 and the pre-commit alejandra gate blocked every commit repo-wide; first commit is the `nix fmt` output, no syntactic change.

Note: open PR #3061 rewrites the failure classification in the same function; this change is orthogonal (boundary type only) and a rebase there is mechanical.

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize `watch_pr` nu records to handle 1-row polars DataFrames
> - Adds `_nu_record` helper in [runtime.py](https://github.com/indexable-inc/index/pull/3177/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) that normalizes a nu pipeline result to a plain dict, accepting either a dict or a 1-row DataFrame (via `to_dicts()`).
> - Updates `watch_pr` to wrap `gh pr view` and `gh pr merge` results with `_nu_record`, preventing crashes when nu returns a DataFrame instead of a dict.
> - Raises a clear `TypeError` with a source-specific message for unexpected shapes (multi-row frames or non-dict/non-frame types).
> - Adds tests in [test_pr_watch_automerge.py](https://github.com/indexable-inc/index/pull/3177/files#diff-d243930ff12d7f05a5b5592577c7a8444edb1403b703fecd4f559c185cc67ca3) covering 1-row frame success and rejection of unexpected shapes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e8134d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->