### PR TITLE
playbook: codex darwin cross closure postmortem

### DIFF
--- a/packages/site/src/lib/updates/codex-cross-closure-postmortem.svx
+++ b/packages/site/src/lib/updates/codex-cross-closure-postmortem.svx
@@ -1,0 +1,23 @@
+---
+id: codex-cross-closure-postmortem
+postedAt: 2026-07-14T00:55:00-07:00
+title: "Postmortem: the codex darwin cross closure that merged green and broke every switch"
+tags: [interesting, nix, ci, darwin, postmortem]
+links:
+  - label: postmortem
+    href: https://github.com/indexable-inc/index/blob/main/playbook/src/routes/codex-cross-closure-postmortem/+page.svx
+  - label: "#3196"
+    href: https://github.com/indexable-inc/index/issues/3196
+  - label: toolchain fix
+    href: https://github.com/indexable-inc/index/pull/3197
+  - label: publish-hole gate
+    href: https://github.com/indexable-inc/index/pull/3200
+  - label: closure-gate
+    href: https://github.com/indexable-inc/index/pull/3202
+---
+
+PR #2690 put codex-rs on the cargo-unit cross DAG while `lib/darwin/apple-sdk-toolchain.nix` exported unsuffixed darwin `CFLAGS`, cc-rs concatenates flags for every target, and linux gcc build-script units died on `-iframework`. The drv hashed identically at every flake pin, so the cache hole was permanent, and every darwin `home-manager switch` broke while CI stayed green: `flake-check` only evaluates, and the post-merge cache push recorded the failed roots yet concluded success.
+
+Three fixes, one per lying layer: the apple toolchain env is now target-suffixed only (#3197), a cache-push run that leaves publish holes fails before the consumer pin moves (#3200), and a required pre-merge `closure-gate` realises `.#cachePushRoots.x86_64-linux` so a closure that cannot build cannot merge (#3202). Full postmortem in the playbook.
+
+*Written by an AI agent via Claude Code (Claude Opus 4.5).*

--- a/playbook/src/routes/codex-cross-closure-postmortem/+page.svx
+++ b/playbook/src/routes/codex-cross-closure-postmortem/+page.svx
@@ -1,0 +1,77 @@
+---
+title: "Postmortem: the codex darwin cross closure that merged green and broke every switch"
+date: 2026-07-14
+---
+
+On 2026-07-13, `home-manager switch` on hydra started failing while
+building
+`/nix/store/rljk1k1d1il7f0wapqcbmh8m8aqx6kkn-libsqlite3-sys-build-script-output-0.37.0.drv`
+on `ssh-ng://andrew@vc1-nix` with
+`gcc: error: unrecognized command-line option '-iframework'`, and the
+failure cascaded through every codex crate. Nothing in CI had gone red.
+Master issue #3196; one sub-issue and one fix per layer.
+
+## Root cause chain
+
+PR #2690 put codex-rs on the cargo-unit cross DAG (darwin binaries
+cross-compiled on x86_64-linux). `lib/darwin/apple-sdk-toolchain.nix`
+exported the darwin toolchain in unsuffixed variables too:
+`CFLAGS`/`CXXFLAGS` carrying darwin-only flags (`-iframework`,
+`-isysroot` into a `MacOSX*.sdk`) landed in every unit's environment.
+cc-rs picks its *tool* first-match across suffixed and plain variables,
+but gathers `*FLAGS` cumulatively from every matching variable for
+every target, so the linux gcc compiling host build-script units
+received clang/darwin flags even with the target-suffixed linux flags
+set. The host libsqlite3-sys build-script unit was broken by
+construction (#3188).
+
+Derivation identity settled the "cache publish lag?" question: the
+failing drv hashed identically across flake pins, so no pin was ever
+going to substitute it. A deterministic drv that cannot build is a
+permanent cache hole, not a slow publisher.
+
+## Why nothing went red
+
+- The only required check on main was `flake-check`, which
+  eval-validates `packages` and never builds them; it passed #2690 in
+  under six minutes.
+- `cache-push.yml` does build the closure, but post-merge and
+  non-gating. Its realise loop recorded each failed root and exited 0:
+  run 29295767529 concluded success while its own log recorded the
+  whole codex closure failing to realise.
+- `advance-cache-ready` then moved the consumer pin over the hole, onto
+  every darwin consumer.
+
+## Fixes, one per layer
+
+- **The bug** (#3188, fixed by #3197, `6785ed72`): the apple SDK
+  toolchain env is target-suffixed only, and the codex host-triple pin
+  is gone. Suffixed-only is the invariant that survives cc-rs's
+  cumulative flag lookup.
+- **The lying publisher** (#3195, fixed by #3200, `dc37a246`): the push
+  lanes still stay green over individual failed roots, so partial
+  publishes land, but each lane now reports a failed-roots count and
+  `advance-cache-ready` fails the run before any pin move. A publish
+  hole can no longer conclude success.
+- **The missing gate** (#1873, advanced by #3202, `96e05909`): a
+  pre-merge `closure-gate` workflow realises exactly the roots the
+  linux cache-push lane publishes, `.#cachePushRoots.x86_64-linux`, via
+  `nix run .#check -- closure` (nix-fast-build with `--skip-cached` on
+  the warm-store runner pool: an average PR pays eval plus cache
+  probes, a package-changing PR builds its delta). The main ruleset now
+  requires the `closure-gate` status next to `flake-check`. A shared
+  `.github/actions/check-logged` action keeps the Actions log quiet:
+  it prints the runner host and a runner-local log path, and cats the
+  full log only on failure.
+
+## Lessons
+
+- Eval-green is not build-green. A gate that never builds cannot
+  protect consumers of builds; gate exactly the roots you publish.
+- A green publisher that records failures and exits 0 is worse than a
+  red one: red at least alarms, green advances the pin.
+- When a substitution is missing, check drv identity across pins first.
+  Same hash everywhere means broken by construction, and no amount of
+  waiting on the cache will fix it.
+
+*Written by an AI agent via Claude Code (Claude Opus 4.5).*


### PR DESCRIPTION
Postmortem for the 2026-07-13/14 codex darwin cross closure breakage (#3196): full writeup at `playbook/src/routes/codex-cross-closure-postmortem/+page.svx`, plus a site update entry (`packages/site/src/lib/updates/`) giving it a live URL at https://indexable-inc.github.io/index/codex-cross-closure-postmortem after Pages deploys.

Covers the root cause chain (#2690 on the cross DAG, unsuffixed apple toolchain CFLAGS, cc-rs cumulative flag lookup), why CI stayed green (eval-only gate, green-masked cache-push), and the three fixes (#3197, #3200, #3202).

Local validation: `nix build .#site` on darwin got through svelte-check, eslint, and the vite build + prerender with the new entry (node then hit a known unrelated libuv kqueue abort at exit in the darwin sandbox); linux closure-gate builds the site for real.

(opened by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add postmortem playbook page for the codex darwin cross closure incident
> Adds a new SvelteKit route at [+page.svx](https://github.com/indexable-inc/index/pull/3210/files#diff-4c3b27e99ede1d48d47ee468b3ae399e799350b5b64a33ecf7cba81d60a35936) with a full postmortem write-up covering root cause, why CI passed, fixes applied, and lessons learned. Also adds a corresponding update entry at [codex-cross-closure-postmortem.svx](https://github.com/indexable-inc/index/pull/3210/files#diff-6b818a98a8c8a100dca1bb64bdf3a5450701aeaf4f8c19d9af971b118ead24c0) that surfaces the postmortem in the site's updates feed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a15003.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->