### PR TITLE
ci: require reasons for workflow cancellation

### DIFF
--- a/.github/actions/ci-budget/action.yml
+++ b/.github/actions/ci-budget/action.yml
@@ -102,7 +102,15 @@ runs:
         CI_BUDGET_RUN_ID: ${{ inputs.run-id }}
         CI_BUDGET_TARGET_JOB_NAME: ${{ inputs.target-job-name }}
         CI_BUDGET_TOKEN: ${{ inputs.token }}
+        WORKFLOW_CANCELLATION_RECORD_DIRECTORY: ${{ runner.temp }}/workflow-cancellations
       run: python3 "$GITHUB_ACTION_PATH/ci_deadline.py"
+    - name: Preserve workflow cancellation records
+      if: inputs.mode == 'cancel' && always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: workflow-cancellations-${{ inputs.run-id }}-${{ inputs.run-attempt }}
+        path: ${{ runner.temp }}/workflow-cancellations
+        if-no-files-found: ignore
     - name: Reject unknown CI budget mode
       if: inputs.mode != 'classify' && inputs.mode != 'gate' && inputs.mode != 'cancel'
       shell: bash

--- a/.github/actions/ci-budget/ci_budget.py
+++ b/.github/actions/ci-budget/ci_budget.py
@@ -545,9 +545,6 @@ class GitHubClient:
                 return jobs
             page += 1
 
-    def cancel_workflow_run(self, run_id: int) -> None:
-        self.request("POST", f"actions/runs/{run_id}/cancel")
-
     def upsert_comment(self, number: int, body: str) -> None:
         comments = self.paginated(f"issues/{number}/comments")
         owned = [

--- a/.github/actions/ci-budget/ci_deadline.py
+++ b/.github/actions/ci-budget/ci_deadline.py
@@ -235,6 +235,7 @@ def main() -> int:
         )
         canceller = WorkflowCanceller(
             client.request,
+            repository,
             Path(os.environ["WORKFLOW_CANCELLATION_RECORD_DIRECTORY"]),
             Path(os.environ["GITHUB_STEP_SUMMARY"]),
         )

--- a/.github/actions/ci-budget/ci_deadline.py
+++ b/.github/actions/ci-budget/ci_deadline.py
@@ -9,6 +9,7 @@ import sys
 import time
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from ci_budget import (
     BudgetSnapshot,
@@ -18,6 +19,16 @@ from ci_budget import (
     parse_positive_int,
 )
 from ci_policy import STANDARD_BUDGET, parse_timestamp
+from workflow_cancellation import (
+    Canceller,
+    CancellationReason,
+    CancellationReasonCode,
+    CancellationSource,
+    CancellationSourceKind,
+    WorkflowCancellation,
+    WorkflowCanceller,
+    source_from_environment,
+)
 
 
 def target_job(jobs: Sequence[JsonObject], target_name: str) -> JsonObject:
@@ -93,10 +104,13 @@ def verify_required_gate(
 
 def cancel_at_deadline(
     client: GitHubClient,
+    canceller: Canceller,
+    repository: str,
     run_id: int,
     run_attempt: int,
     budget: timedelta,
     *,
+    source: CancellationSource,
     force_big_change: bool,
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
     sleep: Callable[[float], None] = time.sleep,
@@ -127,7 +141,15 @@ def cancel_at_deadline(
                 "source workflow did not publish its budget snapshot before "
                 f"{deadline.isoformat()}"
             )
-            client.cancel_workflow_run(run_id)
+            canceller.cancel(
+                deadline_cancellation(
+                    repository,
+                    run_id,
+                    run_attempt,
+                    source,
+                    deadline,
+                )
+            )
             return True
         if snapshot is None:
             sleep(min(2, remaining))
@@ -153,14 +175,43 @@ def cancel_at_deadline(
         f"::error title=CI total deadline exceeded::"
         f"cancelling run {run_id} attempt {run_attempt} at {deadline.isoformat()}"
     )
-    client.cancel_workflow_run(run_id)
+    canceller.cancel(
+        deadline_cancellation(
+            repository,
+            run_id,
+            run_attempt,
+            source,
+            deadline,
+        )
+    )
     return True
 
 
-def main() -> int:
-    client = GitHubClient(
-        os.environ["CI_BUDGET_REPOSITORY"], os.environ["CI_BUDGET_TOKEN"]
+def deadline_cancellation(
+    repository: str,
+    run_id: int,
+    run_attempt: int,
+    source: CancellationSource,
+    deadline: datetime,
+) -> WorkflowCancellation:
+    return WorkflowCancellation(
+        repository=repository,
+        run_id=run_id,
+        run_attempt=run_attempt,
+        reason=CancellationReason(
+            code=CancellationReasonCode.CI_TOTAL_DEADLINE_EXCEEDED,
+            detail=(
+                f"ordinary CI exceeded its {int(STANDARD_BUDGET.total_seconds())} "
+                f"second total budget at {deadline.isoformat()}"
+            ),
+        ),
+        source=source,
     )
+
+
+def main() -> int:
+    repository = os.environ["CI_BUDGET_REPOSITORY"]
+    client = GitHubClient(repository, os.environ["CI_BUDGET_TOKEN"])
     mode = os.environ["CI_BUDGET_DEADLINE_MODE"]
     run_id = parse_positive_int(os.environ["CI_BUDGET_RUN_ID"], "run-id")
     run_attempt = parse_positive_int(os.environ["CI_BUDGET_RUN_ATTEMPT"], "run-attempt")
@@ -178,11 +229,23 @@ def main() -> int:
         )
         return 0
     if mode == "cancel":
+        source = source_from_environment(
+            CancellationSourceKind.CI_DEADLINE_CONTROLLER,
+            os.environ,
+        )
+        canceller = WorkflowCanceller(
+            client.request,
+            Path(os.environ["WORKFLOW_CANCELLATION_RECORD_DIRECTORY"]),
+            Path(os.environ["GITHUB_STEP_SUMMARY"]),
+        )
         cancel_at_deadline(
             client,
+            canceller,
+            repository,
             run_id,
             run_attempt,
             STANDARD_BUDGET,
+            source=source,
             force_big_change=parse_bool(
                 os.environ["CI_BUDGET_FORCE_BIG_CHANGE"], "force-big-change"
             ),

--- a/.github/actions/ci-budget/test_ci_deadline.py
+++ b/.github/actions/ci-budget/test_ci_deadline.py
@@ -32,18 +32,15 @@ class FakeClient:
         attempts: list[dict[str, Any]],
         jobs: list[dict[str, Any]] | None = None,
         *,
-        cancel_error: RuntimeError | None = None,
         snapshots: list[ci_deadline.BudgetSnapshot | None] | None = None,
     ) -> None:
         self.attempts = attempts
         self.jobs = jobs or []
-        self.cancel_error = cancel_error
         self.snapshots = (
             snapshots
             if snapshots is not None
             else [ci_deadline.BudgetSnapshot(big_change=False)]
         )
-        self.cancelled: list[int] = []
 
     def workflow_attempt(self, run_id: int, run_attempt: int) -> dict[str, Any]:
         assert run_id == 12
@@ -66,10 +63,29 @@ class FakeClient:
             return None
         return self.snapshots.pop(0)
 
-    def cancel_workflow_run(self, run_id: int) -> None:
-        if self.cancel_error:
-            raise self.cancel_error
-        self.cancelled.append(run_id)
+
+class FakeCanceller:
+    def __init__(self, error: RuntimeError | None = None) -> None:
+        self.error = error
+        self.cancellations: list[ci_deadline.WorkflowCancellation] = []
+
+    def cancel(self, cancellation: ci_deadline.WorkflowCancellation) -> Path:
+        if self.error is not None:
+            raise self.error
+        self.cancellations.append(cancellation)
+        return Path("cancellation.json")
+
+
+SOURCE = ci_deadline.CancellationSource(
+    kind=ci_deadline.CancellationSourceKind.CI_DEADLINE_CONTROLLER,
+    actor="github-actions[bot]",
+    repository="indexable-inc/index",
+    run_id=99,
+    run_attempt=1,
+    workflow_ref="indexable-inc/index/.github/workflows/ci-deadline-controller.yml@main",
+    job="deadline",
+)
+REPOSITORY = "indexable-inc/index"
 
 
 def attempt(
@@ -288,34 +304,46 @@ class CancellationControllerTests(unittest.TestCase):
                 )
             ]
         )
+        canceller = FakeCanceller()
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=False,
             now=lambda: datetime(2026, 7, 15, 10, 0, tzinfo=UTC),
             sleep=lambda _: self.fail("stale retry must not receive a fresh budget"),
         )
 
         assert cancelled
