### PR TITLE
nushell: add infra fleet status

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1504,6 +1504,7 @@
             pkgs.runCommand "nushell-config-check"
             {
               nativeBuildInputs = [
+                pkgs.binutils
                 pkgs.jq
                 pkgs.nushell
               ];
@@ -1520,6 +1521,13 @@
                 jq -s 'map(select(.type == "diagnostic"))' "$diagnostics" >&2
                 exit 1
               fi
+              if [[ $(nu --no-config-file -c 'nu-check functions/infra/status.nu') != true ]]; then
+                echo "infra status probe did not parse" >&2
+                exit 1
+              fi
+              for test in tests/test_*.nu; do
+                nu --no-config-file "$test"
+              done
               touch "$out"
             '';
           # Exercises the trusted half of the blast-radius PR comment: the

--- a/users/andrewgazelka/config/nushell/functions/infra.nu
+++ b/users/andrewgazelka/config/nushell/functions/infra.nu
@@ -1,0 +1,216 @@
+const REMOTE_STATUS_PATH = path self ./infra/status.nu
+const PROBE_OUTPUT_BLOCKS = 1_024
+const PROBE_OUTPUT_LIMIT = 1MiB
+const REMOTE_WRAPPER = '
+/run/current-system/sw/bin/timeout --signal=TERM --kill-after=1s "$1" nu --no-config-file /dev/stdin
+code=$?
+case "$code" in
+  0) exit 0 ;;
+  124|137) exit 200 ;;
+  *) printf "remote probe exited with code %s\n" "$code" >&2; exit 201 ;;
+esac
+'
+const PROBE_WRAPPER = '
+output_blocks=$1
+stdout=$2
+stderr=$3
+status=$4
+shift 4
+if ! ulimit -f "$output_blocks"; then
+  exit 70
+fi
+"$@" >"$stdout" 2>"$stderr"
+code=$?
+printf "%s\n" "$code" >"$status"
+'
+
+def "_infra error" [host: record, reachable: bool, message: string] {
+    {
+        host: $host.name
+        reported_host: null
+        ssh: $host.sshAlias
+        reachable: $reachable
+        generation: null
+        activated: null
+        revision: null
+        system: null
+        failed: null
+        failed_units: []
+        error: $message
+    }
+}
+
+def "_infra status" [host: record, output: string] {
+    let status = ($output | from json)
+    let errors = [
+        (if $status.host != $host.name {
+            $"reported host ($status.host) does not match ($host.name)"
+        })
+        (if $status.active_generation != null and not $status.profile_matches_active {
+            $"active generation ($status.active_generation) differs from profile generation ($status.profile_generation)"
+        })
+        (if $status.active_generation == null {
+            "active system has no matching profile generation"
+        })
+    ] | compact
+
+    {
+        host: $host.name
+        reported_host: $status.host
+        ssh: $host.sshAlias
+        reachable: true
+        generation: $status.active_generation
+        activated: (
+            $status.activated * 1_000_000_000
+            | into datetime
+            | date to-timezone local
+        )
+        revision: $status.revision
+        system: $status.system
+        failed: ($status.failed_units | length)
+        failed_units: $status.failed_units
+        error: (if ($errors | is-empty) { null } else { $errors | str join "; " })
+    }
+}
+
+def "_infra capped" [path] {
+    try {
+        (ls $path | get size | first) >= $PROBE_OUTPUT_LIMIT
+    } catch {
+        false
+    }
+}
+
+# Show the active generation and failed systemd units across the NixOS fleet.
+export def "infra ls" [
+    --threads (-t): int = 8  # Maximum hosts queried concurrently.
+    --timeout: duration = 8sec  # Timeout for connection setup and the remote probe.
+] {
+    if $threads < 1 {
+        error make { msg: "threads must be positive" }
+    }
+    if $timeout <= 0sec {
+        error make { msg: "timeout must be positive" }
+    }
+
+    let inventory = ($env.HOME | path join ".config" "infra" "hosts.json")
+    let hosts = (open $inventory)
+    let remote_status = (open --raw $REMOTE_STATUS_PATH)
+    let timeout_seconds = ($timeout / 1sec | math ceil | into int)
+    let watchdog_seconds = $timeout_seconds + 1
+    let worker_count = if ($hosts | is-empty) {
+        1
+    } else {
+        [$threads ($hosts | length)] | math min
+    }
+    let environment_options = ["-u" "LINEAR_API_KEY"]
+    let ssh_options = [
+        "-o" $"ConnectTimeout=($timeout_seconds)"
+        "-o" "BatchMode=yes"
+        "-o" "ClearAllForwardings=yes"
+        "-o" "ForwardAgent=no"
+        "-o" "ForwardX11=no"
+        "-o" "LogLevel=ERROR"
+        "-o" $"ServerAliveInterval=($timeout_seconds)"
+        "-o" "ServerAliveCountMax=1"
+    ]
+    let quoted_remote_wrapper = $"'($REMOTE_WRAPPER)'"
+    let remote_command = [
+        "/bin/sh"
+        "-c"
+        $quoted_remote_wrapper
+        "infra-status"
+        $"($timeout_seconds)s"
+    ]
+
+    $hosts
+    | par-each --keep-order --threads $worker_count { |host|
+        let capture_directory = (^mktemp -d | str trim | path expand)
+        let stdout_path = ($capture_directory | path join "stdout")
+        let stderr_path = ($capture_directory | path join "stderr")
+        let status_path = ($capture_directory | path join "status")
+        let local_command = [
+            "/bin/sh"
+            "-c"
+            $PROBE_WRAPPER
+            "infra-probe"
+            $PROBE_OUTPUT_BLOCKS
+            $stdout_path
+            $stderr_path
+            $status_path
+            "timeout"
+            "--signal=TERM"
+            "--kill-after=1s"
+            $"($watchdog_seconds)s"
+            "ssh"
+            ...$ssh_options
+            "--"
+            $host.sshAlias
+            ...$remote_command
+        ]
+        let wrapper = (
+            $remote_status
+            | do {
+                ^env ...$environment_options ...$local_command
+            }
+            | complete
+        )
+        let result = {
+            exit_code: (try {
+                open --raw $status_path | str trim | into int
+            } catch {
+                null
+            })
+            stdout: (try { open --raw $stdout_path } catch { "" })
+            stderr: (try {
+                open --raw $stderr_path | str trim | str substring 0..<4_096
+            } catch {
+                ""
+            })
+            output_capped: ((_infra capped $stdout_path) or (_infra capped $stderr_path))
+        }
+        let reached_host = $result.exit_code in [0 200 201]
+        rm --recursive --force $capture_directory
+
+        if $result.exit_code == null {
+            let detail = ($wrapper.stderr | str trim)
+            let message = if ($detail | is-empty) {
+                "local probe wrapper failed"
+            } else {
+                $"local probe wrapper failed: ($detail)"
+            }
+            _infra error $host false $message
+        } else if $result.output_capped {
+            _infra error $host false $"probe output exceeded ($PROBE_OUTPUT_LIMIT)"
+        } else if $result.exit_code == 0 {
+            let parsed = try {
+                { row: (_infra status $host $result.stdout), error: null }
+            } catch { |error|
+                {
+                    row: null
+                    error: ($error.msg? | default "invalid probe response")
+                }
+            }
+            if $parsed.error == null {
+                $parsed.row
+            } else {
+                _infra error $host true $parsed.error
+            }
+        } else {
+            let message = if $result.exit_code in [124 137] {
+                $"ssh exceeded the ($watchdog_seconds)s local watchdog"
+            } else if $result.exit_code == 200 {
+                $"probe timed out after ($timeout)"
+            } else if $result.exit_code == 201 {
+                if ($result.stderr | is-empty) { "remote probe failed" } else { $result.stderr }
+            } else if $result.exit_code in [125 126 127] {
+                $"local probe command failed with code ($result.exit_code)"
+            } else if ($result.stderr | is-empty) {
+                $"ssh exited with code ($result.exit_code)"
+            } else {
+                $result.stderr
+            }
+            _infra error $host $reached_host $message
+        }
+    }
+}

