### PR TITLE
ci: bind check log runner identity

### DIFF
--- a/.github/actions/check-logged/action.yml
+++ b/.github/actions/check-logged/action.yml
@@ -3,9 +3,9 @@ description: >-
   Run `nix run .#check` with its output redirected to a runner-local file
   instead of the Actions log: the nix-fast-build stream for a warm run is
   megabytes of eval warnings and per-drv noise that drowns the signal. The
-  step prints only the host and log path (readable over ssh on the runner
-  host, e.g. vin-compute-1), mirrors both into the step summary, and cats the
-  full log into the Actions log only when the check fails.
+  step prints only the runner identity and log path, mirrors both into the
+  step summary, and cats the full log into the Actions log only when the
+  check fails.
 inputs:
   subcommand:
     description: >-
@@ -20,32 +20,5 @@ runs:
       shell: bash
       env:
         CHECK_SUBCOMMAND: ${{ inputs.subcommand }}
-      run: |
-        set -euo pipefail
-
-        commit="$(git rev-parse HEAD 2>/dev/null || printf 'unknown')"
-        workflow="${GITHUB_WORKFLOW:-local}"
-        run_tag="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
-        log_root="${IX_CI_RUN_LOG_ROOT:-/var/log/ix-ci/runs}"
-        log_dir="${log_root}/${commit}/${workflow}"
-        if install -d -m 0755 "${log_dir}" 2>/tmp/index-ci-log-dir.err && [[ -w "${log_dir}" ]]; then
-          check_log="${log_dir}/${run_tag}.stdout"
-        else
-          fallback_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
-          check_log="${fallback_dir%/}/index-check-${run_tag}.stdout"
-        fi
-
-        printf 'index check log: %s on %s\n' "${check_log}" "$(hostname)"
-        nix --version
-        nix store info --json
-        if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-          {
-            printf "## index check\n\n"
-            printf "log: \`%s\` on \`%s\`\n" "${check_log}" "$(hostname)"
-          } >>"${GITHUB_STEP_SUMMARY}"
-        fi
-
-        if ! nix run .#check ${CHECK_SUBCOMMAND:+-- "${CHECK_SUBCOMMAND}"} >"${check_log}" 2>&1; then
-          cat "${check_log}"
-          exit 1
-        fi
+        RUNNER_IDENTITY: ${{ runner.name }}
+      run: bash "$GITHUB_ACTION_PATH/run.sh"

--- a/.github/actions/check-logged/run.sh
+++ b/.github/actions/check-logged/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit="$(git rev-parse HEAD 2>/dev/null || printf 'unknown')"
+workflow="${GITHUB_WORKFLOW:-local}"
+run_tag="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
+log_root="${IX_CI_RUN_LOG_ROOT:-/var/log/ix-ci/runs}"
+log_dir="${log_root}/${commit}/${workflow}"
+if install -d -m 0755 "${log_dir}" 2>/tmp/index-ci-log-dir.err && [[ -w "${log_dir}" ]]; then
+  check_log="${log_dir}/${run_tag}.stdout"
+else
+  fallback_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+  check_log="${fallback_dir%/}/index-check-${run_tag}.stdout"
+fi
+
+printf 'index check log: %s on %s\n' "${check_log}" "${RUNNER_IDENTITY}"
+nix --version
+nix store info --json
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    printf "## index check\n\n"
+    printf "log: \`%s\` on \`%s\`\n" "${check_log}" "${RUNNER_IDENTITY}"
+  } >>"${GITHUB_STEP_SUMMARY}"
+fi
+
+if ! nix run .#check ${CHECK_SUBCOMMAND:+-- "${CHECK_SUBCOMMAND}"} >"${check_log}" 2>&1; then
+  cat "${check_log}"
+  exit 1
+fi

--- a/.github/actions/check-logged/run.sh
+++ b/.github/actions/check-logged/run.sh
@@ -6,6 +6,10 @@ workflow="${GITHUB_WORKFLOW:-local}"
 run_tag="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
 log_root="${IX_CI_RUN_LOG_ROOT:-/var/log/ix-ci/runs}"
 log_dir="${log_root}/${commit}/${workflow}"