-        assert client.cancelled == [12]
+        assert [item.run_id for item in canceller.cancellations] == [12]
+        assert canceller.cancellations[0].reason.code == (
+            ci_deadline.CancellationReasonCode.CI_TOTAL_DEADLINE_EXCEEDED
+        )
+        assert "300 second total budget" in (canceller.cancellations[0].reason.detail)
 
     def test_controller_exits_when_attempt_already_completed(self) -> None:
         client = FakeClient([attempt(status="completed")], snapshots=[None])
+        canceller = FakeCanceller()
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=False,
             sleep=lambda _: self.fail("completed attempt must not sleep"),
         )
 
         assert not cancelled
-        assert not client.cancelled
+        assert not canceller.cancellations
 
     def test_fork_pull_request_uses_source_snapshot_when_payload_is_empty(self) -> None:
         fork_attempt = attempt()
@@ -326,13 +354,17 @@ class CancellationControllerTests(unittest.TestCase):
             [fork_attempt, completed],
             snapshots=[ci_deadline.BudgetSnapshot(big_change=False)],
         )
+        canceller = FakeCanceller()
         sleeps: list[float] = []
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=False,
             now=lambda: datetime(2026, 7, 15, 10, 0, tzinfo=UTC),
             sleep=sleeps.append,
@@ -343,32 +375,40 @@ class CancellationControllerTests(unittest.TestCase):
 
     def test_missing_source_snapshot_cancels_at_deadline(self) -> None:
         client = FakeClient([attempt(), attempt()], snapshots=[None])
+        canceller = FakeCanceller()
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=False,
             now=lambda: datetime(2026, 7, 15, 10, 5, 1, tzinfo=UTC),
             sleep=lambda _: self.fail("elapsed deadline must not sleep"),
         )
 
         assert cancelled
-        assert client.cancelled == [12]
+        assert [item.run_id for item in canceller.cancellations] == [12]
 
     def test_main_push_waits_for_classified_snapshot(self) -> None:
         client = FakeClient(
             [attempt(event="push"), attempt(status="completed", event="push")],
             snapshots=[None, ci_deadline.BudgetSnapshot(big_change=False)],
         )
+        canceller = FakeCanceller()
         sleeps: list[float] = []
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=False,
             now=lambda: datetime(2026, 7, 15, 10, 0, tzinfo=UTC),
             sleep=sleeps.append,
@@ -385,13 +425,17 @@ class CancellationControllerTests(unittest.TestCase):
             ],
             snapshots=[None, ci_deadline.BudgetSnapshot(big_change=False)],
         )
+        canceller = FakeCanceller()
         sleeps: list[float] = []
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=False,
             now=lambda: datetime(2026, 7, 15, 10, 0, tzinfo=UTC),
             sleep=sleeps.append,
@@ -402,44 +446,56 @@ class CancellationControllerTests(unittest.TestCase):
 
     def test_queue_time_counts_toward_cancellation(self) -> None:
         client = FakeClient([attempt(), attempt()])
+        canceller = FakeCanceller()
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=False,
             now=lambda: datetime(2026, 7, 15, 10, 5, 1, tzinfo=UTC),
             sleep=lambda _: self.fail("elapsed deadline must not sleep"),
         )
 
         assert cancelled
-        assert client.cancelled == [12]
+        assert [item.run_id for item in canceller.cancellations] == [12]
 
     def test_completed_attempt_is_not_cancelled(self) -> None:
         client = FakeClient([attempt(), attempt(status="completed")])