--- a/users/andrewgazelka/config/nushell/functions/infra/status.nu
+++ b/users/andrewgazelka/config/nushell/functions/infra/status.nu
@@ -1,0 +1,61 @@
+def main [
+    --profiles: path = "/nix/var/nix/profiles"
+    --current-system: path = "/run/current-system"
+] {
+    let profile = ($profiles | path join "system")
+    let profile_link = (^readlink $profile | str trim)
+    let profile_generation = (
+        $profile_link
+        | path basename
+        | str replace "system-" ""
+        | str replace "-link" ""
+        | into int
+    )
+    let profile_system = (^readlink -f $profile | str trim)
+    let system = (^readlink -f $current_system | str trim)
+    let active_generations = (
+        glob ($profiles | path join "system-*-link")
+        | where { |link| (^readlink -f $link | str trim) == $system }
+        | each { |link|
+            $link
+            | path basename
+            | str replace "system-" ""
+            | str replace "-link" ""
+            | into int
+        }
+    )
+    let active_generation = if ($active_generations | is-empty) {
+        null
+    } else {
+        $active_generations | math max
+    }
+    let activated = (
+        ^stat -c "%Y" $current_system
+        | str trim
+        | into int
+    )
+    let failed_units = (
+        ^systemctl list-units --failed --all --output=json --no-pager
+        | from json
+        | get unit
+    )
+    let revision_result = (
+        do { ^sudo -n cat /var/lib/ix-deploy-record/last-rev }
+        | complete
+    )
+    let revision = if $revision_result.exit_code == 0 {
+        $revision_result.stdout | str trim
+    } else {
+        null
+    }
+    {
+        host: (^hostname | str trim)
+        active_generation: $active_generation
+        profile_generation: $profile_generation
+        profile_matches_active: ($profile_system == $system)
+        activated: $activated
+        system: $system
+        revision: $revision
+        failed_units: $failed_units
+    } | to json --raw
+}

