### PR TITLE
kernel: user-defined names win over retired sh/zsh stubs

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -3949,6 +3949,14 @@ _baseline_names: frozenset[str] = frozenset()
 # checkpoint and the namespace pane -- an untouched proxy is dropped by TYPE, not
 # by name (see _snapshot_candidates / _namespace_candidates).
 _lazy_module_names: frozenset[str] = frozenset()
+# The retired `sh`/`zsh` stubs, keyed to the exact object install() bound. Bound
+# AFTER the baseline snapshot and never protected, so a user's own definition of
+# the name wins for the rest of the session (issue #3215: the per-cell builtin
+# restore used to rebind the disabled stub over a user-defined `sh`) and, like
+# any user name, is checkpointed; an untouched stub is excluded by identity
+# instead (see _snapshot_candidates / _namespace_candidates), the way an
+# untouched lazy proxy is excluded by type.
+_retired_stubs: dict[str, Any] = {}
 # True while __ix_restore is replaying. The debounced checkpoint must not fire
 # then: replayed cells' source rows carry ended_at from the PREVIOUS run, so a
 # mid-restore checkpoint would advance the anchor past the cells not yet
@@ -4040,6 +4048,7 @@ def _snapshot_candidates(ns: dict) -> dict:
         and not _IPYTHON_MACHINERY.fullmatch(name)
         and not isinstance(value, types.ModuleType)
         and not isinstance(value, _LazyModule)  # untouched lazy proxy: not user state
+        and _retired_stubs.get(name) is not value  # untouched retired stub: not user state
     }
 
 
@@ -4055,6 +4064,7 @@ def _namespace_candidates(ns: dict) -> dict:
         and not name.startswith("__")
         and not _IPYTHON_MACHINERY.fullmatch(name)
         and not isinstance(value, _LazyModule)  # untouched lazy proxy: not user state
+        and _retired_stubs.get(name) is not value  # untouched retired stub: not user state
     }
 
 
@@ -4261,6 +4271,11 @@ def _session_ns(session: str | None) -> dict:
         # into every fresh session. A fresh proxy is stateless and correct.
         for name in _lazy_module_names:
             ns[name] = _LazyModule(name)
+        # Seed the retired stubs from their canonical objects, never from
+        # `shared[name]`, for the same reason: the shared binding may be a
+        # user's own `sh` by now.
+        for name, stub in _retired_stubs.items():
+            ns[name] = stub
         _session_namespaces[session] = ns
     return ns
 
@@ -4826,16 +4841,6 @@ def install(user_ns: dict | None = None) -> None:
     _bind("__ix_snapshot", __ix_snapshot)
     _bind("__ix_restore", __ix_restore)
     _bind("DASHBOARD_URL", os.environ.get("IX_MCP_DASHBOARD_URL", ""))
-    # `sh`/`zsh` are RETIRED (agents shell out through `await nu(...)`; the sh
-    # module's public entry points now raise a migration hint). Bind them anyway
-    # so a stale `await sh(cmd)` in an old transcript fails LOUDLY with that hint
-    # rather than a bare NameError. The kernel's own internals reach the private
-    # runner via `from sh import _exec`, which is never bound into the namespace.
-    with contextlib.suppress(Exception):  # sh may be absent outside the bundled interpreter; skip it
-        import sh as _sh_module
-
-        _bind("sh", _sh_module)
-        _bind("zsh", _sh_module.zsh)
     # Bind the filesystem-search helpers as top-level callables (`await grep(...)`
     # / `find(...)` / `spotlight(...)`) the way `sh` is bound, so the most common
     # search/listing actions need no import. They live in the bundled `fsearch`
@@ -4890,6 +4895,22 @@ def install(user_ns: dict | None = None) -> None:
     _lazy_module_names = frozenset(_lazy_names)
     for _mod_name in _lazy_names:
         target[_mod_name] = _LazyModule(_mod_name)
+    # `sh`/`zsh` are RETIRED (agents shell out through `await nu(...)`; the sh
+    # module's public entry points now raise a migration hint). Bind them anyway
+    # so a stale `await sh(cmd)` in an old transcript fails LOUDLY with that hint
+    # rather than a bare NameError -- but after the baseline snapshot and never
+    # through _bind, so a user's own `sh` wins over the disabled stub for the
+    # rest of the session (issue #3215; see _retired_stubs). The kernel's own
+    # internals reach the private runner via `from sh import _exec`, which is
+    # never bound into the namespace.
+    _retired_stubs.clear()
+    with contextlib.suppress(Exception):  # sh may be absent outside the bundled interpreter; skip it
+        import sh as _sh_module
+
+        _retired_stubs["sh"] = _sh_module
+        _retired_stubs["zsh"] = _sh_module.zsh
+    for _stub_name, _stub in _retired_stubs.items():
+        target[_stub_name] = _stub
     # A fresh session starts with no recorded references (the namespace is empty of
     # user names; refs accumulate as runs touch them).
     _name_refs.clear()

