### PR TITLE
ci: collapse required roots onto one runner claim

### DIFF
--- a/.github/actions/check-logged/action.yml
+++ b/.github/actions/check-logged/action.yml
@@ -9,8 +9,9 @@ description: >-
 inputs:
   subcommand:
     description: >-
-      Optional `check` app subcommand passed after `--`, e.g. `closure` for
-      the cache-push closure gate. Empty runs the full default gate.
+      Optional `check` app subcommand passed after `--`: `required` runs the
+      combined PR gate, while `closure` runs the manual cache-push closure
+      probe. Empty runs the checks-only default gate.
     required: false
     default: ""
 runs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -123,10 +123,10 @@ jobs:
           fi
           nix run .#clone -- . --diff "${base_sha}" > /dev/null
 
-      # Run the full gate through the repo-owned `check` app (lib/per-system.nix),
-      # so CI and a local `nix run .#check` execute the same two commands from one
-      # definition: nix-fast-build over `.#ciChecks.x86_64-linux`, then nix-eval-jobs
-      # over `.#packages.x86_64-linux` with the JSON error-line gate. The
+      # Run the required gate through the repo-owned `check` app
+      # (lib/per-system.nix): one bounded nix-fast-build evaluator owns the
+      # namespaced union of ciChecks and cachePushRoots, then nix-eval-jobs
+      # validates packages with the JSON error-line gate. The
       # command-specific rationale (tool choice, the worker/memory tuning, why the
       # eval cache is off, the error-line gate) and the pinned tool revisions live
       # next to that wrapper. The job inherits NIX_CONFIG (above), so the inner
@@ -135,6 +135,8 @@ jobs:
       # check fails to build or the flake stops evaluating.
       - name: Build all flake checks
         uses: ./.github/actions/check-logged
+        with:
+          subcommand: required
 
       # The `check` app writes nix-fast-build per-attr durations to
       # check-results.json in the workspace (see lib/per-system.nix). Upload it
@@ -150,3 +152,22 @@ jobs:
           path: check-results.json
           if-no-files-found: warn
           retention-days: 30
+
+  # Keep the existing required context while consuming no second self-hosted
+  # runner. The single gate above builds closure roots and checks together;
+  # this hosted terminal job fails closed for every non-success conclusion,
+  # including cancellation and a missing upstream result.
+  closure-gate:
+    needs: flake-check
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Mirror the required-root gate
+        env:
+          FLAKE_CHECK_RESULT: ${{ needs.flake-check.result }}
+        run: |
+          if [[ "${FLAKE_CHECK_RESULT}" != "success" ]]; then
+            printf 'flake-check result was %s; refusing a false-green closure gate\n' "${FLAKE_CHECK_RESULT}" >&2
+            exit 1
+          fi

--- a/.github/workflows/closure-gate.yml
+++ b/.github/workflows/closure-gate.yml
@@ -1,13 +1,9 @@
 name: Closure gate
 
-# Build the publishable closure before merge (#1873). flake-check only
-# eval-validates `packages`, so a package whose *build* breaks -- #2690's
-# codex darwin cross closure (root cause #3188) -- merged green and broke
-# every consumer. This job realises, pre-merge on the warm-store pool, exactly
-# the roots the post-merge Cache push linux lane publishes: `nix run .#check
-# -- closure` builds `.#cachePushRoots.x86_64-linux` with nix-fast-build
-# --skip-cached, so an average PR is eval plus cache probe only and a
-# package-changing PR builds just its delta.
+# Manual probe for the publishable closure (#1873). The required PR and merge
+# group path moved into check.yml's single `requiredGateRoots` evaluator, which
+# preserves the `closure-gate` status without competing for a second runner.
+# This workflow retains an operator-triggered closure-only diagnostic.
 #
 # Build-only, no publish: the ci-dispatcher attaches the ix-public push token
 # only to `-cache-push` jobs on main pushes (spawn.rs ix_public_push_eligible);
@@ -21,16 +17,6 @@ name: Closure gate
 # 40-80 min) is not gated here; it stays a post-merge cache-push concern.
 
 on:
-  pull_request:
-    branches:
-      - main
-    # A manual budget override must start a fresh run. A job's timeout is fixed
-    # when it starts, so changing the label cannot extend an in-flight job.
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-  # Same rationale as check.yml: the main ruleset demands this status inside
-  # the merge queue too, should one be enabled.
-  merge_group:
-  # Manual run against any ref, e.g. probing main's closure health.
   workflow_dispatch:
 
 permissions:
@@ -38,7 +24,7 @@ permissions:
 
 concurrency:
   group: closure-gate-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 env:
   # Client-side eval knobs only, same set and rationale as check.yml: the
@@ -56,17 +42,12 @@ jobs:
       pull-requests: read
     uses: indexable-inc/index/.github/workflows/ci-budget-read-only.yml@main
     with:
-      pull-request-number: ${{ github.event.pull_request.number || 0 }}
-      # Manual and merge-queue runs have no pull request label. Keep their
-      # existing extended budget.
-      force-big-change: ${{ github.event_name != 'pull_request' }}
+      pull-request-number: 0
+      force-big-change: true
 
-  # Branch protection requires a status named `closure-gate`; this job is it.
-  # Separate from flake-check on purpose: it runs in parallel on its own
-  # ephemeral runner, so the existing gate's latency is untouched.
-  closure-gate:
+  closure-probe:
     needs: ci-budget
-    runs-on: ["${{ format('ix-ci-run-{0}-{1}-closure-gate', github.run_id, github.run_attempt) }}"]
+    runs-on: ["${{ format('ix-ci-run-{0}-{1}-closure-probe', github.run_id, github.run_attempt) }}"]
     # A relock-class PR realises a near-full closure; match the cache-push
     # linux lane budget, which fits that worst case.
     timeout-minutes: ${{ needs.ci-budget.outputs.big_change == 'true' && 180 || 5 }}

--- a/flake.nix
+++ b/flake.nix
@@ -416,6 +416,27 @@
         "aarch64-darwin"
       ] (system: raw.${system} // (linuxDarwinAliases.${system} or {}));
     packages = withDarwinAliases (collect "packages");
+    ciChecks = collect "ciChecks";
+    cachePushRoots = withDarwinAliases (collect "cachePushRoots");
+    # One evaluator pool owns every required Linux build root. Prefix closure
+    # roots so a package and a check may share their natural name without one
+    # silently replacing the other. The explicit collision guard keeps a
+    # future check named `closure-*` from weakening the gate.
+    requiredGateRoots =
+      lib.mapAttrs (
+        system: systemChecks: let
+          closureRoots =
+            lib.mapAttrs' (
+              name: root: lib.nameValuePair "closure-${name}" root
+            )
+            cachePushRoots.${system};
+          collisions = builtins.attrNames (lib.intersectAttrs systemChecks closureRoots);
+        in
+          assert lib.assertMsg (collisions == [])
+          "requiredGateRoots.${system}: prefixed cache roots collide with ciChecks: ${builtins.concatStringsSep ", " collisions}";
+            systemChecks // closureRoots
+      )
+      ciChecks;
     rawSecurityRoots = collect "securityRoots";
     rawSecurityRootPaths = collect "securityRootPaths";
     securityRoots =
@@ -666,7 +687,7 @@
     # (ENG-2201). Kept separate from `checks` because its per-package
     # `recurseForDerivations` groups are not derivations, which the flake
     # `checks` schema requires.
-    ciChecks = collect "ciChecks";
+    inherit ciChecks;
     # Registry-derived map of package directory -> flake attr for every
     # `updateScript` package exposed on a system. update.yml's "Build changed
     # packages" step evaluates this to find which attr owns each file the
@@ -684,7 +705,11 @@
     # `toplevel` closure; cache-push.yml publishes this instead of the
     # monolithic `*-oci.tar` archives, which nothing substitutes. Non-schema,
     # so surfaced through `collect` like `ciChecks`. See lib/per-system.nix.
-    cachePushRoots = withDarwinAliases (collect "cachePushRoots");
+    inherit cachePushRoots;
+    # Union consumed by `nix run .#check -- required`: one bounded
+    # nix-fast-build evaluator replaces the former flake-check and closure-gate
+    # self-hosted jobs without dropping either required status context.
+    inherit requiredGateRoots;
     # Typed security exposure roots consumed as JSON by the runtime DAG scanner.
     # Unlike cachePushRoots, every entry carries policy metadata and names only
     # a shipped runtime output or an example service closure. securityRootPaths

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -365,13 +365,14 @@
   # `set -o pipefail`). Uses the repo-built nix-eval-jobs directly by store path
   # rather than `nix run`.
   #
