### PR TITLE
profiles(darwin): supervise weave serve with a launchd agent

### DIFF
--- a/users/andrewgazelka/profiles/darwin-home.nix
+++ b/users/andrewgazelka/profiles/darwin-home.nix
@@ -657,6 +657,36 @@ in {
     };
   };
 
+  # Weave fact server (indexable-inc/weave): the ix-mcp kernel store's
+  # write-behind flusher POSTs facts to 127.0.0.1:7677; with no listener every
+  # kernel cell logs connection-refused retries and drops facts (index#3203).
+  # No --agents: the in-process agent host wedges POST /api/facts
+  # (indexable-inc/weave#240). Binary + ui are gc-rooted out-links (this
+  # config has no weave input); refresh with
+  #   nix build ~/Projects/indexable-inc/weave#default --out-link ~/.local/share/weave/app
+  #   nix build ~/Projects/indexable-inc/weave#ui --out-link ~/.local/share/weave/ui
+  # Log stays at ~/.local/share/weave/serve.log next to the store: the path
+  # existing tooling and memories already reference.
+  launchd.agents.weave-serve = {
+    enable = true;
+    config = {
+      ProgramArguments = lockArgs "weave-serve" [
+        "${config.home.homeDirectory}/.local/share/weave/app/bin/weave"
+        "--store"
+        "${config.home.homeDirectory}/.local/share/weave/store"
+        "serve"
+        "--addr"
+        "127.0.0.1:7677"
+        "--ui"
+        "${config.home.homeDirectory}/.local/share/weave/ui"
+      ];
+      KeepAlive = true;
+      RunAtLoad = true;
+      StandardOutPath = "${config.home.homeDirectory}/.local/share/weave/serve.log";
+      StandardErrorPath = "${config.home.homeDirectory}/.local/share/weave/serve.log";
+    };
+  };
+
   launchd.agents.grayscale-off = {
     enable = false;
     config = {


### PR DESCRIPTION
Closes #3203.

`launchd.agents.weave-serve` in the personal darwin profile, following the room-server pattern: binary and ui dist are gc-rooted out-links under `~/.local/share/weave/` (this config has no weave input), KeepAlive + RunAtLoad, per-label lock. Serves `--store ~/.local/share/weave/store` on `127.0.0.1:7677`, no `--agents` (the in-process agent host wedges POST /api/facts, indexable-inc/weave#240). Log stays at `~/.local/share/weave/serve.log` next to the store, the path existing tooling references.

Validated on hydra: manual serve restored, API answering, kernel fact drops stopped (details on #3203).

(PR by an AI agent via Claude Code, Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Supervise `weave serve` with a launchd agent on Darwin
> Adds a user launchd agent in [darwin-home.nix](https://github.com/indexable-inc/index/pull/3204/files#diff-7b4b5d284711ad1f33b0b8435434d62bae77f9441d69ae1563fb02b61e408671) that starts `weave serve` at login and keeps it alive. The agent binds to `127.0.0.1:7677`, uses `~/.local/share/weave/store` and `~/.local/share/weave/ui`, and logs stdout/stderr to `~/.local/share/weave/serve.log`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3dbb33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->