### PR TITLE
fork-sync: own rebase scratch identity

### DIFF
--- a/packages/rebase-patches/default.nix
+++ b/packages/rebase-patches/default.nix
@@ -68,6 +68,12 @@
       use ${dagLib} *
 
       const fork_data = "${forkData}"
+      const scratch_identity = {name: "rebase-patches", email: "rebase-patches@indexable.dev"}
+
+      def "scratch configure-identity" [scratch: string] {
+        git -C $scratch config user.name $scratch_identity.name
+        git -C $scratch config user.email $scratch_identity.email
+      }
 
       # Set up a scratch git repo for `fork`: mergiraf merge driver, zdiff3
       # conflict style, and committed rerere seeded from packages/<name>/rerere/.
@@ -83,6 +89,7 @@
         # worktree `.gitattributes`: an untracked worktree file would collide with
         # a tracked `.gitattributes` in the fetched upstream tree on checkout.
         git -C $scratch init --quiet
+        scratch configure-identity $scratch
         git -C $scratch config merge.conflictStyle zdiff3
         # rerere replays a resolution the moment the same conflict recurs. The
         # committed cache (seeded below) makes it earn its keep for conflicts that
@@ -134,7 +141,8 @@
           cp --recursive ($rr_scratch | path join $key) $dest
           # `thisimage` is Git's transient current-conflict snapshot. Replaying a
           # resolution needs only the numbered or unnumbered pre/postimage pairs.
-          rm --force ...(glob ($dest | path join "thisimage*"))
+          let transient = (glob ($dest | path join "thisimage*"))
+          if ($transient | is-not-empty) { rm --force ...$transient }
         }
         print $"(ansi yellow)rebase-patches: ($fork.name): exported (($resolved | length)) rerere resolution\(s\) to ($fork.patchDir)/rerere: (($resolved) | str join ', ')(ansi reset)"
       }
@@ -310,6 +318,7 @@
           error make { msg: $"rebase-patches: resume state does not match ($fork.name) at ($new): ($state | to json)" }
         }
 
+        scratch configure-identity $scratch
         rebase unresolved $fork $scratch $new
         let rebase_dir = ($scratch | path join ".git" "rebase-merge")
         if ($rebase_dir | path exists) {
@@ -400,6 +409,12 @@
       package
     ];
   } (builtins.readFile ./resume-test.sh);
+  identityTest = runCommand "rebase-patches-identity-test" {
+    nativeBuildInputs = [
+      git
+      package
+    ];
+  } (builtins.readFile ./identity-test.sh);
   seedTest = runCommand "rebase-patches-seed-test" {
     nativeBuildInputs = [
       coreutils
@@ -418,6 +433,7 @@ in
           (old.passthru.tests or {})
           // {
             resume = resumeTest;
+            identity = identityTest;
             seed = seedTest;
           };
       };

