### PR TITLE
ci: make flake updater self-contained

### DIFF
--- a/.github/actions/bootstrap-patched-nix/action.yml
+++ b/.github/actions/bootstrap-patched-nix/action.yml
@@ -1,89 +1,15 @@
 name: Bootstrap patched Nix client
 description: >-
-  Put the fleet's patched Nix client (nix-ix, packages/nix/nix) first on
-  PATH for every later step. Repo .nix files use underscore digit separators
-  in numeric literals, which a stock client cannot parse, so every nix
-  invocation that evaluates this tree must go through the patched client
-  (builds still talk to the host daemon; the 2.34.7+ix client is
-  protocol-compatible with the fleet daemon family). Evaluating the current
-  tree to build that client would be circular, so the client is built from a
-  pinned separator-free revision and substituted from the warm store /
-  cache.ix.dev on repeat runs. Downstream repositories fetch that revision
-  from the repository that owns this action. Requires git and a nix client on
-  PATH (the host daemon's on self-hosted runners, the install-nix action's
-  elsewhere).
+  Put the fleet's patched Nix client first on PATH. A compatible preinstalled
+  client is reused; otherwise build the pinned separator-free bootstrap source
+  in fresh private temporary directories.
 
 runs:
   using: composite
   steps:
-    - name: Build the patched Nix client from the pinned rev
+    - name: Resolve the patched Nix client
       shell: bash
       env:
         BOOTSTRAP_LOCK: ${{ github.action_path }}/lock.json
         BOOTSTRAP_LOCK_READER: ${{ github.action_path }}/read-lock.nix
-      run: |
-        set -euo pipefail
-        # Runner logs are not always reachable from automation, so failures
-        # must explain themselves through annotations: name the command that
-        # died and where.
-        trap 'echo "::error title=bootstrap-patched-nix::failed at line $LINENO: $BASH_COMMAND"' ERR
-        source_repository="$(BOOTSTRAP_LOCK_FIELD=repository \
-          nix --extra-experimental-features nix-command \
-            eval --impure --raw --file "$BOOTSTRAP_LOCK_READER")"
-        bootstrap_rev="$(BOOTSTRAP_LOCK_FIELD=revision \
-          nix --extra-experimental-features nix-command \
-            eval --impure --raw --file "$BOOTSTRAP_LOCK_READER")"
-        source_repo="$GITHUB_WORKSPACE"
-        if [[ "$GITHUB_REPOSITORY" == "$source_repository" ]]; then
-          if ! git -C "$source_repo" rev-parse --verify --quiet "$bootstrap_rev^{commit}" >/dev/null; then
-            echo "::notice title=bootstrap-patched-nix::pinned rev not in checkout; fetching $bootstrap_rev"
-            git -C "$source_repo" fetch --depth 1 origin "$bootstrap_rev"
-          fi
-        else
-          # A downstream checkout's origin cannot supply index's pinned
-          # bootstrap revision. Fetch it from the action owner so consumers do
-          # not copy this bootstrap machinery into their own repositories.
-          source_repo="$RUNNER_TEMP/nix-ix-bootstrap-source"
-          git init -q "$source_repo"
-          git -C "$source_repo" fetch \
-            --depth 1 \
-            "https://github.com/$source_repository.git" \
-            "$bootstrap_rev"
-        fi
-        if ! git -C "$source_repo" rev-parse --verify --quiet "$bootstrap_rev^{commit}" >/dev/null; then
-          echo "::error title=bootstrap-patched-nix::pinned rev $bootstrap_rev is unavailable from $source_repository"
-          exit 1
-        fi
-        # Materialize the pinned tree with `git archive` and build it from a
-        # synthetic single-commit git repo. Every other flake-ref shape hits
-        # a fetcher edge somewhere in the runner fleet: git+file on the
-        # checkout refuses the shallow clones hosted jobs make, and the
-        # `path:` fetcher failed on the warm pool -- while a fresh full-depth
-        # repo of exactly the pinned tree is the same shape every developer
-        # checkout builds from.
-        src="$RUNNER_TEMP/nix-ix-bootstrap"
-        mkdir -p "$src"
-        git -C "$source_repo" archive "$bootstrap_rev" | tar -x -C "$src"
-        git -C "$src" -c init.defaultBranch=bootstrap init -q
-        git -C "$src" add -A
-        git -C "$src" \
-          -c user.email=bootstrap@ix.dev -c user.name=bootstrap \
-          -c commit.gpgsign=false \
-          commit -q -m "nix-ix bootstrap @ $bootstrap_rev"
-        if ! out=$(nix build \
-          --extra-experimental-features "nix-command flakes" \
-          --out-link "$RUNNER_TEMP/nix-ix" \
-          "git+file://$src#nix-ix" 2>&1); then
-          printf '%s\n' "$out" | tail -n 40
-          short=$(printf '%s' "$out" | tail -c 600 | tr '\n' ' ')
-          echo "::error title=bootstrap-patched-nix::nix build failed: $short"
-          exit 1
-        fi
-        client="$RUNNER_TEMP/nix-ix/bin/nix"
-        if [[ "$("$client" --extra-experimental-features nix-command \
-          eval --raw --expr 'toString 25_565')" != 25565 ]]; then
-          echo "::error title=bootstrap-patched-nix::built client does not accept underscore digit separators"
-          exit 1
-        fi
-        echo "$RUNNER_TEMP/nix-ix/bin" >> "$GITHUB_PATH"
-        echo "::notice title=bootstrap-patched-nix::$("$client" --version) on PATH"
+      run: bash "$GITHUB_ACTION_PATH/run.sh"

--- a/.github/actions/bootstrap-patched-nix/run.sh
+++ b/.github/actions/bootstrap-patched-nix/run.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+temp_dirs=()
+
+cleanup() {
+  local dir
+  for dir in "${temp_dirs[@]}"; do
+    rm -rf -- "$dir"
+  done
+}
+
+on_error() {
+  echo "::error title=bootstrap-patched-nix::failed at line $1: $2"
+}
+
+private_dir() {
+  local output_name="$1"
+  local prefix="$2"
+  local lifetime="$3"
+  local dir
+
+  umask 077
+  dir="$(mktemp -d -- "${RUNNER_TEMP:?RUNNER_TEMP is required}/${prefix}.XXXXXX")"
+  chmod 700 "$dir"
+  if [[ ! -d "$dir" || -L "$dir" || "$(stat -c '%a' "$dir")" != 700 ]]; then
+    echo "bootstrap-patched-nix: temporary directory is not private: $dir" >&2
+    exit 1
+  fi
+  if [[ "$lifetime" == step ]]; then
+    temp_dirs+=("$dir")
+  elif [[ "$lifetime" != job ]]; then
+    echo "bootstrap-patched-nix: invalid private directory lifetime: $lifetime" >&2
+    exit 65
+  fi
+  printf -v "$output_name" '%s' "$dir"
+}
+
+private_temp_dir() {
+  private_dir "$1" "$2" step
+}
+
+private_job_dir() {
+  private_dir "$1" "$2" job
+}
+
+trusted_git() {
+  GIT_CONFIG_NOSYSTEM=1 \
+  GIT_CONFIG_GLOBAL=/dev/null \
+  GIT_CONFIG_COUNT=2 \
+  GIT_CONFIG_KEY_0=core.hooksPath \
+  GIT_CONFIG_VALUE_0=/dev/null \
+  GIT_CONFIG_KEY_1=core.fsmonitor \
+  GIT_CONFIG_VALUE_1=false \
+    git "$@"
+}
+
+assert_clean_repo() {
+  local repo="$1"
+  local expected="$2"
+  local dangerous
+
+  if [[ "$(trusted_git -C "$repo" rev-parse HEAD)" != "$expected" ]]; then
+    echo "bootstrap-patched-nix: repository revision mismatch in $repo" >&2
+    exit 1
+  fi
+  if [[ -n "$(trusted_git -C "$repo" status --porcelain=v1 --untracked-files=all)" ]]; then
+    echo "bootstrap-patched-nix: repository is not clean: $repo" >&2
+    exit 1
+  fi
+  dangerous="$(trusted_git -C "$repo" config --local --get-regexp \
+    '^(core\.(hooksPath|fsmonitor)|url\..*\.insteadOf|filter\..*\.(clean|smudge|process|required))$' || true)"
+  if [[ -n "$dangerous" ]]; then
+    echo "bootstrap-patched-nix: executable local Git config is forbidden in $repo" >&2
+    exit 1
+  fi
+}
+
+main() {
+  local probe source_repository bootstrap_rev
+  local source_root source_repo source_tree src src_commit job_root out_link client_root client out short
+
+  # The self-hosted runner image normally already carries nix-ix. This avoids
+  # fetching and archiving the 40 MiB bootstrap source on every five-minute
+  # healthy escalation tick while retaining the pinned fallback for recovery.
+  if probe="$(nix --extra-experimental-features nix-command \
+      eval --raw --expr 'toString 25_565' 2>/dev/null)" && [[ "$probe" == 25565 ]]; then
+    echo "::notice title=bootstrap-patched-nix::compatible preinstalled $(nix --version) reused"
+    return
+  fi
+
+  source_repository="$(BOOTSTRAP_LOCK_FIELD=repository \
+    nix --extra-experimental-features nix-command \
+      eval --impure --raw --file "${BOOTSTRAP_LOCK_READER:?BOOTSTRAP_LOCK_READER is required}")"
+  bootstrap_rev="$(BOOTSTRAP_LOCK_FIELD=revision \
+    nix --extra-experimental-features nix-command \
+      eval --impure --raw --file "$BOOTSTRAP_LOCK_READER")"
+  if [[ ! "$source_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+     [[ ! "$bootstrap_rev" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "::error title=bootstrap-patched-nix::invalid bootstrap lock"
+    exit 65
+  fi
+
+  private_temp_dir source_root nix-ix-bootstrap-source
+  source_repo="$source_root/repository"
+  mkdir -- "$source_repo"
+  trusted_git init -q --template= "$source_repo"
+  trusted_git -C "$source_repo" remote add origin \
+    "https://github.com/$source_repository.git"
+  trusted_git -C "$source_repo" fetch --no-tags --depth 1 origin \
+    "+$bootstrap_rev:refs/remotes/origin/bootstrap"
+  trusted_git -C "$source_repo" checkout -q --detach refs/remotes/origin/bootstrap
+  assert_clean_repo "$source_repo" "$bootstrap_rev"
+  source_tree="$(trusted_git -C "$source_repo" rev-parse "$bootstrap_rev^{tree}")"
+
+  # The pinned tree becomes a fresh single-commit repository because that is
+  # the one flake-ref shape proven across the runner fleet.
+  private_temp_dir src nix-ix-bootstrap-tree
+  trusted_git -C "$source_repo" archive "$bootstrap_rev" | tar -x -C "$src"
+  trusted_git -C "$src" -c init.defaultBranch=bootstrap init -q --template=
+  trusted_git -C "$src" add -A
+  trusted_git -C "$src" \
+    -c user.email=bootstrap@ix.dev -c user.name=bootstrap \
+    -c commit.gpgsign=false \
+    commit -q -m "nix-ix bootstrap @ $bootstrap_rev"
+  src_commit="$(trusted_git -C "$src" rev-parse HEAD)"
+  assert_clean_repo "$src" "$src_commit"
+  if [[ "$(trusted_git -C "$src" rev-parse 'HEAD^{tree}')" != "$source_tree" ]]; then
+    echo "::error title=bootstrap-patched-nix::synthetic bootstrap tree differs from the pinned revision"
+    exit 1
+  fi
+
+  # Keep the out-link until RUNNER_TEMP is removed at job teardown. PATH is
+  # not a GC root, so deleting this link at action exit races concurrent GC.
+  private_job_dir job_root nix-ix-bootstrap-gc-root
+  out_link="$job_root/result"
+  if ! out="$(nix build \
+      --extra-experimental-features "nix-command flakes" \
+      --out-link "$out_link" \
+      "git+file://$src#nix-ix" 2>&1)"; then
+    printf '%s\n' "$out" | tail -n 40
+    short="$(printf '%s' "$out" | tail -c 600 | tr '\n' ' ')"
+    echo "::error title=bootstrap-patched-nix::nix build failed: $short"
+    exit 1
+  fi
+  client_root="$(readlink -f "$out_link")"
+  client="$client_root/bin/nix"
+  if [[ "$($client --extra-experimental-features nix-command \
+      eval --raw --expr 'toString 25_565')" != 25565 ]]; then
+    echo "::error title=bootstrap-patched-nix::built client does not accept underscore digit separators"
+    exit 1
+  fi
+  echo "$client_root/bin" >> "${GITHUB_PATH:?GITHUB_PATH is required}"
+  echo "::notice title=bootstrap-patched-nix::$($client --version) on PATH"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  trap 'on_error "$LINENO" "$BASH_COMMAND"' ERR
+  trap cleanup EXIT
+  main "$@"
+fi

--- a/.github/actions/bootstrap-patched-nix/test.sh
+++ b/.github/actions/bootstrap-patched-nix/test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tools="${1:?tool closure is required}"
+action_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+export PATH="$tools/bin"
+
+# shellcheck disable=SC1091
+source "$action_dir/run.sh"
+
+scratch="$(mktemp -d)"
+scratch="$(cd "$scratch" && pwd -P)"
+trap 'rm -rf -- "$scratch"' EXIT
+export RUNNER_TEMP="$scratch/runner-temp"
+mkdir "$RUNNER_TEMP"
+
+# Seed the fixed paths the old action reused, plus executable global Git
+# configuration. Trusted helpers must neither reuse nor execute any of it.
+mkdir -p "$RUNNER_TEMP/nix-ix-bootstrap-source/.git" \
+  "$RUNNER_TEMP/nix-ix-bootstrap/.git" "$scratch/template/hooks" "$scratch/bin"
+printf 'stale\n' > "$RUNNER_TEMP/nix-ix-bootstrap-source/stale"
+printf '#!/usr/bin/env bash\nprintf hook > %q\n' "$scratch/hook-ran" > "$scratch/template/hooks/post-checkout"
+printf '#!/usr/bin/env bash\nprintf fsmonitor > %q\n' "$scratch/fsmonitor-ran" > "$scratch/fsmonitor"
+printf '#!/usr/bin/env bash\nprintf remote > %q\nexit 1\n' "$scratch/remote-helper-ran" > "$scratch/bin/git-remote-marker"
+chmod +x "$scratch/template/hooks/post-checkout" "$scratch/fsmonitor" "$scratch/bin/git-remote-marker"
+hostile_global="$scratch/hostile.gitconfig"
+git config --file "$hostile_global" init.templateDir "$scratch/template"
+git config --file "$hostile_global" core.hooksPath "$scratch/template/hooks"
+git config --file "$hostile_global" core.fsmonitor "$scratch/fsmonitor"
+git config --file "$hostile_global" url.marker::.insteadOf file://
+
+origin="$scratch/origin"
+GIT_CONFIG_GLOBAL=/dev/null git init -q --template= "$origin"
+printf 'trusted\n' > "$origin/payload"
+GIT_CONFIG_GLOBAL=/dev/null git -C "$origin" add payload
+GIT_CONFIG_GLOBAL=/dev/null git -C "$origin" -c user.name=test -c user.email=test@example.com -c commit.gpgsign=false \
+  commit -q -m trusted
+revision="$(GIT_CONFIG_GLOBAL=/dev/null git -C "$origin" rev-parse HEAD)"
+export GIT_CONFIG_GLOBAL="$hostile_global"
+export PATH="$scratch/bin:$PATH"
+
+# Populated by private_temp_dir from the sourced action implementation.
+# shellcheck disable=SC2034
+temp_dirs=()
+checkout_root=""
+private_temp_dir checkout_root bootstrap-test-checkout
+checkout="$checkout_root/repository"
+mkdir "$checkout"
+trusted_git init -q --template= "$checkout"
+trusted_git -C "$checkout" remote add origin "file://$origin"
+trusted_git -C "$checkout" fetch -q --no-tags --depth 1 origin \
+  "+$revision:refs/remotes/origin/bootstrap"
+trusted_git -C "$checkout" checkout -q --detach refs/remotes/origin/bootstrap
+assert_clean_repo "$checkout" "$revision"
+
+if [[ -e "$scratch/hook-ran" || -e "$scratch/fsmonitor-ran" ||
+      -e "$scratch/remote-helper-ran" || -L "$checkout_root" ||
+      "$(stat -c '%a' "$checkout_root")" != 700 ]]; then
+  printf 'trusted bootstrap checkout executed inherited Git configuration\n' >&2
+  exit 1
+fi
+
+archive_root=""
+private_temp_dir archive_root bootstrap-test-archive
+trusted_git -C "$checkout" archive "$revision" | tar -x -C "$archive_root"
+if [[ "$(cat "$archive_root/payload")" != trusted ]]; then
+  printf 'trusted bootstrap archive did not contain the exact tree\n' >&2
+  exit 1
+fi
+job_root=""
+private_job_dir job_root bootstrap-test-job-root
+cleanup
+if [[ ! -d "$job_root" ]]; then
+  printf 'job-lifetime GC root was removed at action exit\n' >&2
+  exit 1
+fi
+
+# A compatible runner-provided nix-ix is the five-minute hot path: it must
+# return before reading the lock, fetching 40 MiB, or touching stale temp dirs.
+cat > "$scratch/bin/nix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"eval --raw --expr toString 25_565"*) printf 'benign warning\n' >&2; printf '25565' ;;
+  "--version") printf 'nix (nix-ix) test\n' ;;
+  *) printf 'unexpected fake nix invocation: %s\n' "$*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "$scratch/bin/nix"
+GITHUB_PATH="$scratch/github-path"
+export GITHUB_PATH
+SECONDS=0
+main
+if ((SECONDS >= 5)) || [[ ! -e "$RUNNER_TEMP/nix-ix-bootstrap-source/stale" ]]; then
+  printf 'compatible preinstalled Nix did not take the bounded hot path\n' >&2
+  exit 1
+fi

--- a/.github/actions/ci-budget/test_ci_policy.py
+++ b/.github/actions/ci-budget/test_ci_policy.py
@@ -65,14 +65,22 @@ class PolicyTests(unittest.TestCase):
                     not in source
                 )
 
