### PR TITLE
workstation: remove vestigial ~/.local/bin/{claude,codex} symlinks

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -1007,26 +1007,6 @@ in {
     source = config.lib.file.mkOutOfStoreSymlink "${configDir}/mitmproxy";
   };
 
-  # Claude CLI binary on PATH at a stable path. The package itself is installed
-  # via programs.claude-code below (as finalPackage); this is just a fixed
-  # location some tooling expects.
-  home.file.".local/bin/claude" = {
-    # finalPackage, not the raw claudeCode: the module wraps it with the
-    # declarative MCP plugin dir (see programs.claude-code.mcpServers), so this
-    # stable-path binary carries the same MCP set as the one on the home profile
-    # PATH instead of silently bypassing it.
-    source = "${config.programs.claude-code.finalPackage}/bin/claude";
-    force = true;
-  };
-
-  # Our own Codex on PATH at a stable path, same pattern as claude above. This
-  # is the MCP-injecting wrapper (see the `codex` let-binding), so the declared
-  # MCP set rides every invocation.
-  home.file.".local/bin/codex" = {
-    source = "${codex}/bin/codex";
-    force = true;
-  };
-
   # Agents, commands, and skills are managed declaratively by the upstream
   # home-manager programs.claude-code module: each is written as an in-store
   # path under ~/.claude (no out-of-store symlink, no SessionStart hook).


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove vestigial `~/.local/bin/claude` and `~/.local/bin/codex` symlinks from workstation profile
Removes two manual symlink definitions from [workstation.nix](https://github.com/indexable-inc/index/pull/3185/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) that pointed `~/.local/bin/claude` and `~/.local/bin/codex` at their respective package binaries. These symlinks are no longer needed and will no longer be created or managed by home-manager.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6adf752.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->