### PR TITLE
mcp: bundle embed, in-process code embeddings (torch/MPS)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1642,10 +1642,6 @@
     # Pygments builds public re-exports through module __getattr__, and several
     # lexer/highlight helpers remain untyped in its partial stubs.
     "mypy-pygments.*".disallow_untyped_calls = false;
-    # embed's inference runtime is bundled on darwin only (torch/MPS), so on a
-    # Linux check env these imports have no source or stubs to resolve.
-    "mypy-sentence_transformers.*".ignore_missing_imports = true;
-    "mypy-huggingface_hub.*".ignore_missing_imports = true;
   };
   strictTypecheck = let
     # All src module package dirs go on MYPYPATH so first-party cross-imports

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -289,6 +289,28 @@
     ''
   );
 
+  # `embed`: Python-native code embeddings (chunk / embed / parquet cache /
+  # similarity search) for semantic clone detection and code search
+  # (index#3417). Pure Python over the bundled numpy + polars; the inference
+  # runtime (torch + sentence-transformers on MPS) is darwin-only and gated in
+  # `darwinExtraPackages`, imported lazily inside the functions that need it.
+  embedPythonSource = builtins.path {
+    name = "ix-mcp-embed-python-source";
+    path = ./src/embed;
+  };
+  embedModule = pkgs.python3.pkgs.toPythonModule (
+    pkgs.runCommand "ix-mcp-embed-python-module"
+    {
+      strictDeps = true;
+      meta.description = "In-process code-embedding battery (torch/MPS) bundled into the ix-mcp interpreter";
+    }
+    ''
+      site="$out/${pkgs.python3.sitePackages}/embed"
+      mkdir -p "$site"
+      cp -r ${embedPythonSource}/embed/. "$site/"
+    ''
+  );
+
   # The `ix_google` package: typed PyO3 bindings for the google-gmail and
   # google-calendar Rust crates, baked into the pinned interpreter as a
   # complement to the (untyped) `google_auth` helper. Notebook users pick
@@ -1013,6 +1035,21 @@
       vmkitModule
       imessageModule
       ghosttyModule
+      # `embed` (code embeddings, index#3417) infers on torch/MPS, so its
+      # heavyweight runtime joins the interpreter only on Darwin; the module
+      # itself is bundled everywhere and imports these lazily with a clear
+      # error where they are absent. `torch` substitutes from the official
+      # cache. `sentence-transformers` is overridden because the stock package
+      # folds every optional-dependencies extra into its nativeCheckInputs and
+      # the `audio` extra carries phonemizer -> dlinfo, which this nixpkgs
+      # marks broken, refusing evaluation outright. The extras are test-only:
+      # drop the test run rather than allowlist a broken leaf; runtime
+      # dependencies are untouched.
+      ps.torch
+      (ps.sentence-transformers.overridePythonAttrs (_: {
+        doCheck = false;
+        nativeCheckInputs = [];
+      }))
     ];
 
   # htpy: build HTML in plain Python (`div(class_="x")[ ... ]`), auto-escaping
@@ -1392,6 +1429,7 @@
       scipqlModule
       flecsQueryModule
       fsearchModule
+      embedModule
       privateSessionModule
       googleAuthModule
       ixGoogleModule
@@ -1588,6 +1626,7 @@
     "mesh"
     "fabric"
     "claude_history"
+    "embed"
   ];
   # The `ix_notebook_mcp` server package is migrated file-by-file (the package
   # as a whole is still ~200 errors from strict-clean, index#1902): each file
@@ -1603,6 +1642,10 @@
     # Pygments builds public re-exports through module __getattr__, and several
     # lexer/highlight helpers remain untyped in its partial stubs.
     "mypy-pygments.*".disallow_untyped_calls = false;
+    # embed's inference runtime is bundled on darwin only (torch/MPS), so on a
+    # Linux check env these imports have no source or stubs to resolve.
+    "mypy-sentence_transformers.*".ignore_missing_imports = true;
+    "mypy-huggingface_hub.*".ignore_missing_imports = true;
   };
   strictTypecheck = let
     # All src module package dirs go on MYPYPATH so first-party cross-imports
