### PR TITLE
darwin cross: keep apple toolchain env target-suffixed only

### DIFF
--- a/lib/darwin/apple-sdk-toolchain.nix
+++ b/lib/darwin/apple-sdk-toolchain.nix
@@ -257,15 +257,18 @@ in
       pkgs.llvmPackages.bintools-unwrapped
     ];
 
+    # Target-suffixed vars only. cc-rs resolves tools first-match
+    # (CC_<triple> > HOST_CC/TARGET_CC > CC) but gathers *FLAGS from every
+    # matching var cumulatively (CFLAGS_<triple> AND plain CFLAGS), so an
+    # unqualified CFLAGS carrying clang-only Darwin flags (-iframework,
+    # -isysroot <macOS SDK>) reaches the gcc compile of host (Linux)
+    # build-script units in the same graph and fails it (#3188). The same
+    # first-match lookup makes an unqualified CC/CMAKE_TOOLCHAIN_FILE point
+    # host units at the Darwin toolchain, so no unqualified tool vars either.
+    # MACOSX_DEPLOYMENT_TARGET and SDKROOT stay unqualified: they have
+    # Apple-target semantics only, so host compiles never read them.
     env = {
-      AR = appleAr;
-      CC = appleCc;
-      CFLAGS = targetFlags;
-      CMAKE_TOOLCHAIN_FILE = appleCmakeToolchain;
-      CXX = appleCxx;
-      CXXFLAGS = targetFlags;
       MACOSX_DEPLOYMENT_TARGET = "11.0";
-      RANLIB = appleRanlib;
       SDKROOT = appleSdk;
       "AR_${targetEnvName}" = appleAr;
       "CC_${targetEnvName}" = appleCc;

--- a/packages/agent/codex/rust.nix
+++ b/packages/agent/codex/rust.nix
@@ -42,10 +42,6 @@
 
   prebuilt = import ./prebuilt.nix {inherit (pkgs) fetchurl runCommand unzip;} targetSystem;
 
-  # The build host's Rust triple in env-var spelling (x86_64_unknown_linux_gnu),
-  # for the host-side cc-rs overrides below.
-  hostEnvName = lib.replaceStrings ["-"] ["_"] pkgs.stdenv.hostPlatform.rust.rustcTarget;
-
   # The Apple cross toolchain (zig cc + macOS SDK), or null for a native build.
   # Same wiring as lib/rust/workspace.nix `mkUnits`.
   appleToolchain =
@@ -137,24 +133,11 @@
             ++ lib.optional stdenv.cc.isClang "-Wno-error=character-conversion"
           );
         }
-        // lib.optionalAttrs (appleToolchain != null) appleToolchain.env
-        // lib.optionalAttrs (appleToolchain != null) {
-          # appleToolchain.env's *unqualified* CC/CXX/CFLAGS/CXXFLAGS are the
-          # Darwin cross wrappers and `-isysroot <appleSdk>` flags, and cc-rs
-          # falls back to them for host units too (CC_<triple> > HOST_CC > CC).
-          # The cross graph builds proc-macro deps for the host (sqlx-macros ->
-          # sqlx-sqlite -> libsqlite3-sys), where a Darwin-targeting zig cc
-          # with Apple headers cannot compile the bundled sqlite3.c
-          # (`__linux__` turns on mremap/pread64 paths the macOS SDK lacks).
-          # Triple-qualified vars outrank the unqualified fallback in cc-rs, so
-          # pin the host triple back to the host stdenv toolchain and empty
-          # flags. AR/RANLIB stay the bare llvm ones: llvm-ar is
-          # object-format-agnostic, so it archives host ELF objects fine.
-          "CC_${hostEnvName}" = "${pkgs.stdenv.cc}/bin/cc";
-          "CXX_${hostEnvName}" = "${pkgs.stdenv.cc}/bin/c++";
-          "CFLAGS_${hostEnvName}" = "";
-          "CXXFLAGS_${hostEnvName}" = "";
-        };
+        # appleToolchain.env carries the Darwin toolchain in target-suffixed
+        # vars only, so host units (the cross graph builds proc-macro deps for
+        # the host: sqlx-macros -> sqlx-sqlite -> libsqlite3-sys) fall through
+        # to the ordinary host toolchain on PATH; no host-triple pins needed.
+        // lib.optionalAttrs (appleToolchain != null) appleToolchain.env;
       # Build scripts emit `-l` flags that reach the final link, but their
       # `rustc-link-search` paths do not cross cargoUnit's per-unit boundary, so
       # the native libs the codex binary links (openssl, libcap on Linux) need


