### PR TITLE
ci: share the CI budget classifier

### DIFF
--- a/.github/actions/ci-budget/action.yml
+++ b/.github/actions/ci-budget/action.yml
@@ -1,0 +1,45 @@
+name: Classify CI budget
+description: Classify a pull request and publish its shared CI budget policy
+
+inputs:
+  repository:
+    description: GitHub repository in owner/name form
+    required: true
+  pull-request-number:
+    description: Pull request number, or 0 outside a pull request
+    required: true
+  token:
+    description: Token with pull request read and, when publishing, issues write
+    required: true
+  extra-costly-paths:
+    description: JSON array of repository-specific costly path globs
+    default: "[]"
+  force-big-change:
+    description: Grant the extended budget without a path or label match
+    default: "false"
+  publish:
+    description: Add the automatic label and publish the sticky comment
+    default: "true"
+
+outputs:
+  big_change:
+    description: Whether the extended CI budget applies
+    value: ${{ steps.classify.outputs.big_change }}
+  reason:
+    description: JSON object describing every source of the decision
+    value: ${{ steps.classify.outputs.reason }}
+
+runs:
+  using: composite
+  steps:
+    - name: Classify CI budget
+      id: classify
+      shell: bash
+      env:
+        CI_BUDGET_EXTRA_COSTLY_PATHS: ${{ inputs.extra-costly-paths }}
+        CI_BUDGET_FORCE_BIG_CHANGE: ${{ inputs.force-big-change }}
+        CI_BUDGET_PUBLISH: ${{ inputs.publish }}
+        CI_BUDGET_PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
+        CI_BUDGET_REPOSITORY: ${{ inputs.repository }}
+        CI_BUDGET_TOKEN: ${{ inputs.token }}
+      run: python3 "$GITHUB_ACTION_PATH/ci_budget.py"

