### PR TITLE
revert: restore clone diff_pct = 0.0 after the fmt lane landed

### DIFF
--- a/clone.toml
+++ b/clone.toml
@@ -38,9 +38,5 @@ ignore = [
 # measured on the same code).
 [budget]
 global_pct = 0.45
-# ONE-SHOT EXCEPTION (#3454, revert tracked by #3456): the tree-wide cargo
-# fmt the new rust fixer lane applies touches 239 lines inside PRE-EXISTING
-# clone fragments, and the diff gate is not base-aware (#3455), so it counts
-# them as new duplication (6.34%). Restore 0.0 immediately after #3454 lands.
-diff_pct = 7.0
+diff_pct = 0.0
 diff_base = "origin/main"


### PR DESCRIPTION
Restores the clone diff gate to `diff_pct = 0.0` now that #3454 (tree-wide cargo fmt lane) is merged; the one-shot 7.0 exception and its comment are removed. The root fix for why the exception was needed at all (diff gate not base-aware) is tracked by #3455.

Closes #3456.

🤖 Authored by an AI agent (Claude Opus 4.5 via Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `diff_pct` to 0.0 in clone budget config after fmt lane landed
> Reverts the temporary exception in [clone.toml](https://github.com/indexable-inc/index/pull/3464/files#diff-71d9798ec940a623c1ae0813b562b8a292318681adc4a729e6243e6be7e59385) that raised `diff_pct` to 7.0 during the fmt lane rollout. Now that the fmt lane has landed, the clone duplication budget threshold is restored to 0.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0f68a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->