### PR TITLE
fix(nix): restore identifiers mangled by 0a394ab7 underscore-strip

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1246,7 +1246,7 @@
   # on 0.24's surface, exercised by the import-smoke check). setuptools-scm reads
   # the version from the sdist's PKG-INFO, pinned so the build never needs a .git.
   # Upstream tests need a device, so checks are off.
-  pymobiledevice3927 = mcpPythonInterp.pkgs.pymobiledevice3.overridePythonAttrs (old: {
+  pymobiledevice3_927 = mcpPythonInterp.pkgs.pymobiledevice3.overridePythonAttrs (old: {
     inherit (pypiPins.pymobiledevice3) version;
     src = pkgs.fetchPypi {
       pname = "pymobiledevice3";
@@ -1405,7 +1405,7 @@
       # under memory pressure) carries args and results. We use Ray rather than
       # reinvent Plasma/Arrow/refcount-GC. It bundles its own cloudpickle, so a
       # function defined in a cell ships by value without a separate serializer.
-      # nixpkgs ray builds on aarch64-darwin + {aarch64,x8664}-linux, the exact
+      # nixpkgs ray builds on aarch64-darwin + {aarch64,x86_64}-linux, the exact
       # platforms the fleet and dev boxes run, so it joins the pinned interpreter
       # like any other module.
       ps.ray
@@ -1459,7 +1459,7 @@
       # the interpreter, so both ride in the same env. Cross-platform: a USB
       # iDevice + a root `tunneld` are what the developer commands need, not macOS,
       # so CI builds the whole closure and import-checks it on Linux too.
-      pymobiledevice3927
+      pymobiledevice3_927
       iphoneModule
     ]
     # Ray's `client` extra (grpcio): `fabric.remote` attaches to the fleet head
@@ -4682,7 +4682,7 @@
     show = {
         "packages": {
             "aarch64-darwin": {"mcp": {"type": "derivation", "description": "the mcp"}},
-            "x8664-linux": {},
+            "x86_64-linux": {},
         },
         "nixosConfigurations": {"host": {"type": "nixos-configuration"}},
     }
@@ -4702,7 +4702,7 @@
     assert nix._eval_args(".#x", raw=True)[2] == "--raw", nix._eval_args(".#x", raw=True)
     sysd = nix._current_system()
     assert nix._eval_args(".#checks.{system}.lint")[1] == f".#checks.{sysd}.lint"
-    assert nix._eval_args(".#checks.{system}", system="x8664-linux")[1] == ".#checks.x8664-linux"
+    assert nix._eval_args(".#checks.{system}", system="x86_64-linux")[1] == ".#checks.x86_64-linux"
 
     print("nix-ok", nix.__version__)
   '';

--- a/packages/vm/panes/guest-image/nixos.nix
+++ b/packages/vm/panes/guest-image/nixos.nix
@@ -203,7 +203,7 @@ in {
       {
         name = "arm64-16k-pages";
         patch = null;
-        structuredExtraConfig.ARM6416K_PAGES = lib.kernel.yes;
+        structuredExtraConfig.ARM64_16K_PAGES = lib.kernel.yes;
       }
     ];
     # Register the shipped closure in the nix database on first boot: repart's

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -677,7 +677,7 @@ in {
       nix-index # find which package provides a given file/binary (`nix-locate`)
       nvd # diff Nix store paths and profile generations after rebuilds
       indexPkgs.nix-output-monitor # `nom` patched so nix-derivation parses content-addressed derivations (index repo builds them); upstream nixpkgs nom spams DerivationParseError. Bump with `nix flake update index`
-      # indexable-inc/index#1711: eval needs the x8664-linux IFD output
+      # indexable-inc/index#1711: eval needs the x86_64-linux IFD output
       # (cargo-units.nix); when cache.ix.dev lacks it, copy it from the fleet:
       # `nix copy --no-check-sigs --from ssh-ng://vin-compute-1 <path from the eval error>`
       indexPkgs.nix-web-monitor # `nwm` web build monitor on :7532


### PR DESCRIPTION
## Summary
Restores the non-blocking semantic identifiers mangled by `0a394ab7`'s naive digit-underscore strip, which matched digit pairs inside identifiers and platform strings, not just numeric literals. The blocking eval break (`isx86_64`) was already restored in #3427; this handles the rest.

## Changes
- `packages/vm/panes/guest-image/nixos.nix`: `ARM6416K_PAGES` back to `ARM64_16K_PAGES`. `structuredExtraConfig` accepts arbitrary names, so the mangle evaluated but silently dropped the 16K-pages option from the aarch64 guest kernel, building the wrong kernel.
- `packages/mcp/default.nix`: nix test fixture `x8664-linux` back to `x86_64-linux` (was asserting on a nonexistent system name), the `pymobiledevice3927` binding back to `pymobiledevice3_927`, and a mangled `x8664` comment.
- `users/andrewgazelka/profiles/workstation.nix`: mangled `x8664-linux` comment restored.

## Validation
`nix eval .#packages.aarch64-darwin.mcp.drvPath` resolves (exercises the renamed binding + iphone module path); pre-commit lint suite green.

Closes #3447

_(authored by an AI agent via Claude Code)_


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore identifiers mangled by underscore-stripping in Nix package configs
> - Fixes `pymobiledevice3_927` attribute name in [default.nix](https://github.com/indexable-inc/index/pull/3452/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db), which was mangled to `pymobiledevice3927` by a prior commit.
> - Corrects architecture strings from `x8664-linux` to `x86_64-linux` in comments, attribute map keys, and an embedded Python assertion across [default.nix](https://github.com/indexable-inc/index/pull/3452/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) and [workstation.nix](https://github.com/indexable-inc/index/pull/3452/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962).
> - Fixes kernel config option `ARM64_16K_PAGES` (was `ARM6416K_PAGES`) in [nixos.nix](https://github.com/indexable-inc/index/pull/3452/files#diff-547f31c0eac033ab8d65e4bb0e3c4ce6a6b52121e137f9ad93b16366dcf3af76), ensuring the ARM64 16K page size is correctly applied.
> - Behavioral Change: `show.packages` in [default.nix](https://github.com/indexable-inc/index/pull/3452/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) now exposes the `x86_64-linux` key instead of the broken `x8664-linux` key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf0fdbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->