### PR TITLE
fabric: bundled call-first delegation module (phase 1)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -528,6 +528,27 @@
       cp -r ${weavePythonSource}/weave/. "$site/"
     ''
   );
+  # Call-first local delegation on the weave journal (index#3191): `await
+  # fabric.run(fn, *args)` executes fn on this node with the ask/started/
+  # terminal facts recorded via the bundled weave client, and `fabric.claude`
+  # opens self-recording, interruptible Claude Agent SDK sessions. Pure Python
+  # over the bundled weave + claude-agent-sdk.
+  fabricPythonSource = builtins.path {
+    name = "ix-mcp-fabric-python-source";
+    path = ./src/fabric;
+  };
+  fabricModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-fabric-python-module"
+    {
+      strictDeps = true;
+      meta.description = "Call-first fabric delegation bundled into the ix-mcp interpreter";
+    }
+    ''
+      site="$out/${pkgs.python3.sitePackages}/fabric"
+      mkdir -p "$site"
+      cp -r ${fabricPythonSource}/fabric/. "$site/"
+    ''
+  );
   # The kernel's process runner. The public `sh()`/`zsh()` are RETIRED (agents
   # shell out through `await nu(...)`); they stay importable as disabled shims
   # that raise a migration hint. The private `sh._exec` runs on the kernel's loop
@@ -1352,6 +1373,10 @@
       # read/searched without shelling out or falling back to a host tool. Pure
       # Python, small (`from pypdf import PdfReader`).
       ps.pypdf
+      # claude-agent-sdk: the Claude Agent SDK the `fabric.claude` session
+      # helper drives (streaming input + native interrupt over the Claude Code
+      # CLI subprocess), replacing PTY scraping for programmatic claudes.
+      ps.claude-agent-sdk
       tuiModule
       searchModule
       nuPyModule
@@ -1369,6 +1394,7 @@
       fleetModule
       meshModule
       weaveModule
+      fabricModule
       shModule
       svelteModule
       worktreeModule
@@ -1534,6 +1560,7 @@
     "view"
     "worktree"
     "mesh"
+    "fabric"
     "claude_history"
   ];
   # The `ix_notebook_mcp` server package is migrated file-by-file (the package
@@ -5391,6 +5418,7 @@
   ghosttyBundled = importTest "ghostty" "import ghostty; print('ghostty-ok', all(callable(getattr(ghostty, n)) for n in ('surfaces', 'my_tty', 'my_surface', 'close', 'close_me', 'focus', 'activate', 'is_running')), ghostty.__version__)";
   xBundled = importTest "x" "import x; print('x-ok', callable(x.posts), x.__version__)";
   meshBundled = importTest "mesh" "import mesh, asyncio; print('mesh-ok', all(asyncio.iscoroutinefunction(getattr(mesh, n)) for n in ('peers', 'sessions')), mesh.__version__)";