+check_args=(run .#check)
+if [[ -n "${CHECK_SUBCOMMAND}" ]]; then
+  check_args+=(-- "${CHECK_SUBCOMMAND}")
+fi
 if install -d -m 0755 "${log_dir}" 2>/tmp/index-ci-log-dir.err && [[ -w "${log_dir}" ]]; then
   check_log="${log_dir}/${run_tag}.stdout"
 else
@@ -23,7 +27,7 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   } >>"${GITHUB_STEP_SUMMARY}"
 fi
 
-if ! nix run .#check ${CHECK_SUBCOMMAND:+-- "${CHECK_SUBCOMMAND}"} >"${check_log}" 2>&1; then
+if ! nix "${check_args[@]}" >"${check_log}" 2>&1; then
   cat "${check_log}"
   exit 1
 fi

--- a/.github/actions/check-logged/run.sh
+++ b/.github/actions/check-logged/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+: "${RUNNER_IDENTITY:?RUNNER_IDENTITY is required}"
 
 commit="$(git rev-parse HEAD 2>/dev/null || printf 'unknown')"
 workflow="${GITHUB_WORKFLOW:-local}"

--- a/.github/actions/check-logged/test.sh
+++ b/.github/actions/check-logged/test.sh
@@ -16,15 +16,11 @@ check_log="${log_root}/${commit}/${workflow}/${run_id}-${run_attempt}.stdout"
 summary="${scratch}/summary"
 stdout="${scratch}/stdout"
 stderr="${scratch}/stderr"
-missing_identity_stdout="${scratch}/missing-identity-stdout"
-missing_identity_stderr="${scratch}/missing-identity-stderr"
-missing_identity_summary="${scratch}/missing-identity-summary"
-missing_identity_run="${scratch}/missing-identity-run"
 nix_run="${scratch}/nix-run"
 bash_bin="$(command -v bash)"
 env_bin="$(command -v env)"
 
-mkdir -p "${bin_dir}" "$(dirname -- "${check_log}")"
+mkdir -p "${bin_dir}"
 ln -s "$(command -v cat)" "${bin_dir}/cat"
 ln -s "$(command -v install)" "${bin_dir}/install"
 
@@ -63,13 +59,13 @@ action_env=(
   GITHUB_RUN_ATTEMPT="${run_attempt}"
   GITHUB_RUN_ID="${run_id}"
   GITHUB_WORKFLOW="${workflow}"
-  IX_CI_RUN_LOG_ROOT="${log_root}"
   RUNNER_TEMP="${scratch}/runner-temp"
 )
 
 "${env_bin}" -i \
   "${action_env[@]}" \
   GITHUB_STEP_SUMMARY="${summary}" \
+  IX_CI_RUN_LOG_ROOT="${log_root}" \
   NIX_RUN_SENTINEL="${nix_run}" \
   RUNNER_IDENTITY="${runner_identity}" \
   "${bash_bin}" "${action_dir}/run.sh" >"${stdout}" 2>"${stderr}"
@@ -91,25 +87,40 @@ if [[ "$(<"${check_log}")" != "check passed" ]]; then
   exit 1
 fi
 
