### PR TITLE
rebase-patches: preserve source snapshots in DAG checks

### DIFF
--- a/packages/rebase-patches/dag-lib.nu
+++ b/packages/rebase-patches/dag-lib.nu
@@ -30,17 +30,11 @@ export def "dag neutralize-config" [scratch: string] {
 # Seed a fresh git repo at `dest` from the read-only `src_dir` tree and commit it
 # as a single base commit; returns the base rev. Used by the `patch-dag-<name>`
 # check, whose base is the flake's already-fetched `flake = false` src (a
-# store path with no `.git`), not a network fetch. IMPORTANT: nushell's
-# `cp --recursive src/. dest` nests `src` under `dest` rather than copying its
-# contents (unlike coreutils `cp`), so we copy each top-level entry explicitly,
-# including dotfiles like `.gitattributes` (which affect `git apply`/`am`).
+# store path with no `.git`), not a network fetch.
 export def "dag seed-base-repo" [src_dir: string, dest: string] {
-  # `ls -a` yields dotfiles too; exclude only the `.`/`..` self-links.
-  for entry in (ls -a $src_dir | get name) {
-    let base = ($entry | path basename)
-    if $base == "." or $base == ".." { continue }
-    cp --recursive $entry $dest
-  }
+  # coreutils `cp -a src/. dest` preserves dotfiles, modes, and symlinks. The
+  # latter matters because Nushell's recursive copy chmods symlink targets.
+  ^cp -a ($src_dir | path join ".") $dest
   # Store paths are read-only (0444) and `cp` preserves that, so `git am` would
   # fail with "unable to write file ... Permission denied" mid-apply and be
   # misread as a non-applying patch. Make the working copy writable.
@@ -49,7 +43,9 @@ export def "dag seed-base-repo" [src_dir: string, dest: string] {
   git -C $dest config user.email "check@indexable.dev"
   git -C $dest config user.name "patch-dag check"
   dag neutralize-config $dest
-  git -C $dest add --all
+  # indexable-inc/index#3351: the snapshot can contain upstream-tracked paths
+  # matched by its own .gitignore, which a fresh repo must still retain.
+  git -C $dest add --all --force
   git -C $dest commit --quiet --no-gpg-sign -m base
   (git -C $dest rev-parse HEAD | str trim)
 }

--- a/packages/rebase-patches/default.nix
+++ b/packages/rebase-patches/default.nix
@@ -34,11 +34,13 @@
 # there. One tool, parameterized by data, never copied per repo.
 {
   ix,
+  coreutils,
   formats,
   writeNushellApplication,
   runCommand,
   git,
   mergiraf,
+  nushell,
 }: let
   # Fork-package mapping from the single source of truth (lib/fork-packages.nix,
   # surfaced as `ix.forkPackages`), rendered to JSON and baked in as a store
@@ -398,11 +400,25 @@
       package
     ];
   } (builtins.readFile ./resume-test.sh);
+  seedTest = runCommand "rebase-patches-seed-test" {
+    nativeBuildInputs = [
+      coreutils
+      git
+      nushell
+    ];
+    dagLib = ./dag-lib.nu;
+    seedTestScript = ./seed-test.nu;
+  } (builtins.readFile ./seed-test.sh);
 in
   package.overrideAttrs (old: {
     passthru =
       (old.passthru or {})
       // {
-        tests = (old.passthru.tests or {}) // {resume = resumeTest;};
+        tests =
+          (old.passthru.tests or {})
+          // {
+            resume = resumeTest;
+            seed = seedTest;
+          };
       };
   })

--- a/packages/rebase-patches/seed-test.nu
+++ b/packages/rebase-patches/seed-test.nu
@@ -1,0 +1,13 @@
+use dag-lib.nu *
+
+def main [source: string, expected_tree: string] {
+  let scratch = (mktemp --directory --tmpdir "rebase-patches-seed-test.XXXXXX")
+  let base = (dag seed-base-repo $source $scratch)
+  let actual_tree = (git -C $scratch rev-parse $"($base)^{tree}" | str trim)
+
+  if $actual_tree != $expected_tree {
+    error make {
+      msg: $"seeded tree ($actual_tree) differs from source tree ($expected_tree)"
+    }
+  }
+}

--- a/packages/rebase-patches/seed-test.sh
+++ b/packages/rebase-patches/seed-test.sh
@@ -1,0 +1,21 @@
+set -eu
+
+export HOME="$TMPDIR/home"
+mkdir -p "$HOME" upstream/ignored source scratch
+git config --global user.email test@example.com
+git config --global user.name Test
+
+git -C upstream init --quiet
+printf 'ignored/\n' >upstream/.gitignore
+printf 'tracked despite ignore\n' >upstream/ignored/tracked.txt
+git -C upstream add .gitignore
+git -C upstream add --force ignored/tracked.txt
+git -C upstream commit --quiet -m base
+expected_tree=$(git -C upstream rev-parse 'HEAD^{tree}')
+
+git -C upstream checkout-index --all --prefix="$PWD/source/"
+cp "$dagLib" scratch/dag-lib.nu
+cp "$seedTestScript" scratch/seed-test.nu
+nu scratch/seed-test.nu "$PWD/source" "$expected_tree"
+
+touch "$out"


### PR DESCRIPTION
## What changed

- Copy fetched source snapshots with archival semantics, preserving symlinks and file modes.
- Force-add the snapshot so upstream-tracked paths matching upstream `.gitignore` remain in the seeded repository.
- Add a regression that compares the complete seeded tree with a fixture containing an ignored tracked file.

## Validation

- Regression fails on `origin/main`: seeded tree `4ec44fbb...` differs from fixture tree `90045478...`.
- Regression passes with this change.
- Pinned Nix source `2c6d06e...` seeds to its exact upstream tree `46a77f452e23e4f7df71ff9ad9494df743261047`.
- Full #3345 21-patch DAG invariant check passes: 21 patches, 6 edges.
- `bash -n packages/rebase-patches/seed-test.sh`
- `git diff --check`

PR #3268 replaces this Nushell path and needs the same invariant in its Rust implementation before landing.

Closes #3351.

Assisted-by: Codex <codex@openai.com>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve source snapshots including ignored-but-tracked files in DAG base repo seeding
> - Replaces a manual recursive copy loop in `dag seed-base-repo` with `^cp -a` to preserve symlinks, dotfiles, and file modes during seeding.
> - Adds `--force` to the `git add` step so that paths matched by the snapshot's `.gitignore` are still committed to the base repo.
> - Adds a test derivation (`seedTest`) in [default.nix](https://github.com/indexable-inc/index/pull/3352/files#diff-dd450ae43106772c7bb417e4f0f4b3d25042f7302914086c517c3c1c46e7726b) that wires up [seed-test.nu](https://github.com/indexable-inc/index/pull/3352/files#diff-1b3f355172b531d6fd59d0eecbbb58c275ec8024413aad3dd0b91bc282f3c227) and [seed-test.sh](https://github.com/indexable-inc/index/pull/3352/files#diff-7f1cbcd5418a37aa8ce9a23106b7fd2bcde0357b4f66319b03c8b56ceb765fdb) to verify the seeded tree matches an expected tree, covering the ignored-but-tracked file case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b47ec24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->