### PR TITLE
claude-code: expose the baked system prompt as passthru.systemPrompt

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -643,6 +643,16 @@ in
         settings = settingsDefaults;
         settingsFile = settingsDefaultsFile;
 
+        # The exact string baked into the `--system-prompt-file` flag in
+        # `wrapperFlags` -- same binding as the flag, so passthru and argv
+        # cannot drift. Exposed because the `builtins.toFile` output behind
+        # that flag is otherwise anonymous: `nix eval --raw
+        # .#claude-code.systemPrompt` prints the realized prompt without
+        # digging the store path out of the launch spec. Null when the caller
+        # opted into the stock prompt (HM `systemPrompt.source = "stock"`),
+        # mirroring that no flag is baked then.
+        inherit systemPrompt;
+
         # Same capture path as extractSystemPrompt, but depends only on the fetched
         # upstream binary so prompt snapshots do not rebuild the wrapped package.
         extractStockSystemPrompt = import ./extract-system-prompt.nix {

--- a/packages/agent/prompt/default.nix
+++ b/packages/agent/prompt/default.nix
@@ -20,6 +20,8 @@
 #   nix eval --raw --impure --expr \
 #     '(import ./packages/agent/prompt { lib = (import <nixpkgs> {}).lib; }).systemPrompt'
 # Swap `.systemPrompt` for `.contextFor "codex"` and friends for the variants.
+# The copy actually baked into the wrapper (after any `omitRules`) is
+# `nix eval --raw .#claude-code.systemPrompt`.
 {
   lib,
   # Rule names dropped from every render, e.g.


### PR DESCRIPTION
Closes #3504

## Problem

The claude-code wrapper bakes its house system prompt via
`--system-prompt-file=${builtins.toFile "claude-code-system-prompt.txt" systemPrompt}`.
The `toFile` output is anonymous, so nothing in the flake's eval surface shows the
realized prompt a given build ships; inspecting it meant digging the store path out
of the launch-spec JSON in the built output.

## Change

- Add `inherit systemPrompt;` to the wrapper's `passthru` (same binding the flag
  uses, so the exposed value cannot drift from what is baked). It may be null when
  the caller selects the stock prompt (HM `systemPrompt.source = "stock"`),
  mirroring that no flag is baked then. This matches cursor-cli, which already
  exposes `passthru.systemPrompt`.
- Point the render one-liner comment in packages/agent/prompt/default.nix at the
  new passthru.

## Validation

- `nix eval --raw '.#claude-code.systemPrompt'` prints the full realized house
  prompt (~20.7 KB).
- Precommit lint suite passed (alejandra, statix, deadnix, astlog, clone, ...).

---

Authored by Claude Code (AI), reviewed run of an agent session.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose the baked system prompt via `claude-code.systemPrompt` passthru
> Adds a `passthru.systemPrompt` binding in [default.nix](https://github.com/indexable-inc/index/pull/3505/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) so the exact prompt string used for `--system-prompt-file` is accessible at evaluation time via `nix eval --raw .#claude-code.systemPrompt`. Adds comments in [packages/agent/prompt/default.nix](https://github.com/indexable-inc/index/pull/3505/files#diff-e8a9dbad9aa8e58667520a5a3b49e22bdfc725bf372a359ca15871a9c844d1ae) documenting this retrieval pattern.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df6299a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->