### PR TITLE
kbuild-unit: scope each unit to its recorded .cmd deps (P2, #3412)

### DIFF
--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -12,9 +12,12 @@ command inside a symlink farm of src + snapshot + dep unit outputs.
 The plan build's monolithic vmlinux is kept as the equivalence reference:
 `vmlinuxEquivalence` cmp's it byte-for-byte against the unit-built vmlinux.
 
-Unit trees currently take the whole kernel source as input, so an edit to
-any source rebuilds every unit's tree (CA cutoff still dedups unchanged
-outputs); per-unit source scoping is #3412.
+Each unit's build tree is scoped to the sources its .cmd recorded (#3412):
+compile units see their .c plus tracked headers as per-file store paths,
+the link unit adds the script-read Makefile and header trees, and archive
+aggregation sees only dep unit outputs plus the snapshot. A one-file body
+edit thus re-instantiates one TU derivation and its link chain; a
+comment-only edit cuts off at the unchanged CA object.
 */
 {
   lib,
@@ -141,10 +144,21 @@ outputs); per-unit source scoping is #3412.
           < ${plan}/plan.json > $out
       '';
 
+    # Stable-path hop for the snapshot: the plan's output path shifts with
+    # every source edit (its reference vmlinux changes), which would perturb
+    # every unit's `generated` input. Re-homing the snapshot in its own CA
+    # derivation keeps the path fixed while the harvested content is
+    # unchanged, so unrelated units stay cached across plan reruns (#3412).
+    generatedSnapshot =
+      pkgs.runCommand "kbuild-unit-generated"
+      (lib.optionalAttrs contentAddressed contentAddressing) ''
+        cp -a ${plan}/generated $out
+      '';
+
     imported = import unitsNix {
       inherit pkgs;
       src = srcTree;
-      generated = "${plan}/generated";
+      generated = "${generatedSnapshot}";
       extraNativeBuildInputs = kbuildInputs;
       extraEnv = reproEnv;
     };

--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -94,12 +94,17 @@ comment-only edit cuts off at the unchanged CA object.
         configurePhase = ''
           # shell
           runHook preConfigure
-          # kbuild passes -frandom-seed=<objtree hash> per object; the
-          # cc-wrapper appends NIX_CFLAGS_COMPILE after user argv, so the last
-          # seed wins. Pin the appended seed to a constant here and in every
-          # unit replay (templates/units.nix.in), making the saved command's
-          # own seed irrelevant on both sides.
-          export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE:-} -frandom-seed=kbuild-unit"
+          # The cc-wrapper seeds -frandom-seed from a fragment of this
+          # derivation's $out and appends NIX_CFLAGS_COMPILE after user argv,
+          # so the last seed wins codegen. Appending a constant pins objects,
+          # but the assembler listings the snapshot keeps (asm-offsets.s,
+          # bounds.s) record every passed option, so a surviving $out-derived
+          # seed would shift the snapshot's content address on every plan drv
+          # change and re-execute every unit. Strip the wrapper seed and pin
+          # the constant as the only seed, here and in every unit replay
+          # (templates/units.nix.in).
+          NIX_CFLAGS_COMPILE=$(printf '%s' "''${NIX_CFLAGS_COMPILE:-}" | sed 's/-frandom-seed=[^ ]*//g')
+          export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -frandom-seed=kbuild-unit"
           # Capture the env kbuild exports to scripts/link-vmlinux.sh so the
           # rendered link unit can replay it (CC/LD/LINUXINCLUDE/KBUILD_* for
           # the in-script init/version-timestamp.o compile and postlink make).

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -2193,6 +2193,12 @@ in {
     kernel-unit = (ix.kernelUnitFor pkgs).buildKernel {
       inherit (pkgs.linux_6_12) src;
     };
+    # defconfig-scale lane (#3412): thousands of units per eval, kept here
+    # solely so the eval-cost measurement has a stable attr to time.
+    kernel-unit-defconfig = (ix.kernelUnitFor pkgs).buildKernel {
+      inherit (pkgs.linux_6_12) src;
+      configTarget = "defconfig";
+    };
   };
 
   # `nix run .#bench` runs the repo's self-demo perf job (timing + RSS + custom

--- a/packages/nix/nix-kbuild-unit/src/harvest.rs
+++ b/packages/nix/nix-kbuild-unit/src/harvest.rs
@@ -140,8 +140,15 @@ fn walk(root: &Path) -> color_eyre::Result<Vec<String>> {
 }
 
 /// `.cmd` sidecars are dotfiles (`.fork.o.cmd`); `auto.conf.cmd` and friends
-/// are make includes in a different format, not saved commands.
+/// are make includes in a different format, not saved commands. Host tools
+/// under `tools/` (objtool at defconfig scale) build with tools/build, whose
+/// sidecar dialect is `cmd_<absolute target> :=` with no `savedcmd_` line;
+/// nothing under `tools/` is ever a unit, and the built tools themselves
+/// flow into the generated snapshot, so skip their sidecars entirely.
 fn is_cmd_file(rel: &str) -> bool {
+    if rel.starts_with("tools/") {
+        return false;
+    }
     let name = file_name(rel);
     name.starts_with('.') && name.ends_with(".cmd")
 }