--- a/users/andrewgazelka/config/nushell/functions/mod.nu
+++ b/users/andrewgazelka/config/nushell/functions/mod.nu
@@ -8,3 +8,4 @@ export use share.nu *
 export use abbr.nu
 export use paths.nu *
 export use rstrings.nu *
+export use infra.nu *

--- a/users/andrewgazelka/config/nushell/tests/test_abbr.nu
+++ b/users/andrewgazelka/config/nushell/tests/test_abbr.nu
@@ -314,3 +314,7 @@ export def run-all [] {
 
     print "\n✅ All 31 tests passed!"
 }
+
+def main [] {
+    run-all
+}

--- a/users/andrewgazelka/config/nushell/tests/test_infra.nu
+++ b/users/andrewgazelka/config/nushell/tests/test_infra.nu
@@ -1,0 +1,164 @@
+use std/assert
+use ../functions/infra.nu *
+
+const STATUS_PROBE_PATH = path self ../functions/infra/status.nu
+
+#[test]
+def test_remote_status_probe [] {
+    let directory = (^mktemp -d | str trim | path expand)
+    let bin = ($directory | path join "bin")
+    let profiles = ($directory | path join "profiles")
+    let current_system = ($directory | path join "current-system")
+    mkdir $bin $profiles
+    touch $current_system
+    for generation in [41 42 43] {
+        touch ($profiles | path join $"system-($generation)-link")
+    }
+    touch ($profiles | path join "system")
+
+    '#!/bin/sh
+case "$*" in
+  *"-f "*"system-41-link") printf "/nix/store/old-nixos-system-up\n" ;;
+  *"-f "*"system-42-link") printf "/nix/store/abc-nixos-system-up\n" ;;
+  *"-f "*"system-43-link") printf "/nix/store/new-nixos-system-up\n" ;;
+  *"-f "*"current-system") printf "/nix/store/abc-nixos-system-up\n" ;;
+  *"-f "*"profiles/system") printf "/nix/store/new-nixos-system-up\n" ;;
+  *"profiles/system") printf "system-43-link\n" ;;
+  *) exit 1 ;;
+esac
+' | save --raw ($bin | path join "readlink")
+    '#!/bin/sh
+printf "1700000000\n"
+' | save --raw ($bin | path join "stat")
+    '#!/bin/sh
+printf "[%s]\n" "{\"unit\":\"broken.service\"},{\"unit\":\"other.service\"}"
+' | save --raw ($bin | path join "systemctl")
+    '#!/bin/sh
+printf "0123456789abcdef\n"
+' | save --raw ($bin | path join "sudo")
+    '#!/bin/sh
+printf "up\n"
+' | save --raw ($bin | path join "hostname")
+    for command in [readlink stat systemctl sudo hostname] {
+        chmod +x ($bin | path join $command)
+    }
+
+    let original_path = $env.PATH
+    $env.PATH = [$bin] ++ $original_path
+    let status = (
+        nu --no-config-file $STATUS_PROBE_PATH --profiles $profiles --current-system $current_system
+        | from json
+    )
+    $env.PATH = $original_path
+
+    assert equal $status.host "up"
+    assert equal $status.active_generation 42
+    assert equal $status.profile_generation 43
+    assert not $status.profile_matches_active
+    assert equal $status.activated 1_700_000_000
+    assert equal $status.system "/nix/store/abc-nixos-system-up"
+    assert equal $status.revision "0123456789abcdef"
+    assert equal $status.failed_units ["broken.service" "other.service"]
+
+    rm --recursive --force $directory
+}
+
+#[test]
+def test_reachable_and_unreachable_hosts [] {
+    let directory = (^mktemp -d | str trim | path expand)
+    let bin = ($directory | path join "bin")
+    let inventory_directory = ($directory | path join ".config" "infra")
+    let response = ($directory | path join "response.json")
+    mkdir $bin $inventory_directory
+
+    '#!/bin/sh
+cat >/dev/null
+if [ -n "${LINEAR_API_KEY-}" ]; then
+  printf "credential leaked\n" >&2
+  exit 99
+fi
+case "$*" in
+  *ClearAllForwardings=yes*ForwardAgent=no*ForwardX11=no*) ;;
+  *) printf "unsafe ssh options\n" >&2; exit 98 ;;
+esac
+case "$*" in
+  *"-- down "*) printf "connection refused\n" >&2; exit 255 ;;
+  *"-- invalid "*) printf "not json\n"; exit 0 ;;
+  *"-- timeout "*) exit 200 ;;
+  *"-- slow "*) sleep 5; exit 0 ;;
+  *"-- large "*) yes x | head -c 2097152; exit 0 ;;
+esac
+cat "$FAKE_INFRA_RESPONSE"
+' | save --raw ($bin | path join "ssh")
+    chmod +x ($bin | path join "ssh")
+
+    {
+        host: "up"
+        active_generation: 42
+        profile_generation: 42
+        profile_matches_active: true
+        activated: 1_700_000_000
+        system: "/nix/store/abc-nixos-system-up"
+        revision: "0123456789abcdef"
+        failed_units: ["broken.service"]
+    }
+    | to json
+    | save --raw $response
+
+    [
+        { name: "up", sshAlias: "up" }
+        { name: "down", sshAlias: "down" }
+        { name: "invalid", sshAlias: "invalid" }
+        { name: "timeout", sshAlias: "timeout" }
+        { name: "slow", sshAlias: "slow" }
+        { name: "large", sshAlias: "large" }
+    ]
+    | to json
+    | save --raw ($inventory_directory | path join "hosts.json")
+
+    let original_home = $env.HOME
+    let original_path = $env.PATH
+    let original_linear_api_key = $env.LINEAR_API_KEY?
+    $env.HOME = $directory
+    $env.PATH = [$bin] ++ $original_path
+    $env.FAKE_INFRA_RESPONSE = $response
+    $env.LINEAR_API_KEY = "must-not-leak"
+    let started = date now
+    let rows = (infra ls --timeout 1sec)
+    let elapsed = (date now) - $started
+    $env.HOME = $original_home
+    $env.PATH = $original_path
+    if $original_linear_api_key == null {
+        hide-env LINEAR_API_KEY
+    } else {
+        $env.LINEAR_API_KEY = $original_linear_api_key
+    }
+
+    assert equal ($rows | length) 6
+    assert ($elapsed < 4sec)
+    assert equal $rows.0.generation 42
+    assert equal $rows.0.revision "0123456789abcdef"
+    assert equal $rows.0.system "/nix/store/abc-nixos-system-up"
+    assert equal $rows.0.failed_units ["broken.service"]
+    assert not $rows.1.reachable
+    assert str contains $rows.1.error "connection refused"
+    assert $rows.2.reachable
+    assert not ($rows.2.error | is-empty)
+    assert $rows.3.reachable
+    assert str contains $rows.3.error "timed out"
+    assert not $rows.4.reachable
+    assert str contains $rows.4.error "local watchdog"
+    assert not $rows.5.reachable
+    assert str contains $rows.5.error "probe output exceeded"
+
+    rm --recursive --force $directory
+}
+
+export def run-all [] {
+    test_remote_status_probe
+    test_reachable_and_unreachable_hosts
+}
+
+def main [] {
+    run-all
+}

