### PR TITLE
languages: use supported Erlang package

### DIFF
--- a/lib/languages/erlang.nix
+++ b/lib/languages/erlang.nix
@@ -1,13 +1,13 @@
 {errors}: let
   /**
-  Erlang/OTP major → nixpkgs attribute mapping. `pkgs.erlang` floats
-  with whatever the channel ships; the OTP-numbered attributes are
-  for builds that need to pin against a specific release line
-  (distribution-protocol compatibility, BEAM JIT availability,
-  `gen_statem` API changes between majors).
+  Erlang/OTP major → nixpkgs attribute mapping.
+  `pkgs.beamPackages.erlang` floats with whatever the channel ships;
+  the OTP-numbered attributes are for builds that need to pin against
+  a specific release line (distribution-protocol compatibility, BEAM
+  JIT availability, `gen_statem` API changes between majors).
   */
   toolchainsFor = pkgs: {
-    latest = pkgs.erlang;
+    latest = pkgs.beamPackages.erlang;
     "26" = pkgs.erlang_26;
     "27" = pkgs.erlang_27;
     "28" = pkgs.beam28Packages.erlang;
@@ -24,7 +24,7 @@ in {
   Arguments:
   - `pkgs`: nixpkgs instance the toolchain comes from.
   - `version`: required, one of `"latest" | "26" | "27" | "28"`. Pass
-    `"latest"` to follow `pkgs.erlang`.
+    `"latest"` to follow `pkgs.beamPackages.erlang`.
 
   Example:
   ```nix
@@ -57,10 +57,10 @@ in {
   Arguments:
   - `pkgs`: nixpkgs instance the rebar3 and Erlang packages come from.
   - `erlang`: optional resolved Erlang toolchain. Defaults to the same
-    `pkgs.erlang` the `toolchain` helper returns when called with no
-    version.
+    `pkgs.beamPackages.erlang` the `toolchain` helper returns for
+    `version = "latest"`.
   */
-  rebar3 = pkgs: {erlang ? pkgs.erlang}:
+  rebar3 = pkgs: {erlang ? pkgs.beamPackages.erlang}:
     pkgs.rebar3.overrideAttrs (_: {
       buildInputs = [erlang];
     });

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2438,6 +2438,9 @@
 
   languages = {
     elixirLatest = ix.languages.elixir.toolchain pkgs {version = "latest";};
+    erlangLatest = ix.languages.erlang.toolchain pkgs {version = "latest";};
+    erlangRebarDefault = ix.languages.erlang.rebar3 pkgs {};
+    erlangRebarExplicit = ix.languages.erlang.rebar3 pkgs {erlang = pkgs.beamPackages.erlang;};
     pythonMissingVersion = builtins.tryEval (
       builtins.deepSeq (ix.languages.python.interpreter pkgs {}).pythonVersion true
     );
@@ -5486,6 +5489,14 @@
       {
         assertion = languages.elixirLatest.drvPath == pkgs.beamPackages.elixir.drvPath;
         message = "ix.languages.elixir latest should follow beamPackages.elixir";
+      }
+      {
+        assertion = languages.erlangLatest.drvPath == pkgs.beamPackages.erlang.drvPath;
+        message = "ix.languages.erlang latest should follow beamPackages.erlang";
+      }
+      {
+        assertion = languages.erlangRebarDefault.drvPath == languages.erlangRebarExplicit.drvPath;
+        message = "ix.languages.erlang rebar3 should default to beamPackages.erlang";
       }
       {
         assertion = !languages.pythonMissingVersion.success;


### PR DESCRIPTION
## Summary

- resolve the `latest` Erlang toolchain through `pkgs.beamPackages.erlang`
- use the same supported package as Rebar3's default Erlang
- update the documented contracts and assert both defaults during evaluation

## Validation

- `nix build .#checks.x86_64-linux.eval --no-link`
- `nix flake check --no-build`
- `nix fmt -- --check lib/languages/erlang.nix tests/default.nix`
- exact search confirms `lib/languages/erlang.nix` has no remaining `pkgs.erlang` alias use

Closes #3295
Unblocks indexable-inc/ix#7294 and indexable-inc/ix#7310.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch Erlang language toolchain source to `pkgs.beamPackages.erlang`
> - Changes the `latest` toolchain and default `rebar3` build in [erlang.nix](https://github.com/indexable-inc/index/pull/3296/files#diff-55d2e9127d67f16e801c7bf7beaf0e3f353bde61270be93c20d41e28f1b9a718) to use `pkgs.beamPackages.erlang` instead of `pkgs.erlang`.
> - Adds tests in [tests/default.nix](https://github.com/indexable-inc/index/pull/3296/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) asserting that the `latest` toolchain resolves to `pkgs.beamPackages.erlang` and that the default `rebar3` matches an explicit `beamPackages.erlang` build.
> - Behavioral Change: the `latest` Erlang toolchain and default `rebar3` now resolve to a different derivation than before if `pkgs.erlang` and `pkgs.beamPackages.erlang` diverge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6351ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->