### PR TITLE
profiles: leave Ctrl-R history to Atuin

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -291,14 +291,15 @@ in {
           enableZshIntegration = true;
           enableFishIntegration = true;
         };
-        # Fuzzy finder. Closes the loop with atuin (Ctrl+R history) and
-        # zoxide (z foo) so the same interaction model picks files,
-        # processes, branches, anything the operator pipes into fzf.
+        # Fuzzy finder for files, processes, branches, and anything else the
+        # operator pipes into fzf. Atuin owns Ctrl-R history search above, so
+        # leave fzf's overlapping history widget disabled.
         fzf = {
           enable = true;
           enableBashIntegration = true;
           enableZshIntegration = true;
           enableFishIntegration = true;
+          historyWidget.command = "";
         };
         # AST-aware merge driver. Parses 30+ languages (Nix, Rust,
         # Python, TS/JS, Go, Java, ...) and resolves structural conflicts

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3464,6 +3464,10 @@
         message = "base profile should make root land in nushell (via platform users.defaultUserShell)";
       }
       {
+        assertion = base.config.home-manager.users.root.programs.fzf.historyWidget.command == "";
+        message = "base profile should leave Ctrl-R history search to Atuin";
+      }
+      {
         assertion =
           lib.any (
             rule: lib.hasPrefix "d ${base.cfg.shellWorkspace.directory} " rule


### PR DESCRIPTION
## Summary

- keep Atuin as the root shell `Ctrl-R` history owner
- disable fzf's overlapping history widget while preserving its other integrations
- fence the ownership choice in the base profile evaluation test

## Validation

- `nix build .#checks.x86_64-linux.eval --no-link`
- focused evaluation emits no fzf history-manager conflict warning
- `git diff --check`
- `nix run .#lint` reaches two pre-existing `lib/users.nix` `prefer-genattrs-listtoattrs` errors that reproduce on `main`

Closes #2808
Unblocks indexable-inc/ix#7294 and indexable-inc/ix#7310.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable fzf's Ctrl-R history widget in the base profile to defer to Atuin
> Sets `programs.fzf.historyWidget.command = ""` in [modules/profiles/base/default.nix](https://github.com/indexable-inc/index/pull/3286/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) so fzf no longer handles Ctrl-R history search, leaving that to Atuin. A test assertion in [tests/default.nix](https://github.com/indexable-inc/index/pull/3286/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) verifies the empty command is present in the generated Home Manager config for root.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 612f0f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->