-    def test_update_workflow_accepts_a_nix_owned_runner(self) -> None:
-        workflow = (
-            Path(__file__).resolve().parents[2] / "workflows" / "update-flake-lock.yml"
-        ).read_text()
+    def test_update_workflow_requires_the_exact_jit_nix_runner(self) -> None:
+        workflows = Path(__file__).resolve().parents[2] / "workflows"
+        workflow = (workflows / "update-flake-lock.yml").read_text()
+        wrapper = (workflows / "update-flake-lock-index.yml").read_text()
         assert "runner-label:" in workflow
         assert "nix-preinstalled:" in workflow
-        assert "runs-on: ${{ inputs.runner-label || 'ubuntu-latest' }}" in workflow
+        assert workflow.count("runs-on: ${{ inputs.runner-label }}") == 2
+        assert "runs-on: [self-hosted," not in workflow
+        assert "ubuntu-" not in workflow
         assert "if: ${{ !inputs.nix-preinstalled }}" in workflow
+        assert "required: true" in workflow
+        assert "workflow_dispatch:" in wrapper
+        assert "schedule:" not in wrapper
+        assert "ix-ci-run-{0}-{1}-index-update-flake-lock" in wrapper
+        assert "checks: read" in wrapper
+        assert "statuses: read" in wrapper
 
     def test_owner_policy_classifies_repository_data(self) -> None:
         costly_paths = (

--- a/.github/actions/update-flake-checkout-auth/action.yml
+++ b/.github/actions/update-flake-checkout-auth/action.yml
@@ -1,0 +1,18 @@
+name: Prepare alias-safe flake update checkout authentication
+description: >-
+  Preserve private-repository checkout authentication when the runner's
+  logical workspace path resolves to a different canonical git directory.
+
+inputs:
+  token:
+    description: Repository token used only for an aliased checkout fetch
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare alias-safe checkout authentication
+      shell: bash
+      env:
+        CHECKOUT_TOKEN: ${{ inputs.token }}
+      run: bash "$GITHUB_ACTION_PATH/run.sh" prepare

--- a/.github/actions/update-flake-checkout-auth/run.sh
+++ b/.github/actions/update-flake-checkout-auth/run.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cleanup() {
+  local github_env="${GITHUB_ENV:?GITHUB_ENV is required}"
+  local added_count="${UPDATE_FLAKE_CHECKOUT_AUTH_COUNT:-}"
+  local runner_temp="${RUNNER_TEMP:?RUNNER_TEMP is required}"
+  local safe_global="${GIT_CONFIG_GLOBAL:-}"
+  local safe_parent runner_temp_canonical
+  local slot
+
+  if [[ -z "$added_count" ]]; then
+    return
+  fi
+  if [[ "$added_count" != 2 ]]; then
+    printf 'update-flake-checkout-auth: invalid saved config count %q\n' "$added_count" >&2
+    exit 65
+  fi
+  if [[ -z "$safe_global" || ! -f "$safe_global" || -L "$safe_global" ||
+        "$(stat -c '%a' "$safe_global")" != 600 ]]; then
+    printf 'update-flake-checkout-auth: safe global config cannot be scrubbed\n' >&2
+    exit 1
+  fi
+  safe_parent="$(cd -- "$(dirname -- "$safe_global")" && pwd -P)"
+  runner_temp_canonical="$(cd -- "$runner_temp" && pwd -P)"
+  if [[ "$safe_parent" != "$runner_temp_canonical" ]]; then
+    printf 'update-flake-checkout-auth: safe global config escaped RUNNER_TEMP\n' >&2
+    exit 1
+  fi
+
+  # The alias-safe bearer lives only in this private file. Scrub it before any
+  # updater step runs while retaining a valid global-config target.
+  : >"$safe_global"
+
+  {
+    printf 'GIT_CONFIG_COUNT=0\n'
+    for ((slot = 0; slot < added_count; slot++)); do
+      printf 'GIT_CONFIG_KEY_%s=\n' "$slot"
+      printf 'GIT_CONFIG_VALUE_%s=\n' "$slot"
+    done
+    printf 'UPDATE_FLAKE_CHECKOUT_AUTH_COUNT=\n'
+  } >>"$github_env"
+}
+
+prepare() {
+  local workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+  local github_env="${GITHUB_ENV:?GITHUB_ENV is required}"
+  local runner_temp="${RUNNER_TEMP:?RUNNER_TEMP is required}"
+  local server_url="${GITHUB_SERVER_URL:?GITHUB_SERVER_URL is required}"
+  local logical_workspace canonical_workspace checkout_token basic_credential safe_global
+
+  if [[ -L "$workspace" ]]; then
+    printf 'update-flake-checkout-auth: workspace leaf must not be a symlink\n' >&2
+    exit 65
+  fi
+  mkdir -p -- "$workspace"
+  if [[ ! -d "$workspace" || -L "$workspace" ]]; then
+    printf 'update-flake-checkout-auth: workspace is not a regular directory\n' >&2
+    exit 1
+  fi
+  logical_workspace="${workspace%/}"
+  canonical_workspace="$(cd -- "$workspace" && pwd -P)"
+  if [[ "${GIT_CONFIG_COUNT:-0}" != 0 ]]; then
+    printf 'update-flake-checkout-auth: inherited command-scoped Git config is not trusted\n' >&2
+    exit 65
+  fi
+
+  umask 077
+  safe_global="$(mktemp "$runner_temp/update-flake-gitconfig.XXXXXX")"
+  chmod 600 "$safe_global"
+  if [[ ! -f "$safe_global" || -L "$safe_global" || "$(stat -c '%a' "$safe_global")" != 600 ]]; then
+    printf 'update-flake-checkout-auth: safe global config is not a regular file\n' >&2
+    exit 1
+  fi
+
+  # checkout@v7 conditions its credential include on the logical gitdir. A
+  # systemd DynamicUser StateDirectory canonicalizes through /var/lib/private,
+  # so a private global header is the stable authentication owner. The fresh
+  # global config and command overrides also prevent a prior runner user from
+  # injecting hooks, fsmonitor commands, or URL rewrites into checkout.
+  # https://github.com/actions/checkout/blob/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0/src/git-auth-helper.ts#L360-L406
+  if [[ "$logical_workspace" != "$canonical_workspace" ]]; then
+    : "${CHECKOUT_TOKEN:?CHECKOUT_TOKEN is required for an aliased workspace}"
+    checkout_token="$CHECKOUT_TOKEN"
+    unset CHECKOUT_TOKEN
+    basic_credential="$(printf 'x-access-token:%s' "$checkout_token" | base64 | tr -d '\n')"
+    unset checkout_token
+    printf '::add-mask::%s\n' "$basic_credential"
+    if [[ ! "$server_url" =~ ^https://[A-Za-z0-9.-]+(:[0-9]+)?$ ]]; then
+      printf 'update-flake-checkout-auth: invalid GitHub server URL\n' >&2
+      exit 65
+    fi
+    {
+      printf '[http "%s/"]\n' "${server_url%/}"
+      printf '\textraheader = AUTHORIZATION: basic %s\n' "$basic_credential"
+    } >"$safe_global"
+  fi
+
+  # Only non-secret isolation settings enter the job environment. The bearer
+  # stays in the mode-0600 global file until the immediate post-checkout scrub.
+  {
+    printf 'GIT_CONFIG_GLOBAL=%s\n' "$safe_global"
+    printf 'GIT_CONFIG_NOSYSTEM=1\n'
+    printf 'GIT_CONFIG_KEY_0=core.hooksPath\n'
+    printf 'GIT_CONFIG_VALUE_0=/dev/null\n'
+    printf 'GIT_CONFIG_KEY_1=core.fsmonitor\n'
+    printf 'GIT_CONFIG_VALUE_1=false\n'
+    printf 'GIT_CONFIG_COUNT=2\n'
+    printf 'UPDATE_FLAKE_CHECKOUT_AUTH_COUNT=2\n'
+  } >>"$github_env"
+  unset CHECKOUT_TOKEN checkout_token basic_credential
+  printf '::notice title=update-flake-checkout-auth::prepared isolated checkout Git configuration\n'
+}
+
+case "${1:-}" in
+  cleanup)
+    cleanup
+    ;;
+  prepare)
+    prepare
+    ;;
+  *)
+    printf 'update-flake-checkout-auth: expected prepare or cleanup\n' >&2
+    exit 64
+    ;;
+esac

