### PR TITLE
mcp: preserve pr watch command failures

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2061,6 +2061,50 @@ def _nu_record(value: Any, *, source: str) -> dict[str, Any]:
     raise TypeError(f"{source}: expected a record, got {type(value).__name__}")
 
 
+@dataclasses.dataclass(frozen=True)
+class _NuCompletion:
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+def _nu_completion(value: Any, *, source: str) -> _NuCompletion:
+    """Validate one Nushell `complete` record at the command boundary."""
+    record = _nu_record(value, source=source)
+    missing = {"stdout", "stderr", "exit_code"} - record.keys()
+    if missing:
+        raise TypeError(f"{source}: complete record missing {', '.join(sorted(missing))}")
+    stdout = record["stdout"]
+    stderr = record["stderr"]
+    exit_code = record["exit_code"]
+    if not isinstance(stdout, str):
+        raise TypeError(f"{source}: expected stdout to be str, got {type(stdout).__name__}")
+    if not isinstance(stderr, str):
+        raise TypeError(f"{source}: expected stderr to be str, got {type(stderr).__name__}")
+    if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+        raise TypeError(f"{source}: expected exit_code to be int, got {type(exit_code).__name__}")
+    return _NuCompletion(stdout=stdout, stderr=stderr, exit_code=exit_code)
+
+
+def _nu_failure(source: str, completion: _NuCompletion) -> str:
+    detail = completion.stderr.strip() or completion.stdout.strip() or "no error text"
+    return f"{source} failed with exit code {completion.exit_code}: {detail}"
+
+
+def _nu_json_record(value: Any, *, source: str) -> dict[str, Any]:
+    """Validate a completed command, then decode its stdout as one JSON record."""
+    completion = _nu_completion(value, source=source)
+    if completion.exit_code != 0:
+        raise RuntimeError(_nu_failure(source, completion))
+    try:
+        parsed = json.loads(completion.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{source} returned invalid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, dict):
+        raise TypeError(f"{source}: expected a JSON record, got {type(parsed).__name__}")
+    return parsed
+
+
 async def watch_pr(
     pr: str | int,
     *,
@@ -2098,6 +2142,26 @@ async def watch_pr(
         kind="pr",
         alive=lambda: state.get("status") not in {"merged", "closed", "failed", "timed out"},
     )
+
+    async def fail_watch(error: Exception) -> None:
+        state.update(
+            {
+                "status": "failed",
+                "error": str(error),
+                "elapsed": _format_duration(time.time() - started),
+            }
+        )
+        resource.close()
+        try:
+            await notify(
+                f"PR {clean_pr} watch failed: {error}", resource=resource.id, pr=clean_pr
+            )
+        except Exception as notify_error:
+            error.add_note(
+                "pr_watch failure notification also raised "
+                f"{type(notify_error).__name__}: {notify_error}"
+            )
+
     import nu as nu_call
 
     async def run_nu(code: str) -> Any:
@@ -2109,13 +2173,17 @@ async def watch_pr(
         )
 
     async def refresh() -> dict[str, Any]:
-        row = _nu_record(
-            await run_nu(
-                'gh pr view $env.PR --json number,title,state,mergeStateStatus,statusCheckRollup,'
-                'url,autoMergeRequest,isDraft,reviewDecision | complete | get stdout | from json'
-            ),
-            source="gh pr view",
-        )
+        try:
+            row = _nu_json_record(
+                await run_nu(
+                    'gh pr view $env.PR --json number,title,state,mergeStateStatus,statusCheckRollup,'
+                    'url,autoMergeRequest,isDraft,reviewDecision | complete'
+                ),
+                source="gh pr view",
+            )
+        except Exception as exc:
+            await fail_watch(exc)
+            raise
         checks = row.get("statusCheckRollup") or []
         title = row.get("title") or f"PR {row.get('number') or clean_pr}"
         state.update(
@@ -2166,12 +2234,16 @@ async def watch_pr(
         else:
             flag = f"--{merge_method}"
             delete = "--delete-branch" if delete_branch else ""
-            merge = _nu_record(
-                await run_nu(f"gh pr merge $env.PR --auto {flag} {delete} | complete"),
-                source="gh pr merge",
-            )
-            if int(merge["exit_code"]) != 0:
-                state["error"] = str(merge["stderr"] or merge["stdout"])
+            try:
+                merge = _nu_completion(
+                    await run_nu(f"gh pr merge $env.PR --auto {flag} {delete} | complete"),
+                    source="gh pr merge",
+                )
+                if merge.exit_code != 0:
+                    raise RuntimeError(_nu_failure("gh pr merge", merge))
+            except Exception as exc:
+                await fail_watch(exc)
+                raise
 
     def finished(result: dict[str, Any]) -> dict[str, Any]:
         """Carry the skipped-auto-merge note onto the returned summary."""

--- a/packages/mcp/tests/test_pr_watch_automerge.py
+++ b/packages/mcp/tests/test_pr_watch_automerge.py
@@ -6,7 +6,10 @@ reads mergeStateStatus first and skips arming with a loud note instead.
 """
 
 import asyncio
+import json
+import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -19,8 +22,11 @@ class _ScriptedNu:
     `__call__`. Serves scripted `gh pr view` rows (the last row repeats) and
     records every `gh pr merge` invocation."""
 
-    def __init__(self, views: list[dict[str, object]]) -> None:
+    def __init__(
+        self, views: list[dict[str, object]], *, merge_error: str | None = None
+    ) -> None:
         self._views = list(views)
+        self._merge_error = merge_error
         self.merges: list[str] = []
 
     async def __call__(
@@ -33,9 +39,12 @@ class _ScriptedNu:
     ) -> dict[str, object]:
         if "gh pr merge" in code:
             self.merges.append(code)
+            if self._merge_error is not None:
+                return {"exit_code": 1, "stdout": "", "stderr": self._merge_error}
             return {"exit_code": 0, "stdout": "", "stderr": ""}
         assert "gh pr view" in code
-        return self._views.pop(0) if len(self._views) > 1 else self._views[0]
+        view = self._views.pop(0) if len(self._views) > 1 else self._views[0]
+        return {"exit_code": 0, "stdout": json.dumps(view), "stderr": ""}
 
 
 def _view(pr: int, state: str, merge_state: str) -> dict[str, object]:
@@ -120,6 +129,33 @@ class _FrameNu(_ScriptedNu):
         return pl.DataFrame([value])
 
 
+class _TrackedResource:
+    id = "pr-test"
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _capture_terminal_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[_TrackedResource, list[str]]:
+    resource = _TrackedResource()
+    notifications: list[str] = []
+
+    def register_resource(**kwargs: object) -> _TrackedResource:
+        return resource
+
+    async def fake_notify(content: str, **meta: object) -> None:
+        notifications.append(content)
+
+    monkeypatch.setattr(runtime, "register_resource", register_resource)
+    monkeypatch.setattr(runtime, "notify", fake_notify)
+    return resource, notifications
+
+
 def test_one_row_frame_from_stale_nu_still_watches(monkeypatch: pytest.MonkeyPatch) -> None:
     """#3175: `refresh()` died with AttributeError DataFrame.get when nu
     returned a 1-row frame for the gh pr view record; the boundary now
@@ -145,3 +181,72 @@ def test_nu_record_rejects_unexpected_shapes() -> None:
         runtime._nu_record(pl.DataFrame([{"a": 1}, {"a": 2}]), source="t")
     with pytest.raises(TypeError, match="expected a record"):
         runtime._nu_record("text", source="t")
+
+
+def test_failed_view_preserves_completion_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#2637: validate `complete` before parsing stdout, so a failed gh call
+    keeps its real diagnostic instead of becoming an empty DataFrame."""
+    gh = tmp_path / "gh"
+    gh.write_text(
+        "#!/bin/sh\nprintf '%s\\n' 'GraphQL: API rate limit already exceeded' >&2\nexit 1\n"
+    )
+    gh.chmod(0o755)
+    monkeypatch.setenv("PATH", os.pathsep.join((str(tmp_path), os.environ["PATH"])))
+    resource, notifications = _capture_terminal_failure(monkeypatch)
+    import nu
+
+    nu.reset()
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="gh pr view failed with exit code 1: GraphQL: API rate limit already exceeded",
+        ):
+            asyncio.run(runtime.watch_pr(9105, auto_merge=False))
+    finally:
+        nu.reset()
+
+    assert resource.closed
+    assert notifications == [
+        "PR 9105 watch failed: gh pr view failed with exit code 1: "
+        "GraphQL: API rate limit already exceeded"
+    ]
+
+
+def test_failed_auto_merge_is_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _ScriptedNu([_view(9106, "OPEN", "BLOCKED")], merge_error="merge denied")
+    monkeypatch.setitem(sys.modules, "nu", fake)
+    resource, notifications = _capture_terminal_failure(monkeypatch)
+
+    with pytest.raises(
+        RuntimeError, match="gh pr merge failed with exit code 1: merge denied"
+    ):
+        asyncio.run(runtime.watch_pr(9106, auto_merge=True, interval=0.01))
+
+    assert resource.closed
+    assert notifications == [
+        "PR 9106 watch failed: gh pr merge failed with exit code 1: merge denied"
+    ]
+
+
+def test_notification_error_does_not_mask_command_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _ScriptedNu([_view(9107, "OPEN", "BLOCKED")], merge_error="merge denied")
+    monkeypatch.setitem(sys.modules, "nu", fake)
+    resource, _notifications = _capture_terminal_failure(monkeypatch)
+
+    async def failing_notify(content: str, **meta: object) -> None:
+        raise RuntimeError("outbox unavailable")
+
+    monkeypatch.setattr(runtime, "notify", failing_notify)
+    with pytest.raises(
+        RuntimeError, match="gh pr merge failed with exit code 1: merge denied"
+    ) as caught:
+        asyncio.run(runtime.watch_pr(9107, auto_merge=True, interval=0.01))
+
+    assert resource.closed
+    assert caught.value.__notes__ == [
+        "pr_watch failure notification also raised RuntimeError: outbox unavailable"
+    ]


### PR DESCRIPTION
## Problem

`pr_watch` parsed `gh pr view` stdout before checking the Nushell `complete` record. When GitHub rejected the request during GraphQL quota exhaustion, the pipeline discarded exit code 1 and stderr, parsed empty stdout into a `(0, 0)` Polars DataFrame, then crashed on `DataFrame.get`.

The exact deployed interpreter produced a dict after the quota reset, so this is a failed-command boundary bug rather than the legacy one-row framing fixed by #3177.

## Fix

* Validate `stdout`, `stderr`, and `exit_code` once as a typed completion record.
* Parse JSON only after a successful command.
* Preserve the original command diagnostic, close the PR resource, notify, and reraise on failure.
* Treat failed auto-merge arming as terminal instead of clearing the error on the next refresh.
* Exercise the real bundled Nushell engine with a temporary failing `gh` executable.

Open PR #3061 changes the same watcher state machine. This boundary change is orthogonal, but whichever lands second will need a mechanical rebase.

## Validation

* `nix build .#mcp.tests.typecheckSmoke --no-link -L`: 151 passed
* `nix build .#mcp --no-link -L`
* `nix run .#lint`: 9 of 10 stages passed, including `ruff`; `astlog` is blocked by unchanged `lib/users.nix` findings tracked in #2460
* Two independent adversarial reviews found no remaining blockers

Fixes #2637

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise RuntimeError and send failure notifications on `gh pr view` or `gh pr merge` failures in `watch_pr`
> - Adds `_nu_completion`, `_nu_failure`, and `_nu_json_record` helpers in [runtime.py](https://github.com/indexable-inc/index/pull/3283/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) to validate Nushell command completions and format failure messages.
> - `watch_pr` now calls `gh pr view` and `gh pr merge` with `| complete` and validates results; a non-zero exit code raises a `RuntimeError` with stderr/stdout details.
> - On terminal failure, `watch_pr` closes the tracked resource and sends a failure notification; if the notification itself fails, a note is attached to the original exception rather than masking it.
> - Behavioral Change: previously, a non-zero `gh pr merge` exit only stored error text without raising; now it raises and terminates the watch loop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ede8f63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->