### PR TITLE
config-launch: encode spec env vars as a JSON object, not a {key,value} list

### DIFF
--- a/doc/config-launch/overview.md
+++ b/doc/config-launch/overview.md
@@ -23,9 +23,9 @@ consumer uses only the layers it needs (`src/main.rs:23-26`):
 
 - `target` (`:30`): the real binary to `exec`.
 - **Generic launcher layers**:
-  - `env` (`:48`): variables set unconditionally.
-  - `env_defaults` (`:52`): set only when not already present in the caller's
-    environment (the `export NAME="${NAME-default}"` idiom).
+  - `env` (`:60`): a name-to-value object of variables set unconditionally.
+  - `env_defaults` (`:64`): same shape, set only when not already present in the
+    caller's environment (the `export NAME="${NAME-default}"` idiom).
   - `path_prepend` (`:55`): directories prepended ahead of the caller's `PATH`.
   - `flags` (`:58`): flags prepended before the user argv, unconditionally.
   - `conditional_flags` (`:61`): flag blocks (`ConditionalFlags`, `:18`) prepended

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -468,8 +468,6 @@
     # Plugins carry namespaced skills, agents, hooks, and MCP declarations.
     ++ map (d: "--plugin-dir=${d}") pluginDirs;
 
-  envEntries = attrs: lib.mapAttrsToList (key: value: {inherit key value;}) attrs;
-
   # The launch spec consumed by the shared Rust launcher (packages/config-launch):
   # it sets env/PATH, prepends `wrapperFlags`, injects `--settings` only when the
   # caller passed none (the CLI is first-wins between two `--settings` flags),
