### PR TITLE
pins: move updater engine to a Rust pin-update crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8911,6 +8911,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-update"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "clap",
+ "hex",
+ "indexmap 2.14.0",
+ "lazy-regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ members = [
   "packages/nix/nix-web-monitor/parser",
   "packages/nix/nix-web-monitor/server",
   "packages/nix/oci-image-builder",
+  "packages/nix/pin-update",
   "packages/search/polars-mixedbread",
   "packages/progress-style",
   "packages/tui/reel",
@@ -254,6 +255,7 @@ iceberg = "0.9"
 iceberg-catalog-rest = "0.9"
 iceberg-storage-opendal = { version = "0.9", features = ["opendal-s3"] }
 ignore = "0.4"
+indexmap = "2"
 indicatif = "0.18"
 insta = { version = "1.42", features = ["json"] }
 lazy-regex = "3.4"

--- a/lib/fork-updater.nix
+++ b/lib/fork-updater.nix
@@ -3,14 +3,16 @@
 # (`rebase-patches <name>`), so the fork joins the registry-discovered
 # `nix run .#update` DAG like every other updater (one node per fork, no
 # hardcoded fork list in lib/per-system.nix). Same "human reviews the bump, the
-# tool regenerates bytes" posture as lib/util/pins.nix's mkUpdater.
+# tool regenerates bytes" posture as lib/util/pins.nix's mkUpdater. The
+# behavior lives in the pin-update engine's `fork` mode
+# (packages/nix/pin-update); this file only renders the spec.
 #
 # clippy is deliberately NOT wired here: it is nightly-toolchain-coupled and
 # rev-pinned, so it must not free-float under the routine updater (see
 # flake.nix); its patches are rebased by hand alongside a toolchain bump via
 # `nix run .#rebase-patches -- clippy`.
 {
-  writeNushellApplication,
+  pinUpdate,
   nix,
   rebasePatches,
 }:
@@ -20,21 +22,16 @@
   name,
   input,
 }:
-writeNushellApplication {
+pinUpdate.mkUpdateScript {
   name = "${name}-fork-update";
+  description = "Bump the ${input} base and regenerate ${name}'s patch series";
   runtimeInputs = [
     nix
     rebasePatches
   ];
-  meta.description = "Bump the ${input} base and regenerate ${name}'s patch series";
-  text = ''
-    # nu
-    # Run from the repo root: `nix run .#<pkg>.updateScript`.
-    def main [] {
-      # Bump the base; `rebase-patches` no-ops if the rev did not move, and
-      # fails loudly (naming the conflicting patch) on an unresolved rebase.
-      nix flake update ${input}
-      rebase-patches ${name}
-    }
-  '';
+  spec = {
+    mode = "fork";
+    fork = name;
+    inherit input;
+  };
 }

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -64,5 +64,11 @@ in
       // context
       // {
         inherit entry repoPackages;
+        # The repo's pin/updater engine for nullable `passthru.updateScript`
+        # builders (lib/util/pins.nix, lib/fork-updater.nix, mcp,
+        # claude-code), bound only on this registry path: the overlay path
+        # leaves each consumer's `pinUpdate ? null` unset, which is the
+        # signal to omit the updater.
+        pinUpdate = repoPackages.pin-update or null;
       };
   }

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -854,6 +854,9 @@
         ix = crossIxFor target;
         writeNushellApplication = ix.writeNushellApplication pkgs;
         updateScriptWriter = ix.writeNushellApplication pkgs;
+        # Native engine on purpose: a cross updater still runs on the build
+        # host and rewrites the same repo files.
+        pinUpdate = repoPackages.pin-update or null;
       }
     )
     entry.path {};

--- a/lib/util/pins.nix
+++ b/lib/util/pins.nix
@@ -111,7 +111,8 @@
     is worse than asking the human.
 
   Arguments:
-  - `writeNushellApplication`: the caller's `updateScriptWriter`.
+  - `pinUpdate`: the repo's pin-update engine package
+    (`packages/nix/pin-update`), whose `pins` mode implements this contract.
   - `nix`: the nix package (for `nix store prefetch-file`, `nix-prefetch-url`
     and `nix hash convert`).
   - `pname`: package name, for the script name and messages.
@@ -124,59 +125,26 @@
   leaves such entries untouched and reports them.
   */
   mkUpdater = {
-    writeNushellApplication,
+    pinUpdate,
     nix,
     pname,
     relPath,
   }:
-    writeNushellApplication {
+    pinUpdate.mkUpdateScript {
       name = "${pname}-update";
+      description = "Re-pin the SRI hashes in ${relPath} from their pinned URLs";
       runtimeInputs = [nix];
-      meta.description = "Re-pin the SRI hashes in ${relPath} from their pinned URLs";
-      text = ''
-        # nu
-        # Run from the repo root: `nix run .#${pname}.updateScript`.
-        def main [] {
-          const out = "${relPath}"
-          let pins = (open $out)
-          let updated = (
-            $pins
-            | transpose name entry
-            | reduce --fold {} {|row acc|
-                let entry = $row.entry
-                let mode = (if ("prefetch" in ($entry | columns)) { $entry.prefetch } else { "file" })
-                if ($mode == "manual") {
-                  print $"(ansi yellow)skipping ($row.name): prefetch=manual; refresh by building with the new url and copying the got: hash(ansi reset)"
-                  $acc | insert $row.name $entry
-                } else if not ("url" in ($entry | columns)) {
-                  print $"(ansi yellow)skipping ($row.name): no `url` to re-fetch(ansi reset)"
-                  $acc | insert $row.name $entry
-                } else if ($mode == "unpack") {
-                  # fetchzip/fetchCrate validate the UNPACKED tree, not the
-                  # archive bytes; `nix-prefetch-url --unpack` reproduces that
-                  # hash (fetchTarball semantics: single root dir stripped).
-                  let b32 = (^nix-prefetch-url --unpack $entry.url | str trim)
-                  let sri = (^nix hash convert --hash-algo sha256 --to sri $b32 | str trim)
-                  $acc | insert $row.name ($entry | upsert hash $sri)
-                } else if ($mode == "file") {
-                  let sri = (^nix store prefetch-file --json $entry.url | from json | get hash)
-                  $acc | insert $row.name ($entry | upsert hash $sri)
-                } else {
-                  error make { msg: $"($out): pin ($row.name) has unknown prefetch mode ($mode); expected file, unpack, or manual" }
-                }
-              }
-          )
-          $updated | to json --indent 2 | save --force $out
-          print $"re-pinned ($out)"
-        }
-      '';
+      spec = {
+        mode = "pins";
+        pins = relPath;
+      };
     };
 
   # Overlay consumers do not receive update tooling. Keep that nullable
   # package boundary here so every pinned package cannot drift into its own
   # copy of the same conditional wrapper.
-  mkOptionalUpdater = args @ {writeNushellApplication, ...}:
-    if writeNushellApplication == null
+  mkOptionalUpdater = args @ {pinUpdate, ...}:
+    if pinUpdate == null
     then null
     else mkUpdater args;
 in {

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -183,11 +183,11 @@
       inherit lib ix repoPackages;
       promptOmitRules = omitRules;
     }).systemPrompt,
-  # Writer used to build `passthru.updateScript`. Only the flake package set
-  # supplies it (lib/packages.nix); the overlay eval context leaves it null. The
-  # updater is a maintainer-facing flake output, so the overlay build of
-  # `pkgs.claude-code` simply omits `passthru.updateScript`.
-  updateScriptWriter ? null,
+  # Pin-update engine used to build `passthru.updateScript`. Only the flake
+  # package set supplies it (lib/packages.nix); the overlay eval context leaves
+  # it null. The updater is a maintainer-facing flake output, so the overlay
+  # build of `pkgs.claude-code` simply omits `passthru.updateScript`.
+  pinUpdate ? null,
 }: let
   # Read the package set from `ix`, not a `pkgs` callPackage formal: a `pkgs`
   # arg in the formal set breaks `.override` (astlog no-pkgs-in-callpackage),
@@ -538,17 +538,13 @@
 
   # Maintainer-facing updater that refreshes manifest.json from Anthropic's
   # signed per-version manifest (fails closed on a bad GPG signature); see
-  # ./update.nix. Built only when this eval context supplied a writer (the flake
-  # package set), so the overlay build of `pkgs.claude-code` omits
-  # `passthru.updateScript`.
+  # ./update.nix. Built only when this eval context supplied the pin-update
+  # engine (the flake package set), so the overlay build of `pkgs.claude-code`
+  # omits `passthru.updateScript`.
   updateScript =
-    if updateScriptWriter == null
+    if pinUpdate == null
     then null
-    else
-      import ./update.nix {
-        writeNushellApplication = updateScriptWriter;
-        inherit nix gnupg;
-      };
+    else import ./update.nix {inherit pinUpdate nix gnupg;};
 in
   # `allowVendoredUnfree` strips the honest `meta.license` tag below so the
   # per-system flake package set (evaluated without `allowUnfree`) can build

