### PR TITLE
checks: run nushell-config under the fork nushell

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1506,7 +1506,11 @@
               nativeBuildInputs = [
                 pkgs.binutils
                 pkgs.jq
-                pkgs.nushell
+                # The fork package, not pkgs.nushell: the deployed shell that
+                # executes this config is newer than the repo's nixpkgs pin
+                # (0.114 names vs 0.113.1), so the check must run a
+                # repo-controlled interpreter that tracks upstream (#3428).
+                repoPackages.nushell
               ];
             }
             ''

--- a/users/andrewgazelka/config/nushell/functions/infra.nu
+++ b/users/andrewgazelka/config/nushell/functions/infra.nu
@@ -1,5 +1,7 @@
 const REMOTE_STATUS_PATH = path self ./infra/status.nu
-const PROBE_OUTPUT_BLOCKS = 1_024
+# ulimit -f counts 512-byte POSIX blocks, so 2_048 blocks caps probe output
+# at exactly PROBE_OUTPUT_LIMIT; `_infra capped` relies on that equality.
+const PROBE_OUTPUT_BLOCKS = 2_048
 const PROBE_OUTPUT_LIMIT = 1MiB
 const REMOTE_WRAPPER = '
 /run/current-system/sw/bin/timeout --signal=TERM --kill-after=1s "$1" nu --no-config-file /dev/stdin


### PR DESCRIPTION
Fixes #3428.

The `nushell-config` ciCheck has been red on main since #3404, breaking `flake-check` for every open PR. Two independent root causes, both fixed here:

1. **Interpreter skew** (introduced by #3406, merged with flake-check red): the check ran `pkgs.nushell` from the repo nixpkgs pin (0.113.1), which lacks the 0.114 `str lowercase`/`str uppercase` names the config now uses. The check now runs `repoPackages.nushell` (the repo's fork package, 0.114.0), the same interpreter family actually deployed, so the check tracks the interpreter the config is written for.

2. **Unreachable probe-output guard** (introduced by #3404, itself merged with flake-check red, so `test_infra.nu` never passed in CI): `ulimit -f` counts 512-byte POSIX blocks, so the wrapper's 1_024-block cap truncated probe output at 512KiB while `_infra capped` compared against `PROBE_OUTPUT_LIMIT = 1MiB`. The guard could never fire; the "large" host case parsed truncated JSON, reported `reachable=true`, and the test's `assert not $rows.5.reachable` failed. Now 2_048 blocks, so the cap equals the limit.

Validation: all three `tests/test_*.nu` pass under the fork nu on vin-compute-1, and `ciChecks.x86_64-linux.nushell-config` builds green from this branch (build in progress at PR update time, will confirm before merge).

sent by an AI agent via Claude Code