-  # `check closure` (the closure-gate.yml required check, #1873) reuses step 1's
-  # build gate over `.#cachePushRoots.x86_64-linux`: the exact set the
-  # post-merge cache-push linux lane publishes, so a package whose build broke
-  # (not just its eval) goes red at the PR instead of on every consumer.
+  # `check required` is the required PR path. It builds the namespaced union of
+  # ciChecks and cachePushRoots through one 16-worker evaluator pool, then runs
+  # the package schema gate. This replaces two competing self-hosted claims
+  # without running two 16-worker clients side by side (which has OOM-killed a
+  # 96 GiB runner before). `check closure` remains the manual closure probe.
   check = ix.writeNushellApplication pkgs {
     name = "check";
-    meta.description = "Run the full CI gate: build .#ciChecks.x86_64-linux and eval-validate .#packages.x86_64-linux (`closure` subcommand: build .#cachePushRoots.x86_64-linux)";
+    meta.description = "Run CI gates: default checks, `required` checks plus publishable closure, or `closure` only";
     text = ''
       # Patched nix-fast-build (packages/nix/nix-fast-build): stock --skip-cached
       # only skips a job whose nix-eval-jobs cacheStatus is `cached` (in a remote
@@ -389,8 +390,9 @@
 
       # Shared build gate: build every derivation under $flake with
       # nix-fast-build and exit 1 on any failure, after replaying each failed
-      # build's log. `main` runs it over ciChecks; `main closure` over the
-      # cache-push roots.
+      # build's log. `main` runs it over ciChecks, `main required` over the
+      # namespaced union of checks and cache-push roots, and `main closure` over
+      # cache-push roots alone.
       def build-gate [flake: string] {
         # ca-derivations: the rust workspace units default to
         # `contentAddressed = true` (lib/rust/cargo-unit.nix), so evaluating
@@ -529,9 +531,7 @@
         }
       }
 
-      def main [] {
-        build-gate ".#ciChecks.x86_64-linux"
-
+      def eval-package-schema [] {
         let tmp = (mktemp --directory --tmpdir "ix-check.XXXXXX")
         let report = ($tmp | path join "flake-schema-eval.jsonl")
         do --capture-errors {
@@ -554,6 +554,19 @@
           exit 1
         }
         rm --recursive --force $tmp
+      }
+
+      def main [] {
+        build-gate ".#ciChecks.x86_64-linux"
+        eval-package-schema
+      }
+
+      # Required PR/merge-group gate. One nix-fast-build invocation evaluates
+      # and builds both check roots and publishable closure roots with the same
+      # bounded pool; a second package-schema pass retains the broader eval gate.
+      def "main required" [] {
+        build-gate ".#requiredGateRoots.x86_64-linux"
+        eval-package-schema
       }
 
       # Pre-merge closure gate (closure-gate.yml, #1873): the same build gate


### PR DESCRIPTION
## Summary

- evaluate and build `ciChecks` plus namespaced `cachePushRoots` through one bounded 16-worker pool
- preserve required `flake-check` and `closure-gate` contexts with a fail-closed GitHub-hosted terminal job
- make the old closure workflow manual-only to remove the duplicate self-hosted claim

## Validation

- 535 required root groups evaluated: 176 check groups and 359 namespaced closure roots
- `.#packages.x86_64-linux.check` built with the patched Nix 2.34 client
- actionlint on both workflows
- check-logged action test
- git diff --check

This is the live one-claim canary for the <=5 minute CI recovery.

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse CI required gate and closure roots onto a single runner claim
> - Adds a `requiredGateRoots` flake output that unions `ciChecks` with prefixed `cachePushRoots` entries per system, asserting no name collisions between the two sets.
> - Adds a `required` subcommand to the `check` Nushell app that builds `requiredGateRoots` and then runs the package schema evaluation pass.
> - Updates the `flake-check` CI job to invoke `subcommand: required`, replacing the previous separate closure gate runner claim with a single self-hosted run.
> - Adds a lightweight hosted `closure-gate` job that mirrors the `flake-check` result and fails for any non-success outcome, preserving the required status check without a second self-hosted runner.
> - Converts [closure-gate.yml](https://github.com/indexable-inc/index/pull/3391/files#diff-638c892010bcf9fe87805596d2ebfceacbae7736e255f41d266a68cd531ff840) from an automatic PR/merge-group trigger to a `workflow_dispatch`-only manual probe with extended budget settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4df19e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->