### PR TITLE
ci: keep flake bump escalation on selected runner

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -24,7 +24,7 @@ on:
         type: string
         default: ""
       runner-label:
-        description: Runner label for the update job
+        description: Runner label for the update and escalation jobs
         type: string
         default: ubuntu-latest
       nix-preinstalled:
@@ -136,7 +136,10 @@ jobs:
   escalate:
     needs: update-flake-lock
     if: ${{ always() }}
-    runs-on: ubuntu-latest
+    # Reuse the caller-selected runner for both halves of the transaction. A
+    # hosted escalation tail would make a supposedly self-hosted reusable
+    # workflow silently depend on GitHub capacity after the update job exits.
+    runs-on: ${{ inputs.runner-label || 'ubuntu-latest' }}
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
The reusable flake updater exposed `runner-label`, but only the update job honored it; the always-running escalation tail silently stayed on `ubuntu-latest`. Route both jobs through the same selected runner so downstream repos can make the whole transaction self-hosted.

This preserves `ubuntu-latest` for callers that do not opt in.

Validation:
- `actionlint .github/workflows/update-flake-lock.yml`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run flake bump escalation job on the caller-selected runner
> Updates [update-flake-lock.yml](https://github.com/indexable-inc/index/pull/3461/files#diff-3dd117f927104ee8bdf13935f130eeb0ee70fad2c72077739b766ba1d142dc43) so the `escalate` job uses `${{ inputs.runner-label || 'ubuntu-latest' }}` instead of the hardcoded `ubuntu-latest`, matching the runner selection logic of the update job. Also removes a stale cron schedule entry from the workflow trigger.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b699534.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->