--- a/packages/mcp/tests/test_builtin_shadow_restore.py
+++ b/packages/mcp/tests/test_builtin_shadow_restore.py
@@ -78,6 +78,40 @@ def test_reimporting_the_same_module_is_not_a_clobber(monkeypatch: pytest.Monkey
     assert "kernel builtin" not in job.output
 
 
+def test_user_definition_wins_over_retired_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    # issue #3215: the retired `sh` stub was install()-protected, so the
+    # post-cell restore silently rebound the disabled stub over a user's own
+    # `async def sh` between cells. A user definition must win and stay bound.
+    sh_module = pytest.importorskip("sh")
+    ns: dict = {}
+    runtime.install(ns)
+    monkeypatch.setattr(runtime, "_session_namespaces", {})
+    assert ns["sh"] is sh_module, "the loud migration stub is bound at start"
+    assert "sh" not in runtime._protected_builtins
+    assert "zsh" not in runtime._protected_builtins
+    job = _run("async def sh(cmd: str) -> str:\n    return 'user:' + cmd")
+    assert job.status == "done"
+    assert "kernel builtin" not in job.output, "shadowing a retired stub must not warn"
+    assert ns["sh"] is not sh_module, "the user's `sh` must survive the cell's end"
+    job = _run("out = await sh('ls')")
+    assert job.status == "done", job.error
+    assert ns["out"] == "user:ls", "a later cell must call the user's binding, not the stub"
+
+
+def test_untouched_stub_is_not_user_state() -> None:
+    # An untouched stub binding stays out of checkpoints and the namespace pane
+    # (it is runtime courtesy surface, not user state); a rebound name is kept.
+    stub = object()
+    ns = {"sh": stub, "mine": 41}
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(runtime, "_baseline_names", frozenset())
+        mp.setattr(runtime, "_retired_stubs", {"sh": stub})
+        assert set(runtime._snapshot_candidates(ns)) == {"mine"}
+        assert set(runtime._namespace_candidates(ns)) == {"mine"}
+        ns["sh"] = "rebound"
+        assert set(runtime._snapshot_candidates(ns)) == {"sh", "mine"}
+
+
 def test_install_registers_builtins_but_not_lazy_modules(monkeypatch: pytest.MonkeyPatch) -> None:
     # End-to-end against the real install(): the helper surface (api, jobs, and
     # the preimported modules) is protected; lazy-proxied module names are NOT --


### PR DESCRIPTION
Fixes #3215.

**Bug:** defining `async def sh(...)` in a cell worked in that cell, then silently reverted to the disabled bundled stub (`RuntimeError: sh() is disabled: use await nu(...)`) in later cells. The retired `sh`/`zsh` stubs were bound through `_bind`, which registers them in `_protected_builtins`, so the post-cell builtin restore (#2430) re-injected the stub over the user's definition after every cell.

**Fix:** bind the stubs after the baseline snapshot, unprotected, tracked in a new `_retired_stubs` map:

- a user definition of the name wins for the rest of the session and is checkpointed like any user name
- an untouched stub is excluded from checkpoints and the namespace pane by identity (the way an untouched lazy proxy is excluded by type)
- fresh per-session namespaces seed the stubs from their canonical objects, never from the shared binding (which may be user state by then)

**Regression tests** in `tests/test_builtin_shadow_restore.py`: define `sh` in one exec, call it in a later exec, assert the user binding survives with no clobber warning; plus identity-exclusion coverage. Both fail on pre-fix `runtime.py` (verified via stash).

(sent by an AI agent via Claude Code, model claude-opus-4-6)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow user-defined `sh`/`zsh` names to override retired stubs in kernel namespace
> - `sh` and `zsh` migration stubs are now bound after the baseline snapshot and outside of install protection, so user definitions of these names take precedence and persist across sessions.
> - A new `_retired_stubs` dict tracks the canonical stub objects by name so untouched stubs can be identified by identity.
> - Untouched stubs are excluded from checkpoint snapshot candidates and the namespace pane; once a user rebinds a name, it is treated as normal user state.
> - New sessions receive stubs from `_retired_stubs` directly, independent of any user-rebound shared binding.
> - Behavioral Change: previously, `sh`/`zsh` were install-protected builtins included in snapshots; they are now unprotected and excluded from snapshots unless rebound by the user.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73375d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->