### PR TITLE
fleet: drop buildOn/buildVm; all switches go through `ix up`

### DIFF
--- a/doc/ix-fleet/overview.md
+++ b/doc/ix-fleet/overview.md
@@ -77,13 +77,12 @@ each node key matches its `name`; and that every `dependsOn` names a real node.
   false), an optional `updateStrategy` (`UpdateStrategy`: `maxUnavailable`,
   int >= 1), and the lists/maps `tags`, `groups`, `env`, `secrets`,
   `l7ProxyPorts`, `dependsOn`, `healthChecks` (name -> `HealthCheck`).
-- **`SwitchSpec`** (`:44`): `target`, `buildOn` (`auto`|`local`|`remote`,
-  default `auto`), optional `buildVm`, `sourceInstallable`, `overrideInputs`.
+- **`SwitchSpec`**: `sourceInstallable`, `overrideInputs`.
   `sourceInstallable` defaults to the bare node name `.#<node>` (not
   `.#<node>-system`): `mkFleet` exposes a `nixosConfigurations.<node>` output
   (bare external name -> the node's system) so `ix up .#<node>` resolves it, and
-  the simple attr lets the native multi-VM `ix up .#a .#b --build-vm <builder>`
-  derive each VM name. The `<node>-system` package stays as a build alias. Merge
+  the simple attr lets the native multi-VM `ix up .#a .#b` derive each VM
+  name. The `<node>-system` package stays as a build alias. Merge
   the fleet's `nixosConfigurations` into your flake's top-level
   `nixosConfigurations` (see `examples/nixos/switch-multi/flake.nix` for a
   direct `ix up` flake and `examples/dev/fleet/default.nix` for the mkDev
@@ -114,9 +113,7 @@ uses. A node maps to an ix branch (`ix_sdk.BranchInfo`/`BranchStatus`:
   `ix image push-manifest --locator <out>/locator.bin <out>/manifest.cas
   <destination> --region <region>` (`push_replacement_image`, `:338`); the CLI
   prints the pushed reference on stdout.
-- snapshot: `client().snapshot(name=...)` (`snapshot_node`, `:423`).
-- in-place switch: `client().switch_system(name, target, build_on)`
-  (`switch_node`, `:430`).
+- snapshot: `client().snapshot(name=...)` (`snapshot_node`).
 - east-west groups: `client().create_group(...)` / `add_group_member(...)`,
   idempotent on `ix_sdk.IxConflictError` (`ensure_group` `:461`,
   `ensure_node_groups` `:472`).
@@ -156,9 +153,10 @@ are what `switch` is for.
 - **`switch` batches in-process through the native multi-VM `ix up`.**
   `cmd_switch` walks `dependency_batches` layers in order (so `dependsOn` still
   gates the switch) and, within each layer, groups the batchable nodes by
-  `(buildVm, overrideInputs)` and runs one `ix up .#a .#b --build-vm <builder>`
-  per group (`switch_nodes_from_source`); the platform builds every closure on
-  the one warm builder and activates each on its own VM. Each group's VMs are
+  `(region, overrideInputs)` and runs one `ix up .#a .#b` per group
+  (`switch_nodes_from_source`); the platform builds every closure on the
+  tenant's managed builder VM (`ix-builder-<region>`, created on demand) and
+  activates each on its own VM. Each group's VMs are
   pre-created with their full fleet config and snapshotted first
   (`switch_group_workflow`), then the batch only switches existing VMs. Groups
   and single-node fallbacks within a layer run concurrently via `asyncio.gather`.
@@ -170,13 +168,11 @@ are what `switch` is for.
   -> ensure groups -> snapshot (if `node.snapshot` and not `--no-snapshot` and
   the node was not just created) -> switch -> health.
 - **Switch picks a path per node.** A node is batched into the native multi-VM
-  `ix up` only when it builds remotely, names a `buildVm`, and its installable is
-  exactly `.#<node-name>` (`is_batchable_switch`); the multi `ix up` derives each
-  VM name from that attr and rejects `--name`. Anything else falls back to the
-  single-target `ix up <installable> --name <node>` (`switch_node_from_source`,
-  `buildOn == "remote"` without a build VM or with a custom installable) or the
-  SDK `switch_system` (`switch_node`, `buildOn` `local`/`auto`), bounded by
-  `SWITCH_TIMEOUT_SECS = 1800`. Both source paths retry a transient
+  `ix up` only when its installable is exactly `.#<node-name>`
+  (`is_batchable_switch`); the multi `ix up` derives each VM name from that
+  attr and rejects `--name`. A custom installable falls back to the
+  single-target `ix up <installable> --name <node>`
+  (`switch_node_from_source`). Both paths retry a transient
   `stream framing error` up to `MAX_SWITCH_RETRIES` (`run_source_switch`).
 
 ## Health checks (`__init__.py:540-624`)

--- a/doc/ix/fleet.md
+++ b/doc/ix/fleet.md
@@ -99,8 +99,8 @@ deployment key: declare them in a node module as `ix.healthChecks.<name>`
 
 Rendered plan (pydantic, `__init__.py:34-146`): a `FleetPlan` is `order`, `nodes`
 (name -> `FleetNode`), `secrets`. A `FleetNode` carries `name`, `system`,
-`switch` (`SwitchSpec`: `target`, `buildOn` auto|local|remote, `buildVm`,
-`sourceInstallable`, `overrideInputs`), `bootstrapImage`, `replacementImage`,
+`switch` (`SwitchSpec`: `sourceInstallable`, `overrideInputs`),
+`bootstrapImage`, `replacementImage`,
 `region`, `ipv4`, `snapshot`, `recreateOnUp`, `tags`, `groups`, `env`,
 `l7ProxyPorts`, `dependsOn`, `healthChecks`, `secrets`, `noDefaultSecrets`,
 `updateStrategy`.

--- a/doc/ix/lifecycle.md
+++ b/doc/ix/lifecycle.md
@@ -37,8 +37,9 @@ back, exits with the command's exit code, and leaves the VM running.
 creates the VM from `--base` if it does not exist yet, then activates that system
 in place. Re-running converges the VM to the current config: the same contract as
 `nixos-rebuild switch`, with no separate switch command for an existing VM.
-Default target is `.`;
-several targets in one run (for example `.#web .#worker`) need `--build-vm`.
+Default target is `.`; a run may name several targets (for example
+`.#web .#worker`). Source builds run on the tenant's managed builder VM
+(`ix-builder-<region>`, created on demand).
 
 ## Recreate vs switch: the key distinction
 

--- a/examples/nixos/switch-multi/README.md
+++ b/examples/nixos/switch-multi/README.md
@@ -1,37 +1,34 @@
-<p align="center"><img src="assets/hero.svg" width="720" alt="one builder VM builds three closures that fan out through regional CAS to the web, worker, and edge VMs"></p>
+<p align="center"><img src="assets/hero.svg" width="720" alt="the managed tenant builder builds three closures that fan out through regional CAS to the web, worker, and edge VMs"></p>
 
 # NixOS switch: many VMs, one build VM
 
 How do you rebuild a fleet of NixOS VMs without N cold builds, and without
 routing every closure through your laptop? This example switches three VMs in
-a single command, building every closure on one shared build-time VM: the
-source uploads once, each closure builds on the warm builder, and the
-activations fan out to their VMs through regional CAS. It is the
-colmena-style "build once, push many" loop as a first-class `ix up`.
+a single command. Every closure builds on your tenant's managed builder VM
+(`ix-builder-<region>`, created on demand): the source uploads once, each
+closure builds on the warm builder, and the activations fan out to their VMs
+through regional CAS. It is the colmena-style "build once, push many" loop as
+a first-class `ix up`.
 
 ## Run
 
 ```sh
-# 1. Bring up the build VM once.
-ix up .#builder
-
-# 2. Build all three app VMs on that builder and switch each in place.
-ix up .#web .#worker .#edge --build-vm builder
+ix up .#web .#worker .#edge
 ```
 
-The second command creates `web`, `worker`, and `edge` from `ix/base` if they
-do not exist, builds their closures on `builder`, and activates each on its
-own VM. Re-run it to converge them, the same contract as
-`nixos-rebuild switch`.
+That one command creates `web`, `worker`, and `edge` from `ix/base` if they
+do not exist, builds their closures on the tenant builder (creating it too on
+first use), and activates each on its own VM. Re-run it to converge them, the
+same contract as `nixos-rebuild switch`.
 
 ## Why one build VM
 
-`builder` keeps a warm `/nix/store`, so the first closure pays the full build
-and the rest only build their own delta. The built closures travel builder to
-target through regional CAS, which deduplicates the shared system paths, so
-the bytes on the wire for `worker` and `edge` are a fraction of a full
-closure. You get fleet rebuilds without N cold builds and without routing
-closures through your laptop.
+The builder keeps a warm `/nix/store`, so the first closure pays the full
+build and the rest only build their own delta. The built closures travel
+builder to target through regional CAS, which deduplicates the shared system
+paths, so the bytes on the wire for `worker` and `edge` are a fraction of a
+full closure. You get fleet rebuilds without N cold builds and without
+routing closures through your laptop.
 
 ## The loop
 
@@ -43,19 +40,17 @@ closures through your laptop.
 
 ## Rules
 
-- Multiple targets require `--build-vm`: one build-time VM is what makes this
-  one operation instead of N. The build VM must already exist (step 1).
 - Each target names its own configuration (`.#web`), so `--name` is not used
   with multiple targets.
-- The builder and every target must share a region (CAS chunks are
-  region-scoped). A cross-region target is a typed error, not a silent
-  fallback.
+- Every target must share a region (CAS chunks are region-scoped, and one
+  regional builder serves the batch). A cross-region target is a typed error,
+  not a silent fallback.
 - A failed target is reported on its own; its siblings still switch.
 
 ## Shape
 
 - [`flake.nix`](flake.nix) is the entrypoint; unlike the `mkFleet` examples
-  it exposes raw `nixosConfigurations` (`builder`, `web`, `worker`, `edge`).
+  it exposes raw `nixosConfigurations` (`web`, `worker`, `edge`).
 - [`ix.nix`](ix.nix) builds those systems; each target differs only by its
   sentinel package.
 - [`configuration.nix`](configuration.nix) is the shared NixOS module every
@@ -64,6 +59,6 @@ closures through your laptop.
 
 ## Fork it
 
-Copy this directory, add or rename configurations in [`ix.nix`](ix.nix), and
-point `--build-vm` at your own builder VM. The `index` flake input pulls
-`github:indexable-inc/index` for you; no admin rights are needed.
+Copy this directory and add or rename configurations in [`ix.nix`](ix.nix).
+The `index` flake input pulls `github:indexable-inc/index` for you; no admin
+rights are needed.

--- a/examples/nixos/switch-multi/assets/hero.svg
+++ b/examples/nixos/switch-multi/assets/hero.svg
@@ -20,7 +20,7 @@
   </defs>
 
   <rect class="box" x="20" y="73" width="150" height="56" rx="8"/>
-  <text x="95" y="96" text-anchor="middle" font-size="14" font-weight="600">builder VM</text>
+  <text x="95" y="96" text-anchor="middle" font-size="14" font-weight="600">tenant builder</text>
   <text x="95" y="114" text-anchor="middle" font-size="11" class="muted">warm /nix/store</text>
 
   <line class="edge" x1="170" y1="101" x2="285" y2="101"/>
@@ -42,5 +42,5 @@
   <rect class="box" x="542" y="136" width="150" height="44" rx="8"/>
   <text x="617" y="163" text-anchor="middle" font-size="13" font-weight="600">edge</text>
 
-  <text x="20" y="172" font-size="12" class="muted">ix up .#web .#worker .#edge --build-vm builder</text>
+  <text x="20" y="172" font-size="12" class="muted">ix up .#web .#worker .#edge</text>
 </svg>

--- a/examples/nixos/switch-multi/ix.nix
+++ b/examples/nixos/switch-multi/ix.nix
@@ -20,12 +20,8 @@
     };
 in {
   nixosConfigurations = {
-    # The shared build VM. It only needs Nix (every NixOS system has the
-    # daemon), so it carries no sentinel; `ix up .#builder` brings it up once.
-    builder = mkSystem (_: []);
-
-    # The target VMs. `ix up .#web .#worker .#edge --build-vm builder` builds
-    # all three closures on `builder` and activates each on its own VM.
+    # The target VMs. `ix up .#web .#worker .#edge` builds all three closures
+    # on the tenant's managed builder and activates each on its own VM.
     web = mkSystem (pkgs: [pkgs.ripgrep]);
     worker = mkSystem (pkgs: [pkgs.jq]);
     edge = mkSystem (pkgs: [pkgs.hello]);

--- a/examples/nixos/switch/README.md
+++ b/examples/nixos/switch/README.md
@@ -49,6 +49,6 @@ onto your own VM.
 
 ## Scope
 
-This builds on the target VM itself, the `ix up` default. Building several
-VMs on one shared builder VM is what [`switch-multi`](../switch-multi)
-demonstrates with `--build-vm`.
+This switches a single VM. Switching several VMs in one command, with all
+closures built on the tenant's shared builder, is what
+[`switch-multi`](../switch-multi) demonstrates.

--- a/lib/image/fleet.nix
+++ b/lib/image/fleet.nix
@@ -34,22 +34,16 @@ rendered fleet plan, image attrset, and wrapped CLI app.
 
   moduleList = spec: toList (spec.modules or spec.module or []);
 
-  # Default `switch.sourceInstallable`. The remote path goes through `ix up`,
-  # which rewrites a bare `.#<node>` to `nixosConfigurations.<node>...` and (for
-  # the native multi-VM switch) derives the VM name from that attr. The local
-  # path runs a plain `nix build <installable>` with no such rewrite, so it must
-  # name the `.#<node>-system` package alias that resolves to the toplevel.
-  defaultSourceInstallable = nodeName: buildOn:
-    if buildOn == "local"
-    then ".#${nodeName}-system"
-    else ".#${nodeName}";
+  # Default `switch.sourceInstallable`. Switches go through `ix up`, which
+  # rewrites a bare `.#<node>` to `nixosConfigurations.<node>...` and (for the
+  # native multi-VM switch) derives the VM name from that attr.
+  defaultSourceInstallable = nodeName: ".#${nodeName}";
 
   deploymentDefaults = {
     bootstrapImage = "registry.ix.dev/${bootstrapImage.name}:${bootstrapImage.tag}";
     region = "us-west-1";
     ipv4 = false;
     snapshot = true;
-    switch.buildOn = "remote";
   };
   isSecretName = name: builtins.match "[a-z][a-z0-9_]*" name != null;
 
@@ -297,16 +291,7 @@ rendered fleet plan, image attrset, and wrapped CLI app.
         imageName = config.ix.image.name;
         deploy = spec.deployment;
         replacementDestination = deploy.destination or "${imageName}:latest";
-        switchBuildOn = deploy.switch.buildOn or "remote";
         ipv4HealthChecks = lib.filterAttrs (_: check: check.requiresIpv4) config.ix.healthChecks;
-        # ix up expects a system out-path for local copy and a .drv for remote
-        # build. Picking the wrong shape uploads the build-time closure and tries
-        # to run `<drv>/bin/switch-to-configuration`, which deadlocks.
-        switchTarget = deploy.switch.target or unsafeDiscardStringContext (
-          if switchBuildOn == "local"
-          then "${config.system.build.toplevel}"
-          else config.system.build.toplevel.drvPath
-        );
         # Image-declared membership (`ix.networking.groups`) unions with the
         # fleet-level `nodes.<name>.groups`: the image carries its own network
         # identity, the fleet adds deployment-specific memberships on top.
@@ -327,14 +312,10 @@ rendered fleet plan, image attrset, and wrapped CLI app.
           replicaIndex = spec.replicaIndex or null;
           system = unsafeDiscardStringContext "${config.system.build.toplevel}";
           switch = {
-            target = switchTarget;
-            buildOn = switchBuildOn;
-            buildVm = deploy.switch.buildVm or null;
-            # Remote switches default to the bare `.#<node>` so the native multi-VM
-            # `ix up` can derive each VM name from the attr; local switches keep the
-            # `.#<node>-system` package alias (see `defaultSourceInstallable`).
+            # Defaults to the bare `.#<node>` so the native multi-VM `ix up`
+            # can derive each VM name from the attr.
             sourceInstallable =
-              deploy.switch.sourceInstallable or (defaultSourceInstallable name switchBuildOn);
+              deploy.switch.sourceInstallable or (defaultSourceInstallable name);
             overrideInputs = deploy.switch.overrideInputs or {};
           };
           inherit (deploy) bootstrapImage;
@@ -422,7 +403,7 @@ rendered fleet plan, image attrset, and wrapped CLI app.
               switch =
                 node.switch
                 // lib.optionalAttrs (!((checkedNodeSpecs.${name}.deployment.switch or {}) ? sourceInstallable)) {
-                  sourceInstallable = defaultSourceInstallable (prefixName name) node.switch.buildOn;
+                  sourceInstallable = defaultSourceInstallable (prefixName name);
                 };
             }
           )
@@ -507,7 +488,7 @@ rendered fleet plan, image attrset, and wrapped CLI app.
       )
       nodeConfigs;
     # Each node's NixOS system under its bare external name, so `ix up .#<node>`
