### PR TITLE
darwin-deploy: colmena-shaped nix-darwin remote deployment tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,6 +2791,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "darwin-deploy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "shlex 1.3.0",
+]
+
+[[package]]
 name = "dashboard"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
   "packages/code/code-highlight",
   "packages/search/code-tokenizer",
   "packages/dag-runner",
+  "packages/darwin-deploy",
   "packages/code/edit-applier",
   "packages/code/error-chain",
   "packages/efx/cli",
@@ -336,6 +337,7 @@ serde = "1"
 serde_json = "1"
 serde_norway = "0.9"
 sha2 = "0.11"
+shlex = "1"
 similar = "3"
 source-slack = { path = "packages/search/source/slack" }
 source-parquet = { path = "packages/search/source/parquet" }

--- a/packages/darwin-deploy/Cargo.toml
+++ b/packages/darwin-deploy/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "darwin-deploy"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Deploy nix-darwin configurations to remote macOS hosts over ssh"
+license = "MIT"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+shlex = { workspace = true }

--- a/packages/darwin-deploy/README.md
+++ b/packages/darwin-deploy/README.md
@@ -1,0 +1,31 @@
+# darwin-deploy
+
+Deploy nix-darwin configurations to remote macOS hosts, colmena-style.
+`darwin-rebuild` has no `--target-host`, so remote Macs (guest VMs, CI
+runners) otherwise drift to imperative scripts.
+
+```sh
+darwin-deploy --flake github:owner/repo mac1=admin@192.168.64.6 mac2=ci@mac2.local
+```
+
+For each `name=[user@]host` node, in parallel:
+
+1. `nix build` `darwinConfigurations.<name>.system` locally
+2. `nix copy --to ssh://<host>` the closure
+3. remotely set `/nix/var/nix/profiles/system` and run the nix-darwin
+   activation scripts (legacy `activate-user` as the ssh user when the
+   generation still ships a live one, then `activate` as root)
+
+Remote root steps run under `sudo --set-home`, so the ssh user needs
+passwordless sudo (or connect as `root`). `nix copy` pushes unsigned local
+builds, so the ssh user should be a nix `trusted-user` on the target.
+All ssh runs with `BatchMode=yes`: missing keys fail loudly instead of
+prompting.
+
+`--dry-run` builds and reports each host's current vs built system without
+copying or activating. `--json` emits one machine-readable report document
+on stdout; human logs stream to stderr either way. The exit code is non-zero
+if any node failed, and one node's failure never blocks the others.
+
+One-time bootstrap (installing nix on a fresh host, TCC grants) is out of
+scope; see the nix-darwin manual.

--- a/packages/darwin-deploy/default.nix
+++ b/packages/darwin-deploy/default.nix
@@ -1,0 +1,13 @@
+{
+  ix,
+  lib,
+  ...
+}:
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "darwin-deploy";
+  meta = {
+    description = "Deploy nix-darwin configurations to remote macOS hosts over ssh";
+    license = lib.licenses.mit;
+    mainProgram = "darwin-deploy";
+  };
+}

