### PR TITLE
declarative iMessage guest: pinned bbctl + launchd agent apply

### DIFF
--- a/packages/bbctl/default.nix
+++ b/packages/bbctl/default.nix
@@ -1,0 +1,51 @@
+{
+  fetchurl,
+  ix,
+  lib,
+  nix,
+  stdenvNoCC,
+  # Writer for `passthru.updateScript`, bound only on the flake-package path
+  # (lib/packages.nix); the overlay path leaves it null so `pkgs.*` carries no
+  # updater. Same nullable-writer pattern as vector-bin / claude-code.
+  updateScriptWriter ? null,
+}: let
+  # Prebuilt upstream release binary, aarch64-darwin only: the motivating
+  # consumer is the vmkit macOS guest's iMessage bridge (ENG-7746), which needs
+  # the exact darwin arm64 bytes to push into the guest. Version + URL + SRI
+  # hash live in the sibling pins.json, never inline here (repo policy). Bump
+  # the version/url in pins.json, then `nix run .#update` re-pins the hash.
+  pin = ix.pins.loadPin ./pins.json "bbctl";
+  updateScript = ix.pins.mkOptionalUpdater {
+    writeNushellApplication = updateScriptWriter;
+    inherit nix;
+    pname = "bbctl";
+    relPath = "packages/bbctl/pins.json";
+  };
+in
+  stdenvNoCC.mkDerivation {
+    pname = "bbctl";
+    inherit (pin) version;
+
+    src = fetchurl {inherit (pin) url hash;};
+    dontUnpack = true;
+
+    passthru = lib.optionalAttrs (updateScript != null) {inherit updateScript;};
+
+    installPhase = ''
+      # shell
+      runHook preInstall
+
+      install -Dm755 "$src" "$out/bin/bbctl"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Beeper bridge-manager CLI: run self-hosted Matrix bridges on a Beeper account";
+      homepage = "https://github.com/beeper/bridge-manager";
+      license = lib.licenses.asl20;
+      mainProgram = "bbctl";
+      platforms = ["aarch64-darwin"];
+      sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+    };
+  }

--- a/packages/bbctl/package.nix
+++ b/packages/bbctl/package.nix
@@ -1,0 +1,11 @@
+{
+  id = "bbctl";
+  packageSet = {
+    systems = ["aarch64-darwin"];
+  };
+  flake = {
+    systems = ["aarch64-darwin"];
+  };
+  overlay = false;
+  updateScript = true;
+}

--- a/packages/bbctl/pins.json
+++ b/packages/bbctl/pins.json
@@ -1,0 +1,7 @@
+{
+  "bbctl": {
+    "hash": "sha256-sG4JTkofHiEthS21EvEGpacHrl4lcfs1JqBB0vysCWs=",
+    "url": "https://github.com/beeper/bridge-manager/releases/download/v0.14.0/bbctl-macos-arm64",
+    "version": "0.14.0"
+  }
+}

