### PR TITLE
vmkit: supervise macOS guests with launchd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -454,7 +454,9 @@
     # agents from structured attrs, pinned binaries, idempotent ssh apply).
     # One instance shared by homeModules.macos-guests and the personal darwin
     # profile. See modules/home/macos-guests.nix.
-    macosGuestsHomeModule = import ./modules/home/macos-guests.nix {inherit ix;};
+    macosGuestsHomeModule = import ./modules/home/macos-guests.nix {
+      inherit indexPackages ix;
+    };
     claudeCodeHomeModule = import ./packages/agent/home-manager/claude-code.nix {
       inherit indexPackages;
       promptModule = ./packages/agent/prompt;

--- a/modules/home/macos-guests.nix
+++ b/modules/home/macos-guests.nix
@@ -310,7 +310,7 @@
       RunAtLoad = true;
       ProcessType = "Background";
       ThrottleInterval = 10;
-      ExitTimeOut = 120;
+      ExitTimeOut = 60;
       StandardOutPath = guest.lifecycle.logPath;
       StandardErrorPath = guest.lifecycle.logPath;
     };

--- a/modules/home/macos-guests.nix
+++ b/modules/home/macos-guests.nix
@@ -12,13 +12,19 @@
 # bootstrap (see ./macos-guests/tcc-bootstrap.md). Consumers hold only data:
 # the guest spec, plist attrs, and pinned binary packages (hashes live in the
 # owning package's pins.json, never inline — see e.g. packages/bbctl).
-{ix}: {
+{
+  indexPackages,
+  ix,
+}: {
   config,
   lib,
   pkgs,
   ...
 }: let
   cfg = config.macosGuests;
+  homeDirectory = config.home.homeDirectory;
+  indexPkgs = indexPackages pkgs.stdenv.hostPlatform.system;
+  inherit (indexPkgs) vmkit;
   jsonFormat = pkgs.formats.json {};
 
   # The one plist renderer: structured attrs in, XML out. User config never
@@ -78,8 +84,25 @@
 
       vmkitGuestDir = lib.mkOption {
         type = lib.types.str;
-        default = "~/.local/share/vmkit/guests/${name}";
+        default = "${homeDirectory}/.local/share/vmkit/guests/${name}";
         description = "Host-side vmkit bundle directory for this guest.";
+      };
+
+      lifecycle = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether launchd keeps this guest running on the host.";
+        };
+        macAddress = lib.mkOption {
+          type = lib.types.strMatching "[0-9a-f][26ae](:[0-9a-f]{2}){5}";
+          description = "Stable locally administered unicast MAC address for the guest.";
+        };
+        logPath = lib.mkOption {
+          type = lib.types.str;
+          default = "${homeDirectory}/Library/Logs/macos-guest-${name}.log";
+          description = "Host path receiving vmkit stdout and stderr.";
+        };
       };
 
       launchAgents = lib.mkOption {
@@ -272,6 +295,27 @@
       '';
     };
 
