### PR TITLE
pi-harnesses: add kimi alias for Kimi K3 via Moonshot provider extension

### DIFF
--- a/packages/agent/pi-harnesses/README.md
+++ b/packages/agent/pi-harnesses/README.md
@@ -53,10 +53,11 @@ nix run github:indexable-inc/index#pi-prosecutor -- "your task"   # opus-4-8 exe
 nix run github:indexable-inc/index#pi-beam       -- "your task"
 nix run github:indexable-inc/index#pi-fusion     -- "your task"   # fable-5 primary + gpt-5.6-sol sidekick at low reasoning
 PI_HARNESS_MODEL=codex nix run github:indexable-inc/index#pi-prosecutor -- "..."   # gpt-5.6-sol medium
+PI_HARNESS_MODEL=kimi  nix run github:indexable-inc/index#pi-base       -- "..."   # kimi-k3, needs MOONSHOT_API_KEY
 ```
 
 API keys come from the caller's environment (`ANTHROPIC_API_KEY` /
-`OPENAI_API_KEY`); the harness owns model *selection* only. Every harness execs
+`OPENAI_API_KEY` / `MOONSHOT_API_KEY`); the harness owns model *selection* only. Every harness execs
 nixpkgs' pinned `pi-coding-agent` binary, never a `pi` resolved from the
 caller's PATH (host-level wrappers there inject conflicting flags and
 extensions); swap it with `.override { pi = ...; }`.

--- a/packages/agent/pi-harnesses/shared/mk-pi-harness.nix
+++ b/packages/agent/pi-harnesses/shared/mk-pi-harness.nix
@@ -87,7 +87,15 @@
     lib.mapAttrsToList (k: v: "export ${k}=${lib.escapeShellArg (toString v)}") env
   );
 
-  extBasenames = lib.concatStringsSep " " (map (e: lib.escapeShellArg (baseNameOf e)) extensions);
+  # Provider extensions declared on model aliases (e.g. the moonshot provider
+  # for kimi). Loaded like entry extensions; explicit `-e` survives even the
+  # lockdown posture's --no-extensions, so aliases work in every harness.
+  providerExtensions = lib.unique (
+    lib.filter (e: e != null) (lib.mapAttrsToList (_: m: m.providerExtension or null) models)
+  );
+  allExtensions = extensions ++ providerExtensions;
+
+  extBasenames = lib.concatStringsSep " " (map (e: lib.escapeShellArg (baseNameOf e)) allExtensions);
 
   copyInto = dest: files:
     lib.concatMapStringsSep "\n" (f: ''install -Dm644 ${f} "${dest}/${baseNameOf f}"'') files;
@@ -104,7 +112,7 @@ in
       # shell
       runHook preBuild
       mkdir -p share/${name}/lib
-      ${copyInto "share/${name}" extensions}
+      ${copyInto "share/${name}" allExtensions}
       ${copyInto "share/${name}" auxFiles}
       ${copyInto "share/${name}/lib" libFiles}
 

--- a/packages/agent/pi-harnesses/shared/models.nix
+++ b/packages/agent/pi-harnesses/shared/models.nix
@@ -32,6 +32,17 @@
     apiKeyEnv = "ANTHROPIC_API_KEY";
   };
 
+  # Kimi K3 via Moonshot's OpenAI-compatible API. The pinned pi build has no
+  # built-in kimi-k3 provider, so this alias carries a provider extension that
+  # registers one (see providers/moonshot.js). No `thinking`: K3 only accepts
+  # reasoning_effort=max and the extension pins every level to it.
+  kimi = {
+    provider = "moonshot";
+    model = "kimi-k3";
+    apiKeyEnv = "MOONSHOT_API_KEY";
+    providerExtension = ./providers/moonshot.js;
+  };
+
   # Cheap delegated worker for fusion-style harnesses.
   codex-low = {
     provider = "openai";

--- a/packages/agent/pi-harnesses/shared/providers/moonshot.js
+++ b/packages/agent/pi-harnesses/shared/providers/moonshot.js
@@ -1,0 +1,36 @@
+// Kimi K3 via Moonshot's OpenAI-compatible endpoint. pi 0.80.3's built-in
+// moonshotai provider stops at K2.x, so register a custom one (#3476).
+// K3 quirks (https://platform.kimi.ai/docs/guide/kimi-k3-quickstart):
+// reasoning_effort supports only "max", and the API rejects OpenAI-isms
+// pi sends by default (store: false, developer role), hence the compat map.
+export default function (pi) {
+  pi.registerProvider("moonshot", {
+    name: "Moonshot AI",
+    baseUrl: "https://api.moonshot.ai/v1",
+    apiKey: "$MOONSHOT_API_KEY",
+    api: "openai-completions",
+    models: [
+      {
+        id: "kimi-k3",
+        name: "Kimi K3",
+        reasoning: true,
+        // Every pi thinking level maps to "max": it is the only effort K3 accepts.
+        thinkingLevelMap: {
+          off: "max",
+          minimal: "max",
+          low: "max",
+          medium: "max",
+          high: "max",
+          xhigh: "max",
+          max: "max",
+        },
+        input: ["text", "image"],
+        // USD per MTok, platform.kimi.ai launch pricing (2026-07-16).
+        cost: { input: 3.0, output: 15.0, cacheRead: 0.3, cacheWrite: 0 },
+        contextWindow: 1048576,
+        maxTokens: 131072,
+        compat: { supportsStore: false, supportsDeveloperRole: false },
+      },
+    ],
+  });
+}


### PR DESCRIPTION
Adds a `kimi` model alias to the pi-harnesses shared model table, backed by a provider extension (`shared/providers/moonshot.js`) that registers Kimi K3 via Moonshot's OpenAI-compatible endpoint. The pinned pi-coding-agent 0.80.3 has no built-in kimi-k3 provider (its `moonshotai` provider stops at K2.x).

- `mk-pi-harness.nix` now collects `providerExtension` paths from the model table and loads them with `-e` alongside entry extensions (explicit `-e` survives `--no-extensions`, so this works under the lockdown posture too).
- K3 API quirks handled in the extension: `reasoning_effort` only accepts `"max"` (thinkingLevelMap pins every pi thinking level to it); the endpoint rejects `store` and the `developer` role that pi sends by default, masked via `compat`.
- Pricing from platform.kimi.ai launch rates (2026-07-16): $3/$15 per MTok in/out, $0.30 cache hit.

Verification (built `.#pi-base` from the worktree):
- `PI_HARNESS_MODEL=kimi MOONSHOT_API_KEY=sk-dummy pi-base -p hi` reaches api.moonshot.ai and gets `401 Invalid Authentication` (full chain: alias -> extension -> provider -> request).
- Default `claude` alias still resolves with the extension loaded and no `MOONSHOT_API_KEY` set.

