### PR TITLE
agent: add call-owned Fabric workflow runner

### DIFF
--- a/packages/agent/fabric-agent-run/default.nix
+++ b/packages/agent/fabric-agent-run/default.nix
@@ -1,0 +1,66 @@
+{
+  ix,
+  lib,
+  pkgs,
+}: let
+  fs = lib.fileset;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./pyproject.toml
+      ./src
+      ./uv.lock
+    ];
+  };
+
+  package = ix.buildUvApplication pkgs {
+    pname = "fabric-agent-run";
+    version = "0.1.0";
+    inherit src;
+    mainProgram = "fabric-agent-run";
+    pyChecker = "zuban";
+    meta = {
+      description = "Call-owned Claude and Codex runs recorded in the Weave journal";
+      license = lib.licenses.mit;
+      mainProgram = "fabric-agent-run";
+    };
+  };
+
+  unit =
+    pkgs.runCommand "fabric-agent-run-unit"
+    {
+      strictDeps = true;
+    }
+    ''
+      ${package}/venv/bin/python -m unittest discover -s ${./tests} -v
+      mkdir -p "$out"
+    '';
+
+  printsHelp =
+    pkgs.runCommand "fabric-agent-run-prints-help"
+    {
+      nativeBuildInputs = [package];
+      strictDeps = true;
+    }
+    ''
+      help=$(fabric-agent-run --help)
+      case "$help" in
+        *"Run one Claude or Codex call"*) ;;
+        *)
+          echo "fabric-agent-run --help did not describe the command" >&2
+          printf '%s\n' "$help" >&2
+          exit 1
+          ;;
+      esac
+      mkdir -p "$out"
+    '';
+in
+  package.overrideAttrs (old: {
+    passthru =
+      (old.passthru or {})
+      // {
+        tests = {
+          inherit printsHelp unit;
+        };
+      };
+  })

--- a/packages/agent/fabric-agent-run/package.nix
+++ b/packages/agent/fabric-agent-run/package.nix
@@ -1,0 +1,9 @@
+{
+  id = "fabric-agent-run";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  passthruTests = {
+    prefix = "fabric-agent-run";
+  };
+}

--- a/packages/agent/fabric-agent-run/pyproject.toml
+++ b/packages/agent/fabric-agent-run/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "fabric-agent-run"
+version = "0.1.0"
+description = "Call-owned Claude and Codex runs recorded in the Weave journal"
+requires-python = ">=3.13"
+dependencies = [
+    "httpx>=0.28,<1",
+    "pydantic>=2,<3",
+]
+
+[project.scripts]
+fabric-agent-run = "fabric_agent_run.cli:main"
+
+[build-system]
+requires = ["uv_build>=0.11.0,<0.12.0"]
+build-backend = "uv_build"

--- a/packages/agent/fabric-agent-run/src/fabric_agent_run/__init__.py
+++ b/packages/agent/fabric-agent-run/src/fabric_agent_run/__init__.py
@@ -1,0 +1,7 @@
+"""Production owner for one Fabric-recorded agent run."""
+
+from .runner import AgentSpec, Outcome, RunState, run_agent
+
+__all__ = ["AgentSpec", "Outcome", "RunState", "run_agent"]
+
+__version__ = "0.1.0"