+  lifecycleAgent = _: guest: {
+    enable = guest.lifecycle.enable;
+    config = {
+      ProgramArguments = [
+        (lib.getExe vmkit)
+        "run-macos"
+        "--bundle"
+        guest.vmkitGuestDir
+        "--mac-address"
+        guest.lifecycle.macAddress
+      ];
+      KeepAlive = true;
+      RunAtLoad = true;
+      ProcessType = "Background";
+      ThrottleInterval = 10;
+      ExitTimeOut = 120;
+      StandardOutPath = guest.lifecycle.logPath;
+      StandardErrorPath = guest.lifecycle.logPath;
+    };
+  };
+
   labelAssertions = lib.concatLists (lib.mapAttrsToList (
       name: guest:
         lib.mapAttrsToList (label: agent: {
@@ -296,5 +340,6 @@ in {
   config = lib.mkIf (cfg != {}) {
     assertions = labelAssertions;
     home.packages = lib.mapAttrsToList applyFor cfg;
+    launchd.agents = lib.mapAttrs lifecycleAgent cfg;
   };
 }

--- a/packages/vm/vmkit/README.md
+++ b/packages/vm/vmkit/README.md
@@ -95,6 +95,10 @@ What works today:
   screenshots its display to PNGs, with no visible window, no
   ScreenCaptureKit, and no Screen-Recording permission (see
   [Off-screen capture](#off-screen-capture)).
+- `run-macos` runs an installed macOS guest as a headless foreground process
+  for launchd or another supervisor. A stable locally administered MAC keeps
+  the guest's network identity across restarts. SIGTERM and SIGINT request a
+  clean guest shutdown.
 - `drive-macos` boots the guest off-screen and reads newline commands from
   stdin to drive it: synthetic keyboard (`key`/`down`/`up`/`type`), mouse
   (`click`), `wait`, and on-demand `shot`, with a one-line ack per command (see
@@ -222,6 +226,7 @@ nix run .#vmkit -- install-macos --ipsw ./UniversalMac_26.5_Restore.ipsw --bundl
 # omit --password-stdin for an empty password.
 printf '%s' "$PASSWORD" | nix run .#vmkit -- provision --bundle ./guest --user ix --autologin --password-stdin
 nix run .#vmkit -- drive-macos --bundle ./guest   # lands on the desktop, no Setup Assistant
+nix run .#vmkit -- run-macos --bundle ./guest --mac-address 0e:c9:c7:6c:25:a8
 ```
 
 It attaches the bundle's `disk.img` read-write with no auto-mount, finds the

--- a/packages/vm/vmkit/src/macguest.rs
+++ b/packages/vm/vmkit/src/macguest.rs
@@ -9,17 +9,20 @@
 //! github.com/thecrypticace/vzautomation.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use block2::RcBlock;
 use dispatch2::{DispatchQueue, dispatch_main};
 use objc2::rc::Retained;
-use objc2::runtime::AnyObject;
-use objc2::{AllocAnyThread, MainThreadMarker};
+use objc2::runtime::{AnyObject, ProtocolObject};
+use objc2::{AllocAnyThread, MainThreadMarker, MainThreadOnly, define_class};
 use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSWindow, NSWindowStyleMask,
 };
-use objc2_foundation::{NSArray, NSData, NSError, NSPoint, NSRect, NSSize, NSString};
+use objc2_foundation::{
+    NSArray, NSData, NSError, NSObject, NSObjectProtocol, NSPoint, NSRect, NSSize, NSString,
+};
 use objc2_io_surface::{IOSurface, IOSurfaceLockOptions, IOSurfaceRef};
 // Named explicitly so the dependency is a direct, visible use (the type is
 // otherwise only reachable through `NSView::layer()`'s return type).
@@ -27,7 +30,7 @@ use objc2_quartz_core::CALayer;
 use objc2_virtualization::{
     VZBootLoader, VZDirectoryShare, VZDirectorySharingDeviceConfiguration,
     VZDiskImageStorageDeviceAttachment, VZGraphicsDeviceConfiguration, VZKeyboardConfiguration,
-    VZMacAuxiliaryStorage, VZMacAuxiliaryStorageInitializationOptions,
+    VZMACAddress, VZMacAuxiliaryStorage, VZMacAuxiliaryStorageInitializationOptions,
     VZMacGraphicsDeviceConfiguration, VZMacGraphicsDisplayConfiguration, VZMacHardwareModel,
     VZMacMachineIdentifier, VZMacOSBootLoader, VZMacOSInstaller, VZMacOSRestoreImage,
     VZMacPlatformConfiguration, VZNATNetworkDeviceAttachment, VZNetworkDeviceConfiguration,
@@ -35,13 +38,52 @@ use objc2_virtualization::{
     VZSingleDirectoryShare, VZStorageDeviceConfiguration, VZUSBKeyboardConfiguration,
     VZUSBScreenCoordinatePointingDeviceConfiguration, VZVirtioBlockDeviceConfiguration,
     VZVirtioFileSystemDeviceConfiguration, VZVirtioNetworkDeviceConfiguration, VZVirtualMachine,
-    VZVirtualMachineConfiguration, VZVirtualMachineView,
+    VZVirtualMachineConfiguration, VZVirtualMachineDelegate, VZVirtualMachineView,
 };
 
 use crate::imp::{Error, file_url, ns_error_message};
 
 /// `kCVPixelFormatType_32BGRA` ('BGRA'): the layout the `IOSurface` read assumes.
 const PIXEL_FORMAT_BGRA: u32 = 0x4247_5241;
+
+static STOP_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn request_stop(_signal: libc::c_int) {
+    STOP_REQUESTED.store(true, Ordering::Relaxed);
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "VmkitVirtualMachineDelegate"]
+    struct VirtualMachineDelegate;
+
+    unsafe impl NSObjectProtocol for VirtualMachineDelegate {}
+
+    unsafe impl VZVirtualMachineDelegate for VirtualMachineDelegate {
+        #[unsafe(method(guestDidStopVirtualMachine:))]
+        fn guest_did_stop(&self, _virtual_machine: &VZVirtualMachine) {
+            eprintln!("vmkit: guest stopped");
+            std::process::exit(0);
+        }
+
+        #[unsafe(method(virtualMachine:didStopWithError:))]
+        fn virtual_machine_did_stop(&self, _virtual_machine: &VZVirtualMachine, error: &NSError) {
+            eprintln!(
+                "vmkit: guest stopped with error: {}",
+                ns_error_message(error)
+            );
+            std::process::exit(1);
+        }
+    }
+);
+
+impl VirtualMachineDelegate {
+    fn new(mtm: MainThreadMarker) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(());
+        unsafe { objc2::msg_send![super(this), init] }
+    }
+}
 
 /// A host directory shared into the guest over virtio-fs (read-write).
 pub struct DirShare {
@@ -74,13 +116,76 @@ pub fn start_guest_offscreen(
     bundle: &Path,
     shares: &[DirShare],
 ) -> Result<Retained<VZVirtualMachineView>, Error> {
-    let config = build_macos_config(bundle, shares)?;
+    let config = build_macos_config(bundle, shares, None)?;
     if let Err(error) = unsafe { config.validateWithError() } {
         return Err(Error::InvalidConfiguration {
             message: ns_error_message(&error),
         });
     }
     Ok(start_vm_offscreen(mtm, &config))
+}
+
+/// Run a macOS guest as a supervisor-owned foreground process.
+pub fn run_macos(bundle: &Path, mac_address: &str, shares: &[DirShare]) -> Result<(), Error> {
+    let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread)?;
+    let config = build_macos_config(bundle, shares, Some(mac_address))?;
+    if let Err(error) = unsafe { config.validateWithError() } {
+        return Err(Error::InvalidConfiguration {
+            message: ns_error_message(&error),
+        });
+    }
+
+    let vm = unsafe { VZVirtualMachine::initWithConfiguration(VZVirtualMachine::alloc(), &config) };
+    let delegate = VirtualMachineDelegate::new(mtm);
+    unsafe {
+        vm.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+    }
+
+    let completion = RcBlock::new(|error: *mut NSError| {
+        if error.is_null() {
+            eprintln!("vmkit: guest started");
+        } else {
+            eprintln!(
+                "vmkit: guest failed to start: {}",
+                ns_error_message(unsafe { &*error })
+            );
+            std::process::exit(1);
+        }
+    });
+    unsafe { vm.startWithCompletionHandler(&completion) };
+
+    STOP_REQUESTED.store(false, Ordering::Relaxed);
+    unsafe {
+        libc::signal(
+            libc::SIGTERM,
+            request_stop as *const () as libc::sighandler_t,
+        );
+        libc::signal(
+            libc::SIGINT,
+            request_stop as *const () as libc::sighandler_t,
+        );
+    }
+    let vm_ptr = Retained::into_raw(vm) as usize;
+    std::thread::spawn(move || {
+        while !STOP_REQUESTED.load(Ordering::Relaxed) {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        DispatchQueue::main().exec_async(move || {
+            let vm = unsafe { &*(vm_ptr as *const VZVirtualMachine) };
+            eprintln!("vmkit: requesting guest shutdown");
+            if let Err(error) = unsafe { vm.requestStopWithError() } {
+                eprintln!(
+                    "vmkit: guest shutdown request failed: {}",
+                    ns_error_message(&error)
+                );
+                std::process::exit(1);
+            }
+        });
+    });
+
+    std::mem::forget(delegate);
+    std::mem::forget(completion);
+    dispatch_main();
 }
 
 /// Off-screen window + `VZVirtualMachineView` + VM start for any already-built,
@@ -556,7 +661,7 @@ fn start_install(bundle: &Path, ipsw: &Path, hw_data: &[u8], disk_gib: u64) -> R
         message: format!("create aux storage: {}", ns_error_message(&e)),
     })?;
 
-    let config = build_macos_config(bundle, &[])?;
+    let config = build_macos_config(bundle, &[], None)?;
     if let Err(error) = unsafe { config.validateWithError() } {
         return Err(Error::InvalidConfiguration {
             message: ns_error_message(&error),
@@ -598,6 +703,7 @@ fn start_install(bundle: &Path, ipsw: &Path, hw_data: &[u8], disk_gib: u64) -> R
 fn build_macos_config(
     bundle: &Path,
     shares: &[DirShare],
+    mac_address: Option<&str>,
 ) -> Result<Retained<VZVirtualMachineConfiguration>, Error> {
     let hw_data = std::fs::read(bundle.join("hardware-model.bin")).map_err(|e| Error::Bundle {
         message: format!("hardware-model.bin: {e}"),
@@ -669,7 +775,17 @@ fn build_macos_config(
 
     let net = unsafe { VZVirtioNetworkDeviceConfiguration::new() };
     let nat = unsafe { VZNATNetworkDeviceAttachment::new() };
-    unsafe { net.setAttachment(Some(&nat)) };
+    unsafe {
+        net.setAttachment(Some(&nat));
+        if let Some(value) = mac_address {
+            let mac =
+                VZMACAddress::initWithString(VZMACAddress::alloc(), &NSString::from_str(value))
+                    .ok_or_else(|| Error::Bundle {
+                        message: format!("invalid MAC address {value:?}"),
+                    })?;
+            net.setMACAddress(&mac);
+        }
+    }
 
     let keyboard = unsafe { VZUSBKeyboardConfiguration::new() };
     let pointing = unsafe { VZUSBScreenCoordinatePointingDeviceConfiguration::new() };

--- a/packages/vm/vmkit/src/main.rs
+++ b/packages/vm/vmkit/src/main.rs
@@ -194,6 +194,20 @@ enum Command {
         #[arg(long = "share", value_name = "TAG=HOSTDIR")]
         shares: Vec<String>,
     },
+    /// Run an installed macOS guest headlessly until it stops. SIGTERM and
+    /// SIGINT request a clean shutdown from the guest.
+    #[cfg(target_os = "macos")]
+    RunMacos {
+        /// Guest bundle directory.
+        #[arg(long)]
+        bundle: std::path::PathBuf,
+        /// Stable locally administered unicast MAC address.
+        #[arg(long, value_parser = parse_mac_address)]
+        mac_address: String,
+        /// Share a host directory into the guest over virtio-fs, repeatable.
+        #[arg(long = "share", value_name = "TAG=HOSTDIR")]
+        shares: Vec<String>,
+    },
     /// Boot an installed macOS guest fully off-screen and drive it from stdin:
     /// synthetic keyboard/mouse input and on-demand framebuffer screenshots, with
     /// no host cursor or visible window. Reads newline commands
@@ -514,12 +528,45 @@ fn build_vsock_ports(specs: &[String]) -> Result<Vec<linuxkrun::VsockPort>, Stri
     Ok(ports)
 }
 
+fn parse_mac_address(value: &str) -> Result<String, String> {
+    let octets = value
+        .split(':')
+        .map(|octet| {
+            if octet.len() != 2 || !octet.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                return Err(format!(
+                    "{value:?} must contain six two-digit hexadecimal octets"
+                ));
+            }
+            u8::from_str_radix(octet, 16).map_err(|error| error.to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if octets.len() != 6 {
+        return Err(format!(
+            "{value:?} must contain six two-digit hexadecimal octets"
+        ));
+    }
+    if octets[0] & 1 != 0 {
+        return Err(format!("{value:?} must be a unicast MAC address"));
+    }
+    if octets[0] & 2 == 0 {
+        return Err(format!(
+            "{value:?} must be a locally administered MAC address"
+        ));
+    }
+    Ok(octets
+        .iter()
+        .map(|octet| format!("{octet:02x}"))
+        .collect::<Vec<_>>()
+        .join(":"))
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
     use super::build_vsock_ports;
     use super::linuxkrun::VsockPort;
+    use super::parse_mac_address;
 
     #[test]
     fn vsock_port_spec_parses_port_and_path() {
@@ -547,6 +594,26 @@ mod tests {
         for bad in ["7100", "nope:/tmp/x.sock", "7100:", "-1:/tmp/x.sock", "0:/tmp/x.sock", "4294967295:/tmp/x.sock"] {
             let specs = [String::from(bad)];
             assert!(build_vsock_ports(&specs).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn mac_address_is_canonicalized() {
+        assert_eq!(
+            parse_mac_address("0E:C9:C7:6C:25:A8").expect("valid local unicast address"),
+            "0e:c9:c7:6c:25:a8"
+        );
+    }
+
+    #[test]
+    fn mac_address_rejects_invalid_or_unsafe_addresses() {
+        for bad in [
+            "0e:c9:c7:6c:25",
+            "0e:c9:c7:6c:25:xyz",
+            "01:23:45:67:89:ab",
+            "00:23:45:67:89:ab",
+        ] {
+            assert!(parse_mac_address(bad).is_err(), "{bad:?} must be rejected");
         }
     }
 }
@@ -708,6 +775,11 @@ mod imp {
                 seconds,
                 shares: parse_shares(&shares)?,
             }),
+            Command::RunMacos {
+                bundle,
+                mac_address,
+                shares,
+            } => crate::macguest::run_macos(&bundle, &mac_address, &parse_shares(&shares)?),
             Command::DriveMacos { bundle, shares } => {
                 crate::drive::drive_macos(crate::drive::DriveMacos {
                     bundle,

--- a/playbook/src/routes/declarative-macos-guest/+page.svx
+++ b/playbook/src/routes/declarative-macos-guest/+page.svx
@@ -1,0 +1,54 @@
+---
+title: "A declarative macOS guest on hydra"
+date: 2026-07-14
+---
+
+The macOS guest on hydra was offline for a simple reason: its bundle existed,
+but no process owned its lifecycle. The Linux builder already had a root
+LaunchDaemon, although an older manually started vfkit process still owned its
+disk and left the declared service crash looping.
+
+## What shipped
+
+`vmkit run-macos` is a headless foreground runner for
+Virtualization.framework. It validates a stable locally administered MAC,
+starts the guest without AppKit or a window, and keeps the process alive for
+the lifetime of the virtual machine. SIGTERM and SIGINT request a guest
+shutdown. Guest stop and error callbacks become supervisor exit status.
+
+The existing `homeModules.macos-guests` declaration now owns the host
+LaunchAgent too. Each guest supplies its bundle, MAC, and log path as data.
+Home Manager renders `org.nix-community.home.<name>` with `KeepAlive`,
+`RunAtLoad`, and a 60 second exit window. The macOS VM is a user LaunchAgent
+because its bundle and signing cache are user owned. The Linux builder remains
+a root LaunchDaemon because vfkit networking and its state are root owned.
+
+## Live result
+
+Home Manager activated `org.nix-community.home.macos-primary` on hydra. The
+guest renewed `192.168.64.6` with MAC `0e:c9:c7:6c:25:a8`, SSH reported macOS
+26.5, and `com.beeper.sh-imessage` returned to `running`. A stop and restart
+produced a new guest boot timestamp while preserving the network identity and
+bridge health.
+
+The shutdown request reached macOS, but the guest's `heard` service repeatedly
+delayed its shutdown check past launchd's exit window. Launchd then terminated
+the old VM process at its declared boundary and restarted it cleanly. That
+behavior is visible in the host log rather than hidden behind a retry path.
+
+The Linux guest was powered off cleanly once no build was active. Its manual
+vfkit owner exited, the existing `org.nixos.vm-builder` LaunchDaemon acquired
+the disk, and `vm-ssh` returned a new boot ID. Both VMs now have exactly one
+declarative launchd owner.
+
+## Validation
+
+`nix build .#vmkit` produced the native Darwin runner. Seventeen vmkit unit
+tests passed, including canonical MAC validation. `nix run .#lint` passed all
+ten repository gates. The full Home Manager activation built and ran on hydra,
+followed by launchctl, process, MAC, SSH, guest boot, and bridge checks.
+
+The implementation and rollout are tracked by index#2682, index#2683,
+index#2687, and PR index#3237.
+
+*Written by Codex, an AI coding agent.*

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2855,7 +2855,7 @@
         assertion =
           macosGuestAgent.config.KeepAlive
           && macosGuestAgent.config.RunAtLoad
-          && macosGuestAgent.config.ExitTimeOut == 120;
+          && macosGuestAgent.config.ExitTimeOut == 60;
         message = "launchd should keep the guest alive while allowing a clean shutdown window";
       }
     ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -250,6 +250,51 @@
         }
       ];
     }).config;
+  macosGuestsConfig =
+    (lib.evalModules {
+      specialArgs.pkgs = homeAgentPkgs;
+      modules = [
+        (import (paths.root + "/modules/home/macos-guests.nix") {
+          inherit ix;
+          indexPackages = homeAgentIndexPackages;
+        })
+        ({lib, ...}: {
+          options = {
+            assertions = lib.mkOption {
+              type = lib.types.listOf lib.types.anything;
+              default = [];
+            };
+            home = {
+              homeDirectory = lib.mkOption {type = lib.types.str;};
+              packages = lib.mkOption {
+                type = lib.types.listOf lib.types.package;
+                default = [];
+              };
+            };
+            launchd.agents = lib.mkOption {
+              type = lib.types.attrsOf (lib.types.submodule {
+                options = {
+                  enable = lib.mkOption {type = lib.types.bool;};
+                  config = lib.mkOption {type = lib.types.attrsOf lib.types.anything;};
+                };
+              });
+              default = {};
+            };
+          };
+          config = {
+            home.homeDirectory = "/Users/agent";
+            macosGuests.test = {
+              lifecycle.macAddress = "0e:c9:c7:6c:25:a8";
+              ssh = {
+                host = "192.168.64.6";
+                user = "ix";
+              };
+            };
+          };
+        })
+      ];
+    }).config;
+  macosGuestAgent = macosGuestsConfig.launchd.agents.test;
 
   minecraft = let
     config = evalConfig [
@@ -2793,6 +2838,27 @@
   );
 
   groups = {
+    macos-guests = [
+      {
+        assertion = macosGuestAgent.enable;
+        message = "declared macOS guests should enable their host launchd agent";
+      }
+      {
+        assertion =
+          builtins.elemAt macosGuestAgent.config.ProgramArguments 1
+          == "run-macos"
+          && builtins.elemAt macosGuestAgent.config.ProgramArguments 3 == "/Users/agent/.local/share/vmkit/guests/test"
+          && builtins.elemAt macosGuestAgent.config.ProgramArguments 5 == "0e:c9:c7:6c:25:a8";
+        message = "the host launchd agent should pass the declared bundle and MAC to vmkit run-macos";
+      }
+      {
+        assertion =
+          macosGuestAgent.config.KeepAlive
+          && macosGuestAgent.config.RunAtLoad
+          && macosGuestAgent.config.ExitTimeOut == 120;
+        message = "launchd should keep the guest alive while allowing a clean shutdown window";
+      }
+    ];
     security-roots = [
       {
         assertion =

--- a/users/andrewgazelka/guests/default.nix
+++ b/users/andrewgazelka/guests/default.nix
@@ -18,6 +18,7 @@
   indexPkgs = indexPackages pkgs.stdenv.hostPlatform.system;
 in {
   macosGuests.macos-primary = {
+    lifecycle.macAddress = "0e:c9:c7:6c:25:a8";
     ssh = {
       host = "192.168.64.6";
       user = "ix";


### PR DESCRIPTION
Closes #2683.
Closes #2687.
Refs #2682.

Adds a headless `vmkit run-macos` process with stable MAC identity and graceful signal handling. The existing Home Manager guest declaration now renders a user LaunchAgent for `macos-primary`.

Validation:
* `nix build .#vmkit`
* `RUSTFLAGS="-A warnings" cargo test -p vmkit --tests` (17 passed)
* `nix run .#lint`
* Home Manager activation build and live guest verification are in progress

Authored by Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Supervise macOS guests with launchd via a new `vmkit run-macos` subcommand
> - Adds a `run-macos` subcommand to the `vmkit` CLI that runs a macOS guest headlessly in the foreground, exiting 0 on clean stop and 1 on error, with SIGTERM/SIGINT triggering a graceful shutdown.
> - Accepts a required `--mac-address` argument (validated as unicast, locally administered) so guests retain a stable network identity across restarts.
> - Extends [modules/home/macos-guests.nix](https://github.com/indexable-inc/index/pull/3237/files#diff-1859e24dc83f1789b6f094a04c78bde5f99b308320e6473f216913e9582ce56a) to generate a per-guest launchd `LaunchAgent` that invokes `vmkit run-macos`, sets `KeepAlive`/`RunAtLoad`, and routes logs to `~/Library/Logs/macos-guest-<name>.log`.
> - Changes the default guest bundle directory from a tilde-expanded path to an absolute path rooted at `config.home.homeDirectory`.
> - Behavioral Change: guests declared in the home module now automatically get a supervised launchd agent; a valid MAC address is required per guest.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec3f1e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->