### PR TITLE
fabric: Nix fabric env, Ray fleet cluster, and remote runner (phase 2)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -532,6 +532,10 @@
       mutable-files = import ./modules/darwin/mutable-files.nix {
         indexPackages = system: packages.${system};
       };
+      # Fabric Ray worker for macs (index#3192): join the fleet cluster as a
+      # worker behind `services.ix-ray.enable`, same pinned ports and env as
+      # the NixOS module. See modules/darwin/ray.nix.
+      ray = import ./modules/darwin/ray.nix {indexLib = ix;};
       # Declarative NFS automounts via macOS autofs: each entry renders a
       # direct-map line, /etc/auto_master gains the include idempotently, and
       # activation reloads automountd. See modules/darwin/nfs.nix.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -315,6 +315,13 @@
   systemdHardening = import ./services/systemd-hardening.nix;
 
   /**
+  The pinned fabric/Ray execution environment as data: env tag, node
+  resources, cluster env vars, wrapped `ray` CLI. One owner shared by the
+  ray modules and the mcp wrappers. See [`lib/fabric.nix`](lib/fabric.nix).
+  */
+  fabric = import ./fabric.nix {inherit lib;};
+
+  /**
   Helpers that throw with a fixable error message instead of a deep-eval
   crash. See [`lib/util/errors.nix`](lib/util/errors.nix) for the full surface:
   `assertEnum`, `requireArg`, `requireAttr`.
@@ -654,6 +661,7 @@
       deepMerge
       efx
       evalTimeSubstitutable
+      fabric
       forkClosureGates
       forkPackages
       forkDagCheckSrc

--- a/lib/fabric.nix
+++ b/lib/fabric.nix
@@ -1,0 +1,109 @@
+/**
+The pinned fabric execution environment (index#3192, design index#3190): the
+one owner of how a fabric/Ray cluster node identifies and configures itself.
+Consumed by the NixOS cluster module ([`modules/services/ray`](modules/services/ray/default.nix)),
+the darwin worker module ([`modules/darwin/ray.nix`](modules/darwin/ray.nix)),
+and the ix-mcp wrappers ([`packages/mcp`](packages/mcp/default.nix)), so the
+daemons, the kernels driving them, and the submit-time handshake can never
+disagree about the env.
+
+Identity is deliberately platform-independent: cloudpickled bytecode travels
+across OS/arch when (and only when) the python and ray versions match, so the
+tag is `py<maj.min>-ray<version>` -- store paths would differ per platform and
+falsely fail the darwin -> linux handshake. ray vendors its own cloudpickle
+(`ray.cloudpickle`), so pinning ray pins cloudpickle with it; one nixpkgs pin
+gives darwin and linux identical python/ray/cloudpickle.
+*/
+{lib}: let
+  # Ray refuses multi-node participation on darwin without this gate, and it
+  # is read at `ray_constants` import time by EVERY ray process -- the daemon
+  # joining as a worker AND a driver attaching to a local raylet (without it a
+  # darwin driver binds loopback instead of its routable address). The large
+  # object store is capped to 2GiB on macOS unless the second var lifts it.
+  # These are set ONLY through the Nix wrappers below, never in user shells.
+  clusterEnv = {
+    RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER = "1";
+    RAY_ENABLE_MAC_LARGE_OBJECT_STORE = "1";
+  };
+
+  envTag = python: "py${lib.versions.majorMinor python.version}-ray${python.pkgs.ray.version}";
+
+  envResource = python: "fabric_env:${envTag python}";
+in {
+  inherit clusterEnv envTag envResource;
+
+  /**
+  The pinned inter-node port claims of the one fleet Ray cluster, shared by
+  the NixOS module and the darwin worker module so peers (and their
+  firewalls) can never disagree about the fixed raylet port range. The
+  notebook/exec ports are NixOS-only and stay with that module.
+  */
+  ports = {
+    gcs = 6379;
+    clientServer = 10_001;
+    nodeManager = 6380;
+    objectManager = 6381;
+    workerLow = 10_002;
+    workerHigh = 10_031;
+  };
+
+  /**
+  The Ray custom resources a fabric node advertises, as data: its addressable
+  host label (`host_<name>`, what `fabric.run(node=...)` targets), its OS
+  label, the env-handshake resource, and `gpu` when the host has one. Rendered
+  to `ray start --resources` JSON by the modules.
+  */
+  nodeResources = {
+    python,
+    hostName,
+    os,
+    gpu ? false,
+  }:
+    assert lib.assertMsg (lib.elem os ["linux" "darwin"]) "ix.fabric.nodeResources: os must be \"linux\" or \"darwin\", got ${toString os}";
+      {
+        "host_${hostName}" = 1;
+        "${os}" = 1;
+        "${envResource python}" = 1;
+      }
+      // lib.optionalAttrs gpu {gpu = 1;};
+
+  /**
+  Env vars for a kernel/driver process (the ix-mcp wrappers): the cluster
+  gate plus `IX_FABRIC_ENV`, this env's handshake resource name, which
+  `fabric.remote` compares against the target node's advertised resource at
+  submit. `python` must be the interpreter the process actually runs.
+  */
+  kernelEnv = python:
+    clusterEnv
+    // {
+      IX_FABRIC_ENV = envResource python;
+    };
+
+  /**
+  The `ray` daemon CLI of the pinned fabric env: the same nixpkgs ray the
+  ix-mcp interpreter imports (Ray requires matching versions cluster-wide),
+  wrapped with the cluster env vars so one package serves darwin and linux
+  workers alike, plus git on PATH for the runner actor's per-run workspace
+  clones (fleet units run with a minimal PATH).
+  */
+  rayEnv = pkgs: let
+    # The head's Ray Client server (`--ray-client-server-port`, what `ray://`
+    # drivers attach through) needs ray's `client` extra (grpcio); plain
+    # `ps.ray` refuses to even start with the port configured. One env for
+    # every role, so head and workers cannot drift.
+    env = pkgs.python3.withPackages (ps: [ps.ray] ++ ps.ray.optional-dependencies.client);
+  in
+    pkgs.runCommand "fabric-ray-env" {
+      nativeBuildInputs = [pkgs.makeWrapper];
+      strictDeps = true;
+      meta = {
+        description = "Pinned fabric ray daemon: nixpkgs ray wrapped with the cluster env vars";
+        mainProgram = "ray";
+      };
+    } ''
+      mkdir -p $out/bin
+      makeWrapper ${lib.getExe' env "ray"} $out/bin/ray \
+        ${lib.concatStringsSep " " (lib.mapAttrsToList (name: value: "--set ${name} ${lib.escapeShellArg value}") clusterEnv)} \
+        --prefix PATH : ${lib.makeBinPath [pkgs.git]}
+    '';
+}

