### PR TITLE
workstation: remove local Claude symlink

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -1010,13 +1010,6 @@ in {
     source = config.lib.file.mkOutOfStoreSymlink "${configDir}/mitmproxy";
   };
 
-  # Claude's self-managed updater writes here, ahead of the Home Manager
-  # profile on PATH. Keep that path pinned to the declarative wrapper (#3222).
-  home.file.".local/bin/claude" = {
-    source = "${config.programs.claude-code.finalPackage}/bin/claude";
-    force = true;
-  };
-
   # Agents, commands, and skills are managed declaratively by the upstream
   # home-manager programs.claude-code module: each is written as an in-store
   # path under ~/.claude (no out-of-store symlink, no SessionStart hook).


### PR DESCRIPTION
## Summary

* remove the Home Manager declaration for ~/.local/bin/claude
* leave Claude Code installed through the Home Manager package profile

Fixes #3181

## Validation

* nix run .#lint -- --json
* confirmed no home.file declarations remain for ~/.local/bin/claude or ~/.local/bin/codex

Authored by Codex (GPT-5.4).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `~/.local/bin/claude` symlink from workstation Home Manager profile
> Removes the `home.file.".local/bin/claude"` attribute from [workstation.nix](https://github.com/indexable-inc/index/pull/3246/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962), so the declarative symlink to the claude-code package is no longer created or force-linked on the workstation profile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5c2fee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->