### PR TITLE
ci: skip patched Nix bootstrap when runner is ready

### DIFF
--- a/.github/actions/bootstrap-patched-nix/action.yml
+++ b/.github/actions/bootstrap-patched-nix/action.yml
@@ -8,15 +8,29 @@ description: >-
   protocol-compatible with the fleet daemon family). Evaluating the current
   tree to build that client would be circular, so the client is built from a
   pinned separator-free revision and substituted from the warm store /
-  cache.ix.dev on repeat runs. Downstream repositories fetch that revision
-  from the repository that owns this action. Requires git and a nix client on
-  PATH (the host daemon's on self-hosted runners, the install-nix action's
-  elsewhere).
+  cache.ix.dev only when the runner does not already provide a compatible
+  client. Downstream repositories fetch that revision from the repository that
+  owns this action. Requires git and a nix client on PATH (the immutable
+  runner client on self-hosted runners, the install-nix action's elsewhere).
 
 runs:
   using: composite
   steps:
+    - name: Detect a compatible runner Nix client
+      id: ambient
+      shell: bash
+      run: |
+        set -euo pipefail
+        if value="$(nix --extra-experimental-features nix-command \
+          eval --raw --expr 'toString 25_565' 2>&1)" && [[ "$value" == 25565 ]]; then
+          printf 'compatible=true\n' >> "$GITHUB_OUTPUT"
+          echo "::notice title=bootstrap-patched-nix::$(nix --version 2>&1) already compatible; bootstrap skipped"
+        else
+          printf 'compatible=false\n' >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Build the patched Nix client from the pinned rev
+      if: steps.ambient.outputs.compatible != 'true'
       shell: bash
       env:
         BOOTSTRAP_LOCK: ${{ github.action_path }}/lock.json


### PR DESCRIPTION
## Summary

- probe the ambient runner Nix client for grouped numeric literal support
- skip the pinned client fetch/materialization when the immutable runner client is compatible
- preserve the existing pinned fallback on hosted or stale runners

## Validation

- compatibility fast path executed end-to-end in 1s
- `nix run .#lint` (10/10, 195s including flake evaluation contention)
- `git diff --check`

Paired with the ix runner-closure change that puts the exact Index `nix-ix` client first on every JIT runner PATH. This keeps the existing 120s setup deadline honest while removing the observed 3m27 bootstrap from self-hosted CI.

(sent by Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip patched Nix bootstrap when runner already provides a compatible client
> - Adds a detection step to [action.yml](https://github.com/indexable-inc/index/pull/3468/files#diff-f6fe2966a16c528dfac9acd7f0b2a88a0f4327a03253a2a455f1460b121280ae) that runs `nix eval` to check if the ambient client supports underscore digit separators (e.g. `25_565`).
> - If the check passes, the action sets `compatible=true`, emits a notice with the current Nix version, and skips the build step entirely.
> - The patched client build and `GITHUB_PATH` export now run only when the ambient client is incompatible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fb3d53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->