### PR TITLE
nushell: add structured commits command

### DIFF
--- a/users/andrewgazelka/config/nushell/config.nu
+++ b/users/andrewgazelka/config/nushell/config.nu
@@ -1856,6 +1856,23 @@ def packages [] {
 
 
 
+def commits [] {
+    ^git log --format="%H%x00%aN%x00%aE%x00%aI%x00%s%x00"
+    | split row (char nul)
+    | drop
+    | chunks 5
+    | each {|row|
+        {
+            hash: ($row.0 | str trim)
+            author: $row.1
+            email: $row.2
+            authored_at: ($row.3 | into datetime)
+            subject: $row.4
+        }
+    }
+}
+
+
 def git-files [
     dir: string = ''       # Directory path or prefix filter
     --glob: glob           # Optional glob pattern to filter files (e.g., '*.rs', '**/*.toml')


### PR DESCRIPTION
## Summary

* add `commits`, which returns Git history as native Nushell records
* parse NUL-delimited Git fields and type `authored_at` as a datetime

## Validation

* `nix run .#lint`
* isolated Nushell execution against repository history

Closes #3227

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `commits` command to nushell config that returns structured git log records
> Adds a `commits` def to [config.nu](https://github.com/indexable-inc/index/pull/3229/files#diff-627a418eac8fc15bab29ef833dc9d31b38469a2dd272021e8640a29425a9cdae) that runs `git log` with a NUL-delimited format, parses the output, and returns a table of records with `hash`, `author`, `email`, `authored_at` (as datetime), and `subject` fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f353ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->