### PR TITLE
zed: disable Tombi table-order warning

### DIFF
--- a/users/andrewgazelka/config/zed/settings.nix
+++ b/users/andrewgazelka/config/zed/settings.nix
@@ -230,6 +230,15 @@
         };
       };
     };
+    tombi = {
+      settings = {
+        lint = {
+          rules = {
+            tables-out-of-order = "off";
+          };
+        };
+      };
+    };
   };
   outline_panel = {
     auto_fold_dirs = true;


### PR DESCRIPTION
Fixes #3407.\n\nSets Tombi’s `lint.rules.tables-out-of-order` severity to `off` through Zed LSP settings, preserving other TOML diagnostics. Verified with `nix run .#lint`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable Tombi `tables-out-of-order` lint rule in Zed settings
> Sets `tables-out-of-order` to `"off"` in the Tombi linter config in [settings.nix](https://github.com/indexable-inc/index/pull/3408/files#diff-ab09fc7f5bab958641754df125cfcc77298b8edbc57359f398cc3f0b1985b327), suppressing warnings about TOML table ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c61cec0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->