### PR TITLE
ci: enforce independent clocks on required gate

### DIFF
--- a/.github/scripts/run-required-gate-test.sh
+++ b/.github/scripts/run-required-gate-test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "${scratch}"' EXIT
+
+bin_dir="${scratch}/bin"
+calls="${scratch}/calls"
+pr_base=1111111111111111111111111111111111111111
+push_base=3333333333333333333333333333333333333333
+mkdir -p "${bin_dir}" "${scratch}/runner-temp"
+
+bash_bin="$(command -v bash)"
+env_bin="$(command -v env)"
+for command in cat install; do
+  ln -s "$(command -v "${command}")" "${bin_dir}/${command}"
+done
+ln -s "${bash_bin}" "${bin_dir}/bash"
+
+cat >"${bin_dir}/git" <<EOF
+#!${bash_bin}
+set -euo pipefail
+case "\$*" in
+  "rev-parse --verify HEAD^1") printf '%s\\n' '${pr_base}' ;;
+  "rev-parse HEAD") printf '%s\\n' '2222222222222222222222222222222222222222' ;;
+  *) printf 'unexpected git arguments: %s\\n' "\$*" >&2; exit 64 ;;
+esac
+EOF
+
+cat >"${bin_dir}/nix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  --version)
+    printf 'nix (Nix) test\n'
+    ;;
+  store)
+    [[ "$*" == "store info --json" ]]
+    printf '{"trusted":false}\n'
+    ;;
+  run)
+    if [[ "${2:-}" == ".#clone" ]]; then
+      [[ "$*" == "run .#clone -- . --diff ${EXPECTED_BASE_SHA:?}" ]]
+      printf 'clone\n' >>"${CALLS:?}"
+    elif [[ "${2:-}" == ".#check" ]]; then
+      [[ "$*" == "run .#check -- required" ]]
+      printf 'check\n' >>"${CALLS:?}"
+      printf 'required gate passed\n'
+    else
+      printf 'unexpected nix arguments: %s\n' "$*" >&2
+      exit 65
+    fi
+    ;;
+  *)
+    printf 'unexpected nix command: %s\n' "$*" >&2
+    exit 66
+    ;;
+esac
+EOF
+chmod +x "${bin_dir}/git" "${bin_dir}/nix"
+
+run_gate() {
+  local event_name=$1 expected_base=$2
+  shift 2
+  : >"${calls}"
+  "${env_bin}" -i \
+    PATH="${bin_dir}" \
+    CALLS="${calls}" \
+    EXPECTED_BASE_SHA="${expected_base}" \
+    GITHUB_EVENT_NAME="${event_name}" \
+    GITHUB_RUN_ATTEMPT=1 \
+    GITHUB_RUN_ID=1234 \
+    GITHUB_WORKFLOW=Check \
+    IX_CI_RUN_LOG_ROOT="${scratch}/logs" \
+    RUNNER_NAME=ix-ci-test-runner \
+    RUNNER_TEMP="${scratch}/runner-temp" \
+    "$@" \
+    "${bash_bin}" "${repo_root}/.github/scripts/run-required-gate.sh"
+  [[ "$(<"${calls}")" == $'clone\ncheck' ]]
+}
+
+run_gate pull_request "${pr_base}"
+run_gate push "${push_base}" EVENT_BASE_SHA="${push_base}"
+
+if "${env_bin}" -i \
+  PATH="${bin_dir}" \
+  GITHUB_EVENT_NAME=push \
+  RUNNER_NAME=ix-ci-test-runner \
+  "${bash_bin}" "${repo_root}/.github/scripts/run-required-gate.sh" \
+  >"${scratch}/missing-base.out" 2>"${scratch}/missing-base.err"; then
+  echo "required gate accepted a push without EVENT_BASE_SHA" >&2
+  exit 1
+fi
+grep -q 'EVENT_BASE_SHA is required' "${scratch}/missing-base.err"

--- a/.github/scripts/run-required-gate.sh
+++ b/.github/scripts/run-required-gate.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The changed-line clone gate needs the checked-out synthetic merge's first
+# parent for pull requests; the event base can predate that merge after main
+# advances. Push and merge-group callers provide their immutable event base.
+if [[ "${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}" == "pull_request" ]]; then
+  base_sha="$(git rev-parse --verify HEAD^1)"
+else
+  base_sha="${EVENT_BASE_SHA:?EVENT_BASE_SHA is required outside pull requests}"
+fi
+
+# This checkout-only check cannot live in the pure `.#check` derivation because
+# that derivation intentionally has no .git directory.
+nix run .#clone -- . --diff "${base_sha}" >/dev/null
+
+# Reuse the repository-owned quiet-log wrapper for the combined required-root
+# gate. The phase-clock worker owns this script's process group, so cancellation
+# and validation timeout terminate both this wrapper and every Nix descendant.
+export CHECK_SUBCOMMAND=required
+export RUNNER_IDENTITY="${RUNNER_NAME:?RUNNER_NAME is required}"
+exec bash .github/actions/check-logged/run.sh

