### PR TITLE
ci: make reusable jobs runner-selectable

### DIFF
--- a/.github/actions/ci-budget/test_ci_policy.py
+++ b/.github/actions/ci-budget/test_ci_policy.py
@@ -57,10 +57,22 @@ class PolicyTests(unittest.TestCase):
                 assert "repository: ${{ job.workflow_repository }}" in source
                 assert "ref: ${{ job.workflow_sha }}" in source
                 assert "uses: ./.ci-budget-owner/.github/actions/ci-budget" in source
+                assert "runner-label:" in source
+                assert "default: ubuntu-latest" in source
+                assert "runs-on: ${{ inputs.runner-label }}" in source
                 assert (
                     "uses: indexable-inc/index/.github/actions/ci-budget@main"
                     not in source
                 )
+
+    def test_update_workflow_accepts_a_nix_owned_runner(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[2] / "workflows" / "update-flake-lock.yml"
+        ).read_text()
+        assert "runner-label:" in workflow
+        assert "nix-preinstalled:" in workflow
+        assert "runs-on: ${{ inputs.runner-label || 'ubuntu-latest' }}" in workflow
+        assert "if: ${{ !inputs.nix-preinstalled }}" in workflow
 
     def test_owner_policy_classifies_repository_data(self) -> None:
         decision = decide(

--- a/.github/workflows/ci-budget-read-only.yml
+++ b/.github/workflows/ci-budget-read-only.yml
@@ -19,6 +19,10 @@ on:
         description: Push base commit that bounds a main-branch change
         type: string
         default: ""
+      runner-label:
+        description: Runner label for the policy job
+        type: string
+        default: ubuntu-latest
     outputs:
       big_change:
         description: Whether the extended CI budget applies
@@ -44,7 +48,7 @@ on:
 
 jobs:
   classify:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-label }}
     timeout-minutes: 5
     permissions:
       actions: read

--- a/.github/workflows/ci-budget.yml
+++ b/.github/workflows/ci-budget.yml
@@ -19,6 +19,10 @@ on:
         description: Push base commit that bounds a main-branch change
         type: string
         default: ""
+      runner-label:
+        description: Runner label for the policy job
+        type: string
+        default: ubuntu-latest
     outputs:
       big_change:
         description: Whether the extended CI budget applies
@@ -44,7 +48,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-label }}
     timeout-minutes: 5
     permissions:
       actions: read

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -23,6 +23,14 @@ on:
         description: "Client id of a GitHub App (contents + pull-requests write) that authors the bump PR; empty falls back to GITHUB_TOKEN, whose PRs never get pull_request CI on private repos."
         type: string
         default: ""
+      runner-label:
+        description: Runner label for the update job
+        type: string
+        default: ubuntu-latest
+      nix-preinstalled:
+        description: Whether the selected runner already provides Nix
+        type: boolean
+        default: false
       escalate-after-hours:
         description: "Hours the rolling bump PR may stay failing before the escalate job alerts; see the escalate job below."
         type: number
@@ -46,7 +54,11 @@ permissions:
 
 jobs:
   update-flake-lock:
-    runs-on: ubuntu-latest
+    # Schedule/dispatch have no workflow_call inputs, so retain the hosted
+    # default for index itself and for callers that have not opted into a
+    # Nix-owned runner profile.
+    runs-on: ${{ inputs.runner-label || 'ubuntu-latest' }}
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write
@@ -63,6 +75,7 @@ jobs:
       # #2064 introduced the local action). Referencing the action by repo
       # resolves it from index@main regardless of which repo called the job.
       - name: Install Determinate Nix
+        if: ${{ !inputs.nix-preinstalled }}
         uses: indexable-inc/index/.github/actions/install-nix@main
 
       # Underscore digit separators require the patched client in index and in


### PR DESCRIPTION
This lets reusable CI-budget and flake-update workflows accept a caller-selected runner label. Callers whose runner profile already owns Nix can also skip the hosted Nix installer, while existing callers retain hosted-compatible defaults.

Validation:
- `python3 test_ci_policy.py`
- `actionlint` on all three changed workflows, excluding its known unsupported `job.workflow_repository` and `job.workflow_sha` context diagnostics

The repository-wide lint currently reaches 139 pre-existing digit-grouping findings outside this diff.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make reusable CI workflows runner-selectable via `runner-label` input
> - Adds a `runner-label` string input (default `ubuntu-latest`) to the reusable workflows [`ci-budget-read-only.yml`](https://github.com/indexable-inc/index/pull/3439/files#diff-474af1fa7d93a51cab405079d5789879f1f7ba2d67735feff8a75978f5a876e1), [`ci-budget.yml`](https://github.com/indexable-inc/index/pull/3439/files#diff-72e11fc346031eaedff7be6aff257f69614db08532a27e188a650cbc1ff543e2), and [`update-flake-lock.yml`](https://github.com/indexable-inc/index/pull/3439/files#diff-3dd117f927104ee8bdf13935f130eeb0ee70fad2c72077739b766ba1d142dc43), allowing callers to target a custom runner.
> - Adds a `nix-preinstalled` boolean input to [`update-flake-lock.yml`](https://github.com/indexable-inc/index/pull/3439/files#diff-3dd117f927104ee8bdf13935f130eeb0ee70fad2c72077739b766ba1d142dc43) that skips the Nix installation step when the runner already has Nix; also adds a 15-minute job timeout.
> - Extends CI policy tests in [`test_ci_policy.py`](https://github.com/indexable-inc/index/pull/3439/files#diff-a9c433a70b28356526deca2041d824115d393894e0199a20d474cf73707ced8a) to assert reusable workflows expose the `runner-label` input and use it for `runs-on`, and that `update-flake-lock` supports both new inputs correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51c6a2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->