### PR TITLE
fabric: render the tmux pane as a live human-readable transcript

### DIFF
--- a/packages/mcp/src/fabric/fabric/render.py
+++ b/packages/mcp/src/fabric/fabric/render.py
@@ -1,0 +1,193 @@
+"""Human-readable rendering of the agent CLI's stream-json (index#3496).
+
+The tmux pane a ``fabric.claude.session`` CLI runs in (:mod:`fabric.tmux`)
+used to show the CLI's raw stream-json: machine framing, not something a
+human can follow. This module is the pane's display side:
+``Transcript.feed`` takes one raw stdout line and returns the text to
+show, so the pane reads as a live transcript (assistant text, tool calls
+with compact inputs, truncated tool results, a final result summary)
+while the SDK keeps the raw bytes through its own FIFO.
+
+Rendering never swallows information silently: a line that is not JSON,
+or a JSON event this module does not know, is shown as-is (unknown JSON
+dimmed and clipped), so a CLI format change degrades to the old raw view
+rather than a blank pane. Only frames that are protocol traffic, not
+conversation (SDK<->CLI control frames, ``stream_event`` partial deltas
+that a complete message always follows), render as nothing.
+"""
+
+from __future__ import annotations
+
+import json
+
+__all__ = ["Transcript"]
+
+# ANSI SGR fragments; the pane is a tmux terminal, so ANSI always applies.
+_RESET = "\x1b[0m"
+_DIM = "\x1b[2m"
+_BOLD = "\x1b[1m"
+_CYAN = "\x1b[36m"
+_GREEN = "\x1b[32m"
+_RED = "\x1b[31m"
+
+# SDK<->CLI protocol frames, never conversation content.
+_CONTROL_TYPES = frozenset({"control_request", "control_response", "control_cancel_request"})
+
+# Clipping budgets: a tool input can be a whole file write and a tool
+# result a whole build log; the pane wants the shape, the journal keeps
+# the payload (fabric.claude records every raw message to CAS).
+_INPUT_LIMIT = 200
+_THINKING_LIMIT = 200
+_UNKNOWN_LIMIT = 400
+_RESULT_LINES = 4
+_RESULT_LINE_LIMIT = 200
+
+
+def _clip(text: str, limit: int) -> str:
+    return text if len(text) <= limit else text[: limit - 1] + "\u2026"
+
+
+def _compact(value: object, limit: int) -> str:
+    """One clipped line of JSON, for tool inputs and unknown payloads."""
+
+    return _clip(json.dumps(value, default=repr), limit)
+
+
+def _tool_result_text(content: object) -> str:
+    """Flatten a tool_result ``content`` (str | block list | None) to text."""
+
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+            else:
+                parts.append(json.dumps(block, default=repr))
+        return "\n".join(parts)
+    return json.dumps(content, default=repr)
+
+
+def _excerpt(text: str) -> list[str]:
+    """The first few clipped lines of ``text``, with a ``+N lines`` tail."""
+
+    lines = text.splitlines() or [""]
+    shown = [_clip(line, _RESULT_LINE_LIMIT) for line in lines[:_RESULT_LINES]]
+    hidden = len(lines) - len(shown)
+    if hidden > 0:
+        shown.append(f"\u2026 +{hidden} lines")
+    return shown
+
+
+class Transcript:
+    """Stateful line renderer: one raw stream-json line in, pane text out.
+
+    ``feed`` returns the text to display for that line (may span several
+    display lines), or ``None`` for protocol frames with nothing to show.
+    State is one map from tool_use id to tool name, so a later
+    tool_result can be labeled with the call it answers.
+    """
+
+    def __init__(self) -> None:
+        self._tool_names: dict[str, str] = {}
+
+    def feed(self, raw: bytes) -> str | None:
+        line = raw.decode("utf-8", errors="replace").strip()
+        if not line:
+            return None
+        try:
+            event = json.loads(line)
+        except ValueError:
+            return line  # not stream-json: show verbatim
+        if not isinstance(event, dict):
+            return line
+        kind = event.get("type")
+        if kind in _CONTROL_TYPES or kind == "stream_event":
+            return None
+        if kind == "system":
+            return self._system(event)
+        if kind in ("assistant", "user"):
+            return self._message(event)
+        if kind == "result":
+            return self._result(event)
+        return f"{_DIM}{_clip(line, _UNKNOWN_LIMIT)}{_RESET}"
+
+    def _system(self, event: dict[str, object]) -> str:
+        subtype = event.get("subtype") or "system"
+        if subtype == "init":
+            fields = " ".join(
+                f"{key}={event[key]}"
+                for key in ("model", "permissionMode", "cwd", "session_id")
+                if event.get(key)
+            )
+            return f"{_DIM}\u00b7 init {fields}{_RESET}"
+        return f"{_DIM}\u00b7 {subtype}{_RESET}"
+
+    def _message(self, event: dict[str, object]) -> str | None:
+        role = event.get("type")
+        message = event.get("message")
+        content = message.get("content") if isinstance(message, dict) else None
+        if isinstance(content, str):
+            return self._text(role, content)
+        out: list[str] = []
+        for block in content if isinstance(content, list) else []:
+            if not isinstance(block, dict):
+                continue
+            rendered = self._block(role, block)
+            if rendered is not None:
+                out.append(rendered)
+        return "\n".join(out) or None
+
+    def _block(self, role: object, block: dict[str, object]) -> str | None:
+        kind = block.get("type")
+        if kind == "text":
+            return self._text(role, str(block.get("text", "")))
+        if kind == "thinking":
+            first = str(block.get("thinking", "")).strip().splitlines()
+            head = _clip(first[0], _THINKING_LIMIT) if first else ""
+            return f"{_DIM}\u273b {head}{_RESET}"
+        if kind in ("tool_use", "server_tool_use"):
+            name = str(block.get("name", "tool"))
+            block_id = block.get("id")
+            if isinstance(block_id, str):
+                self._tool_names[block_id] = name
+            return f"{_CYAN}{_BOLD}\u23fa {name}{_RESET}{_CYAN} {_compact(block.get('input'), _INPUT_LIMIT)}{_RESET}"
+        if kind == "tool_result":
+            name = self._tool_names.get(str(block.get("tool_use_id")), "tool")
+            color = _RED if block.get("is_error") else _DIM
+            lines = _excerpt(_tool_result_text(block.get("content")))
+            body = "\n".join(f"    {line}" for line in lines[1:])
+            head = f"{color}  \u23bf {name}: {lines[0]}{_RESET}"
+            return head if not body else f"{head}\n{color}{body}{_RESET}"
+        return f"{_DIM}{_compact(block, _UNKNOWN_LIMIT)}{_RESET}"
+
+    def _text(self, role: object, text: str) -> str:
+        marker = "\u23fa" if role == "assistant" else "\u276f"
+        lines = text.splitlines() or [""]
+        head = f"{_BOLD}{marker} {lines[0]}{_RESET}" if role == "assistant" else f"{_DIM}{marker} {lines[0]}{_RESET}"
+        rest = [f"  {line}" for line in lines[1:]]
+        return "\n".join([head, *rest])
+
+    def _result(self, event: dict[str, object]) -> str:
+        failed = bool(event.get("is_error"))
+        duration = event.get("duration_ms")
+        parts = [] if not isinstance(duration, (int, float)) else [f"{duration / 1000:.1f}s"]
+        turns = event.get("num_turns")
+        if turns is not None:
+            parts.append(f"{turns} turns")
+        cost = event.get("total_cost_usd")
+        if isinstance(cost, (int, float)):
+            parts.append(f"${cost:.4f}")
+        head = (
+            f"{_RED}\u2717 {event.get('subtype') or 'error'}"
+            if failed
+            else f"{_GREEN}\u2714 done"
+        )
+        line = f"{head}{' \u00b7 ' if parts else ''}{' \u00b7 '.join(parts)}{_RESET}"
+        result = event.get("result")
+        if failed and result:
+            line += f"\n{_RED}{_clip(str(result), _UNKNOWN_LIMIT)}{_RESET}"
+        return line