+  fabricBundled = importTest "fabric" "import fabric, asyncio; print('fabric-ok', asyncio.iscoroutinefunction(fabric.run), asyncio.iscoroutinefunction(fabric.claude.session), fabric.__version__)";
   linearBundled = importTest "linear" "import linear; print('linear-ok', all(callable(getattr(linear, n)) for n in ('issue', 'issue_update', 'issue_create', 'issue_search', 'comment_create', 'project_create')), linear.__version__)";
   notionBundled = importTest "notion" "import notion, asyncio; print('notion-ok', all(asyncio.iscoroutinefunction(getattr(notion, n)) for n in ('search', 'page', 'blocks', 'db_query', 'page_create', 'blocks_append', 'page_update')), notion.__version__)";
   notionTestPython = pkgs.python3.withPackages (ps: [
@@ -5715,6 +5743,41 @@
       cat stdout
       mkdir -p "$out"
     '';
+  # Network-free tests for the call-first fabric (index#3191): the run record
+  # contract against an httpx.MockTransport weave double (ask facts at submit
+  # with state strictly last, started/terminal facts from the worker side, a
+  # fn that raises before its first line still leaving ask + failed), and
+  # claude.session's CAS-pointer turn facts plus both interrupt paths (handle
+  # and journal fact) converging on the SDK interrupt as state=interrupted.
+  fabricTestPython = pkgs.python3.withPackages (ps: [
+    ps.pytest
+    ps.httpx
+    ps.claude-agent-sdk
+    fabricModule
+    weaveModule
+  ]);
+  fabricTestSource = builtins.path {
+    name = "ix-mcp-fabric-test";
+    path = ./src/fabric/test_fabric.py;
+  };
+  fabricTests =
+    pkgs.runCommand "ix-mcp-fabric-tests"
+    {
+      nativeBuildInputs = [fabricTestPython];
+      strictDeps = true;
+    }
+    ''
+      export HOME=$TMPDIR/home
+      mkdir -p "$HOME"
+      cp ${fabricTestSource} "$TMPDIR/test_fabric.py"
+      ${lib.getExe fabricTestPython} -m pytest "$TMPDIR/test_fabric.py" -q -p no:cacheprovider >stdout 2>stderr || {
+        echo "ix-mcp fabric tests failed:" >&2
+        cat stdout stderr >&2
+        exit 1
+      }
+      cat stdout
+      mkdir -p "$out"
+    '';
 in
   package.overrideAttrs (old: {
     passthru =
@@ -5741,6 +5804,8 @@ in
               resourcesBridgeTests
               meshBundled
               meshTests
+              fabricBundled
+              fabricTests
               beeperBundled
               requirementsSmoke
               engineBundled

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -112,6 +112,13 @@ MODULES: tuple[Module, ...] = (
         "OpenAI Codex CLI instead of Claude",
     ),
     Module(
+        "fabric",
+        "call-first delegation recorded to the weave journal: `await fabric.run(fn, *args)` "
+        "executes fn on this node (ask fact at submit, started/terminal facts from the "
+        "worker, source + result in CAS), and `fabric.claude.session(prompt)` opens a "
+        "self-recording, interruptible Claude Agent SDK session",
+    ),
+    Module(
         "search",
         "meaning-based recall across the fleet corpus (code + agent/shell history): "
         "`await search.semantic(q, since='7d', compact=True)` / `grep(pattern)` / "

--- a/packages/mcp/src/fabric/fabric/__init__.py
+++ b/packages/mcp/src/fabric/fabric/__init__.py
@@ -1,0 +1,135 @@
+"""Call-first local delegation recorded to the weave journal (index#3191).
+
+Calls create work; facts record it. ``await fabric.run(fn, *args)`` executes
+``fn`` on this node (phase 1 of index#3190: no Ray placement yet) and appends
+the record to the shared weave journal via the bundled :mod:`weave` client:
+the ask-fact at submit (so the intent is never invisible), started and
+terminal facts from the worker side, and the function's source text in CAS.
+The journal never dispatches: the ask state is ``submitted``, distinct from
+the ``pending`` state that the weave app fulfills.
+
+``fabric.claude`` holds the Claude Agent SDK session helper: an agent is a
+library call (``await claude.session(prompt)``), not a task type.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+import platform
+import textwrap
+from collections.abc import Callable, Generator
+from dataclasses import dataclass
+
+import weave
+
+from . import claude
+
+__all__ = [
+    "RunHandle",
+    "claude",
+    "run",
+]
+
+__version__ = "0.1.0"
+
+# The ask state. Deliberately NOT the weave app's "pending": pending is what
+# its fulfiller loop dispatches, and fabric's model is that the call already
+# created the work -- the journal only records it (index#3190).
+ASK_STATE = "submitted"
+
+
+def _requested_by() -> str:
+    return os.environ.get("IX_WEAVE_AGENT") or "agent:main"
+
+
+@dataclass
+class RunHandle:
+    """One live fabric run: the journal task entity plus the local execution."""
+
+    task: str
+    _work: asyncio.Task[object]
+
+    async def wait(self) -> object:
+        """Wait for the run and return the function's value (re-raises its error)."""
+
+        return await self._work
+
+    def __await__(self) -> Generator[object, None, object]:
+        return self._work.__await__()
+
+    async def interrupt(self) -> None:
+        """Cancel the run; the worker wrapper records ``state=interrupted``.
+
+        Returns once the run has settled, so the interrupted fact is on the
+        journal when this returns. The run's own outcome (the cancellation, or
+        an error it already failed with) surfaces via :meth:`wait`, not here.
+        """
+
+        self._work.cancel()
+        await asyncio.gather(self._work, return_exceptions=True)
+
+
+async def run(fn: Callable[..., object], *args: object, local: bool = True, **kwargs: object) -> RunHandle:
+    """Execute ``fn(*args, **kwargs)`` on this node, recorded on the journal.
+
+    At submit, one ask-facts batch describes the task entity: type,
+    requested_by, node, the function's qualname, and its source text stored in
+    CAS (``put_blob``) with the hash on the ``source`` fact -- with
+    ``state=submitted`` written strictly last, so a half-written record is
+    never read as a live task. The worker wrapper then appends ``running`` and
+    the terminal fact: ``done`` (result repr in CAS), ``failed`` (with the
+    error detail), or ``interrupted``. A ``fn`` that raises before its first
+    line (a bad signature bind, a first-statement raise) still leaves the ask
+    and ``failed`` facts.
+
+    Sync functions run in ``asyncio.to_thread`` so the kernel loop never
+    blocks; async functions are awaited natively. Note a cancelled sync ``fn``
+    settles the run (and records ``interrupted``) while its thread finishes in
+    the background: threads cannot be killed.
+
+    ``local=False`` (Ray placement, ``node=``) is index#3190 phase 2+.
+    """
+
+    if not local:
+        raise NotImplementedError(
+            "fabric phase 1 is local-only: run(fn, *args, local=True); "
+            "Ray placement across the fleet is index#3190 phase 2"
+        )
+    source = textwrap.dedent(inspect.getsource(fn))
+    task = weave.mint("task")
+    source_hash = await weave.put_blob(source.encode())
+    await weave.assert_facts([
+        (task, "type", "task"),
+        (task, "fn", fn.__qualname__),
+        (task, "node", platform.node()),
+        (task, "requested_by", _requested_by()),
+        (task, "source", weave.hashref(source_hash)),
+        (task, "state", ASK_STATE),
+    ])
+
+    async def _work() -> object:
+        await weave.assert_fact(task, "state", "running")
+        try:
+            if inspect.iscoroutinefunction(fn):
+                result = await fn(*args, **kwargs)
+            else:
+                result = await asyncio.to_thread(fn, *args, **kwargs)
+        except asyncio.CancelledError:
+            await weave.assert_fact(task, "state", "interrupted")
+            raise
+        except BaseException as exc:
+            await weave.assert_facts([
+                (task, "error", f"{type(exc).__name__}: {exc}"),
+                (task, "state", "failed"),
+            ])
+            raise
+        result_hash = await weave.put_blob(repr(result).encode())
+        await weave.assert_facts([
+            (task, "result", weave.hashref(result_hash)),
+            (task, "state", "done"),
+        ])
+        return result
+
+    return RunHandle(task, asyncio.create_task(_work(), name=f"fabric:{task}"))

--- a/packages/mcp/src/fabric/fabric/claude.py
+++ b/packages/mcp/src/fabric/fabric/claude.py
@@ -1,0 +1,251 @@
+"""Claude Agent SDK sessions, self-recorded to the weave journal.
+
+``s = await claude.session(prompt)`` opens a live, interruptible Claude
+session on the Claude Agent SDK (streaming mode: native ``interrupt()``,
+follow-up input via ``send()``), bound to one weave task entity. Every
+message and the final result go to CAS; facts carry only pointers, never
+payloads. Two interrupt paths converge on the SDK interrupt and both leave
+``state=interrupted``: ``s.interrupt()``, and an ``interrupt=requested``
+fact asserted on the task entity by anyone watching the journal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import platform
+from typing import TYPE_CHECKING, Protocol
+
+import weave
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Sequence
+
+    from claude_agent_sdk import Message, PermissionMode
+
+__all__ = ["Session", "session"]
+
+# How often the journal is polled for an externally asserted
+# interrupt=requested fact. Module-level so tests can shrink it.
+INTERRUPT_POLL_S = 0.5
+
+
+class SdkClient(Protocol):
+    """The slice of ``claude_agent_sdk.ClaudeSDKClient`` a session drives.
+
+    A structural type so tests can stand in a fake without touching the real
+    SDK subprocess transport.
+    """
+
+    async def connect(self, prompt: str | None = None) -> None: ...
+
+    async def query(self, prompt: str, session_id: str = "default") -> None: ...
+
+    def receive_messages(self) -> AsyncIterator[Message]: ...
+
+    async def interrupt(self) -> None: ...
+
+    async def disconnect(self) -> None: ...
+
+
+def _sdk_client(
+    *,
+    system_prompt: str | None,
+    model: str | None,
+    cwd: str | None,
+    allowed_tools: Sequence[str] | None,
+    permission_mode: PermissionMode | None,
+    max_turns: int | None,
+) -> SdkClient:
+    """Build the real SDK client; tests monkeypatch this factory."""
+
+    from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+    return ClaudeSDKClient(
+        ClaudeAgentOptions(
+            system_prompt=system_prompt,
+            model=model,
+            cwd=cwd,
+            allowed_tools=list(allowed_tools or []),
+            permission_mode=permission_mode,
+            max_turns=max_turns,
+        )
+    )
+
+
+def _turn_blob(message: Message) -> bytes:
+    """Serialize one SDK message for CAS: the full payload, typed."""
+
+    return json.dumps(
+        {"type": type(message).__name__, "message": dataclasses.asdict(message)},
+        default=repr,
+    ).encode()
+
+
+class Session:
+    """One live SDK session bound to a weave task entity.
+
+    The reader task records a ``turn`` fact (a CAS pointer) per SDK message
+    and a ``result`` fact per ``ResultMessage``; the watcher task polls the
+    journal for ``interrupt=requested``. Terminal state lands exactly once:
+    ``interrupted`` at interrupt time, ``failed`` if the SDK stream errors,
+    else ``done`` at :meth:`close` -- always the entity's last state fact.
+    """
+
+    def __init__(self, task: str, client: SdkClient) -> None:
+        self.task = task
+        self._client = client
+        self._interrupted = False
+        self._terminal_written = False
+        self._result: str | None = None
+        self._error: BaseException | None = None
+        self._turn_done = asyncio.Event()
+        self._reader: asyncio.Task[None] | None = None
+        self._watcher: asyncio.Task[None] | None = None
+
+    def _start(self) -> None:
+        self._reader = asyncio.create_task(self._read(), name=f"fabric:claude:read:{self.task}")
+        self._watcher = asyncio.create_task(self._watch_interrupt(), name=f"fabric:claude:watch:{self.task}")
+
+    async def _read(self) -> None:
+        from claude_agent_sdk import ResultMessage
+
+        try:
+            async for message in self._client.receive_messages():
+                turn_hash = await weave.put_blob(_turn_blob(message))
+                await weave.assert_fact(self.task, "turn", weave.hashref(turn_hash))
+                if isinstance(message, ResultMessage):
+                    self._result = message.result or ""
+                    result_hash = await weave.put_blob(self._result.encode())
+                    await weave.assert_fact(self.task, "result", weave.hashref(result_hash))
+                    self._turn_done.set()
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            self._error = exc
+            await self._write_terminal("failed", error=f"{type(exc).__name__}: {exc}")
+            self._turn_done.set()
+            raise
+
+    async def _watch_interrupt(self) -> None:
+        while not self._interrupted:
+            rows = (await weave.query(f'?- latest("{self.task}", interrupt, I).'))["rows"]
+            if rows and rows[0][0] == "requested":
+                await self._do_interrupt()
+                return
+            await asyncio.sleep(INTERRUPT_POLL_S)
+
+    async def _write_terminal(self, state: str, *, error: str | None = None) -> None:
+        if self._terminal_written:
+            return
+        self._terminal_written = True
+        facts: list[tuple[str, str, object]] = [] if error is None else [(self.task, "error", error)]
+        await weave.assert_facts([*facts, (self.task, "state", state)])
+
+    async def _do_interrupt(self) -> None:
+        if self._interrupted:
+            return
+        self._interrupted = True
+        await self._client.interrupt()
+        await self._write_terminal("interrupted")
+        self._turn_done.set()
+
+    async def send(self, text: str) -> None:
+        """Stream a follow-up user message into the live session."""
+
+        if self._interrupted or self._terminal_written:
+            raise RuntimeError(f"session is closed: {self.task}")
+        turn_hash = await weave.put_blob(
+            json.dumps({"type": "UserMessage", "message": {"content": text}}).encode()
+        )
+        await weave.assert_fact(self.task, "turn", weave.hashref(turn_hash))
+        self._turn_done.clear()
+        await self._client.query(text)
+
+    async def result(self, *, timeout: float | None = None) -> str:
+        """Wait for the current turn's result text (also set on interrupt/failure)."""
+
+        async with asyncio.timeout(timeout):
+            await self._turn_done.wait()
+        if self._error is not None:
+            raise self._error
+        return self._result or ""
+
+    async def interrupt(self) -> None:
+        """Interrupt natively: record the request, stop the SDK, mark interrupted."""
+
+        await weave.assert_fact(self.task, "interrupt", "requested")
+        await self._do_interrupt()
+
+    async def close(self) -> None:
+        """Disconnect and write the terminal state (``done`` unless one landed)."""
+
+        for task in (self._reader, self._watcher):
+            if task is not None:
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+        await self._client.disconnect()
+        await self._write_terminal("done")
+
+    async def __aenter__(self) -> Session:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.close()
+
+
+async def session(
+    prompt: str,
+    *,
+    system_prompt: str | None = None,
+    model: str | None = None,
+    cwd: str | None = None,
+    allowed_tools: Sequence[str] | None = None,
+    permission_mode: PermissionMode | None = None,
+    max_turns: int | None = None,
+) -> Session:
+    """Open a recorded, interruptible Claude session and send ``prompt``.
+
+    Ask facts land first (prompt text in CAS, ``state=submitted`` last), so
+    the intent is on the journal before the SDK subprocess spawns; a connect
+    or first-send failure still appends the ``failed`` terminal fact. On
+    success the session is live (``state=running``) and returns immediately:
+    ``await s.result()`` waits for the turn, ``s.send()`` streams follow-up
+    input, ``s.interrupt()`` stops it.
+    """
+
+    from . import _requested_by
+
+    task = weave.mint("task")
+    prompt_hash = await weave.put_blob(prompt.encode())
+    facts: list[tuple[str, str, object]] = [
+        (task, "type", "task"),
+        (task, "fn", "claude.session"),
+        (task, "node", platform.node()),
+        (task, "requested_by", _requested_by()),
+        (task, "prompt", weave.hashref(prompt_hash)),
+    ]
+    if model is not None:
+        facts.append((task, "model", model))
+    facts.append((task, "state", "submitted"))
+    await weave.assert_facts(facts)
+
+    client = _sdk_client(
+        system_prompt=system_prompt,
+        model=model,
+        cwd=cwd,
+        allowed_tools=allowed_tools,
+        permission_mode=permission_mode,
+        max_turns=max_turns,
+    )
+    live = Session(task, client)
+    try:
+        await client.connect()
+        await client.query(prompt)
+    except BaseException as exc:
+        await live._write_terminal("failed", error=f"{type(exc).__name__}: {exc}")
+        raise
+    await weave.assert_fact(task, "state", "running")
+    live._start()
+    return live

--- a/packages/mcp/src/fabric/test_fabric.py
+++ b/packages/mcp/src/fabric/test_fabric.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import sys
+import threading
+from collections.abc import AsyncIterator, Coroutine
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeVar
+
+import httpx
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "weave"))
+sys.path.insert(0, str(ROOT / "fabric"))
+
+import weave
+from claude_agent_sdk import AssistantMessage, Message, ResultMessage, TextBlock
+
+import fabric
+from fabric import claude
+
+_T = TypeVar("_T")
+
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def run(coro: Coroutine[Any, Any, _T]) -> _T:
+    return asyncio.run(coro)
+
+
+@dataclass
+class Journal:
+    """In-memory weave double behind an ``httpx.MockTransport``."""
+
+    facts: list[tuple[object, str, object]] = field(default_factory=list)
+    blobs: dict[str, bytes] = field(default_factory=dict)
+    interrupt: str | None = None
+
+    def handler(self, req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        if path == "/api/blob":
+            body = req.read()
+            # Any 64-hex digest satisfies the client's hash contract.
+            digest = hashlib.sha256(body).hexdigest()
+            self.blobs[digest] = body
+            return httpx.Response(200, json={"hash": digest})
+        if path == "/api/facts":
+            payload = json.loads(req.read())
+            batch = payload if isinstance(payload, list) else [payload]
+            for item in batch:
+                fact = item["fact"]
+                self.facts.append((fact["entity"]["v"], fact["attr"], fact["value"]["v"]))
+            return httpx.Response(200, json=[{"seq": i, "id": f"f{i}"} for i in range(len(batch))])
+        if path == "/api/query":
+            rows = [] if self.interrupt is None else [[{"t": "str", "v": self.interrupt}]]
+            return httpx.Response(200, json={"vars": ["I"], "rows": rows, "as_of": 1})
+        raise AssertionError(f"unexpected weave call: {path}")
+
+    def states(self, task: str) -> list[object]:
+        return [v for e, a, v in self.facts if e == task and a == "state"]
+
+    def blob_for(self, task: str, attr: str) -> bytes:
+        values = [v for e, a, v in self.facts if e == task and a == attr]
+        assert values, f"no {attr} fact on {task}"
+        digest = values[-1]
+        assert isinstance(digest, str), digest
+        assert _HEX64.fullmatch(digest), digest
+        return self.blobs[digest]
+
+
+def install(monkeypatch: pytest.MonkeyPatch) -> Journal:
+    journal = Journal()
+    transport = httpx.MockTransport(journal.handler)
+    monkeypatch.setattr(
+        weave,
+        "_client",
+        lambda **kw: httpx.AsyncClient(transport=transport, base_url="http://weave.test", **kw),
+    )
+    monkeypatch.setenv("IX_WEAVE_AGENT", "agent:tester")
+    return journal
+
+
+class FakeClient:
+    """Structural stand-in for ``ClaudeSDKClient`` (see ``claude.SdkClient``)."""
+
+    def __init__(self, *, connect_error: Exception | None = None) -> None:
+        self.connected = False
+        self.interrupts = 0
+        self.queries: list[str] = []
+        self._connect_error = connect_error
+        self._messages: asyncio.Queue[Message | None] = asyncio.Queue()
+
+    def feed(self, message: Message) -> None:
+        self._messages.put_nowait(message)
+
+    async def connect(self, prompt: str | None = None) -> None:
+        if self._connect_error is not None:
+            raise self._connect_error
+        self.connected = True
+
+    async def query(self, prompt: str, session_id: str = "default") -> None:
+        self.queries.append(prompt)
+
+    async def receive_messages(self) -> AsyncIterator[Message]:
+        while True:
+            message = await self._messages.get()
+            if message is None:
+                return
+            yield message
+
+    async def interrupt(self) -> None:
+        self.interrupts += 1
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+
+def use_fake(monkeypatch: pytest.MonkeyPatch, fake: FakeClient) -> None:
+    monkeypatch.setattr(claude, "_sdk_client", lambda **kw: fake)
+    monkeypatch.setattr(claude, "INTERRUPT_POLL_S", 0.01)
+
+
+def result_message(text: str) -> ResultMessage:
+    return ResultMessage(
+        subtype="success",
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=False,
+        num_turns=1,
+        session_id="s1",
+        result=text,
+    )
+
+
+# --- fabric.run ---------------------------------------------------------------
+
+
+def test_run_records_ask_then_started_then_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    async def main() -> tuple[fabric.RunHandle, object]:
+        handle = await fabric.run(add, 2, 3)
+        return handle, await handle.wait()
+
+    handle, value = run(main())
+    assert value == 5
+    assert re.fullmatch(r"task:[0-9a-f]{8}", handle.task)
+    attrs = [(a, v) for e, a, v in journal.facts if e == handle.task]
+    # Ask facts land at submit, state strictly last; the worker wrapper then
+    # appends started (running) and the terminal state, again last.
+    assert [a for a, _ in attrs] == [
+        "type",
+        "fn",
+        "node",
+        "requested_by",
+        "source",
+        "state",
+        "state",
+        "result",
+        "state",
+    ]
+    assert dict(attrs)["requested_by"] == "agent:tester"
+    assert dict(attrs)["fn"].endswith("add")
+    assert journal.states(handle.task) == ["submitted", "running", "done"]
+    assert b"def add(a: int, b: int) -> int:" in journal.blob_for(handle.task, "source")
+    assert journal.blob_for(handle.task, "result") == b"5"
+
+
+def test_run_sync_off_loop_and_async_native(monkeypatch: pytest.MonkeyPatch) -> None:
+    install(monkeypatch)
+
+    def thread_name() -> str:
+        return threading.current_thread().name
+
+    async def double(n: int) -> int:
+        return n * 2
+
+    async def main() -> tuple[object, object]:
+        sync_result = await (await fabric.run(thread_name))
+        async_result = await (await fabric.run(double, 21))
+        return sync_result, async_result
+
+    sync_result, async_result = run(main())
+    assert sync_result != "MainThread"  # sync fns run in to_thread, off the loop
+    assert async_result == 42
+
+
+@pytest.mark.parametrize(
+    ("args", "detail"),
+    [
+        ((), "RuntimeError: nope"),  # raises on its first line
+        ((1, 2), "TypeError"),  # raises before its first line: bad signature bind
+    ],
+)
+def test_run_failure_still_leaves_ask_and_failed(
+    monkeypatch: pytest.MonkeyPatch, args: tuple[int, ...], detail: str
+) -> None:
+    journal = install(monkeypatch)
+
+    def boom() -> None:
+        raise RuntimeError("nope")
+
+    async def main() -> fabric.RunHandle:
+        handle = await fabric.run(boom, *args)
+        with pytest.raises((RuntimeError, TypeError)):
+            await handle.wait()
+        return handle
+
+    handle = run(main())
+    assert journal.states(handle.task) == ["submitted", "running", "failed"]
+    errors = [v for e, a, v in journal.facts if e == handle.task and a == "error"]
+    assert len(errors) == 1
+    assert str(errors[0]).startswith(detail)
+    # The terminal state is the entity's last fact.
+    assert journal.facts[-1] == (handle.task, "state", "failed")
+    assert b"def boom() -> None:" in journal.blob_for(handle.task, "source")
+
+
+def test_run_remote_placement_not_implemented(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+
+    async def main() -> None:
+        await fabric.run(int, local=False)
+
+    with pytest.raises(NotImplementedError, match="local-only"):
+        run(main())
+    assert journal.facts == []  # rejected before any journal write
+
+
+def test_run_interrupt_records_interrupted(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+
+    async def forever() -> None:
+        await asyncio.sleep(60)
+
+    async def main() -> fabric.RunHandle:
+        handle = await fabric.run(forever)
+        await asyncio.sleep(0)  # let the worker publish running
+        await handle.interrupt()
+        with pytest.raises(asyncio.CancelledError):
+            await handle.wait()
+        return handle
+
+    handle = run(main())
+    assert journal.states(handle.task) == ["submitted", "running", "interrupted"]
+
+
+# --- claude.session -----------------------------------------------------------
+
+
+def test_session_records_turns_result_and_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+    fake = FakeClient()
+    use_fake(monkeypatch, fake)
+
+    async def main() -> claude.Session:
+        live = await claude.session("solve the riddle", model="opus")
+        assert fake.connected
+        assert fake.queries == ["solve the riddle"]
+        fake.feed(AssistantMessage(content=[TextBlock(text="thinking")], model="opus"))
+        fake.feed(result_message("the answer"))
+        assert await live.result(timeout=5) == "the answer"
+        await live.close()
+        return live
+
+    live = run(main())
+    task = live.task
+    assert journal.states(task) == ["submitted", "running", "done"]
+    assert journal.facts[-1] == (task, "state", "done")
+    # Payloads live in CAS; facts carry only pointers.
+    assert journal.blob_for(task, "prompt") == b"solve the riddle"
+    assert journal.blob_for(task, "result") == b"the answer"
+    for _, _attr, value in [f for f in journal.facts if f[0] == task]:
+        assert "the answer" not in str(value)
+        assert "solve the riddle" not in str(value)
+    turns = [v for e, a, v in journal.facts if e == task and a == "turn"]
+    assert len(turns) == 2
+    first = json.loads(journal.blobs[str(turns[0])])
+    assert first["type"] == "AssistantMessage"
+    assert first["message"]["content"] == [{"text": "thinking"}]
+    assert json.loads(journal.blobs[str(turns[1])])["type"] == "ResultMessage"
+
+
+def test_session_follow_up_input_streams(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+    fake = FakeClient()
+    use_fake(monkeypatch, fake)
+
+    async def main() -> claude.Session:
+        live = await claude.session("first")
+        fake.feed(result_message("one"))
+        assert await live.result(timeout=5) == "one"
+        await live.send("second")
+        fake.feed(result_message("two"))
+        assert await live.result(timeout=5) == "two"
+        await live.close()
+        return live
+
+    live = run(main())
+    assert fake.queries == ["first", "second"]
+    turns = [v for e, a, v in journal.facts if e == live.task and a == "turn"]
+    assert len(turns) == 3  # result one, the follow-up user turn, result two
+    follow_up = json.loads(journal.blobs[str(turns[1])])
+    assert follow_up == {"type": "UserMessage", "message": {"content": "second"}}
+
+
+def test_interrupt_handle_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+    fake = FakeClient()
+    use_fake(monkeypatch, fake)
+
+    async def main() -> claude.Session:
+        live = await claude.session("long job")
+        await live.interrupt()
+        await live.close()  # must not overwrite the terminal state
+        return live
+
+    live = run(main())
+    assert fake.interrupts == 1  # converged on the SDK interrupt
+    assert journal.states(live.task) == ["submitted", "running", "interrupted"]
+    assert (live.task, "interrupt", "requested") in journal.facts
+
+
+def test_interrupt_fact_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+    fake = FakeClient()
+    use_fake(monkeypatch, fake)
+
+    async def main() -> claude.Session:
+        live = await claude.session("long job")
+        # Someone else asserts interrupt=requested on the run entity.
+        journal.interrupt = "requested"
+        await live.result(timeout=5)  # released by the interrupt
+        await live.close()
+        return live
+
+    live = run(main())
+    assert fake.interrupts == 1  # the journal watcher converged on the SDK interrupt
+    assert journal.states(live.task) == ["submitted", "running", "interrupted"]
+
+
+def test_session_connect_failure_leaves_ask_and_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+    fake = FakeClient(connect_error=OSError("claude CLI missing"))
+    use_fake(monkeypatch, fake)
+
+    async def main() -> None:
+        await claude.session("never starts")
+
+    with pytest.raises(OSError, match="claude CLI missing"):
+        run(main())
+    tasks = {e for e, a, v in journal.facts if a == "type"}
+    assert len(tasks) == 1
+    task = tasks.pop()
+    assert isinstance(task, str)
+    assert journal.states(task) == ["submitted", "failed"]
+    assert journal.blob_for(task, "prompt") == b"never starts"
+    assert journal.facts[-1] == (task, "state", "failed")


### PR DESCRIPTION
Implements #3191 (agent fabric phase 1, design: #3190).

- New bundled kernel module `fabric`: `await fabric.run(fn, *args, local=True)` runs fn on this node (sync fns via `asyncio.to_thread`, async awaited natively) and records ask facts at submit (type/fn/node/requested_by/source, state last) plus started/terminal facts from the worker; source and result blobs live in CAS, facts carry only hashrefs. Ask state is `submitted`, never `pending`, so the weave dispatcher leaves fabric tasks alone.
- `fabric.claude.session(prompt, ...)` on the pinned `claude-agent-sdk` (0.2.110 from nixpkgs, added to the mcp interpreter): streamed follow-up input via `send()`, per-turn CAS blobs, result blob, and a two-path interrupt contract: `handle.interrupt()` and an `interrupt=requested` fact both converge on SDK `interrupt()` and `state=interrupted`.
- `fabric` joins `strictGreenModules` (zuban --strict + ruff ANN); tests mock the weave server with `httpx.MockTransport` and a structural SDK fake, wired as `mcp.tests.fabricTests` + `fabricBundled`.

Validated: `nix build .#mcp .#mcp.tests.fabricTests .#mcp.tests.fabricBundled .#mcp.tests.strictTypecheck` green; 11 pytest cases pass locally and in the derivation.

🤖 Generated with Claude Code (Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bundled `fabric` module for call-first delegation with Claude Agent SDK journaling
> - Adds a new `fabric` Python package to the MCP bundle, exposing `fabric.run` for local async task execution and `fabric.claude.session` for Claude Agent SDK sessions, both recording lifecycle facts to the weave journal.
> - `fabric.run` captures function source, mints a weave task id, writes source/result to CAS, and journals state transitions (`submitted` → `running` → `done`/`failed`/`interrupted`); returns a `RunHandle` that supports awaiting or cancellation.
> - `fabric.claude.session` manages a Claude SDK session that streams turns to the journal, supports follow-up queries, and converges interrupts from either the handle or an externally asserted journal fact into an SDK interrupt with a terminal `interrupted` state.
> - Registers `fabric` in the MCP module registry and wires import and pytest tests (covering run, session, and interrupt paths) into the build's test suite.
> - `local=False` in `fabric.run` raises `NotImplementedError` (delegation to remote nodes is not yet implemented).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c479cce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->