### PR TITLE
ci: push a style: autofix commit to PR branches from the lint fixer lanes

### DIFF
--- a/.github/scripts/push-lint-autofix.sh
+++ b/.github/scripts/push-lint-autofix.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The composed fix patch for the checked-out tree (the PR's synthetic merge).
+# The required gate already built the fixer lanes (the lint check judges the
+# fixed tree), so this build only assembles the diff on top of cached lanes;
+# an empty patch is the common no-drift exit.
+patch="$(nix build .#lint-fix-patch --no-link --print-out-paths \
+  --option extra-experimental-features ca-derivations)"
+if [[ ! -s "$patch" ]]; then
+  echo "lint autofix: no fixable drift"
+  exit 0
+fi
+
+# The lint gate passed on the FIXED tree, so without a pushable fix this
+# drift would merge unrepaired; fail rather than go silently green. Token
+# minting is skipped for fork PRs and when the MIRROR_APP_* credentials are
+# absent (see check.yml).
+if [[ -z "${AUTOFIX_PUSH_TOKEN:-}" ]]; then
+  echo "fixable lint drift, but no autofix push token is available;" \
+    "apply the fix locally with: nix run .#lint -- --fix" >&2
+  exit 1
+fi
+
+# The patch is computed against the synthetic merge tree but the commit must
+# sit on the PR head, so apply it in a scratch worktree of the head SHA (the
+# merge commit's second parent, always present in this full clone). main is
+# lint-clean by induction (this gate), so merge-tree drift is head drift and
+# the patch applies; `git apply` inside lint-autofix is all-or-nothing, so
+# when main touched the same hunks the run fails loudly and rebasing the PR
+# is the fix.
+worktree="${RUNNER_TEMP:?RUNNER_TEMP is required}/lint-autofix"
+git worktree add --quiet "$worktree" "${HEAD_SHA:?HEAD_SHA is required}"
+cd "$worktree"
+exec nix run "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}#lint-autofix" -- \
+  --patch "$patch" \
+  --push-url "https://github.com/${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}.git" \
+  --branch "${HEAD_REF:?HEAD_REF is required}" \
+  --expected-head "$HEAD_SHA"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,6 +152,44 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+      # Autofix push (#3435): the lint check above judged the composed FIXED
+      # tree (lib/per-system.nix `lintFix`), so a green gate plus a non-empty
+      # `.#lint-fix-patch` means the PR head carries drift the fixer lanes
+      # repair; push that diff back to the PR branch as one `style: autofix`
+      # commit instead of failing. The new head SHA goes through the normal
+      # required checks -- green by construction, since the gate already
+      # passed on the fixed tree. Pushed with a token minted from the
+      # ix-mirror-sync GitHub App (the repo's only push-capable CI
+      # credential; AUTOBUMP_TOKEN was never configured), narrowed to
+      # contents:write: a default-GITHUB_TOKEN push never retriggers
+      # workflows, which would leave the fix commit checkless. These steps
+      # run after the artifact upload on purpose: the push retriggers this
+      # workflow on the new head, whose concurrency group cancels the rest
+      # of this run.
+      - name: Mint autofix push token
+        id: autofix-token
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && vars.MIRROR_APP_CLIENT_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MIRROR_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MIRROR_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Push lint autofix commit
+        if: github.event_name == 'pull_request'
+        env:
+          AUTOFIX_PUSH_TOKEN: ${{ steps.autofix-token.outputs.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # The app's bot identity, so the commit is attributed to the app
+          # that pushed it. 300601727 is ix-mirror-sync[bot]'s stable user id
+          # (https://api.github.com/users/ix-mirror-sync%5Bbot%5D).
+          GIT_AUTHOR_NAME: ix-mirror-sync[bot]
+          GIT_AUTHOR_EMAIL: 300601727+ix-mirror-sync[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: ix-mirror-sync[bot]
+          GIT_COMMITTER_EMAIL: 300601727+ix-mirror-sync[bot]@users.noreply.github.com
+        run: bash .github/scripts/push-lint-autofix.sh
+
   # Keep the existing required context while consuming no second self-hosted
   # runner. The single gate above builds closure roots and checks together;
   # this hosted terminal job fails closed for every non-success conclusion,

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1983,8 +1983,10 @@
 
               # Race: the stale run expected $head but the branch moved; it
               # must skip without touching the remote.
-              out=$(cd stale && "$tool" --patch "$patch" --push-url "$remote" --branch main --expected-head "$head")
-              echo "$out" | grep -q "skipping"
+              # `skip_out`, not `out`: assigning `out` would clobber the
+              # derivation's output path and the build could never produce it.
+              skip_out=$(cd stale && "$tool" --patch "$patch" --push-url "$remote" --branch main --expected-head "$head")
+              echo "$skip_out" | grep -q "skipping"
               [ "$(git -C origin.git rev-parse refs/heads/main)" = "$fixed_head" ]
 
               # Loop guard: head is already `style: autofix`, yet the fixed

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -543,8 +543,124 @@
       # apply; anything else is a diff failure.
       [ "$status" -le 1 ]
     '';
+
+    # The whole-repo consumer view (#3435): the full tracked tree with every
+    # lane's fixed output overlaid -- the tree the repo becomes once CI's
+    # autofix commit lands. The lint check judges this tree, so fixable
+    # drift produces the autofix commit instead of a red run, and a failure
+    # on it is genuinely unresolvable by the fixers.
+    appliedTo = src:
+      pkgs.runCommand "lint-fixed-tree" contentAddressed ''
+        cp -R ${src} "$out"
+        chmod -R u+w "$out"
+        cp -R ${fixed}/. "$out"/
+      '';
   in {
-    inherit lanes unite fixed patch rustFmtToolchain;
+    inherit
+      appliedTo
+      fixed
+      lanes
+      patch
+      rustFmtToolchain
+      unite
+      ;
+  };
+
+  # CI's autofix committer (#3435): apply a lane-built fix patch to the
+  # checked-out PR head, commit it as `style: autofix`, and push it back to
+  # the PR branch -- race-checked against the head SHA the run validated,
+  # and never forced. Deliberately free of GitHub specifics (the patch and
+  # push URL arrive as arguments) so the `lint-autofix` flake check drives
+  # the whole commit/push flow against local bare remotes; check.yml owns
+  # the CI glue and supplies app-token auth via $AUTOFIX_PUSH_TOKEN.
+  lintAutofix = ix.writeNushellApplication pkgs {
+    name = "lint-autofix";
+    meta.description = "Commit a lint fixer patch as one `style: autofix` commit and push it to a PR branch (race-checked, never forced)";
+    runtimeInputs = [pkgs.git];
+    text = ''
+      # nu
+      def remote-head [push_url: string, branch: string] {
+        ^git ls-remote $push_url $"refs/heads/($branch)"
+        | lines
+        | get -o 0
+        | default ""
+        | split row "\t"
+        | get -o 0
+        | default ""
+      }
+
+      def main [
+        --patch: string # unified diff (a/ -> b/), from `nix build .#lint-fix-patch`
+        --push-url: string # remote to push to (URL or local path)
+        --branch: string # remote branch name to update
+        --expected-head: string # the head SHA this CI run checked out and validated
+      ] {
+        for arg in [
+          [name value];
+          ["--patch" $patch]
+          ["--push-url" $push_url]
+          ["--branch" $branch]
+          ["--expected-head" $expected_head]
+        ] {
+          if ($arg.value | is-empty) {
+            error make {msg: $"($arg.name) is required"}
+          }
+        }
+        cd (^git rev-parse --show-toplevel | str trim)
+        if (open --raw $patch | is-empty) {
+          print "lint-autofix: empty patch, tree already clean"
+          return
+        }
+        # Loop guard: a non-empty patch on top of an autofix commit means a
+        # fixer is not idempotent (its output still differs after one
+        # pass). Pushing again would ping-pong CI forever; fail loudly.
+        if (^git log -1 --format=%s | str trim) == "style: autofix" {
+          error make {msg: "head commit is already `style: autofix` but the fixed tree still differs: a fixer lane is not idempotent; refusing to push another autofix commit"}
+        }
+        # actions/checkout persists the default GITHUB_TOKEN as an
+        # http.<host>.extraheader in the shared repo config, and git sends
+        # every configured extraheader on a request -- so a push from a CI
+        # checkout would authenticate as github-actions, whose pushes never
+        # retrigger workflows, leaving the autofix commit checkless. When
+        # the caller provides an app token, reset the inherited header list
+        # (an empty extraheader value clears it) and install the app
+        # credential, via GIT_CONFIG_* so the token reaches neither argv
+        # nor on-disk config.
+        if ($env.AUTOFIX_PUSH_TOKEN? | default "" | is-not-empty) {
+          $env.GIT_CONFIG_COUNT = "2"
+          $env.GIT_CONFIG_KEY_0 = "http.https://github.com/.extraheader"
+          $env.GIT_CONFIG_VALUE_0 = ""
+          $env.GIT_CONFIG_KEY_1 = "http.https://github.com/.extraheader"
+          let credential = ($"x-access-token:($env.AUTOFIX_PUSH_TOKEN)" | encode base64)
+          $env.GIT_CONFIG_VALUE_1 = $"AUTHORIZATION: basic ($credential)"
+        }
+        ^git apply --index $patch
+        ^git commit --quiet -m "style: autofix"
+        # Race check: the branch moving while this run validated means a
+        # newer run exists that redoes the fix against the new head, and an
+        # empty ls-remote is a deleted branch (PR closed) -- both a skip,
+        # never something to push over. An author push racing the autofix
+        # is the only acceptable "conflict".
+        let remote = (remote-head $push_url $branch)
+        if $remote != $expected_head {
+          print $"lint-autofix: ($branch) is no longer at ($expected_head); skipping, the newer run redoes the fix"
+          return
+        }
+        # Plain push, never --force: a move inside the window since the
+        # check above is rejected by git itself; treat exactly that
+        # rejection as the same skip, and anything else as a real failure.
+        let push = (do {^git push --quiet $push_url $"HEAD:refs/heads/($branch)"} | complete)
+        if $push.exit_code != 0 {
+          if (remote-head $push_url $branch) != $expected_head {
+            print $"lint-autofix: ($branch) moved during the push; skipping, the newer run redoes the fix"
+            return
+          }
+          print --stderr $push.stderr
+          error make {msg: $"push to ($branch) failed"}
+        }
+        print $"lint-autofix: pushed `style: autofix` to ($branch)"
+      }
+    '';
   };
 
   # `check` is the full CI gate as one repo-owned command: check.yml runs
@@ -1675,8 +1791,15 @@
           # timing/RSS, so it earns a flake check; the timing/RSS perf job lives
           # under `apps.bench` instead.
           indexbench-self-demo-alloc = indexbenchSelfDemo.check;
+          # Judged over the composed FIXED tree, not the head tree (#3435):
+          # head drift the fixer lanes repair no longer fails this check --
+          # on PRs, check.yml pushes it back as a `style: autofix` commit
+          # instead (see `lintAutofix`) -- so a failure here is genuinely
+          # unresolvable by the fixers. The fixable stages still run, now
+          # over the lanes' own output: a lane emitting code its check stage
+          # rejects turns this red (a live idempotence gate).
           lint = pkgs.runCommand "ix-lint" {nativeBuildInputs = [pkgs.coreutils];} ''
-            cp -R ${lintSource} source
+            cp -R ${lintFix.appliedTo lintSource} source
             chmod -R u+w source
             cd source
             ${lib.getExe lint}
@@ -1795,6 +1918,89 @@
               diff -r ${fixedNix} ${lintFix.lanes.nix fixedNix}
               diff -r ${fixedPython} ${lintFix.lanes.python fixedPython}
               diff -r ${fixedRust} ${lintFix.lanes.rust fixedRust}
+              mkdir -p "$out"
+            '';
+          # The autofix committer's whole commit/push flow (#3435) against
+          # local bare remotes, through the same `lint-autofix` binary
+          # check.yml runs: an empty patch is a no-op, a real patch becomes
+          # exactly one `style: autofix` commit fast-forwarding the branch
+          # head, a moved remote is a silent skip (the newer CI run redoes
+          # the fix, so pushing over it could drop an author's work), and a
+          # non-empty patch on top of an existing autofix head fails loudly
+          # (the non-idempotent-fixer loop guard). AUTOFIX_PUSH_TOKEN is set
+          # on the pushing case to prove the github.com-scoped credential
+          # override leaves a non-GitHub push untouched.
+          lint-autofix =
+            pkgs.runCommand "lint-autofix-check"
+            {
+              nativeBuildInputs = [
+                pkgs.diffutils
+                pkgs.git
+              ];
+            }
+            ''
+              export HOME="$TMPDIR"
+              git config --global user.name fixture
+              git config --global user.email fixture@example.invalid
+              git config --global init.defaultBranch main
+              tool=${lib.getExe lintAutofix}
+
+              # A "PR branch" origin seeded with one badly formatted file.
+              git init --quiet seed
+              printf 'hello   world\n' > seed/file.txt
+              git -C seed add file.txt
+              git -C seed commit --quiet -m 'seed: violating file'
+              git clone --quiet --bare seed origin.git
+              remote="$PWD/origin.git"
+              head=$(git -C origin.git rev-parse refs/heads/main)
+
+              # The fix patch, byte-shaped like `lint-fix-patch` (a/ -> b/).
+              mkdir a b
+              cp seed/file.txt a/
+              printf 'hello world\n' > b/file.txt
+              status=0
+              diff -ruN a b > fix.patch || status=$?
+              [ "$status" -eq 1 ]
+              patch="$PWD/fix.patch"
+
+              # Two checkouts of the same head: `ci` pushes first, so `stale`
+              # models the older run whose branch moved under it.
+              git clone --quiet origin.git ci
+              git clone --quiet origin.git stale
+
+              # Empty patch: a no-op that pushes nothing.
+              : > empty.patch
+              (cd ci && "$tool" --patch "$OLDPWD/empty.patch" --push-url "$remote" --branch main --expected-head "$head")
+              [ "$(git -C origin.git rev-parse refs/heads/main)" = "$head" ]
+
+              # Real patch: exactly one autofix commit on top of the head.
+              (cd ci && AUTOFIX_PUSH_TOKEN=fixture "$tool" --patch "$patch" --push-url "$remote" --branch main --expected-head "$head")
+              fixed_head=$(git -C origin.git rev-parse refs/heads/main)
+              [ "$fixed_head" != "$head" ]
+              [ "$(git -C origin.git rev-parse "$fixed_head^")" = "$head" ]
+              [ "$(git -C origin.git log -1 --format=%s "$fixed_head")" = "style: autofix" ]
+              [ "$(git -C origin.git show "$fixed_head:file.txt")" = "hello world" ]
+
+              # Race: the stale run expected $head but the branch moved; it
+              # must skip without touching the remote.
+              out=$(cd stale && "$tool" --patch "$patch" --push-url "$remote" --branch main --expected-head "$head")
+              echo "$out" | grep -q "skipping"
+              [ "$(git -C origin.git rev-parse refs/heads/main)" = "$fixed_head" ]
+
+              # Loop guard: head is already `style: autofix`, yet the fixed
+              # tree still differs. Refuse loudly, push nothing.
+              git clone --quiet origin.git loop
+              mkdir a2 b2
+              cp b/file.txt a2/file.txt
+              printf 'hello world again\n' > b2/file.txt
+              status=0
+              diff -ruN a2 b2 > loop.patch || status=$?
+              [ "$status" -eq 1 ]
+              if (cd loop && "$tool" --patch "$OLDPWD/loop.patch" --push-url "$remote" --branch main --expected-head "$fixed_head"); then
+                echo "loop guard did not fire on a second autofix" >&2
+                exit 1
+              fi
+              [ "$(git -C origin.git rev-parse refs/heads/main)" = "$fixed_head" ]
               mkdir -p "$out"
             '';
           filename-policy =
@@ -1963,7 +2169,10 @@
       # Fixer-lane outputs (#3432): `lint-fixed` is the union of the lanes'
       # fixed trees; `lint-fix-patch` is diff(snapshot, fixed), the artifact
       # `nix run .#lint -- --fix` builds and git-applies. An empty patch
-      # means the tree is already clean.
+      # means the tree is already clean. `lint-autofix` (#3435) is CI's
+      # consumer of the patch: commit it as `style: autofix` and push it to
+      # the PR branch (check.yml).
+      lint-autofix = lintAutofix;
       lint-fixed = lintFix.fixed;
       lint-fix-patch = lintFix.patch;
       site-dev = site.passthru.devServer;


### PR DESCRIPTION
Implements #3435: on PR CI, when the lint fixer lanes (#3431, #3450, #3454) produce changes, push a single `style: autofix` commit to the PR branch instead of failing the run.

## What changed

**`lib/per-system.nix`**
- `lintFix.appliedTo`: composes the full tracked tree with every lane's `fixed` output overlaid (the tree the repo becomes once the autofix commit lands).
- `checks.lint` now judges the verdict stages (astlog, filenames, dirnames, clone) over that **fixed** tree, per the #3431 design: fixable drift no longer fails the gate (CI commits it instead); genuinely unresolvable findings still do. The fixable stages keep running over the lanes' own output, which doubles as a live fixer-idempotence gate.
- New `lint-autofix` tool (`ix.writeNushellApplication`): applies the lane patch with `git apply --index`, commits as `style: autofix`, and pushes. Race-safe (pre-push `ls-remote` head check against the SHA the run checked out, plain non-force push, post-failure re-check to distinguish branch-moved from real failure) and loop-guarded (head commit already `style: autofix` while the fixed tree still differs means a non-idempotent fixer; the run fails loudly rather than pushing again).
- New flake check `lint-autofix` covering the tool end-to-end against local fixture remotes: empty-patch no-op, real push (commit parentage, subject, content), stale-head race skip, and the loop guard.

**`.github/workflows/check.yml` + `.github/scripts/push-lint-autofix.sh`** (minimal glue)
- On `pull_request` runs from same-repo branches, mint a `contents: write` token from the ix-mirror-sync app (the default `GITHUB_TOKEN` would not retrigger workflows on the pushed commit) narrowed via `permission-contents`, build `.#lint-fix-patch`, and run the tool from a clean worktree at the PR head SHA. The token travels via `GIT_CONFIG_*` env (never argv or on-disk config), and the checkout-persisted `GITHUB_TOKEN` extraheader is reset for the push so the app token actually authenticates it.
- Fork PRs and repos without the app configured get a loud failure message pointing at `nix run .#lint -- --fix` instead of a silent skip.

The pushed commit creates a new head SHA that goes through the normal required checks; nothing bypasses branch protection.

## Validation
- flake check `lint-autofix` green on aarch64-darwin and x86_64-linux
- `checks.lint` (fixed-tree gate) green on x86_64-linux
- `nix run .#lint` green on the branch
- this PR's own CI run exercises the workflow steps' no-drift path

Depends on the cache-masked lint fix that landed as 15990f63 (#3473).

🤖 Authored by Claude Opus 4.5 via Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Push a `style: autofix` commit to PR branches from CI lint fixer lanes
> - Adds [push-lint-autofix.sh](.github/scripts/push-lint-autofix.sh) to build the lint-fix patch via Nix, apply it in a scratch Git worktree at the PR head SHA, and push a single `style: autofix` commit.
> - Extends the `flake-check` CI job in [check.yml](.github/workflows/check.yml) with two steps: minting an app token via `actions/create-github-app-token` (only on same-repo PRs with `MIRROR_APP_CLIENT_ID` set), then running the push script.
> - Introduces a `lintAutofix` Nushell application in [lib/per-system.nix](lib/per-system.nix) with safeguards: exits on empty patch, prevents idempotence loops if the head commit is already `style: autofix`, race-checks remote head SHA before pushing, and handles branch movement as a skip.
> - Adds a `checks.lint-autofix` derivation that validates push, skip, and loop-guard behaviors against local bare Git remotes.
> - Risk: if the app token is not minted (missing `MIRROR_APP_CLIENT_ID` or non-same-repo PR), the script fails the job rather than skipping silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92cc83a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->