### PR TITLE
claude-code: enable 1M context by default

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -51,9 +51,8 @@
   # CLAUDE_CODE_AUTO_COMPACT_WINDOW into settings `env` (null bakes nothing).
   # Unknown keys throw, like systemTools. Merged over `defaultFeatures` in the
   # let-block:
-  #  - context1M = false: every 1M path in the CLI (the [1m] model suffix, the
-  #    silent auto-upgrade, the context-1m beta header) is ~5x input price;
-  #    past-the-window work belongs in subagents.
+  #  - context1M = true: keep the CLI's stock 1M paths available (the [1m]
+  #    model suffix, the silent auto-upgrade, and the context-1m beta header).
   #  - cron = false: drops the scheduling/loop tools.
   #  - autoCompactWindow = 300000: native-1M models (Fable 5, Sonnet 5,
   #    Opus 4.8) otherwise autocompact near the 1M cliff; 300K matches the
@@ -239,7 +238,7 @@
     cron = "CLAUDE_CODE_DISABLE_CRON";
   };
   defaultFeatures = {
-    context1M = false;
+    context1M = true;
     cron = false;
     autoCompactWindow = 300000;
   };


### PR DESCRIPTION
## Summary

- enable Claude Code's stock 1M context paths by default
- retain the typed `context1M` override for consumers that explicitly disable them

## Validation

- `nix build .#claude-code --no-link`
- `nix eval --json .#packages.aarch64-darwin.claude-code.passthru.settings --apply 'settings: settings.env'` confirms `CLAUDE_CODE_DISABLE_1M_CONTEXT` is absent
- `nix run .#lint` passes all Nix checks; the whole-tree Ruff lane reports the pre-existing `ANN401` at `packages/mcp/src/fabric/test_fabric.py:690`

Fixes #3487

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable 1M context by default in claude-code
> Sets `context1M` to `true` in the `defaultFeatures` attrset in [default.nix](https://github.com/indexable-inc/index/pull/3488/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8). This keeps the CLI's stock 1M context paths active, including the `[1m]` model suffix, silent auto-upgrade, and the `context-1m` beta header. Behavioral Change: any deployments relying on the previous default (`context1M=false`) will now use 1M context paths without explicit opt-in.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b7b6d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->