--- a/users/andrewgazelka/config/nushell/tests/test_rstrings.nu
+++ b/users/andrewgazelka/config/nushell/tests/test_rstrings.nu
@@ -43,3 +43,7 @@ export def run-all [] {
     test_depth_and_cycle_deduplication
     test_pipeline_and_input_validation
 }
+
+def main [] {
+    run-all
+}

--- a/users/andrewgazelka/options.nix
+++ b/users/andrewgazelka/options.nix
@@ -16,6 +16,19 @@
       description = "Domains redirected by the workstation browser-tab guard.";
     };
 
+    infra.hosts = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule {
+        options = {
+          sshAlias = lib.mkOption {
+            type = lib.types.nonEmptyStr;
+            description = "SSH alias used to query the host.";
+          };
+        };
+      });
+      default = {};
+      description = "NixOS infrastructure hosts queried by `infra ls`.";
+    };
+
     configurationRevision = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;

--- a/users/andrewgazelka/profiles/darwin-home.nix
+++ b/users/andrewgazelka/profiles/darwin-home.nix
@@ -106,6 +106,7 @@ in {
   # the personal config consuming it. Mechanism in index, values here.
   imports = [
     (import ./nushell.nix {inherit configRoot;})
+    ./infra.nix
     optionsModule
     raycastModule
     # Ghostty config, generated from Nix (home/ghostty.nix). Replaces the former

--- a/users/andrewgazelka/profiles/infra.nix
+++ b/users/andrewgazelka/profiles/infra.nix
@@ -1,0 +1,13 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  hosts = config.users.andrewgazelka.infra.hosts;
+  hostRows = lib.mapAttrsToList (name: host: host // {inherit name;}) hosts;
+  json = pkgs.formats.json {};
+in {
+  home.file.".config/infra/hosts.json".source = json.generate "infra-hosts.json" hostRows;
+  home.packages = [pkgs.coreutils];
+}


### PR DESCRIPTION
## Summary

- add a typed private-consumer host inventory and structured `infra ls` rows
- probe hosts concurrently with bounded local and remote execution
- disable forwarding, remove `LINEAR_API_KEY`, and cap endpoint-controlled output
- report active generations, closures, revisions, activation time, and failed units

## Validation

- `nix run .#lint`
- Nushell tests under 0.112.3 and 0.114.0
- standalone remote status probe test
- live six-host fleet probe

Fixes #3400

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `infra ls` command to concurrently probe fleet host status over SSH
> - Adds [`functions/infra/status.nu`](https://github.com/indexable-inc/index/pull/3404/files#diff-4dfb077e23a4fce9dda6dd48e13d4b6983572b8e717014f7db62a8e931ddec59), a remote-executable Nushell probe that emits JSON describing each host's active generation, activation time, systemd failed units, and revision.
> - Adds [`functions/infra.nu`](https://github.com/indexable-inc/index/pull/3404/files#diff-821adbae708d4fe0342809a480fd6f3978bcc11e182c22574b1ee49d7e966c4c) with the `infra ls` command, which reads `~/.config/infra/hosts.json`, SSHes to each host concurrently, and returns normalized per-host rows with reachability and error classification.
> - Adds an `infra.hosts` NixOS option (keyed by `sshAlias`) and [`profiles/infra.nix`](https://github.com/indexable-inc/index/pull/3404/files#diff-508f82142f3f18d2955857b2f695f0d1046b6aee4c98dc9ad2299e2763230f0b) to generate `hosts.json` from NixOS config and make `coreutils` available.
> - Extends the `nushell-config-check` derivation to validate `status.nu` via `nu-check` and run all `tests/test_*.nu` scripts at build time.
> - Adds integration tests in [`tests/test_infra.nu`](https://github.com/indexable-inc/index/pull/3404/files#diff-cce7c1fe2cd653293da91b1b53da6235f07b65c97b62d2f12dd199c256fd6897) covering the status probe and `infra ls` with mocked SSH and filesystem.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f32b19d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->