### PR TITLE
ci: gate merges on the cache-push closure building (closure-gate)

### DIFF
--- a/.github/actions/check-logged/action.yml
+++ b/.github/actions/check-logged/action.yml
@@ -1,0 +1,51 @@
+name: Run .#check with a runner-local log
+description: >-
+  Run `nix run .#check` with its output redirected to a runner-local file
+  instead of the Actions log: the nix-fast-build stream for a warm run is
+  megabytes of eval warnings and per-drv noise that drowns the signal. The
+  step prints only the host and log path (readable over ssh on the runner
+  host, e.g. vin-compute-1), mirrors both into the step summary, and cats the
+  full log into the Actions log only when the check fails.
+inputs:
+  subcommand:
+    description: >-
+      Optional `check` app subcommand passed after `--`, e.g. `closure` for
+      the cache-push closure gate. Empty runs the full default gate.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Run check with logged output
+      shell: bash
+      env:
+        CHECK_SUBCOMMAND: ${{ inputs.subcommand }}
+      run: |
+        set -euo pipefail
+
+        commit="$(git rev-parse HEAD 2>/dev/null || printf 'unknown')"
+        workflow="${GITHUB_WORKFLOW:-local}"
+        run_tag="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
+        log_root="${IX_CI_RUN_LOG_ROOT:-/var/log/ix-ci/runs}"
+        log_dir="${log_root}/${commit}/${workflow}"
+        if install -d -m 0755 "${log_dir}" 2>/tmp/index-ci-log-dir.err && [[ -w "${log_dir}" ]]; then
+          check_log="${log_dir}/${run_tag}.stdout"
+        else
+          fallback_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+          check_log="${fallback_dir%/}/index-check-${run_tag}.stdout"
+        fi
+
+        printf 'index check log: %s on %s\n' "${check_log}" "$(hostname)"
+        nix --version
+        nix store info --json
+        if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+          {
+            printf "## index check\n\n"
+            printf "log: \`%s\` on \`%s\`\n" "${check_log}" "$(hostname)"
+          } >>"${GITHUB_STEP_SUMMARY}"
+        fi
+
+        if ! nix run .#check ${CHECK_SUBCOMMAND:+-- "${CHECK_SUBCOMMAND}"} >"${check_log}" 2>&1; then
+          cat "${check_log}"
+          exit 1
+        fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -117,35 +117,7 @@ jobs:
       # requires a status named `flake-check`; this job is it, and it fails iff a
       # check fails to build or the flake stops evaluating.
       - name: Build all flake checks
-        run: |
-          set -euo pipefail
-
-          commit="$(git rev-parse HEAD 2>/dev/null || printf 'unknown')"
-          workflow="${GITHUB_WORKFLOW:-local}"
-          run_tag="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
-          log_root="${IX_CI_RUN_LOG_ROOT:-/var/log/ix-ci/runs}"
-          log_dir="${log_root}/${commit}/${workflow}"
-          if install -d -m 0755 "${log_dir}" 2>/tmp/index-ci-log-dir.err && [[ -w "${log_dir}" ]]; then
-            check_log="${log_dir}/${run_tag}.stdout"
-          else
-            fallback_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
-            check_log="${fallback_dir%/}/index-check-${run_tag}.stdout"
-          fi
-
-          printf 'index check log: %s\n' "${check_log}"
-          nix --version
-          nix store info --json
-          if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-            {
-              printf "## index check\n\n"
-              printf "log: \`%s\`\n" "${check_log}"
-            } >>"${GITHUB_STEP_SUMMARY}"
-          fi
-
-          if ! nix run .#check >"${check_log}" 2>&1; then
-            cat "${check_log}"
-            exit 1
-          fi
+        uses: ./.github/actions/check-logged
 
       # The `check` app writes nix-fast-build per-attr durations to
       # check-results.json in the workspace (see lib/per-system.nix). Upload it

--- a/.github/workflows/closure-gate.yml
+++ b/.github/workflows/closure-gate.yml
@@ -64,5 +64,9 @@ jobs:
       - name: Bootstrap patched Nix client
         uses: ./.github/actions/bootstrap-patched-nix
 
+      # Output goes to a runner-local log (the action prints the host and
+      # path); the Actions log stays quiet unless the build fails.
       - name: Build the cache-push closure
-        run: nix run .#check -- closure
+        uses: ./.github/actions/check-logged
+        with:
+          subcommand: closure

