### PR TITLE
macos guests: add ssh subcommand

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -589,7 +589,7 @@
       mutable-files = mutableFilesHomeModule;
       # Reusable workstation module (macOS): declare vmkit macOS guest VMs
       # (ssh endpoint, launchd agents from structured attrs, pinned binaries)
-      # and get an idempotent `macos-guest-<name>` push command per guest.
+      # and get a `macos-guest-<name>` apply/status/ssh command per guest.
       # Import it and set `macosGuests.<name> = { ssh = ...; ... }`. Manual
       # TCC bootstrap: modules/home/macos-guests/tcc-bootstrap.md. See
       # modules/home/macos-guests.nix (index#3206, toward index#2682).

--- a/modules/home/macos-guests.nix
+++ b/modules/home/macos-guests.nix
@@ -4,7 +4,8 @@
 # structured Nix attrs and pinned binaries — and get one idempotent
 # `macos-guest-<name>` command that pushes only drift over ssh and bootstraps
 # launchd (bootout + bootstrap in the gui domain) only for changed or
-# unloaded agents. `macos-guest-<name> status` reports drift read-only.
+# unloaded agents. `macos-guest-<name> ssh` opens a shell, while `status`
+# reports drift read-only.
 #
 # The guest bundle itself stays a stateful pet until #2683's mkMacGuest lands:
 # VM creation, Apple ID sign-in, and the GUI-only TCC grants are manual
@@ -158,7 +159,7 @@
   applyFor = name: guest:
     ix.writeNushellApplication pkgs {
       name = "macos-guest-${name}";
-      meta.description = "Push declared state to the ${name} macOS guest and bootstrap launchd";
+      meta.description = "Manage declared state and open an ssh shell for the ${name} macOS guest";
       text = ''
         # nu
         const manifest_file = "${guestManifest name guest}"
@@ -172,6 +173,10 @@
           ^/usr/bin/ssh -o BatchMode=yes $tgt $cmd
         }
 
+        def ssh-target [spec: record] {
+          $"($spec.ssh.user)@($spec.ssh.host)"
+        }
+
         # null when the file is absent on the guest.
         def remote-hash [tgt: string, path: string] {
           let probe = do { ^/usr/bin/ssh -o BatchMode=yes $tgt $"shasum -a 256 '($path)'" } | complete
@@ -181,7 +186,7 @@
         # One row per resource: local vs guest content hash.
         def drift-table [] {
           let spec = open $manifest_file
-          let tgt = $"($spec.ssh.user)@($spec.ssh.host)"
+          let tgt = ssh-target $spec
           $spec.resources | each {|r|
             let remote_path = $"($spec.home)/($r.target)"
             let local = open --raw $r.source | hash sha256
@@ -202,7 +207,7 @@
         # the terminal check reads each agent's live launchd state.
         def main [] {
           let spec = open $manifest_file
-          let tgt = $"($spec.ssh.user)@($spec.ssh.host)"
+          let tgt = ssh-target $spec
           let uid = ssh-run $tgt "id -u" | str trim
           for row in (drift-table) {
             if $row.in_sync {
@@ -258,6 +263,12 @@
             exit 1
           }
         }
+
+        # Open an interactive guest shell or run one command.
+        def --wrapped "main ssh" [...command: string] {
+          let spec = open $manifest_file
+          exec /usr/bin/ssh -o BatchMode=yes (ssh-target $spec) ...$command
+        }
       '';
     };
 
@@ -276,7 +287,7 @@ in {
     default = {};
     description = ''
       vmkit macOS guest VMs whose in-guest state (launchd agents, pinned
-      binaries) is declared here and pushed over ssh by the generated
+      binaries) is declared here and managed over ssh by the generated
       `macos-guest-<name>` command. See modules/home/macos-guests/tcc-bootstrap.md
       for the manual TCC bootstrap a fresh guest still needs.
     '';

--- a/users/andrewgazelka/guests/README.md
+++ b/users/andrewgazelka/guests/README.md
@@ -17,6 +17,8 @@ vmkit guest at `~/.local/share/vmkit/guests/macos-primary`, auto-login user
 ```sh
 macos-guest-macos-primary          # idempotent apply
 macos-guest-macos-primary status   # read-only drift report, exit 1 on drift
+macos-guest-macos-primary ssh      # interactive guest shell
+macos-guest-macos-primary ssh -- sw_vers  # run one guest command
 ```
 
 ### One-time bootstrap (stateful / GUI-gated, deliberately not applied)


### PR DESCRIPTION
## Summary

- add `macos-guest-<name> ssh [command...]` for an interactive shell or one remote command
- render the declared SSH target in one helper shared by apply, status, and ssh
- document the personal `macos-primary` command

## Validation

- `nix run .#lint`
- built a minimal Home Manager evaluation of `homeModules.macos-guests`
- generated command help exposes `ssh` and `status`

Live connection validation is pending because the macOS guest is currently unreachable at `192.168.64.6`.

Refs #2682

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ssh` subcommand to `macos-guest-<name>` management tool
> - Adds a `ssh` subcommand to the generated `macos-guest-<name>` scripts that opens an interactive shell or runs a single command on the guest via `/usr/bin/ssh`.
> - Extracts a shared `ssh-target` helper in the embedded Nushell script to centralize `user@host` construction, replacing inline string interpolation in `drift-table` and `main`.
> - Updates [flake.nix](https://github.com/indexable-inc/index/pull/3230/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) comments and [modules/home/macos-guests.nix](https://github.com/indexable-inc/index/pull/3230/files#diff-1859e24dc83f1789b6f094a04c78bde5f99b308320e6473f216913e9582ce56a) option descriptions to reflect the new subcommand.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40030a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->