--- a/packages/darwin-deploy/package.nix
+++ b/packages/darwin-deploy/package.nix
@@ -1,0 +1,10 @@
+{
+  id = "darwin-deploy";
+  packageSet = true;
+  flake = true;
+  # Deploy CLI invoked by operators and modules' deploy scripts; nothing
+  # consumes it as `pkgs.darwin-deploy` from modules yet.
+  overlay = false;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/darwin-deploy/src/deploy.rs
+++ b/packages/darwin-deploy/src/deploy.rs
@@ -1,0 +1,134 @@
+//! Per-node deployment flow: build the closure locally, copy it, then
+//! activate the way `darwin-rebuild switch` does: set the system profile,
+//! run legacy `activate-user` if the generation still ships a live one, then
+//! run `activate` as root.
+
+use anyhow::{Context, Result, bail};
+
+use crate::exec;
+use crate::node::{NodeSpec, Target};
+use crate::plan::{self, Installable, Invocation, RunAs};
+use crate::report::NodeReport;
+
+const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
+
+/// Deploy one node, folding any failure into its report so parallel nodes
+/// never mask each other.
+pub fn node(flake: &str, spec: &NodeSpec, dry_run: bool) -> NodeReport {
+    let mut report = NodeReport::new(spec);
+    match flow(flake, spec, dry_run, &mut report) {
+        Ok(()) => report.ok = true,
+        Err(error) => {
+            eprintln!("[{}] FAILED: {error:#}", spec.name);
+            report.error = Some(format!("{error:#}"));
+        }
+    }
+    report
+}
+
+fn flow(flake: &str, spec: &NodeSpec, dry_run: bool, report: &mut NodeReport) -> Result<()> {
+    let name = &spec.name;
+    let target = &spec.target;
+
+    let installable = Installable::darwin_system(flake, name);
+    let rendered = installable.render()?;
+    eprintln!("[{name}] building {rendered}");
+    let built = exec::succeed(&plan::build(&installable)?)
+        .with_context(|| format!("building {rendered}"))?;
+    let Some(system) = built.lines().last().map(str::to_owned) else {
+        bail!("`nix build` printed no out path for {rendered}");
+    };
+    report.system = Some(system.clone());
+
+    let previous = current_system(target).context("reading the current system")?;
+    let changed = previous.as_deref() != Some(system.as_str());
+    report.changed = Some(changed);
+    report.previous = previous;
+
+    if dry_run {
+        if changed {
+            eprintln!(
+                "[{name}] would activate {system} (currently {})",
+                report.previous.as_deref().unwrap_or("not activated")
+            );
+        } else {
+            eprintln!("[{name}] up to date at {system}");
+        }
+        return Ok(());
+    }
+
+    eprintln!("[{name}] copying closure to {}", target.store_url());
+    exec::succeed(&plan::copy(target, &system)?).context("copying the closure")?;
+
+    eprintln!("[{name}] setting the system profile");
+    exec::succeed(&plan::remote(
+        target,
+        RunAs::Root,
+        &["nix-env", "--profile", SYSTEM_PROFILE, "--set", &system],
+    )?)
+    .context("setting the system profile")?;
+
+    if legacy_activate_user(target, &system)? {
+        eprintln!("[{name}] running activate-user");
+        exec::succeed(&plan::remote(
+            target,
+            RunAs::SshUser,
+            &[&format!("{system}/activate-user")],
+        )?)
+        .context("running activate-user")?;
+    }
+
+    eprintln!("[{name}] activating");
+    exec::succeed(&plan::remote(
+        target,
+        RunAs::Root,
+        &[&format!("{system}/activate")],
+    )?)
+    .context("activating")?;
+
+    eprintln!("[{name}] activated {system}");
+    Ok(())
+}
+
+/// The store path `/run/current-system` points at, or `None` on a host that
+/// has never activated a generation.
+fn current_system(target: &Target) -> Result<Option<String>> {
+    let invocation = plan::remote(
+        target,
+        RunAs::SshUser,
+        &["readlink", "/run/current-system"],
+    )?;
+    let completed = exec::run(&invocation)?;
+    match completed.code {
+        0 => Ok(Some(completed.stdout.trim().to_owned())),
+        1 => Ok(None),
+        code => bail!("`{invocation}` exited {code}: {}", completed.stderr.trim()),
+    }
+}
+
+/// Whether the copied generation still ships a live legacy `activate-user`.
+/// Modern nix-darwin keeps a stub marked `# nix-darwin: deprecated`, which
+/// `darwin-rebuild` skips, and so do we.
+fn legacy_activate_user(target: &Target, system: &str) -> Result<bool> {
+    let activate_user = format!("{system}/activate-user");
+    if !probe(&plan::remote(target, RunAs::SshUser, &["test", "-x", &activate_user])?)? {
+        return Ok(false);
+    }
+    let deprecated = probe(&plan::remote(
+        target,
+        RunAs::SshUser,
+        &["grep", "-q", "^# nix-darwin: deprecated$", &activate_user],
+    )?)?;
+    Ok(!deprecated)
+}
+
+/// Run a yes/no remote check: exit 0 is yes, exit 1 is no, anything else
+/// (including ssh's own 255) is a hard error.
+fn probe(invocation: &Invocation) -> Result<bool> {
+    let completed = exec::run(invocation)?;
+    match completed.code {
+        0 => Ok(true),
+        1 => Ok(false),
+        code => bail!("`{invocation}` exited {code}: {}", completed.stderr.trim()),
+    }
+}

--- a/packages/darwin-deploy/src/exec.rs
+++ b/packages/darwin-deploy/src/exec.rs
@@ -1,0 +1,49 @@
+//! Captured-output subprocess runner: every nix/ssh interaction goes through
+//! one function so a failure always names the command line and its stderr.
+
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+use crate::plan::Invocation;
+
+pub struct Completed {
+    pub code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Run the invocation to completion, capturing output. Errors only on spawn
+/// failure or death by signal; a non-zero exit is a normal `Completed`.
+pub fn run(invocation: &Invocation) -> Result<Completed> {
+    let mut command = Command::new(invocation.program);
+    command.args(&invocation.args);
+    for variable in &invocation.env {
+        command.env(variable.name, &variable.value);
+    }
+    let output = command
+        .output()
+        .with_context(|| format!("spawning `{invocation}` (is it installed?)"))?;
+    let Some(code) = output.status.code() else {
+        bail!("`{invocation}` was terminated by a signal");
+    };
+    Ok(Completed {
+        code,
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+/// Run the invocation and require exit 0; returns trimmed stdout. A non-zero
+/// exit becomes an error carrying the command line and stderr.
+pub fn succeed(invocation: &Invocation) -> Result<String> {
+    let completed = run(invocation)?;
+    if completed.code != 0 {
+        bail!(
+            "`{invocation}` exited {}: {}",
+            completed.code,
+            completed.stderr.trim()
+        );
+    }
+    Ok(completed.stdout.trim().to_owned())
+}

--- a/packages/darwin-deploy/src/main.rs
+++ b/packages/darwin-deploy/src/main.rs
@@ -1,0 +1,73 @@
+//! Deploy nix-darwin configurations to remote macOS hosts, colmena-style:
+//! build each system closure locally, `nix copy` it to its host over ssh,
+//! then set the system profile and run the nix-darwin activation scripts.
+
+mod deploy;
+mod exec;
+mod node;
+mod plan;
+mod report;
+
+use std::process::ExitCode;
+use std::thread;
+
+use anyhow::Result;
+use clap::Parser;
+
+use crate::node::NodeSpec;
+use crate::report::{NodeReport, Report};
+
+/// Deploy `darwinConfigurations.<name>` from a flake to remote macOS hosts.
+#[derive(Parser)]
+#[command(version, about)]
+struct Cli {
+    /// Flake ref holding `darwinConfigurations` (a path, `github:owner/repo`, ...).
+    #[arg(long, default_value = ".")]
+    flake: String,
+
+    /// Build and compare against each host's current system; skip copy and
+    /// activation.
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Emit one JSON report document on stdout instead of a human summary.
+    #[arg(long)]
+    json: bool,
+
+    /// Nodes to deploy, each `<name>=<[user@]host>`: `<name>` indexes
+    /// `darwinConfigurations`, the right side is the ssh destination.
+    #[arg(required = true, value_name = "NAME=[USER@]HOST")]
+    nodes: Vec<NodeSpec>,
+}
+
+fn main() -> Result<ExitCode> {
+    let cli = Cli::parse();
+
+    let nodes: Vec<NodeReport> = thread::scope(|scope| {
+        // Collect all spawns before the first join: folding this into one
+        // iterator chain (clippy's suggestion) would join each thread before
+        // spawning the next, serializing the deploys.
+        #[allow(clippy::needless_collect)]
+        let handles: Vec<_> = cli
+            .nodes
+            .iter()
+            .map(|spec| scope.spawn(|| deploy::node(&cli.flake, spec, cli.dry_run)))
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("deploy thread panicked"))
+            .collect()
+    });
+
+    let report = Report::new(nodes, cli.dry_run);
+    if cli.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        report.print_human();
+    }
+    Ok(if report.ok {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    })
+}

--- a/packages/darwin-deploy/src/node.rs
+++ b/packages/darwin-deploy/src/node.rs
@@ -1,0 +1,120 @@
+//! Node specs: which `darwinConfigurations` attribute goes to which ssh
+//! destination.
+
+use std::str::FromStr;
+
+use anyhow::{Context, Result, bail};
+
+/// An ssh destination, kept as typed fields so the ssh argv and the
+/// `ssh://` store URL are rendered from the same facts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Target {
+    pub user: Option<String>,
+    pub host: String,
+}
+
+impl Target {
+    /// The `[user@]host` token ssh and `ssh://` store URLs share.
+    pub fn ssh_destination(&self) -> String {
+        self.user
+            .as_ref()
+            .map_or_else(|| self.host.clone(), |user| format!("{user}@{}", self.host))
+    }
+
+    /// The store URL `nix copy --to` pushes through.
+    pub fn store_url(&self) -> String {
+        format!("ssh://{}", self.ssh_destination())
+    }
+
+    /// Whether remote commands already run as root (no sudo prefix needed).
+    pub fn is_root(&self) -> bool {
+        self.user.as_deref() == Some("root")
+    }
+}
+
+impl FromStr for Target {
+    type Err = anyhow::Error;
+
+    fn from_str(destination: &str) -> Result<Self> {
+        let (user, host) = destination
+            .split_once('@')
+            .map_or((None, destination), |(user, host)| (Some(user), host));
+        if let Some(user) = user
+            && user.is_empty()
+        {
+            bail!("destination `{destination}` has an empty user");
+        }
+        if host.is_empty() {
+            bail!("destination `{destination}` has an empty host");
+        }
+        Ok(Self {
+            user: user.map(str::to_owned),
+            host: host.to_owned(),
+        })
+    }
+}
+
+/// One deployment target: `name` indexes `darwinConfigurations` in the flake,
+/// `target` is where the closure goes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeSpec {
+    pub name: String,
+    pub target: Target,
+}
+
+impl FromStr for NodeSpec {
+    type Err = anyhow::Error;
+
+    fn from_str(spec: &str) -> Result<Self> {
+        let (name, destination) = spec
+            .split_once('=')
+            .with_context(|| format!("node `{spec}` is not of the form `<name>=<[user@]host>`"))?;
+        if name.is_empty() {
+            bail!("node `{spec}` has an empty configuration name");
+        }
+        let target = destination
+            .parse()
+            .with_context(|| format!("node `{spec}` has an invalid destination"))?;
+        Ok(Self {
+            name: name.to_owned(),
+            target,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_name_user_and_host() {
+        let spec: NodeSpec = "mac1=admin@192.168.64.6".parse().expect("parses");
+        assert_eq!(spec.name, "mac1");
+        assert_eq!(spec.target.user.as_deref(), Some("admin"));
+        assert_eq!(spec.target.host, "192.168.64.6");
+        assert_eq!(spec.target.ssh_destination(), "admin@192.168.64.6");
+        assert_eq!(spec.target.store_url(), "ssh://admin@192.168.64.6");
+        assert!(!spec.target.is_root());
+    }
+
+    #[test]
+    fn parses_bare_host() {
+        let spec: NodeSpec = "mac1=mac1.local".parse().expect("parses");
+        assert_eq!(spec.target.user, None);
+        assert_eq!(spec.target.ssh_destination(), "mac1.local");
+        assert_eq!(spec.target.store_url(), "ssh://mac1.local");
+    }
+
+    #[test]
+    fn recognizes_root_user() {
+        let spec: NodeSpec = "mac1=root@mac1.local".parse().expect("parses");
+        assert!(spec.target.is_root());
+    }
+
+    #[test]
+    fn rejects_malformed_specs() {
+        for spec in ["mac1", "=host", "mac1=", "mac1=@host", "mac1=user@"] {
+            assert!(spec.parse::<NodeSpec>().is_err(), "`{spec}` should be rejected");
+        }
+    }
+}

--- a/packages/darwin-deploy/src/plan.rs
+++ b/packages/darwin-deploy/src/plan.rs
@@ -1,0 +1,291 @@
+//! Typed command plans. Every fact (flake ref, attr name, ssh destination,
+//! store path) stays a typed binding until one renderer serializes it at the
+//! boundary its format owns: nix installables, `ssh://` store URLs, and the
+//! shell-quoted remote command line ssh delivers.
+
+use std::fmt;
+
+use anyhow::{Context, Result, bail};
+
+use crate::node::Target;
+
+/// Options every ssh connection gets, both our own `ssh` argv and (via
+/// `NIX_SSHOPTS`) the ssh processes `nix copy` spawns: fail loudly instead of
+/// hanging on an interactive password prompt.
+const SSH_OPTIONS: [&str; 2] = ["-o", "BatchMode=yes"];
+
+/// A fully rendered local process invocation: program plus argv, never a
+/// shell string.
+pub struct Invocation {
+    pub program: &'static str,
+    pub args: Vec<String>,
+    pub env: Vec<EnvVar>,
+}
+
+pub struct EnvVar {
+    pub name: &'static str,
+    pub value: String,
+}
+
+impl fmt::Display for Invocation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.program)?;
+        for arg in &self.args {
+            match shlex::try_quote(arg) {
+                Ok(quoted) => write!(formatter, " {quoted}")?,
+                // A nul byte cannot be shell-quoted; this rendering is
+                // diagnostics-only (never executed), so show the arg debug-quoted.
+                Err(_) => write!(formatter, " {arg:?}")?,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A flake output attribute: flake ref plus attr path, rendered as one
+/// `<flake>#<attr.path>` installable.
+pub struct Installable {
+    flake_ref: String,
+    attr_path: Vec<String>,
+}
+
+impl Installable {
+    /// The system closure of `darwinConfigurations.<name>` (what
+    /// `darwin-rebuild build --flake` builds).
+    pub fn darwin_system(flake_ref: &str, name: &str) -> Self {
+        Self {
+            flake_ref: flake_ref.to_owned(),
+            attr_path: vec![
+                "darwinConfigurations".to_owned(),
+                name.to_owned(),
+                "system".to_owned(),
+            ],
+        }
+    }
+
+    pub fn render(&self) -> Result<String> {
+        let elements: Vec<String> = self
+            .attr_path
+            .iter()
+            .map(|element| attr_element(element))
+            .collect::<Result<_>>()?;
+        Ok(format!("{}#{}", self.flake_ref, elements.join(".")))
+    }
+}
+
+/// Render one attr-path element the way nix's installable parser reads it:
+/// bare identifiers pass through, anything else is double-quoted. The parser
+/// has no escape sequences inside quotes, so a name containing `"` cannot be
+/// expressed at all.
+fn attr_element(name: &str) -> Result<String> {
+    let bare = name
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '\''));
+    if bare {
+        return Ok(name.to_owned());
+    }
+    if name.contains('"') {
+        bail!("attribute name `{name}` contains `\"`, which nix attr paths cannot quote");
+    }
+    Ok(format!("\"{name}\""))
+}
+
+/// Build the system closure locally and print its out path.
+pub fn build(installable: &Installable) -> Result<Invocation> {
+    Ok(Invocation {
+        program: "nix",
+        args: vec![
+            "build".to_owned(),
+            "--no-link".to_owned(),
+            "--print-out-paths".to_owned(),
+            installable.render()?,
+        ],
+        env: Vec::new(),
+    })
+}
+
+/// Render `NIX_SSHOPTS`: nix tokenizes it on plain whitespace (no shell
+/// unquoting), so the only representable options are whitespace-free tokens
+/// joined by spaces; anything else must fail here, not silently misparse.
+fn nix_ssh_opts() -> Result<String> {
+    for option in SSH_OPTIONS {
+        if option.chars().any(char::is_whitespace) {
+            bail!("ssh option `{option}` contains whitespace, which NIX_SSHOPTS cannot carry");
+        }
+    }
+    Ok(SSH_OPTIONS.join(" "))
+}
+
+/// Copy the closure to the target's store over ssh.
+pub fn copy(target: &Target, store_path: &str) -> Result<Invocation> {
+    let ssh_options = nix_ssh_opts()?;
+    Ok(Invocation {
+        program: "nix",
+        args: vec![
+            "copy".to_owned(),
+            "--to".to_owned(),
+            target.store_url(),
+            store_path.to_owned(),
+        ],
+        env: vec![EnvVar {
+            name: "NIX_SSHOPTS",
+            value: ssh_options,
+        }],
+    })
+}
+
+/// Who a remote command runs as.
+#[derive(Clone, Copy)]
+pub enum RunAs {
+    /// Prefixed with `sudo --set-home --` unless the ssh user is already root.
+    Root,
+    SshUser,
+}
+
+/// Render `argv` into one ssh invocation against `target`. This is the single
+/// place a remote command becomes a shell string.
+pub fn remote(target: &Target, run_as: RunAs, argv: &[&str]) -> Result<Invocation> {
+    let mut words: Vec<&str> = Vec::new();
+    if matches!(run_as, RunAs::Root) && !target.is_root() {
+        words.extend(["sudo", "--set-home", "--"]);
+    }
+    words.extend(argv);
+    let command = shlex::try_join(words).context("rendering remote command")?;
+
+    let mut ssh_args: Vec<String> =
+        SSH_OPTIONS.iter().map(|option| (*option).to_owned()).collect();
+    ssh_args.push(target.ssh_destination());
+    ssh_args.push(command);
+    Ok(Invocation {
+        program: "ssh",
+        args: ssh_args,
+        env: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(destination: &str) -> Target {
+        destination.parse().expect("valid destination")
+    }
+
+    #[test]
+    fn renders_plain_installable() {
+        let installable = Installable::darwin_system(".", "mac1");
+        assert_eq!(
+            installable.render().expect("renders"),
+            ".#darwinConfigurations.mac1.system"
+        );
+    }
+
+    #[test]
+    fn quotes_non_identifier_attr_names() {
+        let installable = Installable::darwin_system("github:owner/repo", "ci runner.2");
+        assert_eq!(
+            installable.render().expect("renders"),
+            "github:owner/repo#darwinConfigurations.\"ci runner.2\".system"
+        );
+    }
+
+    #[test]
+    fn rejects_unquotable_attr_names() {
+        let installable = Installable::darwin_system(".", "bad\"name");
+        assert!(installable.render().is_err());
+    }
+
+    #[test]
+    fn builds_the_system_closure() {
+        let invocation =
+            build(&Installable::darwin_system(".", "mac1")).expect("renders");
+        assert_eq!(invocation.program, "nix");
+        assert_eq!(
+            invocation.args,
+            [
+                "build",
+                "--no-link",
+                "--print-out-paths",
+                ".#darwinConfigurations.mac1.system"
+            ]
+        );
+    }
+
+    #[test]
+    fn copies_through_a_batch_mode_ssh_store() {
+        let invocation =
+            copy(&target("admin@mac1.local"), "/nix/store/abc-system").expect("renders");
+        assert_eq!(invocation.program, "nix");
+        assert_eq!(
+            invocation.args,
+            ["copy", "--to", "ssh://admin@mac1.local", "/nix/store/abc-system"]
+        );
+        assert_eq!(invocation.env.len(), 1);
+        assert_eq!(invocation.env[0].name, "NIX_SSHOPTS");
+        assert_eq!(invocation.env[0].value, "-o BatchMode=yes");
+    }
+
+    #[test]
+    fn remote_root_commands_gain_sudo() {
+        let invocation = remote(
+            &target("admin@mac1.local"),
+            RunAs::Root,
+            &["nix-env", "--profile", "/nix/var/nix/profiles/system", "--set", "/nix/store/abc"],
+        )
+        .expect("renders");
+        assert_eq!(invocation.program, "ssh");
+        assert_eq!(
+            invocation.args,
+            [
+                "-o",
+                "BatchMode=yes",
+                "admin@mac1.local",
+                "sudo --set-home -- nix-env --profile /nix/var/nix/profiles/system --set /nix/store/abc"
+            ]
+        );
+    }
+
+    #[test]
+    fn remote_root_commands_skip_sudo_for_root() {
+        let invocation =
+            remote(&target("root@mac1.local"), RunAs::Root, &["/nix/store/abc/activate"])
+                .expect("renders");
+        assert_eq!(
+            invocation.args,
+            ["-o", "BatchMode=yes", "root@mac1.local", "/nix/store/abc/activate"]
+        );
+    }
+
+    #[test]
+    fn remote_commands_shell_quote_arguments() {
+        let invocation = remote(
+            &target("mac1.local"),
+            RunAs::SshUser,
+            &["grep", "-q", "^# nix-darwin: deprecated$", "/nix/store/abc/activate-user"],
+        )
+        .expect("renders");
+        assert_eq!(
+            invocation.args,
+            [
+                "-o",
+                "BatchMode=yes",
+                "mac1.local",
+                "grep -q '^# nix-darwin: deprecated$' /nix/store/abc/activate-user"
+            ]
+        );
+    }
+
+    #[test]
+    fn displays_a_quoted_command_line() {
+        let invocation = remote(&target("mac1.local"), RunAs::SshUser, &["readlink", "/run/current-system"])
+            .expect("renders");
+        assert_eq!(
+            invocation.to_string(),
+            "ssh -o 'BatchMode=yes' mac1.local 'readlink /run/current-system'"
+        );
+    }
+}

--- a/packages/darwin-deploy/src/report.rs
+++ b/packages/darwin-deploy/src/report.rs
@@ -1,0 +1,112 @@
+//! The structured deployment report: one JSON document on stdout under
+//! `--json`, a per-node summary otherwise. Fields are always present so
+//! consumers get a stable schema.
+
+use serde::Serialize;
+
+use crate::node::NodeSpec;
+
+#[derive(Serialize)]
+pub struct Report {
+    pub dry_run: bool,
+    pub ok: bool,
+    pub nodes: Vec<NodeReport>,
+}
+
+impl Report {
+    pub fn new(nodes: Vec<NodeReport>, dry_run: bool) -> Self {
+        let ok = nodes.iter().all(|node| node.ok);
+        Self { dry_run, ok, nodes }
+    }
+
+    pub fn print_human(&self) {
+        for node in &self.nodes {
+            println!("{}: {}", node.name, node.status(self.dry_run));
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct NodeReport {
+    pub name: String,
+    pub target: String,
+    /// The freshly built system closure, once the build succeeded.
+    pub system: Option<String>,
+    /// What `/run/current-system` pointed at before this deploy, if anything.
+    pub previous: Option<String>,
+    pub changed: Option<bool>,
+    pub ok: bool,
+    pub error: Option<String>,
+}
+
+impl NodeReport {
+    pub fn new(spec: &NodeSpec) -> Self {
+        Self {
+            name: spec.name.clone(),
+            target: spec.target.ssh_destination(),
+            system: None,
+            previous: None,
+            changed: None,
+            ok: false,
+            error: None,
+        }
+    }
+
+    fn status(&self, dry_run: bool) -> String {
+        if let Some(error) = &self.error {
+            return format!("FAILED: {error}");
+        }
+        let system = self.system.as_deref().unwrap_or("<unknown>");
+        match (dry_run, self.changed) {
+            (true, Some(true)) => format!("would activate {system}"),
+            (true, _) => format!("up to date at {system}"),
+            (false, _) => format!("activated {system}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> NodeSpec {
+        "mac1=admin@mac1.local".parse().expect("valid spec")
+    }
+
+    #[test]
+    fn serializes_a_stable_schema() {
+        let mut node = NodeReport::new(&spec());
+        node.system = Some("/nix/store/new".to_owned());
+        node.previous = Some("/nix/store/old".to_owned());
+        node.changed = Some(true);
+        node.ok = true;
+        let report = Report::new(vec![node], true);
+
+        let value = serde_json::to_value(&report).expect("serializes");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "dry_run": true,
+                "ok": true,
+                "nodes": [{
+                    "name": "mac1",
+                    "target": "admin@mac1.local",
+                    "system": "/nix/store/new",
+                    "previous": "/nix/store/old",
+                    "changed": true,
+                    "ok": true,
+                    "error": null,
+                }],
+            })
+        );
+    }
+
+    #[test]
+    fn a_failed_node_fails_the_report() {
+        let mut node = NodeReport::new(&spec());
+        node.error = Some("ssh exploded".to_owned());
+        let report = Report::new(vec![node], false);
+        assert!(!report.ok);
+        assert_eq!(report.nodes[0].status(false), "FAILED: ssh exploded");
+    }
+}


### PR DESCRIPTION
Closes #3209.

A general colmena-shaped Rust tool for deploying `darwinConfigurations.<name>` from a flake to remote macOS hosts (`darwin-rebuild` has no `--target-host`; colmena is NixOS-only).

**Flow per node (`name=[user@]host`, all nodes in parallel):**
1. `nix build --no-link --print-out-paths <flake>#darwinConfigurations.<name>.system` locally
2. probe `readlink /run/current-system` (exit 1 = never activated, `previous: null`; ssh 255 = hard error)
3. `nix copy --to ssh://<dest>` (with `NIX_SSHOPTS` carrying `BatchMode=yes` so it fails loudly instead of prompting)
4. `nix-env --profile /nix/var/nix/profiles/system --set` as root, legacy `activate-user` as the ssh user only when the generation ships a live one (skipping the `# nix-darwin: deprecated` stub, exactly like `darwin-rebuild`), then `activate` as root via `sudo --set-home`

**Shape:**
- Every fact stays a typed binding (flake ref + attr path, `Target {user, host}`, store path); each serialized form has one renderer at the boundary: nix installable (with attr-path quoting rules), `ssh://` store URL, shlex-joined remote command line, and whitespace-joined `NIX_SSHOPTS` (nix tokenizes it without shell unquoting, so shlex there would misparse; the renderer errors on unrepresentable tokens)
- `--dry-run` = build + current-vs-built diff only; `--json` = one stable report document on stdout (human logs stream to stderr either way); per-node failures are isolated and loud, exit non-zero if any node failed
- Standard crate shape: `package.nix` registry marker, cargo-unit, `passthruTests`

**Validated:**
- `nix build .#darwin-deploy` (aarch64-darwin) green
- `checks.x86_64-linux.rust-darwin-deploy-{clippy,darwin-deploy-all,package,unusedCrateDependencies}` all green (15 unit tests over the plan/render layer)
- Live e2e `--dry-run --json` against the macOS guest VM at 192.168.64.6: see issue comment
- Consumer coordination for the mkMacGuest modules noted on #2682

(PR by an AI agent via Claude Code, Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `darwin-deploy`, a colmena-style nix-darwin remote deployment CLI
> - Adds a new `darwin-deploy` binary crate that deploys nix-darwin configurations to remote hosts in parallel, one scoped thread per node.
> - Each deployment builds the target `darwinConfigurations.<name>.system`, copies the closure over SSH, sets the Nix profile remotely, and runs activation (with optional legacy `activate-user` handling mirroring `darwin-rebuild` behavior).
> - Supports `--dry-run` (skips copy/activation), `--json` (structured output), and `--flake` (defaults to `.`); exits non-zero if any node fails.
> - Remote commands are represented as structured `Invocation` objects, shell-quoted via `shlex` for safe display and execution; `sudo` elevation is applied automatically when the SSH user is not root.
> - Integrates into the Nix workspace via [`default.nix`](https://github.com/indexable-inc/index/pull/3212/files#diff-7bdf0e5ff1139d15732985943661f4d00f1ce5c412c09fdd65e0ef09c50d5011) and [`package.nix`](https://github.com/indexable-inc/index/pull/3212/files#diff-671b20f135e8d71907cf724eff72e96add699aa0e4ca75f02745ee01001501d5), and into the Cargo workspace via [`Cargo.toml`](https://github.com/indexable-inc/index/pull/3212/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e827dda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->