-if "${env_bin}" -i \
-  "${action_env[@]}" \
-  GITHUB_STEP_SUMMARY="${missing_identity_summary}" \
-  NIX_RUN_SENTINEL="${missing_identity_run}" \
-  "${bash_bin}" "${action_dir}/run.sh" \
-  >"${missing_identity_stdout}" 2>"${missing_identity_stderr}"; then
-  printf 'action accepted a missing RUNNER_IDENTITY\n' >&2
-  exit 1
-fi
-if [[ -e "${missing_identity_run}" ]]; then
-  printf 'check ran without a RUNNER_IDENTITY\n' >&2
-  exit 1
-fi
-if [[ -s "${missing_identity_stdout}" || -e "${missing_identity_summary}" ]]; then
-  printf 'action emitted a guessed runner identity\n' >&2
-  exit 1
-fi
-if [[ "$(<"${missing_identity_stderr}")" != *RUNNER_IDENTITY* ]]; then
-  printf 'missing identity failure did not name RUNNER_IDENTITY:\n%s\n' \
-    "$(<"${missing_identity_stderr}")" >&2
-  exit 1
-fi
+assert_identity_rejected() {
+  local label="$1"
+  shift
+  local rejected_log_root="${scratch}/${label}-logs"
+  local rejected_run="${scratch}/${label}-run"
+  local rejected_stderr="${scratch}/${label}-stderr"
+  local rejected_stdout="${scratch}/${label}-stdout"
+  local rejected_summary="${scratch}/${label}-summary"
+
+  if "${env_bin}" -i \
+    "${action_env[@]}" \
+    GITHUB_STEP_SUMMARY="${rejected_summary}" \
+    IX_CI_RUN_LOG_ROOT="${rejected_log_root}" \
+    NIX_RUN_SENTINEL="${rejected_run}" \
+    "$@" \
+    "${bash_bin}" "${action_dir}/run.sh" \
+    >"${rejected_stdout}" 2>"${rejected_stderr}"; then
+    printf 'action accepted %s RUNNER_IDENTITY\n' "${label}" >&2
+    exit 1
+  fi
+  if [[ -e "${rejected_log_root}" || -e "${rejected_run}" ]]; then
+    printf 'action performed work with %s RUNNER_IDENTITY\n' "${label}" >&2
+    exit 1
+  fi
+  if [[ -s "${rejected_stdout}" || -e "${rejected_summary}" ]]; then
+    printf 'action emitted a guessed runner identity for %s input\n' "${label}" >&2
+    exit 1
+  fi
+  if [[ "$(<"${rejected_stderr}")" != *RUNNER_IDENTITY* ]]; then
+    printf '%s identity failure did not name RUNNER_IDENTITY:\n%s\n' \
+      "${label}" "$(<"${rejected_stderr}")" >&2
+    exit 1
+  fi
+}
+
+assert_identity_rejected missing
+assert_identity_rejected empty RUNNER_IDENTITY=

--- a/.github/actions/check-logged/test.sh
+++ b/.github/actions/check-logged/test.sh
@@ -16,6 +16,11 @@ check_log="${log_root}/${commit}/${workflow}/${run_id}-${run_attempt}.stdout"
 summary="${scratch}/summary"
 stdout="${scratch}/stdout"
 stderr="${scratch}/stderr"
+missing_identity_stdout="${scratch}/missing-identity-stdout"
+missing_identity_stderr="${scratch}/missing-identity-stderr"
+missing_identity_summary="${scratch}/missing-identity-summary"
+missing_identity_run="${scratch}/missing-identity-run"
+nix_run="${scratch}/nix-run"
 bash_bin="$(command -v bash)"
 env_bin="$(command -v env)"
 
@@ -38,6 +43,11 @@ case "$1" in
     printf '{"trusted":false}\n'
     ;;
   run)
+    if [[ "$#" -ne 4 || "$2" != ".#check" || "$3" != "--" || "$4" != "closure" ]]; then
+      printf 'unexpected nix arguments' >&2
+      exit 65
+    fi
+    : >"${NIX_RUN_SENTINEL:?NIX_RUN_SENTINEL is required}"
     printf 'check passed\n'
     ;;
   *)
@@ -47,16 +57,21 @@ esac
 EOF
 chmod +x "${bin_dir}/git" "${bin_dir}/nix"
 
+action_env=(
+  PATH="${bin_dir}"
+  CHECK_SUBCOMMAND=closure
+  GITHUB_RUN_ATTEMPT="${run_attempt}"
+  GITHUB_RUN_ID="${run_id}"
+  GITHUB_WORKFLOW="${workflow}"
+  IX_CI_RUN_LOG_ROOT="${log_root}"
+  RUNNER_TEMP="${scratch}/runner-temp"
+)
+
 "${env_bin}" -i \