+        canceller = FakeCanceller()
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=False,
             now=lambda: datetime(2026, 7, 15, 10, 5, tzinfo=UTC),
             sleep=lambda _: self.fail("elapsed deadline must not sleep"),
         )
 
         assert not cancelled
-        assert not client.cancelled
+        assert not canceller.cancellations
 
     def test_big_change_is_exempt(self) -> None:
         client = FakeClient([attempt()])
+        canceller = FakeCanceller()
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=True,
             sleep=lambda _: self.fail("big change must not sleep"),
         )
@@ -451,12 +507,16 @@ class CancellationControllerTests(unittest.TestCase):
             [attempt()],
             snapshots=[ci_deadline.BudgetSnapshot(big_change=True)],
         )
+        canceller = FakeCanceller()
 
         cancelled = ci_deadline.cancel_at_deadline(
             client,
+            canceller,
+            REPOSITORY,
             12,
             2,
             timedelta(minutes=5),
+            source=SOURCE,
             force_big_change=False,
             sleep=lambda _: self.fail("extended snapshot must not sleep"),
         )
@@ -465,13 +525,17 @@ class CancellationControllerTests(unittest.TestCase):
 
     def test_denied_cancellation_cannot_make_late_target_green(self) -> None:
         denial = RuntimeError("HTTP 403: Resource not accessible by integration")