--- a/.github/workflows/check-logged-test.yml
+++ b/.github/workflows/check-logged-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/actions/check-logged/**
+      - .github/scripts/run-required-gate*.sh
       - .github/workflows/check-logged-test.yml
 
 permissions:
@@ -16,4 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Test minimal PATH logging
-        run: bash .github/actions/check-logged/test.sh
+        run: |
+          bash .github/actions/check-logged/test.sh
+          bash .github/scripts/run-required-gate-test.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -88,8 +88,24 @@ jobs:
     # with a warm, persistent /nix/store. See the ix repo's ci.yml for the
     # label scheme.
     runs-on: ["${{ format('ix-ci-run-{0}-{1}-flake-check', github.run_id, github.run_attempt) }}"]
-    timeout-minutes: ${{ needs.ci-budget.outputs.big_change == 'true' && 60 || 5 }}
+    # Assignment-relative backstop. The worker action below owns independent
+    # queue, setup, validation, and cleanup clocks; this job timeout is only a
+    # final runner-level guard.
+    timeout-minutes: ${{ fromJSON(needs.ci-budget.outputs.worker_timeout_minutes) }}
+    permissions:
+      actions: read
+      contents: read
     steps:
+      - name: Enforce runner queue admission
+        uses: indexable-inc/index/.github/actions/ci-budget/worker@main
+        with:
+          mode: check
+          repository: ${{ github.repository }}
+          token: ${{ github.token }}
+          run-id: ${{ github.run_id }}
+          run-attempt: ${{ github.run_attempt }}
+          big-change: ${{ needs.ci-budget.outputs.big_change }}
+
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -101,43 +117,22 @@ jobs:
       - name: Bootstrap patched Nix client
         uses: ./.github/actions/bootstrap-patched-nix
 
-      # The global clone budget also runs inside `.#check`, but that derivation
-      # intentionally has no `.git`. Run the zero-tolerance changed-line gate
-      # in the checkout so a PR cannot add duplication while staying under the
-      # repository-wide percentage ratchet.
-      - name: Reject duplication on changed lines
-        # Warm runs finish in minutes; the only way this step reaches double
-        # digits is a wedged nix daemon (index#2750 ate the whole 60-minute job
-        # limit across every PR). Fail fast and loudly instead.
-        timeout-minutes: 15
+      # One budgeted process group owns both the changed-line clone gate and the
+      # required-root Nix gate. The worker action starts a fresh validation clock
+      # after setup, terminates the whole descendant group on timeout or cancel,
+      # and leaves queue time out of the build budget.
+      - name: Run required gate within its validation clock
+        uses: indexable-inc/index/.github/actions/ci-budget/worker@main
+        with:
+          mode: run
+          repository: ${{ github.repository }}
+          token: ${{ github.token }}
+          run-id: ${{ github.run_id }}
+          run-attempt: ${{ github.run_attempt }}
+          big-change: ${{ needs.ci-budget.outputs.big_change }}
+          script: .github/scripts/run-required-gate.sh
         env:
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            # index#3038: the event base can predate the synthetic merge that
-            # checkout regenerates after main advances. Its first parent is the
-            # base whose tree the checked-out PR contribution was merged into.
-            base_sha="$(git rev-parse --verify HEAD^1)"
-          else
-            base_sha="${EVENT_BASE_SHA}"
-          fi
-          nix run .#clone -- . --diff "${base_sha}" > /dev/null
-
-      # Run the required gate through the repo-owned `check` app
-      # (lib/per-system.nix): one bounded nix-fast-build evaluator owns the
-      # namespaced union of ciChecks and cachePushRoots, then nix-eval-jobs
-      # validates packages with the JSON error-line gate. The
-      # command-specific rationale (tool choice, the worker/memory tuning, why the
-      # eval cache is off, the error-line gate) and the pinned tool revisions live
-      # next to that wrapper. The job inherits NIX_CONFIG (above), so the inner
-      # builds still see `gccarch-znver5` and the eval knobs. Branch protection
-      # requires a status named `flake-check`; this job is it, and it fails iff a
-      # check fails to build or the flake stops evaluating.
-      - name: Build all flake checks
-        uses: ./.github/actions/check-logged
-        with:
-          subcommand: required
 
       # The `check` app writes nix-fast-build per-attr durations to
       # check-results.json in the workspace (see lib/per-system.nix). Upload it


### PR DESCRIPTION
## Summary

- enforce the five-minute queue admission boundary before checkout
- give setup and required validation independent clocks
- run clone-diff plus the combined required-root gate as one cancellable process group
- use the policy-derived runner timeout only as a final backstop

## Validation

- Actionlint + ShellCheck
- 11 CI budget worker tests, including timeout and cancellation descendant cleanup
- end-to-end required-gate wrapper test for PR/push bases and exact clone/check arguments
- git diff --check

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce independent clocks on the required gate in the flake-check CI job
> - Introduces [run-required-gate.sh](https://github.com/indexable-inc/index/pull/3392/files#diff-1b1924de13e5b45de81c2963a34e9a4f2e997029a17a31e8ddb9d8bc781c69bb), a wrapper that determines the base SHA (from `HEAD^1` on `pull_request` or `EVENT_BASE_SHA` on push), runs the clone diff gate via `nix run .#clone`, then execs the required check-logged runner with `CHECK_SUBCOMMAND=required`.
> - Updates the `flake-check` job in [check.yml](https://github.com/indexable-inc/index/pull/3392/files#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428) to gate admission via a `ci-budget` worker action and delegate both the clone diff and Nix check steps to the new script under a worker-managed validation clock, replacing the previous inline steps.
> - Adds [run-required-gate-test.sh](https://github.com/indexable-inc/index/pull/3392/files#diff-94fd8040e64cff91be9232a7cfdffc37e6a7bd09f10749f22c693a37b36daba3), a self-contained test harness with stubbed `git` and `nix` that validates the clone+check sequence and rejects pushes missing `EVENT_BASE_SHA`.
> - Extends [check-logged-test.yml](https://github.com/indexable-inc/index/pull/3392/files#diff-d29fd140f4e192d75626802cd68a7b705484c41cabc73c3dc4c14f651bd8da8f) to trigger on changes to the new gate scripts and run the new test.
> - Behavioral Change: push events to the required gate now fail explicitly if `EVENT_BASE_SHA` is not set in the environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd0b561.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->