@@ -482,7 +480,7 @@
   # tests below.
   launchSpec = (formats.json {}).generate "claude-code-launch-spec.json" {
     target = "@helper@";
-    env = envEntries (
+    env =
       {
         DISABLE_AUTOUPDATER = "1";
         DISABLE_INSTALLATION_CHECKS = "1";
@@ -491,9 +489,8 @@
       }
       // lib.optionalAttrs (agentAgentsDir != null) {
         IX_CLAUDE_AGENTS_DIR = "${agentAgentsDir}";
-      }
-    );
-    env_defaults = envEntries (lib.mapAttrs (_: toString) wrapperEnvDefaults);
+      };
+    env_defaults = lib.mapAttrs (_: toString) wrapperEnvDefaults;
     path_prepend = pathPrepend;
     flags = wrapperFlags;
     conditional_flags = [

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -36,7 +36,7 @@
     sed "s|@helper@|$stub|" ${launchSpec} > "$PWD/test-spec.json"
 
     spec_env() {
-      ${lib.getExe jq} -r --arg key "$1" '.env[] | select(.key == $key) | .value' \
+      ${lib.getExe jq} -r --arg key "$1" '.env[$key]' \
         "$PWD/test-spec.json"
     }
 
@@ -61,7 +61,7 @@
     check_env_default() {
       local key="$1" got
       got="$(${lib.getExe jq} -r --arg key "$key" \
-        '.env_defaults[] | select(.key == $key) | .value' \
+        '.env_defaults[$key]' \
         "$PWD/test-spec.json")"
       if [ "$got" != 1 ]; then
         printf 'claude launcher env check failed: %s env_default is %s, want 1\n' \
@@ -86,7 +86,7 @@
     done
 
     if ${lib.getExe jq} -e --argjson names ${lib.escapeShellArg (builtins.toJSON (builtins.attrNames wrapperEnvDefaults))} \
-      '.env[] | select(.key as $k | $names | index($k))' \
+      '.env | keys[] | select(. as $k | $names | index($k))' \
       "$PWD/test-spec.json"; then
       printf 'claude launcher env check failed: disabled-feature vars must be env_defaults, not env\n' >&2
       exit 1

--- a/packages/config-launch/src/main.rs
+++ b/packages/config-launch/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
@@ -56,11 +57,11 @@ struct Spec {
     // --- generic launcher layers ---
     /// Environment variables set unconditionally.
     #[serde(default)]
-    env: Vec<Entry>,
+    env: BTreeMap<String, String>,
     /// Environment variables set only when not already present in the caller's
     /// environment (the old `export NAME="${NAME-default}"`).
     #[serde(default)]
-    env_defaults: Vec<Entry>,
+    env_defaults: BTreeMap<String, String>,
     /// Directories prepended to `PATH` (ahead of the caller's PATH).
     #[serde(default)]
     path_prepend: Vec<String>,
@@ -207,12 +208,12 @@ fn main() -> ExitCode {
 
     let mut cmd = Command::new(&spec.target);
     cmd.arg0(&argv0);
-    for entry in &spec.env {
-        cmd.env(&entry.key, &entry.value);
+    for (key, value) in &spec.env {
+        cmd.env(key, value);
     }
-    for entry in &spec.env_defaults {
-        if std::env::var_os(&entry.key).is_none() {
-            cmd.env(&entry.key, &entry.value);
+    for (key, value) in &spec.env_defaults {
+        if std::env::var_os(key).is_none() {
+            cmd.env(key, value);
         }
     }
     if !spec.path_prepend.is_empty() {
@@ -229,6 +230,7 @@ fn main() -> ExitCode {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::ffi::OsString;
 
     use super::{
@@ -263,8 +265,8 @@ mod tests {
             config_file: "config.toml".to_owned(),
             forced: entries(b.forced),
             soft: entries(b.soft),
-            env: Vec::new(),
-            env_defaults: Vec::new(),
+            env: BTreeMap::new(),
+            env_defaults: BTreeMap::new(),
             path_prepend: Vec::new(),
             flags: b.flags.into_iter().map(str::to_owned).collect(),
             conditional_flags: b

--- a/packages/config-launch/tests/cli.rs
+++ b/packages/config-launch/tests/cli.rs
@@ -231,8 +231,8 @@ fn env_always_set_and_defaults_only_when_unset() {
         &tmp,
         &serde_json::json!({
             "target": stub.to_str().unwrap(),
-            "env": [{ "key": "ALWAYS", "value": "a" }],
-            "env_defaults": [{ "key": "DEF", "value": "d" }],
+            "env": { "ALWAYS": "a" },
+            "env_defaults": { "DEF": "d" },
         }),
     );
 


### PR DESCRIPTION
Closes #3182.

The launch spec's `env` / `env_defaults` were `[{key, value}]` lists, a JSON-ism: both are maps by nature. They are now JSON objects end to end.

- `packages/config-launch/src/main.rs`: `Spec.env` / `Spec.env_defaults` are `BTreeMap<String, String>`; apply loops and unit tests updated. `Entry` stays: the codex `forced`/`soft` `--config` layer keeps `{key, value}` entries (dotted TOML key paths, a different concept), so `packages/agent/codex/default.nix` is untouched.
- `packages/agent/claude-code/default.nix`: passes the env attrsets straight into the spec; `envEntries` deleted.
- `packages/agent/claude-code/install-check.nix`: jq reads `.env[$key]` / `.env_defaults[$key]` instead of scanning entry lists.
- `packages/config-launch/tests/cli.rs` fixture and `doc/config-launch/overview.md` updated. Pre-v1: no compat shim, every producer migrated here.

Validation: `cargo test -p config-launch` (25 passed), `nix build .#claude-code` green including its installCheck (which drives the real generated spec through the launcher), repo lint suite via the pre-commit hook.

🤖 Opened by Claude Code (Claude Opus 4.5).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change `config-launch` env and env_defaults format from `{key,value}` list to JSON object
> - Changes the `Spec` struct in [main.rs](https://github.com/indexable-inc/index/pull/3186/files#diff-52dfa1b259d2f3edd308d01de86d04c8d0c75ba51209d71983b4928f00c44346) to use `BTreeMap<String, String>` for `env` and `env_defaults` instead of `Vec<Entry>`, so the launch spec now expects a JSON object mapping names to values.
> - Updates the Nix package in [default.nix](https://github.com/indexable-inc/index/pull/3186/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) to emit `env` and `env_defaults` as attribute sets rather than lists of `{key,value}` entries.
> - Updates install-check jq queries and CLI tests to match the new object format.
> - Behavioral Change: any existing `IX_LAUNCH_SPEC` JSON using the old array format will be rejected; callers must migrate to the object format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4d3831.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->