### PR TITLE
languages: use supported Elixir package

### DIFF
--- a/lib/languages/elixir.nix
+++ b/lib/languages/elixir.nix
@@ -4,12 +4,12 @@
   a "toolchain" here means the `elixir` package which bundles `elixir`,
   `elixirc`, `iex`, and `mix` against a chosen Erlang/OTP.
 
-  `"latest"` follows whatever `pkgs.elixir` resolves to in the pinned
-  nixpkgs (currently 1.19); the explicit minors are for builds that
-  need to stay on a tested Elixir/OTP pairing.
+  `"latest"` follows whatever `pkgs.beamPackages.elixir` resolves to in
+  the pinned nixpkgs (currently 1.19); the explicit minors are for builds
+  that need to stay on a tested Elixir/OTP pairing.
   */
   toolchainsFor = pkgs: {
-    latest = pkgs.elixir;
+    latest = pkgs.beamPackages.elixir;
     "1.15" = pkgs.elixir_1_15;
     "1.16" = pkgs.elixir_1_16;
     "1.17" = pkgs.elixir_1_17;
@@ -33,7 +33,8 @@ in {
   Arguments:
   - `pkgs`: nixpkgs instance the toolchain comes from.
   - `version`: required, one of `"latest" | "1.15" | "1.16" | "1.17"
-    | "1.18" | "1.19"`. Pass `"latest"` to follow `pkgs.elixir`.
+    | "1.18" | "1.19"`. Pass `"latest"` to follow
+    `pkgs.beamPackages.elixir`.
 
   Example:
   ```nix

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2437,6 +2437,7 @@
   # --- Language helpers -----------------------------------------------------
 
   languages = {
+    elixirLatest = ix.languages.elixir.toolchain pkgs {version = "latest";};
     pythonMissingVersion = builtins.tryEval (
       builtins.deepSeq (ix.languages.python.interpreter pkgs {}).pythonVersion true
     );
@@ -5482,6 +5483,10 @@
     ];
 
     languages = [
+      {
+        assertion = languages.elixirLatest.drvPath == pkgs.beamPackages.elixir.drvPath;
+        message = "ix.languages.elixir latest should follow beamPackages.elixir";
+      }
       {
         assertion = !languages.pythonMissingVersion.success;
         message = "ix.languages.python should require an explicit interpreter version";


### PR DESCRIPTION
## Summary

- resolve the `latest` Elixir toolchain through `pkgs.beamPackages.elixir`
- update the toolchain documentation to name the supported package owner
- assert that `latest` resolves to the BEAM package derivation

## Validation

- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix flake check --no-build`
- `git diff --check`

Closes #3287
Unblocks indexable-inc/ix#7294 and indexable-inc/ix#7310.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch Elixir `latest` toolchain to resolve to `pkgs.beamPackages.elixir`
> The `latest` case in `toolchainsFor` in [elixir.nix](https://github.com/indexable-inc/index/pull/3288/files#diff-730a2ff2cc4b467d4215e41480fe4f8105ea4148c6bdffa755eb953e8837e097) now points to `pkgs.beamPackages.elixir` instead of `pkgs.elixir`, using the officially supported BEAM packages attribute. A corresponding test assertion is added in [tests/default.nix](https://github.com/indexable-inc/index/pull/3288/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to verify the derivation path matches `pkgs.beamPackages.elixir`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d35d4ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->