### PR TITLE
ci: make workflow retries independent of expired artifacts

### DIFF
--- a/.github/actions/ci-budget/ci_budget.py
+++ b/.github/actions/ci-budget/ci_budget.py
@@ -85,6 +85,22 @@ def classification_from_snapshot(snapshot: BudgetSnapshot) -> Classification:
     )
 
 
+def classification_for_retry(snapshot: BudgetSnapshot | None) -> Classification:
+    if snapshot is not None:
+        return classification_from_snapshot(snapshot)
+
+    # GitHub removes artifacts produced by the previous attempt before a
+    # workflow rerun starts. The artifact is still useful for partial job
+    # reruns on platforms that retain it, but its absence must not make the
+    # policy job itself impossible to retry. Fall back to the conservative
+    # tier: a retry is an explicit maintainer operation, and extending its
+    # timeout cannot turn a failing validation green.
+    return Classification(
+        big_change=True,
+        reason={"sources": ["retry_snapshot_unavailable"], "matches": []},
+    )
+
+
 def parse_bool(value: str, name: str) -> bool:
     if value == "true":
         return True
@@ -758,11 +774,10 @@ def main() -> int:
     labels: list[str] = []
     if run_attempt > 1:
         snapshot = client.ci_budget_snapshot(run_id, run_attempt)
-        if snapshot is None:
-            raise RuntimeError("workflow retry has no earlier CI budget snapshot")
-        classification = classification_from_snapshot(snapshot)
+        classification = classification_for_retry(snapshot)
         # The attempt-one publisher owns the human-facing reason. A retry must
-        # consume that frozen tier without rewriting it from live PR state.
+        # consume the frozen tier when GitHub retained it, or the conservative
+        # fallback above, without rewriting the decision from live PR state.
         publish = False
     elif pull_request_number:
         pull_request = client.pull_request(pull_request_number)

--- a/.github/actions/ci-budget/test_ci_budget.py
+++ b/.github/actions/ci-budget/test_ci_budget.py
@@ -102,13 +102,22 @@ class ClassificationTests(unittest.TestCase):
         assert result.reason["sources"] == ["forced"]
 
     def test_retry_classification_uses_only_the_frozen_snapshot(self) -> None:
-        result = ci_budget.classification_from_snapshot(
+        result = ci_budget.classification_for_retry(
             ci_budget.BudgetSnapshot(big_change=True)
         )
 
         assert result.big_change
         assert result.reason == {
             "sources": ["attempt_snapshot"],
+            "matches": [],
+        }
+
+    def test_retry_without_retained_artifact_gets_conservative_budget(self) -> None:
+        result = ci_budget.classification_for_retry(None)
+
+        assert result.big_change
+        assert result.reason == {
+            "sources": ["retry_snapshot_unavailable"],
             "matches": [],
         }
 


### PR DESCRIPTION
GitHub removes artifacts from earlier attempts when a workflow is rerun. The budget job therefore could not consume the snapshot it had successfully uploaded and every retry failed before dispatch.

Retain the frozen tier when available; if GitHub has removed it, use a conservative extended timeout without changing pass/fail semantics or rereading mutable PR state.

Validation:
- 27 ci_budget unit tests
- 18 ci_deadline unit tests
- 6 ci_policy unit tests
- 13 worker process/integration tests
- git diff --check

Fixes the attempt-2 failure observed in ix run 29454228805.

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI budget workflow retries when prior attempt artifacts are expired
> - Adds `classification_for_retry` in [ci_budget.py](https://github.com/indexable-inc/index/pull/3395/files#diff-c0b72d4d13e44f5bc04171e6ec8159ca0febc581f4577c9a63bdf9ad66acb485) to handle reruns where the previous attempt's budget snapshot artifact is unavailable.
> - When a snapshot exists, it delegates to `classification_from_snapshot`; when absent (artifact expired or missing), it returns a conservative fallback with `big_change=True` and reason `retry_snapshot_unavailable` instead of raising a `RuntimeError`.
> - Publishes remain disabled for all retries regardless of snapshot availability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20265ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->