--- a/modules/darwin/ray.nix
+++ b/modules/darwin/ray.nix
@@ -1,0 +1,204 @@
+# Darwin fabric worker (index#3192): joins a mac (behind an explicit enable
+# flag) to the one fleet Ray cluster as a worker. The head and the full
+# node-level story live in modules/services/ray/default.nix (NixOS); this is
+# the deliberately smaller nix-darwin counterpart -- worker role only (macs
+# never hold the GCS), no notebook engine (workstation kernels run under the
+# user's own profile), same pinned inter-node ports via `indexLib.fabric.ports`
+# and the same wrapped daemon env via `indexLib.fabric.rayEnv`, whose
+# RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER gate is what lets a darwin node join a
+# multi-node cluster at all.
+# `indexLib` is the index flake lib, injected at the flake's darwinModules
+# wiring for the same reason modules/services/ray/default.nix documents.
+{indexLib}: {
+  # Same dedup story as modules/darwin/provenance.nix: applying the injection
+  # makes each import site a distinct anonymous attrset, so an explicit `key`
+  # restores module-system dedup and `_file` restores error attribution.
+  key = "index/modules/darwin/ray.nix";
+  _file = "index/modules/darwin/ray.nix";
+
+  imports = [
+    ({
+      config,
+      lib,
+      pkgs,
+      ...
+    }: let
+      cfg = config.services.ix-ray;
+
+      # Worker join flags. Unlike the NixOS unit there is no explicit spill
+      # directory: macOS /tmp is disk-backed (not a tmpfs), so Ray's default
+      # spill location under the temp dir already lands on real disk. The
+      # short /tmp path also keeps the plasma AF_UNIX socket under the
+      # 108-byte sun_path limit.
+      startArgs =
+        [
+          "start"
+          "--address"
+          "${cfg.headAddress}:${toString cfg.gcsPort}"
+          "--node-manager-port"
+          (toString cfg.nodeManagerPort)
+          "--object-manager-port"
+          (toString cfg.objectManagerPort)
+          "--min-worker-port"
+          (toString cfg.workerPortLow)
+          "--max-worker-port"
+          (toString cfg.workerPortHigh)
+          "--temp-dir"
+          "/tmp/ix-ray"
+          # Same data as the NixOS module: host label, os label, env
+          # handshake resource (see `indexLib.fabric.nodeResources`).
+          "--resources"
+          (builtins.toJSON cfg.resources)
+        ]
+        ++ lib.optionals (cfg.objectStoreMemory != null) [
+          "--object-store-memory"
+          (toString cfg.objectStoreMemory)
+        ];
+
+      startArgsNu = "[ ${lib.concatMapStringsSep " " builtins.toJSON startArgs} ]";
+
+      # Resolve the node's tailscale IPv4 at runtime and exec the daemon bound
+      # to it, mirroring the NixOS launcher. The tailscale CLI is host state on
+      # darwin (the standalone install or the app bundle), not a Nix input:
+      # only the CLI matching the running tailscaled can query it.
+      launcher = indexLib.writeNushellApplication pkgs {
+        name = "ix-ray-launch";
+        meta.description = "Resolve this mac's tailscale IPv4 and exec the ray worker daemon bound to it";
+        runtimeInputs = [
+          cfg.package
+          # Same constraint as the NixOS launcher: ray execs worker wrappers
+          # via `os.execvp("bash", ...)`, so bash must be on the daemon PATH.
+          pkgs.bash
+        ];
+        text = ''
+          # nu
+          def main [] {
+            let candidates = [
+              "/usr/local/bin/tailscale"
+              "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+            ]
+            let found = ($candidates | where ($it | path exists))
+            if ($found | is-empty) {
+              print --stderr $"ix-ray: no tailscale CLI at any of ($candidates)"
+              exit 1
+            }
+            let ts = ($found | first)
+            let ip = (do --ignore-errors {
+              ^$ts ip -4 | lines | where ($it | str trim | is-not-empty) | first
+            } | default "")
+            if ($ip | str trim | is-empty) {
+              print --stderr "ix-ray: no tailscale IPv4 yet; is tailscale up?"
+              exit 1
+            }
+            let args = [ ...${startArgsNu} "--node-ip-address" $ip "--block" ]
+            exec ${lib.getExe' cfg.package "ray"} ...$args
+          }
+        '';
+      };
+    in {
+      options.services.ix-ray = {
+        enable = lib.mkEnableOption "joining this mac to the fleet Ray cluster as a fabric worker";
+
+        headAddress = lib.mkOption {
+          type = lib.types.str;
+          example = "100.64.0.1";
+          description = "The head node's tailscale IPv4 (see the NixOS module's `role = \"head\"`).";
+        };
+
+        package = lib.mkOption {
+          type = lib.types.package;
+          default = indexLib.fabric.rayEnv pkgs;
+          defaultText = lib.literalExpression "indexLib.fabric.rayEnv pkgs";
+          description = ''
+            The `ray` daemon: the pinned fabric env (same nixpkgs ray as the
+            ix-mcp interpreter, wrapped with the cluster env vars).
+          '';
+        };
+
+        resources = lib.mkOption {
+          type = lib.types.attrsOf lib.types.number;
+          default = {};
+          example = {ssd = 1;};
+          description = ''
+            Ray custom resources this node advertises. The fabric baseline
+            (`host_<hostName>`, `darwin`, the `fabric_env:<tag>` handshake
+            resource) is merged in below; set extra keys here for
+            host-specific capabilities.
+          '';
+        };
+
+        gcsPort = lib.mkOption {
+          type = lib.types.port;
+          default = indexLib.fabric.ports.gcs;
+          description = "Head GCS port this worker joins.";
+        };
+
+        nodeManagerPort = lib.mkOption {
+          type = lib.types.port;
+          default = indexLib.fabric.ports.nodeManager;
+          description = "Ray node-manager port (inter-node scheduling), pinned fleet-wide.";
+        };
+
+        objectManagerPort = lib.mkOption {
+          type = lib.types.port;
+          default = indexLib.fabric.ports.objectManager;
+          description = "Ray object-manager port (object-store transfers), pinned fleet-wide.";
+        };
+
+        workerPortLow = lib.mkOption {
+          type = lib.types.port;
+          default = indexLib.fabric.ports.workerLow;
+          description = "Low end of the pinned per-worker port range (inter-node worker RPC).";
+        };
+
+        workerPortHigh = lib.mkOption {
+          type = lib.types.port;
+          default = indexLib.fabric.ports.workerHigh;
+          description = "High end of the pinned per-worker port range.";
+        };
+
+        objectStoreMemory = lib.mkOption {
+          type = lib.types.nullOr lib.types.ints.positive;
+          default = null;
+          example = 8_000_000_000;
+          description = ''
+            Bytes of RAM for this node's object store (Plasma). Null lets Ray
+            autodetect. The fabric env lifts Ray's 2GiB macOS cap
+            (RAY_ENABLE_MAC_LARGE_OBJECT_STORE).
+          '';
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = config.networking.hostName != null;
+            message = "services.ix-ray (darwin): networking.hostName must be set; it names this node's `host_<name>` fabric label.";
+          }
+        ];
+
+        services.ix-ray.resources = indexLib.fabric.nodeResources {
+          python = pkgs.python3;
+          hostName = config.networking.hostName;
+          os = "darwin";
+        };
+
+        launchd.daemons.ix-ray = {
+          serviceConfig = {
+            ProgramArguments = [(lib.getExe launcher)];
+            RunAtLoad = true;
+            KeepAlive = true;
+            # Root's real home: the nushell launcher needs a writable
+            # $HOME/.config/nushell and ray writes only under its temp dir.
+            EnvironmentVariables = {
+              HOME = "/var/root";
+              RAY_DISABLE_USAGE_STATS = "1";
+            };
+            StandardOutPath = "/var/log/ix-ray.log";
+            StandardErrorPath = "/var/log/ix-ray.log";
+          };
+        };
+      };
+    })
+  ];
+}

--- a/modules/services/ray/default.nix
+++ b/modules/services/ray/default.nix
@@ -23,10 +23,12 @@
 # temp-dir so Ray's AF_UNIX plasma socket stays under the 108-byte sun_path
 # limit, and PrivateDevices/PrivateUsers off so an attaching kernel can map the
 # shared-memory object store) mirrors the proven `examples/ray/cluster`
-# cluster-node module. Use nixpkgs `python3Packages.ray` -- the same Ray the
-# ix-mcp interpreter imports, so the cluster and the kernels driving it run an
-# identical version (Ray requires matching versions cluster-wide) and the
-# daemons are FHS-correct with no nix-ld shim.
+# cluster-node module. The daemon runs `indexLib.fabric.rayEnv` -- nixpkgs
+# `python3Packages.ray` (the same Ray the ix-mcp interpreter imports, so the
+# cluster and the kernels driving it run an identical version, required
+# cluster-wide; FHS-correct with no nix-ld shim) wrapped with the fabric
+# cluster env vars, so darwin and linux nodes share one pinned env
+# (index#3192).
 # `indexLib` is the index flake lib (writeNushellApplication/systemdHardening),
 # supplied by the consumer via `_module.args.indexLib`. It is deliberately NOT
 # named `ix`: a host binds `ix` to its own specialArg (the ix monorepo's is a
@@ -46,7 +48,6 @@
     mkEnableOption
     mkIf
     mkOption
-    mkPackageOption
     optional
     optionalAttrs
     optionals
@@ -101,6 +102,13 @@
       "/run/ray"
       "--object-spilling-directory"
       spillDir
+      # Custom resources this node advertises, as data (see
+      # `indexLib.fabric.nodeResources`): the `host_<name>` label
+      # `fabric.run(node=...)` targets, os/gpu labels, and the
+      # `fabric_env:<tag>` handshake resource submitters compare against
+      # their own env before shipping cloudpickled code here.
+      "--resources"
+      (builtins.toJSON cfg.resources)
     ]
     ++ optionals (cfg.objectStoreMemory != null) [
       "--object-store-memory"
@@ -233,11 +241,14 @@ in {
       '';
     };
 
-    package = mkPackageOption pkgs.python3Packages "ray" {
-      extraDescription = ''
-        The `ray` daemon, from the same nixpkgs pin as the ray bundled in the
-        ix-mcp interpreter, so the cluster and the kernels driving it run an
-        identical Ray version (required cluster-wide).
+    package = mkOption {
+      type = types.package;
+      default = indexLib.fabric.rayEnv pkgs;
+      defaultText = lib.literalExpression "indexLib.fabric.rayEnv pkgs";
+      description = ''
+        The `ray` daemon: the pinned fabric env, i.e. the same nixpkgs ray the
+        ix-mcp interpreter imports (Ray requires matching versions
+        cluster-wide) wrapped with the fabric cluster env vars.
       '';
     };
 
@@ -254,13 +265,13 @@ in {
 
     gcsPort = mkOption {
       type = types.port;
-      default = 6379;
+      default = indexLib.fabric.ports.gcs;
       description = "Head GCS port; workers connect here.";
     };
 
     clientServerPort = mkOption {
       type = types.port;
-      default = 10_001;
+      default = indexLib.fabric.ports.clientServer;
       description = ''
         Head Ray Client server port. Off-cluster drivers reach the cluster at
         `ray://<headAddress>:<this>` (what `fleet.connect()` uses via
@@ -270,26 +281,49 @@ in {
 
     nodeManagerPort = mkOption {
       type = types.port;
-      default = 6380;
+      default = indexLib.fabric.ports.nodeManager;
       description = "Ray node-manager port (inter-node scheduling). Pinned so the firewall can name it.";
     };
 
     objectManagerPort = mkOption {
       type = types.port;
-      default = 6381;
+      default = indexLib.fabric.ports.objectManager;
       description = "Ray object-manager port (object-store transfers). Pinned so the firewall can name it.";
     };
 
     workerPortLow = mkOption {
       type = types.port;
-      default = 10_002;
+      default = indexLib.fabric.ports.workerLow;
       description = "Low end of the pinned per-worker port range (inter-node worker RPC).";
     };
 
     workerPortHigh = mkOption {
       type = types.port;
-      default = 10_031;
+      default = indexLib.fabric.ports.workerHigh;
       description = "High end of the pinned per-worker port range.";
+    };
+
+    resources = mkOption {
+      type = types.attrsOf types.number;
+      default = {};
+      example = {ssd = 1;};
+      description = ''
+        Ray custom resources this node advertises (`ray start --resources`).
+        The fabric baseline (`host_<hostName>`, os/gpu labels, and the
+        `fabric_env:<tag>` handshake resource) is merged in below from
+        `indexLib.fabric.nodeResources`; set extra keys here for
+        host-specific capabilities.
+      '';
+    };
+
+    gpu = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Advertise the `gpu` fabric label. Defaulted below from the host's
+        configured video drivers; set explicitly for a compute GPU with no
+        display stack.
+      '';
     };
 
     execPort = mkOption {
@@ -377,6 +411,19 @@ in {
   };
 
   config = mkIf cfg.enable {
+    services.ix-ray = {
+      # Baseline fabric labels as data, derived from host config rather than a
+      # hand-kept per-host enumeration. attrsOf merges these with user-set
+      # extras; a same-key collision is a loud eval error.
+      resources = indexLib.fabric.nodeResources {
+        python = pkgs.python3;
+        hostName = config.networking.hostName;
+        os = "linux";
+        inherit (cfg) gpu;
+      };
+      gpu = lib.mkDefault (lib.elem "nvidia" config.services.xserver.videoDrivers);
+    };
+
     assertions = [
       {
         assertion = cfg.role == "head" -> cfg.headAddress == null;

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -528,11 +528,13 @@
       cp -r ${weavePythonSource}/weave/. "$site/"
     ''
   );
-  # Call-first local delegation on the weave journal (index#3191): `await
-  # fabric.run(fn, *args)` executes fn on this node with the ask/started/
-  # terminal facts recorded via the bundled weave client, and `fabric.claude`
-  # opens self-recording, interruptible Claude Agent SDK sessions. Pure Python
-  # over the bundled weave + claude-agent-sdk.
+  # Call-first delegation on the weave journal (index#3191, #3192): `await
+  # fabric.run(fn, *args)` executes fn on this node -- or, with node='<host>',
+  # on that fleet node's runner actor over Ray, env-handshake-checked at
+  # submit -- with the ask/started/terminal facts recorded via the bundled
+  # weave client, and `fabric.claude` opens self-recording, interruptible
+  # Claude Agent SDK sessions. Pure Python over the bundled weave +
+  # claude-agent-sdk + ray (+ fleet for cluster discovery).
   fabricPythonSource = builtins.path {
     name = "ix-mcp-fabric-python-source";
     path = ./src/fabric;
@@ -1416,6 +1418,11 @@
       pymobiledevice3_927
       iphoneModule
     ]
+    # Ray's `client` extra (grpcio): `fabric.remote` attaches to the fleet head
+    # over `ray://` (Ray Client), which plain ps.ray refuses without it. Derived
+    # from ray's own extra rather than named: pysparkConnect happens to carry
+    # grpcio today, but reaching the cluster must not hinge on spark.
+    ++ ps.ray.optional-dependencies.client
     ++ darwinExtraPackages ps;
   mcpPython = mcpPythonInterp.withPackages mcpPythonPackages;
 
@@ -1452,6 +1459,17 @@
   # bundle (a corporate CA) must still win.
   caBundle = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 
+  # The fabric env handshake + Ray darwin-cluster gates (index#3192), baked
+  # onto both wrappers from the one owner of the format (lib/fabric.nix):
+  # IX_FABRIC_ENV names this driver's `fabric_env:<tag>` resource, which
+  # fabric.remote compares against the target node's advertised resource at
+  # submit, and the RAY_ENABLE_* darwin gates live ONLY on these wrappers and
+  # the node daemons, never in user shells.
+  fabricWrapperFlags = lib.concatStringsSep " " (
+    lib.mapAttrsToList (name: value: "--set ${name} ${lib.escapeShellArg value}")
+    (ix.fabric.kernelEnv mcpPythonInterp)
+  );
+
   package =
     pkgs.runCommand "ix-mcp"
     {
@@ -1468,6 +1486,7 @@
         --add-flags "-m ix_notebook_mcp" \
         --set IX_BUILD_REV ${lib.escapeShellArg ix.rev} \
         --set IX_BUILD_EPOCH ${lib.escapeShellArg (toString ix.revEpoch)} \
+        ${fabricWrapperFlags} \
         --set PLAYWRIGHT_BROWSERS_PATH ${lib.escapeShellArg playwrightBrowsers} \
         --set IX_SVELTE_BUNDLE_BIN ${lib.escapeShellArg (lib.getExe svelteBundleBin)} \
         --set IX_GCAL_BIN ${lib.escapeShellArg "${gcalBin}/bin/gcal"} \
@@ -1491,6 +1510,7 @@
         --add-flags "-m ix_notebook_mcp notebook" \
         --set IX_BUILD_REV ${lib.escapeShellArg ix.rev} \
         --set IX_BUILD_EPOCH ${lib.escapeShellArg (toString ix.revEpoch)} \
+        ${fabricWrapperFlags} \
         --set PLAYWRIGHT_BROWSERS_PATH ${lib.escapeShellArg playwrightBrowsers} \
         --set IX_SVELTE_BUNDLE_BIN ${lib.escapeShellArg (lib.getExe svelteBundleBin)} \
         --set IX_GCAL_BIN ${lib.escapeShellArg "${gcalBin}/bin/gcal"} \
@@ -5743,16 +5763,22 @@
       cat stdout
       mkdir -p "$out"
     '';
-  # Network-free tests for the call-first fabric (index#3191): the run record
-  # contract against an httpx.MockTransport weave double (ask facts at submit
-  # with state strictly last, started/terminal facts from the worker side, a
-  # fn that raises before its first line still leaving ask + failed), and
+  # Network-free tests for the call-first fabric (index#3191, #3192): the run
+  # record contract against an httpx.MockTransport weave double (ask facts at
+  # submit with state strictly last, started/terminal facts from the worker
+  # side, a fn that raises before its first line still leaving ask + failed),
   # claude.session's CAS-pointer turn facts plus both interrupt paths (handle
-  # and journal fact) converging on the SDK interrupt as state=interrupted.
+  # and journal fact) converging on the SDK interrupt as state=interrupted,
+  # and the remote-placement submit contract with fakes (env handshake, host
+  # label existence, zero-restart runner policy, cloudpickle payload round
+  # trip through the real ray.cloudpickle, workspace materialization against
+  # a local git fixture). Live-cluster behavior is validated manually
+  # (index#3192 PR body); the sandbox proves everything submit-side.
   fabricTestPython = pkgs.python3.withPackages (ps: [
     ps.pytest
     ps.httpx
     ps.claude-agent-sdk
+    ps.ray
     fabricModule
     weaveModule
   ]);
@@ -5763,7 +5789,11 @@
   fabricTests =
     pkgs.runCommand "ix-mcp-fabric-tests"
     {
-      nativeBuildInputs = [fabricTestPython];
+      nativeBuildInputs = [
+        fabricTestPython
+        # The workspace tests build and clone a local git fixture.
+        pkgs.git
+      ];
       strictDeps = true;
     }
     ''

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -114,9 +114,11 @@ MODULES: tuple[Module, ...] = (
     Module(
         "fabric",
         "call-first delegation recorded to the weave journal: `await fabric.run(fn, *args)` "
-        "executes fn on this node (ask fact at submit, started/terminal facts from the "
-        "worker, source + result in CAS), and `fabric.claude.session(prompt)` opens a "
-        "self-recording, interruptible Claude Agent SDK session",
+        "executes fn on this node, or with `node='<host>'` on that fleet node's runner "
+        "actor over Ray (env handshake + host label checked at submit; `cpus=` for a "
+        "dedicated CPU reservation, `repo=`/`rev=` for a per-run workspace clone), with "
+        "ask/started/terminal facts and source + result in CAS; `fabric.claude.session("
+        "prompt)` opens a self-recording, interruptible Claude Agent SDK session",
     ),
     Module(
         "search",

--- a/packages/mcp/src/fabric/fabric/__init__.py
+++ b/packages/mcp/src/fabric/fabric/__init__.py
@@ -1,12 +1,17 @@
-"""Call-first local delegation recorded to the weave journal (index#3191).
+"""Call-first delegation recorded to the weave journal (index#3191, #3192).
 
 Calls create work; facts record it. ``await fabric.run(fn, *args)`` executes
-``fn`` on this node (phase 1 of index#3190: no Ray placement yet) and appends
-the record to the shared weave journal via the bundled :mod:`weave` client:
-the ask-fact at submit (so the intent is never invisible), started and
+``fn`` on this node; ``await fabric.run(fn, *args, node="hc1")`` ships it to
+that fleet node's runner actor over Ray (phase 2 of index#3190). Either way
+the record lands on the shared weave journal via the bundled :mod:`weave`
+client: the ask-fact at submit (so the intent is never invisible), started and
 terminal facts from the worker side, and the function's source text in CAS.
 The journal never dispatches: the ask state is ``submitted``, distinct from
 the ``pending`` state that the weave app fulfills.
+
+Remote placement (:mod:`fabric.remote`) fails loud at submit: no reachable
+cluster, an env-hash mismatch with the target node, or a host label no node
+advertises each raise from the ``run`` call itself, before any journal fact.
 
 ``fabric.claude`` holds the Claude Agent SDK session helper: an agent is a
 library call (``await claude.session(prompt)``), not a task type.
@@ -24,15 +29,20 @@ from dataclasses import dataclass
 
 import weave
 
-from . import claude
+from . import claude, remote
+from .remote import EnvSkewError, FabricError, Workspace
 
 __all__ = [
+    "EnvSkewError",
+    "FabricError",
     "RunHandle",
+    "Workspace",
     "claude",
+    "remote",
     "run",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 # The ask state. Deliberately NOT the weave app's "pending": pending is what
 # its fulfiller loop dispatches, and fabric's model is that the call already
@@ -46,7 +56,7 @@ def _requested_by() -> str:
 
 @dataclass
 class RunHandle:
-    """One live fabric run: the journal task entity plus the local execution."""
+    """One live fabric run: the journal task entity plus the execution."""
 
     task: str
     _work: asyncio.Task[object]
@@ -63,16 +73,58 @@ class RunHandle:
         """Cancel the run; the worker wrapper records ``state=interrupted``.
 
         Returns once the run has settled, so the interrupted fact is on the
-        journal when this returns. The run's own outcome (the cancellation, or
-        an error it already failed with) surfaces via :meth:`wait`, not here.
+        journal when this returns. A remote run's Ray task is cancelled on the
+        node too (see :func:`fabric.remote.execute`). The run's own outcome
+        (the cancellation, or an error it already failed with) surfaces via
+        :meth:`wait`, not here.
         """
 
         self._work.cancel()
         await asyncio.gather(self._work, return_exceptions=True)
 
 
-async def run(fn: Callable[..., object], *args: object, local: bool = True, **kwargs: object) -> RunHandle:
-    """Execute ``fn(*args, **kwargs)`` on this node, recorded on the journal.
+def _check_arguments(
+    *,
+    node: str | None,
+    local: bool | None,
+    cpus: float | None,
+    repo: str | None,
+    rev: str | None,
+) -> None:
+    """Reject contradictory placement arguments before anything runs."""
+
+    if node is not None and local:
+        raise ValueError(f"fabric.run: node={node!r} contradicts local=True")
+    if local is False and node is None:
+        raise ValueError("fabric.run: local=False requires node='<host>' (see fleet.nodes())")
+    if (repo is None) != (rev is None):
+        raise ValueError("fabric.run: repo and rev come together (a task pins an exact rev)")
+    if node is None and (cpus is not None or repo is not None):
+        raise ValueError(
+            "fabric.run: cpus/repo/rev are remote placement arguments; add node='<host>'"
+        )
+
+
+async def run(
+    fn: Callable[..., object],
+    *args: object,
+    node: str | None = None,
+    local: bool | None = None,
+    cpus: float | None = None,
+    repo: str | None = None,
+    rev: str | None = None,
+    **kwargs: object,
+) -> RunHandle:
+    """Execute ``fn(*args, **kwargs)``, recorded on the journal.
+
+    Placement: with no ``node`` the run is local to this kernel; with
+    ``node='<host>'`` it ships (cloudpickled) to that fleet node's detached
+    ``runner:<host>`` actor, validated at submit (env handshake + host label,
+    see :mod:`fabric.remote`) so a bad target raises here, not as a
+    forever-queued task. ``cpus=N`` opts a CPU-bound function out of the
+    shared runner into a dedicated Ray task with an honest ``num_cpus``
+    reservation. ``repo=``/``rev=`` make the runner materialize that checkout
+    in a per-run temp dir and pass its path as the function's first argument.
 
     At submit, one ask-facts batch describes the task entity: type,
     requested_by, node, the function's qualname, and its source text stored in
@@ -84,38 +136,41 @@ async def run(fn: Callable[..., object], *args: object, local: bool = True, **kw
     line (a bad signature bind, a first-statement raise) still leaves the ask
     and ``failed`` facts.
 
-    Sync functions run in ``asyncio.to_thread`` so the kernel loop never
-    blocks; async functions are awaited natively. Note a cancelled sync ``fn``
-    settles the run (and records ``interrupted``) while its thread finishes in
-    the background: threads cannot be killed.
-
-    ``local=False`` (Ray placement, ``node=``) is index#3190 phase 2+.
+    Locally, sync functions run in ``asyncio.to_thread`` so the kernel loop
+    never blocks; async functions are awaited natively (the runner actor does
+    the same on the node). Note a cancelled sync ``fn`` settles the run (and
+    records ``interrupted``) while its thread finishes in the background:
+    threads cannot be killed.
     """
 
-    if not local:
-        raise NotImplementedError(
-            "fabric phase 1 is local-only: run(fn, *args, local=True); "
-            "Ray placement across the fleet is index#3190 phase 2"
-        )
+    _check_arguments(node=node, local=local, cpus=cpus, repo=repo, rev=rev)
+    placement = await remote.prepare(node) if node is not None else None
+    workspace = Workspace(repo=repo, rev=rev) if repo is not None and rev is not None else None
     source = textwrap.dedent(inspect.getsource(fn))
     task = weave.mint("task")
     source_hash = await weave.put_blob(source.encode())
     await weave.assert_facts([
         (task, "type", "task"),
         (task, "fn", fn.__qualname__),
-        (task, "node", platform.node()),
+        (task, "node", node if node is not None else platform.node()),
         (task, "requested_by", _requested_by()),
         (task, "source", weave.hashref(source_hash)),
         (task, "state", ASK_STATE),
     ])
 
+    async def _invoke() -> object:
+        if placement is not None:
+            return await remote.execute(
+                placement, fn, args, kwargs, cpus=cpus, workspace=workspace
+            )
+        if inspect.iscoroutinefunction(fn):
+            return await fn(*args, **kwargs)
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
     async def _work() -> object:
         await weave.assert_fact(task, "state", "running")
         try:
-            if inspect.iscoroutinefunction(fn):
-                result = await fn(*args, **kwargs)
-            else:
-                result = await asyncio.to_thread(fn, *args, **kwargs)
+            result = await _invoke()
         except asyncio.CancelledError:
             await weave.assert_fact(task, "state", "interrupted")
             raise

--- a/packages/mcp/src/fabric/fabric/remote.py
+++ b/packages/mcp/src/fabric/fabric/remote.py
@@ -1,0 +1,397 @@
+"""Ray placement for :func:`fabric.run` (index#3192, phase 2 of index#3190).
+
+The cluster contract, end to end:
+
+- **Env handshake.** Every fabric node advertises a ``fabric_env:<tag>`` Ray
+  resource (tag = ``py<maj.min>-ray<version>``, declared in Nix by
+  ``lib/fabric.nix``); every fabric driver carries the same string in
+  ``IX_FABRIC_ENV`` (baked onto the ix-mcp wrappers). :func:`prepare` compares
+  them at submit and raises :class:`EnvSkewError` on mismatch -- cloudpickled
+  bytecode only travels safely between identical python/ray pins.
+
+- **Placement.** A node is targeted by its ``host_<name>`` resource label.
+  A label no live node advertises would make Ray queue the task forever, so
+  :func:`prepare` checks the cluster's resource table first and raises
+  :class:`FabricError` naming the known hosts.
+
+- **Runner.** Work lands on a per-node detached named async actor
+  (``runner:<host>``, namespace ``fabric``): ``num_cpus=0`` so it never
+  competes for scheduling slots, high ``max_concurrency`` so runs interleave,
+  and ``max_restarts=0`` ALWAYS -- a restarted runner would silently re-run
+  or orphan work; the journal, not Ray, owns retry policy (index#3190).
+  ``cpus=`` opts out into a dedicated Ray task with an honest ``num_cpus``
+  reservation (and ``max_retries=0``, same policy).
+
+- **Payload.** Tasks travel as explicit cloudpickle bytes both ways (ray's
+  vendored ``ray.cloudpickle``, pinned with ray itself). The daemon env on the
+  nodes carries ray alone -- no fabric/weave -- so this module registers
+  itself for pickle-by-value: everything it ships is self-contained.
+
+- **Workspace.** A task may carry ``repo`` + ``rev``; the runner materializes
+  a fresh clone at that rev in a per-run temp dir and hands the path to the
+  function as its first argument.
+
+No fallbacks anywhere: no reachable cluster, env skew, a missing label, or a
+failed clone each raise a precise error at the earliest point they are
+knowable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "ENV_PREFIX",
+    "ENV_VAR",
+    "NAMESPACE",
+    "EnvSkewError",
+    "FabricError",
+    "Placement",
+    "Workspace",
+    "actor_options",
+    "check_env",
+    "check_host_label",
+    "execute",
+    "local_env",
+    "materialize",
+    "prepare",
+    "task_options",
+]
+
+# The driver-side half of the env handshake, baked onto the ix-mcp wrappers by
+# packages/mcp (from `lib/fabric.nix`, the one owner of the format).
+ENV_VAR = "IX_FABRIC_ENV"
+# The node-side half: the resource-name prefix fabric nodes advertise.
+ENV_PREFIX = "fabric_env:"
+
+# All runner actors live in one named Ray namespace so `runner:<host>` lookup
+# works from any driver (anonymous namespaces are per-driver).
+NAMESPACE = "fabric"
+
+# The runner is I/O-shaped (async fns, to_thread-wrapped sync fns), so many
+# runs interleave on one actor; a CPU-bound run should use `cpus=` instead.
+RUNNER_CONCURRENCY = 256
+
+# What a placement consumes of the node's `host_<name>` capacity (1): small
+# enough that hundreds of concurrent placements never exhaust the label.
+HOST_SLICE = 0.001
+
+
+class FabricError(RuntimeError):
+    """A fabric placement could not be carried out; the message says why."""
+
+
+class EnvSkewError(FabricError):
+    """The target node's fabric env differs from this driver's."""
+
+
+@dataclass(frozen=True)
+class Workspace:
+    """A repo checkout the runner materializes per run (``repo`` + ``rev``)."""
+
+    repo: str
+    rev: str
+
+
+@dataclass(frozen=True)
+class Placement:
+    """A validated submit target: the node and its host resource label."""
+
+    node: str
+    label: str
+
+
+@dataclass(frozen=True)
+class _Task:
+    """The cloudpickled payload shipped to the runner."""
+
+    fn: Callable[..., object]
+    args: tuple[object, ...]
+    kwargs: dict[str, object]
+    workspace: Workspace | None
+
+
+def local_env() -> str:
+    """This driver's ``fabric_env:<tag>`` resource name, from ``IX_FABRIC_ENV``."""
+
+    value = os.environ.get(ENV_VAR)
+    if not value:
+        raise FabricError(
+            f"fabric: {ENV_VAR} is not set; remote placement requires the pinned fabric env "
+            "(the ix-mcp wrappers bake it in -- see lib/fabric.nix)"
+        )
+    return value
+
+
+def check_host_label(node: str, cluster_resources: Mapping[str, float]) -> str:
+    """The ``host_<node>`` label, after proving some live node advertises it.
+
+    Checked against the cluster's *total* resource table, not
+    ``available_resources``: a busy node's label drops out of the available
+    view while the node is still there, and existence -- not headroom -- is
+    what separates "will schedule" from "queues forever".
+    """
+
+    label = f"host_{node}"
+    if label not in cluster_resources:
+        hosts = sorted(
+            key.removeprefix("host_") for key in cluster_resources if key.startswith("host_")
+        )
+        raise FabricError(
+            f"fabric: no live Ray node advertises {label!r} (known hosts: {hosts or 'none'}); "
+            "a task on a missing label would queue forever, so this fails at submit"
+        )
+    return label
+
+
+def check_env(node: str, node_resources: Mapping[str, float], local: str) -> None:
+    """Raise :class:`EnvSkewError` unless ``node`` advertises this driver's env."""
+
+    advertised = sorted(key for key in node_resources if key.startswith(ENV_PREFIX))
+    if local not in advertised:
+        raise EnvSkewError(
+            f"fabric: env skew: this driver runs {local!r} but node {node!r} advertises "
+            f"{advertised or 'no fabric_env resource'}; cloudpickled code only travels "
+            "between identical python/ray pins -- redeploy the node or the driver"
+        )
+
+
+def actor_options(node: str) -> dict[str, object]:
+    """Options for the ``runner:<node>`` detached async actor.
+
+    ``max_restarts=0`` is policy, not a default: no caller input reaches this,
+    so a restarted-runner path cannot be configured into existence.
+    """
+
+    return {
+        "name": f"runner:{node}",
+        "namespace": NAMESPACE,
+        "lifetime": "detached",
+        "get_if_exists": True,
+        "num_cpus": 0,
+        "resources": {f"host_{node}": HOST_SLICE},
+        "max_concurrency": RUNNER_CONCURRENCY,
+        "max_restarts": 0,
+    }
+
+
+def task_options(node: str, cpus: float) -> dict[str, object]:
+    """Options for a dedicated CPU-bound task (``fabric.run(..., cpus=N)``)."""
+
+    return {
+        "num_cpus": cpus,
+        "resources": {f"host_{node}": HOST_SLICE},
+        "max_retries": 0,
+    }
+
+
+def materialize(workspace: Workspace) -> Path:
+    """Clone ``workspace.repo`` at ``workspace.rev`` into a fresh temp dir."""
+
+    dest = Path(tempfile.mkdtemp(prefix=f"fabric-{workspace.rev[:8]}-")) / "repo"
+    for cmd in (
+        ["git", "clone", "--no-checkout", workspace.repo, str(dest)],
+        ["git", "-C", str(dest), "checkout", "--detach", workspace.rev],
+    ):
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if proc.returncode != 0:
+            shutil.rmtree(dest.parent, ignore_errors=True)
+            raise FabricError(f"fabric: `{' '.join(cmd)}` failed: {proc.stderr.strip()}")
+    return dest
+
+
+def _dumps(obj: object) -> bytes:
+    """Typed seam over ray's vendored cloudpickle (untyped, not re-exported)."""
+
+    from ray import cloudpickle
+
+    data: bytes = cloudpickle.dumps(obj)  # type: ignore[attr-defined, no-untyped-call]
+    return data
+
+
+def _scrub(path: Path) -> None:
+    """Single-arg :func:`shutil.rmtree` shape: zuban's typeshed overloads
+    reject ``to_thread(shutil.rmtree, ..., ignore_errors=True)``."""
+
+    shutil.rmtree(path, ignore_errors=True)
+
+
+class Runner:
+    """The per-node runner actor body (shipped by value; see module doc).
+
+    Bytes in, bytes out: the payload is a cloudpickled :class:`_Task`, the
+    return a cloudpickled result, so the wire contract is one explicit
+    serializer (ray's vendored cloudpickle) in both directions.
+    """
+
+    async def run(self, payload: bytes) -> bytes:
+        from ray import cloudpickle
+
+        task: _Task = cloudpickle.loads(payload)
+        args = task.args
+        workdir: Path | None = None
+        if task.workspace is not None:
+            workdir = await asyncio.to_thread(materialize, task.workspace)
+            args = (workdir, *args)
+        try:
+            if inspect.iscoroutinefunction(task.fn):
+                result = await task.fn(*args, **task.kwargs)
+            else:
+                result = await asyncio.to_thread(task.fn, *args, **task.kwargs)
+        finally:
+            # Per-run scratch: the result travels by value, so nothing may
+            # outlive the run inside the clone.
+            if workdir is not None:
+                await asyncio.to_thread(_scrub, workdir.parent)
+        return _dumps(result)
+
+
+def _run_task(payload: bytes) -> bytes:
+    """The dedicated-task twin of :meth:`Runner.run` (``cpus=`` path): a plain
+    Ray task with an honest CPU reservation, sync by design -- the reserved
+    core is for the function itself."""
+
+    from ray import cloudpickle
+
+    task: _Task = cloudpickle.loads(payload)
+    args = task.args
+    workdir: Path | None = None
+    if task.workspace is not None:
+        workdir = materialize(task.workspace)
+        args = (workdir, *args)
+    try:
+        if inspect.iscoroutinefunction(task.fn):
+            result: object = asyncio.run(task.fn(*args, **task.kwargs))
+        else:
+            result = task.fn(*args, **task.kwargs)
+    finally:
+        if workdir is not None:
+            shutil.rmtree(workdir.parent, ignore_errors=True)
+    return _dumps(result)
+
+
+def _register_by_value() -> None:
+    """Ship this module's classes/functions by value, not module reference:
+    the node daemons run the wrapped ray env alone (no fabric installed), so a
+    by-reference pickle would die with ``ModuleNotFoundError`` on the worker.
+    Idempotent; ray's registry is keyed by module."""
+
+    from ray import cloudpickle
+
+    cloudpickle.register_pickle_by_value(sys.modules[__name__])  # type: ignore[no-untyped-call]
+
+
+def _connect() -> None:
+    """Attach this driver to the fleet Ray cluster, or raise.
+
+    Resolution mirrors ``fleet.connect`` (explicit env address, else the
+    tailnet auto-probe) MINUS its local-Ray fallback: fabric placement names a
+    specific host, and a silently started single-node Ray would turn
+    ``run(node='hc1')`` into local execution -- the exact failure mode the
+    submit-time checks exist to prevent.
+    """
+
+    import ray
+
+    if ray.is_initialized():
+        return
+    target = os.environ.get("IX_FLEET_RAY_ADDRESS") or os.environ.get("RAY_ADDRESS")
+    note = ""
+    if not target:
+        from fleet.cluster import _resolve_auto_target
+
+        target, note = _resolve_auto_target()
+    if not target:
+        raise FabricError(
+            "fabric: no Ray cluster target: set IX_FLEET_RAY_ADDRESS (ray://<head>:10001) "
+            f"or RAY_ADDRESS; {note}"
+        )
+    try:
+        ray.init(
+            address=target,
+            logging_level=logging.ERROR,
+            configure_logging=False,
+            ignore_reinit_error=True,
+        )
+    except Exception as error:
+        raise FabricError(
+            f"fabric: cannot attach to Ray at {target!r}: {type(error).__name__}: {error}"
+        ) from error
+
+
+def _prepare_sync(node: str) -> Placement:
+    import ray
+
+    _connect()
+    label = check_host_label(node, ray.cluster_resources())
+    local = local_env()
+    for entry in ray.nodes():
+        resources: Mapping[str, float] = entry.get("Resources") or {}
+        if entry.get("Alive") and label in resources:
+            check_env(node, resources, local)
+            return Placement(node=node, label=label)
+    # The label was in the cluster table but no alive node carries it: the
+    # node died between the two reads. Same forever-queue hazard, same answer.
+    raise FabricError(f"fabric: node {node!r} is no longer alive; resubmit when it rejoins")
+
+
+async def prepare(node: str) -> Placement:
+    """Validate ``node`` as a submit target (connect, label, env handshake).
+
+    Raises before any work (or journal fact) exists, so a bad target fails the
+    ``fabric.run`` call itself. Sync Ray driver calls run off the kernel loop.
+    """
+
+    return await asyncio.to_thread(_prepare_sync, node)
+
+
+def _submit(placement: Placement, payload: bytes, cpus: float | None) -> object:
+    """Ship the payload and return the Ray ObjectRef (sync driver calls)."""
+
+    import ray
+
+    if cpus is not None:
+        return ray.remote(_run_task).options(**task_options(placement.node, cpus)).remote(payload)
+    actor = ray.remote(Runner).options(**actor_options(placement.node)).remote()
+    return actor.run.remote(payload)  # type: ignore[attr-defined]  # ActorHandle method proxy
+
+
+async def execute(
+    placement: Placement,
+    fn: Callable[..., object],
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+    *,
+    cpus: float | None = None,
+    workspace: Workspace | None = None,
+) -> object:
+    """Run ``fn`` on the placed node and return its (deserialized) result.
+
+    Cancellation propagates: cancelling the awaiting task also cancels the Ray
+    task on the node, so an interrupt is not a silent orphan.
+    """
+
+    from ray import cloudpickle
+
+    _register_by_value()
+    payload = _dumps(_Task(fn=fn, args=args, kwargs=kwargs, workspace=workspace))
+    ref = await asyncio.to_thread(_submit, placement, payload, cpus)
+    try:
+        out: bytes = await ref  # type: ignore[misc]  # ObjectRef is awaitable
+    except asyncio.CancelledError:
+        import ray
+
+        ray.cancel(ref)
+        raise
+    result: object = cloudpickle.loads(out)
+    return result

--- a/packages/mcp/src/fabric/test_fabric.py
+++ b/packages/mcp/src/fabric/test_fabric.py
@@ -22,7 +22,7 @@ import weave
 from claude_agent_sdk import AssistantMessage, Message, ResultMessage, TextBlock
 
 import fabric
-from fabric import claude
+from fabric import claude, remote
 
 _T = TypeVar("_T")
 
@@ -224,15 +224,170 @@ def test_run_failure_still_leaves_ask_and_failed(
     assert b"def boom() -> None:" in journal.blob_for(handle.task, "source")
 
 
-def test_run_remote_placement_not_implemented(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"local": False}, "requires node="),
+        ({"node": "hc1", "local": True}, "contradicts"),
+        ({"cpus": 2.0}, "remote placement"),
+        ({"node": "hc1", "repo": "r"}, "come together"),
+    ],
+)
+def test_run_rejects_contradictory_placement(
+    monkeypatch: pytest.MonkeyPatch, kwargs: dict[str, object], match: str
+) -> None:
     journal = install(monkeypatch)
 
     async def main() -> None:
-        await fabric.run(int, local=False)
+        await fabric.run(int, **kwargs)
 
-    with pytest.raises(NotImplementedError, match="local-only"):
+    with pytest.raises(ValueError, match=match):
         run(main())
     assert journal.facts == []  # rejected before any journal write
+
+
+def test_run_remote_records_target_node_and_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+    placement = remote.Placement(node="hc1", label="host_hc1")
+    shipped: list[tuple[object, ...]] = []
+
+    async def fake_prepare(node: str) -> remote.Placement:
+        assert node == "hc1"
+        return placement
+
+    async def fake_execute(*args: object, **kwargs: object) -> object:
+        shipped.append(args)
+        return 7
+
+    monkeypatch.setattr(remote, "prepare", fake_prepare)
+    monkeypatch.setattr(remote, "execute", fake_execute)
+
+    def seven() -> int:
+        return 7
+
+    async def main() -> tuple[fabric.RunHandle, object]:
+        handle = await fabric.run(seven, node="hc1")
+        return handle, await handle.wait()
+
+    handle, value = run(main())
+    assert value == 7
+    assert shipped
+    assert shipped[0][0] is placement
+    # The ask's node fact names the TARGET, not the submitting host.
+    assert (handle.task, "node", "hc1") in journal.facts
+    assert journal.states(handle.task) == ["submitted", "running", "done"]
+
+
+def test_run_remote_bad_target_raises_before_facts(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+
+    async def fake_prepare(node: str) -> remote.Placement:
+        raise remote.FabricError(f"no live Ray node advertises 'host_{node}'")
+
+    monkeypatch.setattr(remote, "prepare", fake_prepare)
+
+    async def main() -> None:
+        await fabric.run(int, node="ghost")
+
+    with pytest.raises(remote.FabricError, match="host_ghost"):
+        run(main())
+    assert journal.facts == []  # a bad target fails the run() call itself
+
+
+# --- fabric.remote submit-time checks ------------------------------------------
+
+
+def test_local_env_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(remote.ENV_VAR, raising=False)
+    with pytest.raises(remote.FabricError, match="IX_FABRIC_ENV"):
+        remote.local_env()
+
+
+def test_check_host_label_names_known_hosts() -> None:
+    resources = {"host_hc1": 1.0, "host_hydra": 1.0, "CPU": 8.0}
+    assert remote.check_host_label("hc1", resources) == "host_hc1"
+    with pytest.raises(remote.FabricError, match=r"host_ghost.*hc1.*hydra"):
+        remote.check_host_label("ghost", resources)
+
+
+def test_check_env_skew_names_both_sides() -> None:
+    local = "fabric_env:py3.13-ray2.56.0"
+    remote.check_env("hc1", {local: 1.0, "CPU": 8.0}, local)
+    with pytest.raises(remote.EnvSkewError, match=r"py3\.13-ray2\.56\.0.*py3\.12-ray2\.44\.0"):
+        remote.check_env("hc1", {"fabric_env:py3.12-ray2.44.0": 1.0}, local)
+    with pytest.raises(remote.EnvSkewError, match="no fabric_env resource"):
+        remote.check_env("hc1", {"CPU": 8.0}, local)
+
+
+def test_zero_restart_policy_everywhere() -> None:
+    # Policy, not a default: no caller input reaches these, so this is the
+    # one place a restarted-runner path could sneak back in.
+    actor = remote.actor_options("hc1")
+    assert actor["max_restarts"] == 0
+    assert actor["lifetime"] == "detached"
+    assert actor["name"] == "runner:hc1"
+    assert remote.task_options("hc1", cpus=4)["max_retries"] == 0
+
+
+def test_runner_payload_roundtrip_through_ray_cloudpickle() -> None:
+    from ray import cloudpickle
+
+    offset = 100
+
+    def work(a: int, b: int) -> int:  # a closure: travels by value
+        return a + b + offset
+
+    payload = cloudpickle.dumps(
+        remote._Task(fn=work, args=(2, 3), kwargs={}, workspace=None)
+    )
+    out = run(remote.Runner().run(payload))
+    assert cloudpickle.loads(out) == 105
+
+
+def _git_fixture(root: Path) -> tuple[str, str]:
+    """A two-commit repo; returns (repo path, first rev)."""
+    import subprocess
+
+    repo = root / "fixture"
+    repo.mkdir()
+    env_git = ["git", "-C", str(repo), "-c", "user.name=t", "-c", "user.email=t@t"]
+    subprocess.run([*env_git[:3], "init", "-q", "-b", "main"], check=True)
+    (repo / "data.txt").write_text("one")
+    subprocess.run([*env_git, "add", "data.txt"], check=True)
+    subprocess.run([*env_git, "commit", "-qm", "one"], check=True)
+    first = subprocess.run(
+        [*env_git[:3], "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    (repo / "data.txt").write_text("two")
+    subprocess.run([*env_git, "commit", "-qam", "two"], check=True)
+    return str(repo), first
+
+
+def test_workspace_materializes_exact_rev(tmp_path: Path) -> None:
+    repo, first = _git_fixture(tmp_path)
+    checkout = remote.materialize(remote.Workspace(repo=repo, rev=first))
+    assert (checkout / "data.txt").read_text() == "one"  # the pinned rev, not HEAD
+    with pytest.raises(remote.FabricError, match="checkout"):
+        remote.materialize(remote.Workspace(repo=repo, rev="0" * 40))
+
+
+def test_runner_hands_workspace_path_and_cleans_up(tmp_path: Path) -> None:
+    from ray import cloudpickle
+
+    repo, first = _git_fixture(tmp_path)
+
+    # cloudpickle ships closures by value, so report the workdir through the
+    # return value rather than a captured list.
+    def read(workdir: Path) -> tuple[str, str]:
+        return str(workdir), (workdir / "data.txt").read_text()
+
+    payload = cloudpickle.dumps(
+        remote._Task(fn=read, args=(), kwargs={}, workspace=remote.Workspace(repo=repo, rev=first))
+    )
+    out = run(remote.Runner().run(payload))
+    workdir, content = cloudpickle.loads(out)
+    assert content == "one"
+    assert not Path(workdir).exists()  # per-run scratch removed after the run
 
 
 def test_run_interrupt_records_interrupted(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3163,6 +3163,21 @@
         message = "ix-ray launcher must exec `ray start` (the `start` subcommand ahead of --head/--address), never `ray --head`";
       }
       {
+        # The fabric labels declared as data in lib/fabric.nix must reach the
+        # daemon's argv: the rendered launcher carries `--resources` JSON with
+        # the host label, the os label, and the env-handshake resource
+        # (index#3192). Guards the option -> nodeResources -> argv wiring, not
+        # the literal values.
+        assertion = let
+          workerScript = builtins.readFile ixRayWorker.systemd.services.ix-ray.serviceConfig.ExecStart;
+        in
+          lib.hasInfix "--resources" workerScript
+          && lib.hasInfix "host_" workerScript
+          && lib.hasInfix "fabric_env:" workerScript
+          && lib.hasInfix "linux" workerScript;
+        message = "ix-ray must advertise the fabric labels (host_<name>, os, fabric_env:<tag>) via --resources";
+      }
+      {
         # A worker with no headAddress cannot know where to join: fail eval.
         assertion = let
           failures = failedAssertionsFor [


### PR DESCRIPTION
Phase 2 of #3190. Closes #3192.

## What shipped
- `lib/fabric.nix`: one Nix-pinned fabric env (python 3.13.13, ray 2.56.0, cloudpickle vendored by ray) with env tag `py3.13-ray2.56.0` and resource `fabric_env:py3.13-ray2.56.0`. `RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1` and `RAY_ENABLE_MAC_LARGE_OBJECT_STORE=1` are set only on the wrapped `ray` binary, never user shells. The env bundles ray's `client` extra (grpcio): plain nixpkgs `ps.ray` refuses to start a head with `--ray-client-server-port` at all (`ValueError: Ray Client requires pip package ray[client]`), found live.
- `modules/services/ray`: head/worker roles; head on hil-compute-1 (gcs 6379, client server 10001), workers join over the tailnet with fixed node/object-manager and worker port ranges. Per-host custom resources (`host_<name>`, `linux`/`darwin`, `fabric_env:<tag>`, `gpu`) are derived in `lib/fabric.nix` as data, no hand-kept enumeration. `modules/darwin/ray.nix` puts macs behind a flag.
- `fabric/remote.py`: per-node detached named async runner actor `runner:<host>` (`num_cpus=0`, high `max_concurrency`, `max_restarts=0` always); sync fns auto-wrapped in `asyncio.to_thread`; CPU-bound opt-in with honest `num_cpus`. `prepare()` fails loud at submit on a missing host label or env skew (no fallback, no silent queueing). Tasks carry cloudpickle payloads; a `Workspace(repo, rev)` is materialized as a fresh clone per run and scrubbed after.
- `fabric.run(node=...)` routes through the runner and journals facts; the mcp env gains the same derived ray client extra so the kernel can reach `ray://`.

## Validation
Unit tests (fakes), all passing in `nix build` gates (23 tests) plus zuban strict + ruff + repo lint:
- fact contract, argument validation, zero-restart policy, cloudpickle round trip, workspace materialization + scrub.

Live (ad-hoc head on hil-compute-2; hil-compute-1 sshd has a session-channel wedge, tracked separately):
- darwin/arm64 (hydra) -> linux/x86_64 dynamic function round trip over `ray://` returned `('hil-compute-2', 'x86_64', '2.56.0')`.
- bad node -> `FabricError` naming known hosts; skewed `IX_FABRIC_ENV` -> `EnvSkewError` naming both tags.
- `--resources` verified in the raylet argv (`--static_resource_list=host_hil-compute-2,1,linux,1,fabric_env:py3.13-ray2.56.0,1,...`).

Manual fleet validation once deployed:
```
ssh hil-compute-1 systemctl status ix-ray
python -c "import ray; ray.init('ray://<head>:10001'); print(ray.cluster_resources())"
```
Expect one `host_<name>` per node plus `fabric_env:py3.13-ray2.56.0` on every node.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Ray fleet cluster remote execution support with Nix fabric env and mac worker module
> - Introduces [lib/fabric.nix](https://github.com/indexable-inc/index/pull/3218/files#diff-26b44d4af24930e5798a18f9282b9485f2516cc000b25e9830b7cf7ed3b7f007) with cluster env vars, pinned inter-node ports, node resource helpers, and a wrapped `ray` binary (`rayEnv`) that includes the Ray Client extra and mac cluster gate env vars.
> - Adds a new nix-darwin module [modules/darwin/ray.nix](https://github.com/indexable-inc/index/pull/3218/files#diff-a6bc042d68a40f9bdad20992cbc11f2ed245b6e07cc919c9da498b77a9a253d1) (`services.ix-ray`) that starts a launchd daemon joining a Ray head node, advertising host/os/env labels and binding to the machine's Tailscale IPv4.
> - Extends [modules/services/ray/default.nix](https://github.com/indexable-inc/index/pull/3218/files#diff-fcb55115d0f76c61bd91044049504b687d342d6087ea0e2046702ed9a5133333) (NixOS Ray service) to advertise host/os/env/gpu resources and use `indexLib.fabric.rayEnv` as the default package, with ports centralized via `lib.fabric`.
> - Adds [packages/mcp/src/fabric/fabric/remote.py](https://github.com/indexable-inc/index/pull/3218/files#diff-4ff4cd790168593b7c4c7b0c95b4f9de9092be8d6821c6e5e8baf7e7f98a7a14) implementing remote task placement over Ray with submit-time env handshake, host label validation, optional CPU reservation, per-run workspace materialization via git clone, and cancellation support.
> - Extends `fabric.run` in [packages/mcp/src/fabric/fabric/__init__.py](https://github.com/indexable-inc/index/pull/3218/files#diff-4296e34ab4fac6c0d5c1e02c185abf6314d10be93f0ab536a5b7f7d61f588bd6) to support remote placement via a `node` argument, with submit-time validation before any journal facts are written.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02ea38d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->