--- a/.github/actions/update-flake-checkout-auth/test.sh
+++ b/.github/actions/update-flake-checkout-auth/test.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tools="${1:?tool closure is required}"
+action_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$action_dir/../../.." && pwd)"
+export PATH="$tools/bin"
+
+for executable in \
+  base64 bash cat chmod cp dirname env git grep ln mkdir mktemp mv readlink rm sed stat tail tr; do
+  if [[ ! -x "$tools/bin/$executable" ]]; then
+    printf 'workflow tool closure omits %s\n' "$executable" >&2
+    exit 1
+  fi
+done
+
+scratch="$(mktemp -d)"
+scratch="$(cd -- "$scratch" && pwd -P)"
+trap 'rm -rf "$scratch"' EXIT
+
+canonical_state="$scratch/var/lib/private/ix-ci-job"
+logical_state="$scratch/var/lib/ix-ci-job"
+workspace_suffix="_work/repository/repository"
+canonical_workspace="$canonical_state/$workspace_suffix"
+logical_workspace="$logical_state/$workspace_suffix"
+github_env="$scratch/github-env"
+previous_config="$scratch/previous.gitconfig"
+runner_temp="$scratch/runner-temp"
+
+mkdir -p "$canonical_workspace" "$(dirname "$logical_state")" "$runner_temp"
+ln -s private/ix-ci-job "$logical_state"
+git config --file "$previous_config" user.name preserved
+
+GITHUB_WORKSPACE="$logical_workspace" \
+GITHUB_ENV="$github_env" \
+GITHUB_SERVER_URL=https://github.com \
+RUNNER_TEMP="$runner_temp" \
+CHECKOUT_TOKEN=test-token \
+  bash "$action_dir/run.sh" prepare >"$scratch/prepare.stdout"
+
+value_from_env() {
+  local key="$1"
+  sed -n "s/^${key}=//p" "$github_env" | tail -n 1
+}
+
+config_count="$(value_from_env GIT_CONFIG_COUNT)"
+config_global="$(value_from_env GIT_CONFIG_GLOBAL)"
+config_added="$(value_from_env UPDATE_FLAKE_CHECKOUT_AUTH_COUNT)"
+expected_header="AUTHORIZATION: basic $(printf 'x-access-token:test-token' | base64 | tr -d '\n')"
+if [[ "$config_count" != 2 || "$config_added" != 2 ||
+      "$(value_from_env GIT_CONFIG_KEY_0)" != core.hooksPath ||
+      "$(value_from_env GIT_CONFIG_VALUE_0)" != /dev/null ||
+      "$(value_from_env GIT_CONFIG_KEY_1)" != core.fsmonitor ||
+      "$(value_from_env GIT_CONFIG_VALUE_1)" != false ]] ||
+   grep -F "$expected_header" "$github_env" > "$scratch/job-env-token"; then
+  printf 'aliased workspace did not produce isolated command-scoped authentication\n' >&2
+  exit 1
+fi
+if [[ ! -f "$config_global" || -L "$config_global" || "$(stat -c '%a' "$config_global")" != 600 ]]; then
+  printf 'checkout helper did not create a private global config\n' >&2
+  exit 1
+fi
+
+git init -q "$canonical_workspace"
+# Mirror checkout@v7's mismatched local include. It must remain inactive when
+# Git resolves the repository through the canonical DynamicUser path.
+checkout_config="$scratch/checkout-credentials.config"
+git config --file "$checkout_config" http.https://github.com/.extraheader \
+  'AUTHORIZATION: basic duplicate'
+git -C "$canonical_workspace" config \
+  "includeIf.gitdir:$logical_workspace/.git.path" "$checkout_config"
+isolated_git() {
+  GIT_CONFIG_GLOBAL="$config_global" \
+  GIT_CONFIG_NOSYSTEM=1 \
+  GIT_CONFIG_COUNT="$config_count" \
+  GIT_CONFIG_KEY_0="$(value_from_env GIT_CONFIG_KEY_0)" \
+  GIT_CONFIG_VALUE_0="$(value_from_env GIT_CONFIG_VALUE_0)" \
+  GIT_CONFIG_KEY_1="$(value_from_env GIT_CONFIG_KEY_1)" \
+  GIT_CONFIG_VALUE_1="$(value_from_env GIT_CONFIG_VALUE_1)" \
+    git "$@"
+}
+for workspace in "$logical_workspace" "$canonical_workspace"; do
+  headers="$(isolated_git -C "$workspace" config --get-all http.https://github.com/.extraheader)"
+  if [[ "$(grep -Fc "$expected_header" <<<"$headers")" != 1 ||
+        "$(isolated_git -C "$workspace" config --get core.hooksPath)" != /dev/null ||
+        "$(isolated_git -C "$workspace" config --get core.fsmonitor)" != false ]]; then
+    printf 'authentication is unavailable through workspace spelling %s\n' "$workspace" >&2
+    exit 1
+  fi
+  if isolated_git -C "$workspace" config --get user.name > "$scratch/untrusted-global"; then
+    printf 'prior global config survived checkout isolation through %s\n' "$workspace" >&2
+    exit 1
+  fi
+done
+
+# Apply the exact cleanup environment a later workflow step receives. The
+# token slot must be blank and the prior command-config count restored.
+GITHUB_ENV="$github_env" \
+RUNNER_TEMP="$runner_temp" \
+GIT_CONFIG_GLOBAL="$config_global" \
+GIT_CONFIG_COUNT="$config_count" \
+UPDATE_FLAKE_CHECKOUT_AUTH_COUNT="$config_added" \
+  bash "$action_dir/run.sh" cleanup
+if [[ "$(value_from_env GIT_CONFIG_COUNT)" != 0 ||
+      -n "$(value_from_env GIT_CONFIG_VALUE_0)" ||
+      -s "$config_global" ]]; then
+  printf 'cleanup did not scrub command-scoped checkout authentication\n' >&2
+  exit 1
+fi
+
+# The private global file remains a valid target for updater-style global Git
+# writes after the credential slots are scrubbed.
+GIT_CONFIG_GLOBAL="$config_global" GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_COUNT=0 \
+  git config --global --add safe.directory "$canonical_workspace"
+if [[ "$(GIT_CONFIG_GLOBAL="$config_global" GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_COUNT=0 git config --global --get safe.directory)" != "$canonical_workspace" ]]; then
+  printf 'checkout authentication leaked into a later global Git write\n' >&2
+  exit 1
+fi
+
+# Inherited command config can execute remote helpers before checkout has a
+# chance to clean the repository, so the helper rejects it rather than merging.
+prior_env="$scratch/prior-env"
+if GITHUB_WORKSPACE="$logical_workspace" \
+  GITHUB_ENV="$prior_env" \
+  GITHUB_SERVER_URL=https://github.com \
+  RUNNER_TEMP="$runner_temp" \
+  GIT_CONFIG_COUNT=1 \
+  GIT_CONFIG_KEY_0=url.file:///hostile.insteadOf \
+  GIT_CONFIG_VALUE_0=https://github.com/ \
+  CHECKOUT_TOKEN=test-token \
+    bash "$action_dir/run.sh" prepare >"$scratch/prior-prepare.stdout" 2>"$scratch/prior-prepare.stderr"; then
+  printf 'prepare accepted inherited command-scoped Git config\n' >&2
+  exit 1
+fi
+grep -F 'inherited command-scoped Git config is not trusted' "$scratch/prior-prepare.stderr" >/dev/null
+
+# Reproduce the workflow-owner trust bootstrap with a workspace containing a
+# hostile prior repo. Fetch happens in a fresh private temp repo; only the
+# attested exact tree may replace the aliased workspace.
+owner_source="$scratch/workflow-owner-source"
+owner_workspace="$logical_state/_work/workflow-owner/workflow-owner"
+git init -q "$owner_source"
+printf 'exact owner\n' > "$owner_source/payload"
+git -C "$owner_source" add payload
+git -C "$owner_source" -c user.name=test -c user.email=test@example.com -c commit.gpgsign=false \
+  commit -q -m owner
+owner_sha="$(git -C "$owner_source" rev-parse HEAD)"
+mkdir -p "$owner_workspace"
+owner_runner_temp="$logical_state/_work/_temp"
+mkdir -p "$owner_runner_temp"
+git init -q "$owner_workspace"
+git -C "$owner_workspace" remote add origin marker::stale
+hostile_hooks="$scratch/hostile-hooks"
+mkdir -p "$hostile_hooks" "$owner_workspace/.update-flake-workflow-actions"
+printf '#!/usr/bin/env bash\nprintf hook > %q\n' "$scratch/hook-ran" > "$hostile_hooks/post-checkout"
+chmod +x "$hostile_hooks/post-checkout"
+git -C "$owner_workspace" config core.hooksPath "$hostile_hooks"
+git -C "$owner_workspace" config core.fsmonitor "$scratch/fsmonitor-ran"
+git -C "$owner_workspace" config url.marker::.insteadOf "file://$owner_source"
+printf 'hostile\n' > "$owner_workspace/.update-flake-workflow-actions/payload"
+
+owner_root="$(mktemp -d -- "$runner_temp/update-flake-owner.XXXXXX")"
+chmod 700 "$owner_root"
+owner_repo="$owner_root/repository"
+mkdir "$owner_repo"
+owner_auth="$owner_root/git-auth"
+: > "$owner_auth"
+chmod 600 "$owner_auth"
+trusted_owner_git() {
+  GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL="$owner_auth" GIT_CONFIG_COUNT=0 \
+    git -c core.hooksPath=/dev/null -c core.fsmonitor=false "$@"
+}
+trusted_owner_git init -q --template= "$owner_repo"
+trusted_owner_git -C "$owner_repo" remote add origin "file://$owner_source"
+{
+  printf '[http "https://github.com/"]\n'
+  printf '\textraheader = %s\n' "$expected_header"
+} > "$owner_auth"
+trusted_owner_git -C "$owner_repo" fetch -q --no-tags --depth 1 origin \
+  "+$owner_sha:refs/remotes/origin/workflow-owner"
+: > "$owner_auth"
+trusted_owner_git -C "$owner_repo" checkout -q --detach refs/remotes/origin/workflow-owner
+if [[ "$(trusted_owner_git -C "$owner_repo" rev-parse HEAD)" != "$owner_sha" ||
+      -n "$(trusted_owner_git -C "$owner_repo" status --porcelain=v1 --untracked-files=all)" ]]; then
+  printf 'temporary workflow-owner checkout failed attestation\n' >&2
+  exit 1
+fi
+GITHUB_WORKSPACE="$owner_workspace" RUNNER_TEMP="$owner_runner_temp" \
+  bash "$repo_root/.github/scripts/update-flake-reset-workspace.sh"
+cp -R -- "$owner_repo"/. "$owner_workspace"/
+if [[ "$(trusted_owner_git -C "$owner_workspace" rev-parse HEAD)" != "$owner_sha" ||
+      -n "$(trusted_owner_git -C "$owner_workspace" status --porcelain=v1 --untracked-files=all)" ]]; then
+  printf 'aliased workflow-owner fetch did not materialize the exact revision\n' >&2
+  exit 1
+fi
+if [[ -e "$scratch/hook-ran" || -e "$scratch/fsmonitor-ran" ||
+      -e "$owner_workspace/.update-flake-workflow-actions" || ! -L "$logical_state" ]] ||
+   trusted_owner_git -C "$owner_workspace" config --get-all http.https://github.com/.extraheader > "$scratch/persisted-owner-auth" ||
+   trusted_owner_git -C "$owner_workspace" config --local --get-regexp '^(core\.(hooksPath|fsmonitor)|url\..*\.insteadOf)$' > "$scratch/persisted-owner-config"; then
+  printf 'hostile owner state or command-scoped credential survived attestation\n' >&2
+  exit 1
+fi
+rm -rf -- "$owner_root"
+
+# A stale workspace leaf must be unlinked, never traversed. An intermediate
+# alias may resolve only inside the runner's own _work tree.
+outside="$scratch/outside-workspace"
+leaf_parent="$logical_state/_work/leaf-repro"
+leaf_workspace="$leaf_parent/repository"
+mkdir -p "$outside" "$leaf_parent"
+printf 'preserve\n' > "$outside/sentinel"
+ln -s "$outside" "$leaf_workspace"
+GITHUB_WORKSPACE="$leaf_workspace" RUNNER_TEMP="$owner_runner_temp" \
+  bash "$repo_root/.github/scripts/update-flake-reset-workspace.sh"
+if [[ ! -f "$outside/sentinel" || -L "$leaf_workspace" || ! -d "$leaf_workspace" ]]; then
+  printf 'workspace reset followed a stale leaf symlink\n' >&2
+  exit 1
+fi
+
+escaped_parent="$logical_state/_work/escaped-parent"
+ln -s "$outside" "$escaped_parent"
+if GITHUB_WORKSPACE="$escaped_parent/repository" RUNNER_TEMP="$owner_runner_temp" \
+  bash "$repo_root/.github/scripts/update-flake-reset-workspace.sh" \
+    > "$scratch/escaped-reset.stdout" 2> "$scratch/escaped-reset.stderr"; then
+  printf 'workspace reset accepted an ancestor escaping the runner work root\n' >&2
+  exit 1
+fi
+grep -F 'workspace parent escapes the runner work root' "$scratch/escaped-reset.stdout" >/dev/null
+[[ -f "$outside/sentinel" ]]
+
+plain_workspace="$scratch/plain/workspace"
+plain_env="$scratch/plain-env"
+mkdir -p "$plain_workspace"
+GITHUB_WORKSPACE="$plain_workspace" \
+GITHUB_ENV="$plain_env" \
+GITHUB_SERVER_URL=https://github.com \
+RUNNER_TEMP="$runner_temp" \
+CHECKOUT_TOKEN='' \
+  bash "$action_dir/run.sh" prepare
+if [[ "$(sed -n 's/^GIT_CONFIG_COUNT=//p' "$plain_env" | tail -n1)" != 2 ||
+      "$(sed -n 's/^UPDATE_FLAKE_CHECKOUT_AUTH_COUNT=//p' "$plain_env" | tail -n1)" != 2 ]]; then
+  printf 'canonical workspace did not receive isolated non-auth Git config\n' >&2
+  exit 1
+fi
+
+if GITHUB_WORKSPACE="$logical_workspace" \
+  GITHUB_ENV="$scratch/missing-token-env" \
+  GITHUB_SERVER_URL=https://github.com \
+  RUNNER_TEMP="$runner_temp" \
+  CHECKOUT_TOKEN='' \
+    bash "$action_dir/run.sh" prepare >"$scratch/missing-token.stdout" 2>"$scratch/missing-token.stderr"; then
+  printf 'aliased workspace accepted an empty checkout token\n' >&2
+  exit 1
+fi
+grep -F 'CHECKOUT_TOKEN is required' "$scratch/missing-token.stderr" >/dev/null
+
+auth_symlink="$scratch/auth-workspace-symlink"
+ln -s "$outside" "$auth_symlink"
+if GITHUB_WORKSPACE="$auth_symlink" \
+  GITHUB_ENV="$scratch/symlink-auth-env" \
+  GITHUB_SERVER_URL=https://github.com \
+  RUNNER_TEMP="$runner_temp" \
+  CHECKOUT_TOKEN=test-token \
+    bash "$action_dir/run.sh" prepare > "$scratch/symlink-auth.stdout" 2> "$scratch/symlink-auth.stderr"; then
+  printf 'checkout authentication followed a workspace leaf symlink\n' >&2
+  exit 1
+fi
+grep -F 'workspace leaf must not be a symlink' "$scratch/symlink-auth.stderr" >/dev/null
+[[ -f "$outside/sentinel" ]]
+
+fake_base64_bin="$scratch/fake-base64-bin"
+mkdir "$fake_base64_bin"
+cat > "$fake_base64_bin/base64" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "${CHECKOUT_TOKEN-}" > "$FAKE_BASE64_ENV"
+exec "$REAL_BASE64" "$@"
+EOF
+chmod +x "$fake_base64_bin/base64"
+probe_env="$scratch/probe-env"
+FAKE_BASE64_ENV="$scratch/base64-env" \
+REAL_BASE64="$tools/bin/base64" \
+PATH="$fake_base64_bin:$PATH" \
+GITHUB_WORKSPACE="$logical_workspace" \
+GITHUB_ENV="$probe_env" \
+GITHUB_SERVER_URL=https://github.com \
+RUNNER_TEMP="$runner_temp" \
+CHECKOUT_TOKEN=process-env-sentinel \
+  bash "$action_dir/run.sh" prepare > "$scratch/probe-prepare.stdout"
+if [[ -s "$scratch/base64-env" ]] || grep -F process-env-sentinel "$probe_env" > "$scratch/probe-job-env"; then
+  printf 'checkout token escaped into a child or job-wide environment\n' >&2
+  exit 1
+fi
+probe_global="$(sed -n 's/^GIT_CONFIG_GLOBAL=//p' "$probe_env" | tail -n 1)"
+GITHUB_ENV="$probe_env" RUNNER_TEMP="$runner_temp" \
+GIT_CONFIG_GLOBAL="$probe_global" UPDATE_FLAKE_CHECKOUT_AUTH_COUNT=2 \
+  bash "$action_dir/run.sh" cleanup
+[[ ! -s "$probe_global" ]]
+
+workflow="$repo_root/.github/workflows/update-flake-lock.yml"
+wrapper="$repo_root/.github/workflows/update-flake-lock-index.yml"
+if grep -Eq 'indexable-inc/index/.github/actions/(update-flake-checkout-auth|install-nix|bootstrap-patched-nix)@' "$workflow"; then
+  printf 'credential-bearing reusable-workflow action is fetched from a mutable ref\n' >&2
+  exit 1
+fi
+# These are literal GitHub expressions; the shell must not expand them.
+# shellcheck disable=SC2016
+workflow_repository='WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}'
+# shellcheck disable=SC2016
+workflow_revision='WORKFLOW_SHA: ${{ job.workflow_sha }}'
+# shellcheck disable=SC2016
+workflow_owner_token='CHECKOUT_TOKEN: ${{ secrets.workflow-owner-read-token || github.token }}'
+if [[ "$(grep -Fc 'name: Materialize exact workflow owner' "$workflow")" != 1 ||
+      "$(grep -Fc "$workflow_revision" "$workflow")" != 1 ]]; then
+  printf 'update job does not resolve its workflow owner at the exact called revision\n' >&2
+  exit 1
+fi
+if grep -Eq '&materialize-workflow-owner|\*materialize-workflow-owner' "$workflow"; then
+  printf 'watcher retained a duplicate workflow-owner checkout\n' >&2
+  exit 1
+fi
+if [[ "$(grep -Fc "$workflow_owner_token" "$workflow")" != 1 ]] ||
+   grep -Eq 'workflow-owner-token|Require cross-repository workflow-owner token' "$workflow"; then
+  printf 'workflow-owner read auth is coupled to the caller PR App\n' >&2
+  exit 1
+fi
+if [[ "$(grep -Fc "$workflow_repository" "$workflow")" != 1 ]] ||
+   grep -F 'name: Checkout workflow owner' "$workflow" > "$scratch/owner-checkout"; then
+  printf 'workflow owner is not fetched through the alias-safe bootstrap path\n' >&2
+  exit 1
+fi
+# This is a literal GitHub expression; the shell must not expand it.
+# shellcheck disable=SC2016
+if grep -Eq 'ubuntu-|runner-label \|\||id-token:|^  (schedule|workflow_dispatch):' "$workflow" ||
+   [[ "$(grep -Fc 'runs-on: ${{ inputs.runner-label }}' "$workflow")" != 2 ]] ||
+   grep -F 'runs-on: [self-hosted,' "$workflow" > "$scratch/runner-label-subset" ||
+   ! grep -F 'required: true' "$workflow" > "$scratch/required-inputs" ||
+   ! grep -F "runner-label: \${{ format('ix-ci-run-" "$wrapper" > "$scratch/wrapper-label"; then
+  printf 'flake updater lacks the exact JIT runner-label contract or its self-hosted wrapper\n' >&2
+  exit 1
+fi
+# These are literal GitHub expressions; the shell must not expand them.
+# shellcheck disable=SC2016
+if [[ "$(grep -Fc 'github-token: ${{ github.token }}' "$workflow")" != 1 ||
+      "$(grep -Fc 'SLACK_BOT_TOKEN: ${{ secrets.slack-bot-token }}' "$workflow")" != 1 ]] ||
+   grep -F 'GH_TOKEN:' "$workflow" > "$scratch/gh-token-env" ||
+   grep -F -- '-H "Authorization: Bearer ${SLACK_BOT_TOKEN}"' "$workflow" > "$scratch/bearer-argv" ||
+   grep -F 'GIT_CONFIG_VALUE_1="AUTHORIZATION:' "$workflow" > "$scratch/git-auth-env"; then
+  printf 'API credentials are not scoped to the final escalation step\n' >&2
+  exit 1
+fi
+# shellcheck disable=SC2016
+grep -F 'if: ${{ always() }}' "$workflow" >/dev/null
+# shellcheck disable=SC2016
+grep -F 'group: update-flake-lock-${{ github.repository }}' "$workflow" >/dev/null
+# shellcheck disable=SC2016
+grep -F "const priorBody = issue?.state === 'open' ? (issue.body || '') : '';" "$workflow" >/dev/null
+grep -F 'uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3' "$workflow" >/dev/null
+if [[ "$(grep -Fc 'name: Bootstrap patched Nix client' "$workflow")" != 1 ]] ||
+   grep -Eq 'update-flake-workflow-tools|update-flake-slack-post|curl ' "$workflow"; then
+  printf 'API watcher retained the duplicate workflow-owner toolchain\n' >&2
+  exit 1
+fi
+grep -F "['success', 'failure', 'cancelled', 'skipped']" "$workflow" >/dev/null
+# shellcheck disable=SC2016
+grep -F 'bash "$reset_script"' "$workflow" >/dev/null
+# shellcheck disable=SC2016
+reset_command='run: bash "$UPDATE_FLAKE_ACTIONS/reset-workspace.sh"'
+grep -F "$reset_command" "$workflow" >/dev/null
+# shellcheck disable=SC2016
+prepare_command='run: bash "$UPDATE_FLAKE_ACTIONS/update-flake-checkout-auth/run.sh" prepare'
+grep -F "$prepare_command" "$workflow" >/dev/null
+# shellcheck disable=SC2016
+cleanup_command='run: bash "$UPDATE_FLAKE_ACTIONS/update-flake-checkout-auth/run.sh" cleanup'
+grep -F "$cleanup_command" "$workflow" >/dev/null

