### PR TITLE
Add composable user source records

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -327,6 +327,7 @@
       skills = skills.outPath;
       modules = ./modules;
       examples = examples.outPath;
+      users = ./users;
       tests = tests.outPath;
       bench.filesystem = bench-filesystem.outPath;
       site = site.outPath;
@@ -428,15 +429,12 @@
               // {
                 attr = "packages.aarch64-darwin.${name}";
               }
-          )
-          (linuxDarwinAliases.aarch64-darwin or {});
+          ) (linuxDarwinAliases.aarch64-darwin or {});
       };
     securityRootPaths =
       rawSecurityRootPaths
       // {
-        aarch64-darwin =
-          rawSecurityRootPaths.aarch64-darwin
-          // (linuxDarwinAliases.aarch64-darwin or {});
+        aarch64-darwin = rawSecurityRootPaths.aarch64-darwin // (linuxDarwinAliases.aarch64-darwin or {});
       };
     indexPackages = system: packages.${system};
     personalConfigRoot = ./users/andrewgazelka/config;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -144,8 +144,11 @@
   # patch bytes owned by index so fleet configurations consume one source of
   # truth instead of copying the fix into each repository.
   nixPatches = {
-    autoGcRecheckAfterLock = paths.packagesRoot + "/nix/nix/patches/0017-fix-libstore-recheck-free-space-after-GC-lock.patch";
-    opaqueTemporaryRootFilenames = paths.packagesRoot + "/nix/nix/patches/0016-fix-libstore-accept-opaque-temporary-root-filenames.patch";
+    autoGcRecheckAfterLock =
+      paths.packagesRoot + "/nix/nix/patches/0017-fix-libstore-recheck-free-space-after-GC-lock.patch";
+    opaqueTemporaryRootFilenames =
+      paths.packagesRoot
+      + "/nix/nix/patches/0016-fix-libstore-accept-opaque-temporary-root-filenames.patch";
   };
   secretRefs = import ./util/secret-refs.nix {inherit lib;};
   selfVersionFor = self: import ./util/self-version.nix {inherit lib self;};
@@ -245,6 +248,7 @@
   # typed wrappers that generate small `.md` files with parseable metadata.
   markdown = import ./util/markdown.nix {inherit lib;};
   skills = import ./skills.nix {inherit lib paths;};
+  users = import ./users.nix {inherit lib paths;};
   agents = import ./agents.nix {inherit lib markdown;};
   hermes = import ./hermes {};
   claudePlugin = import ./claude-plugin.nix {inherit lib skills;};
@@ -615,7 +619,13 @@
     };
   in {
     package = bin;
-    wrap = label: args: ["${bin}/bin/with-lock" label "--"] ++ args;
+    wrap = label: args:
+      [
+        "${bin}/bin/with-lock"
+        label
+        "--"
+      ]
+      ++ args;
   };
 
   /**
@@ -705,6 +715,7 @@
       toml
       unibind
       unibindFor
+      users
       withLockFor
       writeBashApplication
       writeNushellApplication

--- a/lib/users.nix
+++ b/lib/users.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  paths,
+}: let
+  usersRoot = paths.users;
+
+  directoryNames = root:
+    lib.pipe root [
+      builtins.readDir
+      (lib.filterAttrs (_: type: type == "directory"))
+      lib.attrNames
+      (lib.sort lib.lessThan)
+    ];
+
+  optionalPath = root: rel: attrName:
+    lib.optionalAttrs (builtins.pathExists (root + "/${rel}")) {
+      ${attrName} = root + "/${rel}";
+    };
+
+  repoFor = userName: repoName: let
+    root = usersRoot + "/${userName}/${repoName}";
+  in
+    {
+      inherit root;
+    }
+    // lib.optionalAttrs (builtins.pathExists (root + "/agent-context")) {
+      agentContext =
+        {
+          root = root + "/agent-context";
+        }
+        // optionalPath (root + "/agent-context") "sections" "sections"
+        // optionalPath (root + "/agent-context") "overlays" "overlays";
+    }
+    // optionalPath root "skills" "skills";
+
+  reposFor = userName:
+    lib.listToAttrs (
+      map (repoName: {
+        name = repoName;
+        value = repoFor userName repoName;
+      }) (directoryNames (usersRoot + "/${userName}"))
+    );
+in
+  lib.listToAttrs (
+    map (userName: {
+      name = userName;
+      value = reposFor userName;
+    }) (directoryNames usersRoot)
+  )

--- a/users/README.md
+++ b/users/README.md
@@ -1,0 +1,13 @@
+# User Sources
+
+This directory holds user-owned source material that other repositories consume
+through `index.lib.users.<user>.<repo>`.
+
+The `index.lib.users` surface discovers every directory under `users/`, so adding
+`users/<another-user>/<repo>` exposes the same source-record shape without a
+library change.
+
+Repository-local bootstrap files should stay in the consuming repository when
+tools discover them by fixed path. Larger authored inputs, such as agent
+instruction fragments and skills, can live here and be exposed as composable
+source records.


### PR DESCRIPTION
## Summary
- add `index.lib.users`, a composable source-record surface for every `users/<user>/<repo>` directory
- export `lib.users` through the public flake lib and module helper surface
- document that user discovery is generic across all users, not tied to one account

## Validation
- `nix eval --json .#lib.users --apply 'users: builtins.attrNames users'` -> `andrewgazelka`, `harivansh-afk`
- `nix eval --json .#lib.users --apply 'users: builtins.attrNames users.andrewgazelka'`
- `nix eval --json .#lib.users --apply 'users: builtins.attrNames users."harivansh-afk"'`
- `nix run nixpkgs#alejandra -- flake.nix lib/default.nix lib/users.nix`

No ix agent-context or skill data is included in this branch.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add composable user source records discoverable via `lib.users`
> - Adds [lib/users.nix](https://github.com/indexable-inc/index/pull/3263/files#diff-a0307cb1d29944e2fc8aa03f9aa840ea0df2689992ec4d136f570cc03db0ad61) which scans the `./users` directory and builds a nested attribute set mapping each user to their repositories, with `root` and optional `agentContext` (sections, overlays) and `skills` paths.
> - Exposes this as `lib.users` in [lib/default.nix](https://github.com/indexable-inc/index/pull/3263/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) and registers `./users` as a path in [flake.nix](https://github.com/indexable-inc/index/pull/3263/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0).
> - Adds [users/README.md](https://github.com/indexable-inc/index/pull/3263/files#diff-02c1e767355fdce425fcde731db362514a82bcd0025e5ba8db66277e8bb3362c) documenting the discovery layout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2854b6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->