### PR TITLE
nix: reject broad repository root interpolation

### DIFF
--- a/astlog-rules/nix-lints.md
+++ b/astlog-rules/nix-lints.md
@@ -33,7 +33,7 @@ truth. **102 lints total: 98 `error`, 4 `warning`.**
 | 9 | [`no-nixpkgs-channel-ref`](#no-nixpkgs-channel-ref) | err | `<nixpkgs>` channel reference is banned; use flake inputs |
 | 10 | [`no-path-flake-ref`](#no-path-flake-ref) | err | whole-tree `path:` flake refs copy the working tree byte-for-byte; use `.#...`, `git+file:///abs/path`, a relative `path:./<subtree>` input, or a proper flake input |
 | 11 | [`no-parent-path`](#no-parent-path) | err | relative parent path `../` reaches across a directory; use ix.<helper> / index.lib, ix.paths.<root> + a relative string, or the package registry instead of a `../` literal |
-| 12 | [`no-root-string-interp`](#no-root-string-interp) | err | `"${root}/..."` string-interpolates the workspace tree, leaking full-tree context; use `root + "/..."` (path concat) or `builtins.path { name; path; }` |
+| 12 | [`no-root-string-interp`](#no-root-string-interp) | err | interpolating a repository-root binding such as `ix.paths.root` records the whole tree as a derivation input; select the file or subtree as a path before interpolation |
 | 13 | [`no-fake-hash`](#no-fake-hash) | err | fake hashes are banned; compute the real SRI hash before editing tracked Nix files |
 | 14 | [`no-fetchfromgithub-fixed-hash`](#no-fetchfromgithub-fixed-hash) | err | do not pin GitHub source with `fetchFromGitHub { ... hash = ...; }`; add it as a flake input with `flake = false` and consume that source instead |
 | 15 | [`prefer-sri-hash`](#prefer-sri-hash) | err | legacy `sha256`-flavored hash attr; use the SRI `hash` slot: `hash` in fetchers, `cargoHash` / `vendorHash` / `npmDepsHash` in the language builders (or the typed `cargoLock` block for Rust) |
@@ -425,20 +425,26 @@ import ../util/writers.nix { inherit lib; }
 
 **🔴 error**
 
-`"${root}/..."` string-interpolates the workspace tree into a string, leaking full-tree context. Use `root + "/..."` (path concat) or `builtins.path { name = "..."; path = root + "/..."; }`.
+String interpolation coerces a repository-root binding such as `root`, `workspaceRoot`, or `ix.paths.root` into a whole-tree store dependency. Select the file or subtree as a path before interpolation.
 
 *Matches:* `string_expression` · *predicates:* `text-match` · *1 pattern variant*
 
 <table><tr><th>flagged</th><th>ok</th></tr><tr><td>
 
 ```nix
-{ root }: "${root}/nix/file.cmake"
+{ ix, root }: [
+  "${root}/nix/file.cmake"
+  "${ix.paths.root}/lib/build/helper.py"
+]
 ```
 
 </td><td>
 
 ```nix
-{ root }: root + "/nix/file.cmake"
+{ ix, root }: [
+  (root + "/nix/file.cmake")
+  (ix.paths.root + "/lib/build/helper.py")
+]
 ```
 
 </td></tr></table>

--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -611,17 +611,17 @@
 (lint no-recursive-update error
   "lib.recursiveUpdate silently replaces at leaf collisions; use ix.deepMerge.strict (throws on collision) or ix.deepMerge.rhs (rhs wins) from `lib/util/deep-merge.nix`")
 
-;; no-root-string-interp: `"${root}/..."` string-interpolates the workspace
-;; tree into a string, leaking full-tree context. Use `root + "/..."` (path
-;; concat) or `builtins.path { name = "..."; path = root + "/..."; }`.
+;; no-root-string-interp: coercing a repository root inside a string records
+;; the whole tree as a derivation input. Select the file or subtree as a path
+;; before interpolation so unrelated repository edits preserve the dependency.
 (rule (no-root-string-interp n)
   (match nix "
     (string_expression
-      . (interpolation
-          expression: (variable_expression) @v)) @n")
-  (text-match v "^(root|workspaceRoot)$"))
+      (interpolation
+        expression: (_) @v)) @n")
+  (text-match v "^([^[:space:]]+\\.)*(root|workspaceRoot|repoRoot)$"))
 (lint no-root-string-interp error
-  "`\"${{root}}/...\"` string-interpolates the workspace tree, leaking full-tree context; use `root + \"/...\"` (path concat) or `builtins.path {{ name; path; }}`")
+  "string interpolation coerces a repository root into a whole-tree store dependency; select the file or subtree as a path before interpolation")
 
 ;; no-stringly-flags: Build flag attrs are list-of-string, not one string
 ;; with spaces. Whitespace inside flag values breaks paths-with-spaces and

--- a/astlog-rules/tests/no-root-string-interp/bad.fixture
+++ b/astlog-rules/tests/no-root-string-interp/bad.fixture
@@ -1,1 +1,7 @@
-{ root }: "${root}/nix/file.cmake"
+{ ix, paths, repoRoot, root, workspaceRoot }: [
+  "${root}/nix/file.cmake"
+  "prefix-${workspaceRoot}/suffix"
+  "${repoRoot}/flake.nix"
+  "${paths.root}/lib/build/helper.py"
+  "${ix.paths.root}/lib/build/pyo3-wheel.py"
+]

--- a/astlog-rules/tests/no-root-string-interp/good.fixture
+++ b/astlog-rules/tests/no-root-string-interp/good.fixture
@@ -1,1 +1,8 @@
-{ root }: root + "/nix/file.cmake"
+{ helper, ix, paths, repoRoot, root, workspaceRoot }: [
+  (root + "/nix/file.cmake")
+  (workspaceRoot + "/flake.nix")
+  (repoRoot + "/ruff.toml")
+  (paths.root + "/lib/build/helper.py")
+  (ix.paths.root + "/lib/build/pyo3-wheel.py")
+  "${helper}/pyo3-wheel.py"
+]

--- a/packages/agent/skills/nix-style/SKILL.md
+++ b/packages/agent/skills/nix-style/SKILL.md
@@ -50,8 +50,9 @@ line above it, with a comment naming the reason. The common hard rules are:
 - `builtins.path { path = ./.; }` must set `name = "<stable>"` so the store
   path is reproducible across clones.
 - Prefer `lib.fileset.toSource` over `lib.cleanSource`/`lib.sources.cleanSourceWith`.
-- No `"${root}/..."` string interpolation of the workspace tree at the root
-  level; use `root + "/..."` or `builtins.path { name; path; }`.
+- Do not interpolate a repository-root binding such as `root`, `workspaceRoot`,
+  or `ix.paths.root`. Select the file or subtree with path concatenation before
+  interpolation so derivations do not depend on the whole repository.
 
 ### Migration / deprecated APIs
 

--- a/packages/polars-sftp/default.nix
+++ b/packages/polars-sftp/default.nix
@@ -90,7 +90,7 @@ let
         exit 1
       fi
       mkdir -p "$out"
-      python3 ${ix.paths.root}/lib/build/pyo3-wheel.py \
+      python3 ${ix.paths.root + "/lib/build/pyo3-wheel.py"} \
         --package polars_sftp \
         --dist-name polars-sftp \
         --so-name _polars_sftp.abi3.so \

--- a/packages/search/search-py/default.nix
+++ b/packages/search/search-py/default.nix
@@ -88,7 +88,7 @@ in
       "$sanitized"
 
     mkdir -p "$out"
-    python3 ${ix.paths.root}/lib/build/pyo3-wheel.py \
+    python3 ${ix.paths.root + "/lib/build/pyo3-wheel.py"} \
       --package search \
       --dist-name ix-search \
       --so-name _search.abi3.so \

--- a/packages/tui/tui-py/default.nix
+++ b/packages/tui/tui-py/default.nix
@@ -88,7 +88,7 @@ in
       "$sanitized"
 
     mkdir -p "$out"
-    python3 ${ix.paths.root}/lib/build/pyo3-wheel.py \
+    python3 ${ix.paths.root + "/lib/build/pyo3-wheel.py"} \
       --package tui \
       --dist-name ix-tui \
       --so-name _tui.abi3.so \


### PR DESCRIPTION
## Summary

* generalize `no-root-string-interp` to detect dotted repository-root bindings such as `ix.paths.root`
* narrow every current `pyo3-wheel.py` consumer to the file path
* update fixtures, lint reference, and Nix style guidance

## Validation

* `nix build .#checks.x86_64-linux.astlog-rules`
* `nix run .#lint -- --json`
* evaluated `polars-sftp` derivation references `/nix/store/...-pyo3-wheel.py` directly

Fixes #3265

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Broaden `no-root-string-interp` Nix lint to detect namespaced repository root interpolations
> - Expands the `no-root-string-interp` lint rule to match interpolations of dotted paths ending in `root`, `workspaceRoot`, or `repoRoot` (e.g. `ix.paths.root`), not just bare variable names.
> - Updates the lint message to explain that coercing a repository root into a string records the whole tree as a build input, and recommends path concatenation (e.g. `ix.paths.root + "/lib/build/pyo3-wheel.py"`) instead.
> - Fixes three packages ([polars-sftp](https://github.com/indexable-inc/index/pull/3267/files#diff-85eaa74afe5546fce7bd75b74d6fdba54b39db92b931f7a136a8dd1776ae14b8), [search-py](https://github.com/indexable-inc/index/pull/3267/files#diff-87885964a46477ffbbbc1adb817a0cf66f11a2b227fc63fa48ed314b193e39d1), [tui-py](https://github.com/indexable-inc/index/pull/3267/files#diff-9a98aca051720bade5becbf974b9ac9f3b5caab92d39e835b4858de73f34dcd3)) that were already violating the broadened rule by switching to path concatenation before interpolation.
> - Updates the [SKILL.md](https://github.com/indexable-inc/index/pull/3267/files#diff-ef466966718c4871dc331657ef7799cbef767439cb333347ad4b1915ead87a32) agent guideline and [nix-lints.md](https://github.com/indexable-inc/index/pull/3267/files#diff-f25486ae961c19e2ea7339be8c225f596b5bc916f5e840136050f040d5359930) documentation to reflect the broader rule.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c048a49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->