### PR TITLE
fix identifiers and strings mangled by 0a394ab7 beyond yourkit

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1209,7 +1209,7 @@
   # on 0.24's surface, exercised by the import-smoke check). setuptools-scm reads
   # the version from the sdist's PKG-INFO, pinned so the build never needs a .git.
   # Upstream tests need a device, so checks are off.
-  pymobiledevice3927 = mcpPythonInterp.pkgs.pymobiledevice3.overridePythonAttrs (old: {
+  pymobiledevice3_927 = mcpPythonInterp.pkgs.pymobiledevice3.overridePythonAttrs (old: {
     inherit (pypiPins.pymobiledevice3) version;
     src = pkgs.fetchPypi {
       pname = "pymobiledevice3";
@@ -1368,7 +1368,7 @@
       # under memory pressure) carries args and results. We use Ray rather than
       # reinvent Plasma/Arrow/refcount-GC. It bundles its own cloudpickle, so a
       # function defined in a cell ships by value without a separate serializer.
-      # nixpkgs ray builds on aarch64-darwin + {aarch64,x8664}-linux, the exact
+      # nixpkgs ray builds on aarch64-darwin + {aarch64,x86_64}-linux, the exact
       # platforms the fleet and dev boxes run, so it joins the pinned interpreter
       # like any other module.
       ps.ray
@@ -1421,7 +1421,7 @@
       # the interpreter, so both ride in the same env. Cross-platform: a USB
       # iDevice + a root `tunneld` are what the developer commands need, not macOS,
       # so CI builds the whole closure and import-checks it on Linux too.
-      pymobiledevice3927
+      pymobiledevice3_927
       iphoneModule
     ]
     # Ray's `client` extra (grpcio): `fabric.remote` attaches to the fleet head
@@ -4640,7 +4640,7 @@
     show = {
         "packages": {
             "aarch64-darwin": {"mcp": {"type": "derivation", "description": "the mcp"}},
-            "x8664-linux": {},
+            "x86_64-linux": {},
         },
         "nixosConfigurations": {"host": {"type": "nixos-configuration"}},
     }
@@ -4660,7 +4660,7 @@
     assert nix._eval_args(".#x", raw=True)[2] == "--raw", nix._eval_args(".#x", raw=True)
     sysd = nix._current_system()
     assert nix._eval_args(".#checks.{system}.lint")[1] == f".#checks.{sysd}.lint"
-    assert nix._eval_args(".#checks.{system}", system="x8664-linux")[1] == ".#checks.x8664-linux"
+    assert nix._eval_args(".#checks.{system}", system="x86_64-linux")[1] == ".#checks.x86_64-linux"
 
     print("nix-ok", nix.__version__)
   '';

--- a/packages/vm/panes/guest-image/nixos.nix
+++ b/packages/vm/panes/guest-image/nixos.nix
@@ -203,7 +203,7 @@ in {
       {
         name = "arm64-16k-pages";
         patch = null;
-        structuredExtraConfig.ARM6416K_PAGES = lib.kernel.yes;
+        structuredExtraConfig.ARM64_16K_PAGES = lib.kernel.yes;
       }
     ];
     # Register the shipped closure in the nix database on first boot: repart's

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -677,7 +677,7 @@ in {
       nix-index # find which package provides a given file/binary (`nix-locate`)
       nvd # diff Nix store paths and profile generations after rebuilds
       indexPkgs.nix-output-monitor # `nom` patched so nix-derivation parses content-addressed derivations (index repo builds them); upstream nixpkgs nom spams DerivationParseError. Bump with `nix flake update index`
-      # indexable-inc/index#1711: eval needs the x8664-linux IFD output
+      # indexable-inc/index#1711: eval needs the x86_64-linux IFD output
       # (cargo-units.nix); when cache.ix.dev lacks it, copy it from the fleet:
       # `nix copy --no-check-sigs --from ssh-ng://vin-compute-1 <path from the eval error>`
       indexPkgs.nix-web-monitor # `nwm` web build monitor on :7532


### PR DESCRIPTION
Fixes #3449. Restores the non-literal text 0a394ab7's treewide digit un-grouping mangled beyond the yourkit case (#3443, already fixed):

- `packages/vm/panes/guest-image/nixos.nix`: `structuredExtraConfig.ARM6416K_PAGES` -> `ARM64_16K_PAGES` (the real Kconfig symbol; the mangled name meant the panes guest kernel silently dropped 16K pages, which the venus/lavapipe stack requires)
- `packages/mcp/default.nix`: nix-module test fixture and assertion `"x8664-linux"` -> `"x86_64-linux"` (the test passed while asserting a system string that cannot occur); `pymobiledevice3927` -> `pymobiledevice3_927` (binding name encodes the 9.27 version); comment `{aarch64,x8664}-linux` restored
- `users/andrewgazelka/profiles/workstation.nix`: comment `x8664-linux IFD output` restored

Verified: `nix build .#mcp.tests.nixSmoke` passes with the corrected strings; `nix run .#lint` 10/10 green. The kernel config change restores the exact pre-mangle text (0a394ab7^); no kernel rebuild was done, the symbol is standard arm64 Kconfig.

Written and driven by an AI agent via Claude Code (Claude Opus 4.5).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix identifiers mangled by prior commit in platform strings and kernel config keys
> - Corrects `x8664-linux` typos to `x86_64-linux` in platform keys, test assertions, and comments across [default.nix](https://github.com/indexable-inc/index/pull/3451/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) and [workstation.nix](https://github.com/indexable-inc/index/pull/3451/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962)
> - Renames Nix attribute `pymobiledevice3927` to `pymobiledevice3_927` in [packages/mcp/default.nix](https://github.com/indexable-inc/index/pull/3451/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) to restore the correct identifier
> - Fixes kernel config key `ARM6416K_PAGES` to `ARM64_16K_PAGES` in [nixos.nix](https://github.com/indexable-inc/index/pull/3451/files#diff-547f31c0eac033ab8d65e4bb0e3c4ce6a6b52121e137f9ad93b16366dcf3af76), so the 16K pages option is actually applied
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a1b100.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->