### PR TITLE
mcp: concrete ClaudeSDKClient return type for _real_sdk_client test helper

### DIFF
--- a/packages/mcp/src/fabric/test_fabric.py
+++ b/packages/mcp/src/fabric/test_fabric.py
@@ -19,7 +19,7 @@ sys.path.insert(0, str(ROOT / "weave"))
 sys.path.insert(0, str(ROOT / "fabric"))
 
 import weave
-from claude_agent_sdk import AssistantMessage, Message, ResultMessage, TextBlock
+from claude_agent_sdk import AssistantMessage, ClaudeSDKClient, Message, ResultMessage, TextBlock
 
 import fabric
 from fabric import activity, claude, reconcile, remote, tmux
@@ -687,8 +687,8 @@ def test_auth_env_scrubs_key_only_under_subscription(
     assert claude._auth_env() == expected
 
 
-def _real_sdk_client(tmux_window: str | None) -> Any:
-    return claude._sdk_client(
+def _real_sdk_client(tmux_window: str | None) -> ClaudeSDKClient:
+    client = claude._sdk_client(
         system_prompt=None,
         model=None,
         cwd=None,
@@ -697,6 +697,10 @@ def _real_sdk_client(tmux_window: str | None) -> Any:
         max_turns=None,
         tmux_window=tmux_window,
     )
+    # The tests read `client.options`, which the SdkClient protocol deliberately
+    # omits; narrow to the real SDK client instead of widening to Any (ANN401).
+    assert isinstance(client, ClaudeSDKClient)
+    return client
 
 
 def test_sdk_client_env_carries_auth_scrub(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #3492.

`bbfc67a9` (#3484) added `_real_sdk_client(...) -> Any` in `packages/mcp/src/fabric/test_fabric.py`, and the global ruff lane (ANN401) now fails every local commit in every checkout. `claude._sdk_client` really builds a `ClaudeSDKClient`, whose `.options` the tests read (the `SdkClient` protocol deliberately omits it), so narrow with a runtime `isinstance` check instead of widening to `Any`.

Validated locally: repo lint suite green (ruff lane included), the two `sdk_client` tests pass, and `nix build .#mcp.tests.fabricTests` runs as a second gate.

🤖 Generated with Claude Code (Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add runtime type assertion to `_real_sdk_client` test helper in `test_fabric`
> Changes the return type of `_real_sdk_client` in [test_fabric.py](https://github.com/indexable-inc/index/pull/3493/files#diff-0a77f17e830aba0f8edc996978e1caa17c385d912fd2f7b1a880dc6fda342444) from `Any` to `ClaudeSDKClient` and adds an `isinstance` assertion to enforce it at runtime. This ensures tests fail with a clear `AssertionError` if the underlying `claude._sdk_client` is not a `ClaudeSDKClient`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28a6980.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->