### PR TITLE
nushell: link config directories out of store

### DIFF
--- a/users/andrewgazelka/profiles/nushell.nix
+++ b/users/andrewgazelka/profiles/nushell.nix
@@ -5,29 +5,67 @@
 }: let
   sourceRoot = configRoot + "/nushell";
   checkoutRoot = "${config.users.andrewgazelka.paths.indexCheckout}/users/andrewgazelka/config/nushell";
-  files = lib.filesystem.listFilesRecursive sourceRoot;
-  relativePath = file:
-    lib.removePrefix "${toString sourceRoot}/" (toString file);
+  rootEntries = builtins.readDir sourceRoot;
+  entries = builtins.attrNames rootEntries;
+  directories = builtins.filter (name: rootEntries."${name}" == "directory") entries;
 in {
   # Nushell writes history and plugin state beside its config on macOS. Keep
-  # that directory writable while linking every tracked leaf to the mutable
-  # index checkout, so edits take effect without a Home Manager switch.
-  home.file = lib.genAttrs' files (
-    file: let
-      path = relativePath file;
-    in
-      lib.nameValuePair "Library/Application Support/nushell/${path}" {
-        source = config.lib.file.mkOutOfStoreSymlink "${checkoutRoot}/${path}";
-      }
-  );
+  # that root writable while linking each tracked top-level entry to the
+  # mutable checkout, so new files in config directories need no switch.
+  home = {
+    file = lib.genAttrs' entries (
+      name:
+        lib.nameValuePair "Library/Application Support/nushell/${name}" {
+          source = config.lib.file.mkOutOfStoreSymlink "${checkoutRoot}/${name}";
+        }
+    );
 
-  # Home Manager does not replace a managed directory symlink when its source
-  # changes to leaf links. Remove only the previous generation-owned link so
-  # linkGeneration can create the writable parent directory.
-  home.activation.migrateNushellDataDirectory = config.lib.dag.entryBefore ["checkLinkTargets"] ''
-    dataDir=${lib.escapeShellArg "${config.home.homeDirectory}/Library/Application Support/nushell"}
-    if [[ -L "$dataDir" ]] && [[ $(readlink "$dataDir") == /nix/store/*-home-manager-files/* ]]; then
-      run rm "$dataDir"
-    fi
-  '';
+    # Home Manager does not replace a managed directory symlink when its source
+    # changes to leaf links. Remove only the previous generation-owned link so
+    # linkGeneration can create the writable parent directory.
+    activation.migrateNushellDataDirectory = config.lib.dag.entryBefore ["checkLinkTargets"] ''
+      dataDir=${lib.escapeShellArg "${config.home.homeDirectory}/Library/Application Support/nushell"}
+      if [[ -L "$dataDir" ]] && [[ $(readlink "$dataDir") == /nix/store/*-home-manager-files/* ]]; then
+        run rm "$dataDir"
+      fi
+    '';
+
+    # #3401: The previous layout created real directories containing
+    # generation-owned leaf links. Refuse migration for unknown directories
+    # or leaves that are not links from a Home Manager generation.
+    activation.migrateNushellConfigDirectories = config.lib.dag.entryBefore ["checkLinkTargets"] ''
+      dataDir=${lib.escapeShellArg "${config.home.homeDirectory}/Library/Application Support/nushell"}
+      checkoutDir=${lib.escapeShellArg checkoutRoot}
+      directories=(${lib.escapeShellArgs directories})
+      isManagedDirectory() {
+        local target="$1"
+        local source="$2"
+        local entry name tracked
+        for entry in "$target"/*; do
+          name="''${entry##*/}"
+          tracked="$source/$name"
+          if [[ -d "$entry" ]] && [[ ! -L "$entry" ]]; then
+            if [[ ! -d "$tracked" ]] || ! isManagedDirectory "$entry" "$tracked"; then
+              return 1
+            fi
+          elif [[ ! -L "$entry" ]] || [[ $(readlink "$entry") != /nix/store/*-home-manager-files/* ]]; then
+            return 1
+          fi
+        done
+        return 0
+      }
+      for directory in "''${directories[@]}"; do
+        target="$dataDir/$directory"
+        source="$checkoutDir/$directory"
+        if [[ -d "$target" ]] && [[ ! -L "$target" ]]; then
+          (
+            shopt -s dotglob nullglob
+            if isManagedDirectory "$target" "$source"; then
+              run rm -r "$target"
+            fi
+          )
+        fi
+      done
+    '';
+  };
 }


### PR DESCRIPTION
## Summary

- link each tracked top-level Nushell config entry directly to the mutable checkout
- keep the Nushell data root writable for history and plugin state
- safely migrate prior generation-owned leaf-link directories

## Validation

- `nix run .#lint`
- Home Manager evaluation with the branch supplied as the `index` input
- migration safety checks for hidden files and unexpected directories

Fixes #3398
Refs #3401

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Link top-level Nushell config directories out of store instead of leaf files
> - Changes [nushell.nix](https://github.com/indexable-inc/index/pull/3402/files#diff-ef363f56adfb507f78ceeaac16eaa7129832f25a8584783918c10a0a3ab0af92) to symlink each top-level entry (file or directory) from the checkout root into `Library/Application Support/nushell/` via `mkOutOfStoreSymlink`, rather than recursively symlinking every leaf file.
> - Adds a `migrateNushellConfigDirectories` activation step that runs before `checkLinkTargets`, removing real directories that contain only Home Manager generation-owned symlinks so new top-level directory symlinks can be created cleanly.
> - Directories containing non-managed or foreign content are left untouched by the migration script.
> - Behavioral Change: the Nushell data directory itself is now writable; only top-level entries are symlinked, so files added inside a tracked directory at runtime are preserved rather than overwritten.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 402479f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->