@@ -232,6 +239,16 @@ mod tests {
         write(&objtree, "kernel/.fork.o.d", "deps");
         write(&objtree, ".tmp_vmlinux1", "elf");
         write(&objtree, "System.map", "map");
+        // tools/build sidecar dialect (objtool at defconfig scale): no
+        // `savedcmd_` line, absolute target. Skipped, while the built tool
+        // itself flows into the snapshot.
+        write(
+            &objtree,
+            "tools/objtool/.builtin-check.o.cmd",
+            "cmd_/build/src/tools/objtool/builtin-check.o := gcc -c builtin-check.c\n",
+        );
+        write(&objtree, "tools/objtool/builtin-check.o", "ELF");
+        write(&objtree, "tools/objtool/objtool", "ELF");
 
         let plan = harvest(&objtree, &srctree, Some(&out)).expect("harvest");
 
@@ -247,6 +264,7 @@ mod tests {
                 ".kbuild-unit-link-env",
                 "include/config/kernel.release",
                 "include/generated/autoconf.h",
+                "tools/objtool/objtool",
             ]
         );
         for rel in &plan.generated {

--- a/packages/nix/nix-kbuild-unit/src/model.rs
+++ b/packages/nix/nix-kbuild-unit/src/model.rs
@@ -49,6 +49,10 @@ pub enum UnitKind {
     Link,
     /// `scripts/mod/modpost` export check over `vmlinux.o`.
     Modpost,
+    /// A savedcmd-only object rule with no dep tracking (`if_changed`, not
+    /// `if_changed_dep`): EFI libstub's stubcopy strip/objcopy at defconfig
+    /// scale. Replays the exact argv over the unit outputs it references.
+    Command,
 }
 
 impl CmdEntry {
@@ -64,11 +68,14 @@ impl CmdEntry {
             "vmlinux.symvers" => Some(UnitKind::Modpost),
             _ if target.ends_with(".a") => Some(UnitKind::Archive),
             _ if target.ends_with(".o")
-                && self.source.is_some()
                 && !target.starts_with("scripts/")
                 && !target.starts_with("tools/") =>
             {
-                Some(UnitKind::Compile)
+                if self.source.is_some() {
+                    Some(UnitKind::Compile)
+                } else {
+                    Some(UnitKind::Command)
+                }
             }
             _ => None,
         }
@@ -124,7 +131,16 @@ mod tests {
             .unit_kind(),
             None
         );
-        // An .o with no dep tracking (compiled inside a script) is not a unit.
-        assert_eq!(entry("init/version-timestamp.o", None).unit_kind(), None);
+        // An .o with a savedcmd but no dep tracking (`if_changed` rules)
+        // replays as an opaque command unit; ones nothing references (the
+        // link script rebuilds init/version-timestamp.o itself) get pruned.
+        assert_eq!(
+            entry("drivers/firmware/efi/libstub/alignedmem.stub.o", None).unit_kind(),
+            Some(UnitKind::Command)
+        );
+        assert_eq!(
+            entry("init/version-timestamp.o", None).unit_kind(),
+            Some(UnitKind::Command)
+        );
     }
 }

--- a/packages/nix/nix-kbuild-unit/src/render.rs
+++ b/packages/nix/nix-kbuild-unit/src/render.rs
@@ -59,14 +59,15 @@ pub fn render_units_nix(plan: &Plan, content_addressed: bool) -> color_eyre::Res
 
     let srcarch = detect_srcarch(&units)?;
 
-    let mut farm: BTreeSet<&str> = BTreeSet::new();
     let mut scopes: BTreeMap<&str, SourceScope> = BTreeMap::new();
     for &target in &reachable {
         let (entry, kind) = units[target];
-        let scope = source_scope(entry, kind, &units, &generated, &srcarch)?;
-        farm.extend(scope.files.iter().copied());
-        scopes.insert(target, scope);
+        scopes.insert(target, source_scope(entry, kind, &units, &generated, &srcarch)?);
     }
+    let farm: BTreeSet<&str> = scopes
+        .values()
+        .flat_map(|scope| scope.files.iter().map(String::as_str))
+        .collect();
 
     let mut entries = String::new();
     for &target in &reachable {
@@ -221,9 +222,32 @@ fn closure_of<'plan>(
 /// The srctree inputs a unit's replay is allowed to see (#3412): tracked
 /// files resolved through the per-file source farm, plus directory prefixes
 /// for the script-driven link whose reads no .cmd records.
-struct SourceScope<'plan> {
-    files: BTreeSet<&'plan str>,
+struct SourceScope {
+    files: BTreeSet<String>,
     dirs: Vec<String>,
+}
+
+/// Lexically resolve `.` and `..` in a srctree-relative path. kbuild records
+/// cpp -MD prerequisites verbatim, so one header can appear under several
+/// spellings (e.g. `arch/x86/mm/../include/asm/trace/exceptions.h`) and
+/// collide in the replay symlink farm unless canonicalized.
+fn normalize_rel(rel: &str) -> color_eyre::Result<String> {
+    let mut parts: Vec<&str> = Vec::new();
+    for part in rel.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                if parts.pop().is_none() {
+                    bail!("source path {rel:?} escapes the source tree");
+                }
+            }
+            _ => parts.push(part),
+        }
+    }
+    if parts.is_empty() {
+        bail!("source path {rel:?} normalizes to nothing");
+    }
+    Ok(parts.join("/"))
 }
 
 /// The single arch the plan builds for, from `arch/<srcarch>/` unit targets.
@@ -240,29 +264,29 @@ fn detect_srcarch(units: &BTreeMap<&str, (&CmdEntry, UnitKind)>) -> color_eyre::
     }
 }
 