### PR DESCRIPTION
Fixes #3188.

## Root cause

`appleSdkToolchain.env` exported the Darwin cross toolchain in **unqualified** vars (`CC`, `CXX`, `AR`, `RANLIB`, `CFLAGS`, `CXXFLAGS`, `CMAKE_TOOLCHAIN_FILE`) alongside the target-suffixed ones. cc-rs resolves *tools* first-match (`CC_<triple>` > `HOST_CC`/`TARGET_CC` > `CC`) but gathers `*FLAGS` cumulatively from every matching var, so the plain `CFLAGS` (clang-only: `-iframework`, `-isysroot <macOS SDK>`, nullability warnings) reached the gcc compile of host (Linux) build-script units in the same cross graph:

```
gcc: error: unrecognized command-line option '-iframework'
```

Since #2690 moved codex-rs onto the cargo-unit cross DAG, its host-side libsqlite3-sys build-script unit (`sqlx-macros -> sqlx-sqlite -> libsqlite3-sys`, `HOST = TARGET = x86_64-unknown-linux-gnu`) was broken by construction: `/nix/store/rljk1k1d1il7f0wapqcbmh8m8aqx6kkn-libsqlite3-sys-build-script-output-0.37.0.drv` fails identically at every pin, no cache push can supply it, and every darwin consumer of the codex closure has been broken since the merge.

## Fix

Drop all unqualified toolchain vars from `appleSdkToolchain.env`; the target-suffixed vars already carry them for the darwin triple, and host units fall through to the ordinary host toolchain. `MACOSX_DEPLOYMENT_TARGET`/`SDKROOT` stay unqualified (Apple-target semantics only). This makes codex rust.nix's host-triple pin workaround dead, so it is removed too. The sibling `ix` repo no longer carries its own copy of this file (de-forked), so index is the sole owner.

## Validation

- Reproduced the failing drv on vc1-nix before the fix (same `-iframework` error).
- After the fix, both regenerated `libsqlite3-sys-build-script-output-0.37.0` units of the codex `aarch64-apple-darwin` cross graph build: the host unit now emits an ELF x86-64 `sqlite3.o`, the darwin unit a Mach-O arm64 `sqlite3.o` (suffixed vars still deliver the SDK flags).
- Full codex cross root build in flight; will confirm before merge.

(PR by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unqualified tool variables from Apple SDK toolchain env for Darwin cross-compilation
> - [apple-sdk-toolchain.nix](https://github.com/indexable-inc/index/pull/3197/files#diff-280b8ec772b384638a8cf0c0343253ce69ad4920a97b562518ef17b33ba436d8) now exports only target-suffixed tool variables (e.g. `CC_${targetEnvName}`) plus `MACOSX_DEPLOYMENT_TARGET` and `SDKROOT`; unqualified `AR`, `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `RANLIB`, and `CMAKE_TOOLCHAIN_FILE` are removed.
> - [rust.nix](https://github.com/indexable-inc/index/pull/3197/files#diff-564fc78368b3048bfa140966788f25e51035f27b60466c886fa66cfbc03eca93) drops the host-triple `CC`/`CXX`/`CFLAGS`/`CXXFLAGS` overrides, relying on PATH resolution for the build host instead of explicit pins.
> - Risk: any caller expecting unqualified `CC`/`CXX`/`CFLAGS`/`CXXFLAGS`/`AR`/`RANLIB`/`CMAKE_TOOLCHAIN_FILE` from the Apple toolchain env will no longer find them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1936382.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->