-  PATH="${bin_dir}" \
-  CHECK_SUBCOMMAND=closure \
-  GITHUB_RUN_ATTEMPT="${run_attempt}" \
-  GITHUB_RUN_ID="${run_id}" \
+  "${action_env[@]}" \
   GITHUB_STEP_SUMMARY="${summary}" \
-  GITHUB_WORKFLOW="${workflow}" \
-  IX_CI_RUN_LOG_ROOT="${log_root}" \
+  NIX_RUN_SENTINEL="${nix_run}" \
   RUNNER_IDENTITY="${runner_identity}" \
-  RUNNER_TEMP="${scratch}/runner-temp" \
   "${bash_bin}" "${action_dir}/run.sh" >"${stdout}" 2>"${stderr}"
 
 if [[ -s "${stderr}" ]]; then
@@ -73,5 +88,28 @@ if [[ "$(<"${summary}")" != *"log: \`${check_log}\` on \`${runner_identity}\`"* 
 fi
 if [[ "$(<"${check_log}")" != "check passed" ]]; then
   printf 'check output was not written to %s\n' "${check_log}" >&2
+  exit 1
+fi
+
+if "${env_bin}" -i \
+  "${action_env[@]}" \
+  GITHUB_STEP_SUMMARY="${missing_identity_summary}" \
+  NIX_RUN_SENTINEL="${missing_identity_run}" \
+  "${bash_bin}" "${action_dir}/run.sh" \
+  >"${missing_identity_stdout}" 2>"${missing_identity_stderr}"; then
+  printf 'action accepted a missing RUNNER_IDENTITY\n' >&2
+  exit 1
+fi
+if [[ -e "${missing_identity_run}" ]]; then
+  printf 'check ran without a RUNNER_IDENTITY\n' >&2
+  exit 1
+fi
+if [[ -s "${missing_identity_stdout}" || -e "${missing_identity_summary}" ]]; then
+  printf 'action emitted a guessed runner identity\n' >&2
+  exit 1
+fi
+if [[ "$(<"${missing_identity_stderr}")" != *RUNNER_IDENTITY* ]]; then
+  printf 'missing identity failure did not name RUNNER_IDENTITY:\n%s\n' \
+    "$(<"${missing_identity_stderr}")" >&2
   exit 1
 fi

--- a/.github/actions/check-logged/test.sh
+++ b/.github/actions/check-logged/test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+action_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "${scratch}"' EXIT
+
+bin_dir="${scratch}/bin"
+commit="3365b8ad742ed57b7db3b06d8b62e1aeb3c0bad5"
+workflow="Closure gate"
+run_id="29414110217"
+run_attempt="1"
+runner_identity="ix-ci-job-index-29414110217-87347897797"
+log_root="${scratch}/logs"
+check_log="${log_root}/${commit}/${workflow}/${run_id}-${run_attempt}.stdout"
+summary="${scratch}/summary"
+stdout="${scratch}/stdout"
+stderr="${scratch}/stderr"
+bash_bin="$(command -v bash)"
+env_bin="$(command -v env)"
+
+mkdir -p "${bin_dir}" "$(dirname -- "${check_log}")"
+ln -s "$(command -v cat)" "${bin_dir}/cat"
+ln -s "$(command -v install)" "${bin_dir}/install"
+
+printf '#!%s\n' "${bash_bin}" >"${bin_dir}/git"
+cat >>"${bin_dir}/git" <<EOF
+printf '%s\\n' '${commit}'
+EOF
+
+printf '#!%s\n' "${bash_bin}" >"${bin_dir}/nix"
+cat >>"${bin_dir}/nix" <<'EOF'
+case "$1" in
+  --version)
+    printf 'nix (Nix) test\n'
+    ;;
+  store)
+    printf '{"trusted":false}\n'
+    ;;
+  run)
+    printf 'check passed\n'
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+EOF
+chmod +x "${bin_dir}/git" "${bin_dir}/nix"
+
+"${env_bin}" -i \
+  PATH="${bin_dir}" \
+  CHECK_SUBCOMMAND=closure \
+  GITHUB_RUN_ATTEMPT="${run_attempt}" \
+  GITHUB_RUN_ID="${run_id}" \
+  GITHUB_STEP_SUMMARY="${summary}" \
+  GITHUB_WORKFLOW="${workflow}" \
+  IX_CI_RUN_LOG_ROOT="${log_root}" \
+  RUNNER_IDENTITY="${runner_identity}" \
+  RUNNER_TEMP="${scratch}/runner-temp" \
+  "${bash_bin}" "${action_dir}/run.sh" >"${stdout}" 2>"${stderr}"
+
+if [[ -s "${stderr}" ]]; then
+  printf 'unexpected stderr:\n%s\n' "$(<"${stderr}")" >&2
+  exit 1
+fi
+if [[ "$(<"${stdout}")" != *"index check log: ${check_log} on ${runner_identity}"* ]]; then
+  printf 'stdout omits the log path or runner identity:\n%s\n' "$(<"${stdout}")" >&2
+  exit 1
+fi
+if [[ "$(<"${summary}")" != *"log: \`${check_log}\` on \`${runner_identity}\`"* ]]; then
+  printf 'step summary omits the log path or runner identity:\n%s\n' "$(<"${summary}")" >&2
+  exit 1
+fi
+if [[ "$(<"${check_log}")" != "check passed" ]]; then
+  printf 'check output was not written to %s\n' "${check_log}" >&2
+  exit 1
+fi