@@ -1648,6 +1691,9 @@
     '';
 
   tuiBundled = importTest "tui" "import tui; print('tui-ok', tui.__version__)";
+  # `embed` imports everywhere (its torch/MPS runtime loads lazily inside the
+  # embedding calls), so the import test runs on Linux too.
+  embedBundled = importTest "embed" "import embed; print('embed-ok', embed.__version__)";
   # htpy must import and auto-escape: a `<` in a text node comes out as `&lt;`.
   htpyBundled = importTest "htpy" "import htpy; print('htpy-ok' if '&lt;' in str(htpy.div['<']) else 'htpy-bad')";
   searchBundled = importTest "search" "import search; print('search-ok', search.__version__)";
@@ -5837,6 +5883,7 @@ in
               searchBundled
               astlogBundled
               fsearchBundled
+              embedBundled
               dataLibsBundled
               gmailLibsBundled
               exaBundled

--- a/packages/mcp/ix_notebook_mcp/registry.py
+++ b/packages/mcp/ix_notebook_mcp/registry.py
@@ -142,6 +142,16 @@ MODULES: tuple[Module, ...] = (
         ),
     ),
     Module(
+        "embed",
+        "code embeddings in-process (Qwen3-Embedding-0.6B on torch/MPS): `embed.ensure(root)` "
+        "chunks a repo at function level, embeds only content-hash misses into a per-model-rev "
+        "parquet cache (~/.cache/index-embed), and returns the full frame; "
+        "`embed.similar(text_or_path, k=)` is semantic code search and `embed.pairs(k=)` mines "
+        "near-duplicate function pairs over the cache; `embed.texts(list[str])` is the raw "
+        "[n,1024] encoder. Calls are synchronous and compute-bound: run the long ones as "
+        "`await asyncio.to_thread(embed.ensure, '.')` (inference is macOS only)",
+    ),
+    Module(
         "claude_history",
         "find past local Claude Code sessions by content: `await claude_history.search(pattern)` "
         "greps every transcript under ~/.claude/projects and returns one polars row per matching "

--- a/packages/mcp/src/embed/embed/__init__.py
+++ b/packages/mcp/src/embed/embed/__init__.py
@@ -1,0 +1,338 @@
+"""Code embeddings for the ix-mcp kernel: chunk, embed, cache, search.
+
+Bundled like ``view``/``nix``/``fsearch`` so every session can ``import embed``
+with no setup. Inference is Python-native and in-process: a resident
+``SentenceTransformer`` (Qwen/Qwen3-Embedding-0.6B) on torch/MPS fp16, measured
+at ~12.3k tok/s on an M5 Max -- roughly 2x a llama.cpp Metal server pipeline on
+the same corpus, with 0.9998 mean-cosine agreement (index#3417). No server
+process, no HTTP seam.
+
+* :func:`texts` -- the raw encoder: ``list[str]`` in, unit-normalized
+  ``float32[n, 1024]`` out. The model lazy-loads on first call (~17 s, one
+  download on the very first use) and stays resident.
+* :func:`ensure` -- chunk a repo at function level, embed only the chunks whose
+  content hash misses the parquet cache, upsert, and return the full frame.
+  The content-hash cache is the incrementality story: a typical edit re-embeds
+  dozens of functions (seconds), never the corpus (~2.5 min cold).
+* :func:`similar` -- semantic code search: the cached chunks nearest a query
+  text (or a file's contents), one normalized GEMM over the cache matrix.
+* :func:`pairs` -- near-duplicate mining: the top all-pairs cosine hits, the
+  candidate band for type-4 (semantic) clone review.
+
+The cache is one parquet file per model revision at
+``~/.cache/index-embed/<model_rev>.parquet`` (columns ``hash``, ``path``,
+``embedding: array[f32, 1024]``); a model bump changes the revision and so
+starts a fresh file, never mixing vector spaces.
+
+Every call here is synchronous and compute-bound; from a kernel cell run the
+long ones in a thread so the shared event loop stays free::
+
+    frame = await asyncio.to_thread(embed.ensure, ".")
+    hits = await asyncio.to_thread(embed.similar, "capped exponential backoff")
+
+The chunker is a deliberate regex port of the measured prototype (fn/def
+extraction for Rust and Python, a ``// <path> :: <signature>`` header line,
+8000-char truncation, blake2b-16 content hash). The tree-sitter chunker over
+``clone_hash::significant_nodes`` supersedes it (index#3423).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+    from sentence_transformers import SentenceTransformer
+
+__all__ = ["EmbedError", "ensure", "pairs", "similar", "texts"]
+
+__version__ = "0.1.0"
+
+MODEL_ID = "Qwen/Qwen3-Embedding-0.6B"
+DIM = 1024
+MAX_SEQ_LENGTH = 2048
+BATCH_SIZE = 32
+# ~2k tokens: chunks past this are truncated so one pathological function
+# cannot dominate batch latency. Matches the measured prototype.
+MAX_CHUNK_CHARS = 8000
+CACHE_DIR = Path("~/.cache/index-embed")
+
+
+class EmbedError(Exception):
+    """The embedder cannot proceed (missing dependency, empty cache, bad input)."""
+
+
+_model: SentenceTransformer | None = None
+
+
+def _load_model() -> SentenceTransformer:
+    """The resident model, loaded on first use and kept for the session."""
+    global _model
+    if _model is not None:
+        return _model
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError as exc:
+        raise EmbedError(
+            "embed: `sentence-transformers` (with torch) is not importable; it is "
+            "bundled into the ix-mcp interpreter on macOS only (inference runs on "
+            "torch/MPS). On this interpreter, `pip install sentence-transformers` "
+            "or use a darwin session."
+        ) from exc
+    model = SentenceTransformer(
+        MODEL_ID,
+        device="mps",
+        model_kwargs={"torch_dtype": "float16"},
+        # sentence-transformers 5.4 renamed tokenizer_kwargs to processor_kwargs.
+        processor_kwargs={"model_max_length": MAX_SEQ_LENGTH},
+    )
+    model.max_seq_length = MAX_SEQ_LENGTH
+    _model = model
+    return model
+
+
+def _model_rev() -> str:
+    """The model weights identity: the HF commit the local snapshot resolved to.
+
+    Read from the hub cache's ``refs/main`` file; the first call on a machine
+    without the snapshot loads the model (which downloads it and writes the
+    ref). Names the cache file, so two revisions never share vectors.
+    """
+    try:
+        from huggingface_hub import constants
+    except ImportError as exc:
+        raise EmbedError(
+            "embed: `huggingface_hub` is not importable; it ships with "
+            "sentence-transformers, so this interpreter lacks the embed "
+            "dependencies (bundled on macOS only)."
+        ) from exc
+    ref = Path(constants.HF_HUB_CACHE) / f"models--{MODEL_ID.replace('/', '--')}" / "refs" / "main"
+    if not ref.is_file():
+        _load_model()
+    if not ref.is_file():
+        raise EmbedError(f"embed: model snapshot loaded but no ref file at {ref}")
+    return ref.read_text(encoding="utf-8").strip()
+
+
+def texts(items: list[str]) -> npt.NDArray[np.float32]:
+    """Embed ``items`` into unit-normalized ``float32[n, 1024]`` rows."""
+    model = _load_model()
+    vectors = model.encode(
+        items,
+        batch_size=BATCH_SIZE,
+        show_progress_bar=False,
+        normalize_embeddings=True,
+    )
+    return np.asarray(vectors, dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Chunking (regex prototype port; see the module docstring for the successor)
+
+_SKIP_DIRS = {".git", "target", "node_modules", ".direnv", "result", "vendor"}
+_RUST_FN = re.compile(
+    r'^\s*(?:pub(?:\([^)]*\))?\s+)?(?:const\s+|async\s+|unsafe\s+|extern\s+"[^"]*"\s+)*fn\s+\w+',
+    re.MULTILINE,
+)
+_PY_DEF = re.compile(r"^(?:async\s+)?def\s+\w+", re.MULTILINE)
+# A chunk keeps at least this many newlines (5 lines): shorter bodies are
+# mostly signature noise and embed poorly.
+_MIN_BODY_NEWLINES = 4
+# Brace-matching scan cap: a pathological unclosed brace stops here instead of
+# scanning the whole file per match.
+_BRACE_SCAN_CAP = 200_000
+
+
+def _rust_body(src: str, start: int) -> str | None:
+    """The braced body from a ``fn`` match, or None for a bodyless declaration."""
+    brace = src.find("{", start)
+    if brace == -1:
+        return None
+    if ";" in src[start:brace]:  # a trait/extern declaration, not a definition
+        return None
+    depth = 0
+    for i in range(brace, min(len(src), brace + _BRACE_SCAN_CAP)):
+        char = src[i]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    return None
+
+
+def _py_body(src: str, start: int) -> str:
+    """The indented suite from a ``def`` match, ended by the first dedent."""
+    lines = src[start:].split("\n")
+    head_indent = len(lines[0]) - len(lines[0].lstrip())
+    body = [lines[0]]
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped and (len(line) - len(stripped)) <= head_indent and not stripped.startswith(("#", ")", "]")):
+            break
+        body.append(line)
+    return "\n".join(body).rstrip()
+
+
+def _chunks(root: str) -> pl.DataFrame:
+    """Function-level chunks under ``root``: one row per unique content hash.
+
+    Columns ``hash`` (blake2b-16 hex of the final text), ``path`` (relative to
+    ``root``), ``text`` (a ``// <path> :: <signature>`` header line plus the
+    body, truncated to :data:`MAX_CHUNK_CHARS`).
+    """
+    base = Path(root).expanduser()
+    if not base.is_dir():
+        raise EmbedError(f"embed: root {str(base)!r} is not a directory")
+    hashes: list[str] = []
+    paths: list[str] = []
+    chunk_texts: list[str] = []
+    seen: set[str] = set()
+    for dirpath, dirnames, filenames in base.walk():
+        dirnames[:] = sorted(d for d in dirnames if d not in _SKIP_DIRS)
+        for fname in sorted(filenames):
+            if fname.endswith(".rs"):
+                rust = True
+            elif fname.endswith(".py"):
+                rust = False
+            else:
+                continue
+            fpath = dirpath / fname
+            try:
+                src = fpath.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            rel = str(fpath.relative_to(base))
+            matcher = _RUST_FN if rust else _PY_DEF
+            for match in matcher.finditer(src):
+                body = _rust_body(src, match.start()) if rust else _py_body(src, match.start())
+                if body is None or body.count("\n") < _MIN_BODY_NEWLINES:
+                    continue
+                signature = body.split("\n", 1)[0].strip()
+                chunk = (f"// {rel} :: {signature}\n" + body)[:MAX_CHUNK_CHARS]
+                digest = hashlib.blake2b(chunk.encode(), digest_size=16).hexdigest()
+                if digest in seen:
+                    continue
+                seen.add(digest)
+                hashes.append(digest)
+                paths.append(rel)
+                chunk_texts.append(chunk)
+    return pl.DataFrame({"hash": hashes, "path": paths, "text": chunk_texts})
+
+
+# ---------------------------------------------------------------------------
+# Cache (one parquet file per model revision)
+
+
+def _cache_path() -> Path:
+    return CACHE_DIR.expanduser() / f"{_model_rev()}.parquet"
+
+
+def _cache_schema() -> dict[str, pl.DataType]:
+    return {"hash": pl.Utf8(), "path": pl.Utf8(), "embedding": pl.Array(pl.Float32, DIM)}
+
+
+def _read_cache() -> pl.DataFrame:
+    path = _cache_path()
+    if path.is_file():
+        return pl.read_parquet(path)
+    return pl.DataFrame(schema=_cache_schema())
+
+
+def _matrix(cache: pl.DataFrame) -> npt.NDArray[np.float32]:
+    """The cache's embedding column as a dense ``float32[n, 1024]`` matrix.
+
+    Rows are stored unit-normalized (``texts`` normalizes at encode time), so a
+    plain GEMM over this matrix IS cosine similarity.
+    """
+    return cache.get_column("embedding").to_numpy().astype(np.float32, copy=False)
+
+
+def ensure(root: str = ".") -> pl.DataFrame:
+    """Chunk ``root``, embed the cache misses, upsert, return the full frame.
+
+    The anti-join on content hash keeps repeat runs off the GPU entirely; only
+    new or edited functions embed. Returns one row per unique chunk under
+    ``root`` with columns ``hash``, ``path``, ``text``, ``embedding``.
+    """
+    chunk_frame = _chunks(root)
+    cache = _read_cache()
+    misses = chunk_frame.join(cache, on="hash", how="anti")
+    if misses.height:
+        vectors = texts(misses.get_column("text").to_list())
+        fresh = misses.select("hash", "path").with_columns(
+            pl.Series("embedding", vectors, dtype=pl.Array(pl.Float32, DIM))
+        )
+        cache = pl.concat([cache, fresh]).unique(subset="hash", keep="last")
+        target = _cache_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        staging = target.with_suffix(".parquet.tmp")
+        cache.write_parquet(staging)
+        staging.replace(target)
+    return chunk_frame.join(cache.select("hash", "embedding"), on="hash", how="inner")
+
+
+# ---------------------------------------------------------------------------
+# Query (numpy is the vector database at this corpus size)
+
+
+def similar(text_or_path: str, k: int = 10) -> pl.DataFrame:
+    """The ``k`` cached chunks most similar to a query text (or a file's contents).
+
+    Returns ``hash`` / ``path`` / ``score`` sorted by descending cosine.
+    """
+    query = text_or_path
+    if "\n" not in query and len(query) < 1024:
+        candidate = Path(query).expanduser()
+        try:
+            if candidate.is_file():
+                query = candidate.read_text(encoding="utf-8")
+        except OSError:
+            pass
+    cache = _read_cache()
+    if cache.height == 0:
+        raise EmbedError("embed: the cache is empty; run embed.ensure(root) first")
+    vector = texts([query[:MAX_CHUNK_CHARS]])[0]
+    scores = _matrix(cache) @ vector
+    return (
+        cache.select("hash", "path")
+        .with_columns(pl.Series("score", scores))
+        .sort("score", descending=True)
+        .head(k)
+    )
+
+
+def pairs(k: int = 10) -> pl.DataFrame:
+    """The ``k`` most similar distinct cached chunk pairs (type-4 candidates).
+
+    Returns ``path_a`` / ``path_b`` / ``hash_a`` / ``hash_b`` / ``score``
+    sorted by descending cosine over the strict upper triangle.
+    """
+    cache = _read_cache()
+    if cache.height < 2:
+        raise EmbedError("embed: fewer than two cached chunks; run embed.ensure(root) first")
+    matrix = _matrix(cache)
+    sims = matrix @ matrix.T
+    rows, cols = np.triu_indices(matrix.shape[0], k=1)
+    scores = sims[rows, cols]
+    top_k = min(k, scores.shape[0])
+    top = np.argpartition(-scores, top_k - 1)[:top_k]
+    top = top[np.argsort(-scores[top])]
+    paths = cache.get_column("path")
+    hashes = cache.get_column("hash")
+    return pl.DataFrame(
+        {
+            "path_a": [paths[int(rows[i])] for i in top],
+            "path_b": [paths[int(cols[i])] for i in top],
+            "hash_a": [hashes[int(rows[i])] for i in top],
+            "hash_b": [hashes[int(cols[i])] for i in top],
+            "score": scores[top],
+        }
+    )

--- a/packages/mcp/src/embed/embed/__init__.py
+++ b/packages/mcp/src/embed/embed/__init__.py
@@ -48,7 +48,7 @@ import polars as pl
 
 if TYPE_CHECKING:
     import numpy.typing as npt
-    from sentence_transformers import SentenceTransformer
+    from sentence_transformers import SentenceTransformer  # type: ignore[import-not-found]  # darwin-only optional dep (index#3417); zuban ignores per-module config
 
 __all__ = ["EmbedError", "ensure", "pairs", "similar", "texts"]
 
@@ -77,7 +77,7 @@ def _load_model() -> SentenceTransformer:
     if _model is not None:
         return _model
     try:
-        from sentence_transformers import SentenceTransformer
+        from sentence_transformers import SentenceTransformer  # type: ignore[import-not-found]  # darwin-only optional dep (index#3417); zuban ignores per-module config
     except ImportError as exc:
         raise EmbedError(
             "embed: `sentence-transformers` (with torch) is not importable; it is "
@@ -105,7 +105,7 @@ def _model_rev() -> str:
     ref). Names the cache file, so two revisions never share vectors.
     """
     try:
-        from huggingface_hub import constants
+        from huggingface_hub import constants  # type: ignore[import-not-found]  # darwin-only optional dep (index#3417); zuban ignores per-module config
     except ImportError as exc:
         raise EmbedError(
             "embed: `huggingface_hub` is not importable; it ships with "


### PR DESCRIPTION
Bundles the embed kernel battery with the two infra fixes that main flake-check needs (they were mutually deadlocked with each other, so they land together).

## Embed (Closes #3417)
In-process code embeddings for the kernel via torch/MPS + sentence-transformers (Qwen3-Embedding-0.6B). Bakeoff verdict: Python-native inference beat the llama.cpp Metal pipeline ~2x on bulk prefill.

## Infra unbreak
- **checks: run nushell-config against the repo nushell pin (Closes #3440).** The check validated the config with nixpkgs `pkgs.nushell` (0.113.1) while the deployed shell is the repo fork 0.114.0; #3406 correctly moved the config to 0.114 names (`str lowercase`), which 0.113 rejects. #3406 merged red during the org billing lock, so the gate never fired. Now points at `repoPackages.nushell`.
- **astlog: retire prefer-digit-grouping (Closes #3422).** Stock Nix rejects the underscore-digit dialect, so consumer flakes could not parse; the rule flagged 139 tree-wide literals. Supersedes #3425.

Verified: nushell-config-check drv now pins nu-0.114.0 and builds on x86_64-linux; 0.114 gives zero ide-check diagnostics and passes nu-check + all tests on the current config.

(opened by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle an in-process code embedding module into the MCP server (torch/MPS)
> - Adds a new `embed` Python package ([`__init__.py`](https://github.com/indexable-inc/index/pull/3427/files#diff-3d91fcc0d1048637d0f430e0ec296cfebba8950eaf4dfd86f3d882b6ca1bf9c8)) that provides function-level code chunking (Rust + Python via regex), incremental parquet-backed embedding cache, semantic search, and near-duplicate pair mining.
> - Model loading uses `sentence-transformers` with MPS (Apple Silicon) and is lazy — the heavy import is deferred to first call, so `import embed` works on Linux even without GPU deps installed.
> - Bundles `torch` and `sentence-transformers` (tests disabled) into the Darwin interpreter environment via [`default.nix`](https://github.com/indexable-inc/index/pull/3427/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db); the `embed` module is registered in the MCP catalog via [`registry.py`](https://github.com/indexable-inc/index/pull/3427/files#diff-92f567578e1217b8207dbbd21af1cdee4978728a8ca9e774cd65ed17170d2ae5).
> - Adds a build-time import smoke test (`embedBundled`) to confirm `embed.__version__` is accessible.
> - Risk: embedding calls are synchronous and compute-bound; the registry doc recommends wrapping in `asyncio.to_thread` but does not enforce it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e1c86e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->