### PR TITLE
ci: bootstrap Nix in nightly updater

### DIFF
--- a/.github/workflows/update-rust-nightly.yml
+++ b/.github/workflows/update-rust-nightly.yml
@@ -26,6 +26,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Install Determinate Nix
+        uses: ./.github/actions/install-nix
+
+      # Underscore digit separators: every nix invocation that evaluates this
+      # tree must go through the patched client (see the action's description).
+      - name: Bootstrap patched Nix client
+        uses: ./.github/actions/bootstrap-patched-nix
+
       # The rolling Rust manifest can publish before rust-overlay has generated
       # that day's expressions. Advance the overlay first so a toolchain bump
       # and the resolver data required to evaluate it land atomically.


### PR DESCRIPTION
## What changed

* install Determinate Nix before the nightly updater's first Nix command
* bootstrap the index-owned patched client before evaluating the repository
* preserve #2728's separate updater auto-merge work for a later rebase

## Root cause

Scheduled run `29396407306`, job `87290804618`, ran on `ubuntu-latest` and failed at `nix flake update rust-overlay` with `nix: command not found`. Installing stock Nix alone would expose the next failure because this repository evaluates underscore digit separators, so the updater now uses the same install plus patched-client boundary as its sibling updater workflows.

The class-level owner lint is tracked by #3369.

## Validation

* `nix run nixpkgs#actionlint -- .github/workflows/update-rust-nightly.yml`
* `git diff --check`

Refs #1698

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bootstrap Nix in the nightly Rust updater workflow
> Adds two steps to [update-rust-nightly.yml](.github/workflows/update-rust-nightly.yml) that run after checkout: one to install Determinate Nix via `.github/actions/install-nix` and one to bootstrap a patched Nix client via `.github/actions/bootstrap-patched-nix`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8645ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->