--- a/.github/scripts/test-update-flake-watcher.mjs
+++ b/.github/scripts/test-update-flake-watcher.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const workflow = fs.readFileSync(process.argv[2], "utf8");
+const marker = "          script: |\n";
+const markerOffset = workflow.indexOf(marker);
+assert.notEqual(markerOffset, -1, "watcher script is missing");
+const script = workflow
+  .slice(markerOffset + marker.length)
+  .split("\n")
+  .map((line) => (line.startsWith("            ") ? line.slice(12) : line))
+  .join("\n");
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const execute = new AsyncFunction(
+  "github",
+  "context",
+  "core",
+  "fetch",
+  "process",
+  "Buffer",
+  script,
+);
+
+const now = Date.now();
+const lock = {
+  root: "root",
+  nodes: {
+    root: { inputs: {} },
+  },
+};
+
+async function runScenario(overrides = {}) {
+  const scenario = {
+    result: "success",
+    pulls: [],
+    checkRuns: [],
+    statuses: [],
+    issues: [],
+    branchSha: "",
+    aheadBy: 0,
+    locks: { main: lock },
+    thresholdHours: 6,
+    ...overrides,
+  };
+  const calls = {
+    comments: [],
+    createdIssues: [],
+    failed: [],
+    notices: [],
+    slack: [],
+    updates: [],
+  };
+
+  const endpoints = {
+    pullsList: async () => {},
+    checksList: async () => {},
+    statusesList: async () => {},
+    issuesList: async () => {},
+  };
+  const github = {
+    paginate: async (endpoint, _params, mapFn) => {
+      assert.equal(mapFn, undefined, "watcher supplied a custom Octokit pagination mapper");
+      if (endpoint === endpoints.pullsList) return scenario.pulls;
+      if (endpoint === endpoints.checksList) return scenario.checkRuns;
+      if (endpoint === endpoints.statusesList) return scenario.statuses;
+      if (endpoint === endpoints.issuesList) return scenario.issues;
+      throw new Error("unexpected paginated endpoint");
+    },
+    rest: {
+      pulls: { list: endpoints.pullsList },
+      checks: { listForRef: endpoints.checksList },
+      repos: {
+        listCommitStatusesForRef: endpoints.statusesList,
+        compareCommitsWithBasehead: async () => ({ data: { ahead_by: scenario.aheadBy } }),
+        getContent: async ({ ref }) => ({
+          data: {
+            content: Buffer.from(JSON.stringify(scenario.locks[ref] || lock)).toString("base64"),
+          },
+        }),
+      },
+      git: {
+        getRef: async () => {
+          if (scenario.branchSha) return { data: { object: { sha: scenario.branchSha } } };
+          throw Object.assign(new Error("not found"), { status: 404 });
+        },
+      },
+      issues: {
+        updateLabel: async () => {},
+        createLabel: async () => {},
+        listForRepo: endpoints.issuesList,
+        create: async (request) => {
+          calls.createdIssues.push(request);
+          return {
+            data: {
+              number: 41,
+              state: "open",
+              body: request.body,
+              html_url: "https://github.com/indexable-inc/index/issues/41",
+            },
+          };
+        },
+        update: async (request) => {
+          calls.updates.push(request);
+          return {
+            data: {
+              number: request.issue_number,
+              state: request.state || "open",
+              body: request.body || "",
+              html_url: `https://github.com/indexable-inc/index/issues/${request.issue_number}`,
+            },
+          };
+        },
+        createComment: async (request) => {
+          calls.comments.push(request);
+        },
+      },
+    },
+  };
+  const core = {
+    notice: (message) => calls.notices.push(message),
+    warning: () => {},
+    setFailed: (message) => calls.failed.push(message),
+  };
+  const fetch = async (_url, request) => {
+    calls.slack.push(JSON.parse(request.body));
+    return { ok: true, json: async () => ({ ok: true }) };
+  };
+  const processScope = {
+    env: {
+      ESCALATE_AFTER_HOURS: String(scenario.thresholdHours),
+      SLACK_BOT_TOKEN: "test-slack-token",
+      SLACK_CHANNEL: "C0123456789",
+      UPDATE_RESULT: scenario.result,
+    },
+  };
+  await execute(
+    github,
+    { repo: { owner: "indexable-inc", repo: "index" }, runId: 99 },
+    core,
+    fetch,
+    processScope,
+    Buffer,
+  );
+  return calls;
+}
+
+const youngPr = {
+  number: 7,
+  html_url: "https://github.com/indexable-inc/index/pull/7",
+  created_at: new Date(now - 60_000).toISOString(),
+  head: { sha: "bump-sha" },
+};
+
+{
+  const calls = await runScenario({
+    pulls: [youngPr],
+    statuses: [
+      { context: "ci", state: "success" },
+      { context: "ci", state: "failure" },
+    ],
+    locks: { main: lock, "bump-sha": lock },
+  });
+  assert.deepEqual(calls.failed, [], "stale status history made a healthy PR red");
+  assert.match(calls.notices[0], /healthy/);
+}
+
+{
+  const oldPr = {
+    ...youngPr,
+    created_at: new Date(now - 7 * 3_600_000).toISOString(),
+  };
+  const calls = await runScenario({
+    pulls: [oldPr],
+    statuses: [{ context: "ci", state: "success" }],
+    locks: { main: lock, "bump-sha": lock },
+  });
+  assert.equal(calls.createdIssues.length, 1);
+  assert.match(calls.createdIssues[0].body, /checks green but the PR is still unmerged/);
+  assert.equal(calls.failed.length, 1);
+}
+
+{
+  const calls = await runScenario({
+    result: "failure",
+    thresholdHours: 0,
+    issues: [
+      {
+        number: 9,
+        state: "closed",
+        body: "<!-- first-detected: 2020-01-01T00:00:00Z -->\n<!-- slack-escalated: 2020-01-01T01:00:00Z -->",
+        html_url: "https://github.com/indexable-inc/index/issues/9",
+      },
+    ],
+  });
+  assert.equal(calls.slack.length, 1, "closed episode suppressed a new Slack escalation");
+  assert.ok(calls.updates.every((call) => !call.body?.includes("2020-01-01")));
+  assert.ok(calls.updates.at(-1).body.includes("<!-- slack-escalated:"));
+}
+
+{
+  const calls = await runScenario({ result: "failure" });
+  assert.equal(calls.createdIssues.length, 1);
+  assert.match(calls.createdIssues[0].body, /Bump job did not succeed/);
+  assert.equal(calls.failed.length, 1);
+}

