### PR TITLE
ci: cancel superseded main validation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,10 @@ permissions:
 
 concurrency:
   group: check-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # A newer PR synchronization or main push makes the older revision's result
+  # unusable. Cancel it immediately so obsolete work never waits in front of,
+  # or consumes a runner after, the current head. Tag refs remain independent.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
   # The self-hosted runner's Nix daemon owns substituters (cache.ix.dev plus the


### PR DESCRIPTION
Cancel obsolete main CI when a newer main revision exists. An old main job waited 85 minutes, then consumed a runner after four newer commits had superseded its result. PR and main refs now both keep only the current head; tag refs remain isolated by the concurrency key.

Validated with actionlint and git diff --check.

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel superseded CI runs on push events to main
> Extends the `cancel-in-progress` condition in [check.yml](.github/workflows/check.yml) to include `push` events alongside `pull_request` events. Previously, only PR workflow runs were auto-cancelled when superseded; push runs (e.g. merges to main) would queue and run to completion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a6b19c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->