--- a/packages/agent/fabric-agent-run/src/fabric_agent_run/backends.py
+++ b/packages/agent/fabric-agent-run/src/fabric_agent_run/backends.py
@@ -1,0 +1,234 @@
+"""Bounded subprocess backends for the supported production harnesses."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+_ERROR_TAIL_BYTES = 8 * 1024
+_STOP_GRACE_SECONDS = 10.0
+_KILL_GRACE_SECONDS = 5.0
+
+
+class Backend(Protocol):
+    """One live agent process."""
+
+    async def result(self) -> str: ...
+
+    async def interrupt(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+
+class AgentExitError(RuntimeError):
+    """The agent process exited without a usable final answer."""
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    harness: str
+    model: str
+    effort: str | None
+    cwd: Path
+    max_result_bytes: int
+
+
+def child_environment(source: Mapping[str, str]) -> dict[str, str]:
+    """Keep workflow/provider credentials but withhold record-plane authority."""
+
+    return {
+        key: value
+        for key, value in source.items()
+        if key not in {"WEAVE_IDENTITY", "WEAVE_TOKEN", "WEAVE_URL"}
+    }
+
+
+def validate_provider_credential(harness: str, environ: Mapping[str, str]) -> None:
+    """Fail before recording a call that cannot authenticate its model."""
+
+    names = {
+        "claude": ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"),
+        "codex": ("OPENAI_API_KEY",),
+    }[harness]
+    if not any(environ.get(name) for name in names):
+        joined = " or ".join(names)
+        raise RuntimeError(f"{harness} requires {joined} in the runner environment")
+
+
+def argv_for(spec: BackendSpec, result_file: Path) -> list[str]:
+    """Return the non-secret argv; the prompt is always delivered on stdin."""
+
+    if spec.harness == "claude":
+        return [
+            "claude",
+            "-p",
+            "--no-session-persistence",
+            "--model",
+            spec.model,
+        ]
+    effort = spec.effort or "medium"
+    return [
+        "codex",
+        "exec",
+        "--skip-git-repo-check",
+        "--ephemeral",
+        "-c",
+        f"model_reasoning_effort={effort!r}",
+        "--model",
+        spec.model,
+        "--sandbox",
+        "danger-full-access",
+        "--output-last-message",
+        os.fspath(result_file),
+        "-",
+    ]
+
+
+def _read_bounded(path: Path, limit: int, *, label: str) -> bytes:
+    size = path.stat().st_size
+    if size > limit:
+        raise AgentExitError(f"{label} is {size} bytes; limit is {limit} bytes")
+    return path.read_bytes()
+
+
+def _read_tail(path: Path, limit: int = _ERROR_TAIL_BYTES) -> str:
+    with path.open("rb") as stream:
+        stream.seek(0, os.SEEK_END)
+        size = stream.tell()
+        stream.seek(max(0, size - limit))
+        return stream.read().decode(errors="replace").strip()
+
+
+def _signal_group(process: asyncio.subprocess.Process, signum: signal.Signals) -> None:
+    """Signal a still-live process group, tolerating an exit between checks."""
+
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process.pid, signum)
+
+
+class ProcessBackend:
+    """A process group with disk-spooled output and bounded final reads."""
+
+    def __init__(
+        self,
+        *,
+        spec: BackendSpec,
+        tempdir: tempfile.TemporaryDirectory[str],
+        process: asyncio.subprocess.Process,
+        stdout_path: Path,
+        stderr_path: Path,
+        result_path: Path,
+    ) -> None:
+        self._spec = spec
+        self._tempdir = tempdir
+        self._process = process
+        self._stdout_path = stdout_path
+        self._stderr_path = stderr_path
+        self._result_path = result_path
+        self._interrupted = False
+
+    @classmethod
+    async def spawn(
+        cls,
+        spec: BackendSpec,
+        prompt: bytes,
+        *,
+        environ: Mapping[str, str],
+    ) -> ProcessBackend:
+        tempdir = tempfile.TemporaryDirectory(prefix="fabric-agent-run-")
+        root = Path(tempdir.name)
+        stdout_path = root / "stdout.log"
+        stderr_path = root / "stderr.log"
+        result_path = root / "result.txt"
+        argv = argv_for(spec, result_path)
+        process: asyncio.subprocess.Process | None = None
+        try:
+            with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+                process = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=stdout,
+                    stderr=stderr,
+                    cwd=spec.cwd,
+                    env=child_environment(environ),
+                    start_new_session=True,
+                )
+            if process.stdin is None:
+                raise RuntimeError("agent process has no stdin pipe")
+            process.stdin.write(prompt)
+            await process.stdin.drain()
+            process.stdin.close()
+            await process.stdin.wait_closed()
+        except BaseException:
+            if process is not None and process.returncode is None:
+                _signal_group(process, signal.SIGKILL)
+                await process.wait()
+            tempdir.cleanup()
+            raise
+        return cls(
+            spec=spec,
+            tempdir=tempdir,
+            process=process,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            result_path=result_path,
+        )
+
+    async def result(self) -> str:
+        code = await self._process.wait()
+        if code != 0:
+            detail = _read_tail(self._stderr_path) or _read_tail(self._stdout_path)
+            suffix = f": {detail}" if detail else ""
+            raise AgentExitError(f"{self._spec.harness} exited {code}{suffix}")
+        path = self._stdout_path if self._spec.harness == "claude" else self._result_path
+        if not path.exists():
+            raise AgentExitError(f"{self._spec.harness} wrote no final result")
+        body = _read_bounded(path, self._spec.max_result_bytes, label="agent result")
+        return body.decode(errors="replace").strip()
+
+    async def interrupt(self) -> None:
+        if self._interrupted or self._process.returncode is not None:
+            return
+        self._interrupted = True
+        _signal_group(self._process, signal.SIGINT)
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self._process.wait()),
+                timeout=_STOP_GRACE_SECONDS,
+            )
+            return
+        except TimeoutError:
+            _signal_group(self._process, signal.SIGTERM)
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self._process.wait()),
+                timeout=_KILL_GRACE_SECONDS,
+            )
+        except TimeoutError:
+            _signal_group(self._process, signal.SIGKILL)
+            await self._process.wait()
+
+    async def close(self) -> None:
+        if self._process.returncode is None:
+            await self.interrupt()
+        self._tempdir.cleanup()
+
+
+async def spawn_backend(
+    spec: BackendSpec,
+    prompt: bytes,
+    *,
+    environ: Mapping[str, str],
+) -> Backend:
+    return await ProcessBackend.spawn(spec, prompt, environ=environ)
+
+
+def supported_harnesses() -> Sequence[str]:
+    return ("claude", "codex")

--- a/packages/agent/fabric-agent-run/src/fabric_agent_run/cli.py
+++ b/packages/agent/fabric-agent-run/src/fabric_agent_run/cli.py
@@ -1,0 +1,140 @@
+"""Command-line boundary for a single production Fabric agent call."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import signal
+import sys
+from pathlib import Path
+
+from .backends import supported_harnesses, validate_provider_credential
+from .runner import AgentSpec, Outcome, RunState, run_agent
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="fabric-agent-run",
+        description="Run one Claude or Codex call and record its full lifecycle in Weave.",
+    )
+    parser.add_argument("--name", required=True, help="workflow name recorded on the task")
+    parser.add_argument("--harness", required=True, choices=supported_harnesses())
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--effort", help="reasoning effort (Codex only)")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=_positive_float,
+        default=3600.0,
+        help="hard wall-clock deadline (default: 3600)",
+    )
+    parser.add_argument(
+        "--max-result-bytes",
+        type=_positive_int,
+        default=16 * 1024 * 1024,
+        help="maximum final answer size read into memory (default: 16777216)",
+    )
+    parser.add_argument("--cwd", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--requested-by",
+        default=os.environ.get("IX_WEAVE_AGENT") or "fabric-agent-run",
+    )
+    parser.add_argument(
+        "--prompt-file",
+        type=argparse.FileType("rb"),
+        default=sys.stdin.buffer,
+        help="prompt file; default is stdin",
+    )
+    parser.add_argument(
+        "--output",
+        choices=("text", "json"),
+        default="text",
+        help="terminal output format (default: text)",
+    )
+    return parser
+
+
+def _install_signal_handlers(stop: asyncio.Event) -> None:
+    loop = asyncio.get_running_loop()
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(signum, stop.set)
+
+
+def _emit(outcome: Outcome, output: str) -> None:
+    if output == "json":
+        print(
+            json.dumps(
+                {
+                    "task": outcome.task,
+                    "state": outcome.state.value,
+                    "result": outcome.result,
+                    "error": outcome.error,
+                },
+                separators=(",", ":"),
+            )
+        )
+        return
+    if outcome.state == RunState.DONE:
+        print(outcome.result or "")
+    elif outcome.error:
+        print(f"fabric-agent-run: {outcome.task}: {outcome.error}", file=sys.stderr)
+    else:
+        print(f"fabric-agent-run: {outcome.task}: {outcome.state.value}", file=sys.stderr)
+
+
+async def _run(args: argparse.Namespace) -> Outcome:
+    harness: str = args.harness
+    validate_provider_credential(harness, os.environ)
+    prompt: bytes = args.prompt_file.read()
+    if not prompt.strip():
+        raise ValueError("prompt is empty")
+    cwd: Path = await asyncio.to_thread(args.cwd.resolve, strict=True)
+    if not await asyncio.to_thread(cwd.is_dir):
+        raise NotADirectoryError(cwd)
+    if harness == "claude" and args.effort is not None:
+        raise ValueError("--effort is supported only by the codex harness")
+    stop = asyncio.Event()
+    _install_signal_handlers(stop)
+    spec = AgentSpec(
+        name=args.name,
+        harness=harness,
+        model=args.model,
+        effort=args.effort,
+        prompt=prompt,
+        cwd=cwd,
+        timeout_seconds=args.timeout_seconds,
+        requested_by=args.requested_by,
+        max_result_bytes=args.max_result_bytes,
+    )
+    return await run_agent(spec, stop=stop)
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    try:
+        outcome = asyncio.run(_run(args))
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"fabric-agent-run: {exc}", file=sys.stderr)
+        raise SystemExit(2) from None
+    _emit(outcome, args.output)
+    exit_code = {
+        RunState.DONE: 0,
+        RunState.FAILED: 1,
+        RunState.INTERRUPTED: 130,
+    }[outcome.state]
+    raise SystemExit(exit_code)

