### PR TITLE
fabric: subscription auth precedence and API-error failure surfacing

### DIFF
--- a/packages/mcp/src/fabric/fabric/claude.py
+++ b/packages/mcp/src/fabric/fabric/claude.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import json
+import os
 import platform
 from typing import TYPE_CHECKING, Protocol
 
@@ -24,9 +25,39 @@ from . import tmux as _tmux
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Sequence
 
-    from claude_agent_sdk import Message, PermissionMode
+    from claude_agent_sdk import Message, PermissionMode, ResultMessage
 
-__all__ = ["Session", "session"]
+__all__ = ["ENV_API_KEY", "ENV_SUBSCRIPTION", "Session", "SessionError", "session"]
+
+
+class SessionError(RuntimeError):
+    """A turn ended in an SDK error result; carries the CLI's error text."""
+
+
+# Subscription-auth signal for kernel-spawned agents (index#3420): when set
+# truthy, an inherited ANTHROPIC_API_KEY (e.g. an exhausted org key in the
+# kernel's launchd env) must not shadow claude.ai subscription auth, since
+# the CLI prefers the key over OAuth login.
+ENV_SUBSCRIPTION = "CLAUDE_USE_SUBSCRIPTION"
+ENV_API_KEY = "ANTHROPIC_API_KEY"
+
+_FALSE = frozenset({"", "0", "false", "no", "off"})
+
+
+def _auth_env() -> dict[str, str]:
+    """The one auth decision for every CLI this module spawns (index#3420).
+
+    The SDK merges ``ClaudeAgentOptions.env`` OVER the inherited process env
+    (a key can be overridden, never removed), so scrubbing means overriding
+    ``ANTHROPIC_API_KEY`` with the empty string, which the CLI reads as
+    unset. The tmux pane respawns the CLI with the shim subprocess's own
+    env, so this covers both spawn paths.
+    """
+
+    subscribed = os.environ.get(ENV_SUBSCRIPTION, "").strip().lower() not in _FALSE
+    if subscribed and ENV_API_KEY in os.environ:
+        return {ENV_API_KEY: ""}
+    return {}
 
 
 class SdkClient(Protocol):
@@ -73,6 +104,7 @@ def _sdk_client(
         allowed_tools=list(allowed_tools or []),
         permission_mode=permission_mode,
         max_turns=max_turns,
+        env=_auth_env(),
     )
     if tmux_window is not None:
         options.cli_path = _tmux.shim_path()
@@ -82,6 +114,24 @@ def _sdk_client(
             _tmux.ENV_WINDOW: tmux_window,
         }
     return ClaudeSDKClient(options)
+
+
+# The CLI reports an in-band API failure as its final result text with this
+# prefix (e.g. "API Error: 400 ... usage limits ..."), historically under
+# success-shaped flags, so the text is matched as well as the error fields
+# (index#3420).
+_API_ERROR_PREFIX = "API Error:"
+
+
+def _result_error(message: ResultMessage) -> str | None:
+    """The error text of a failed turn, or ``None`` for a genuine success."""
+
+    text = message.result or ""
+    if message.is_error or message.api_error_status is not None:
+        return text or f"SDK error result: subtype={message.subtype}"
+    if text.startswith(_API_ERROR_PREFIX):
+        return text
+    return None
 
 
 def _turn_blob(message: Message) -> bytes:
@@ -99,8 +149,10 @@ class Session:
     The reader task records a ``turn`` fact (a CAS pointer) per SDK message
     and a ``result`` fact per ``ResultMessage``; the watcher task polls the
     journal for ``interrupt=requested``. Terminal state lands exactly once:
-    ``interrupted`` at interrupt time, ``failed`` if the SDK stream errors,
-    else ``done`` at :meth:`close` -- always the entity's last state fact.
+    ``interrupted`` at interrupt time, ``failed`` if the SDK stream errors
+    or a turn ends in an SDK error result (:func:`_result_error`, raised
+    from :meth:`result` as :class:`SessionError`), else ``done`` at
+    :meth:`close` -- always the entity's last state fact.
     """
 
     def __init__(self, task: str, client: SdkClient) -> None:
@@ -127,6 +179,10 @@ class Session:
                 if isinstance(message, ResultMessage):
                     self._result = message.result or ""
                     await weave.record([(self.task, "result", weave.Blob(self._result.encode()))])
+                    error = _result_error(message)
+                    if error is not None:
+                        self._error = SessionError(f"{self.task}: {error}")
+                        await self._write_terminal("failed", error=error)
                     self._turn_done.set()
         except asyncio.CancelledError:
             raise
@@ -167,7 +223,7 @@ class Session:
         await self._client.query(text)
 
     async def result(self, *, timeout: float | None = None) -> str:
-        """Wait for the current turn's result text (also set on interrupt/failure)."""
+        """Wait for the turn's result text; an error result raises :class:`SessionError`."""
 
         async with asyncio.timeout(timeout):
             await self._turn_done.wait()

--- a/packages/mcp/src/fabric/fabric/tmux.py
+++ b/packages/mcp/src/fabric/fabric/tmux.py
@@ -24,6 +24,7 @@ and the stdout FIFO, and records the exit code for the shim to exit with.
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import shlex
@@ -203,7 +204,11 @@ def shim_main() -> None:
         # SDK's stdin through; closing on EOF is the CLI's stdin EOF.
         with fifo_in.open("wb") as sink:
             paired.set()
-            while chunk := sys.stdin.buffer.read1(65536):
+            stdin = sys.stdin.buffer
+            # typeshed widens sys.stdin.buffer to BinaryIO, which lacks read1
+            # (read would block for a full buffer).
+            assert isinstance(stdin, io.BufferedReader), type(stdin)
+            while chunk := stdin.read1(65536):
                 sink.write(chunk)
                 sink.flush()
 
@@ -251,8 +256,11 @@ def pane_main(spec_path: str) -> None:
                 print(f"fabric.tmux pane: spawn failed: {exc}", file=sys.stderr)
                 code = record(127)
             else:
-                assert proc.stdout is not None
-                while chunk := proc.stdout.read1(65536):
+                stdout = proc.stdout
+                # PIPE with default bufsize is buffered; typeshed widens to
+                # IO[bytes], which lacks read1.
+                assert isinstance(stdout, io.BufferedReader), type(stdout)
+                while chunk := stdout.read1(65536):
                     mirror.write(chunk)
                     mirror.flush()
                     sys.stdout.buffer.write(chunk)

