### PR TITLE
agent: avoid whole-tree local flake snapshots

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -386,6 +386,23 @@
     };
   }
   {
+    gitBackedFlakeReferences = {
+      text = ''
+        When evaluating a local Git checkout as a flake, never use
+        `builtins.getFlake (toString ./...)` or a whole-tree `path:` reference:
+        both copy ignored build outputs and every other file into the Nix store.
+        Use the Git fetcher (`"git+file://" + toString ./...`), a declared flake
+        input, or the CLI's `.#...` reference so Git filters the source tree.
+      '';
+      reason = ''
+        `builtins.getFlake (toString ./.)` appeared hung while it copied a 30 GB
+        checkout, including a 26 GB ignored `target/` and `node_modules`. The
+        repo's no-getflake-tostring and no-path-flake-ref lints already enforce
+        the same source-filtering boundary in Nix code (index#3485).
+      '';
+    };
+  }
+  {
     fixAtSource = {
       text = ''
         Fix problems at their source: prefer architectural changes that remove


### PR DESCRIPTION
## Summary

- warn against `builtins.getFlake (toString ./...)` and whole-tree `path:` references in the house prompt
- direct agents to Git-filtered local flake references
- record the observed 30 GB source-copy failure

## Validation

- rendered and reread the Claude Code system prompt
- `nix run .#lint`

Fixes #3485.

PR #3109 also touches `packages/agent/prompt/rules.nix` in a separate rule and non-overlapping hunk.

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent rule discouraging whole-tree local flake snapshots via `builtins.getFlake`
> Adds a `gitBackedFlakeReferences` rule to [rules.nix](https://github.com/indexable-inc/index/pull/3486/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) that instructs the agent to avoid evaluating local paths as flakes using `builtins.getFlake (toString ./.)` or `path:` references, which snapshot the entire working tree. The rule recommends `git+file://`, declared flake inputs, or CLI `.#` references instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a516741.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->