### PR TITLE
upstream tools: fix Clippy regressions

### DIFF
--- a/packages/upstream-sync/src/bin/upstream_pr.rs
+++ b/packages/upstream-sync/src/bin/upstream_pr.rs
@@ -93,9 +93,10 @@ fn main() -> Result<()> {
     println!("{}", paint(CYAN, &format!("upstream-pr: {}: target patch {target}", cli.pkg)));
 
     // Ancestor closure from the DAG, in NNNN order, plus the target last.
-    let closure = doc.closure(&target);
+    let mut closure = doc.closure(&target);
     let pos: HashMap<&str, usize> = all_patches.iter().enumerate().map(|(i, n)| (n.as_str(), i)).collect();
     let by_series = |p: &String| pos.get(p.as_str()).copied().unwrap_or(usize::MAX);
+    closure.sort_by_key(by_series);
     let mut ordered = closure.clone();
     ordered.push(target.clone());
     ordered.sort_by_key(by_series);
@@ -107,9 +108,7 @@ fn main() -> Result<()> {
             "{}",
             paint(YELLOW, &format!("upstream-pr: {}: {target} is NOT independent; its upstream contribution drags {} ancestor patch(es):", cli.pkg, closure.len()))
         );
-        let mut sorted = closure.clone();
-        sorted.sort_by_key(by_series);
-        for c in &sorted {
+        for c in &closure {
             println!("  - {c}");
         }
         println!("{}", paint(YELLOW, "upstream-pr: consider splitting, or send the closure as one PR."));
@@ -126,7 +125,7 @@ fn main() -> Result<()> {
         .tempdir()
         .wrap_err("cannot create scratch dir")?
         .keep();
-    let (head_ref, tip) = prepare_branch(&scratch, &fork, &slug, &branch, &cli.pkg)?;
+    let PreparedBranch { head_ref, tip } = prepare_branch(&scratch, &fork, &slug, &branch, &cli.pkg)?;
     apply_closure(&scratch, &patch_dir, &ordered, &tip, &cli.pkg)?;
 
     let n_commits = cmd::run_in(&scratch, "git", &["rev-list", "--count", &format!("{tip}..HEAD")])?;
@@ -186,8 +185,13 @@ fn neutralize_config(scratch: &Path) -> Result<()> {
 }
 
 /// Init the scratch repo, discover + fetch the upstream default branch, and
-/// check out the contribution branch at its tip. Returns (head_ref, tip).
-fn prepare_branch(scratch: &Path, fork: &Fork, slug: &Slug, branch: &str, pkg: &str) -> Result<(String, String)> {
+/// check out the contribution branch at its tip.
+struct PreparedBranch {
+    head_ref: String,
+    tip: String,
+}
+
+fn prepare_branch(scratch: &Path, fork: &Fork, slug: &Slug, branch: &str, pkg: &str) -> Result<PreparedBranch> {
     cmd::run_in(scratch, "git", &["init", "--quiet"])?;
     neutralize_config(scratch)?;
     println!("upstream-pr: fetching {}/{} default branch tip...", slug.owner, slug.repo);
@@ -206,7 +210,7 @@ fn prepare_branch(scratch: &Path, fork: &Fork, slug: &Slug, branch: &str, pkg: &
     cmd::run_in(scratch, "git", &["fetch", "--quiet", "upstream", &head_ref])?;
     let tip = cmd::run_in(scratch, "git", &["rev-parse", "FETCH_HEAD"])?;
     cmd::run_in(scratch, "git", &["checkout", "--quiet", "-b", branch, &tip])?;
-    Ok((head_ref, tip))
+    Ok(PreparedBranch { head_ref, tip })
 }
 
 /// Apply the closure onto the tip with 3-way. On conflict, fail loudly: this

--- a/packages/upstream-sync/src/drift.rs
+++ b/packages/upstream-sync/src/drift.rs
@@ -165,7 +165,13 @@ fn age_days(date: &str) -> Result<i64> {
 
 /// Patch stances walk dag.json node order (the canonical series, same as the
 /// sync loop); an unclassified patch defaults to hold (fail-safe).
-fn stance_counts(fork: &Fork) -> Result<(usize, usize, usize)> {
+struct StanceCounts {
+    attempt: usize,
+    hold: usize,
+    never: usize,
+}
+
+fn stance_counts(fork: &Fork) -> Result<StanceCounts> {
     let dag_file = fork.patch_dir_abs().join("dag.json");
     let series: Vec<String> = if dag_file.exists() {
         dag::Doc::load(&dag_file)?.patch_names()
@@ -174,7 +180,11 @@ fn stance_counts(fork: &Fork) -> Result<(usize, usize, usize)> {
     };
     let stances: Vec<String> = series.iter().map(|p| fork.stance(p)).collect();
     let count = |wanted: &str| stances.iter().filter(|s| *s == wanted).count();
-    Ok((count("attempt"), count("hold"), count("never")))
+    Ok(StanceCounts {
+        attempt: count("attempt"),
+        hold: count("hold"),
+        never: count("never"),
+    })
 }
 
 fn row(fork: &Fork) -> Result<Row> {
@@ -201,7 +211,7 @@ fn row(fork: &Fork) -> Result<Row> {
     let base_date = base_date(fork, forge, &slug, rev.as_deref())?;
     let age_days = base_date.as_deref().map(age_days).transpose()?;
 
-    let (attempt, hold, never) = stance_counts(fork)?;
+    let stances = stance_counts(fork)?;
     let retired = status::Doc::load(&status::path(fork))?
         .patches
         .values()
@@ -240,9 +250,9 @@ fn row(fork: &Fork) -> Result<Row> {
         behind,
         base_date,
         age_days,
-        attempt,
-        hold,
-        never,
+        attempt: stances.attempt,
+        hold: stances.hold,
+        never: stances.never,
         retired,
         action: action.to_owned(),
         note: note.to_owned(),

--- a/packages/upstream-sync/src/main.rs
+++ b/packages/upstream-sync/src/main.rs
@@ -153,7 +153,12 @@ fn run_sync(args: &SyncArgs) -> Result<()> {
 /// Repo-level gates: a non-github host has no gh path; PRs unwelcome or AI
 /// banned means we never open here. We still LOAD + report status, but skip
 /// any outward act.
-fn repo_gate(fork: &Fork, slug: &Slug, gh_ok: bool) -> (bool, String) {
+struct RepoGate {
+    blocked: bool,
+    reason: String,
+}
+
+fn repo_gate(fork: &Fork, slug: &Slug, gh_ok: bool) -> RepoGate {
     let policy = fork.policy();
     let blocked = !policy.prs_welcome || policy.ai_prs_allowed == "false" || !gh_ok;
     let reason = if !gh_ok {
@@ -165,7 +170,7 @@ fn repo_gate(fork: &Fork, slug: &Slug, gh_ok: bool) -> (bool, String) {
     } else {
         String::new()
     };
-    (blocked, reason)
+    RepoGate { blocked, reason }
 }
 
 fn process_fork(fork: &Fork, args: &SyncArgs, plan: &mut Vec<PlanEntry>) -> Result<()> {
@@ -173,7 +178,10 @@ fn process_fork(fork: &Fork, args: &SyncArgs, plan: &mut Vec<PlanEntry>) -> Resu
     let patch_dir = fork.patch_dir_abs();
     let policy = fork.policy();
     let gh_ok = mapping::is_github(&fork.url);
-    let (repo_blocked, repo_block_reason) = repo_gate(fork, &slug, gh_ok);
+    let RepoGate {
+        blocked: repo_blocked,
+        reason: repo_block_reason,
+    } = repo_gate(fork, &slug, gh_ok);
 
     println!("{}", paint(CYAN, &format!("== {} [{}/{}] ==", fork.name, slug.owner, slug.repo)));
     if repo_blocked {
@@ -425,8 +433,7 @@ fn open_one(ctx: &ForkCtx, pf: &str, doc: &mut status::Doc, plan: &mut Vec<PlanE
     let pr_url = opened
         .stdout
         .lines()
-        .filter(|l| l.contains("github.com") && l.contains("/pull/"))
-        .next_back()
+        .rfind(|l| l.contains("github.com") && l.contains("/pull/"))
         .map(str::to_owned);
     if let Some(url) = &pr_url {
         let number = regex!(r"/pull/([0-9]+)")


### PR DESCRIPTION
## Summary

- replace anonymous tuple returns with named result structs
- remove a redundant clone and use the iterator method Clippy requests
- restore the upstream-sync Clippy gate after PR #3270

## Validation

- .#ciChecks.x86_64-linux.upstream-sync.clippy
- .#ciChecks.x86_64-linux.upstream-sync.upstream-sync-all
- .#ciChecks.x86_64-linux.upstream-sync.upstream-pr-all

Fixes #3272

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Clippy regressions in upstream sync tools by replacing tuples with named structs
> - Introduces `PreparedBranch`, `StanceCounts`, and `RepoGate` structs in place of tuple return types across [upstream_pr.rs](https://github.com/indexable-inc/index/pull/3273/files#diff-4ecb0e79f594154adf1698d7a7de4e471cbe31603735be2b53e641648a1a4b7e), [drift.rs](https://github.com/indexable-inc/index/pull/3273/files#diff-a4c4d98908bc2b61f69c2295f3c4d9c303170f0f7c709f16897ef5d1c665e6dd), and [main.rs](https://github.com/indexable-inc/index/pull/3273/files#diff-f8543fd12122bf7b97a81e36b6ec57c54073e53d6443fff97115a061e97b5b37).
> - Makes the DAG closure mutable and sorts it in place using `by_series` before iteration, removing the temporary `sorted` clone.
> - Changes `open_one` to use `rfind` instead of `filter` + `next_back` to extract the last matching PR URL line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0732509.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->