### PR TITLE
ci: escalate stuck flake bump PRs from the reusable workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -106,7 +106,7 @@ jobs:
   #
   #   - RED PR: the rolling bump PR's latest head has failing checks.
   #   - STUCK PR: the PR has been open past the threshold without merging
-  #     (hourly branch updates reset checks to pending, so an episode can
+  #     (each scheduled branch update resets checks to pending, so an episode can
   #     look pending at every observation; age is the churn-proof signal).
   #   - ORPHANED BUMP: the bump branch is ahead of main with no open PR
   #     (closed unmerged, or PR creation failed).
@@ -367,7 +367,7 @@ jobs:
                 echo "Input revisions waiting to land: \`${rev_range}\`"
                 echo
               fi
-              echo "Maintained by the \`escalate\` job of the reusable update-flake-lock workflow (indexable-inc/index): refreshed hourly while the episode persists, closed automatically once a bump lands cleanly. Motivating incident: indexable-inc/ix#7235."
+              echo "Maintained by the \`escalate\` job of the reusable update-flake-lock workflow (indexable-inc/index): refreshed each scheduled run while the episode persists, closed automatically once a bump lands cleanly. Motivating incident: indexable-inc/ix#7235."
               echo
               echo "_Made with Claude Opus 4.5._"
             } > /tmp/tracking-body.md

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -23,9 +23,20 @@ on:
         description: "Client id of a GitHub App (contents + pull-requests write) that authors the bump PR; empty falls back to GITHUB_TOKEN, whose PRs never get pull_request CI on private repos."
         type: string
         default: ""
+      escalate-after-hours:
+        description: "Hours the rolling bump PR may stay failing before the escalate job alerts; see the escalate job below."
+        type: number
+        default: 6
+      slack-channel:
+        description: "Slack channel id for escalation posts; used only when slack-bot-token is provided."
+        type: string
+        default: "C0A4TD9G7HR"
     secrets:
       app-private-key:
         description: "Private key for app-client-id."
+        required: false
+      slack-bot-token:
+        description: "Slack bot token (chat:write) for escalation posts; empty escalates through the tracking issue only."
         required: false
   schedule:
     - cron: "17 * * * *"
@@ -86,3 +97,333 @@ jobs:
           # scopes this to avoid fetching private inputs it can't auth for.
           inputs: ${{ inputs.flake-inputs }}
           token: ${{ steps.app-token.outputs.token || github.token }}
