### PR TITLE
nix: lint indented repository root interpolation

### DIFF
--- a/astlog-rules/nix-lints.md
+++ b/astlog-rules/nix-lints.md
@@ -427,7 +427,7 @@ import ../util/writers.nix { inherit lib; }
 
 String interpolation coerces a repository-root binding such as `root`, `workspaceRoot`, or `ix.paths.root` into a whole-tree store dependency. Select the file or subtree as a path before interpolation.
 
-*Matches:* `string_expression` · *predicates:* `text-match` · *1 pattern variant*
+*Matches:* `string_expression`, `indented_string_expression` · *predicates:* `text-match` · *2 pattern variants*
 
 <table><tr><th>flagged</th><th>ok</th></tr><tr><td>
 
@@ -435,6 +435,7 @@ String interpolation coerces a repository-root binding such as `root`, `workspac
 { ix, root }: [
   "${root}/nix/file.cmake"
   "${ix.paths.root}/lib/build/helper.py"
+  ''${ix.paths.root}/lib/build/helper.py''
 ]
 ```
 
@@ -444,6 +445,7 @@ String interpolation coerces a repository-root binding such as `root`, `workspac
 { ix, root }: [
   (root + "/nix/file.cmake")
   (ix.paths.root + "/lib/build/helper.py")
+  ''${ix.paths.root + "/lib/build/helper.py"}''
 ]
 ```
 

--- a/astlog-rules/nix.astlog
+++ b/astlog-rules/nix.astlog
@@ -619,7 +619,13 @@
     (string_expression
       (interpolation
         expression: (_) @v)) @n")
-  (text-match v "^([^[:space:]]+\\.)*(root|workspaceRoot|repoRoot)$"))
+  (text-match v "^(([^[:space:]]+\\.)*paths\\.root|root|workspaceRoot|repoRoot)$"))
+(rule (no-root-string-interp n)
+  (match nix "
+    (indented_string_expression
+      (interpolation
+        expression: (_) @v)) @n")
+  (text-match v "^(([^[:space:]]+\\.)*paths\\.root|root|workspaceRoot|repoRoot)$"))
 (lint no-root-string-interp error
   "string interpolation coerces a repository root into a whole-tree store dependency; select the file or subtree as a path before interpolation")
 

--- a/astlog-rules/tests/no-root-string-interp/bad.fixture
+++ b/astlog-rules/tests/no-root-string-interp/bad.fixture
@@ -4,4 +4,7 @@
   "${repoRoot}/flake.nix"
   "${paths.root}/lib/build/helper.py"
   "${ix.paths.root}/lib/build/pyo3-wheel.py"
+  ''
+    python3 ${ix.paths.root}/lib/build/pyo3-wheel.py
+  ''
 ]

--- a/astlog-rules/tests/no-root-string-interp/good.fixture
+++ b/astlog-rules/tests/no-root-string-interp/good.fixture
@@ -1,8 +1,12 @@
-{ helper, ix, paths, repoRoot, root, workspaceRoot }: [
+{ checks, helper, ix, paths, repoRoot, root, workspaceRoot }: [
   (root + "/nix/file.cmake")
   (workspaceRoot + "/flake.nix")
   (repoRoot + "/ruff.toml")
   (paths.root + "/lib/build/helper.py")
   (ix.paths.root + "/lib/build/pyo3-wheel.py")
   "${helper}/pyo3-wheel.py"
+  "${checks.root}/result"
+  ''
+    python3 ${ix.paths.root + "/lib/build/pyo3-wheel.py"}
+  ''
 ]

--- a/lib/util/relative-path.nix
+++ b/lib/util/relative-path.nix
@@ -18,13 +18,13 @@
         else "<${builtins.typeOf path}>"
       )
     ); path;
-  shellPath = root: path: ''"${root}"/${lib.escapeShellArg (assertSafe path)}'';
-  shellParent = root: path: let
+  shellPath = base: path: ''"${base}"/${lib.escapeShellArg (assertSafe path)}'';
+  shellParent = base: path: let
     parent = dirOf (assertSafe path);
   in
     if parent == "."
-    then ''"${root}"''
-    else shellPath root parent;
+    then ''"${base}"''
+    else shellPath base parent;
 in {
   inherit
     isSafe

--- a/packages/search/polars-mixedbread/default.nix
+++ b/packages/search/polars-mixedbread/default.nix
@@ -88,7 +88,7 @@
       ''}
 
       mkdir -p "$out"
-      python3 ${ix.paths.root}/lib/build/pyo3-wheel.py \
+      python3 ${ix.paths.root + "/lib/build/pyo3-wheel.py"} \
         --package polars_mixedbread \
         --dist-name polars-mixedbread \
         --so-name _polars_mixedbread.abi3.so \


### PR DESCRIPTION
## Summary

* cover `indented_string_expression`, the AST shape used by Nix build phases
* keep dotted matching specific to `paths.root` so unrelated outputs such as `tests.root` stay valid
* narrow the remaining `polars-mixedbread` wheel helper input
* rename the generic relative-path helper argument from `root` to `base`

## Validation

* focused scan: 6 bad-fixture findings, 0 good-fixture findings, 0 findings across index Nix sources
* `nix build .#checks.x86_64-linux.astlog-rules`
* `nix run .#lint -- --json` reaches only the two unrelated `lib/users.nix` findings already tracked by #2460

Follow-up to #3267. Refs #3265.

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend `no-root-string-interp` nix lint to cover indented strings and namespaced paths
> - Adds a second matcher to the `no-root-string-interp` rule in [nix.astlog](https://github.com/indexable-inc/index/pull/3271/files#diff-de5bc8426aac324b41bb80bf1cfa277c527b5423c78e6e4767189c3b0330cc60) that targets `indented_string_expression` nodes, so the lint fires inside multiline strings as well as regular strings.
> - Broadens the text-match regex to also flag namespaced forms like `ix.paths.root` (any `<prefix>.paths.root`).
> - Updates [packages/search/polars-mixedbread/default.nix](https://github.com/indexable-inc/index/pull/3271/files#diff-84b8e3441fae6a2bee22d67059d3e9cb1107cc2276b014cb8cdfcf6058009060) to use the accepted pattern `${ix.paths.root + "/lib/build/pyo3-wheel.py"}` instead of the now-flagged bare interpolation.
> - Renames the `root` parameter to `base` in `shellPath` and `shellParent` in [lib/util/relative-path.nix](https://github.com/indexable-inc/index/pull/3271/files#diff-145334ea79215a2a78ed6c11b740c89bd8312920b89c9d6a04319f2d835e317d) to avoid triggering the lint.
> - Updates fixtures and docs to cover the new indented-string and namespaced-path cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c21a14e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->