--- a/packages/rebase-patches/identity-test.sh
+++ b/packages/rebase-patches/identity-test.sh
@@ -1,0 +1,85 @@
+set -eu
+
+root="$TMPDIR/rebase-patches-identity-test"
+home="$root/home"
+upstream="$root/upstream"
+series="$root/series"
+work="$root/work"
+mkdir -p "$home" "$upstream" "$work/patches"
+
+commit() {
+  repo="$1"
+  shift
+  git -C "$repo" \
+    -c user.name=Fixture \
+    -c user.email=fixture@example.com \
+    -c commit.gpgsign=false \
+    commit "$@"
+}
+
+git -C "$upstream" init --quiet
+printf 'base\n' >"$upstream/content.txt"
+git -C "$upstream" add content.txt
+commit "$upstream" --quiet -m 'fixture: add base'
+old=$(git -C "$upstream" rev-parse HEAD)
+
+git clone --quiet "$upstream" "$series"
+printf 'patch\n' >"$series/content.txt"
+git -C "$series" add content.txt
+commit "$series" --quiet \
+  -m 'fixture: change content' \
+  -m 'Exercise scratch repository identity during rebase.'
+git -C "$series" format-patch \
+  --zero-commit --no-signature --no-stat -N \
+  -o "$work/patches" "$old..HEAD"
+
+printf 'upstream\n' >"$upstream/content.txt"
+git -C "$upstream" add content.txt
+commit "$upstream" --quiet -m 'fixture: move upstream content'
+new=$(git -C "$upstream" rev-parse HEAD)
+
+git -C "$work" init --quiet
+printf '{"nodes":{"fake-src":{"locked":{"rev":"%s"}}}}\n' "$old" >"$work/flake.lock"
+printf '[{"name":"fake","input":"fake-src","url":"%s","patchDir":"patches"}]\n' \
+  "$upstream" >"$work/mapping.json"
+git -C "$work" add flake.lock mapping.json patches
+commit "$work" --quiet -m 'fixture: pin old upstream'
+printf '{"nodes":{"fake-src":{"locked":{"rev":"%s"}}}}\n' "$new" >"$work/flake.lock"
+
+cat >"$root/global.gitconfig" <<'EOF'
+[user]
+	useConfigOnly = true
+EOF
+export HOME="$home"
+export GIT_CONFIG_GLOBAL="$root/global.gitconfig"
+export GIT_CONFIG_NOSYSTEM=1
+unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+
+cd "$work"
+if rebase-patches fake --mapping mapping.json >"$root/rebase.log" 2>&1; then
+  echo 'expected the fixture rebase to stop on a conflict' >&2
+  exit 1
+fi
+if ! grep -Fq 'unresolved conflicts in [content.txt]' "$root/rebase.log"; then
+  cat "$root/rebase.log" >&2
+  exit 1
+fi
+
+scratch_paths=("$TMPDIR"/rebase-patches-fake.*)
+test "${#scratch_paths[@]}" = 1
+scratch="${scratch_paths[0]}"
+test "$(git -C "$scratch" config --local --get user.name)" = rebase-patches
+test "$(git -C "$scratch" config --local --get user.email)" = rebase-patches@indexable.dev
+git -C "$scratch" config --unset-all user.name
+git -C "$scratch" config --unset-all user.email
+printf 'merged\n' >"$scratch/content.txt"
+git -C "$scratch" add content.txt
+
+rebase-patches resume fake "$scratch" --mapping mapping.json
+
+test ! -e "$scratch"
+test "$(find patches -maxdepth 1 -name '*.patch' | wc -l | tr -d ' ')" = 1
+grep -Fq 'fixture: change content' patches/0001-fixture-change-content.patch
+grep -Fq '+merged' patches/0001-fixture-change-content.patch
+grep -Fq "\"base\": \"$new\"" patches/dag.json
+touch "$out"


### PR DESCRIPTION
## Summary

* give every rebase scratch repository one deterministic local Git identity
* reassert that identity after validating a resumed scratch repository
* tolerate Git removing the optional transient rerere image before export
* cover the scheduled runner environment, a real rebase conflict, and resume in one hermetic regression

## Root cause

The fork sync workflow invokes `rebase-patches` on a clean hosted runner. The tool creates commits with `git am` and `git rebase`, but its scratch repository did not own `user.name` or `user.email`, so Git stopped with `Committer identity unknown`.

The regression disables system identity, enables `user.useConfigOnly`, proves the initial run writes repository-local identity, removes it, and proves `resume` reasserts it. The real resume path also showed that Git can remove `thisimage` before rerere export, so the exporter now handles that optional state without weakening the required `preimage` and `postimage` checks.

## Validation

* `nix build .#rebase-patches.tests.identity --no-link -L`
* `nix build .#rebase-patches .#rebase-patches.tests.resume .#rebase-patches.tests.seed --no-link -L`
* `nix run .#lint`
* `bash -n packages/rebase-patches/identity-test.sh`
* `git diff --check`

Fixes #3367
Fixes #3368

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Configure a fixed git identity in fork-sync rebase scratch repositories
> - Adds a `scratch configure-identity` Nushell function in [default.nix](https://github.com/indexable-inc/index/pull/3371/files#diff-dd450ae43106772c7bb417e4f0f4b3d25042f7302914086c517c3c1c46e7726b) that sets `user.name` and `user.email` to `rebase-patches` / `rebase-patches@indexable.dev` in a given scratch repo.
> - Calls this function both during scratch repo initialization and before rebase resume, ensuring a consistent identity is present throughout the rebase lifecycle.
> - Fixes a bug where `rm` was invoked with an empty spread during rerere export cleanup when no `thisimage*` files matched the glob.
> - Adds an automated test in [identity-test.sh](https://github.com/indexable-inc/index/pull/3371/files#diff-e9579c0857fa2c4929661786d8d1f4194fedf955c1a015cfb50738bdc32b0e2f) that verifies the scratch identity is set correctly and that rebase resume completes with the expected output; exposed as `passthru.tests.identity`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a4a65b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->