### PR TITLE
kbuild-unit: pin NIX_NO_SELF_RPATH so the vdso drops the self rpath (#3411)

### DIFF
--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -45,10 +45,13 @@ outputs); per-unit source scoping is #3412.
     KBUILD_BUILD_USER = "nixbld";
     KBUILD_BUILD_HOST = "ix";
     KBUILD_BUILD_VERSION = "1";
-    # The ld-wrapper otherwise injects `-rpath $out/lib` into shared-object
-    # links; the 32-bit vdso is linked as a .so, so the builder's own store
-    # path lands inside vmlinux and plan/unit outputs can never match.
-    NIX_DONT_SET_RPATH = "1";
+    # stdenv setup's _addRpathPrefix otherwise prepends `-rpath $out/lib` to
+    # NIX_LDFLAGS; the 32-bit vdso is linked as a .so, so the builder's own
+    # store path lands inside vmlinux and plan/unit outputs can never match
+    # (#3411: gate diverged by exactly this 30-byte hash). NIX_DONT_SET_RPATH
+    # is the wrong knob: it governs the ld-wrapper's -L auto-rpath and is
+    # suffix-salted, so the bare name is ignored.
+    NIX_NO_SELF_RPATH = "1";
   };
 
   contentAddressing = {


### PR DESCRIPTION
Fixes the #3411 exit gate (master: #3409).

## Problem

`vmlinuxEquivalence` fails on merged main: unit-composed and monolithic vmlinux differ by exactly 30 contiguous bytes at offset 979682. The bytes decode to a nix store hash: the embedded 32-bit vdso (`linux-gate.so.1`) carries `-rpath /nix/store/<own drv>-.../lib` on each side, so the two can never match.

```
$ cmp -l A/vmlinux B/vmlinux | wc -l
30
# context: ...linux-gate.so.1 ... /nix/store/jb6sk3r5...-kbuild-vmlinux/lib   (unit side)
#          ...linux-gate.so.1 ... /nix/store/vn8s2rln...-kbuild-unit-plan/lib (plan side)
```

## Root cause

The self-rpath is injected by stdenv setup's `_addRpathPrefix "$out"` into `NIX_LDFLAGS`, guarded by `NIX_NO_SELF_RPATH`. The existing pin `NIX_DONT_SET_RPATH = "1"` is the wrong knob: it governs the ld-wrapper's `-L` auto-rpath, and is suffix-salted in modern wrappers so the bare name is ignored entirely.

## Fix

One line in `reproEnv` (which already flows to both the plan drv and every unit replay): `NIX_NO_SELF_RPATH = "1"` replaces the dead pin.

## Validation

Gate rerun from this branch in flight on vin-compute-1 (`/tmp/kbuild-gate-fix.log`); result will be posted here and on #3411 before merge.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `NIX_NO_SELF_RPATH` in kbuild-unit to drop self rpath from vdso
> Replaces `NIX_DONT_SET_RPATH=1` with `NIX_NO_SELF_RPATH=1` in [kbuild-unit.nix](https://github.com/indexable-inc/index/pull/3472/files#diff-894edbcee0d2e832bb188198d9520c9019d57088c5a061e3b3a327a243c1d7ad). `NIX_DONT_SET_RPATH` controls the ld-wrapper's auto-rpath behavior and is suffix-salted, so it was not matching correctly; `NIX_NO_SELF_RPATH` targets the rpath prefix added by stdenv's `_addRpathPrefix` and correctly suppresses the self rpath on the vdso during linking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee25861.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->