-fn source_scope<'plan>(
-    entry: &'plan CmdEntry,
+fn source_scope(
+    entry: &CmdEntry,
     kind: UnitKind,
     units: &BTreeMap<&str, (&CmdEntry, UnitKind)>,
     generated: &BTreeSet<&str>,
     srcarch: &str,
-) -> color_eyre::Result<SourceScope<'plan>> {
-    let mut files: BTreeSet<&'plan str> = BTreeSet::new();
+) -> color_eyre::Result<SourceScope> {
+    let mut files: BTreeSet<String> = BTreeSet::new();
     let mut dirs: Vec<String> = Vec::new();
     match kind {
         UnitKind::Compile => {
             for dep in entry.source.iter().chain(&entry.deps) {
-                let rel = dep.strip_prefix("./").unwrap_or(dep);
-                if rel.starts_with('/') {
+                if dep.starts_with('/') {
                     // Toolchain-owned (store) headers arrive via the compiler.
                     continue;
                 }
-                if units.contains_key(rel) || generated.contains(rel) {
+                if dep.chars().any(char::is_whitespace) {
+                    bail!("whitespace in source path {dep:?} of {}", entry.target);
+                }
+                let rel = normalize_rel(dep)?;
+                if units.contains_key(rel.as_str()) || generated.contains(rel.as_str()) {
                     // Dep unit outputs and snapshot members overlay the tree.
                     continue;
-                }
-                if rel.chars().any(char::is_whitespace) {
-                    bail!("whitespace in source path {rel:?} of {}", entry.target);
                 }
                 files.insert(rel);
             }
@@ -271,15 +295,14 @@ fn source_scope<'plan>(
             // link-vmlinux.sh (snapshot member, sed-patched at plan time)
             // shells back into make and compiles sources with no .cmd of
             // their own; give it the Makefile machinery and header trees.
-            files.insert("Makefile");
-            files.insert("init/version-timestamp.c");
+            files.insert("Makefile".to_owned());
+            files.insert("init/version-timestamp.c".to_owned());
             if let Some(postlink) = entry
                 .cmd
                 .split_whitespace()
-                .map(|token| token.strip_prefix("./").unwrap_or(token))
                 .find(|token| token.ends_with("Makefile.postlink"))
             {
-                files.insert(postlink);
+                files.insert(normalize_rel(postlink)?);
             }
             dirs = vec![
                 format!("arch/{srcarch}/include"),
@@ -625,6 +648,38 @@ mod tests {
             rendered
                 .contains("\"kernel/fork.c\" = srcFile \"kbuild-src-fork.c\" \"kernel/fork.c\";")
         );
+    }
+
+    #[test]
+    fn normalizes_dotdot_dep_spellings_to_one_farm_entry() {
+        let mut plan = sample_plan();
+        // kbuild records cpp -MD prerequisites verbatim: the same header can
+        // appear relative to the object dir and relative to the srctree.
+        plan.cmds[0].deps = vec![
+            "arch/x86/mm/../include/asm/trace/./exceptions.h".to_owned(),
+            "arch/x86/include/asm/trace/exceptions.h".to_owned(),
+        ];
+
+        let rendered = render_units_nix(&plan, true).expect("render");
+        assert_eq!(
+            rendered
+                .matches("\"arch/x86/include/asm/trace/exceptions.h\" = srcFile")
+                .count(),
+            1,
+            "duplicate spellings must collapse to one farm entry"
+        );
+        assert!(
+            !rendered.contains(".."),
+            "no unnormalized path may survive rendering"
+        );
+    }
+
+    #[test]
+    fn rejects_source_paths_escaping_the_tree() {
+        let mut plan = sample_plan();
+        plan.cmds[0].deps = vec!["../outside.h".to_owned()];
+        let err = render_units_nix(&plan, true).expect_err("escape must fail");
+        assert!(err.to_string().contains("escapes the source tree"));
     }
 
     #[test]

--- a/packages/nix/nix-kbuild-unit/src/render.rs
+++ b/packages/nix/nix-kbuild-unit/src/render.rs
@@ -57,10 +57,39 @@ pub fn render_units_nix(plan: &Plan, content_addressed: bool) -> color_eyre::Res
         closure_of(target, &direct_deps, &mut closures)?;
     }
 
+    let srcarch = detect_srcarch(&units)?;
+
+    let mut farm: BTreeSet<&str> = BTreeSet::new();
+    let mut scopes: BTreeMap<&str, SourceScope> = BTreeMap::new();
+    for &target in &reachable {
+        let (entry, kind) = units[target];
+        let scope = source_scope(entry, kind, &units, &generated, &srcarch)?;
+        farm.extend(scope.files.iter().copied());
+        scopes.insert(target, scope);
+    }
+
     let mut entries = String::new();
     for &target in &reachable {
         let (entry, kind) = units[target];
-        render_unit(&mut entries, entry, kind, &closures[target]);
+        render_unit(
+            &mut entries,
+            entry,
+            kind,
+            &closures[target],
+            &scopes[target],
+        );
+    }
+
+    let mut farm_entries = String::new();
+    for rel in &farm {
+        writeln!(
+            farm_entries,
+            "    {} = srcFile {} {};",
+            nix_string(rel),
+            nix_string(&store_name(rel)),
+            nix_string(rel)
+        )
+        .expect("write to string");
     }
 
     let mut pruned_list = String::new();
@@ -74,6 +103,7 @@ pub fn render_units_nix(plan: &Plan, content_addressed: bool) -> color_eyre::Res
             ("kernel_release", nix_string(&plan.kernel_release)),
             ("content_addressed", content_addressed.to_string()),
             ("unit_entries", entries),
+            ("source_farm_entries", farm_entries),
             ("pruned_targets", pruned_list),
         ],
     )
@@ -188,7 +218,104 @@ fn closure_of<'plan>(
     Ok(())
 }
 
-fn render_unit(out: &mut String, entry: &CmdEntry, kind: UnitKind, closure: &BTreeSet<&str>) {
+/// The srctree inputs a unit's replay is allowed to see (#3412): tracked
+/// files resolved through the per-file source farm, plus directory prefixes
+/// for the script-driven link whose reads no .cmd records.
+struct SourceScope<'plan> {
+    files: BTreeSet<&'plan str>,
+    dirs: Vec<String>,
+}
+
+/// The single arch the plan builds for, from `arch/<srcarch>/` unit targets.
+fn detect_srcarch(units: &BTreeMap<&str, (&CmdEntry, UnitKind)>) -> color_eyre::Result<String> {
+    let arches: BTreeSet<&str> = units
+        .keys()
+        .filter_map(|target| target.strip_prefix("arch/"))
+        .filter_map(|rest| rest.split('/').next())
+        .collect();
+    match arches.len() {
+        1 => Ok((*arches.first().expect("len checked")).to_owned()),
+        0 => bail!("no arch/<srcarch>/ unit targets in plan"),
+        _ => bail!("multiple srcarch candidates in plan: {arches:?}"),
+    }
+}
+
+fn source_scope<'plan>(
+    entry: &'plan CmdEntry,
+    kind: UnitKind,
+    units: &BTreeMap<&str, (&CmdEntry, UnitKind)>,
+    generated: &BTreeSet<&str>,
+    srcarch: &str,
+) -> color_eyre::Result<SourceScope<'plan>> {
+    let mut files: BTreeSet<&'plan str> = BTreeSet::new();
+    let mut dirs: Vec<String> = Vec::new();
+    match kind {
+        UnitKind::Compile => {
+            for dep in entry.source.iter().chain(&entry.deps) {
+                let rel = dep.strip_prefix("./").unwrap_or(dep);
+                if rel.starts_with('/') {
+                    // Toolchain-owned (store) headers arrive via the compiler.
+                    continue;
+                }
+                if units.contains_key(rel) || generated.contains(rel) {
+                    // Dep unit outputs and snapshot members overlay the tree.
+                    continue;
+                }
+                if rel.chars().any(char::is_whitespace) {
+                    bail!("whitespace in source path {rel:?} of {}", entry.target);
+                }
+                files.insert(rel);
+            }
+        }
+        UnitKind::Link => {
+            // link-vmlinux.sh (snapshot member, sed-patched at plan time)
+            // shells back into make and compiles sources with no .cmd of
+            // their own; give it the Makefile machinery and header trees.
+            files.insert("Makefile");
+            files.insert("init/version-timestamp.c");
+            if let Some(postlink) = entry
+                .cmd
+                .split_whitespace()
+                .map(|token| token.strip_prefix("./").unwrap_or(token))
+                .find(|token| token.ends_with("Makefile.postlink"))
+            {
+                files.insert(postlink);
+            }
+            dirs = vec![
+                format!("arch/{srcarch}/include"),
+                "include".to_owned(),
+                "scripts".to_owned(),
+            ];
+        }
+        // Pure aggregation over dep unit outputs plus snapshot tools.
+        UnitKind::Archive | UnitKind::ObjectAggregate | UnitKind::Modpost => {}
+    }
+    Ok(SourceScope { files, dirs })
+}
+
+/// Store-path name for a farm entry: sanitized basename, never dot-leading.
+fn store_name(rel: &str) -> String {
+    let base = rel.rsplit('/').next().unwrap_or(rel);
+    let sanitized: String = base
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '+' | '=' | '?') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    format!("kbuild-src-{sanitized}")
+}
+
+fn render_unit(
+    out: &mut String,
+    entry: &CmdEntry,
+    kind: UnitKind,
+    closure: &BTreeSet<&str>,
+    scope: &SourceScope,
+) {
     let target = entry.target.as_str();
     writeln!(out, "    {} = mkUnit {{", nix_string(target)).expect("write to string");
     writeln!(out, "      pname = {};", nix_string(&pname(target))).expect("write to string");
@@ -198,6 +325,20 @@ fn render_unit(out: &mut String, entry: &CmdEntry, kind: UnitKind, closure: &BTr
         writeln!(out, "      depUnits = [").expect("write to string");
         for dep in closure {
             writeln!(out, "        units.{}", nix_string(dep)).expect("write to string");
+        }
+        writeln!(out, "      ];").expect("write to string");
+    }
+    if !scope.files.is_empty() {
+        writeln!(out, "      sourceFiles = [").expect("write to string");
+        for rel in &scope.files {
+            writeln!(out, "        {}", nix_string(rel)).expect("write to string");
+        }
+        writeln!(out, "      ];").expect("write to string");
+    }
+    if !scope.dirs.is_empty() {
+        writeln!(out, "      sourceDirs = [").expect("write to string");
+        for dir in &scope.dirs {
+            writeln!(out, "        {}", nix_string(dir)).expect("write to string");
         }
         writeln!(out, "      ];").expect("write to string");
     }
@@ -445,6 +586,110 @@ mod tests {
         };
         let err = render_units_nix(&plan, false).expect_err("missing link must fail");
         assert!(err.to_string().contains("no vmlinux link command"));
+    }
+
+    #[test]
+    fn scopes_compile_units_to_tracked_srctree_files() {
+        let mut plan = sample_plan();
+        plan.cmds[0].deps = vec![
+            "include/linux/sched.h".to_owned(),
+            "./include/linux/mm.h".to_owned(),
+            // Toolchain header: rides in via the compiler, not the tree.
+            "/nix/store/abc-gcc/include/stdarg.h".to_owned(),
+            // Snapshot member: overlaid at build time.
+            "include/generated/autoconf.h".to_owned(),
+        ];
+
+        let rendered = render_units_nix(&plan, true).expect("render");
+        let fork = rendered
+            .split("\"kernel/fork.o\" = mkUnit {")
+            .nth(1)
+            .expect("fork.o unit rendered")
+            .split("};")
+            .next()
+            .expect("unit body");
+        for rel in [
+            "\"kernel/fork.c\"",
+            "\"include/linux/sched.h\"",
+            "\"include/linux/mm.h\"",
+        ] {
+            assert!(fork.contains(rel), "fork.o scope missing {rel}");
+        }
+        assert!(!fork.contains("stdarg.h"));
+        assert!(!fork.contains("include/generated/autoconf.h"));
+        // Every scoped file resolves through a farm entry.
+        assert!(rendered.contains(
+            "\"include/linux/mm.h\" = srcFile \"kbuild-src-mm.h\" \"include/linux/mm.h\";"
+        ));
+        assert!(
+            rendered
+                .contains("\"kernel/fork.c\" = srcFile \"kbuild-src-fork.c\" \"kernel/fork.c\";")
+        );
+    }
+
+    #[test]
+    fn scopes_the_link_to_makefiles_and_header_trees() {
+        let rendered = render_units_nix(&sample_plan(), true).expect("render");
+        let link = rendered
+            .split("\"vmlinux\" = mkUnit {")
+            .nth(1)
+            .expect("vmlinux unit rendered")
+            .split("};")
+            .next()
+            .expect("unit body");
+        for rel in [
+            "\"Makefile\"",
+            "\"arch/x86/Makefile.postlink\"",
+            "\"init/version-timestamp.c\"",
+        ] {
+            assert!(link.contains(rel), "link scope missing {rel}");
+        }
+        let dirs = link
+            .split("sourceDirs = [")
+            .nth(1)
+            .expect("link has sourceDirs")
+            .split("];")
+            .next()
+            .expect("sourceDirs body");
+        for dir in ["\"arch/x86/include\"", "\"include\"", "\"scripts\""] {
+            assert!(dirs.contains(dir), "link sourceDirs missing {dir}");
+        }
+    }
+
+    #[test]
+    fn aggregation_units_carry_no_source_scope() {
+        let rendered = render_units_nix(&sample_plan(), true).expect("render");
+        for target in [
+            "\"kernel/built-in.a\"",
+            "\"vmlinux.o\"",
+            "\"vmlinux.symvers\"",
+        ] {
+            let body = rendered
+                .split(&format!("{target} = mkUnit {{"))
+                .nth(1)
+                .unwrap_or_else(|| panic!("{target} unit rendered"))
+                .split("};")
+                .next()
+                .expect("unit body");
+            assert!(
+                !body.contains("sourceFiles"),
+                "{target} must not scope sources"
+            );
+            assert!(!body.contains("sourceDirs"), "{target} must not scope dirs");
+        }
+    }
+
+    #[test]
+    fn rejects_ambiguous_srcarch() {
+        let mut plan = sample_plan();
+        plan.cmds.push(entry(
+            "arch/arm64/kernel/setup.o",
+            "gcc -c -o arch/arm64/kernel/setup.o arch/arm64/kernel/setup.c",
+            Some("arch/arm64/kernel/setup.c"),
+            &[],
+        ));
+        let err = render_units_nix(&plan, false).expect_err("two arches must fail");
+        assert!(err.to_string().contains("multiple srcarch"));
     }
 
     #[test]

