### PR TITLE
ci: apply the shared five minute budget

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     uses: indexable-inc/index/.github/workflows/ci-budget.yml@main
     with:
       pull-request-number: ${{ github.event.pull_request.number || 0 }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches:
       - main
+    # A manual budget override must start a fresh run. A job's timeout is fixed
+    # when it starts, so changing the label cannot extend an in-flight job.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   # Required status for the merge queue: GitHub fires `merge_group` against a
   # temporary `gh-readonly-queue/main/...` ref, and the `main` ruleset demands a
   # `flake-check` status on it. Without this trigger the check never runs in the
@@ -56,6 +59,20 @@ env:
     cores = 1
 
 jobs:
+  ci-budget:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    uses: indexable-inc/index/.github/workflows/ci-budget.yml@main
+    with:
+      pull-request-number: ${{ github.event.pull_request.number || 0 }}
+      # Labels exist only on pull requests. Preserve the existing limit for
+      # main, tag, and merge-queue validation rather than silently shrinking
+      # those non-PR operational gates.
+      force-big-change: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ github.event_name == 'pull_request' }}
+
   # One job on one runner, on purpose. Every check shares a single
   # znver5-tuned nixpkgs base, so fanning the checks across several runners
   # would rebuild that shared base on each cold runner (a thundering herd). We
@@ -64,13 +81,14 @@ jobs:
   # this job is it, and it fails iff a check fails to build or the flake stops
   # evaluating.
   flake-check:
+    needs: ci-budget
     # Dispatched to the org-wide ix-ci-dispatcher (vin-compute-1), the same
     # self-hosted runner the ix repo uses. The `ix-ci-run-*` label is claimed
     # by that dispatcher, which mints an ephemeral runner per job on a host
     # with a warm, persistent /nix/store. See the ix repo's ci.yml for the
     # label scheme.
     runs-on: ["${{ format('ix-ci-run-{0}-{1}-flake-check', github.run_id, github.run_attempt) }}"]
-    timeout-minutes: 60
+    timeout-minutes: ${{ needs.ci-budget.outputs.big_change == 'true' && 60 || 5 }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,7 +71,6 @@ jobs:
       # main, tag, and merge-queue validation rather than silently shrinking
       # those non-PR operational gates.
       force-big-change: ${{ github.event_name != 'pull_request' }}
-      publish: ${{ github.event_name == 'pull_request' }}
 
   # One job on one runner, on purpose. Every check shares a single
   # znver5-tuned nixpkgs base, so fanning the checks across several runners

--- a/.github/workflows/closure-gate.yml
+++ b/.github/workflows/closure-gate.yml
@@ -60,9 +60,6 @@ jobs:
       # Manual and merge-queue runs have no pull request label. Keep their
       # existing extended budget.
       force-big-change: ${{ github.event_name != 'pull_request' }}
-      # check.yml owns the single sticky comment and automatic label. This
-      # invocation only supplies the same decision to the parallel gate.
-      publish: false
 
   # Branch protection requires a status named `closure-gate`; this job is it.
   # Separate from flake-check on purpose: it runs in parallel on its own

--- a/.github/workflows/closure-gate.yml
+++ b/.github/workflows/closure-gate.yml
@@ -24,6 +24,9 @@ on:
   pull_request:
     branches:
       - main
+    # A manual budget override must start a fresh run. A job's timeout is fixed
+    # when it starts, so changing the label cannot extend an in-flight job.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   # Same rationale as check.yml: the main ruleset demands this status inside
   # the merge queue too, should one be enabled.
   merge_group:
@@ -47,14 +50,30 @@ env:
     cores = 1
 
 jobs:
+  ci-budget:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    uses: indexable-inc/index/.github/workflows/ci-budget.yml@main
+    with:
+      pull-request-number: ${{ github.event.pull_request.number || 0 }}
+      # Manual and merge-queue runs have no pull request label. Keep their
+      # existing extended budget.
+      force-big-change: ${{ github.event_name != 'pull_request' }}
+      # check.yml owns the single sticky comment and automatic label. This
+      # invocation only supplies the same decision to the parallel gate.
+      publish: false
+
   # Branch protection requires a status named `closure-gate`; this job is it.
   # Separate from flake-check on purpose: it runs in parallel on its own
   # ephemeral runner, so the existing gate's latency is untouched.
   closure-gate:
+    needs: ci-budget
     runs-on: ["${{ format('ix-ci-run-{0}-{1}-closure-gate', github.run_id, github.run_attempt) }}"]
     # A relock-class PR realises a near-full closure; match the cache-push
     # linux lane budget, which fits that worst case.
-    timeout-minutes: 180
+    timeout-minutes: ${{ needs.ci-budget.outputs.big_change == 'true' && 180 || 5 }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/closure-gate.yml
+++ b/.github/workflows/closure-gate.yml
@@ -53,9 +53,8 @@ jobs:
   ci-budget:
     permissions:
       contents: read
-      issues: write
       pull-requests: read
-    uses: indexable-inc/index/.github/workflows/ci-budget.yml@main
+    uses: indexable-inc/index/.github/workflows/ci-budget-read-only.yml@main
     with:
       pull-request-number: ${{ github.event.pull_request.number || 0 }}
       # Manual and merge-queue runs have no pull request label. Keep their


### PR DESCRIPTION
## Summary

- classify each required workflow before allocating a self-hosted runner
- give ordinary pull requests 5 minutes while retaining the 60 and 180 minute extended limits
- rerun on `ci/big-change` label changes and let `check.yml` alone own the sticky comment and automatic label
- retain the existing non-PR limits, context names, event coverage, permissions, and concurrency groups

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/check.yml .github/workflows/closure-gate.yml`
- `git diff --check`
- `nix run .#lint` (known baseline failure tracked by #2460: `lib/users.nix` has two `prefer-genattrs-listtoattrs` findings; all other lint lanes passed)

Closes #3294

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply shared five-minute CI budget to `check` and `closure-gate` workflows
> - Adds a `ci-budget` reusable job to [check.yml](https://github.com/indexable-inc/index/pull/3297/files#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428) and [closure-gate.yml](https://github.com/indexable-inc/index/pull/3297/files#diff-638c892010bcf9fe87805596d2ebfceacbae7736e255f41d266a68cd531ff840) that determines whether a PR is a "big change".
> - Both workflows now default to a 5-minute timeout, expanding to 60 or 180 minutes respectively only when the budget job signals a big change.
> - Adds `labeled`/`unlabeled` to the `pull_request` trigger so label changes start a fresh run and can re-evaluate the budget.
> - Behavioral Change: CI jobs that previously had fixed timeouts of 60 or 180 minutes will now time out in 5 minutes for most PRs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9b804b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->