### PR TITLE
agent: point reportToPlaybook at the rendering site updates path

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -755,13 +755,23 @@
     reportToPlaybook = {
       text = ''
         Publish substantial investigations, decisions, shipped changes, and eval
-        scorecards to `playbook/src/routes/<slug>/+page.svx`, then post the live link
-        to Slack `#general` (`C0A4TD9G7HR`) with AI attribution. Skip quick or
-        throwaway tasks.
+        scorecards as a site update entry: an `.svx` file at
+        `packages/site/src/lib/updates/<slug>.svx` whose frontmatter carries
+        `id` (the slug), `postedAt` (ISO 8601 with timezone offset), `title`
+        (markdown), `links` (array of `{ label, href }` with absolute https
+        URLs), and `tags` (lowercase slugs; include `interesting` for the
+        front page). The body is mdsvex, so keep every `{` and `<...>` inside
+        code fences or backticks. It renders at
+        `https://indexable-inc.github.io/index/<slug>` once the Pages build
+        ships. Post that live link to Slack `#general` (`C0A4TD9G7HR`) with AI
+        attribution. Skip quick or throwaway tasks.
       '';
       reason = ''
-        Substantial investigations evaporated with the session; publishing to the
-        playbook makes them citable and searchable.
+        Substantial investigations evaporated with the session; publishing them
+        as a site update entry makes them citable and searchable. The path is
+        named exactly because `playbook/src/routes/` does not render on the
+        live site (index#3458), so an earlier writeup landed where it produced
+        no live link.
       '';
     };
   }


### PR DESCRIPTION
Corrects the `reportToPlaybook` house rule to point at the location that actually renders on the live site.

The rule said publish to `playbook/src/routes/<slug>/+page.svx` then post the live link, but `playbook/src/routes/` does not render on any live site (404). The live updates site is the flake `.#site` output from `packages/site` (`https://indexable-inc.github.io/index/<slug>`); entries are `.svx` files in `packages/site/src/lib/updates/` with SvxModule frontmatter (`id`, `postedAt`, `title`, `links`, `tags`). Now documents that path, the frontmatter, the mdsvex brace/angle gotcha, and the resulting live URL.

Fixes #3458

_Authored by Claude Code (an AI coding agent)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Point `reportToPlaybook` prompt rule at the site updates rendering path
> Updates the `reportToPlaybook` rule in [rules.nix](https://github.com/indexable-inc/index/pull/3459/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to direct substantial work outputs to `packages/site/src/lib/updates/<slug>.svx` instead of the prior playbook path, which does not render on the live site. The new guidance specifies required frontmatter fields (`id`, `postedAt` with timezone, `title`, `links` as `{label, href}` array with absolute URLs, and lowercase `tags`), mdsvex body constraints (braces and angle brackets must be inside code fences), and instructs posting the resulting public URL to Slack.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a858dd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->