### PR TITLE
agent: place worktrees under user tempdir

### DIFF
--- a/packages/agent/skills/workflow/SKILL.md
+++ b/packages/agent/skills/workflow/SKILL.md
@@ -24,12 +24,11 @@ moved, `git pull --rebase origin main` and push again.
 Open a PR only when you want human review on a change, not as the default path
 to land. When you do, create the branch and worktree from the updated `main`
 checkout. Use the `codex/` branch prefix unless the user asks for a different
-name. Place the worktree as a sibling of the repo root (the `../` prefix) so it
-stays outside the flake source tree and does not slow down Nix source-copy or
-lint walks:
+name. Place the worktree under `/tmp/<username>/` so it stays outside the flake
+source tree and does not slow down Nix source-copy or lint walks:
 
 ```sh
-git worktree add ../<short-name>-<branch> -b codex/<branch> main
+git worktree add /tmp/<username>/<branch> -b codex/<branch> main
 ```
 
 Never place worktrees under the repo root (e.g. `.claude/worktrees/` or


### PR DESCRIPTION
## Summary

- place agent worktrees under `/tmp/<username>/<branch>`
- align the global workflow skill with repository guards that reserve the main checkout

## Validation

- `nix run .#skill-lint -- packages/agent/skills/workflow/SKILL.md`
- `git diff --check`

Refs indexable-inc/ix#7293.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Place git worktrees under /tmp/<username>/ in agent workflow documentation
> Updates [SKILL.md](https://github.com/indexable-inc/index/pull/3278/files#diff-8375248fd2aa9576a706ef83507a7ab835d26512f18cd73689e008cad948705a) to recommend creating git worktrees under `/tmp/<username>/<branch>` instead of as a sibling of the repo root. The rationale (keeping worktrees outside the flake source tree to avoid slowing Nix source-copy or lint walks) is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15b4edd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->