### PR TITLE
ci: classify ix workspace invalidators as costly

### DIFF
--- a/.github/actions/ci-budget/catalog/policy.json
+++ b/.github/actions/ci-budget/catalog/policy.json
@@ -21,17 +21,27 @@
     },
     "indexable-inc/ix": {
       "costly_paths": [
+        ".cargo/config.toml",
+        ".github/workflows/ci.yml",
         "Cargo.lock",
         "**/Cargo.lock",
+        "Cargo.toml",
         "flake.lock",
         "**/flake.lock",
+        "flake.nix",
+        "crates/vm/guest/console/terminal/zig/deps.nix",
+        "nix/checks/default.nix",
         "rust-toolchain.toml",
         "**/rust-toolchain.toml",
         "rust-toolchain",
         "**/rust-toolchain",
         "lib/workspace-cargo-unit.nix",
+        "nix/flake/outputs/default.nix",
         "nix/flake/outputs/workspace.nix",
-        "nix/packages/workspace-*.nix"
+        "nix/packages/workspace-*.nix",
+        "nix/packages/workspace-binaries.json",
+        "nix/packages/workspace-bins/**",
+        "nix/shells/toolchain.nix"
       ],
       "managed_workflows": [
         ".github/workflows/ci.yml"

--- a/.github/actions/ci-budget/test_ci_policy.py
+++ b/.github/actions/ci-budget/test_ci_policy.py
@@ -75,17 +75,56 @@ class PolicyTests(unittest.TestCase):
         assert "if: ${{ !inputs.nix-preinstalled }}" in workflow
 
     def test_owner_policy_classifies_repository_data(self) -> None:
-        decision = decide(
-            ["nix/packages/workspace-bins.nix"],
-            [],
-            "indexable-inc/ix",
+        costly_paths = (
+            ".cargo/config.toml",
             ".github/workflows/ci.yml",
-            force_big_change=False,
+            "Cargo.lock",
+            "Cargo.toml",
+            "flake.lock",
+            "flake.nix",
+            "crates/vm/guest/console/terminal/zig/deps.nix",
+            "nix/checks/default.nix",
+            "lib/workspace-cargo-unit.nix",
+            "nix/flake/outputs/default.nix",
+            "nix/flake/outputs/workspace.nix",
+            "nix/packages/workspace-binaries.json",
+            "nix/packages/workspace-bins.nix",
+            "nix/packages/workspace-bins/example.nix",
+            "nix/packages/workspace-rust-ci.nix",
+            "nix/shells/toolchain.nix",
+            "rust-toolchain.toml",
         )
+        for path in costly_paths:
+            with self.subTest(path=path):
+                decision = decide(
+                    [path],
+                    [],
+                    "indexable-inc/ix",
+                    ".github/workflows/ci.yml",
+                    force_big_change=False,
+                )
 
-        assert decision.managed_workflow
-        assert decision.classification.big_change
-        assert decision.classification.reason["sources"] == ["costly_path"]
+                assert decision.managed_workflow
+                assert decision.classification.big_change
+                assert decision.classification.reason["sources"] == ["costly_path"]
+
+        routine_paths = (
+            ".github/actions/ci-setup/action.yml",
+            "docs/operators/ci.md",
+            "nix/checks/workflow-ci-one-claim.jq",
+            "scripts/ci/run-ci-phases.sh",
+        )
+        for path in routine_paths:
+            with self.subTest(routine_path=path):
+                routine = decide(
+                    [path],
+                    [],
+                    "indexable-inc/ix",
+                    ".github/workflows/ci.yml",
+                    force_big_change=False,
+                )
+                assert routine.managed_workflow
+                assert not routine.classification.big_change
 
     def test_cli_contract_rejects_unmanaged_workflow_without_reclassifying(
         self,


### PR DESCRIPTION
Classify every ix full-workspace invalidation path for the extended validation tier.

This keeps setup and CI-control-only paths on the routine deadline while preventing cold full-workspace rebuilds from failing at the five-minute policy boundary.

Tests:
- python3 unittest discovery: 52 passed
- Node worker tests: 13 passed
- all 17 ix global invalidators matched
- broad setup/script paths remain routine


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify ix workspace invalidator paths as costly in CI budget policy
> - Adds path patterns to [policy.json](https://github.com/indexable-inc/index/pull/3462/files#diff-8f21aab076c62de6c8ce200f623b760868bc5ffef5b79976e37c13de48af697c) that invalidate the ix workspace (e.g. `Cargo.toml`, `flake.nix`, `.cargo/config.toml`, CI workflow, and several nix package paths) so they trigger `big_change` classification.
> - Updates [test_ci_policy.py](https://github.com/indexable-inc/index/pull/3462/files#diff-a9c433a70b28356526deca2041d824115d393894e0199a20d474cf73707ced8a) to iterate over all costly paths and assert each produces `big_change` with `reason.sources == ["costly_path"]`, and checks that routine paths do not trigger `big_change`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 886075d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->