--- a/.github/workflows/check-logged-test.yml
+++ b/.github/workflows/check-logged-test.yml
@@ -1,0 +1,19 @@
+name: Check logged action
+
+on:
+  pull_request:
+    paths:
+      - .github/actions/check-logged/**
+      - .github/workflows/check-logged-test.yml
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Test minimal PATH logging
+        run: bash .github/actions/check-logged/test.sh


### PR DESCRIPTION
## Summary

- bind the GitHub runner context once instead of invoking `hostname`
- keep the action shell in a directly executable `run.sh`
- test the run log and step summary under a PATH with no `hostname`

Fixes #3346.

## Verification

- `bash -n .github/actions/check-logged/{run,test}.sh`
- `bash .github/actions/check-logged/test.sh`
- Ruby YAML parse for the action and test workflow
- `git diff --check`

Nix was not run, per the issue constraint.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind runner identity to the `check-logged` CI action instead of hostname
> - Replaces the inline Bash script in [action.yml](https://github.com/indexable-inc/index/pull/3347/files#diff-2ff034f172b29e5e3c47c959e0a76b917ee558570d5af976517eda97696f7cab) with a call to [run.sh](https://github.com/indexable-inc/index/pull/3347/files#diff-1f0e6fc58a2a9661af85e83d58934eddfa9e3d5e4dfc4bc386285732b922fcc5), passing `runner.name` as `RUNNER_IDENTITY`.
> - [run.sh](https://github.com/indexable-inc/index/pull/3347/files#diff-1f0e6fc58a2a9661af85e83d58934eddfa9e3d5e4dfc4bc386285732b922fcc5) validates `RUNNER_IDENTITY` is set, constructs the log path, runs `nix .#check`, and reports the runner identity in the step summary.
> - [test.sh](https://github.com/indexable-inc/index/pull/3347/files#diff-8141180081a2d2d3a5d183ecf34621fc4e01f018f458496c81c9e4a80e650e1d) provides a test harness with stubbed `git`/`nix` binaries, verifying correct output and fast-fail behavior when `RUNNER_IDENTITY` is unset.
> - Adds [check-logged-test.yml](https://github.com/indexable-inc/index/pull/3347/files#diff-d29fd140f4e192d75626802cd68a7b705484c41cabc73c3dc4c14f651bd8da8f), a workflow that runs `test.sh` on pull requests touching the action.
> - Behavioral Change: the step now reports `runner.name` instead of the machine hostname, and fails immediately if `RUNNER_IDENTITY` is missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3f409b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->