--- a/.github/scripts/update-flake-reset-workspace.sh
+++ b/.github/scripts/update-flake-reset-workspace.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+runner_temp="${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+if [[ "$workspace" != /* || "$workspace" == / || "$runner_temp" != /* ]]; then
+  echo "::error::runner workspace and temporary directory must be absolute non-root paths"
+  exit 65
+fi
+if [[ ! -d "$runner_temp" || -L "$runner_temp" ]]; then
+  echo "::error::runner temporary directory is not a regular directory"
+  exit 1
+fi
+
+# GitHub places RUNNER_TEMP at <runner-work>/_temp and checkouts below that
+# same work root. Resolve the intentional DynamicUser parent alias, then refuse
+# any stale intermediate symlink that escapes the runner-owned tree.
+runner_temp_canonical="$(cd -- "$runner_temp" && pwd -P)"
+runner_work_root="$(dirname -- "$runner_temp_canonical")"
+workspace_parent="${workspace%/*}"
+if [[ ! -d "$workspace_parent" ]]; then
+  echo "::error::runner workspace parent does not exist"
+  exit 1
+fi
+workspace_parent_canonical="$(cd -- "$workspace_parent" && pwd -P)"
+case "$workspace_parent_canonical/" in
+  "$runner_work_root/"*) ;;
+  *)
+    echo "::error::runner workspace parent escapes the runner work root"
+    exit 1
+    ;;
+esac
+
+# A legitimate DynamicUser alias is an ancestor of GITHUB_WORKSPACE, never the
+# workspace leaf. Unlink a stale leaf instead of globbing through it.
+if [[ -L "$workspace" || ( -e "$workspace" && ! -d "$workspace" ) ]]; then
+  rm -f -- "$workspace"
+fi
+if [[ ! -e "$workspace" ]]; then
+  mkdir -- "$workspace"
+fi
+if [[ ! -d "$workspace" || -L "$workspace" ]]; then
+  echo "::error::runner workspace is not a regular directory"
+  exit 1
+fi
+
+canonical_workspace="$(cd -- "$workspace" && pwd -P)"
+case "$canonical_workspace/" in
+  "$runner_work_root/"*) ;;
+  *)
+    echo "::error::runner workspace escapes the runner work root"
+    exit 1
+    ;;
+esac
+case "$runner_temp_canonical/" in
+  "$canonical_workspace/"*)
+    echo "::error::runner workspace contains RUNNER_TEMP"
+    exit 1
+    ;;
+esac
+
+shopt -s dotglob nullglob
+workspace_entries=("$canonical_workspace"/*)
+if ((${#workspace_entries[@]} != 0)); then
+  rm -rf -- "${workspace_entries[@]}"
+fi
+workspace_entries=("$canonical_workspace"/*)
+if [[ -L "$workspace" || "$(cd -- "$workspace" && pwd -P)" != "$canonical_workspace" ]] ||
+   ((${#workspace_entries[@]} != 0)); then
+  echo "::error::runner workspace reset failed attestation"
+  exit 1
+fi

--- a/.github/workflows/update-flake-lock-index.yml
+++ b/.github/workflows/update-flake-lock-index.yml
@@ -1,0 +1,25 @@
+name: Update flake.lock (index)
+
+on:
+  workflow_dispatch:
+  # Re-enable the hourly schedule only after a manual self-hosted run proves
+  # both the update and always-running escalation jobs end to end.
+
+permissions:
+  contents: read
+
+jobs:
+  update-flake-lock:
+    permissions:
+      checks: read
+      contents: write
+      issues: write
+      pull-requests: write
+      statuses: read
+    uses: ./.github/workflows/update-flake-lock.yml
+    with:
+      app-client-id: ${{ vars.PLAYBOOK_APP_CLIENT_ID }}
+      nix-preinstalled: true
+      runner-label: ${{ format('ix-ci-run-{0}-{1}-index-update-flake-lock', github.run_id, github.run_attempt) }}
+    secrets:
+      app-private-key: ${{ secrets.PLAYBOOK_APP_PRIVATE_KEY }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,18 +1,12 @@
 name: Update flake.lock
 
 on:
-  workflow_dispatch:
-    inputs:
-      flake-inputs:
-        description: "Space-separated flake inputs to update; empty updates all."
-        type: string
-        default: ""
   # Reusable: ix (and any other indexable-inc repo) calls this same job via
   # `uses: indexable-inc/index/.github/workflows/update-flake-lock.yml@main`
   # so the flake-bump mechanics live in one place. The caller supplies the
-  # schedule and the contents/PR permissions. A caller whose flake has private
-  # inputs the GitHub-hosted runner cannot fetch passes `flake-inputs` to
-  # update only the public ones (e.g. ix scopes to `index`).
+  # self-hosted runner label, schedule, and contents/PR permissions. A caller
+  # can scope `flake-inputs` when only selected locks should move (ix updates
+  # `index`).
   workflow_call:
     inputs:
       flake-inputs:
@@ -24,13 +18,13 @@ on:
         type: string
         default: ""
       runner-label:
-        description: Runner label for the update and escalation jobs
+        description: Unique self-hosted runner label provisioned by the caller
         type: string
-        default: ubuntu-latest
+        required: true
       nix-preinstalled:
         description: Whether the selected runner already provides Nix
         type: boolean
-        default: false
+        required: true
       escalate-after-hours:
         description: "Hours the rolling bump PR may stay failing before the escalate job alerts; see the escalate job below."
         type: number
@@ -43,54 +37,147 @@ on:
       app-private-key:
         description: "Private key for app-client-id."
         required: false
+      workflow-owner-read-token:
+        description: "Read token for a private cross-repository workflow owner; public owners and same-repository calls need none."
+        required: false
       slack-bot-token:
         description: "Slack bot token (chat:write) for escalation posts; empty escalates through the tracking issue only."
         required: false
-  schedule:
-    - cron: "17 * * * *"
-
 permissions:
   contents: read
 
+concurrency:
+  group: update-flake-lock-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   update-flake-lock:
-    # Schedule/dispatch have no workflow_call inputs, so retain the hosted
-    # default for index itself and for callers that have not opted into a
-    # Nix-owned runner profile.
-    runs-on: ${{ inputs.runner-label || 'ubuntu-latest' }}
+    # ix JIT runners advertise only their per-job identity label. GitHub
+    # requires every requested label, so adding `self-hosted` would strand
+    # these jobs in the queue.
+    runs-on: ${{ inputs.runner-label }}
     timeout-minutes: 15
     permissions:
       contents: write
-      id-token: write
       pull-requests: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # Fetch into a new private directory, with every inherited Git config
+      # source disabled, before replacing the workspace contents. The exact
+      # owner keeps the called implementation independent of caller state.
+      - name: Materialize exact workflow owner
+        shell: bash
+        env:
+          CHECKOUT_TOKEN: ${{ secrets.workflow-owner-read-token || github.token }}
+          WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
+          WORKFLOW_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$WORKFLOW_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "::error title=update-flake-lock::invalid workflow owner repository"
+            exit 65
+          fi
+          if [[ ! "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=update-flake-lock::invalid workflow owner revision"
+            exit 65
+          fi
 
-      # Fully qualified, not `./.github/actions/install-nix`: this workflow is
-      # reusable (`workflow_call`), and for a cross-repo caller (ix) the
-      # `actions/checkout` above checks out the CALLER's repository, which does
-      # not contain index's local composite action. A local-path `uses:` then
-      # fails with "Can't find 'action.yml'" (broke ix's hourly flake bump when
-      # #2064 introduced the local action). Referencing the action by repo
-      # resolves it from index@main regardless of which repo called the job.
-      - name: Install Determinate Nix
-        if: ${{ !inputs.nix-preinstalled }}
-        uses: indexable-inc/index/.github/actions/install-nix@main
+          umask 077
+          owner_root="$(mktemp -d -- "$RUNNER_TEMP/update-flake-owner.XXXXXX")"
+          trap 'rm -rf -- "$owner_root"' EXIT
+          chmod 700 "$owner_root"
+          if [[ ! -d "$owner_root" || -L "$owner_root" || "$(stat -c '%a' "$owner_root")" != 700 ]]; then
+            echo "::error title=update-flake-lock::workflow owner temporary directory is not private"
+            exit 1
+          fi
+          owner_repo="$owner_root/repository"
+          mkdir -- "$owner_repo"
+          owner_auth="$owner_root/git-auth"
+          : > "$owner_auth"
+          chmod 600 "$owner_auth"
 
-      # Underscore digit separators require the patched client in index and in
-      # downstream callers such as ix. The action reads its source lock from
-      # index and fetches that source independently when the checkout belongs
-      # to a caller. Fully qualified like install-nix above because a reusable
-      # workflow checks out the caller's repository.
-      - name: Bootstrap patched Nix client
-        uses: indexable-inc/index/.github/actions/bootstrap-patched-nix@main
+          export GIT_CONFIG_NOSYSTEM=1
+          export GIT_CONFIG_GLOBAL="$owner_auth"
+          export GIT_CONFIG_COUNT=0
+          trusted_git() {
+            git -c core.hooksPath=/dev/null -c core.fsmonitor=false "$@"
+          }
+          trusted_git init -q --template= "$owner_repo"
+          trusted_git -C "$owner_repo" remote add origin \
+            "${GITHUB_SERVER_URL%/}/${WORKFLOW_REPOSITORY}.git"
+          checkout_token="$CHECKOUT_TOKEN"
+          unset CHECKOUT_TOKEN
+          credential="$(printf 'x-access-token:%s' "$checkout_token" | base64 | tr -d '\n')"
+          unset checkout_token
+          echo "::add-mask::$credential"
+          if [[ ! "$GITHUB_SERVER_URL" =~ ^https://[A-Za-z0-9.-]+(:[0-9]+)?$ ]]; then
+            echo "::error title=update-flake-lock::invalid GitHub server URL"
+            exit 65
+          fi
+          {
+            printf '[http "%s/"]\n' "${GITHUB_SERVER_URL%/}"
+            printf '\textraheader = AUTHORIZATION: basic %s\n' "$credential"
+          } > "$owner_auth"
+          if ! trusted_git -C "$owner_repo" fetch --no-tags --depth 1 origin \
+            "+$WORKFLOW_SHA:refs/remotes/origin/workflow-owner"; then
+            echo "::error title=update-flake-lock::exact workflow owner fetch failed; private cross-repository owners must pass workflow-owner-read-token"
+            exit 1
+          fi
+          : > "$owner_auth"
+          unset CHECKOUT_TOKEN checkout_token credential
+          trusted_git -C "$owner_repo" checkout -q --detach refs/remotes/origin/workflow-owner
+          if [[ "$(trusted_git -C "$owner_repo" rev-parse HEAD)" != "$WORKFLOW_SHA" ]]; then
+            echo "::error title=update-flake-lock::workflow owner revision mismatch"
+            exit 1
+          fi
+          if [[ -n "$(trusted_git -C "$owner_repo" status --porcelain=v1 --untracked-files=all)" ]]; then
+            echo "::error title=update-flake-lock::workflow owner checkout is not clean"
+            exit 1
+          fi
 
-      # PRs authored by the default GITHUB_TOKEN never get pull_request CI on
-      # private repos: GitHub parks every run in action_required and the
-      # fork-approval API cannot clear them (ix#6566). When the caller supplies
-      # a GitHub App with contents + pull-requests write, mint a token scoped
-      # to this repository and author the PR with it so CI triggers normally.
+          reset_script="$owner_repo/.github/scripts/update-flake-reset-workspace.sh"
+          if [[ ! -f "$reset_script" || -L "$reset_script" ]]; then
+            echo "::error title=update-flake-lock::workflow owner workspace reset helper is not a regular file"
+            exit 1
+          fi
+          bash "$reset_script"
+          cp -R -- "$owner_repo"/. "$GITHUB_WORKSPACE"/
+          if [[ "$(trusted_git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" != "$WORKFLOW_SHA" ]] ||
+             [[ -n "$(trusted_git -C "$GITHUB_WORKSPACE" status --porcelain=v1 --untracked-files=all)" ]]; then
+            echo "::error title=update-flake-lock::copied workflow owner failed attestation"
+            exit 1
+          fi
+
+      # The caller checkout below replaces GITHUB_WORKSPACE. Preserve only the
+      # exact-revision actions needed afterward in the job-private temp dir.
+      - name: Stage workflow-owner actions
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          staged="$(mktemp -d -- "$RUNNER_TEMP/update-flake-actions.XXXXXX")"
+          chmod 700 "$staged"
+          if [[ ! -d "$staged" || -L "$staged" || "$(stat -c '%a' "$staged")" != 700 ]]; then
+            echo "::error title=update-flake-lock::staged action directory is not private"
+            exit 1
+          fi
+          for action in install-nix bootstrap-patched-nix update-flake-checkout-auth; do
+            source=".github/actions/$action"
+            if [[ ! -d "$source" || -L "$source" || ! -f "$source/action.yml" || -L "$source/action.yml" ]]; then
+              echo "::error title=update-flake-lock::workflow owner action path is not a regular directory: $action"
+              exit 1
+            fi
+            cp -R -- "$source" "$staged/$action"
+          done
+          reset_source=".github/scripts/update-flake-reset-workspace.sh"
+          if [[ ! -f "$reset_source" || -L "$reset_source" ]]; then
+            echo "::error title=update-flake-lock::workspace reset helper is not a regular file"
+            exit 1
+          fi
+          cp -- "$reset_source" "$staged/reset-workspace.sh"
+          printf 'UPDATE_FLAKE_ACTIONS=%s\n' "$staged" >> "$GITHUB_ENV"
+
+      # Mint before checkout so one identity reads the private repository,
+      # updates its branch, and opens the PR. The fallback is the job token.
       - name: Mint PR token
         id: app-token
         if: ${{ inputs.app-client-id != '' }}
@@ -98,6 +185,64 @@ jobs:
         with:
           client-id: ${{ inputs.app-client-id }}
           private-key: ${{ secrets.app-private-key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      # Remove the exact-owner checkout and any content a persistent runner
+      # left behind, while preserving the DynamicUser workspace path itself.
+      - name: Reset caller workspace
+        shell: bash
+        run: bash "$UPDATE_FLAKE_ACTIONS/reset-workspace.sh"
+
+      - name: Prepare alias-safe checkout authentication
+        id: checkout-auth
+        shell: bash
+        env:
+          CHECKOUT_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: bash "$UPDATE_FLAKE_ACTIONS/update-flake-checkout-auth/run.sh" prepare
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      # Scrub the private global auth file and command-scoped isolation slots
+      # before any updater-controlled process can inherit them.
+      - name: Remove alias-safe checkout authentication
+        if: ${{ always() && steps.checkout-auth.outcome != 'skipped' }}
+        shell: bash
+        run: bash "$UPDATE_FLAKE_ACTIONS/update-flake-checkout-auth/run.sh" cleanup
+
+      - name: Restore workflow-owner actions
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -e .update-flake-workflow-actions || -L .update-flake-workflow-actions ]]; then
+            echo "::error title=update-flake-lock::caller repository occupies reserved path .update-flake-workflow-actions"
+            exit 1
+          fi
+          cp -R -- "$UPDATE_FLAKE_ACTIONS" .update-flake-workflow-actions
+
+      - name: Install Determinate Nix
+        if: ${{ !inputs.nix-preinstalled }}
+        uses: ./.update-flake-workflow-actions/install-nix
+
+      # Underscore digit separators require the patched client in index and in
+      # downstream callers such as ix. The action reads its source lock from
+      # index and fetches that source independently when the checkout belongs
+      # to a caller.
+      - name: Bootstrap patched Nix client
+        uses: ./.update-flake-workflow-actions/bootstrap-patched-nix
+
+      # create-pull-request commits every untracked path in GITHUB_WORKSPACE.
+      # Remove the staged action code before handing ownership to the updater.
+      - name: Remove workflow-owner actions
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf -- .update-flake-workflow-actions
 
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
@@ -132,314 +277,338 @@ jobs:
   # issue plus a Slack post (when the caller supplies slack-bot-token),
   # recorded as a body marker so later ticks do not re-fire. Watcher-internal
   # failures (API errors) exit loudly without claiming health or closing the
-  # issue. Callers must grant `issues: write` on the calling job.
+  # issue. The update-failure reporter deliberately has no checkout, Nix, or
+  # bootstrap dependency: a broken bootstrap must still report itself. Callers
+  # must grant `issues: write` on the calling job.
   escalate:
     needs: update-flake-lock
     if: ${{ always() }}
-    # Reuse the caller-selected runner for both halves of the transaction. A
-    # hosted escalation tail would make a supposedly self-hosted reusable
-    # workflow silently depend on GitHub capacity after the update job exits.
-    runs-on: ${{ inputs.runner-label || 'ubuntu-latest' }}
-    timeout-minutes: 10
+    runs-on: ${{ inputs.runner-label }}
+    timeout-minutes: 5
     permissions:
+      checks: read
       contents: read
       issues: write
       pull-requests: read
-    env:
-      GH_TOKEN: ${{ github.token }}
-      REPOSITORY: ${{ github.repository }}
-      # Must match the `branch:` given to update-flake-lock above.
-      BUMP_BRANCH: update-flake-lock
-      UPDATE_RESULT: ${{ needs.update-flake-lock.result }}
-      # `inputs.*` is empty on index's own schedule/dispatch runs; the ||
-      # arms mirror the workflow_call defaults for those events.
-      ESCALATE_AFTER_HOURS: ${{ inputs.escalate-after-hours || 6 }}
-      SLACK_CHANNEL: ${{ inputs.slack-channel || 'C0A4TD9G7HR' }}
-      SLACK_BOT_TOKEN: ${{ secrets.slack-bot-token }}
+      statuses: read
     steps:
-      - name: Escalate a stuck flake bump
-        run: |
-          set -euo pipefail
-
-          marker="<!-- update-flake-lock-escalation -->"
-          issue_title="update-flake-lock: rolling bump PR is stuck"
-          label="flake-bump-stuck"
-          now_epoch="$(date -u +%s)"
-          now_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          threshold_s=$(( ESCALATE_AFTER_HOURS * 3600 ))
-
-          note() { echo "::notice::escalate: $*"; }
-          # Internal failure is loud and neither claims health nor closes the
-          # tracking issue (same contract as cache-push-watchdog.yml).
-          fail_loud() { echo "::error::flake-bump escalation internal failure: $*"; exit 2; }
-
-          reasons=""
-          add_reason() { reasons="${reasons}$1"$'\n'; }
-
-          # Slack signals rejection in-body (ok:false) with HTTP 200, so parse
-          # the response; non-zero return means the message did NOT post.
-          slack_post() {
-            local text="$1" resp
-            resp="$(jq -n --arg channel "${SLACK_CHANNEL}" --arg text "$text" \
-                '{channel: $channel, text: $text}' \
-              | curl -sS -X POST "https://slack.com/api/chat.postMessage" \
-                  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-                  -H "Content-Type: application/json; charset=utf-8" \
-                  --data @-)" \
-              || { echo "::error::slack chat.postMessage transport failed"; return 1; }
-            if [ "$(jq -r '.ok' <<<"$resp")" != "true" ]; then
-              echo "::error::slack rejected the escalation post: $(jq -r '.error // "unknown"' <<<"$resp")"
-              return 1
-            fi
-          }
-
-          # --- State: the bump job itself failed ------------------------------
-          if [ "${UPDATE_RESULT}" = "failure" ]; then
-            add_reason "- **Bump job failed**: \`update-flake-lock\` concluded \`failure\` in run [${GITHUB_RUN_ID}](https://github.com/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
-          fi
-
-          # --- State: the rolling PR (red, or stuck past the threshold) -------
-          pr_json=/tmp/bump-pr.json
-          gh pr list --repo "${REPOSITORY}" --head "${BUMP_BRANCH}" --base main \
-              --state open --json number,url,createdAt,statusCheckRollup \
-              --jq '.[0] // empty' > "$pr_json" \
-            || fail_loud "listing the rolling bump PR failed"
-
-          pr_number=""
-          pr_url=""
-          failing_checks=""
-          pending_count=0
-          pr_age_s=0
-          if [ -s "$pr_json" ]; then
-            pr_number="$(jq -r '.number' "$pr_json")"
-            pr_url="$(jq -r '.url' "$pr_json")"
-            pr_age_s=$(( now_epoch - $(date -u -d "$(jq -r '.createdAt' "$pr_json")" +%s) ))
-            # CheckRun rows carry .conclusion ("" until completed), StatusContext
-            # rows carry .state; normalize both shapes before classifying.
-            failing_checks="$(jq -r '[(.statusCheckRollup // [])[]
-                | ((.conclusion // .state // "") | ascii_upcase) as $c
-                | select($c == "FAILURE" or $c == "TIMED_OUT" or $c == "CANCELLED"
-                         or $c == "ERROR" or $c == "STARTUP_FAILURE")
-                | (.name // .context)] | unique | join(", ")' "$pr_json")" \
-              || fail_loud "parsing the PR check rollup failed"
-            pending_count="$(jq -r '[(.statusCheckRollup // [])[]
-                | ((.conclusion // .state // "") | ascii_upcase)
-                | select(. == "" or . == "PENDING" or . == "EXPECTED"
-                         or . == "QUEUED" or . == "IN_PROGRESS")] | length' "$pr_json")" \
-              || fail_loud "counting pending checks failed"
-            # No checks materialized yet (head pushed moments ago) is pending,
-            # not green: reading it as green would flap the tracking issue.
-            if [ "$(jq -r '(.statusCheckRollup // []) | length' "$pr_json")" -eq 0 ]; then
-              pending_count=1
-            fi
-            pr_age_h=$(( pr_age_s / 3600 ))
-            if [ -n "$failing_checks" ]; then
-              add_reason "- **Red bump PR**: [#${pr_number}](${pr_url}) (open ${pr_age_h}h) failing: \`${failing_checks}\`."
-            elif [ "$pending_count" -gt 0 ] && [ "$pr_age_s" -ge "$threshold_s" ]; then
-              add_reason "- **Stuck bump PR**: [#${pr_number}](${pr_url}) open ${pr_age_h}h (>= ${ESCALATE_AFTER_HOURS}h) and unmerged; checks pending on the latest head."
-            fi
-          fi
-
-          # --- State: bump branch ahead of main with no open PR ---------------
-          branch_ref=""
-          if [ -z "$pr_number" ]; then
-            set +e
-            branch_ref="$(gh api "repos/${REPOSITORY}/git/ref/heads/${BUMP_BRANCH}" --jq '.object.sha' 2>/tmp/ref-err)"
-            ref_rc=$?
-            set -e
-            if [ "$ref_rc" -ne 0 ]; then
-              # Only a missing branch reads as clean; any other API failure is
-              # an internal error, never a claim of health.
-              if grep -q "Not Found" /tmp/ref-err; then
-                branch_ref=""
-              else
-                fail_loud "reading the ${BUMP_BRANCH} ref failed: $(cat /tmp/ref-err)"
-              fi
-            fi
-            if [ -n "$branch_ref" ]; then
-              ahead="$(gh api "repos/${REPOSITORY}/compare/main...${branch_ref}" --jq '.ahead_by')" \
-                || fail_loud "comparing ${BUMP_BRANCH} to main failed"
-              if [ "$ahead" -gt 0 ]; then
-                add_reason "- **Bump without a PR**: \`${BUMP_BRANCH}\` is ${ahead} commit(s) ahead of main with no open PR (closed unmerged?)."
-              else
-                branch_ref=""
-              fi
-            fi
-          fi
-
-          # --- Input rev range: locked on main -> candidate on the branch -----
-          rev_range=""
-          if [ -n "$pr_number" ] || [ -n "$branch_ref" ]; then
-            fetch_lock() {
-              gh api -H "Accept: application/vnd.github.raw" \
-                "repos/${REPOSITORY}/contents/flake.lock?ref=$1"
+      - name: Track flake update health
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ESCALATE_AFTER_HOURS: ${{ inputs.escalate-after-hours }}
+          SLACK_BOT_TOKEN: ${{ secrets.slack-bot-token }}
+          SLACK_CHANNEL: ${{ inputs.slack-channel }}
+          UPDATE_RESULT: ${{ needs.update-flake-lock.result }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const result = process.env.UPDATE_RESULT;
+            if (!['success', 'failure', 'cancelled', 'skipped'].includes(result)) {
+              throw new Error(`unexpected update job result: ${result}`);
             }
-            fetch_lock main > /tmp/lock-main.json \
-              || fail_loud "fetching flake.lock at main failed"
-            fetch_lock "refs/heads/${BUMP_BRANCH}" > /tmp/lock-bump.json \
-              || fail_loud "fetching flake.lock at ${BUMP_BRANCH} failed"
-            # Only the root node's direct inputs: internal dedup nodes
-            # (nixpkgs_2, flake-parts_4, ...) are noise in an alert.
-            rev_range="$(jq -rn --slurpfile base /tmp/lock-main.json --slurpfile bump /tmp/lock-bump.json '
-                ($base[0]) as $B | ($bump[0]) as $H |
-                [($H.nodes[$H.root].inputs // {}) | keys[] | . as $name
-                  | ($H.nodes[$H.root].inputs[$name]) as $hk
-                  | select(($hk | type) == "string")
-                  | ($B.nodes[$B.root].inputs[$name]? // null) as $bk
-                  | (if ($bk | type) == "string"
-                     then ($B.nodes[$bk].locked.rev? // "absent") else "absent" end) as $old
-                  | ($H.nodes[$hk].locked.rev? // "absent") as $new
-                  | select($old != $new)
-                  | "\($name) \($old[0:11]) -> \($new[0:11])"]
-                | join(", ")')" \
-              || fail_loud "diffing flake.lock revs failed"
-          fi
 
-          # --- Locate the tracking issue (label filter, not search: the search
-          # index lags minutes to hours and a lagged miss would mint duplicate
-          # episode issues) ----------------------------------------------------
-          issue_json=/tmp/tracking-issue.json
-          gh issue list --repo "${REPOSITORY}" --label "$label" --state all \
-              --json number,url,state,body --jq '.[0] // empty' > "$issue_json" \
-            || fail_loud "listing tracking issues failed"
-          issue_number=""
-          issue_state=""
-          issue_url=""
-          : > /tmp/issue-body.md
-          if [ -s "$issue_json" ]; then
-            issue_number="$(jq -r '.number' "$issue_json")"
-            issue_state="$(jq -r '.state' "$issue_json")"
-            issue_url="$(jq -r '.url' "$issue_json")"
-            jq -r '.body // ""' "$issue_json" > /tmp/issue-body.md
-          fi
+            const thresholdHours = Number(process.env.ESCALATE_AFTER_HOURS);
+            if (!Number.isFinite(thresholdHours) || thresholdHours < 0) {
+              throw new Error('invalid escalation threshold');
+            }
+            const { owner, repo } = context.repo;
+            const bumpBranch = 'update-flake-lock';
+            const label = 'flake-bump-stuck';
+            const issueTitle = 'update-flake-lock: rolling bump PR is stuck';
+            const now = new Date();
+            const nowIso = now.toISOString().replace(/\.\d{3}Z$/, 'Z');
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const slackToken = process.env.SLACK_BOT_TOKEN || '';
+            delete process.env.SLACK_BOT_TOKEN;
+            const reasons = [];
 
-          # --- Healthy: PR merged/green, branch clean, bump job green ---------
-          healthy=""
-          if [ -z "$reasons" ]; then
-            if [ -z "$pr_number" ] || { [ -z "$failing_checks" ] && [ "$pending_count" -eq 0 ]; }; then
-              healthy=1
-            fi
-          fi
-          if [ -n "$healthy" ]; then
-            note "flake bump healthy (bump job ${UPDATE_RESULT}, no stuck PR, branch clean)"
-            if [ -n "$issue_number" ] && [ "$issue_state" = "OPEN" ]; then
-              if grep -q '<!-- slack-escalated:' /tmp/issue-body.md && [ -n "${SLACK_BOT_TOKEN}" ]; then
-                slack_post "flake bump recovered in ${REPOSITORY}; closing <${issue_url}|the tracking issue>." \
-                  || echo "::warning::recovery note did not post to Slack"
-              fi
-              gh issue comment "$issue_number" --repo "${REPOSITORY}" \
-                  --body "Resolved: flake bump healthy at \`${now_iso}\` (run ${GITHUB_RUN_ID}). Closing." \
-                || fail_loud "commenting the resolution failed"
-              gh issue close "$issue_number" --repo "${REPOSITORY}" \
-                || fail_loud "closing the tracking issue failed"
-            fi
-            exit 0
-          fi
+            const postSlack = async text => {
+              const response = await fetch('https://slack.com/api/chat.postMessage', {
+                method: 'POST',
+                redirect: 'error',
+                headers: {
+                  Authorization: `Bearer ${slackToken}`,
+                  'Content-Type': 'application/json; charset=utf-8',
+                },
+                body: JSON.stringify({ channel: process.env.SLACK_CHANNEL, text }),
+              });
+              const payload = await response.json();
+              if (!response.ok || payload.ok !== true) {
+                throw new Error(payload.error || `HTTP ${response.status}`);
+              }
+            };
 
-          # A young all-pending PR with no episode open is just CI in flight.
-          if [ -z "$reasons" ] && { [ -z "$issue_number" ] || [ "$issue_state" != "OPEN" ]; }; then
-            note "bump PR checks pending and below the ${ESCALATE_AFTER_HOURS}h threshold; nothing to escalate yet"
-            exit 0
-          fi
-          if [ -z "$reasons" ]; then
-            add_reason "- **Episode continuing**: bump PR [#${pr_number}](${pr_url}) checks pending on the latest head."
-          fi
+            if (result !== 'success') {
+              reasons.push(`- **Bump job did not succeed**: \`update-flake-lock\` concluded \`${result}\` in run [${context.runId}](${runUrl}).`);
+            }
 
-          # --- Episode clock: persisted in the issue body; a red PR that
-          # predates the first observation backdates the start to PR creation --
-          first_detected=""
-          escalated_at=""
-          if [ "$issue_state" = "OPEN" ]; then
-            first_detected="$(sed -n 's/.*<!-- first-detected: \([0-9TZ:-]*\) -->.*/\1/p' /tmp/issue-body.md | head -n1)"
-            escalated_at="$(sed -n 's/.*<!-- slack-escalated: \([0-9TZ:-]*\) -->.*/\1/p' /tmp/issue-body.md | head -n1)"
-          fi
-          if [ -z "$first_detected" ]; then first_detected="$now_iso"; fi
-          first_epoch="$(date -u -d "$first_detected" +%s)"
-          if [ -n "$pr_number" ] && [ "$pr_age_s" -gt $(( now_epoch - first_epoch )) ]; then
-            first_epoch=$(( now_epoch - pr_age_s ))
-            first_detected="$(date -u -d "@${first_epoch}" +%Y-%m-%dT%H:%M:%SZ)"
-          fi
-          failing_for_s=$(( now_epoch - first_epoch ))
-          failing_for_h=$(( failing_for_s / 3600 ))
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              head: `${owner}:${bumpBranch}`,
+              base: 'main',
+              state: 'open',
+              per_page: 100,
+            });
+            const pr = pulls[0] || null;
+            const failingChecks = [];
+            let pendingCount = 0;
+            let prAgeMs = 0;
+            let branchSha = '';
 
