### PR TITLE
ci: keep budget classification read-only

### DIFF
--- a/.github/workflows/ci-budget.yml
+++ b/.github/workflows/ci-budget.yml
@@ -22,21 +22,19 @@ on:
     outputs:
       big_change:
         description: Whether the extended CI budget applies
-        value: ${{ jobs.classify.outputs.big_change }}
+        value: ${{ jobs.classify.outputs.big_change || jobs.publish.outputs.big_change }}
       reason:
         description: JSON object describing every source of the decision
-        value: ${{ jobs.classify.outputs.reason }}
+        value: ${{ jobs.classify.outputs.reason || jobs.publish.outputs.reason }}
 
 jobs:
   classify:
+    if: ${{ !inputs.publish }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
-      issues: write
-      # Pull request timeline comments require this permission even though the
-      # REST resource is exposed through the issues comments endpoint.
-      pull-requests: write
+      pull-requests: read
     outputs:
       big_change: ${{ steps.budget.outputs.big_change }}
       reason: ${{ steps.budget.outputs.reason }}
@@ -52,4 +50,29 @@ jobs:
           token: ${{ github.token }}
           extra-costly-paths: ${{ inputs.extra-costly-paths }}
           force-big-change: ${{ inputs.force-big-change }}
-          publish: ${{ inputs.publish }}
+          publish: false
+
+  publish:
+    if: ${{ inputs.publish }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      # Pull request timeline comments require this permission even though the
+      # REST resource is exposed through the issues comments endpoint.
+      pull-requests: write
+    outputs:
+      big_change: ${{ steps.budget.outputs.big_change }}
+      reason: ${{ steps.budget.outputs.reason }}
+    steps:
+      - name: Classify and publish CI budget
+        id: budget
+        uses: indexable-inc/index/.github/actions/ci-budget@main
+        with:
+          repository: ${{ github.repository }}
+          pull-request-number: ${{ inputs.pull-request-number }}
+          token: ${{ github.token }}
+          extra-costly-paths: ${{ inputs.extra-costly-paths }}
+          force-big-change: ${{ inputs.force-big-change }}
+          publish: true


### PR DESCRIPTION
## Summary

Split the shared budget workflow at its permission boundary:

- `publish:false` runs a read-only classifier
- `publish:true` runs the label and sticky-comment publisher with write access
- both paths preserve the same structured workflow outputs

This fixes the Closure gate startup failure on #3297 without granting a non-publishing caller write access.

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/ci-budget.yml`
- live read and publish caller validation will run on #3297 after landing

Closes #3301

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split CI budget classification into a separate read-only job
> - Adds a `classify` job in [ci-budget.yml](.github/workflows/ci-budget.yml) that runs when `inputs.publish` is false, with read-only permissions and a short timeout, invoking the ci-budget action with `publish: false`.
> - The `publish` job now always passes `publish: true` to the action, since the job itself is already gated on `inputs.publish`.
> - Workflow-level `big_change` and `reason` outputs fall back between whichever job ran, using `jobs.classify.outputs.X || jobs.publish.outputs.X`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 693a75b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->