### PR TITLE
yourkit: restore hostPlatform attr `isx86_64` mangled by 0a394ab7

### DIFF
--- a/lib/languages/java/yourkit.nix
+++ b/lib/languages/java/yourkit.nix
@@ -31,10 +31,10 @@
       isLinux
       isDarwin
       isAarch64
-      isx8664
+      isx86_64
       ;
   in
-    if isLinux && isx8664
+    if isLinux && isx86_64
     then "bin/linux-x86-64/libyjpagent.so"
     else if isLinux && isAarch64
     then "bin/linux-arm-64/libyjpagent.so"


### PR DESCRIPTION
Fixes #3443. The digit-ungrouping sed in 0a394ab7 also mangled the identifier `isx86_64` -> `isx8664` in `lib/languages/java/yourkit.nix`; `pkgs.stdenv.hostPlatform` has no such attr, so every eval of `checks.<system>.eval` failed. Identifiers with underscores are stock-Nix parseable; only numeric literals were the compatibility concern.

Verified locally: `nix eval --raw .#checks.x86_64-linux.eval.drvPath` (running; was an instant "attribute missing" error before).

🤖 Generated with Claude Code (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isx86_64` attribute name typo in YourKit agent path selection
> Fixes a typo introduced in commit `0a394ab7` where `isx86_64` was mangled to `isx8664` in [yourkit.nix](https://github.com/indexable-inc/index/pull/3444/files#diff-a8a73239dc3b78169808bb7fe37935dae16fa2ad58be7b3aeaeb01c822550ebb). Restores the correct attribute name so Linux x86_64 systems select `bin/linux-x86-64/libyjpagent.so` as intended.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a25d47c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->