-    # (and the native multi-VM `ix up .#a .#b --build-vm <builder>`) resolves
+    # (and the native multi-VM `ix up .#a .#b`) resolves
     # `nixosConfigurations.<node>.config.system.build.toplevel`. `nodeConfigs`
     # is already the evaluated `config` (`evalImageConfig` returns `.config`),
     # so the `{ config }` wrapper reuses that closure with no second eval; this

--- a/packages/ix-fleet/default.nix
+++ b/packages/ix-fleet/default.nix
@@ -22,10 +22,7 @@
       name = "api";
       baseName = "api";
       system = "/nix/store/api-system";
-      switch = {
-        target = "/nix/store/api-system";
-        sourceInstallable = ".#api";
-      };
+      switch.sourceInstallable = ".#api";
       bootstrapImage = "registry.ix.dev/ix/base:latest";
       replacementImage = {
         imageName = "api";
@@ -66,9 +63,9 @@
       mkdir -p "$out"
     '';
 
-  # Two remote-source nodes that share a build VM, so `switch --dry-run` exercises
-  # the native multi-VM batch path: both must land in one `ix up .#web .#worker
-  # --build-vm builder` command.
+  # Two source nodes in one region, so `switch --dry-run` exercises the native
+  # multi-VM batch path: both must land in one `ix up .#web .#worker` command
+  # (the CLI routes the build to the tenant's managed builder).
   dryRunSwitchPlan = jsonFormat.generate "ix-fleet-dry-run-switch-plan.json" {
     order = [
       "web"
@@ -78,12 +75,7 @@
       inherit name;
       baseName = name;
       system = "/nix/store/${name}-system";
-      switch = {
-        target = "/nix/store/${name}-system.drv";
-        buildOn = "remote";
-        buildVm = "builder";
-        sourceInstallable = ".#${name}";
-      };
+      switch.sourceInstallable = ".#${name}";
       bootstrapImage = "registry.ix.dev/ix/base:latest";
       replacementImage = {
         imageName = name;
@@ -136,10 +128,7 @@
         baseName = "api";
         replicaIndex = index;
         system = "/nix/store/api-system";
-        switch = {
-          target = "/nix/store/api-system";
-          sourceInstallable = ".#api";
-        };
+        switch.sourceInstallable = ".#api";
         bootstrapImage = "registry.ix.dev/ix/base:latest";
         replacementImage = {
           imageName = "api";
@@ -196,8 +185,12 @@
     }
     ''
       ix-fleet --plan ${dryRunSwitchPlan} switch --skip-health --no-snapshot --dry-run | tee switch.log
-      grep -qE '\+ ix up \.#web \.#worker --build-vm builder' switch.log \
-        || { echo "expected a single batched 'ix up .#web .#worker --build-vm builder'" >&2; exit 1; }
+      grep -qE '\+ ix up \.#web \.#worker --workdir' switch.log \
+        || { echo "expected a single batched 'ix up .#web .#worker'" >&2; exit 1; }
+      if grep -qE -- '--build-vm|--build-on' switch.log; then
+        echo "retired placement flags must not be emitted" >&2
+        exit 1
+      fi
       mkdir -p "$out"
     '';
 

--- a/packages/ix-fleet/src/ix_fleet/__init__.py
+++ b/packages/ix-fleet/src/ix_fleet/__init__.py
@@ -46,9 +46,6 @@ class ReplacementImage(BaseModel):
 class SwitchSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    target: str = Field(min_length=1)
-    buildOn: typing.Literal["auto", "local", "remote"] = "auto"
-    buildVm: str | None = None
     sourceInstallable: str = Field(min_length=1)
     overrideInputs: dict[str, str] = Field(default_factory=empty_str_dict)
 
@@ -522,37 +519,6 @@ async def snapshot_node(node: FleetNode, *, dry_run: bool) -> None:
     await client().snapshot(name=node.name)
 
 
-async def switch_node(node: FleetNode, *, dry_run: bool) -> None:
-    if node.switch.buildOn == "local":
-        # build-on=local expects the system out-path already in the local store;
-        # the nix build stays a host-side step (it drives the local builder), and
-        # the switch RPC itself goes through the SDK.
-        await run_cli(
-            ["nix", "build", "--no-link", "--print-out-paths", node.switch.sourceInstallable],
-            dry_run=dry_run,
-        )
-    step(f"switching {node.name} (build-on={node.switch.buildOn})")
-    if dry_run:
-        step(f"+ switch {node.name} -> {node.switch.target} (build-on={node.switch.buildOn})")
-        return
-    # The SDK switch RPC has no deadline of its own; bound it like the old CLI
-    # path (which passed timeout=1800) so a hung remote/local switch can't block
-    # the fleet workflow forever.
-    try:
-        await asyncio.wait_for(
-            client().switch_system(
-                name=node.name,
-                target=node.switch.target,
-                build_on=node.switch.buildOn,
-            ),
-            SWITCH_TIMEOUT_SECS,
-        )
-    except TimeoutError as error:
-        raise RuntimeError(
-            f"switch of {node.name} timed out after {SWITCH_TIMEOUT_SECS}s"
-        ) from error
-
-
 async def ensure_node_groups(node: FleetNode, *, dry_run: bool) -> None:
     """Reconcile the node's east-west membership to exactly `node.groups`.
 
@@ -741,9 +707,6 @@ def default_source_workdir(cwd: Path, source_root: Path) -> Path:
         return Path()
 
 
-# Bound a target-based `switch` (matches the old CLI `timeout=1800`). The
-# source-build switch below uses its own, longer deadline.
-SWITCH_TIMEOUT_SECS = 1800
 MAX_SWITCH_RETRIES = 3
 RETRY_DELAY_SECS = 10
 
@@ -801,8 +764,6 @@ async def switch_node_from_source(
         "--workdir",
         str(workdir),
     ]
-    if node.switch.buildVm is not None:
-        command.extend(["--build-vm", node.switch.buildVm])
     for name, path in sorted(node.switch.overrideInputs.items()):
         command.extend(["--override-input", f"{name}={path}"])
     await run_source_switch(command, source_root, node.name, dry_run=dry_run)
@@ -815,20 +776,16 @@ async def switch_nodes_from_source(
     *,
     dry_run: bool,
 ) -> None:
-    # The native multi-VM switch: `ix up .#a .#b .#c --build-vm <builder>` builds
-    # every closure on one warm builder and activates each on its own VM. The CLI
-    # rejects `--name` and derives each VM name from the installable's simple attr,
-    # and shares one `--build-vm`/`--workdir`/`--override-input` set across the
-    # batch, so `batch_groups` only ever passes nodes that agree on those.
+    # The native multi-VM switch: `ix up .#a .#b .#c` builds every closure on
+    # the tenant's managed builder VM and activates each on its own VM. The CLI
+    # rejects `--name` and derives each VM name from the installable's simple
+    # attr, and shares one `--workdir`/`--override-input` set across the batch,
+    # so `batch_groups` only ever passes nodes that agree on those.
     workdir = relative_source_workdir(source_root, source_workdir)
-    build_vm = nodes[0].switch.buildVm
-    assert build_vm is not None, "batched switch requires a shared build VM"
     command = [
         "ix",
         "up",
         *[node.switch.sourceInstallable for node in nodes],
-        "--build-vm",
-        build_vm,
         "--workdir",
         str(workdir),
     ]
@@ -838,32 +795,23 @@ async def switch_nodes_from_source(
 
 
 def is_batchable_switch(node: FleetNode) -> bool:
-    # The native multi-VM `ix up` builds on one shared `--build-vm` and names each
-    # VM from the installable's simple attr, so a node joins a batch only when it
-    # builds remotely, names a build VM, and its installable is exactly
-    # `.#<node-name>`. Anything else (local build, no build VM, a custom or dotted
-    # installable) falls back to the single-target `ix up --name` path.
-    switch = node.switch
-    return (
-        switch.buildOn == "remote"
-        and switch.buildVm is not None
-        and switch.sourceInstallable == f".#{node.name}"
-    )
+    # The native multi-VM `ix up` names each VM from the installable's simple
+    # attr, so a node joins a batch only when its installable is exactly
+    # `.#<node-name>`. Anything else (a custom or dotted installable) falls
+    # back to the single-target `ix up --name` path.
+    return node.switch.sourceInstallable == f".#{node.name}"
 
 
 def batch_groups(nodes: list[FleetNode]) -> list[list[FleetNode]]:
-    # One native multi-VM `ix up` per (build VM, region, override-input set). The
-    # CLI shares one `--build-vm` and `--override-input` set across the batch, and
-    # the server's multi-switch requires every target to share the builder's
-    # region (CAS chunks are region-scoped). Grouping on region keeps a
-    # cross-region fleet from failing a whole batch instead of just the
-    # wrong-region nodes.
-    groups: dict[tuple[str, str, tuple[tuple[str, str], ...]], list[FleetNode]] = {}
-    order: list[tuple[str, str, tuple[tuple[str, str], ...]]] = []
+    # One native multi-VM `ix up` per (region, override-input set). The CLI
+    # shares one `--override-input` set across the batch, and every target in a
+    # multi-switch shares the tenant builder in its own region (CAS chunks are
+    # region-scoped). Grouping on region keeps a cross-region fleet from
+    # failing a whole batch instead of just the wrong-region nodes.
+    groups: dict[tuple[str, tuple[tuple[str, str], ...]], list[FleetNode]] = {}
+    order: list[tuple[str, tuple[tuple[str, str], ...]]] = []
     for node in nodes:
-        assert node.switch.buildVm is not None
         key = (
-            node.switch.buildVm,
             node.region,
             tuple(sorted(node.switch.overrideInputs.items())),
         )
@@ -900,10 +848,7 @@ async def up_node(node: FleetNode, image: str, *, dry_run: bool) -> None:
 
 async def cmd_diff(plan: FleetPlan, args: argparse.Namespace) -> None:
     for node in selected_nodes(plan, args.on):
-        if node.switch.buildOn == "remote":
-            print(f"{node.name}\twant {node.switch.sourceInstallable} (remote source)")
-        else:
-            print(f"{node.name}\twant {node.switch.target} ({node.switch.buildOn})")
+        print(f"{node.name}\twant {node.switch.sourceInstallable} (source)")
 
 
 async def run_switch_node_workflow(node: FleetNode, args: argparse.Namespace) -> None:
@@ -913,15 +858,12 @@ async def run_switch_node_workflow(node: FleetNode, args: argparse.Namespace) ->
     await ensure_node_groups(node, dry_run=args.dry_run)
     if not created and node.snapshot and not args.no_snapshot:
         await snapshot_node(node, dry_run=args.dry_run)
-    if node.switch.buildOn == "remote":
-        await switch_node_from_source(
-            node,
-            source_root,
-            source_workdir,
-            dry_run=args.dry_run,
-        )
-    else:
-        await switch_node(node, dry_run=args.dry_run)
+    await switch_node_from_source(
+        node,
+        source_root,
+        source_workdir,
+        dry_run=args.dry_run,
+    )
     if not args.skip_health:
         await run_node_health_checks(node, dry_run=args.dry_run)
 

--- a/packages/ix-fleet/tests/test_ix_fleet.py
+++ b/packages/ix-fleet/tests/test_ix_fleet.py
@@ -24,7 +24,6 @@ def fleet_node(name: str, *, depends_on: list[str] | None = None) -> dict[str, t
         "baseName": name,
         "system": f"/nix/store/{name}-system",
         "switch": {
-            "target": f"/nix/store/{name}-system.drv",
             "sourceInstallable": f".#{name}",
         },
         "bootstrapImage": "registry.ix.dev/ix/base:latest",
@@ -165,7 +164,6 @@ class PushReplacementImageTests(unittest.TestCase):
                 "baseName": "nginx",
                 "system": "/nix/store/example-system",
                 "switch": {
-                    "target": "/nix/store/example-system.drv",
                     "sourceInstallable": ".#health-check-nginx-system",
                 },
                 "bootstrapImage": "registry.ix.dev/ix/base:latest",
@@ -602,7 +600,7 @@ class SingleNodeWorkflowTests(unittest.TestCase):
             patch.object(ix_fleet, "ensure_node", async_recorder(calls, "ensure", result=False)),
             patch.object(ix_fleet, "ensure_node_groups", async_recorder(calls, "groups")),
             patch.object(ix_fleet, "snapshot_node", async_recorder(calls, "snapshot")),
-            patch.object(ix_fleet, "switch_node", async_recorder(calls, "switch")),
+            patch.object(ix_fleet, "switch_node_from_source", async_recorder(calls, "switch")),
             patch.object(ix_fleet, "run_node_health_checks", async_recorder(calls, "health")),
         ):
             asyncio.run(ix_fleet.run_switch_node_workflow(plan.nodes["api"], args))
@@ -645,7 +643,6 @@ class SwitchSourceTests(unittest.TestCase):
         calls: list[list[str]] = []
         cwds: list[Path | None] = []
         node_data = fleet_node("api")
-        node_data["switch"]["buildVm"] = "builder"
         node_data["switch"]["overrideInputs"] = {
             "ix": "github:indexable-inc/ix",
             "ix-images": "path:/workspace/index",
@@ -668,8 +665,6 @@ class SwitchSourceTests(unittest.TestCase):
                 "api",
                 "--workdir",
                 "subdir",
-                "--build-vm",
-                "builder",
                 "--override-input",
                 "ix=github:indexable-inc/ix",
                 "--override-input",
@@ -698,18 +693,6 @@ class SwitchSourceTests(unittest.TestCase):
                     dry_run=False,
                 ),
             )
-
-
-def remote_node(
-    name: str,
-    *,
-    build_vm: str = "builder",
-    depends_on: list[str] | None = None,
-) -> dict[str, typing.Any]:
-    node = fleet_node(name, depends_on=depends_on)
-    node["switch"]["buildOn"] = "remote"
-    node["switch"]["buildVm"] = build_vm
-    return node
 
 
 def cli_recorder(
@@ -744,40 +727,31 @@ class SwitchBatchTests(unittest.TestCase):
         return ix_fleet.FleetNode.model_validate(data)
 
     def test_is_batchable_switch(self) -> None:
-        assert ix_fleet.is_batchable_switch(self._node(remote_node("api")))
-        # local build: no shared builder to batch on.
-        local = fleet_node("api")
-        local["switch"]["buildOn"] = "local"
-        assert not ix_fleet.is_batchable_switch(self._node(local))
-        # remote but no build VM: multi `ix up` requires --build-vm.
-        no_vm = fleet_node("api")
-        no_vm["switch"]["buildOn"] = "remote"
-        assert not ix_fleet.is_batchable_switch(self._node(no_vm))
+        assert ix_fleet.is_batchable_switch(self._node(fleet_node("api")))
         # installable attr must equal the node name (multi derives the VM name
         # from it and rejects --name).
-        custom = remote_node("api")
+        custom = fleet_node("api")
         custom["switch"]["sourceInstallable"] = ".#api-system"
         assert not ix_fleet.is_batchable_switch(self._node(custom))
 
-    def test_batch_groups_split_by_build_vm_region_and_overrides(self) -> None:
-        a = self._node(remote_node("a", build_vm="b1"))
-        b = self._node(remote_node("b", build_vm="b1"))
-        c = self._node(remote_node("c", build_vm="b2"))
-        d = remote_node("d", build_vm="b1")
+    def test_batch_groups_split_by_region_and_overrides(self) -> None:
+        a = self._node(fleet_node("a"))
+        b = self._node(fleet_node("b"))
+        d = fleet_node("d")
         d["switch"]["overrideInputs"] = {"ix": "github:indexable-inc/ix"}
         d_node = self._node(d)
-        # Same build VM as a/b, but a different region: the server's multi-switch
-        # requires every target to share the builder's region, so it splits off.
-        e = remote_node("e", build_vm="b1")
+        # A different region splits off: every target in a multi-switch shares
+        # the tenant builder in its own region (CAS chunks are region-scoped).
+        e = fleet_node("e")
         e["region"] = "us-east-1"
         e_node = self._node(e)
 
-        groups = ix_fleet.batch_groups([a, b, c, d_node, e_node])
+        groups = ix_fleet.batch_groups([a, b, d_node, e_node])
         names = [[node.name for node in group] for group in groups]
-        assert names == [["a", "b"], ["c"], ["d"], ["e"]]
+        assert names == [["a", "b"], ["d"], ["e"]]
 
     def test_switch_nodes_from_source_builds_one_multi_ix_up(self) -> None:
-        nodes = [self._node(remote_node("web")), self._node(remote_node("worker"))]
+        nodes = [self._node(fleet_node("web")), self._node(fleet_node("worker"))]
         calls: list[list[str]] = []
         cwds: list[Path | None] = []
 
@@ -788,16 +762,15 @@ class SwitchBatchTests(unittest.TestCase):
             ),
         )
 
-        # One native multi-VM `ix up`: every installable, one shared --build-vm,
-        # and no --name (multi derives each VM name from its installable attr).
+        # One native multi-VM `ix up`: every installable, no --name (multi
+        # derives each VM name from its installable attr), no placement flags
+        # (the CLI routes the build to the tenant's managed builder).
         assert calls == [
             [
                 "ix",
                 "up",
                 ".#web",
                 ".#worker",
-                "--build-vm",
-                "builder",
                 "--workdir",
                 "subdir",
             ]
@@ -805,10 +778,13 @@ class SwitchBatchTests(unittest.TestCase):
         assert "--name" not in calls[0]
         assert cwds == [Path("/source")]
 
-    def test_cmd_switch_batches_remote_nodes_and_runs_singles(self) -> None:
-        api = remote_node("api")
-        web = remote_node("web")
-        cache = fleet_node("cache")  # buildOn defaults to auto -> single fallback
+    def test_cmd_switch_batches_nodes_and_runs_singles(self) -> None:
+        api = fleet_node("api")
+        web = fleet_node("web")
+        cache = fleet_node("cache")
+        # A custom installable attr cannot join a batch (multi derives each VM
+        # name from the attr), so cache falls back to the single-target path.
+        cache["switch"]["sourceInstallable"] = ".#cache-system"
         plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api", "web", "cache"], [api, web, cache]))
         groups: list[list[str]] = []
         singles: list[str] = []
@@ -852,8 +828,8 @@ class SwitchBatchTests(unittest.TestCase):
         assert singles == ["cache"]
 
     def test_cmd_switch_respects_dependency_layers(self) -> None:
-        api = remote_node("api")
-        worker = remote_node("worker", depends_on=["api"])
+        api = fleet_node("api")
+        worker = fleet_node("worker", depends_on=["api"])
         plan = ix_fleet.FleetPlan.model_validate(fleet_plan(["api", "worker"], [api, worker]))
         switched: list[list[str]] = []
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1843,16 +1843,6 @@
   # rather than falling back to anything.
   fleetMissingCasBuilderEval = builtins.tryEval (builtins.seq prefixedFleetBase.packages.api true);
 
-  # A local-build node: its source switch runs a plain `nix build`, so the
-  # default installable must be the `.#<node>-system` package alias, not the
-  # bare `.#<node>` (which only `ix up`'s resolver expands).
-  localBuildFleet = ix.mkFleet {
-    nodes.svc = {
-      deployment.switch.buildOn = "local";
-      modules = [{}];
-    };
-  };
-
   # An explicit `sourceInstallable` that happens to equal the bare default must
   # survive `withNodePrefix` unchanged: prefixing keys on provenance (user-set
   # vs defaulted), not on the rendered string.
@@ -5636,13 +5626,10 @@
         assertion =
           fleetPlan.web.switch
           == {
-            target = builtins.unsafeDiscardStringContext fleet.nodes.web.system.build.toplevel.drvPath;
-            buildOn = "remote";
-            buildVm = null;
             sourceInstallable = ".#web";
             overrideInputs = {};
           };
-        message = "fleet plans should default to local eval and remote build switch metadata";
+        message = "fleet plans should carry only the flake installable; `ix up` owns build placement";
       }
       {
         assertion = fleetPlan.web.replacementImage.sourceInstallable == ".#web";
@@ -5809,10 +5796,6 @@
           prefixedFleet.nixosConfigurations.tprefix-api.config.system.build.toplevel
           == prefixedFleetBase.nixosConfigurations.api.config.system.build.toplevel;
         message = "withNodePrefix should expose nixosConfigurations under the prefixed name while reusing the base closure (no second eval)";
-      }
-      {
-        assertion = localBuildFleet.planValue.nodes.svc.switch.sourceInstallable == ".#svc-system";
-        message = "a local-build node should default to the `.#<node>-system` package alias, since its plain `nix build` has no `ix up` rewrite";
       }
       {
         assertion =


### PR DESCRIPTION
Closes #3426. Companion to indexable-inc/ix#7523 (merged): `ix up` now routes every source build through the tenant's managed builder VM (`ix-builder-<region>`, created on demand), so the fleet layer stops choosing build placement.

## What changed
- **`lib/image/fleet.nix`**: plan `switch` is now just `{ sourceInstallable, overrideInputs }`. `deployment.switch.buildOn`/`buildVm` and the plan `target` (toplevel outPath/drvPath) are gone; fleet.nix no longer forces the system closure into plans.
- **`ix_fleet`**: the SDK-switch path (`switch_node` / `client().switch_system`, `SWITCH_TIMEOUT_SECS`) is deleted; every switch is `ix up` from source. Batch groups key on `(region, overrideInputs)`; batchable = installable is exactly `.#<node>`.
- **`examples/nixos/switch-multi`**: no explicit `builder` node; the command is plain `ix up .#web .#worker .#edge`.
- Docs (`doc/ix/fleet.md`, `doc/ix/lifecycle.md`, `doc/ix-fleet/overview.md`, switch README) updated; fixtures in `packages/ix-fleet/default.nix` and `tests/default.nix` follow the new SwitchSpec (pydantic `extra="forbid"` rejects the old fields).

## Validation
- `pytest` (ix-fleet): 48 passed. 4 `StatusTests` failures reproduce byte-identically on origin/main (stale prebuilt darwin `ix_sdk`: unhashable `BranchStatus`), as do the 2 zuban `attr-defined` errors (`system_ready`, `apply_vm_groups` missing from the prebuilt stub) — pre-existing, not this diff.
- Example fleet plan eval (`.#nginx-lifecycle-switch`) evaluates; local darwin build then hits the same pre-existing prebuilt-SDK ty failure as main.
- Local `nix run .#lint` and `checks.x86_64-linux.eval` are red on origin/main itself under this machine's toolchain (139 astlog findings / yourkit `isx8664`), so Linux CI is the authority here.

🤖 Generated with Claude Code (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `buildOn`/`buildVm` from fleet switch; route all switches through `ix up`
> - Removes the SDK-based in-place switch path (`switch_node`) and `SwitchSpec` fields `target`, `buildOn`, and `buildVm`; all node switches now go through `ix up` via `switch_node_from_source`.
> - `run_switch_node_workflow` no longer branches on `buildOn`; it always calls the source-based path, with build placement owned by `ix up` and the tenant's managed builder VM.
> - Batch grouping key changes from `(buildVm, region, overrides)` to `(region, overrides)`, and `--build-vm`/`--build-on` flags are no longer emitted in any `ix up` invocation.
> - `defaultSourceInstallable` now always returns `.#<node>` regardless of build placement, and the fleet plan no longer carries a default `buildOn` value.
> - Behavioral Change: any existing fleet plans referencing `target`, `buildOn`, or `buildVm` in `SwitchSpec` will have those fields rejected/ignored by the updated Pydantic model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0eb726.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->