### PR TITLE
claude-code: materialize settings into the writable user layer

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -4,9 +4,10 @@
 [Claude Code](https://www.anthropic.com/claude-code), Anthropic's agentic coding
 CLI, as a prebuilt-binary install with a thick layer of baked-in fleet defaults.
 The upstream artifact is a Bun single-file executable pinned per platform; this
-package wraps it so every session starts with the repo's flags, env, settings,
-MCP servers, system prompt, and hooks already applied, while keeping the store
-binary itself read-only and pristine. It is the richest wrapper in this domain.
+package wraps it so every session starts with the repo's flags, env, MCP
+servers, and system prompt already applied (and its settings render, hooks
+included, materialized into the user settings layer by the Home Manager
+module), while keeping the store binary itself read-only and pristine. It is the richest wrapper in this domain.
 
 The injection is done through the shared `config-launch` launcher
 (`packages/config-launch`), the same mechanism [codex](../codex/overview.md)
@@ -37,8 +38,9 @@ mirror (`packages/agent/claude-code/default.nix:402-408`).
 
 ## Baked defaults
 
-All flag/env/PATH/settings injection is declared as data in `launchSpec`
-(`packages/agent/claude-code/default.nix:375-391`) and applied by `config-launch`.
+All flag/env/PATH injection is declared as data in `launchSpec`
+(`packages/agent/claude-code/default.nix:375-391`) and applied by
+`config-launch`; the settings render travels separately (see below).
 
 ### Forced env (always set)
 
@@ -66,17 +68,16 @@ One cosmetic residual: server-pushed model options
 valued `claude-fable-5[1m]`) can still appear in the picker — selecting one
 still runs at the standard window when the disable flag is active.
 
-The wrapper also bakes the same knobs into the read-only `--settings` `env`
-layer (`CLAUDE_CODE_DISABLE_1M_CONTEXT=1`,
-`CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000`) so `/context` and autocompact stay
-on the ~300K working window even if launch-time `env_defaults` are missing.
-Install checks assert both paths. Re-enable 1M per machine with
-`export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
+The wrapper also bakes the same knobs into the settings render's `env` map
+(`CLAUDE_CODE_DISABLE_1M_CONTEXT=1`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000`)
+so `/context` and autocompact stay on the ~300K working window even if
+launch-time `env_defaults` are missing. Install checks assert both paths.
+Re-enable 1M per machine with `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
 
 ### Prepended flags (`wrapperFlags`, `default.nix:353-361`)
 
 Flags ride BEFORE the user argv (so root options parse before subcommand
-dispatch, e.g. `claude --settings=F mcp list`), and every option-argument uses
+dispatch, e.g. `claude --debug mcp list`), and every option-argument uses
 the `=` form (one self-contained token, so a variadic flag cannot swallow a
 positional). Both rules are learned from real breakage; see the long comment at
 `default.nix:315-352`.
@@ -101,13 +102,22 @@ positional). Both rules are learned from real breakage; see the long comment at
   rather than appending to it.
 - `--mcp-config=<file>`: the baked MCP server set (below).
 
-### Conditional `--settings` (injected only when the caller passes none)
+### Computed settings render (`passthru.settings`, materialized, not injected)
 
-The CLI is first-wins between two `--settings` flags (they do not merge), so the
-wrapper injects its defaults file only `unless_present` a caller `--settings`
-(`default.nix:385-390`, `conditional_flags`). The file is a deep-merge of caller
-`extraSettings` UNDER the computed defaults so package-owned keys always win
-(`default.nix:226-293`):
+The wrapper computes a settings render but injects no `--settings` flag: a CLI
+arg outranks the local/project/user settings files, so an injected file
+silently shadowed the user's own writable settings (#3180). Instead the render
+is exposed as `passthru.settings` (and `passthru.settingsFile`, the same value
+as a store JSON file) and delivered at the USER layer: the Home Manager module
+(`packages/agent/home-manager/claude-code.nix`, `materializeSettings`, default
+on) reconciles it into the writable `~/.claude/settings.json` on activation
+with the mutable-json last-applied 3-way merge, so declared keys are enforced,
+dropped keys are pruned, and Claude Code's runtime writes survive. Bare
+consumers (`nix run`, no Home Manager) get the wrapper flags/env but no
+settings defaults; they can seed from `passthru.settingsFile` or enforce it
+via Claude's managed layer (`/etc/claude-code/managed-settings.json`, see
+`lib/dev/agents.nix`). The render is a deep-merge of caller `extraSettings`
+UNDER the computed defaults so package-owned keys always win:
 
 - `cleanupPeriodDays = 365`: keep transcripts and `--debug` logs ~1yr.
 - `skipDangerousModePermissionPrompt = true` (when
@@ -192,9 +202,9 @@ and on Linux the sandbox helpers `bubblewrap` and `socat`.
   appended trailer (`default.nix:425-427`); `autoPatchelfHook` runs on ELF
   hosts.
 - Install checks (`install-check.nix`): an offline argv regression net driven
-  through the real launcher against a stub target (flags prepend, `=` form,
-  `--settings` defers to the caller) plus behavioral nets for all three hooks
-  (`default.nix:464-480`).
+  through the real launcher against a stub target (flags prepend, `=` form, no
+  injected settings, caller `--settings` passes through) plus behavioral nets
+  for all three hooks (`default.nix:464-480`).
 - Flake output: `nix run .#claude-code` / `nix build .#claude-code`, plus
   `pkgs.claude-code` (overlay). `package.nix` sets `packageSet`, `flake`,
   `overlay`, `updateScript` all `true` (`packages/agent/claude-code/package.nix`).

--- a/doc/config-launch/overview.md
+++ b/doc/config-launch/overview.md
@@ -1,10 +1,10 @@
 # config-launch
 
 `packages/config-launch` is a spec-driven exec launcher: it reads a JSON spec,
-sets environment variables and `PATH`, injects CLI flags (static,
-argv-conditional, and config-file-gated `--config`), then `exec`s a target binary
-while preserving argv0. It is a small Rust workspace crate used to wrap
-third-party CLIs (codex, claude-code) with repo defaults.
+sets environment variables and `PATH`, injects CLI flags (static, and
+config-file-gated `--config`), then `exec`s a target binary while preserving
+argv0. It is a small Rust workspace crate used to wrap third-party CLIs
+(codex, claude-code) with repo defaults.
 
 ## Purpose
 
@@ -13,58 +13,56 @@ defaults, but each defaults differently and should not be patched. config-launch
 moves that policy into a declarative JSON spec a Nix wrapper writes, so one tiny
 launcher handles every case and `exec`s the real binary (no extra process in the
 tree). Because it `exec`s rather than spawns and sets argv0 to the original argv0
-(`src/main.rs:163`, `:180`), the target sees itself as if invoked directly.
+(`src/main.rs:121`, `:138`), the target sees itself as if invoked directly.
 
-## Spec (`IX_LAUNCH_SPEC`, `src/main.rs:28`)
+## Spec (`IX_LAUNCH_SPEC`, `src/main.rs:15`)
 
 The launcher reads the path in `IX_LAUNCH_SPEC` and parses it as the `Spec` JSON
