### PR TITLE
lint: use genAttrs in lib/users.nix

### DIFF
--- a/lib/users.nix
+++ b/lib/users.nix
@@ -34,16 +34,8 @@
     // optionalPath root "skills" "skills";
 
   reposFor = userName:
-    lib.listToAttrs (
-      map (repoName: {
-        name = repoName;
-        value = repoFor userName repoName;
-      }) (directoryNames (usersRoot + "/${userName}"))
+    lib.genAttrs (directoryNames (usersRoot + "/${userName}")) (
+      repoName: repoFor userName repoName
     );
 in
-  lib.listToAttrs (
-    map (userName: {
-      name = userName;
-      value = reposFor userName;
-    }) (directoryNames usersRoot)
-  )
+  lib.genAttrs (directoryNames usersRoot) reposFor


### PR DESCRIPTION
## Summary

Replace both `listToAttrs (map ...)` forms in `lib/users.nix` with the canonical `lib.genAttrs` representation.

Fixes #3318

## Validation

- `nix develop --command astlog scan astlog-rules/nix.astlog lib/users.nix --json`
- `nix run .#lint -- --json`
- `git diff --check`

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor `lib/users.nix` attribute set construction to use `lib.genAttrs`
> Replaces `lib.listToAttrs` over manual `{ name, value }` map expressions with `lib.genAttrs` in [lib/users.nix](https://github.com/indexable-inc/index/pull/3340/files#diff-a0307cb1d29944e2fc8aa03f9aa840ea0df2689992ec4d136f570cc03db0ad61). This applies to both the `reposFor` function and the top-level users attribute set. No functional behavior changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3365b8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->