Usage: `PI_HARNESS_MODEL=kimi nix run .#pi-base -- "..."` with `MOONSHOT_API_KEY` in the environment.

Closes #3476

(opened by an AI agent via Claude Code, Claude Opus 4.6)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `kimi` model alias for Kimi K3 via a new Moonshot provider extension in pi-harnesses
> - Adds a [`moonshot.js`](https://github.com/indexable-inc/index/pull/3477/files#diff-c79853c5a334fcd965a60f6a1f3a2c3d2e68497bf5b542b385db46f5620a617a) provider extension that registers the Moonshot provider (`https://api.moonshot.ai/v1`) with the `kimi-k3` model, coercing all thinking levels to `reasoning_effort=max` and disabling OpenAI-incompatible defaults (`store`, developer role).
> - Adds a `kimi` alias in [`models.nix`](https://github.com/indexable-inc/index/pull/3477/files#diff-8c3ff77bd3f53b8d36106cb062322084e095b604e1669ca5308a7816154b1c8e) pointing to this extension and using `MOONSHOT_API_KEY` for auth.
> - Updates [`mk-pi-harness.nix`](https://github.com/indexable-inc/index/pull/3477/files#diff-66729b2d9d77ff38a0ff44d886d56efcff2d2b146821b26ba288f2a08d466dec) to collect `providerExtension` attributes from model aliases and include them in the install step alongside declared extensions, so provider extensions are loaded even under `--no-extensions` lockdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e02f00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->