--- a/.github/workflows/closure-gate.yml
+++ b/.github/workflows/closure-gate.yml
@@ -1,0 +1,68 @@
+name: Closure gate
+
+# Build the publishable closure before merge (#1873). flake-check only
+# eval-validates `packages`, so a package whose *build* breaks -- #2690's
+# codex darwin cross closure (root cause #3188) -- merged green and broke
+# every consumer. This job realises, pre-merge on the warm-store pool, exactly
+# the roots the post-merge Cache push linux lane publishes: `nix run .#check
+# -- closure` builds `.#cachePushRoots.x86_64-linux` with nix-fast-build
+# --skip-cached, so an average PR is eval plus cache probe only and a
+# package-changing PR builds just its delta.
+#
+# Build-only, no publish: the ci-dispatcher attaches the ix-public push token
+# only to `-cache-push` jobs on main pushes (spawn.rs ix_public_push_eligible);
+# PR contexts run unmerged code and must never hold it. The post-merge Cache
+# push remains the publisher, but after a gated merge its realise phase is
+# ~free (this run already built the closure into the shared warm store), so
+# the unpublished window shrinks to roughly upload time. True
+# publish-before-merge (retiring cache-ready) stays open on #1873.
+#
+# The native aarch64-darwin cache lane (GitHub-hosted mac, cold codex is
+# 40-80 min) is not gated here; it stays a post-merge cache-push concern.
+
+on:
+  pull_request:
+    branches:
+      - main
+  # Same rationale as check.yml: the main ruleset demands this status inside
+  # the merge queue too, should one be enabled.
+  merge_group:
+  # Manual run against any ref, e.g. probing main's closure health.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: closure-gate-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Client-side eval knobs only, same set and rationale as check.yml: the
+  # self-hosted daemon owns substituters, trusted keys, and system features.
+  NIX_CONFIG: |-
+    experimental-features = nix-command flakes ca-derivations
+    accept-flake-config = false
+    max-jobs = auto
+    cores = 1
+
+jobs:
+  # Branch protection requires a status named `closure-gate`; this job is it.
+  # Separate from flake-check on purpose: it runs in parallel on its own
+  # ephemeral runner, so the existing gate's latency is untouched.
+  closure-gate:
+    runs-on: ["${{ format('ix-ci-run-{0}-{1}-closure-gate', github.run_id, github.run_attempt) }}"]
+    # A relock-class PR realises a near-full closure; match the cache-push
+    # linux lane budget, which fits that worst case.
+    timeout-minutes: 180
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Underscore digit separators: every nix invocation that evaluates this
+      # tree must go through the patched client (see the action's description).
+      - name: Bootstrap patched Nix client
+        uses: ./.github/actions/bootstrap-patched-nix
+
+      - name: Build the cache-push closure
+        run: nix run .#check -- closure

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -364,9 +364,14 @@
   # and aborts the run (Nushell propagates external failures like bash
   # `set -o pipefail`). Uses the repo-built nix-eval-jobs directly by store path
   # rather than `nix run`.
