### PR TITLE
nushell: use 0.114 string case commands

### DIFF
--- a/users/andrewgazelka/config/nushell/config.nu
+++ b/users/andrewgazelka/config/nushell/config.nu
@@ -69,7 +69,7 @@ def maybe-unix-time [field: string] {
         return $value
     }
 
-    let lower = ($field | str downcase)
+    let lower = ($field | str lowercase)
     let text = ($value | into string)
 
     if (not ($lower | str contains "time")) or (not ($text =~ '^-?\d+$')) {
@@ -1718,10 +1718,10 @@ def "nu-complete c" [context: string] {
     }
 
     # cwd's own dirs, substring-filtered by the token ourselves (filter is off).
-    let lc = ($token | str downcase)
+    let lc = ($token | str lowercase)
     let local = (
         ls --short-names | where type == dir
-        | where {|row| ($lc | is-empty) or ($row.name | str downcase | str contains $lc) }
+        | where {|row| ($lc | is-empty) or ($row.name | str lowercase | str contains $lc) }
         | each {|row| { value: ($row.name + '/'), description: dir } }
     )
     let local_names = ($local | get value)

--- a/users/andrewgazelka/config/nushell/functions/github.nu
+++ b/users/andrewgazelka/config/nushell/functions/github.nu
@@ -160,17 +160,17 @@ def github-path-is-fresh [path: path, max_age: duration] {
 }
 
 def github-pr-check-token [check: record] {
-    let conclusion = ($check.conclusion? | default "" | str upcase)
+    let conclusion = ($check.conclusion? | default "" | str uppercase)
     if not ($conclusion | is-empty) {
         return $conclusion
     }
 
-    let status = ($check.status? | default "" | str upcase)
+    let status = ($check.status? | default "" | str uppercase)
     if not ($status | is-empty) {
         return $status
     }
 
-    $check.state? | default "" | str upcase
+    $check.state? | default "" | str uppercase
 }
 
 def github-pr-check-state [rollup: list] {

--- a/users/andrewgazelka/config/nushell/functions/utils.nu
+++ b/users/andrewgazelka/config/nushell/functions/utils.nu
@@ -155,7 +155,7 @@ export def prefixes [] {
 export def lowercase-columns [] {
     let input = $in
     let cols = $input | columns
-    let new_cols = $cols | each { |col| $col | str downcase }
+    let new_cols = $cols | each { |col| $col | str lowercase }
     $input | rename ...$new_cols
 }
 


### PR DESCRIPTION
Fixes #3397.\n\nReplaces the obsolete `str upcase` and `str downcase` commands with their Nushell 0.114 names. Verified by parsing the complete functions module with Nushell 0.114 and running `nix run .#lint`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace deprecated `str downcase`/`str upcase` with `str lowercase`/`str uppercase` in nushell config
> Updates nushell config files to use the renamed string case commands introduced in nushell 0.114. Affects `config.nu`, `functions/github.nu`, and `functions/utils.nu`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f49c2eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->