-          fire=""
-          if [ "$failing_for_s" -ge "$threshold_s" ] && [ -z "$escalated_at" ]; then
-            fire=1
-          fi
+            if (pr) {
+              branchSha = pr.head.sha;
+              prAgeMs = Math.max(0, now.getTime() - Date.parse(pr.created_at));
+              const checkRuns = await github.paginate(
+                github.rest.checks.listForRef,
+                { owner, repo, ref: pr.head.sha, per_page: 100 },
+              );
+              const statuses = await github.paginate(
+                github.rest.repos.listCommitStatusesForRef,
+                { owner, repo, ref: pr.head.sha, per_page: 100 },
+              );
+              const failed = new Set(['ACTION_REQUIRED', 'CANCELLED', 'ERROR', 'FAILURE', 'STALE', 'STARTUP_FAILURE', 'TIMED_OUT']);
+              for (const check of checkRuns) {
+                const conclusion = (check.conclusion || '').toUpperCase();
+                if (check.status !== 'completed' || !conclusion) {
+                  pendingCount += 1;
+                } else if (failed.has(conclusion)) {
+                  failingChecks.push(check.name);
+                }
+              }
+              const latestStatuses = new Map();
+              for (const status of statuses) {
+                if (!latestStatuses.has(status.context)) latestStatuses.set(status.context, status);
+              }
+              for (const status of latestStatuses.values()) {
+                const state = (status.state || '').toUpperCase();
+                if (state === 'PENDING') {
+                  pendingCount += 1;
+                } else if (failed.has(state)) {
+                  failingChecks.push(status.context);
+                }
+              }
+              if (checkRuns.length + statuses.length === 0) pendingCount = 1;
 
-          write_body() {
-            {
-              echo "${marker}"
-              echo "<!-- first-detected: ${first_detected} -->"
-              if [ -n "$escalated_at" ]; then
-                echo "<!-- slack-escalated: ${escalated_at} -->"
-              fi
-              echo "## Rolling flake bump is stuck"
-              echo
-              echo "Failing since \`${first_detected}\` (${failing_for_h}h; escalation threshold ${ESCALATE_AFTER_HOURS}h). Last checked \`${now_iso}\` by run [${GITHUB_RUN_ID}](https://github.com/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
-              echo
-              echo "${reasons}"
-              if [ -n "$rev_range" ]; then
-                echo "Input revisions waiting to land: \`${rev_range}\`"
-                echo
-              fi
-              echo "Maintained by the \`escalate\` job of the reusable update-flake-lock workflow (indexable-inc/index): refreshed each scheduled run while the episode persists, closed automatically once a bump lands cleanly. Motivating incident: indexable-inc/ix#7235."
-              echo
-              echo "_Made with Claude Opus 4.5._"
-            } > /tmp/tracking-body.md
-          }
+              const prAgeHours = Math.floor(prAgeMs / 3_600_000);
+              const uniqueFailures = [...new Set(failingChecks)].sort();
+              failingChecks.splice(0, failingChecks.length, ...uniqueFailures);
+              if (failingChecks.length > 0) {
+                reasons.push(`- **Red bump PR**: [#${pr.number}](${pr.html_url}) (open ${prAgeHours}h) failing: \`${failingChecks.join(', ')}\`.`);
+              } else if (prAgeMs >= thresholdHours * 3_600_000) {
+                const state = pendingCount > 0
+                  ? 'checks pending on the latest head'
+                  : 'checks green but the PR is still unmerged';
+                reasons.push(`- **Stuck bump PR**: [#${pr.number}](${pr.html_url}) open ${prAgeHours}h (>= ${thresholdHours}h); ${state}.`);
+              }
+            } else {
+              try {
+                const ref = await github.rest.git.getRef({ owner, repo, ref: `heads/${bumpBranch}` });
+                branchSha = ref.data.object.sha;
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+              if (branchSha) {
+                const comparison = await github.rest.repos.compareCommitsWithBasehead({
+                  owner,
+                  repo,
+                  basehead: `main...${branchSha}`,
+                });
+                if (comparison.data.ahead_by > 0) {
+                  reasons.push(`- **Bump without a PR**: \`${bumpBranch}\` is ${comparison.data.ahead_by} commit(s) ahead of main with no open PR (closed unmerged?).`);
+                } else {
+                  branchSha = '';
+                }
+              }
+            }
 
-          # --force: create-or-update, so the label pre-existing is fine.
-          gh label create "$label" --repo "${REPOSITORY}" --force \
-              --color D93F0B --description "rolling flake bump failing past its escalation threshold" \
-            || fail_loud "ensuring the ${label} label failed"
+            let revRange = '';
+            if (pr || branchSha) {
+              const readLock = async ref => {
+                const response = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path: 'flake.lock',
+                  ref,
+                });
+                if (Array.isArray(response.data) || !response.data.content) {
+                  throw new Error(`flake.lock at ${ref} is not a file`);
+                }
+                return JSON.parse(Buffer.from(response.data.content, 'base64').toString('utf8'));
+              };
+              const [baseLock, bumpLock] = await Promise.all([
+                readLock('main'),
+                readLock(branchSha || pr.head.sha),
+              ]);
+              const baseInputs = baseLock.nodes?.[baseLock.root]?.inputs || {};
+              const bumpInputs = bumpLock.nodes?.[bumpLock.root]?.inputs || {};
+              const revisions = [];
+              for (const [name, bumpKey] of Object.entries(bumpInputs)) {
+                if (typeof bumpKey !== 'string') continue;
+                const baseKey = baseInputs[name];
+                const oldRev = typeof baseKey === 'string' ? (baseLock.nodes?.[baseKey]?.locked?.rev || 'absent') : 'absent';
+                const newRev = bumpLock.nodes?.[bumpKey]?.locked?.rev || 'absent';
+                if (oldRev !== newRev) revisions.push(`${name} ${oldRev.slice(0, 11)} -> ${newRev.slice(0, 11)}`);
+              }
+              revRange = revisions.join(', ');
+            }
 