--- a/packages/nix/nix-kbuild-unit/src/render.rs
+++ b/packages/nix/nix-kbuild-unit/src/render.rs
@@ -250,6 +250,42 @@ fn normalize_rel(rel: &str) -> color_eyre::Result<String> {
     Ok(parts.join("/"))
 }
 
+/// Srctree files a saved command reads through `grep -f` (member-list
+/// filters like `scripts/head-object-list.txt`). Such reads leave no .cmd
+/// dep, so the source scope must recover them from the command text. Only a
+/// `-f` inside a grep invocation counts: `rm -f`/`ar`-flag lookalikes in the
+/// same command line stay ignored, and a pipe or statement end closes the
+/// grep. Absolute paths arrive store-resolved and need no farm entry.
+fn grep_file_reads(cmd: &str) -> color_eyre::Result<Vec<String>> {
+    let mut reads = Vec::new();
+    let mut in_grep = false;
+    let mut next_is_file = false;
+    for raw in cmd.split_whitespace() {
+        let token = raw.trim_matches('"');
+        if next_is_file {
+            next_is_file = false;
+            in_grep = false;
+            // Command substitution wraps the pipeline, so the file operand
+            // can carry the closing `)`.
+            let path = token.trim_end_matches([')', ';']);
+            if !path.starts_with('/') {
+                reads.push(normalize_rel(path)?);
+            }
+            continue;
+        }
+        if token == "|" || token == "&&" || token == "||" || token.ends_with(';') {
+            in_grep = false;
+            continue;
+        }
+        match token {
+            "grep" => in_grep = true,
+            "-f" if in_grep => next_is_file = true,
+            _ => {}
+        }
+    }
+    Ok(reads)
+}
+
 /// The single arch the plan builds for, from `arch/<srcarch>/` unit targets.
 fn detect_srcarch(units: &BTreeMap<&str, (&CmdEntry, UnitKind)>) -> color_eyre::Result<String> {
     let arches: BTreeSet<&str> = units
@@ -296,6 +332,12 @@ fn source_scope(
             // shells back into make and compiles sources with no .cmd of
             // their own; give it the Makefile machinery and header trees.
             files.insert("Makefile".to_owned());
+            // The script rebuilds the timestamp object through `${MAKE} -f
+            // ${srctree}/scripts/Makefile.build obj=init
+            // init/version-timestamp.o`, and Makefile.build includes the obj
+            // directory's kbuild file; init/ is the only subdir the script
+            // descends into.
+            files.insert("init/Makefile".to_owned());
             files.insert("init/version-timestamp.c".to_owned());
             if let Some(postlink) = entry
                 .cmd
@@ -310,8 +352,19 @@ fn source_scope(
                 "scripts".to_owned(),
             ];
         }
-        // Pure aggregation over dep unit outputs plus snapshot tools.
-        UnitKind::Archive | UnitKind::ObjectAggregate | UnitKind::Modpost => {}
+        // Aggregation replays dep unit outputs plus snapshot tools, but a
+        // saved command can still read srctree files no .cmd dep records:
+        // cmd_ar_vmlinux.a reorders boot head objects to the archive front
+        // through `grep -F -f $(srctree)/scripts/head-object-list.txt`, and
+        // without that file the grep fails, the reorder silently no-ops, and
+        // the linked vmlinux diverges from the monolithic reference.
+        UnitKind::Archive | UnitKind::ObjectAggregate | UnitKind::Modpost => {
+            for rel in grep_file_reads(&entry.cmd)? {
+                if !units.contains_key(rel.as_str()) && !generated.contains(rel.as_str()) {
+                    files.insert(rel);
+                }
+            }
+        }
     }
     Ok(SourceScope { files, dirs })
 }
