### PR TITLE
ci: execute the worker action under Actions

### DIFF
--- a/.github/actions/ci-budget/worker/action.yml
+++ b/.github/actions/ci-budget/worker/action.yml
@@ -27,6 +27,15 @@ inputs:
     description: JSON array of arguments passed to the repository script
     default: "[]"
 
+outputs:
+  lint_result:
+    description: Optional lint phase result emitted by the budgeted script
+  nix_result:
+    description: Optional Nix phase result emitted by the budgeted script
+
 runs:
   using: node24
-  main: worker.mjs
+  # GitHub's Node action host does not guarantee that argv[1] is the action
+  # module's real path. Keep invocation in a dedicated entrypoint instead of
+  # relying on worker.mjs's direct-execution guard.
+  main: worker-entrypoint.mjs

--- a/.github/actions/ci-budget/worker/worker-entrypoint.mjs
+++ b/.github/actions/ci-budget/worker/worker-entrypoint.mjs
@@ -1,0 +1,3 @@
+import { runAsAction } from "./worker.mjs";
+
+await runAsAction();

--- a/.github/actions/ci-budget/worker/worker.mjs
+++ b/.github/actions/ci-budget/worker/worker.mjs
@@ -408,7 +408,7 @@ export async function main() {
   });
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+export async function runAsAction() {
   try {
     process.exitCode = await main();
   } catch (error) {
@@ -419,4 +419,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     console.error(`::error title=${title}::${error.message}`);
     process.exitCode = error instanceof DeadlineExceeded ? 124 : 1;
   }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await runAsAction();
 }

--- a/.github/actions/ci-budget/worker/worker.test.mjs
+++ b/.github/actions/ci-budget/worker/worker.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -103,6 +105,108 @@ test("policy exposes independent queue, setup, validation, and cleanup clocks", 
   assert.equal(policy.routine_validation_seconds, 300);
   assert.equal(policy.extended_validation_seconds, 10_800);
   assert.equal(policy.termination_grace_seconds, 10);
+});
+
+test("GitHub action entrypoint invokes the worker under a distinct argv path", async () => {
+  const entrypoint = join(import.meta.dirname, "worker-entrypoint.mjs");
+  const child = spawn(process.execPath, [entrypoint], {
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith("INPUT_")),
+    ),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const result = await waitForExit(child);
+  assert.deepEqual(result, { code: 1, signal: null });
+  assert.match(stderr, /input big-change is required/);
+});
+
+test("GitHub action entrypoint runs validation and preserves script outputs", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "ci-budget-entrypoint-"));
+  const startedAt = new Date().toISOString();
+  const createdAt = new Date(Date.now() - 1000).toISOString();
+  const server = createServer((request, responseStream) => {
+    assert.equal(
+      request.url,
+      "/repos/indexable-inc/ix/actions/runs/42/attempts/1/jobs?per_page=100&page=1",
+    );
+    responseStream.writeHead(200, { "content-type": "application/json" });
+    responseStream.end(
+      JSON.stringify({
+        jobs: [
+          workerJob({
+            attempt: 1,
+            createdAt,
+            runnerName: "runner-entrypoint",
+            startedAt,
+          }),
+        ],
+        total_count: 1,
+      }),
+    );
+  });
+
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    assert.notEqual(address, null);
+    assert.equal(typeof address, "object");
+
+    const script = join(directory, "validate.sh");
+    const output = join(directory, "github-output");
+    await writeFile(
+      script,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "printf 'ran\\n' >validation-ran",
+        "printf 'probe_result=success\\n' >>\"$GITHUB_OUTPUT\"",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(output, "");
+
+    const entrypoint = join(import.meta.dirname, "worker-entrypoint.mjs");
+    const child = spawn(process.execPath, [entrypoint], {
+      env: {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(([name]) => !name.startsWith("INPUT_")),
+        ),
+        GITHUB_API_URL: `http://127.0.0.1:${address.port}`,
+        GITHUB_OUTPUT: output,
+        GITHUB_WORKSPACE: directory,
+        "INPUT_BIG-CHANGE": "false",
+        INPUT_MODE: "run",
+        INPUT_REPOSITORY: "indexable-inc/ix",
+        "INPUT_RUN-ATTEMPT": "1",
+        "INPUT_RUN-ID": "42",
+        INPUT_SCRIPT: "validate.sh",
+        INPUT_TOKEN: "test-token",
+        RUNNER_NAME: "runner-entrypoint",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    const result = await waitForExit(child);
+    assert.deepEqual(result, { code: 0, signal: null }, stderr);
+    assert.equal(await readFile(join(directory, "validation-ran"), "utf8"), "ran\n");
+    assert.equal(await readFile(output, "utf8"), "probe_result=success\n");
+  } finally {
+    server.close();
+    await once(server, "close");
+    await rm(directory, { force: true, recursive: true });
+  }
 });
 
 test("worker selects the exact current attempt runner job", async () => {


### PR DESCRIPTION
## Summary

- invoke the shared worker through a dedicated Node entrypoint instead of an argv-path guard that is false under the Actions host
- declare the phase outputs consumed by ix terminal mirrors
- add a process-level regression that proves the entrypoint runs validation and preserves `$GITHUB_OUTPUT`

## Validation

- `node --test .github/actions/ci-budget/worker/worker.test.mjs` (13/13)
- `actionlint .github/workflows/check.yml .github/workflows/ci-budget-check.yml`
- `git diff --cached --check`

Fixes the live false-green/no-op worker invocation observed in index run 29453580716 and ix run 29454228805.

(sent by Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute the CI budget worker action via a dedicated entrypoint module
> - Adds [worker-entrypoint.mjs](https://github.com/indexable-inc/index/pull/3394/files#diff-69cfacd88e867290f0e586295801ca0d8483f1bedede63d2ee4b7a61e1d44216) as the main script for the action, separating the GitHub Actions entrypoint from the worker logic in [worker.mjs](https://github.com/indexable-inc/index/pull/3394/files#diff-0885a0ad7031dc509de7820a9f632cf78668efc319f9b17d2bc9b7db01ed1374)
> - Extracts a `runAsAction` function in `worker.mjs` that wraps `main()` with error handling, maps `DeadlineExceeded` to exit code 124, and sets `process.exitCode` on success
> - Exposes `lint_result` and `nix_result` as declared outputs in [action.yml](https://github.com/indexable-inc/index/pull/3394/files#diff-d6593aa581192a272f8ed12c4d0a36215867bbbe5d7726fc8e90424b9a22d9c7)
> - Adds tests covering the entrypoint invocation, missing-input errors, and `GITHUB_OUTPUT` correctness
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d07101.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->