-        controller = FakeClient([attempt(), attempt()], cancel_error=denial)
+        controller = FakeClient([attempt(), attempt()])
+        canceller = FakeCanceller(denial)
         error = runtime_error(
             lambda: ci_deadline.cancel_at_deadline(
                 controller,
+                canceller,
+                REPOSITORY,
                 12,
                 2,
                 timedelta(minutes=5),
+                source=SOURCE,
                 force_big_change=False,
                 now=lambda: datetime(2026, 7, 15, 10, 5, 1, tzinfo=UTC),
                 sleep=lambda _: self.fail("elapsed deadline must not sleep"),

--- a/.github/actions/ci-budget/test_ci_workflows.py
+++ b/.github/actions/ci-budget/test_ci_workflows.py
@@ -318,6 +318,53 @@ class TrustedWorkflowTests(unittest.TestCase):
         assert "workflow_run.run_attempt" in expression(inputs, "run-attempt")
         assert not any(use.startswith("actions/checkout") for use in all_uses(workflow))
 
+    def test_cancel_mode_always_uploads_its_audit_record(self) -> None:
+        action = load_yaml(ACTION_DIR / "action.yml")
+        steps = child_list(child_object(action, "runs"), "steps")
+        enforce = next(
+            step
+            for step in steps
+            if isinstance(step, dict)
+            and step.get("name") == "Enforce total CI deadline"
+        )
+        preserve = next(
+            step
+            for step in steps
+            if isinstance(step, dict)
+            and step.get("name") == "Preserve workflow cancellation records"
+        )
+        environment = child_object(enforce, "env")
+        inputs = child_object(preserve, "with")
+
+        assert "workflow-cancellations" in expression(
+            environment, "WORKFLOW_CANCELLATION_RECORD_DIRECTORY"
+        )
+        assert expression(preserve, "if") == "inputs.mode == 'cancel' && always()"
+        assert preserve["uses"].startswith("actions/upload-artifact@")
+        assert "inputs.run-id" in expression(inputs, "name")
+        assert inputs["if-no-files-found"] == "ignore"
+
+    def test_watchdog_routes_cancellation_through_the_typed_owner(self) -> None:
+        workflow = load_workflow("cache-push-watchdog.yml")
+        watch = child_object(child_object(workflow, "jobs"), "watch")
+        environment = child_object(watch, "env")
+        steps = child_list(watch, "steps")
+        checkout, detect, preserve = steps
+        if not all(isinstance(step, dict) for step in steps):
+            raise AssertionError("watchdog step is not an object")
+        script = detect.get("run")
+        if not isinstance(script, str):
+            raise AssertionError("watchdog detection step has no script")
+
+        assert checkout["uses"].startswith("actions/checkout@")
+        assert environment["WORKFLOW_CANCELLATION_SOURCE"] == "cache_push_watchdog"
+        assert "workflow_cancellation.py" in script
+        assert "cache_push_zombie" in script
+        assert "cache_push_materialization_stall" in script
+        assert "gh run" + " cancel" not in script
+        assert expression(preserve, "if") == "always()"
+        assert preserve["uses"].startswith("actions/upload-artifact@")
+
     def test_publisher_uses_trusted_base_code_without_checkout(self) -> None:
         workflow = load_workflow("ci-budget-publish.yml")
         assert "pull_request_target" in events(workflow)
@@ -346,6 +393,7 @@ class TrustedWorkflowTests(unittest.TestCase):
             ".github/actions/ci-budget/**",
             ".github/scripts/run-check-logged.sh",
             ".github/scripts/run-clone-diff.sh",
+            ".github/workflows/cache-push-watchdog.yml",
             ".github/workflows/check.yml",
             ".github/workflows/closure-gate.yml",
             ".github/workflows/ci-budget-publish.yml",

--- a/.github/actions/ci-budget/test_workflow_cancellation.py
+++ b/.github/actions/ci-budget/test_workflow_cancellation.py
@@ -83,7 +83,7 @@ def cancellation(
     detail: str = "ordinary CI exceeded its 300 second total budget",
 ) -> workflow_cancellation.WorkflowCancellation:
     return workflow_cancellation.WorkflowCancellation(
-        repository="indexable-inc/ix",
+        repository="indexable-inc/index",
         run_id=12,
         run_attempt=3,
         reason=workflow_cancellation.CancellationReason(
@@ -131,6 +131,24 @@ class WorkflowCancellationTests(unittest.TestCase):
 
         assert "reason code must be typed" in str(error)
 
+    def test_source_cannot_cancel_another_repository(self) -> None:
+        error = value_error(
+            lambda: workflow_cancellation.WorkflowCancellation(
+                repository="indexable-inc/ix",
+                run_id=12,
+                run_attempt=1,
+                reason=workflow_cancellation.CancellationReason(
+                    code=(
+                        workflow_cancellation.CancellationReasonCode.CI_TOTAL_DEADLINE_EXCEEDED
+                    ),
+                    detail="ordinary CI exceeded its budget",
+                ),
+                source=source(),
+            )
+        )
+
+        assert "source and target repositories must match" in str(error)
+
     def test_accepted_cancellation_has_a_durable_structured_record(self) -> None:
         request = FakeRequest()
         recorded_at = datetime(2026, 7, 15, 16, 7, 43, tzinfo=UTC)
@@ -139,6 +157,7 @@ class WorkflowCancellationTests(unittest.TestCase):
             summary = root / "summary.md"
             path = workflow_cancellation.WorkflowCanceller(
                 request,
+                "indexable-inc/index",
                 root / "records",
                 summary,
                 now=lambda: recorded_at,
@@ -166,7 +185,7 @@ class WorkflowCancellationTests(unittest.TestCase):
                     ),
                 },
                 "target": {
-                    "repository": "indexable-inc/ix",
+                    "repository": "indexable-inc/index",
                     "run_attempt": 3,
                     "run_id": 12,
                 },
@@ -183,6 +202,7 @@ class WorkflowCancellationTests(unittest.TestCase):
             root = Path(temporary)
             canceller = workflow_cancellation.WorkflowCanceller(
                 request,
+                "indexable-inc/index",
                 root / "records",
                 root / "summary.md",
             )
@@ -196,6 +216,23 @@ class WorkflowCancellationTests(unittest.TestCase):
             assert record["outcome"] == "rejected"
             assert record["reason"]["code"] == "ci_total_deadline_exceeded"
             assert record["error"] == "RuntimeError: HTTP 403"
+
+    def test_github_client_repository_must_match_the_target(self) -> None:
+        request = FakeRequest()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            canceller = workflow_cancellation.WorkflowCanceller(
+                request,
+                "indexable-inc/ix",
+                root / "records",
+                root / "summary.md",
+            )
+
+            error = value_error(lambda: canceller.cancel(cancellation()))
+
+            assert "target does not match the GitHub client" in str(error)
+            assert request.calls == []
+            assert not (root / "records").exists()
 
     def test_source_identity_comes_from_github_environment(self) -> None:
         result = workflow_cancellation.source_from_environment(

--- a/.github/actions/ci-budget/test_workflow_cancellation.py
+++ b/.github/actions/ci-budget/test_workflow_cancellation.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+import tempfile
+import unittest
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+MODULE_PATH = Path(__file__).with_name("workflow_cancellation.py")
+sys.path.insert(0, str(MODULE_PATH.parent))
+SPEC = importlib.util.spec_from_file_location("workflow_cancellation", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+workflow_cancellation = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = workflow_cancellation
+SPEC.loader.exec_module(workflow_cancellation)
+
+REPOSITORY = MODULE_PATH.parents[3]
+
+
+def value_error(call: Callable[[], object]) -> ValueError:
+    try:
+        call()
+    except ValueError as error:
+        return error
+    raise AssertionError("call did not raise ValueError")
+
+
+def runtime_error(call: Callable[[], object]) -> RuntimeError:
+    try:
+        call()
+    except RuntimeError as error:
+        return error
+    raise AssertionError("call did not raise RuntimeError")
+
+
+class FakeRequest:
+    def __init__(self, error: RuntimeError | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        query: Mapping[str, int | str] | None = None,
+    ) -> tuple[Any, Mapping[str, str]]:
+        assert body is None
+        assert query is None
+        self.calls.append((method, path))
+        if self.error is not None:
+            raise self.error
+        return None, {}
+
+
+def source(
+    kind: workflow_cancellation.CancellationSourceKind = (
+        workflow_cancellation.CancellationSourceKind.CI_DEADLINE_CONTROLLER
+    ),
+) -> workflow_cancellation.CancellationSource:
+    return workflow_cancellation.CancellationSource(
+        kind=kind,
+        actor="github-actions[bot]",
+        repository="indexable-inc/index",
+        run_id=99,
+        run_attempt=2,
+        workflow_ref=(
+            "indexable-inc/index/.github/workflows/"
+            "ci-deadline-controller.yml@refs/heads/main"
+        ),
+        job="deadline",
+    )
+
+
+def cancellation(
+    *,
+    detail: str = "ordinary CI exceeded its 300 second total budget",
+) -> workflow_cancellation.WorkflowCancellation:
+    return workflow_cancellation.WorkflowCancellation(
+        repository="indexable-inc/ix",
+        run_id=12,
+        run_attempt=3,
+        reason=workflow_cancellation.CancellationReason(
+            code=(
+                workflow_cancellation.CancellationReasonCode.CI_TOTAL_DEADLINE_EXCEEDED
+            ),
+            detail=detail,
+        ),
+        source=source(),
+    )
+
+
+class WorkflowCancellationTests(unittest.TestCase):
+    def test_reason_must_not_be_empty(self) -> None:
+        for detail in ("", "   ", "\n"):
+            with self.subTest(detail=detail):
+                error = value_error(lambda detail=detail: cancellation(detail=detail))
+                assert "must not be empty" in str(error)
+
+    def test_source_can_use_only_its_owned_reason_codes(self) -> None:
+        error = value_error(
+            lambda: workflow_cancellation.WorkflowCancellation(
+                repository="indexable-inc/index",
+                run_id=12,
+                run_attempt=1,
+                reason=workflow_cancellation.CancellationReason(
+                    code=(
+                        workflow_cancellation.CancellationReasonCode.CACHE_PUSH_ZOMBIE
+                    ),
+                    detail="wrong owner",
+                ),
+                source=source(),
+            )
+        )
+        assert "cannot use reason" in str(error)
+
+    def test_reason_code_must_be_typed(self) -> None:
+        untyped_code: Any = "ci_total_deadline_exceeded"
+        error = value_error(
+            lambda: workflow_cancellation.CancellationReason(
+                code=untyped_code,
+                detail="ordinary CI exceeded its budget",
+            )
+        )
+
+        assert "reason code must be typed" in str(error)
+
+    def test_accepted_cancellation_has_a_durable_structured_record(self) -> None:
+        request = FakeRequest()
+        recorded_at = datetime(2026, 7, 15, 16, 7, 43, tzinfo=UTC)
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            summary = root / "summary.md"
+            path = workflow_cancellation.WorkflowCanceller(
+                request,
+                root / "records",
+                summary,
+                now=lambda: recorded_at,
+            ).cancel(cancellation())
+
+            record = json.loads(path.read_text())
+            assert record == {
+                "actor": "github-actions[bot]",
+                "outcome": "accepted",
+                "reason": {
+                    "code": "ci_total_deadline_exceeded",
+                    "detail": "ordinary CI exceeded its 300 second total budget",
+                },
+                "recorded_at": "2026-07-15T16:07:43Z",
+                "schema_version": 1,
+                "source": {
+                    "job": "deadline",
+                    "kind": "ci_deadline_controller",
+                    "repository": "indexable-inc/index",
+                    "run_attempt": 2,
+                    "run_id": 99,
+                    "workflow_ref": (
+                        "indexable-inc/index/.github/workflows/"
+                        "ci-deadline-controller.yml@refs/heads/main"
+                    ),
+                },
+                "target": {
+                    "repository": "indexable-inc/ix",
+                    "run_attempt": 3,
+                    "run_id": 12,
+                },
+            }
+            assert request.calls == [("POST", "actions/runs/12/cancel")]
+            summary_text = summary.read_text()
+            assert '"actor":"github-actions[bot]"' in summary_text
+            assert '"outcome":"requested"' in summary_text
+            assert '"outcome":"accepted"' in summary_text
+
+    def test_rejected_cancellation_preserves_the_reason_and_error(self) -> None:
+        request = FakeRequest(RuntimeError("HTTP 403"))
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            canceller = workflow_cancellation.WorkflowCanceller(
+                request,
+                root / "records",
+                root / "summary.md",
+            )
+
+            error = runtime_error(lambda: canceller.cancel(cancellation()))
+            assert "HTTP 403" in str(error)
+
+            records = list((root / "records").glob("*.json"))
+            assert len(records) == 1
+            record = json.loads(records[0].read_text())
+            assert record["outcome"] == "rejected"
+            assert record["reason"]["code"] == "ci_total_deadline_exceeded"
+            assert record["error"] == "RuntimeError: HTTP 403"
+
+    def test_source_identity_comes_from_github_environment(self) -> None:
+        result = workflow_cancellation.source_from_environment(
+            workflow_cancellation.CancellationSourceKind.CACHE_PUSH_WATCHDOG,
+            {
+                "GITHUB_ACTOR": "github-actions[bot]",
+                "GITHUB_REPOSITORY": "indexable-inc/index",
+                "GITHUB_RUN_ID": "44",
+                "GITHUB_RUN_ATTEMPT": "2",
+                "GITHUB_WORKFLOW_REF": "indexable-inc/index/watchdog.yml@main",
+                "GITHUB_JOB": "watch",
+            },
+        )
+
+        assert result.actor == "github-actions[bot]"
+        assert result.kind == (
+            workflow_cancellation.CancellationSourceKind.CACHE_PUSH_WATCHDOG
+        )
+        assert result.run_id == 44
+
+    def test_repo_has_no_direct_workflow_cancellation_calls(self) -> None:
+        allowed = {MODULE_PATH.resolve(), Path(__file__).resolve()}
+        offenders: list[str] = []
+        for path in REPOSITORY.rglob("*"):
+            if path.resolve() in allowed or not path.is_file():
+                continue
+            if path.suffix not in {
+                ".js",
+                ".mjs",
+                ".nix",
+                ".py",
+                ".sh",
+                ".yaml",
+                ".yml",
+            }:
+                continue
+            source_text = path.read_text(errors="replace")
+            has_gh_cancel = "gh run" + " cancel" in source_text
+            has_api_cancel = (
+                re.search(r"actions/runs/[^\n]*/cancel\b", source_text) is not None
+            )
+            if has_gh_cancel or has_api_cancel:
+                offenders.append(str(path.relative_to(REPOSITORY)))
+        assert offenders == []
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/actions/ci-budget/workflow_cancellation.py
+++ b/.github/actions/ci-budget/workflow_cancellation.py
@@ -123,6 +123,10 @@ class WorkflowCancellation:
         repository_name(self.repository, "cancellation target repository")
         positive(self.run_id, "cancellation target run ID")
         positive(self.run_attempt, "cancellation target run attempt")
+        if self.repository != self.source.repository:
+            raise ValueError(
+                "workflow cancellation source and target repositories must match"
+            )
         allowed = ALLOWED_REASONS[self.source.kind]
         if self.reason.code not in allowed:
             raise ValueError(
@@ -185,12 +189,14 @@ class WorkflowCanceller:
     def __init__(
         self,
         request: Request,
+        repository: str,
         record_directory: Path,
         summary_path: Path,
         *,
         now: Callable[[], datetime] = lambda: datetime.now(UTC),
     ) -> None:
         self._request = request
+        self._repository = repository_name(repository, "GitHub client repository")
         self._record_directory = record_directory
         self._summary_path = summary_path
         self._now = now
@@ -215,6 +221,10 @@ class WorkflowCanceller:
             summary.write(f"`workflow-cancellation {compact}`\n\n")
 
     def cancel(self, cancellation: WorkflowCancellation) -> Path:
+        if cancellation.repository != self._repository:
+            raise ValueError(
+                "workflow cancellation target does not match the GitHub client"
+            )
         path = self._path(cancellation)
         self._write(
             path,
@@ -274,6 +284,7 @@ def main() -> int:
     )
     WorkflowCanceller(
         client.request,
+        cancellation.repository,
         Path(environment["WORKFLOW_CANCELLATION_RECORD_DIRECTORY"]),
         Path(environment["GITHUB_STEP_SUMMARY"]),
     ).cancel(cancellation)

--- a/.github/actions/ci-budget/workflow_cancellation.py
+++ b/.github/actions/ci-budget/workflow_cancellation.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Cancel a GitHub workflow through one typed, audited boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Protocol
+
+JsonObject = dict[str, Any]
+
+
+class CancellationReasonCode(StrEnum):
+    CI_TOTAL_DEADLINE_EXCEEDED = "ci_total_deadline_exceeded"
+    CACHE_PUSH_ZOMBIE = "cache_push_zombie"
+    CACHE_PUSH_MATERIALIZATION_STALL = "cache_push_materialization_stall"
+
+
+class CancellationSourceKind(StrEnum):
+    CI_DEADLINE_CONTROLLER = "ci_deadline_controller"
+    CACHE_PUSH_WATCHDOG = "cache_push_watchdog"
+
+
+class CancellationOutcome(StrEnum):
+    REQUESTED = "requested"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+ALLOWED_REASONS = {
+    CancellationSourceKind.CI_DEADLINE_CONTROLLER: frozenset(
+        {CancellationReasonCode.CI_TOTAL_DEADLINE_EXCEEDED}
+    ),
+    CancellationSourceKind.CACHE_PUSH_WATCHDOG: frozenset(
+        {
+            CancellationReasonCode.CACHE_PUSH_MATERIALIZATION_STALL,
+            CancellationReasonCode.CACHE_PUSH_ZOMBIE,
+        }
+    ),
+}
+
+
+class Request(Protocol):
+    def __call__(
+        self,
+        method: str,
+        path: str,
+        body: JsonObject | None = None,
+        query: Mapping[str, int | str] | None = None,
+    ) -> tuple[Any, Mapping[str, str]]: ...
+
+
+class Canceller(Protocol):
+    def cancel(self, cancellation: WorkflowCancellation) -> Path: ...
+
+
+def nonempty(value: str, name: str) -> str:
+    if not value.strip():
+        raise ValueError(f"{name} must not be empty")
+    return value
+
+
+def positive(value: int, name: str) -> int:
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def repository_name(value: str, name: str) -> str:
+    owner, separator, repository = value.partition("/")
+    if not separator or not owner or not repository or "/" in repository:
+        raise ValueError(f"{name} must have owner/name form")
+    return value
+
+
+@dataclass(frozen=True)
+class CancellationReason:
+    code: CancellationReasonCode
+    detail: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.code, CancellationReasonCode):
+            raise ValueError("cancellation reason code must be typed")
+        nonempty(self.detail, "cancellation reason detail")
+
+
+@dataclass(frozen=True)
+class CancellationSource:
+    kind: CancellationSourceKind
+    actor: str
+    repository: str
+    run_id: int
+    run_attempt: int
+    workflow_ref: str
+    job: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, CancellationSourceKind):
+            raise ValueError("cancellation source kind must be typed")
+        nonempty(self.actor, "cancellation actor")
+        repository_name(self.repository, "cancellation source repository")
+        positive(self.run_id, "cancellation source run ID")
+        positive(self.run_attempt, "cancellation source run attempt")
+        nonempty(self.workflow_ref, "cancellation source workflow ref")
+        nonempty(self.job, "cancellation source job")
+
+
+@dataclass(frozen=True)
+class WorkflowCancellation:
+    repository: str
+    run_id: int
+    run_attempt: int
+    reason: CancellationReason
+    source: CancellationSource
+
+    def __post_init__(self) -> None:
+        repository_name(self.repository, "cancellation target repository")
+        positive(self.run_id, "cancellation target run ID")
+        positive(self.run_attempt, "cancellation target run attempt")
+        allowed = ALLOWED_REASONS[self.source.kind]
+        if self.reason.code not in allowed:
+            raise ValueError(
+                f"cancellation source {self.source.kind.value!r} cannot use "
+                f"reason {self.reason.code.value!r}"
+            )
+
+
+def source_from_environment(
+    kind: CancellationSourceKind,
+    environment: Mapping[str, str],
+) -> CancellationSource:
+    return CancellationSource(
+        kind=kind,
+        actor=environment["GITHUB_ACTOR"],
+        repository=environment["GITHUB_REPOSITORY"],
+        run_id=int(environment["GITHUB_RUN_ID"]),
+        run_attempt=int(environment["GITHUB_RUN_ATTEMPT"]),
+        workflow_ref=environment["GITHUB_WORKFLOW_REF"],
+        job=environment["GITHUB_JOB"],
+    )
+
+
+def cancellation_record(
+    cancellation: WorkflowCancellation,
+    outcome: CancellationOutcome,
+    recorded_at: datetime,
+    *,
+    error: str | None = None,
+) -> JsonObject:
+    record: JsonObject = {
+        "actor": cancellation.source.actor,
+        "outcome": outcome.value,
+        "reason": {
+            "code": cancellation.reason.code.value,
+            "detail": cancellation.reason.detail,
+        },
+        "recorded_at": recorded_at.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+        "schema_version": 1,
+        "source": {
+            "job": cancellation.source.job,
+            "kind": cancellation.source.kind.value,
+            "repository": cancellation.source.repository,
+            "run_attempt": cancellation.source.run_attempt,
+            "run_id": cancellation.source.run_id,
+            "workflow_ref": cancellation.source.workflow_ref,
+        },
+        "target": {
+            "repository": cancellation.repository,
+            "run_attempt": cancellation.run_attempt,
+            "run_id": cancellation.run_id,
+        },
+    }
+    if error is not None:
+        record["error"] = error
+    return record
+
+
+class WorkflowCanceller:
+    def __init__(
+        self,
+        request: Request,
+        record_directory: Path,
+        summary_path: Path,
+        *,
+        now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        self._request = request
+        self._record_directory = record_directory
+        self._summary_path = summary_path
+        self._now = now
+
+    def _path(self, cancellation: WorkflowCancellation) -> Path:
+        repository = cancellation.repository.replace("/", "__")
+        return self._record_directory / (
+            f"{repository}__{cancellation.run_id}__attempt_"
+            f"{cancellation.run_attempt}__source_{cancellation.source.run_id}_"
+            f"attempt_{cancellation.source.run_attempt}.json"
+        )
+
+    def _write(self, path: Path, record: JsonObject) -> None:
+        self._record_directory.mkdir(parents=True, exist_ok=True)
+        encoded = json.dumps(record, indent=2, sort_keys=True) + "\n"
+        temporary = path.with_suffix(".tmp")
+        temporary.write_text(encoded, encoding="utf-8")
+        temporary.replace(path)
+        compact = json.dumps(record, separators=(",", ":"), sort_keys=True)
+        print(f"workflow-cancellation {compact}")
+        with self._summary_path.open("a", encoding="utf-8") as summary:
+            summary.write(f"`workflow-cancellation {compact}`\n\n")
+
+    def cancel(self, cancellation: WorkflowCancellation) -> Path:
+        path = self._path(cancellation)
+        self._write(
+            path,
+            cancellation_record(
+                cancellation,
+                CancellationOutcome.REQUESTED,
+                self._now(),
+            ),
+        )
+        try:
+            self._request("POST", f"actions/runs/{cancellation.run_id}/cancel")
+        except Exception as error:
+            self._write(
+                path,
+                cancellation_record(
+                    cancellation,
+                    CancellationOutcome.REJECTED,
+                    self._now(),
+                    error=f"{type(error).__name__}: {error}",
+                ),
+            )
+            raise
+        self._write(
+            path,
+            cancellation_record(
+                cancellation,
+                CancellationOutcome.ACCEPTED,
+                self._now(),
+            ),
+        )
+        return path
+
+
+def main() -> int:
+    from ci_budget import GitHubClient
+
+    environment = os.environ
+    source = source_from_environment(
+        CancellationSourceKind(environment["WORKFLOW_CANCELLATION_SOURCE"]),
+        environment,
+    )
+    cancellation = WorkflowCancellation(
+        repository=environment["WORKFLOW_CANCELLATION_TARGET_REPOSITORY"],
+        run_id=int(environment["WORKFLOW_CANCELLATION_TARGET_RUN_ID"]),
+        run_attempt=int(environment["WORKFLOW_CANCELLATION_TARGET_RUN_ATTEMPT"]),
+        reason=CancellationReason(
+            code=CancellationReasonCode(
+                environment["WORKFLOW_CANCELLATION_REASON_CODE"]
+            ),
+            detail=environment["WORKFLOW_CANCELLATION_REASON_DETAIL"],
+        ),
+        source=source,
+    )
+    client = GitHubClient(
+        cancellation.repository,
+        environment["WORKFLOW_CANCELLATION_TOKEN"],
+    )
+    WorkflowCanceller(
+        client.request,
+        Path(environment["WORKFLOW_CANCELLATION_RECORD_DIRECTORY"]),
+        Path(environment["GITHUB_STEP_SUMMARY"]),
+    ).cancel(cancellation)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (KeyError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"::error title=workflow-cancellation::{error}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/workflows/cache-push-watchdog.yml
+++ b/.github/workflows/cache-push-watchdog.yml
@@ -59,7 +59,7 @@ on:
         default: false
 
 # Read runs/jobs, cancel + redispatch cache-push, and maintain the tracking
-# issue. `actions: write` covers both `gh run cancel` and `gh workflow run`
+# issue. `actions: write` covers both typed run cancellation and `gh workflow run`
 # (workflow_dispatch); issue writes do not need a PAT (unlike PR creation,
 # which the enterprise blocks for GITHUB_TOKEN).
 permissions:
@@ -98,7 +98,11 @@ jobs:
       # dispatched inside this window may still be queued behind the group.
       HEAL_COOLDOWN_MIN: "90"
       DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
+      WORKFLOW_CANCELLATION_RECORD_DIRECTORY: ${{ runner.temp }}/workflow-cancellations
+      WORKFLOW_CANCELLATION_SOURCE: cache_push_watchdog
+      WORKFLOW_CANCELLATION_TOKEN: ${{ github.token }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Detect and heal cache-push wedges
         run: |
           set -euo pipefail
@@ -126,13 +130,26 @@ jobs:
             fi
           }
 
+          cancel_run() {
+            local id="$1"
+            local attempt="$2"
+            local reason_code="$3"
+            local reason_detail="$4"
+            WORKFLOW_CANCELLATION_TARGET_REPOSITORY="${REPOSITORY}" \
+              WORKFLOW_CANCELLATION_TARGET_RUN_ID="${id}" \
+              WORKFLOW_CANCELLATION_TARGET_RUN_ATTEMPT="${attempt}" \
+              WORKFLOW_CANCELLATION_REASON_CODE="${reason_code}" \
+              WORKFLOW_CANCELLATION_REASON_DETAIL="${reason_detail}" \
+              python3 .github/actions/ci-budget/workflow_cancellation.py
+          }
+
           # Every list call lands in a file with an explicit failure branch:
           # `mapfile < <(cmd)` ignores cmd's exit status, which would turn an
           # API outage into an empty array and a false "healthy".
           runs_file=/tmp/active-runs.tsv
           # shellcheck disable=SC2016  # \(...) is jq string interpolation, not shell
           gh api "repos/${REPOSITORY}/actions/workflows/cache-push.yml/runs?per_page=20" \
-            --jq '.workflow_runs[] | select((.status=="queued" or .status=="in_progress" or .status=="pending") and .head_branch=="main") | "\(.id)\t\(.created_at)\t\(.event)"' \
+            --jq '.workflow_runs[] | select((.status=="queued" or .status=="in_progress" or .status=="pending") and .head_branch=="main") | "\(.id)\t\(.created_at)\t\(.event)\t\(.run_attempt)"' \
             > "$runs_file" || fail_loud "listing cache-push runs failed"
 
           # One pass over the active runs: age + job count for each, and
@@ -140,22 +157,27 @@ jobs:
           annotated=/tmp/annotated-runs.tsv
           : > "$annotated"
           holder_exists=""
-          while IFS=$'\t' read -r id created event; do
+          while IFS=$'\t' read -r id created event run_attempt; do
             njobs="$(gh api "repos/${REPOSITORY}/actions/runs/${id}/jobs" --jq '.total_count')" \
               || fail_loud "listing jobs for run ${id} failed"
             created_epoch="$(date -u -d "$created" +%s)"
             age_min=$(( (now_epoch - created_epoch) / 60 ))
             if [ "$njobs" -gt 0 ]; then holder_exists=1; fi
-            printf '%s\t%s\t%s\t%s\n' "$id" "$age_min" "$njobs" "$event" >> "$annotated"
+            printf '%s\t%s\t%s\t%s\t%s\n' "$id" "$age_min" "$njobs" "$event" "$run_attempt" >> "$annotated"
           done < "$runs_file"
 
           # --- Signal 1: zombie holder ----------------------------------------
-          while IFS=$'\t' read -r id age_min njobs event; do
+          while IFS=$'\t' read -r id age_min njobs event run_attempt; do
             if [ "$age_min" -ge "${MAX_RUN_AGE_MIN}" ]; then
               echo "::error::run ${id} active for ${age_min} min (>= ${MAX_RUN_AGE_MIN}): exceeds the sum of cache-push job timeouts; a queued-but-never-assigned job holds the group with no timeout (#1968)"
               add_finding "- **Zombie run**: [${id}](https://github.com/${REPOSITORY}/actions/runs/${id}) active ${age_min} min with ${njobs} job(s)."
               if [ -z "${DRY_RUN}" ]; then
-                gh run cancel "${id}" --repo "${REPOSITORY}" || echo "::warning::could not cancel ${id} (may have just completed)"
+                cancel_run \
+                  "${id}" \
+                  "${run_attempt}" \
+                  cache_push_zombie \
+                  "cache-push run exceeded the ${MAX_RUN_AGE_MIN} minute holder limit at ${age_min} minutes with ${njobs} jobs" \
+                  || fail_loud "typed cancellation of run ${id} failed"
               fi
             fi
           done < "$annotated"
@@ -166,12 +188,17 @@ jobs:
           # keeps one such pending run per group by design. Only a 0-job run
           # with NO holder anywhere means GitHub never scheduled it.
           if [ -z "$holder_exists" ]; then
-            while IFS=$'\t' read -r id age_min njobs event; do
+            while IFS=$'\t' read -r id age_min njobs event run_attempt; do
               if [ "$njobs" -eq 0 ] && [ "$age_min" -ge "${STALL_GRACE_MIN}" ]; then
                 echo "::error::run ${id} pending with 0 jobs for ${age_min} min with no group holder: GitHub never materialized a job (#1968)"
                 add_finding "- **Stalled run**: [${id}](https://github.com/${REPOSITORY}/actions/runs/${id}) pending with 0 jobs for ${age_min} min, no holder."
                 if [ -z "${DRY_RUN}" ]; then
-                  gh run cancel "${id}" --repo "${REPOSITORY}" || echo "::warning::could not cancel ${id} (may have just completed)"
+                  cancel_run \
+                    "${id}" \
+                    "${run_attempt}" \
+                    cache_push_materialization_stall \
+                    "cache-push run had zero jobs after ${age_min} minutes with no concurrency holder" \
+                    || fail_loud "typed cancellation of run ${id} failed"
                 fi
               fi
             done < "$annotated"
@@ -279,3 +306,10 @@ jobs:
               gh issue close "${number}" --repo "${REPOSITORY}"
             fi
           fi
+      - name: Preserve workflow cancellation records
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: workflow-cancellations-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/workflow-cancellations
+          if-no-files-found: ignore

--- a/.github/workflows/ci-budget-check.yml
+++ b/.github/workflows/ci-budget-check.yml
@@ -7,6 +7,7 @@ on:
       - .github/scripts/run-check-logged.sh
       - .github/scripts/run-clone-diff.sh
       - .github/workflows/check.yml
+      - .github/workflows/cache-push-watchdog.yml
       - .github/workflows/ci-budget-publish.yml
       - .github/workflows/closure-gate.yml
       - .github/workflows/ci-budget-read-only.yml


### PR DESCRIPTION
## What changed

* route every explicit repository-owned workflow cancellation through one typed boundary
* require a nonempty reason code and detail that are valid for the source workflow
* bind each request to the source repository and the GitHub client repository before any API call
* record actor, source workflow identity, target repository, run ID, attempt, reason, timestamp, and accepted or rejected outcome as structured JSON
* write the record before the API call, mirror it into the job summary, and retain the final record as an Actions artifact
* move the CI deadline controller and cache-push watchdog off direct cancellation calls
* reject future direct cancellation calls with a repository regression test
* retain the single ordinary 300 second total CI budget unchanged

## Stack

This is stacked on #3333, which is stacked on #3316. It is intentionally draft for user review. It does not change GitHub App permissions, deploy anything, or cancel a live run.

## Validation

* 73 focused Python and workflow tests
* Ruff check and format
* Pyright across the complete action directory
* Python bytecode compilation
* direct workflow YAML parsing
* extracted watchdog Bash syntax
* git diff check
* Nix was not run because this session explicitly prohibits Nix commands

Refs #2952 and #3310.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require structured audit records for CI workflow cancellations
> - Introduces [workflow_cancellation.py](https://github.com/indexable-inc/index/pull/3363/files#diff-973d70c57a4f2500d32da639394a7c7638600c361d1a1ae3eee42190c4b43f9a) with typed enums (`CancellationReasonCode`, `CancellationSourceKind`), a `WorkflowCanceller` class that writes durable JSON audit records to disk and the step summary, and a CLI entrypoint for shell invocation.
> - Updates the cache-push-watchdog and ci-budget deadline controller to cancel runs via the typed Python entrypoint instead of `gh run cancel` or direct API calls.
> - Cancel-mode runs upload a `workflow-cancellations-{run_id}-{run_attempt}` artifact so records are preserved even if the job fails.
> - Behavioral Change: direct `GitHubClient.cancel_workflow_run` is removed; all cancellations must go through `WorkflowCanceller` with a valid reason code and source kind.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2766c4c. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
