### PR TITLE
agent: code-reviewer inherits default model and tools

### DIFF
--- a/packages/agent/subagents.nix
+++ b/packages/agent/subagents.nix
@@ -162,17 +162,7 @@
     code-reviewer = {
       frontmatter = {
         description = "Adversarial, max-effort reviewer for a finished change. Spawn after work is complete (and before declaring it done) to find correctness, security, performance, and maintainability defects. Reviews a PR, a branch vs its base, the working-tree diff, or a given path. Read-only: it reports findings, it does not edit. Returns a severity-ranked report; Correctness + Security findings are blockers.";
-        model = "opus";
-        effort = "xhigh";
         color = "red";
-        tools = [
-          "Read"
-          "Bash"
-          "Glob"
-          "Grep"
-          "mcp__exa__web_search_exa"
-          "mcp__exa__web_fetch_exa"
-        ];
       };
       content = ''
         # Code Reviewer


### PR DESCRIPTION
Drop the pinned `model = opus` / `effort = xhigh` and the declared `tools` allowlist from the code-reviewer subagent so it inherits the session defaults.

The tools list was aspirational anyway: the kernel-first policy (packages/agent/policy/permissions.nix) denies Bash/Read for subagents regardless of the allowlist (#2077), so pinning it only misled spawners about what the agent could do.

Validated: `nix build .#agents` renders code-reviewer.md with only name/description/color in frontmatter.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove explicit model, effort, and tools config from code-reviewer subagent
> The `code-reviewer` frontmatter in [subagents.nix](https://github.com/indexable-inc/index/pull/3501/files#diff-45a91ccd89dc7a844cea2a6fca8aef743ce1cb606f0f101ed57304b99528d898) previously pinned the model to `opus`, effort to `xhigh`, and declared a fixed tools list. These fields are removed so the subagent inherits defaults instead. Only `description` and `color` remain in the frontmatter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 680cffd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->