### PR TITLE
playbook: rust fmt fixer lane writeup

### DIFF
--- a/playbook/src/routes/rust-fmt-lane/+page.svx
+++ b/playbook/src/routes/rust-fmt-lane/+page.svx
@@ -1,0 +1,63 @@
+---
+title: "Rust fmt fixer lane: landing a 208-file reformat through every gate"
+date: 2026-07-16
+---
+
+The lint fixer gained a rust lane (#3433, PR #3454): `cargo fmt` with the
+repo-pinned nightly toolchain, shaped so the future `clippy --fix` lane
+(#3434) absorbs into the same seam. Landing the lane meant landing the
+tree-wide reformat it produces: 208 files, and every downstream gate that
+reformat could trip.
+
+## Reformats surface latent clippy lints
+
+The clippy gate (`-D clippy::all -D clippy::nursery -D clippy::pedantic`,
+enforced per rustc unit) failed on code the reformat merely re-wrapped.
+Two lint classes accounted for every failure:
+
+- `semicolon_if_nothing_returned`: a one-line match arm or closure tail
+  becomes a block, and the now-statement-shaped tail needs a `;`.
+- `too_many_lines`: a dense one-liner expands to several lines and pushes
+  a function past the 100-line budget.
+
+The fixes stayed at the source, no `#[allow]`: extracting
+`index_user_shell`, `reject_unsupported`, `closure_gate_stages`,
+`resolve_closure`, and `dry_run_report` out of over-budget functions.
+One extraction then tripped a third lint,
+`anonymous_tuple_return_type`, and became a named `struct Closure`.
+
+## Hand fixes must survive the lane itself
+
+Any manual restructuring risks being re-expanded by the very formatter
+the lane runs. The loop that guarantees the lane's no-op property: commit,
+build `.#lint-fix-patch`, and while the patch is nonzero, `git apply` it
+and amend. Two iterations converged to a 0-byte patch; a one-line helper
+call the formatter insisted on re-wrapping was restructured rather than
+fought.
+
+## Finding every failure at once
+
+The `flake-check` job log tail never contains the real error; the
+`check-timings-<run-id>` artifact's `check-results.json` does. But
+fail-fast truncates it: successive runs reported 47, then 60 failing-or-
+passing clippy entries while the flake defines 111 `-clippy` check attrs.
+Whack-a-mole ended by enumerating the attrs from the flake itself and
+building all 111 with `--keep-going` on the x86 builder, which exposed
+the full failure set in one pass.
+
+## Infra noise en route
+
+Two non-code failures interleaved. The builder's `/nix/store` hit 100%
+with the GC sweep active, and the storage-admission-patched daemon killed
+client builds with `error: interrupted by the user` (piped and detached
+alike). And CI jobs queued during the sweep started past their queue
+admission deadline, failing instantly; a rerun issued once the dispatcher
+was responsive was admitted in time.
+
+## Aftermath
+
+The reformat touched 239 lines inside pre-existing clone fragments and
+the clone diff gate, not being base-aware, read them as 6.34% new
+duplication. A one-shot `diff_pct = 7.0` exception let #3454 land and was
+reverted the same hour (#3464). The root fix, counting only duplication
+new relative to the diff base, is #3455.


### PR DESCRIPTION
Playbook page for the rust fmt fixer lane (#3433 / PR #3454): the clippy lints a tree-wide reformat surfaces, the lint-fix-patch no-op loop, the 111-attr preflight recipe, the vin storage-admission interrupts, and the clone diff gate aftermath (#3455, #3456).

🤖 Authored by an AI agent (Claude Opus 4.5 via Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add playbook page documenting the Rust fmt fixer lane
> Adds a new [+page.svx](https://github.com/indexable-inc/index/pull/3465/files#diff-3a444a0e900908e5a3038a4d94cbac7028c097aa889e72079a667a6aae43cf98) SvelteKit page that documents the Rust fmt fixer lane, covering its integration with clippy, handling of formatter-induced clippy issues, CI strategies for surfacing all failures, infra issues encountered, and the aftermath around clone-diff gating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5d7d14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->