--- a/users/andrewgazelka/guests/imessage/README.md
+++ b/users/andrewgazelka/guests/imessage/README.md
@@ -1,0 +1,53 @@
+# iMessage bridge guest
+
+Declarative half of the Beeper iMessage bridge (Linear ENG-7746) running in
+the vmkit macOS guest: [`default.nix`](default.nix) renders the
+`com.beeper.sh-imessage` launchd agent and installs `imessage-guest-apply`,
+which pushes the pinned `bbctl` (`packages/bbctl`) and the plist to
+the guest over ssh and (re)loads the agent. Interim consumer increment of
+[index#2682](https://github.com/indexable-inc/index/issues/2682); once
+`mkMacGuest` lands, the guest spec here migrates onto that seam.
+
+## Usage
+
+```nix
+users.andrewgazelka.imessageGuest.enable = true;  # host/user default to ix@192.168.64.6
+```
+
+```sh
+imessage-guest-apply
+```
+
+The apply is idempotent: rerun it after any bump of `packages/bbctl/pins.json`
+(edit version/url, then `nix run .#update` re-pins the hash) or plist change.
+
+## Manual bootstrap (once per guest)
+
+Everything below is stateful or GUI-gated and deliberately not applied by nix.
+
+1. **Guest**: vmkit macOS VM, signed into the Apple ID for iMessage, ssh
+   reachable as `ix@192.168.64.6` with key auth.
+2. **`bbctl login`**: interactive bubbletea TUI; it wedges in headless PTYs
+   (nothing answers its `ESC[6n` cursor probes), so run it in the guest's GUI
+   Terminal.app. This writes the bridge registration under
+   `~/Library/Application Support/bbctl/prod/sh-imessage/` (config.yaml +
+   mautrix-imessage.db). That directory holds SECRETS and is the bridge's
+   durable state: never commit it, and include it in any guest backup.
+3. **TCC grants**: GUI-only; macOS offers no supported non-MDM way to seed
+   them (see index#2684 for the pre-seed machinery plan). Under launchd,
+   `bbctl` is the TCC-responsible process, so grants made to Terminal.app do
+   NOT carry over. After the first `imessage-guest-apply`:
+   - **Full Disk Access**: the agent crash-loops on `chat.db: operation not
+     permitted` until bbctl auto-appears (toggled off) in System Settings >
+     Privacy & Security > Full Disk Access; toggle it on.
+   - **Contacts**: approve the prompt on first bridge start.
+   - **Automation > Messages**: approve the prompt on the first outbound send.
+
+   All three persist across reboots and reapplies (the binary path is stable).
+
+## Verifying
+
+`imessage-guest-apply` ends by printing the agent's live pid. On the guest,
+`/tmp/imsg.log` carries bridge output (block-buffered under launchd, so
+silence is normal); an outbound send logs a `step REMOTE, status SUCCESS`
+checkpoint.

--- a/users/andrewgazelka/guests/imessage/default.nix
+++ b/users/andrewgazelka/guests/imessage/default.nix
@@ -1,0 +1,150 @@
+# Declarative management of the iMessage bridge inside the vmkit macOS guest
+# (ENG-7746; interim consumer increment of index#2682): render the launchd
+# agent plist and install `imessage-guest-apply`, which pushes the pinned
+# bbctl binary (packages/bbctl) plus the plist to the guest over ssh and
+# (re)loads the agent.
+#
+# The guest itself stays a stateful pet until #2682's mkMacGuest machinery
+# lands: VM creation, Apple ID sign-in, the interactive `bbctl login`, and the
+# GUI-only TCC grants are manual bootstrap (see README.md). Everything built
+# from bytes we control (the bridge binary and its launchd agent) is declared
+# here and applied idempotently. Bridge state with secrets
+# (`~/Library/Application Support/bbctl/prod/sh-imessage/`) lives only on the
+# guest and is never rendered from nix.
+{
+  indexPackages,
+  ix,
+}: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.users.andrewgazelka.imessageGuest;
+
+  # Host-system index package set; bbctl is aarch64-darwin only, so every
+  # reference stays under `cfg.enable` (default off) and non-darwin evals
+  # never force it.
+  indexPkgs = indexPackages pkgs.stdenv.hostPlatform.system;
+
+  label = "com.beeper.sh-imessage";
+  bridge = "sh-imessage";
+  guestHome = "/Users/${cfg.user}";
+  agentPath = "${guestHome}/Library/LaunchAgents/${label}.plist";
+
+  # One renderer (lib.generators.toPlist) over a typed attrset, never
+  # hand-written XML. Mirrors the runtime state validated on the guest
+  # 2026-07-14 (ENG-7746): under launchd, bbctl is the TCC-responsible
+  # process, so the grants in README.md attach to this agent, not Terminal.
+  agentPlist = pkgs.writeText "${label}.plist" (lib.generators.toPlist {escape = true;} {
+    Label = label;
+    ProgramArguments = [
+      "${guestHome}/.local/bin/bbctl"
+      "run"
+      "--param"
+      "imessage_platform=mac"
+      "-n"
+      bridge
+    ];
+    EnvironmentVariables = {
+      HOME = guestHome;
+      # launchd agents get the bare system PATH; bbctl re-execs the bridge
+      # binary it manages out of ~/.local/bin, so that must come first.
+      PATH = "${guestHome}/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+    };
+    RunAtLoad = true;
+    KeepAlive = true;
+    ProcessType = "Background";
+    # launchd block-buffers this log, so silence in it is normal.
+    StandardOutPath = "/tmp/imsg.log";
+    StandardErrorPath = "/tmp/imsg.log";
+  });
+
+  apply = ix.writeNushellApplication pkgs {
+    name = "imessage-guest-apply";
+    runtimeInputs = [pkgs.openssh];
+    meta.description = "Push the pinned bbctl + launchd agent to the iMessage guest and (re)load it";
+    text = ''
+      # nu
+      # Idempotent apply: install bbctl and the agent plist on the guest, then
+      # bootout (only if loaded) + bootstrap so launchd picks up the new plist.
+      # Fails loudly on any hop; the terminal check reads the agent's live pid.
+      def main [] {
+        const target = "${cfg.user}@${cfg.host}"
+        const bbctl = "${lib.getExe indexPkgs.bbctl}"
+        const plist = "${agentPlist}"
+        const agent_path = "${agentPath}"
+        const label = "${label}"
+        const home = "${guestHome}"
+
+        ^ssh $target $"mkdir -p ($home)/.local/bin ($home)/Library/LaunchAgents"
+
+        # Stage-then-rename so a KeepAlive respawn never execs a half-copied
+        # binary; the running process keeps its old inode until the reload.
+        ^scp -q $bbctl $"($target):($home)/.local/bin/.bbctl.staged"
+        ^ssh $target $"chmod 755 ($home)/.local/bin/.bbctl.staged && mv -f ($home)/.local/bin/.bbctl.staged ($home)/.local/bin/bbctl"
+        ^scp -q $plist $"($target):($agent_path)"
+
+        let uid = ^ssh $target "id -u" | str trim
+        let service = $"gui/($uid)/($label)"
+
+        # `launchctl bootout` of an absent service is an error, not
+        # idempotence, so probe with `print` first instead of swallowing it.
+        # bootout is also asynchronous: it returns while launchd is still
+        # tearing the job down, and a bootstrap racing that teardown fails
+        # with EIO. Poll for the terminal state (service gone) before
+        # bootstrapping; the deadline turns a wedged teardown into a loud
+        # failure instead of an infinite wait.
+        let loaded = (do { ^ssh $target $"launchctl print ($service)" } | complete | get exit_code) == 0
+        if $loaded {
+          ^ssh $target $"launchctl bootout ($service)"
+          mut gone = false
+          for _ in 1..20 {
+            if (do { ^ssh $target $"launchctl print ($service)" } | complete | get exit_code) != 0 {
+              $gone = true
+              break
+            }
+            sleep 250ms
+          }
+          if not $gone {
+            error make {msg: $"($service) still loaded 5s after bootout"}
+          }
+        }
+        ^ssh $target $"launchctl bootstrap gui/($uid) ($agent_path)"
+
+        # Terminal artifact: RunAtLoad must leave the agent running with a pid.
+        let pid = ^ssh $target $"launchctl print ($service)" | lines | where $it =~ 'pid = ' | first | str trim
+        print $"($label) on ($target): ($pid)"
+      }
+    '';
+  };
+in {
+  options.users.andrewgazelka.imessageGuest = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Install `imessage-guest-apply`, which pushes the pinned bbctl and the
+        rendered launchd agent to the vmkit macOS guest running the Beeper
+        iMessage bridge (ENG-7746) and (re)loads it. Off by default: it needs
+        ssh reachability to the guest and an aarch64-darwin host.
+      '';
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "192.168.64.6";
+      description = "Guest address the apply script sshes to.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "ix";
+      description = "Guest user owning the bridge, its launchd agent, and ~/.local/bin/bbctl.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [apply];
+  };
+}

--- a/users/andrewgazelka/home.nix
+++ b/users/andrewgazelka/home.nix
@@ -179,11 +179,16 @@
     {
       inherit indexPackages portableServicesModule ix;
     };
+
+  # Declarative half of the vmkit macOS guest's iMessage bridge (ENG-7746):
+  # options + the `imessage-guest-apply` pusher live in guests/imessage.
+  imessageGuestModule = import ./guests/imessage {inherit indexPackages ix;};
 in {
   imports = [
     portableServicesModule
     ciBarsModule
     claudeCodeModule
+    imessageGuestModule
   ];
 
   options.users.andrewgazelka = {


### PR DESCRIPTION
Declarative management of the runtime state inside the vmkit macOS guest that runs the Beeper iMessage bridge (Linear ENG-7746). Interim consumer increment of #2682: the guest itself stays a stateful pet until mkMacGuest (#2683) lands, but everything built from bytes we control is now declared in nix and applied idempotently.

**packages/bbctl**: the beeper/bridge-manager CLI as a pinned aarch64-darwin release binary. Version, URL, and SRI hash live in `pins.json` via `ix.pins.loadPin`, with `ix.pins.mkOptionalUpdater` joining it to `nix run .#update` (round-tripped: re-pin reproduces the same hash). The pinned bytes are sha256-identical to the binary validated live on the guest.

**users/andrewgazelka/guests/imessage**: `users.andrewgazelka.imessageGuest` option group (default off) rendering the `com.beeper.sh-imessage` launchd agent via `lib.generators.toPlist` and installing `imessage-guest-apply`, which pushes bbctl + the plist to the guest over ssh and (re)loads the agent. `launchctl bootout` is asynchronous, so the script polls for teardown before `bootstrap` (an immediate bootstrap fails with EIO; hit live). README covers the manual bootstrap that cannot be nix-managed without MDM: interactive `bbctl login` (GUI Terminal only) and the three GUI-only TCC grants (Full Disk Access, Contacts, Automation > Messages), plus the secrets dir that must never be committed.

Validated end to end against the live guest: apply run twice (fresh bootstrap path and loaded reload path), agent running with a pid, bridge log shows startup sync complete and live matrix.beeper.com traffic.

Refs #2682, ENG-7746.

(sent by an AI agent via Claude Code, Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `bbctl` package and `imessage-guest-apply` tool to deploy iMessage bridge to macOS guest
> - Adds a pinned `bbctl` v0.14.0 binary package ([default.nix](https://github.com/indexable-inc/index/pull/3207/files#diff-f93491d5f60074f3344c3a95ec5c494d7105ca0db82e9426a3fc0d137a879e84)) restricted to aarch64-darwin, fetched via SHA256-verified URL.
> - Introduces `imessage-guest-apply`, a Nushell CLI that deploys `bbctl` and a generated launchd agent plist to a macOS guest over SSH, then idempotently reloads the `com.beeper.sh-imessage` agent and prints the resulting PID.
> - The launchd agent runs `bbctl run --param imessage_platform=mac -n sh-imessage` with `RunAtLoad` and `KeepAlive`, logging to `/tmp/imsg.log`.
> - A new NixOS module under `users.andrewgazelka.imessageGuest` exposes `enable`, `host`, and `user` options; the apply tool is only added to `home.packages` when enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03f0700.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->