-(`load_spec`, `src/main.rs:147`). Every field beyond `target` is optional, so each
-consumer uses only the layers it needs (`src/main.rs:23-26`):
+(`load_spec`, `src/main.rs:105`). Every field beyond `target` is optional, so each
+consumer uses only the layers it needs (`src/main.rs:15-18`):
 
-- `target` (`:30`): the real binary to `exec`.
+- `target` (`:22`): the real binary to `exec`.
 - **Generic launcher layers**:
-  - `env` (`:60`): a name-to-value object of variables set unconditionally.
-  - `env_defaults` (`:64`): same shape, set only when not already present in the
+  - `env` (`:40`): a name-to-value object of variables set unconditionally.
+  - `env_defaults` (`:44`): same shape, set only when not already present in the
     caller's environment (the `export NAME="${NAME-default}"` idiom).
-  - `path_prepend` (`:55`): directories prepended ahead of the caller's `PATH`.
-  - `flags` (`:58`): flags prepended before the user argv, unconditionally.
-  - `conditional_flags` (`:61`): flag blocks (`ConditionalFlags`, `:18`) prepended
-    only when the user passed no equivalent option.
+  - `path_prepend` (`:47`): directories prepended ahead of the caller's `PATH`.
+  - `flags` (`:50`): flags prepended before the user argv, unconditionally.
 - **codex `--config k=v` layer**:
-  - `forced` (`:41`): `--config key=value` injected always.
-  - `soft` (`:43`): `--config key=value` injected only when the dotted key is
+  - `forced` (`:33`): `--config key=value` injected always.
+  - `soft` (`:35`): `--config key=value` injected only when the dotted key is
     absent from the target's config file.
-  - `config_dir_env` / `config_dir_default` / `config_file` (`:34-39`): locate
+  - `config_dir_env` / `config_dir_default` / `config_file` (`:27-31`): locate
     that config file (env var, else a `~`-expanded default dir, joined with the
-    file name; `config_path`, `:71`).
+    file name; `config_path`, `:60`).
 
-## Order of operations (`main`, `src/main.rs:153`)
+The launcher deliberately carries no settings-file layer: claude-code's
+computed settings render is materialized into the writable user
+`settings.json` instead of riding argv, where a CLI `--settings` flag would
+outrank the user's own settings files (#3180).
+
+## Order of operations (`main`, `src/main.rs:111`)
 
 1. Load the spec; a missing/unreadable/invalid spec exits 78 (`EX_CONFIG`,
-   `:156-159`).
-2. Split argv into argv0 and the user args (`:162-164`).
+   `:114-117`).
+2. Split argv into argv0 and the user args (`:120-122`).
 3. Read the config file only when there are `soft` keys whose presence it gates
-   (claude-code sets none, so it never needs a config dir; `:168-174`).
-4. Build the prepended args: `flags` plus each conditional block the user did not
-   override (`build_arg_flags`, `:127`), then the `--config` layer
-   (`build_config_flags`, `:91`).
+   (claude-code sets none, so it never needs a config dir; `:126-132`).
+4. Build the prepended args: `flags`, then the `--config` layer
+   (`build_config_flags`, `:80`).
 5. Build the command: `arg0(argv0)`, apply `env` then `env_defaults` (only when
-   unset), prepend `path_prepend` to `PATH` (`build_path`, `:138`), then the
-   prepended flags, then the user args (`:179-194`).
-6. `exec` the target; a failed `exec` prints an error and exits 127 (`:196-198`).
+   unset), prepend `path_prepend` to `PATH` (`build_path`, `:96`), then the
+   prepended flags, then the user args (`:137-152`).
+6. `exec` the target; a failed `exec` prints an error and exits 127 (`:154-156`).
 
-## Conditional and soft gating semantics
+## Soft gating semantics
 
-- **`arg_present`** (`src/main.rs:108`): a user arg counts as overriding a
-  conditional block when it equals one of the block's `unless_present` names or
-  starts with `"<name>="`. Scanning stops at the first `--`, so a value after `--`
-  is treated as a positional, not the option (`:111`, tested at `:459`).
-- **`is_set`** (`src/main.rs:78`): a `soft` key is withheld only when its exact
+- **`is_set`** (`src/main.rs:67`): a `soft` key is withheld only when its exact
   dotted path is present in the parsed TOML config; a sibling leaf under the same
-  table is still injected (tested at `:330-363`). Partial paths count as present
+  table is still injected (tested at `:271-316`). Partial paths count as present
   (`features.multi_agent_v2` is set when `features.multi_agent_v2.enabled` is).
 - **`forced`** always wins, even over a user config that sets the key
-  (`:280-299`).
+  (`:222-243`).
 
 ## Build and packaging
 
@@ -72,4 +70,4 @@ consumer uses only the layers it needs (`src/main.rs:23-26`):
 It is `inRustWorkspace`, `flake = true`, `packageSet = true`. Flake output /
 main program: `config-launch`. Deps: `serde`/`serde_json` (spec) and `toml`
 (target config). Unix-only (`std::os::unix::process::CommandExt` for `arg0`/
-`exec`, `src/main.rs:2`). Tests in `src/main.rs` and `tests/cli.rs`.
+`exec`, `src/main.rs:3`). Tests in `src/main.rs` and `tests/cli.rs`.

