### PR TITLE
mcp: use current required checks for PR verdicts

### DIFF
--- a/packages/mcp/ix_notebook_mcp/runtime.py
+++ b/packages/mcp/ix_notebook_mcp/runtime.py
@@ -2105,6 +2105,20 @@ def _nu_json_record(value: Any, *, source: str) -> dict[str, Any]:
     return parsed
 
 
+def _nu_json_records(value: Any, *, source: str) -> list[dict[str, Any]]:
+    """Validate a completed command, then decode its stdout as JSON records."""
+    completion = _nu_completion(value, source=source)
+    if completion.exit_code != 0:
+        raise RuntimeError(_nu_failure(source, completion))
+    try:
+        parsed = json.loads(completion.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{source} returned invalid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, list) or not all(isinstance(item, dict) for item in parsed):
+        raise TypeError(f"{source}: expected a JSON list of records")
+    return parsed
+
+
 async def watch_pr(
     pr: str | int,
     *,
@@ -2205,6 +2219,19 @@ async def watch_pr(
         )
         return row
 
+    async def required_checks() -> list[dict[str, Any]]:
+        try:
+            return _nu_json_records(
+                await run_nu(
+                    "gh pr checks $env.PR --required "
+                    "--json bucket,completedAt,link,name,startedAt,state,workflow | complete"
+                ),
+                source="gh pr checks --required",
+            )
+        except Exception as exc:
+            await fail_watch(exc)
+            raise
+
     if auto_merge:
         # Arming auto merge on an already-mergeable PR merges it instantly,
         # before any watching happens (#2532): branch-protection endpoints
@@ -2255,7 +2282,7 @@ async def watch_pr(
     while True:
         last = await refresh()
         checks = last.get("statusCheckRollup") or []
-        failures = [
+        failure_attempts = [
             check
             for check in checks
             if check.get("conclusion") in {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}
@@ -2265,6 +2292,17 @@ async def watch_pr(
             resource.close()
             await notify(f"PR {clean_pr} finished with state {last.get('state')}", resource=resource.id, pr=clean_pr)
             return finished({"state": last.get("state"), "url": last.get("url"), "checks": len(checks)})
+        if failure_attempts:
+            # statusCheckRollup preserves every attempt. Ask GitHub to resolve
+            # required contexts on the current head before making a terminal
+            # verdict, so an older cancelled rerun stays history (#3331).
+            failures = [
+                check
+                for check in await required_checks()
+                if check.get("bucket") in {"fail", "cancel"}
+            ]
+        else:
+            failures = []
         if failures:
             state["status"] = "failed"
             state["error"] = "One or more required actions failed."

--- a/packages/mcp/tests/test_pr_watch_automerge.py
+++ b/packages/mcp/tests/test_pr_watch_automerge.py
@@ -23,11 +23,17 @@ class _ScriptedNu:
     records every `gh pr merge` invocation."""
 
     def __init__(
-        self, views: list[dict[str, object]], *, merge_error: str | None = None
+        self,
+        views: list[dict[str, object]],
+        *,
+        required: list[list[dict[str, object]]] | None = None,
+        merge_error: str | None = None,
     ) -> None:
         self._views = list(views)
+        self._required = list(required or [[]])
         self._merge_error = merge_error
         self.merges: list[str] = []
+        self.required_calls = 0
 
     async def __call__(
         self,
@@ -42,6 +48,13 @@ class _ScriptedNu:
             if self._merge_error is not None:
                 return {"exit_code": 1, "stdout": "", "stderr": self._merge_error}
             return {"exit_code": 0, "stdout": "", "stderr": ""}
+        if "gh pr checks" in code:
+            assert "--required" in code
+            self.required_calls += 1
+            checks = (
+                self._required.pop(0) if len(self._required) > 1 else self._required[0]
+            )
+            return {"exit_code": 0, "stdout": json.dumps(checks), "stderr": ""}
         assert "gh pr view" in code
         view = self._views.pop(0) if len(self._views) > 1 else self._views[0]
         return {"exit_code": 0, "stdout": json.dumps(view), "stderr": ""}
@@ -116,6 +129,74 @@ def test_blocked_pr_still_arms_auto_merge(monkeypatch: pytest.MonkeyPatch) -> No
     assert len(fake.merges) == 1
     assert "--auto" in fake.merges[0]
     assert "auto_merge" not in result
+
+
+@pytest.mark.parametrize(
+    ("current_status", "current_conclusion", "current_state", "current_bucket"),
+    [
+        ("COMPLETED", "SUCCESS", "SUCCESS", "pass"),
+        ("QUEUED", "", "QUEUED", "pending"),
+    ],
+)
+def test_stale_cancelled_attempt_does_not_override_current_required_context(
+    monkeypatch: pytest.MonkeyPatch,
+    current_status: str,
+    current_conclusion: str,
+    current_state: str,
+    current_bucket: str,
+) -> None:
+    first = _view(9108, "OPEN", "BLOCKED")
+    attempts = [
+        {
+            "name": "flake-check",
+            "workflowName": "Check",
+            "status": "COMPLETED",
+            "conclusion": "CANCELLED",
+            "startedAt": "2026-07-15T07:08:36Z",
+            "completedAt": "2026-07-15T07:13:46Z",
+        },
+        {
+            "name": "flake-check",
+            "workflowName": "Check",
+            "status": current_status,
+            "conclusion": current_conclusion,
+            "startedAt": "2026-07-15T07:15:00Z",
+            "completedAt": "2026-07-15T07:36:24Z" if current_conclusion else "",
+        },
+    ]
+    first["statusCheckRollup"] = attempts
+    merged = _view(9108, "MERGED", "CLEAN")
+    merged["statusCheckRollup"] = attempts
+    fake = _ScriptedNu(
+        [first, first, merged],
+        required=[
+            [
+                {
+                    "name": "flake-check",
+                    "workflow": "Check",
+                    "state": current_state,
+                    "bucket": current_bucket,
+                    "startedAt": "2026-07-15T07:15:00Z",
+                    "completedAt": "2026-07-15T07:36:24Z" if current_conclusion else "",
+                }
+            ]
+        ],
+    )
+    monkeypatch.setitem(sys.modules, "nu", fake)
+    notified: list[str] = []
+
+    async def fake_notify(content: str, **meta: object) -> None:
+        notified.append(content)
+
+    monkeypatch.setattr(runtime, "notify", fake_notify)
+
+    result = asyncio.run(runtime.watch_pr(9108, auto_merge=True, interval=0.01))
+
+    assert result["state"] == "MERGED"
+    assert fake.required_calls == 1
+    assert not any("failing checks" in message for message in notified)
+    html = asyncio.run(runtime.resources["pr-9108"].render_html())
+    assert html.count("flake-check") == 2
 
 
 class _FrameNu(_ScriptedNu):


### PR DESCRIPTION
## Problem

`statusCheckRollup` preserves every attempt on the current head. `pr_watch` treated any cancelled historical attempt as terminal, even when the rerun for the same required context was passing or pending.

## Fix

- keep the full rollup in the dashboard as attempt history
- ask `gh pr checks --required --json` for GitHub's deduplicated current-head contexts before returning a failed verdict
- fail only when the resolved required bucket is `fail` or `cancel`
- validate the JSON list boundary without parsing human output
- cover cancelled attempt A followed by both passing and pending attempt B for the same context

#3059 remains the owner for a typed zero-required-check result from `gh`; this change does not parse its prose-only empty-set error.

## Validation

- focused regression failed twice before the implementation and passes twice after it
- `uv run --with pytest --with polars python -m pytest packages/mcp/tests/test_pr_watch_automerge.py -k 'not failed_view_preserves_completion_error' -q`: 9 passed, 1 deselected because standalone Python lacks the Nix-bundled `nu` module
- `uvx ruff check packages/mcp/ix_notebook_mcp/runtime.py packages/mcp/tests/test_pr_watch_automerge.py`
- `git diff --check`
- local Nix validation was not run, as required for this task; GitHub-hosted checks cover the packaged test and type-check environment

Fixes #3331

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `watch_pr` to use current required checks instead of stale `statusCheckRollup` attempts for PR verdicts
> - Previously, any failing/cancelled entry in `statusCheckRollup` could cause `watch_pr` to report failure, even if that entry was stale and the current required checks had since passed.
> - Now, when failing/cancelled attempts are detected, `watch_pr` fetches live required check contexts via `gh pr checks --required` and only treats the PR as failing if the current required checks have a `fail` or `cancel` bucket.
> - Adds `_nu_json_records` in [runtime.py](https://github.com/indexable-inc/index/pull/3337/files#diff-a321ac036dbe5148143f01e84f705e2c20bda0e38f193e74b06c66889de27b95) as a helper to decode and validate JSON list-of-dicts output from `run_nu` commands.
> - A new parametrized test in [test_pr_watch_automerge.py](https://github.com/indexable-inc/index/pull/3337/files#diff-d243930ff12d7f05a5b5592577c7a8444edb1403b703fecd4f559c185cc67ca3) verifies that a stale cancelled attempt does not block an otherwise-passing PR from merging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e41503b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->