--- a/packages/agent/claude-code/update.nix
+++ b/packages/agent/claude-code/update.nix
@@ -1,116 +1,57 @@
 # Refreshes manifest.json from Anthropic's published per-version manifest,
-# converting its hex checksums to the SRI hashes the fetcher pins, then refreshes
-# the committed stock system-prompt snapshots. The slug map lives here as the
-# single owner; default.nix only reads it back. The updater fails closed unless
-# the manifest's detached GPG signature verifies against the pinned release
+# converting its hex checksums to the SRI hashes the fetcher pins, then
+# refreshes the committed stock system-prompt snapshots. The slug map lives
+# here as the single owner; default.nix only reads it back. The behavior lives
+# in the pin-update engine's `claude-code` mode (packages/nix/pin-update);
+# this file only renders the spec. The updater fails closed unless the
+# manifest's detached GPG signature verifies against the pinned release
 # signing key (release-signing-key.asc, fingerprint 31DD DE24 DDFA B679 F42D
 # 7BD2 BAA9 29FF 1A7E CACE, published at downloads.claude.ai/keys/claude-code.asc),
 # so a spoofed manifest cannot inject hashes for attacker-controlled binaries.
+#
+# Run from the repo root: `nix run .#claude-code.updateScript -- [version]`.
+# Without a version argument it tracks Anthropic's `latest` pointer. Use
+# --prompts-only to recapture snapshots for the already-pinned package, or
+# --skip-prompts when only the signed binary manifest should move.
 {
-  writeNushellApplication,
+  pinUpdate,
   nix,
   gnupg,
 }:
-writeNushellApplication {
+pinUpdate.mkUpdateScript {
   name = "claude-code-update";
+  description = "Refresh the signed Claude Code manifest and stock system-prompt snapshots";
+  # nix for the prompt recapture (`nix run .#claude-code.extractStockSystemPrompt`);
+  # gnupg for the fail-closed signature check.
   runtimeInputs = [
     nix
     gnupg
   ];
-  meta.description = "Refresh the signed Claude Code manifest and stock system-prompt snapshots";
-  text = ''
-    # nu
-    const base = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
-    const signing_key = "${./release-signing-key.asc}"
-    const slugs = {
-      "aarch64-darwin": "darwin-arm64",
-      "x86_64-darwin": "darwin-x64",
-      "x86_64-linux": "linux-x64",
-      "aarch64-linux": "linux-arm64"
-    }
-
-    def refresh_prompts [] {
-      let prompts_dir = "packages/agent/claude-code/system-prompts"
-      let models = (open $"($prompts_dir)/models.json")
-
-      $models
-      | transpose name model
-      | each {|row|
-          let capture = (
-            ^nix run .#claude-code.extractStockSystemPrompt -- --mode stock --model $row.model --json
-            | complete
-          )
-          if $capture.exit_code != 0 {
-            error make { msg: $"claude-code: failed to capture ($row.name) system prompt\n($capture.stderr)" }
-          }
-
-          let prompt = (
-            $capture.stdout
-            | from json
-            | get system
-            | where {|block| not (($block.text | into string) | str starts-with "x-anthropic-billing-header:") }
-            | get text
-            | str join "\n"
-            | str replace --all --regex "claude-extract-home[-_][A-Za-z0-9_-]+" "claude-extract-home"
-            | str replace --all --regex "claude-extract-cwd[-_][A-Za-z0-9_-]+" "claude-extract-cwd"
-          )
-          let out = $"($prompts_dir)/($row.name).txt"
-          $"($prompt)\n" | save --force $out
-          print $"updated ($out) from model ($row.model)"
-        }
-    }
-
-    # Run from the repo root: `nix run .#claude-code.updateScript -- [version]`.
-    # Without a version argument it tracks Anthropic's `latest` pointer.
-    # Use --prompts-only to recapture snapshots for the already-pinned package,
-    # or --skip-prompts when only the signed binary manifest should move.
-    def main [
-      version?: string
-      --prompts-only
-      --skip-prompts
-    ] {
-      if $prompts_only {
-        refresh_prompts
-        return
+  spec = {
+    mode = "claude-code";
+    base = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
+    signingKey = "${./release-signing-key.asc}";
+    # A list, not an attrset: `builtins.toJSON` sorts attrset keys, and the
+    # rewritten manifest.json keeps its platforms in this order.
+    platforms = [
+      {
+        system = "aarch64-darwin";
+        slug = "darwin-arm64";
       }
-
-      let v = ($version | default (http get $"($base)/latest" | str trim))
-
-      # Download the exact bytes we verify, then parse the same file.
-      let work = (mktemp --directory)
-      let manifest_path = $"($work)/manifest.json"
-      let sig_path = $"($work)/manifest.json.sig"
-      http get --raw $"($base)/($v)/manifest.json" | save --force $manifest_path
-      http get --raw $"($base)/($v)/manifest.json.sig" | save --force $sig_path
-
-      # Fail closed: only the pinned key lives in this GNUPGHOME, so a
-      # zero exit from --verify proves Anthropic signed these exact bytes.
-      let gnupghome = (mktemp --directory)
-      with-env { GNUPGHOME: $gnupghome } {
-        ^gpg --batch --quiet --import $signing_key
-        let check = (do { ^gpg --batch --verify $sig_path $manifest_path } | complete)
-        if $check.exit_code != 0 {
-          error make { msg: $"claude-code: manifest signature verification failed for ($v)\n($check.stderr)" }
-        }
+      {
+        system = "x86_64-darwin";
+        slug = "darwin-x64";
       }
-
-      let upstream = (open $manifest_path)
-      let platforms = (
-        $slugs
-        | transpose system slug
-        | reduce --fold {} {|row acc|
-            let hex = ($upstream.platforms | get $row.slug | get checksum)
-            let sri = (^nix hash convert --hash-algo sha256 --to sri $hex | str trim)
-            $acc | insert $row.system { slug: $row.slug, hash: $sri }
-          }
-      )
-      let out = "packages/agent/claude-code/manifest.json"
-      { version: $v, platforms: $platforms } | to json --indent 2 | save --force $out
-      print $"updated ($out) to ($v); signature verified"
-
-      if not $skip_prompts {
-        refresh_prompts
+      {
+        system = "x86_64-linux";
+        slug = "linux-x64";
       }
-    }
-  '';
+      {
+        system = "aarch64-linux";
+        slug = "linux-arm64";
+      }
+    ];
+    manifest = "packages/agent/claude-code/manifest.json";
+    prompts = "packages/agent/claude-code/system-prompts";
+  };
 }

--- a/packages/bbctl/default.nix
+++ b/packages/bbctl/default.nix
@@ -4,10 +4,10 @@
   lib,
   nix,
   stdenvNoCC,
-  # Writer for `passthru.updateScript`, bound only on the flake-package path
-  # (lib/packages.nix); the overlay path leaves it null so `pkgs.*` carries no
-  # updater. Same nullable-writer pattern as vector-bin / claude-code.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript`, bound only on the
+  # flake-package path (lib/packages.nix); the overlay path leaves it null so
+  # `pkgs.*` carries no updater. Same nullable-engine pattern as vector-bin / claude-code.
+  pinUpdate ? null,
 }: let
   # Prebuilt upstream release binary, aarch64-darwin only: the motivating
   # consumer is the vmkit macOS guest's iMessage bridge (ENG-7746), which needs
@@ -16,8 +16,7 @@
   # the version/url in pins.json, then `nix run .#update` re-pins the hash.
   pin = ix.pins.loadPin ./pins.json "bbctl";
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
-    inherit nix;
+    inherit pinUpdate nix;
     pname = "bbctl";
     relPath = "packages/bbctl/pins.json";
   };

--- a/packages/blender-lab-mcp/default.nix
+++ b/packages/blender-lab-mcp/default.nix
@@ -14,18 +14,17 @@
   lib,
   nix,
   python3,
-  # Writer for `passthru.updateScript` (flake-package path only; the package
-  # is not registered in the overlay). Same nullable-writer pattern as
-  # blender-mcp / vector-bin.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript` (flake-package path only;
+  # the package is not registered in the overlay). Same nullable-engine
+  # pattern as blender-mcp / vector-bin.
+  pinUpdate ? null,
 }: let
   # Rev + SRI hash live in the sibling pins.json, never inline here (repo
   # policy: no `hash = "sha256-..."` literals in tracked .nix). Bump the
   # rev/url in pins.json, then `nix run .#update` re-pins the hash.
   pin = ix.pins.loadPin ./pins.json "blender-lab-mcp";
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
-    inherit nix;
+    inherit pinUpdate nix;
     pname = "blender-lab-mcp";
     relPath = "packages/blender-lab-mcp/pins.json";
   };