@@ -468,7 +521,9 @@ mod tests {
                 ),
                 entry(
                     "vmlinux.a",
-                    "rm -f vmlinux.a; ar cDPrST vmlinux.a ./built-in.a",
+                    "rm -f vmlinux.a; ar cDPrST vmlinux.a ./built-in.a; ar mPiT $(ar t \
+                     vmlinux.a | sed -n 1p) vmlinux.a $(ar t vmlinux.a | grep -F -f \
+                     ./scripts/head-object-list.txt)",
                     None,
                     &[],
                 ),
@@ -695,6 +750,7 @@ mod tests {
         for rel in [
             "\"Makefile\"",
             "\"arch/x86/Makefile.postlink\"",
+            "\"init/Makefile\"",
             "\"init/version-timestamp.c\"",
         ] {
             assert!(link.contains(rel), "link scope missing {rel}");
@@ -709,6 +765,25 @@ mod tests {
         for dir in ["\"arch/x86/include\"", "\"include\"", "\"scripts\""] {
             assert!(dirs.contains(dir), "link sourceDirs missing {dir}");
         }
+    }
+
+    #[test]
+    fn scopes_grep_read_member_list_files_for_archives() {
+        let rendered = render_units_nix(&sample_plan(), true).expect("render");
+        let archive = rendered
+            .split("\"vmlinux.a\" = mkUnit {")
+            .nth(1)
+            .expect("vmlinux.a unit rendered")
+            .split("};")
+            .next()
+            .expect("unit body");
+        // cmd_ar_vmlinux.a reads the head-object list through `grep -F -f`;
+        // the scope must carry it or the reorder silently no-ops.
+        assert!(archive.contains("\"scripts/head-object-list.txt\""));
+        assert!(rendered.contains(
+            "\"scripts/head-object-list.txt\" = srcFile \"kbuild-src-head-object-list.txt\" \
+             \"scripts/head-object-list.txt\";"
+        ));
     }
 
     #[test]

--- a/packages/nix/nix-kbuild-unit/src/render.rs
+++ b/packages/nix/nix-kbuild-unit/src/render.rs
@@ -128,10 +128,10 @@ fn unit_deps<'plan>(
                 }
             }
         }