--- a/packages/agent/fabric-agent-run/src/fabric_agent_run/journal.py
+++ b/packages/agent/fabric-agent-run/src/fabric_agent_run/journal.py
@@ -1,0 +1,144 @@
+"""The narrow Weave record-plane contract used by the agent runner."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import secrets
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+import httpx
+from pydantic import BaseModel, ConfigDict
+
+_DEFAULT_URL = "http://127.0.0.1:7677"
+
+
+@dataclass(frozen=True)
+class HashRef:
+    """A CAS digest that must use Weave's hash wire type."""
+
+    value: str
+
+
+Fact = tuple[str, str, str | HashRef]
+
+
+class Journal(Protocol):
+    """Typed seam so lifecycle tests do not need an HTTP server."""
+
+    async def put_blob(self, body: bytes) -> HashRef: ...
+
+    async def assert_facts(self, facts: Sequence[Fact]) -> None: ...
+
+    async def latest(self, entity: str, attr: str) -> str | None: ...
+
+
+class _BlobResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    hash: str
+
+
+class _Value(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    t: str
+    v: str | int | float | bool | None
+
+
+class _QueryResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    rows: list[list[_Value]]
+
+
+def mint_task() -> str:
+    """Mint the same task id shape as the bundled ``fabric`` module."""
+
+    return f"task:{secrets.token_hex(4)}"
+
+
+def _wire_value(value: str | HashRef) -> dict[str, str]:
+    if isinstance(value, HashRef):
+        return {"t": "hash", "v": value.value.removeprefix("blake3:")}
+    return {"t": "str", "v": value}
+
+
+def _wire_fact(entity: str, attr: str, value: str | HashRef) -> dict[str, object]:
+    return {
+        "fact": {
+            "entity": {"t": "str", "v": entity},
+            "attr": attr,
+            "value": _wire_value(value),
+        }
+    }
+
+
+class WeaveJournal:
+    """Async HTTP client for the local Weave record plane."""
+
+    def __init__(
+        self,
+        *,
+        url: str | None = None,
+        token: str | None = None,
+        identity: str | None = None,
+    ) -> None:
+        self._url = url or os.environ.get("WEAVE_URL") or _DEFAULT_URL
+        self._token = token if token is not None else os.environ.get("WEAVE_TOKEN")
+        self._identity = (
+            identity if identity is not None else os.environ.get("WEAVE_IDENTITY")
+        )
+        self._http = httpx.AsyncClient(base_url=self._url, headers=self._headers())
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self._token:
+            headers["X-Api-Key"] = self._token
+        if self._identity:
+            headers["tailscale-user-login"] = self._identity
+        return headers
+
+    async def put_blob(self, body: bytes) -> HashRef:
+        response = await self._http.post("/api/blob", content=body)
+        response.raise_for_status()
+        parsed = _BlobResponse.model_validate_json(response.content)
+        digest = parsed.hash
+        return HashRef(digest if digest.startswith("blake3:") else f"blake3:{digest}")
+
+    async def assert_facts(self, facts: Sequence[Fact]) -> None:
+        if not facts:
+            return
+        payload = [_wire_fact(entity, attr, value) for entity, attr, value in facts]
+        response = await self._http.post("/api/facts", json=payload)
+        response.raise_for_status()
+
+    async def latest(self, entity: str, attr: str) -> str | None:
+        program = f'?- latest("{entity}", {attr}, V).'
+        response = await self._http.post("/api/query", json={"program": program})
+        response.raise_for_status()
+        parsed = _QueryResponse.model_validate_json(response.content)
+        if not parsed.rows or not parsed.rows[0]:
+            return None
+        value = parsed.rows[0][0].v
+        return value if isinstance(value, str) else None
+
+    async def close(self) -> None:
+        """Release the one pooled HTTP client owned by this run."""
+
+        await self._http.aclose()
+
+
+async def wait_for_interrupt(
+    journal: Journal,
+    task: str,
+    *,
+    poll_seconds: float,
+) -> None:
+    """Return once the durable interrupt request is visible."""
+
+    # A durable remote fact has no local event to await. Polling is the protocol.
+    while await journal.latest(task, "interrupt") != "requested":  # noqa: ASYNC110
+        await asyncio.sleep(poll_seconds)

--- a/packages/agent/fabric-agent-run/src/fabric_agent_run/runner.py
+++ b/packages/agent/fabric-agent-run/src/fabric_agent_run/runner.py
@@ -1,0 +1,202 @@
+"""One call-owned state machine from submission through a terminal fact."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import platform
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from .backends import Backend, BackendSpec, spawn_backend
+from .journal import Fact, Journal, WeaveJournal, mint_task, wait_for_interrupt
+
+_POLL_SECONDS = 0.5
+
+
+class RunState(StrEnum):
+    DONE = "done"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    name: str
+    harness: str
+    model: str
+    prompt: bytes
+    cwd: Path
+    timeout_seconds: float
+    effort: str | None = None
+    requested_by: str = "fabric-agent-run"
+    max_result_bytes: int = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class Outcome:
+    task: str
+    state: RunState
+    result: str | None = None
+    error: str | None = None
+
+
+BackendFactory = Callable[[BackendSpec, bytes, Mapping[str, str]], Awaitable[Backend]]
+
+
+async def _default_backend_factory(
+    spec: BackendSpec,
+    prompt: bytes,
+    environ: Mapping[str, str],
+) -> Backend:
+    return await spawn_backend(spec, prompt, environ=environ)
+
+
+async def _write_terminal(
+    journal: Journal,
+    task: str,
+    state: RunState,
+    *,
+    result: str | None = None,
+    error: str | None = None,
+) -> Outcome:
+    facts: list[Fact] = []
+    if result is not None:
+        result_hash = await journal.put_blob(result.encode())
+        facts.append((task, "result", result_hash))
+    if error is not None:
+        facts.append((task, "error", error))
+    facts.append((task, "state", state.value))
+    await journal.assert_facts(facts)
+    return Outcome(task=task, state=state, result=result, error=error)
+
+
+async def run_agent(
+    spec: AgentSpec,
+    *,
+    journal: Journal | None = None,
+    backend_factory: BackendFactory = _default_backend_factory,
+    stop: asyncio.Event | None = None,
+    environ: Mapping[str, str] | None = None,
+    poll_seconds: float = _POLL_SECONDS,
+) -> Outcome:
+    """Own one agent call until ``done``, ``failed``, or ``interrupted``."""
+
+    owned_record: WeaveJournal | None = None
+    if journal is None:
+        owned_record = WeaveJournal()
+        record: Journal = owned_record
+    else:
+        record = journal
+    environment = environ or os.environ
+    prompt_hash = await record.put_blob(spec.prompt)
+    task = mint_task()
+    await record.assert_facts(
+        [
+            (task, "type", "task"),
+            (task, "fn", f"agent.{spec.harness}"),
+            (task, "name", spec.name),
+            (task, "harness", spec.harness),
+            (task, "model", spec.model),
+            *([(task, "effort", spec.effort)] if spec.effort is not None else []),
+            (task, "node", platform.node()),
+            (task, "requested_by", spec.requested_by),
+            (task, "prompt", prompt_hash),
+            (task, "state", "submitted"),
+        ]
+    )
+
+    backend_spec = BackendSpec(
+        harness=spec.harness,
+        model=spec.model,
+        effort=spec.effort,
+        cwd=spec.cwd,
+        max_result_bytes=spec.max_result_bytes,
+    )
+    backend: Backend | None = None
+    result_task: asyncio.Task[str] | None = None
+    interrupt_task: asyncio.Task[None] | None = None
+    signal_task: asyncio.Task[bool] | None = None
+    timeout_task: asyncio.Task[None] | None = None
+    try:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + spec.timeout_seconds
+        async with asyncio.timeout(spec.timeout_seconds):
+            backend = await backend_factory(backend_spec, spec.prompt, environment)
+        await record.assert_facts([(task, "state", "running")])
+        result_task = asyncio.create_task(backend.result(), name=f"fabric-agent:{task}")
+        interrupt_task = asyncio.create_task(
+            wait_for_interrupt(record, task, poll_seconds=poll_seconds),
+            name=f"fabric-agent:interrupt:{task}",
+        )
+        if stop is not None:
+            signal_task = asyncio.create_task(stop.wait(), name=f"fabric-agent:signal:{task}")
+        timeout_task = asyncio.create_task(
+            asyncio.sleep(max(0.0, deadline - loop.time())),
+            name=f"fabric-agent:timeout:{task}",
+        )
+        waiters: set[asyncio.Task[object]] = {result_task, interrupt_task, timeout_task}
+        if signal_task is not None:
+            waiters.add(signal_task)
+        done, _pending = await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
+
+        if result_task in done:
+            try:
+                result = result_task.result()
+            except BaseException as exc:
+                return await _write_terminal(
+                    record,
+                    task,
+                    RunState.FAILED,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+            return await _write_terminal(record, task, RunState.DONE, result=result)
+
+        await backend.interrupt()
+        await asyncio.gather(result_task, return_exceptions=True)
+        if interrupt_task in done:
+            watch_error = interrupt_task.exception()
+            if watch_error is not None:
+                return await _write_terminal(
+                    record,
+                    task,
+                    RunState.FAILED,
+                    error=f"interrupt watch failed: {type(watch_error).__name__}: {watch_error}",
+                )
+        if timeout_task in done:
+            return await _write_terminal(
+                record,
+                task,
+                RunState.FAILED,
+                error=f"TimeoutError: agent did not finish within {spec.timeout_seconds:g}s",
+            )
+        return await _write_terminal(record, task, RunState.INTERRUPTED)
+    except asyncio.CancelledError:
+        if backend is not None:
+            await asyncio.shield(backend.interrupt())
+        await asyncio.shield(_write_terminal(record, task, RunState.INTERRUPTED))
+        raise
+    except TimeoutError:
+        return await _write_terminal(
+            record,
+            task,
+            RunState.FAILED,
+            error=f"TimeoutError: agent did not start within {spec.timeout_seconds:g}s",
+        )
+    except BaseException as exc:
+        return await _write_terminal(
+            record,
+            task,
+            RunState.FAILED,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    finally:
+        for pending in (interrupt_task, signal_task, timeout_task):
+            if pending is not None:
+                pending.cancel()
+        if backend is not None:
+            await backend.close()
+        if owned_record is not None:
+            await owned_record.close()

--- a/packages/agent/fabric-agent-run/tests/test_runner.py
+++ b/packages/agent/fabric-agent-run/tests/test_runner.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from fabric_agent_run.backends import (
+    Backend,
+    BackendSpec,
+    ProcessBackend,
+    argv_for,
+    child_environment,
+)
+from fabric_agent_run.journal import Fact, HashRef
+from fabric_agent_run.runner import AgentSpec, RunState, run_agent
+
+
+class FakeJournal:
+    def __init__(self) -> None:
+        self.facts: list[Fact] = []
+        self.blobs: dict[str, bytes] = {}
+        self.interrupt: str | None = None
+        self.latest_error: Exception | None = None
+
+    async def put_blob(self, body: bytes) -> HashRef:
+        digest = hashlib.sha256(body).hexdigest()
+        self.blobs[digest] = body
+        return HashRef(f"blake3:{digest}")
+
+    async def assert_facts(self, facts: Sequence[Fact]) -> None:
+        self.facts.extend(facts)
+
+    async def latest(self, entity: str, attr: str) -> str | None:
+        del entity
+        if self.latest_error is not None:
+            raise self.latest_error
+        return self.interrupt if attr == "interrupt" else None
+
+    def states(self, task: str) -> list[str]:
+        return [
+            value
+            for entity, attr, value in self.facts
+            if entity == task and attr == "state" and isinstance(value, str)
+        ]
+
+    def blob(self, task: str, attr: str) -> bytes:
+        refs = [
+            value
+            for entity, fact_attr, value in self.facts
+            if entity == task and fact_attr == attr and isinstance(value, HashRef)
+        ]
+        ref = refs[-1]
+        return self.blobs[ref.value.removeprefix("blake3:")]
+
+
+class FakeBackend(Backend):
+    def __init__(self) -> None:
+        self.answer: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        self.interrupts = 0
+        self.closed = 0
+
+    async def result(self) -> str:
+        return await self.answer
+
+    async def interrupt(self) -> None:
+        self.interrupts += 1
+        if not self.answer.done():
+            self.answer.set_exception(RuntimeError("stopped"))
+
+    async def close(self) -> None:
+        self.closed += 1
+
+
+def spec(*, timeout: float = 10.0) -> AgentSpec:
+    return AgentSpec(
+        name="quality",
+        harness="codex",
+        model="gpt-5.6-sol",
+        effort="medium",
+        prompt=b"fix it",
+        cwd=Path.cwd(),
+        timeout_seconds=timeout,
+    )
+
+
+class LifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_success_is_submitted_running_done_with_cas_payloads(self) -> None:
+        journal = FakeJournal()
+        backend = FakeBackend()
+
+        async def factory(
+            backend_spec: BackendSpec,
+            prompt: bytes,
+            environ: Mapping[str, str],
+        ) -> Backend:
+            assert backend_spec.harness == "codex"
+            assert prompt == b"fix it"
+            assert environ["OPENAI_API_KEY"] == "secret"
+            return backend
+
+        task = asyncio.create_task(
+            run_agent(
+                spec(),
+                journal=journal,
+                backend_factory=factory,
+                environ={"OPENAI_API_KEY": "secret"},
+                poll_seconds=0.001,
+            )
+        )
+        await asyncio.sleep(0)
+        backend.answer.set_result("done well")
+        outcome = await task
+
+        assert outcome.state == RunState.DONE
+        assert journal.states(outcome.task) == ["submitted", "running", "done"]
+        assert "pending" not in journal.states(outcome.task)
+        assert journal.blob(outcome.task, "prompt") == b"fix it"
+        assert journal.blob(outcome.task, "result") == b"done well"
+        assert journal.facts[-1] == (outcome.task, "state", "done")
+        assert backend.closed == 1
+
+    async def test_journal_interrupt_stops_backend_and_writes_one_terminal(self) -> None:
+        journal = FakeJournal()
+        backend = FakeBackend()
+
+        async def factory(
+            backend_spec: BackendSpec,
+            prompt: bytes,
+            environ: Mapping[str, str],
+        ) -> Backend:
+            del backend_spec, prompt, environ
+            return backend
+
+        task = asyncio.create_task(
+            run_agent(
+                spec(),
+                journal=journal,
+                backend_factory=factory,
+                poll_seconds=0.001,
+            )
+        )
+        await asyncio.sleep(0.01)
+        journal.interrupt = "requested"
+        outcome = await task
+
+        assert outcome.state == RunState.INTERRUPTED
+        assert journal.states(outcome.task) == ["submitted", "running", "interrupted"]
+        assert backend.interrupts == 1
+
+    async def test_timeout_stops_backend_and_cannot_later_publish_done(self) -> None:
+        journal = FakeJournal()
+        backend = FakeBackend()
+
+        async def factory(
+            backend_spec: BackendSpec,
+            prompt: bytes,
+            environ: Mapping[str, str],
+        ) -> Backend:
+            del backend_spec, prompt, environ
+            return backend
+
+        outcome = await run_agent(
+            spec(timeout=0.001),
+            journal=journal,
+            backend_factory=factory,
+            poll_seconds=0.001,
+        )
+
+        assert outcome.state == RunState.FAILED
+        assert "TimeoutError" in (outcome.error or "")
+        assert journal.states(outcome.task) == ["submitted", "running", "failed"]
+        assert backend.interrupts == 1
+
+    async def test_signal_stops_backend_and_records_interrupted(self) -> None:
+        journal = FakeJournal()
+        backend = FakeBackend()
+        stop = asyncio.Event()
+
+        async def factory(
+            backend_spec: BackendSpec,
+            prompt: bytes,
+            environ: Mapping[str, str],
+        ) -> Backend:
+            del backend_spec, prompt, environ
+            return backend
+
+        task = asyncio.create_task(
+            run_agent(
+                spec(),
+                journal=journal,
+                backend_factory=factory,
+                stop=stop,
+                poll_seconds=0.001,
+            )
+        )
+        await asyncio.sleep(0.01)
+        stop.set()
+        outcome = await task
+
+        assert outcome.state == RunState.INTERRUPTED
+        assert journal.states(outcome.task) == ["submitted", "running", "interrupted"]
+        assert backend.interrupts == 1
+
+    async def test_interrupt_watch_failure_stops_as_failed_not_interrupted(self) -> None:
+        journal = FakeJournal()
+        backend = FakeBackend()
+        journal.latest_error = ConnectionError("weave unavailable")
+
+        async def factory(
+            backend_spec: BackendSpec,
+            prompt: bytes,
+            environ: Mapping[str, str],
+        ) -> Backend:
+            del backend_spec, prompt, environ
+            return backend
+
+        outcome = await run_agent(
+            spec(),
+            journal=journal,
+            backend_factory=factory,
+            poll_seconds=0.001,
+        )
+
+        assert outcome.state == RunState.FAILED
+        assert "interrupt watch failed" in (outcome.error or "")
+        assert journal.states(outcome.task) == ["submitted", "running", "failed"]
+        assert backend.interrupts == 1
+
+    async def test_start_timeout_is_terminal_without_claiming_running(self) -> None:
+        journal = FakeJournal()
+
+        async def factory(
+            backend_spec: BackendSpec,
+            prompt: bytes,
+            environ: Mapping[str, str],
+        ) -> Backend:
+            del backend_spec, prompt, environ
+            await asyncio.sleep(60)
+            raise AssertionError("unreachable")
+
+        outcome = await run_agent(
+            spec(timeout=0.001),
+            journal=journal,
+            backend_factory=factory,
+        )
+
+        assert outcome.state == RunState.FAILED
+        assert "did not start" in (outcome.error or "")
+        assert journal.states(outcome.task) == ["submitted", "failed"]
+
+    async def test_spawn_failure_is_terminal_and_never_claims_running(self) -> None:
+        journal = FakeJournal()
+
+        async def factory(
+            backend_spec: BackendSpec,
+            prompt: bytes,
+            environ: Mapping[str, str],
+        ) -> Backend:
+            del backend_spec, prompt, environ
+            raise FileNotFoundError("codex")
+
+        outcome = await run_agent(spec(), journal=journal, backend_factory=factory)
+
+        assert outcome.state == RunState.FAILED
+        assert journal.states(outcome.task) == ["submitted", "failed"]
+        assert "FileNotFoundError" in (outcome.error or "")
+
+
+class BackendContractTests(unittest.TestCase):
+    def test_prompt_never_rides_argv(self) -> None:
+        cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as raw:
+            result = Path(raw) / "result"
+            codex = argv_for(
+                BackendSpec("codex", "gpt-5.6-sol", "medium", cwd, 1024),
+                result,
+            )
+            claude = argv_for(BackendSpec("claude", "fable", None, cwd, 1024), result)
+        assert codex[-1] == "-"
+        assert claude == [
+            "claude",
+            "-p",
+            "--no-session-persistence",
+            "--model",
+            "fable",
+        ]
+        assert "--ephemeral" in codex
+        assert "fix it" not in codex + claude
+
+    def test_child_environment_withholds_weave_authority_only(self) -> None:
+        child = child_environment(
+            {
+                "WEAVE_URL": "http://weave",
+                "WEAVE_TOKEN": "record-secret",
+                "WEAVE_IDENTITY": "owner@example.com",
+                "OPENAI_API_KEY": "provider-secret",
+                "GH_TOKEN": "workflow-secret",
+            }
+        )
+        assert "WEAVE_URL" not in child
+        assert "WEAVE_TOKEN" not in child
+        assert "WEAVE_IDENTITY" not in child
+        assert child["OPENAI_API_KEY"] == "provider-secret"
+        assert child["GH_TOKEN"] == "workflow-secret"  # noqa: S105 -- inert fixture
+
+
+class ProcessBackendTests(unittest.IsolatedAsyncioTestCase):
+    async def test_codex_prompt_and_result_cross_the_real_process_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            fake = root / "codex"
+            fake.write_text(
+                f"""#!{sys.executable}
+import pathlib
+import sys
+
+prompt = sys.stdin.read()
+output = pathlib.Path(sys.argv[sys.argv.index("--output-last-message") + 1])
+output.write_text("reply: " + prompt)
+print("activity log")
+"""
+            )
+            fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+            backend = await ProcessBackend.spawn(
+                BackendSpec("codex", "gpt-5.6-sol", "medium", root, 1024),
+                b"from stdin",
+                environ={
+                    "PATH": os.fspath(root),
+                    "OPENAI_API_KEY": "provider-secret",
+                    "WEAVE_TOKEN": "record-secret",
+                },
+            )
+            try:
+                assert await backend.result() == "reply: from stdin"
+            finally:
+                await backend.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agent/fabric-agent-run/uv.lock
+++ b/packages/agent/fabric-agent-run/uv.lock
@@ -1,0 +1,186 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "fabric-agent-run"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "pydantic", specifier = ">=2,<3" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]


### PR DESCRIPTION
Adds the production owner process missing from the call-first Fabric migration.

- records CAS-backed prompts/results and submitted -> running -> terminal lifecycle facts
- drives Claude and Codex through bounded, nonpersistent subprocess backends
- handles journal interrupts, OS signals, startup/runtime deadlines, and process-group teardown
- withholds Weave authority from agent children while preserving explicit provider/workflow credentials

Tests: nix build --no-link .#fabric-agent-run.passthru.tests.unit .#fabric-agent-run.passthru.tests.printsHelp; nix run .#lint

Authored with Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `fabric-agent-run` CLI for call-owned Fabric workflow execution
> - Introduces a new Python package [`fabric-agent-run`](https://github.com/indexable-inc/index/pull/3463/files#diff-5e396c019af36558a9be6e0637873f00a1fe15f01b1e8763249e6db47c9ac69e) that runs external AI agent harnesses (`claude`, `codex`) as subprocesses and records lifecycle state in a Weave record plane.
> - [`runner.py`](https://github.com/indexable-inc/index/pull/3463/files#diff-24a51edb9e933a34e63167e23837d65c5b36f01f629d76029784e4dc931932c3) implements the core async state machine: submits a prompt blob, spawns a backend process, and resolves to `DONE`, `FAILED`, or `INTERRUPTED` with durable Weave fact recording.
> - [`backends.py`](https://github.com/indexable-inc/index/pull/3463/files#diff-2723802f626c6e38d8821f735d6cad0b1c46d31abe3f6d1665052d6741d1fe13) handles process lifecycle — spawning harnesses with bounded stdout/stderr spooling to disk, staged interrupt (SIGINT → SIGTERM → SIGKILL), and filtering Weave identity vars from child environment.
> - [`journal.py`](https://github.com/indexable-inc/index/pull/3463/files#diff-0f690690a3f0210e0cbd833dc3fc7d2097d125e4214a0d04110fae08c16c8045) provides an async HTTP client for the Weave record plane (blob upload, fact assertion, query polling) and a cooperative interrupt poller.
> - The `fabric-agent-run` CLI ([`cli.py`](https://github.com/indexable-inc/index/pull/3463/files#diff-b72c48542e12b0b0a4b9320b9933a0881a39fd2f60e3f13d55d520852da6ffee)) exposes all parameters as flags, installs SIGINT/SIGTERM handlers, and maps terminal states to structured exit codes (0 done, 1 failed, 130 interrupted).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 682461c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->