--- a/flake.nix
+++ b/flake.nix
@@ -453,6 +453,7 @@
     claudeCodeHomeModule = import ./packages/agent/home-manager/claude-code.nix {
       inherit indexPackages;
       promptModule = ./packages/agent/prompt;
+      mutableJsonModule = ix.mutableJson.homeModule;
     };
     codexHomeModule = import ./packages/agent/home-manager/codex.nix {
       inherit indexPackages;

--- a/lib/services/mutable-json.nix
+++ b/lib/services/mutable-json.nix
@@ -39,7 +39,7 @@
 {lib}: let
   inherit (lib) types mkOption;
 
-  homeModule = {
+  moduleBody = {
     config,
     lib,
     pkgs,
@@ -122,7 +122,14 @@
     };
   };
 in {
-  inherit homeModule;
+  # Keyed so a consumer module can embed this one (the agent Home Manager
+  # module imports it to materialize settings) while a downstream config also
+  # imports `homeModules.mutable-json`: the module system deduplicates by key,
+  # so the option is declared once.
+  homeModule = {
+    key = "index/lib/services/mutable-json.nix";
+    imports = [moduleBody];
+  };
   # The merge program, exposed so tests can exercise it directly on fixtures.
   mergeProgram = ./mutable-json-merge.jq;
 }

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -29,16 +29,17 @@
   # managed-settings layer) or turn this off with
   # `claude-code.override { dangerouslySkipPermissions = false; }`.
   dangerouslySkipPermissions ? true,
-  # Extra settings.json keys to ship through the read-only flagSettings layer
-  # (the `--settings` file below), deep-merged UNDER the controlled keys this
-  # package owns (so those always win on a conflict) and OVER the house posture
+  # Extra settings.json keys folded into the computed settings render
+  # (`passthru.settings`), deep-merged UNDER the controlled keys this package
+  # owns (so those always win on a conflict) and OVER the house posture
   # defaults (`houseSettingsDefaults` in the let-block, so any of those can be
-  # overridden per consumer). Lets a consumer keep its whole
-  # static Claude config (hooks, statusLine, enabledPlugins, marketplaces, ...)
-  # in Nix and out of a hand-maintained ~/.claude/settings.json: flagSettings
-  # merges per-key ABOVE user settings and is a separate read-only layer, so it
-  # never occupies (or symlinks) the writable settings.json the CLI churns at
-  # runtime. `{ }` (default) ships the house defaults plus the controlled keys.
+  # overridden per consumer). Lets a consumer keep its whole static Claude
+  # config (hooks, statusLine, enabledPlugins, marketplaces, ...) in Nix. The
+  # wrapper itself injects no settings flag (#3180): a consumer materializes
+  # the render into the writable user layer (the Home Manager module seeds
+  # ~/.claude/settings.json through a mutable-json merge) or enforces it via
+  # Claude's managed layer (lib/dev/agents.nix). `{ }` (default) ships the
+  # house defaults plus the controlled keys.
   extraSettings ? {},
   # Typed Claude Code feature posture, rendered to the CLAUDE_CODE_* env vars
   # so no consumer has to spell (or misspell) the raw names. Booleans gate
@@ -307,8 +308,12 @@
     else defaultSystemTools // systemTools;
   disabledSystemTools = builtins.attrNames (lib.filterAttrs (_: enabled: !enabled) effectiveSystemTools);
 
-  # Settings defaults are injected only when the caller passed no `--settings`;
-  # Claude treats repeated settings flags as first-wins.
+  # The computed settings render leaves this package only through
+  # `passthru.settings` / the rendered file below; nothing rides argv. Per
+  # Claude Code's precedence, CLI args outrank the local/project/user settings
+  # files, so the old injected `--settings` flag silently shadowed the user's
+  # own writable settings (#3180). Materializing into the user layer keeps
+  # every default overridable and the live config explainable from disk.
 
   # House posture defaults every wrapped session starts from: agent-neutral
   # preferences that used to live in per-machine extraSettings. They form the
@@ -334,9 +339,10 @@
     skipAutoPermissionPrompt = true;
     # House statusline (./statusline.nu): context bar, model, effort, and the
     # running CLI version with an update marker against Anthropic's `latest`
-    # release pointer. The house effortLevel rides argv because the script
-    # cannot read this read-only settings layer back from disk; the writable
-    # settings files still win when a user overrides per machine.
+    # release pointer. The house effortLevel also rides argv as the script's
+    # last resort for a settings.json that does not carry the key (nothing
+    # materialized this render, or the user pruned it); the writable settings
+    # files win whenever they answer.
     statusLine = {
       type = "command";
       command = "${lib.getExe pkgs.nushell} ${./statusline.nu} --default-effort ${houseEffortLevel}";
@@ -469,9 +475,10 @@
     ++ map (d: "--plugin-dir=${d}") pluginDirs;
 
   # The launch spec consumed by the shared Rust launcher (packages/config-launch):
-  # it sets env/PATH, prepends `wrapperFlags`, injects `--settings` only when the
-  # caller passed none (the CLI is first-wins between two `--settings` flags),
-  # then execs the real binary preserving argv0. The store output is read-only so
+  # it sets env/PATH, prepends `wrapperFlags`, then execs the real binary
+  # preserving argv0. No settings ride argv: the computed defaults materialize
+  # into the writable user settings layer via `passthru.settings` (#3180),
+  # where they stay overridable and readable. The store output is read-only so
   # the bundled self-updater could never write: DISABLE_AUTOUPDATER turns it off,
   # the install checks are skipped, and USE_BUILTIN_RIPGREP=0 pins search to the
   # Nix ripgrep on PATH so the wrapper owns the version pin. `target` is an
@@ -493,23 +500,6 @@
     env_defaults = lib.mapAttrs (_: toString) wrapperEnvDefaults;
     path_prepend = pathPrepend;
     flags = wrapperFlags;
-    conditional_flags = [
-      {
-        unless_present = ["--settings"];
-        flags = ["--settings=${settingsDefaultsFile}"];
-      }
-    ];
-    # `claude --which-settings` prints the store path of the read-only
-    # settings layer this package injects, then exits (answered by the
-    # launcher; the real CLI never sees the flag). The wrapper passes settings
-    # by flag, so nothing on disk under ~/.claude explains the live config:
-    # this is the introspection that does.
-    introspection = [
-      {
-        flag = "--which-settings";
-        value = "${settingsDefaultsFile}";
-      }
-    ];
   };
 
   inherit (stdenv.hostPlatform) system;
@@ -637,6 +627,15 @@ in
 
     passthru =
       {
+        # The computed settings render (house posture defaults, then the
+        # caller's extraSettings, then the controlled keys), exposed for
+        # consumers to materialize into the writable user layer (#3180): the
+        # Home Manager module seeds ~/.claude/settings.json from this via a
+        # mutable-json merge. `settingsFile` is the same render as a store
+        # JSON file for non-HM consumers and the install checks.
+        settings = settingsDefaults;
+        settingsFile = settingsDefaultsFile;
+
         # Same capture path as extractSystemPrompt, but depends only on the fetched
         # upstream binary so prompt snapshots do not rebuild the wrapped package.
         extractStockSystemPrompt = import ./extract-system-prompt.nix {

--- a/packages/agent/claude-code/extract-system-prompt.nix
+++ b/packages/agent/claude-code/extract-system-prompt.nix
@@ -20,8 +20,8 @@
   # config, or settings.
   stockBinary,
   # The wrapped launcher (`bin/claude`): the config-launch wrapper that applies
-  # the house --system-prompt-file (full prompt replacement), --mcp-config, and
-  # --settings. Probing this shows what our daily-driver prompt collapses to.
+  # the house --system-prompt-file (full prompt replacement) and --mcp-config.
+  # Probing this shows what our daily-driver prompt collapses to.
   wrappedBinary ? "claude",
 }:
 ix.writePythonApplication pkgs {

--- a/packages/agent/claude-code/extract-system-prompt.py
+++ b/packages/agent/claude-code/extract-system-prompt.py
@@ -12,8 +12,8 @@ It can probe two binaries and compare them (`--mode`):
   - stock: the unwrapped upstream binary (the package's `libexec` helper), which
     is the plain download with no house overrides.
   - wrapped: this package's launcher (`bin/claude`), which bakes the house
-    --system-prompt-file (a full replacement of the stock prompt), --mcp-config,
-    and --settings.
+    --system-prompt-file (a full replacement of the stock prompt) and
+    --mcp-config.
   - diff: a unified diff of the two, plus which tools the wrapper adds/removes.
 
 Every capture runs from a fresh temp HOME and an empty temp cwd, so no
@@ -45,8 +45,8 @@ from typing import Any
 # (`--stock-binary <libexec helper>` / `--wrapped-binary <bin/claude>`); a
 # user-supplied value on the CLI lands later in argv and wins, so these are only
 # defaults. "stock" is the unwrapped upstream binary; "wrapped" is the Nix
-# launcher that bakes this package's --system-prompt-file / --mcp-config /
-# --settings overrides.
+# launcher that bakes this package's --system-prompt-file / --mcp-config
+# overrides.
 DEFAULT_STOCK_BINARY = "claude"
 DEFAULT_WRAPPED_BINARY = "claude"
 

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -1,9 +1,9 @@
 # Argv regression net for the launcher spec, run against a stub target so it is
 # offline and instant. Guards the properties the wrapper exists for: injected
 # flags ride BEFORE the user argv (subcommands keep parsing), every injected
-# option-argument is one `=` token (nothing can swallow a positional), and
-# `--settings` defers to a caller-provided one (the CLI is first-wins between
-# two `--settings` flags). Drives the real generated spec with its `@helper@`
+# option-argument is one `=` token (nothing can swallow a positional), and no
+# settings ride argv (#3180: the render materializes into the writable user
+# settings layer). Drives the real generated spec with its `@helper@`
 # target swapped for the stub, through the actual launcher binary (the built
 # `$out/bin/${binName}` forces IX_LAUNCH_SPEC via makeBinaryWrapper `--set`, so
 # the launcher is exercised directly here).
@@ -180,13 +180,15 @@
       fi
     }
 
-    check "flags prepend; settings injected when caller passes none" \
+    # No settings ride argv (#3180: defaults materialize into the writable
+    # user settings layer instead), so the launch is exactly the baked flags
+    # followed by the caller's argv.
+    check "flags prepend; no settings injected" \
       ${
     lib.escapeShellArg (
       lib.concatStringsSep "\n" (
         wrapperFlags
         ++ [
-          "--settings=${settingsDefaultsFile}"
           "mcp"
           "list"
         ]
@@ -195,7 +197,7 @@
   } \
       mcp list
 
-    check "caller --settings wins; package defaults stay out" \
+    check "caller --settings passes through untouched" \
       ${
     lib.escapeShellArg (
       lib.concatStringsSep "\n" (
@@ -210,37 +212,13 @@
   } \
       --settings=/dev/null -p hi
 
-    # `--which-settings` is answered by the launcher itself (exit 0, no exec):
-    # the output is exactly the injected settings store path, with none of the
-    # baked flags the stub would echo on a real launch.
-    check "--which-settings prints the injected settings path" \
-      ${lib.escapeShellArg "${settingsDefaultsFile}"} \
-      --which-settings
-
-    # After `--` the same token is a positional for the CLI, so the launch
-    # proceeds normally (flags, injected settings, then the user argv).
-    check "--which-settings after -- stays a positional" \
-      ${
-    lib.escapeShellArg (
-      lib.concatStringsSep "\n" (
-        wrapperFlags
-        ++ [
-          "--settings=${settingsDefaultsFile}"
-          "--"
-          "--which-settings"
-        ]
-      )
-    )
-  } \
-      -- --which-settings
-
     # addDirs/pluginDirs render as single, prepended `=` tokens. `--add-dir` is
     # variadic in the CLI, so a space-form token would swallow the next positional
     # (proven against the real binary); this guards that the launcher keeps each as
     # one argv entry, ahead of the subcommand. Synthesize a spec with the two flags
     # appended to `flags` (mirrors what `map (d: "--add-dir=${"\${d}"}") addDirs`
     # produces in the wrapper) and assert they land between the baked flags and the
-    # injected `--settings`.
+    # caller argv.
     ${lib.getExe jq} '.flags += ["--add-dir=/nix/store/sample-skills", "--plugin-dir=/nix/store/sample-plugin"]' \
       "$PWD/test-spec.json" > "$PWD/dirs-spec.json"
     dirs_got="$(IX_LAUNCH_SPEC="$PWD/dirs-spec.json" "$launcher" mcp list)"
@@ -251,7 +229,6 @@
         ++ [
           "--add-dir=/nix/store/sample-skills"
           "--plugin-dir=/nix/store/sample-plugin"
-          "--settings=${settingsDefaultsFile}"
           "mcp"
           "list"
         ]

--- a/packages/agent/claude-code/statusline.nu
+++ b/packages/agent/claude-code/statusline.nu
@@ -1,5 +1,5 @@
-# House Claude Code statusline (settings `statusLine.command`, baked by
-# package.nix into the wrapper's read-only settings layer). Renders one
+# House Claude Code statusline (settings `statusLine.command`, shipped in the
+# wrapper's computed settings render, see passthru.settings). Renders one
 # dark-gray line: the ix identity mark, context-window bar, model, effort
 # level, and the running CLI version with an "↑<latest>" marker when
 # Anthropic has published a newer release than the wrapper pins.
@@ -57,9 +57,9 @@ def is-newer [latest: string, current: string] {
   } catch { false }
 }
 
-# `--default-effort` carries the house `effortLevel` baked into the wrapper's
-# read-only settings layer, which this script cannot read back from disk; the
-# writable settings files below still win when the user overrides per-machine.
+# `--default-effort` carries the house `effortLevel` as a last resort for a
+# settings.json that does not answer (nothing materialized the render, or the
+# user pruned the key); the writable settings files below win when they do.
 def main [--default-effort: string = ""] {
   let input = (open --raw /dev/stdin | from json)
 

--- a/packages/agent/claude-hooks/src/friction.rs
+++ b/packages/agent/claude-hooks/src/friction.rs
@@ -344,13 +344,13 @@ fn ask_model(delta: &str, cwd: Option<&str>) -> Vec<Item> {
         "",
         "--setting-sources",
         "",
-        // The index claude-code wrapper injects `--settings <default-settings>`
-        // (Stop hooks included) whenever the caller passes no --settings, and
-        // --setting-sources does not filter that injected file. Without this
-        // override every extractor run is itself sliced by the Stop hooks and
-        // spawns another extractor: 84k recursive transcripts on hydra
-        // (index#2275). An explicit empty hooks object keeps the extractor
-        // session hook-free.
+        // The house Stop hooks live in the materialized ~/.claude/settings.json
+        // (#3180); `--setting-sources ""` above drops that file, and this
+        // explicit empty hooks object pins the session hook-free even if some
+        // other layer (a CLI flag, a managed file) carries hooks. Without a
+        // hook-free session every extractor run is itself sliced by the Stop
+        // hooks and spawns another extractor: 84k recursive transcripts on
+        // hydra (index#2275).
         "--settings",
         "{\"hooks\":{}}",
         "--strict-mcp-config",

--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -3,6 +3,13 @@
   # Path to the house prompt module (packages/agent/prompt), injected by the
   # importing flake so this module never climbs the tree with `../`.
   promptModule,
+  # The mutable-json home module (lib/services/mutable-json.nix), injected by
+  # the importing flake; carries the last-applied 3-way merge that
+  # materializes the wrapper's settings render into the writable user
+  # settings.json (#3180). Keyed, so a config importing
+  # `homeModules.mutable-json` alongside this module still declares the
+  # option once.
+  mutableJsonModule,
 }: {
   config,
   lib,
@@ -54,6 +61,8 @@
     // optionalOverride (cfg.systemPrompt.source == "stock") "systemPrompt" null;
   defaultedPackage = cfg.basePackage.override packageOverrides;
 in {
+  imports = [mutableJsonModule];
+
   options.programs.claude-code = {
     basePackage = lib.mkOption {
       type = lib.types.package;
@@ -66,12 +75,29 @@ in {
       inherit (jsonFormat) type;
       default = {};
       description = ''
-        Lower-priority Claude Code settings passed through the wrapper's
-        read-only default layer. Runtime user settings are still managed by
-        Home Manager's native {option}`programs.claude-code.settings` option.
-        The wrapper answers {command}`claude --which-settings` with the store
-        path of the rendered layer, since no file under {file}`~/.claude`
-        explains it.
+        Claude Code settings folded into the wrapper's computed render
+        (between the house posture defaults and the controlled keys the
+        package owns). With {option}`programs.claude-code.materializeSettings`
+        the merged render lands in the writable
+        {file}`~/.claude/settings.json`, so these stay user-overridable at
+        runtime and the live config is explainable from disk.
+      '';
+    };
+
+    materializeSettings = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Materialize the wrapper package's computed settings render
+        (`passthru.settings`: house posture defaults, {option}`defaults`,
+        then the controlled hooks/permissions/env keys) into the writable
+        {file}`settings.json` under {option}`programs.claude-code.configDir`.
+        Reconciled on activation with a last-applied 3-way merge
+        (`homeModules.mutable-json`): declared keys are enforced, keys the
+        render stops declaring are pruned, and Claude Code's own runtime
+        writes (`/config` toggles, plugin state) survive. Requires
+        {option}`programs.claude-code.package` to be the index wrapper (or
+        any package exposing `passthru.settings`).
       '';
     };
 
@@ -249,11 +275,37 @@ in {
         assertion = cfg.systemPrompt.source == "house" || cfg.systemPrompt.omitRules == [];
         message = "programs.claude-code.systemPrompt.omitRules only applies when source = \"house\".";
       }
+      {
+        # The upstream module renders settings.json as a read-only store
+        # symlink whenever these options are set (settings, marketplaces, or
+        # any disabled MCP server); the materialized file needs a single
+        # declarative owner (see lib/services/mutable-json.nix).
+        assertion =
+          !(cfg.enable && cfg.materializeSettings)
+          || (
+            cfg.settings
+            == {}
+            && cfg.marketplaces == {}
+            && lib.all (server: (server.enabled or null) != false && (server.disabled or false) != true) (
+              lib.attrValues cfg.mcpServers
+            )
+          );
+        message = "programs.claude-code.materializeSettings owns settings.json; move settings/marketplaces/disabled MCP servers into programs.claude-code.defaults (or disable materializeSettings).";
+      }
     ];
 
     programs.claude-code = {
       package = lib.mkDefault defaultedPackage;
       context = lib.mkIf cfg.houseContext.enable (lib.mkDefault houseContextText);
+    };
+
+    # The wrapper injects no `--settings` flag (#3180): its computed render is
+    # seeded into the writable user settings.json instead, where Claude Code's
+    # own runtime writes survive the merge and every key stays overridable by
+    # a project/local scope or a runtime toggle.
+    home.mutableJsonFiles.claude-code-settings = lib.mkIf (cfg.enable && cfg.materializeSettings) {
+      target = "${cfg.configDir}/settings.json";
+      value = cfg.package.passthru.settings;
     };
   };
 }

--- a/packages/agent/plugin/default.nix
+++ b/packages/agent/plugin/default.nix
@@ -9,7 +9,7 @@
 #
 # Deliberately skills-only:
 #  - hooks: both wrappers already deliver the shared hook policy (Claude
-#    through the settings flagSettings layer, Codex through
+#    through the materialized settings render, Codex through
 #    ~/.codex/hooks.json); plugin-carried hooks would double-fire it, the two
 #    runtimes want different hook schemas, and Codex trust-gates plugin hooks
 #    per content hash (a re-approval on every store-path bump).

--- a/packages/config-launch/src/main.rs
+++ b/packages/config-launch/src/main.rs
@@ -12,30 +12,10 @@ struct Entry {
     value: String,
 }
 
-/// A flag block injected only when the user did not already pass an equivalent
-/// option: withheld if any user arg (scanning until the first `--`) equals a
-/// name in `unless_present` or starts with `"<name>="`.
-#[derive(Deserialize)]
-struct ConditionalFlags {
-    unless_present: Vec<String>,
-    flags: Vec<String>,
-}
-
-/// A flag the launcher answers itself instead of launching: when the user
-/// argv contains `flag` (scanning until the first `--`, same as
-/// `unless_present`), print `value` and exit 0. Lets a wrapper expose what it
-/// bakes (e.g. claude-code's `--which-settings` printing the injected
-/// settings store path) without the real binary ever seeing the flag.
-#[derive(Deserialize)]
-struct Introspection {
-    flag: String,
-    value: String,
-}
-
 /// The launch spec, read as JSON from `IX_LAUNCH_SPEC`. Every field beyond
 /// `target` is optional so each consumer uses only the layers it needs: codex
 /// sets the `forced`/`soft` `--config` layer; claude-code sets
-/// `env`/`env_defaults`/`path_prepend`/`flags`/`conditional_flags`.
+/// `env`/`env_defaults`/`path_prepend`/`flags`.
 #[derive(Deserialize)]
 struct Spec {
     /// Real binary to exec.
@@ -68,12 +48,6 @@ struct Spec {
     /// Flags prepended before the user argv, unconditionally.
     #[serde(default)]
     flags: Vec<String>,
-    /// Flag blocks prepended only when the user passed no equivalent option.
-    #[serde(default)]
-    conditional_flags: Vec<ConditionalFlags>,
-    /// Flags answered by the launcher itself: print the paired value, exit 0.
-    #[serde(default)]
-    introspection: Vec<Introspection>,
 }
 
 fn expand_tilde(path: &str) -> String {
@@ -118,46 +92,6 @@ fn build_config_flags(spec: &Spec, cfg: Option<&toml::Value>) -> Vec<String> {
     out
 }
 
-/// True if any user arg (up to the first `--`) is `name` or `name=...` for some
-/// name in `names`.
-fn arg_present(user_args: &[OsString], names: &[String]) -> bool {
-    for arg in user_args {
-        let Some(s) = arg.to_str() else { continue };
-        if s == "--" {
-            break;
-        }
-        for name in names {
-            if s == name
-                || s.strip_prefix(name)
-                    .is_some_and(|rest| rest.starts_with('='))
-            {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// `flags` plus each conditional block whose options the user did not supply.
-fn build_arg_flags(spec: &Spec, user_args: &[OsString]) -> Vec<String> {
-    let mut out = spec.flags.clone();
-    for block in &spec.conditional_flags {
-        if !arg_present(user_args, &block.unless_present) {
-            out.extend(block.flags.iter().cloned());
-        }
-    }
-    out
-}
-
-/// The value to print (instead of launching) for the first introspection flag
-/// present in the user argv, if any.
-fn introspect<'a>(spec: &'a Spec, user_args: &[OsString]) -> Option<&'a str> {
-    spec.introspection
-        .iter()
-        .find(|intro| arg_present(user_args, std::slice::from_ref(&intro.flag)))
-        .map(|intro| intro.value.as_str())
-}
-
 /// `path_prepend` joined ahead of the current `PATH` (or alone if PATH is unset).
 fn build_path(prepend: &[String], current: Option<&str>) -> String {
     let mut p = prepend.join(":");
@@ -187,12 +121,6 @@ fn main() -> ExitCode {
     let argv0 = argv.next().unwrap_or_else(|| spec.target.clone().into());
     let user_args: Vec<OsString> = argv.collect();
 
-    // Introspection short-circuits the launch entirely: the target never runs.
-    if let Some(value) = introspect(&spec, &user_args) {
-        println!("{value}");
-        return ExitCode::SUCCESS;
-    }
-
     // Read the config file only when there are soft keys whose presence it
     // gates (claude-code sets no soft keys, so it never needs a config dir).
     let cfg = if spec.soft.is_empty() {
@@ -203,7 +131,7 @@ fn main() -> ExitCode {
             .and_then(|text| toml::from_str::<toml::Value>(&text).ok())
     };
 
-    let mut prepended = build_arg_flags(&spec, &user_args);
+    let mut prepended = spec.flags.clone();
     prepended.extend(build_config_flags(&spec, cfg.as_ref()));
 
     let mut cmd = Command::new(&spec.target);
@@ -231,20 +159,13 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::ffi::OsString;
 
-    use super::{
-        ConditionalFlags, Entry, Introspection, Spec, arg_present, build_arg_flags,
-        build_config_flags, build_path, introspect, is_set,
-    };
+    use super::{Entry, Spec, build_config_flags, build_path, is_set};
 
     #[derive(Default)]
     struct SpecBuilder {
         forced: Vec<(&'static str, &'static str)>,
         soft: Vec<(&'static str, &'static str)>,
-        flags: Vec<&'static str>,
-        conditional: Vec<(Vec<&'static str>, Vec<&'static str>)>,
-        introspection: Vec<(&'static str, &'static str)>,
     }
 
     fn entries(pairs: Vec<(&str, &str)>) -> Vec<Entry> {
@@ -268,23 +189,7 @@ mod tests {
             env: BTreeMap::new(),
             env_defaults: BTreeMap::new(),
             path_prepend: Vec::new(),
-            flags: b.flags.into_iter().map(str::to_owned).collect(),
-            conditional_flags: b
-                .conditional
-                .into_iter()
-                .map(|(unless, flags)| ConditionalFlags {
-                    unless_present: unless.into_iter().map(str::to_owned).collect(),
-                    flags: flags.into_iter().map(str::to_owned).collect(),
-                })
-                .collect(),
-            introspection: b
-                .introspection
-                .into_iter()
-                .map(|(flag, value)| Introspection {
-                    flag: flag.to_owned(),
-                    value: value.to_owned(),
-                })
-                .collect(),
+            flags: Vec::new(),
         }
     }
 
@@ -311,10 +216,6 @@ mod tests {
 
     fn parse_toml(s: &str) -> toml::Value {
         toml::from_str(s).expect("valid toml")
-    }
-
-    fn os(args: &[&str]) -> Vec<OsString> {
-        args.iter().map(OsString::from).collect()
     }
 
     #[test]
@@ -446,87 +347,6 @@ mod tests {
         assert!(
             flags.is_empty(),
             "no soft flags should be injected when all keys present; got: {flags:?}"
-        );
-    }
-
-    #[test]
-    fn static_flags_prepend() {
-        let spec = make_spec(SpecBuilder {
-            flags: vec!["--debug", "--thinking-display=summarized"],
-            ..SpecBuilder::default()
-        });
-        let flags = build_arg_flags(&spec, &os(&["mcp", "list"]));
-        assert_eq!(flags, vec!["--debug", "--thinking-display=summarized"]);
-    }
-
-    #[test]
-    fn conditional_flag_injected_when_option_absent() {
-        let spec = make_spec(SpecBuilder {
-            conditional: vec![(vec!["--settings"], vec!["--settings=/def.json"])],
-            ..SpecBuilder::default()
-        });
-        let flags = build_arg_flags(&spec, &os(&["-p", "hi"]));
-        assert_eq!(flags, vec!["--settings=/def.json"]);
-    }
-
-    #[test]
-    fn conditional_flag_withheld_for_every_option_spelling() {
-        let spec = make_spec(SpecBuilder {
-            conditional: vec![(vec!["--settings"], vec!["--settings=/def.json"])],
-            ..SpecBuilder::default()
-        });
-        for args in [
-            &["--settings", "/user.json"][..],
-            &["--settings=/user.json"][..],
-        ] {
-            let flags = build_arg_flags(&spec, &os(args));
-            assert!(flags.is_empty(), "conditional leaked for {args:?}: {flags:?}");
-        }
-    }
-
-    #[test]
-    fn arg_present_stops_at_double_dash() {
-        // a `--settings` after `--` is a positional, not our option.
-        assert!(!arg_present(
-            &os(&["--", "--settings", "x"]),
-            &["--settings".to_owned()]
-        ));
-        assert!(arg_present(
-            &os(&["--settings", "x"]),
-            &["--settings".to_owned()]
-        ));
-    }
-
-    #[test]
-    fn introspection_answers_when_flag_present() {
-        let spec = make_spec(SpecBuilder {
-            introspection: vec![("--which-settings", "/nix/store/settings.json")],
-            ..SpecBuilder::default()
-        });
-        assert_eq!(
-            introspect(&spec, &os(&["--which-settings"])),
-            Some("/nix/store/settings.json")
-        );
-        // Position-independent, like the rest of the flag scan.
-        assert_eq!(
-            introspect(&spec, &os(&["-p", "hi", "--which-settings"])),
-            Some("/nix/store/settings.json")
-        );
-    }
-
-    #[test]
-    fn introspection_ignores_absent_and_positional_flags() {
-        let spec = make_spec(SpecBuilder {
-            introspection: vec![("--which-settings", "/nix/store/settings.json")],
-            ..SpecBuilder::default()
-        });
-        assert_eq!(introspect(&spec, &os(&["mcp", "list"])), None);
-        // After `--` the token is a positional for the target, not our flag.
-        assert_eq!(introspect(&spec, &os(&["--", "--which-settings"])), None);
-        // `=` form parity with `arg_present`: still recognized as the flag.
-        assert_eq!(
-            introspect(&spec, &os(&["--which-settings=x"])),
-            Some("/nix/store/settings.json")
         );
     }
 

--- a/packages/config-launch/tests/cli.rs
+++ b/packages/config-launch/tests/cli.rs
@@ -304,7 +304,7 @@ fn path_prepend_rides_ahead_of_caller_path() {
 }
 
 #[test]
-fn static_and_conditional_flags_prepend_before_argv() {
+fn static_flags_prepend_before_argv() {
     let tmp = TempDir::new().unwrap();
     let stub = write_stub(&tmp);
     let spec = write_json_spec(
@@ -312,13 +312,9 @@ fn static_and_conditional_flags_prepend_before_argv() {
         &serde_json::json!({
             "target": stub.to_str().unwrap(),
             "flags": ["--debug", "--thinking-display=summarized"],
-            "conditional_flags": [
-                { "unless_present": ["--settings"], "flags": ["--settings=/def.json"] }
-            ],
         }),
     );
 
-    // No user --settings: defaults inject, before the subcommand argv.
     let out = Command::new(BIN)
         .env("IX_LAUNCH_SPEC", &spec)
         .args(["mcp", "list"])
@@ -331,17 +327,12 @@ fn static_and_conditional_flags_prepend_before_argv() {
         .collect();
     assert_eq!(
         lines,
-        vec![
-            "--debug",
-            "--thinking-display=summarized",
-            "--settings=/def.json",
-            "mcp",
-            "list"
-        ],
+        vec!["--debug", "--thinking-display=summarized", "mcp", "list"],
         "flags must prepend before the user argv"
     );
 
-    // User passes their own --settings: the conditional block is withheld.
+    // A caller option the wrapper knows nothing about rides through untouched,
+    // after the static flags (#3180: the launcher injects no settings).
     let out2 = Command::new(BIN)
         .env("IX_LAUNCH_SPEC", &spec)
         .args(["--settings=/user.json", "-p", "hi"])
@@ -352,54 +343,17 @@ fn static_and_conditional_flags_prepend_before_argv() {
         .lines()
         .map(str::to_owned)
         .collect();
-    assert!(
-        !lines2.iter().any(|l| l == "--settings=/def.json"),
-        "package --settings must defer to the caller's; got: {lines2:?}"
-    );
-    assert!(lines2.contains(&"--settings=/user.json".to_owned()));
-}
-
-#[test]
-fn introspection_prints_value_and_never_execs_target() {
-    let tmp = TempDir::new().unwrap();
-    let stub = write_stub(&tmp);
-    let spec = write_json_spec(
-        &tmp,
-        &serde_json::json!({
-            "target": stub.to_str().unwrap(),
-            "flags": ["--debug"],
-            "introspection": [
-                { "flag": "--which-settings", "value": "/nix/store/settings.json" }
-            ],
-        }),
-    );
-
-    // Flag present: the launcher answers itself; the stub's argv echo (which
-    // would start with --debug) must not appear.
-    let out = Command::new(BIN)
-        .env("IX_LAUNCH_SPEC", &spec)
-        .arg("--which-settings")
-        .output()
-        .expect("run");
-    assert!(out.status.success(), "introspection should exit 0");
     assert_eq!(
-        String::from_utf8(out.stdout).unwrap(),
-        "/nix/store/settings.json\n",
-        "introspection must print exactly the paired value"
+        lines2,
+        vec![
+            "--debug",
+            "--thinking-display=summarized",
+            "--settings=/user.json",
+            "-p",
+            "hi"
+        ],
+        "caller argv must pass through untouched"
     );
-
-    // Flag absent: normal launch, argv passthrough via the stub.
-    let out2 = Command::new(BIN)
-        .env("IX_LAUNCH_SPEC", &spec)
-        .args(["mcp", "list"])
-        .output()
-        .expect("run");
-    let lines2: Vec<String> = String::from_utf8(out2.stdout)
-        .unwrap()
-        .lines()
-        .map(str::to_owned)
-        .collect();
-    assert_eq!(lines2, vec!["--debug", "mcp", "list"]);
 }
 
 #[test]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -223,6 +223,7 @@
         (import (paths.packagesRoot + "/agent/home-manager/claude-code.nix") {
           indexPackages = homeAgentIndexPackages;
           promptModule = paths.packagesRoot + "/agent/prompt";
+          mutableJsonModule = ix.mutableJson.homeModule;
         })
         (import (paths.packagesRoot + "/agent/home-manager/codex.nix") {
           indexPackages = homeAgentIndexPackages;
@@ -4349,6 +4350,22 @@
           homeAgentConfig.home.file.".config/codex-test/hooks.json".source
           == homeAgentConfig.programs.codex.finalPackage.hooksJson;
         message = "Codex Home Manager module should install the shared hook policy under the configured Codex home";
+      }
+      {
+        # #3180: the wrapper injects no --settings flag; the Home Manager
+        # module materializes the package's computed render into the writable
+        # user settings.json through the mutable-json 3-way merge. Pin the
+        # target and that the render actually carries the controlled hook
+        # policy, so a refactor can't silently drop settings delivery.
+        assertion = let
+          entry = homeAgentConfig.home.mutableJsonFiles.claude-code-settings;
+        in
+          entry.target
+          == ".claude/settings.json"
+          && entry.value == homeAgentConfig.programs.claude-code.package.passthru.settings
+          && entry.value ? hooks
+          && entry.value ? statusLine;
+        message = "Claude Code Home Manager module should materialize the wrapper's settings render into the writable user settings.json";
       }
       {
         assertion =

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4361,7 +4361,7 @@
           entry = homeAgentConfig.home.mutableJsonFiles.claude-code-settings;
         in
           entry.target
-          == ".claude/settings.json"
+          == "/home/agent/.claude/settings.json"
           && entry.value == homeAgentConfig.programs.claude-code.package.passthru.settings
           && entry.value ? hooks
           && entry.value ? statusLine;

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -92,10 +92,12 @@
     doCheck = false;
   });
 
-  # Personal-only Claude config, seeded into ~/.claude/settings.json as a
-  # writable mutable file (see `mutable.files` below): the app's native
-  # default layer, which Claude itself edits at runtime (/config, plugin
-  # toggles), so it must not be a read-only store symlink.
+  # Personal-only Claude config, folded into the wrapper's settings render
+  # via `extraSettings` (see the claudeCode override below): the index
+  # claude-code Home Manager module materializes the full render into the
+  # writable ~/.claude/settings.json with a last-applied 3-way merge, so
+  # Claude's own runtime edits (/config, plugin toggles) survive and these
+  # keys still land in the app's native default layer (#3180).
   # House posture lives in the index wrapper itself now: attribution, worktree
   # baseRef, effort/fast/theme runtime-toggle defaults, auto-updates channel,
   # the version-aware statusline, the 1M/cron/autocompact clamps (typed
@@ -163,6 +165,11 @@
       "/Users/*/Projects/*/index"
       "/Users/*/Projects/*/ix"
     ];
+    # Personal settings keys (memory dir, plugins, marketplaces), merged into
+    # the wrapper's computed render between the house defaults and the
+    # controlled keys; the module materializes the result into the writable
+    # ~/.claude/settings.json.
+    extraSettings = claudeSettings;
     # appendSystemPrompt (house rules appended to the stock prompt) comes from
     # the package default. Set `appendSystemPrompt = null;` here to ship the
     # stock prompt alone on this machine.
@@ -390,9 +397,8 @@ in {
       #    (CronCreate/CronDelete/CronList).
       # Agent teams follow the index claude-code wrapper's env_defaults
       # (index#1786 bakes CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1); the context
-      # window is clamped to ~300K via claudeSettings.env above (and index#2167
-      # bakes the same into the wrapper). No per-machine override for either
-      # here.
+      # window clamp is baked into the wrapper's settings render (index#2167).
+      # No per-machine override for either here.
       ENABLE_TOOL_SEARCH = "false";
       CLAUDE_CODE_DISABLE_CRON = "1";
     }
@@ -1014,9 +1020,11 @@ in {
   # dir), delivered bare to ~/.claude/skills/<name> and invoked as `/<skill>`
   # (no `index:` namespace): the same source Codex gets via programs.codex
   # below. This replaces the old baked `--plugin-dir` plugin.
-  # settings.json is NOT declared here (the module would render it as a
-  # read-only store symlink): it is seeded writable from claudeSettings via
-  # `mutable.files` below, because Claude edits it at runtime. .claude.json
+  # settings.json is NOT declared through the module's native `settings`
+  # option (it would render as a read-only store symlink): the index module's
+  # materializeSettings default reconciles the wrapper's full render
+  # (house posture + claudeSettings via extraSettings + controlled keys) into
+  # the writable file, because Claude edits it at runtime. .claude.json
   # remains app-owned runtime state because Claude stores account and session
   # metadata beside user choices there. CLAUDE.md is generation-owned and
   # module-rendered: the house context render (packages/agent/prompt) plus the
@@ -1064,16 +1072,16 @@ in {
     installHooks = false;
   };
 
-  # Both agents edit their own config at runtime, so neither file can be a
-  # read-only store render. Durable: in-app changes survive activation and
-  # login; when the declared base moves under local edits, the file queues in
+  # Codex edits its own config at runtime, so the file cannot be a read-only
+  # store render. Durable: in-app changes survive activation and login; when
+  # the declared base moves under local edits, the file queues in
   # `index-delta status --json` (both diffs as addressed ops) for an explicit
   # discard / adopt / absorb-into-Nix via `index-delta apply-ops`.
-  mutable.files.".claude/settings.json" = {
-    source = jsonFormat.generate "andrewgazelka-claude-settings.json" claudeSettings;
-    persistence = "durable";
-    declaredAt = "users/andrewgazelka/profiles/workstation.nix";
-  };
+  # ~/.claude/settings.json moved off this mechanism (#3180): its declared
+  # base carries store paths that move on every index bump (hooks, statusline),
+  # so durable drift queued a conflict per bump; the claude-code module's
+  # mutable-json 3-way merge updates those keys mechanically while preserving
+  # Claude's runtime writes.
   mutable.files.".codex/config.toml" = {
     source = tomlFormat.generate "andrewgazelka-codex-config.toml" codexSettings;
     persistence = "durable";


### PR DESCRIPTION
Closes #3180.

The wrapper injected its computed settings render as a conditional `--settings` CLI flag. In Claude Code's precedence, CLI args outrank the local/project/user settings files, so the injected flag silently shadowed the user's own writable `~/.claude/settings.json`. This PR stops injecting and delivers the render through the writable user layer instead.

## What changed

- **`packages/agent/claude-code/default.nix`**: no `conditional_flags` / `introspection` in the launch spec. The render is exposed as `passthru.settings` (attrset) and `passthru.settingsFile` (store JSON) for consumers.
- **`packages/agent/home-manager/claude-code.nix`**: new `materializeSettings` option (default on) seeds `<configDir>/settings.json` from `package.passthru.settings` via `homeModules.mutable-json`'s last-applied 3-way merge, so runtime writes by the CLI survive while store-path keys (hooks, statusline) update mechanically on every bump. An assertion keeps the file single-owner (upstream HM renders a read-only settings.json when `settings`/`marketplaces`/disabled MCP servers are set).
- **`lib/services/mutable-json.nix`**: the home module is now keyed (`key = "index/lib/services/mutable-json.nix"`) so the agent module can embed it while a downstream config also imports `homeModules.mutable-json`.
- **`packages/config-launch`**: with the flag gone, `--which-settings` has nothing to answer (the live config is now explainable from disk), and claude-code was the only consumer of `conditional_flags` / `introspection`, so both launcher layers are removed with their tests and docs.
- **workstation profile**: `.claude/settings.json` moves off index-delta `mutable.files` ownership into `extraSettings` -> `materializeSettings`. Its declared base carried store paths that move on every index bump, so durable drift queued a manual conflict per bump; the 3-way merge updates those keys mechanically.

## controlledSettings placement: user layer

Hooks and `permissions.deny` merge cumulatively across scopes in Claude Code, and deny always wins wherever it appears, so delivering the controlled keys (hook policy, system-tool denies, feature env) through the writable user layer keeps them effective without a managed file. The managed layer (`/etc/claude-code/managed-settings.json`, `lib/dev/agents.nix`) already separately enforces the dev-image bypass keys and stays as the enforcement escape hatch for keys that must beat project/local settings.

## Consumers without Home Manager

- **Bare `nix run .#claude-code`**: gets the wrapper flags, env, and PATH, but no settings defaults; seed from `passthru.settingsFile` or use the managed layer if defaults are wanted. This is deliberate: nothing should silently outrank the user's own settings.
- **Fleet dev VMs**: use stock nixpkgs `claude-code` plus managed-settings, not this wrapper; unaffected.

## Migration

Lossless for existing installs: index-delta simply stops managing the file (leaves it in place), and mutable-json's first activation has an empty last-applied state, so the merge preserves every app-written key while enforcing the declared ones.

## Validation

- `cargo test -p config-launch`: 18/18 pass (unit + CLI).
- `nix build .#claude-code`: install checks pass; the built launch spec carries only `env`/`env_defaults`/`flags`/`path_prepend`/`target`.
- `.#checks.x86_64-linux.eval`: evaluates (new materialize assertion included).
- `.#checks.aarch64-darwin.personal-light-profile`: builds.
- Workstation module eval: materialized entry targets `~/.claude/settings.json` with personal + house keys; `.claude/settings.json` gone from `mutable.files`.

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Materialize claude-code settings into the user layer via Home Manager instead of injecting `--settings`
> - The claude-code wrapper no longer injects `--settings` as a CLI flag; instead, the computed settings render is exposed as `passthru.settings`/`passthru.settingsFile` on the package.
> - The Home Manager module gains a `materializeSettings` option (default `true`) that writes `~/.claude/settings.json` using a last-applied 3-way merge, keeping declared keys enforced while preserving runtime edits.
> - `config-launch` removes `ConditionalFlags` and `Introspection` logic, now only prepending static flags and computed `--config` entries before exec.
> - An assertion in the Home Manager module prevents conflicting read-only render paths when `materializeSettings` is enabled.
> - Behavioral Change: sessions no longer receive a wrapper-provided `--settings` argv override; settings land exclusively via the materialized JSON file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 557fe0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->