+
+  # A watcher that only fires on the success path (merge) is silent on
+  # sustained failure: ix's `index` pin sat 4 days stale behind red bump PRs
+  # with no alert (indexable-inc/ix#7235). This job is the failure-path
+  # watcher, running after every bump attempt (`always()`: the bump job
+  # failing is itself one of the states to report). Unhealthy states:
+  #
+  #   - RED PR: the rolling bump PR's latest head has failing checks.
+  #   - STUCK PR: the PR has been open past the threshold without merging
+  #     (hourly branch updates reset checks to pending, so an episode can
+  #     look pending at every observation; age is the churn-proof signal).
+  #   - ORPHANED BUMP: the bump branch is ahead of main with no open PR
+  #     (closed unmerged, or PR creation failed).
+  #   - BUMP JOB FAILED: the update job itself concluded failure.
+  #
+  # Episode state lives in one labeled tracking issue (find-or-reopen, as
+  # cache-push-watchdog.yml): created at onset, body refreshed each tick,
+  # closed with a comment on recovery. Once the episode age crosses
+  # `escalate-after-hours` it escalates ONCE: a threshold comment on the
+  # issue plus a Slack post (when the caller supplies slack-bot-token),
+  # recorded as a body marker so later ticks do not re-fire. Watcher-internal
+  # failures (API errors) exit loudly without claiming health or closing the
+  # issue. Callers must grant `issues: write` on the calling job.
+  escalate:
+    needs: update-flake-lock
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      # Must match the `branch:` given to update-flake-lock above.
+      BUMP_BRANCH: update-flake-lock
+      UPDATE_RESULT: ${{ needs.update-flake-lock.result }}
+      # `inputs.*` is empty on index's own schedule/dispatch runs; the ||
+      # arms mirror the workflow_call defaults for those events.
+      ESCALATE_AFTER_HOURS: ${{ inputs.escalate-after-hours || 6 }}
+      SLACK_CHANNEL: ${{ inputs.slack-channel || 'C0A4TD9G7HR' }}
+      SLACK_BOT_TOKEN: ${{ secrets.slack-bot-token }}
+    steps:
+      - name: Escalate a stuck flake bump
+        run: |
+          set -euo pipefail
+
+          marker="<!-- update-flake-lock-escalation -->"
+          issue_title="update-flake-lock: rolling bump PR is stuck"
+          label="flake-bump-stuck"
+          now_epoch="$(date -u +%s)"
+          now_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          threshold_s=$(( ESCALATE_AFTER_HOURS * 3600 ))
+
+          note() { echo "::notice::escalate: $*"; }
+          # Internal failure is loud and neither claims health nor closes the
+          # tracking issue (same contract as cache-push-watchdog.yml).
+          fail_loud() { echo "::error::flake-bump escalation internal failure: $*"; exit 2; }
+
+          reasons=""
+          add_reason() { reasons="${reasons}$1"$'\n'; }
+
+          # Slack signals rejection in-body (ok:false) with HTTP 200, so parse
+          # the response; non-zero return means the message did NOT post.
+          slack_post() {
+            local text="$1" resp
+            resp="$(jq -n --arg channel "${SLACK_CHANNEL}" --arg text "$text" \
+                '{channel: $channel, text: $text}' \
+              | curl -sS -X POST "https://slack.com/api/chat.postMessage" \
+                  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+                  -H "Content-Type: application/json; charset=utf-8" \
+                  --data @-)" \
+              || { echo "::error::slack chat.postMessage transport failed"; return 1; }
+            if [ "$(jq -r '.ok' <<<"$resp")" != "true" ]; then
+              echo "::error::slack rejected the escalation post: $(jq -r '.error // "unknown"' <<<"$resp")"
+              return 1
+            fi
+          }
+
+          # --- State: the bump job itself failed ------------------------------
+          if [ "${UPDATE_RESULT}" = "failure" ]; then
+            add_reason "- **Bump job failed**: \`update-flake-lock\` concluded \`failure\` in run [${GITHUB_RUN_ID}](https://github.com/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+          fi
+
+          # --- State: the rolling PR (red, or stuck past the threshold) -------
+          pr_json=/tmp/bump-pr.json
+          gh pr list --repo "${REPOSITORY}" --head "${BUMP_BRANCH}" --base main \
+              --state open --json number,url,createdAt,statusCheckRollup \
+              --jq '.[0] // empty' > "$pr_json" \
+            || fail_loud "listing the rolling bump PR failed"
+
+          pr_number=""
+          pr_url=""
+          failing_checks=""
+          pending_count=0
+          pr_age_s=0
+          if [ -s "$pr_json" ]; then
+            pr_number="$(jq -r '.number' "$pr_json")"
+            pr_url="$(jq -r '.url' "$pr_json")"
+            pr_age_s=$(( now_epoch - $(date -u -d "$(jq -r '.createdAt' "$pr_json")" +%s) ))
+            # CheckRun rows carry .conclusion ("" until completed), StatusContext
+            # rows carry .state; normalize both shapes before classifying.
+            failing_checks="$(jq -r '[(.statusCheckRollup // [])[]
+                | ((.conclusion // .state // "") | ascii_upcase) as $c
+                | select($c == "FAILURE" or $c == "TIMED_OUT" or $c == "CANCELLED"
+                         or $c == "ERROR" or $c == "STARTUP_FAILURE")
+                | (.name // .context)] | unique | join(", ")' "$pr_json")" \
+              || fail_loud "parsing the PR check rollup failed"
+            pending_count="$(jq -r '[(.statusCheckRollup // [])[]
+                | ((.conclusion // .state // "") | ascii_upcase)
+                | select(. == "" or . == "PENDING" or . == "EXPECTED"
+                         or . == "QUEUED" or . == "IN_PROGRESS")] | length' "$pr_json")" \
+              || fail_loud "counting pending checks failed"
+            # No checks materialized yet (head pushed moments ago) is pending,
+            # not green: reading it as green would flap the tracking issue.
+            if [ "$(jq -r '(.statusCheckRollup // []) | length' "$pr_json")" -eq 0 ]; then
+              pending_count=1
+            fi
+            pr_age_h=$(( pr_age_s / 3600 ))
+            if [ -n "$failing_checks" ]; then
+              add_reason "- **Red bump PR**: [#${pr_number}](${pr_url}) (open ${pr_age_h}h) failing: \`${failing_checks}\`."
+            elif [ "$pending_count" -gt 0 ] && [ "$pr_age_s" -ge "$threshold_s" ]; then
+              add_reason "- **Stuck bump PR**: [#${pr_number}](${pr_url}) open ${pr_age_h}h (>= ${ESCALATE_AFTER_HOURS}h) and unmerged; checks pending on the latest head."
+            fi
+          fi
+
+          # --- State: bump branch ahead of main with no open PR ---------------
+          branch_ref=""
+          if [ -z "$pr_number" ]; then
+            set +e
+            branch_ref="$(gh api "repos/${REPOSITORY}/git/ref/heads/${BUMP_BRANCH}" --jq '.object.sha' 2>/tmp/ref-err)"
+            ref_rc=$?
+            set -e
+            if [ "$ref_rc" -ne 0 ]; then
+              # Only a missing branch reads as clean; any other API failure is
+              # an internal error, never a claim of health.
+              if grep -q "Not Found" /tmp/ref-err; then
+                branch_ref=""
+              else
+                fail_loud "reading the ${BUMP_BRANCH} ref failed: $(cat /tmp/ref-err)"
+              fi
+            fi
+            if [ -n "$branch_ref" ]; then
+              ahead="$(gh api "repos/${REPOSITORY}/compare/main...${branch_ref}" --jq '.ahead_by')" \
+                || fail_loud "comparing ${BUMP_BRANCH} to main failed"
+              if [ "$ahead" -gt 0 ]; then
+                add_reason "- **Bump without a PR**: \`${BUMP_BRANCH}\` is ${ahead} commit(s) ahead of main with no open PR (closed unmerged?)."
+              else
+                branch_ref=""
+              fi
+            fi
+          fi
+
+          # --- Input rev range: locked on main -> candidate on the branch -----
+          rev_range=""
+          if [ -n "$pr_number" ] || [ -n "$branch_ref" ]; then
+            fetch_lock() {
+              gh api -H "Accept: application/vnd.github.raw" \
+                "repos/${REPOSITORY}/contents/flake.lock?ref=$1"
+            }
+            fetch_lock main > /tmp/lock-main.json \
+              || fail_loud "fetching flake.lock at main failed"
+            fetch_lock "refs/heads/${BUMP_BRANCH}" > /tmp/lock-bump.json \
+              || fail_loud "fetching flake.lock at ${BUMP_BRANCH} failed"
+            # Only the root node's direct inputs: internal dedup nodes
+            # (nixpkgs_2, flake-parts_4, ...) are noise in an alert.
+            rev_range="$(jq -rn --slurpfile base /tmp/lock-main.json --slurpfile bump /tmp/lock-bump.json '
+                ($base[0]) as $B | ($bump[0]) as $H |
+                [($H.nodes[$H.root].inputs // {}) | keys[] | . as $name
+                  | ($H.nodes[$H.root].inputs[$name]) as $hk
+                  | select(($hk | type) == "string")
+                  | ($B.nodes[$B.root].inputs[$name]? // null) as $bk
+                  | (if ($bk | type) == "string"
+                     then ($B.nodes[$bk].locked.rev? // "absent") else "absent" end) as $old
+                  | ($H.nodes[$hk].locked.rev? // "absent") as $new
+                  | select($old != $new)
+                  | "\($name) \($old[0:11]) -> \($new[0:11])"]
+                | join(", ")')" \
+              || fail_loud "diffing flake.lock revs failed"
+          fi
+
+          # --- Locate the tracking issue (label filter, not search: the search
+          # index lags minutes to hours and a lagged miss would mint duplicate
+          # episode issues) ----------------------------------------------------
+          issue_json=/tmp/tracking-issue.json
+          gh issue list --repo "${REPOSITORY}" --label "$label" --state all \
+              --json number,url,state,body --jq '.[0] // empty' > "$issue_json" \
+            || fail_loud "listing tracking issues failed"
+          issue_number=""
+          issue_state=""
+          issue_url=""
+          : > /tmp/issue-body.md
+          if [ -s "$issue_json" ]; then
+            issue_number="$(jq -r '.number' "$issue_json")"
+            issue_state="$(jq -r '.state' "$issue_json")"
+            issue_url="$(jq -r '.url' "$issue_json")"
+            jq -r '.body // ""' "$issue_json" > /tmp/issue-body.md
+          fi
+
+          # --- Healthy: PR merged/green, branch clean, bump job green ---------
+          healthy=""
+          if [ -z "$reasons" ]; then
+            if [ -z "$pr_number" ] || { [ -z "$failing_checks" ] && [ "$pending_count" -eq 0 ]; }; then
+              healthy=1
+            fi
+          fi
+          if [ -n "$healthy" ]; then
+            note "flake bump healthy (bump job ${UPDATE_RESULT}, no stuck PR, branch clean)"
+            if [ -n "$issue_number" ] && [ "$issue_state" = "OPEN" ]; then
+              if grep -q '<!-- slack-escalated:' /tmp/issue-body.md && [ -n "${SLACK_BOT_TOKEN}" ]; then
+                slack_post "flake bump recovered in ${REPOSITORY}; closing <${issue_url}|the tracking issue>." \
+                  || echo "::warning::recovery note did not post to Slack"
+              fi
+              gh issue comment "$issue_number" --repo "${REPOSITORY}" \
+                  --body "Resolved: flake bump healthy at \`${now_iso}\` (run ${GITHUB_RUN_ID}). Closing." \
+                || fail_loud "commenting the resolution failed"
+              gh issue close "$issue_number" --repo "${REPOSITORY}" \
+                || fail_loud "closing the tracking issue failed"
+            fi
+            exit 0
+          fi
+
+          # A young all-pending PR with no episode open is just CI in flight.
+          if [ -z "$reasons" ] && { [ -z "$issue_number" ] || [ "$issue_state" != "OPEN" ]; }; then
+            note "bump PR checks pending and below the ${ESCALATE_AFTER_HOURS}h threshold; nothing to escalate yet"
+            exit 0
+          fi
+          if [ -z "$reasons" ]; then
+            add_reason "- **Episode continuing**: bump PR [#${pr_number}](${pr_url}) checks pending on the latest head."
+          fi
+
+          # --- Episode clock: persisted in the issue body; a red PR that
+          # predates the first observation backdates the start to PR creation --
+          first_detected=""
+          escalated_at=""
+          if [ "$issue_state" = "OPEN" ]; then
+            first_detected="$(sed -n 's/.*<!-- first-detected: \([0-9TZ:-]*\) -->.*/\1/p' /tmp/issue-body.md | head -n1)"
+            escalated_at="$(sed -n 's/.*<!-- slack-escalated: \([0-9TZ:-]*\) -->.*/\1/p' /tmp/issue-body.md | head -n1)"
+          fi
+          if [ -z "$first_detected" ]; then first_detected="$now_iso"; fi
+          first_epoch="$(date -u -d "$first_detected" +%s)"
+          if [ -n "$pr_number" ] && [ "$pr_age_s" -gt $(( now_epoch - first_epoch )) ]; then
+            first_epoch=$(( now_epoch - pr_age_s ))
+            first_detected="$(date -u -d "@${first_epoch}" +%Y-%m-%dT%H:%M:%SZ)"
+          fi
+          failing_for_s=$(( now_epoch - first_epoch ))
+          failing_for_h=$(( failing_for_s / 3600 ))
+
+          fire=""
+          if [ "$failing_for_s" -ge "$threshold_s" ] && [ -z "$escalated_at" ]; then
+            fire=1
+          fi
+
+          write_body() {
+            {
+              echo "${marker}"
+              echo "<!-- first-detected: ${first_detected} -->"
+              if [ -n "$escalated_at" ]; then
+                echo "<!-- slack-escalated: ${escalated_at} -->"
+              fi
+              echo "## Rolling flake bump is stuck"
+              echo
+              echo "Failing since \`${first_detected}\` (${failing_for_h}h; escalation threshold ${ESCALATE_AFTER_HOURS}h). Last checked \`${now_iso}\` by run [${GITHUB_RUN_ID}](https://github.com/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+              echo
+              echo "${reasons}"
+              if [ -n "$rev_range" ]; then
+                echo "Input revisions waiting to land: \`${rev_range}\`"
+                echo
+              fi
+              echo "Maintained by the \`escalate\` job of the reusable update-flake-lock workflow (indexable-inc/index): refreshed hourly while the episode persists, closed automatically once a bump lands cleanly. Motivating incident: indexable-inc/ix#7235."
+              echo
+              echo "_Made with Claude Opus 4.5._"
+            } > /tmp/tracking-body.md
+          }
+
+          # --force: create-or-update, so the label pre-existing is fine.
+          gh label create "$label" --repo "${REPOSITORY}" --force \
+              --color D93F0B --description "rolling flake bump failing past its escalation threshold" \
+            || fail_loud "ensuring the ${label} label failed"
+
+          write_body
+          if [ -z "$issue_number" ]; then
+            issue_url="$(gh issue create --repo "${REPOSITORY}" --title "$issue_title" \
+                --label "$label" --body-file /tmp/tracking-body.md)" \
+              || fail_loud "creating the tracking issue failed"
+            issue_number="${issue_url##*/}"
+          else
+            if [ "$issue_state" = "CLOSED" ]; then
+              gh issue reopen "$issue_number" --repo "${REPOSITORY}" \
+                || fail_loud "reopening the tracking issue failed"
+            fi
+            gh issue edit "$issue_number" --repo "${REPOSITORY}" --body-file /tmp/tracking-body.md \
+              || fail_loud "updating the tracking issue failed"
+          fi
+
+          if [ -n "$fire" ]; then
+            # The comment (unlike body edits) notifies issue subscribers: the
+            # issue channel escalates even when no Slack token is configured.
+            gh issue comment "$issue_number" --repo "${REPOSITORY}" \
+                --body "Failing for ${failing_for_h}h, past the ${ESCALATE_AFTER_HOURS}h threshold: escalating." \
+              || fail_loud "posting the threshold comment failed"
+            slack_ok=1
+            if [ -n "${SLACK_BOT_TOKEN}" ]; then
+              slack_text="flake bump stuck in ${REPOSITORY}: failing for ${failing_for_h}h (threshold ${ESCALATE_AFTER_HOURS}h)."
+              if [ -n "$pr_number" ] && [ -n "$failing_checks" ]; then
+                slack_text="${slack_text} <${pr_url}|#${pr_number}> failing: \`${failing_checks}\`."
+              elif [ -n "$pr_number" ]; then
+                slack_text="${slack_text} <${pr_url}|#${pr_number}> unmerged."
+              fi
+              if [ -n "$rev_range" ]; then
+                slack_text="${slack_text} Waiting revs: \`${rev_range}\`."
+              fi
+              slack_text="${slack_text} Tracking: <${issue_url}|#${issue_number}>."
+              # A rejected post leaves the marker unset so the next tick retries.
+              slack_post "$slack_text" || slack_ok=""
+            else
+              note "no slack-bot-token configured; escalated via the tracking issue only"
+            fi
+            if [ -n "$slack_ok" ]; then
+              escalated_at="$now_iso"
+              write_body
+              gh issue edit "$issue_number" --repo "${REPOSITORY}" --body-file /tmp/tracking-body.md \
+                || fail_loud "recording the escalation marker failed"
+            fi
+          fi
+
+          # Red in the Actions tab too, not only in the issue.
+          echo "::error::flake bump stuck for ${failing_for_h}h; see ${issue_url}"
+          exit 1


### PR DESCRIPTION
Resolves the index-side half of indexable-inc/ix#7235: the rolling flake bump PR (authored by this reusable workflow) can stay red for days with no escalation; ix's `index` pin sat 4 days stale behind red hourly bumps.

**What:** a new `escalate` job runs after every bump attempt (`if: always()`) and handles every terminal state:

- **Red PR**: latest head has failing checks.
- **Stuck PR**: open past the threshold and unmerged even if checks read pending (hourly branch updates reset checks, so age is the churn-proof signal).
- **Orphaned bump**: `update-flake-lock` branch ahead of main with no open PR.
- **Bump job failed**: the update job itself concluded failure.

Episode state lives in one `flake-bump-stuck`-labeled tracking issue in the consumer repo (find-or-reopen, body refreshed hourly, closed with a comment on recovery). Once the episode crosses `escalate-after-hours` (default 6) it escalates exactly once: a threshold comment on the issue, plus a Slack post (default channel C0A4TD9G7HR) naming the failing checks and the root-input rev range (`index 216bb82e91f -> 3d94154286a` style) when the caller supplies the new optional `slack-bot-token` secret. Watcher-internal API failures exit loudly without claiming health or closing the issue (same contract as cache-push-watchdog.yml).

**Callers must grant `issues: write`** on the calling job; the ix wiring (permission + Slack secret) follows in an ix PR once this lands.

**Validation:** actionlint clean; the extracted script dry-ran against the live ix episode with mutating `gh`/`curl` shimmed, exercising red-PR escalation (found #7155, checks `build, lint, nix`, rev range `index 216bb82e91f -> 3d94154286a`), fire-once dedupe, healthy-path issue close with recovery note, and bump-job-failure reopening a closed episode issue with a reset clock.

Compatible with #2728 (auto-merge arming): that PR adds a step inside the update job; this adds a separate job.

Made with Claude Opus 4.5.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add escalation job to the reusable flake bump workflow for stuck PRs
> - Adds an `escalate` job to [update-flake-lock.yml](.github/workflows/update-flake-lock.yml) that always runs after the bump job and inspects PR checks, branch divergence, and job result to detect stuck states.
> - Opens or updates a labeled GitHub tracking issue when the bump is failing or stuck, maintaining timing markers in the issue body to track how long the unhealthy state has persisted.
> - Exposes three new reusable inputs/secrets (`escalate-after-hours`, `slack-channel`, `slack-bot-token`) to control escalation timing and optional Slack notifications.
> - Closes the tracking issue automatically on recovery and exits non-zero to mark the workflow as failed when the stuck condition exceeds the configured threshold.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23ec1fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->