--- a/packages/blender-mcp/default.nix
+++ b/packages/blender-mcp/default.nix
@@ -9,17 +9,17 @@
   ix,
   lib,
   pkgs,
-  # Writer for `passthru.updateScript` (flake-package path only; the package
-  # is not registered in the overlay). Same nullable-writer pattern as
-  # vector-bin / wasm-bindgen-cli.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript` (flake-package path only;
+  # the package is not registered in the overlay). Same nullable-engine
+  # pattern as vector-bin / wasm-bindgen-cli.
+  pinUpdate ? null,
 }: let
   # Rev + SRI hash live in the sibling pins.json, never inline here (repo
   # policy: no `hash = "sha256-..."` literals in tracked .nix). Bump the
   # rev/url in pins.json, then `nix run .#update` re-pins the hash.
   pin = ix.pins.loadPin ./pins.json "blender-mcp";
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
+    inherit pinUpdate;
     inherit (pkgs) nix;
     pname = "blender-mcp";
     relPath = "packages/blender-mcp/pins.json";

--- a/packages/lakekeeper/default.nix
+++ b/packages/lakekeeper/default.nix
@@ -7,9 +7,9 @@
   lib,
   nix,
   stdenv,
-  # Writer for `passthru.updateScript` (flake-package path only); null on the
-  # overlay path. Same nullable-writer pattern as claude-code / yc.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript` (flake-package path only);
+  # null on the overlay path. Same nullable-engine pattern as claude-code / yc.
+  pinUpdate ? null,
 }: let
   # Add a target here, with its own release hash, before building on another
   # arch. The package-set/flake targets and meta.platforms below gate the arch.
@@ -25,8 +25,7 @@
   # wrong hash.
   pin = ix.pins.loadPin ./pins.json "lakekeeper";
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
-    inherit nix;
+    inherit pinUpdate nix;
     pname = "lakekeeper";
     relPath = "packages/lakekeeper/pins.json";
   };

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1,8 +1,7 @@
 {
   ix,
   lib,
-  nix,
-  updateScriptWriter ? null,
+  pinUpdate ? null,
 }: let
   # The headless Nix build-tree emitter. The `nix` module's live-pane path spawns
   # it (`nix-web-monitor --emit ndjson`) so the parser stays the single owner of
@@ -26,13 +25,9 @@
   # loudly instead of guessing.
   pypiPins = ix.pins.loadPins ./pins.json;
   updateScript =
-    if updateScriptWriter == null
+    if pinUpdate == null
     then null
-    else
-      import ./update.nix {
-        inherit nix;
-        writeNushellApplication = updateScriptWriter;
-      };
+    else import ./update.nix {inherit pinUpdate;};
   # The PTY-driving `tui` package, baked into the pinned interpreter so every
   # session can `import tui` with no setup. The PyO3 cdylib comes from the same
   # shared workspace graph the binary is selected from, dropped next to the

--- a/packages/mcp/update.nix
+++ b/packages/mcp/update.nix
@@ -1,121 +1,16 @@
-{
-  nix,
-  writeNushellApplication,
-}:
-writeNushellApplication {
+# Refreshes packages/mcp/pins.json from PyPI release metadata via the shared
+# pin-update engine's `pypi` mode (packages/nix/pin-update); this file only
+# renders the spec. Policy markers in pins.json the engine honors:
+# - `prefetch = "manual"`: URL/hash stay hand-owned (non-sdist artifacts).
+# - `hold = "<reason>"`: version, URL, and hash stay put.
+# - `track = "<dotted prefix>"`: update only within that version line.
+# Run from the repo root: `nix run .#mcp.updateScript`.
+{pinUpdate}:
+pinUpdate.mkUpdateScript {
   name = "mcp-pypi-pins-update";
-  runtimeInputs = [nix];
-  meta.description = "Refresh packages/mcp/pins.json from PyPI release metadata";
-  text = ''
-    # nu
-    # Run from the repo root: `nix run .#mcp.updateScript`.
-    # Policy markers in pins.json:
-    # - `prefetch = "manual"`: keep URL/hash hand-owned for non-sdist artifacts.
-    # - `hold = "<reason>"`: keep the current version, URL, and hash.
-    # - `track = "<dotted prefix>"`: update only within that version line.
-    def source-url [project: string, filename: string] {
-      let first = ($project | str substring 0..0)
-      $"https://pypi.io/packages/source/($first)/($project)/($filename)"
-    }
-
-    def sri-from-hex [hex: string] {
-      ^nix hash convert --hash-algo sha256 --to sri $hex | str trim
-    }
-
-    # A pin candidate is a plain dotted-integer version. PyPI release lists
-    # also carry pre-releases (3.5.6.dev1, 4.0.0rc1); those never become pins,
-    # so they are disqualified here rather than crashing `into int`.
-    def version-segments [version: string] {
-      let segments = ($version | split row ".")
-      if ($segments | all {|segment| $segment =~ '^[0-9]+$' }) {
-        $segments | each { into int }
-      } else {
-        null
-      }
-    }
-
-    def version-matches-track [version: string, track: string] {
-      let version_segments = (version-segments $version)
-      let track_segments = (version-segments $track)
-      if ($version_segments == null) or ($track_segments == null) {
-        false
-      } else if (($version_segments | length) < ($track_segments | length)) {
-        false
-      } else {
-        ($version_segments | first ($track_segments | length)) == $track_segments
-      }
-    }
-
-    def tracked-version [name: string, releases: record, track: string] {
-      let versions = (
-        $releases
-        | columns
-        | where {|version| version-matches-track $version $track }
-        | sort-by {|version| version-segments $version }
-      )
-      if ($versions | is-empty) {
-        error make {msg: $"($name): no PyPI releases match track ($track)"}
-      }
-      $versions | last
-    }
-
-    def refresh-pin [name: string, entry: record] {
-      # pins.json supports three updater policy markers:
-      #
-      # - `prefetch = "manual"`: hash-mode hold for platform-specific artifacts
-      #   whose URL/hash must be refreshed by hand.
-      # - `hold = "<reason>"`: version hold for pins whose dependency override set
-      #   is hand-tuned to one exact upstream release.
-      # - `track = "<version prefix>"`: version-line tracking for packages that
-      #   should follow the newest release under one dotted segment prefix.
-      if ("prefetch" in ($entry | columns)) and ($entry.prefetch != "manual") {
-        error make {msg: $"($name): unsupported prefetch policy ($entry.prefetch); this updater only handles flat PyPI sdist pins and prefetch=manual holds"}
-      }
-      if ("prefetch" in ($entry | columns)) and ($entry.prefetch == "manual") {
-        print $"(ansi yellow)skipping ($name): prefetch=manual; refresh this platform pin by hand(ansi reset)"
-        $entry
-      } else if ("hold" in ($entry | columns)) {
-        print $"(ansi yellow)skipping ($name): hold=($entry.hold)(ansi reset)"
-        $entry
-      } else {
-        let project = $name
-        let metadata = (http get $"https://pypi.org/pypi/($project)/json")
-        let version = (
-          if "track" in ($entry | columns) {
-            tracked-version $name $metadata.releases $entry.track
-          } else {
-            $metadata.info.version
-          }
-        )
-        let sdists = (
-          $metadata.releases
-          | get $version
-          | where packagetype == "sdist"
-        )
-        if ($sdists | is-empty) {
-          error make {msg: $"($name): PyPI release ($version) has no sdist"}
-        }
-        let sdist = ($sdists | first)
-        let hash = (sri-from-hex $sdist.digests.sha256)
-        $entry
-        | upsert version $version
-        | upsert url (source-url $project $sdist.filename)
-        | upsert hash $hash
-      }
-    }
-
-    def main [] {
-      const out = "packages/mcp/pins.json"
-      let pins = (open $out)
-      let updated = (
-        $pins
-        | transpose name entry
-        | reduce --fold {} {|row acc|
-            $acc | insert $row.name (refresh-pin $row.name $row.entry)
-          }
-      )
-      $updated | to json --indent 2 | $in + "\n" | save --force $out
-      print $"updated ($out) from PyPI metadata"
-    }
-  '';
+  description = "Refresh packages/mcp/pins.json from PyPI release metadata";
+  spec = {
+    mode = "pypi";
+    pins = "packages/mcp/pins.json";
+  };
 }

--- a/packages/nix/pin-update/Cargo.toml
+++ b/packages/nix/pin-update/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "pin-update"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Registry update-DAG updaters: re-pin pins.json hashes, refresh PyPI sdist pins, bump fork bases, refresh the signed Claude Code manifest"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+base64.workspace = true
+clap = { workspace = true, features = ["derive"] }
+hex.workspace = true
+indexmap = { workspace = true, features = ["serde"] }
+lazy-regex.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tempfile.workspace = true

--- a/packages/nix/pin-update/default.nix
+++ b/packages/nix/pin-update/default.nix
@@ -1,0 +1,45 @@
+{
+  ix,
+  lib,
+  formats,
+  makeWrapper,
+  runCommand,
+  ...
+}: let
+  package = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+    binary = "pin-update";
+    meta.mainProgram = "pin-update";
+    passthru = {inherit mkUpdateScript;};
+  };
+
+  # Builds an updater's `passthru.updateScript` entry: the pin-update binary
+  # wrapped over a Nix-rendered mode-tagged JSON spec (never a hand-assembled
+  # argv string) plus the PATH its mode shells out to. User arguments (the
+  # claude-code mode's version / --prompts-only) pass through after the baked
+  # spec.
+  mkUpdateScript = {
+    name,
+    description,
+    spec,
+    runtimeInputs ? [],
+  }: let
+    specFile = (formats.json {}).generate "${name}-spec.json" spec;
+    pathArgs = lib.optionalString (runtimeInputs != []) " --prefix PATH : ${lib.makeBinPath runtimeInputs}";
+  in
+    runCommand name
+    {
+      __structuredAttrs = true;
+      nativeBuildInputs = [makeWrapper];
+      meta = {
+        inherit description;
+        mainProgram = name;
+      };
+    }
+    ''
+      # shell
+      makeWrapper ${lib.getExe package} "$out/bin/${name}" --add-flags ${specFile}${pathArgs}
+    '';
+in
+  # selectBinaryWithTests keeps `passthru` nested; lift the builder so
+  # consumers write `pinUpdate.mkUpdateScript` like a mkDerivation passthru.
+  package // {inherit mkUpdateScript;}

