### PR TITLE
geyser: drop Determinate-only underscore literal

### DIFF
--- a/modules/darwin/ray.nix
+++ b/modules/darwin/ray.nix
@@ -160,7 +160,7 @@
         objectStoreMemory = lib.mkOption {
           type = lib.types.nullOr lib.types.ints.positive;
           default = null;
-          example = 8_000_000_000;
+          example = 8000000000;
           description = ''
             Bytes of RAM for this node's object store (Plasma). Null lets Ray
             autodetect. The fabric env lifts Ray's 2GiB macOS cap

--- a/modules/services/geyser/default.nix
+++ b/modules/services/geyser/default.nix
@@ -100,7 +100,7 @@ in {
 
       port = mkOption {
         type = types.port;
-        default = 19_132;
+        default = 19132;
         description = "UDP port Geyser binds for Bedrock clients.";
       };
 
@@ -156,7 +156,7 @@ in {
 
       port = mkOption {
         type = types.port;
-        default = 25_565;
+        default = 25565;
         description = "Java server port Geyser connects to when address is explicit.";
       };
 

--- a/modules/services/inference/default.nix
+++ b/modules/services/inference/default.nix
@@ -139,7 +139,7 @@ in {
 
     port = lib.mkOption {
       type = lib.types.port;
-      default = 18_080;
+      default = 18080;
       description = "Port the server listens on.";
     };
 
@@ -174,7 +174,7 @@ in {
       type = lib.types.attrsOf settingsValueType;
       default = {};
       example = {
-        ctx-size = 65_536;
+        ctx-size = 65536;
         n-gpu-layers = 99;
         mlock = true;
         flash-attn = "on";

--- a/modules/services/minecraft-bedrock/default.nix
+++ b/modules/services/minecraft-bedrock/default.nix
@@ -69,13 +69,13 @@ in {
 
     port = mkOption {
       type = types.port;
-      default = 19_132;
+      default = 19132;
       description = "IPv4 UDP port for Bedrock clients.";
     };
 
     portv6 = mkOption {
       type = types.port;
-      default = 19_133;
+      default = 19133;
       description = "IPv6 UDP port for Bedrock clients.";
     };
 

--- a/modules/services/minecraft/default.nix
+++ b/modules/services/minecraft/default.nix
@@ -237,7 +237,7 @@
 
       diameter = mkOption {
         type = types.ints.positive;
-        default = 12_000;
+        default = 12000;
         description = "World border diameter in blocks.";
       };
 
@@ -951,7 +951,7 @@ in {
 
       port = mkOption {
         type = types.port;
-        default = 25_575;
+        default = 25575;
         description = "TCP port for Minecraft RCON.";
       };
 
@@ -1000,7 +1000,7 @@ in {
 
       rconPort = mkOption {
         type = types.port;
-        default = 25_575;
+        default = 25575;
         description = "Local RCON port used to ask PlugManX to reload Bukkit-family plugins.";
       };
 
@@ -1072,7 +1072,7 @@ in {
 
     port = mkOption {
       type = types.port;
-      default = 25_565;
+      default = 25565;
     };
 
     openFirewall = mkOption {
@@ -1145,7 +1145,7 @@ in {
       properties = lib.mkMerge [
         {
           server-port = lib.mkDefault cfg.port;
-          max-players = lib.mkDefault 100_000;
+          max-players = lib.mkDefault 100000;
           online-mode = lib.mkDefault true;
           enforce-secure-profile = lib.mkDefault true;
           gamemode = lib.mkDefault "survival";

--- a/modules/services/minecraft/mods/simple-voice-chat/default.nix
+++ b/modules/services/minecraft/mods/simple-voice-chat/default.nix
@@ -14,7 +14,7 @@
   modEnabled = modCfg != null && modCfg.enable;
   pluginEnabled = pluginCfg != null && pluginCfg.enable;
   defaults = {
-    port = 24_454;
+    port = 24454;
   };
   modSettings =
     if modCfg == null

--- a/modules/services/minestom/default.nix
+++ b/modules/services/minestom/default.nix
@@ -69,7 +69,7 @@ in {
 
     port = mkOption {
       type = types.port;
-      default = 25_565;
+      default = 25565;
     };
 
     openFirewall = mkOption {

--- a/modules/services/observability/default.nix
+++ b/modules/services/observability/default.nix
@@ -228,7 +228,7 @@ in {
 
       healthPort = mkOption {
         type = types.port;
-        default = 13_133;
+        default = 13133;
         description = "Collector health extension port on loopback.";
       };
 

--- a/modules/services/ray/default.nix
+++ b/modules/services/ray/default.nix
@@ -352,7 +352,7 @@ in {
     objectStoreMemory = mkOption {
       type = types.nullOr types.ints.positive;
       default = null;
-      example = 8_000_000_000;
+      example = 8000000000;
       description = ''
         Bytes of RAM for this node's object store (Plasma). Null lets Ray
         autodetect (~30% of RAM). Either way Ray spills to disk under

--- a/modules/services/spark/default.nix
+++ b/modules/services/spark/default.nix
@@ -279,7 +279,7 @@ in {
       };
       port = mkOption {
         type = types.port;
-        default = 15_002;
+        default = 15002;
         description = "Spark Connect gRPC bind port.";
       };
     };

--- a/modules/services/velocity/default.nix
+++ b/modules/services/velocity/default.nix
@@ -270,7 +270,7 @@ in {
 
     port = mkOption {
       type = types.port;
-      default = 25_565;
+      default = 25565;
       description = "TCP port Velocity binds for Java clients.";
     };
 
@@ -442,7 +442,7 @@ in {
 
       readTimeout = mkOption {
         type = types.ints.positive;
-        default = 30_000;
+        default = 30000;
         description = "Backend read timeout in milliseconds.";
       };
 
@@ -542,7 +542,7 @@ in {
 
       port = mkOption {
         type = types.port;
-        default = 25_565;
+        default = 25565;
         description = "UDP port for query responses.";
       };
 


### PR DESCRIPTION
## Problem

`modules/services/geyser/default.nix` set `default = 25_565;`. Underscore digit separators in numeric literals are a Determinate Nix / patched-nix extension, not standard Nix syntax. Stock Nix lexes `25_565` as `25` followed by the identifier `_565`, so any downstream flake that imports this module tree and forces the option fails:

```
error: undefined variable '_565'
       at modules/services/geyser/default.nix:159:21
```

CI passes because it evaluates with the patched Nix; consumers on stock Nix (e.g. `linux-ix` on hari-compute-1, which follows `index/nixpkgs` and forces the module set) cannot evaluate anything that forces this module.

## Fix

The reported literal is not the only one. This strips underscore separators from every genuine numeric literal in the **consumer-facing `modules/` tree** - the portability boundary a downstream stock-Nix evaluator actually parses - covering option defaults, forced config values, and examples across 11 files (geyser, velocity, minestom, minecraft + bedrock + voice-chat, spark, observability, inference, ray, darwin/ray).

Deliberate uses of the digit-separator dialect are intentionally left in place, because the repo implements this dialect on purpose (`packages/nix/nix/patches/0014-...accept-underscore-digit-separators...` plus the `rnix` patches under `lib/util/rnix-digit-separators/` that teach alejandra/statix/deadnix to format it). Untouched: the formatter fixtures under `packages/nix/`, the `lib/util/rnix-digit-separators` patches, `tests/`, and in-repo `examples/`/`users/` - all evaluated with the patched Nix, and the fixtures require the separators to test the formatters.

String/comment occurrences of the CUDA package-set identifier `cudaPackages_13_1` are not numeric literals and were left alone.

## Verification

- Reproduced the pre-fix failure: `nix-instantiate --parse modules/services/geyser/default.nix` fails on stock Nix 2.34.8.
- Post-fix: all 50 files under `modules/` parse cleanly with stock Nix 2.34.8 (also the repro version in the issue).

## Note for maintainers

This makes the `modules/` tree stock-Nix parseable, but the rest of the repo still uses the dialect by design. If stock-Nix portability of the whole tree is intended, a CI job evaluating the module set with stock Nix would keep it from regressing.

Fixes #3403

(sent by an AI agent via Claude Code, Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove underscore digit separators from numeric literals across NixOS service modules
> Replaces underscore-separated integer literals (e.g. `25_565`, `19_132`) with plain integers across service modules including geyser, minecraft, velocity, spark, and others. Underscore literals are a Determinate Nix extension and are not valid in standard Nix, so this improves compatibility with upstream Nix evaluators.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10ced92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->