--- a/.github/actions/ci-budget/ci_budget.py
+++ b/.github/actions/ci-budget/ci_budget.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Classify and publish the shared pull request CI budget."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+BIG_CHANGE_LABEL = "ci/big-change"
+COMMENT_MARKER = "<!-- ci-budget -->"
+COMMENT_POLICY = (
+    "CI is limited to 5 minutes unless this is a legitimate big change. "
+    "Add the `ci/big-change` label for an extended budget. Lockfile and Rust "
+    "toolchain changes are labeled automatically."
+)
+
+JsonObject = dict[str, Any]
+Transport = Callable[[urllib.request.Request], tuple[Any, Mapping[str, str]]]
+
+
+@dataclass(frozen=True)
+class Classification:
+    big_change: bool
+    reason: JsonObject
+
+
+def parse_bool(value: str, name: str) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ValueError(f"{name} must be 'true' or 'false', got {value!r}")
+
+
+def parse_globs(value: str, name: str) -> list[str]:
+    decoded = json.loads(value)
+    if not isinstance(decoded, list) or not all(
+        isinstance(item, str) and item for item in decoded
+    ):
+        raise ValueError(f"{name} must be a JSON array of non-empty strings")
+    return decoded
+
+
+def load_canonical_globs(path: Path) -> list[str]:
+    return parse_globs(path.read_text(), str(path))
+
+
+def classify(
+    paths: Sequence[str],
+    labels: Sequence[str],
+    globs: Sequence[str],
+    *,
+    force_big_change: bool,
+) -> Classification:
+    matches = [
+        {"path": path, "pattern": pattern}
+        for path in paths
+        for pattern in globs
+        if fnmatch.fnmatchcase(path, pattern)
+    ]
+    sources: list[str] = []
+    if force_big_change:
+        sources.append("forced")
+    if BIG_CHANGE_LABEL in labels:
+        sources.append("label")
+    if matches:
+        sources.append("costly_path")
+    return Classification(
+        big_change=bool(sources),
+        reason={"sources": sources, "matches": matches},
+    )
+
+
+def default_transport(request: urllib.request.Request) -> tuple[Any, Mapping[str, str]]:
+    if urllib.parse.urlparse(request.full_url).scheme != "https":
+        raise ValueError("GitHub API requests must use HTTPS")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+            body = response.read()
+            payload = json.loads(body) if body else None
+            return payload, response.headers
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode(errors="replace")
+        raise RuntimeError(
+            f"GitHub API {request.method} {request.full_url} failed: "
+            f"HTTP {error.code}: {detail}"
+        ) from error
+
+
+class GitHubClient:
+    def __init__(
+        self,
+        repository: str,
+        token: str,
+        transport: Transport = default_transport,
+    ) -> None:
+        owner, separator, name = repository.partition("/")
+        if not separator or not owner or not name or "/" in name:
+            raise ValueError(
+                f"repository must have owner/name form, got {repository!r}"
+            )
+        self._repository = repository
+        self._token = token
+        self._transport = transport
+
+    def _url(self, path: str, query: Mapping[str, int] | None = None) -> str:
+        url = f"https://api.github.com/repos/{self._repository}/{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        return url
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: JsonObject | None = None,
+        query: Mapping[str, int] | None = None,
+    ) -> tuple[Any, Mapping[str, str]]:
+        data = None if body is None else json.dumps(body).encode()
+        request = urllib.request.Request(  # noqa: S310
+            self._url(path, query),
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        return self._transport(request)
+
+    def paginated(self, path: str) -> list[JsonObject]:
+        items: list[JsonObject] = []
+        page = 1
+        while True:
+            payload, _ = self.request(
+                "GET", path, query={"per_page": 100, "page": page}
+            )
+            if not isinstance(payload, list):
+                raise RuntimeError(f"GitHub API {path} returned a non-list page")
+            if not all(isinstance(item, dict) for item in payload):
+                raise RuntimeError(f"GitHub API {path} returned a malformed page")
+            items.extend(payload)
+            if len(payload) < 100:
+                return items
+            page += 1
+
+    def pull_request(self, number: int) -> JsonObject:
+        payload, _ = self.request("GET", f"pulls/{number}")
+        if not isinstance(payload, dict):
+            raise RuntimeError("GitHub API returned a malformed pull request")
+        return payload
+
+    def changed_paths(self, number: int) -> list[str]:
+        files = self.paginated(f"pulls/{number}/files")
+        paths = [item.get("filename") for item in files]
+        if not all(isinstance(path, str) and path for path in paths):
+            raise RuntimeError("GitHub API returned a changed file without a filename")
+        return paths
+
+    def add_label(self, number: int, label: str) -> None:
+        self.request("POST", f"issues/{number}/labels", {"labels": [label]})
+
+    def upsert_comment(self, number: int, body: str) -> None:
+        comments = self.paginated(f"issues/{number}/comments")
+        owned = [
+            item
+            for item in comments
+            if isinstance(item.get("body"), str)
+            and item["body"].startswith(COMMENT_MARKER)
+            and isinstance(item.get("user"), dict)
+            and item["user"].get("login") in {"github-actions", "github-actions[bot]"}
+        ]
+        if len(owned) > 1:
+            raise RuntimeError(
+                "multiple CI budget comments exist; refusing an ambiguous update"
+            )
+        if owned:
+            comment_id = owned[0].get("id")
+            if not isinstance(comment_id, int):
+                raise RuntimeError("existing CI budget comment has no numeric id")
+            self.request("PATCH", f"issues/comments/{comment_id}", {"body": body})
+        else:
+            self.request("POST", f"issues/{number}/comments", {"body": body})
+
+
+def labels_from_pull_request(pull_request: JsonObject) -> list[str]:
+    raw = pull_request.get("labels")
+    if not isinstance(raw, list):
+        raise RuntimeError("GitHub API returned a pull request without labels")
+    labels = [item.get("name") for item in raw if isinstance(item, dict)]
+    if len(labels) != len(raw) or not all(isinstance(label, str) for label in labels):
+        raise RuntimeError("GitHub API returned a malformed pull request label")
+    return labels
+
+
+def render_comment(classification: Classification) -> str:
+    if classification.big_change:
+        matches = classification.reason["matches"]
+        if matches:
+            detail = f"Extended budget: matched `{matches[0]['path']}`."
+        elif "label" in classification.reason["sources"]:
+            detail = "Extended budget: the `ci/big-change` label is present."
+        else:
+            detail = "Extended budget: this run was explicitly classified as large."
+    else:
+        detail = "Standard budget: this change has 5 minutes."
+    return f"{COMMENT_MARKER}\n{COMMENT_POLICY}\n\n{detail}"
+
+
+def write_output(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        raise RuntimeError("GITHUB_OUTPUT is required")
+    with Path(output_path).open("a") as output:
+        output.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    repository = os.environ["CI_BUDGET_REPOSITORY"]
+    token = os.environ["CI_BUDGET_TOKEN"]
+    pull_request_number = int(os.environ["CI_BUDGET_PULL_REQUEST_NUMBER"])
+    if pull_request_number < 0:
+        raise ValueError("pull request number must not be negative")
+    force_big_change = parse_bool(
+        os.environ["CI_BUDGET_FORCE_BIG_CHANGE"], "force-big-change"
+    )
+    publish = parse_bool(os.environ["CI_BUDGET_PUBLISH"], "publish")
+    globs = load_canonical_globs(Path(__file__).with_name("costly-paths.json"))
+    globs.extend(
+        parse_globs(os.environ["CI_BUDGET_EXTRA_COSTLY_PATHS"], "extra-costly-paths")
+    )
+
+    client = GitHubClient(repository, token)
+    paths: list[str] = []
+    labels: list[str] = []
+    if pull_request_number:
+        paths = client.changed_paths(pull_request_number)
+        labels = labels_from_pull_request(client.pull_request(pull_request_number))
+
+    classification = classify(paths, labels, globs, force_big_change=force_big_change)
+    if publish and pull_request_number:
+        if classification.reason["matches"] and BIG_CHANGE_LABEL not in labels:
+            client.add_label(pull_request_number, BIG_CHANGE_LABEL)
+        client.upsert_comment(pull_request_number, render_comment(classification))
+
+    reason = json.dumps(classification.reason, separators=(",", ":"), sort_keys=True)
+    write_output("big_change", str(classification.big_change).lower())
+    write_output("reason", reason)
+    print(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (KeyError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"::error title=ci-budget::{error}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/actions/ci-budget/ci_budget.py
+++ b/.github/actions/ci-budget/ci_budget.py
@@ -51,7 +51,10 @@ def parse_globs(value: str, name: str) -> list[str]:
 
 
 def load_canonical_globs(path: Path) -> list[str]:
-    return parse_globs(path.read_text(), str(path))
+    globs = [line for line in path.read_text().splitlines() if line]
+    if not globs:
+        raise ValueError(f"{path} must contain at least one glob")
+    return globs
 
 
 def classify(
@@ -236,7 +239,7 @@ def main() -> int:
         os.environ["CI_BUDGET_FORCE_BIG_CHANGE"], "force-big-change"
     )
     publish = parse_bool(os.environ["CI_BUDGET_PUBLISH"], "publish")
-    globs = load_canonical_globs(Path(__file__).with_name("costly-paths.json"))
+    globs = load_canonical_globs(Path(__file__).with_name("costly-paths"))
     globs.extend(
         parse_globs(os.environ["CI_BUDGET_EXTRA_COSTLY_PATHS"], "extra-costly-paths")
     )

--- a/.github/actions/ci-budget/costly-paths
+++ b/.github/actions/ci-budget/costly-paths
@@ -1,0 +1,6 @@
+Cargo.lock
+**/Cargo.lock
+flake.lock
+**/flake.lock
+rust-toolchain.toml
+**/rust-toolchain.toml

--- a/.github/actions/ci-budget/costly-paths.json
+++ b/.github/actions/ci-budget/costly-paths.json
@@ -1,8 +1,0 @@
-[
-  "Cargo.lock",
-  "**/Cargo.lock",
-  "flake.lock",
-  "**/flake.lock",
-  "rust-toolchain.toml",
-  "**/rust-toolchain.toml"
-]

--- a/.github/actions/ci-budget/costly-paths.json
+++ b/.github/actions/ci-budget/costly-paths.json
@@ -1,0 +1,8 @@
+[
+  "Cargo.lock",
+  "**/Cargo.lock",
+  "flake.lock",
+  "**/flake.lock",
+  "rust-toolchain.toml",
+  "**/rust-toolchain.toml"
+]

--- a/.github/actions/ci-budget/test_ci_budget.py
+++ b/.github/actions/ci-budget/test_ci_budget.py
@@ -34,7 +34,7 @@ class FakeTransport:
 class ClassificationTests(unittest.TestCase):
     def setUp(self) -> None:
         self.globs = ci_budget.load_canonical_globs(
-            MODULE_PATH.with_name("costly-paths.json")
+            MODULE_PATH.with_name("costly-paths")
         )
 
     def test_routine_change_uses_standard_budget(self) -> None:

--- a/.github/actions/ci-budget/test_ci_budget.py
+++ b/.github/actions/ci-budget/test_ci_budget.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+MODULE_PATH = Path(__file__).with_name("ci_budget.py")
+SPEC = importlib.util.spec_from_file_location("ci_budget", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+ci_budget = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = ci_budget
+SPEC.loader.exec_module(ci_budget)
+
+
+class FakeTransport:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.requests: list[urllib.request.Request] = []
+
+    def __call__(
+        self, request: urllib.request.Request
+    ) -> tuple[Any, Mapping[str, str]]:
+        self.requests.append(request)
+        return self.responses.pop(0), {}
+
+
+class ClassificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.globs = ci_budget.load_canonical_globs(
+            MODULE_PATH.with_name("costly-paths.json")
+        )
+
+    def test_routine_change_uses_standard_budget(self) -> None:
+        result = ci_budget.classify(
+            ["src/main.rs"], [], self.globs, force_big_change=False
+        )
+        assert not result.big_change
+        assert result.reason == {"sources": [], "matches": []}
+
+    def test_root_and_nested_costly_paths_use_extended_budget(self) -> None:
+        result = ci_budget.classify(
+            ["flake.lock", "guest/rust-toolchain.toml", "vendor/Cargo.lock"],
+            [],
+            self.globs,
+            force_big_change=False,
+        )
+        assert result.big_change
+        assert result.reason["sources"] == ["costly_path"]
+        assert {match["path"] for match in result.reason["matches"]} == {
+            "flake.lock",
+            "guest/rust-toolchain.toml",
+            "vendor/Cargo.lock",
+        }
+
+    def test_label_and_extra_glob_are_structured_sources(self) -> None:
+        result = ci_budget.classify(
+            ["images/base.nix"],
+            [ci_budget.BIG_CHANGE_LABEL],
+            ["images/**"],
+            force_big_change=False,
+        )
+        assert result.reason["sources"] == ["label", "costly_path"]
+        assert result.reason["matches"] == [
+            {"path": "images/base.nix", "pattern": "images/**"}
+        ]
+
+    def test_forced_run_uses_extended_budget(self) -> None:
+        result = ci_budget.classify([], [], self.globs, force_big_change=True)
+        assert result.big_change
+        assert result.reason["sources"] == ["forced"]
+
+
+class GitHubClientTests(unittest.TestCase):
+    def test_changed_files_are_paginated(self) -> None:
+        first = [{"filename": f"src/{index}.rs"} for index in range(100)]
+        transport = FakeTransport([first, [{"filename": "flake.lock"}]])
+        client = ci_budget.GitHubClient("indexable-inc/index", "token", transport)
+
+        paths = client.changed_paths(42)
+
+        assert len(paths) == 101
+        assert paths[-1] == "flake.lock"
+        queries = [
+            urllib.parse.parse_qs(urllib.parse.urlparse(request.full_url).query)
+            for request in transport.requests
+        ]
+        assert queries[0]["page"] == ["1"]
+        assert queries[1]["page"] == ["2"]
+
+    def test_owned_sticky_comment_is_updated(self) -> None:
+        transport = FakeTransport(
+            [
+                [
+                    {
+                        "id": 7,
+                        "body": f"{ci_budget.COMMENT_MARKER}\nold",
+                        "user": {"login": "github-actions[bot]"},
+                    }
+                ],
+                None,
+            ]
+        )
+        client = ci_budget.GitHubClient("indexable-inc/index", "token", transport)
+
+        client.upsert_comment(42, "new")
+
+        request = transport.requests[-1]
+        assert request.method == "PATCH"
+        assert request.full_url.endswith("/issues/comments/7")
+        assert json.loads(request.data or b"{}") == {"body": "new"}
+
+    def test_user_marker_is_not_claimed(self) -> None:
+        transport = FakeTransport(
+            [
+                [
+                    {
+                        "id": 7,
+                        "body": f"{ci_budget.COMMENT_MARKER}\nspoof",
+                        "user": {"login": "someone"},
+                    }
+                ],
+                None,
+            ]
+        )
+        client = ci_budget.GitHubClient("indexable-inc/index", "token", transport)
+
+        client.upsert_comment(42, "new")
+
+        assert transport.requests[-1].method == "POST"
+        assert transport.requests[-1].full_url.endswith("/issues/42/comments")
+
+
+class RenderingTests(unittest.TestCase):
+    def test_standard_comment_contains_policy_and_budget(self) -> None:
+        result = ci_budget.Classification(
+            big_change=False, reason={"sources": [], "matches": []}
+        )
+        comment = ci_budget.render_comment(result)
+        assert comment.startswith(ci_budget.COMMENT_MARKER)
+        assert ci_budget.COMMENT_POLICY in comment
+        assert "Standard budget" in comment
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci-budget-check.yml
+++ b/.github/workflows/ci-budget-check.yml
@@ -1,0 +1,20 @@
+name: CI budget checks
+
+on:
+  pull_request:
+    paths:
+      - .github/actions/ci-budget/**
+      - .github/workflows/ci-budget.yml
+      - .github/workflows/ci-budget-check.yml
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Test classifier behavior
+        run: python3 -m unittest .github/actions/ci-budget/test_ci_budget.py

--- a/.github/workflows/ci-budget-check.yml
+++ b/.github/workflows/ci-budget-check.yml
@@ -17,4 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Test classifier behavior
-        run: python3 -m unittest .github/actions/ci-budget/test_ci_budget.py
+        run: >-
+          python3 -m unittest discover
+          -s .github/actions/ci-budget
+          -p 'test_*.py'

--- a/.github/workflows/ci-budget.yml
+++ b/.github/workflows/ci-budget.yml
@@ -1,0 +1,53 @@
+name: Shared CI budget
+
+on:
+  workflow_call:
+    inputs:
+      pull-request-number:
+        description: Pull request number, or 0 outside a pull request
+        type: number
+        default: 0
+      extra-costly-paths:
+        description: JSON array of repository-specific costly path globs
+        type: string
+        default: "[]"
+      force-big-change:
+        description: Grant the extended budget without a path or label match
+        type: boolean
+        default: false
+      publish:
+        description: Add the automatic label and publish the sticky comment
+        type: boolean
+        default: true
+    outputs:
+      big_change:
+        description: Whether the extended CI budget applies
+        value: ${{ jobs.classify.outputs.big_change }}
+      reason:
+        description: JSON object describing every source of the decision
+        value: ${{ jobs.classify.outputs.reason }}
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    outputs:
+      big_change: ${{ steps.budget.outputs.big_change }}
+      reason: ${{ steps.budget.outputs.reason }}
+    steps:
+      # Fully qualified because a cross-repository workflow call keeps the
+      # caller's workspace. A local action path would resolve inside ix.
+      - name: Classify CI budget
+        id: budget
+        uses: indexable-inc/index/.github/actions/ci-budget@main
+        with:
+          repository: ${{ github.repository }}
+          pull-request-number: ${{ inputs.pull-request-number }}
+          token: ${{ github.token }}
+          extra-costly-paths: ${{ inputs.extra-costly-paths }}
+          force-big-change: ${{ inputs.force-big-change }}
+          publish: ${{ inputs.publish }}


### PR DESCRIPTION
## Summary

- add the canonical costly-path policy as index-owned data
- expose one reusable classifier with structured `big_change` and `reason` outputs
- auto-label costly pull requests and maintain one bot-owned sticky budget comment
- cover matching, pagination, comment ownership, and rendering with behavior tests

## Validation

- `python3 -m unittest discover -s .github/actions/ci-budget -p 'test_*.py'`
- `nix run nixpkgs#actionlint -- .github/workflows/ci-budget.yml .github/workflows/ci-budget-check.yml`
- `nix run nixpkgs#action-validator -- .github/actions/ci-budget/action.yml`
- `nix run nixpkgs#ruff -- check .github/actions/ci-budget/*.py`
- `nix run .#lint`

Closes #3292

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared CI budget classifier action and reusable workflow
> - Adds a composite GitHub Action at [`.github/actions/ci-budget/`](https://github.com/indexable-inc/index/pull/3293/files#diff-5f4ca35a347a1450aef0af40f806fc589c4adfcfb5e062b1101930ecd86aebf5) that classifies a PR as requiring an extended CI budget based on changed paths, labels, and a force flag.
> - The core logic in [`ci_budget.py`](https://github.com/indexable-inc/index/pull/3293/files#diff-c0b72d4d13e44f5bc04171e6ec8159ca0febc581f4577c9a63bdf9ad66acb485) matches changed files against glob patterns (e.g. `Cargo.lock`, `flake.lock`, `rust-toolchain.toml`), applies a `ci/big-change` label, and upserts a sticky comment explaining the budget decision.
> - A reusable workflow at [`.github/workflows/ci-budget.yml`](https://github.com/indexable-inc/index/pull/3293/files#diff-72e11fc346031eaedff7be6aff257f69614db08532a27e188a650cbc1ff543e2) wraps the action so other workflows can call it and consume `big_change`/`reason` outputs.
> - A separate [`ci-budget-check.yml`](https://github.com/indexable-inc/index/pull/3293/files#diff-12abf41f22c60680986e58db8878114b5fd33074785e19334b82de4db8564b99) workflow runs the unit tests in [`test_ci_budget.py`](https://github.com/indexable-inc/index/pull/3293/files#diff-1f60477e8c83e7434701047dd2f589dd80d7e7faea1e703ccc5ec2e3b2ee102d) on PRs that touch the action or workflows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0b3d16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->