### PR TITLE
ci: grant budget comments pull request access

### DIFF
--- a/.github/workflows/ci-budget.yml
+++ b/.github/workflows/ci-budget.yml
@@ -34,7 +34,9 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      # Pull request timeline comments require this permission even though the
+      # REST resource is exposed through the issues comments endpoint.
+      pull-requests: write
     outputs:
       big_change: ${{ steps.budget.outputs.big_change }}
       reason: ${{ steps.budget.outputs.reason }}


### PR DESCRIPTION
## Summary

Grant the shared budget workflow the pull request write permission GitHub requires for pull request timeline comments. The existing issues write grant alone returned `HTTP 403: Resource not accessible by integration` on #3297.

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/ci-budget.yml`

Closes #3298

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Grant write access to pull requests in CI budget workflow
> Updates the `classify` job in [ci-budget.yml](.github/workflows/ci-budget.yml) to request `pull-requests: write` instead of `read`, allowing the job to post comments to PR timelines.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee1a409.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->