### PR TITLE
mcp: serialize mutation ownership

### DIFF
--- a/packages/mcp/src/fabric/fabric/__init__.py
+++ b/packages/mcp/src/fabric/fabric/__init__.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import os
 import platform
 import textwrap
 from collections.abc import Awaitable, Callable, Generator
@@ -36,7 +35,7 @@ from dataclasses import dataclass
 
 import weave
 
-from . import activity, claude, reconcile, remote
+from . import activity, claude, reconcile, remote, resources
 from .remote import EnvSkewError, FabricError, Workspace
 
 __all__ = [
@@ -48,11 +47,12 @@ __all__ = [
     "claude",
     "reconcile",
     "remote",
+    "resources",
     "run",
     "watch_interrupt",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 # The ask state. Deliberately NOT "pending" (the state a dispatcher loop
 # would fulfill): fabric's model is that the call already created the work --
@@ -65,7 +65,7 @@ INTERRUPT_POLL_S = 0.5
 
 
 def _requested_by() -> str:
-    return os.environ.get("IX_WEAVE_AGENT") or "agent:main"
+    return resources.current_owner()
 
 
 async def watch_interrupt(task: str, on_requested: Callable[[], Awaitable[None]]) -> None:
@@ -92,6 +92,7 @@ class RunHandle:
     """One live fabric run: the journal task entity plus the execution."""
 
     task: str
+    resource_claim: resources.ResourceClaim | None
     _work: asyncio.Task[object]
     _watcher: asyncio.Task[None]
 
@@ -150,6 +151,7 @@ async def run(
     cpus: float | None = None,
     repo: str | None = None,
     rev: str | None = None,
+    resource_key: resources.ResourceKey | None = None,
     **kwargs: object,
 ) -> RunHandle:
     """Execute ``fn(*args, **kwargs)``, recorded on the journal.
@@ -175,6 +177,11 @@ async def run(
     line (a bad signature bind, a first-statement raise) still leaves the ask
     and ``failed`` facts.
 
+    ``resource_key`` declares the pull request or worktree this task may
+    mutate. Fabric claims it atomically after recording the ask and before
+    starting the worker. A live second owner raises ``ResourceOwnedError`` and
+    leaves this task failed; a terminal owner's claim can be reclaimed.
+
     Locally, sync functions run in ``asyncio.to_thread`` so the kernel loop
     never blocks; async functions are awaited natively (the runner actor does
     the same on the node). Note a cancelled sync ``fn`` settles the run (and
@@ -199,6 +206,18 @@ async def run(
         facts.append((task, "runner", f"runner:{node}"))
     facts.append((task, "state", ASK_STATE))
     await weave.assert_facts(facts)
+    try:
+        resource_claim = (
+            None
+            if resource_key is None
+            else await resources.claim(resource_key, owner=task)
+        )
+    except BaseException as exc:
+        await weave.assert_facts([
+            (task, "error", f"{type(exc).__name__}: {exc}"),
+            (task, "state", "failed"),
+        ])
+        raise
 
     async def _invoke() -> object:
         if placement is not None:
@@ -237,4 +256,9 @@ async def run(
 
     watcher = asyncio.create_task(watch_interrupt(task, _cancel), name=f"fabric:watch:{task}")
     work.add_done_callback(lambda _t: watcher.cancel())
-    return RunHandle(task, work, watcher)
+    return RunHandle(
+        task=task,
+        resource_claim=resource_claim,
+        _work=work,
+        _watcher=watcher,
+    )

--- a/packages/mcp/src/fabric/fabric/claude.py
+++ b/packages/mcp/src/fabric/fabric/claude.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Protocol
 
 import weave
 
+from . import resources
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Sequence
 
@@ -89,8 +91,14 @@ class Session:
     else ``done`` at :meth:`close` -- always the entity's last state fact.
     """
 
-    def __init__(self, task: str, client: SdkClient) -> None:
+    def __init__(
+        self,
+        task: str,
+        client: SdkClient,
+        resource_claim: resources.ResourceClaim | None,
+    ) -> None:
         self.task = task
+        self.resource_claim = resource_claim
         self._client = client
         self._interrupted = False
         self._terminal_written = False
@@ -197,15 +205,19 @@ async def session(
     allowed_tools: Sequence[str] | None = None,
     permission_mode: PermissionMode | None = None,
     max_turns: int | None = None,
+    resource_key: resources.ResourceKey | None = None,
 ) -> Session:
     """Open a recorded, interruptible Claude session and send ``prompt``.
 
     Ask facts land first (prompt text in CAS, ``state=submitted`` last), so
     the intent is on the journal before the SDK subprocess spawns; a connect
-    or first-send failure still appends the ``failed`` terminal fact. On
-    success the session is live (``state=running``) and returns immediately:
-    ``await s.result()`` waits for the turn, ``s.send()`` streams follow-up
-    input, ``s.interrupt()`` stops it.
+    or first-send failure still appends the ``failed`` terminal fact.
+    ``resource_key`` declares the pull request or worktree the child may
+    mutate. The child task claims it before the SDK starts, so a live parent or
+    sibling owner rejects the session loudly. On success the session is live
+    (``state=running``) and returns immediately: ``await s.result()`` waits
+    for the turn, ``s.send()`` streams follow-up input, and ``s.interrupt()``
+    stops it.
     """
 
     from . import _requested_by
@@ -224,15 +236,27 @@ async def session(
     facts.append((task, "state", "submitted"))
     await weave.assert_facts(facts)
 
-    client = _sdk_client(
-        system_prompt=system_prompt,
-        model=model,
-        cwd=cwd,
-        allowed_tools=allowed_tools,
-        permission_mode=permission_mode,
-        max_turns=max_turns,
-    )
-    live = Session(task, client)
+    try:
+        resource_claim = (
+            None
+            if resource_key is None
+            else await resources.claim(resource_key, owner=task)
+        )
+        client = _sdk_client(
+            system_prompt=system_prompt,
+            model=model,
+            cwd=cwd,
+            allowed_tools=allowed_tools,
+            permission_mode=permission_mode,
+            max_turns=max_turns,
+        )
+    except BaseException as exc:
+        await weave.assert_facts([
+            (task, "error", f"{type(exc).__name__}: {exc}"),
+            (task, "state", "failed"),
+        ])
+        raise
+    live = Session(task, client, resource_claim)
     try:
         await client.connect()
         await client.query(prompt)

--- a/packages/mcp/src/fabric/fabric/resources.py
+++ b/packages/mcp/src/fabric/fabric/resources.py
@@ -1,0 +1,527 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+import weave
+
+if TYPE_CHECKING:
+    import polars
+
+__all__ = [
+    "ResourceClaim",
+    "ResourceClaimError",
+    "ResourceKey",
+    "ResourceLedger",
+    "ResourceOwnedError",
+    "ResourceTransferDenied",
+    "ResourceTransitionError",
+    "claim",
+    "current",
+    "current_owner",
+    "frame",
+    "ledger",
+    "release",
+    "transfer",
+]
+
+_TERMINAL_OWNER_STATES = frozenset({"done", "failed", "interrupted", "lost"})
+_ACTIVE = "active"
+_RELEASED = "released"
+
+
+class _Journal(Protocol):
+    async def append_operation(
+        self,
+        operation_id: str,
+        facts: Sequence[tuple[str, str, object]],
+    ) -> list[dict[str, object]]: ...
+
+    async def query(
+        self, program: str, as_of: int | None = None
+    ) -> weave.QueryResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceKey:
+    """One mutation boundary in one repository."""
+
+    repository: str
+    pr: int | None = None
+    worktree: str | None = None
+
+    def __post_init__(self) -> None:
+        repository = self.repository.strip().lower().removesuffix(".git")
+        parts = repository.split("/")
+        if len(parts) != 2 or any(
+            not part or any(char.isspace() for char in part) for part in parts
+        ):
+            raise ValueError("repository must be a canonical owner/name slug")
+        if (self.pr is None) == (self.worktree is None):
+            raise ValueError("resource key needs exactly one of pr or worktree")
+        if self.pr is not None and self.pr <= 0:
+            raise ValueError("pull request number must be positive")
+        object.__setattr__(self, "repository", repository)
+        if self.worktree is not None:
+            path = Path(self.worktree).expanduser()
+            if not path.is_absolute():
+                raise ValueError("worktree path must be absolute")
+            object.__setattr__(self, "worktree", str(path.resolve(strict=False)))
+
+    @classmethod
+    def for_pull_request(cls, repository: str, number: int) -> ResourceKey:
+        return cls(repository=repository, pr=number)
+
+    @classmethod
+    def for_worktree(cls, repository: str, path: str | Path) -> ResourceKey:
+        return cls(repository=repository, worktree=str(path))
+
+    @property
+    def selector_kind(self) -> str:
+        return "pr" if self.pr is not None else "worktree"
+
+    @property
+    def selector(self) -> int | str:
+        if self.pr is not None:
+            return self.pr
+        if self.worktree is None:
+            raise AssertionError("validated resource key has no selector")
+        return self.worktree
+
+    @property
+    def entity(self) -> str:
+        return f"mutation-resource:{_digest(self.repository, self.selector_kind, self.selector)}"
+
+    @property
+    def label(self) -> str:
+        if self.pr is not None:
+            return f"{self.repository}#{self.pr}"
+        return f"{self.repository}:{self.worktree}"
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceClaim:
+    """The current owner generation for a resource."""
+
+    key: ResourceKey
+    id: str
+    owner: str | None
+    state: str
+    owner_state: str | None = None
+    requested_by: str | None = None
+
+    @property
+    def available(self) -> bool:
+        return self.state == _RELEASED or self.owner_state in _TERMINAL_OWNER_STATES
+
+
+class ResourceClaimError(RuntimeError):
+    """Base class for loud resource admission failures."""
+
+
+class ResourceOwnedError(ResourceClaimError):
+    """A live owner already holds the mutation boundary."""
+
+    def __init__(self, key: ResourceKey, claim: ResourceClaim) -> None:
+        owner = claim.owner or "unknown"
+        super().__init__(
+            f"mutation resource {key.label} is already owned by {owner}; "
+            "the current owner must transfer or release it"
+        )
+        self.key = key
+        self.claim = claim
+
+
+class ResourceTransferDenied(ResourceClaimError):
+    """A caller other than the current owner attempted a handoff."""
+
+    def __init__(self, claim: ResourceClaim, actor: str) -> None:
+        super().__init__(
+            f"resource claim {claim.id} belongs to {claim.owner or 'nobody'}, not {actor}"
+        )
+        self.claim = claim
+        self.actor = actor
+
+
+class ResourceTransitionError(ResourceClaimError):
+    """The ownership head changed while a transition was being committed."""
+
+    def __init__(
+        self,
+        key: ResourceKey,
+        expected: ResourceClaim | None,
+        observed: ResourceClaim | None,
+    ) -> None:
+        expected_id = expected.id if expected is not None else "unclaimed"
+        observed_id = observed.id if observed is not None else "unclaimed"
+        super().__init__(
+            f"resource {key.label} changed from {expected_id} to {observed_id}; "
+            "read the ledger before mutating"
+        )
+        self.key = key
+        self.expected = expected
+        self.observed = observed
+
+
+def current_owner() -> str:
+    """The journal identity for this agent subtree."""
+
+    return os.environ.get("IX_WEAVE_AGENT") or "agent:main"
+
+
+def _digest(*parts: object) -> str:
+    body = json.dumps(parts, separators=(",", ":"), sort_keys=True).encode()
+    return hashlib.blake2s(body, digest_size=16).hexdigest()
+
+
+def _claim_id(key: ResourceKey, predecessor: str, owner: str, state: str) -> str:
+    return f"resource-claim:{_digest(key.entity, predecessor, owner, state)}"
+
+
+def _operation_id(predecessor: str) -> str:
+    return f"resource_claim_{_digest(predecessor)}"
+
+
+def _string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _current_query(resource: str) -> str:
+    entity = _string(resource)
+    return (
+        f"?- latest({entity}, current_claim, C), "
+        "latest(C, claimed_by, O), latest(C, state, S)."
+    )
+
+
+def _latest_query(entity: str, attr: str) -> str:
+    if not attr.isidentifier():
+        raise ValueError(f"invalid weave attribute {attr!r}")
+    return f"?- latest({_string(entity)}, {attr}, V)."
+
+
+_LEDGER_QUERY = (
+    '?- type(R, "mutation_resource"), latest(R, repository, Repo), '
+    "latest(R, selector_kind, K), latest(R, selector, V), "
+    "latest(R, current_claim, C), latest(C, claimed_by, O), latest(C, state, S)."
+)
+
+
+def _rows(result: weave.QueryResult) -> list[list[object]]:
+    raw: object = result.get("rows")
+    if not isinstance(raw, list):
+        raise RuntimeError("weave query response has no rows list")
+    rows: list[list[object]] = []
+    for row in raw:
+        if not isinstance(row, list):
+            raise RuntimeError("weave query row must be a list")
+        rows.append(list(row))
+    return rows
+
+
+class ResourceLedger:
+    """Atomic mutation ownership backed by the shared weave journal.
+
+    Weave scopes operation ids to one authenticated principal. Parent and child
+    sessions on an MCP service share that principal. Exclusion across separate
+    principals requires a server-owned conditional write primitive.
+    """
+
+    def __init__(self, journal: _Journal | None = None) -> None:
+        self._journal = journal or weave.Weave()
+
+    async def _owner_attr(self, owner: str | None, attr: str) -> str | None:
+        if not owner:
+            return None
+        rows = _rows(await self._journal.query(_latest_query(owner, attr)))
+        if not rows:
+            return None
+        if len(rows) != 1 or len(rows[0]) != 1 or not isinstance(rows[0][0], str):
+            raise RuntimeError(f"owner {attr} query returned an invalid row for {owner}")
+        return rows[0][0]
+
+    async def current(self, key: ResourceKey) -> ResourceClaim | None:
+        rows = _rows(await self._journal.query(_current_query(key.entity)))
+        if not rows:
+            return None
+        if len(rows) != 1 or len(rows[0]) != 3:
+            raise RuntimeError(
+                f"resource query returned an invalid head for {key.label}"
+            )
+        claim_id, owner, state = rows[0]
+        if (
+            not isinstance(claim_id, str)
+            or not isinstance(owner, str)
+            or not isinstance(state, str)
+        ):
+            raise RuntimeError(
+                f"resource query returned invalid values for {key.label}"
+            )
+        return ResourceClaim(
+            key=key,
+            id=claim_id,
+            owner=owner or None,
+            state=state,
+            owner_state=await self._owner_attr(owner or None, "state"),
+            requested_by=await self._owner_attr(owner or None, "requested_by"),
+        )
+
+    def _resource_facts(self, key: ResourceKey) -> list[tuple[str, str, object]]:
+        return [
+            (key.entity, "type", "mutation_resource"),
+            (key.entity, "repository", key.repository),
+            (key.entity, "selector_kind", key.selector_kind),
+            (key.entity, "selector", key.selector),
+        ]
+
+    def _claim_facts(
+        self,
+        claim: ResourceClaim,
+        predecessor: ResourceClaim | None,
+    ) -> list[tuple[str, str, object]]:
+        facts: list[tuple[str, str, object]] = [
+            (claim.id, "type", "resource_claim"),
+            (claim.id, "resource", claim.key.entity),
+            (claim.id, "claimed_by", claim.owner or ""),
+            (claim.id, "state", claim.state),
+        ]
+        if predecessor is not None:
+            facts.append((claim.id, "previous_claim", predecessor.id))
+        return facts
+
+    async def _append(
+        self,
+        key: ResourceKey,
+        predecessor: ResourceClaim | None,
+        claim: ResourceClaim,
+        *,
+        acknowledged_by: str | None = None,
+    ) -> ResourceClaim:
+        operation_predecessor = (
+            predecessor.id if predecessor is not None else key.entity
+        )
+        facts = self._resource_facts(key) if predecessor is None else []
+        if predecessor is not None:
+            facts.extend(
+                [
+                    (predecessor.id, "state", "superseded"),
+                    (predecessor.id, "next_claim", claim.id),
+                ]
+            )
+            if acknowledged_by is not None:
+                facts.append((predecessor.id, "acknowledged_by", acknowledged_by))
+        facts.extend(self._claim_facts(claim, predecessor))
+        facts.append((key.entity, "current_claim", claim.id))
+        await self._journal.append_operation(
+            _operation_id(operation_predecessor), facts
+        )
+        return claim
+
+    async def claim(
+        self, key: ResourceKey, *, owner: str | None = None
+    ) -> ResourceClaim:
+        holder = owner or current_owner()
+        predecessor = await self.current(key)
+        if predecessor is not None and not predecessor.available:
+            if predecessor.owner == holder:
+                return predecessor
+            raise ResourceOwnedError(key, predecessor)
+
+        predecessor_id = predecessor.id if predecessor is not None else "root"
+        next_claim = ResourceClaim(
+            key=key,
+            id=_claim_id(key, predecessor_id, holder, _ACTIVE),
+            owner=holder,
+            state=_ACTIVE,
+        )
+        try:
+            return await self._append(key, predecessor, next_claim)
+        except weave.OperationConflictError as source:
+            observed = await self.current(key)
+            if (
+                observed is not None
+                and observed.owner == holder
+                and not observed.available
+            ):
+                return observed
+            if observed is not None and not observed.available:
+                raise ResourceOwnedError(key, observed) from source
+            raise ResourceTransitionError(key, predecessor, observed) from source
+
+    async def transfer(
+        self,
+        claim: ResourceClaim,
+        to_owner: str,
+        *,
+        actor: str | None = None,
+    ) -> ResourceClaim:
+        acknowledged_by = actor or current_owner()
+        if claim.owner != acknowledged_by:
+            raise ResourceTransferDenied(claim, acknowledged_by)
+        current = await self.current(claim.key)
+        if current is None or current.id != claim.id or current.owner != claim.owner:
+            raise ResourceTransitionError(claim.key, claim, current)
+        if current.available:
+            raise ResourceTransitionError(claim.key, claim, current)
+        if to_owner == current.owner:
+            return current
+
+        next_claim = ResourceClaim(
+            key=claim.key,
+            id=_claim_id(claim.key, claim.id, to_owner, _ACTIVE),
+            owner=to_owner,
+            state=_ACTIVE,
+        )
+        try:
+            return await self._append(
+                claim.key,
+                current,
+                next_claim,
+                acknowledged_by=acknowledged_by,
+            )
+        except weave.OperationConflictError as source:
+            observed = await self.current(claim.key)
+            if (
+                observed is not None
+                and observed.owner == to_owner
+                and not observed.available
+            ):
+                return observed
+            raise ResourceTransitionError(claim.key, claim, observed) from source
+
+    async def release(
+        self,
+        claim: ResourceClaim,
+        *,
+        actor: str | None = None,
+    ) -> ResourceClaim:
+        acknowledged_by = actor or current_owner()
+        if claim.owner != acknowledged_by:
+            raise ResourceTransferDenied(claim, acknowledged_by)
+        current = await self.current(claim.key)
+        if current is None or current.id != claim.id or current.owner != claim.owner:
+            if current is not None and current.state == _RELEASED:
+                return current
+            raise ResourceTransitionError(claim.key, claim, current)
+
+        released = ResourceClaim(
+            key=claim.key,
+            id=_claim_id(claim.key, claim.id, "", _RELEASED),
+            owner=None,
+            state=_RELEASED,
+        )
+        try:
+            return await self._append(
+                claim.key,
+                current,
+                released,
+                acknowledged_by=acknowledged_by,
+            )
+        except weave.OperationConflictError as source:
+            observed = await self.current(claim.key)
+            if observed is not None and observed.state == _RELEASED:
+                return observed
+            raise ResourceTransitionError(claim.key, claim, observed) from source
+
+    async def ledger(self) -> list[ResourceClaim]:
+        rows = _rows(await self._journal.query(_LEDGER_QUERY))
+        claims: list[ResourceClaim] = []
+        for row in rows:
+            if len(row) != 7:
+                raise RuntimeError("resource ledger query returned an invalid row")
+            resource, repository, kind, selector, claim_id, owner, state = row
+            if (
+                not isinstance(resource, str)
+                or not isinstance(repository, str)
+                or not isinstance(kind, str)
+                or not isinstance(claim_id, str)
+                or not isinstance(owner, str)
+                or not isinstance(state, str)
+            ):
+                raise RuntimeError("resource ledger query returned invalid values")
+            if (
+                kind == "pr"
+                and isinstance(selector, int)
+                and not isinstance(selector, bool)
+            ):
+                key = ResourceKey.for_pull_request(repository, selector)
+            elif kind == "worktree" and isinstance(selector, str):
+                key = ResourceKey.for_worktree(repository, selector)
+            else:
+                raise RuntimeError(
+                    f"resource ledger has invalid selector kind {kind!r}"
+                )
+            if key.entity != resource:
+                raise RuntimeError(
+                    f"resource ledger key does not match entity {resource}"
+                )
+            claims.append(
+                ResourceClaim(
+                    key=key,
+                    id=claim_id,
+                    owner=owner or None,
+                    state=state,
+                    owner_state=await self._owner_attr(owner or None, "state"),
+                    requested_by=await self._owner_attr(owner or None, "requested_by"),
+                )
+            )
+        return sorted(claims, key=lambda item: item.key.label)
+
+    async def frame(self) -> polars.DataFrame:
+        import polars as pl
+
+        rows: list[dict[str, str | int | None]] = [
+            {
+                "repository": claim.key.repository,
+                "kind": claim.key.selector_kind,
+                "selector": claim.key.selector,
+                "owner": claim.owner,
+                "requested_by": claim.requested_by,
+                "owner_state": claim.owner_state,
+                "state": claim.state,
+                "claim": claim.id,
+            }
+            for claim in await self.ledger()
+        ]
+        return pl.DataFrame(rows)
+
+
+_default = ResourceLedger()
+
+
+async def current(key: ResourceKey) -> ResourceClaim | None:
+    return await _default.current(key)
+
+
+async def claim(key: ResourceKey, *, owner: str | None = None) -> ResourceClaim:
+    return await _default.claim(key, owner=owner)
+
+
+async def transfer(
+    claim: ResourceClaim,
+    to_owner: str,
+    *,
+    actor: str | None = None,
+) -> ResourceClaim:
+    return await _default.transfer(claim, to_owner, actor=actor)
+
+
+async def release(
+    claim: ResourceClaim,
+    *,
+    actor: str | None = None,
+) -> ResourceClaim:
+    return await _default.release(claim, actor=actor)
+
+
+async def ledger() -> list[ResourceClaim]:
+    return await _default.ledger()
+
+
+async def frame() -> polars.DataFrame:
+    return await _default.frame()

--- a/packages/mcp/src/fabric/test_fabric.py
+++ b/packages/mcp/src/fabric/test_fabric.py
@@ -22,7 +22,7 @@ import weave
 from claude_agent_sdk import AssistantMessage, Message, ResultMessage, TextBlock
 
 import fabric
-from fabric import activity, claude, reconcile, remote
+from fabric import activity, claude, reconcile, remote, resources
 
 _T = TypeVar("_T")
 
@@ -40,9 +40,46 @@ class Journal:
     facts: list[tuple[object, str, object]] = field(default_factory=list)
     blobs: dict[str, bytes] = field(default_factory=dict)
     interrupt: str | None = None
-    #: canned response per exact datalog program (reconcile/activity queries);
-    #: anything else is answered as a per-entity interrupt watch.
+    #: Canned response per exact datalog program for reconcile and activity.
     queries: dict[str, dict[str, Any]] = field(default_factory=dict)
+    operations: dict[str, tuple[object, dict[str, object]]] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def _append_facts(self, writes: list[dict[str, object]]) -> None:
+        for item in writes:
+            fact = item["fact"]
+            assert isinstance(fact, dict)
+            entity = fact["entity"]
+            value = fact["value"]
+            assert isinstance(entity, dict)
+            assert isinstance(value, dict)
+            self.facts.append((entity["v"], str(fact["attr"]), value["v"]))
+
+    def _latest(self, entity: object, attr: str) -> object | None:
+        values = [
+            value
+            for fact_entity, fact_attr, value in self.facts
+            if fact_entity == entity and fact_attr == attr
+        ]
+        return values[-1] if values else None
+
+    @staticmethod
+    def _query_response(rows: list[list[object]]) -> httpx.Response:
+        def wrap(value: object) -> dict[str, object]:
+            if isinstance(value, bool):
+                return {"t": "bool", "v": value}
+            if isinstance(value, int):
+                return {"t": "int", "v": value}
+            return {"t": "str", "v": str(value)}
+
+        return httpx.Response(
+            200,
+            json={
+                "vars": [],
+                "rows": [[wrap(value) for value in row] for row in rows],
+                "as_of": 1,
+            },
+        )
 
     def handler(self, req: httpx.Request) -> httpx.Response:
         path = req.url.path
@@ -54,15 +91,95 @@ class Journal:
             return httpx.Response(200, json={"hash": digest})
         if path == "/api/facts":
             payload = json.loads(req.read())
+            if isinstance(payload, dict) and "operation_id" in payload:
+                operation_id = payload["operation_id"]
+                raw_writes = payload.get("writes")
+                assert isinstance(operation_id, str)
+                assert isinstance(raw_writes, list)
+                writes: list[dict[str, object]] = []
+                for write in raw_writes:
+                    assert isinstance(write, dict)
+                    writes.append(write)
+                with self._lock:
+                    previous = self.operations.get(operation_id)
+                    if previous is not None:
+                        previous_writes, response = previous
+                        if previous_writes != writes:
+                            return httpx.Response(409, text="operation content differs")
+                        return httpx.Response(200, json=response)
+                    first_seq = len(self.facts) + 1
+                    self._append_facts(writes)
+                    response = {
+                        "operation_id": operation_id,
+                        "acks": [
+                            {"seq": first_seq + offset, "id": f"f{first_seq + offset}"}
+                            for offset in range(len(writes))
+                        ],
+                    }
+                    self.operations[operation_id] = (writes, response)
+                return httpx.Response(200, json=response)
+
             batch = payload if isinstance(payload, list) else [payload]
-            for item in batch:
-                fact = item["fact"]
-                self.facts.append((fact["entity"]["v"], fact["attr"], fact["value"]["v"]))
-            return httpx.Response(200, json=[{"seq": i, "id": f"f{i}"} for i in range(len(batch))])
+            writes = []
+            for write in batch:
+                assert isinstance(write, dict)
+                writes.append(write)
+            self._append_facts(writes)
+            return httpx.Response(
+                200,
+                json=[{"seq": i, "id": f"f{i}"} for i in range(len(batch))],
+            )
         if path == "/api/query":
             program = json.loads(req.read())["program"]
             if program in self.queries:
                 return httpx.Response(200, json=self.queries[program])
+
+            current_prefix = "?- latest("
+            current_suffix = (
+                ", current_claim, C), latest(C, claimed_by, O), "
+                "latest(C, state, S)."
+            )
+            if program.startswith(current_prefix) and program.endswith(current_suffix):
+                encoded_entity = program[len(current_prefix) : -len(current_suffix)]
+                entity = json.loads(encoded_entity)
+                claim = self._latest(entity, "current_claim")
+                if claim is None:
+                    return self._query_response([])
+                owner = self._latest(claim, "claimed_by")
+                state = self._latest(claim, "state")
+                assert owner is not None
+                assert state is not None
+                return self._query_response([[claim, owner, state]])
+
+            if 'type(R, "mutation_resource")' in program:
+                entities = sorted({
+                    entity
+                    for entity, attr, value in self.facts
+                    if attr == "type" and value == "mutation_resource"
+                })
+                ledger_rows = []
+                for entity in entities:
+                    claim = self._latest(entity, "current_claim")
+                    assert claim is not None
+                    ledger_rows.append([
+                        entity,
+                        self._latest(entity, "repository"),
+                        self._latest(entity, "selector_kind"),
+                        self._latest(entity, "selector"),
+                        claim,
+                        self._latest(claim, "claimed_by"),
+                        self._latest(claim, "state"),
+                    ])
+                return self._query_response(ledger_rows)
+
+            for attr in ("state", "requested_by"):
+                attr_suffix = f", {attr}, V)."
+                if program.startswith(current_prefix) and program.endswith(attr_suffix):
+                    encoded_entity = program[len(current_prefix) : -len(attr_suffix)]
+                    entity = json.loads(encoded_entity)
+                    value = self._latest(entity, attr)
+                    return self._query_response([] if value is None else [[value]])
+
             rows = [] if self.interrupt is None else [[{"t": "str", "v": self.interrupt}]]
             return httpx.Response(200, json={"vars": ["I"], "rows": rows, "as_of": 1})
         raise AssertionError(f"unexpected weave call: {path}")
@@ -143,6 +260,94 @@ def result_message(text: str) -> ResultMessage:
     )
 
 
+class RacingLedger(resources.ResourceLedger):
+    # Force two claimers to observe the same unclaimed head.
+    def __init__(self, barrier: asyncio.Barrier) -> None:
+        super().__init__()
+        self._barrier = barrier
+
+    async def current(
+        self,
+        key: resources.ResourceKey,
+    ) -> resources.ResourceClaim | None:
+        claim = await super().current(key)
+        if claim is None:
+            await self._barrier.wait()
+        return claim
+
+
+def test_resource_key_canonicalizes_repository_and_worktree(tmp_path: Path) -> None:
+    canonical = resources.ResourceKey.for_pull_request("indexable-inc/ix", 7439)
+    assert resources.ResourceKey.for_pull_request("Indexable-Inc/IX.git", 7439) == canonical
+
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(worktree)
+    assert (
+        resources.ResourceKey.for_worktree("indexable-inc/ix", alias)
+        == resources.ResourceKey.for_worktree("indexable-inc/ix", worktree)
+    )
+
+
+def test_concurrent_resource_claims_admit_exactly_one_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal = install(monkeypatch)
+    key = resources.ResourceKey.for_pull_request("indexable-inc/ix", 7439)
+
+    async def main() -> list[object]:
+        barrier = asyncio.Barrier(2)
+        first = RacingLedger(barrier)
+        second = RacingLedger(barrier)
+        return await asyncio.gather(
+            first.claim(key, owner="task:old-owner"),
+            second.claim(key, owner="task:new-owner"),
+            return_exceptions=True,
+        )
+
+    outcomes = run(main())
+    claims = [
+        outcome for outcome in outcomes if isinstance(outcome, resources.ResourceClaim)
+    ]
+    failures = [
+        outcome
+        for outcome in outcomes
+        if isinstance(outcome, resources.ResourceOwnedError)
+    ]
+    assert len(claims) == 1
+    assert len(failures) == 1
+    assert failures[0].claim.owner == claims[0].owner
+    assert len(journal.operations) == 1
+    assert run(resources.ResourceLedger().current(key)) == claims[0]
+
+
+def test_resource_transfer_requires_current_owner_acknowledgement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal = install(monkeypatch)
+    ledger = resources.ResourceLedger()
+    key = resources.ResourceKey.for_pull_request("indexable-inc/index", 2973)
+    original = run(ledger.claim(key, owner="task:parent"))
+
+    with pytest.raises(resources.ResourceOwnedError, match="task:parent"):
+        run(ledger.claim(key, owner="task:child"))
+    with pytest.raises(resources.ResourceTransferDenied, match=r"task:parent.*task:child"):
+        run(ledger.transfer(original, "task:child", actor="task:child"))
+
+    transferred = run(ledger.transfer(original, "task:child", actor="task:parent"))
+    assert transferred.owner == "task:child"
+    assert journal._latest(original.id, "acknowledged_by") == "task:parent"
+    assert run(ledger.claim(key, owner="task:child")) == transferred
+    assert run(ledger.ledger()) == [transferred]
+
+    released = run(ledger.release(transferred, actor="task:child"))
+    assert released.available
+    assert journal._latest(transferred.id, "acknowledged_by") == "task:child"
+    replacement = run(ledger.claim(key, owner="task:next"))
+    assert replacement.owner == "task:next"
+
+
 # --- fabric.run ---------------------------------------------------------------
 
 
@@ -178,6 +383,41 @@ def test_run_records_ask_then_started_then_done(monkeypatch: pytest.MonkeyPatch)
     assert journal.states(handle.task) == ["submitted", "running", "done"]
     assert b"def add(a: int, b: int) -> int:" in journal.blob_for(handle.task, "source")
     assert journal.blob_for(handle.task, "result") == b"5"
+
+
+def test_run_rejects_a_second_live_mutator_and_reclaims_terminal_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install(monkeypatch)
+    key = resources.ResourceKey.for_pull_request("indexable-inc/ix", 7439)
+    calls: list[str] = []
+
+    async def main() -> tuple[fabric.RunHandle, fabric.RunHandle]:
+        started = asyncio.Event()
+        finish = asyncio.Event()
+
+        async def mutate() -> None:
+            calls.append("started")
+            started.set()
+            await finish.wait()
+
+        first = await fabric.run(mutate, resource_key=key)
+        await started.wait()
+        with pytest.raises(resources.ResourceOwnedError, match=first.task):
+            await fabric.run(mutate, resource_key=key)
+        finish.set()
+        await first.wait()
+        replacement = await fabric.run(mutate, resource_key=key)
+        await replacement.wait()
+        return first, replacement
+
+    first, replacement = run(main())
+    assert calls == ["started", "started"]
+    assert first.resource_claim is not None
+    assert replacement.resource_claim is not None
+    assert first.resource_claim.owner == first.task
+    assert replacement.resource_claim.owner == replacement.task
+    assert replacement.resource_claim.id != first.resource_claim.id
 
 
 def test_run_sync_off_loop_and_async_native(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -474,6 +714,45 @@ def test_session_records_turns_result_and_done(monkeypatch: pytest.MonkeyPatch) 
     assert first["type"] == "AssistantMessage"
     assert first["message"]["content"] == [{"text": "thinking"}]
     assert json.loads(journal.blobs[str(turns[1])])["type"] == "ResultMessage"
+
+
+def test_session_claims_child_resource_before_starting_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal = install(monkeypatch)
+    clients = [FakeClient(), FakeClient()]
+    monkeypatch.setattr(claude, "_sdk_client", lambda **kwargs: clients.pop(0))
+    monkeypatch.setattr(fabric, "INTERRUPT_POLL_S", 0.01)
+    key = resources.ResourceKey.for_worktree(
+        "indexable-inc/index",
+        "/private/tmp/andrewgazelka/2973-resource-ownership",
+    )
+
+    async def main() -> tuple[claude.Session, claude.Session]:
+        first = await claude.session("mutate", resource_key=key)
+        observed = await resources.current(key)
+        assert observed is not None
+        assert observed.owner == first.task
+        assert observed.requested_by == "agent:tester"
+        with pytest.raises(resources.ResourceOwnedError, match=first.task):
+            await claude.session("conflicting mutation", resource_key=key)
+        assert len(clients) == 1
+        await first.close()
+        replacement = await claude.session("continue mutation", resource_key=key)
+        await replacement.close()
+        return first, replacement
+
+    first, replacement = run(main())
+    assert first.resource_claim is not None
+    assert replacement.resource_claim is not None
+    assert first.resource_claim.owner == first.task
+    assert replacement.resource_claim.owner == replacement.task
+    failed = [
+        entity
+        for entity, attr, value in journal.facts
+        if attr == "state" and value == "failed"
+    ]
+    assert len(failed) == 1
 
 
 def test_session_follow_up_input_streams(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/mcp/src/weave/test_weave.py
+++ b/packages/mcp/src/weave/test_weave.py
@@ -77,6 +77,66 @@ def test_assert_facts_batches_500(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(out) == 1200
 
 
+def test_append_operation_sends_one_atomic_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payloads: list[object] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        payload = weave.json.loads(req.read())
+        payloads.append(payload)
+        return httpx.Response(
+            200,
+            json={
+                "operation_id": "claim-resource",
+                "acks": [{"seq": 41, "id": "f41"}, {"seq": 42, "id": "f42"}],
+            },
+        )
+
+    install_transport(monkeypatch, handler)
+    acknowledgements = run(
+        weave.append_operation(
+            "claim-resource",
+            [("resource:1", "owner", "task:1"), ("resource:1", "generation", 1)],
+        )
+    )
+
+    assert acknowledgements == [{"seq": 41, "id": "f41"}, {"seq": 42, "id": "f42"}]
+    assert payloads == [
+        {
+            "operation_id": "claim-resource",
+            "writes": [
+                {
+                    "fact": {
+                        "entity": {"t": "str", "v": "resource:1"},
+                        "attr": "owner",
+                        "value": {"t": "str", "v": "task:1"},
+                    }
+                },
+                {
+                    "fact": {
+                        "entity": {"t": "str", "v": "resource:1"},
+                        "attr": "generation",
+                        "value": {"t": "int", "v": 1},
+                    }
+                },
+            ],
+        }
+    ]
+
+
+def test_append_operation_reports_conflict(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, text="operation content differs")
+
+    install_transport(monkeypatch, handler)
+    with pytest.raises(
+        weave.OperationConflictError,
+        match=r"claim-resource.*operation content differs",
+    ):
+        run(weave.append_operation("claim-resource", [("resource:1", "owner", "task:2")]))
+
+
 def test_query_unwrap_and_frame(monkeypatch: pytest.MonkeyPatch) -> None:
     def handler(req: httpx.Request) -> httpx.Response:
         return httpx.Response(

--- a/packages/mcp/src/weave/weave/__init__.py
+++ b/packages/mcp/src/weave/weave/__init__.py
@@ -23,10 +23,12 @@ if TYPE_CHECKING:
 
 __all__ = [
     "HashRef",
+    "OperationConflictError",
     "QueryResult",
     "TaskCancelledError",
     "TaskFailedError",
     "Weave",
+    "append_operation",
     "assert_fact",
     "assert_facts",
     "chat",
@@ -41,7 +43,7 @@ __all__ = [
     "watch",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 _DEFAULT_URL = "http://127.0.0.1:7677"
 _HASH_RE = re.compile(r"^(?:blake3:)?[0-9a-fA-F]{64}$")
@@ -61,6 +63,14 @@ class TaskFailedError(RuntimeError):
 
 class TaskCancelledError(RuntimeError):
     """A Weave task published a terminal ``cancelled`` or ``interrupted`` state."""
+
+
+class OperationConflictError(RuntimeError):
+    """An operation id was already committed with different writes."""
+
+    def __init__(self, operation_id: str, detail: str) -> None:
+        super().__init__(f"operation {operation_id!r} conflicts: {detail}")
+        self.operation_id = operation_id
 
 
 def hashref(h: str) -> HashRef:
@@ -166,6 +176,48 @@ class Weave:
                 data = resp.json()
                 out.extend(data if isinstance(data, list) else [data])
         return out
+
+    async def append_operation(
+        self,
+        operation_id: str,
+        facts: Sequence[tuple[str, str, object]],
+    ) -> list[dict[str, object]]:
+        """Atomically append an idempotent fact batch.
+
+        The server commits the first write set for ``operation_id``. Repeating
+        the same set returns its original acknowledgements; different writes
+        raise :class:`OperationConflictError` without appending a fact.
+        """
+
+        payload = {
+            "operation_id": operation_id,
+            "writes": [_fact(entity, attr, value) for entity, attr, value in facts],
+        }
+        async with _client() as client:
+            response = await client.post("/api/facts", json=payload)
+            if response.status_code == 409:
+                detail = response.text.strip() or "the operation id is already committed"
+                raise OperationConflictError(operation_id, detail)
+            response.raise_for_status()
+            body: object = response.json()
+
+        if not isinstance(body, dict):
+            raise RuntimeError("operation response must be an object")
+        returned_id = body.get("operation_id")
+        acknowledgements = body.get("acks")
+        if returned_id != operation_id or not isinstance(acknowledgements, list):
+            raise RuntimeError("operation response has an invalid id or acknowledgements")
+
+        parsed: list[dict[str, object]] = []
+        for acknowledgement in acknowledgements:
+            if not isinstance(acknowledgement, dict):
+                raise RuntimeError("operation acknowledgement must be an object")
+            seq = acknowledgement.get("seq")
+            fact_id = acknowledgement.get("id")
+            if isinstance(seq, bool) or not isinstance(seq, int) or not isinstance(fact_id, str):
+                raise RuntimeError("operation acknowledgement has an invalid seq or id")
+            parsed.append({"seq": seq, "id": fact_id})
+        return parsed
 
     async def retract(self, fact_id: str) -> dict[str, Any]:
         """Retract a fact by id."""
@@ -296,6 +348,13 @@ async def assert_fact(entity: str, attr: str, value: object) -> dict[str, Any]:
 
 async def assert_facts(facts: Sequence[tuple[str, str, Any]]) -> list[dict[str, Any]]:
     return await _default.assert_facts(facts)
+
+
+async def append_operation(
+    operation_id: str,
+    facts: Sequence[tuple[str, str, object]],
+) -> list[dict[str, object]]:
+    return await _default.append_operation(operation_id, facts)
 
 
 async def retract(fact_id: str) -> dict[str, Any]:


### PR DESCRIPTION
## What changed

* Adds a structured mutation key for one repository plus a pull request or canonical worktree.
* Uses Weave's atomic operation envelope so concurrent claimers cannot both become owners.
* Rejects a live second owner before a Fabric run or Claude session starts.
* Records acknowledged transfers, explicit releases, task lineage, and current owner state in one queryable ledger.
* Reclaims ownership only after the owning Fabric task reaches a terminal state.

## Validation

* `45 passed` across `packages/mcp/src/weave/test_weave.py` and `packages/mcp/src/fabric/test_fabric.py`
* `ruff check` passed for all changed Python files
* strict `zuban` passed for all six Fabric source files

## Scope

Weave scopes operation ids to one authenticated principal. This protects parent and child sessions within one MCP service, including the current deployment. Ownership across separate principals would require a server-owned conditional write primitive. This draft does not hide that product boundary.

Fixes #2973.

(authored by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mutation ownership serialization to `fabric.run` and `claude.session`
> - Introduces a new `fabric.resources` module implementing resource ownership tracking via atomic append operations (`weave.append_operation`) with conflict detection, acknowledgement checks, and ledger queries.
> - `fabric.run` and `claude.session` accept a new `resource_key` parameter; if provided, they attempt to claim the resource before executing and mark the task as failed (with error facts) if the claim fails.
> - `weave` gains `append_operation` and `OperationConflictError`, which maps HTTP 409 responses to a typed exception for callers to handle conflicts.
> - Risk: tasks that previously ran unconditionally will now fail fast if another task holds a live claim on the same resource key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3095801.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->