--- a/packages/nix/pin-update/package.nix
+++ b/packages/nix/pin-update/package.nix
@@ -1,0 +1,8 @@
+{
+  id = "pin-update";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/nix/pin-update/src/claude_code.rs
+++ b/packages/nix/pin-update/src/claude_code.rs
@@ -1,0 +1,256 @@
+//! Claude Code updater: refresh manifest.json from Anthropic's published
+//! per-version manifest, converting its hex checksums to the SRI hashes the
+//! fetcher pins, then refresh the committed stock system-prompt snapshots.
+//! Fails closed unless the manifest's detached GPG signature verifies
+//! against the pinned release signing key, so a spoofed manifest cannot
+//! inject hashes for attacker-controlled binaries.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context as _, Result, bail};
+use clap::Parser;
+use indexmap::IndexMap;
+use lazy_regex::regex_replace_all;
+use serde::{Deserialize, Serialize};
+
+use crate::{cmd, http, pins_file, sri};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Spec {
+    /// Release bucket base URL.
+    pub base: String,
+    /// Pinned ASCII-armored release signing key (a store path).
+    pub signing_key: PathBuf,
+    /// Ordered system-to-slug pairs; manifest.json platform order follows
+    /// this list (a JSON list because Nix attrsets serialize sorted).
+    pub platforms: Vec<Platform>,
+    /// Repo-relative manifest.json to rewrite.
+    pub manifest: PathBuf,
+    /// Repo-relative directory of prompt snapshots (holds models.json).
+    pub prompts: PathBuf,
+}
+
+#[derive(Deserialize)]
+pub struct Platform {
+    system: String,
+    slug: String,
+}
+
+/// Run from the repo root: `nix run .#claude-code.updateScript -- [version]`.
+/// Without a version argument it tracks Anthropic's `latest` pointer.
+#[derive(Parser)]
+#[command(name = "claude-code-update")]
+struct Args {
+    /// Exact release version; defaults to the upstream `latest` pointer.
+    version: Option<String>,
+    /// Only recapture prompt snapshots for the already-pinned package.
+    #[arg(long, conflicts_with = "skip_prompts")]
+    prompts_only: bool,
+    /// Only move the signed binary manifest.
+    #[arg(long)]
+    skip_prompts: bool,
+}
+
+pub fn run(spec: &Spec, args: &[String]) -> Result<()> {
+    let program = std::iter::once("claude-code-update");
+    let args = Args::parse_from(program.chain(args.iter().map(String::as_str)));
+    if args.prompts_only {
+        return refresh_prompts(&spec.prompts);
+    }
+
+    let version = match args.version {
+        Some(version) => version,
+        None => http::get_text(&format!("{}/latest", spec.base))?
+            .trim()
+            .to_owned(),
+    };
+
+    // Download the exact bytes we verify, then parse the same bytes.
+    let work = tempfile::tempdir().context("creating manifest workdir")?;
+    let manifest_path = work.path().join("manifest.json");
+    let sig_path = work.path().join("manifest.json.sig");
+    let manifest_bytes = http::get_bytes(&format!("{}/{version}/manifest.json", spec.base))?;
+    std::fs::write(&manifest_path, &manifest_bytes).context("writing manifest workdir copy")?;
+    let sig_bytes = http::get_bytes(&format!("{}/{version}/manifest.json.sig", spec.base))?;
+    std::fs::write(&sig_path, sig_bytes).context("writing signature workdir copy")?;
+
+    verify_signature(&spec.signing_key, &sig_path, &manifest_path, &version)?;
+
+    let upstream: UpstreamManifest = serde_json::from_slice(&manifest_bytes)
+        .with_context(|| format!("parsing upstream manifest for {version}"))?;
+    let platforms = spec
+        .platforms
+        .iter()
+        .map(|platform| {
+            let upstream_platform = upstream
+                .platforms
+                .get(&platform.slug)
+                .with_context(|| format!("upstream manifest lists no platform {}", platform.slug))?;
+            Ok((
+                platform.system.clone(),
+                PinnedPlatform {
+                    slug: platform.slug.clone(),
+                    hash: sri::from_hex(&upstream_platform.checksum)?,
+                },
+            ))
+        })
+        .collect::<Result<IndexMap<String, PinnedPlatform>>>()?;
+
+    pins_file::write(
+        &spec.manifest,
+        &PinnedManifest {
+            version: version.clone(),
+            platforms,
+        },
+    )?;
+    println!(
+        "updated {} to {version}; signature verified",
+        spec.manifest.display()
+    );
+
+    if !args.skip_prompts {
+        refresh_prompts(&spec.prompts)?;
+    }
+    Ok(())
+}
+
+/// Fail closed: only the pinned key lives in this GNUPGHOME, so a zero exit
+/// from `--verify` proves Anthropic signed these exact bytes.
+fn verify_signature(signing_key: &Path, sig: &Path, manifest: &Path, version: &str) -> Result<()> {
+    let gnupghome = tempfile::tempdir().context("creating GNUPGHOME")?;
+    cmd::stdout(
+        Command::new("gpg")
+            .env("GNUPGHOME", gnupghome.path())
+            .args(["--batch", "--quiet", "--import"])
+            .arg(signing_key),
+    )?;
+
+    let output = Command::new("gpg")
+        .env("GNUPGHOME", gnupghome.path())
+        .args(["--batch", "--verify"])
+        .args([sig, manifest])
+        .output()
+        .context("spawning gpg --verify")?;
+    if !output.status.success() {
+        bail!(
+            "claude-code: manifest signature verification failed for {version}\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn refresh_prompts(prompts_dir: &Path) -> Result<()> {
+    let models_path = prompts_dir.join("models.json");
+    let raw = std::fs::read_to_string(&models_path)
+        .with_context(|| format!("reading {}", models_path.display()))?;
+    let models: IndexMap<String, String> =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", models_path.display()))?;
+
+    for (name, model) in &models {
+        let raw = cmd::stdout(Command::new("nix").args([
+            "run",
+            ".#claude-code.extractStockSystemPrompt",
+            "--",
+            "--mode",
+            "stock",
+            "--model",
+            model,
+            "--json",
+        ]))
+        .with_context(|| format!("claude-code: failed to capture {name} system prompt"))?;
+        let capture: Capture = serde_json::from_str(&raw)
+            .with_context(|| format!("parsing {name} system prompt capture"))?;
+
+        let out = prompts_dir.join(format!("{name}.txt"));
+        std::fs::write(&out, format!("{}\n", scrub(&capture)))
+            .with_context(|| format!("writing {}", out.display()))?;
+        println!("updated {} from model {model}", out.display());
+    }
+    Ok(())
+}
+
+/// Join the prompt blocks, dropping the billing-header block and normalizing
+/// the randomized extraction sandbox paths so reruns are byte-stable.
+fn scrub(capture: &Capture) -> String {
+    let joined = capture
+        .system
+        .iter()
+        .filter(|block| !block.text.starts_with("x-anthropic-billing-header:"))
+        .map(|block| block.text.as_str())
+        .collect::<Vec<&str>>()
+        .join("\n");
+    let home = regex_replace_all!(
+        "claude-extract-home[-_][A-Za-z0-9_-]+",
+        &joined,
+        "claude-extract-home"
+    );
+    regex_replace_all!(
+        "claude-extract-cwd[-_][A-Za-z0-9_-]+",
+        &home,
+        "claude-extract-cwd"
+    )
+    .into_owned()
+}
+
+#[derive(Deserialize)]
+struct UpstreamManifest {
+    platforms: std::collections::HashMap<String, UpstreamPlatform>,
+}
+
+#[derive(Deserialize)]
+struct UpstreamPlatform {
+    checksum: String,
+}
+
+#[derive(Serialize)]
+struct PinnedManifest {
+    version: String,
+    platforms: IndexMap<String, PinnedPlatform>,
+}
+
+#[derive(Serialize)]
+struct PinnedPlatform {
+    slug: String,
+    hash: String,
+}
+
+/// The `--json` capture shape of `extractStockSystemPrompt`: the prompt as
+/// ordered content blocks.
+#[derive(Deserialize)]
+struct Capture {
+    system: Vec<Block>,
+}
+
+#[derive(Deserialize)]
+struct Block {
+    text: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrub_drops_billing_header_and_normalizes_paths() {
+        let capture = Capture {
+            system: vec![
+                Block {
+                    text: "x-anthropic-billing-header: abc".to_owned(),
+                },
+                Block {
+                    text: "You are Claude Code in /tmp/claude-extract-home-Xy_9/w".to_owned(),
+                },
+                Block {
+                    text: "cwd is claude-extract-cwd_A1-b".to_owned(),
+                },
+            ],
+        };
+        assert_eq!(
+            scrub(&capture),
+            "You are Claude Code in /tmp/claude-extract-home/w\ncwd is claude-extract-cwd"
+        );
+    }
+}

--- a/packages/nix/pin-update/src/cmd.rs
+++ b/packages/nix/pin-update/src/cmd.rs
@@ -1,0 +1,43 @@
+//! Subprocess helpers: every external command is built from typed args and
+//! checked, so a failure surfaces with the command line and its stderr.
+
+use std::process::{Command, Stdio};
+
+use anyhow::{Context as _, Result, bail};
+
+/// Render a command for error messages.
+fn describe(cmd: &Command) -> String {
+    std::iter::once(cmd.get_program())
+        .chain(cmd.get_args())
+        .map(|part| part.to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Run `cmd` capturing stdout; fail with stderr attached on a non-zero exit.
+pub fn stdout(cmd: &mut Command) -> Result<String> {
+    let what = describe(cmd);
+    let output = cmd
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("spawning `{what}`"))?;
+    if !output.status.success() {
+        bail!(
+            "`{what}` failed ({}):\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    String::from_utf8(output.stdout).with_context(|| format!("`{what}` wrote non-UTF-8 stdout"))
+}
+
+/// Run `cmd` with inherited stdio (progress streams to the caller); fail on
+/// a non-zero exit.
+pub fn run(cmd: &mut Command) -> Result<()> {
+    let what = describe(cmd);
+    let status = cmd.status().with_context(|| format!("spawning `{what}`"))?;
+    if !status.success() {
+        bail!("`{what}` failed ({status})");
+    }
+    Ok(())
+}

--- a/packages/nix/pin-update/src/fork.rs
+++ b/packages/nix/pin-update/src/fork.rs
@@ -1,0 +1,25 @@
+//! Fork-base bump for a de-forked package: advance the flake input its
+//! upstream base is pinned to, then regenerate the in-repo patch series.
+//! `rebase-patches` no-ops when the rev did not move and fails loudly (naming
+//! the conflicting patch) on an unresolved rebase.
+
+use std::process::Command;
+
+use anyhow::Result;
+use serde::Deserialize;
+
+use crate::cmd;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Spec {
+    /// Fork name: matches `lib/fork-packages.nix` and the rebase-patches arg.
+    fork: String,
+    /// The flake.lock input the bump advances.
+    input: String,
+}
+
+pub fn run(spec: &Spec) -> Result<()> {
+    cmd::run(Command::new("nix").args(["flake", "update"]).arg(&spec.input))?;
+    cmd::run(Command::new("rebase-patches").arg(&spec.fork))
+}

--- a/packages/nix/pin-update/src/http.rs
+++ b/packages/nix/pin-update/src/http.rs
@@ -1,0 +1,30 @@
+//! Tiny blocking HTTP surface over reqwest (rustls, webpki roots), enough
+//! for the `PyPI` JSON API and Anthropic's release bucket.
+
+use anyhow::{Context as _, Result};
+use serde::de::DeserializeOwned;
+
+fn get(url: &str) -> Result<reqwest::blocking::Response> {
+    reqwest::blocking::get(url)
+        .and_then(reqwest::blocking::Response::error_for_status)
+        .with_context(|| format!("GET {url}"))
+}
+
+pub fn get_json<T: DeserializeOwned>(url: &str) -> Result<T> {
+    get(url)?
+        .json()
+        .with_context(|| format!("parsing GET {url} as JSON"))
+}
+
+pub fn get_text(url: &str) -> Result<String> {
+    get(url)?
+        .text()
+        .with_context(|| format!("reading GET {url}"))
+}
+
+pub fn get_bytes(url: &str) -> Result<Vec<u8>> {
+    Ok(get(url)?
+        .bytes()
+        .with_context(|| format!("reading GET {url}"))?
+        .to_vec())
+}

--- a/packages/nix/pin-update/src/main.rs
+++ b/packages/nix/pin-update/src/main.rs
@@ -1,0 +1,89 @@
+//! Update-DAG engine for the repo's pinned artifacts (`nix run .#update`).
+//!
+//! Nix renders each updater as this binary wrapped over a mode-tagged JSON
+//! spec (see `packages/nix/pin-update/default.nix`'s `mkUpdateScript`), so
+//! package data stays in Nix and only the machinery lives here. Arguments
+//! after the spec belong to the mode (only `claude-code` takes any). Every
+//! mode runs from the repo root, which the generated `update` app guarantees.
+
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result, ensure};
+use clap::Parser;
+use serde::Deserialize;
+
+mod claude_code;
+mod cmd;
+mod fork;
+mod http;
+mod pins;
+mod pins_file;
+mod pypi;
+mod sri;
+
+#[derive(Parser)]
+#[command(about = "Refresh pinned artifacts from their upstream coordinates")]
+struct Cli {
+    /// Mode-tagged JSON spec rendered from Nix.
+    spec: PathBuf,
+    /// Mode-specific arguments (the claude-code mode's `[version]`,
+    /// `--prompts-only`, `--skip-prompts`).
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    args: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "mode", rename_all = "kebab-case")]
+enum Spec {
+    Pins(pins::Spec),
+    Pypi(pypi::Spec),
+    Fork(fork::Spec),
+    ClaudeCode(claude_code::Spec),
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let raw = std::fs::read_to_string(&cli.spec)
+        .with_context(|| format!("reading spec {}", cli.spec.display()))?;
+    let spec: Spec = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing spec {}", cli.spec.display()))?;
+
+    if !matches!(spec, Spec::ClaudeCode(_)) {
+        ensure!(
+            cli.args.is_empty(),
+            "this updater takes no arguments, got {:?}",
+            cli.args
+        );
+    }
+    match spec {
+        Spec::Pins(spec) => pins::run(&spec),
+        Spec::Pypi(spec) => pypi::run(&spec),
+        Spec::Fork(spec) => fork::run(&spec),
+        Spec::ClaudeCode(spec) => claude_code::run(&spec, &cli.args),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Spec;
+
+    #[test]
+    fn specs_parse_by_mode_tag() {
+        let spec: Spec =
+            serde_json::from_str(r#"{"mode": "pins", "pins": "packages/x/pins.json"}"#).unwrap();
+        assert!(matches!(spec, Spec::Pins(_)));
+
+        let spec: Spec =
+            serde_json::from_str(r#"{"mode": "fork", "fork": "btop", "input": "btop-src"}"#)
+                .unwrap();
+        assert!(matches!(spec, Spec::Fork(_)));
+    }
+
+    #[test]
+    fn unknown_spec_fields_are_rejected() {
+        let parsed =
+            serde_json::from_str::<Spec>(r#"{"mode": "pins", "pins": "p.json", "extra": true}"#);
+        let err = parsed.err().expect("extra field should be rejected");
+        assert!(err.to_string().contains("extra"));
+    }
+}

--- a/packages/nix/pin-update/src/pins.rs
+++ b/packages/nix/pin-update/src/pins.rs
@@ -1,0 +1,145 @@
+//! Generic `pins.json` re-pinner: refresh each entry's SRI `hash` from its
+//! pinned `url`, preserving every other field and the file's entry order.
+//!
+//! The JSON contract (required `hash`, optional `url`/`rev`/`version`
+//! coordinates, `prefetch` mode) is owned by `lib/util/pins.nix`, whose
+//! `loadPins` validates it at eval; this mode is the mechanical rewrite
+//! half. `prefetch` selects how the fetcher's hash is recomputed:
+//!
+//! - `file` (default): flat file hash via `nix store prefetch-file`, matching
+//!   `fetchurl`.
+//! - `unpack`: unpacked-tree hash via `nix-prefetch-url --unpack`, matching
+//!   `fetchzip` (default `stripRoot = true`) and `fetchCrate`.
+//! - `manual`: never rewritten; no prefetch command reproduces the hash
+//!   (e.g. `fetchzip { stripRoot = false; }`), so a human refreshes it from
+//!   the build's `got:` mismatch error.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context as _, Result, bail};
+use serde::Deserialize;
+
+use crate::pins_file::{self, Entry};
+use crate::{cmd, sri};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Spec {
+    /// Repo-relative pins.json to rewrite.
+    pins: PathBuf,
+}
+
+pub fn run(spec: &Spec) -> Result<()> {
+    let mut pins = pins_file::read(&spec.pins)?;
+    for (name, entry) in &mut pins {
+        refresh_entry(&spec.pins, name, entry)?;
+    }
+    pins_file::write(&spec.pins, &pins)?;
+    println!("re-pinned {}", spec.pins.display());
+    Ok(())
+}
+
+fn refresh_entry(path: &Path, name: &str, entry: &mut Entry) -> Result<()> {
+    let mode = pins_file::str_field(entry, "prefetch")
+        .unwrap_or("file")
+        .to_owned();
+    if mode == "manual" {
+        println!(
+            "skipping {name}: prefetch=manual; refresh by building with the new url and copying the got: hash"
+        );
+        return Ok(());
+    }
+    let Some(url) = pins_file::str_field(entry, "url").map(str::to_owned) else {
+        println!("skipping {name}: no `url` to re-fetch");
+        return Ok(());
+    };
+
+    let hash = match mode.as_str() {
+        // fetchzip/fetchCrate validate the UNPACKED tree, not the archive
+        // bytes; `nix-prefetch-url --unpack` reproduces that hash
+        // (fetchTarball semantics: single root dir stripped).
+        "unpack" => {
+            let base32 = cmd::stdout(Command::new("nix-prefetch-url").args(["--unpack", &url]))?;
+            sri::from_nix_base32(&base32)?
+        }
+        "file" => prefetch_file(&url)?,
+        other => bail!(
+            "{}: pin {name} has unknown prefetch mode {other}; expected file, unpack, or manual",
+            path.display()
+        ),
+    };
+    pins_file::set_str(entry, "hash", hash);
+    Ok(())
+}
+
+fn prefetch_file(url: &str) -> Result<String> {
+    #[derive(Deserialize)]
+    struct Prefetched {
+        hash: String,
+    }
+
+    let raw = cmd::stdout(
+        Command::new("nix")
+            .args(["store", "prefetch-file", "--json"])
+            .arg(url),
+    )?;
+    let prefetched: Prefetched = serde_json::from_str(&raw)
+        .with_context(|| format!("unexpected `nix store prefetch-file --json` output for {url}"))?;
+    Ok(prefetched.hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::pins_file::Pins;
+
+    use super::refresh_entry;
+
+    fn pins(json: &str) -> Pins {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn manual_and_urlless_pins_are_left_untouched() {
+        let mut doc = pins(
+            r#"{
+              "held": {"url": "https://example.com/a", "hash": "sha256-x", "prefetch": "manual"},
+              "bare": {"hash": "sha256-y"}
+            }"#,
+        );
+        let before = doc.clone();
+        for (name, entry) in &mut doc {
+            refresh_entry(Path::new("pins.json"), name, entry).unwrap();
+        }
+        assert_eq!(doc, before);
+    }
+
+    #[test]
+    fn unknown_prefetch_mode_fails_loudly() {
+        let mut doc =
+            pins(r#"{"p": {"url": "https://example.com", "hash": "h", "prefetch": "zip"}}"#);
+        let (name, entry) = doc.iter_mut().next().unwrap();
+        let err = refresh_entry(Path::new("pins.json"), name, entry).unwrap_err();
+        assert!(err.to_string().contains("unknown prefetch mode zip"));
+    }
+
+    #[test]
+    fn entry_order_survives_a_round_trip() {
+        let text = r#"{
+  "b": {
+    "version": "1",
+    "url": "https://example.com",
+    "hash": "sha256-x"
+  },
+  "a": {
+    "hash": "sha256-y"
+  }
+}"#;
+        let doc: Pins = serde_json::from_str(text).unwrap();
+        let mut out = serde_json::to_string_pretty(&doc).unwrap();
+        out.push('\n');
+        assert_eq!(out, format!("{text}\n"));
+    }
+}

--- a/packages/nix/pin-update/src/pins_file.rs
+++ b/packages/nix/pin-update/src/pins_file.rs
@@ -1,0 +1,38 @@
+//! pins.json IO. Entries keep their on-disk order (a re-pin rewrites hashes,
+//! not layout), so both map levels are `IndexMap`s; fields beyond the ones an
+//! updater owns pass through as opaque `serde_json::Value`s.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+use indexmap::IndexMap;
+use serde::Serialize;
+use serde_json::Value;
+
+pub type Entry = IndexMap<String, Value>;
+pub type Pins = IndexMap<String, Entry>;
+
+pub fn read(path: &Path) -> Result<Pins> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+/// Write `value` as 2-space-indented JSON with a trailing newline (the repo
+/// convention for generated JSON).
+pub fn write<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let mut rendered = serde_json::to_string_pretty(value)
+        .with_context(|| format!("serializing {}", path.display()))?;
+    rendered.push('\n');
+    fs::write(path, rendered).with_context(|| format!("writing {}", path.display()))
+}
+
+/// A string-valued field of an entry, `None` when absent or non-string.
+pub fn str_field<'entry>(entry: &'entry Entry, key: &str) -> Option<&'entry str> {
+    entry.get(key).and_then(Value::as_str)
+}
+
+/// Set `key` to a string value, preserving its position when it exists.
+pub fn set_str(entry: &mut Entry, key: &str, value: String) {
+    entry.insert(key.to_owned(), Value::String(value));
+}

--- a/packages/nix/pin-update/src/pypi.rs
+++ b/packages/nix/pin-update/src/pypi.rs
@@ -1,0 +1,177 @@
+//! `PyPI` sdist pin refresher for a `pins.json` of Python source pins.
+//!
+//! Policy markers on an entry, honored here so pins are skipped or narrowed
+//! loudly instead of guessed at:
+//!
+//! - `prefetch = "manual"`: hash-mode hold for platform-specific artifacts
+//!   whose URL/hash must be refreshed by hand.
+//! - `hold = "<reason>"`: version hold for pins whose dependency override set
+//!   is hand-tuned to one exact upstream release.
+//! - `track = "<dotted prefix>"`: follow only the newest release inside that
+//!   version line.
+
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result, bail};
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+use crate::pins_file::{self, Entry};
+use crate::{http, sri};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Spec {
+    /// Repo-relative pins.json of `PyPI` sdist pins to rewrite.
+    pins: PathBuf,
+}
+
+pub fn run(spec: &Spec) -> Result<()> {
+    let mut pins = pins_file::read(&spec.pins)?;
+    for (name, entry) in &mut pins {
+        refresh_pin(name, entry)?;
+    }
+    pins_file::write(&spec.pins, &pins)?;
+    println!("updated {} from PyPI metadata", spec.pins.display());
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct Metadata {
+    info: Info,
+    releases: IndexMap<String, Vec<Artifact>>,
+}
+
+#[derive(Deserialize)]
+struct Info {
+    version: String,
+}
+
+#[derive(Deserialize)]
+struct Artifact {
+    packagetype: String,
+    filename: String,
+    digests: Digests,
+}
+
+#[derive(Deserialize)]
+struct Digests {
+    sha256: String,
+}
+
+fn refresh_pin(name: &str, entry: &mut Entry) -> Result<()> {
+    if let Some(prefetch) = pins_file::str_field(entry, "prefetch") {
+        if prefetch != "manual" {
+            bail!(
+                "{name}: unsupported prefetch policy {prefetch}; this updater only handles flat PyPI sdist pins and prefetch=manual holds"
+            );
+        }
+        println!("skipping {name}: prefetch=manual; refresh this platform pin by hand");
+        return Ok(());
+    }
+    if let Some(hold) = pins_file::str_field(entry, "hold") {
+        println!("skipping {name}: hold={hold}");
+        return Ok(());
+    }
+
+    let metadata: Metadata = http::get_json(&format!("https://pypi.org/pypi/{name}/json"))
+        .with_context(|| format!("{name}: failed to fetch PyPI metadata"))?;
+    let version = match pins_file::str_field(entry, "track") {
+        Some(track) => tracked_version(name, metadata.releases.keys(), track)?,
+        None => metadata.info.version,
+    };
+
+    let release = metadata
+        .releases
+        .get(&version)
+        .with_context(|| format!("{name}: PyPI metadata lists no release {version}"))?;
+    let Some(sdist) = release
+        .iter()
+        .find(|artifact| artifact.packagetype == "sdist")
+    else {
+        bail!("{name}: PyPI release {version} has no sdist");
+    };
+
+    let url = source_url(name, &sdist.filename)?;
+    let hash = sri::from_hex(&sdist.digests.sha256)?;
+    pins_file::set_str(entry, "version", version);
+    pins_file::set_str(entry, "url", url);
+    pins_file::set_str(entry, "hash", hash);
+    Ok(())
+}
+
+/// The stable `pypi.io` source redirect for a project's sdist filename.
+fn source_url(project: &str, filename: &str) -> Result<String> {
+    let first = project
+        .chars()
+        .next()
+        .context("empty PyPI project name")?;
+    Ok(format!(
+        "https://pypi.io/packages/source/{first}/{project}/{filename}"
+    ))
+}
+
+/// A pin candidate is a plain dotted-integer version. `PyPI` release lists also
+/// carry pre-releases (3.5.6.dev1, 4.0.0rc1); those never become pins, so
+/// they are disqualified here rather than failing an integer parse.
+fn version_segments(version: &str) -> Option<Vec<u64>> {
+    version
+        .split('.')
+        .map(|segment| segment.parse().ok())
+        .collect()
+}
+
+/// Newest release whose dotted-integer segments start with `track`'s.
+fn tracked_version<'a>(
+    name: &str,
+    releases: impl Iterator<Item = &'a String>,
+    track: &str,
+) -> Result<String> {
+    let track_segments = version_segments(track)
+        .with_context(|| format!("{name}: track {track} is not a dotted-integer prefix"))?;
+    let newest = releases
+        .filter(|version| {
+            version_segments(version).is_some_and(|segments| segments.starts_with(&track_segments))
+        })
+        .max_by_key(|version| version_segments(version));
+    newest
+        .cloned()
+        .with_context(|| format!("{name}: no PyPI releases match track {track}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{source_url, tracked_version, version_segments};
+
+    #[test]
+    fn pre_releases_are_not_version_candidates() {
+        assert_eq!(version_segments("3.5.6"), Some(vec![3, 5, 6]));
+        assert_eq!(version_segments("3.5.6.dev1"), None);
+        assert_eq!(version_segments("4.0.0rc1"), None);
+    }
+
+    #[test]
+    fn track_selects_the_newest_release_in_its_line() {
+        let releases: Vec<String> = ["3.5.4", "3.5.5", "3.6.0", "4.0.0.dev2", "3.5.10"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        let version = tracked_version("pyspark", releases.iter(), "3.5").unwrap();
+        assert_eq!(version, "3.5.10");
+    }
+
+    #[test]
+    fn track_with_no_matching_release_fails() {
+        let releases: Vec<String> = vec!["2.0.0".to_owned()];
+        let err = tracked_version("asn1", releases.iter(), "3").unwrap_err();
+        assert!(err.to_string().contains("no PyPI releases match track 3"));
+    }
+
+    #[test]
+    fn sdist_urls_pin_through_the_source_redirect() {
+        assert_eq!(
+            source_url("htpy", "htpy-26.5.1.tar.gz").unwrap(),
+            "https://pypi.io/packages/source/h/htpy/htpy-26.5.1.tar.gz"
+        );
+    }
+}

--- a/packages/nix/pin-update/src/sri.rs
+++ b/packages/nix/pin-update/src/sri.rs
@@ -1,0 +1,55 @@
+//! SRI (`sha256-<base64>`) hash construction for the fetcher `hash` slots.
+
+use anyhow::{Context, Result, ensure};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+
+/// SRI string from a hex-encoded sha256 digest (`PyPI` digests, upstream
+/// release manifests).
+pub fn from_hex(hex_digest: &str) -> Result<String> {
+    let bytes = hex::decode(hex_digest.trim())
+        .with_context(|| format!("invalid hex sha256 digest `{hex_digest}`"))?;
+    ensure!(
+        bytes.len() == 32,
+        "hex sha256 digest `{hex_digest}` is {} bytes, expected 32",
+        bytes.len()
+    );
+    Ok(format!("sha256-{}", STANDARD.encode(bytes)))
+}
+
+/// SRI string from a nix base32 sha256 (`nix-prefetch-url` output), via
+/// `nix hash convert` so nix's quirky base32 alphabet stays nix's problem.
+pub fn from_nix_base32(base32: &str) -> Result<String> {
+    let output = std::process::Command::new("nix")
+        .args(["hash", "convert", "--hash-algo", "sha256", "--to", "sri"])
+        .arg(base32.trim())
+        .output()
+        .context("failed to run `nix hash convert`")?;
+    ensure!(
+        output.status.success(),
+        "`nix hash convert` failed for `{base32}`:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::from_hex;
+
+    #[test]
+    fn hex_digest_round_trips_to_sri() {
+        // sha256("") in hex vs its well-known SRI form.
+        let hex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        assert_eq!(
+            from_hex(hex).unwrap(),
+            "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+        );
+    }
+
+    #[test]
+    fn short_or_malformed_hex_is_rejected() {
+        assert!(from_hex("abcd").is_err());
+        assert!(from_hex("not hex").is_err());
+    }
+}

--- a/packages/nushell/default.nix
+++ b/packages/nushell/default.nix
@@ -5,9 +5,9 @@
   # Sibling package set (flake path only), for the `rebase-patches` binary the
   # fork updater invokes. `{ }` on the overlay path.
   repoPackages ? {},
-  # Nushell writer for `passthru.updateScript`, pre-bound on the flake path
+  # Pin-update engine for `passthru.updateScript`, pre-bound on the flake path
   # (lib/packages.nix); `null` on the overlay path -> omit the fork updater.
-  updateScriptWriter ? null,
+  pinUpdate ? null,
 }: let
   source = ix.patchedSrc {
     name = "nushell";
@@ -44,11 +44,10 @@ in
       // {
         inherit workspace;
       }
-      // lib.optionalAttrs (updateScriptWriter != null && repoPackages ? rebase-patches) {
+      // lib.optionalAttrs (pinUpdate != null && repoPackages ? rebase-patches) {
         updateScript =
           ix.mkForkUpdater {
-            writeNushellApplication = updateScriptWriter;
-            inherit nix;
+            inherit pinUpdate nix;
             rebasePatches = repoPackages.rebase-patches;
           } {
             name = "nushell";

--- a/packages/spark/spark-gluten/default.nix
+++ b/packages/spark/spark-gluten/default.nix
@@ -27,9 +27,9 @@
   patchelf,
   unzip,
   zip,
-  # Writer for `passthru.updateScript` (flake-package path only); null on the
-  # overlay path.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript` (flake-package path only);
+  # null on the overlay path.
+  pinUpdate ? null,
 }: let
   # Version + URL and SRI hash live in the sibling pins.json, never inline
   # (repo policy). Bump the version/url in pins.json, then `nix run .#update`
@@ -37,8 +37,7 @@
   pin = ix.pins.loadPin ./pins.json "gluten";
   inherit (pin) version;
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
-    inherit nix;
+    inherit pinUpdate nix;
     pname = "spark-gluten";
     relPath = "packages/spark/spark-gluten/pins.json";
   };

--- a/packages/spark/spark-hive/default.nix
+++ b/packages/spark/spark-hive/default.nix
@@ -30,9 +30,9 @@
   python3,
   procps,
   tzdata,
-  # Writer for `passthru.updateScript` (flake-package path only); null on the
-  # overlay path.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript` (flake-package path only);
+  # null on the overlay path.
+  pinUpdate ? null,
   # Pinned, not a parameter: a `jdk ? jdk17_headless` arg collides with the
   # `pkgs.jdk` callPackage auto-fills (currently openjdk 21, which Spark 3.5 does
   # not support), silently overriding the default. Spark 3.5 and Gluten 1.6 both
@@ -45,8 +45,7 @@
   # re-pins the hash.
   pin = ix.pins.loadPin ./pins.json "spark";
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
-    inherit nix;
+    inherit pinUpdate nix;
     pname = "spark-hive";
     relPath = "packages/spark/spark-hive/pins.json";
   };

--- a/packages/terminal/btop/default.nix
+++ b/packages/terminal/btop/default.nix
@@ -6,9 +6,9 @@
   # Sibling package set (flake path only), for the `rebase-patches` binary the
   # fork updater invokes. `{ }` on the overlay path.
   repoPackages ? {},
-  # Nushell writer for `passthru.updateScript`, pre-bound on the flake path
+  # Pin-update engine for `passthru.updateScript`, pre-bound on the flake path
   # (lib/packages.nix); `null` on the overlay path -> omit the fork updater.
-  updateScriptWriter ? null,
+  pinUpdate ? null,
 }:
 # Upstream aristocratos/btop (btop-src input) with the in-repo patch series
 # (./patches) applied: macOS process disk IO sorting, and kernel cwd in the
@@ -25,11 +25,10 @@ btop.overrideAttrs (old: {
   # series, so btop joins the registry-discovered `.#update` DAG.
   passthru =
     (old.passthru or {})
-    // lib.optionalAttrs (updateScriptWriter != null && repoPackages ? rebase-patches) {
+    // lib.optionalAttrs (pinUpdate != null && repoPackages ? rebase-patches) {
       updateScript =
         ix.mkForkUpdater {
-          writeNushellApplication = updateScriptWriter;
-          inherit nix;
+          inherit pinUpdate nix;
           rebasePatches = repoPackages.rebase-patches;
         } {
           name = "btop";

--- a/packages/tonbo-artifacts/default.nix
+++ b/packages/tonbo-artifacts/default.nix
@@ -4,9 +4,9 @@
   nix,
   stdenvNoCC,
   fetchurl,
-  # Writer for `passthru.updateScript` (flake-package path only); null on the
-  # overlay path.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript` (flake-package path only);
+  # null on the overlay path.
+  pinUpdate ? null,
 }: let
   # Version + URL and SRI hash live in the sibling pins.json, never inline
   # (repo policy). Bump the version/url in pins.json, then `nix run .#update`
@@ -14,8 +14,7 @@
   pin = ix.pins.loadPin ./pins.json "artifacts";
   inherit (pin) version;
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
-    inherit nix;
+    inherit pinUpdate nix;
     pname = "tonbo-artifacts";
     relPath = "packages/tonbo-artifacts/pins.json";
   };

--- a/packages/vector-bin/default.nix
+++ b/packages/vector-bin/default.nix
@@ -5,10 +5,10 @@
   lib,
   nix,
   stdenv,
-  # Writer for `passthru.updateScript`, bound only on the flake-package path
-  # (lib/packages.nix); the overlay path leaves it null so `pkgs.*` carries no
-  # updater. Same nullable-writer pattern as claude-code / yc.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript`, bound only on the
+  # flake-package path (lib/packages.nix); the overlay path leaves it null so
+  # `pkgs.*` carries no updater. Same nullable-engine pattern as claude-code / yc.
+  pinUpdate ? null,
 }: let
   # Prebuilt binary is x86_64-linux only; the package-set/flake targets and
   # meta.platforms below gate that, so the unsupported-system throw is redundant.
@@ -20,8 +20,7 @@
   # Bump the version/url in pins.json, then `nix run .#update` re-pins the hash.
   pin = ix.pins.loadPin ./pins.json "vector";
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
-    inherit nix;
+    inherit pinUpdate nix;
     pname = "vector-bin";
     relPath = "packages/vector-bin/pins.json";
   };

--- a/packages/vm/panes/guest-image/default.nix
+++ b/packages/vm/panes/guest-image/default.nix
@@ -13,10 +13,10 @@
   repoPackages,
   ix,
   nix,
-  # Writer for `passthru.updateScript`, bound only on the flake-package path
-  # (lib/packages.nix); the overlay path leaves it null so `pkgs.*` carries no
-  # updater. Same nullable-writer pattern as vector-bin.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript`, bound only on the
+  # flake-package path (lib/packages.nix); the overlay path leaves it null so
+  # `pkgs.*` carries no updater. Same nullable-engine pattern as vector-bin.
+  pinUpdate ? null,
   # Public ssh key authorized for root in the guest, enabling the ssh
   # switch-in-place loop (README, "Iterating on the guest"). Deliberately null
   # by default: the image is repo-built and cacheable, so any default key
@@ -95,8 +95,7 @@
   # Mechanically re-pins the ./pins.json jar hashes from their URLs
   # (`nix run .#update`); bumping the LWJGL version is the human edit.
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
-    inherit nix;
+    inherit pinUpdate nix;
     pname = "panes-guest-image";
     relPath = "packages/vm/panes/guest-image/pins.json";
   };

--- a/packages/wasm-bindgen-cli/default.nix
+++ b/packages/wasm-bindgen-cli/default.nix
@@ -10,9 +10,9 @@
   lib,
   nix,
   rustPlatform,
-  # Writer for `passthru.updateScript` (flake-package path only); null on the
-  # overlay path.
-  updateScriptWriter ? null,
+  # Pin-update engine for `passthru.updateScript` (flake-package path only);
+  # null on the overlay path.
+  pinUpdate ? null,
 }: let
   # Version + crate URL and SRI hash live in the sibling pins.json, never inline
   # (repo policy). Keep in sync with the `wasm-bindgen` Cargo dep; bump the
@@ -20,8 +20,7 @@
   pin = ix.pins.loadPin ./pins.json "wasm-bindgen-cli";
   inherit (pin) version;
   updateScript = ix.pins.mkOptionalUpdater {
-    writeNushellApplication = updateScriptWriter;
-    inherit nix;
+    inherit pinUpdate nix;
     pname = "wasm-bindgen-cli";
     relPath = "packages/wasm-bindgen-cli/pins.json";
   };


### PR DESCRIPTION
Rewrites the pin/updater Nushell scripts as one Rust workspace crate, `packages/nix/pin-update`, per the cluster plan in #3248 (parent: #3247).

## Shape

- **One binary, mode-tagged JSON specs**: `pin-update <spec.json> [args...]`. Each updater is the binary wrapped over a Nix-rendered spec (`(formats.json {}).generate`, never hand-assembled argv), built by `pinUpdate.mkUpdateScript` in `packages/nix/pin-update/default.nix`.
- **`pins` mode** replaces the nu script in `lib/util/pins.nix`'s `mkUpdater`: same `file`/`unpack`/`manual` prefetch contract, entry order and unknown fields preserved (`IndexMap` + opaque `Value`s). `loadPins`/`loadPin` eval-time readers stay untouched.
- **`pypi` mode** replaces `packages/mcp/update.nix`'s script: `prefetch=manual`, `hold`, and `track` policy markers honored; pre-releases disqualified from candidates.
- **`fork` mode** replaces `lib/fork-updater.nix`'s script: `nix flake update <input>` then `rebase-patches <name>`.
- **`claude-code` mode** replaces `packages/agent/claude-code/update.nix`'s script: fail-closed GPG verify against the pinned release key, hex checksums to SRI, prompt snapshot recapture with the same scrubbing; `[version]`, `--prompts-only`, `--skip-prompts` pass through the wrapper.
- The nullable `updateScriptWriter` gate becomes a nullable `pinUpdate` engine (bound in `lib/packages.nix` / `lib/per-system.nix`, null on the overlay path). All 14 consumer call sites migrated; no nushell copy left behind. `updateScriptWriter` itself stays for the sibling clusters' scripts (#3247) until #3256 removes the writer.

## Validation

- `cargo test -p pin-update`: 12 pass; stock `cargo clippy --all-targets`: 0 source findings (fork lints run in CI).
- `nix run .#lint` green (pre-commit hook run).
- `nix build .#pin-update .#{wasm-bindgen-cli,mcp,claude-code,btop}.updateScript .#update` all green (the `.#update` DAG evals every migrated updater node).
- End-to-end runs from the repo root, then reverted to keep the diff scoped:
  - `wasm-bindgen-cli-update`: byte-identical no-op re-pin (unpack mode).
  - `mcp-pypi-pins-update`: real tracked bump (pyspark 3.5.5 -> 3.5.8 inside `track: 3.5`), holds and manual pins skipped.
  - `claude-code-update --skip-prompts`: manifest 2.1.206 -> 2.1.209, signature verified, platform order preserved.

Closes #3248

🤖 Generated with Claude Code (Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move pin updater scripts to a Rust `pin-update` crate replacing inline Nushell implementations
> - Introduces a new `pin-update` Rust binary at [packages/nix/pin-update/](https://github.com/indexable-inc/index/pull/3261/files#diff-b7a957096fdf1a6fccf1da7e8f449a3db1f450e3c77b043388a75846a5fcd3a2) that handles four update modes: `pins`, `pypi`, `fork`, and `claude-code`.
> - Replaces inline Nushell scripts across all package updaters with a shared `pinUpdate.mkUpdateScript` builder that generates a mode-tagged JSON spec and wraps the binary.
> - The `claude-code` mode verifies GPG signatures, converts hex digests to SRI, rewrites `manifest.json` with ordered platforms, and optionally refreshes system-prompt snapshots.
> - The `pins` and `pypi` modes re-pin SRI hashes from URLs and PyPI metadata respectively, preserving file ordering via `IndexMap`.
> - All package definitions replace the `updateScriptWriter`/`writeNushellApplication` parameter with `pinUpdate`, passed down from the flake context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a54b05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->