--- a/packages/mcp/src/fabric/test_fabric.py
+++ b/packages/mcp/src/fabric/test_fabric.py
@@ -581,6 +581,146 @@ def test_session_connect_failure_leaves_ask_and_failed(monkeypatch: pytest.Monke
     assert journal.facts[-1] == (task, "state", "failed")
 
 
+
+# --- claude.session failure surfacing + auth precedence (index#3420) -----------
+
+
+def error_result_message(
+    text: str, *, is_error: bool = True, subtype: str = "error_during_execution",
+    api_error_status: int | None = None,
+) -> ResultMessage:
+    return ResultMessage(
+        subtype=subtype,
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=is_error,
+        num_turns=1,
+        session_id="s1",
+        result=text,
+        api_error_status=api_error_status,
+    )
+
+
+API_ERROR_400 = (
+    "API Error: 400 You have reached your specified API usage limits. "
+    "You will regain access on 2026-08-01 at 00:00 UTC."
+)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # The SDK-flagged shape: is_error=True on the result event.
+        error_result_message(API_ERROR_400),
+        # The incident shape (index#3420): the CLI ended the turn with the API
+        # error as plain result text under success-shaped flags.
+        error_result_message(API_ERROR_400, is_error=False, subtype="success"),
+        # Error flagged only via the API status field.
+        error_result_message("boom", is_error=False, subtype="success", api_error_status=500),
+    ],
+    ids=["is_error", "api_error_text", "api_error_status"],
+)
+def test_session_error_result_fails_journal_and_raises(
+    monkeypatch: pytest.MonkeyPatch, message: ResultMessage
+) -> None:
+    journal = install(monkeypatch)
+    fake = FakeClient()
+    use_fake(monkeypatch, fake)
+    detail = message.result or ""
+
+    async def main() -> claude.Session:
+        live = await claude.session("doomed")
+        fake.feed(message)
+        with pytest.raises(claude.SessionError, match=re.escape(detail[:40])):
+            await live.result(timeout=5)
+        await live.close()  # must not overwrite the failed terminal
+        return live
+
+    live = run(main())
+    drain()
+    assert journal.states(live.task) == ["submitted", "running", "failed"]
+    assert journal.facts[-1] == (live.task, "state", "failed")
+    errors = [v for e, a, v in journal.facts if e == live.task and a == "error"]
+    assert errors == [detail]
+    # The error text is still recorded as the turn's result blob.
+    assert journal.blob_for(live.task, "result") == detail.encode()
+
+
+def test_session_empty_error_result_names_subtype(monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = install(monkeypatch)
+    fake = FakeClient()
+    use_fake(monkeypatch, fake)
+
+    async def main() -> claude.Session:
+        live = await claude.session("doomed")
+        fake.feed(error_result_message(""))
+        with pytest.raises(claude.SessionError, match="error_during_execution"):
+            await live.result(timeout=5)
+        await live.close()
+        return live
+
+    live = run(main())
+    drain()
+    assert journal.states(live.task) == ["submitted", "running", "failed"]
+
+
+@pytest.mark.parametrize(
+    ("subscription", "key", "expect_scrub"),
+    [
+        ("1", "sk-ant-exhausted", True),
+        ("yes", "sk-ant-exhausted", True),
+        ("0", "sk-ant-exhausted", False),
+        ("off", "sk-ant-exhausted", False),
+        (None, "sk-ant-exhausted", False),
+        ("1", None, False),
+    ],
+)
+def test_auth_env_scrubs_key_only_under_subscription(
+    monkeypatch: pytest.MonkeyPatch, subscription: str | None, key: str | None, *, expect_scrub: bool
+) -> None:
+    for name, value in ((claude.ENV_SUBSCRIPTION, subscription), (claude.ENV_API_KEY, key)):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+    expected = {claude.ENV_API_KEY: ""} if expect_scrub else {}
+    assert claude._auth_env() == expected
+
+
+def _real_sdk_client(tmux_window: str | None) -> Any:
+    return claude._sdk_client(
+        system_prompt=None,
+        model=None,
+        cwd=None,
+        allowed_tools=None,
+        permission_mode=None,
+        max_turns=None,
+        tmux_window=tmux_window,
+    )
+
+
+def test_sdk_client_env_carries_auth_scrub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The scrub rides ClaudeAgentOptions.env, the ONE env the SDK overlays
+    onto the subprocess (the SDK can override but never remove an inherited
+    key, so the scrub is the empty-string override)."""
+    monkeypatch.setenv(claude.ENV_SUBSCRIPTION, "1")
+    monkeypatch.setenv(claude.ENV_API_KEY, "sk-ant-exhausted")
+    client = _real_sdk_client(None)
+    assert client.options.env == {claude.ENV_API_KEY: ""}
+
+    monkeypatch.setenv(claude.ENV_SUBSCRIPTION, "0")
+    assert _real_sdk_client(None).options.env == {}
+
+
+def test_sdk_client_tmux_env_keeps_auth_scrub(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(claude.ENV_SUBSCRIPTION, "1")
+    monkeypatch.setenv(claude.ENV_API_KEY, "sk-ant-exhausted")
+    monkeypatch.setattr(tmux, "real_cli", lambda: "/bin/claude")
+    client = _real_sdk_client("task-test")
+    assert client.options.env[claude.ENV_API_KEY] == ""
+    assert client.options.env[tmux.ENV_WINDOW] == "task-test"
+
+
 # --- fabric.reconcile -----------------------------------------------------------
 
 


### PR DESCRIPTION
Fixes #3420.

## Auth precedence

`fabric.claude` sessions inherited the kernel's `ANTHROPIC_API_KEY` (an exhausted org key in the launchd env), which the Claude CLI prefers over claude.ai subscription login, so every spawned agent died with `API Error: 401` while the interactive CLI worked fine.

The auth decision now lives in ONE place, `_auth_env()` in `claude.py`, wired into `ClaudeAgentOptions.env` where the SDK subprocess env is assembled. Mechanics, validated live against the real CLI:

- The SDK merges `options.env` OVER the inherited process env: a key can be overridden but never removed. So the scrub is the empty-string override.
- The CLI treats `ANTHROPIC_API_KEY=""` as unset: probe with empty key prints `OK` and exits 0 under subscription auth; a bogus key fails with `API Error: 401 API key is invalid` exit 1 and stderr saying the key "takes precedence over your claude.ai login".
- The tmux pane respawns the CLI with the shim subprocess's own env, so the one scrub covers both the headless and tmux spawn paths.

The scrub applies only when `CLAUDE_USE_SUBSCRIPTION` is set truthy, so key-auth deployments are untouched. No call-site `os.environ.pop` anywhere.

## Failure surfacing

A turn whose `ResultMessage` is SDK-flagged as an error (`is_error` or `api_error_status`) or whose result text is the CLI's in-band `API Error:` report (historically delivered under success-shaped flags) now:

- writes an error fact plus `state=failed` to the weave journal (same terminal-fact pattern as #3416), and
- raises `SessionError` from `Session.result()` instead of resolving as a normal done.

`API Error:` is matched as a prefix only, so a legitimate result that merely quotes an error cannot false-positive.

## Also

First commit fixes the pre-existing `mcp.tests.strictTypecheck` breakage on main (4 `read1` typing errors in `fabric/tmux.py` from #3479, reproduced on both aarch64-darwin and x86_64-linux at 606a6c70): narrow `sys.stdin.buffer` and `Popen.stdout` to `io.BufferedReader` with isinstance asserts (true at runtime under CPython; `cast` is banned by TID251).

## Validation

- `nix build .#mcp.tests.strictTypecheck`: `Success: no issues found in 23 source files` + ruff `All checks passed!`
- `nix build .#mcp.tests.fabricTests`: 71 passed (includes new tests: parametrized error-result surfacing over is_error / API-error text / api_error_status, empty-error subtype naming, `_auth_env` truth table, options.env wiring for both plain and tmux paths)
- `nix build .#mcp.tests.typecheckSmoke`: 155 passed

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix subscription auth precedence and surface API-error failures in fabric sessions
> - Adds `CLAUDE_USE_SUBSCRIPTION` env support: when set to a truthy value and `ANTHROPIC_API_KEY` is present, the SDK client env scrubs the API key (sets it to empty string) so subscription auth takes precedence.
> - Introduces `SessionError` (a `RuntimeError` subclass) raised by `Session.result()` when a turn ends with an SDK-flagged error, a non-zero `api_error_status`, or result text prefixed with `'API Error:'`.
> - Adds `_result_error` helper in [claude.py](https://github.com/indexable-inc/index/pull/3484/files#diff-a3385e17c91b79847e45af2e742bb2999d0bdcfa37e20a74f40e55d9428219a0) to classify these failure cases, including synthesizing an error message naming the subtype when result text is empty.
> - Behavioral Change: previously, error-shaped results from the SDK were silently recorded; now they mark the session as failed and cause `result()` to raise `SessionError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6945d3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->