### PR TITLE
finder-spin-watchdog: lower CPU pre-filter to 25%

### DIFF
--- a/users/andrewgazelka/config/scripts/finder-spin-watchdog.sh
+++ b/users/andrewgazelka/config/scripts/finder-spin-watchdog.sh
@@ -14,9 +14,12 @@
 # Detection:
 #   - macOS `ps` reports pcpu 0.0 for Finder, so real CPU comes from the SECOND
 #     sample of `top -l 2` (the first sample is a since-boot average).
-#   - CPU > 50% alone is not enough (a big copy also spikes Finder): the fix
+#   - High CPU alone is not enough (a big copy also spikes Finder): the fix
 #     only fires when `sample <pid> 3` shows SynchronizeChildren
-#     (DesktopServicesPriv) on a stack.
+#     (DesktopServicesPriv) on a stack. That sample check is the real
+#     false-positive guard, so the CPU threshold is only a cheap pre-filter:
+#     25 not 50 because on 2026-07-14 a just-relaunched Finder respun at
+#     35-50% CPU for 9.5h undetected at threshold 50 (nix#66).
 #
 # Remediation (order matters, validated live 2026-07-07):
 #   1. `defaults delete com.apple.finder FXRecentFolders` FIRST: prevents the
@@ -29,7 +32,7 @@
 # with the sample excerpt (stdout/stderr land in
 # ~/Library/Logs/finder-spin-watchdog.log via launchd). No silent activations.
 
-threshold=50
+threshold=25
 
 log() {
   printf '%s finder-spin-watchdog: %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*"


### PR DESCRIPTION
On 2026-07-14 the watchdog killed a spinning Finder at 03:59:41 PT; the relaunched Finder immediately respun at 35-50% CPU for 9.5 hours undetected because `threshold=50`. The `sample` + `SynchronizeChildren` signature check is the real false-positive guard (high CPU without the signature is never remediated), so the CPU threshold is only a cheap pre-filter and can safely drop to 25.

Refs https://github.com/andrewgazelka/nix/issues/66

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lower `finder-spin-watchdog` CPU pre-filter threshold from 50% to 25%
> Reduces the `threshold` variable in [finder-spin-watchdog.sh](https://github.com/indexable-inc/index/pull/3234/files#diff-653a81587e1d8fc88ddeb31db57418cf73e814dbfa229d6710167d1396046271) so Finder is considered high-CPU at ≥25% instead of ≥50%, causing detection and remediation steps to trigger more frequently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66e80c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->