### PR TITLE
mcp: Python-first kernel guidance, bundle githubkit

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1288,6 +1288,12 @@
       # async via asyncssh/playwright/tui but had no way to call a REST API). Sync
       # `httpx.get(...)` and `async with httpx.AsyncClient()` both work.
       ps.httpx
+      # githubkit: typed async GitHub API client generated from GitHub's OpenAPI
+      # spec, so a session does GitHub reads/writes as direct API calls instead
+      # of `gh` subprocesses (index#3258: a REST call answers in under a second
+      # where each `gh` fork costs several; `gh` stays for auth bootstrap via
+      # `gh auth token`).
+      ps.githubkit
       # pydantic (v2): the boundary parser for untrusted/JSON data. The bundled
       # `linear` and `google_auth` modules parse their GraphQL/CLI JSON responses
       # into typed models with it instead of threading untyped dicts. (The MCP SDK

--- a/packages/mcp/ix_notebook_mcp/guide.py
+++ b/packages/mcp/ix_notebook_mcp/guide.py
@@ -163,6 +163,20 @@ DISCOVER = (
     "cannot drift from the code and the catalog remains the source of truth."
 )
 
+PYTHON_FIRST = (
+    "HIGHLY recommended: solve tasks in plain Python, not shell. Shell traps live in the glue "
+    "between programs (pipes, redirects, quoting, builtin shadowing), never in the programs "
+    "themselves, so skip the glue: `psutil` for process questions instead of `ps`/`lsof`, "
+    "`pathlib`/`os.stat` instead of `find`/`stat`, `datetime` instead of `date`, `httpx` "
+    "instead of `curl`, and `githubkit` instead of the `gh` CLI (typed async GitHub client; "
+    "mint it once per session with `from githubkit import GitHub; gh = GitHub((await "
+    "nu('^gh auth token')).strip())` and reuse it: a direct API call returns structured data "
+    "in well under a second where every `gh` fork costs several). Reach for `nu(...)` ONLY "
+    "when a real external program is genuinely needed (git plumbing, `gh auth token`, a CLI "
+    "with no Python-native equivalent), and even then prefer one program per call with a "
+    "`--json` flag over multi-stage pipelines."
+)
+
 NO_SHELL = (
     "Do NOT hand-roll shell through Python: never `subprocess.run`, `os.system`, or "
     "`asyncio.create_subprocess_exec` for `ls`/`cat`/`grep`/`find`/`rg`/`fd` or any command whose "
@@ -179,9 +193,12 @@ NO_SHELL = (
 )
 
 NU = (
-    "`nu` is the ONE shell-out path: running a command, a pipeline, "
-    "listing/filtering/transforming, reaching into files or the web all go through it (the old "
-    "`sh()`/`zsh()` are retired and now raise a migration hint). `await nu(\"ls | where size > "
+    "`nu` is the ONE shell-out path, reserved for when an external program is genuinely "
+    "needed (Python-first rule above; the old `sh()`/`zsh()` are retired and now raise a "
+    "migration hint). It runs NUSHELL, not bash: bash reflexes are traps here (`ps aux` is a "
+    "parse error against the `ps` builtin, `2>/dev/null` is passed to an external as a "
+    "literal argument, `&&` does not chain, GNU coreutils shadow the BSD flags), so write "
+    "actual nushell or stay in Python. `await nu(\"ls | where size > "
     "1kb | sort-by size\")` runs a real nushell pipeline and every tabular result comes back as a Polars "
     "DataFrame, structured end to end (`ls`, `ps`, `sys`, `open Cargo.toml`, `from csv`, `http "
     "get`, `where`, `group-by`, `select`) — no jq/awk/sed/cut text munging and no scraping "

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -414,6 +414,14 @@ LIBRARIES: tuple[Library, ...] = (
     Library("polars"),
     Library("duckdb"),
     Library("httpx"),
+    Library(
+        "githubkit",
+        # index#3258: steer GitHub work off `gh` subprocesses; a direct typed
+        # API call is faster and returns structured data, no JSON flag scraping.
+        note="preferred over the `gh` CLI for GitHub API work: "
+        "`from githubkit import GitHub`, mint once with the token from "
+        "`gh auth token`, reuse all session",
+    ),
     Library("matplotlib"),
     Library("pypdf"),
     Library(

--- a/packages/mcp/ix_notebook_mcp/tools.py
+++ b/packages/mcp/ix_notebook_mcp/tools.py
@@ -64,6 +64,7 @@ _KERNEL_GUIDE = guide.compose(
     guide.SESSION,
     guide.NAMESPACE,
     guide.DISCOVER,
+    guide.PYTHON_FIRST,
     guide.NO_SHELL,
     guide.NU,
     guide.NIX,


### PR DESCRIPTION
Closes #3258.

The kernel guide now HIGHLY recommends solving tasks in plain Python and reserves `nu()` for genuinely-needed externals. A single session hit five nu-as-bash traps in a row (`ps aux` builtin shadow, `2>/dev/null` as literal arg, GNU `stat -f` shadowing BSD, bare `date` printing help, str/NuResult split); the same probes in raw Python (psutil, pathlib, datetime, httpx) worked first try. Nushell is close enough to bash that trained reflexes actively mislead, so the guide says so explicitly and names the traps.

- `guide.py`: new `PYTHON_FIRST` fragment (composed before `NO_SHELL`/`NU` so truncation cannot drop it); `NU` opener demoted and given a nushell-is-not-bash trap list.
- `default.nix`: bundle `ps.githubkit` (0.16.0 in the pinned nixpkgs); typed async GitHub API client, so GitHub reads/writes are direct sub-second API calls instead of multi-second `gh` forks (`gh` stays for auth bootstrap).
- `registry.py`: list `githubkit` as import-ready with a steer over the `gh` CLI, so `modules_index()` advertises it automatically.

Validated locally: `.#mcp.tests.typecheckSmoke` (148 passed) and `.#mcp.tests.strictTypecheck` both green with the new dep and fragments.

(opened by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `githubkit` to MCP kernel with Python-first guidance over subprocess usage
> - Bundles `githubkit` (typed async GitHub API client) into the Nix package in [default.nix](https://github.com/indexable-inc/index/pull/3260/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db), making it available at runtime.
> - Adds a `PYTHON_FIRST` guidance constant in [guide.py](https://github.com/indexable-inc/index/pull/3260/files#diff-03416e032f2f437bc1f5feeb6a43b54379221e5b079c2b2a98873b435daa8a76) that steers kernel users toward `psutil`, `pathlib`, `httpx`, and `githubkit` instead of shelling out.
> - Registers `githubkit` in [registry.py](https://github.com/indexable-inc/index/pull/3260/files#diff-92f567578e1217b8207dbbd21af1cdee4978728a8ca9e774cd65ed17170d2ae5) with a note to prefer it over the `gh` CLI, minting a client once per session via `gh auth token`.
> - Inserts the new `PYTHON_FIRST` section early in the `_KERNEL_GUIDE` assembly in [tools.py](https://github.com/indexable-inc/index/pull/3260/files#diff-5663cdf400300f377c9e4e2b021527ebf564c20364f79a77d25f888b294320f6) so it appears before the no-shell guidance.
> - Rewrites the `NU` guidance constant to clarify nushell-specific pitfalls (bash reflexes, redirection, `&&` absence) and reinforces it as the sole shell-out path when external programs are required.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e16795d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->