-          write_body
-          if [ -z "$issue_number" ]; then
-            issue_url="$(gh issue create --repo "${REPOSITORY}" --title "$issue_title" \
-                --label "$label" --body-file /tmp/tracking-body.md)" \
-              || fail_loud "creating the tracking issue failed"
-            issue_number="${issue_url##*/}"
-          else
-            if [ "$issue_state" = "CLOSED" ]; then
-              gh issue reopen "$issue_number" --repo "${REPOSITORY}" \
-                || fail_loud "reopening the tracking issue failed"
-            fi
-            gh issue edit "$issue_number" --repo "${REPOSITORY}" --body-file /tmp/tracking-body.md \
-              || fail_loud "updating the tracking issue failed"
-          fi
+            try {
+              await github.rest.issues.updateLabel({
+                owner,
+                repo,
+                name: label,
+                new_name: label,
+                color: 'D93F0B',
+                description: 'rolling flake bump failing past its escalation threshold',
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label,
+                  color: 'D93F0B',
+                  description: 'rolling flake bump failing past its escalation threshold',
+                });
+              } catch (createError) {
+                if (createError.status !== 422) throw createError;
+              }
+            }
 
-          if [ -n "$fire" ]; then
-            # The comment (unlike body edits) notifies issue subscribers: the
-            # issue channel escalates even when no Slack token is configured.
-            gh issue comment "$issue_number" --repo "${REPOSITORY}" \
-                --body "Failing for ${failing_for_h}h, past the ${ESCALATE_AFTER_HOURS}h threshold: escalating." \
-              || fail_loud "posting the threshold comment failed"
-            slack_ok=1
-            if [ -n "${SLACK_BOT_TOKEN}" ]; then
-              slack_text="flake bump stuck in ${REPOSITORY}: failing for ${failing_for_h}h (threshold ${ESCALATE_AFTER_HOURS}h)."
-              if [ -n "$pr_number" ] && [ -n "$failing_checks" ]; then
-                slack_text="${slack_text} <${pr_url}|#${pr_number}> failing: \`${failing_checks}\`."
-              elif [ -n "$pr_number" ]; then
-                slack_text="${slack_text} <${pr_url}|#${pr_number}> unmerged."
-              fi
-              if [ -n "$rev_range" ]; then
-                slack_text="${slack_text} Waiting revs: \`${rev_range}\`."
-              fi
-              slack_text="${slack_text} Tracking: <${issue_url}|#${issue_number}>."
-              # A rejected post leaves the marker unset so the next tick retries.
-              slack_post "$slack_text" || slack_ok=""
-            else
-              note "no slack-bot-token configured; escalated via the tracking issue only"
-            fi
-            if [ -n "$slack_ok" ]; then
-              escalated_at="$now_iso"
-              write_body
-              gh issue edit "$issue_number" --repo "${REPOSITORY}" --body-file /tmp/tracking-body.md \
-                || fail_loud "recording the escalation marker failed"
-            fi
-          fi
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              labels: label,
+              state: 'all',
+              per_page: 100,
+            });
+            let issue = issues.find(candidate => !candidate.pull_request);
+            const priorBody = issue?.state === 'open' ? (issue.body || '') : '';
+            const healthy = reasons.length === 0 && (!pr || (failingChecks.length === 0 && pendingCount === 0));
+            if (healthy) {
+              core.notice(`flake bump healthy (bump job ${result}, no stuck PR, branch clean)`);
+              if (issue?.state === 'open') {
+                if (priorBody.includes('<!-- slack-escalated:') && slackToken) {
+                  try {
+                    await postSlack(`flake bump recovered in ${owner}/${repo}; closing <${issue.html_url}|the tracking issue>.`);
+                  } catch (error) {
+                    core.warning(`Slack recovery note failed: ${error.message}`);
+                  }
+                }
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: `Resolved: flake bump healthy at \`${nowIso}\` (run ${context.runId}). Closing.`,
+                });
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                });
+              }
+              return;
+            }
+            if (reasons.length === 0 && issue?.state !== 'open') {
+              core.notice(`bump PR checks pending and below the ${thresholdHours}h threshold; nothing to escalate yet`);
+              return;
+            }
+            if (reasons.length === 0) {
+              reasons.push(`- **Episode continuing**: bump PR [#${pr.number}](${pr.html_url}) checks pending on the latest head.`);
+            }
 