+  #
+  # `check closure` (the closure-gate.yml required check, #1873) reuses step 1's
+  # build gate over `.#cachePushRoots.x86_64-linux`: the exact set the
+  # post-merge cache-push linux lane publishes, so a package whose build broke
+  # (not just its eval) goes red at the PR instead of on every consumer.
   check = ix.writeNushellApplication pkgs {
     name = "check";
-    meta.description = "Run the full CI gate: build .#ciChecks.x86_64-linux and eval-validate .#packages.x86_64-linux";
+    meta.description = "Run the full CI gate: build .#ciChecks.x86_64-linux and eval-validate .#packages.x86_64-linux (`closure` subcommand: build .#cachePushRoots.x86_64-linux)";
     text = ''
       # Patched nix-fast-build (packages/nix/nix-fast-build): stock --skip-cached
       # only skips a job whose nix-eval-jobs cacheStatus is `cached` (in a remote
@@ -382,10 +387,14 @@
       # is x86_64-linux-only.
       const eval_jobs = "${lib.getExe repoPackages.nix-eval-jobs}"
 
-      def main [] {
+      # Shared build gate: build every derivation under $flake with
+      # nix-fast-build and exit 1 on any failure, after replaying each failed
+      # build's log. `main` runs it over ciChecks; `main closure` over the
+      # cache-push roots.
+      def build-gate [flake: string] {
         # ca-derivations: the rust workspace units default to
         # `contentAddressed = true` (lib/rust/cargo-unit.nix), so evaluating
-        # `.#ciChecks.x86_64-linux` resolves floating content-addressed drvs. The
+        # the target set resolves floating content-addressed drvs. The
         # evaluator (nix-eval-jobs, which nix-fast-build wraps) needs the
         # `ca-derivations` experimental feature, or it aborts with
         # "experimental Nix feature 'ca-derivations' is disabled". The caller
@@ -410,7 +419,7 @@
         let build_failed = (
           try {
             ^$fast_build ...[
-              "--flake" ".#ciChecks.x86_64-linux"
+              "--flake" $flake
               # Drive nix-fast-build with the daemon-family-compatible
               # evaluator rather than its nixpkgs default.
               "--nix-eval-jobs" $eval_jobs
@@ -447,7 +456,7 @@
             # GitHub Actions log group so a long clippy dump stays collapsible;
             # harmless plain text in a local `nix run .#check`.
             print --stderr $"::group::build log: ($f.attr)"
-            let inst = $".#ciChecks.x86_64-linux.($f.attr)"
+            let inst = $"($flake).($f.attr)"
             # Fast path: replay the retained build log via `nix log` (works for
             # input-addressed checks like the browser smoke test).
             let drv = (
@@ -518,6 +527,10 @@
         if $build_failed {
           exit 1
         }
+      }
+
+      def main [] {
+        build-gate ".#ciChecks.x86_64-linux"
 
         let tmp = (mktemp --directory --tmpdir "ix-check.XXXXXX")
         let report = ($tmp | path join "flake-schema-eval.jsonl")
@@ -541,6 +554,16 @@
           exit 1
         }
         rm --recursive --force $tmp
+      }
+
+      # Pre-merge closure gate (closure-gate.yml, #1873): the same build gate
+      # over the roots the post-merge cache-push linux lane publishes, darwin
+      # cross closure included -- the set #2690 broke while flake-check stayed
+      # green (packages are eval-gated only). --skip-cached keeps it
+      # O(changed): on the warm-store pool only drvs new relative to main's
+      # already-built closure realise.
+      def "main closure" [] {
+        build-gate ".#cachePushRoots.x86_64-linux"
       }
     '';
   };


### PR DESCRIPTION
Implements the gate half of #1873 (see the [design sketch](https://github.com/indexable-inc/index/issues/1873#issuecomment-4966229814)); the "PR goes red" leg of #3196.

**What**
- `check` app grows a `closure` subcommand: the exact nix-fast-build `--skip-cached` gate step 1 already runs for `ciChecks`, refactored into a shared `build-gate` function and retargeted at `.#cachePushRoots.x86_64-linux` (everything the post-merge Cache push linux lane publishes, darwin cross closure included). Failed roots replay their real build logs as PR annotations, same as flake-check.
- New `closure-gate.yml` (`pull_request` + `merge_group` + `workflow_dispatch`): one job `closure-gate` on the warm-store `ix-ci-run-*` pool running `nix run .#check -- closure`. Parallel to flake-check on its own runner, so flake-check latency is untouched. O(changed): the patched nix-fast-build skips `local` warm-store outputs, so an average PR is eval + probe only; a relock-class PR builds its real delta, which is the point (#2690 would have gone red here).

**Deliberately not in scope**
- No publish from PR context: the ix-public push token stays on `-cache-push` main-push jobs only (ci-dispatcher `ix_public_push_eligible`). Publish-before-merge / retiring `cache-ready` stays open on #1873.
- No `cache-push.yml` changes: #3195 (push-lane truthfulness) proceeds independently.
- Native aarch64-darwin lane stays post-merge (hosted mac, cold codex 40-80 min).

**Required-check wiring (repo settings, after merge)**
Add `closure-gate` to the `main` ruleset's required status checks, once #3197 has landed: main's closure is currently red with exactly the #3188 breakage this gate detects, so flipping required first would block every PR. I have admin and will do this after merge + a green run.

**Validation**
- `nix run .#lint`: 10/10 stages green (also via pre-commit hook).
- `nix build .#packages.x86_64-linux.check`: builds; the writer's `nu --ide-check` parses the refactored script.
- `actionlint` on `closure-gate.yml`: clean.
- Nushell `main closure` subcommand dispatch verified against a live `nu` run.

Fixes the gating leg of #1873's plan; #1873 stays open for publish-before-merge.

(PR by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate PR merges on cache-push closure building via new `closure-gate` CI workflow
> - Adds a new [`closure-gate` workflow](https://github.com/indexable-inc/index/pull/3202/files#diff-638c892010bcf9fe87805596d2ebfceacbae7736e255f41d266a68cd531ff840) that runs on PRs and merge groups, invoking `nix run .#check -- closure` to build `.#cachePushRoots.x86_64-linux` as a branch protection check.
> - Adds a `closure` subcommand to the `check` Nushell script in [`lib/per-system.nix`](https://github.com/indexable-inc/index/pull/3202/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) by extracting a reusable `build-gate` function parameterized by flake attribute set.
> - Extracts log-capture and failure-reporting logic into a reusable composite action at [`.github/actions/check-logged`](https://github.com/indexable-inc/index/pull/3202/files#diff-2ff034f172b29e5e3c47c959e0a76b917ee558570d5af976517eda97696f7cab); stdout/stderr are redirected to a runner-local file and only streamed to the Actions log on failure.
> - Updates the existing [`check.yml`](https://github.com/indexable-inc/index/pull/3202/files#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428) flake-check job to use the new composite action instead of an inline bash block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec94c4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->