### PR TITLE
devshell: export shared package manifest

### DIFF
--- a/lib/dev-shell-packages.nix
+++ b/lib/dev-shell-packages.nix
@@ -1,0 +1,21 @@
+{
+  packageNames = [
+    "alejandra"
+    "coreutils"
+    "fd"
+    "gh"
+    "git"
+    "graphite-cli"
+    "jq"
+    "python3"
+    "ripgrep"
+    "skopeo"
+    "tea"
+  ];
+
+  # nixpkgs evaluates the wrapper on Linux and its unwrapped package on Darwin.
+  unfreePackageNames = [
+    "graphite-cli"
+    "graphite-cli-unwrapped"
+  ];
+}


### PR DESCRIPTION
## Summary

- define the generic ix bootstrap package names in Index
- keep Graphite's wrapped and unwrapped unfree names beside that manifest
- expose the data as a flake-independent Nix file so bootstrap consumers can import it before nixpkgs exists

## Validation

- evaluated every package derivation for `aarch64-darwin` and `x86_64-linux`
- `alejandra`, `deadnix`, `statix`, and the new file's astlog scan pass
- full `nix run .#lint` reaches the same two unrelated `lib/users.nix` astlog errors on unchanged `main`

Closes #3276
Tracks indexable-inc/ix#7289.

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export shared devshell package manifest to a dedicated Nix file
> Extracts the list of common devshell packages into [lib/dev-shell-packages.nix](https://github.com/indexable-inc/index/pull/3277/files#diff-b2b6e218c365f9cdcb869d9520f2e4a63e20b9c8290c09b00840fa6ce757d32e), defining `packageNames` and `unfreePackageNames` as top-level attributes. `unfreePackageNames` includes both `graphite-cli` and `graphite-cli-unwrapped` to handle the difference in nixpkgs evaluation between Linux (wrapper) and Darwin (unwrapped).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fdac7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->