### PR TITLE
workstation: pin Claude stable path to wrapper

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -1013,6 +1013,13 @@ in {
     source = config.lib.file.mkOutOfStoreSymlink "${configDir}/mitmproxy";
   };
 
+  # Claude's self-managed updater writes here, ahead of the Home Manager
+  # profile on PATH. Keep that path pinned to the declarative wrapper (#3222).
+  home.file.".local/bin/claude" = {
+    source = "${config.programs.claude-code.finalPackage}/bin/claude";
+    force = true;
+  };
+
   # Agents, commands, and skills are managed declaratively by the upstream
   # home-manager programs.claude-code module: each is written as an in-store
   # path under ~/.claude (no out-of-store symlink, no SessionStart hook).


### PR DESCRIPTION
## Summary

Restore Home Manager ownership of `~/.local/bin/claude` so Anthropic's self-managed installer cannot shadow the declarative index wrapper.

## Evidence

* `zsh -lic 'command -v claude'` resolved to `~/.local/bin/claude` after #3185.
* The live affected process had no index launch arguments, while `~/.nix-profile/bin/claude` carries `IX_LAUNCH_SPEC`.
* `nix run .#lint -- --json` passes.

PR #3129 touches a separate hunk in the same file.

Fixes #3222

Authored by Codex (GPT-5.4).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `~/.local/bin/claude` to the declarative claude-code wrapper in workstation config
> Adds a Home Manager `home.file` entry in [workstation.nix](https://github.com/indexable-inc/index/pull/3223/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) that creates `~/.local/bin/claude` as a managed link to `${config.programs.claude-code.finalPackage}/bin/claude` with `force = true`, ensuring the path always points to the declaratively managed binary rather than any manually installed version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca9274f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->