-          # Red in the Actions tab too, not only in the issue.
-          echo "::error::flake bump stuck for ${failing_for_h}h; see ${issue_url}"
-          exit 1
+            const firstMatch = priorBody.match(/<!-- first-detected: ([0-9TZ:-]+) -->/);
+            const escalatedMatch = priorBody.match(/<!-- slack-escalated: ([0-9TZ:-]+) -->/);
+            let firstDetected = firstMatch?.[1] || nowIso;
+            let firstEpoch = Date.parse(firstDetected);
+            if (!Number.isFinite(firstEpoch)) {
+              firstDetected = nowIso;
+              firstEpoch = now.getTime();
+            }
+            let escalatedAt = escalatedMatch?.[1] || '';
+            if (pr && prAgeMs > now.getTime() - firstEpoch) {
+              firstEpoch = now.getTime() - prAgeMs;
+              firstDetected = new Date(firstEpoch).toISOString().replace(/\.\d{3}Z$/, 'Z');
+            }
+            const failingForMs = Math.max(0, now.getTime() - firstEpoch);
+            const failingForHours = Math.floor(failingForMs / 3_600_000);
+
+            const renderBody = () => [
+              '<!-- update-flake-lock-escalation -->',
+              `<!-- first-detected: ${firstDetected} -->`,
+              ...(escalatedAt ? [`<!-- slack-escalated: ${escalatedAt} -->`] : []),
+              '## Rolling flake bump is stuck',
+              '',
+              `Failing since \`${firstDetected}\` (${failingForHours}h; escalation threshold ${thresholdHours}h). Last checked \`${nowIso}\` by run [${context.runId}](${runUrl}).`,
+              '',
+              reasons.join('\n'),
+              '',
+              ...(revRange ? [`Input revisions waiting to land: \`${revRange}\``, ''] : []),
+              'Maintained by the failure-independent watcher in the reusable update-flake-lock workflow (indexable-inc/index); refreshed each run and closed automatically after recovery. Motivating incident: indexable-inc/ix#7235.',
+              '',
+              '_Made with Claude Opus 4.5._',
+            ].join('\n');
+
+            if (!issue) {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title: issueTitle,
+                labels: [label],
+                body: renderBody(),
+              });
+              issue = created.data;
+            } else {
+              const updated = await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issue.number,
+                state: 'open',
+                body: renderBody(),
+              });
+              issue = updated.data;
+            }
+
+            const shouldEscalate = failingForMs >= thresholdHours * 3_600_000 && !escalatedAt;
+            if (shouldEscalate) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `Failing for ${failingForHours}h, past the ${thresholdHours}h threshold: escalating.`,
+              });
+
+              let slackOk = true;
+              if (slackToken) {
+                let slackText = `flake bump stuck in ${owner}/${repo}: failing for ${failingForHours}h (threshold ${thresholdHours}h).`;
+                if (pr && failingChecks.length > 0) {
+                  slackText += ` <${pr.html_url}|#${pr.number}> failing: \`${failingChecks.join(', ')}\`.`;
+                } else if (pr) {
+                  slackText += ` <${pr.html_url}|#${pr.number}> unmerged.`;
+                }
+                if (revRange) slackText += ` Waiting revs: \`${revRange}\`.`;
+                slackText += ` Tracking: <${issue.html_url}|#${issue.number}>.`;
+                try {
+                  await postSlack(slackText);
+                } catch (error) {
+                  core.warning(`Slack escalation failed: ${error.message}`);
+                  slackOk = false;
+                }
+              } else {
+                core.notice('no slack-bot-token configured; escalated through the tracking issue only');
+              }
+              if (slackOk) {
+                escalatedAt = nowIso;
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: renderBody(),
+                });
+              }
+            }
+
+            core.setFailed(`flake bump unhealthy for ${failingForHours}h; see ${issue.html_url}`);

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1272,6 +1272,22 @@
     fileset = fs.gitTracked paths.root;
   };
 
+  # Exercise the shell helpers against one explicit tool set instead of the
+  # ambient developer PATH used to launch the Nix check.
+  updateFlakeWorkflowTestTools = pkgs.buildEnv {
+    name = "update-flake-workflow-test-tools";
+    paths = [
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.git
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.gnutar
+    ];
+    pathsToLink = ["/bin"];
+    meta.description = "Pinned test tools for the reusable flake update workflow";
+  };
+
   # Just the astlog rules file plus its fixture pairs, so the rules self-test
   # below only rebuilds when the rules or fixtures change, not on every
   # tracked-file edit the way `lintSource` does.
@@ -1899,6 +1915,35 @@
               export HOME="$TMPDIR/home"
               mkdir -p "$HOME"
               bash packages/blast-radius/tests/blast-radius-test.sh
+              mkdir -p "$out"
+            '';
+          # Crosses both failure boundaries from ix run 29489082838: checkout
+          # auth must survive systemd's logical/canonical workspace aliases,
+          # and watcher state transitions must be proven without live API calls.
+          update-flake-workflow =
+            pkgs.runCommand "update-flake-workflow-check" {
+              nativeBuildInputs = [
+                pkgs.nodejs
+                pkgs.shellcheck
+                updateFlakeWorkflowTestTools
+              ];
+            }
+            ''
+              shellcheck \
+                ${paths.root + "/.github/actions/bootstrap-patched-nix/run.sh"} \
+                ${paths.root + "/.github/actions/bootstrap-patched-nix/test.sh"} \
+                ${paths.root + "/.github/actions/update-flake-checkout-auth/run.sh"} \
+                ${paths.root + "/.github/actions/update-flake-checkout-auth/test.sh"} \
+                ${paths.root + "/.github/scripts/update-flake-reset-workspace.sh"}
+              node \
+                ${paths.root + "/.github/scripts/test-update-flake-watcher.mjs"} \
+                ${paths.root + "/.github/workflows/update-flake-lock.yml"}
+              ${updateFlakeWorkflowTestTools}/bin/bash \
+                ${paths.root + "/.github/actions/bootstrap-patched-nix/test.sh"} \
+                ${updateFlakeWorkflowTestTools}
+              ${updateFlakeWorkflowTestTools}/bin/bash \
+                ${paths.root + "/.github/actions/update-flake-checkout-auth/test.sh"} \
+                ${updateFlakeWorkflowTestTools}
               mkdir -p "$out"
             '';
           # Proves the Linux→macOS cross toolchain actually emits a Darwin object,


### PR DESCRIPTION
## Summary

- run flake updates only on the caller-provisioned exact JIT runner label
- isolate DynamicUser checkout auth and reject workspace symlink escapes
- GC-root the patched Nix fallback for the job lifetime
- replace the duplicate checkout/Nix watcher with a failure-independent pinned GitHub API watcher
- keep the index schedule disabled until the manual cross-repo E2E passes

## Verification

- hostile DynamicUser reset/auth and token-lifetime tests
- bootstrap lifecycle and warning-tolerant fast-path tests
- watcher state-machine mocks, including status history, recurrence, and green-but-unmerged PRs
- ShellCheck, actionlint, seven policy tests, and full repository lint (10/10)
- independent adversarial review of exact commit `692806b00b8ca81710efbdbb2b8dc7c5066389aa`

## Rollout gate

Do not invoke the reusable watcher from ix until its call job grants `checks: read` and `statuses: read`. After that lands, manually dispatch update + escalation and require completion under five minutes before restoring schedules.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the flake lock updater workflow self-contained with isolated runner and auth handling
> - Adds a new dispatchable index workflow ([update-flake-lock-index.yml](https://github.com/indexable-inc/index/pull/3467/files#diff-bd9b95091119b454a962149233686d6655b63952f2b1b5813fde09339f8664b6)) that invokes the reusable updater with a caller-provided self-hosted runner label and GitHub App credentials.
> - The reusable workflow ([update-flake-lock.yml](https://github.com/indexable-inc/index/pull/3467/files#diff-3dd117f927104ee8bdf13935f130eeb0ee70fad2c72077739b766ba1d142dc43)) now self-materializes the workflow owner's actions and scripts at exact revisions, isolates and removes temporary auth before committing, and serializes runs per-repository via a concurrency group.
> - A new composite action ([update-flake-checkout-auth](https://github.com/indexable-inc/index/pull/3467/files#diff-83596dd5ba2d45e7f866d7bafb6eff0525ce9d8cc32e36117a236e6f048916b3)) creates a private Git config with scoped auth overrides and a cleanup subcommand that scrubs the bearer token from the runner environment.
> - The `bootstrap-patched-nix` action now delegates to [run.sh](https://github.com/indexable-inc/index/pull/3467/files#diff-604f8ce595251dc88d175bfae2682c069def0a25bc00ed93df8582cf00c25d22), which reuses a compatible preinstalled Nix client when available and otherwise builds from a securely fetched pinned revision in private directories.
> - Escalation logic is rewritten as a single `actions/github-script` step that tracks flake bump health in a GitHub issue, posts Slack alerts when configured, and fails the workflow when the bump is stuck or failing.
> - Test coverage is added via shellcheck linting, a Node.js watcher test ([test-update-flake-watcher.mjs](https://github.com/indexable-inc/index/pull/3467/files#diff-9580a0f32db114379d2e505f8fbc4eb01aa6abf293f1d8d731293cec0374b22f)), and bash test harnesses for the new actions, all gated by a new Nix check in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/3467/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 692806b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->