-        UnitKind::Archive | UnitKind::ObjectAggregate | UnitKind::Modpost => {
+        UnitKind::Archive | UnitKind::ObjectAggregate | UnitKind::Modpost | UnitKind::Command => {
             // Member lists live in the command line itself (`ar`/`ld`/modpost
-            // argv, or the `printf ... | xargs ar` form for the top-level
-            // archive). Token-scan for object and archive operands only;
+            // argv, the `printf ... | xargs ar` form for the top-level
+            // archive, or a Command unit's strip/objcopy input operands);
             // interpreting any more shell than that is out of scope.
             // Nested archives name members relative to their directory, with
             // the prefix in the printf format: `printf "arch/x86/%s " entry/...`;
@@ -358,7 +358,7 @@ fn source_scope(
         // through `grep -F -f $(srctree)/scripts/head-object-list.txt`, and
         // without that file the grep fails, the reorder silently no-ops, and
         // the linked vmlinux diverges from the monolithic reference.
-        UnitKind::Archive | UnitKind::ObjectAggregate | UnitKind::Modpost => {
+        UnitKind::Archive | UnitKind::ObjectAggregate | UnitKind::Modpost | UnitKind::Command => {
             for rel in grep_file_reads(&entry.cmd)? {
                 if !units.contains_key(rel.as_str()) && !generated.contains(rel.as_str()) {
                     files.insert(rel);
@@ -636,6 +636,58 @@ mod tests {
             .expect("unit body");
         assert!(top.contains("units.\"arch/x86/built-in.a\""));
         assert!(top.contains("units.\"arch/x86/entry/built-in.a\""));
+    }
+
+    #[test]
+    fn wires_command_units_from_argv_references() {
+        let mut plan = sample_plan();
+        // EFI libstub (defconfig): a dep-tracked compile, an if_changed
+        // stubcopy with no dep tracking, and the archive over the copies.
+        plan.cmds.push(entry(
+            "drivers/firmware/efi/libstub/alignedmem.o",
+            "gcc -c -o drivers/firmware/efi/libstub/alignedmem.o \
+             drivers/firmware/efi/libstub/alignedmem.c",
+            Some("drivers/firmware/efi/libstub/alignedmem.c"),
+            &[],
+        ));
+        plan.cmds.push(entry(
+            "drivers/firmware/efi/libstub/alignedmem.stub.o",
+            "strip --strip-debug -o drivers/firmware/efi/libstub/alignedmem.stub.o \
+             drivers/firmware/efi/libstub/alignedmem.o; objcopy \
+             --remove-section=.note.gnu.property drivers/firmware/efi/libstub/alignedmem.o \
+             drivers/firmware/efi/libstub/alignedmem.stub.o",
+            None,
+            &[],
+        ));
+        plan.cmds.push(entry(
+            "drivers/firmware/efi/libstub/lib.a",
+            "rm -f drivers/firmware/efi/libstub/lib.a; ar cDPrsT \
+             drivers/firmware/efi/libstub/lib.a drivers/firmware/efi/libstub/alignedmem.stub.o",
+            None,
+            &[],
+        ));
+        plan.cmds[4].cmd = "ld -r -o vmlinux.o --whole-archive vmlinux.a --no-whole-archive \
+             --start-group drivers/firmware/efi/libstub/lib.a --end-group"
+            .to_owned();
+
+        let rendered = render_units_nix(&plan, true).expect("render");
+        let stub = rendered
+            .split("\"drivers/firmware/efi/libstub/alignedmem.stub.o\" = mkUnit {")
+            .nth(1)
+            .expect("stub.o unit rendered")
+            .split("};")
+            .next()
+            .expect("unit body");
+        assert!(stub.contains("units.\"drivers/firmware/efi/libstub/alignedmem.o\""));
+        let aggregate = rendered
+            .split("\"vmlinux.o\" = mkUnit {")
+            .nth(1)
+            .expect("vmlinux.o unit rendered")
+            .split("};")
+            .next()
+            .expect("unit body");
+        assert!(aggregate.contains("units.\"drivers/firmware/efi/libstub/lib.a\""));
+        assert!(aggregate.contains("units.\"drivers/firmware/efi/libstub/alignedmem.stub.o\""));
     }
 
     #[test]

--- a/packages/nix/nix-kbuild-unit/templates/units.nix.in
+++ b/packages/nix/nix-kbuild-unit/templates/units.nix.in
@@ -106,11 +106,12 @@ let
           done
           cd "$tree"
           mkdir -p "$(dirname ${lib.escapeShellArg target})"
-          # kbuild passes -frandom-seed=<objtree hash> per object; the
-          # cc-wrapper appends NIX_CFLAGS_COMPILE after user argv, so the last
-          # seed wins. Pin the appended seed to the same constant the plan
-          # build pinned, making the saved command's own seed irrelevant.
-          export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE:-} -frandom-seed=kbuild-unit"
+          # Mirror the plan build (lib/kernel/kbuild-unit.nix): the
+          # cc-wrapper seeds -frandom-seed from this derivation's $out, so
+          # strip it and pin the same constant as the only seed, keeping
+          # replayed flags byte-identical to the plan's.
+          NIX_CFLAGS_COMPILE=$(printf '%s' "''${NIX_CFLAGS_COMPILE:-}" | sed 's/-frandom-seed=[^ ]*//g')
+          export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -frandom-seed=kbuild-unit"
           ${lib.optionalString sourceLinkEnv ". ./.kbuild-unit-link-env"}
           sh -c ${lib.escapeShellArg kbuildCmd}
           runHook postBuild

--- a/packages/nix/nix-kbuild-unit/templates/units.nix.in
+++ b/packages/nix/nix-kbuild-unit/templates/units.nix.in
@@ -2,8 +2,8 @@
 #
 # One derivation per kbuild unit, replaying the exact saved command
 # (`savedcmd_*`) from the plan build's .cmd files inside a symlink farm of
-# the pristine kernel source, the plan's generated-file snapshot, and the
-# unit's transitive dependency outputs. See lib/kernel/kbuild-unit.nix.
+# the unit's scoped sources (#3412), the plan's generated-file snapshot, and
+# the unit's transitive dependency outputs. See lib/kernel/kbuild-unit.nix.
 {
   pkgs,
   src,
@@ -17,12 +17,49 @@ let
   kernelRelease = {{ kernel_release }};
   contentAddressed = {{ content_addressed }};
 
+  srcRoot = builtins.toString src;
+
+  # One content-addressed store path per pristine source file. Units link
+  # exactly the files their .cmd recorded, so an edit invalidates only the
+  # units that actually read the edited file, and unchanged content keeps
+  # the same store path across source revisions (#3412).
+  srcFile =
+    name: rel:
+    builtins.path {
+      inherit name;
+      path = "${srcRoot}/${rel}";
+    };
+
+  # Scoped copy of whole directory prefixes for units that consume trees
+  # rather than tracked file lists (the vmlinux link's script-driven
+  # compiles read Makefile includes and header dirs no .cmd records).
+  dirScope =
+    name: prefixes:
+    builtins.path {
+      inherit name;
+      path = srcRoot;
+      filter =
+        path: _type:
+        let
+          rel = lib.removePrefix (srcRoot + "/") (builtins.toString path);
+        in
+        builtins.any (
+          prefix: rel == prefix || lib.hasPrefix (prefix + "/") rel || lib.hasPrefix (rel + "/") prefix
+        ) prefixes;
+    };
+
+  sourceFarm = {
+{{ source_farm_entries }}
+  };
+
   mkUnit =
     {
       pname,
       target,
       kbuildCmd,
       depUnits ? [ ],
+      sourceFiles ? [ ],
+      sourceDirs ? [ ],
       installFiles ? [ target ],
       sourceLinkEnv ? false,
     }:
@@ -38,17 +75,37 @@ let
         nativeBuildInputs = extraNativeBuildInputs;
         env = extraEnv;
         passthru = { inherit target; };
+        sourceFileRels = lib.concatStringsSep "\n" sourceFiles;
+        sourceFilePaths = lib.concatStringsSep "\n" (
+          map (rel: toString sourceFarm.${rel}) sourceFiles
+        );
+        # Dep closures and source lists can exceed the kernel's 128KiB
+        # single-env-string cap (MAX_ARG_STRLEN) at defconfig scale.
+        passAsFile = [
+          "depUnits"
+          "sourceFileRels"
+          "sourceFilePaths"
+        ];
         buildPhase = ''
           runHook preBuild
           tree="$NIX_BUILD_TOP/kbuild-tree"
           mkdir -p "$tree"
-          cp -rs --no-preserve=mode ${src}/. "$tree/"
+          ${lib.optionalString (sourceDirs != [ ]) ''
+            cp -rs --no-preserve=mode ${dirScope "${pname}-src-dirs" sourceDirs}/. "$tree/"
+          ''}
+          mapfile -t srcRels < "$sourceFileRelsPath"
+          mapfile -t srcPaths < "$sourceFilePathsPath"
+          for i in "''${!srcRels[@]}"; do
+            mkdir -p "$tree/$(dirname "''${srcRels[$i]}")"
+            ln -s "''${srcPaths[$i]}" "$tree/''${srcRels[$i]}"
+          done
           # The snapshot may shadow files the plan build modified in place.
           cp -rs --remove-destination --no-preserve=mode ${generated}/. "$tree/"
-          for dep in $depUnits; do
+          for dep in $(cat "$depUnitsPath"); do
             cp -rs --no-preserve=mode "$dep"/. "$tree/"
           done
           cd "$tree"
+          mkdir -p "$(dirname ${lib.escapeShellArg target})"
           # kbuild passes -frandom-seed=<objtree hash> per object; the
           # cc-wrapper appends NIX_CFLAGS_COMPILE after user argv, so the last
           # seed wins. Pin the appended seed to the same constant the plan


### PR DESCRIPTION
Closes #3412 (kbuild-unit P2: per-TU source scoping).

## What

Scopes each kbuild unit's inputs to its .c plus the exact dep list recorded in its `.cmd`, cargo-unit's per-crate scoping applied per TU:

- **render**: every `.cmd` dep is classified as toolchain header (absolute path, skipped), dep unit output, generated-snapshot member, or pristine srctree file; the srctree files are emitted per unit as `sourceFiles`. Files resolve through one shared per-file `builtins.path` farm, so unchanged file content keeps a stable store path across source revisions. The link unit additionally receives the script-read `Makefile`, `init/version-timestamp.c`, the arch postlink makefile, and the `arch/<srcarch>/include` / `include` / `scripts` trees as a single filtered copy (`srcarch` is derived from unit target paths and must be unique). Archive / object-aggregate / modpost units get no source scope at all.
- **units.nix template**: unit trees are now assembled sparsely from farm symlinks + optional dir scope + generated snapshot + dep outputs, replacing the whole-kernel-source symlink farm. Large dep/source lists ride `passAsFile` past the kernel's 128KiB per-env-string cap.
- **kbuild-unit.nix**: the harvested snapshot is re-homed in its own CA derivation, so a plan rerun with identical harvest content keeps every unit's `generated` input path stable (without this, any source edit invalidated all units through the plan's shifting output path).
- **per-system.nix**: adds the `kernel-unit-defconfig` legacyPackages lane used for the defconfig-scale eval-cost measurement the issue calls for.

## Effect

- one-file body edit: exactly 1 TU derivation re-instantiates, plus the link chain (plan rerun accepted in this phase)
- comment-only edit: CA cutoff at the unchanged object; link chain untouched

Exit-criteria evidence (rebuild counts, cutoff, defconfig eval cost) is being produced on vin-compute-1 and will be posted on #3412 before merge.

Both `legacyPackages` attrs stay outside `packages` and every CI gate closure, as in P1 (#3442, #3472).

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope each kbuild unit to its recorded `.cmd` deps to improve cache reuse
> - Each unit derivation now builds in a symlink farm containing only its tracked source files and directory prefixes, computed from `.cmd` sidecar data during rendering in [render.rs](https://github.com/indexable-inc/index/pull/3482/files#diff-8a91badcf6e01087a54586f6d9d917c4ad18516a38b3358b204492ce5ee2f73d).
> - A stable content-addressed `generatedSnapshot` derivation is introduced in [kbuild-unit.nix](https://github.com/indexable-inc/index/pull/3482/files#diff-894edbcee0d2e832bb188198d9520c9019d57088c5a061e3b3a327a243c1d7ad) to hold the plan's `generated/` directory at a fixed store path across plan reruns.
> - Savedcmd-only `.o` targets (produced by `if_changed` rather than `if_changed_dep`) are now classified as `Command` units and have their deps wired by argv scanning, rather than being silently dropped.
> - `.cmd` files under `tools/` are excluded from harvesting; built host tools flow into the generated snapshot instead.
> - `-frandom-seed` from the cc-wrapper is stripped and replaced with a constant `kbuild-unit` seed in both the plan configure phase and the units template, preventing store-path-derived seeds from perturbing snapshot contents.
> - Behavioral Change: unit builds now see only their scoped inputs rather than the full source tree, which may surface missing dep declarations in out-of-tree or unusual units.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3bcccf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->