--- a/packages/mcp/src/fabric/fabric/tmux.py
+++ b/packages/mcp/src/fabric/fabric/tmux.py
@@ -18,8 +18,10 @@ pipes to two FIFOs, then opens a tmux window running
 ``python -m fabric.tmux <spec.json>`` (:func:`pane_main`). The pane process
 spawns the real CLI with the shim's full environment (a tmux pane otherwise
 inherits the tmux *server's* environment, losing the SDK's env), feeds it
-the stdin FIFO, tees its stdout to both the pane (what the human watches)
-and the stdout FIFO, and records the exit code for the shim to exit with.
+the stdin FIFO, mirrors its raw stdout to the stdout FIFO (the SDK's
+transport, byte-exact), renders that stream-json as a live human-readable
+transcript in the pane (:mod:`fabric.render`, index#3496), and records the
+exit code for the shim to exit with.
 """
 
 from __future__ import annotations
@@ -36,6 +38,8 @@ import tempfile
 import threading
 from pathlib import Path
 from types import FrameType
+
+from . import render
 
 __all__ = [
     "ENV_CLI",
@@ -187,7 +191,15 @@ def shim_main() -> None:
         )
     )
     # `exec` so kill-pane HUPs the pane python directly, not a wrapper shell.
-    command = "exec " + shlex.join([sys.executable, "-m", "fabric.tmux", str(spec_path)])
+    # The pane inherits the tmux *server's* environment, so the shim's own
+    # PYTHONPATH rides along explicitly: the pane's `import fabric` must
+    # resolve the same module tree as the shim (the spec env only covers the
+    # CLI child, which spawns after that import).
+    pythonpath = os.environ.get("PYTHONPATH")
+    argv = [sys.executable, "-m", "fabric.tmux", str(spec_path)]
+    if pythonpath is not None:
+        argv = ["env", f"PYTHONPATH={pythonpath}", *argv]
+    command = "exec " + shlex.join(argv)
     tmux, pane = _new_window(window, command)
 
     def _on_terminate(signum: int, _frame: FrameType | None) -> None:
@@ -232,8 +244,25 @@ def shim_main() -> None:
     raise SystemExit(code)
 
 
+def _display(transcript: render.Transcript, line: bytes) -> None:
+    """Show one CLI stdout line in the pane, rendered.
+
+    The mirror FIFO is the SDK's transport, so a display bug must never
+    sever the session: a rendering failure prints loudly and falls back to
+    the raw line instead of raising out of the mirror loop.
+    """
+
+    try:
+        text = transcript.feed(line)
+    except Exception as exc:  # viewer only; see docstring
+        text = f"fabric.render failed ({exc!r}) on: {line[:200]!r}"
+    if text is not None:
+        sys.stdout.write(text + "\n")
+        sys.stdout.flush()
+
+
 def pane_main(spec_path: str) -> None:
-    """Pane-facing side: run the real CLI, tee stdout to the pane and the SDK."""
+    """Pane-facing side: run the real CLI, mirror raw stdout to the SDK, render it in the pane."""
 
     spec = json.loads(Path(spec_path).read_text())
 
@@ -260,11 +289,17 @@ def pane_main(spec_path: str) -> None:
                 # PIPE with default bufsize is buffered; typeshed widens to
                 # IO[bytes], which lacks read1.
                 assert isinstance(stdout, io.BufferedReader), type(stdout)
+                transcript = render.Transcript()
+                pending = b""
                 while chunk := stdout.read1(65536):
                     mirror.write(chunk)
                     mirror.flush()
-                    sys.stdout.buffer.write(chunk)
-                    sys.stdout.buffer.flush()
+                    pending += chunk
+                    while (end := pending.find(b"\n")) != -1:
+                        line, pending = pending[:end], pending[end + 1 :]
+                        _display(transcript, line)
+                if pending:
+                    _display(transcript, pending)
                 # Record BEFORE the mirror FIFO closes: its EOF is the shim's
                 # cue to read the exit code, so the file must exist by then.
                 code = record(proc.wait())

--- a/packages/mcp/src/fabric/test_fabric.py
+++ b/packages/mcp/src/fabric/test_fabric.py
@@ -22,7 +22,7 @@ import weave
 from claude_agent_sdk import AssistantMessage, ClaudeSDKClient, Message, ResultMessage, TextBlock
 
 import fabric
-from fabric import activity, claude, reconcile, remote, tmux
+from fabric import activity, claude, reconcile, remote, render, tmux
 
 _T = TypeVar("_T")
 
@@ -1066,3 +1066,140 @@ def test_tmux_shim_answers_version_probe_directly(tmp_path: Path) -> None:
     )
     assert done.stdout == b"fake-claude 1.2.3\n"
     assert done.returncode == 0
+
+
+# --- fabric.render ---------------------------------------------------------------
+
+
+def _rendered(transcript: render.Transcript, event: dict[str, object]) -> str:
+    shown = transcript.feed(json.dumps(event).encode())
+    assert shown is not None
+    return shown
+
+
+def test_render_turn_reads_as_transcript() -> None:
+    """Assistant text, tool calls, and labeled tool results render readably."""
+
+    transcript = render.Transcript()
+    header = _rendered(transcript, {"type": "system", "subtype": "init", "model": "opus", "cwd": "/repo"})
+    assert "model=opus" in header
+    assert "cwd=/repo" in header
+    call = _rendered(
+        transcript,
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": "tu1", "name": "Bash", "input": {"command": "ls"}}]},
+        },
+    )
+    assert "Bash" in call
+    assert '"ls"' in call
+    result = _rendered(
+        transcript,
+        {
+            "type": "user",
+            "message": {
+                "content": [{"type": "tool_result", "tool_use_id": "tu1", "content": "a\nb\nc\nd\ne\nf"}]
+            },
+        },
+    )
+    assert "Bash" in result  # labeled by the remembered tool_use id
+    assert "a" in result
+    assert "+2 lines" in result
+    assert "f" not in result.replace("\x1b", "")
+    answer = _rendered(
+        transcript,
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "done\nsee diff"}]}},
+    )
+    assert "done" in answer
+    assert "see diff" in answer
+
+
+def test_render_result_summary_and_error() -> None:
+    ok = render.Transcript().feed(
+        json.dumps(
+            {"type": "result", "subtype": "success", "is_error": False, "duration_ms": 12300, "num_turns": 4, "total_cost_usd": 0.04}
+        ).encode()
+    )
+    assert ok is not None
+    assert "12.3s" in ok
+    assert "4 turns" in ok
+    assert "$0.0400" in ok
+    failed = render.Transcript().feed(
+        json.dumps(
+            {"type": "result", "subtype": "error_during_execution", "is_error": True, "duration_ms": 500, "result": "API Error: 400"}
+        ).encode()
+    )
+    assert failed is not None
+    assert "error_during_execution" in failed
+    assert "API Error: 400" in failed
+
+
+def test_render_passthrough_and_protocol_silence() -> None:
+    """Non-JSON shows verbatim; SDK control frames and partial deltas show nothing."""
+
+    transcript = render.Transcript()
+    assert transcript.feed(b"plain CLI noise") == "plain CLI noise"
+    assert transcript.feed(b"") is None
+    assert transcript.feed(json.dumps({"type": "control_response", "response": {}}).encode()) is None
+    assert transcript.feed(json.dumps({"type": "stream_event", "event": {}}).encode()) is None
+    unknown = transcript.feed(json.dumps({"type": "novel_event", "x": 1}).encode())
+    assert unknown is not None
+    assert "novel_event" in unknown
+
+
+def test_render_clips_unbounded_payloads() -> None:
+    """A whole-file Write input renders as one bounded line, not megabytes."""
+
+    event = {
+        "type": "assistant",
+        "message": {"content": [{"type": "tool_use", "id": "tu2", "name": "Write", "input": {"content": "A" * 10_000}}]},
+    }
+    shown = render.Transcript().feed(json.dumps(event).encode())
+    assert shown is not None
+    assert len(shown) < 400
+
+
+def test_pane_renders_stream_json_and_mirrors_raw(tmp_path: Path) -> None:
+    """pane_main shows a rendered transcript while the SDK mirror stays byte-exact."""
+
+    import os
+    import subprocess
+
+    raw = (
+        json.dumps({"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}}]}})
+        + "\n"
+        + json.dumps({"type": "result", "subtype": "success", "is_error": False, "duration_ms": 1000, "num_turns": 1})
+        + "\n"
+    )
+    cli = tmp_path / "fake-cli"
+    cli.write_text("#!/bin/sh\ncat " + str(tmp_path / "script-output") + "\n")
+    cli.chmod(0o755)
+    (tmp_path / "script-output").write_text(raw)
+    (tmp_path / "in").write_bytes(b"")
+    spec = tmp_path / "spec.json"
+    spec.write_text(
+        json.dumps(
+            {
+                "argv": [str(cli)],
+                "env": dict(os.environ),
+                "cwd": str(tmp_path),
+                "stdin": str(tmp_path / "in"),
+                "stdout": str(tmp_path / "mirror"),
+                "rc": str(tmp_path / "rc"),
+            }
+        )
+    )
+    done = subprocess.run(
+        [sys.executable, "-m", "fabric.tmux", str(spec)],
+        capture_output=True,
+        env={**os.environ, "PYTHONPATH": f"{ROOT / 'fabric'}:{ROOT / 'weave'}"},
+        timeout=60,
+        check=False,
+    )
+    assert done.returncode == 0, done.stderr.decode()
+    assert (tmp_path / "mirror").read_bytes() == raw.encode()  # SDK transport untouched
+    assert (tmp_path / "rc").read_text() == "0"
+    pane = done.stdout.decode()
+    assert "Bash" in pane
+    assert "done" in pane
+    assert '"type": "assistant"' not in pane  # rendered, not raw JSON


### PR DESCRIPTION
Closes #3496.

The `ix-agents` tmux window (#3478) gave every `fabric.claude.session` agent a pane, but it showed the CLI's raw stream-json. This makes the pane actually watchable:

- `fabric.render.Transcript`: one stateful line renderer; assistant text, tool calls with compact clipped inputs, tool results labeled by their `tool_use_id` and truncated, thinking lines, and a final `✔ done · 45.1s · 2 turns · $1.05`-style summary. Non-JSON and unknown events pass through verbatim/dimmed, so a CLI format change degrades to the old raw view, never a blank pane. Control frames and `stream_event` partial deltas (protocol, not conversation) show nothing.
- `pane_main` mirrors raw bytes to the SDK FIFO byte-exact (the transport is untouched) and renders per line to the pane; a render failure prints loudly and falls back to the raw line rather than severing the session.
- The pane command now carries the shim's `PYTHONPATH`, so the pane's `import fabric` resolves the same module tree as the shim (found live-testing: the tmux server env made the pane import a different fabric than the SDK side).

Validated: unit tests plus a pane end-to-end test (raw mirror byte-exact, rendered pane), `.#mcp.tests.strictTypecheck` and `.#mcp.tests.fabricTests` green, and a live `claude.session` on this machine whose tmux pane rendered the whole turn correctly.

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render the tmux pane as a live human-readable transcript of stream-json events
> - Adds a `Transcript` class in [render.py](https://github.com/indexable-inc/index/pull/3499/files#diff-904a18faafd7b77aed7ae4c6788d59a343bcb5f4ae12f2d384d10bd4c1ee88d8) that parses stream-json SDK/CLI events and emits ANSI-colored, human-readable lines; ignores control/stream_event frames, clips large payloads, and summarizes tool calls by name.
> - Updates `pane_main` in [tmux.py](https://github.com/indexable-inc/index/pull/3499/files#diff-c82b6a261843e9b2a3a81a5a60fe6a245e3f1bdf206886ae77c300d9c673d8de) to feed stdout lines through `Transcript` for display while keeping the raw byte-exact mirror to the SDK FIFO unchanged.
> - Fixes pane process launch to inherit the shim's `PYTHONPATH` so import resolution works correctly in the pane subprocess.
> - Adds tests covering transcript rendering, result summaries, passthrough of non-JSON, payload clipping, and end-to-end pane mirroring.
> - Behavioral Change: the tmux pane now shows a formatted transcript instead of raw JSON; the SDK-facing FIFO is unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b3d750.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->