### PR TITLE
tui: delegate timeout parameter, scoped to oneshot prompts (#3184)

### DIFF
--- a/packages/tui/tui-py/python/tui/harness.py
+++ b/packages/tui/tui-py/python/tui/harness.py
@@ -420,21 +420,33 @@ class Agent:
     # -- headless delegation --------------------------------------------------
 
     @classmethod
+    def _oneshot_argv(cls, prompt: str, *, model: str | None = None) -> list[str]:
+        """argv of this agent's headless one-shot run (`claude -p`-style).
+
+        Subclasses whose CLI has one implement it; the shared `oneshot` runs
+        it. A CLI whose one-shot flow needs more than an argv (e.g. Codex's
+        `--output-last-message` file) overrides `oneshot` itself instead.
+        """
+        raise NotImplementedError(f"{cls.__name__} has no headless one-shot mode")
+
+    @classmethod
     async def oneshot(
         cls,
         prompt: str,
         *,
         model: str | None = None,
         cwd: str | None = None,
-        timeout: float = 300.0,
+        timeout: float | None = 300.0,
     ) -> str:
         """Run one prompt in this agent's headless mode and return the reply.
 
         No PTY, no onboarding gates, no dashboard tile: the cheap path for
-        fire-and-forget delegation (see the module-level `delegate`).
-        Subclasses whose CLI has a headless one-shot mode implement it.
+        fire-and-forget delegation (see the module-level `delegate`, which
+        also documents `timeout`).
         """
-        raise NotImplementedError(f"{cls.__name__} has no headless one-shot mode")
+        return await _run_oneshot(
+            cls._oneshot_argv(prompt, model=model), cwd=cwd, timeout=timeout
+        )
 
     # -- internals ----------------------------------------------------------
 
@@ -517,20 +529,6 @@ class Claude(Agent):
         """argv of a headless one-shot run (`claude -p`)."""
         return [cls.binary, "-p", *(() if model is None else ("--model", model)), prompt]
 
-    @classmethod
-    async def oneshot(
-        cls,
-        prompt: str,
-        *,
-        model: str | None = None,
-        cwd: str | None = None,
-        timeout: float = 300.0,
-    ) -> str:
-        """Run one prompt through headless `claude -p` and return the reply."""
-        return await _run_oneshot(
-            cls._oneshot_argv(prompt, model=model), cwd=cwd, timeout=timeout
-        )
-
 
 class Codex(Agent):
     """OpenAI Codex (`codex`) in a PTY.
@@ -586,7 +584,7 @@ class Codex(Agent):
         return "\n".join(out).strip()
 
     @classmethod
-    def _oneshot_argv(
+    def _exec_argv(
         cls,
         prompt: str,
         last_message_file: str,
@@ -596,7 +594,9 @@ class Codex(Agent):
         """argv of a headless one-shot run (`codex exec`).
 
         `codex exec` interleaves activity logs with the answer on stdout, so
-        the reply is read from `--output-last-message` instead.
+        the reply is read from `--output-last-message` instead; needing that
+        file path makes this not the base `_oneshot_argv` seam, and `oneshot`
+        is overridden wholesale.
         """
         return [
             cls.binary,
@@ -620,13 +620,13 @@ class Codex(Agent):
         *,
         model: str | None = None,
         cwd: str | None = None,
-        timeout: float = 300.0,
+        timeout: float | None = 300.0,
     ) -> str:
         """Run one prompt through headless `codex exec` and return the reply."""
         with tempfile.TemporaryDirectory() as td:
             last = Path(td) / "last-message.txt"
             out = await _run_oneshot(
-                cls._oneshot_argv(prompt, os.fspath(last), model=model),
+                cls._exec_argv(prompt, os.fspath(last), model=model),
                 cwd=cwd,
                 timeout=timeout,
             )
@@ -696,20 +696,6 @@ class Cursor(Agent):
             prompt,
         ]
 
-    @classmethod
-    async def oneshot(
-        cls,
-        prompt: str,
-        *,
-        model: str | None = None,
-        cwd: str | None = None,
-        timeout: float = 300.0,
-    ) -> str:
-        """Run one prompt through headless `cursor-agent -p`, return the reply."""
-        return await _run_oneshot(
-            cls._oneshot_argv(prompt, model=model), cwd=cwd, timeout=timeout
-        )
-
 
 # --------------------------------------------------------------------------- #
 # Delegation (headless one-shots)
@@ -730,15 +716,22 @@ async def delegate(
     agent: str = "claude",
     model: str | None = None,
     cwd: str | None = None,
-    timeout: float = 300.0,
+    timeout: float | None = 300.0,
 ) -> str:
-    """Run one prompt on a coding agent and return its reply, in one call.
+    """Run one short prompt on a coding agent and return its reply, in one call.
 
     Headless by default: `claude -p`, `codex exec`, or `cursor-agent -p`
     (`agent="claude" | "codex" | "cursor"`). No PTY, no onboarding gates, no
     dashboard tile: the cheap path for fire-and-forget delegation.
 
         answer = await delegate("What is 2+2? Reply with just the number.")
+
+    Scope: oneshot-question-sized prompts (a lookup, a small mechanical edit).
+    Past `timeout` seconds (default 300) the agent process is killed and
+    `WaitTimeout` raised; pass a larger value or `timeout=None` (no cap) when
+    the task genuinely needs longer. A real delegated task (issue + PR + CI)
+    does not belong here at any timeout: it gets no live view and dies with the
+    kernel. Use `weave.delegate` or `claude --bg` for those (#3184).
 
     For an observable, interruptible session (a task a human may watch or
     stop), launch the TUI harness instead: `agent = await Claude.launch();
@@ -753,12 +746,15 @@ async def delegate(
     return await cls.oneshot(prompt, model=model, cwd=cwd, timeout=timeout)
 
 
-async def _run_oneshot(argv: Sequence[str], *, cwd: str | None, timeout: float) -> str:
+async def _run_oneshot(
+    argv: Sequence[str], *, cwd: str | None, timeout: float | None
+) -> str:
     """Run a headless one-shot agent command; its stripped stdout is the reply.
 
     stdin is closed (`claude -p` would otherwise concatenate anything it reads
-    there into the prompt). Past `timeout` the process is killed and
-    `WaitTimeout` raised; a non-zero exit raises with the command's stderr.
+    there into the prompt). Past `timeout` (`None` = no cap) the process is
+    killed and `WaitTimeout` raised; a non-zero exit raises with the command's
+    stderr.
     """
     proc = await asyncio.create_subprocess_exec(
         *argv,

--- a/packages/tui/tui-py/python/tui/harness_test.py
+++ b/packages/tui/tui-py/python/tui/harness_test.py
@@ -10,13 +10,16 @@ from __future__ import annotations
 import re
 import unittest
 
+from . import WaitTimeout
 from .harness import (
+    Agent,
     Claude,
     Codex,
     Cursor,
     _gate_matches,
     _parse_claude_reply,
     _parse_cursor_reply,
+    _run_oneshot,
     _shquote,
     _submit_probe,
     _tail_delta,
@@ -82,7 +85,7 @@ class OneshotArgvTests(unittest.TestCase):
         ]
 
     def test_codex_reply_goes_to_last_message_file(self) -> None:
-        argv = Codex._oneshot_argv("q", "/scratch/last.txt")
+        argv = Codex._exec_argv("q", "/scratch/last.txt")
         assert argv[:2] == ["codex", "exec"]
         assert argv[-1] == "q"
         assert argv[argv.index("--output-last-message") + 1] == "/scratch/last.txt"
@@ -92,6 +95,34 @@ class OneshotArgvTests(unittest.TestCase):
         assert argv[:2] == ["cursor-agent", "-p"]
         assert "--force" in argv
         assert argv[-1] == "q"
+
+
+class OneshotSharedTests(unittest.IsolatedAsyncioTestCase):
+    async def test_agent_without_headless_mode_raises(self) -> None:
+        try:
+            await Agent.oneshot("q")
+        except NotImplementedError:
+            return
+        self.fail("expected NotImplementedError")
+
+
+class RunOneshotTests(unittest.IsolatedAsyncioTestCase):
+    # #3184: the timeout is a parameter, not a hardcoded cap, and None disables
+    # it entirely (the caller owns the deadline).
+    async def test_returns_stripped_stdout(self) -> None:
+        assert await _run_oneshot(["echo", " hi "], cwd=None, timeout=10.0) == "hi"
+
+    async def test_timeout_none_means_no_cap(self) -> None:
+        assert await _run_oneshot(["echo", "hi"], cwd=None, timeout=None) == "hi"
+
+    async def test_past_timeout_raises_wait_timeout(self) -> None:
+        # Not assertRaises/pytest.raises: the file stays runnable by bare
+        # `python -m unittest` (no pytest dep) and lint-clean (PT027).
+        try:
+            await _run_oneshot(["sleep", "60"], cwd=None, timeout=0.1)
+        except WaitTimeout:
+            return
+        self.fail("expected WaitTimeout")
 
 
 class ClaudeGateTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #3184.

`tui.delegate` (and each agent `oneshot`) capped every run at a hardcoded 300s; a PR-length delegated task died mid-work with `timeout: claude did not finish within 300s`.

- `timeout` widens to `float | None = 300.0`; `None` disables the cap (the caller owns the deadline). `_run_oneshot` passes it straight to `asyncio.wait_for`, which already treats `None` as no timeout.
- `delegate`'s docstring documents the parameter and scopes the helper to oneshot-question-sized prompts, pointing real tasks (issue + PR + CI) at `weave.delegate` / `claude --bg`: those need a live view and must survive the kernel, so no timeout value makes them belong here.
- The identical `Claude.oneshot` / `Cursor.oneshot` bodies (flagged by the clone diff gate) consolidate into a shared `Agent.oneshot` over a `_oneshot_argv` seam; Codex keeps its own `oneshot` (reply travels via `--output-last-message`), with its argv builder renamed `_exec_argv` so it is not a signature-incompatible override.
- New tests: `RunOneshotTests` (timeout kill raises `WaitTimeout`, `timeout=None` uncapped, stdout stripping) and `OneshotSharedTests` (agent without a headless mode raises `NotImplementedError`).

Validated locally: `python -m unittest tui.harness_test` (25 tests OK), `nix run .#clone -- . --diff origin/main`, `tui-py.tests.pyStrict` (zuban --strict + ruff ANN), `mcp.tests.tuiBundled`.

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `timeout=None` support to `delegate` and oneshot prompts in tui harness
> - Allows callers to pass `timeout=None` to `delegate` and `_run_oneshot` to wait indefinitely for a one-shot process, rather than enforcing a deadline.
> - Refactors `Agent.oneshot` in [harness.py](https://github.com/indexable-inc/index/pull/3187/files#diff-2fc410689b430c18113770dec5a98ea57e4cb0602d8df3e9c95ad810425242bf) to provide a shared base implementation that delegates argv construction to a new `_oneshot_argv` seam, reducing duplication in `Claude` and `Cursor` subclasses.
> - Renames `Codex._oneshot_argv` to `_exec_argv` to clarify why `Codex.oneshot` still overrides the base (it needs a temp output file path).
> - Adds tests for `_run_oneshot` covering stdout return, `timeout=None` behavior, and `WaitTimeout` on deadline exceeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72b7cfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->