### PR TITLE
claude-code: block every updater path

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -479,8 +479,10 @@
   # preserving argv0. No settings ride argv: the computed defaults materialize
   # into the writable user settings layer via `passthru.settings` (#3180),
   # where they stay overridable and readable. The store output is read-only so
-  # the bundled self-updater could never write: DISABLE_AUTOUPDATER turns it off,
-  # the install checks are skipped, and USE_BUILTIN_RIPGREP=0 pins search to the
+  # the bundled self-updater must never mutate it. DISABLE_UPDATES blocks every
+  # update path, including `claude update` and `claude install`:
+  # https://code.claude.com/docs/en/getting-started#disable-auto-updates
+  # The install checks are skipped, and USE_BUILTIN_RIPGREP=0 pins search to the
   # Nix ripgrep on PATH so the wrapper owns the version pin. `target` is an
   # `@helper@` placeholder substituted at install time (the real binary lives
   # under `$out/libexec`, unknowable here). Covered by the installCheck argv
@@ -489,7 +491,7 @@
     target = "@helper@";
     env =
       {
-        DISABLE_AUTOUPDATER = "1";
+        DISABLE_UPDATES = "1";
         DISABLE_INSTALLATION_CHECKS = "1";
         USE_BUILTIN_RIPGREP = "0";
         IX_CLAUDE_SKILLS_DIR = "${agentSkillsDir}";

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -40,6 +40,13 @@
         "$PWD/test-spec.json"
     }
 
+    if ! ${lib.getExe jq} -e \
+      '.env.DISABLE_UPDATES == "1" and (.env | has("DISABLE_AUTOUPDATER") | not)' \
+      "$PWD/test-spec.json" >/dev/null; then
+      printf 'claude launcher env check failed: strict update disable is missing or legacy background-only disable remains\n' >&2
+      exit 1
+    fi
+
     skills_dir="$(spec_env IX_CLAUDE_SKILLS_DIR)"
     if [ ! -d "$skills_dir" ]; then
       printf 'claude launcher env check failed: IX_CLAUDE_SKILLS_DIR is not a directory: %s\n' \


### PR DESCRIPTION
## Summary

Use Anthropic’s strict `DISABLE_UPDATES=1` launch environment contract for the Nix-managed Claude Code wrapper. This blocks background checks plus explicit `claude update` and `claude install`; `DISABLE_AUTOUPDATER` only blocks the background check.

The install check now requires the strict variable and rejects the legacy variable. `packages/agent/claude-code/manifest.json` remains untouched for #2660.

Source: https://code.claude.com/docs/en/getting-started#disable-auto-updates

## Validation

- `nix build .#claude-code --print-build-logs`
- `nix run .#lint`

Closes #3224

(sent by Codex, GPT-5.4)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block all claude-code update paths by replacing `DISABLE_AUTOUPDATER` with `DISABLE_UPDATES`
> - Renames the env variable in the [claude-code launcher](https://github.com/indexable-inc/index/pull/3226/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) from `DISABLE_AUTOUPDATER=1` to `DISABLE_UPDATES=1` to cover all update paths, not just the auto-updater.
> - Updates [install-check.sh](https://github.com/indexable-inc/index/pull/3226/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) to assert `DISABLE_UPDATES=1` is present and that the legacy `DISABLE_AUTOUPDATER` key is absent, failing the build if either condition is violated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0332ca3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->