### PR TITLE
ci: split budget workflows by permission

### DIFF
--- a/.github/workflows/ci-budget-check.yml
+++ b/.github/workflows/ci-budget-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/actions/ci-budget/**
+      - .github/workflows/ci-budget-read-only.yml
       - .github/workflows/ci-budget.yml
       - .github/workflows/ci-budget-check.yml
 

--- a/.github/workflows/ci-budget-check.yml
+++ b/.github/workflows/ci-budget-check.yml
@@ -12,11 +12,24 @@ permissions:
   contents: read
 
 jobs:
+  classify:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/ci-budget-read-only.yml
+    with:
+      force-big-change: true
+
   test:
+    needs: classify
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check read-only workflow output
+        env:
+          BIG_CHANGE: ${{ needs.classify.outputs.big_change }}
+        run: test "$BIG_CHANGE" = true
       - name: Test classifier behavior
         run: >-
           python3 -m unittest discover

--- a/.github/workflows/ci-budget-read-only.yml
+++ b/.github/workflows/ci-budget-read-only.yml
@@ -1,4 +1,4 @@
-name: Shared CI budget
+name: Shared read-only CI budget
 
 on:
   workflow_call:
@@ -18,26 +18,25 @@ on:
     outputs:
       big_change:
         description: Whether the extended CI budget applies
-        value: ${{ jobs.publish.outputs.big_change }}
+        value: ${{ jobs.classify.outputs.big_change }}
       reason:
         description: JSON object describing every source of the decision
-        value: ${{ jobs.publish.outputs.reason }}
+        value: ${{ jobs.classify.outputs.reason }}
 
 jobs:
-  publish:
+  classify:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
-      issues: write
-      # Pull request timeline comments require this permission even though the
-      # REST resource is exposed through the issues comments endpoint.
-      pull-requests: write
+      pull-requests: read
     outputs:
       big_change: ${{ steps.budget.outputs.big_change }}
       reason: ${{ steps.budget.outputs.reason }}
     steps:
-      - name: Classify and publish CI budget
+      # Fully qualified because a cross-repository workflow call keeps the
+      # caller's workspace. A local action path would resolve inside ix.
+      - name: Classify CI budget
         id: budget
         uses: indexable-inc/index/.github/actions/ci-budget@main
         with:
@@ -46,4 +45,4 @@ jobs:
           token: ${{ github.token }}
           extra-costly-paths: ${{ inputs.extra-costly-paths }}
           force-big-change: ${{ inputs.force-big-change }}
-          publish: true
+          publish: false


### PR DESCRIPTION
## Summary

- keep `.github/workflows/ci-budget.yml` publishing-only with write permissions
- add `.github/workflows/ci-budget-read-only.yml` for classification with read permissions
- run the existing classifier tests when either reusable workflow changes

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/ci-budget.yml .github/workflows/ci-budget-read-only.yml .github/workflows/ci-budget-check.yml`
- `python3 -m unittest discover -s .github/actions/ci-budget -p 'test_*.py'`
- `git diff --check`

Fixes #3307

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split CI budget workflows by read-only and publish permissions
> - Extracts a new reusable workflow [ci-budget-read-only.yml](https://github.com/indexable-inc/index/pull/3308/files#diff-474af1fa7d93a51cab405079d5789879f1f7ba2d67735feff8a75978f5a876e1) that classifies CI budget without publishing labels or comments, using `publish: false`.
> - Updates [ci-budget.yml](https://github.com/indexable-inc/index/pull/3308/files#diff-72e11fc346031eaedff7be6aff257f69614db08532a27e188a650cbc1ff543e2) to always run the publish job unconditionally, removing the `publish` input and the separate classify-only path.
> - Updates [ci-budget-check.yml](https://github.com/indexable-inc/index/pull/3308/files#diff-12abf41f22c60680986e58db8878114b5fd33074785e19334b82de4db8564b99) to call the new read-only workflow as a `classify` job and assert it reports a big change.
> - Behavioral Change: callers of `ci-budget.yml` can no longer pass a `publish` input to suppress publishing; the publish job now always runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a58a5e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->